### PR TITLE
PR #886 follow-ups: review nits + the jump chip moves bottom-left

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2610,6 +2610,12 @@ class SdkSession:
         finally:
             self._ctx_refreshing = False
         if not isinstance(cu, dict):
+            # a queued ask survives THIS attempt's outcome: this early return used to sit before the
+            # rerun tail, so a failed/None payload dropped a switch-time ask on the floor and the old
+            # model's number stood until the next turn (PR #886 review) — same tail, both exits
+            if self._ctx_refresh_again:
+                self._ctx_refresh_again = False
+                await self._do_refresh_context()
             return
         changed = False
         pct = cu.get("percentage")

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -859,6 +859,28 @@ class LiveTail(unittest.TestCase):
         self.assertEqual(s.client.calls, 2, "the queued rerun fires after the live refresh lands")
         self.assertFalse(s._ctx_refresh_again, "the queue holds ONE rerun, not a storm")
 
+    def test_queued_refresh_survives_a_failed_attempt(self):
+        """PR #886 review: the early return on a failed/None payload sat BEFORE the rerun tail, so a
+        switch-time ask queued behind a refresh that then errored was dropped on the floor — the old
+        model's number stood until the next turn. The rerun fires however the attempt ended."""
+        import asyncio
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        s = sb.SdkSession(be, {"sid": "11111111-2222-3333-4444-555555555555", "name": "n", "cwd": "/tmp"})
+
+        class _FailThenWork:
+            def __init__(self): self.calls = 0
+            async def get_context_usage(self):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("control channel hiccup")
+                return {"percentage": 40}
+        s.client = _FailThenWork()
+        s._ctx_refresh_again = True                    # an ask queued while the failing one was in flight
+        asyncio.run(s._do_refresh_context())           # attempt 1 fails; the queued rerun must still run
+        self.assertEqual(s.client.calls, 2, "the queued ask reruns even when the attempt it waited on failed")
+        self.assertEqual(s._ctx_pct(), 40, "…and the rerun's answer lands")
+        self.assertFalse(s._ctx_refresh_again)
+
     def test_assistant_model_sets_badge_but_synthetic_does_not_corrupt_it(self):
         """The model 'doesn't show' mid-conversation (the user 2026-06-24): injected/synthetic assistant turns
         carry model='<synthetic>', which an unguarded assign wrote straight onto the statusline + timeline

--- a/ui/webview/css-vocab.test.ts
+++ b/ui/webview/css-vocab.test.ts
@@ -110,6 +110,7 @@ test("centered modals wear ONE card (CLAUDE.md): --radius-modal 10px + --shadow-
     [".picker-box", CHAT, "styles.css"], [".fileview", CHAT, "styles.css"],
     [".fileview", FEED, "feed.css"], [".fconfirm-box", FEED, "feed.css"],
     [".feed-modal-inner", FEED, "feed.css"], [".pickdlg-box", FEED, "feed.css"],
+    [".filebrowse", CHAT, "styles.css"], [".filebrowse", FEED, "feed.css"],   // a card since 2026-09-04
   ] as const) {
     // regex, not indexOf: a selector may have a second (e.g. mobile) rule that skips the box chrome
     const esc = sel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -218,4 +219,11 @@ test("the bubble's inner-markdown overrides OUTRANK .md — the doubled-selector
   assert.match(CHAT, /\.user-bubble a, \.user-bubble\.md a \{ color: #fff;/, "bubble links stay white");
   assert.match(CHAT, /\.user-bubble blockquote, \.user-bubble\.md blockquote \{ color: rgba\(255, 255, 255, 0\.88\);/,
     "the quoted-assistant tint actually lands");
+  // the third hit of the same trap (the user 2026-09-04, red text in their light bubbles): inline
+  // code fell to .md's page code-ink on the saturated fill, fenced code wore the page-tuned hljs
+  // palette on the wrong ground, and bold fell to the near-page text tone
+  assert.match(CHAT, /\.user-bubble :not\(pre\) > code, \.user-bubble\.md :not\(pre\) > code \{ background: rgba\(255, 255, 255, 0\.2\); color: #fff; \}/);
+  assert.match(CHAT, /\.user-bubble pre, \.user-bubble\.md pre \{ background: var\(--bg\); \}/,
+    "fenced code sits in a page-colored well, where the hljs palette is correct in both themes");
+  assert.match(CHAT, /\.user-bubble strong, \.user-bubble\.md strong \{ color: #fff; \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1622,10 +1622,16 @@ a.fileview-btn[hidden] { display: none; }
 .fask-bellbtn.on { visibility: visible; opacity: 0.85; color: var(--accent); }
 
 /* ── the file BROWSER (file-browse.ts) ── the viewer's sibling overlay, one z layer BENEATH it
-   so a file opened from a listing overlays the listing and closing the file returns to it. Same
-   pane-takeover reasoning as .fileview; body.filebrowse-open stops the cards scrolling behind it. */
-.filebrowse { position: fixed; inset: 0; z-index: 890; display: flex; flex-direction: column;
-  background: var(--bg, #1e1e1e); }
+   so a file opened from a listing overlays the listing and closing the file returns to it. The
+   pane takeover it wore was superseded 2026-09-04 (the user found it odd once the listing was
+   capped): the viewer's centered-card treatment now, the id on the BACKDROP (every open/close
+   check looks it up); body.filebrowse-open stops the cards scrolling behind it. Height caps in
+   px/%, never vh (in a pane iframe vh is the pane — the cap must lose to 95% on short panes). */
+#romp-filebrowse { position: fixed; inset: 0; z-index: 890; background: var(--overlay-dim);
+  display: flex; align-items: center; justify-content: center; }
+.filebrowse { width: min(720px, 95%); height: min(760px, 95%); display: flex; flex-direction: column;
+  overflow: hidden; background: var(--bg, #1e1e1e); border: 1px solid var(--box-border);
+  border-radius: var(--radius-modal); box-shadow: var(--shadow-modal); }
 body.filebrowse-open { overflow: hidden; }
 .fb-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
@@ -1638,10 +1644,7 @@ body.filebrowse-open { overflow: hidden; }
 .fb-crumb:hover { color: var(--accent); text-decoration: underline; }
 .fb-crumb:last-child { color: var(--fg); }
 .fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
-/* the overlay still takes the whole pane (the user 2026-08-24 ruling) — but the LISTING reads at a
-   centered 720px measure on a wide pane (the user 2026-09-02: full-width rows put a file's size
-   ~800px from its name); 100% wins on narrow panes/phones, pixel-identical to before */
-.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; width: min(720px, 100%); margin-inline: auto; }
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
 /* compact one-line rows (progressive disclosure): marker + name, size right-aligned on files; mtime
    and the full path live in the row's hover title */
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;

--- a/ui/webview/file-browse.ts
+++ b/ui/webview/file-browse.ts
@@ -110,8 +110,14 @@ export function openFileBrowse(path: string, sid?: string | null): void {
   const hb = document.getElementById("fb-hidden");
   if (hb) { hb.classList.remove("on"); hb.setAttribute("aria-pressed", "false"); }
   if (!had) {
+    // the id rides the BACKDROP — every open/close/topmost check looks up #romp-filebrowse, and
+    // the outermost element is what closeFileBrowse removes. The card inside is the viewer's
+    // treatment (the user 2026-09-04, superseding the 2026-08-24 pane takeover): centered over
+    // the dim, backdrop click closes (the lightbox contract — content clicks never do).
+    const wrap = el("div", "");
+    wrap.id = "romp-filebrowse";
+    wrap.onclick = (ev) => { if (ev.target === wrap) closeFileBrowse(); };
     const box = el("div", "filebrowse");
-    box.id = "romp-filebrowse";
     document.body.classList.add("filebrowse-open");
 
     const bar = el("div", "fb-bar");
@@ -138,7 +144,8 @@ export function openFileBrowse(path: string, sid?: string | null): void {
     const list = el("div", "fb-list");
     list.id = "fb-list";
     box.appendChild(bar); box.appendChild(list);
-    document.body.appendChild(box);
+    wrap.appendChild(box);
+    document.body.appendChild(wrap);
 
     // ONE click listener on the stable list root — rows are rebuilt per navigation, so per-row
     // listeners are exactly the destroyed-mid-click bug (ui/CLAUDE.md); the crumbs delegate the

--- a/ui/webview/filebrowse-chat-overlay.test.ts
+++ b/ui/webview/filebrowse-chat-overlay.test.ts
@@ -15,7 +15,7 @@ const CHAT = read("styles.css");
 const FEED = read("feed.css");
 
 const RULES = [
-  ".filebrowse {", "body.filebrowse-open {", ".fb-bar {", ".fb-crumbs {", ".fb-crumb {",
+  "#romp-filebrowse {", ".filebrowse {", "body.filebrowse-open {", ".fb-bar {", ".fb-crumbs {", ".fb-crumb {",
   ".fb-list {", ".fb-row {", ".fb-name {", ".fb-size {", ".fb-more {", "#fb-ctx {", ".fb-crumb-up {",
 ];
 
@@ -31,18 +31,16 @@ test("every browser overlay rule exists in BOTH sheets, byte-equal — the chat 
   }
 });
 
-test("the overlay geometry: pane-filling, viewer stays one layer above, scroll locked while open", () => {
-  assert.match(CHAT, /\.filebrowse \{ position: fixed; inset: 0; z-index: 890;/,
-    "GIANT — fixed inset-0 fills the pane, thread AND composer beneath");
+test("the browser is a centered CARD over a dimmed backdrop; viewer one layer above; scroll locked", () => {
+  // the 2026-08-24 pane takeover was superseded 2026-09-04 (the user found it odd once the listing
+  // was capped): the viewer's own treatment now — the id/dim on the backdrop, the card capped in
+  // px/% (never vh: in a pane iframe vh IS the pane, and the cap must lose to 95% on short panes)
+  assert.match(CHAT, /#romp-filebrowse \{ position: fixed; inset: 0; z-index: 890; background: var\(--overlay-dim\);/);
+  assert.match(CHAT, /\.filebrowse \{ width: min\(720px, 95%\); height: min\(760px, 95%\);/);
   assert.match(CHAT, /body\.filebrowse-open \{ overflow: hidden; \}/, "the thread cannot scroll behind it");
   // the viewer overlays the listing (the one-directional stack): 1200 > 890
   const vz = Number((CHAT.match(/#romp-fileview \{[^}]*z-index: (\d+)/s) || [])[1]);
   assert.ok(vz > 890, "the viewer's backdrop sits above the browser (got " + vz + ")");
-});
-
-test("the overlay stays GIANT; the LISTING reads at a centered measure on wide panes", () => {
-  // the 2026-08-24 ruling stands (fixed inset-0 over the whole chat area) — the 2026-09-02 fix caps
-  // only the rows' measure: full-width rows put a file's size ~800px from its name on desktop.
-  // min(720px, 100%) keeps narrow panes and phones pixel-identical.
-  assert.match(CHAT, /\.fb-list \{[^}]*width: min\(720px, 100%\); margin-inline: auto; \}/);
+  // the card bounds the rows itself — the interim .fb-list measure cap is gone with the takeover
+  assert.match(CHAT, /\.fb-list \{ flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; \}/);
 });

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -14,12 +14,17 @@ const FEED = web("feed.ts");
 const FEED_CSS = web("feed.css");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-test("the browser is the viewer's sibling overlay, one z layer BENEATH it", () => {
+test("the browser is the viewer's sibling MODAL, one z layer BENEATH it", () => {
   // beneath by design: a file opened from a listing overlays the listing, and closing it returns
-  // there (the viewer is a MODAL since 2026-08-15 — its backdrop, not a pane fill, draws above)
-  assert.match(FEED_CSS, /\.filebrowse \{ position: fixed; inset: 0; z-index: 890;/);
+  // there (the viewer is a MODAL since 2026-08-15). The browser joined the same centered-card
+  // treatment 2026-09-04 (the user, superseding the 2026-08-24 pane takeover they came to find
+  // odd): backdrop wears the id + the dim, the card wears the modal vocabulary.
+  assert.match(FEED_CSS, /#romp-filebrowse \{ position: fixed; inset: 0; z-index: 890; background: var\(--overlay-dim\);/);
+  assert.match(FEED_CSS, /\.filebrowse \{ width: min\(720px, 95%\); height: min\(760px, 95%\);/);
   assert.match(FEED_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200;/);
-  assert.match(BROWSE, /box\.id = "romp-filebrowse";/);
+  assert.match(BROWSE, /wrap\.id = "romp-filebrowse";/);
+  assert.match(BROWSE, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) closeFileBrowse\(\); \};/,
+    "backdrop clicks close; content clicks never do (the lightbox contract)");
   assert.match(BROWSE, /document\.body\.classList\.add\("filebrowse-open"\);/);
 });
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -1102,7 +1102,7 @@ function initGear(post) {
     svg += '<text x="' + cx2 + '" y="' + (baseY + 18) + '" text-anchor="middle" style="fill:var(--text-muted, #9aa0a6)" font-size="12">Judges</text>';
     svg += '</svg>'; raChart.innerHTML = svg;
     var lg = segs.map(function (s) { return '<span class=ra-li><span class=ra-sw style="background:' + s.color + '"></span>' + raEsc(s.label) + ' <b>' + raFmt(raVal(s)) + '</b></span>'; }).join('');
-    raLegend.innerHTML = '<span class=ra-li><span class="ra-sw" style="background:#7d8590"></span>sessions <b>' + raFmt(sessTot) + '</b></span>' + lg;
+    raLegend.innerHTML = '<span class=ra-li><span class="ra-sw" style="background:var(--text-faint, #7d8590)"></span>sessions <b>' + raFmt(sessTot) + '</b></span>' + lg;   // the swatch matches its bar (PR #886 review: the bar moved to --text-faint and they split in classic)
     var ratio = sessTot ? (judgeTot / sessTot * 100) : 0;
     raNote.textContent = 'last ' + raState.periodLabel + ' · judges = ' + (sessTot ? ratio.toFixed(1) : '0') + '% of session ' + (raCost() ? 'cost' : 'tokens') + ' · combined ' + raFmt(sessTot + judgeTot); }
   function raFetch() { raState.loading = true; raRender();

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -220,3 +220,11 @@ test("one tooltip per settings row: the Account row's live status is NOT a secon
   assert.ok(GEAR_CSS.includes("#rsettings .rs-row:has(#rs-cmap-list:not([hidden])) .rs-sub"), "open cmap menu owns the row");
   assert.ok(GEAR_CSS.includes("#rsettings .rs-row:has(.rs-mixed:hover) .rs-sub { display: none; }"), "the mixed mark's title stands alone");
 });
+
+test("the analytics legend swatch matches its bar (PR #886 review: they split in classic)", () => {
+  // the sessions BAR moved to var(--text-faint, #7d8590) while the legend swatch stayed a literal —
+  // dark resolves --text-faint to #6e7681, so bar and legend no longer agreed in classic
+  assert.ok(GEAR.includes('"ra-sw" style="background:var(--text-faint, #7d8590)"'),
+    "the legend swatch reads the same token as the bar it explains");
+  assert.doesNotMatch(GEAR, /"ra-sw" style="background:#7d8590"/);
+});

--- a/ui/webview/jump-bottom.test.ts
+++ b/ui/webview/jump-bottom.test.ts
@@ -40,7 +40,13 @@ test("the send gate stays byte-intact — the chip is the sanctioned mover, send
 });
 
 test("the chip wears the menu-card vocabulary and survives [hidden] against its own display:flex", () => {
-  assert.match(CSS, /#jump-bottom \{\s*\n\s*position: fixed; left: 50%; transform: translateX\(-50%\);/);
+  // bottom-LEFT (the user 2026-09-03: the centered pill went unnoticed — they were still clicking
+  // into the transcript and hitting End), and the border reads through the menu token: the raw
+  // white-alpha it wore vanished on the light page (cream on cream)
+  assert.match(CSS, /#jump-bottom \{\s*\n\s*position: fixed; left: 14px;/);
+  assert.match(CSS, /#jump-bottom \{[\s\S]{0,700}?border: 1px solid var\(--menu-border\);/);
+  assert.match(RENDER, /setTip\(jumpBtn, "go to bottom — then follow new content"\);/,
+    "the tooltip says what the user asked it to say, in the one styled tip");
   assert.match(CSS, /#jump-bottom\[hidden\] \{ display: none; \}/);
   assert.match(CSS, /#jump-bottom:hover \{ border-color: var\(--accent\); color: var\(--accent\); \}/);
   // the phone target WIDENS, never heightens — the compact pill is the ask (the user 2026-08-31)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9226,8 +9226,8 @@ if (typeof ResizeObserver === "function") {
 // ResizeObserver below (the composer growing moves that edge) — event-based, no polling.
 const jumpBtn = document.createElement("button");
 jumpBtn.id = "jump-bottom";
-jumpBtn.title = "jump to newest — then follow new content";
-jumpBtn.setAttribute("aria-label", "jump to newest");
+jumpBtn.setAttribute("aria-label", "go to bottom");
+setTip(jumpBtn, "go to bottom — then follow new content");   // the user 2026-09-03's word for it, in the one styled tip
 jumpBtn.hidden = true;
 jumpBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"'
   + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2678,11 +2678,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    it; render.ts measures its bottom against #content's edge (the composer growing moves it). Below
    toasts/seek (60), above the transcript. */
 #jump-bottom {
-  position: fixed; left: 50%; transform: translateX(-50%); z-index: 40;
+  position: fixed; left: 14px; z-index: 40;   /* bottom-LEFT (the user 2026-09-03; it sat centered and went unnoticed — they were still clicking in + End) */
   width: 40px; height: 22px; border-radius: var(--radius-pill); cursor: pointer; padding: 0;   /* a short PILL, wider than tall, hugging the bottom (the user 2026-08-31, revising the circle) */
   display: flex; align-items: center; justify-content: center;
   background: var(--vscode-menu-background, var(--surface-raised)); color: var(--dim);
-  border: 1px solid rgba(255, 255, 255, 0.12); box-shadow: var(--shadow-toast);
+  border: 1px solid var(--menu-border); box-shadow: var(--shadow-toast);   /* the raw white-alpha border vanished on the light page — cream on cream */
 }
 #jump-bottom:hover { border-color: var(--accent); color: var(--accent); }
 #jump-bottom[hidden] { display: none; }   /* author display:flex defeats [hidden] — the login-modal lesson */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1678,7 +1678,15 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    as the links above: `.md blockquote` ties it later in the sheet and was silently winning. */
 .user-bubble blockquote, .user-bubble.md blockquote { color: rgba(255, 255, 255, 0.88); border-left-color: rgba(255, 255, 255, 0.40);
   font-family: var(--font-prose); }
-.user-bubble :not(pre) > code { background: rgba(255, 255, 255, 0.2); color: #fff; }
+.user-bubble :not(pre) > code, .user-bubble.md :not(pre) > code { background: rgba(255, 255, 255, 0.2); color: #fff; }
+/* fenced code in YOUR bubble sits in a PAGE-colored well: the hljs palette is tuned for the page
+   ground in each theme, and on the saturated fill its inks read as stray reds (the user 2026-09-04,
+   whose light bubbles showed red text). Bold joins the white family — .md's near-page text tones
+   are unreadable on the fill. All doubled: the bubble element wears .md, which ties bare selectors. */
+.user-bubble pre, .user-bubble.md pre { background: var(--bg); }
+.user-bubble strong, .user-bubble.md strong { color: #fff; }
+.user-bubble h1, .user-bubble h2, .user-bubble h3, .user-bubble h4,
+.user-bubble.md h1, .user-bubble.md h2, .user-bubble.md h3, .user-bubble.md h4 { color: #fff; }
 /* a slash COMMAND you sent (the user 2026-06-29): the "/cmd" token renders as a monospace KEYWORD chip inside
    the blue bubble — a darkened, outlined pill so it reads as a command, not prose. Args sit after it as text. */
 .slash-cmd-chip {
@@ -3315,14 +3323,20 @@ a.fileview-btn[hidden] { display: none; }
 
 /* ── the file BROWSER (file-browse.ts) in the CHAT document ── the 642 move made the browser
    pane-local here, but its overlay dress lived only in feed.css, so it mounted as unstyled block
-   flow at the document bottom, below the composer (the user 2026-08-24, near-verbatim: "totally
-   messed up — showing at the bottom"). This block MIRRORS feed.css's (the .romp-acted precedent:
-   the two pages load different sheets, so shared overlays are declared in both — a test pins the
-   pair equal). The browser fills the pane (fixed inset-0), sits one z layer BENEATH the viewer
-   (890 < 1200) so a file opened from a listing overlays it, and body.filebrowse-open locks the
-   thread's scroll while open. */
-.filebrowse { position: fixed; inset: 0; z-index: 890; display: flex; flex-direction: column;
-  background: var(--bg, #1e1e1e); }
+   flow at the document bottom, below the composer (the user 2026-08-24, who found it broken at
+   the page bottom). This block MIRRORS feed.css's (the .romp-acted precedent: the two pages load
+   different sheets, so shared overlays are declared in both — a test pins the pair equal). The
+   browser WORE the whole pane through 2026-09-04, when the user found the takeover odd once the
+   listing was capped — it presents like the file viewer now: a centered card over the dimmed
+   backdrop (the id rides the BACKDROP: every open/close check looks it up), one z layer BENEATH
+   the viewer (890 < 1200) so a file opened from a listing overlays it, and body.filebrowse-open
+   locks the thread's scroll while open. Height caps in px/%, never vh — in a pane iframe vh IS
+   the pane, so a vh cap would beat 95% on the short panes it exists to protect. */
+#romp-filebrowse { position: fixed; inset: 0; z-index: 890; background: var(--overlay-dim);
+  display: flex; align-items: center; justify-content: center; }
+.filebrowse { width: min(720px, 95%); height: min(760px, 95%); display: flex; flex-direction: column;
+  overflow: hidden; background: var(--bg, #1e1e1e); border: 1px solid var(--box-border);
+  border-radius: var(--radius-modal); box-shadow: var(--shadow-modal); }
 body.filebrowse-open { overflow: hidden; }
 .fb-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
   padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
@@ -3333,10 +3347,7 @@ body.filebrowse-open { overflow: hidden; }
 .fb-crumb:hover { color: var(--accent); text-decoration: underline; }
 .fb-crumb:last-child { color: var(--fg); }
 .fb-crumb-sep { margin: 0 3px; opacity: 0.6; }
-/* the overlay still takes the whole pane (the user 2026-08-24 ruling) — but the LISTING reads at a
-   centered 720px measure on a wide pane (the user 2026-09-02: full-width rows put a file's size
-   ~800px from its name); 100% wins on narrow panes/phones, pixel-identical to before */
-.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; width: min(720px, 100%); margin-inline: auto; }
+.fb-list { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 4px 0; }
 .fb-row { display: flex; align-items: baseline; gap: 8px; padding: 4px 14px; cursor: pointer;
   font-size: 0.86em; }
 .fb-row:hover, .fb-row.active { background: var(--menu-hover); }


### PR DESCRIPTION
The two nits from #886's merge note, plus one live-board ask:

- **Legend swatch matches its bar**: `var(--text-faint, #7d8590)` — the bar moved to the token in #886 and they split in classic.
- **Queued context refresh survives a failed attempt**: the None-payload early return sat before the rerun tail, so an ask queued behind a refresh that then errored was dropped; the rerun now fires on both exits (fail-then-work test).
- **The jump chip moves bottom-left, says "go to bottom"** (the user's word for it, in the styled tip), and its border reads through `--menu-border` — the raw white-alpha border made it a cream-on-cream ghost in the light theme, which is why the user never noticed it existed. Shape/size/behavior unchanged.

2782 webview tests + 7180 pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)