### PR TITLE
Add Codex Auto mode and a managed 0.153.3 runtime

### DIFF
--- a/bin/romp-codex-setup
+++ b/bin/romp-codex-setup
@@ -5,8 +5,8 @@
 # state dir ($STATE/codexvenv) and the kernel adds its site-packages to sys.path (ensure_codex_sdk in
 # kernel/codex_backend.py) — never the system python. The package is PINNED: `codex app-server`
 # self-describes as experimental, so upgrades are deliberate (bump the pin here and in
-# kernel/codex_backend.py SDK_PIN together). openai-codex bundles its own codex binary via the
-# openai-codex-cli-bin dependency, so no separate CLI install is required — though a machine still
+# kernel/codex_backend.py SDK_PIN together). kernel/codex_runtime.py separately pins the CLI
+# and its release hashes; the SDK dependency stays intact. No global CLI install is required, but a machine still
 # needs `codex login` once before sessions can run. Idempotent; other backends are unaffected.
 set -euo pipefail
 STATE="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"
@@ -71,16 +71,16 @@ v = getattr(m, "__version__", "?")
 print("romp-codex-setup: openai-codex %s ready (python %s)" % (v, ".".join(map(str, sys.version_info[:3]))))
 PY
 
-# Expose the BUNDLED codex CLI (2026-08-14 proofread finding): openai-codex ships the binary
-# INSIDE the venv (site-packages/codex_cli_bin/bin/codex) with no entry point on PATH — so
-# `codex login`, the very next setup step, was command-not-found on any machine without a
-# separate CLI install. An existing `codex` on PATH is respected (never clobbered); otherwise
-# the bundled one is symlinked to ~/.local/bin/codex, the spot the judges and `romp engine`
-# already probe.
+# Install the separately pinned official CLI wheel without replacing the SDK's own dependency.
+# The helper stages and verifies the complete package before publishing it under the state dir.
+_INSTALLER="$("$PY" -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve().parents[1] / "kernel/codex_runtime.py")' "${BASH_SOURCE[0]}")"
+_bundled="$("$VENV/bin/python" "$_INSTALLER" "$STATE")"
+echo "romp-codex-setup: $("$_bundled" --version) ready"
+
+# Expose the managed CLI for login only if the user has no existing CLI on PATH.
 if command -v codex >/dev/null 2>&1; then
     echo "romp-codex-setup: codex CLI already on PATH ($(command -v codex)) — leaving it be"
 else
-    _bundled="$(ls -d "$VENV"/lib/python3.*/site-packages/codex_cli_bin/bin/codex 2>/dev/null | head -n1 || true)"
     if [ -n "$_bundled" ] && [ -x "$_bundled" ]; then
         mkdir -p "$HOME/.local/bin"
         ln -sf "$_bundled" "$HOME/.local/bin/codex"
@@ -90,9 +90,9 @@ else
             *) echo "romp-codex-setup: note — ~/.local/bin isn't on this shell's PATH; add it, or call ~/.local/bin/codex directly" ;;
         esac
     else
-        echo "romp-codex-setup: warning — no bundled codex binary found in the venv; install the CLI yourself (npm i -g @openai/codex) before \`codex login\`" >&2
+        echo "romp-codex-setup: warning — managed Codex runtime is unavailable; rerun romp-codex-setup before \`codex login\`" >&2
     fi
 fi
 
 echo "romp-codex-setup: done. If this machine hasn't logged in yet, run: codex login"
-echo "romp-codex-setup: no restart needed — the kernel and judges pick this up automatically."
+echo "romp-codex-setup: restart the ROMP kernel to use the updated runtime in an already-running backend."

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -21,6 +21,8 @@ Codex sessions need, once per machine:
 
     This provisions a dedicated, pinned venv under romp's state dir (it never
     touches your system Python) and bundles the Codex binary.
+    Sessions use that SDK-bundled runtime even if another `codex` is on PATH.
+    Your existing CLI remains available for `codex login`.
 
 2. **A Codex login:**
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -69,6 +69,29 @@ Honest caveats while this is new:
   default model — a `gpt-*` value in `~/.local/state/romp/judge-model` is
   honored where the plan permits).
 
+## Approval modes
+
+Click the session's mode badge in the chat status line to choose **Sandboxed** or
+**Auto** while the session is idle. The choice is saved per session and restored
+when the kernel restarts. Existing and new sessions default to Sandboxed.
+
+- **Sandboxed:** commands stay within the workspace permission profile;
+  requests to execute outside it are denied.
+- **Auto:** the same sandbox stays enabled. Codex's own automatic reviewer
+  evaluates escalation requests (`on-request` with `auto_review`); ROMP does not
+  approve them itself. A reviewer refusal remains a refusal. Requests routed
+  back to ROMP for manual approval are declined with a warning because the
+  current SDK cannot wait for a UI answer without blocking its shared reader.
+
+Change modes between turns; an in-flight turn retains the mode it started with.
+Auto may allow a reviewed command to run outside the sandbox, so it has a wider
+execution scope than Sandboxed. It does not disable AppArmor or modify host
+security settings. It also cannot repair a runtime that fails before a thread
+starts, and reviewer availability is determined by Codex and your account.
+If the API says a model needs a newer Codex, select a compatible model from the
+model picker or upgrade the SDK and its runtime together; Auto cannot fix a
+model/runtime version mismatch.
+
 ## Sandboxing
 
 Codex runs its commands inside its own Linux sandbox (bubblewrap). Every
@@ -95,9 +118,9 @@ reads. Two host notes:
 
     (persist it in `/etc/sysctl.d/` to survive reboots).
 
-- There is no permission-prompt flow yet (approvals are pinned off; the
-  sandbox is the guardrail). Codex approval prompts surfacing as romp's
-  needs-you cards is planned.
+- Manual approval prompts are not yet interactive in ROMP. Auto mode uses
+  Codex's reviewer; a manual request that reaches ROMP is declined, never
+  silently accepted. Interactive needs-you approval cards remain planned.
 
 ## What works, what's coming
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -19,10 +19,18 @@ Codex sessions need, once per machine:
 
         romp-codex-setup
 
-    This provisions a dedicated, pinned venv under romp's state dir (it never
-    touches your system Python) and bundles the Codex binary.
-    Sessions use that SDK-bundled runtime even if another `codex` is on PATH.
-    Your existing CLI remains available for `codex login`.
+    This installs Python SDK **0.144.4** in a dedicated venv and Codex runtime
+    **0.153.3** under `codex-runtime/0.153.3/` in ROMP's state directory.
+    The runtime comes from OpenAI's official release wheels, pinned by SHA-256,
+    with its sandbox and code-mode helpers. Linux and macOS, x86-64 and ARM64,
+    are supported. Neither system Python nor the SDK's own dependency is replaced.
+    Sessions explicitly use this managed runtime even if another `codex` is on
+    PATH. Your existing CLI remains available for `codex login`.
+
+    Rerun setup to install the runtime when upgrading from an older ROMP version.
+    Restart the ROMP kernel after setup if its Codex backend is already running.
+    A missing or incomplete runtime produces a setup error; ROMP does not fall
+    back to an older SDK runtime or a CLI from PATH.
 
 2. **A Codex login:**
 
@@ -89,8 +97,9 @@ execution scope than Sandboxed. It does not disable AppArmor or modify host
 security settings. It also cannot repair a runtime that fails before a thread
 starts, and reviewer availability is determined by Codex and your account.
 If the API says a model needs a newer Codex, select a compatible model from the
-model picker or upgrade the SDK and its runtime together; Auto cannot fix a
-model/runtime version mismatch.
+model picker or update ROMP's pinned runtime; Auto cannot fix a model/runtime
+version mismatch. Bundling 0.153.3 addresses the older runtime's Astra version
+requirement, but does not guarantee startup on a host that blocks its sandbox.
 
 ## Sandboxing
 
@@ -101,22 +110,15 @@ and supplies exactly that session's working directory in
 files plus that workspace, so other user files on the host are not readable.
 Network remains enabled so git and web work keep working.
 
-There is an important pinned-runtime limitation: Codex 0.144.4 does not enforce
-narrower child rules against arbitrary processes inside a custom writable root.
-A shell command can therefore still modify `.git`, `.agents`, and `.codex`.
-The built-in `:workspace` profile enforces the metadata masks, but also grants
-read access to the whole host; romp currently chooses user-file
-confidentiality and documents this
-remaining metadata-integrity gap rather than silently restoring host-wide
-reads. Two host notes:
+The current profile grants write access to the entire workspace, including
+`.git`, `.agents`, and `.codex`. Metadata protection needs narrower filesystem
+rules; it is not provided by this profile. Two host notes:
 
-- The sandbox needs **unprivileged user namespaces**. Some images (notably
-  newer GCP Ubuntu) restrict them; every command then fails visibly with
-  `bwrap: … Permission denied`. To enable:
-
-        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-    (persist it in `/etc/sysctl.d/` to survive reboots).
+- The Linux sandbox needs **unprivileged user namespaces**. Host policy can
+  block it with a `bwrap: … Permission denied` error, including while Codex
+  reads instructions during thread creation. Installing 0.153.3 does not change
+  that policy. Follow your host's approved sandbox configuration; ROMP setup
+  does not modify AppArmor or system-wide namespace settings.
 
 - Manual approval prompts are not yet interactive in ROMP. Auto mode uses
   Codex's reviewer; a manual request that reaches ROMP is declined, never

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -98,8 +98,8 @@ security settings. It also cannot repair a runtime that fails before a thread
 starts, and reviewer availability is determined by Codex and your account.
 If the API says a model needs a newer Codex, select a compatible model from the
 model picker or update ROMP's pinned runtime; Auto cannot fix a model/runtime
-version mismatch. Bundling 0.153.3 addresses the older runtime's Astra version
-requirement, but does not guarantee startup on a host that blocks its sandbox.
+version mismatch. Runtime 0.153.3 supports Astra, but the host must also support
+sandbox creation as described below.
 
 ## Sandboxing
 
@@ -107,18 +107,30 @@ Codex runs its commands inside its own Linux sandbox (bubblewrap). Every
 thread and turn selects romp's custom `romp_workspace` permission profile
 and supplies exactly that session's working directory in
 `runtimeWorkspaceRoots`. The profile permits only Codex's minimal runtime
-files plus that workspace, so other user files on the host are not readable.
-Network remains enabled so git and web work keep working.
+files, the selected Codex executable and its packaged helpers, plus that
+workspace. Runtime assets are read-only; unrelated user files and the containing
+ROMP state directory are not exposed. Codex needs its own executable inside the
+sandbox to apply seccomp before starting a command. Network remains enabled so
+git and web work keep working.
 
 The current profile grants write access to the entire workspace, including
 `.git`, `.agents`, and `.codex`. Metadata protection needs narrower filesystem
 rules; it is not provided by this profile. Two host notes:
 
-- The Linux sandbox needs **unprivileged user namespaces**. Host policy can
-  block it with a `bwrap: … Permission denied` error, including while Codex
-  reads instructions during thread creation. Installing 0.153.3 does not change
-  that policy. Follow your host's approved sandbox configuration; ROMP setup
-  does not modify AppArmor or system-wide namespace settings.
+- On Linux, install the distribution's **bubblewrap** package. Codex 0.153.3
+  prefers a compatible system `bwrap` from PATH over its bundled helper.
+  Ubuntu 24.04 can additionally require its standard **bwrap-userns-restrict**
+  AppArmor profile, supplied by `apparmor-profiles`. That confined profile lets
+  `/usr/bin/bwrap` create the sandbox and denies capabilities to its children;
+  AppArmor and the global unprivileged-user-namespace restriction stay enabled.
+  Have the host administrator review and load that profile as appropriate;
+  see [Codex's Linux prerequisites](https://learn.chatgpt.com/docs/sandboxing#prerequisites).
+  ROMP setup does not change host security policy automatically.
+
+  Without a working helper, startup can fail while loading instructions with
+  `bwrap: … Permission denied` or `Failed RTM_NEWADDR: Operation not permitted`.
+  Auto review cannot repair this earlier initialization stage. The legacy
+  Landlock fallback cannot enforce this profile's restricted host reads.
 
 - Manual approval prompts are not yet interactive in ROMP. Auto mode uses
   Codex's reviewer; a manual request that reaches ROMP is declined, never

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -21,7 +21,7 @@ Shape of the machine:
   loudly, the moment a session tries to run (the 2026-07-28 rule: never a silent non-start).
 
 Everything Claude-only returns its documented empty value and the kernel stays loud about it:
-set_fast/set_mode/set_auth/stop_task/rewind_files → False, on_ask → False, current_ask → None.
+set_fast/set_auth/stop_task/rewind_files → False, on_ask → False, current_ask → None.
 """
 from __future__ import annotations
 
@@ -61,7 +61,18 @@ _WORKSPACE_PROFILE_OVERRIDE = (
 CODEX_CONFIG_OVERRIDES = (_WORKSPACE_PROFILE_OVERRIDE,
                           'default_permissions="romp_workspace"')
 TURN_SANDBOX = None   # explicit smoke-only legacy override (for hosts unable to run the sandbox)
-APPROVAL_POLICY = "never"
+APPROVAL_POLICY = "never"  # default: existing sessions remain sandboxed
+MODES = ("sandboxed", "auto")
+
+
+def _approval_params(mode="sandboxed"):
+    if mode == "auto":
+        return {"approvalPolicy": "on-request", "approvalsReviewer": "auto_review"}
+    if mode != "sandboxed":
+        raise ValueError("Unsupported Codex mode: %s" % mode)
+    # Reset the reviewer as well: thread/resume otherwise inherits a previous Auto selection.
+    return {"approvalPolicy": APPROVAL_POLICY, "approvalsReviewer": "user"}
+
 # romp effort names → Codex ReasoningEffort. Identity for the shared four; max/ultracode are
 # Claude-only knobs and set_effort refuses them (False → the kernel warns instead of pretending).
 EFFORTS = ("low", "medium", "high", "xhigh")
@@ -197,6 +208,8 @@ class _Session:
         self.cwd = cwd
         self.model = model
         self.effort = effort
+        self.mode = "sandboxed"
+        self.mode_lock = threading.Lock()  # guards policy changes against an in-flight turn
         self.color = color            # identity bg — also in names/<sid> (fields 3/4), the shared store
         self.dead = False
         self.state = "waiting"        # waiting | working (the two states this backend can know)
@@ -280,6 +293,11 @@ class CodexBackend:
                     continue
                 s = _Session(sid, r["tid"], r.get("name", ""), r.get("cwd", ""),
                              r.get("model", ""), r.get("effort", ""), r.get("color", ""))
+                saved_mode = r.get("mode", "sandboxed")
+                if saved_mode in MODES:
+                    s.mode = saved_mode
+                else:
+                    self.log("unknown Codex mode in registry; retaining sandboxed mode")
                 s.dead = bool(r.get("dead"))
                 queue_entries = self._registry_queue_entries(sid, r.get("queue"))
                 s.queue = [entry["text"] for entry in queue_entries]
@@ -341,7 +359,7 @@ class CodexBackend:
             if len(s.queue_ids) != len(s.queue):
                 raise RuntimeError("Codex in-memory queue identity invariant failed for %s" % s.sid)
             return {"tid": s.tid, "name": s.name, "cwd": s.cwd,
-                    "model": s.model, "effort": s.effort, "dead": s.dead,
+                    "model": s.model, "effort": s.effort, "mode": s.mode, "dead": s.dead,
                     "queue": [{"id": entry_id, "text": text}
                               for entry_id, text in zip(s.queue_ids, s.queue)],
                     "note": s.note, "color": s.color,
@@ -396,7 +414,7 @@ class CodexBackend:
         its session RLock through this transaction, so same-process snapshots cannot commit out of
         order. Snapshotting still happens before the registry lock, so no reverse lock edge exists.
         """
-        allowed = {"tid", "name", "cwd", "model", "effort", "dead", "note", "color",
+        allowed = {"tid", "name", "cwd", "model", "effort", "mode", "dead", "note", "color",
                    "launchError"}
         fields = set(fields)
         unknown = fields - allowed
@@ -480,7 +498,7 @@ class CodexBackend:
                         raise RuntimeError(SETUP_HINT)
                     from openai_codex.client import CodexClient, CodexConfig
                     cfg = _codex_config(CodexConfig, self.codex_bin)
-                    candidate = CodexClient(config=cfg)
+                    candidate = CodexClient(config=cfg, approval_handler=self._handle_approval)
                     candidate.start()
                     candidate.initialize()
                 self._check_auth(candidate)
@@ -535,6 +553,30 @@ class CodexBackend:
             # If it was invalidated between _get_client and turn/start, use a deliberately stale
             # sentinel. The worker then sees the generation mismatch and rebuilds automatically.
             return self._client_generation if self._client is client else -1
+
+    def _handle_approval(self, method, params):
+        """Never inherit the SDK's permissive default for requests routed to the client.
+
+        Auto review happens inside Codex. A request reaching this callback needs a human,
+        but the pinned SDK invokes it on its single reader thread. Waiting for UI input
+        here would stall responses and notifications for every session, including interrupts.
+        Decline supported requests immediately and make the limitation visible.
+        """
+        text = ("Codex requested input or manual approval that romp cannot handle yet. "
+                "The request was declined; no permission was granted.")
+        self.log("manual Codex request declined: %s" % method)
+        try:
+            self.notify("chat", {"type": "warn", "text": text})
+        except Exception:
+            pass  # a disconnected UI must never turn a denial into an approval
+        if method in ("item/commandExecution/requestApproval", "item/fileChange/requestApproval"):
+            return {"decision": "decline"}
+        if method == "item/permissions/requestApproval":
+            return {"permissions": {}, "scope": "turn"}
+        if method == "item/tool/requestUserInput":
+            return {"answers": {}}
+        # Unknown reply schemas must fail the transport rather than accidentally grant access.
+        raise RuntimeError("Unsupported Codex server request: %s" % method)
 
     def _check_auth(self, client):
         """A missing `codex login` must surface as text on the session, not as a hung turn."""
@@ -646,7 +688,7 @@ class CodexBackend:
                 if s.dead:
                     continue
                 row = {"state": s.state, "model": s.model, "effort": s.effort,
-                       "mode": "sandboxed", "since": s.since, "context": None,
+                       "mode": s.mode, "since": s.since, "context": None,
                        "compactPct": None, "backend": "codex", "name": s.name,
                        "cwd": s.cwd, "color": s.color or None}
             with s.norm_lock:
@@ -762,7 +804,29 @@ class CodexBackend:
         return self._catalog
 
     def set_mode(self, sid, mode):
-        return False   # phase 1 pins approval never + the custom permission profile; no live knob
+        s = self._session(sid)
+        if not s or mode not in MODES or not s.mode_lock.acquire(blocking=False):
+            return False
+        try:
+            with s.lock:
+                if s.dead:
+                    return False
+                previous = s.mode
+                s.mode = mode
+                try:
+                    self._save_registry(s, fields=("mode",))
+                except BaseException:
+                    s.mode = previous
+                    raise
+                s.change_generation += 1
+                queued = bool(s.queue)
+            if queued:
+                self._ensure_worker(s)
+                s.kick.set()
+        finally:
+            s.mode_lock.release()
+        self.push_session(sid)
+        return True
 
     def set_effort(self, sid, value):
         s = self._session(sid)
@@ -857,7 +921,7 @@ class CodexBackend:
             #                                retry mint a duplicate live "web" (the v1.3.12 audit)
             return sid
         try:
-            resp = c.thread_start({"cwd": cwd, "approvalPolicy": APPROVAL_POLICY,
+            resp = c.thread_start({"cwd": cwd, **_approval_params(),
                                    **_execution_permissions(cwd, thread_start=True)})
             tid = resp.thread.id
             model = getattr(resp, "model", "") or ""
@@ -1046,7 +1110,7 @@ class CodexBackend:
             tid, cwd = s.tid, s.cwd
             create = tid.startswith("pending-") or tid.startswith("failed-")
         if create:
-            resp = c.thread_start({"cwd": cwd, "approvalPolicy": APPROVAL_POLICY,
+            resp = c.thread_start({"cwd": cwd, **_approval_params(s.mode),
                                    **_execution_permissions(cwd, thread_start=True)})
             with s.lock:
                 if s.dead:
@@ -1099,7 +1163,8 @@ class CodexBackend:
                              % (s.sid, e))
             self.push()
             return True
-        c.thread_resume(tid, {"cwd": cwd, **_execution_permissions(cwd, thread_start=True)})
+        c.thread_resume(tid, {"cwd": cwd, **_approval_params(s.mode),
+                              **_execution_permissions(cwd, thread_start=True)})
         with s.lock:
             if s.dead:
                 return False
@@ -1182,6 +1247,12 @@ class CodexBackend:
                     s.worker = None
 
     def _run_turn(self, s):
+        # Mode changes take effect between turns. Nonblocking set_mode refuses while this
+        # lock is held, including thread preparation and the turn/start acknowledgement gap.
+        with s.mode_lock:
+            return self._run_turn_in_mode(s)
+
+    def _run_turn_in_mode(self, s):
         c = self._get_client()
         if c is None:
             try:
@@ -1218,7 +1289,7 @@ class CodexBackend:
                 raise RuntimeError("Codex in-memory queue identity invariant failed for %s" % s.sid)
             if not batch:
                 return True
-            params = {"approvalPolicy": APPROVAL_POLICY, "cwd": s.cwd,
+            params = {**_approval_params(s.mode), "cwd": s.cwd,
                       **_execution_permissions(s.cwd)}
             if s.model:
                 params["model"] = s.model

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -54,9 +54,17 @@ LOGIN_HINT = "Codex isn't logged in on this machine — run: codex login"
 # metadata directories remain writable (documented in docs/codex.md) rather than carrying misleading
 # read-only entries that its arbitrary-process sandbox ignores.
 WORKSPACE_PERMISSION = "romp_workspace"
-_WORKSPACE_PROFILE_OVERRIDE = (
-    'permissions.romp_workspace={ filesystem = { ":minimal" = "read", '
-    '":workspace_roots" = { "." = "write" } }, network = { enabled = true } }')
+
+
+def _workspace_profile_override(runtime_reads=()):
+    entries = ['":minimal" = "read"', '":workspace_roots" = { "." = "write" }']
+    entries.extend('%s = "read"' % json.dumps(str(path), ensure_ascii=False)
+                   for path in runtime_reads)
+    return ('permissions.romp_workspace={ filesystem = { %s }, '
+            'network = { enabled = true } }') % ", ".join(entries)
+
+
+_WORKSPACE_PROFILE_OVERRIDE = _workspace_profile_override()
 # 0.144.4 rejects any custom [permissions] table unless default_permissions is also selected.
 # Selecting it globally is a defense in depth; thread/resume/turn still name it explicitly.
 CODEX_CONFIG_OVERRIDES = (_WORKSPACE_PROFILE_OVERRIDE,
@@ -144,11 +152,20 @@ def _codex_config(config_cls, codex_bin, state_dir=None):
     if codex_bin is None:
         exe = _runtime.runtime_path(state_dir)
         codex_bin = str(exe)
-    helpers = Path(codex_bin).parent.parent / "codex-path"
+    exe = Path(codex_bin).resolve()
+    package = exe.parent.parent if exe.parent.name == "bin" else exe.parent
+    helpers = package / "codex-path"
     if helpers.is_dir():
         extra["env"] = {"PATH": str(helpers) + os.pathsep + os.environ.get("PATH", os.defpath)}
+    # bwrap re-enters Codex to apply seccomp before launching the requested command.
+    # :minimal covers OS runtime files, not an installation in the user's state directory.
+    # Expose only the executable and known packaged assets, never its containing state/home dir.
+    assets = (exe.parent / "codex-code-mode-host", package / "codex-package.json",
+              package / "codex-resources", helpers)
+    reads = tuple(dict.fromkeys([exe, *(path.resolve() for path in assets if path.exists())]))
+    overrides = (_workspace_profile_override(reads), *CODEX_CONFIG_OVERRIDES[1:])
     return config_cls(codex_bin=codex_bin, client_name="romp",
-                      config_overrides=CODEX_CONFIG_OVERRIDES, **extra)
+                      config_overrides=overrides, **extra)
 
 
 def ensure_codex_sdk(state_dir):

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 HERE = Path(os.path.dirname(os.path.realpath(__file__)))
 _events = SourceFileLoader("romp_codex_events", str(HERE / "codex_events.py")).load_module()
+_runtime = SourceFileLoader("romp_codex_runtime", str(HERE / "codex_runtime.py")).load_module()
 
 SDK_PIN = "openai-codex==0.144.4"     # bin/romp-codex-setup installs exactly this into codexvenv
 SETUP_HINT = ("Session not created: the Codex backend isn't installed. "
@@ -134,13 +135,20 @@ def _execution_permissions(cwd, thread_start=False):
     return {"permissions": WORKSPACE_PERMISSION, "runtimeWorkspaceRoots": [root]}
 
 
-def _codex_config(config_cls, codex_bin):
-    """Build the pinned SDK launch config in one testable place.
+def _codex_config(config_cls, codex_bin, state_dir=None):
+    """Launch ROMP's managed CLI, with its matching helpers, independently of PATH.
 
-    In 0.144.4, custom profiles are process config while each thread/turn supplies its runtime root.
+    An explicit executable remains available for callers testing another runtime.
     """
+    extra = {}
+    if codex_bin is None:
+        exe = _runtime.runtime_path(state_dir)
+        codex_bin = str(exe)
+    helpers = Path(codex_bin).parent.parent / "codex-path"
+    if helpers.is_dir():
+        extra["env"] = {"PATH": str(helpers) + os.pathsep + os.environ.get("PATH", os.defpath)}
     return config_cls(codex_bin=codex_bin, client_name="romp",
-                      config_overrides=CODEX_CONFIG_OVERRIDES)
+                      config_overrides=CODEX_CONFIG_OVERRIDES, **extra)
 
 
 def ensure_codex_sdk(state_dir):
@@ -497,7 +505,7 @@ class CodexBackend:
                     if not ensure_codex_sdk(self.state):
                         raise RuntimeError(SETUP_HINT)
                     from openai_codex.client import CodexClient, CodexConfig
-                    cfg = _codex_config(CodexConfig, self.codex_bin)
+                    cfg = _codex_config(CodexConfig, self.codex_bin, self.state)
                     candidate = CodexClient(config=cfg, approval_handler=self._handle_approval)
                     candidate.start()
                     candidate.initialize()

--- a/kernel/codex_runtime.py
+++ b/kernel/codex_runtime.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Install ROMP's pinned CLI separately from the Python SDK's runtime dependency.
+
+The CLI wheel is an official release artifact, not yet published on PyPI. Keep
+its complete package layout (including sandbox and code-mode helpers) intact.
+"""
+import fcntl
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+VERSION = '0.153.3'
+# SHA-256 digests published with OpenAI's rust-v0.153.3 GitHub release.
+_WHEELS = {
+    ('Linux', 'x86_64'): ('manylinux_2_17_x86_64', '35e8524f7d3ad16afa2fbabfff8730a932b74db09831514ffe7b0181e6169b65'),
+    ('Linux', 'aarch64'): ('manylinux_2_17_aarch64', '52649619ca29d09981e4502d054c03358be6e9fdc992f073117157453e69014d'),
+    ('Darwin', 'x86_64'): ('macosx_10_9_x86_64', '1cb81fb889433556de776211eea39ab475410f740e66916b02e3196735409535'),
+    ('Darwin', 'arm64'): ('macosx_11_0_arm64', 'd8908affb145935f506554d7575178d8b66ff5434d816d533a5ae253c97e6983'),
+}
+
+
+def wheel_url(system=None, machine=None):
+    key = (system or platform.system(), machine or platform.machine())
+    try:
+        tag, digest = _WHEELS[key]
+    except KeyError:
+        raise RuntimeError('Unsupported Codex runtime platform: %s %s' % key) from None
+    name = 'openai_codex_cli_bin-%s-py3-none-%s.whl' % (VERSION, tag)
+    return ('https://github.com/openai/codex/releases/download/rust-v%s/%s#sha256=%s'
+            % (VERSION, name, digest))
+
+
+def _package_path(target):
+    root = Path(target) / 'codex_cli_bin'
+    try:
+        metadata = json.loads((root / 'codex-package.json').read_text())
+        if metadata.get('version') != VERSION:
+            raise ValueError('wrong runtime version')
+        files = ['bin/codex', 'bin/codex-code-mode-host', 'codex-path/rg']
+        if platform.system() == 'Linux':
+            files += ['codex-resources/bwrap', 'codex-resources/zsh/bin/zsh']
+        if any(not (root / name).is_file() or not os.access(root / name, os.X_OK)
+               for name in files):
+            raise ValueError('missing runtime executable or helper')
+    except (OSError, ValueError, AttributeError) as e:
+        raise RuntimeError('Codex runtime %s is missing or incomplete. '
+                           'Run romp-codex-setup, then restart the ROMP kernel.' % VERSION) from e
+    return root / 'bin/codex'
+
+
+def runtime_path(state_dir):
+    return _package_path(Path(state_dir) / 'codex-runtime' / VERSION)
+
+
+def install_runtime(state_dir):
+    url = wheel_url()  # Refuse unsupported hosts before creating an installation.
+    base = Path(state_dir).resolve() / 'codex-runtime'
+    base.mkdir(parents=True, exist_ok=True)
+    target = base / VERSION
+    # Serialize concurrent setup calls and publish only a validated full package.
+    with (base / 'install.lock').open('a') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            return _package_path(target)
+        except RuntimeError:
+            pass
+        with tempfile.TemporaryDirectory(prefix='.install-', dir=base) as scratch:
+            staging = Path(scratch) / 'runtime'
+            subprocess.run([
+                sys.executable, '-m', 'pip', '--isolated', 'install', '--quiet',
+                '--disable-pip-version-check', '--no-index', '--no-deps',
+                '--only-binary=:all:', '--require-hashes', '--target', str(staging), url,
+            ], check=True)
+            exe = _package_path(staging)
+            result = subprocess.run([str(exe), '--version'], check=True,
+                                    capture_output=True, text=True, timeout=15)
+            if result.stdout.strip() != 'codex-cli ' + VERSION:
+                raise RuntimeError('Downloaded Codex runtime has an unexpected version')
+            # A corrupt previous installation can be repaired; other versions remain intact.
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif target.exists():
+                shutil.rmtree(target)
+            staging.rename(target)
+    return _package_path(target)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit('Usage: codex_runtime.py STATE_DIR')
+    try:
+        print(install_runtime(sys.argv[1]))
+    except (RuntimeError, OSError, subprocess.SubprocessError) as exc:
+        sys.exit('romp-codex-setup: %s' % exc)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9719,7 +9719,8 @@ def _codex():
                     jd.STATE, notify=_send_to_app,
                     poke=_wake_kernel, push=_pusher_wake.set,
                     push_session=_push_session_now,
-                    codex_bin=shutil.which("codex"),   # None → the SDK's bundled binary resolver
+                    # Keep the app-server runtime paired with the installed SDK.
+                    # A separately installed CLI on PATH may use a different protocol.
                     log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
             except Exception:
                 sys.stderr.write("codex-backend unavailable: %s\n" % traceback.format_exc())

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9719,7 +9719,7 @@ def _codex():
                     jd.STATE, notify=_send_to_app,
                     poke=_wake_kernel, push=_pusher_wake.set,
                     push_session=_push_session_now,
-                    # Keep the app-server runtime paired with the installed SDK.
+                    # Let the backend choose ROMP's managed runtime and helpers.
                     # A separately installed CLI on PATH may use a different protocol.
                     log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
             except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10659,9 +10659,11 @@ def _drive(msg, client):
         # mode only through the shift+tab cycle, so Bypass — which the picker offers on SDK sessions —
         # has no keystroke there. Without this the badge just sat on the old mode with no reason given.
         if not be.set_mode(sid, str(msg["value"])):
-            client["send"](json.dumps({"type": "warn",
-                                       "text": "A terminal session can only reach the modes in its "
-                                               "shift+tab cycle — Normal, Accept, Auto, Plan."}))
+            text = ("Codex mode changes require an idle session. Choose Sandboxed or Auto "
+                    "after the current turn finishes." if be is _codex_backend else
+                    "A terminal session can only reach the modes in its "
+                    "shift+tab cycle — Normal, Accept, Auto, Plan.")
+            client["send"](json.dumps({"type": "warn", "text": text}))
         _push_soon()
     elif t == "setAuth" and msg.get("value") in ("login", "key"):
         # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -42,7 +42,6 @@ def until(fn, timeout, step=0.25, what=""):
 def main():
     state = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-state-"))
     workdir = Path(tempfile.mkdtemp(prefix="romp-codex-smoke-cwd-"))
-    codex_bin = os.path.expanduser("~/.local/bin/codex")
     if os.environ.get("ROMP_SMOKE_SANDBOX") == "danger-full-access":
         # Boxes whose kernel restricts unprivileged user namespaces can't run Codex's bwrap
         # sandbox at all (bwrap: setting up uid map: Permission denied) — every command/patch
@@ -52,7 +51,7 @@ def main():
         #   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0   (+ persist in sysctl.d)
         cb.TURN_SANDBOX = {"type": "dangerFullAccess"}
         print("(sandbox override: dangerFullAccess — bwrap unavailable on this box)")
-    be = cb.CodexBackend(str(state), codex_bin=(codex_bin if os.path.exists(codex_bin) else None))
+    be = cb.CodexBackend(str(state))
     if not be.available():
         print("SMOKE SKIPPED: %s" % (be._client_err or "codex backend unavailable"))
         return 2

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -61,6 +61,8 @@ def main():
     err = be.launch_error(sid)
     assert not err, "spawn launch_error: %r" % err
     print("   sid=%s tid=%s model=%s" % (sid, be._sessions[sid].tid, be._sessions[sid].model))
+    mode = os.environ.get("ROMP_SMOKE_MODE", "sandboxed")
+    assert be.set_mode(sid, mode), "unsupported smoke mode: %s" % mode
 
     print("== turn 1: file-writing task")
     be.send(sid, "Create a file named hello.txt in the current directory containing exactly "

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -6,7 +6,7 @@ to the logged-in account, so CI never runs it. Run by hand when validating the b
 new Codex release:
 
     romp-codex-setup
-    python3 tests/smoke_codex_live.py
+    ROMP_SMOKE_MODEL=gpt-6-astra ROMP_SMOKE_EFFORT=low ROMP_SMOKE_MODE=auto python3 tests/smoke_codex_live.py
 
 Exercises the seams the unit tests fake: a real turn's notification stream materializing the
 transcript (items → tokenUsage → completed), the parse of that file into ended turns, live
@@ -68,6 +68,12 @@ def main():
     print("   sid=%s tid=%s model=%s" % (sid, be._sessions[sid].tid, be._sessions[sid].model))
     mode = os.environ.get("ROMP_SMOKE_MODE", "sandboxed")
     assert be.set_mode(sid, mode), "unsupported smoke mode: %s" % mode
+    model = os.environ.get("ROMP_SMOKE_MODEL")
+    effort = os.environ.get("ROMP_SMOKE_EFFORT")
+    if model:
+        assert be.set_model(sid, model), "unsupported smoke model: %s" % model
+    if effort:
+        assert be.set_effort(sid, effort), "unsupported smoke effort: %s" % effort
 
     print("== turn 1: file-writing task")
     be.send(sid, "Create a file named hello.txt in the current directory containing exactly "
@@ -87,7 +93,8 @@ def main():
     if settles[-1].get("message", {}).get("usage"):
         print("   usage on settle: %s" % settles[-1]["message"]["usage"])
     hello = workdir / "hello.txt"
-    print("   hello.txt exists: %s (%r)" % (hello.exists(), hello.read_text().strip() if hello.exists() else ""))
+    assert hello.is_file() and hello.read_text().strip() == "hello from codex", "file-writing turn failed"
+    print("   hello.txt has the expected content")
     ctx = be.live_sessions()[sid]["context"]
     print("   context%%: %s" % ctx)
 
@@ -104,7 +111,13 @@ def main():
     assert until(lambda: be.live_sessions()[sid]["state"] == "working", 60, what="turn 2 start")
     # wait for the sleep command's tool_use to MATERIALIZE (the command is genuinely running),
     # then cut it — a fixed grace raced turns that settled early (a sandbox-refused sleep)
-    assert until(lambda: "sleep 300" in path.read_text(), 90, what="sleep tool_use record")
+    def sleep_started():
+        for record in map(json.loads, path.read_text().splitlines()):
+            for block in record.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use" and "sleep 300" in json.dumps(block.get("input", {})):
+                    return True
+        return False
+    assert until(sleep_started, 90, what="sleep tool_use record")
     assert be.live_sessions()[sid]["state"] == "working", "turn settled before interrupt"
     assert be.interrupt(sid), "interrupt refused"
     assert until(lambda: be.live_sessions()[sid]["state"] == "waiting", 120, what="turn 2 settle")

--- a/tests/smoke_codex_live.py
+++ b/tests/smoke_codex_live.py
@@ -5,7 +5,8 @@ Deliberately not named test_* : it needs a `codex login` on the machine and bill
 to the logged-in account, so CI never runs it. Run by hand when validating the backend against a
 new Codex release:
 
-    uv run --with 'openai-codex==0.144.4' python tests/smoke_codex_live.py
+    romp-codex-setup
+    python3 tests/smoke_codex_live.py
 
 Exercises the seams the unit tests fake: a real turn's notification stream materializing the
 transcript (items → tokenUsage → completed), the parse of that file into ended turns, live
@@ -23,6 +24,8 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 
+RUNTIME_STATE = Path(os.environ.get("ROMP_STATE_DIR") or
+                     str(Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))) / "romp"))
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
 cb = SourceFileLoader("romp_codex_backend_live", os.path.join(ROOT, "kernel", "codex_backend.py")).load_module()
@@ -47,11 +50,13 @@ def main():
         # sandbox at all (bwrap: setting up uid map: Permission denied) — every command/patch
         # fails. This override exercises the SAME protocol machinery without the sandbox; the
         # shipped default stays romp's custom profile with one runtime workspace root.
-        # Fix the box for sandboxed operation:
-        #   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0   (+ persist in sysctl.d)
         cb.TURN_SANDBOX = {"type": "dangerFullAccess"}
         print("(sandbox override: dangerFullAccess — bwrap unavailable on this box)")
-    be = cb.CodexBackend(str(state))
+    if not cb.ensure_codex_sdk(RUNTIME_STATE):
+        print("SMOKE SKIPPED: run romp-codex-setup first")
+        return 2
+    runtime = cb._runtime.runtime_path(RUNTIME_STATE)
+    be = cb.CodexBackend(str(state), codex_bin=str(runtime))
     if not be.available():
         print("SMOKE SKIPPED: %s" % (be._client_err or "codex backend unavailable"))
         return 2

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1063,8 +1063,9 @@ for i in range(20):
         self.assertEqual(captured[0]["codex_bin"], "/opt/codex")
         self.assertEqual(captured[0]["client_name"], "romp")
         overrides = captured[0]["config_overrides"]
-        self.assertEqual(overrides, cb.CODEX_CONFIG_OVERRIDES)
         profile = overrides[0]
+        self.assertIn('"/opt/codex" = "read"', profile)
+        self.assertNotIn('"/opt" = "read"', profile)
         self.assertIn('":minimal" = "read"', profile)
         self.assertIn('"." = "write"', profile)
         for metadata in (".git", ".agents", ".codex"):

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -196,6 +196,129 @@ class Conformance(unittest.TestCase):
             error_type("CodexRpcError", -32001, "temporary backend failure")))
 
 
+class ApprovalModes(unittest.TestCase):
+    def test_auto_mode_persists_and_is_sent_on_resume_and_every_turn(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertEqual(be.live_sessions()[sid]["mode"], "sandboxed")
+        self.assertTrue(be.set_mode(sid, "auto"))
+        restored = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertEqual(restored.live_sessions()[sid]["mode"], "auto")
+        for text in ("first synthetic turn", "second synthetic turn"):
+            self.assertTrue(restored.send(sid, text))
+            self.assertTrue(until(lambda: not restored.busy(sid)))
+        requests = [c[2] for c in fake.called("thread_resume")]
+        requests += [c[3] for c in fake.called("turn_start")]
+        self.assertEqual(len(requests), 3)
+        for params in requests:
+            self.assertEqual(params["approvalPolicy"], "on-request")
+            self.assertEqual(params["approvalsReviewer"], "auto_review")
+            self.assertEqual(params["permissions"], cb.WORKSPACE_PERMISSION)
+            self.assertEqual(params["runtimeWorkspaceRoots"], ["/TESTDIR"])
+            self.assertNotIn("sandboxPolicy", params)
+        restored.kill(sid)
+
+    def test_switch_back_resets_reviewer_and_legacy_rows_stay_sandboxed(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.set_mode(sid, "auto"))
+        self.assertTrue(be.set_mode(sid, "sandboxed"))
+        self.assertTrue(be.send(sid, "synthetic turn"))
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        params = fake.called("turn_start")[-1][3]
+        self.assertEqual(params["approvalPolicy"], "never")
+        self.assertEqual(params["approvalsReviewer"], "user")
+        be.kill(sid)
+        rows = json.loads(be._reg_path().read_text())
+        rows[sid].pop("mode")
+        be._reg_path().write_text(json.dumps(rows))
+        restored = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertEqual(restored._sessions[sid].mode, "sandboxed")
+
+    def test_pending_session_recovery_uses_selected_mode(self):
+        def unavailable():
+            raise RuntimeError("synthetic unavailable client")
+        be, _, tmp = build(factory=unavailable)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.set_mode(sid, "auto"))
+        fake = FakeClient()
+        restored = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertTrue(restored.send(sid, "synthetic recovery"))
+        self.assertTrue(until(lambda: not restored.busy(sid)))
+        params = fake.called("thread_start")[-1][1]
+        self.assertEqual(params["approvalPolicy"], "on-request")
+        self.assertEqual(params["approvalsReviewer"], "auto_review")
+        restored.kill(sid)
+
+    def test_mode_change_refuses_inflight_turn_and_rolls_back_failed_save(self):
+        be, fake, _ = build()
+        sid = be.spawn("web", "/TESTDIR")
+        s = be._sessions[sid]
+        with s.mode_lock:
+            self.assertFalse(be.set_mode(sid, "auto"))
+        self.assertFalse(be.set_mode(sid, "bypassPermissions"))
+        with mock.patch.object(be, "_save_registry", side_effect=OSError("synthetic save failure")):
+            with self.assertRaises(OSError):
+                be.set_mode(sid, "auto")
+        self.assertEqual(s.mode, "sandboxed")
+        be.kill(sid)
+        self.assertFalse(be.set_mode(sid, "auto"))
+
+    def test_inflight_turn_keeps_its_mode_and_interrupt_still_works(self):
+        be, fake, _ = build()
+        fake.hold_open = True
+        fake.scripts = [[]]
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.set_mode(sid, "auto"))
+        self.assertTrue(be.send(sid, "synthetic held turn"))
+        try:
+            self.assertTrue(until(lambda: be._sessions[sid].turn_id is not None))
+            self.assertFalse(be.set_mode(sid, "sandboxed"))
+            self.assertEqual(be.live_sessions()[sid]["mode"], "auto")
+            self.assertTrue(be.interrupt(sid))
+            self.assertTrue(until(lambda: not be.busy(sid)))
+            self.assertTrue(be.set_mode(sid, "sandboxed"))
+        finally:
+            be.kill(sid)
+
+    def test_invalid_saved_mode_defaults_to_sandboxed(self):
+        be, _, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        rows = json.loads(be._reg_path().read_text())
+        rows[sid]["mode"] = "bypassPermissions"
+        be._reg_path().write_text(json.dumps(rows))
+        logs = []
+        restored = cb.CodexBackend(tmp, client_factory=FakeClient, log=logs.append)
+        self.assertEqual(restored.live_sessions()[sid]["mode"], "sandboxed")
+        self.assertTrue(logs)
+        restored.kill(sid)
+
+    def test_manual_approval_fallback_never_accepts_or_blocks_the_reader(self):
+        be, _, _ = build()
+        notices = []
+        be.notify = lambda app, msg: notices.append(msg)
+        for method in ("item/commandExecution/requestApproval", "item/fileChange/requestApproval"):
+            self.assertEqual(be._handle_approval(method, {}), {"decision": "decline"})
+        self.assertEqual(be._handle_approval("item/permissions/requestApproval", {}),
+                         {"permissions": {}, "scope": "turn"})
+        with self.assertRaises(RuntimeError):
+            be._handle_approval("unknown/requestApproval", {})
+        self.assertTrue(notices)
+        self.assertTrue(all(msg["type"] == "warn" for msg in notices))
+
+    def test_real_client_is_constructed_with_fail_closed_handler(self):
+        be, _, _ = build()
+        be._client_factory = None
+        fake = FakeClient()
+        fake.start = lambda: None
+        module = SimpleNamespace(CodexClient=mock.Mock(return_value=fake),
+                                 CodexConfig=lambda **kwargs: kwargs)
+        with mock.patch.object(cb, "ensure_codex_sdk", return_value=True), \
+             mock.patch.dict(sys.modules, {"openai_codex.client": module}):
+            self.assertIs(be._get_client(), fake)
+        self.assertEqual(module.CodexClient.call_args.kwargs["approval_handler"], be._handle_approval)
+
+
 class Lifecycle(unittest.TestCase):
     def test_spawn_send_turn_materializes_transcript(self):
         be, fake, _ = build()

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -309,6 +309,7 @@ class ApprovalModes(unittest.TestCase):
     def test_real_client_is_constructed_with_fail_closed_handler(self):
         be, _, _ = build()
         be._client_factory = None
+        be.codex_bin = "/TESTBIN/codex"
         fake = FakeClient()
         fake.start = lambda: None
         module = SimpleNamespace(CodexClient=mock.Mock(return_value=fake),

--- a/tests/test_codex_runtime.py
+++ b/tests/test_codex_runtime.py
@@ -1,0 +1,140 @@
+"""The managed runtime is independent of PATH and the SDK's older dependency."""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+
+HERE = Path(__file__).resolve().parents[1]
+rt = SourceFileLoader('test_romp_codex_runtime', str(HERE / 'kernel/codex_runtime.py')).load_module()
+
+
+def package(target, version=None):
+    root = target / 'codex_cli_bin'
+    for name in ('bin/codex', 'bin/codex-code-mode-host', 'codex-path/rg',
+                 'codex-resources/bwrap', 'codex-resources/zsh/bin/zsh'):
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('synthetic executable')
+        path.chmod(0o755)
+    (root / 'codex-package.json').write_text(json.dumps({'version': version or rt.VERSION}))
+    return root / 'bin/codex'
+
+
+class ManagedRuntime(unittest.TestCase):
+    def test_all_supported_platforms_have_pinned_official_wheels(self):
+        for system, machine in [('Linux', 'x86_64'), ('Linux', 'aarch64'),
+                                ('Darwin', 'x86_64'), ('Darwin', 'arm64')]:
+            with self.subTest(system=system, machine=machine):
+                url = rt.wheel_url(system, machine)
+                self.assertTrue(url.startswith('https://github.com/openai/codex/releases/download/rust-v0.153.3/'))
+                self.assertRegex(url, r'\.whl#sha256=[0-9a-f]{64}$')
+        with self.assertRaisesRegex(RuntimeError, 'Unsupported'):
+            rt.wheel_url('Linux', 'riscv64')
+
+    def test_missing_runtime_fails_with_setup_hint(self):
+        with tempfile.TemporaryDirectory() as state:
+            with self.assertRaisesRegex(RuntimeError, 'romp-codex-setup'):
+                rt.runtime_path(state)
+
+    def test_incomplete_or_wrong_version_is_not_usable(self):
+        with tempfile.TemporaryDirectory() as state:
+            target = Path(state) / 'codex-runtime' / rt.VERSION
+            exe = package(target, '0.144.4')
+            with self.assertRaisesRegex(RuntimeError, 'romp-codex-setup'):
+                rt.runtime_path(state)
+            package(target)
+            self.assertEqual(rt.runtime_path(state), exe)
+            (target / 'codex_cli_bin/codex-path/rg').unlink()
+            with self.assertRaisesRegex(RuntimeError, 'romp-codex-setup'):
+                rt.runtime_path(state)
+
+    def test_install_stages_verified_wheel_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory(prefix='romp runtime ') as state:
+            def run(args, **kwargs):
+                if '--target' in args:
+                    target = Path(args[args.index('--target') + 1])
+                    self.assertNotEqual(target, Path(state) / 'codex-runtime' / rt.VERSION)
+                    package(target)
+                    self.assertIn('--require-hashes', args)
+                    self.assertIn('--no-deps', args)
+                    self.assertIn('--no-index', args)
+                    self.assertIn('--only-binary=:all:', args)
+                    self.assertIn('#sha256=', args[-1])
+                return subprocess.CompletedProcess(args, 0, 'codex-cli ' + rt.VERSION + '\n')
+            with mock.patch.object(rt.subprocess, 'run', side_effect=run) as install:
+                exe = rt.install_runtime(state)
+                self.assertEqual(exe, rt.runtime_path(state))
+                calls = install.call_count
+                self.assertEqual(rt.install_runtime(state), exe)
+                self.assertEqual(install.call_count, calls)
+
+    def test_failed_install_never_publishes_partial_runtime(self):
+        with tempfile.TemporaryDirectory() as state:
+            old = package(Path(state) / 'codex-runtime/0.144.4', '0.144.4')
+            with mock.patch.object(rt.subprocess, 'run', side_effect=subprocess.CalledProcessError(1, 'pip')):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    rt.install_runtime(state)
+            self.assertTrue(old.exists())
+            self.assertFalse((Path(state) / 'codex-runtime' / rt.VERSION).exists())
+
+    def test_setup_repairs_an_incomplete_existing_target(self):
+        for kind in ('file', 'directory'):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as state:
+                target = Path(state) / 'codex-runtime' / rt.VERSION
+                target.parent.mkdir(parents=True)
+                if kind == 'file':
+                    target.write_text('incomplete installation')
+                else:
+                    target.mkdir()
+                def run(args, **kwargs):
+                    if '--target' in args:
+                        package(Path(args[args.index('--target') + 1]))
+                    return subprocess.CompletedProcess(args, 0, 'codex-cli ' + rt.VERSION + '\n')
+                with mock.patch.object(rt.subprocess, 'run', side_effect=run):
+                    self.assertEqual(rt.install_runtime(state), rt.runtime_path(state))
+
+    def test_wrong_executable_version_is_not_published(self):
+        with tempfile.TemporaryDirectory() as state:
+            def run(args, **kwargs):
+                if '--target' in args:
+                    package(Path(args[args.index('--target') + 1]))
+                return subprocess.CompletedProcess(args, 0, 'codex-cli 0.144.4\n')
+            with mock.patch.object(rt.subprocess, 'run', side_effect=run):
+                with self.assertRaisesRegex(RuntimeError, 'version'):
+                    rt.install_runtime(state)
+            self.assertFalse((Path(state) / 'codex-runtime' / rt.VERSION).exists())
+
+
+class BackendRuntimeSelection(unittest.TestCase):
+    def test_managed_executable_and_helpers_win_over_path(self):
+        cb = SourceFileLoader('runtime_selection_backend', str(HERE / 'kernel/codex_backend.py')).load_module()
+        with tempfile.TemporaryDirectory() as state:
+            exe = package(Path(state) / 'codex-runtime' / rt.VERSION)
+            with mock.patch.dict('os.environ', {'PATH': '/TESTBIN'}):
+                config = cb._codex_config(lambda **kwargs: kwargs, None, state)
+            self.assertEqual(config['codex_bin'], str(exe))
+            self.assertEqual(config['env']['PATH'], str(exe.parent.parent / 'codex-path') + ':/TESTBIN')
+            self.assertEqual(config['config_overrides'], cb.CODEX_CONFIG_OVERRIDES)
+
+    def test_missing_runtime_does_not_fall_back_to_sdk_or_path(self):
+        cb = SourceFileLoader('runtime_missing_backend', str(HERE / 'kernel/codex_backend.py')).load_module()
+        with tempfile.TemporaryDirectory() as state:
+            config = mock.Mock()
+            with self.assertRaisesRegex(RuntimeError, 'romp-codex-setup'):
+                cb._codex_config(config, None, state)
+            config.assert_not_called()
+
+    def test_explicit_packaged_runtime_keeps_its_matching_helpers(self):
+        cb = SourceFileLoader('runtime_override_backend', str(HERE / 'kernel/codex_backend.py')).load_module()
+        with tempfile.TemporaryDirectory() as state:
+            exe = package(Path(state) / 'custom')
+            config = cb._codex_config(lambda **kwargs: kwargs, str(exe))
+            self.assertEqual(config['codex_bin'], str(exe))
+            self.assertTrue(config['env']['PATH'].startswith(str(exe.parent.parent / 'codex-path')))

--- a/tests/test_codex_runtime.py
+++ b/tests/test_codex_runtime.py
@@ -121,7 +121,14 @@ class BackendRuntimeSelection(unittest.TestCase):
                 config = cb._codex_config(lambda **kwargs: kwargs, None, state)
             self.assertEqual(config['codex_bin'], str(exe))
             self.assertEqual(config['env']['PATH'], str(exe.parent.parent / 'codex-path') + ':/TESTBIN')
-            self.assertEqual(config['config_overrides'], cb.CODEX_CONFIG_OVERRIDES)
+            profile = config['config_overrides'][0]
+            for path in (exe, exe.parent / 'codex-code-mode-host',
+                         exe.parent.parent / 'codex-package.json',
+                         exe.parent.parent / 'codex-resources', exe.parent.parent / 'codex-path'):
+                self.assertIn(json.dumps(str(path)) + ' = "read"', profile)
+            self.assertNotIn(json.dumps(state) + ' = "read"', profile)
+            self.assertNotIn(json.dumps(str(exe.parent.parent)) + ' = "read"', profile)
+            self.assertNotIn('":root"', profile)
 
     def test_missing_runtime_does_not_fall_back_to_sdk_or_path(self):
         cb = SourceFileLoader('runtime_missing_backend', str(HERE / 'kernel/codex_backend.py')).load_module()
@@ -138,3 +145,14 @@ class BackendRuntimeSelection(unittest.TestCase):
             config = cb._codex_config(lambda **kwargs: kwargs, str(exe))
             self.assertEqual(config['codex_bin'], str(exe))
             self.assertTrue(config['env']['PATH'].startswith(str(exe.parent.parent / 'codex-path')))
+
+    def test_bare_executable_does_not_grant_reads_to_its_parent(self):
+        cb = SourceFileLoader('runtime_bare_backend', str(HERE / 'kernel/codex_backend.py')).load_module()
+        with tempfile.TemporaryDirectory(prefix='romp runtime ') as state:
+            exe = Path(state) / 'codex'
+            exe.touch()
+            (Path(state) / 'private.json').write_text('synthetic private fixture')
+            profile = cb._codex_config(lambda **kwargs: kwargs, str(exe))['config_overrides'][0]
+            self.assertIn(json.dumps(str(exe)) + ' = "read"', profile)
+            self.assertNotIn(json.dumps(state) + ' = "read"', profile)
+            self.assertNotIn('private.json', profile)

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -201,6 +201,22 @@ class HeadlessRoutes(unittest.TestCase):
         self.assertFalse(resp.get("ok"))
 
 
+class CodexRuntimeSelection(unittest.TestCase):
+    def test_path_codex_does_not_override_sdk_runtime(self):
+        fake_mod = mock.Mock()
+        fake_loader = mock.Mock()
+        fake_loader.load_module.return_value = fake_mod
+        with mock.patch.object(km, "_codex_backend", None), \
+             mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+             mock.patch.object(km.shutil, "which", return_value="/TESTBIN/codex"):
+            backend = km._codex()
+            self.assertIs(backend, fake_mod.CodexBackend.return_value)
+            self.assertIs(km._codex(), backend)
+        fake_mod.CodexBackend.assert_called_once()
+        self.assertIsNone(fake_mod.CodexBackend.call_args.kwargs.get("codex_bin"),
+                          "the SDK must resolve its bundled runtime even when codex is on PATH")
+
+
 class SdkSingleFlight(unittest.TestCase):
     """Concurrent _sdk() calls must construct exactly ONE backend. The 2026-07-06 storm: the eager
     boot thread + handler threads each passed the unlocked `if _sdk_backend is None` check and built

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -202,7 +202,7 @@ class HeadlessRoutes(unittest.TestCase):
 
 
 class CodexRuntimeSelection(unittest.TestCase):
-    def test_path_codex_does_not_override_sdk_runtime(self):
+    def test_path_codex_does_not_override_managed_runtime(self):
         fake_mod = mock.Mock()
         fake_loader = mock.Mock()
         fake_loader.load_module.return_value = fake_mod
@@ -214,7 +214,7 @@ class CodexRuntimeSelection(unittest.TestCase):
             self.assertIs(km._codex(), backend)
         fake_mod.CodexBackend.assert_called_once()
         self.assertIsNone(fake_mod.CodexBackend.call_args.kwargs.get("codex_bin"),
-                          "the SDK must resolve its bundled runtime even when codex is on PATH")
+                          "the backend must resolve its managed runtime even when codex is on PATH")
 
 
 class SdkSingleFlight(unittest.TestCase):

--- a/ui/webview/codex-meta-choices.test.ts
+++ b/ui/webview/codex-meta-choices.test.ts
@@ -1,7 +1,6 @@
 // A CODEX session's statusline menus speak Codex's vocabulary (docs/codex.md): the model/effort
-// pickers read the /models payload's codex section, the fixed sandbox mode shows as an
-// informational badge (no Claude permission-cycle menu opens under it), and the mode label says
-// "Sandboxed" instead of falling through to "Normal". Source-pin over render.ts, the same style
+// pickers read the /models payload's codex section, and its mode picker offers Sandboxed and
+// Auto without exposing unsupported Claude modes. Source-pin over render.ts, the same style
 // as picker-backend.test.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -28,7 +27,10 @@ test("menu construction picks the choice list by the session's backend", () => {
   assert.match(TIMELINE, /\? \(kind === 'model' \? CODEX_MODEL_CHOICES : CODEX_EFFORT_CHOICES\)/);
 });
 
-test("a codex session's fixed mode is informational: no permission-cycle menu, a Sandboxed label", () => {
-  assert.match(RENDER, /if \(kind === "mode" && s\.status\.backend === "codex"\) return;/);
+test("Codex offers only its supported modes and opens the mode picker", () => {
+  const choices = RENDER.match(/const CODEX_MODE_CHOICES: MetaChoice\[\] = \[([\s\S]*?)\n\];/)![1];
+  assert.deepEqual([...choices.matchAll(/value: "([^"]+)"/g)].map(m => m[1]), ["sandboxed", "auto"]);
+  assert.match(RENDER, /if \(kind === "mode"\) return CODEX_MODE_CHOICES;/);
+  assert.doesNotMatch(RENDER, /if \(kind === "mode" && s\.status\.backend === "codex"\) return;/);
   assert.match(RENDER, /case "sandboxed": return "Sandboxed";/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10398,19 +10398,23 @@ function prettyMode(m: string | undefined): string {
     case "auto": return "Auto";
     case "dontask": return "Don’t ask";
     case "bypasspermissions": return "Bypass";
-    case "sandboxed": return "Sandboxed";   // a Codex session's fixed posture (workspace-write)
+    case "sandboxed": return "Sandboxed";
     default: return "Normal";   // default / normal / unknown
   }
 }
+const CODEX_MODE_CHOICES: MetaChoice[] = [
+  { label: "Sandboxed", value: "sandboxed", sub: "commands stay sandboxed; escalation is denied" },
+  { label: "Auto", value: "auto", sub: "Codex reviews escalations; manual requests are denied" },
+];
 const META_CHOICES: Record<MetaKind, MetaChoice[]> = {
   mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
 };
 // The choices a menu offers depend on the session's BACKEND: a Codex session speaks Codex's
 // vocabulary (its own model list, the four efforts it accepts) — never Claude's, whose aliases
-// the codex backend refuses (docs/codex.md). Mode/fast never reach here for codex (see the
-// toggleMetaMenu guard / the fast badge's report gate).
+// the codex backend refuses (docs/codex.md). Codex modes use its own approval reviewer.
 function metaChoices(kind: MetaKind, st: Status): MetaChoice[] {
   if (st.backend === "codex") {
+    if (kind === "mode") return CODEX_MODE_CHOICES;
     if (kind === "model") return CODEX_MODEL_CHOICES;
     if (kind === "effort") return CODEX_EFFORT_CHOICES;
   }
@@ -10574,9 +10578,6 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   // slash command there would answer the prompt instead (host guards this too)
   if (status.state === "needsInput" || status.state === "awaiting") return;
   const s = { status };
-  // a Codex session's mode is fixed (sandboxed, plans/codex-backend.md phase 1) — the badge is
-  // informational, and opening Claude's permission-mode cycle under it would offer four no-ops
-  if (kind === "mode" && s.status.backend === "codex") return;
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
   const pickValue = (value: string, floating = false) => {


### PR DESCRIPTION
Codex sessions hardcode `approvalPolicy="never"`, preventing reviewed execution outside the sandbox. The SDK's bundled runtime also rejects Astra, and a runtime installed under ROMP's state directory cannot re-enter its executable inside the workspace sandbox. This adds per-session **Auto** mode, a managed **Codex 0.153.3** runtime, and read-only sandbox access to that runtime's required files.

- Install official release wheels pinned by SHA-256 for Linux/macOS on x86-64/ARM64. Stage and validate complete installations under a lock; reruns reuse a valid installation. Keep Python SDK 0.144.4 and its dependency intact, and launch the managed CLI with matching helpers. Missing or incomplete installations produce a setup error.
- Keep **Sandboxed** as the default. **Auto** uses native `on-request` / `auto_review` with the same workspace profile. Persist the choice through recovery/resume and apply it on every turn; switching back resets the reviewer. Refuse changes during a turn while keeping interruption available.
- Grant read-only access to the selected executable and known packaged assets, without exposing their containing state directory. This lets Codex re-enter its executable to apply seccomp before running a command.
- Decline unexpected manual approval requests with a warning and reject unknown schemas. Interactive approval cards require further SDK/UI work because waiting on the SDK's shared reader would block other sessions.
- Document Ubuntu's system bubblewrap and standard confined `bwrap-userns-restrict` AppArmor profile. ROMP setup does not change host policy. AppArmor and the global user-namespace restriction remained enabled during live validation.

This includes #929's runtime-selection change.

Validation:

- Full Python suite: **7,349 passed**, 44 skipped, 354 subtests passed. Focused backend/runtime/headless checks: **90 passed**, 11 subtests passed; the runtime-read regressions failed before the fix.
- Live **Astra / Codex 0.153.3**: thread creation, command execution, file creation, Auto-approved access to an explicitly authorized synthetic fixture, persisted Auto mode after backend restart, resume, and interruption all passed. No manual approval warnings or skipped normalizer events.
- Sandbox validation blocked reads of an outside fixture and left the host fixture unchanged after an attempted write.
- The strengthened repository live smoke passed with Astra in Auto mode, including file-content, transcript parsing, and interruption checks.
- Runtime installation, idempotent setup through a symlink, dependency checks, and approval-response schema validation passed. **All six required CI checks passed on this revision**: Python 3.10–3.13, shell, and frontend (typecheck, tests, and build).

Upgrade: rerun `romp-codex-setup`, restart the ROMP kernel, then select **Auto** from an idle Codex session's mode badge. Hosts must meet the documented sandbox prerequisites. Manual approval cards and workspace metadata-directory protection remain outside this change.
