### PR TITLE
Hot-swappable API key: romp keyswap, no kernel restart

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -34,6 +34,7 @@ no separate implementation to point at.
 | `romp-judge` | `kernel/judge.py` | Layer 2: the judge engine + all judge prompts (captioner, archiver, planner, …). `docs/judges.md`. |
 | `romp-askparse` | `kernel/askparse.py` | Parses the AskUserQuestion picker out of a captured tmux pane (tmux backend only; SDK sessions get the picker natively). |
 | `romp_sdk_backend.py` | `kernel/sdk_backend.py` | The **SDK session backend** (current default): drives sessions via the Claude Agent SDK. |
+| _(no bin entry)_ | `kernel/keysource.py` | The live source of the manager's API key: the `ANTHROPIC_API_KEY=` line of `service.env`, re-read at every session launch. Shared by the kernel and `romp keyswap`, so the reader and the writer cannot disagree. |
 | `romp_session_backend.py` | `kernel/session_backend.py` | The `SessionBackend` ABC — the one seam both backends (SDK, tmux) implement. |
 | `romp_colormap.py` | `kernel/colormap.py` | The recency colormaps, single source of truth shared with the web bundles. |
 | `romp_palette.py` | `kernel/palette.py` | The session-identity color palettes. |
@@ -50,6 +51,7 @@ no separate implementation to point at.
 |---|---|---|
 | `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp update [host]`). |
 | `romp-version` | `cli/version.py` | Version report across the moving parts (`romp version`). |
+| `romp-keyswap` | `cli/keyswap.py` | Switches which API key the sessions bill without restarting the manager: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from a sibling file, and `--cycle`/`--cycle-all` reconnects running sessions onto it (`romp keyswap`). |
 | `romp-idle-dots` | `cli/idle_dots.py` | tmux backend only: heals stranded `working` state / fades idle tab dots by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |
 
 ## tmux backend only (real files)

--- a/bin/romp
+++ b/bin/romp
@@ -644,6 +644,7 @@ EOF
     _romp_cmd "romp update [host]"         romp-update  "Push this machine's committed romp to attached remotes and restart them"
     _romp_cmd "romp up"                    romp-manager "Run the kernel manager in the foreground (rare — the login service runs it)"
     _romp_cmd "romp version"               romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
+    _romp_cmd "romp keyswap [<name>]"      romp-keyswap "Switch which API key the sessions bill, no restart (service.env.<name>; --cycle-all reconnects running ones)"
     _romp_cmd "romp uninstall"             romp-uninstall "Remove romp's installed footprint (--purge also deletes recorded state)"
     _romp_cmd "romp help"                  -            "Show this help"
     cat <<'EOF'
@@ -715,6 +716,16 @@ fi
 if [[ "${1:-}" == "update" ]]; then
     shift
     exec romp-update "$@"
+fi
+
+# `romp keyswap [<name>] [--cycle <session,...> | --cycle-all]` — point the sessions at another API
+# key WITHOUT restarting the manager (the user 2026-09-04). Rewrites only the ANTHROPIC_API_KEY= line
+# of ~/.config/romp/service.env from a sibling file (service.env.<name>); the kernel reads that line
+# live at every session launch, and --cycle reconnects named running sessions so they re-present the
+# new key with their history intact. Delegates to romp-keyswap (python). Prints fingerprints, never keys.
+if [[ "${1:-}" == "keyswap" ]]; then
+    shift
+    exec romp-keyswap "$@"
 fi
 
 # The kernel serve token — required on EVERY kernel/bus request, loopback included (Jupyter's

--- a/bin/romp-keyswap
+++ b/bin/romp-keyswap
@@ -1,0 +1,1 @@
+../cli/keyswap.py

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,11 +1,12 @@
 # cli/ — terminal tools
 
 Python implementations of the terminal-facing romp commands. Run them via
-their `bin/` symlinks (`romp version`, `romp update`)
+their `bin/` symlinks (`romp version`, `romp update`, `romp keyswap`)
 — see `bin/README.md` for the command surface.
 
 | File | Command | What it is |
 |---|---|---|
 | `version.py` | `romp version` | Version report across the moving parts (working tree vs running kernel vs built bundles). |
 | `update.py` | `romp update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
+| `keyswap.py` | `romp keyswap [<name>]` | Switches which API key the sessions bill, with no kernel restart: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from a sibling file, and `--cycle`/`--cycle-all` reconnects running sessions onto it. Prints sha256 heads, never a key. |
 | `idle_dots.py` | (hook-fired) | tmux backend only: heals stranded `working` state by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |

--- a/cli/keyswap.py
+++ b/cli/keyswap.py
@@ -117,6 +117,13 @@ def _cycle(sessions, all_, out):
         out("            next launch or revive. Re-run `romp keyswap --cycle…` once romp is up.")
         return 1
     body = _post(u, "/keycycle", {"all": True} if all_ else {"sessions": sessions})
+    if body.get("error") == "HTTP 404":
+        # The one restart this feature genuinely needs: a kernel started before this code has no
+        # /keycycle route AND no live key read, so it is still on the key it booted with.
+        out("cycle       NOT DONE — the running kernel predates `romp keyswap` (no /keycycle route).")
+        out("            Take the patch once with `romp refresh`, and every swap after that is")
+        out("            restart-free. The file is already swapped.")
+        return 1
     if not body.get("ok"):
         out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
         return 1
@@ -222,8 +229,8 @@ def main(argv, out=None):
     out("effect      new and revived sessions bill this key immediately; no manager restart needed")
     if cycle or cycle_all:
         return _cycle(cycle, cycle_all, out)
-    out("running      keep the key they launched with — reconnect them with")
-    out("             romp keyswap %s --cycle-all   (or --cycle <session,…>)" % args[0])
+    out("running     sessions keep the key they launched with — reconnect them with")
+    out("            romp keyswap %s --cycle-all   (or --cycle <session,…>)" % args[0])
     return 0
 
 

--- a/cli/keyswap.py
+++ b/cli/keyswap.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""romp-keyswap — point every romp session at another API key, without restarting anything.
+
+`romp keyswap` rewrites ONE line of the manager's env file (`~/.config/romp/service.env`): the
+`ANTHROPIC_API_KEY=` line, taken from a sibling file you keep beside it (`service.env.highprio`,
+`service.env.lowprio`, …). The kernel reads that line live, per session launch, so:
+
+  * a session started or revived from then on bills the new key with no further action;
+  * a session already running keeps the key its CLI process started with, because the key rides
+    the launch environment — `--cycle <names>` or `--cycle-all` reconnects those sessions so they
+    re-present the new one, each resuming its own conversation with its history intact;
+  * the manager itself never restarts, so no session loses an open turn and no subagent is killed.
+
+No key value is ever printed, logged or passed over the wire. The only rendered form is the first
+12 hex of its sha256 ("sha256:1a2b3c…"), which is enough to see that the swap landed and that the
+kernel reads the same value this command wrote.
+
+Usage:
+    romp keyswap                            # what is live now, and which candidates exist
+    romp keyswap lowprio                    # rewrite the key line from service.env.lowprio
+    romp keyswap lowprio --cycle web,api    # …and reconnect those two sessions onto it
+    romp keyswap lowprio --cycle-all        # …and reconnect every live key-billed session
+    romp keyswap /path/to/other.env         # an explicit file instead of a sibling name
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+# The SAME module the kernel reads the key with, not a second copy of the rules: writer and reader
+# then cannot disagree about which file holds the key, which line wins, or how it is parsed.
+ks = SourceFileLoader("romp_keysource", str(ROOT / "kernel" / "keysource.py")).load_module()
+
+KPORTS = ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
+
+
+def _token():
+    """The serve token — required on every kernel request, loopback included (Jupyter's model).
+    Same resolution romp-update uses: env override, else the 0600 state file."""
+    t = (os.environ.get("ROMP_SERVE_TOKEN") or "").strip()
+    if t:
+        return t
+    try:
+        root = Path(os.environ.get("ROMP_STATE_DIR")
+                    or Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")) / "romp")
+        return (root / "serve-token").read_text().strip()
+    except OSError:
+        return ""
+
+
+def _kernel():
+    """The base URL of the running local kernel, or None."""
+    for u in KPORTS:
+        try:
+            with urllib.request.urlopen(u + "/version", timeout=1.5) as r:   # /version is auth-exempt
+                if r.status == 200:
+                    return u
+        except Exception:
+            continue
+    return None
+
+
+def _post(u, path, body):
+    req = urllib.request.Request(u + path, data=json.dumps(body).encode(),
+                                headers={"Content-Type": "application/json",
+                                         "X-Romp-Token": _token()}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        try:
+            return json.loads(e.read().decode() or "{}")
+        except Exception:
+            return {"ok": False, "error": "HTTP %s" % e.code}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+def _fp(key):
+    """A key as the only thing that may be shown of it."""
+    f = ks.fingerprint(key)
+    return ("sha256:" + f) if f else "(none)"
+
+
+def _candidates(path, out):
+    """List the sibling `service.env.<name>` files, each by fingerprint only — so `romp keyswap`
+    with no argument answers both "which key is live" and "what can I swap to"."""
+    d = os.path.dirname(path) or "."
+    base = os.path.basename(path) + "."
+    try:
+        names = sorted(n[len(base):] for n in os.listdir(d) if n.startswith(base) and not n.endswith("~"))
+    except OSError:
+        names = []
+    live = ks.read_key(path)
+    if not names:
+        out("candidates  none — keep one file per key beside it, e.g. %s.lowprio (chmod 600),"
+            % os.path.basename(path))
+        out("            each a single %s=… line" % ks.KEY_VAR)
+        return
+    out("candidates")
+    for n in names:
+        k = ks.read_key(ks.sibling_path(n, path))
+        mark = "  <- live" if (k and k == live) else ""
+        out("  %-14s %s%s" % (n, _fp(k) if k else "(no %s line)" % ks.KEY_VAR, mark))
+
+
+def _cycle(sessions, all_, out):
+    """Reconnect the named sessions through the kernel, and report what it did per session."""
+    u = _kernel()
+    if not u:
+        out("cycle       NOT DONE — no running kernel found (is romp on? `romp status`).")
+        out("            The file is already swapped: every session picks the new key up at its")
+        out("            next launch or revive. Re-run `romp keyswap --cycle…` once romp is up.")
+        return 1
+    body = _post(u, "/keycycle", {"all": True} if all_ else {"sessions": sessions})
+    if not body.get("ok"):
+        out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
+        return 1
+    out("kernel      reads %s" % (("sha256:" + body["keyFp"]) if body.get("keyFp") else "(none)"))
+    rows = body.get("rows") or []
+    if not rows:
+        out("cycle       no sessions matched")
+        return 0
+    for r in rows:
+        out("  %-14s %s" % (str(r.get("session"))[:14], _explain(str(r.get("status") or ""))))
+    return 0
+
+
+def _explain(status):
+    return {
+        "cycling": "reconnecting now (idle) or at the end of its turn — history kept",
+        "login":   "skipped: bills the machine login, not the key",
+        "dormant": "not running — its next launch reads the new key",
+        "unknown": "no such session",
+    }.get(status, status)
+
+
+def parse_args(argv):
+    """(source, cycle-list, cycle-all, error). Positional: at most one source name or path."""
+    src, cycle, cycle_all, err = "", [], False, ""
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--cycle-all":
+            cycle_all = True
+        elif a == "--cycle" or a.startswith("--cycle="):
+            if a == "--cycle":
+                i += 1
+                val = argv[i] if i < len(argv) else ""
+            else:
+                val = a.split("=", 1)[1]
+            cycle = [s.strip() for s in val.split(",") if s.strip()]
+            if not cycle:
+                err = err or "--cycle needs a session list, e.g. --cycle web,api"
+        elif a.startswith("-"):
+            err = err or ("unknown option %s" % a)
+        elif not src:
+            src = a
+        else:
+            err = err or "one source at a time (got %s and %s)" % (src, a)
+        i += 1
+    return src, cycle, cycle_all, err
+
+
+def main(argv, out=None):
+    out = out or (lambda line: sys.stdout.write(line + "\n"))
+    src_arg, cycle, cycle_all, err = parse_args(list(argv))
+    if err:
+        sys.stderr.write("romp keyswap: %s\n" % err)
+        return 2
+    args = [src_arg] if src_arg else []
+    path = ks.service_env_path()
+    if not args:
+        # Read-only report. Deliberately the no-argument behaviour: a swap is a real change and
+        # should be asked for by name.
+        out("service.env %s" % path)
+        out("live key    %s" % _fp(ks.read_key(path)))
+        _candidates(path, out)
+        if cycle or cycle_all:
+            return _cycle(cycle, cycle_all, out)
+        out("")
+        out("swap with:  romp keyswap <name> [--cycle <session,…> | --cycle-all]")
+        return 0
+    src = ks.sibling_path(args[0], path)
+    if not os.path.exists(src):
+        sys.stderr.write("romp keyswap: no such key file: %s\n" % src)
+        sys.stderr.write("             keep one per key beside the env file (e.g. %s.lowprio, chmod 600)\n"
+                         % os.path.basename(path))
+        return 2
+    new = ks.read_key(src)
+    if not new:
+        # Refuse rather than write an empty key: the CLI reads an empty ANTHROPIC_API_KEY as
+        # "API-key mode, no key" and every session would then fail to authenticate.
+        sys.stderr.write("romp keyswap: %s has no %s= line — nothing to swap to (file untouched)\n"
+                         % (src, ks.KEY_VAR))
+        return 2
+    cur = ks.read_key(path)
+    if new == cur:
+        out("service.env %s" % path)
+        out("live key    %s — already this key, nothing rewritten" % _fp(cur))
+    else:
+        try:
+            res = ks.write_key(new, path)
+        except OSError as e:
+            sys.stderr.write("romp keyswap: could not rewrite %s: %s\n" % (path, e))
+            return 1
+        # Verify from the FILE, not from what we meant to write: re-read and fingerprint it.
+        landed = ks.read_key(path)
+        if landed != new:
+            sys.stderr.write("romp keyswap: the rewrite did not land (file reads %s, expected %s) — "
+                             "check %s by hand\n" % (_fp(landed), _fp(new), path))
+            return 1
+        out("service.env %s" % res["path"])
+        out("key line    %s -> %s  (%d lines, mode %o%s)"
+            % (_fp(res["old"]), _fp(new), res["lines"], res["mode"],
+               ", tightened from a group/other-readable mode" if res["tightened"] else ""))
+        out("source      %s" % src)
+    out("effect      new and revived sessions bill this key immediately; no manager restart needed")
+    if cycle or cycle_all:
+        return _cycle(cycle, cycle_all, out)
+    out("running      keep the key they launched with — reconnect them with")
+    out("             romp keyswap %s --cycle-all   (or --cycle <session,…>)" % args[0])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -380,10 +380,10 @@ without either side showing the key.
 
 **One restart, once:** a kernel that is already running when this feature is
 installed neither reads the file live nor knows the `--cycle` route, so it is
-still on the key it booted with. Take the update with `romp refresh` (or
-`systemctl --user restart romp-manager` on Linux) a single time; every swap
-after that is restart-free. `romp keyswap --cycle-all` says so plainly if it
-meets an older kernel.
+still on the key it booted with. Take the update a single time with `romp
+refresh` — or `romp refresh --quiet`, which waits for the sessions to finish
+their turns first — and every swap after that is restart-free. `romp keyswap
+--cycle-all` says so plainly if it meets an older kernel.
 
 Remote kernels each have their own `service.env` and their own key: run
 `romp keyswap` on that machine.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -24,6 +24,7 @@ update` starts a session called "update".
 | `romp update [host…]` | Push this machine's committed Romp to attached remotes and restart them |
 | `romp up` | Run the kernel manager in the foreground; rare, since the login service runs it |
 | `romp version` | Version report across the moving parts |
+| `romp keyswap [<name>] [--cycle <session,…>\|--cycle-all]` | Switch which API key the sessions bill, with no restart: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from `service.env.<name>`, and `--cycle` moves running sessions onto it. Bare, it reports the live key and the candidates. See [Switching which API key the sessions bill](#switching-which-api-key-the-sessions-bill-romp-keyswap) |
 | `romp help` | The same list, from the terminal |
 
 These are for scripting and for agents rather than daily use:
@@ -326,6 +327,69 @@ manager starts (the systemd unit via `EnvironmentFile=-`, the macOS login
 agent's launcher by parsing it — line by line, never sourced, so a malformed
 line is skipped rather than executed). Rotate a value by editing the file and
 restarting the manager (`romp-service install`); a missing file is a no-op.
+
+`ANTHROPIC_API_KEY` is the one exception to that last sentence — it needs no
+restart at all. See below.
+
+### Switching which API key the sessions bill (`romp keyswap`)
+
+The key a session bills rides its launch environment, and romp reads the
+`ANTHROPIC_API_KEY=` line of `service.env` **fresh at every session launch**.
+So changing keys — moving to another organisation's key, rotating a leaked
+one, switching between a high-priority and a batch key — costs no manager
+restart, and no session loses an open turn.
+
+Keep one file per key beside `service.env`, each a single `ANTHROPIC_API_KEY=`
+line, `chmod 600`:
+
+    ~/.config/romp/service.env.highprio
+    ~/.config/romp/service.env.lowprio
+
+Then:
+
+    romp keyswap                       # which key is live, and what you can swap to
+    romp keyswap lowprio               # rewrite the key line from service.env.lowprio
+    romp keyswap lowprio --cycle-all   # …and move the running sessions onto it too
+    romp keyswap lowprio --cycle web,api
+
+`romp keyswap <name>` rewrites **only** the `ANTHROPIC_API_KEY=` line, in
+place, keeping every other line of the file byte for byte — a temp file and a
+rename, so no reader ever sees the file half-written, and the mode stays `600`
+(a looser one is tightened). It refuses a source file with no key line rather
+than writing an empty key, which the CLI would read as "API-key mode, no key".
+
+After the rewrite:
+
+* **new sessions, and any session you revive, bill the new key immediately** —
+  nothing else to do;
+* **already-running sessions keep the key their process started with**, because
+  the key is handed over at launch. `--cycle-all` (or `--cycle <session,…>`)
+  reconnects them so they re-present the new one. A reconnect resumes the same
+  conversation with its history intact — the same mechanism a reasoning-effort
+  or billing switch uses — immediately if the session is idle, at the end of
+  the current turn if it is busy. Sessions billing the machine login are
+  skipped, and dormant ones are reported as needing nothing;
+* **the judges and the model catalog** pick the new key up on their next call,
+  with no cycling at all.
+
+No key value is ever printed, logged, or sent over a socket. The only rendered
+form is the first 12 hex of its sha256 — `sha256:1a2b3c4d5e6f` — which appears
+in the command's output, in the Log panel when the key changes, and in the
+kernel's own answer to `--cycle`. Comparing those tells you the swap landed
+without either side showing the key.
+
+**One restart, once:** a kernel that is already running when this feature is
+installed neither reads the file live nor knows the `--cycle` route, so it is
+still on the key it booted with. Take the update with `romp refresh` (or
+`systemctl --user restart romp-manager` on Linux) a single time; every swap
+after that is restart-free. `romp keyswap --cycle-all` says so plainly if it
+meets an older kernel.
+
+Remote kernels each have their own `service.env` and their own key: run
+`romp keyswap` on that machine.
+
+`ROMP_SERVICE_ENV_FILE` overrides the path of the file, for both the installer
+and the live read.
 
 ## Where things live
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -25,6 +25,14 @@ Session control (how romp drives Claude Code) sits behind one seam:
 Shared lookup tables: `colormap.py` (recency tints, single source shared with
 the web bundles) and `palette.py` (session-identity colors).
 
+`keysource.py` is the live source of the manager's API key: the
+`ANTHROPIC_API_KEY=` line of `service.env`, re-read at every session launch so
+switching keys needs no manager restart. `cli/keyswap.py` (`romp keyswap`) loads
+the same module to write that line, so the reader and the writer cannot disagree
+about the path or the parse. A key value never lands in the kernel's own
+environment and never reaches a log — `fingerprint()` (the sha256 head) is the
+only renderable form.
+
 Everything here is loaded by file path (`SourceFileLoader`), not installed as a
 package — the repo runs straight from a git clone. Python tests live in
 `tests/test_*.py`.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32995,6 +32995,10 @@ class Handler(BaseHTTPRequestHandler):
                                 for sid, s in list(be.sessions.items())]
                 else:
                     raw = b.get("sessions") or []
+                    if not isinstance(raw, list):   # a bare string would iterate its CHARACTERS
+                        return self._send(400, json.dumps({"ok": False,
+                                                           "error": "sessions must be a list"}),
+                                          "application/json")
                     who_list = [(str(w), _sid_of(str(w))) for w in raw if str(w or "").strip()]
                 for who, sid in who_list:
                     try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9504,11 +9504,8 @@ def _work_key_fp():
     to anyone who reads it. Never a fragment of the key itself — the same rule _auth_key_present
     keeps for the browser, applied to the terminal."""
     be = _sdk()
-    ks = getattr(sys.modules.get("romp_sdk_backend"), "_keysrc", None)
-    if be is None or ks is None:
-        return ""
     try:
-        return ks.fingerprint(be.work_key)
+        return getattr(be, "work_key_fp", lambda: "")()
     except Exception:
         return ""
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9497,6 +9497,22 @@ def _auth_key_present():
     return bool(str(getattr(be, "work_key", "") or "") if be else "")
 
 
+def _work_key_fp():
+    """The first 12 hex of the sha256 of the key sessions currently launch on — "" when there is
+    none. The ONE renderable form of a key (keysource.fingerprint): enough for an operator to
+    confirm a keyswap landed and that the kernel reads the same value `romp keyswap` wrote, useless
+    to anyone who reads it. Never a fragment of the key itself — the same rule _auth_key_present
+    keeps for the browser, applied to the terminal."""
+    be = _sdk()
+    ks = getattr(sys.modules.get("romp_sdk_backend"), "_keysrc", None)
+    if be is None or ks is None:
+        return ""
+    try:
+        return ks.fingerprint(be.work_key)
+    except Exception:
+        return ""
+
+
 def _auth_both():
     """True when this machine offers BOTH billing choices (a signed-in login and a manager-env key) —
     the condition for the per-session auth selector to exist anywhere (picker, gear). Cheap per-push:
@@ -32951,6 +32967,47 @@ class Handler(BaseHTTPRequestHandler):
                 res = _compact_request(who)
                 status = res.pop("_status", 200)
                 return self._send(status, json.dumps(res), "application/json")
+            if u.path == "/keycycle":
+                # `romp keyswap … --cycle <names>` / `--cycle-all` (the user 2026-09-04). The API key
+                # rides a session's LAUNCH environment, so a running CLI keeps the key it started with;
+                # this reconnects the named sessions so they re-present the CURRENT one, each resuming
+                # its own conversation with history intact. It is the alternative to restarting the
+                # manager, which would cut every open turn and kill every subagent under it.
+                #
+                # The kernel takes NO key from the client — not a value, not a path. The swap is a file
+                # the operator (or `romp keyswap`) rewrote; all this route does is make live sessions
+                # re-read it. So the door cannot be used to point a session at a key of the caller's
+                # choosing, and the response carries only a FINGERPRINT (sha256 head) so the caller can
+                # confirm that the kernel reads what it just wrote without either side printing a key.
+                # Body: {"sessions": [<id-or-name>…]} or {"all": true}.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                b = b if isinstance(b, dict) else {}
+                be = _sdk()
+                if be is None:
+                    return self._send(503, json.dumps({"ok": False, "error": "no SDK backend"}),
+                                      "application/json")
+                keyfp = _work_key_fp()
+                rows = []
+                if b.get("all"):
+                    # every LIVE SDK session: the dormant ones need nothing (their next launch reads
+                    # the file), and cycle_key says so per session rather than guessing here
+                    who_list = [(getattr(s, "name", "") or sid, sid)
+                                for sid, s in list(be.sessions.items())]
+                else:
+                    raw = b.get("sessions") or []
+                    who_list = [(str(w), _sid_of(str(w))) for w in raw if str(w or "").strip()]
+                for who, sid in who_list:
+                    try:
+                        status = be.cycle_key(sid)
+                    except Exception as e:
+                        status = "error: %s" % str(e)[:80]
+                    rows.append({"session": _name_of(sid) or who, "status": status})
+                _push_soon()
+                return self._send(200, json.dumps({"ok": True, "keyFp": keyfp, "rows": rows}),
+                                  "application/json")
             if u.path in ("/interrupt", "/end"):
                 # Headless session control (2026-07-05): interrupt/end existed ONLY as WS drive ops, so
                 # a session could be FED without a browser (POST /send, postal) but never STOPPED — a

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -1,0 +1,187 @@
+"""keysource — where the manager's API key comes from, read LIVE instead of once at startup.
+
+The manager runs as a login service and gets its environment from `service.env`
+(`~/.config/romp/service.env`; systemd reads it via `EnvironmentFile=-`, the macOS login
+agent's launcher parses it before exec). Until 2026-09-04 the kernel claimed
+`ANTHROPIC_API_KEY` out of its own process environment ONCE at startup, so changing which
+key the sessions bill meant restarting the manager — which cuts every session's turn and
+kills every subagent. This module is the live source instead: every place that needs the key
+re-reads the FILE, so an edit takes effect on the next session connect with no restart.
+
+Three properties this module exists to hold:
+
+* **The value never lands in the kernel's own environment.** It is read, handed to one
+  session's launch environment, and dropped. Nothing here writes `os.environ`.
+* **The value never reaches a log, a screen or a wire.** `fingerprint()` is the only thing
+  callers may print: the first 12 hex of the sha256 of the exact value. Enough to say
+  "the key changed" or "both sides agree", useless to anyone who reads it.
+* **A read never raises and never blocks a launch.** A missing file, a file with no
+  `ANTHROPIC_API_KEY=` line, a permission error — all read as "" so the caller falls back
+  to whatever the process environment carried at startup, which is exactly the old
+  behaviour. The feature can only ADD a key source, never take one away.
+
+Parsing follows the same line-by-line rule the two launchers use (never sourced, so a
+malformed line is skipped rather than executed): blank and `#` lines ignored, `NAME=value`
+otherwise, and the LAST assignment wins — that is what both systemd and a repeated `export`
+do, so what this module reads is what the service would actually have got. One layer of
+matching surrounding quotes is stripped, because systemd strips it and a quoted value would
+otherwise be handed to the CLI with the quotes still on.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+
+KEY_VAR = "ANTHROPIC_API_KEY"
+
+# (stat identity, parsed value) for the last file read — an EVENT-keyed cache, not a timed one:
+# the identity is the file's own (inode, mtime_ns, size), so a rewrite invalidates it by
+# construction and a swap is picked up on the very next read. Without it, `work_key` (read per
+# push through the kernel's has-a-key bool) would parse the file thousands of times a minute.
+_CACHE: tuple = ((), "")
+
+
+def service_env_path() -> str:
+    """The path of the env file the manager is configured from.
+
+    `ROMP_SERVICE_ENV_FILE` is the name the installer and the macOS launcher already use
+    (`bin/romp-service`, `bin/romp-node-launch`), so it is the primary; `ROMP_SERVICE_ENV` is
+    accepted as an alias. Default `${XDG_CONFIG_HOME:-~/.config}/romp/service.env` — the same
+    expression those two scripts compute, so all three always name one file.
+    """
+    for var in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV"):
+        p = (os.environ.get(var) or "").strip()
+        if p:
+            return os.path.expanduser(p)
+    base = (os.environ.get("XDG_CONFIG_HOME") or "").strip() or os.path.join(os.path.expanduser("~"), ".config")
+    return os.path.join(base, "romp", "service.env")
+
+
+def sibling_path(name: str, path: str | None = None) -> str:
+    """The candidate file a keyswap reads from. A bare name (`highprio`) means the sibling
+    `service.env.<name>` beside the live file — the convention that keeps every candidate in one
+    0600 directory. Anything with a separator, or an explicit path, is taken as given."""
+    name = str(name or "").strip()
+    if not name:
+        return ""
+    if os.sep in name or name.startswith("~"):
+        return os.path.expanduser(name)
+    return (path or service_env_path()) + "." + name
+
+
+def parse_key(text: str) -> str:
+    """The value the LAST `ANTHROPIC_API_KEY=` assignment in an env-file body would set — "" when
+    the body has none. Last wins, matching systemd and a repeated `export`."""
+    out = ""
+    for raw in str(text or "").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, sep, value = line.partition("=")
+        if not sep or name.strip() != KEY_VAR:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]     # systemd strips one layer; without this the CLI gets the quotes
+        out = value
+    return out
+
+
+def read_key(path: str | None = None) -> str:
+    """The key the env file currently sets, or "" for every failure — missing file, no such line,
+    unreadable, undecodable. Cached on the file's own stat identity (see _CACHE)."""
+    global _CACHE
+    p = path or service_env_path()
+    try:
+        st = os.stat(p)
+        ident = (p, st.st_ino, st.st_mtime_ns, st.st_size)
+    except OSError:
+        _CACHE = ((p, "absent"), "")
+        return ""
+    if _CACHE[0] == ident:
+        return _CACHE[1]
+    try:
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            key = parse_key(fh.read())
+    except OSError:
+        key = ""
+    _CACHE = (ident, key)
+    return key
+
+
+def fingerprint(key: str) -> str:
+    """The ONLY renderable form of a key: first 12 hex of its sha256, "" for no key. Same value in
+    the kernel log and in `romp keyswap`'s output, so an operator can check that the kernel reads
+    the key they just wrote without either side ever printing it."""
+    key = str(key or "")
+    if not key:
+        return ""
+    return hashlib.sha256(key.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def write_key(key: str, path: str | None = None) -> dict:
+    """Rewrite ONLY the `ANTHROPIC_API_KEY=` line of the env file, atomically.
+
+    Every other line survives byte for byte, in place — the file also carries things like
+    `ROMP_PERF=1` and `ROMP_EXPECTED_AUTH`, and a rewrite that dropped them would change the
+    manager's behaviour on its next start for reasons nobody would connect to a key swap. The
+    key line keeps its POSITION (last assignment replaced in place, any earlier duplicate
+    removed so the file cannot disagree with itself); a file with no such line gets one appended.
+
+    Written to a temp file in the same directory, created 0600 with O_EXCL, then `os.replace` —
+    so no reader ever sees a half-written file and the key is never briefly world-readable. The
+    mode is the original file's, narrowed to 0600 if it granted group or other any access at all;
+    a new file is 0600.
+
+    Returns {"path", "old", "new", "mode", "tightened", "lines"} — `old`/`new` are the raw values,
+    for the caller to fingerprint. Raises OSError on a real failure (the caller reports it).
+    """
+    p = path or service_env_path()
+    try:
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            body = fh.read()
+        existed = True
+    except FileNotFoundError:
+        body, existed = "", False
+    old = parse_key(body)
+    lines = body.splitlines()
+    trailing_nl = (not body) or body.endswith("\n")
+    # Which physical lines assign the key: the LAST one is rewritten in place, earlier ones drop.
+    hits = [i for i, raw in enumerate(lines)
+            if raw.strip() and not raw.strip().startswith("#")
+            and raw.strip().partition("=")[1] and raw.strip().partition("=")[0].strip() == KEY_VAR]
+    new_line = "%s=%s" % (KEY_VAR, key)
+    if hits:
+        lines[hits[-1]] = new_line
+        for i in reversed(hits[:-1]):
+            del lines[i]
+    else:
+        lines.append(new_line)
+        trailing_nl = True
+    out = "\n".join(lines) + ("\n" if trailing_nl else "")
+    mode, tightened = 0o600, False
+    if existed:
+        try:
+            mode = os.stat(p).st_mode & 0o777
+            if mode & 0o077:            # never leave a key group- or world-readable
+                mode, tightened = 0o600, True
+        except OSError:
+            mode = 0o600
+    d = os.path.dirname(p) or "."
+    tmp = os.path.join(d, ".%s.keyswap.%d" % (os.path.basename(p), os.getpid()))
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(out)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, p)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return {"path": p, "old": old, "new": key, "mode": mode, "tightened": tightened,
+            "lines": len(lines)}

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import tempfile
 
 KEY_VAR = "ANTHROPIC_API_KEY"
 
@@ -168,8 +169,10 @@ def write_key(key: str, path: str | None = None) -> dict:
         except OSError:
             mode = 0o600
     d = os.path.dirname(p) or "."
-    tmp = os.path.join(d, ".%s.keyswap.%d" % (os.path.basename(p), os.getpid()))
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    # mkstemp: same directory (so the rename is atomic — a cross-filesystem one is a copy), a name
+    # nothing can collide with, and 0600 from the moment the file exists, so the key is never
+    # briefly readable by anyone else.
+    fd, tmp = tempfile.mkstemp(dir=d, prefix="." + os.path.basename(p) + ".keyswap.")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(out)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2795,15 +2795,22 @@ class SdkSession:
         if isinstance(info, dict) and self._adopt_fast_state(info):
             self.backend._poke()
 
-    def effective_auth(self) -> str:
+    def effective_auth(self, key=None) -> str:
         """'key' or 'login' — what _options launches this session with. An explicit pick wins; unset
         preserves the pre-selector world, where a manager environment that carried a key billed every
         session to it (so absent a choice, the key still wins when one exists). 'key' with no key to
         inject falls to login rather than launching with a var the CLI would refuse on — _options
-        logs that fall loudly (it is a misconfiguration, not a preference)."""
+        logs that fall loudly (it is a misconfiguration, not a preference).
+
+        `key` lets a caller supply the key it already read, so a connect decides and injects on ONE
+        read: the source is live now (a keyswap can land between two reads), and re-reading here
+        could have _options inject a key the decision was never made against. Absent, it reads the
+        backend's live key exactly as it always did."""
         if self.auth == "login":
             return "login"
-        return "key" if self.backend.work_key else "login"
+        if key is None:
+            key = self.backend.work_key
+        return "key" if key else "login"
 
     async def _do_refresh_usage(self):
         """Pull the EXACT account-wide /usage snapshot from the CLI — the designed data behind the /usage
@@ -4729,6 +4736,12 @@ class SdkBackend:
     def work_key(self, value) -> None:
         self._work_key_pin = str(value or "")
 
+    def work_key_fp(self) -> str:
+        """The renderable form of the key sessions launch on: the sha256 head, "" for none. The
+        kernel's /keycycle answer carries this so an operator can confirm the kernel re-read the
+        file they just wrote — the value itself never leaves this process."""
+        return _keysrc.fingerprint(self.work_key)
+
     def _note_work_key(self, key: str) -> None:
         """Log WHICH key a launch is billing, as a fingerprint, and only when it changes. That makes
         a keyswap visible in the Log panel — "the kernel now reads sha256:… " — which is the only
@@ -5861,12 +5874,11 @@ class SdkBackend:
         # login on its own; a key session gets the key injected here, explicitly. options.env merges
         # OVER the inherited env in the SDK's transport, which is exactly the one-way door we need —
         # inject or stay silent; never blank (an empty var reads as "API-key mode, no key" to the CLI).
-        # The key is read ONCE here, per connect, and the same value is what gets injected: the source
-        # is live now (a keyswap can land between two reads), so a second read could hand the CLI a key
-        # the auth decision was never made against. An empty read also means DON'T inject — falling to
-        # login is right, and blanking the var would leave the CLI in key-mode-without-a-key.
+        # The key is read ONCE here, per connect, and the value the auth decision was made on is the
+        # value injected: the source is live now (a keyswap can land between two reads). An empty read
+        # decides login — blanking the var would leave the CLI in key-mode-without-a-key.
         work_key = self.work_key
-        launch_keyed = sess.effective_auth() == "key" and bool(work_key)
+        launch_keyed = sess.effective_auth(work_key) == "key"
         if launch_keyed:
             self._note_work_key(work_key)
             kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=work_key,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -44,6 +44,10 @@ from pathlib import Path
 # consistent colour without cross-backend "used" bookkeeping.
 from importlib.machinery import SourceFileLoader as _SFL
 _pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py")).load_module()
+# The LIVE source of the manager's API key (keysource.py — stdlib only, loaded the same way so the
+# module works from bin/ symlinks too). `romp keyswap` loads the identical file, so the writer and
+# the reader can never disagree about which path holds the key or how its line is parsed.
+_keysrc = _SFL("romp_keysource", str(Path(__file__).resolve().parent / "keysource.py")).load_module()
 
 
 def _bin_on_path_env(environ) -> dict:
@@ -1756,24 +1760,75 @@ def _cli_refusal(e: BaseException) -> bool:
 
 
 _WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
+_KEY_FILE_CHECKED = False      # the startup-vs-file agreement check (one line, once per process)
 
 
-def work_api_key() -> str:
-    """The API key the manager's environment carried at startup (service.env, or however the manager
-    was launched), CLAIMED OUT of os.environ on first read — "" when it carried none. The SDK's
-    transport hands the CLI this process's environment wholesale (options.env merges OVER it), so an
-    ambient ANTHROPIC_API_KEY bills EVERY session to the key no matter what auth the user picked for
-    it; popping it here makes the key explicit per session — _options injects it only where the
-    session's auth says so, and a login session launches with a genuinely clean environment (the CLI
-    treats even an EMPTY var as "API-key mode, no key" and refuses with "Not logged in" — verified
-    live 2026-08-08 — so removal, not blanking, is the only correct strip). Module-level so a
-    re-constructed backend (tests, the WS handler's lazy construction) still finds the key after the
-    first pop; the kernel process never re-execs itself, so a manager restart re-inherits the
-    service env and a fresh process re-stashes."""
+def startup_api_key() -> str:
+    """The API key the manager's environment carried AT STARTUP, CLAIMED OUT of os.environ on first
+    read — "" when it carried none. The SDK's transport hands the CLI this process's environment
+    wholesale (options.env merges OVER it), so an ambient ANTHROPIC_API_KEY bills EVERY session to
+    the key no matter what auth the user picked for it; popping it here makes the key explicit per
+    session — _options injects it only where the session's auth says so, and a login session
+    launches with a genuinely clean environment (the CLI treats even an EMPTY var as "API-key mode,
+    no key" and refuses with "Not logged in" — verified live 2026-08-08 — so removal, not blanking,
+    is the only correct strip). Module-level so a re-constructed backend (tests, the WS handler's
+    lazy construction) still finds the key after the first pop.
+
+    This is now the FALLBACK, not the source: work_api_key() prefers the live env file. It still
+    matters on its own — a box whose key never rides service.env (an apiKeyHelper machine, a
+    foreground `romp up` from a shell that exported one) has no file line to read, and there the
+    startup claim is the whole answer, exactly as before."""
     global _WORK_KEY
     if _WORK_KEY is None:
         _WORK_KEY = os.environ.pop("ANTHROPIC_API_KEY", "") or ""
     return _WORK_KEY
+
+
+def work_api_key() -> str:
+    """The key a session started RIGHT NOW should bill: the live `ANTHROPIC_API_KEY=` line of the
+    manager's env file (`~/.config/romp/service.env`), falling back to what the process environment
+    carried at startup. "" when neither exists.
+
+    Live, because the alternative was a restart (the user 2026-09-04): the key used to be popped
+    once at boot, so moving the sessions to another org key meant `systemctl --user restart
+    romp-manager` — which cuts every session's open turn and kills every subagent under it. Reading
+    the file instead makes the swap cost one reconnect per session (`romp keyswap <name> --cycle…`,
+    which resumes each conversation with its history intact) and nothing at all for a session that
+    is next launched or revived anyway.
+
+    The read is cheap and event-keyed: keysource caches on the file's own (inode, mtime_ns, size),
+    so a repeated call is a stat and a rewrite invalidates by construction. The value is never
+    written back into os.environ — the one-claimer property above is what keeps an ambient key from
+    billing every session, and a live source must not undo it."""
+    startup = startup_api_key()      # ALWAYS first: the pop must happen even when the file answers
+    live = _keysrc.read_key()
+    _check_key_file_agrees(startup, live)
+    return live or startup
+
+
+def _check_key_file_agrees(startup: str, live: str) -> None:
+    """Say ONCE, on stderr (the kernel's log wire), whether the file this process reads holds the
+    same key its environment was started with. Both sides are fingerprints, never values.
+
+    Worth the six lines: this is the one way the live read can go quietly wrong. The launchers do
+    not parse identically to each other — systemd's EnvironmentFile strips one layer of quotes, the
+    macOS launcher's `export` does not — so a quoted value, a stray duplicate line, or a key that
+    reaches the manager some other way makes the file disagree with the environment, and every
+    session would then launch on a key nobody chose. Disagreement at startup is a configuration
+    fact the operator can fix in a minute, and silence about it would surface hours later as
+    inexplicable 401s."""
+    global _KEY_FILE_CHECKED
+    if _KEY_FILE_CHECKED:
+        return
+    _KEY_FILE_CHECKED = True
+    if not startup or not live or startup == live:
+        return
+    sys.stderr.write(
+        "work key: the manager env file sets a DIFFERENT key than this process started with "
+        "(file sha256:%s, startup sha256:%s) — sessions launch on the file's. If that is not what "
+        "you meant, check %s for a quoted or duplicated %s line.\n"
+        % (_keysrc.fingerprint(live), _keysrc.fingerprint(startup),
+           _keysrc.service_env_path(), _keysrc.KEY_VAR))
 
 
 def _expected_auth() -> str:
@@ -4597,9 +4652,12 @@ class SdkBackend:
         #                                           pollable session exists again, so the 60s rail timer
         #                                           logs the condition once per episode, not per call
         self._fork_children_memo = None           # (sdk/ dir mtime_ns, {parent sid: [child lineage]}) — fork_children()
-        self.work_key = work_api_key()            # the manager env's API key, claimed out of os.environ
-        #   ("" = none): per-session auth injects it via _options; its presence is the "key" half of
-        #   the availability the kernel publishes to the picker/gear (the user 2026-08-08)
+        self._work_key_pin: str | None = None     # a test's explicit `be.work_key = …` (see the property)
+        startup_api_key()                         # claim any ambient key OUT of os.environ, right here:
+        #   the transport merges options.env over this process's env, so an ambient key would bill
+        #   EVERY session whatever its pick. The VALUE is read per launch off `work_key` below, live,
+        #   so a keyswap needs no kernel restart (the user 2026-09-04).
+        self._key_fp_said = None                  # last key fingerprint written to the log (change-only)
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -4651,6 +4709,63 @@ class SdkBackend:
         # in-progress sessions). A session that genuinely FINISHED a turn before the restart already logged
         # "waiting" (ResultMessage), so it stays nudge-eligible. The dormant in-flight→waiting DISPLAY heal lives
         # independently in live_sessions, so the feed/fleet still render dormant sessions as waiting.
+
+    @property
+    def work_key(self) -> str:
+        """The manager's API key, READ LIVE per access (work_api_key: the env file's current line,
+        else the startup claim). A property rather than the frozen attribute it used to be, so
+        every existing reader becomes hot-swap-aware at once — _options' injection, effective_auth
+        and default_auth's key/login fallback, set_auth's refusal to pick a key that isn't there,
+        and the kernel's has-a-key bool for the picker. Cheap enough for all of them: the parse is
+        cached on the file's stat identity, so an access is a stat.
+
+        Assignment PINS a value for this backend and stops the live read (`be.work_key = ""` — how
+        the tests stand up a keyless manager). A pin is deliberate and never set by romp itself."""
+        if self._work_key_pin is not None:
+            return self._work_key_pin
+        return work_api_key()
+
+    @work_key.setter
+    def work_key(self, value) -> None:
+        self._work_key_pin = str(value or "")
+
+    def _note_work_key(self, key: str) -> None:
+        """Log WHICH key a launch is billing, as a fingerprint, and only when it changes. That makes
+        a keyswap visible in the Log panel — "the kernel now reads sha256:… " — which is the only
+        way an operator can confirm the swap landed, since no surface may carry the key itself. The
+        change-only rule keeps it off every ordinary connect."""
+        fp = _keysrc.fingerprint(key)
+        if fp and fp != self._key_fp_said:
+            self._key_fp_said = fp
+            self._log("work key: sessions now launch on the key sha256:%s (read from %s)"
+                      % (fp, _keysrc.service_env_path()))
+
+    def cycle_key(self, sid: str) -> str:
+        """Re-present the CURRENT work key to one LIVE session by reconnecting it — the apply half of
+        `romp keyswap --cycle` (the user 2026-09-04).
+
+        The key rides the launch environment, so it is connect-time exactly like --effort and the
+        auth pick: a running CLI keeps the key it started with until it is replaced. request_reconnect
+        is the same mechanism set_effort/set_auth/set_env use — resume continues the same conversation
+        with its history intact, immediately when the session is idle and at the end of the current
+        turn when it is busy. Nothing is persisted, because nothing about the SESSION changed: which
+        key the box uses is not a per-session setting.
+
+        Returns what happened, for the CLI to print per session: "cycling" (a live key-billed session
+        is reconnecting), "login" (billed to the machine login — the key would not be injected, so a
+        reconnect would cost a turn for nothing), "dormant" (no live CLI — its next launch reads the
+        new key anyway), "unknown" (this backend has no such session)."""
+        if not self.owns(sid):
+            return "unknown"
+        s = self.sessions.get(sid)
+        if s is None:
+            return "dormant"
+        if s.effective_auth() != "key":
+            return "login"
+        s.request_reconnect()
+        self._log("keyswap (%s): reconnecting to pick up the current work key (sha256:%s)"
+                  % (s.name, _keysrc.fingerprint(self.work_key)))
+        return "cycling"
 
     def _heal_stale_awaiting(self, sid: str) -> None:
         """Clear a stale awaiting:true overlay for a NOT-running session. A dormant SDK session can't have live
@@ -5746,10 +5861,16 @@ class SdkBackend:
         # login on its own; a key session gets the key injected here, explicitly. options.env merges
         # OVER the inherited env in the SDK's transport, which is exactly the one-way door we need —
         # inject or stay silent; never blank (an empty var reads as "API-key mode, no key" to the CLI).
-        launch_keyed = sess.effective_auth() == "key"
+        # The key is read ONCE here, per connect, and the same value is what gets injected: the source
+        # is live now (a keyswap can land between two reads), so a second read could hand the CLI a key
+        # the auth decision was never made against. An empty read also means DON'T inject — falling to
+        # login is right, and blanking the var would leave the CLI in key-mode-without-a-key.
+        work_key = self.work_key
+        launch_keyed = sess.effective_auth() == "key" and bool(work_key)
         if launch_keyed:
-            kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key,
-                             **key_fast_org_env(self.work_key, self._log))
+            self._note_work_key(work_key)
+            kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=work_key,
+                             **key_fast_org_env(work_key, self._log))
         elif sess.auth == "key":
             # picked "key", but this manager's env carries none — falling to login silently would bill
             # the wrong account with nothing to see; say so where the Log panel shows it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,30 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sess
 # safe against every consumer. Import-time, so collection-time code is floored too.
 os.environ["ROMP_MANAGER_PORT"] = "1"
 
+# No test may read the REAL service.env (2026-09-04): sdk_backend.work_api_key now reads the manager
+# env file LIVE (kernel/keysource.py) instead of popping os.environ once, so on a machine running a
+# live romp every auth test would otherwise resolve the developer's ACTUAL API key — quietly billing
+# nothing, but making the key material a test input, putting it one assertion message away from a
+# terminal, and making the pinned fixture-key tests pass or fail on whether this box happens to have
+# a key configured. Pointed at a path inside the temp state root that is never created, so every read
+# is the "no file" case and the startup-pop fallback governs, exactly as before the live source
+# existed. Both spellings, because keysource accepts both. Import-time (collection is floored too)
+# plus a per-test re-assert below, on the same reasoning as the manager port.
+_NO_SERVICE_ENV = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
+os.environ["ROMP_SERVICE_ENV_FILE"] = _NO_SERVICE_ENV
+os.environ["ROMP_SERVICE_ENV"] = _NO_SERVICE_ENV
+
+
+@pytest.fixture(autouse=True)
+def _no_real_service_env():
+    """Re-asserted, not defaulted: a module-level write in one test file executes during collection
+    and would otherwise hold for the whole run. A test that needs its own env file points the vars at
+    a temp path in setUp, which runs AFTER this fixture (pytest fills fixtures in the item's setup
+    phase, before TestCase.run calls setUp) — so per-test intent still wins."""
+    for var in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV"):
+        os.environ[var] = _NO_SERVICE_ENV
+    yield
+
 
 @pytest.fixture(autouse=True)
 def _dead_manager_port():

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -1577,3 +1577,60 @@ PY
     [ "$status" -eq 0 ]
     [[ "$output" == *"--env NAME=VALUE"* ]]
 }
+
+# ─── romp keyswap — switch the sessions' API key with no restart ──────
+# End-to-end through the dispatcher and the real cli/keyswap.py, against a temp
+# env file (ROMP_SERVICE_ENV_FILE): the mock-PATH shadowing other dispatch tests
+# use cannot shadow romp-keyswap, since bin/romp prepends its own bin dir. Fake
+# keys only, and the point of the assertions is that no key value is printed.
+
+_keyswap_files() {
+    export ROMP_SERVICE_ENV_FILE="$TEST_DIR/service.env"
+    printf 'ROMP_PERF=1\nANTHROPIC_API_KEY=sk-ant-TEST-0000\nROMP_EXPECTED_AUTH=key\n' \
+        > "$ROMP_SERVICE_ENV_FILE"
+    chmod 600 "$ROMP_SERVICE_ENV_FILE"
+    printf 'ANTHROPIC_API_KEY=sk-ant-TEST-1111\n' > "$ROMP_SERVICE_ENV_FILE.lowprio"
+    chmod 600 "$ROMP_SERVICE_ENV_FILE.lowprio"
+}
+
+@test "keyswap: bare reports the live key and its candidates, by fingerprint only" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _keyswap_files
+    run run_romp keyswap
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sha256:"* ]]
+    [[ "$output" == *"lowprio"* ]]
+    [[ "$output" != *"sk-ant-TEST"* ]]          # never a key value on a surface
+    grep -q 'ANTHROPIC_API_KEY=sk-ant-TEST-0000' "$ROMP_SERVICE_ENV_FILE"   # read-only
+}
+
+@test "keyswap: a named source rewrites only the key line and keeps mode 600" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _keyswap_files
+    run run_romp keyswap lowprio
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no manager restart needed"* ]]
+    [[ "$output" != *"sk-ant-TEST"* ]]
+    grep -q 'ANTHROPIC_API_KEY=sk-ant-TEST-1111' "$ROMP_SERVICE_ENV_FILE"
+    grep -q 'ROMP_PERF=1' "$ROMP_SERVICE_ENV_FILE"                 # every other line survives
+    grep -q 'ROMP_EXPECTED_AUTH=key' "$ROMP_SERVICE_ENV_FILE"
+    [ "$(ls -l "$ROMP_SERVICE_ENV_FILE" | cut -c1-10)" = "-rw-------" ]
+}
+
+@test "keyswap: an unknown source is a loud refusal that touches nothing" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    _keyswap_files
+    run run_romp keyswap nosuch
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no such key file"* ]]
+    grep -q 'ANTHROPIC_API_KEY=sk-ant-TEST-0000' "$ROMP_SERVICE_ENV_FILE"
+}
+
+@test "keyswap: help names it (the presence-checked command list)" {
+    run run_romp -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp keyswap"* ]]
+}

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -281,8 +281,8 @@ class LiveSpawnEnv(_Backend):
             ks.read_key = orig
         self.assertEqual(len(reads), 1, "two reads could return two different keys")
 
-    def test_an_emptied_file_falls_to_login_rather_than_injecting_a_blank(self):
-        self.write_env("", lines=["ROMP_PERF=1"])
+    def test_an_empty_key_line_falls_to_login_rather_than_injecting_a_blank(self):
+        self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
         env = self._launch_env(4)
         self.assertNotIn("ANTHROPIC_API_KEY", env,
                          "an empty var reads as key-mode-without-a-key to the CLI — removal, never blanking")
@@ -309,9 +309,15 @@ class StartupFallback(_Backend):
     BOOT = BOOT_KEY
 
     def test_a_file_with_no_key_line_falls_back_to_the_startup_claim(self):
-        self.write_env("", lines=["ROMP_PERF=1"])
+        with open(self.path, "w") as fh:                # genuinely no assignment, not an empty one
+            fh.write("ROMP_PERF=1\n")
+        ks._CACHE = ((), "")
         self.assertEqual(self.be.work_key, BOOT_KEY)
         self.assertEqual(self._launch_env(1).get("ANTHROPIC_API_KEY"), BOOT_KEY)
+
+    def test_an_empty_key_line_falls_back_too(self):
+        self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
+        self.assertEqual(self.be.work_key, BOOT_KEY)
 
     def test_a_missing_file_falls_back_too(self):
         os.unlink(self.path)

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -590,6 +590,11 @@ class KeycycleRoute(unittest.TestCase):
         self.assertEqual(len(resp["rows"]), 2, "one bad session must not abandon the rest")
         self.assertIn("boom", resp["rows"][0]["status"])
 
+    def test_a_sessions_value_that_is_not_a_list_is_a_400(self):
+        code, resp = self._with(self._Fake({}), {"sessions": "web"})
+        self.assertEqual(code, 400, "a bare string would otherwise iterate its characters")
+        self.assertFalse(resp.get("ok"))
+
     def test_the_route_needs_the_serve_token(self):
         import urllib.error
         import urllib.request

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""Hot-swapping the API key the sessions bill, with no kernel restart (the user 2026-09-04).
+
+The manager's `ANTHROPIC_API_KEY` used to be claimed out of `os.environ` once at kernel start, so
+changing which org key the sessions billed meant restarting `romp-manager` — cutting every open turn
+and killing every subagent. Now:
+
+  * `kernel/keysource.py` reads the `ANTHROPIC_API_KEY=` line of the manager's env file LIVE, and
+    `sdk_backend.work_api_key` prefers it, falling back to the startup claim;
+  * `_options` therefore injects the CURRENT key into every session it launches or revives;
+  * `romp keyswap <name>` rewrites only that one line, atomically, from a sibling file;
+  * `--cycle`/`--cycle-all` reconnect running sessions through `SdkBackend.cycle_key` so they
+    re-present the new key with their conversations intact.
+
+What these tests pin, in the order the feature is used:
+  KeySourceParsing / AtomicRewrite — the file layer: last assignment wins, one layer of quotes is
+    stripped (systemd does), every other line survives byte for byte, mode never widens past 0600.
+  LiveSpawnEnv — the point of the whole thing: change the file, and the NEXT launch's env carries
+    the new key with no restart and no re-construction of the backend.
+  StartupFallback — a box whose key does not ride the file behaves exactly as before.
+  CycleReconnects — the apply half for already-running sessions.
+  NothingLeaksTheKey — no key value in any log line, any printed line, or any wire payload; the
+    only rendered form anywhere is the sha256 head.
+
+Synthetic keys only (`sk-ant-TEST-…`), synthetic sids, temp paths. No real key material, and the
+module points the env-file path at its own temp dir so it can never read the machine's real one.
+"""
+import json
+import os
+import stat
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads (they resolve their state root at import time), and a service.env
+# path that does not exist — so a bare non-pytest run of this file cannot read the real one either.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
+os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
+
+sb = SourceFileLoader("romp_sdk_backend_keyswap", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+cli = SourceFileLoader("romp_keyswap_cli", os.path.join(BIN, "romp-keyswap")).load_module()
+# ONE keysource module object for the whole test, taken off the backend: the kernel, the CLI and
+# these tests must be patching and cache-resetting the same module, and a second SourceFileLoader
+# call under a different name would quietly give a second copy of it (with its own _CACHE).
+ks = sb._keysrc
+assert ks is cli.ks, "the CLI and the kernel must read the key through one module"
+
+OLD_KEY = "sk-ant-TEST-0000"
+NEW_KEY = "sk-ant-TEST-1111"
+BOOT_KEY = "sk-ant-TEST-BOOT"
+
+
+class _EnvFile(unittest.TestCase):
+    """A temp service.env with the shape the real one has: the key line between other settings."""
+
+    OTHER_LINES = ["# romp service environment", "ROMP_PERF=1", "ROMP_EXPECTED_AUTH=key"]
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.path = os.path.join(self.d, "service.env")
+        self._before = {v: os.environ.get(v) for v in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
+                                                       "ANTHROPIC_API_KEY")}
+        os.environ["ROMP_SERVICE_ENV_FILE"] = self.path
+        os.environ["ROMP_SERVICE_ENV"] = self.path
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        self.write_env(OLD_KEY)
+        ks._CACHE = ((), "")          # the stat-identity cache is module-global
+
+    def tearDown(self):
+        for v, was in self._before.items():
+            if was is None:
+                os.environ.pop(v, None)
+            else:
+                os.environ[v] = was
+        ks._CACHE = ((), "")
+
+    def write_env(self, key, lines=None, mode=0o600, path=None):
+        lines = list(self.OTHER_LINES if lines is None else lines)
+        lines.insert(2, "%s=%s" % (ks.KEY_VAR, key))
+        p = path or self.path
+        with open(p, "w") as fh:
+            fh.write("\n".join(lines) + "\n")
+        os.chmod(p, mode)
+        ks._CACHE = ((), "")          # a same-second rewrite in a test can reuse the stat identity
+        return p
+
+    def sibling(self, name, body):
+        p = self.path + "." + name
+        with open(p, "w") as fh:
+            fh.write(body)
+        os.chmod(p, 0o600)
+        return p
+
+
+class KeySourceParsing(_EnvFile):
+    def test_it_reads_the_key_line_and_ignores_everything_else(self):
+        self.assertEqual(ks.read_key(self.path), OLD_KEY)
+
+    def test_the_last_assignment_wins_like_systemd_and_export(self):
+        with open(self.path, "a") as fh:
+            fh.write("%s=%s\n" % (ks.KEY_VAR, NEW_KEY))
+        ks._CACHE = ((), "")
+        self.assertEqual(ks.read_key(self.path), NEW_KEY,
+                         "a repeated EnvironmentFile assignment overrides — read what the service gets")
+
+    def test_one_layer_of_quotes_is_stripped(self):
+        for q in ('"', "'"):
+            self.write_env("%s%s%s" % (q, NEW_KEY, q))
+            self.assertEqual(ks.read_key(self.path), NEW_KEY,
+                             "systemd strips it; without this the CLI is handed the quotes too")
+
+    def test_comments_blank_lines_and_other_vars_are_not_the_key(self):
+        with open(self.path, "w") as fh:
+            fh.write("\n# %s=sk-ant-TEST-COMMENTED\n\nROMP_PERF=1\nOTHER_API_KEY=x\n" % ks.KEY_VAR)
+        ks._CACHE = ((), "")
+        self.assertEqual(ks.read_key(self.path), "")
+
+    def test_every_failure_reads_as_no_key_never_an_exception(self):
+        self.assertEqual(ks.read_key(os.path.join(self.d, "nope.env")), "")
+        self.assertEqual(ks.read_key(self.d), "", "a directory is not a key file")
+
+    def test_a_rewrite_invalidates_the_cache_by_the_files_own_identity(self):
+        self.assertEqual(ks.read_key(self.path), OLD_KEY)
+        ks.write_key(NEW_KEY, self.path)
+        self.assertEqual(ks.read_key(self.path), NEW_KEY,
+                         "the cache is keyed on (inode, mtime_ns, size) — a rename invalidates it")
+
+    def test_the_path_comes_from_the_installers_own_variable(self):
+        os.environ["ROMP_SERVICE_ENV_FILE"] = "/tmp/from-installer.env"
+        os.environ["ROMP_SERVICE_ENV"] = "/tmp/from-alias.env"
+        self.assertEqual(ks.service_env_path(), "/tmp/from-installer.env",
+                         "ROMP_SERVICE_ENV_FILE is the name bin/romp-service already uses")
+        os.environ.pop("ROMP_SERVICE_ENV_FILE")
+        self.assertEqual(ks.service_env_path(), "/tmp/from-alias.env")
+        os.environ.pop("ROMP_SERVICE_ENV")
+        os.environ["XDG_CONFIG_HOME"] = "/tmp/cfg"
+        try:
+            self.assertEqual(ks.service_env_path(), "/tmp/cfg/romp/service.env")
+        finally:
+            os.environ.pop("XDG_CONFIG_HOME", None)
+
+    def test_a_bare_name_means_the_sibling_file_and_a_path_is_taken_as_given(self):
+        self.assertEqual(ks.sibling_path("lowprio", self.path), self.path + ".lowprio")
+        self.assertEqual(ks.sibling_path("/etc/other.env", self.path), "/etc/other.env")
+
+
+class AtomicRewrite(_EnvFile):
+    def test_only_the_key_line_changes_and_it_keeps_its_position(self):
+        before = open(self.path).read().splitlines()
+        res = ks.write_key(NEW_KEY, self.path)
+        after = open(self.path).read().splitlines()
+        self.assertEqual(res["old"], OLD_KEY)
+        self.assertEqual(len(before), len(after))
+        for i, (b, a) in enumerate(zip(before, after)):
+            if b.startswith(ks.KEY_VAR + "="):
+                self.assertEqual(a, "%s=%s" % (ks.KEY_VAR, NEW_KEY))
+            else:
+                self.assertEqual(a, b, "line %d changed — every other setting must survive" % i)
+        self.assertIn("ROMP_PERF=1", after)
+        self.assertIn("ROMP_EXPECTED_AUTH=key", after)
+
+    def test_the_mode_stays_600_and_a_loose_one_is_tightened(self):
+        ks.write_key(NEW_KEY, self.path)
+        self.assertEqual(stat.S_IMODE(os.stat(self.path).st_mode), 0o600)
+        self.write_env(OLD_KEY, mode=0o644)
+        res = ks.write_key(NEW_KEY, self.path)
+        self.assertEqual(stat.S_IMODE(os.stat(self.path).st_mode), 0o600)
+        self.assertTrue(res["tightened"], "a key must never be left group- or world-readable")
+
+    def test_it_leaves_no_temp_file_behind(self):
+        ks.write_key(NEW_KEY, self.path)
+        self.assertEqual(sorted(os.listdir(self.d)), ["service.env"],
+                         "temp file + rename: nothing else may be left in the directory")
+
+    def test_a_duplicate_key_line_is_collapsed_so_the_file_cannot_disagree_with_itself(self):
+        with open(self.path, "a") as fh:
+            fh.write("%s=sk-ant-TEST-STALE\n" % ks.KEY_VAR)
+        ks.write_key(NEW_KEY, self.path)
+        body = open(self.path).read()
+        self.assertEqual(body.count(ks.KEY_VAR + "="), 1)
+        self.assertEqual(ks.read_key(self.path), NEW_KEY)
+
+    def test_a_file_with_no_key_line_gets_one_appended(self):
+        with open(self.path, "w") as fh:
+            fh.write("ROMP_PERF=1\n")
+        ks.write_key(NEW_KEY, self.path)
+        self.assertEqual(open(self.path).read(), "ROMP_PERF=1\n%s=%s\n" % (ks.KEY_VAR, NEW_KEY))
+
+    def test_a_missing_file_is_created_0600(self):
+        p = os.path.join(self.d, "fresh.env")
+        ks.write_key(NEW_KEY, p)
+        self.assertEqual(ks.read_key(p), NEW_KEY)
+        self.assertEqual(stat.S_IMODE(os.stat(p).st_mode), 0o600)
+
+
+class _Backend(_EnvFile):
+    """A backend whose key source is the temp env file. The startup stash is module-global and
+    once-per-process, so each test re-arms it explicitly and restores the world after."""
+
+    BOOT = ""          # what the process environment carried at "startup"
+
+    def setUp(self):
+        super().setUp()
+        self.state = tempfile.mkdtemp()
+        self._stash = sb._WORK_KEY
+        self._checked = sb._KEY_FILE_CHECKED
+        sb._WORK_KEY = self.BOOT              # the startup claim, already made
+        sb._KEY_FILE_CHECKED = True           # the one-shot agreement line is asserted on its own
+        self._fetch = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None      # never a real HTTPS GET from a test
+        sb._FAST_ORG_VERDICTS.clear()
+        self.logged = []
+        # NB `log=` is a keyword: the third positional is `notify`. A line reaches self.logged only
+        # through the log wire, which is what the no-leak tests below read.
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None,
+                                log=lambda m: self.logged.append(str(m)))
+        import sys
+        import types
+        self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
+        if self._fake_sdk:                    # _options' in-function import (CI without the venv)
+            fake = types.ModuleType("claude_agent_sdk")
+            fake.HookMatcher = lambda **kw: kw
+            sys.modules["claude_agent_sdk"] = fake
+
+    def tearDown(self):
+        import sys
+        if self._fake_sdk:
+            sys.modules.pop("claude_agent_sdk", None)
+        sb._WORK_KEY = self._stash
+        sb._KEY_FILE_CHECKED = self._checked
+        sb._fetch_key_fast_org = self._fetch
+        sb._FAST_ORG_VERDICTS.clear()
+        super().tearDown()
+
+    def _sess(self, n=1, **reg):
+        return sb.SdkSession(self.be, {"sid": "11111111-2222-3333-4444-%012d" % n,
+                                       "name": "s%d" % n, "cwd": "/tmp", **reg})
+
+    def _launch_env(self, n=1, **reg):
+        return self.be._options(self._sess(n, auth="key", **reg), dict)["env"]
+
+
+class LiveSpawnEnv(_Backend):
+    """The whole point: a session launched (or revived) AFTER the file changed carries the new key,
+    with no kernel restart and no re-construction of the backend."""
+
+    def test_the_spawn_env_carries_the_key_the_file_holds_now(self):
+        self.assertEqual(self._launch_env(1).get("ANTHROPIC_API_KEY"), OLD_KEY)
+        self.write_env(NEW_KEY)                       # the swap, mid-life of one backend object
+        self.assertEqual(self._launch_env(2).get("ANTHROPIC_API_KEY"), NEW_KEY,
+                         "the key is read per launch — this is what removes the restart")
+        self.assertEqual(self.be.work_key, NEW_KEY)
+
+    def test_a_revive_reads_it_too_because_both_go_through_one_seam(self):
+        # resume + connect build their options through _options, the same call the tests above make;
+        # pin that there is no second place a key could be frozen.
+        src = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
+        self.assertEqual(src.count("ANTHROPIC_API_KEY=work_key"), 1,
+                         "one injection site only — a second would need its own live read")
+        self.assertIn("work_key = self.work_key", src)
+
+    def test_the_key_is_read_once_per_connect_so_a_launch_cannot_straddle_a_swap(self):
+        reads = []
+        orig = ks.read_key
+
+        def counting(path=None):
+            reads.append(path)
+            return orig(path)
+
+        ks.read_key = counting
+        try:
+            self.be._options(self._sess(3, auth="key"), dict)
+        finally:
+            ks.read_key = orig
+        self.assertEqual(len(reads), 1, "two reads could return two different keys")
+
+    def test_an_emptied_file_falls_to_login_rather_than_injecting_a_blank(self):
+        self.write_env("", lines=["ROMP_PERF=1"])
+        env = self._launch_env(4)
+        self.assertNotIn("ANTHROPIC_API_KEY", env,
+                         "an empty var reads as key-mode-without-a-key to the CLI — removal, never blanking")
+        texts = [p["text"] for p in self.be.problems(10)]
+        self.assertTrue(any("carries none" in t for t in texts),
+                        "a key session with no key to inject is a logged problem, not a silent fall")
+
+    def test_the_live_key_reaches_the_has_a_key_bool_and_the_auth_default(self):
+        self.assertEqual(self.be.default_auth({}), "key")
+        self.write_env("", lines=["ROMP_PERF=1"])
+        self.assertEqual(self.be.default_auth({}), "login")
+        self.assertFalse(self.be.work_key)
+
+    def test_an_explicit_pin_still_stands_up_a_keyless_manager(self):
+        self.be.work_key = ""
+        self.assertEqual(self.be.work_key, "")
+        self.assertEqual(self.be.default_auth({}), "login")
+
+
+class StartupFallback(_Backend):
+    """A box whose key does NOT ride the env file — an apiKeyHelper machine, a foreground `romp up`
+    from a shell that exported one — must behave exactly as it did before the live source existed."""
+
+    BOOT = BOOT_KEY
+
+    def test_a_file_with_no_key_line_falls_back_to_the_startup_claim(self):
+        self.write_env("", lines=["ROMP_PERF=1"])
+        self.assertEqual(self.be.work_key, BOOT_KEY)
+        self.assertEqual(self._launch_env(1).get("ANTHROPIC_API_KEY"), BOOT_KEY)
+
+    def test_a_missing_file_falls_back_too(self):
+        os.unlink(self.path)
+        ks._CACHE = ((), "")
+        self.assertEqual(self.be.work_key, BOOT_KEY)
+
+    def test_the_file_wins_when_it_has_a_line(self):
+        self.assertEqual(self.be.work_key, OLD_KEY,
+                         "the file is the live source; the startup claim is only the fallback")
+
+    def test_the_ambient_key_is_still_claimed_out_of_the_environment(self):
+        sb._WORK_KEY = None
+        os.environ["ANTHROPIC_API_KEY"] = BOOT_KEY
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        self.assertNotIn("ANTHROPIC_API_KEY", os.environ,
+                         "an ambient key bills EVERY session — constructing a backend must still strip it")
+        self.assertEqual(be.work_key, OLD_KEY, "and the FILE still decides what a launch bills")
+
+    def test_a_disagreement_between_the_file_and_the_startup_env_is_said_once(self):
+        sb._KEY_FILE_CHECKED = False
+        sb._WORK_KEY = BOOT_KEY
+        import io
+        import sys
+        buf, was = io.StringIO(), sys.stderr
+        sys.stderr = buf
+        try:
+            sb.work_api_key()
+            sb.work_api_key()
+        finally:
+            sys.stderr = was
+        said = buf.getvalue()
+        self.assertEqual(said.count("DIFFERENT key"), 1, "a configuration fact, said once")
+        self.assertNotIn(OLD_KEY, said)
+        self.assertNotIn(BOOT_KEY, said)
+        self.assertIn(ks.fingerprint(OLD_KEY), said)
+
+
+class CycleReconnects(_Backend):
+    """The apply half for sessions already running: the key rides the launch environment, so a live
+    CLI keeps the key it started with until a reconnect re-presents the current one."""
+
+    def _live(self, sid, auth="key"):
+        s = self._sess(7, auth=auth)
+        s.sid = sid
+        s.name = "live"
+        self.reconnects = getattr(self, "reconnects", [])
+        s.request_reconnect = lambda: self.reconnects.append(sid)
+        self.be.sessions[sid] = s
+        return s
+
+    def test_a_live_key_billed_session_reconnects(self):
+        sid = self.be.spawn("n", "/tmp")
+        self._live(sid)
+        self.assertEqual(self.be.cycle_key(sid), "cycling")
+        self.assertEqual(self.reconnects, [sid],
+                         "reconnect is what applies a connect-time option — and resume keeps the history")
+
+    def test_a_login_billed_session_is_left_alone(self):
+        sid = self.be.spawn("n", "/tmp", auth="login")
+        self._live(sid, auth="login")
+        self.assertEqual(self.be.cycle_key(sid), "login")
+        self.assertEqual(getattr(self, "reconnects", []), [],
+                         "the key is not injected there — a reconnect would cost a turn for nothing")
+
+    def test_a_dormant_session_needs_nothing_and_an_unknown_one_says_so(self):
+        sid = self.be.spawn("n", "/tmp")
+        self.assertEqual(self.be.cycle_key(sid), "dormant",
+                         "no live CLI — its next launch reads the new key anyway")
+        self.assertEqual(self.be.cycle_key("11111111-2222-3333-4444-999999999999"), "unknown")
+
+    def test_nothing_about_the_session_is_persisted_because_nothing_about_it_changed(self):
+        sid = self.be.spawn("n", "/tmp")
+        before = json.dumps(sb.read_reg(self.be.state_dir, sid), sort_keys=True)
+        self._live(sid)
+        self.be.cycle_key(sid)
+        self.assertEqual(json.dumps(sb.read_reg(self.be.state_dir, sid), sort_keys=True), before,
+                         "which key the BOX uses is not a per-session setting")
+
+
+class KeyswapCli(_EnvFile):
+    """`romp keyswap` — the operator surface. The kernel is stubbed: these tests must never dial a
+    real one (a developer box runs a live romp on the same loopback ports)."""
+
+    def setUp(self):
+        super().setUp()
+        self.out = []
+        self.posted = []
+        self._kernel_before, self._post_before = cli._kernel, cli._post
+        cli._kernel = lambda: None            # default: no kernel, so nothing reaches the network
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {"ok": True, "keyFp": "abc123abc123",
+                                                                      "rows": []}
+        self.sibling("lowprio", "%s=%s\n" % (ks.KEY_VAR, NEW_KEY))
+
+    def tearDown(self):
+        cli._kernel, cli._post = self._kernel_before, self._post_before
+        super().tearDown()
+
+    def run_cli(self, *argv):
+        self.out = []
+        rc = cli.main(list(argv), out=self.out.append)
+        return rc, "\n".join(self.out)
+
+    def test_a_named_source_rewrites_the_line_and_reports_both_fingerprints(self):
+        rc, said = self.run_cli("lowprio")
+        self.assertEqual(rc, 0)
+        self.assertEqual(ks.read_key(self.path), NEW_KEY)
+        self.assertIn("sha256:" + ks.fingerprint(OLD_KEY), said)
+        self.assertIn("sha256:" + ks.fingerprint(NEW_KEY), said)
+        self.assertIn("no manager restart needed", said)
+
+    def test_the_bare_command_reports_and_changes_nothing(self):
+        rc, said = self.run_cli()
+        self.assertEqual(rc, 0)
+        self.assertEqual(ks.read_key(self.path), OLD_KEY, "a swap is asked for by name")
+        self.assertIn("sha256:" + ks.fingerprint(OLD_KEY), said)
+        self.assertIn("lowprio", said, "the candidates it could swap to")
+
+    def test_it_refuses_a_source_with_no_key_line_and_touches_nothing(self):
+        self.sibling("empty", "ROMP_PERF=1\n")
+        rc, _ = self.run_cli("empty")
+        self.assertEqual(rc, 2)
+        self.assertEqual(ks.read_key(self.path), OLD_KEY)
+
+    def test_it_refuses_a_missing_source_and_touches_nothing(self):
+        rc, _ = self.run_cli("nosuch")
+        self.assertEqual(rc, 2)
+        self.assertEqual(ks.read_key(self.path), OLD_KEY)
+
+    def test_swapping_to_the_key_already_live_rewrites_nothing(self):
+        self.sibling("same", "%s=%s\n" % (ks.KEY_VAR, OLD_KEY))
+        mtime = os.stat(self.path).st_mtime_ns
+        rc, said = self.run_cli("same")
+        self.assertEqual(rc, 0)
+        self.assertIn("already this key", said)
+        self.assertEqual(os.stat(self.path).st_mtime_ns, mtime)
+
+    def test_cycle_asks_the_kernel_for_exactly_the_named_sessions(self):
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "keyFp": ks.fingerprint(NEW_KEY),
+            "rows": [{"session": "web", "status": "cycling"}, {"session": "api", "status": "dormant"}]}
+        rc, said = self.run_cli("lowprio", "--cycle", "web,api")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.posted[0][1], "/keycycle")
+        self.assertEqual(self.posted[0][2], {"sessions": ["web", "api"]})
+        self.assertIn("history kept", said)
+        self.assertIn("sha256:" + ks.fingerprint(NEW_KEY), said,
+                      "the kernel's own fingerprint is how the operator confirms it re-read the file")
+
+    def test_cycle_all_asks_for_all_and_never_names_a_session_itself(self):
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        rc, _ = self.run_cli("lowprio", "--cycle-all")
+        self.assertEqual(self.posted[0][2], {"all": True})
+
+    def test_the_swap_still_lands_when_no_kernel_is_reachable(self):
+        rc, said = self.run_cli("lowprio", "--cycle-all")
+        self.assertEqual(rc, 1, "the cycle failed and must exit non-zero")
+        self.assertEqual(ks.read_key(self.path), NEW_KEY, "…but the file swap already happened")
+        self.assertIn("no running kernel", said)
+
+    def test_a_kernel_predating_the_patch_names_the_one_restart_this_needs(self):
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: {"ok": False, "error": "HTTP 404"}
+        rc, said = self.run_cli("lowprio", "--cycle-all")
+        self.assertEqual(rc, 1)
+        self.assertIn("romp refresh", said)
+
+    def test_junk_options_are_refused_rather_than_read_as_a_source_name(self):
+        self.assertEqual(self.run_cli("--wat")[0], 2)
+        self.assertEqual(self.run_cli("lowprio", "extra")[0], 2)
+        self.assertEqual(self.run_cli("lowprio", "--cycle")[0], 2)
+        self.assertEqual(ks.read_key(self.path), OLD_KEY)
+
+    def test_no_printed_line_ever_carries_a_key_value(self):
+        import io
+        import sys
+        self.sibling("same", "%s=%s\n" % (ks.KEY_VAR, OLD_KEY))
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        for argv in ([], ["lowprio"], ["same"], ["nosuch"], ["lowprio", "--cycle-all"], ["--wat"]):
+            buf, was = io.StringIO(), sys.stderr
+            sys.stderr = buf
+            said = []
+            try:
+                cli.main(list(argv), out=said.append)
+            finally:
+                sys.stderr = was
+            whole = "\n".join(said) + buf.getvalue()
+            for key in (OLD_KEY, NEW_KEY):
+                self.assertNotIn(key, whole, "`romp keyswap %s` printed a key" % " ".join(argv))
+
+    def test_the_cli_and_the_kernel_read_the_key_through_the_same_module(self):
+        src = open(os.path.join(ROOT, "cli", "keyswap.py")).read()
+        self.assertIn('"kernel" / "keysource.py"', src.replace("'", '"'),
+                      "writer and reader must not carry two copies of the path or the parse rules")
+
+
+class KeycycleRoute(unittest.TestCase):
+    """POST /keycycle over the REAL kernel handler on loopback (the HeadlessRoutes pattern). The
+    route takes NO key from the caller — not a value, not a path — so the door cannot be used to
+    point a session at a key of the caller's choosing; all it does is make live sessions re-read
+    the file, and all it returns is a fingerprint."""
+
+    @classmethod
+    def setUpClass(cls):
+        import threading
+        from http.server import ThreadingHTTPServer
+        cls.km = SourceFileLoader("romp_kernel_keyswap", os.path.join(BIN, "romp-kernel")).load_module()
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), cls.km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    class _Fake:
+        """Just the surface the route uses."""
+
+        def __init__(self, sessions):
+            self.sessions = sessions
+            self.asked = []
+
+        def work_key_fp(self):
+            return ks.fingerprint(NEW_KEY)
+
+        def cycle_key(self, sid):
+            self.asked.append(sid)
+            return {"s-web": "cycling", "s-api": "login"}.get(sid, "dormant")
+
+    def _post(self, body):
+        import urllib.error
+        import urllib.request
+        req = urllib.request.Request("http://127.0.0.1:%d/keycycle" % self.port, method="POST",
+                                     data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json",
+                                              "X-Romp-Token": self.km.TOKEN})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def _with(self, fake, body):
+        from unittest import mock
+        with mock.patch.object(self.km, "_sdk", lambda: fake), \
+             mock.patch.object(self.km, "_sid_of", lambda w: "s-" + w), \
+             mock.patch.object(self.km, "_name_of", lambda sid: str(sid)[2:]), \
+             mock.patch.object(self.km, "_push_soon", lambda: None):
+            return self._post(body)
+
+    def test_it_cycles_exactly_the_named_sessions_and_reports_each(self):
+        fake = self._Fake({})
+        code, resp = self._with(fake, {"sessions": ["web", "api", "gone"]})
+        self.assertEqual(code, 200)
+        self.assertEqual(fake.asked, ["s-web", "s-api", "s-gone"])
+        self.assertEqual(resp["rows"], [{"session": "web", "status": "cycling"},
+                                        {"session": "api", "status": "login"},
+                                        {"session": "gone", "status": "dormant"}])
+
+    def test_all_covers_every_live_session_and_no_dormant_one(self):
+        fake = self._Fake({"s-web": object(), "s-api": object()})
+        code, resp = self._with(fake, {"all": True})
+        self.assertEqual(sorted(fake.asked), ["s-api", "s-web"],
+                         "dormant sessions need nothing — their next launch reads the file")
+
+    def test_the_answer_carries_a_fingerprint_and_never_a_key(self):
+        code, resp = self._with(self._Fake({}), {"sessions": ["web"]})
+        self.assertEqual(resp["keyFp"], ks.fingerprint(NEW_KEY))
+        self.assertNotIn(NEW_KEY, json.dumps(resp))
+
+    def test_a_session_that_raises_is_reported_not_fatal(self):
+        fake = self._Fake({})
+        fake.cycle_key = lambda sid: (_ for _ in ()).throw(RuntimeError("boom"))
+        code, resp = self._with(fake, {"sessions": ["web", "api"]})
+        self.assertEqual(code, 200)
+        self.assertEqual(len(resp["rows"]), 2, "one bad session must not abandon the rest")
+        self.assertIn("boom", resp["rows"][0]["status"])
+
+    def test_the_route_needs_the_serve_token(self):
+        import urllib.error
+        import urllib.request
+        req = urllib.request.Request("http://127.0.0.1:%d/keycycle" % self.port, method="POST",
+                                     data=b"{}", headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                self.fail("an untokened caller reached the route (status %s)" % r.status)
+        except urllib.error.HTTPError as e:
+            self.assertEqual(e.code, 403)
+
+
+class NothingLeaksTheKey(_Backend):
+    """No key value in any log line, printed line, or wire payload. The fingerprint is the only
+    rendered form — the same rule the browser side has always had for the key (2026-08-08)."""
+
+    def test_no_log_line_from_a_keyed_launch_contains_the_key(self):
+        self._launch_env(1)
+        self.write_env(NEW_KEY)
+        self._launch_env(2)
+        for line in self.logged + [p["text"] for p in self.be.problems(50)]:
+            self.assertNotIn(OLD_KEY, line)
+            self.assertNotIn(NEW_KEY, line)
+
+    def test_the_change_is_announced_by_fingerprint_and_only_when_it_changes(self):
+        self._launch_env(1)
+        first = [l for l in self.logged if "work key" in l]
+        self.assertEqual(len(first), 1)
+        self.assertIn(ks.fingerprint(OLD_KEY), first[0])
+        self._launch_env(2)
+        self.assertEqual(len([l for l in self.logged if "work key" in l]), 1,
+                         "change-only — an ordinary connect must not log the key at all")
+        self.write_env(NEW_KEY)
+        self._launch_env(3)
+        said = [l for l in self.logged if "work key" in l]
+        self.assertEqual(len(said), 2)
+        self.assertIn(ks.fingerprint(NEW_KEY), said[1])
+
+    def test_a_cycle_log_line_carries_the_fingerprint_only(self):
+        sid = self.be.spawn("n", "/tmp")
+        s = self._sess(8, auth="key")
+        s.sid, s.name = sid, "live"
+        s.request_reconnect = lambda: None
+        self.be.sessions[sid] = s
+        self.be.cycle_key(sid)
+        line = [l for l in self.logged if "keyswap" in l][0]
+        self.assertNotIn(OLD_KEY, line)
+        self.assertIn(ks.fingerprint(OLD_KEY), line)
+
+    def test_a_fingerprint_is_twelve_hex_and_says_nothing_about_an_absent_key(self):
+        fp = ks.fingerprint(OLD_KEY)
+        self.assertEqual(len(fp), 12)
+        self.assertTrue(all(c in "0123456789abcdef" for c in fp))
+        self.assertNotIn(fp, OLD_KEY)
+        self.assertEqual(ks.fingerprint(""), "")
+
+    def test_the_key_never_lands_back_in_the_kernels_own_environment(self):
+        self.be.work_key
+        self._launch_env(1)
+        self.assertNotIn("ANTHROPIC_API_KEY", os.environ,
+                         "the one-claimer property: an ambient key bills every session")
+
+    def test_the_problem_ring_the_dashboard_reads_never_carries_a_key(self):
+        self.write_env("", lines=["ROMP_PERF=1"])       # a key pick with no key: the loudest path
+        self._launch_env(1)
+        self.write_env(NEW_KEY)
+        self._launch_env(2)
+        for p in self.be.problems(50):
+            self.assertNotIn(NEW_KEY, p["text"])
+            self.assertNotIn(OLD_KEY, p["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -37,6 +37,11 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+# The manager env file is a LIVE key source now (kernel/keysource.py), so floor it too: without this
+# a bare (non-pytest) run of this file on a machine with a real ~/.config/romp/service.env resolves
+# the developer's actual key instead of the fixture's. conftest.py holds the same floor for pytest.
+os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
+os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
 sb = SourceFileLoader("romp_sdk_backend_auth", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 km = SourceFileLoader("romp_kernel_auth", os.path.join(BIN, "romp-kernel")).load_module()
 
@@ -164,7 +169,7 @@ class OptionsInjection(_OptionsHarness):
     def test_a_key_pick_with_no_key_is_a_logged_problem_not_a_silent_fall(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
         self.assertIn("session is set to the API key but the manager environment carries", src)
-        self.assertIn('ANTHROPIC_API_KEY=self.work_key', src)
+        self.assertIn('ANTHROPIC_API_KEY=work_key', src)
 
 
 class FastOrgPermissionFollowsBilling(_OptionsHarness):


### PR DESCRIPTION
## Why

The manager's `ANTHROPIC_API_KEY` was claimed out of `os.environ` once at kernel start (`work_api_key()` in `kernel/sdk_backend.py`) and handed to every session at spawn. Changing which key the sessions bill therefore meant `systemctl --user restart romp-manager.service`, which cuts every open turn and kills every Agent-tool subagent. On 2026-09-04 an org-wide rate-limit storm forced exactly that choice: restart the kernel to move to a second key, or run degraded. The user asked for keys to be hot-swappable so only one restart is ever needed again (this patch's own uptake).

## What changes

- **`kernel/keysource.py`** (new): reads the `ANTHROPIC_API_KEY=` line of the manager's env file (`ROMP_SERVICE_ENV_FILE`, the name `bin/romp-service` and `bin/romp-node-launch` already use; `ROMP_SERVICE_ENV` as an alias; default `${XDG_CONFIG_HOME:-~/.config}/romp/service.env`). Cached on the file's `(inode, mtime_ns, size)`, so a repeated read is a stat and a rewrite invalidates it by construction. The value never returns to `os.environ` and never reaches a log; the sha256 head is the only renderable form, logged only when it changes.
- **`kernel/sdk_backend.py`**: `work_api_key()` returns the file's key first and the startup pop (renamed `startup_api_key()`) as the fallback, so a session never inherits an ambient key. `SdkBackend.work_key` is now a property over that read, which makes every existing consumer hot-swap-aware at once: the `_options` env injection, `effective_auth`, `default_auth`, `set_auth`'s refusal, the kernel's has-a-key bool, and through `judge._WORK_KEY_FN` the judges and the models-API credential. `_options` reads the key once per connect, so no launch straddles a swap.
- **`cli/keyswap.py`** + `bin/` entry: `romp keyswap` shows the live key's fingerprint and lists the sibling files (`service.env.<name>`), marking which is live. `romp keyswap <name>` rewrites only the `ANTHROPIC_API_KEY=` line from the sibling, preserving every other line and position, mode 600, temp file (`mkstemp`) + rename, printing only the sha256 head. `--cycle a,b` / `--cycle-all` reconnect the named running sessions through a new `POST /keycycle` route (token required; a non-list `sessions` is a 400): idle sessions immediately, busy ones at the end of the current turn, each resuming its own conversation with history intact. Login-billed and dormant sessions are reported as needing nothing.
- **Docs**: `docs/reference.md` "Switching which API key the sessions bill", `kernel/README.md`, `cli/README.md`.

## Tests

- `tests/test_keyswap.py` (new, 54 cases): env-file parsing (last assignment wins, one layer of quotes, comments); the atomic rewrite (other lines byte-identical, position kept, duplicates collapsed, mode 600 with a loose mode tightened, no temp file left); the spawn env carries the CURRENT file's key after a mid-life change; the startup fallback when the file lacks the line; `cycle_key`'s four verdicts; `/keycycle` over the real handler on loopback; no key value in any log line, printed line, problem-ring entry or wire payload.
- `tests/romp.bats`: 4 end-to-end cases through the dispatcher against a temp env file.
- `tests/conftest.py` floors the env-file path at a non-existent path so no test can resolve a real key from the developer's box; `tests/test_session_auth.py` floors it too for a bare run. One pre-existing assert updated (`ANTHROPIC_API_KEY=self.work_key` → `=work_key`).
- Full Python suite: 7039 passed, 50 skipped, 340 subtests. Full bats suite: 383 tests, 0 failures. Fixtures use `sk-ant-TEST-*` only.

## Operator procedure

One time, to take this patch: pull, then `romp refresh --quiet` (kernel bounce at the next quiet window). After that, every swap is `romp keyswap lowprio --cycle-all` and back with `highprio`, no kernel restart; verify that the key line's fingerprint equals the "kernel reads sha256:…" line. Remote kernels have their own `service.env` and run `romp keyswap` on their own machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)