### PR TITLE
Use the SDK-bundled Codex runtime for sessions

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -21,6 +21,8 @@ Codex sessions need, once per machine:
 
     This provisions a dedicated, pinned venv under romp's state dir (it never
     touches your system Python) and bundles the Codex binary.
+    Sessions use that SDK-bundled runtime even if another `codex` is on PATH.
+    Your existing CLI remains available for `codex login`.
 
 2. **A Codex login:**
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9719,7 +9719,8 @@ def _codex():
                     jd.STATE, notify=_send_to_app,
                     poke=_wake_kernel, push=_pusher_wake.set,
                     push_session=_push_session_now,
-                    codex_bin=shutil.which("codex"),   # None → the SDK's bundled binary resolver
+                    # Keep the app-server runtime paired with the installed SDK.
+                    # A separately installed CLI on PATH may use a different protocol.
                     log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
             except Exception:
                 sys.stderr.write("codex-backend unavailable: %s\n" % traceback.format_exc())

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -42,7 +42,6 @@ def until(fn, timeout, step=0.25, what=""):
 def main():
     state = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-state-"))
     workdir = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-cwd-"))
-    codex_bin = os.path.expanduser("~/.local/bin/codex")
     if os.environ.get("ROMP_SMOKE_SANDBOX") == "danger-full-access":
         # Boxes whose kernel restricts unprivileged user namespaces can't run Codex's bwrap
         # sandbox at all (bwrap: setting up uid map: Permission denied) — every command/patch
@@ -52,7 +51,7 @@ def main():
         #   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0   (+ persist in sysctl.d)
         cb.TURN_SANDBOX = {"type": "dangerFullAccess"}
         print("(sandbox override: dangerFullAccess — bwrap unavailable on this box)")
-    be = cb.CodexBackend(str(state), codex_bin=(codex_bin if os.path.exists(codex_bin) else None))
+    be = cb.CodexBackend(str(state))
     if not be.available():
         print("SMOKE SKIPPED: %s" % (be._client_err or "codex backend unavailable"))
         return 2

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -201,6 +201,22 @@ class HeadlessRoutes(unittest.TestCase):
         self.assertFalse(resp.get("ok"))
 
 
+class CodexRuntimeSelection(unittest.TestCase):
+    def test_path_codex_does_not_override_sdk_runtime(self):
+        fake_mod = mock.Mock()
+        fake_loader = mock.Mock()
+        fake_loader.load_module.return_value = fake_mod
+        with mock.patch.object(km, "_codex_backend", None), \
+             mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+             mock.patch.object(km.shutil, "which", return_value="/TESTBIN/codex"):
+            backend = km._codex()
+            self.assertIs(backend, fake_mod.CodexBackend.return_value)
+            self.assertIs(km._codex(), backend)
+        fake_mod.CodexBackend.assert_called_once()
+        self.assertIsNone(fake_mod.CodexBackend.call_args.kwargs.get("codex_bin"),
+                          "the SDK must resolve its bundled runtime even when codex is on PATH")
+
+
 class SdkSingleFlight(unittest.TestCase):
     """Concurrent _sdk() calls must construct exactly ONE backend. The 2026-07-06 storm: the eager
     boot thread + handler threads each passed the unlocked `if _sdk_backend is None` check and built


### PR DESCRIPTION
ROMP installs a pinned Codex SDK/runtime, but the kernel passes `shutil.which("codex")` to the backend. A separately installed CLI therefore overrides the runtime paired with the SDK.

Let the SDK resolve its bundled runtime for session app-server startup. Make the live smoke use the same default and document that the existing CLI can still be used for login. Explicit `CodexBackend(codex_bin=...)` overrides remain supported.

Validation:
- Added a behavioral kernel regression test with an unrelated Codex on PATH; it fails before the fix and passes afterward.
- Focused kernel/Codex suite: 104 passed, 5 subtests passed.
- Compared SDK 0.144.4 against PATH CLI 0.153.3 and bundled CLI 0.144.4 using the same ROMP workspace permission profile and temporary empty workspaces. Both initialized and recognized the login. CLI 0.153.3 failed at thread/start with a Bubblewrap loopback permission error; bundled 0.144.4 successfully created the thread. No model turns were sent.

This is a runtime-consistency fix, not a host sandbox workaround: a separate harmless sandbox command still failed with a UID-map permission error under bundled 0.144.4 on the restricted host. No AppArmor settings, sandbox policies, or approval behavior are changed. Full live turn smoke remains blocked by the host restriction; the full repository suite was not run locally.


Follow-up validation: a live turn with `gpt-6-astra` was rejected by the API because runtime 0.144.4 is too old for that model. A temporary session using the bundled runtime's advertised default `gpt-5.6-sol` and the new native Auto-review mode successfully executed a harmless command via escalation without host security changes. See the follow-up Auto-review PR for that feature. This PR alone changes runtime selection; it does not guarantee compatibility with every model configured for a newer standalone CLI.
