### PR TITLE
Review fold on #914: one sender per client, the resets and the chat sender share the client's slot lock

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26896,6 +26896,8 @@ def _new_ws_client(app, wid, sock, lock=None, q=None, start_sender=True):
     lock = lock if lock is not None else threading.Lock()
     now = _ws_clock()
     client = {"app": app, "wid": wid, "alive": True, "qbytes": 0, "qlock": threading.Lock(),
+              "dlock": threading.RLock(),   # serializes _send_slot per client: the handler's connect push and the
+              #                               pusher both send slots to one client (see _send_slot)
               "sock": sock, "since": now, "lastIn": now, "pingAt": None,
               "inRead": True}      # False while the handler thread is inside a dispatch (see _keepalive_all)
     client["send"] = _mk_ws_send(q, sock, client)
@@ -27022,8 +27024,8 @@ def _ws_recv_message(rfile, on_ping, on_pong=None):
     (a multi-MB base64 message) dissolved into one unparseable JSON prefix plus a train of silently
     dropped continuation frames, so the 📎 pick looked like it did nothing (the user 2026-08-10,
     Chrome on a phone; small desktop files sat under the threshold, which is why it never surfaced).
-    Control frames may interleave between fragments: pings are answered via on_ping, pongs are
-    dropped, close ends the read."""
+    Control frames may interleave between fragments: pings are answered via on_ping, pongs go to
+    on_pong (the liveness beat's answer) or are dropped without one, close ends the read."""
     frag_op, frag = None, None
     while True:
         op, payload, fin = _ws_recv(rfile)
@@ -27095,6 +27097,10 @@ def _keepalive_all(now=None):
         # LIVENESS (2026-09-03): a ping whose pong never came within WS_DEAD_S means the peer is gone —
         # however open the forwarder in between keeps the socket. Clients from before the factory (no
         # `sock`) are never judged: they cannot be shut down, and they cannot have been pinged.
+        in_read = c.get("inRead", True)          # read BEFORE the stamp: the handler ends a dispatch by clearing pingAt
+        #                                          and THEN setting inRead — read the other way round, a beat between
+        #                                          those two writes paired a stale ping with a fresh read state and
+        #                                          dropped a live peer (review find, 2026-09-04)
         pa = c.get("pingAt")                     # any pong or message clears this (see _note_ws_inbound), so an
         if pa is not None and c.get("sock") is not None and (now - pa) >= WS_DEAD_S:   # outstanding ping IS the silence…
             why = None
@@ -27102,7 +27108,7 @@ def _keepalive_all(now=None):
             # tab synchronously on that thread — tens of seconds on a cold kernel) the pong sits unread in
             # the receive buffer: unread is not missing. The handler resets the clock when it re-enters the
             # read (review 2026-09-03).
-            if not c.get("inRead", True):
+            if not in_read:
                 pass
             else:
                 # …and never a peer that is still DRAINING: sendall returning means the ping entered the socket,
@@ -27419,6 +27425,7 @@ _DELTA_SLOTS = {
 _DELTA_SEP = "\u001f"          # joins composite keys; never appears in an id or a sid
 _DELTA_MAX_FRACTION = 0.6      # a delta this large a fraction of the full payload is sent as the full instead
 _delta_parts_cache = {}        # frame type -> (payload object identity, parts) — one split per BUILD, shared by clients
+_delta_unkeyable_said = set()  # (frame type, why) already written to stderr: an unkeyable shape is said once, not per cycle
 
 
 def _delta_key(kind, it, prefix=""):
@@ -27466,6 +27473,12 @@ def _delta_split(kind, value):
                 continue
             for it in lst:
                 put(_delta_key(kind, it, pre), it, pre)
+    else:
+        # a value the kind cannot key (None where a list belongs, a list where a dict does): NOT zero entries —
+        # that split carried the value nowhere, and the client kept its assembled [] / {} while the kernel held
+        # something else, with no resync ever asked (review find, 2026-09-04). Unkeyable → the whole frame goes.
+        raise ValueError("%s collection is a %s, not a %s" % (
+            kind, type(value).__name__, "dict" if kind == "dict" or kind.startswith("dictlist:") else "list"))
     return ents, order
 
 
@@ -27476,9 +27489,17 @@ def _delta_parts(ftype, payload):
         return hit[1]
     kinds = _DELTA_SLOTS[ftype][1]
     try:
-        colls = {name: _delta_split(kind, payload.get(name)) for name, kind in kinds.items()}
-    except ValueError:
+        colls = {}
+        for name, kind in kinds.items():
+            try:
+                colls[name] = _delta_split(kind, payload.get(name))
+            except ValueError as e:
+                raise ValueError("%s: %s" % (name, e)) from None     # name the collection for the log line
+    except ValueError as e:
         parts = None                                   # a payload the protocol cannot key: this build goes whole
+        if (ftype, str(e)) not in _delta_unkeyable_said:   # …and says so once: a silent whole is a silent perf loss
+            _delta_unkeyable_said.add((ftype, str(e)))
+            sys.stderr.write("view-delta %s: payload cannot be keyed (%s); sending whole frames\n" % (ftype, e))
     else:
         rest = {kk: v for kk, v in payload.items() if kk not in kinds}
         rest_sig = json.dumps({kk: v for kk, v in rest.items() if kk not in _DEDUP_VOLATILE}, sort_keys=True, default=str)
@@ -27523,7 +27544,19 @@ def _order_shape(kind, order):
 def _send_slot(c, ftype, payload, pre, sig):
     """Send a bars/feed payload to one client: whole for a client without delta support (exactly as before),
     else as a delta against what that client holds. `pre`/`sig` are the shared full serialization and
-    dedup signature the pusher computed once per build."""
+    dedup signature the pusher computed once per build.
+    One thread at a time per client (review find, 2026-09-04): the socket handler's connect push (`ready` →
+    _push_one, on the handler thread) and the pusher's cycle both reach here for the same client, and both
+    read and write its held delta state. Unserialized, one interleaving — both find nothing held, a rebuild
+    lands between them, the handler's dedup slot is written first but its bytes go second — left the client
+    holding payload A while the kernel believed B, and every later delta was computed against B: silent
+    divergence until the next full. Before deltas the same race touched only the dedup dict, where a double
+    full was harmless. Re-entrant: the size fallback in _send_slot_delta calls back in on the same thread."""
+    with c.setdefault("dlock", threading.RLock()):     # setdefault is atomic: a client made without one gets one
+        _send_slot_locked(c, ftype, payload, pre, sig)
+
+
+def _send_slot_locked(c, ftype, payload, pre, sig):
     key = _DELTA_SLOTS[ftype][0]
     if not c.get("delta"):
         _send_client(c, key, payload, pre=pre, sig=sig)
@@ -30186,7 +30219,8 @@ ws.onerror=function(){try{ws.close();}catch(e){}};}
 function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);else queue.push(s);}
 // The delta reassembler. DELTA_KINDS mirrors the kernel's _DELTA_SLOTS: which top-level collections of each
 // slot are keyed, and how — "dict" (an object keyed by its own keys), "byid" (a list keyed by item id),
-// "bysid" (a list grouped by item sid, one entry per group). LAST holds, per slot, the revision, the last
+// "bykeys:a,b" (a list keyed by a composite of item fields), "dictlist:id" (an object of lists, each item keyed by its
+// lane and id). LAST holds, per slot, the revision, the last
 // full message handed to the bundle, and per-collection maps {order:[keys], items:{key:value}}. A delta
 // builds a NEW message object (the bundle may still hold the previous one) reusing every unchanged part.
 var DELTA_KINDS={bars:{turns:"dictlist:id",judging:"bykeys:sid,t,judge,t1",messages:"byid"},feed:{asks:"byid:itemId"}};var LAST={};var SEP="\u001f";

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27390,17 +27390,44 @@ def _dedup_sig(msg, s):
     return s
 
 
+def _client_lock(c):
+    """The client's slot lock (see _send_slot): made once by _new_ws_client; a client dict made without one (a
+    test, an older caller) gets one here. `get` first — setdefault would build and discard an RLock per call,
+    and _send_client runs per slot per client per cycle."""
+    lk = c.get("dlock")
+    return lk if lk is not None else c.setdefault("dlock", threading.RLock())
+
+
+def _client_reset_chat_sid(client, sid):
+    """needFull's per-sid half of _client_reset_chat_base: forget the tail we believe this client holds for ONE
+    session and drop its dedup slot — under the client's slot lock, for the same reason (review find,
+    2026-09-04): the pusher's _send_chat must land as a whole before or after these pops, or a tail decided
+    before them lands after them, echat is written back, and the repair push sends a chatTail the renderer
+    cannot apply (render.ts latches awaitingFull until a full session lands: the tab froze until reconnect)."""
+    with _client_lock(client):
+        client.get("echat", {}).pop(sid, None)
+        client.get("sent", {}).pop(("chat", sid), None)
+
+
 def _client_reset_chat_base(client):
     """Forget every session tail we believe this client holds. Both suppressors must go: the echat
     entries (their absence is what routes _send_chat down its full-session path) AND the ("chat", sid)
     dedup slots (_DEDUP_REPOST_S would otherwise eat the re-send as unchanged for 60s). The needFull
     handler does this per-sid; `ready` does it for the whole client — a renderer that just evaluated
     holds NOTHING, whatever this socket was sent before its listener existed (the stuck-« opening … »
-    class, the user 2026-09-02)."""
-    client.get("echat", {}).clear()
-    snt = client.get("sent", {})
-    for k in [k for k in snt if isinstance(k, tuple) and k and k[0] == "chat"]:
-        snt.pop(k, None)
+    class, the user 2026-09-02).
+    Under the client's slot lock (2026-09-04): this runs on the handler thread while the pusher's
+    _send_client inserts keys into the same `sent` dict — unserialized, the comprehension below raised
+    "dictionary changed size during iteration" (reproduced 161/200 runs at the default switch interval,
+    rarer live), the `ready` dispatch died in the handler's generic except, and the _push_one repair this
+    exists for was skipped for that pane, once per renderer life. The same lock serializes the two — and
+    _send_chat holds it across its read-decide-send-write, so a pusher chat send lands as a whole either
+    before the reset (its slot and tail entry are cleared, _push_one re-sends) or after it."""
+    with _client_lock(client):
+        client.get("echat", {}).clear()
+        snt = client.get("sent", {})
+        for k in [k for k in snt if isinstance(k, tuple) and k and k[0] == "chat"]:
+            snt.pop(k, None)
 
 
 # View deltas (2026-09-03). The timeline's bars and the feed used to cross the wire WHOLE on every change —
@@ -27552,7 +27579,7 @@ def _send_slot(c, ftype, payload, pre, sig):
     holding payload A while the kernel believed B, and every later delta was computed against B: silent
     divergence until the next full. Before deltas the same race touched only the dedup dict, where a double
     full was harmless. Re-entrant: the size fallback in _send_slot_delta calls back in on the same thread."""
-    with c.setdefault("dlock", threading.RLock()):     # setdefault is atomic: a client made without one gets one
+    with _client_lock(c):                             # one per client, made by _new_ws_client
         _send_slot_locked(c, ftype, payload, pre, sig)
 
 
@@ -27673,17 +27700,18 @@ def _send_client(c, key, msg, pre=None, sig=None):
     WebSocket client; the log makes the next one obvious."""
     s = pre if pre is not None else json.dumps(msg)
     sig = sig if sig is not None else _dedup_sig(msg, s)
-    prev = c.setdefault("sent", {}).get(key)
-    now = time.time()
-    if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
-        _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
-        return
-    c["sent"][key] = (sig, now)
-    _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
-    try:
-        c["send"](s)
-    except Exception:
-        c["alive"] = False
+    with _client_lock(c):    # the dedup dict is shared with the handler thread's `ready`
+        prev = c.setdefault("sent", {}).get(key)      # reset (_client_reset_chat_base) — one writer at a time
+        now = time.time()
+        if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
+            _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
+            return
+        c["sent"][key] = (sig, now)
+        _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
+        try:
+            c["send"](s)                              # enqueue only (never blocks): the lock is held for microseconds
+        except Exception:
+            c["alive"] = False
 
 
 def _send_chat(c, m, ms, change_from, led_changed):
@@ -27702,7 +27730,19 @@ def _send_chat(c, m, ms, change_from, led_changed):
     `ms` is the payload's full serialization, LAZY (the 2026-08-10 CPU fix, round two): None until some
     client actually takes the untrimmed full-send branch — the only consumer — at which point it is
     materialized ONCE and RETURNED, so the caller can hand it to the next client and keep it in the build
-    cache. The steady-state delta path never serializes the whole payload at all."""
+    cache. The steady-state delta path never serializes the whole payload at all.
+
+    Under the client's slot lock, read-decide-send-write as one step (2026-09-04): the handler thread's
+    `ready` reset (_client_reset_chat_base) clears echat and the dedup slots so its connect push sends the
+    full session to a renderer that holds nothing. With only the inner _send_client locked, a pusher send
+    DECIDED before the reset (pc read, tail branch chosen) could land after it — the popped slot let the
+    tail through and the write-back re-populated echat — and the connect push then found a held tail and
+    sent a chatTail the renderer had to refuse (needFull) and repair on a second round trip."""
+    with _client_lock(c):
+        return _send_chat_locked(c, m, ms, change_from, led_changed)
+
+
+def _send_chat_locked(c, m, ms, change_from, led_changed):
     sid = m["id"]
     evs = m.get("events") or []
     total = len(evs)
@@ -35499,8 +35539,7 @@ class Handler(BaseHTTPRequestHandler):
             # whole session (_send_chat's full path fires when echat has no entry for the sid) and the
             # delta stream re-bases from there. Per-CLIENT, so one stale pane never re-sends for the rest.
             sid = str(msg["id"])
-            client.get("echat", {}).pop(sid, None)
-            client.get("sent", {}).pop(("chat", sid), None)   # …and drop the dedup slot, so the full send lands
+            _client_reset_chat_sid(client, sid)               # …and drop the dedup slot, so the full send lands
             self._push_one(client)                            # repair NOW, not on the next 0.5-3s tick
             return
         if msg and msg.get("type") == "loadOlder" and msg.get("id"):

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -122,6 +122,10 @@ def test_needfull_handler_is_wired_in_the_kernel():
     i = src.find('msg.get("type") == "needFull"')
     assert i > 0, "the kernel must handle the client's needFull resync request"
     body = src[i:i + 1200]
+    if "_client_reset_chat_sid(client, sid)" in body:     # the pops moved under the client's slot lock (2026-09-04):
+        j = src.find("def _client_reset_chat_sid")        # pin the helper the handler calls
+        assert j > 0
+        body = src[j:j + 1200]
     assert '"echat"' in body and ".pop(sid, None)" in body, "must forget the client's tail base"
     assert '("chat", sid)' in body, "must drop the dedup slot so the full send lands"
 

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -501,6 +501,7 @@ class TwoThreadsOneClient(unittest.TestCase):
 
     def setUp(self):
         km._delta_parts_cache.clear()
+        km._delta_unkeyable_said.clear()      # the said-once latch is module-global: each test starts unsaid
         self._frac = km._DELTA_MAX_FRACTION
         km._DELTA_MAX_FRACTION = 10.0
 
@@ -528,8 +529,9 @@ class TwoThreadsOneClient(unittest.TestCase):
         self.assertTrue(entered.wait(5), "thread A is inside its frame")
         tb = threading.Thread(target=push, args=(pb,)); tb.start()
         tb.join(0.3)
-        self.assertTrue(tb.is_alive(), "thread B waits: the client's slot state is one thread's at a time")
-        self.assertEqual(c.frames, [], "…and nothing of B's crossed ahead of A's frame")
+        self.assertTrue(tb.is_alive(), "thread B is still inside _send_slot (with the lock, waiting for A; the frame "
+                                       "order below is what pins the lock — without it B parks in the same gate)")
+        self.assertEqual(c.frames, [], "nothing has crossed yet")
         gate.set(); ta.join(5); tb.join(5)
         self.assertFalse(ta.is_alive() or tb.is_alive())
         last = None                             # replay what the wire carried through the shim's mirror
@@ -588,6 +590,162 @@ class TwoThreadsOneClient(unittest.TestCase):
             km._keepalive_all(now=km.WS_DEAD_S + 1)
         self.assertEqual(dropped, [], "a live peer finishing its dispatch is never judged silent")
         self.assertEqual(c.reads, 2, "both keys were read once, read state first")
+
+    def test_d_the_ready_reset_and_a_chat_send_serialize_on_the_clients_lock(self):
+        # pre-existing (predates the PR), closed with the same lock: the handler thread's `ready` reset iterated the
+        # client's dedup dict while the pusher's _send_client inserted keys into it — "dictionary changed size during
+        # iteration", the ready dispatch dying in the handler's generic except, and the _push_one repair skipped.
+        client, _q, _lock = km._new_ws_client("chat", "w1", object(), start_sender=False)
+        client["send"] = lambda s: None
+        client.setdefault("sent", {})[("chat", S1)] = ("sig", 0.0); client["echat"] = {S1: 1}
+        client["dlock"].acquire()                       # "another thread" holds the client's lock…
+        done = []
+        t1 = threading.Thread(target=lambda: (km._client_reset_chat_base(client), done.append("reset")))
+        t2 = threading.Thread(target=lambda: (km._send_client(client, ("chat", S2), {"type": "chat"}), done.append("send")))
+        t1.start(); t2.start(); t1.join(0.3); t2.join(0.3)
+        try:
+            self.assertEqual(done, [], "…and both the reset and the send wait for it")
+        finally:
+            client["dlock"].release()
+        t1.join(5); t2.join(5)
+        self.assertEqual(sorted(done), ["reset", "send"])
+        self.assertNotIn(("chat", S1), client["sent"], "the reset cleared the slot it found (whichever ran first)")
+        self.assertEqual(client["echat"], {})
+        # and the interleaving itself, driven hard: many resets against many inserts, no RuntimeError
+        client2, _q2, _l2 = km._new_ws_client("chat", "w2", object(), start_sender=False)
+        client2["send"] = lambda s: None
+        errors = []
+        stop = threading.Event()
+
+        def inserter():
+            i = 0
+            while not stop.is_set():
+                try:
+                    km._send_client(client2, ("chat", "s%d" % i), {"type": "chat"})
+                except RuntimeError as e:
+                    errors.append(e)
+                i += 1
+
+        def resetter():
+            for _ in range(300):
+                try:
+                    km._client_reset_chat_base(client2)
+                except RuntimeError as e:
+                    errors.append(e)
+        prev = __import__("sys").getswitchinterval()
+        __import__("sys").setswitchinterval(1e-6)
+        try:
+            ti = threading.Thread(target=inserter); tr = threading.Thread(target=resetter)
+            ti.start(); tr.start(); tr.join(30); stop.set(); ti.join(30)
+        finally:
+            __import__("sys").setswitchinterval(prev)
+        self.assertFalse(tr.is_alive() or ti.is_alive())
+        self.assertEqual(errors, [])
+
+    def test_f_the_chat_sender_holds_the_clients_lock_across_its_read_decide_send_write(self):
+        # the reset clears echat AND the slots; a pusher chat send DECIDED before the reset (tail branch chosen from
+        # the old echat) and landed after it slipped its tail through the popped slot and wrote echat back, and the
+        # connect push then sent a chatTail to a renderer holding nothing. Discriminating shape: echat holds a tail
+        # base, the send is parked at the lock before it can read echat, the reset lands (re-entrant, from the lock's
+        # holder) and the lock is released — the fold sends the FULL session; a lock only around the inner
+        # _send_client would have read echat first and sent the chatTail.
+        client, _q, _lock = km._new_ws_client("chat", "w1", object(), start_sender=False)
+        frames = []
+        client["send"] = lambda s: frames.append(json.loads(s)["type"])
+        client["echat"] = {S1: ("u1", 0)}
+        client.setdefault("sent", {})[("chat", S1)] = ("sig", time.time())
+        m = {"type": "session", "id": S1, "events": [{"uuid": "u1", "kind": "prompt"}, {"uuid": "u2", "kind": "text"}],
+             "status": "ready"}
+        client["dlock"].acquire()
+        t = threading.Thread(target=lambda: km._send_chat(client, m, None, 1, False), daemon=True)
+        t.start(); t.join(0.3)
+        try:
+            self.assertTrue(t.is_alive(), "the chat send waits for the client's lock before reading anything")
+            self.assertEqual(frames, [])
+            km._client_reset_chat_base(client)          # the reset lands first (re-entrant: this thread holds the lock)
+            self.assertEqual(client["echat"], {})
+        finally:
+            client["dlock"].release()
+        t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertEqual(frames, ["session"], "decided after the reset: the whole session, not a tail")
+        self.assertEqual(client["echat"][S1], ("u1", 0))
+
+    def test_g_the_needfull_reset_takes_the_same_lock(self):
+        # the per-sid reset behind needFull popped echat[sid] and the dedup slot with no lock — the same race as the
+        # ready reset, and worse on the client: render.ts latches awaitingFull until a full session lands, so a
+        # chatTail sent instead left the tab frozen until reconnect. It now runs under the client's slot lock.
+        client, _q, _lock = km._new_ws_client("chat", "w1", object(), start_sender=False)
+        frames = []
+        client["send"] = lambda s: frames.append(json.loads(s)["type"])
+        client["echat"] = {S1: ("u1", 0), S2: ("x1", 0)}
+        client.setdefault("sent", {})[("chat", S1)] = ("sig", time.time())
+        client["dlock"].acquire()
+        done = []
+        tr = threading.Thread(target=lambda: (km._client_reset_chat_sid(client, S2), done.append("reset")), daemon=True)
+        tr.start(); tr.join(0.3)
+        self.assertTrue(tr.is_alive(), "the per-sid reset waits for the lock")
+        m = {"type": "session", "id": S1, "events": [{"uuid": "u1", "kind": "prompt"}, {"uuid": "u2", "kind": "text"}],
+             "status": "ready"}
+        ts = threading.Thread(target=lambda: km._send_chat(client, m, None, 1, False), daemon=True)
+        ts.start(); ts.join(0.3)
+        try:
+            self.assertTrue(ts.is_alive())
+            km._client_reset_chat_sid(client, S1)       # needFull for S1 lands before the parked send decides
+        finally:
+            client["dlock"].release()
+        tr.join(5); ts.join(5)
+        self.assertEqual(done, ["reset"])
+        self.assertNotIn(S2, client["echat"], "the parked per-sid reset ran once released")
+        self.assertEqual(frames, ["session"], "the send, decided after the needFull reset, is the whole session")
+
+    def test_h_the_lock_spans_the_send_decision_and_write_back_not_just_the_echat_read(self):
+        # test_f/test_g park the sender BEFORE it reads echat, so a lock around the read alone would also pass them.
+        # Here the sender has already DECIDED the tail and is parked inside _send_client: a reset arriving now must
+        # still wait, or the tail lands after the pops, echat is written back, and the repair push finds a held tail.
+        client, _q, _lock = km._new_ws_client("chat", "w1", object(), start_sender=False)
+        client["send"] = lambda s: None
+        client["echat"] = {S1: ("u1", 0)}
+        client.setdefault("sent", {})[("chat", S1)] = ("sig", time.time())
+        m = {"type": "session", "id": S1, "events": [{"uuid": "u1", "kind": "prompt"}, {"uuid": "u2", "kind": "text"}],
+             "status": "ready"}
+        gate, inside = threading.Event(), threading.Event()
+        real = km._send_client
+
+        def parked(c, key, msg, pre=None, sig=None):    # the tail branch was chosen; park before the bytes go
+            inside.set()
+            gate.wait(5)
+            return real(c, key, msg, pre=pre, sig=sig)
+        done = []
+        with mock.patch.object(km, "_send_client", parked):
+            ts = threading.Thread(target=lambda: km._send_chat(client, m, None, 1, False), daemon=True); ts.start()
+            self.assertTrue(inside.wait(5), "the sender decided its tail and is parked inside the send")
+            tr = threading.Thread(target=lambda: (km._client_reset_chat_base(client), done.append("reset")), daemon=True)
+            tr.start(); tr.join(0.3)
+            self.assertEqual(done, [], "the reset waits: the sender holds the lock through decision, send and write-back")
+            gate.set(); ts.join(5); tr.join(5)
+        self.assertFalse(ts.is_alive() or tr.is_alive())
+        self.assertEqual(done, ["reset"])
+        self.assertEqual(client["echat"], {}, "the reset ran after the whole send: the write-back did not survive it")
+        self.assertNotIn(("chat", S1), client["sent"])
+
+    def test_e_the_size_fallback_re_enters_the_slot_send_under_the_held_lock_and_completes(self):
+        # _send_slot_delta's 60% fallback calls _send_slot again on the SAME thread while the client's lock is held:
+        # the lock must be re-entrant — with a plain Lock the pusher hangs here forever (verified writing the fold)
+        km._DELTA_MAX_FRACTION = self._frac             # the real threshold
+        bar = lambda i: {"id": "seg-%d" % i, "t": i, "end": i + 1, "open": False}
+        st = _Stream("bars")
+        p1 = _bars({S1: [bar(i) for i in range(3)]}, [], [], now=1)
+        p2 = _bars({S1: [bar(i + 10) for i in range(3)]}, [], [], now=2)   # everything changed: no delta is smaller
+        done = []
+        # BOTH pushes on the guarded thread: with a plain Lock even the first (full) frame deadlocks in-thread
+        # (_send_slot → _send_client both take it), so a push on the main thread would hang the suite, not fail it
+        t = threading.Thread(target=lambda: (st.push(p1), done.append(st.push(p2))), daemon=True); t.start(); t.join(5)
+        self.assertFalse(t.is_alive(), "the fallback re-entered the lock and returned")
+        self.assertEqual([f["type"] for f in done[0]], ["bars"], "sent whole, and the stream re-based")
+        self.assertEqual(st.held, p2)
+        self.assertEqual(st.c["dstate"]["bars"]["rev"], 0)
+
 
 
 

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -18,7 +18,11 @@ import subprocess
 import tempfile
 import time
 import unittest
+import io
+import threading
+from contextlib import redirect_stderr
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -487,6 +491,105 @@ process.stdout.write(JSON.stringify({refused:r===null,rev:LAST.bars.rev}));"""
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertEqual(json.loads(r.stdout), {"refused": True, "rev": 0}, "a base mismatch is refused and nothing moves")
 
+class TwoThreadsOneClient(unittest.TestCase):
+    """The socket handler's connect push (`ready` runs _push_one on the handler thread) and the pusher's cycle
+    both reach _send_slot for the same client, and both read and write that client's held delta state.
+    Review find (2026-09-04): unserialized, one interleaving — both see nothing held, a rebuild lands between
+    them, the handler's dedup slot is written first but its bytes go second — left the client holding payload
+    A while the kernel believed B, and every later delta was computed against B: silent divergence until the
+    next full. The pre-PR race was on the stateless dedup dict alone, where a double full was harmless."""
+
+    def setUp(self):
+        km._delta_parts_cache.clear()
+        self._frac = km._DELTA_MAX_FRACTION
+        km._DELTA_MAX_FRACTION = 10.0
+
+    def tearDown(self):
+        km._DELTA_MAX_FRACTION = self._frac
+
+    def test_a_a_second_sender_waits_for_the_first_frame_and_the_client_ends_holding_the_newer_payload(self):
+        c = _Client()
+        gate, entered = threading.Event(), threading.Event()
+        real_send = c["send"]
+
+        def parked_send(s):                     # thread A parks INSIDE its frame: dedup slot written, state not yet
+            entered.set()
+            gate.wait(5)
+            real_send(s)
+        c["send"] = parked_send
+        bar = lambda i: {"id": "seg-%d" % i, "t": i, "end": i + 1, "open": False}
+        pa = _bars({S1: [bar(1)]}, [], [], now=1)
+        pb = _bars({S1: [bar(1), bar(2)]}, [], [], now=2)
+
+        def push(p):
+            pre = json.dumps(p)
+            km._send_slot(c, "bars", p, pre, km._dedup_sig(p, pre))
+        ta = threading.Thread(target=push, args=(pa,)); ta.start()
+        self.assertTrue(entered.wait(5), "thread A is inside its frame")
+        tb = threading.Thread(target=push, args=(pb,)); tb.start()
+        tb.join(0.3)
+        self.assertTrue(tb.is_alive(), "thread B waits: the client's slot state is one thread's at a time")
+        self.assertEqual(c.frames, [], "…and nothing of B's crossed ahead of A's frame")
+        gate.set(); ta.join(5); tb.join(5)
+        self.assertFalse(ta.is_alive() or tb.is_alive())
+        last = None                             # replay what the wire carried through the shim's mirror
+        for fr in c.frames:
+            if fr.get("type") == "delta":
+                out = _py_apply(last, fr)
+                self.assertIsNotNone(out, "the client could apply every delta it was sent")
+            else:
+                keys = fr.get("_keys")
+                msg = {kk: v for kk, v in fr.items() if kk != "_keys"}
+                last = {"rev": 0, "msg": msg, "maps": _py_maps(msg, keys)}
+        self.assertEqual([f["type"] for f in c.frames], ["bars", "delta"], "A's keyed full, then B's delta against it")
+        self.assertEqual(last["msg"], pb, "the client holds the newer payload…")
+        self.assertEqual(c["dstate"]["bars"]["rev"], 1, "…and the kernel's belief about it agrees")
+        self.assertEqual(c["dstate"]["bars"]["coll"]["turns"], {S1 + SEP + "seg-1": json.dumps(bar(1)), S1 + SEP + "seg-2": json.dumps(bar(2))})
+
+    def test_b_a_collection_that_is_neither_list_nor_dict_goes_whole_and_is_logged_once(self):
+        # _delta_split used to split an unexpected value (None where a list belongs) into ZERO entries, and the
+        # remainder did not carry it either: the client kept its assembled [] while the kernel held None, with no
+        # resync ever asked. Now the payload is unkeyable → the whole frame goes, and stderr says so once per shape.
+        st = _Stream("bars")
+        p1 = _bars({S1: [{"id": "seg-1", "t": 1, "end": 2, "open": False}]}, [], [{"id": "m1", "sent": 1}], now=1)
+        st.push(p1)
+        p2 = dict(p1, messages=None, now=2)
+        p3 = dict(p2, now=3, warming=True)      # a real change (`now` alone is volatile and dedups)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            frames = st.push(p2)
+            frames2 = st.push(p3)
+        self.assertEqual(frames, [p2], "unkeyable: the whole payload crossed, no keys, no empty split")
+        self.assertEqual(frames2, [p3])
+        self.assertNotIn("bars", st.c.get("dstate", {}), "the kernel holds nothing for a client it sent a keyless whole")
+        self.assertEqual(err.getvalue().count("cannot be keyed"), 1, "said once, not once per cycle")
+        self.assertIn("messages", err.getvalue())
+
+    def test_c_the_beat_reads_the_read_state_before_the_ping_stamp(self):
+        # the handler ends a dispatch with two writes: pingAt = None, THEN inRead = True. A beat reading pingAt
+        # first could pair the stale stamp with the fresh read state and drop a live peer as silent. Modelled
+        # exactly: whichever of the two keys the beat reads FIRST sees the pre-end state, the second the post state.
+        class _Handoff(dict):
+            def __init__(self):
+                super().__init__(app="timeline", wid="w1", alive=True, sock=object(), send=lambda s: None,
+                                 qlock=threading.Lock(), lastIn=0.0)
+                self.reads = 0
+
+            def get(self, k, d=None):
+                if k in ("pingAt", "inRead"):
+                    self.reads += 1
+                    pre = self.reads == 1
+                    return (0.0 if pre else None) if k == "pingAt" else (False if pre else True)
+                return super().get(k, d)
+        c = _Handoff()
+        dropped = []
+        with mock.patch.object(km, "_drop_dead_ws_client", lambda cl, why: dropped.append(why)), \
+             mock.patch.object(km, "_clients", [c]):
+            km._keepalive_all(now=km.WS_DEAD_S + 1)
+        self.assertEqual(dropped, [], "a live peer finishing its dispatch is never judged silent")
+        self.assertEqual(c.reads, 2, "both keys were read once, read state first")
+
+
 
 if __name__ == "__main__":
     unittest.main()
@@ -545,4 +648,3 @@ class HandlerWiring(unittest.TestCase):
         self.assertIn('send({type:"needSlot",slot:msg.slot})', js)
         self.assertIn("var IID=", js)
         self.assertNotIn('sessionStorage.setItem("romp:iid"', js, "the page id is never stored: a duplicated tab must not inherit it")
-

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -47,8 +47,14 @@ test("the kernel handles needFull by forgetting what that client holds", () => {
   assert.ok(KERNEL.includes('msg.get("type") == "needFull"'), "the kernel must handle the frame");
   const i = KERNEL.indexOf('msg.get("type") == "needFull"');
   const body = KERNEL.slice(i, i + 1200);
-  assert.ok(body.includes('"echat"'), "drop the client's tail base → next push sends a full session");
-  assert.ok(body.includes('("chat", sid)'), "drop the dedup slot → the full send isn't swallowed");
+  // the two pops live in _client_reset_chat_sid since 2026-09-04 (they run under the client's slot lock, so
+  // the pusher's _send_chat lands whole before or after them) — pin the handler's call AND the helper's body
+  assert.ok(body.includes("_client_reset_chat_sid(client, sid)"), "the handler forgets through the locked helper");
+  const h = KERNEL.indexOf("def _client_reset_chat_sid(client, sid):");
+  assert.ok(h >= 0, "the helper must exist");
+  const helper = KERNEL.slice(h, h + 1500);
+  assert.ok(helper.includes('"echat"'), "drop the client's tail base → next push sends a full session");
+  assert.ok(helper.includes('("chat", sid)'), "drop the dedup slot → the full send isn't swallowed");
   assert.ok(body.includes("_push_one(client)"), "repair immediately, not on the next tick");
 });
 


### PR DESCRIPTION
Review fold on #914 (merged as fcdaa5e3), landing as its own pull request because pushes to contributor fork branches are not available to the review session. Two commits:

## One thread at a time sends a client its view slots, an unkeyable collection goes whole and says so, and the beat reads the read state before the ping stamp

Review finds on #914. (1) The socket handler's connect push (ready → _push_one, on the handler thread) and
the pusher's cycle both reach _send_slot for the same client, and both read and write its held delta
state. Unserialized, one interleaving — both find nothing held, a rebuild lands between them, the
handler's dedup slot is written first but its bytes go second — left the client holding payload A while
the kernel believed B, and every later delta was computed against B: silent divergence until the next
full. A per-client re-entrant lock now serializes the slot send. (2) _delta_split split a value its kind
could not key (None where a list belongs) into zero entries, and the remainder did not carry it either:
the client kept its assembled [] while the kernel held None, with no resync ever asked. Unkeyable now
raises, so the whole frame goes, and stderr says so once per shape. (3) _keepalive_all read pingAt before
inRead; the handler ends a dispatch by clearing pingAt and THEN setting inRead, so a beat between those
two writes paired a stale stamp with a fresh read state and dropped a live peer — the beat reads inRead
first. Also: the shim comment names the kinds that exist, the reader docstring names on_pong. Tests: the
second sender waits and the client ends holding the newer payload with the kernel agreeing; an unkeyable
collection crosses whole, logged once; the two-write handoff modelled exactly never drops the peer.


## The ready reset, the needFull reset, the chat sender and every per-client send share the client's slot lock

Pre-existing (predates #914, present on main), surfaced by the adversarial passes over the previous fold
and reproduced: the socket handler's ready dispatch runs _client_reset_chat_base, a comprehension over
the client's dedup dict, while the pusher thread's _send_client inserts new slots into the same dict —
CPython raises 'dictionary changed size during iteration', the dispatch dies in the handler's generic
except, and the _push_one repair the reset exists for is skipped for that pane (once per renderer life).
Both now take the per-client re-entrant lock the previous fold introduced for the slot sends, and
_send_chat holds it across its whole read-decide-send-write: a chat send decided before a reset (tail
branch chosen from the old echat) but landed after it slipped its tail through the popped slot and wrote
echat back, so the repair push sent a chatTail to a renderer holding nothing — for the needFull reset
(now _client_reset_chat_sid, under the same lock) the renderer latches awaitingFull until a full session
lands, so that tab froze until reconnect. A pusher send now lands as a whole either before a reset or
after it. _client_lock reads the lock before falling back to setdefault, which would have built and
discarded an RLock per send. The lock is held across dict work and the enqueue, never a socket write.
Tests: reset, per-sid reset, slot send and chat send each wait while another thread holds the lock;
a chat send parked at the lock with a held tail base sends the FULL session once a reset lands ahead of it
(a lock only around the inner send would have sent the tail); 300 resets against a tight insert loop
raise nothing; the size fallback's re-entry completes (a plain Lock would hang); the said-once latch is
cleared per test.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
