### PR TITLE
Fix truncated Claude OAuth links and disappearing login dialog

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24881,6 +24881,7 @@ def _login_code(code):
 
 def _login_start():
     """Spawn the PTY login flow; the reader thread drives the gates and parses the URL."""
+    import fcntl, struct, termios
     import pty as _pty
     with _login_lock:
         if _login_flow["state"] in ("starting", "url", "verifying"):
@@ -24895,6 +24896,9 @@ def _login_start():
         env.pop("CLAUDE_CODE_CHILD_SESSION", None)  # a plain top-level CLI
         try:
             m, s = _pty.openpty()
+            # There is no visible terminal. Give the CLI room to print its OAuth URL intact
+            # instead of hard-wrapping it at the default 80 columns (including inside OSC-8).
+            fcntl.ioctl(s, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 4096, 0, 0))
             proc = subprocess.Popen([_claude_bin()], stdin=s, stdout=s, stderr=s,
                                     env=env, cwd=str(scratch), close_fds=True)
             os.close(s)
@@ -24908,7 +24912,40 @@ def _login_start():
     return ""
 
 
-_LOGIN_URL_RE = re.compile(r"https://claude\.com/[^\s\x1b\x07]*oauth[^\s\x1b\x07]*")
+_LOGIN_URL_RE = re.compile(
+    r"https://(?:claude\.com/(?:cai/)?|claude\.ai/)oauth/authorize\?[^\s\x1b\x07]*")
+_LOGIN_OSC_RE = re.compile(r"\x1b\]8;[^;\x07\x1b]*;([^\x07\x1b]*)(?:\x07|\x1b\\)")
+
+
+def _login_url(buf):
+    """Return a complete CLI-issued URL, never the first line or an unfinished PTY read.
+
+    OSC-8's terminator bounds the actual link even when its visible label is wrapped. Some
+    CLI versions also wrap the target: remove only its layout whitespace, preserving all OAuth
+    values, including the CLI's registered code-display redirect and PKCE challenge/state.
+    """
+    def valid(url):
+        if not _LOGIN_URL_RE.fullmatch(url):
+            return False
+        q = parse_qs(urlparse(url).query)
+        required = ("client_id", "redirect_uri", "scope", "state", "code_challenge")
+        return (all(len(q.get(key, [])) == 1 and q[key][0] for key in required)
+                and q.get("code") == ["true"] and q.get("response_type") == ["code"]
+                and q.get("code_challenge_method") == ["S256"])
+
+    for link in _LOGIN_OSC_RE.finditer(buf):
+        url = re.sub(r"\s+", "", link.group(1))
+        if valid(url):
+            return url
+    # Plain output is usable only when a delimiter has arrived. End-of-buffer can be mid-URL,
+    # even after every required parameter has begun; publishing then permanently latches it.
+    plain = _LOGIN_OSC_RE.sub("", buf)
+    # An unfinished OSC target belongs to the next read, not to the plain-text fallback.
+    plain = plain.split("\x1b]", 1)[0]
+    for link in _LOGIN_URL_RE.finditer(plain):
+        if link.end() < len(plain) and valid(link.group(0)):
+            return link.group(0)
+    return ""
 
 
 def trust_gate_passed(low0):
@@ -24929,14 +24966,17 @@ def _login_reader(fd, proc):
         with _login_lock:
             if _login_flow["pid"] != proc.pid:      # cancelled/superseded
                 break
-        r, _, _ = _select.select([fd], [], [], 0.5)
+        try:
+            r, _, _ = _select.select([fd], [], [], 0.5)
+        except (OSError, ValueError):               # Cancel can close the PTY during select.
+            break
         if r:
             try:
                 chunk = os.read(fd, 8192).decode("utf-8", "replace")
             except OSError:
                 break
             buf = (buf + chunk)[-20000:]
-        plain = re.sub(r"\x1b\][^\x07\x1b]*(\x07|\x1b\\\\)", "", buf)
+        plain = re.sub(r"\x1b\][^\x07\x1b]*(\x07|\x1b\\)", "", buf)
         plain = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", plain)
         low0 = plain.lower().replace(" ", "")
         if not trust_answered and "trustthisfolder" in low0:
@@ -24956,11 +24996,11 @@ def _login_reader(fd, proc):
             sent_pick = True
             buf = ""
             continue
-        murl = _LOGIN_URL_RE.search(plain)
-        if murl:
+        url = _login_url(buf)
+        if url:
             with _login_lock:
                 if _login_flow["pid"] == proc.pid and _login_flow["state"] in ("starting",):
-                    _login_flow.update(state="url", url=murl.group(0), t=time.time())
+                    _login_flow.update(state="url", url=url, t=time.time())
             _push_soon()
         low = plain.lower()
         # the VERDICT WINDOW is anchored on the paste prompt itself, not a buffer clear (a clear

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -13,8 +13,10 @@ import stat
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -29,9 +31,16 @@ os.environ.pop("ROMP_STATE_DIR", None)
 _MOCK_DIR = tempfile.mkdtemp()
 _MOCK = os.path.join(_MOCK_DIR, "claude")
 _MARKER = os.path.join(_MOCK_DIR, "code-sha.txt")
+_URL = "https://claude.com/cai/oauth/authorize?" + urlencode({
+    "code": "true", "client_id": "11111111-2222-4333-8444-555555555555",
+    "response_type": "code",
+    "redirect_uri": "https://platform.claude.com/oauth/code/callback",
+    "scope": "user:profile user:inference", "code_challenge": "SYNTHETIC-CHALLENGE",
+    "code_challenge_method": "S256", "state": "SYNTHETIC-STATE",
+})
 with open(_MOCK, "w") as f:
     f.write('''#!/usr/bin/env python3
-import sys, os, hashlib
+import sys, os, hashlib, time
 def say(s):
     sys.stdout.write(s); sys.stdout.flush()
 say("Do you trust this folder?\\n1. Yes, I trust this folder\\n")
@@ -42,9 +51,21 @@ if "/login" not in line:
     say("Not logged in\\n"); sys.exit(1)
 say("Select login method:\\n1. Claude account with subscription\\n2. Anthropic Console account\\n")
 line = sys.stdin.readline()          # option 1
-url = "https://claude.com/cai/oauth/authorize?code=true&client_id=x&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&state=SYNTH"
+url = @@URL@@
 say("Browser didn't open? Use the url below to sign in\\n")
-say("\\x1b]8;id=1;" + url + "\\x1b\\\\\\\\" + url + "\\x1b]8;;\\x1b\\\\\\\\\\n")
+mode = os.environ.get("ROMP_LOGIN_TEST_OUTPUT", "osc")
+if mode == "chunked":
+    say(url[:80])
+    time.sleep(0.3)
+    say(url[80:] + "\\n")
+elif mode == "wrapped":
+    # Terminal layouts may wrap the hyperlink target as well as its visible label.
+    wrapped = "\\r\\n  ".join(url[i:i+80] for i in range(0, len(url), 80))
+    say("\\x1b]8;;" + wrapped + "\\x1b\\\\" + wrapped + "\\x1b]8;;\\x1b\\\\\\n")
+elif mode == "ai":
+    say(url.replace("claude.com/cai/", "claude.ai/") + "\\n")
+else:
+    say("\\x1b]8;id=1;" + url + "\\x1b\\\\" + url + "\\x1b]8;;\\x1b\\\\\\n")
 say("Paste code here if prompted >\\n")
 code = sys.stdin.readline().strip()
 open(@@MARKER@@, "w").write(hashlib.sha256(code.encode()).hexdigest())
@@ -52,7 +73,7 @@ if code == "SYNTH-GOOD-CODE":
     say("Logged in as Test User (test@example.invalid)\\n")
 else:
     say("Invalid code. Login error.\\n")
-'''.replace("@@MARKER@@", repr(_MARKER)))
+'''.replace("@@MARKER@@", repr(_MARKER)).replace("@@URL@@", repr(_URL)))
 os.chmod(_MOCK, os.stat(_MOCK).st_mode | stat.S_IEXEC)
 os.environ["ROMP_CLAUDE_BIN"] = _MOCK
 
@@ -72,6 +93,42 @@ def _wait_state(want, seconds=15):
     return km._login_state()
 
 
+class LoginURL(unittest.TestCase):
+    def test_plain_link_waits_at_every_read_boundary(self):
+        for cut in range(len(_URL) + 1):
+            with self.subTest(cut=cut):
+                self.assertEqual(km._login_url(_URL[:cut]), "")
+        self.assertEqual(km._login_url(_URL + "\r\nPaste code here"), _URL)
+
+    def test_osc_link_waits_for_its_complete_terminator(self):
+        for end in ("\x07", "\x1b\\"):
+            stream = "\x1b]8;;" + _URL + end
+            for cut in range(len(stream)):
+                with self.subTest(terminator=repr(end), cut=cut):
+                    self.assertEqual(km._login_url(stream[:cut]), "")
+            self.assertEqual(km._login_url(stream), _URL)
+
+    def test_wrapped_label_does_not_replace_full_hyperlink(self):
+        stream = "\x1b]8;;" + _URL + "\x1b\\" + _URL[:80] + "\r\n"
+        self.assertEqual(km._login_url(stream), _URL)
+
+    def test_missing_parameters_never_produce_a_login_link(self):
+        u = urlsplit(_URL)
+        params = parse_qs(u.query)
+        for key in params:
+            incomplete = u._replace(query=urlencode({k: v for k, v in params.items()
+                                                     if k != key}, doseq=True)).geturl()
+            with self.subTest(missing=key):
+                self.assertEqual(km._login_url(incomplete + "\n"), "")
+
+    def test_partial_first_line_does_not_hide_a_complete_link_later(self):
+        self.assertEqual(km._login_url(_URL[:80] + "\n" + _URL + "\n"), _URL)
+
+    def test_unrelated_hosts_are_not_login_links(self):
+        self.assertEqual(km._login_url(_URL.replace("claude.com", "claude.com.example.invalid")
+                                      + "\n"), "")
+
+
 class LoginFlow(unittest.TestCase):
     def setUp(self):
         km._login_cancel()
@@ -87,6 +144,7 @@ class LoginFlow(unittest.TestCase):
         self.assertEqual(km._login_start(), "")
         st = _wait_state("url")
         self.assertEqual(st["state"], "url", "the driver walked the gates to the URL: %r" % st)
+        self.assertEqual(st["url"], _URL)
         self.assertTrue(st["url"].startswith("https://claude.com/cai/oauth/authorize?code=true"),
                         "the code=true URL, parsed clean out of the OSC-8 wrapping: %r" % st["url"])
         self.assertNotIn("\x1b", st["url"], "no terminal escapes survive into the link")
@@ -115,6 +173,22 @@ class LoginFlow(unittest.TestCase):
         self.assertEqual(st["state"], "error")
         self.assertIn("start", st["err"].lower(), "the copy names the retry, never the code: %r" % st["err"])
         self.assertNotIn("SYNTH-BAD-CODE", st["err"])
+
+    def test_url_waits_for_the_rest_of_a_pty_read(self):
+        with mock.patch.dict(os.environ, {"ROMP_LOGIN_TEST_OUTPUT": "chunked"}):
+            self.assertEqual(km._login_start(), "")
+        self.assertEqual(_wait_state("url")["url"], _URL)
+
+    def test_wrapped_hyperlink_preserves_every_oauth_parameter(self):
+        with mock.patch.dict(os.environ, {"ROMP_LOGIN_TEST_OUTPUT": "wrapped"}):
+            self.assertEqual(km._login_start(), "")
+        self.assertEqual(_wait_state("url")["url"], _URL)
+
+    def test_claude_ai_authorize_url_is_supported(self):
+        with mock.patch.dict(os.environ, {"ROMP_LOGIN_TEST_OUTPUT": "ai"}):
+            self.assertEqual(km._login_start(), "")
+        self.assertEqual(_wait_state("url", seconds=3)["url"],
+                         _URL.replace("claude.com/cai/", "claude.ai/"))
 
     def test_one_flow_at_a_time_and_cancel(self):
         self.assertEqual(km._login_start(), "")

--- a/tools/romp-lab/login-loop.mjs
+++ b/tools/romp-lab/login-loop.mjs
@@ -54,8 +54,14 @@ const url = await (async () => {
 check("url-streams-as-link", url.startsWith("https://claude.com/cai/oauth/authorize?code=true"),
   url || "no link rendered");
 await shot("url-shown");
+// Clicking to paste must retain settings: closing it also drops the shell's full-window
+// feed iframe, which makes the login dialog disappear under the pointer.
+await page.click("#rs-login-input");
+check("input-click-keeps-settings-open", await page.isVisible("#rsettings"));
+check("input-keeps-focus", await page.evaluate(() => document.activeElement?.id === "rs-login-input"));
 await page.fill("#rs-login-input", "LAB-SYNTH-CODE");
 await page.click("#rs-login-send");
+check("submit-keeps-settings-open", await page.isVisible("#rsettings"));
 const done = await (async () => {
   const t0 = Date.now();
   while (Date.now() - t0 < 20000) {

--- a/tools/romp-lab/login-mock-claude.py
+++ b/tools/romp-lab/login-mock-claude.py
@@ -19,7 +19,9 @@ if "/login" not in line:
 say("Select login method:\n1. Claude account with subscription\n2. Anthropic Console account\n")
 sys.stdin.readline()
 url = ("https://claude.com/cai/oauth/authorize?code=true&client_id=SYNTHETIC"
-       "&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback&state=LABFIXTURE")
+       "&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback"
+       "&scope=user%3Aprofile+user%3Ainference&code_challenge=SYNTHETIC-CHALLENGE"
+       "&code_challenge_method=S256&state=LABFIXTURE")
 say("Browser didn't open? Use the url below to sign in\n")
 say("\x1b]8;id=1;" + url + "\x1b\\" + url + "\x1b]8;;\x1b\\\n")
 say("Paste code here if prompted >\n")

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -474,7 +474,12 @@ function initGear(post) {
   // and the button reopens the modal mid-flow instead of restarting the login.
   var lgM = document.getElementById('rs-login-modal');
   function lgModal(on) { if (lgM) lgM.hidden = !on; }
-  if (lgM) lgM.addEventListener('click', function (e) { if (e.target === lgM) lgModal(false); });
+  if (lgM) lgM.addEventListener('click', function (e) {
+    // This dialog is a sibling of settings. Keep its clicks inside the dialog so the
+    // settings outside-click handler cannot close the panel and shrink its host iframe.
+    e.stopPropagation();
+    if (e.target === lgM) lgModal(false);
+  });
   document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && lgM && !lgM.hidden) lgModal(false); });
   function lgRender(v) {
     if (!lgB) return;


### PR DESCRIPTION
Claude login could expose an incomplete authorization URL when terminal output wrapped or arrived in chunks, causing “Missing redirect_uri”. Clicking the code input also closed settings and collapsed the login dialog.

Capture and validate complete OAuth URLs, including terminal hyperlink targets, and keep clicks inside the login dialog from triggering the settings outside-click handler. Add parser/integration regressions and an input-focus check in the login browser harness.

Validation: 15 login-flow tests and 16 existing gear tests passed; production UI build passed. Manually verified input focus, code submission, and cancellation in the browser harness.

This change covers the truncated URL and disappearing dialog. The separately observed delayed verification result has not been established as fixed.
