### PR TITLE
keyswap --cycle reconnects only quiet sessions and converges, the CLI compares the kernel's key with the file's before anything moves, and the env-file path reaches the kernel

### DIFF
--- a/bin/romp-service
+++ b/bin/romp-service
@@ -89,12 +89,36 @@ _instance_env_block() {
     printf '%s' "$out"
 }
 
+# The kernel resolves the env file's path from ITS OWN environment (kernel/keysource.py reads
+# ROMP_SERVICE_ENV_FILE, else ${XDG_CONFIG_HOME:-~/.config}/romp/service.env) — and the service gets
+# neither variable from the installing shell. So a non-default path baked into EnvironmentFile= below
+# would be read by systemd/launchd and NOT by the kernel's live key read: `romp keyswap` would rewrite
+# a file the kernel never looks at (review find, 2026-09-04). Carry the resolved path across whenever
+# it is not the kernel's own default; a default install writes the same unit it always did.
+_service_env_override() {
+    [[ "$SERVICE_ENV_FILE" != "$HOME/.config/romp/service.env" ]] || return 0
+    if [[ "$1" == plist ]]; then
+        # XML-escaped: a path with & or < would otherwise yield a plist launchd cannot parse
+        printf '    <key>ROMP_SERVICE_ENV_FILE</key><string>%s</string>\n' \
+            "$(printf '%s' "$SERVICE_ENV_FILE" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')"
+    else
+        # quoted: systemd word-splits an unquoted Environment= value, so a path with a space would be cut;
+        # a backslash or double quote inside the value is escaped, or systemd drops the whole assignment;
+        # % is doubled because Environment= undergoes specifier expansion (%h → home, %z → "invalid slot",
+        # the assignment dropped) — verified with systemd-analyze --user verify
+        printf 'Environment="ROMP_SERVICE_ENV_FILE=%s"\n' \
+            "$(printf '%s' "$SERVICE_ENV_FILE" | sed 's/\\/\\\\/g; s/"/\\"/g; s/%/%%/g')"
+    fi
+}
+
 write_plist() {
     mkdir -p "$LAUNCHD_DIR" "$STATE"
     # $() eats the trailing newline; put it back so </dict> keeps its own line. Empty → the
     # dict closes exactly as it did before this existed.
     local _plist_env; _plist_env="$(_instance_env_block plist)"
     if [[ -n "$_plist_env" ]]; then _plist_env+=$'\n'; fi
+    local _plist_envf; _plist_envf="$(_service_env_override plist)"
+    if [[ -n "$_plist_envf" ]]; then _plist_envf+=$'\n'; fi
     cat > "$PLIST" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -112,7 +136,7 @@ write_plist() {
     <key>PATH</key><string>$PATH</string>
     <key>ROMP_DIR</key><string>$ROMP_DIR</string>
     <key>ROMP_SUPERVISED</key><string>1</string>
-${_plist_env}  </dict>
+${_plist_envf}${_plist_env}  </dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>StandardOutPath</key><string>$LOG</string>
@@ -128,6 +152,8 @@ write_unit() {
     # Empty → the block collapses to exactly the unit this wrote before it existed.
     local _unit_env; _unit_env="$(_instance_env_block unit)"
     if [[ -n "$_unit_env" ]]; then _unit_env+=$'\n'; fi
+    local _unit_envf; _unit_envf="$(_service_env_override unit)"
+    if [[ -n "$_unit_envf" ]]; then _unit_envf+=$'\n'; fi
     cat > "$UNIT" <<EOF
 [Unit]
 Description=romp kernel supervisor (romp-manager)
@@ -140,7 +166,7 @@ RestartSec=2
 Environment=PATH=$PATH
 Environment=ROMP_DIR=$ROMP_DIR
 Environment=ROMP_SUPERVISED=1
-EnvironmentFile=-$SERVICE_ENV_FILE
+${_unit_envf}EnvironmentFile=-$(printf '%s' "$SERVICE_ENV_FILE" | sed 's/%/%%/g')
 ${_unit_env}
 [Install]
 WantedBy=default.target

--- a/cli/keyswap.py
+++ b/cli/keyswap.py
@@ -9,7 +9,9 @@
   * a session already running keeps the key its CLI process started with, because the key rides
     the launch environment — `--cycle <names>` or `--cycle-all` reconnects those sessions so they
     re-present the new one, each resuming its own conversation with its history intact;
-  * the manager itself never restarts, so no session loses an open turn and no subagent is killed.
+  * the manager itself never restarts, so no session loses an open turn; a session with subagents or
+    background tasks in flight is skipped by --cycle (a reconnect would kill them) and named, so you
+    cycle it again once they are done.
 
 No key value is ever printed, logged or passed over the wire. The only rendered form is the first
 12 hex of its sha256 ("sha256:1a2b3c…"), which is enough to see that the swap landed and that the
@@ -38,6 +40,23 @@ ks = SourceFileLoader("romp_keysource", str(ROOT / "kernel" / "keysource.py")).l
 KPORTS = ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
 
 
+def _kernel_urls():
+    """Where the local kernel may answer. ROMP_KERNEL_PORT / ROMP_SERVE_PORT when set — the port
+    bin/romp and the installer resolve — and ONLY that one: a renumbered second-OS-user instance must
+    never hand its serve token to whatever answers on the primary user's default port (review find,
+    2026-09-04). Unset, the defaults `romp version` and `romp update` probe."""
+    for var in ("ROMP_KERNEL_PORT", "ROMP_SERVE_PORT"):
+        p = (os.environ.get(var) or "").strip()
+        if not p:
+            continue
+        if not (p.isdigit() and 0 < int(p) < 65536):
+            # an unusable override is refused, never silently replaced by the default ports — that
+            # replacement is exactly the token-to-the-wrong-kernel path this function exists to close
+            raise ValueError("%s=%r is not a port" % (var, p))
+        return ["http://127.0.0.1:%s" % p]
+    return list(KPORTS)
+
+
 def _token():
     """The serve token — required on every kernel request, loopback included (Jupyter's model).
     Same resolution romp-update uses: env override, else the 0600 state file."""
@@ -54,7 +73,11 @@ def _token():
 
 def _kernel():
     """The base URL of the running local kernel, or None."""
-    for u in KPORTS:
+    try:
+        urls = _kernel_urls()
+    except ValueError:
+        return None                                  # the callers report it (they check _kernel_urls first)
+    for u in urls:
         try:
             with urllib.request.urlopen(u + "/version", timeout=1.5) as r:   # /version is auth-exempt
                 if r.status == 200:
@@ -108,15 +131,62 @@ def _candidates(path, out):
         out("  %-14s %s%s" % (n, _fp(k) if k else "(no %s line)" % ks.KEY_VAR, mark))
 
 
-def _cycle(sessions, all_, out):
-    """Reconnect the named sessions through the kernel, and report what it did per session."""
+def _kernel_check(path, out):
+    """Compare what the KERNEL reads with what the FILE says — the check the operator procedure used
+    to ask for by eye (review find, 2026-09-04). The two can differ: the service was installed with
+    another env-file path that never reached the kernel's environment, the file is unreadable to the
+    kernel, the kernel still holds its startup key because the file has no key line, or the kernel
+    predates this feature. Reads the fingerprint through /keycycle with no sessions named — a read,
+    nothing cycles. Returns 0 when they agree (or no kernel is up to ask), 1 when they do not — or when
+    the port override is unusable, which is a misconfiguration to fix, not "no kernel"."""
+    try:
+        _kernel_urls()
+    except ValueError as e:
+        out("kernel      NOT ASKED — %s; fix the variable and re-run" % e)
+        return 1
+    u = _kernel()
+    if not u:
+        out("kernel      not running — sessions read the file when it is")
+        return 0
+    body = _post(u, "/keycycle", {"sessions": []})
+    if body.get("error") == "HTTP 404":
+        out("kernel      predates `romp keyswap` (no /keycycle route): it is still on the key it booted")
+        out("            with. Take the patch once with `romp refresh`; every swap after that is restart-free.")
+        return 1
+    if not body.get("ok"):
+        out("kernel      could not be asked — %s" % (body.get("error") or body.get("detail") or "unknown"))
+        return 1
+    return _compare(body.get("keyFp") or "", path, out)
+
+
+def _compare(kfp, path, out):
+    """Print the kernel's fingerprint and, when it is not the file's, say so and why it may be."""
+    out("kernel      reads %s" % (("sha256:" + kfp) if kfp else "(none)"))
+    if kfp == ks.fingerprint(ks.read_key(path)):
+        return 0
+    out("MISMATCH    the kernel is not reading this file's key. Usual causes: the service was installed")
+    out("            with another env-file path that the kernel's environment does not carry (re-run")
+    out("            `romp service install`), the file is unreadable to the kernel, or the file has no")
+    out("            %s line and the kernel still holds its startup key." % ks.KEY_VAR)
+    return 1
+
+
+def _cycle(sessions, all_, out, path=None):
+    """Reconnect the named sessions through the kernel, and report what it did per session. The
+    kernel's fingerprint is READ and compared with the file's FIRST: cycling a session while the kernel
+    reads another file would re-present the kernel's unchanged key, so a mismatch refuses to cycle."""
+    try:
+        _kernel_urls()
+    except ValueError as e:
+        out("cycle       NOT DONE — %s; fix the variable and re-run" % e)
+        return 1
     u = _kernel()
     if not u:
         out("cycle       NOT DONE — no running kernel found (is romp on? `romp status`).")
         out("            The file is already swapped: every session picks the new key up at its")
         out("            next launch or revive. Re-run `romp keyswap --cycle…` once romp is up.")
         return 1
-    body = _post(u, "/keycycle", {"all": True} if all_ else {"sessions": sessions})
+    body = _post(u, "/keycycle", {"sessions": []})          # the read: which key does the kernel hold?
     if body.get("error") == "HTTP 404":
         # The one restart this feature genuinely needs: a kernel started before this code has no
         # /keycycle route AND no live key read, so it is still on the key it booted with.
@@ -127,21 +197,35 @@ def _cycle(sessions, all_, out):
     if not body.get("ok"):
         out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
         return 1
-    out("kernel      reads %s" % (("sha256:" + body["keyFp"]) if body.get("keyFp") else "(none)"))
+    if _compare(body.get("keyFp") or "", path or ks.service_env_path(), out):
+        out("cycle       NOT DONE — the kernel is not on this file's key, so a reconnect would re-present")
+        out("            the key it already has. Fix the mismatch above first, then cycle.")
+        return 1
+    body = _post(u, "/keycycle", {"all": True} if all_ else {"sessions": sessions})
+    if not body.get("ok"):
+        out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
+        return 1
     rows = body.get("rows") or []
     if not rows:
         out("cycle       no sessions matched")
         return 0
     for r in rows:
         out("  %-14s %s" % (str(r.get("session"))[:14], _explain(str(r.get("status") or ""))))
+    if any(str(r.get("status")) == "working" for r in rows):
+        out("            re-run the same --cycle once those are quiet; sessions already moved read \"current\"")
     return 0
 
 
 def _explain(status):
     return {
-        "cycling": "reconnecting now (idle) or at the end of its turn — history kept",
+        "cycling": "reconnecting now — history kept",
+        "current": "already on this key — nothing to do",
         "login":   "skipped: bills the machine login, not the key",
         "dormant": "not running — its next launch reads the new key",
+        "working": "skipped: a turn, subagents or background tasks are in flight (a reconnect would kill "
+                   "the work) — cycle it again when it is quiet; its next launch reads the new key anyway. "
+                   "A standing background task (a dev server, a monitor) never goes quiet: end it, or "
+                   "revive the session",
         "unknown": "no such session",
     }.get(status, status)
 
@@ -188,10 +272,11 @@ def main(argv, out=None):
         out("live key    %s" % _fp(ks.read_key(path)))
         _candidates(path, out)
         if cycle or cycle_all:
-            return _cycle(cycle, cycle_all, out)
+            return _cycle(cycle, cycle_all, out, path)
+        rc = _kernel_check(path, out)
         out("")
         out("swap with:  romp keyswap <name> [--cycle <session,…> | --cycle-all]")
-        return 0
+        return rc
     src = ks.sibling_path(args[0], path)
     if not os.path.exists(src):
         sys.stderr.write("romp keyswap: no such key file: %s\n" % src)
@@ -222,16 +307,19 @@ def main(argv, out=None):
                              "check %s by hand\n" % (_fp(landed), _fp(new), path))
             return 1
         out("service.env %s" % res["path"])
+        if res.get("target") and res["target"] != res["path"]:
+            out("            (a link: written through to %s)" % res["target"])
         out("key line    %s -> %s  (%d lines, mode %o%s)"
             % (_fp(res["old"]), _fp(new), res["lines"], res["mode"],
                ", tightened from a group/other-readable mode" if res["tightened"] else ""))
         out("source      %s" % src)
     out("effect      new and revived sessions bill this key immediately; no manager restart needed")
     if cycle or cycle_all:
-        return _cycle(cycle, cycle_all, out)
+        return _cycle(cycle, cycle_all, out, path)
+    rc = _kernel_check(path, out)
     out("running     sessions keep the key they launched with — reconnect them with")
     out("            romp keyswap %s --cycle-all   (or --cycle <session,…>)" % args[0])
-    return 0
+    return rc
 
 
 if __name__ == "__main__":

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -353,9 +353,11 @@ Then:
     romp keyswap lowprio --cycle web,api
 
 `romp keyswap <name>` rewrites **only** the `ANTHROPIC_API_KEY=` line, in
-place, keeping every other line of the file byte for byte — a temp file and a
-rename, so no reader ever sees the file half-written, and the mode stays `600`
-(a looser one is tightened). It refuses a source file with no key line rather
+place, keeping every other line of the file as it was (line endings come out
+as LF) — a temp file and a rename, so no reader ever sees the file
+half-written, and the mode stays `600` (a looser one is tightened). A
+symlinked `service.env` is written through: the target changes, the link
+stays. It refuses a source file with no key line rather
 than writing an empty key, which the CLI would read as "API-key mode, no key".
 
 After the rewrite:
@@ -366,9 +368,12 @@ After the rewrite:
   the key is handed over at launch. `--cycle-all` (or `--cycle <session,…>`)
   reconnects them so they re-present the new one. A reconnect resumes the same
   conversation with its history intact — the same mechanism a reasoning-effort
-  or billing switch uses — immediately if the session is idle, at the end of
-  the current turn if it is busy. Sessions billing the machine login are
-  skipped, and dormant ones are reported as needing nothing;
+  or billing switch uses — and only for a session that is quiet right now. Sessions billing the machine login are
+  skipped, dormant ones are reported as needing nothing, a session already
+  launched on the live key reads `current`, and a session with a turn,
+  subagents or background tasks in flight is skipped and named — a reconnect
+  would kill that work — so you re-run the same `--cycle` once it is quiet,
+  until every session reads `current`;
 * **the judges and the model catalog** pick the new key up on their next call,
   with no cycling at all.
 
@@ -388,8 +393,12 @@ their turns first — and every swap after that is restart-free. `romp keyswap
 Remote kernels each have their own `service.env` and their own key: run
 `romp keyswap` on that machine.
 
-`ROMP_SERVICE_ENV_FILE` overrides the path of the file, for both the installer
-and the live read.
+`ROMP_SERVICE_ENV_FILE` overrides the path of the file. The installer bakes
+the path it resolved into the unit and, when that is not the default, exports
+it to the service as well, so the kernel's live read and the installer name
+one file; a service installed before that carries only the default. `romp
+keyswap` asks the running kernel which key it reads and says `MISMATCH` when
+that is not the file's — the check to make after a swap.
 
 ## Where things live
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -34201,7 +34201,8 @@ class Handler(BaseHTTPRequestHandler):
                     except Exception as e:
                         status = "error: %s" % str(e)[:80]
                     rows.append({"session": _name_of(sid) or who, "status": status})
-                _push_soon()
+                if any(r["status"] == "cycling" for r in rows):
+                    _push_soon()                      # something changed; a fingerprint READ ({"sessions": []}) did not
                 return self._send(200, json.dumps({"ok": True, "keyFp": keyfp, "rows": rows}),
                                   "application/json")
             if u.path in ("/interrupt", "/end"):

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -134,10 +134,16 @@ def write_key(key: str, path: str | None = None) -> dict:
     mode is the original file's, narrowed to 0600 if it granted group or other any access at all;
     a new file is 0600.
 
-    Returns {"path", "old", "new", "mode", "tightened", "lines"} — `old`/`new` are the raw values,
-    for the caller to fingerprint. Raises OSError on a real failure (the caller reports it).
+    A SYMLINKED env file is written THROUGH (2026-09-04): a dotfiles-managed `service.env` is a link,
+    and an `os.replace` onto the link's own name would swap the link for a plain file and leave its
+    target — what the operator's repo tracks and what a re-link would restore — on the old key.
+
+    Returns {"path", "old", "new", "mode", "tightened", "lines", "target"} — `old`/`new` are the raw
+    values, for the caller to fingerprint; `target` is the file actually rewritten (the link's target,
+    else `path`). Raises OSError on a real failure (the caller reports it).
     """
-    p = path or service_env_path()
+    given = path or service_env_path()
+    p = os.path.realpath(given) if os.path.islink(given) else given
     try:
         with open(p, "r", encoding="utf-8", errors="replace") as fh:
             body = fh.read()
@@ -186,5 +192,5 @@ def write_key(key: str, path: str | None = None) -> dict:
         except OSError:
             pass
         raise
-    return {"path": p, "old": old, "new": key, "mode": mode, "tightened": tightened,
-            "lines": len(lines)}
+    return {"path": given, "old": old, "new": key, "mode": mode, "tightened": tightened,
+            "lines": len(lines), "target": p}

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1844,8 +1844,10 @@ def _check_key_file_agrees(startup: str, live: str) -> None:
     global _KEY_FILE_CHECKED
     if _KEY_FILE_CHECKED:
         return
-    _KEY_FILE_CHECKED = True
-    if not startup or not live or startup == live:
+    if not startup or not live:
+        return                       # nothing to compare YET: the file may gain its line later (review find,
+    _KEY_FILE_CHECKED = True         # 2026-09-04: the one shot was spent on a first read with nothing to say)
+    if startup == live:
         return
     sys.stderr.write(
         "work key: the manager env file sets a DIFFERENT key than this process started with "
@@ -2087,6 +2089,9 @@ class SdkSession:
         self.retry_info = None                        # the CURRENT storm's latest api_retry detail (attempt/max, error status+message, next-attempt epoch) → the chat retrying element's extra context (the user 2026-07-10); lives and dies with `retrying`
         self._interrupted = False                    # user interrupted the in-flight turn → snapshot reads 'waiting' (display only; inflight stays event-driven)
         self._intr_level = 0                         # interrupt escalation rung this episode (interrupt_action); reset on settle / fresh turn
+        self._launched_key_fp = None                 # fingerprint of the work key this session's CURRENT client launched on
+        #   ("" = launched on the login); set per connect in _options, read by cycle_key so `romp keyswap --cycle`
+        #   is idempotent — a session already on the live key is "current", never reconnected again
         self._subagents: dict[str, dict] = {}        # LIVE subagents (Task/Agent AND Workflow-run agents): agent_id ->
         #   {"type","since"}. Fed by the SubagentStart hook — the exact, event-based "what's running right now"
         #   signal the tmux backend never had; drained by SubagentStop, a Workflow run's per-agent progress list,
@@ -2443,23 +2448,39 @@ class SdkSession:
         if self._wake is not None:
             self._wake.set()
 
-    def request_reconnect(self):
+    def request_reconnect(self, defer=True):
         """Apply a connect-time option change (effort) by reconnecting the client — resume continues the same
         conversation. Reconnect NOW when idle; defer to the end of the current turn when busy. No-op if the
-        session is shutting down or not yet connected (the new value is in the registry → it applies on connect)."""
+        session is shutting down or not yet connected (the new value is in the registry → it applies on connect).
+
+        `defer=False` (the key cycle, 2026-09-04): reconnect ONLY if the session is still quiet when the loop
+        gets to it — nothing in flight, nothing queued, no live subagent or background task. The deferred
+        end-of-turn reconnect fires without re-checking the work that turn launched, so a key cycle never
+        arms it: a turn that arrived between the caller's check and this one drops the request, with a log
+        line, and the operator cycles again when the session is quiet (cycle_key reads "current" once it is)."""
         if self.loop is None or self.ended:
             return
-        self.loop.call_soon_threadsafe(self._do_request_reconnect)
+        self.loop.call_soon_threadsafe(self._do_request_reconnect, defer)
 
-    def _do_request_reconnect(self):
+    def _do_request_reconnect(self, defer=True):
         # a rewind-HELD queue must not defer the reconnect: those turns can't start until the
         # reconnect arms them (the input gate) — deferring on their account would deadlock the rewind
         held = bool(self._rewind_to and not self._rewind_armed)
         if self.inflight == 0 and (held or not self._pending):
+            if not defer:
+                with self._sub_lock:             # the loop-side re-check the key cycle relies on: live work
+                    busy_work = bool(self._subagents or self._bg_tasks)   # that registered since the caller looked
+                if busy_work:
+                    self.backend._log("keyswap (%s): live work registered before the reconnect ran — not "
+                                      "cycled; cycle it again when it is quiet" % self.name)
+                    return
             self._reconnect = True
             self._wake_set()
-        else:
+        elif defer:
             self._reconnect_when_idle = True   # the ResultMessage handler fires it when the turn ends
+        else:
+            self.backend._log("keyswap (%s): became busy before the reconnect ran — not cycled; cycle it "
+                              "again when it is quiet" % self.name)
 
     def _reconcile_stranded(self):
         """RECONCILE ACROSS A RECONNECT, at the loop's top where no client is connected so nothing can
@@ -4764,13 +4785,27 @@ class SdkBackend:
     def work_key(self, value) -> None:
         self._work_key_pin = str(value or "")
 
+    def _work_key_and_source(self) -> tuple:
+        """(key, source) in ONE read of the file — "file" (the env file's line), "startup" (the claim
+        made at boot, because the file has no usable line), "pin" (a test's explicit value), "" (no
+        key anywhere). _options wants both, and must not read the file twice per connect: a keyswap
+        can land between two reads, and the source named in the log must be the source injected."""
+        if self._work_key_pin is not None:
+            return self._work_key_pin, ("pin" if self._work_key_pin else "")
+        startup = startup_api_key()
+        live = _keysrc.read_key()
+        _check_key_file_agrees(startup, live)
+        if live:
+            return live, "file"
+        return startup, ("startup" if startup else "")
+
     def work_key_fp(self) -> str:
         """The renderable form of the key sessions launch on: the sha256 head, "" for none. The
         kernel's /keycycle answer carries this so an operator can confirm the kernel re-read the
         file they just wrote — the value itself never leaves this process."""
         return _keysrc.fingerprint(self.work_key)
 
-    def _note_work_key(self, key: str) -> None:
+    def _note_work_key(self, key: str, source: str = "file") -> None:
         """Log WHICH key a launch is billing, as a fingerprint, and only when it changes. That makes
         a keyswap visible in the Log panel — "the kernel now reads sha256:… " — which is the only
         way an operator can confirm the swap landed, since no surface may carry the key itself. The
@@ -4778,8 +4813,12 @@ class SdkBackend:
         fp = _keysrc.fingerprint(key)
         if fp and fp != self._key_fp_said:
             self._key_fp_said = fp
-            self._log("work key: sessions now launch on the key sha256:%s (read from %s)"
-                      % (fp, _keysrc.service_env_path()))
+            if source == "startup":  # the fallback: say so, rather than name a file that does not hold the key
+                src = ("the environment this manager started with; %s has no %s line the kernel can use"
+                       % (_keysrc.service_env_path(), _keysrc.KEY_VAR))
+            else:
+                src = "read from %s" % _keysrc.service_env_path()
+            self._log("work key: sessions now launch on the key sha256:%s (%s)" % (fp, src))
 
     def cycle_key(self, sid: str) -> str:
         """Re-present the CURRENT work key to one LIVE session by reconnecting it — the apply half of
@@ -4788,14 +4827,26 @@ class SdkBackend:
         The key rides the launch environment, so it is connect-time exactly like --effort and the
         auth pick: a running CLI keeps the key it started with until it is replaced. request_reconnect
         is the same mechanism set_effort/set_auth/set_env use — resume continues the same conversation
-        with its history intact, immediately when the session is idle and at the end of the current
-        turn when it is busy. Nothing is persisted, because nothing about the SESSION changed: which
-        key the box uses is not a per-session setting.
+        with its history intact — called here in its immediate-only form (defer=False): a session that
+        is not quiet is skipped, never handed the end-of-turn reconnect. Nothing is persisted, because
+        nothing about the SESSION changed: which key the box uses is not a per-session setting.
 
-        Returns what happened, for the CLI to print per session: "cycling" (a live key-billed session
-        is reconnecting), "login" (billed to the machine login — the key would not be injected, so a
-        reconnect would cost a turn for nothing), "dormant" (no live CLI — its next launch reads the
-        new key anyway), "unknown" (this backend has no such session)."""
+        Returns what happened, for the CLI to print per session: "cycling" (a quiet, live, key-billed
+        session is reconnecting NOW), "current" (its client already launched on the live key — nothing
+        to re-present, so a repeated --cycle-all converges instead of churning every idle session),
+        "login" (billed to the machine login — the key would not be injected, so a reconnect would cost
+        a turn for nothing), "dormant" (no live CLI — its next launch reads the new key anyway),
+        "working" (a turn, a queued turn, live subagents or background tasks are in flight — see below),
+        "unknown" (this backend has no such session).
+
+        "working": a reconnect abandons the CLI process, and the subagents and background tasks INSIDE
+        it die with it (_drop_live_work) — the very loss the keyswap exists to avoid, and one an idle-
+        looking session can carry (a session waiting on a background agent has nothing in flight of its
+        own). A BUSY session is skipped too, rather than handed the deferred end-of-turn reconnect the
+        settings switches use: that reconnect fires unconditionally when the turn ends, so work the turn
+        launches after this check would die with it (second review pass, 2026-09-04). So "cycling" means
+        exactly one thing — an immediate reconnect of a session with nothing in flight — and the operator
+        re-runs --cycle-all until every session reads "current" (review find, 2026-09-04)."""
         if not self.owns(sid):
             return "unknown"
         s = self.sessions.get(sid)
@@ -4803,7 +4854,14 @@ class SdkBackend:
             return "dormant"
         if s.effective_auth() != "key":
             return "login"
-        s.request_reconnect()
+        fp = self.work_key_fp()
+        if fp and getattr(s, "_launched_key_fp", None) == fp:
+            return "current"
+        with s._sub_lock:
+            live_work = len(s._subagents) + len(s._bg_tasks)
+        if live_work or s.inflight > 0 or s._pending:
+            return "working"
+        s.request_reconnect(defer=False)
         self._log("keyswap (%s): reconnecting to pick up the current work key (sha256:%s)"
                   % (s.name, _keysrc.fingerprint(self.work_key)))
         return "cycling"
@@ -5905,10 +5963,10 @@ class SdkBackend:
         # The key is read ONCE here, per connect, and the value the auth decision was made on is the
         # value injected: the source is live now (a keyswap can land between two reads). An empty read
         # decides login — blanking the var would leave the CLI in key-mode-without-a-key.
-        work_key = self.work_key
+        work_key, key_src = self._work_key_and_source()
         launch_keyed = sess.effective_auth(work_key) == "key"
         if launch_keyed:
-            self._note_work_key(work_key)
+            self._note_work_key(work_key, key_src)
             kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=work_key,
                              **key_fast_org_env(work_key, self._log))
         elif sess.auth == "key":
@@ -5917,6 +5975,7 @@ class SdkBackend:
             self._log("auth (%s): session is set to the API key but the manager environment carries "
                       "none (service.env) — launching on the login instead" % sess.name, problem=True)
         sess._launched_keyed = launch_keyed
+        sess._launched_key_fp = _keysrc.fingerprint(work_key) if launch_keyed else ""
         return ClaudeAgentOptions(**kw)
 
     # ---- lifecycle (kernel-thread API) ----

--- a/tests/romp-service.bats
+++ b/tests/romp-service.bats
@@ -24,6 +24,9 @@ setup() {
     # reading the developer's machine instead of the code. Clear the whole instance set; the
     # tests that want them set them explicitly.
     unset ROMP_SERVE_PORT ROMP_KERNEL_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET
+    # The env-file path is baked (and, when non-default, exported) into the unit too; a developer shell
+    # that carries either variable must not leak it into the default-install assertions below.
+    unset ROMP_SERVICE_ENV_FILE XDG_CONFIG_HOME
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
@@ -277,7 +280,8 @@ EOF2
     [ -z "$(sed -n '/^EnvironmentFile=-/{n;p;}' "$unit")" ]
     ROMP_OS_OVERRIDE=Darwin run "$SVC" install
     [ "$status" -eq 0 ]
-    ! grep -q "ROMP_SERVE_PORT\|ROMP_STATE_DIR\|ROMP_TMUX_SOCKET" "$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+    run grep -q "ROMP_SERVE_PORT\|ROMP_STATE_DIR\|ROMP_TMUX_SOCKET" "$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+    [ "$status" -ne 0 ]        # (a bare `! cmd` that is not the test's last statement can never fail it)
 }
 
 @test "the rendered unit and plist stay well-formed with the instance env present" {
@@ -309,4 +313,39 @@ EOF2
     XDG_CONFIG_HOME="$HOME/.config" ROMP_OS_OVERRIDE=Linux run "$SVC" install
     [ "$status" -eq 0 ]
     grep -Fq "EnvironmentFile=-$HOME/.config/romp/service.env" "$ROMP_SYSTEMD_DIR/romp-manager.service"
+}
+
+@test "install carries a non-default env-file path into the unit (quoted) and the plist (escaped); a default install does not" {
+    # kernel/keysource.py resolves the env file from the SERVICE's environment, which never sees the
+    # installing shell's ROMP_SERVICE_ENV_FILE — so a non-default path baked into EnvironmentFile= alone
+    # was read by systemd and not by the kernel's live key read (romp keyswap rewrote a file the kernel
+    # never looked at). The resolved path now rides the unit and the plist whenever it is not the default.
+    # every character class systemd or XML would mangle: a space (word-split), a double quote and a
+    # backslash (quoting), a percent sign (specifier expansion), an ampersand (XML)
+    local odd='alt "q" \b %z & dir'
+    export ROMP_SERVICE_ENV_FILE="$TEST_DIR/$odd/service.env"
+    mkdir -p "$TEST_DIR/$odd"
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
+    local exp_env='Environment="ROMP_SERVICE_ENV_FILE='"$TEST_DIR"'/alt \"q\" \\b %%z & dir/service.env"'   # quoted, escaped, % doubled
+    grep -Fq "$exp_env" "$unit"
+    local exp_file='EnvironmentFile=-'"$TEST_DIR"'/alt "q" \b %%z & dir/service.env'                         # % doubled here too
+    grep -Fq "$exp_file" "$unit"
+    [ -z "$(sed -n '/^EnvironmentFile=-/{n;p;}' "$unit")" ]                                     # the seam is unchanged
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    local plist="$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+    local exp_plist='<key>ROMP_SERVICE_ENV_FILE</key><string>'"$TEST_DIR"'/alt &quot;q&quot; \b %z &amp; dir/service.env</string>'
+    grep -Fq "$exp_plist" "$plist"
+    command -v python3 >/dev/null 2>&1 && python3 -c "import plistlib,sys; plistlib.load(open(sys.argv[1],'rb'))" "$plist"
+    unset ROMP_SERVICE_ENV_FILE
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    run grep -q "ROMP_SERVICE_ENV_FILE" "$unit"
+    [ "$status" -ne 0 ]        # (a bare `! cmd` that is not the test's last statement can never fail it)
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    run grep -q "ROMP_SERVICE_ENV_FILE" "$plist"
+    [ "$status" -ne 0 ]
 }

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -1599,6 +1599,10 @@ PY
 
 _keyswap_files() {
     export ROMP_SERVICE_ENV_FILE="$TEST_DIR/service.env"
+    # romp keyswap now asks the running kernel which key it reads (a /keycycle read) on every run, and
+    # honours ROMP_KERNEL_PORT as the ONLY port it probes — pin a dead port so a developer box with a
+    # live kernel on the default port stays out of these cases (CI has no kernel either way)
+    export ROMP_KERNEL_PORT=1
     printf 'ROMP_PERF=1\nANTHROPIC_API_KEY=sk-ant-TEST-0000\nROMP_EXPECTED_AUTH=key\n' \
         > "$ROMP_SERVICE_ENV_FILE"
     chmod 600 "$ROMP_SERVICE_ENV_FILE"

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -193,6 +193,25 @@ class AtomicRewrite(_EnvFile):
         ks.write_key(NEW_KEY, self.path)
         self.assertEqual(open(self.path).read(), "ROMP_PERF=1\n%s=%s\n" % (ks.KEY_VAR, NEW_KEY))
 
+    def test_a_symlinked_env_file_is_written_through_and_stays_a_link(self):
+        # a dotfiles-managed service.env is a symlink; os.replace onto the link's own name would swap the link
+        # for a plain file and leave its target (what the repo tracks) on the old key (review find, reproduced)
+        target_dir = tempfile.mkdtemp()
+        target = os.path.join(target_dir, "service.env")
+        with open(target, "w") as f:
+            f.write("ROMP_PERF=1\n%s=%s\n" % (ks.KEY_VAR, OLD_KEY))
+        os.chmod(target, 0o600)
+        link = os.path.join(self.d, "linked.env")
+        os.symlink(target, link)
+        res = ks.write_key(NEW_KEY, link)
+        self.assertTrue(os.path.islink(link), "the link is still a link")
+        self.assertEqual(os.path.realpath(link), os.path.realpath(target))
+        self.assertEqual(ks.parse_key(open(target).read()), NEW_KEY, "the TARGET carries the new key")
+        self.assertIn("ROMP_PERF=1", open(target).read())
+        self.assertEqual(res["path"], link)
+        self.assertEqual(os.path.realpath(res["target"]), os.path.realpath(target))
+        self.assertEqual(ks.read_key(link), NEW_KEY)
+
     def test_a_missing_file_is_created_0600(self):
         p = os.path.join(self.d, "fresh.env")
         ks.write_key(NEW_KEY, p)
@@ -264,7 +283,7 @@ class LiveSpawnEnv(_Backend):
         src = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
         self.assertEqual(src.count("ANTHROPIC_API_KEY=work_key"), 1,
                          "one injection site only — a second would need its own live read")
-        self.assertIn("work_key = self.work_key", src)
+        self.assertIn("work_key, key_src = self._work_key_and_source()", src)
 
     def test_the_key_is_read_once_per_connect_so_a_launch_cannot_straddle_a_swap(self):
         reads = []
@@ -336,6 +355,28 @@ class StartupFallback(_Backend):
                          "an ambient key bills EVERY session — constructing a backend must still strip it")
         self.assertEqual(be.work_key, OLD_KEY, "and the FILE still decides what a launch bills")
 
+    def test_the_agreement_check_is_not_spent_on_a_read_with_nothing_to_compare(self):
+        # the one-shot used to be consumed by the FIRST read even when the file had no key line, so a
+        # disagreement that appeared later (the line added, quoted differently) was never reported
+        import io
+        from contextlib import redirect_stderr
+        sb._KEY_FILE_CHECKED = False
+        with open(self.path, "w") as f:
+            f.write("ROMP_PERF=1\n")                                  # no key line yet
+        err = io.StringIO()
+        with redirect_stderr(err):
+            self.assertEqual(self.be.work_key, self.BOOT, "the startup claim governs")
+        self.assertFalse(sb._KEY_FILE_CHECKED, "nothing to compare: the check is still armed")
+        self.assertEqual(err.getvalue(), "")
+        with open(self.path, "w") as f:
+            f.write("ROMP_PERF=1\n%s=%s\n" % (ks.KEY_VAR, NEW_KEY))    # a DIFFERENT key appears in the file
+        with redirect_stderr(err):
+            self.assertEqual(self.be.work_key, NEW_KEY)
+            self.be.work_key                                          # a second read says nothing more
+        self.assertTrue(sb._KEY_FILE_CHECKED)
+        self.assertEqual(err.getvalue().count("DIFFERENT key"), 1, "said once, when there was something to say")
+        self.assertNotIn(NEW_KEY, err.getvalue()); self.assertNotIn(self.BOOT, err.getvalue())
+
     def test_a_disagreement_between_the_file_and_the_startup_env_is_said_once(self):
         sb._KEY_FILE_CHECKED = False
         sb._WORK_KEY = BOOT_KEY
@@ -364,7 +405,8 @@ class CycleReconnects(_Backend):
         s.sid = sid
         s.name = "live"
         self.reconnects = getattr(self, "reconnects", [])
-        s.request_reconnect = lambda: self.reconnects.append(sid)
+        self.defers = getattr(self, "defers", [])
+        s.request_reconnect = lambda defer=True: (self.reconnects.append(sid), self.defers.append(defer))
         self.be.sessions[sid] = s
         return s
 
@@ -374,6 +416,41 @@ class CycleReconnects(_Backend):
         self.assertEqual(self.be.cycle_key(sid), "cycling")
         self.assertEqual(self.reconnects, [sid],
                          "reconnect is what applies a connect-time option — and resume keeps the history")
+        self.assertEqual(self.defers, [False], "immediate-only: a key cycle never arms the end-of-turn reconnect")
+
+    def test_the_defer_flag_rides_the_loop_callback(self):
+        # the seam between the kernel-thread request and the loop-side re-check: request_reconnect(defer=False)
+        # must schedule _do_request_reconnect WITH defer=False — a call_soon_threadsafe that dropped the argument
+        # passed every other test and silently restored the end-of-turn reconnect for key cycles (fourth pass)
+        s = self._sess(7, auth="key")
+        scheduled = []
+
+        class _Loop:
+            def call_soon_threadsafe(self, cb, *args):
+                scheduled.append((cb, args))
+        s.loop = _Loop()
+        s.request_reconnect(defer=False)
+        s.request_reconnect()
+        self.assertEqual([(cb.__name__, args) for cb, args in scheduled],
+                         [("_do_request_reconnect", (False,)), ("_do_request_reconnect", (True,))])
+        s.ended = True
+        s.request_reconnect(defer=False)
+        self.assertEqual(len(scheduled), 2, "an ended session schedules nothing")
+
+    def test_the_loop_side_recheck_drops_a_key_cycle_that_found_the_session_busy(self):
+        # the kernel-thread check and the loop callback are two moments; a turn fed in between used to take
+        # _do_request_reconnect's else branch and arm the unconditional end-of-turn reconnect (third review pass)
+        s = self._sess(7, auth="key")
+        s._pending.append("a turn that arrived in between")
+        s._do_request_reconnect(defer=False)
+        self.assertFalse(s._reconnect); self.assertFalse(s._reconnect_when_idle, "not deferred: dropped")
+        self.assertTrue(any("before the reconnect ran" in m for m in self.logged))
+        s._do_request_reconnect(defer=True)                             # the settings switches still defer
+        self.assertTrue(s._reconnect_when_idle)
+        s._reconnect_when_idle = False; s._pending.clear()
+        s._subagents["agent-1"] = {"type": "local_agent", "since": 1.0}   # live work registered in between
+        s._do_request_reconnect(defer=False)
+        self.assertFalse(s._reconnect); self.assertFalse(s._reconnect_when_idle)
 
     def test_a_login_billed_session_is_left_alone(self):
         sid = self.be.spawn("n", "/tmp", auth="login")
@@ -387,6 +464,59 @@ class CycleReconnects(_Backend):
         self.assertEqual(self.be.cycle_key(sid), "dormant",
                          "no live CLI — its next launch reads the new key anyway")
         self.assertEqual(self.be.cycle_key("11111111-2222-3333-4444-999999999999"), "unknown")
+
+    def test_a_session_with_subagents_or_background_tasks_in_flight_is_skipped_not_cycled(self):
+        # a reconnect abandons the CLI process and _drop_live_work retires every subagent and background task
+        # inside it — the loss the keyswap exists to avoid, on a session that LOOKS idle (nothing of its own in
+        # flight while it waits on a background agent). Named, never cycled under its work (review find).
+        sid = self.be.spawn("n", "/tmp")
+        s = self._live(sid)
+        s._subagents["agent-1"] = {"type": "local_agent", "since": 1.0}
+        self.assertEqual(self.be.cycle_key(sid), "working")
+        self.assertEqual(self.reconnects, [], "no reconnect while a subagent runs")
+        s._subagents.clear()
+        s._bg_tasks["toolu_1"] = {"desc": "a long build", "type": "", "since": 2.0}
+        self.assertEqual(self.be.cycle_key(sid), "working")
+        self.assertEqual(self.reconnects, [], "…nor while a background task runs")
+        s._bg_tasks.clear()
+        self.assertEqual(self.be.cycle_key(sid), "cycling", "work all back → it cycles")
+        self.assertEqual(self.reconnects, [sid])
+
+    def test_a_busy_session_is_skipped_too_so_no_deferred_reconnect_can_kill_work_the_turn_starts_later(self):
+        # the settings switches hand a busy session a deferred end-of-turn reconnect that fires unconditionally;
+        # a background task the turn launches AFTER this check would die with it. "cycling" therefore means an
+        # immediate reconnect of a quiet session, nothing else (second review pass).
+        sid = self.be.spawn("n", "/tmp")
+        s = self._live(sid)
+        s.inflight = 1
+        self.assertEqual(self.be.cycle_key(sid), "working")
+        s.inflight = 0
+        s._pending.append("a queued turn")
+        self.assertEqual(self.be.cycle_key(sid), "working")
+        s._pending.clear()
+        self.assertEqual(self.reconnects, [], "never armed while a turn was in flight or queued")
+        self.assertEqual(self.be.cycle_key(sid), "cycling")
+        self.assertEqual(self.reconnects, [sid])
+
+    def test_a_session_whose_client_already_launched_on_the_live_key_is_current(self):
+        # idempotence: the operator re-runs --cycle-all until every session reads "current"; a session that
+        # already moved must not be reconnected again on every run
+        sid = self.be.spawn("n", "/tmp")
+        s = self._live(sid)
+        s._launched_key_fp = self.be.work_key_fp()
+        self.assertEqual(self.be.cycle_key(sid), "current")
+        self.assertEqual(self.reconnects, [])
+        s._launched_key_fp = "000000000000"                          # launched on some other key
+        self.assertEqual(self.be.cycle_key(sid), "cycling")
+        self.assertEqual(self.reconnects, [sid])
+
+    def test_a_connect_records_the_fingerprint_of_the_key_it_launched_on(self):
+        s = self._sess(9, auth="key")
+        self.be._options(s, dict)
+        self.assertEqual(s._launched_key_fp, ks.fingerprint(ks.read_key(self.path)))
+        s2 = self._sess(8, auth="login")
+        self.be._options(s2, dict)
+        self.assertEqual(s2._launched_key_fp, "")
 
     def test_nothing_about_the_session_is_persisted_because_nothing_about_it_changed(self):
         sid = self.be.spawn("n", "/tmp")
@@ -461,16 +591,20 @@ class KeyswapCli(_EnvFile):
             "rows": [{"session": "web", "status": "cycling"}, {"session": "api", "status": "dormant"}]}
         rc, said = self.run_cli("lowprio", "--cycle", "web,api")
         self.assertEqual(rc, 0)
-        self.assertEqual(self.posted[0][1], "/keycycle")
-        self.assertEqual(self.posted[0][2], {"sessions": ["web", "api"]})
+        self.assertEqual(self.posted[0][1:], ("/keycycle", {"sessions": []}), "the read comes first")
+        self.assertEqual(self.posted[-1][1], "/keycycle")
+        self.assertEqual(self.posted[-1][2], {"sessions": ["web", "api"]})
         self.assertIn("history kept", said)
         self.assertIn("sha256:" + ks.fingerprint(NEW_KEY), said,
                       "the kernel's own fingerprint is how the operator confirms it re-read the file")
 
     def test_cycle_all_asks_for_all_and_never_names_a_session_itself(self):
         cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "keyFp": ks.fingerprint(NEW_KEY), "rows": []}
         rc, _ = self.run_cli("lowprio", "--cycle-all")
-        self.assertEqual(self.posted[0][2], {"all": True})
+        self.assertEqual([b for _u, _p, b in self.posted], [{"sessions": []}, {"all": True}],
+                         "the read, then the cycle — and never a session named by the CLI itself")
 
     def test_the_swap_still_lands_when_no_kernel_is_reachable(self):
         rc, said = self.run_cli("lowprio", "--cycle-all")
@@ -484,6 +618,97 @@ class KeyswapCli(_EnvFile):
         rc, said = self.run_cli("lowprio", "--cycle-all")
         self.assertEqual(rc, 1)
         self.assertIn("romp refresh", said)
+
+    def test_the_kernels_fingerprint_is_compared_with_the_files_and_a_mismatch_is_loud(self):
+        # the operator procedure used to be "compare the two sha256 lines by eye"; the CLI now asks the kernel
+        # (a /keycycle read that names no session) and says MISMATCH when the kernel reads another key — the
+        # symptom of a path the kernel's environment does not carry, an unreadable file, or a startup fallback
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {"ok": True, "keyFp": "deadbeefcafe", "rows": []}
+        rc, said = self.run_cli()
+        self.assertEqual(self.posted[0][1:], ("/keycycle", {"sessions": []}), "a read: no session named")
+        self.assertEqual(rc, 1)
+        self.assertIn("MISMATCH", said)
+        self.assertIn("sha256:deadbeefcafe", said)
+        self.posted.clear()
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "keyFp": ks.fingerprint(ks.read_key(self.path)), "rows": []}
+        rc, said = self.run_cli()
+        self.assertEqual(rc, 0)
+        self.assertNotIn("MISMATCH", said)
+        self.assertIn("kernel      reads sha256:" + ks.fingerprint(ks.read_key(self.path)), said)
+        # after a swap the same check runs against the NEW key
+        cli._post = lambda u, p, b: {"ok": True, "keyFp": ks.fingerprint(NEW_KEY), "rows": []}
+        rc, said = self.run_cli("lowprio")
+        self.assertEqual(rc, 0); self.assertNotIn("MISMATCH", said)
+        cli._post = lambda u, p, b: {"ok": True, "keyFp": ks.fingerprint(OLD_KEY), "rows": []}
+        rc, said = self.run_cli("lowprio")                             # already swapped; the kernel still on the old
+        self.assertEqual(rc, 1); self.assertIn("MISMATCH", said)
+
+    def test_cycle_reads_and_compares_first_and_refuses_to_cycle_on_a_mismatch(self):
+        # cycling while the kernel reads another file would re-present the kernel's unchanged key to every
+        # named session; the read comes first and a mismatch stops the cycle before any reconnect
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {"ok": True, "keyFp": "deadbeefcafe",
+                                                                      "rows": [{"session": "web", "status": "cycling"}]}
+        rc, said = self.run_cli("lowprio", "--cycle", "web")
+        self.assertEqual(rc, 1)
+        self.assertIn("MISMATCH", said)
+        self.assertIn("NOT DONE", said)
+        self.assertEqual([b for _u, _p, b in self.posted], [{"sessions": []}], "the read only — nothing was cycled")
+        self.posted.clear()
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "keyFp": ks.fingerprint(NEW_KEY),
+            "rows": [{"session": "web", "status": "working"}, {"session": "api", "status": "current"}]}
+        rc, said = self.run_cli("lowprio", "--cycle", "web,api")
+        self.assertEqual(rc, 0)
+        self.assertEqual([b for _u, _p, b in self.posted], [{"sessions": []}, {"sessions": ["web", "api"]}])
+        self.assertIn("skipped: a turn, subagents or background tasks are in flight", said)
+        self.assertIn("already on this key", said)
+        self.assertIn("re-run the same --cycle", said)
+
+    def test_the_probe_itself_honours_the_override_and_refuses_an_unusable_one(self):
+        # _kernel() must USE _kernel_urls(): a revert of that one line passed every test (second review pass)
+        import io
+        import unittest.mock as mock
+        from contextlib import redirect_stderr
+        cli._kernel = self._kernel_before                            # the real probe, with urlopen stubbed
+        seen = []
+
+        def refuse(url, timeout=None):
+            seen.append(url)
+            raise OSError("refused")
+        with mock.patch.object(cli.urllib.request, "urlopen", refuse), \
+             mock.patch.dict(os.environ, {"ROMP_KERNEL_PORT": "45678"}):
+            self.assertIsNone(cli._kernel())
+        self.assertEqual(seen, ["http://127.0.0.1:45678/version"], "the override port, and nothing else, was probed")
+        seen.clear()
+        with mock.patch.object(cli.urllib.request, "urlopen", refuse), \
+             mock.patch.dict(os.environ, {"ROMP_KERNEL_PORT": "not-a-port"}):
+            self.assertIsNone(cli._kernel())
+            self.assertEqual(seen, [], "an unusable override probes nothing: the defaults are not a fallback")
+            # …and every surface says so with a non-zero exit, instead of "kernel not running" and rc 0
+            rc, said = self.run_cli()
+            self.assertEqual(rc, 1); self.assertIn("NOT ASKED", said); self.assertIn("not a port", said)
+            rc, said = self.run_cli("lowprio")
+            self.assertEqual(rc, 1); self.assertIn("NOT ASKED", said)
+            self.assertEqual(ks.read_key(self.path), NEW_KEY, "the file swap itself still landed")
+            rc, said = self.run_cli("lowprio", "--cycle-all")
+            self.assertEqual(rc, 1); self.assertIn("NOT DONE", said)
+        self.assertEqual(self.posted, [], "nothing was posted anywhere")
+
+    def test_the_kernel_port_override_is_the_only_port_probed(self):
+        # a renumbered second-OS-user instance must never hand its serve token to whatever answers on the
+        # primary user's default port (review find): with the override set, that port and nothing else
+        import unittest.mock as mock
+        with mock.patch.dict(os.environ, {"ROMP_KERNEL_PORT": "45678"}):
+            self.assertEqual(cli._kernel_urls(), ["http://127.0.0.1:45678"])
+        with mock.patch.dict(os.environ, {"ROMP_SERVE_PORT": "45679"}, clear=False):
+            os.environ.pop("ROMP_KERNEL_PORT", None)
+            self.assertEqual(cli._kernel_urls(), ["http://127.0.0.1:45679"])
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROMP_KERNEL_PORT", None); os.environ.pop("ROMP_SERVE_PORT", None)
+            self.assertEqual(cli._kernel_urls(), cli.KPORTS)
 
     def test_junk_options_are_refused_rather_than_read_as_a_source_name(self):
         self.assertEqual(self.run_cli("--wat")[0], 2)
@@ -596,6 +821,24 @@ class KeycycleRoute(unittest.TestCase):
         self.assertEqual(len(resp["rows"]), 2, "one bad session must not abandon the rest")
         self.assertIn("boom", resp["rows"][0]["status"])
 
+    def test_an_empty_session_list_is_a_read_of_the_fingerprint_and_cycles_nothing(self):
+        from unittest import mock
+        fake = self._Fake({"s-web": object()})
+        woke = []
+        with mock.patch.object(self.km, "_sdk", lambda: fake), \
+             mock.patch.object(self.km, "_sid_of", lambda w: "s-" + w), \
+             mock.patch.object(self.km, "_name_of", lambda sid: str(sid)[2:]), \
+             mock.patch.object(self.km, "_push_soon", lambda: woke.append(1)):
+            code, body = self._post({"sessions": []})
+            self.assertEqual(code, 200)
+            self.assertEqual(body["keyFp"], ks.fingerprint(NEW_KEY))
+            self.assertEqual(body["rows"], [])
+            self.assertEqual(fake.asked, [], "nothing was cycled")
+            self.assertEqual(woke, [], "a read does not wake the dashboard pusher")
+            code, body = self._post({"sessions": ["web"]})
+            self.assertEqual([r["status"] for r in body["rows"]], ["cycling"])
+            self.assertEqual(woke, [1], "a cycle does")
+
     def test_a_sessions_value_that_is_not_a_list_is_a_400(self):
         code, resp = self._with(self._Fake({}), {"sessions": "web"})
         self.assertEqual(code, 400, "a bare string would otherwise iterate its characters")
@@ -639,11 +882,23 @@ class NothingLeaksTheKey(_Backend):
         self.assertEqual(len(said), 2)
         self.assertIn(ks.fingerprint(NEW_KEY), said[1])
 
+    def test_the_announcement_names_the_startup_environment_when_the_file_has_no_line(self):
+        sb._WORK_KEY = OLD_KEY                                        # the boot claim (restored by tearDown)
+        with open(self.path, "w") as f:
+            f.write("ROMP_PERF=1\n")                                  # no key line: the startup claim is injected
+        self.assertEqual(self._launch_env()[ks.KEY_VAR], OLD_KEY)
+        said = [m for m in self.logged if m.startswith("work key:")]
+        self.assertEqual(len(said), 1)
+        self.assertIn("sha256:" + ks.fingerprint(OLD_KEY), said[0])
+        self.assertIn("environment this manager started with", said[0])
+        self.assertNotIn("read from", said[0], "never claim the file holds a key it does not")
+        self.assertNotIn(OLD_KEY, said[0])
+
     def test_a_cycle_log_line_carries_the_fingerprint_only(self):
         sid = self.be.spawn("n", "/tmp")
         s = self._sess(8, auth="key")
         s.sid, s.name = sid, "live"
-        s.request_reconnect = lambda: None
+        s.request_reconnect = lambda defer=True: None
         self.be.sessions[sid] = s
         self.be.cycle_key(sid)
         line = [l for l in self.logged if "keyswap" in l][0]


### PR DESCRIPTION
Review fold on #921 (merged as 96b378ba), landing as its own pull request because pushes to contributor fork branches are not available to the review session.

Review finds on #921 (two adversarial passes, each reproduced). (1) cycle_key reconnected any idle
key-billed session, and a reconnect abandons the CLI process — the subagents and background tasks
inside it die (_drop_live_work), the very loss the keyswap exists to avoid, on a session that looks
idle while it waits on a background agent; and a BUSY session was handed the deferred end-of-turn
reconnect the settings switches use, which fires unconditionally, so work the turn launched after the
check died with it. 'cycling' now means exactly one thing: an immediate reconnect of a session with
nothing in flight (no turn, no queued turn, no subagent, no background task); anything else reads
'working' and is named. Each connect records the fingerprint of the key it launched on, and a session
already on the live key reads 'current', so a repeated --cycle-all converges instead of churning.
(2) The operator procedure asked for the kernel's and the file's fingerprints to be compared by eye;
romp keyswap now asks the running kernel on every run (a /keycycle read that names no session), says
MISMATCH when they differ, and a --cycle refuses to reconnect anything until they agree. The read no
longer wakes the dashboard pusher; a cycle does. (3) The installer baked a non-default env-file path
into EnvironmentFile= but exported no variable, so the kernel's live read (keysource.service_env_path,
from the service's own environment) fell to the default path and keyswap rewrote a file the kernel
never read; romp-service now carries ROMP_SERVICE_ENV_FILE into the unit (quoted: systemd word-splits
an unquoted value) and the plist (XML-escaped) whenever the path is not the kernel's default; a default
install writes the identical unit and plist. (4) A symlinked service.env was replaced by a plain file,
leaving the link's target on the old key; write_key writes through the link. (5) The CLI probed three
fixed loopback ports and posted the serve token to the first responder, ignoring ROMP_KERNEL_PORT — a
renumbered instance would hand its token to the primary user's kernel; the override port is now the
only one probed, and an unusable override is refused rather than replaced by the defaults. (6) The
startup-vs-file agreement check was spent on a first read with nothing to compare. (7) The
change-only 'work key' log line claimed the key was read from the file even when the startup fallback
was injected; the provenance rides the one per-connect read. Docs follow. Tests for each, including
a bats case for the installer and a dead-port pin so the CLI cases never reach a developer's kernel.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
