### PR TITLE
The newline-less tail is read from the same cache entry that served the fold's records, and its verdict is memoized per file version

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -272,7 +272,9 @@ def _scan_bg_tasks(path, want_all=False):
 def _bg_fresh(want_all=False):
     """A fresh pairing state. `all`: keep every task's row (the launch-ordered history view); otherwise a
     task that reaches a terminal status is dropped from the state at once — the running-only view can
-    never show it again (no branch below ever returns an existing task to "running"), so a long-lived
+    never show it again (no record the harness emits returns an existing task to "running"; a literal
+    <status>running</status> notification after a terminal one is the one shape the old whole-file walk
+    would have resurrected, and the fold refuses), so a long-lived
     transcript's fold state stays the size of its in-flight work, not its history. `done` is that view's
     tombstone set: transcripts DO replay records — a duplicate async ack (same tool-use id, even the same
     uuid) can land after the terminal notification — and with the row gone such a replay would pass the
@@ -455,6 +457,9 @@ def scan_bg_tasks_cached(path, cache, want_all=False):
     is the caller's dict (the kernel keeps a running-only and an every-task cache; the judge its own), so
     the two views never invalidate each other and a test's `.clear()` still forces a re-fold."""
     state = fold_records(cache, path, lambda: _bg_fresh(want_all), _bg_step)
+    if state["all"] != bool(want_all):                    # the view is baked into the state at init: a cache handed to
+        raise ValueError("bg fold cache for %s is shaped for want_all=%r, asked for %r"   # both views would answer
+                         % (path, state["all"], bool(want_all)))                          # one of them wrong
     return _bg_finish(state, want_all)
 
 
@@ -584,13 +589,19 @@ def fold_records(cache, path, init, step):
 
     Lives here (moved from the kernel, 2026-09-03) so the judge's readers can fold too — the
     background-task pairing below is shared by both."""
-    recs = _read_jsonl_incremental(path)
     key = str(path)
-    hit = cache.get(key)
+    recs = _read_jsonl_incremental(path)
+    ent = _pinned_entry(key, recs)                        # the reader's entry for THIS read, pinned by identity: another
+    if ent is _UNPINNED:                                  # thread (the judge pool, a handler) may advance the shared entry
+        recs = _read_jsonl_incremental(path)              # past our records before we look at its tail, and a newer tail
+        ent = _pinned_entry(key, recs)                    # folded onto an older prefix would skip the records between. A
+        if ent is _UNPINNED:                              # lost pin re-reads once — the newer entry pins cleanly, so the
+            ent = None                                    # answer is current, not a poll behind; lost twice, the fold
+    hit = cache.get(key)                                  # answers without the tail, never with the wrong one
     if hit is not None:
         n0, last0, state0 = hit
         if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
-            return _fold_eof_fragment(key, state0, step)   # unchanged records; a newline-less tail may still sit past them
+            return _fold_eof_fragment(key, ent, state0, step)   # unchanged records; a newline-less tail may still sit past them
         if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
             state, start = copy.deepcopy(state0), n0
         else:
@@ -603,36 +614,78 @@ def fold_records(cache, path, init, step):
     if len(cache) > 256:                                  # bounded by the session count; never unbounded
         cache.clear()
     cache[key] = (len(recs), recs[-1] if recs else None, state)
-    return _fold_eof_fragment(key, state, step)
+    return _fold_eof_fragment(key, ent, state, step)
 
 
-def _trailing_record(path):
-    """The complete JSON record sitting past _read_jsonl_incremental's consumed offset WITHOUT its newline
-    yet, or None. The incremental reader leaves such a line unconsumed by design (a writer caught
-    mid-append must not enter the cache torn); the readers folded here used to walk the text to EOF and
-    saw a final newline-less record — so the fold reads it provisionally (see _fold_eof_fragment)."""
+_UNPINNED = object()
+
+
+def _pinned_entry(key, recs):
+    """The shared reader's cache entry for `key` if it still describes the read that returned `recs` (its
+    records list IS `recs`), None when the reader holds nothing for the path, _UNPINNED when another thread
+    has advanced the entry past that read."""
     with _JSONL_CACHE_LOCK:
-        hit = _JSONL_CACHE.get(path)
-    if hit is None or hit[1] <= hit[2]:                   # nothing past the consumed offset (the common case)
+        ent = _JSONL_CACHE.get(key)
+    if ent is not None and ent[4] is recs:
+        return ent
+    if ent is None and not recs:
+        return None                                        # the reader holds nothing because there is nothing (or no file)
+    return _UNPINNED                                       # advanced past our read — or evicted from under it (LRU)
+
+
+_TRAILING_CACHE = {}          # path -> ((mtime, size, offset), record|None): the tail verdict per file version, so a
+#                               torn tail that never completes (a CLI killed mid-write) costs one read, not one per poll.
+#                               LRU at _TRAILING_CACHE_MAX (the least recently used entry goes, never the whole memo:
+#                               a clear-at-cap above the cap re-reads every pending tail per poll — see _JSONL_CACHE_MAX)
+_TRAILING_CACHE_MAX = 256
+_TRAILING_LOCK = threading.Lock()   # the memo is shared by the pusher, the handler threads and the judge pools: the
+#                                     LRU pop/reinsert/evict are several dict ops, not one (an unlocked evict raised
+#                                     KeyError under two inserters at the cap, reproduced 2026-09-04)
+
+
+def _trailing_record(path, ent):
+    """The complete JSON record sitting past _read_jsonl_incremental's consumed offset WITHOUT its newline
+    yet, or None. `ent` is the reader's cache entry for the read being folded (mtime, size, offset, tail,
+    records; None when there is none). The incremental reader leaves such a line unconsumed by design (a
+    writer caught mid-append must not enter the cache torn); the readers folded here used to walk the text
+    to EOF and saw a final newline-less record — so the fold reads it provisionally (see _fold_eof_fragment).
+    The verdict is memoized per (mtime, size, offset): an unchanged file answers from memory, whether its
+    tail was a record or a torn fragment, with no I/O and no failed parse per poll (review find, 2026-09-04:
+    a CLI killed mid-write left a torn line that every fold reader re-read and re-failed on every push)."""
+    if ent is None or ent[1] <= ent[2]:                   # nothing past the consumed offset (the common case)
         return None
+    ver = (ent[0], ent[1], ent[2])
+    with _TRAILING_LOCK:
+        hit = _TRAILING_CACHE.get(path)
+        if hit is not None and hit[0] == ver:
+            _TRAILING_CACHE.pop(path, None)               # a served verdict is a used one: to the LRU tail
+            _TRAILING_CACHE[path] = hit
+            return hit[1]
+    o = None
     try:
         with open(path, "rb") as fh:
-            fh.seek(hit[2])
-            frag = fh.read(hit[1] - hit[2]).strip()
-        if not frag or b"\n" in frag:
-            return None
-        o = json.loads(frag.decode("utf-8", "replace"))
+            fh.seek(ent[2])
+            frag = fh.read(ent[1] - ent[2]).strip()
+        if frag and b"\n" not in frag:
+            o = json.loads(frag.decode("utf-8", "replace"))
     except (OSError, ValueError):
-        return None
-    return o if isinstance(o, dict) else None
+        o = None
+    o = o if isinstance(o, dict) else None
+    with _TRAILING_LOCK:                                  # the read above ran unlocked; two readers of one version
+        _TRAILING_CACHE.pop(path, None)                   # agree on the verdict, so the last writer wins harmlessly
+        while len(_TRAILING_CACHE) >= _TRAILING_CACHE_MAX:
+            del _TRAILING_CACHE[next(iter(_TRAILING_CACHE))]   # the least recently used goes first
+        _TRAILING_CACHE[path] = (ver, o)
+    return o
 
 
-def _fold_eof_fragment(key, state, step):
+def _fold_eof_fragment(key, ent, state, step):
     """fold_records' answer with a newline-less final record folded in PROVISIONALLY: applied to a copy,
     never to the cached state, so the record is folded for good exactly once — when its newline lands and
     the incremental reader serves it as a record. Keeps the old whole-file readers' answer (they saw that
-    final line) without giving up the cache's torn-write safety."""
-    frag = _trailing_record(key)
+    final line) without giving up the cache's torn-write safety. `ent` is the reader's entry for the very
+    read being folded (fold_records pins it by the identity of its records list), never a fresh lookup."""
+    frag = _trailing_record(key, ent)
     if frag is None:
         return state
     return step(copy.deepcopy(state), frag)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5923,7 +5923,7 @@ _BG_SCAN_CACHE = {}                       # path -> em.fold_records entry (runni
 
 
 def _bg_unresolved(path):
-    """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), mtime+size-cached.
+    """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), folded append-incrementally.
     The DURABLE awaited-work source: the pairing lives in the transcript, so unlike any live backend
     snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, copy
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
@@ -17621,7 +17621,7 @@ def _cmd_gestures(sid):
 # Surface run_in_background tasks in the chat: a launch (a tool_use with run_in_background:true) paired with
 # its <task-notification> result. The harness folds those notifications into "system reminders" inline; this
 # pulls them out as structured rows for a dedicated box (#bg-tasks) between the transcript and the composer.
-_bgtasks_cache = {}   # path -> ((mtime,size), [task dicts, no output])
+_bgtasks_cache = {}   # path -> em.fold_records entry (the running-only pairing state)
 
 
 # _result_text / _parse_task_notification / _scan_bg_tasks moved to event_model (2026-08-08): the judge's
@@ -17706,7 +17706,7 @@ def _bg_scan_cached(path):
     return em.scan_bg_tasks_cached(path, _bgtasks_cache, want_all=False)
 
 
-_bgall_cache = {}             # path -> ((mtime,size), [every task, launch-ordered])
+_bgall_cache = {}             # path -> em.fold_records entry (every task, launch-ordered)
 
 
 def _bg_scan_all_cached(path):

--- a/tests/test_bg_scan_fold.py
+++ b/tests/test_bg_scan_fold.py
@@ -14,6 +14,7 @@ import os
 import tempfile
 import time
 import unittest
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -371,6 +372,146 @@ class LastState(unittest.TestCase):
         finally:
             del sb.open
         self.assertLess(sum(sizes), self.p.stat().st_size // 4, "one block from the end, not the file")
+
+
+class FoldTailSafety(unittest.TestCase):
+    """The newline-less tail is read from the SAME cache entry that served the records being folded, and its
+    verdict is memoized per file version (review finds, 2026-09-04)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, "t.jsonl")
+        em._TRAILING_CACHE.clear()
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    @staticmethod
+    def _step(st, o):
+        return st + [o["n"]]
+
+    def test_a_tail_another_thread_exposed_is_never_folded_onto_an_older_prefix(self):
+        # thread A (the pusher) has read one record; the writer appends a newline-closed record and a newline-less
+        # one; thread B (a judge worker) reads and advances the SHARED reader entry past record 2; A resumes its fold
+        # with ITS one record. The tail past B's offset (3) belongs to B's read — folded onto A's prefix it would
+        # skip 2, and a one-poll "nothing running" feeds the settle gate and the awaiting lift, both irreversible.
+        cache = {}
+        _append(self.p, {"n": 1})
+        recs_a = em._read_jsonl_incremental(self.p)
+        self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1])
+        with open(self.p, "a") as f:
+            f.write(json.dumps({"n": 2}) + "\n" + json.dumps({"n": 3}))
+        _bump(self.p)
+        em._read_jsonl_incremental(self.p)                                    # B advances the shared entry
+        real, calls = em._read_jsonl_incremental, []
+
+        def stale_once(path):                                                 # A's first read is the stale one…
+            calls.append(path)
+            return recs_a if len(calls) == 1 else real(path)
+        with mock.patch.object(em, "_read_jsonl_incremental", stale_once):
+            self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2, 3],
+                             "the lost pin re-read: 2 for good and 3 provisionally — never 3 folded onto 1")
+        self.assertEqual(len(calls), 2, "…and one re-read pinned cleanly")
+        self.assertEqual(cache[self.p][0], 2, "3 waits for its newline before it enters the cache")
+        with mock.patch.object(em, "_read_jsonl_incremental", lambda path: recs_a):   # lost twice (a stale reader)
+            self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1],
+                             "no pin at all: the fold answers its own records without a tail, not with the wrong one")
+
+    def test_b_a_torn_tail_costs_one_read_per_file_version_not_one_per_poll(self):
+        cache = {}
+        _append(self.p, {"n": 1})
+        with open(self.p, "a") as f:
+            f.write('{"n": 2')                                                 # a writer killed mid-append
+        _bump(self.p)
+        self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1])
+        real_open, opened = open, []
+
+        def spy(path, *a, **k):
+            opened.append(str(path))
+            return real_open(path, *a, **k)
+        with mock.patch("builtins.open", spy):
+            for _ in range(3):
+                self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1])
+        self.assertEqual([o for o in opened if o == self.p], [], "an unchanged torn tail is not re-read per poll")
+        with open(self.p, "a") as f:
+            f.write("}")                                                       # the record completes, still no newline
+        _bump(self.p)
+        self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2], "a new file version is re-read")
+        with open(self.p, "a") as f:
+            f.write("\n")
+        _bump(self.p)
+        self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2])
+        self.assertEqual(cache[self.p][0], 2)
+
+    def test_d_the_tail_memo_evicts_its_least_recently_used_entry_never_the_whole_memo(self):
+        ent = (1.0, 10, 5, b"", [])                                            # a tail past the offset; the file is absent
+        for i in range(300):
+            self.assertIsNone(em._trailing_record("/nonexistent/TESTHOST/%d" % i, ent))
+        self.assertEqual(len(em._TRAILING_CACHE), em._TRAILING_CACHE_MAX)
+        self.assertIn("/nonexistent/TESTHOST/299", em._TRAILING_CACHE)
+        self.assertNotIn("/nonexistent/TESTHOST/43", em._TRAILING_CACHE, "the oldest went first")
+        em._trailing_record("/nonexistent/TESTHOST/44", ent)                    # a hit moves to the tail…
+        em._trailing_record("/nonexistent/TESTHOST/300", ent)                   # …so the next eviction skips it
+        self.assertIn("/nonexistent/TESTHOST/44", em._TRAILING_CACHE)
+        self.assertNotIn("/nonexistent/TESTHOST/45", em._TRAILING_CACHE)
+
+    def test_e_the_tail_memo_survives_concurrent_inserters_at_its_cap(self):
+        # the LRU pop / reinsert / evict are several dict operations: unlocked, two inserters at the cap took the same
+        # oldest key and the second `del` raised KeyError out of fold_records — an abandoned push or judge cycle
+        ent = (1.0, 10, 5, b"", [])
+        for i in range(em._TRAILING_CACHE_MAX):
+            em._trailing_record("/nonexistent/TESTHOST/seed/%d" % i, ent)
+        errors = []
+
+        def inserter(tag):
+            for i in range(400):
+                try:
+                    em._trailing_record("/nonexistent/TESTHOST/%s/%d" % (tag, i), (float(i), 10, 5, b"", []))
+                except Exception as e:                                          # noqa: BLE001 — the test collects them
+                    errors.append(e)
+        prev = __import__("sys").getswitchinterval()
+        __import__("sys").setswitchinterval(1e-6)
+        try:
+            ts = [__import__("threading").Thread(target=inserter, args=("t%d" % k,)) for k in range(8)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(60)
+        finally:
+            __import__("sys").setswitchinterval(prev)
+        self.assertFalse(any(t.is_alive() for t in ts))
+        self.assertEqual(errors, [])
+        self.assertLessEqual(len(em._TRAILING_CACHE), em._TRAILING_CACHE_MAX)
+
+    def test_f_a_pin_lost_to_eviction_re_reads_and_keeps_the_tail(self):
+        # the reader's entry can be evicted (its own LRU) between the read and the pin: a None entry with records in
+        # hand is a lost pin, not "the reader holds nothing" — it re-reads once and answers with the tail, as for a pin
+        # lost to a peer's advance
+        cache = {}
+        _append(self.p, {"n": 1})
+        with open(self.p, "a") as f:
+            f.write(json.dumps({"n": 2}))                                      # complete, no newline yet
+        _bump(self.p)
+        real, calls = em._read_jsonl_incremental, []
+
+        def evicted_once(path):
+            recs = real(path)
+            calls.append(path)
+            if len(calls) == 1:
+                with em._JSONL_CACHE_LOCK:
+                    em._JSONL_CACHE.pop(str(path), None)                       # gone from under the fold
+            return recs
+        with mock.patch.object(em, "_read_jsonl_incremental", evicted_once):
+            self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2], "re-read once; the tail rides")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(cache[self.p][0], 1)
+
+    def test_c_a_bg_cache_shaped_for_the_other_view_is_refused_loudly(self):
+        _append(self.p, _launch("toolu_1", "a"))
+        cache = {}
+        self.assertEqual([t["id"] for t in em.scan_bg_tasks_cached(self.p, cache, want_all=False)], ["toolu_1"])
+        with self.assertRaises(ValueError):
+            em.scan_bg_tasks_cached(self.p, cache, want_all=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Review fold on #916 (merged as 4ed07cf1), landing as its own pull request because pushes to contributor fork branches are not available to the review session.

Review finds on #916. (1) _trailing_record looked the reader's shared _JSONL_CACHE entry up afresh, after
fold_records had already taken its records: another thread (a judge worker, a handler) reading the same
transcript between the two could advance the entry, and the tail past ITS offset was folded onto the older
prefix — the records between were skipped, and a one-poll 'nothing running' feeds two irreversible
decisions (the settle gate's release, the awaiting-stamp lift). fold_records now takes the entry right
after its read and keeps it only when the entry's records list IS the list it holds; a lost pin (advanced
by a peer, or evicted from under the read) re-reads once — the newer entry pins cleanly, so the answer is
current — and lost twice the fold answers without the tail, never with the wrong one. (2) A torn tail
that never completes (a CLI killed mid-write) made every fold reader open, seek, read and fail a JSON
parse on every push, forever; the verdict is now memoized per (mtime, size, offset) under its own lock
(the memo is shared by the pusher, the handler threads and the judge pools), LRU-evicted at 256 paths
(never cleared whole: a clear-at-cap above the cap re-reads every pending tail per poll). (3)
scan_bg_tasks_cached refuses a cache shaped for the other view instead of answering one of them wrong.
Also: the _bg_fresh docstring names the one shape (a running notification after a terminal one) where
the fold and the old walk differ, stale cache-shape comments, and the kernel's now-unused copy import.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
