### PR TITLE
Support runtime 1Password API-key sources

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -34,7 +34,7 @@ no separate implementation to point at.
 | `romp-judge` | `kernel/judge.py` | Layer 2: the judge engine + all judge prompts (captioner, archiver, planner, …). `docs/judges.md`. |
 | `romp-askparse` | `kernel/askparse.py` | Parses the AskUserQuestion picker out of a captured tmux pane (tmux backend only; SDK sessions get the picker natively). |
 | `romp_sdk_backend.py` | `kernel/sdk_backend.py` | The **SDK session backend** (current default): drives sessions via the Claude Agent SDK. |
-| _(no bin entry)_ | `kernel/keysource.py` | The live source of the manager's API key: the `ANTHROPIC_API_KEY=` line of `service.env`, re-read at every session launch. Shared by the kernel and `romp keyswap`, so the reader and the writer cannot disagree. |
+| _(no bin entry)_ | `kernel/keysource.py` | The live API key source: an optional `ROMP_API_KEY_REF` resolved by `op` at runtime, or a legacy key. Source inspection never fetches secrets. Shared by the kernel and `romp keyswap`. |
 | `romp_session_backend.py` | `kernel/session_backend.py` | The `SessionBackend` ABC — the one seam both backends (SDK, tmux) implement. |
 | `romp_colormap.py` | `kernel/colormap.py` | The recency colormaps, single source of truth shared with the web bundles. |
 | `romp_palette.py` | `kernel/palette.py` | The session-identity color palettes. |
@@ -51,7 +51,7 @@ no separate implementation to point at.
 |---|---|---|
 | `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp update [host]`). |
 | `romp-version` | `cli/version.py` | Version report across the moving parts (`romp version`). |
-| `romp-keyswap` | `cli/keyswap.py` | Switches which API key the sessions bill without restarting the manager: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from a sibling file, and `--cycle`/`--cycle-all` reconnects running sessions onto it (`romp keyswap`). |
+| `romp-keyswap` | `cli/keyswap.py` | Switches `ROMP_API_KEY_REF` references or legacy API keys using sibling `service.env.<name>` profiles without restarting the manager. Listing/selection never fetch secrets; `--cycle`/`--cycle-all` reconnects running sessions onto the source (`romp keyswap`). |
 | `romp-idle-dots` | `cli/idle_dots.py` | tmux backend only: heals stranded `working` state / fades idle tab dots by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |
 
 ## tmux backend only (real files)

--- a/bin/romp
+++ b/bin/romp
@@ -2252,6 +2252,14 @@ if tmux has-session -t "=$name" 2>/dev/null; then
         tmux attach-session -t "$name"
     fi
 else
+    # op's credential never rides a session: when romp itself runs `op` (a reference is configured), the
+    # tmux SERVER's globals — what every new pane inherits — are scrubbed of it before the pane exists
+    # (review, 2026-09-05: the server the manager started carried service.env's token to `exec claude`).
+    if [[ -n "${ROMP_API_KEY_REF:-}" ]]; then
+        while IFS= read -r op_var; do
+            [[ -n "$op_var" ]] && tmux set-environment -gu "$op_var" 2>/dev/null || true
+        done < <(tmux show-environment -g 2>/dev/null | sed -n -E 's/^(OP_SERVICE_ACCOUNT_TOKEN|OP_CONNECT_HOST|OP_CONNECT_TOKEN|OP_ACCOUNT|OP_SESSION_[A-Za-z0-9_]*)=.*/\1/p')
+    fi
     # Create new detached session in working directory
     tmux new-session -d -s "$name" -c "$work_dir"
 

--- a/bin/romp
+++ b/bin/romp
@@ -644,7 +644,7 @@ EOF
     _romp_cmd "romp update [host]"         romp-update  "Push this machine's committed romp to attached remotes and restart them"
     _romp_cmd "romp up"                    romp-manager "Run the kernel manager in the foreground (rare — the login service runs it)"
     _romp_cmd "romp version"               romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
-    _romp_cmd "romp keyswap [<name>]"      romp-keyswap "Switch which API key the sessions bill, no restart (service.env.<name>; --cycle-all reconnects running ones)"
+    _romp_cmd "romp keyswap [<name>]"      romp-keyswap "Select a 1Password reference or legacy key (service.env.<name>; --cycle-all reconnects running sessions)"
     _romp_cmd "romp uninstall"             romp-uninstall "Remove romp's installed footprint (--purge also deletes recorded state)"
     _romp_cmd "romp help"                  -            "Show this help"
     cat <<'EOF'
@@ -718,11 +718,10 @@ if [[ "${1:-}" == "update" ]]; then
     exec romp-update "$@"
 fi
 
-# `romp keyswap [<name>] [--cycle <session,...> | --cycle-all]` — point the sessions at another API
-# key WITHOUT restarting the manager (the user 2026-09-04). Rewrites only the ANTHROPIC_API_KEY= line
-# of ~/.config/romp/service.env from a sibling file (service.env.<name>); the kernel reads that line
-# live at every session launch, and --cycle reconnects named running sessions so they re-present the
-# new key with their history intact. Delegates to romp-keyswap (python). Prints fingerprints, never keys.
+# `romp keyswap [<name>] [--cycle <session,...> | --cycle-all]` selects ROMP_API_KEY_REF or a legacy
+# ANTHROPIC_API_KEY from a sibling service.env.<name>, removing the competing assignment. Listing
+# and selection inspect sources without fetching secrets; --cycle asks the kernel to reconnect
+# sessions, resolving provider keys at launch. Delegates to romp-keyswap (python); never prints keys.
 if [[ "${1:-}" == "keyswap" ]]; then
     shift
     exec romp-keyswap "$@"
@@ -1821,7 +1820,7 @@ case "${1:-}" in
                            # VALUE is meaningful (explicitly setting empty), but a missing '=' or a
                            # NAME outside [A-Za-z_][A-Za-z0-9_]* is a usage error, never a silent
                            # skip. Toggles only (FEATURE_FLAG=1, CLAUDE_CODE_*) — real secrets stay
-                           # in service.env / the apiKeyHelper, since this payload is copied into
+                           # behind ROMP_API_KEY_REF or the apiKeyHelper, since this payload is copied into
                            # per-sid files and the session registry.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
                                echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] [--env NAME=VALUE] [--no-env] <name>" >&2; exit 2

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -549,9 +549,22 @@ function runManager() {
 // prompt "Visual Studio Code wants to access…" — even with VS Code closed (its helpers linger). Starting
 // the server here at login fixes it permanently. `exit-empty off` keeps the (initially empty) server alive
 // until real sessions join; it's a no-op if a server is already running (the user 2026-06-16).
+// op's own credential (a service-account token in service.env, for the kernel's `op read`) must not
+// become the tmux SERVER's environment: every pane the server ever creates inherits the server's
+// globals, not the launching client's, so a scrubbed `romp new` client still handed the token to
+// `exec claude` (review, 2026-09-05). Scrubbed only when romp is the op consumer (a reference is
+// configured); a box whose sessions run `op` through Claude Code's apiKeyHelper keeps its environment.
+function withoutOpCredentials(env) {
+  const out = Object.assign({}, env);
+  if (!out.ROMP_API_KEY_REF) return out;
+  for (const k of Object.keys(out)) {
+    if (k === 'OP_SERVICE_ACCOUNT_TOKEN' || k === 'OP_CONNECT_HOST' || k === 'OP_CONNECT_TOKEN' || k === 'OP_ACCOUNT' || k.startsWith('OP_SESSION_')) delete out[k];
+  }
+  return out;
+}
 function startTmuxServer() {
   try {
-    execFileSync('tmux', ['start-server', ';', 'set', '-g', 'exit-empty', 'off'], { stdio: 'ignore', timeout: 5000 });
+    execFileSync('tmux', ['start-server', ';', 'set', '-g', 'exit-empty', 'off'], { stdio: 'ignore', timeout: 5000, env: withoutOpCredentials(process.env) });
     log('tmux server ensured (launchd-rooted) — new sessions won\'t inherit a terminal\'s TCC identity');
   } catch (e) { /* tmux not installed, or a server is already up — nothing to do */ }
 }

--- a/bin/romp-node-launch
+++ b/bin/romp-node-launch
@@ -46,9 +46,9 @@ if [ -n "$sys_node" ]; then
 fi
 
 # Extra service environment (parity with the systemd unit's EnvironmentFile=-):
-# plain KEY=VALUE lines exported to the manager, so env a login shell has but
-# launchd doesn't (e.g. ANTHROPIC_API_KEY where claude auth is env-var-only)
-# reaches kernel-spawned sessions. Parsed line-by-line, never sourced: a
+# plain KEY=VALUE lines exported to the manager, so variables available only in
+# a login shell also reach the kernel. ROMP_API_KEY_REF remains a reference here;
+# the kernel resolves it through op when needed. Parsed line-by-line, never sourced: a
 # malformed line is skipped instead of executing code or (under set -eu)
 # taking the manager — and the whole kernel — down with it.
 ENV_FILE="${ROMP_SERVICE_ENV_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/romp/service.env}"

--- a/bin/romp-service
+++ b/bin/romp-service
@@ -10,9 +10,9 @@
 # presence-gated (zero model calls when no browser is connected). Runs as a USER-level
 # agent (no root). PATH + ROMP_DIR are baked into the unit so the service finds
 # node / python3 / claude / the romp bins (reinstall after a PATH change to refresh).
-# Secrets the service needs but only login shells have (e.g. ANTHROPIC_API_KEY on an
-# API-key-auth box) go in ~/.config/romp/service.env — read at manager start, never
-# baked into the unit. See SERVICE_ENV_FILE below and docs/reference.md.
+# Service configuration goes in ~/.config/romp/service.env, never baked into the
+# unit. ROMP_API_KEY_REF stores a 1Password reference; the kernel resolves it via op
+# when a key is needed. See SERVICE_ENV_FILE below and docs/reference.md.
 set -euo pipefail
 
 # Resolve the repo root through any symlink (matches the other bin/ consumers).
@@ -48,10 +48,10 @@ UNIT="$SYSTEMD_DIR/romp-manager.service"
 # Extra service environment: plain KEY=VALUE lines loaded when the manager STARTS
 # (not baked at install) — systemd reads the file via EnvironmentFile=-, the macOS
 # login agent's launcher (romp-node-launch) parses it before exec. This is the
-# documented seam for env a login shell has but a service doesn't: on a box where
-# claude auth is env-var-only (no OAuth credentials file), kernel-spawned SDK
-# sessions are silently unauthenticated without ANTHROPIC_API_KEY here. Values are
-# read fresh on every manager (re)start, so rotating one never needs a reinstall.
+# documented seam for env a login shell has but a service doesn't. Prefer an
+# optional ROMP_API_KEY_REF for API keys fetched through op at runtime; legacy
+# ANTHROPIC_API_KEY is also supported. The kernel re-reads key source assignments
+# live. Other values are read fresh on every manager (re)start.
 # chmod 600 the file; ROMP_SERVICE_ENV_FILE overrides the path (tests).
 SERVICE_ENV_FILE="${ROMP_SERVICE_ENV_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/romp/service.env}"
 
@@ -261,7 +261,7 @@ case "${1:-status}" in
         fi
         echo "  Installed launchd agent: $PLIST"
         echo "  romp-manager now auto-starts at login — just open the browser."
-        echo "  Extra service env (e.g. ANTHROPIC_API_KEY): $SERVICE_ENV_FILE"
+        echo "  Extra service env (e.g. ROMP_API_KEY_REF): $SERVICE_ENV_FILE"
         echo "      KEY=VALUE lines, chmod 600, picked up at manager (re)start."
         if [[ -x "$ROMP_NODE" ]]; then
             echo
@@ -279,7 +279,7 @@ case "${1:-status}" in
         fi
         echo "  Installed systemd --user service: $UNIT"
         echo "  romp-manager now auto-starts at login — just open the browser."
-        echo "  Extra service env (e.g. ANTHROPIC_API_KEY): $SERVICE_ENV_FILE"
+        echo "  Extra service env (e.g. ROMP_API_KEY_REF): $SERVICE_ENV_FILE"
         echo "      KEY=VALUE lines, chmod 600, picked up at manager (re)start." ;;
       *) echo "romp-service: unsupported OS '$os'" >&2; exit 1 ;;
     esac ;;

--- a/cli/README.md
+++ b/cli/README.md
@@ -8,5 +8,5 @@ their `bin/` symlinks (`romp version`, `romp update`, `romp keyswap`)
 |---|---|---|
 | `version.py` | `romp version` | Version report across the moving parts (working tree vs running kernel vs built bundles). |
 | `update.py` | `romp update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
-| `keyswap.py` | `romp keyswap [<name>]` | Switches which API key the sessions bill, with no kernel restart: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from a sibling file, and `--cycle`/`--cycle-all` reconnects running sessions onto it. Prints sha256 heads, never a key. |
+| `keyswap.py` | `romp keyswap [<name>]` | Switches the API key source without a kernel restart: selects `ROMP_API_KEY_REF` or legacy `ANTHROPIC_API_KEY` from a sibling profile, removing the competing assignment. Listing and selection never resolve secrets; `--cycle`/`--cycle-all` asks the kernel to reconnect running sessions. Prints source identities, never key values. |
 | `idle_dots.py` | (hook-fired) | tmux backend only: heals stranded `working` state by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |

--- a/cli/keyswap.py
+++ b/cli/keyswap.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """romp-keyswap — point every romp session at another API key, without restarting anything.
 
-`romp keyswap` rewrites ONE line of the manager's env file (`~/.config/romp/service.env`): the
-`ANTHROPIC_API_KEY=` line, taken from a sibling file you keep beside it (`service.env.highprio`,
-`service.env.lowprio`, …). The kernel reads that line live, per session launch, so:
+`romp keyswap` selects a credential source in the manager's env file
+(`~/.config/romp/service.env`), taken from a sibling profile (`service.env.highprio`,
+`service.env.lowprio`, …). A profile contains `ROMP_API_KEY_REF=op://…` for runtime 1Password
+retrieval, or `ANTHROPIC_API_KEY=…` for a conventional key. Switching removes competing credential
+assignments. This command never resolves a 1Password reference. The kernel reads the source live:
 
   * a session started or revived from then on bills the new key with no further action;
   * a session already running keeps the key its CLI process started with, because the key rides
@@ -13,9 +15,9 @@
     background tasks in flight is skipped by --cycle (a reconnect would kill them) and named, so you
     cycle it again once they are done.
 
-No key value is ever printed, logged or passed over the wire. The only rendered form is the first
-12 hex of its sha256 ("sha256:1a2b3c…"), which is enough to see that the swap landed and that the
-kernel reads the same value this command wrote.
+No key value is ever printed, logged or passed over the wire. Keys and references are represented
+by fingerprints. Reference comparisons confirm the kernel's configured source; runtime retrieval
+and rotation checks happen in the kernel.
 
 Usage:
     romp keyswap                            # what is live now, and which candidates exist
@@ -35,7 +37,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 # The SAME module the kernel reads the key with, not a second copy of the rules: writer and reader
 # then cannot disagree about which file holds the key, which line wins, or how it is parsed.
-ks = SourceFileLoader("romp_keysource", str(ROOT / "kernel" / "keysource.py")).load_module()
+ks = sys.modules.get("romp_keysource") or SourceFileLoader(
+    "romp_keysource", str(ROOT / "kernel" / "keysource.py")).load_module()
 
 KPORTS = ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
 
@@ -109,6 +112,27 @@ def _fp(key):
     return ("sha256:" + f) if f else "(none)"
 
 
+def _source_label(source):
+    """Describe configuration without retrieving a provider's secret or exposing a literal key."""
+    try:
+        source.validate()
+    except ks.KeySourceError:
+        return "(invalid key source)"
+    if source.kind == "op":
+        return "1Password reference " + source.fingerprint()
+    return _fp(source.value)
+
+
+def _legacy_key_present(path):
+    """Detect plaintext hidden by a higher-priority reference so selecting it also cleans up."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return bool(ks.parse_key(fh.read()))
+    except (OSError, UnicodeError):
+        # Attempt the write so its ordinary error path reports an unreadable live file.
+        return True
+
+
 def _candidates(path, out):
     """List the sibling `service.env.<name>` files, each by fingerprint only — so `romp keyswap`
     with no argument answers both "which key is live" and "what can I swap to"."""
@@ -118,17 +142,18 @@ def _candidates(path, out):
         names = sorted(n[len(base):] for n in os.listdir(d) if n.startswith(base) and not n.endswith("~"))
     except OSError:
         names = []
-    live = ks.read_key(path)
+    live = ks.read_source(path)
     if not names:
         out("candidates  none — keep one file per key beside it, e.g. %s.lowprio (chmod 600),"
             % os.path.basename(path))
-        out("            each a single %s=… line" % ks.KEY_VAR)
+        out("            each a single ROMP_API_KEY_REF=op://… or %s=… line" % ks.KEY_VAR)
         return
     out("candidates")
     for n in names:
-        k = ks.read_key(ks.sibling_path(n, path))
-        mark = "  <- live" if (k and k == live) else ""
-        out("  %-14s %s%s" % (n, _fp(k) if k else "(no %s line)" % ks.KEY_VAR, mark))
+        source = ks.read_source(ks.sibling_path(n, path))
+        mark = "  <- live" if (source.configured and source == live) else ""
+        label = _source_label(source) if source.kind != "none" else "(no key source)"
+        out("  %-14s %s%s" % (n, label, mark))
 
 
 def _kernel_check(path, out):
@@ -156,18 +181,35 @@ def _kernel_check(path, out):
     if not body.get("ok"):
         out("kernel      could not be asked — %s" % (body.get("error") or body.get("detail") or "unknown"))
         return 1
-    return _compare(body.get("keyFp") or "", path, out)
+    return _compare(body, path, out)
 
 
-def _compare(kfp, path, out):
-    """Print the kernel's fingerprint and, when it is not the file's, say so and why it may be."""
-    out("kernel      reads %s" % (("sha256:" + kfp) if kfp else "(none)"))
-    if kfp == ks.fingerprint(ks.read_key(path)):
-        return 0
-    out("MISMATCH    the kernel is not reading this file's key. Usual causes: the service was installed")
+def _compare(body, path, out):
+    """Compare provider configuration, or conventional keys for compatibility with older kernels."""
+    source = ks.read_source(path)
+    try:
+        source.validate()
+    except ks.KeySourceError as exc:
+        out("MISMATCH    this file has an invalid key source — %s" % exc)
+        return 1
+    if source.kind == "op":
+        if "sourceFp" not in body:
+            out("kernel      predates runtime key sources; update it with `romp refresh` before cycling")
+            return 1
+        source_fp = body.get("sourceFp") or ""
+        out("kernel      source %s" % (source_fp or "(none)"))
+        if source_fp == source.fingerprint():
+            out("            1Password reference matches; credentials are retrieved at runtime")
+            return 0
+    else:
+        kfp = body.get("keyFp") or ""
+        out("kernel      reads %s" % (("sha256:" + kfp) if kfp else "(none)"))
+        if kfp == source.fingerprint():
+            return 0
+    out("MISMATCH    the kernel is not reading this file's key source. Usual causes: the service was installed")
     out("            with another env-file path that the kernel's environment does not carry (re-run")
-    out("            `romp service install`), the file is unreadable to the kernel, or the file has no")
-    out("            %s line and the kernel still holds its startup key." % ks.KEY_VAR)
+    out("            `romp service install`), the file is unreadable to the kernel, or its credential")
+    out("            configuration differs from the running manager's.")
     return 1
 
 
@@ -197,13 +239,18 @@ def _cycle(sessions, all_, out, path=None):
     if not body.get("ok"):
         out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
         return 1
-    if _compare(body.get("keyFp") or "", path or ks.service_env_path(), out):
-        out("cycle       NOT DONE — the kernel is not on this file's key, so a reconnect would re-present")
-        out("            the key it already has. Fix the mismatch above first, then cycle.")
+    if _compare(body, path or ks.service_env_path(), out):
+        out("cycle       NOT DONE — the kernel's key source could not be verified; fix the issue above first")
         return 1
-    body = _post(u, "/keycycle", {"all": True} if all_ else {"sessions": sessions})
+    expected_fp = body.get("sourceFp", body.get("keyFp") or "") or ""
+    request = {"all": True} if all_ else {"sessions": sessions}
+    request["expectedSourceFp"] = expected_fp
+    body = _post(u, "/keycycle", request)
     if not body.get("ok"):
         out("cycle       FAILED — %s" % (body.get("error") or body.get("detail") or "unknown"))
+        return 1
+    if (body.get("sourceFp", body.get("keyFp") or "") or "") != expected_fp:
+        out("cycle       FAILED — the key source changed during the request; check it before cycling again")
         return 1
     rows = body.get("rows") or []
     if not rows:
@@ -212,8 +259,8 @@ def _cycle(sessions, all_, out, path=None):
     for r in rows:
         out("  %-14s %s" % (str(r.get("session"))[:14], _explain(str(r.get("status") or ""))))
     if any(str(r.get("status")) == "working" for r in rows):
-        out("            re-run the same --cycle once those are quiet; sessions already moved read \"current\"")
-    return 0
+        out("            re-run --cycle for the skipped sessions once those are quiet")
+    return 1 if any(str(r.get("status")).startswith("error:") for r in rows) else 0
 
 
 def _explain(status):
@@ -269,8 +316,14 @@ def main(argv, out=None):
         # Read-only report. Deliberately the no-argument behaviour: a swap is a real change and
         # should be asked for by name.
         out("service.env %s" % path)
-        out("live key    %s" % _fp(ks.read_key(path)))
+        current = ks.read_source(path)
+        out("live key    %s" % _source_label(current))
         _candidates(path, out)
+        try:
+            current.validate()
+        except ks.KeySourceError as exc:
+            out("configuration invalid — %s" % exc)
+            return 1
         if cycle or cycle_all:
             return _cycle(cycle, cycle_all, out, path)
         rc = _kernel_check(path, out)
@@ -283,37 +336,47 @@ def main(argv, out=None):
         sys.stderr.write("             keep one per key beside the env file (e.g. %s.lowprio, chmod 600)\n"
                          % os.path.basename(path))
         return 2
-    new = ks.read_key(src)
-    if not new:
+    new = ks.read_source(src)
+    try:
+        new.validate()
+    except ks.KeySourceError as exc:
+        sys.stderr.write("romp keyswap: %s has an invalid key source — %s (file untouched)\n"
+                         % (src, exc))
+        return 2
+    if not new.configured or not new.value:
         # Refuse rather than write an empty key: the CLI reads an empty ANTHROPIC_API_KEY as
         # "API-key mode, no key" and every session would then fail to authenticate.
-        sys.stderr.write("romp keyswap: %s has no %s= line — nothing to swap to (file untouched)\n"
-                         % (src, ks.KEY_VAR))
+        sys.stderr.write("romp keyswap: %s has no usable ROMP_API_KEY_REF= or %s= line — "
+                         "nothing to swap to (file untouched)\n" % (src, ks.KEY_VAR))
         return 2
-    cur = ks.read_key(path)
-    if new == cur:
+    cur = ks.read_source(path)
+    # A pre-existing reference may still sit beside a legacy plaintext key. Selecting that same
+    # reference also migrates the file: remove the leftover secret instead of treating it as done.
+    if new == cur and not (new.kind == "op" and _legacy_key_present(path)):
         out("service.env %s" % path)
-        out("live key    %s — already this key, nothing rewritten" % _fp(cur))
+        out("live key    %s — already this key source, nothing rewritten" % _source_label(cur))
     else:
         try:
-            res = ks.write_key(new, path)
+            res = ks.write_source(new, path)
         except OSError as e:
             sys.stderr.write("romp keyswap: could not rewrite %s: %s\n" % (path, e))
             return 1
         # Verify from the FILE, not from what we meant to write: re-read and fingerprint it.
-        landed = ks.read_key(path)
+        landed = ks.read_source(path)
         if landed != new:
             sys.stderr.write("romp keyswap: the rewrite did not land (file reads %s, expected %s) — "
-                             "check %s by hand\n" % (_fp(landed), _fp(new), path))
+                             "check %s by hand\n" % (_source_label(landed), _source_label(new), path))
             return 1
         out("service.env %s" % res["path"])
         if res.get("target") and res["target"] != res["path"]:
             out("            (a link: written through to %s)" % res["target"])
-        out("key line    %s -> %s  (%d lines, mode %o%s)"
-            % (_fp(res["old"]), _fp(new), res["lines"], res["mode"],
+        out("key source  %s -> %s  (%d lines, mode %o%s)"
+            % (_source_label(res["old"]), _source_label(new), res["lines"], res["mode"],
                ", tightened from a group/other-readable mode" if res["tightened"] else ""))
         out("source      %s" % src)
-    out("effect      new and revived sessions bill this key immediately; no manager restart needed")
+    out("effect      new and revived sessions use this key source; no manager restart needed")
+    if new.kind == "op":
+        out("            the kernel retrieves the key through op at runtime; no key was copied to disk")
     if cycle or cycle_all:
         return _cycle(cycle, cycle_all, out, path)
     rc = _kernel_check(path, out)

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -374,7 +374,10 @@ A judge call bills **the account of the session it judges** — the same pick th
 session's own Billing selector holds, read from the same registry, with the same
 selection (an explicit login pick → the login; otherwise the configured API
 key source when one exists, else the login). With `ROMP_API_KEY_REF` configured,
-each key-billed judge call resolves the reference through `op read --no-newline`.
+each key-billed judge call resolves the reference through `op read --no-newline`; a
+retrieval that fails is not retried by later calls in the same judging pass, and the first
+call of a pass to reach the key gates the others until its retrieval returns. The next pass,
+or a changed source, retries.
 The resolved key is used for that call without a provider cache or a plaintext
 file. The same source selection applies to standalone `romp-judge --once`.
 Every judge child environment strips ambient Anthropic credentials and injects

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -372,18 +372,19 @@ toward nothing.
 
 A judge call bills **the account of the session it judges** — the same pick the
 session's own Billing selector holds, read from the same registry, with the same
-fallback (an explicit login pick → the login; anything else → the manager env's
-API key when one exists, else the login). The key itself has exactly one claimer:
-the SDK backend pops it out of the kernel's environment at first use so no
-session CLI inherits it ambiently, and judges read that same stash through a wire
-the kernel installs (`judge._WORK_KEY_FN`) — before the wire lands, or standalone
-(`romp-judge --once`), the key is still sitting in the environment and is read in
-place. Every judge child env is built with the ambient variable stripped and the
-key injected back only for a key-mode call: billing is an explicit choice per
-call, never inheritance. (Before this, judges inherited the post-claim
-environment: on a host with no login, every call refused "Not logged in" for 13
-hours — ~53k errors — while the board sat frozen in Working with nothing saying
-why.)
+selection (an explicit login pick → the login; otherwise the configured API
+key source when one exists, else the login). With `ROMP_API_KEY_REF` configured,
+each key-billed judge call resolves the reference through `op read --no-newline`.
+The resolved key is used for that call without a provider cache or a plaintext
+file. The same source selection applies to standalone `romp-judge --once`.
+Every judge child environment strips ambient Anthropic credentials and injects
+the selected key only for a key-mode call. A provider failure fails that call
+with a credential error; it cannot silently use the machine login or a stale
+key. An explicitly login-billed call does not run `op`.
+
+Legacy `ANTHROPIC_API_KEY` and Claude login remain supported when no runtime
+provider is selected. See [Service environment and credentials](reference.md#service-environment-and-credentials)
+for setup, service PATH and authentication requirements, and migration.
 
 A **credential-class** failure (not logged in, an invalid key, an expired OAuth
 token) is one no retry can fix — only the user can. The first such error

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -24,7 +24,7 @@ update` starts a session called "update".
 | `romp update [host…]` | Push this machine's committed Romp to attached remotes and restart them |
 | `romp up` | Run the kernel manager in the foreground; rare, since the login service runs it |
 | `romp version` | Version report across the moving parts |
-| `romp keyswap [<name>] [--cycle <session,…>\|--cycle-all]` | Switch which API key the sessions bill, with no restart: rewrites only the `ANTHROPIC_API_KEY=` line of `service.env` from `service.env.<name>`, and `--cycle` moves running sessions onto it. Bare, it reports the live key and the candidates. See [Switching which API key the sessions bill](#switching-which-api-key-the-sessions-bill-romp-keyswap) |
+| `romp keyswap [<name>] [--cycle <session,…>\|--cycle-all]` | Switch the API key source without restarting the manager: selects a 1Password reference or a legacy key from `service.env.<name>`, and `--cycle` reconnects running sessions onto it. Bare, it reports the configured source and candidates without fetching secrets. See [Switching which API key the sessions bill](#switching-which-api-key-the-sessions-bill-romp-keyswap) |
 | `romp help` | The same list, from the terminal |
 
 These are for scripting and for agents rather than daily use:
@@ -54,8 +54,9 @@ every session there and outlives them all. Re-running `romp new --env` against
 a running session declares its full per-session env: any var you don't name
 again is dropped, and `romp new --no-env <name>` declares the empty set — it
 clears them all. Keep real secrets out of it: each value is copied into
-per-session files and the session registry under `~/.local/state/romp/`. Keys
-and credentials stay in `service.env` or the `apiKeyHelper`.
+per-session files and the session registry under `~/.local/state/romp/`. For
+runtime API keys, configure a 1Password reference in the service environment
+instead; see [Service environment and credentials](#service-environment-and-credentials).
 
 Two things to know before building on `romp sessions --json`. **`waiting` means
 at rest**, the ordinary state of a session that has finished its turn, so
@@ -196,7 +197,8 @@ the control never silently disappears.
 ### Per-session billing (login vs API key)
 
 An SDK session can bill either the machine's Claude login (subscription usage)
-or the `ANTHROPIC_API_KEY` the manager's environment carries — per session.
+or the configured API key source — per session. That source can be a 1Password
+reference resolved at runtime or a legacy `ANTHROPIC_API_KEY`.
 
 The new-session picker's **Billing** row states the case whenever the backend
 toggle says SDK: segmented buttons when the selected host offers both choices,
@@ -307,58 +309,124 @@ Run `romp-service install` again after changing one. The service unit bakes in
 whatever is set at install time, so a renumbered port that only lives in your
 shell leaves the supervised manager on the old one, and the two collide.
 
-### Service environment (secrets)
+### Service environment and credentials
 
 The manager runs as a login service (launchd on macOS, systemd --user on
-Linux), so it never sees variables your shell rc exports — a terminal having
-`ANTHROPIC_API_KEY` does nothing for the sessions the kernel spawns. On a
-machine where Claude authenticates through an OAuth login this gap is
-invisible (the credentials live in a file any process can read); on an
-API-key-only machine it means SDK sessions come up unauthenticated while
-`claude` in your terminal works fine.
+Linux), so it does not receive variables exported by your shell rc. Configure
+the service in `~/.config/romp/service.env` using plain `KEY=VALUE` lines and
+owner-only permissions (`chmod 600`). The service reads this file at manager
+startup; API key source settings are also read live before use. Other changes
+need a manager restart. `ROMP_SERVICE_ENV_FILE` overrides the file's path.
+Supervised services use this file as their API key source. An empty or missing
+source cannot fall back to credentials inherited from an earlier manager
+start, including after a kernel refresh or crash restart. Foreground managers
+can use an environment source when no service-file source governs them.
 
-Env like that goes in `~/.config/romp/service.env` — plain `KEY=VALUE` lines,
-`chmod 600`:
+#### API keys from 1Password at runtime
 
-    ANTHROPIC_API_KEY=sk-ant-...
+To keep API key values out of Romp's configuration files, set a
+[1Password secret reference](https://www.1password.dev/cli/secret-references):
 
-Unlike the ports above it is NOT baked at install: it is read each time the
-manager starts (the systemd unit via `EnvironmentFile=-`, the macOS login
-agent's launcher by parsing it — line by line, never sourced, so a malformed
-line is skipped rather than executed). Rotate a value by editing the file and
-restarting the manager (`romp-service install`); a missing file is a no-op.
+    ROMP_API_KEY_REF=op://vault/item/field
 
-`ANTHROPIC_API_KEY` is the one exception to that last sentence — it needs no
-restart at all. See below.
+`ROMP_API_KEY_REF` takes priority over a legacy `ANTHROPIC_API_KEY` in the
+selected configuration. An empty or invalid reference is an error, not a
+request to use the legacy key. Remove competing plaintext assignments when
+migrating; `romp keyswap` does this automatically when selecting a profile.
+
+Romp runs [`op read --no-newline`](https://www.1password.dev/cli/reference/commands/read)
+for each Claude SDK session launch or reconnect, each API-key-billed judge
+call, and each direct model-catalog refresh. A paginated catalog refresh uses
+that credential for all its pages. An explicit `romp keyswap --cycle` also
+resolves the key to check whether each quiet session needs a reconnect. Romp
+captures the value in memory and passes it to that operation. It does not write the resolved key
+to disk or cache it for later operations. A running Claude process retains
+the key it received at launch until it reconnects; this is not retrieval
+before every message in an existing session.
+
+The `op` executable must be on the **service's PATH**, and 1Password access
+must work for the OS user running the service. The service installer records
+PATH at install time; run `romp-service install` again after changing it.
+Arrange authentication for unattended use through an approved 1Password
+setup separately from Romp. An interactive terminal sign-in does not by
+itself establish that a headless login service can read the same secret.
+Keep any credentials needed to authenticate `op` out of Romp's files and
+per-session environment settings.
+
+For a foreground manager, the same reference can be supplied in its
+environment:
+
+    ROMP_API_KEY_REF=op://vault/item/field romp up
+
+The Billing picker, status displays, and `romp keyswap` listing and selection
+inspect the configured source without running `op`. A configured reference
+therefore means "API key available to try", not "1Password access verified".
+If a selected provider cannot resolve the key, the operation fails with a
+credential error. It does not use an ambient key, a previous resolved key,
+or a Claude login as a fallback. Choosing **Login** explicitly still uses
+Claude Code's supported login flow and does not resolve the API key source.
+
+To migrate an existing service:
+
+1. Put the API key in 1Password and obtain its field's secret reference.
+2. Replace `ANTHROPIC_API_KEY=...` in `service.env` with
+   `ROMP_API_KEY_REF=op://vault/item/field`. Replace any sibling profiles used
+   by `romp keyswap` in the same way, and remove obsolete plaintext copies.
+3. Refresh the kernel once to load this version of Romp. Future source edits
+   take effect without restarting the manager.
+4. Reconnect existing key-billed sessions with `romp keyswap --cycle-all`
+   when they are quiet. Newly launched sessions and subsequent judge/model
+   requests use the configured source immediately.
+
+Removing or emptying an explicit service-file key source cannot revive the
+key inherited when the kernel started. After removing a selected provider,
+API-key operations fail until a valid source is selected; choose **Login**
+explicitly to use that mode. Removing a source does not revoke a credential
+already held by a running Claude process; reconnect or end those sessions too.
+Rotate a previously exposed key with its issuer as appropriate.
+
+#### Existing API keys and Claude login
+
+1Password is optional for general use. Without a runtime provider selected,
+Romp continues to support legacy `ANTHROPIC_API_KEY` configuration, including
+in `service.env`, and the existing Claude Code login. A foreground manager
+can also use its inherited API key when no service-file source governs it.
+For login, authenticate through Claude Code's supported CLI login flow and
+select **Login** in Billing; no extracted OAuth token is needed.
+
+Plaintext keys remain supported for compatibility, but do not meet policies
+that require secrets to be fetched from 1Password at runtime. File permissions
+do not change that distinction.
 
 ### Switching which API key the sessions bill (`romp keyswap`)
 
-The key a session bills rides its launch environment, and romp reads the
-`ANTHROPIC_API_KEY=` line of `service.env` **fresh at every session launch**.
+The key a session bills rides its launch environment, and Romp checks the
+API key source in `service.env` **at every session launch**.
 So changing keys — moving to another organisation's key, rotating a leaked
 one, switching between a high-priority and a batch key — costs no manager
 restart, and no session loses an open turn.
 
-Keep one file per key beside `service.env`, each a single `ANTHROPIC_API_KEY=`
-line, `chmod 600`:
+Keep one file per profile beside `service.env`, each with a single
+`ROMP_API_KEY_REF=op://vault/item/field` assignment, `chmod 600`:
 
     ~/.config/romp/service.env.highprio
     ~/.config/romp/service.env.lowprio
 
 Then:
 
-    romp keyswap                       # which key is live, and what you can swap to
-    romp keyswap lowprio               # rewrite the key line from service.env.lowprio
+    romp keyswap                       # configured source and candidate profiles
+    romp keyswap lowprio               # select the source from service.env.lowprio
     romp keyswap lowprio --cycle-all   # …and move the running sessions onto it too
     romp keyswap lowprio --cycle web,api
 
-`romp keyswap <name>` rewrites **only** the `ANTHROPIC_API_KEY=` line, in
-place, keeping every other line of the file as it was (line endings come out
-as LF) — a temp file and a rename, so no reader ever sees the file
-half-written, and the mode stays `600` (a looser one is tightened). A
-symlinked `service.env` is written through: the target changes, the link
-stays. It refuses a source file with no key line rather
-than writing an empty key, which the CLI would read as "API-key mode, no key".
+Legacy profiles containing a single `ANTHROPIC_API_KEY=` assignment also
+work. `romp keyswap <name>` writes the selected assignment and removes the
+competing key-source assignment, keeping all unrelated lines as they were
+(line endings come out as LF). A temp file and rename make the update atomic,
+and the mode stays `600` (a looser one is tightened). A symlinked `service.env`
+is written through: the target changes, the link stays. A profile without a
+usable source is rejected. Listing or selecting a reference never retrieves
+its key; an explicit `--cycle` check asks the kernel to resolve it.
 
 After the rewrite:
 
@@ -370,25 +438,29 @@ After the rewrite:
   conversation with its history intact — the same mechanism a reasoning-effort
   or billing switch uses — and only for a session that is quiet right now. Sessions billing the machine login are
   skipped, dormant ones are reported as needing nothing, a session already
-  launched on the live key reads `current`, and a session with a turn,
+  launched on the current resolved key reads `current`, and a session with a turn,
   subagents or background tasks in flight is skipped and named — a reconnect
-  would kill that work — so you re-run the same `--cycle` once it is quiet,
-  until every session reads `current`;
-* **the judges and the model catalog** pick the new key up on their next call,
-  with no cycling at all.
+  would kill that work — so re-run `--cycle` for those sessions once they are
+  quiet;
+* **the judges and direct model-catalog refreshes** pick the new source up on
+  their next call, with no cycling at all.
 
-No key value is ever printed, logged, or sent over a socket. The only rendered
-form is the first 12 hex of its sha256 — `sha256:1a2b3c4d5e6f` — which appears
-in the command's output, in the Log panel when the key changes, and in the
-kernel's own answer to `--cycle`. Comparing those tells you the swap landed
-without either side showing the key.
+No key value is printed or sent in Romp's status/control responses. Legacy
+keys are identified by the first 12 hex of their sha256, such as
+`sha256:1a2b3c4d5e6f`. Provider status uses a fingerprint of the reference,
+without resolving it; this cannot verify the secret value or detect a rotation
+behind an unchanged reference. An explicit `--cycle` resolves the current key
+for each quiet session and reconnects it if that key differs from its launch
+key, including when the reference itself is unchanged. A session already
+using that key reads `current` and stays connected. A reconnect resolves the
+source again at the actual launch, so it does not reuse a key cached by the
+cycle check.
 
-**One restart, once:** a kernel that is already running when this feature is
-installed neither reads the file live nor knows the `--cycle` route, so it is
-still on the key it booted with. Take the update a single time with `romp
-refresh` — or `romp refresh --quiet`, which waits for the sessions to finish
-their turns first — and every swap after that is restart-free. `romp keyswap
---cycle-all` says so plainly if it meets an older kernel.
+**One restart, once:** a running kernel needs to load this version to support
+runtime providers. Take the update with `romp refresh` — or `romp refresh
+--quiet`, which waits for sessions to finish their turns first — and later
+source swaps need no manager restart. `romp keyswap --cycle-all` reports when
+it encounters a kernel too old to support cycling.
 
 Remote kernels each have their own `service.env` and their own key: run
 `romp keyswap` on that machine.
@@ -397,8 +469,8 @@ Remote kernels each have their own `service.env` and their own key: run
 the path it resolved into the unit and, when that is not the default, exports
 it to the service as well, so the kernel's live read and the installer name
 one file; a service installed before that carries only the default. `romp
-keyswap` asks the running kernel which key it reads and says `MISMATCH` when
-that is not the file's — the check to make after a swap.
+keyswap` compares the running kernel's source identity with the file's and
+says `MISMATCH` when they differ — the check to make after a swap.
 
 ## Where things live
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -337,8 +337,11 @@ migrating; `romp keyswap` does this automatically when selecting a profile.
 Romp runs [`op read --no-newline`](https://www.1password.dev/cli/reference/commands/read)
 for each Claude SDK session launch or reconnect, each API-key-billed judge
 call, and each direct model-catalog refresh. A paginated catalog refresh uses
-that credential for all its pages. An explicit `romp keyswap --cycle` also
-resolves the key to check whether each quiet session needs a reconnect. Romp
+that credential for all its pages. An explicit `romp keyswap --cycle` resolves
+the key once per request to check which quiet sessions need a reconnect. When
+a retrieval fails, the judges do not retry it on every call: the failure holds
+for the rest of that judging pass and is retried when the next pass begins or
+the source changes, so an unreachable `op` costs one timeout per pass. Romp
 captures the value in memory and passes it to that operation. It does not write the resolved key
 to disk or cache it for later operations. A running Claude process retains
 the key it received at launch until it reconnects; this is not retrieval
@@ -347,11 +350,41 @@ before every message in an existing session.
 The `op` executable must be on the **service's PATH**, and 1Password access
 must work for the OS user running the service. The service installer records
 PATH at install time; run `romp-service install` again after changing it.
-Arrange authentication for unattended use through an approved 1Password
-setup separately from Romp. An interactive terminal sign-in does not by
-itself establish that a headless login service can read the same secret.
-Keep any credentials needed to authenticate `op` out of Romp's files and
-per-session environment settings.
+An interactive terminal sign-in does not by itself establish that a headless
+login service can read the same secret: a service has no desktop app to
+unlock. The supported unattended route is a
+[1Password service account](https://developer.1password.com/docs/service-accounts/):
+put its token in `service.env` beside the reference,
+
+    OP_SERVICE_ACCOUNT_TOKEN=ops_...
+    ROMP_API_KEY_REF=op://vault/item/field
+
+and give the account read access to that one vault, and nothing else. When a
+reference is configured, Romp takes `op`'s own credential names
+(`OP_SERVICE_ACCOUNT_TOKEN`, `OP_SESSION_*`, `OP_CONNECT_*`, `OP_ACCOUNT`) out
+of its environment as its first act at startup, says which names it claimed in
+the kernel log, hands them to the `op read` subprocess alone, and scrubs them
+from the tmux server's global environment: no Claude session, judge call, or
+tmux launch inherits them, so an agent running `env` sees neither the API key
+nor the credential. This keeps the token out of every agent's shell by
+default; it is inheritance hygiene, not isolation. The file stays readable to
+the same OS user (keep it `chmod 600`), and a same-user process can read the
+manager's original environment, which is why the account must see only the
+one vault. Like the rest of `service.env`, the token line loads when the
+manager starts; changing it needs a manager restart, where the reference
+itself is read live. Do not put the token in a per-session environment
+(`romp new --env`), which is copied into per-session files.
+
+On a box where the sessions fetch their key through Claude Code's
+`apiKeyHelper` calling `op`, and no reference is configured, Romp leaves
+`op`'s environment alone: the sessions need it.
+
+A supervised manager (the systemd or launchd service) reads its key source
+from `service.env` **only**. A key that reaches the manager some other way, a
+systemd drop-in `Environment=` or a launchd plist entry, is ignored and said
+so once in the kernel log with its fingerprint; sessions without an explicit
+Billing pick then launch on the login. Move such a key into `service.env`, or
+replace it with a reference.
 
 For a foreground manager, the same reference can be supplied in its
 environment:

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -25,13 +25,17 @@ Session control (how romp drives Claude Code) sits behind one seam:
 Shared lookup tables: `colormap.py` (recency tints, single source shared with
 the web bundles) and `palette.py` (session-identity colors).
 
-`keysource.py` is the live source of the manager's API key: the
-`ANTHROPIC_API_KEY=` line of `service.env`, re-read at every session launch so
-switching keys needs no manager restart. `cli/keyswap.py` (`romp keyswap`) loads
-the same module to write that line, so the reader and the writer cannot disagree
-about the path or the parse. A key value never lands in the kernel's own
-environment and never reaches a log — `fingerprint()` (the sha256 head) is the
-only renderable form.
+`keysource.py` selects the manager's live API key source: a
+`ROMP_API_KEY_REF=op://vault/item/field` reference or a legacy
+`ANTHROPIC_API_KEY`. Source inspection is separate from resolution so UI/status
+reads do not fetch secrets. A selected reference is resolved with `op read
+--no-newline` for each Claude session launch/reconnect, key-billed judge call,
+and direct model-catalog refresh. Explicit cycle checks also resolve the key
+to detect rotations; a reconnect resolves it again at launch. Resolved provider
+keys are not cached or written to disk. Resolution failures fail closed.
+`cli/keyswap.py` (`romp keyswap`) shares the path and parser to switch references or legacy keys without
+resolving them. Removing a service-file source cannot restore a stale startup
+key. See `docs/reference.md` for migration and service authentication setup.
 
 Everything here is loaded by file path (`SourceFileLoader`), not installed as a
 package — the repo runs straight from a git clone. Python tests live in

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -20,6 +20,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 HERE = Path(__file__).resolve().parent
 em = SourceFileLoader("romp_event_model", str(HERE / "event_model.py")).load_module()
+_keysrc = sys.modules.get("romp_keysource") or SourceFileLoader(
+    "romp_keysource", str(HERE / "keysource.py")).load_module()
 
 HOME     = Path.home()
 STATE    = Path(os.environ.get("ROMP_STATE_DIR")   # per-kernel state root override (plans/multi-kernel.md)
@@ -940,6 +942,8 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
 
 _WORK_KEY_FN = None   # the kernel wires this to sdk_backend.work_api_key when it loads that module
                       # (_sdk_locked), so judges read the SAME once-per-process stash sessions bill from
+_WORK_KEY_CONFIGURED_FN = None  # metadata only; never retrieve a secret to decide billing
+_LOGIN_AUTH_ENV_FN = None      # login tokens claimed out of the manager's ambient environment
 
 
 def _work_key():
@@ -954,11 +958,28 @@ def _work_key():
     post-claim environment on a host with no login, and every call refused "Not logged in" for
     13 hours (~53k errors) while the cards sat parked in Working."""
     if _WORK_KEY_FN is not None:
-        try:
-            return _WORK_KEY_FN() or ""
-        except Exception:
-            return ""
-    return os.environ.get("ANTHROPIC_API_KEY", "") or ""
+        return _WORK_KEY_FN() or ""
+    return _keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "").resolve()
+
+
+def _work_key_configured():
+    if _WORK_KEY_CONFIGURED_FN is not None:
+        return bool(_WORK_KEY_CONFIGURED_FN())
+    # Compatibility for standalone callers wiring only the original callback.
+    if _WORK_KEY_FN is not None:
+        return bool(_work_key())
+    return _keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "").configured
+
+
+def _login_auth_env():
+    if _LOGIN_AUTH_ENV_FN is not None:
+        return _LOGIN_AUTH_ENV_FN()
+    return {k: os.environ[k] for k in ("ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+            if os.environ.get(k)}
+
+
+def _credential_error_note(exc):
+    return str(exc) if isinstance(exc, _keysrc.KeySourceError) else "API credential source failed"
 
 
 def _judge_auth(fsid):
@@ -976,9 +997,9 @@ def _judge_auth(fsid):
             a = json.loads((SDKDIR / (fsid + ".json")).read_text()).get("auth") or ""
         except Exception:
             a = ""
-    if a == "login":
-        return "login"
-    return "key" if _work_key() else "login"
+    if a in ("login", "key"):
+        return a
+    return "key" if _work_key_configured() else "login"
 
 
 def _is_auth_error(text):
@@ -1205,9 +1226,11 @@ def _judge_env(tier, auth="login", model=None):
     inheritance — and injected back EXPLICITLY for a key-mode call only. Removal, not blanking, same
     rule as sdk_backend._options: the CLI treats even an empty var as key-mode-without-a-key and
     refuses with "Not logged in"."""
-    wk = _work_key()                                  # read before the strip (standalone: same env)
     env = dict(os.environ)
-    env.pop("ANTHROPIC_API_KEY", None)                # never ambient: billing is an explicit choice per call
+    for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        env.pop(k, None)                             # billing is an explicit choice per call
+    if auth == "login":
+        env.update(_login_auth_env())
     for k in ("TMUX", "TMUX_PANE"):
         env.pop(k, None)
     env["ROMP_SUMMARIZING"] = "1"                     # trips the Stop-hook recursion guard
@@ -1229,7 +1252,10 @@ def _judge_env(tier, auth="login", model=None):
         # where the CLI drops it (Fable, Mythos, strangers) it is a harmless no-op and `--effort` in
         # _judge_run is the lever that lands. Both ride together; neither can hurt the other.
         env["MAX_THINKING_TOKENS"] = "0"
-    if auth == "key" and wk:
+    if auth == "key":
+        wk = _work_key()                             # resolve only at the call boundary
+        if not wk:
+            raise _keysrc.KeySourceError("No API key source is configured for this judge call")
         env["ANTHROPIC_API_KEY"] = wk
     return env
 
@@ -1310,7 +1336,14 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
         pass
     fsid = getattr(_judge_ctx, "fsid", None)
     engine = _judge_engine()                          # "claude" | "codex" (docs/codex.md §judges)
-    auth = _judge_auth(fsid)                          # this call bills what the judged session bills
+    try:
+        auth = "codex" if engine == "codex" else _judge_auth(fsid)
+    except Exception as e:
+        note = _credential_error_note(e)
+        _judge_ctx.paused = True
+        _auth_down_mark(fsid, "key", note)
+        _log_judge_error(judge or tier, fsid, "auth", note=note)
+        return ""
     try:
         # RATE-LIMIT GATE (the user 2026-07-07), scoped to the calls it can actually starve (the user
         # 2026-08-28, who watched key-billed cards keep landing under a "paused" banner): usage.json is
@@ -1351,7 +1384,14 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
         # win against. Nothing else about it changes — it still rides the SYSTEM prompt, never the
         # payload, and a call with no marked sections still gets no suffix at all.
         sys_prompt += UNTRUSTED_SYS % (mark, mark)
-    env = _judge_env(tier, auth, model)               # auth resolved above, before the gate (2026-08-28);
+    try:
+        env = _judge_env(tier, auth, model)
+    except Exception as e:
+        note = _credential_error_note(e)
+        _judge_ctx.paused = True
+        _auth_down_mark(fsid, auth, note)
+        _log_judge_error(judge or tier, fsid, "auth", note=note)
+        return ""
     #                                                   the MODEL decides the index tier's lever (below)
     # Per-tier effort from the gear (STATE/judge-effort | index-effort | distill-effort) when the caller
     # didn't pass one — "" or None means NO --effort flag, the long-standing default. An explicit caller

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1229,6 +1229,7 @@ def _judge_env(tier, auth="login", model=None):
     env = dict(os.environ)
     for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
         env.pop(k, None)                             # billing is an explicit choice per call
+    _keysrc.strip_op_env(env)                        # op's own credential never rides a judge child (2026-09-05)
     if auth == "login":
         env.update(_login_auth_env())
     for k in ("TMUX", "TMUX_PANE"):
@@ -1253,11 +1254,57 @@ def _judge_env(tier, auth="login", model=None):
         # _judge_run is the lever that lands. Both ride together; neither can hurt the other.
         env["MAX_THINKING_TOKENS"] = "0"
     if auth == "key":
-        wk = _work_key()                             # resolve only at the call boundary
+        wk = _resolve_work_key_gated()               # resolve only at the call boundary — once per pass on failure
         if not wk:
             raise _keysrc.KeySourceError("No API key source is configured for this judge call")
         env["ANTHROPIC_API_KEY"] = wk
     return env
+
+
+# A failed retrieval is remembered for the rest of the PASS it happened in, keyed on the source's
+# identity: the next key-billed call in that pass fails at once with the same note instead of spawning
+# `op` and waiting out its 15 s timeout again (six judge threads, hundreds of calls a pass — review
+# find, 2026-09-05). The deciding events that retry are exact, not timed: the source changes (another
+# fingerprint), or a new pass begins (begin_pass_frame). Standalone callers with no pass frame retry
+# every call, as before.
+_KEY_GATE = {"fp": None, "gen": None, "note": ""}
+_PASS_GEN = [0]
+_KEY_GATE_CV = threading.Condition()                 # guards _KEY_GATE and the in-flight first retrieval of a pass
+_KEY_INFLIGHT = [None]                               # (fp, gen) being retrieved right now, or None
+
+
+def _resolve_work_key_gated():
+    try:
+        src = _keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "")
+        fp = src.fingerprint() if src.kind != "error" else "error"
+    except Exception:
+        fp = None
+    gen = _PASS_GEN[0]
+    key = (fp, gen) if (fp is not None and gen) else None
+    if key is None:
+        return _work_key()                           # no pass frame (standalone) or no source identity: as before
+    with _KEY_GATE_CV:
+        # The first wave: six judge threads reach a pass's first key call together, and every one of them
+        # would spawn `op` and wait out its own timeout. The first to arrive retrieves; the others wait for
+        # its verdict — then raise the remembered failure, or retrieve for themselves (no value is shared).
+        while _KEY_INFLIGHT[0] == key:
+            _KEY_GATE_CV.wait(timeout=_keysrc.OP_TIMEOUT + 1)
+        if _KEY_GATE["fp"] == fp and _KEY_GATE["gen"] == gen:
+            raise _keysrc.KeySourceError(_KEY_GATE["note"] or "API credential retrieval failed earlier in this pass")
+        first = _KEY_INFLIGHT[0] is None
+        if first:
+            _KEY_INFLIGHT[0] = key
+    try:
+        return _work_key()
+    except _keysrc.KeySourceError as e:
+        with _KEY_GATE_CV:
+            _KEY_GATE.update(fp=fp, gen=gen, note=str(e))
+        raise
+    finally:
+        if first:
+            with _KEY_GATE_CV:
+                _KEY_INFLIGHT[0] = None
+                _KEY_GATE_CV.notify_all()
 
 
 _RATE_GATE_LOGGED = {}                   # bucket -> resets_at already announced (one line per window)
@@ -2112,8 +2159,9 @@ def begin_pass_frame():
     global _frame
     with _frame_lock:
         if _frame is not None:
-            return False
+            return False                             # a joiner shares the creator's pass — and its key gate
         _frame = {"parses": {}, "keys": {}}
+        _PASS_GEN[0] += 1                            # a CREATED pass is the event that lets a failed key retrieval retry
         return True
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1044,14 +1044,12 @@ def _models_api_credential():
     fn = getattr(jd, "_WORK_KEY_FN", None)
     key = ""
     if fn is not None:
-        try:
-            key = fn() or ""
-        except Exception:
-            key = ""
-    key = key or os.environ.get("ANTHROPIC_API_KEY", "") or ""
+        key = fn() or ""  # A selected provider's failure must not borrow another credential.
+    else:
+        key = jd._keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "").resolve()
     if key:
         return ("x-api-key", key)
-    tok = os.environ.get("ANTHROPIC_AUTH_TOKEN", "") or ""
+    tok = jd._login_auth_env().get("ANTHROPIC_AUTH_TOKEN", "") or ""
     if tok:
         return ("Authorization", "Bearer " + tok)
     return None
@@ -1095,14 +1093,14 @@ def _refresh_model_catalog(reason, _async=True):
 
     def go():
         try:
-            cred = _models_api_credential()
-            if cred is None:
-                _catalog_status["lastError"] = "no API credential in the kernel's environment"
-                sys.stderr.write("model catalog (%s): no API credential the kernel can use — serving the "
-                                 "%s list; new models need ANTHROPIC_API_KEY in the manager env (or a "
-                                 "MODEL_VERSIONS edit)\n" % (reason, _catalog_status["source"]))
-                return
             try:
+                cred = _models_api_credential()
+                if cred is None:
+                    _catalog_status["lastError"] = "no API credential in the kernel's environment"
+                    sys.stderr.write("model catalog (%s): no API credential the kernel can use — serving the "
+                                     "%s list; configure an API key source to refresh it\n"
+                                     % (reason, _catalog_status["source"]))
+                    return
                 rows = _fetch_models_api(cred)
             except Exception as e:
                 _catalog_status["lastError"] = "%s: %s" % (type(e).__name__, str(e)[:200])
@@ -8108,6 +8106,9 @@ def _env_error(env):
         if k in _ENV_RESERVED_NAMES:
             return ("env: %s is reserved — romp sets the session's identity env "
                     "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
+        if (k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+                and jd._keysrc.select_source().kind in ("op", "error")):
+            return "env: %s is reserved while runtime API key retrieval is configured" % k
         if not isinstance(v, str):
             return "env: the value for %r must be a string" % (k,)
         if "\x00" in v:
@@ -9634,6 +9635,8 @@ def _sdk_locked():
             # the unwired judges inherited the post-claim env on a login-less host and every call
             # refused "Not logged in" for 13 hours while the cards sat parked in Working).
             jd._WORK_KEY_FN = sbmod.work_api_key
+            jd._WORK_KEY_CONFIGURED_FN = lambda: sbmod.work_api_key_source().configured
+            jd._LOGIN_AUTH_ENV_FN = sbmod.startup_auth_env
             # T222: the live model catalog — the last fetched list installs before any picker asks,
             # then the BOOT event refreshes it (async; the key is claimable from here on)
             try:
@@ -9784,7 +9787,7 @@ def _auth_key_present():
     display everywhere, and host names already tell keys apart in the per-host hover). Cheap: an
     attribute read off the backend singleton, safe per-push."""
     be = _sdk()
-    return bool(str(getattr(be, "work_key", "") or "") if be else "")
+    return bool(getattr(be, "work_key_configured", False)) if be else False
 
 
 def _work_key_fp():
@@ -34677,7 +34680,28 @@ class Handler(BaseHTTPRequestHandler):
                 if be is None:
                     return self._send(503, json.dumps({"ok": False, "error": "no SDK backend"}),
                                       "application/json")
-                keyfp = _work_key_fp()
+                try:
+                    source_reader = getattr(be, "_work_key_source", None)
+                    if source_reader is not None:
+                        source = source_reader()
+                        source.validate()
+                        sourcefp = source.fingerprint()
+                        # A status read must never fetch a provider. Its reference identity is
+                        # sufficient to confirm that keyswap and this kernel see the same source.
+                        keyfp = "" if source.kind == "op" else sourcefp
+                    else:
+                        keyfp = sourcefp = _work_key_fp()  # older backend/test doubles
+                except Exception as e:
+                    return self._send(200, json.dumps({"ok": False,
+                        "error": jd._credential_error_note(e)}), "application/json")
+                expected_source_fp = b.get("expectedSourceFp")
+                if "expectedSourceFp" in b:
+                    if not isinstance(expected_source_fp, str):
+                        return self._send(400, json.dumps({"ok": False,
+                            "error": "expectedSourceFp must be a string"}), "application/json")
+                    if expected_source_fp != sourcefp:
+                        return self._send(409, json.dumps({"ok": False,
+                            "error": "API key source changed; check it before cycling again"}), "application/json")
                 rows = []
                 if b.get("all"):
                     # every LIVE SDK session: the dormant ones need nothing (their next launch reads
@@ -34693,13 +34717,17 @@ class Handler(BaseHTTPRequestHandler):
                     who_list = [(str(w), _sid_of(str(w))) for w in raw if str(w or "").strip()]
                 for who, sid in who_list:
                     try:
-                        status = be.cycle_key(sid)
+                        if expected_source_fp is not None and source_reader is not None:
+                            status = be.cycle_key(sid, expected_source_fp=expected_source_fp)
+                        else:
+                            status = be.cycle_key(sid)
                     except Exception as e:
-                        status = "error: %s" % str(e)[:80]
+                        status = "error: %s" % jd._credential_error_note(e)
                     rows.append({"session": _name_of(sid) or who, "status": status})
                 if any(r["status"] == "cycling" for r in rows):
                     _push_soon()                      # something changed; a fingerprint READ ({"sessions": []}) did not
-                return self._send(200, json.dumps({"ok": True, "keyFp": keyfp, "rows": rows}),
+                return self._send(200, json.dumps({"ok": True, "keyFp": keyfp,
+                                                  "sourceFp": sourcefp, "rows": rows}),
                                   "application/json")
             if u.path in ("/interrupt", "/end"):
                 # Headless session control (2026-07-05): interrupt/end existed ONLY as WS drive ops, so

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8033,6 +8033,7 @@ def _spawn_session(name, cwd=None):
     cwd = cwd or _default_create_dir()
     _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
     env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
+    jd._keysrc.strip_op_env(env)     # op's credential stays with the kernel; a tmux launch may predate the backend's claim
     try:
         subprocess.run([str(BIN / "romp"), "new", "-t", "--detach", name], cwd=cwd, env=env, timeout=25,
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -8086,7 +8087,7 @@ _ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")   # the shell-identifier 
 _ENV_RESERVED_NAMES = ("ROMP_SID", "ROMP_SESSION_NAME")
 
 
-def _env_error(env):
+def _env_error(env, auth=""):
     """Why POST /new's "env" is not a valid per-session env payload — "" when it is. The kernel-side
     mirror of sdk_backend.env_request_error (that module loads lazily inside _sdk(), so the handler
     can't import it at the door): a dict of NAME → string-value pairs, names in the shell-identifier
@@ -8107,7 +8108,7 @@ def _env_error(env):
             return ("env: %s is reserved — romp sets the session's identity env "
                     "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
         if (k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
-                and jd._keysrc.select_source().kind in ("op", "error")):
+                and k in jd._keysrc.runtime_reserved_names(auth or "", jd._keysrc.select_source())):
             return "env: %s is reserved while runtime API key retrieval is configured" % k
         if not isinstance(v, str):
             return "env: the value for %r must be a string" % (k,)
@@ -11023,7 +11024,8 @@ def _revive_session(sid, client=None):
             cwd = _cwd_of(sid)
             workdir = cwd if cwd and os.path.isdir(cwd) else os.path.expanduser("~")
             r = subprocess.run([str(BIN / "romp"), "resume", sid, "--name", name, "--detach"],
-                               cwd=workdir, capture_output=True, text=True, timeout=40)
+                               cwd=workdir, capture_output=True, text=True, timeout=40,
+                               env=jd._keysrc.strip_op_env(dict(os.environ)))
             ok = r.returncode == 0
             if not ok:
                 detail = (r.stderr or r.stdout or "romp exited %d" % r.returncode).strip()[:200]
@@ -34715,10 +34717,42 @@ class Handler(BaseHTTPRequestHandler):
                                                            "error": "sessions must be a list"}),
                                           "application/json")
                     who_list = [(str(w), _sid_of(str(w))) for w in raw if str(w or "").strip()]
+                # Resolve the key ONCE for the whole request (an `op read` may take seconds): every session
+                # below is compared against this fingerprint instead of each retrieving its own — a dozen
+                # quiet sessions used to mean a dozen serial retrievals on this thread, past the CLI's
+                # timeout (review find, 2026-09-05). Only when there is a session to cycle: a status read
+                # retrieves nothing. A failure, or a source that changed while retrieving, is reported on
+                # every row and reconnects nothing — the per-session contract, kept. The reconnects this
+                # schedules still resolve afresh at launch.
+                current_key_fp, resolve_error = None, None
+                probes = {}
+                if source_reader is not None and hasattr(be, "_work_key_and_source"):
+                    for who, sid in who_list:
+                        try:
+                            probes[sid] = be.cycle_key(sid, probe=True)
+                        except Exception as e:
+                            probes[sid] = "error: %s" % jd._credential_error_note(e)
+                needs_key = any(v == "cycle" for v in probes.values())
+                if needs_key:
+                    try:
+                        key, _src = be._work_key_and_source(source)
+                        if not key:
+                            raise jd._keysrc.KeySourceError("API key billing selected but no API key source is configured")
+                        after = source_reader()
+                        after.validate()
+                        if after.fingerprint() != sourcefp:
+                            raise jd._keysrc.KeySourceError("API key source changed during retrieval; check it before cycling again")
+                        current_key_fp = jd._keysrc.fingerprint(key)
+                    except Exception as e:
+                        resolve_error = jd._credential_error_note(e)
                 for who, sid in who_list:
                     try:
-                        if expected_source_fp is not None and source_reader is not None:
-                            status = be.cycle_key(sid, expected_source_fp=expected_source_fp)
+                        pre = probes.get(sid)
+                        if pre is not None and pre != "cycle":
+                            status = pre                       # unknown / dormant / login / working: needs no key
+                        elif source_reader is not None and hasattr(be, "_work_key_and_source"):
+                            status = be.cycle_key(sid, expected_source_fp=expected_source_fp,
+                                                  current_key_fp=current_key_fp, resolve_error=resolve_error)
                         else:
                             status = be.cycle_key(sid)
                     except Exception as e:
@@ -34797,7 +34831,7 @@ class Handler(BaseHTTPRequestHandler):
                 # swallowed as "not asked" while the caller reads ok:true as the env applying.
                 env_req = (b or {}).get("env")
                 if env_req is not None:
-                    eerr = _env_error(env_req)
+                    eerr = _env_error(env_req, str((b or {}).get("auth") or ""))
                     if eerr:
                         return self._send(400, json.dumps({"ok": False, "error": eerr}),
                                           "application/json")
@@ -36764,6 +36798,13 @@ def main():
     # (a federated host) has no ~/.local/bin on PATH — bare `claude` exec-failed silently there.
     os.environ.setdefault("ROMP_CLAUDE_BIN", _claude_bin())
     signal.signal(signal.SIGTERM, _graceful_term)             # drain, don't die mid-flight (see _graceful_term)
+    # op's own credential (a service-account token in service.env) leaves the environment BEFORE anything
+    # is spawned — the bundler, the postal bus, tmux launches, the SDK backend's own claim later is a
+    # no-op re-assert — and the tmux server the manager started with that environment is scrubbed too,
+    # since every pane inherits the SERVER's globals, not the launching client's (review, 2026-09-05).
+    _claimed = jd._keysrc.claim_op_env()
+    if _claimed:
+        jd._keysrc.tmux_unset_global(_claimed, os.environ.get("ROMP_TMUX_SOCKET", ""))
     _ensure_bundles()
     try:                                                      # the diary boot sweep (2026-07-07): migrate every
         _death_boot_pass()                                    # deaths no kernel was up to see: stamp them

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -1,9 +1,27 @@
 """Live API-key configuration, separate from credential retrieval.
 
-ROMP_API_KEY_REF selects 1Password explicitly. Only resolve() runs ``op read``; metadata
-reads, UI updates and keyswap never do. Resolved provider values are not cached or written
-to disk. A selected source is authoritative: an empty, removed or unreadable configuration
-must not resurrect the manager's startup key. Legacy environment/file keys remain supported.
+The design, in four rules:
+
+* A SOURCE is configuration, not a secret: a static key line, or a 1Password reference
+  (``ROMP_API_KEY_REF=op://vault/item/field``) that names where the key lives. Everything that
+  needs to KNOW about the key — the Billing picker, status displays, ``romp keyswap``'s listing and
+  identity checks — reads the source. Only resolve() ever runs ``op read``, at the moment a Claude
+  session launches, an API-key-billed judge call is made, or the model catalog refreshes; the value
+  is handed to that one operation and never written to disk or cached for a later one.
+* A selected source is AUTHORITATIVE. A file that once carried a key line or a reference keeps
+  governing this process: emptying it, removing the line, or making it unreadable is an error the
+  operation reports, never permission to fall back to the key the manager started with or to a
+  login. That is what makes ``romp keyswap`` a swap — nothing an operator removed can come back.
+* Supervised managers (``ROMP_SUPERVISED=1``: the systemd/launchd service) read the FILE only. The
+  manager process keeps the environment it started with across every kernel restart, so a key it
+  inherited would otherwise resurrect after the operator removed it from the file. A startup key
+  the kernel therefore ignores is said once on the log wire (sdk_backend.work_api_key_source).
+* ``op``'s OWN credential (a service-account token, a session token) is the one secret that must
+  reach the kernel's environment for headless use — and nothing else: claim_op_env() takes those
+  names out of os.environ at startup and resolve() hands them back to the ``op read`` subprocess
+  alone, so no Claude session, judge child or tmux launch inherits a vault-wide credential.
+
+Legacy environment/file keys and Claude login remain supported without 1Password.
 """
 from __future__ import annotations
 
@@ -16,6 +34,87 @@ from dataclasses import dataclass, field
 KEY_VAR = "ANTHROPIC_API_KEY"
 REF_VAR = "ROMP_API_KEY_REF"
 OP_TIMEOUT = 15
+# The environment names the 1Password CLI authenticates from. Claimed out of the kernel's environment
+# once (claim_op_env) and given back to the `op read` subprocess only (resolve): a service-account
+# token reads every field the account can see, and a child that inherits it — a Claude session's
+# Bash, a judge call, a subagent — could print it with `env`. OP_SESSION_<account> is the name shape
+# `op signin` exports; anything with that prefix is treated the same way.
+OP_ENV_NAMES = ("OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT")
+OP_ENV_PREFIX = "OP_SESSION_"
+_OP_ENV: dict[str, str] = {}
+_OP_CLAIM_SAID = False
+
+
+def is_op_env_name(name: str) -> bool:
+    return name in OP_ENV_NAMES or name.startswith(OP_ENV_PREFIX)
+
+
+def op_consumer() -> bool:
+    """Is romp itself the one running `op`? Only when a 1Password reference is selected (in the env file
+    or the manager's environment). A box whose SESSIONS fetch their key through Claude Code's apiKeyHelper
+    calling `op` needs op's credential in every session's environment, and romp then leaves it alone."""
+    if REF_VAR in os.environ:
+        return True
+    return read_source().kind in ("op", "error") if os.path.exists(service_env_path()) else False
+
+
+def claim_op_env() -> dict[str, str]:
+    """Take op's credential names out of os.environ and return the running stash — but only while romp
+    is the op consumer (see op_consumer): otherwise the environment is left exactly as found, since a
+    session-side helper may need it. Idempotent and cheap; a value that appears later is claimed too. The
+    claimed NAMES (never values) are said once on the log wire so a helper that stops working has a
+    line to be found by."""
+    global _OP_CLAIM_SAID
+    if not op_consumer():
+        return _OP_ENV
+    names = [k for k in os.environ if is_op_env_name(k)]
+    for k in names:
+        _OP_ENV[k] = os.environ.pop(k)
+    if names and not _OP_CLAIM_SAID:
+        _OP_CLAIM_SAID = True
+        import sys
+        sys.stderr.write("op credentials claimed from the environment for `op read`: %s — sessions, judge "
+                         "calls and tmux launches will not see them\n" % ", ".join(sorted(names)))
+    return _OP_ENV
+
+
+def strip_op_env(env: dict) -> dict:
+    """The same names removed from a child environment built before the claim (a standalone judge, a
+    kernel that spawned a tmux launch before its backend existed) — while romp is the op consumer; a
+    helper box keeps its environment. Returns `env` for chaining."""
+    if _OP_ENV or op_consumer():
+        for k in [k for k in env if is_op_env_name(k)]:
+            env.pop(k, None)
+    return env
+
+
+def tmux_unset_global(names, socket: str = "") -> list:
+    """Remove op's credential names from a tmux SERVER's global environment — the environment every new
+    pane inherits, which the manager-started server carried from service.env (review find, 2026-09-05:
+    a tmux session's `exec claude` saw the token although the launching client had been scrubbed). Best
+    effort: no tmux, no server, an old tmux → nothing happens. Returns the commands run, for tests."""
+    ran = []
+    for name in sorted(set(n for n in names if is_op_env_name(n))):
+        cmd = ["tmux"] + (["-L", socket] if socket else []) + ["set-environment", "-gu", name]
+        try:
+            subprocess.run(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                           timeout=5, check=False)
+            ran.append(cmd)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return ran
+
+
+def runtime_reserved_names(auth: str, source) -> tuple:
+    """The credential names a per-session environment may NOT carry while runtime retrieval governs.
+    A per-session ANTHROPIC_API_KEY always competes with the selected source. A KEYED launch (an explicit
+    key pick, or no pick with a configured source) must carry no token beside the key it resolves either;
+    a LOGIN session's own token override bills the account the user chose for it and never touches the
+    key source, so it stays (review find, 2026-09-05). One rule for the doors, the launch and the fork."""
+    if source is None or source.kind not in ("op", "error"):
+        return ()
+    keyed = auth == "key" or (auth != "login" and source.configured)
+    return ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN") if keyed else ("ANTHROPIC_API_KEY",)
 
 # Cache file configuration only. ctime/mode also invalidate permission changes; a formerly
 # readable credential must not survive a chmod merely because its content did not change.
@@ -64,11 +163,16 @@ class KeySource:
         self.validate()
         if self.kind != "op":
             return self.value
+        # op authenticates from the credential names claimed at startup; they ride into THIS subprocess
+        # and no other (see claim_op_env). The rest of the environment goes along so op finds its PATH,
+        # HOME and config the way the manager's shell would have given them.
+        op_env = dict(os.environ)
+        op_env.update(claim_op_env())
         try:
             result = subprocess.run(
                 ["op", "read", "--no-newline", self.value], stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=OP_TIMEOUT,
-                check=False,
+                check=False, env=op_env,
             )
         except FileNotFoundError:
             raise KeySourceError("1Password CLI (op) is not on the manager's PATH") from None
@@ -134,12 +238,25 @@ def _assignments(text: str) -> dict[str, str]:
     return out
 
 
+def _garbled(values: dict) -> str:
+    """The name of a key/reference line that did not decode as UTF-8 (the read replaces bad bytes with
+    U+FFFD, which no real key contains) — "" when both are clean. A garbled key must fail HERE, with a
+    readable note, not at the API as an unexplained invalid-key error."""
+    for name in (REF_VAR, KEY_VAR):
+        if "\ufffd" in values.get(name, ""):
+            return name
+    return ""
+
+
 def parse_key(text: str) -> str:
     return _assignments(text).get(KEY_VAR, "")
 
 
 def parse_source(text: str) -> KeySource:
     values = _assignments(text)
+    bad = _garbled(values)
+    if bad:
+        return KeySource("error", error="the %s line in the API key source configuration is not valid UTF-8" % bad)
     if REF_VAR in values:
         return KeySource("op", values[REF_VAR])
     if KEY_VAR in values:
@@ -162,9 +279,9 @@ def read_source(path: str | None = None) -> KeySource:
     if _CACHE[0] == ident:
         return _CACHE[1]
     try:
-        with open(p, "r", encoding="utf-8") as fh:
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:   # a stray byte in a comment is not an outage
             source = parse_source(fh.read())
-    except (OSError, UnicodeError):
+    except OSError:
         return KeySource("error", error="Cannot read the API key source configuration")
     _CACHE = (ident, source)
     return source

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -1,45 +1,91 @@
-"""keysource — where the manager's API key comes from, read LIVE instead of once at startup.
+"""Live API-key configuration, separate from credential retrieval.
 
-The manager runs as a login service and gets its environment from `service.env`
-(`~/.config/romp/service.env`; systemd reads it via `EnvironmentFile=-`, the macOS login
-agent's launcher parses it before exec). Until 2026-09-04 the kernel claimed
-`ANTHROPIC_API_KEY` out of its own process environment ONCE at startup, so changing which
-key the sessions bill meant restarting the manager — which cuts every session's turn and
-kills every subagent. This module is the live source instead: every place that needs the key
-re-reads the FILE, so an edit takes effect on the next session connect with no restart.
-
-Three properties this module exists to hold:
-
-* **The value never lands in the kernel's own environment.** It is read, handed to one
-  session's launch environment, and dropped. Nothing here writes `os.environ`.
-* **The value never reaches a log, a screen or a wire.** `fingerprint()` is the only thing
-  callers may print: the first 12 hex of the sha256 of the exact value. Enough to say
-  "the key changed" or "both sides agree", useless to anyone who reads it.
-* **A read never raises and never blocks a launch.** A missing file, a file with no
-  `ANTHROPIC_API_KEY=` line, a permission error — all read as "" so the caller falls back
-  to whatever the process environment carried at startup, which is exactly the old
-  behaviour. The feature can only ADD a key source, never take one away.
-
-Parsing follows the same line-by-line rule the two launchers use (never sourced, so a
-malformed line is skipped rather than executed): blank and `#` lines ignored, `NAME=value`
-otherwise, and the LAST assignment wins — that is what both systemd and a repeated `export`
-do, so what this module reads is what the service would actually have got. One layer of
-matching surrounding quotes is stripped, because systemd strips it and a quoted value would
-otherwise be handed to the CLI with the quotes still on.
+ROMP_API_KEY_REF selects 1Password explicitly. Only resolve() runs ``op read``; metadata
+reads, UI updates and keyswap never do. Resolved provider values are not cached or written
+to disk. A selected source is authoritative: an empty, removed or unreadable configuration
+must not resurrect the manager's startup key. Legacy environment/file keys remain supported.
 """
 from __future__ import annotations
 
 import hashlib
 import os
+import subprocess
 import tempfile
+from dataclasses import dataclass, field
 
 KEY_VAR = "ANTHROPIC_API_KEY"
+REF_VAR = "ROMP_API_KEY_REF"
+OP_TIMEOUT = 15
 
-# (stat identity, parsed value) for the last file read — an EVENT-keyed cache, not a timed one:
-# the identity is the file's own (inode, mtime_ns, size), so a rewrite invalidates it by
-# construction and a swap is picked up on the very next read. Without it, `work_key` (read per
-# push through the kernel's has-a-key bool) would parse the file thousands of times a minute.
+# Cache file configuration only. ctime/mode also invalidate permission changes; a formerly
+# readable credential must not survive a chmod merely because its content did not change.
 _CACHE: tuple = ((), "")
+_AUTHORITATIVE_PATHS: dict[str, str] = {}
+_ENV_PROVIDER_PATHS: set[str] = set()
+
+
+class KeySourceError(RuntimeError):
+    """A credential failure whose message is safe for user-visible logs."""
+
+
+@dataclass(frozen=True)
+class KeySource:
+    kind: str
+    value: str = field(default="", repr=False)
+    error: str = ""
+
+    @property
+    def configured(self) -> bool:
+        # An invalid provider remains an explicit choice, never permission to use a login.
+        return self.kind in ("op", "error") or bool(self.value)
+
+    def validate(self) -> None:
+        if self.kind == "error":
+            raise KeySourceError(self.error or "Cannot read the configured API key source")
+        if self.kind == "op":
+            parts = self.value[5:].split("/") if self.value.startswith("op://") else []
+            if (len(parts) not in (3, 4) or not all(parts)
+                    or any(c in self.value for c in ("\r", "\n", "\0"))):
+                raise KeySourceError("ROMP_API_KEY_REF must be an op://vault/item/[section/]field reference")
+        elif self.kind not in ("file", "environment", "none"):
+            raise KeySourceError("Unknown API key source")
+        elif any(c in self.value for c in ("\r", "\n", "\0")):
+            raise KeySourceError("API keys must be a single line")
+
+    def fingerprint(self) -> str:
+        """Configuration identity; for op this hashes the reference, never retrieves its value."""
+        if self.kind == "op":
+            return fingerprint("op:" + self.value)
+        if self.kind == "error":
+            return ""
+        return fingerprint(self.value)
+
+    def resolve(self) -> str:
+        self.validate()
+        if self.kind != "op":
+            return self.value
+        try:
+            result = subprocess.run(
+                ["op", "read", "--no-newline", self.value], stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=OP_TIMEOUT,
+                check=False,
+            )
+        except FileNotFoundError:
+            raise KeySourceError("1Password CLI (op) is not on the manager's PATH") from None
+        except subprocess.TimeoutExpired:
+            raise KeySourceError("1Password credential retrieval timed out; check op authentication") from None
+        except OSError:
+            raise KeySourceError("Cannot run 1Password CLI; check the manager's op installation") from None
+        if result.returncode:
+            # Neither subprocess stderr nor its exception repr is safe to log.
+            raise KeySourceError("1Password credential retrieval failed; check op authentication and vault access")
+        try:
+            value = result.stdout.decode("utf-8")
+        except UnicodeError:
+            raise KeySourceError("1Password returned an invalid API key") from None
+        if not value or len(value) > 16384 or any(c.isspace() or c == "\0" for c in value):
+            raise KeySourceError("1Password returned an empty or invalid API key")
+        return value
 
 
 def service_env_path() -> str:
@@ -60,8 +106,9 @@ def service_env_path() -> str:
 
 def sibling_path(name: str, path: str | None = None) -> str:
     """The candidate file a keyswap reads from. A bare name (`highprio`) means the sibling
-    `service.env.<name>` beside the live file — the convention that keeps every candidate in one
-    0600 directory. Anything with a separator, or an explicit path, is taken as given."""
+    `service.env.<name>` beside the live file — the convention that keeps candidate files together
+    with mode 0600 (a private parent directory needs 0700). Anything with a separator, or an explicit
+    path, is taken as given."""
     name = str(name or "").strip()
     if not name:
         return ""
@@ -70,44 +117,98 @@ def sibling_path(name: str, path: str | None = None) -> str:
     return (path or service_env_path()) + "." + name
 
 
-def parse_key(text: str) -> str:
-    """The value the LAST `ANTHROPIC_API_KEY=` assignment in an env-file body would set — "" when
-    the body has none. Last wins, matching systemd and a repeated `export`."""
-    out = ""
+def _assignments(text: str) -> dict[str, str]:
+    """Read literal env assignments; never execute or expand the file's contents."""
+    out = {}
     for raw in str(text or "").splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
         name, sep, value = line.partition("=")
-        if not sep or name.strip() != KEY_VAR:
+        if not sep or name.strip() not in (KEY_VAR, REF_VAR):
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]     # systemd strips one layer; without this the CLI gets the quotes
-        out = value
+        out[name.strip()] = value
     return out
 
 
-def read_key(path: str | None = None) -> str:
-    """The key the env file currently sets, or "" for every failure — missing file, no such line,
-    unreadable, undecodable. Cached on the file's own stat identity (see _CACHE)."""
+def parse_key(text: str) -> str:
+    return _assignments(text).get(KEY_VAR, "")
+
+
+def parse_source(text: str) -> KeySource:
+    values = _assignments(text)
+    if REF_VAR in values:
+        return KeySource("op", values[REF_VAR])
+    if KEY_VAR in values:
+        return KeySource("file", values[KEY_VAR])
+    return KeySource("none")
+
+
+def read_source(path: str | None = None) -> KeySource:
+    """Read configuration only. Read errors remain errors, never an absent credential."""
     global _CACHE
     p = path or service_env_path()
     try:
         st = os.stat(p)
-        ident = (p, st.st_ino, st.st_mtime_ns, st.st_size)
+        ident = (p, st.st_ino, st.st_mtime_ns, st.st_ctime_ns, st.st_size, st.st_mode)
+    except FileNotFoundError:
+        _CACHE = ((p, "absent"), KeySource("none"))
+        return _CACHE[1]
     except OSError:
-        _CACHE = ((p, "absent"), "")
-        return ""
+        return KeySource("error", error="Cannot read the API key source configuration")
     if _CACHE[0] == ident:
         return _CACHE[1]
     try:
-        with open(p, "r", encoding="utf-8", errors="replace") as fh:
-            key = parse_key(fh.read())
-    except OSError:
-        key = ""
-    _CACHE = (ident, key)
-    return key
+        with open(p, "r", encoding="utf-8") as fh:
+            source = parse_source(fh.read())
+    except (OSError, UnicodeError):
+        return KeySource("error", error="Cannot read the API key source configuration")
+    _CACHE = (ident, source)
+    return source
+
+
+def select_source(startup_key: str = "") -> KeySource:
+    """Choose a source without fetching it; only a never-configured file permits env fallback.
+
+    Track the path, not one global flag, so isolated kernels/tests with different config roots
+    cannot change each other's source policy. An unreadable file is always an error. Once an op
+    reference has been selected from a file or the environment, deleting it is an error until a new
+    source is configured. A previously selected file stays authoritative over the environment.
+    Supervised services always use the file: their manager may still hold an old assignment across
+    kernel restarts, so inherited credentials cannot establish a fallback for a fresh kernel.
+    """
+    path = service_env_path()
+    source = read_source(path)
+    if source.kind != "none":
+        if source.kind != "error":
+            _AUTHORITATIVE_PATHS[path] = source.kind
+        return source
+    previous = _AUTHORITATIVE_PATHS.get(path)
+    if previous == "op":
+        return KeySource("error", error="The 1Password reference was removed; configure an API key source explicitly")
+    if previous:
+        return KeySource("file")
+    if os.environ.get("ROMP_SUPERVISED") == "1":
+        if REF_VAR in os.environ:
+            _AUTHORITATIVE_PATHS[path] = "op"
+            return KeySource("error", error="The 1Password reference was removed; configure an API key source explicitly")
+        _AUTHORITATIVE_PATHS[path] = "file"
+        return KeySource("file")
+    if REF_VAR in os.environ:
+        _ENV_PROVIDER_PATHS.add(path)
+        return KeySource("op", os.environ[REF_VAR].strip())
+    if path in _ENV_PROVIDER_PATHS:
+        return KeySource("error", error="The 1Password reference was removed from the environment; configure an API key source explicitly")
+    return KeySource("environment", startup_key) if startup_key else source
+
+
+def read_key(path: str | None = None) -> str:
+    """Legacy file reader. Provider references are never interpreted as raw keys."""
+    source = read_source(path)
+    return source.value if source.kind == "file" else ""
 
 
 def fingerprint(key: str) -> str:
@@ -120,8 +221,8 @@ def fingerprint(key: str) -> str:
     return hashlib.sha256(key.encode("utf-8", "replace")).hexdigest()[:12]
 
 
-def write_key(key: str, path: str | None = None) -> dict:
-    """Rewrite ONLY the `ANTHROPIC_API_KEY=` line of the env file, atomically.
+def write_source(source: KeySource, path: str | None = None) -> dict:
+    """Atomically select a source, removing competing key/reference assignments.
 
     Every other line survives byte for byte, in place — the file also carries things like
     `ROMP_PERF=1` and `ROMP_EXPECTED_AUTH`, and a rewrite that dropped them would change the
@@ -138,10 +239,14 @@ def write_key(key: str, path: str | None = None) -> dict:
     and an `os.replace` onto the link's own name would swap the link for a plain file and leave its
     target — what the operator's repo tracks and what a re-link would restore — on the old key.
 
-    Returns {"path", "old", "new", "mode", "tightened", "lines", "target"} — `old`/`new` are the raw
-    values, for the caller to fingerprint; `target` is the file actually rewritten (the link's target,
-    else `path`). Raises OSError on a real failure (the caller reports it).
+    Returns {"path", "old", "new", "mode", "tightened", "lines", "target"} — `old`/`new` are source
+    descriptors, so the caller can report their identities without resolving provider credentials;
+    `target` is the file actually rewritten (the link's target, else `path`). Raises OSError on a real
+    failure (the caller reports it).
     """
+    source.validate()
+    if source.kind not in ("op", "file", "environment"):
+        raise KeySourceError("Select an API key or a 1Password reference")
     given = path or service_env_path()
     p = os.path.realpath(given) if os.path.islink(given) else given
     try:
@@ -150,14 +255,15 @@ def write_key(key: str, path: str | None = None) -> dict:
         existed = True
     except FileNotFoundError:
         body, existed = "", False
-    old = parse_key(body)
+    old = parse_source(body)
     lines = body.splitlines()
     trailing_nl = (not body) or body.endswith("\n")
     # Which physical lines assign the key: the LAST one is rewritten in place, earlier ones drop.
     hits = [i for i, raw in enumerate(lines)
             if raw.strip() and not raw.strip().startswith("#")
-            and raw.strip().partition("=")[1] and raw.strip().partition("=")[0].strip() == KEY_VAR]
-    new_line = "%s=%s" % (KEY_VAR, key)
+            and raw.strip().partition("=")[1]
+            and raw.strip().partition("=")[0].strip() in (KEY_VAR, REF_VAR)]
+    new_line = "%s=%s" % (REF_VAR if source.kind == "op" else KEY_VAR, source.value)
     if hits:
         lines[hits[-1]] = new_line
         for i in reversed(hits[:-1]):
@@ -192,5 +298,11 @@ def write_key(key: str, path: str | None = None) -> dict:
         except OSError:
             pass
         raise
-    return {"path": given, "old": old, "new": key, "mode": mode, "tightened": tightened,
+    return {"path": given, "old": old, "new": source, "mode": mode, "tightened": tightened,
             "lines": len(lines), "target": p}
+
+
+def write_key(key: str, path: str | None = None) -> dict:
+    """Compatibility API for callers explicitly writing a legacy static key."""
+    result = write_source(KeySource("file", key), path)
+    return dict(result, old=result["old"].value if result["old"].kind == "file" else "", new=key)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -47,7 +47,8 @@ _pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py"))
 # The LIVE source of the manager's API key (keysource.py — stdlib only, loaded the same way so the
 # module works from bin/ symlinks too). `romp keyswap` loads the identical file, so the writer and
 # the reader can never disagree about which path holds the key or how its line is parsed.
-_keysrc = _SFL("romp_keysource", str(Path(__file__).resolve().parent / "keysource.py")).load_module()
+_keysrc = sys.modules.get("romp_keysource") or _SFL(
+    "romp_keysource", str(Path(__file__).resolve().parent / "keysource.py")).load_module()
 
 
 def _bin_on_path_env(environ) -> dict:
@@ -1545,6 +1546,7 @@ ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")   # the shell-identifier a
 # flag-settings file), whose rank against options.env is unverified — so it would silently shadow
 # or be shadowed, and the break surfaces nowhere. Reserved at the door instead.
 ENV_RESERVED_NAMES = ("ROMP_SID", "ROMP_SESSION_NAME")
+AUTH_ENV_NAMES = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
 
 
 def env_request_error(env) -> str:
@@ -1564,6 +1566,8 @@ def env_request_error(env) -> str:
         if k in ENV_RESERVED_NAMES:
             return ("env: %s is reserved — romp sets the session's identity env "
                     "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
+        if k in AUTH_ENV_NAMES and work_api_key_source().kind in ("op", "error"):
+            return "env: %s is reserved while runtime API key retrieval is configured" % k
         if not isinstance(v, str):
             return "env: the value for %r must be a string" % (k,)
         if "\x00" in v:
@@ -1785,6 +1789,8 @@ def _cli_refusal(e: BaseException) -> bool:
 
 _WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
 _KEY_FILE_CHECKED = False      # the startup-vs-file agreement check (one line, once per process)
+_STARTUP_AUTH_ENV: dict | None = None
+_WORK_AUTH_LOCK = threading.RLock()
 
 
 def startup_api_key() -> str:
@@ -1803,31 +1809,50 @@ def startup_api_key() -> str:
     foreground `romp up` from a shell that exported one) has no file line to read, and there the
     startup claim is the whole answer, exactly as before."""
     global _WORK_KEY
-    if _WORK_KEY is None:
-        _WORK_KEY = os.environ.pop("ANTHROPIC_API_KEY", "") or ""
-    return _WORK_KEY
+    with _WORK_AUTH_LOCK:
+        if _WORK_KEY is None:
+            _WORK_KEY = os.environ.pop("ANTHROPIC_API_KEY", "") or ""
+        return _WORK_KEY
+
+
+def startup_auth_env() -> dict:
+    """Claim competing token credentials so key launches cannot inherit them.
+
+    Login launches may explicitly restore these credentials in their child environment.
+    Returning a copy keeps callers from changing the manager's startup credentials.
+    """
+    global _STARTUP_AUTH_ENV
+    with _WORK_AUTH_LOCK:
+        if _STARTUP_AUTH_ENV is None:
+            _STARTUP_AUTH_ENV = {name: os.environ.pop(name)
+                                 for name in AUTH_ENV_NAMES[1:] if name in os.environ}
+        return dict(_STARTUP_AUTH_ENV)
+
+
+def work_api_key_source():
+    """The selected credential descriptor, without invoking a secret provider.
+
+    Once a file or runtime source takes over, discard the startup key. Removing that
+    source must never restore a credential that the operator already replaced.
+    """
+    global _WORK_KEY
+    with _WORK_AUTH_LOCK:
+        startup = startup_api_key()
+        source = _keysrc.select_source(startup)
+        if source.kind == "file":
+            _check_key_file_agrees(startup, source.value)
+        if source.kind in ("file", "op", "error"):
+            _WORK_KEY = ""
+        return source
 
 
 def work_api_key() -> str:
-    """The key a session started RIGHT NOW should bill: the live `ANTHROPIC_API_KEY=` line of the
-    manager's env file (`~/.config/romp/service.env`), falling back to what the process environment
-    carried at startup. "" when neither exists.
+    """Resolve the current key for an actual launch or API call; failures propagate.
 
-    Live, because the alternative was a restart (the user 2026-09-04): the key used to be popped
-    once at boot, so moving the sessions to another org key meant `systemctl --user restart
-    romp-manager` — which cuts every session's open turn and kills every subagent under it. Reading
-    the file instead makes the swap cost one reconnect per session (`romp keyswap <name> --cycle…`,
-    which resumes each conversation with its history intact) and nothing at all for a session that
-    is next launched or revived anyway.
-
-    The read is cheap and event-keyed: keysource caches on the file's own (inode, mtime_ns, size),
-    so a repeated call is a stat and a rewrite invalidates by construction. The value is never
-    written back into os.environ — the one-claimer property above is what keeps an ambient key from
-    billing every session, and a live source must not undo it."""
-    startup = startup_api_key()      # ALWAYS first: the pop must happen even when the file answers
-    live = _keysrc.read_key()
-    _check_key_file_agrees(startup, live)
-    return live or startup
+    Runtime providers are invoked per call. UI and billing decisions use the source
+    descriptor instead, and no resolved provider value is cached by this module.
+    """
+    return work_api_key_source().resolve()
 
 
 def _check_key_file_agrees(startup: str, live: str) -> None:
@@ -1900,7 +1925,7 @@ def _declared_auth(state_dir) -> tuple:
 
 FAST_ORG_PATH = "/api/claude_code_penguin_mode"   # the CLI's own fast-mode availability endpoint
 
-_FAST_ORG_VERDICTS: dict[str, bool] = {}   # key -> the server's last definitive answer
+_FAST_ORG_VERDICTS: dict[str, bool] = {}   # key digest -> the server's last definitive answer
 
 
 def _fetch_key_fast_org(key: str) -> bool | None:
@@ -1938,10 +1963,11 @@ def key_fast_org_env(key: str, log) -> dict[str, str]:
     check is fresh exactly when it matters), capped at 3s so a black-holed network cannot hang a
     connect. Never injected for login sessions: there the CLI's probe already asks the account that
     pays."""
+    key_id = hashlib.sha256(key.encode("utf-8")).hexdigest()
     verdict = _fetch_key_fast_org(key)
     if verdict is None:
-        if key in _FAST_ORG_VERDICTS:
-            verdict = _FAST_ORG_VERDICTS[key]
+        if key_id in _FAST_ORG_VERDICTS:
+            verdict = _FAST_ORG_VERDICTS[key_id]
             log("fast-mode org check (key account): unreachable — standing on the last answer "
                 "(%s)" % ("enabled" if verdict else "disabled"))
         else:
@@ -1950,9 +1976,9 @@ def key_fast_org_env(key: str, log) -> dict[str, str]:
                 problem=True)
             return {}
     else:
-        if _FAST_ORG_VERDICTS.get(key) != verdict:
+        if _FAST_ORG_VERDICTS.get(key_id) != verdict:
             log("fast-mode org check (key account): %s" % ("enabled" if verdict else "disabled"))
-        _FAST_ORG_VERDICTS[key] = verdict
+        _FAST_ORG_VERDICTS[key_id] = verdict
     if verdict:
         return {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1"}
     return {"CLAUDE_CODE_DISABLE_FAST_MODE": "1"}
@@ -2841,20 +2867,18 @@ class SdkSession:
             self.backend._poke()
 
     def effective_auth(self, key=None) -> str:
-        """'key' or 'login' — what _options launches this session with. An explicit pick wins; unset
-        preserves the pre-selector world, where a manager environment that carried a key billed every
-        session to it (so absent a choice, the key still wins when one exists). 'key' with no key to
-        inject falls to login rather than launching with a var the CLI would refuse on — _options
-        logs that fall loudly (it is a misconfiguration, not a preference).
+        """Billing intent, without retrieving credentials for repeated UI snapshots.
 
-        `key` lets a caller supply the key it already read, so a connect decides and injects on ONE
-        read: the source is live now (a keyswap can land between two reads), and re-reading here
-        could have _options inject a key the decision was never made against. Absent, it reads the
-        backend's live key exactly as it always did."""
+        An explicit key pick stays keyed even when retrieval fails: launch must report
+        the missing credential instead of billing the login. `key` permits callers
+        holding an already-resolved credential to avoid a second source read.
+        """
         if self.auth == "login":
             return "login"
+        if self.auth == "key":
+            return "key"
         if key is None:
-            key = self.backend.work_key
+            key = self.backend.work_key_configured
         return "key" if key else "login"
 
     async def _do_refresh_usage(self):
@@ -3044,7 +3068,13 @@ class SdkSession:
             self._drop_live_work("reconnect")
             # settle + recover anything the abandoned client stranded — see _reconcile_stranded
             self._reconcile_stranded()
-            opts = self.backend._options(self, ClaudeAgentOptions)
+            try:
+                opts = self.backend._options(self, ClaudeAgentOptions)
+            except Exception as e:
+                # Credential retrieval precedes CLI construction. Surface its failure
+                # as a launch problem without treating it as a refused rewind.
+                self.backend._record_launch_error(self, e)
+                raise
             # Whether THIS connection carries the fastMode opt-in — snapshotted at the same moment
             # _options composes the flag-settings file, so the two can never disagree. The CLI only
             # interprets literal '/fast on|off' sends on a connection made with the flag; set_fast
@@ -4709,7 +4739,8 @@ class SdkBackend:
         #                                           logs the condition once per episode, not per call
         self._fork_children_memo = None           # (sdk/ dir mtime_ns, {parent sid: [child lineage]}) — fork_children()
         self._work_key_pin: str | None = None     # a test's explicit `be.work_key = …` (see the property)
-        startup_api_key()                         # claim any ambient key OUT of os.environ, right here:
+        work_api_key_source()                     # claim ambient auth; inspect config without resolving op
+        startup_auth_env()
         #   the transport merges options.env over this process's env, so an ambient key would bill
         #   EVERY session whatever its pick. The VALUE is read per launch off `work_key` below, live,
         #   so a keyswap needs no kernel restart (the user 2026-09-04).
@@ -4768,15 +4799,10 @@ class SdkBackend:
 
     @property
     def work_key(self) -> str:
-        """The manager's API key, READ LIVE per access (work_api_key: the env file's current line,
-        else the startup claim). A property rather than the frozen attribute it used to be, so
-        every existing reader becomes hot-swap-aware at once — _options' injection, effective_auth
-        and default_auth's key/login fallback, set_auth's refusal to pick a key that isn't there,
-        and the kernel's has-a-key bool for the picker. Cheap enough for all of them: the parse is
-        cached on the file's stat identity, so an access is a stat.
+        """Resolve the current key. UI readers must use work_key_configured instead.
 
-        Assignment PINS a value for this backend and stops the live read (`be.work_key = ""` — how
-        the tests stand up a keyless manager). A pin is deliberate and never set by romp itself."""
+        Assignment pins a synthetic key for tests; production never assigns here.
+        """
         if self._work_key_pin is not None:
             return self._work_key_pin
         return work_api_key()
@@ -4785,19 +4811,27 @@ class SdkBackend:
     def work_key(self, value) -> None:
         self._work_key_pin = str(value or "")
 
-    def _work_key_and_source(self) -> tuple:
-        """(key, source) in ONE read of the file — "file" (the env file's line), "startup" (the claim
-        made at boot, because the file has no usable line), "pin" (a test's explicit value), "" (no
-        key anywhere). _options wants both, and must not read the file twice per connect: a keyswap
-        can land between two reads, and the source named in the log must be the source injected."""
+    def _work_key_source(self):
+        if self._work_key_pin is not None:
+            return _keysrc.KeySource("environment", self._work_key_pin)
+        return work_api_key_source()
+
+    @property
+    def work_key_configured(self) -> bool:
+        """Whether a key source is selected, without invoking a provider."""
+        return self._work_key_source().configured
+
+    def work_key_source_fp(self) -> str:
+        """Non-secret source identity; runtime references never resolve here."""
+        return self._work_key_source().fingerprint()
+
+    def _work_key_and_source(self, source=None) -> tuple:
+        """Resolve ONE selected source and report its kind for safe launch logging."""
         if self._work_key_pin is not None:
             return self._work_key_pin, ("pin" if self._work_key_pin else "")
-        startup = startup_api_key()
-        live = _keysrc.read_key()
-        _check_key_file_agrees(startup, live)
-        if live:
-            return live, "file"
-        return startup, ("startup" if startup else "")
+        if source is None:
+            source = work_api_key_source()
+        return source.resolve(), ("startup" if source.kind == "environment" else source.kind)
 
     def work_key_fp(self) -> str:
         """The renderable form of the key sessions launch on: the sha256 head, "" for none. The
@@ -4816,11 +4850,13 @@ class SdkBackend:
             if source == "startup":  # the fallback: say so, rather than name a file that does not hold the key
                 src = ("the environment this manager started with; %s has no %s line the kernel can use"
                        % (_keysrc.service_env_path(), _keysrc.KEY_VAR))
+            elif source == "op":
+                src = "retrieved at runtime from 1Password"
             else:
                 src = "read from %s" % _keysrc.service_env_path()
             self._log("work key: sessions now launch on the key sha256:%s (%s)" % (fp, src))
 
-    def cycle_key(self, sid: str) -> str:
+    def cycle_key(self, sid: str, expected_source_fp: str | None = None) -> str:
         """Re-present the CURRENT work key to one LIVE session by reconnecting it — the apply half of
         `romp keyswap --cycle` (the user 2026-09-04).
 
@@ -4846,24 +4882,41 @@ class SdkBackend:
         settings switches use: that reconnect fires unconditionally when the turn ends, so work the turn
         launches after this check would die with it (second review pass, 2026-09-04). So "cycling" means
         exactly one thing — an immediate reconnect of a session with nothing in flight — and the operator
-        re-runs --cycle-all until every session reads "current" (review find, 2026-09-04)."""
+        re-runs --cycle-all until every session reads "current" (review find, 2026-09-04).
+
+        An optional source fingerprint binds the request to the CLI's preflight check. Check
+        metadata again after provider retrieval, which can take time, before scheduling a reconnect.
+        The actual launch still reads its source afresh; no credential is retained for that launch.
+        """
         if not self.owns(sid):
             return "unknown"
         s = self.sessions.get(sid)
         if s is None:
             return "dormant"
-        if s.effective_auth() != "key":
+        source = self._work_key_source()
+        if s.effective_auth(source.configured) != "key":
             return "login"
-        fp = self.work_key_fp()
-        if fp and getattr(s, "_launched_key_fp", None) == fp:
-            return "current"
         with s._sub_lock:
             live_work = len(s._subagents) + len(s._bg_tasks)
         if live_work or s.inflight > 0 or s._pending:
             return "working"
+        source.validate()
+        source_fp = source.fingerprint()
+        if expected_source_fp is not None and source_fp != expected_source_fp:
+            raise _keysrc.KeySourceError("API key source changed; check it before cycling again")
+        key, _source = self._work_key_and_source(source)
+        if not key:
+            raise _keysrc.KeySourceError("API key billing selected but no API key source is configured")
+        current_source = self._work_key_source()
+        current_source.validate()
+        if current_source.fingerprint() != source_fp:
+            raise _keysrc.KeySourceError("API key source changed during retrieval; check it before cycling again")
+        fp = _keysrc.fingerprint(key)
+        if getattr(s, "_launched_key_fp", None) == fp:
+            return "current"
         s.request_reconnect(defer=False)
         self._log("keyswap (%s): reconnecting to pick up the current work key (sha256:%s)"
-                  % (s.name, _keysrc.fingerprint(self.work_key)))
+                  % (s.name, fp))
         return "cycling"
 
     def _heal_stale_awaiting(self, sid: str) -> None:
@@ -5944,36 +5997,32 @@ class SdkBackend:
         # rest, launch the session — and say so (fail-loudly: the line lands on stderr via the
         # kernel's log wire and in the problem ring the dashboard's error center reads).
         env_vars = sess.env_vars
-        legacy = [k for k in ENV_RESERVED_NAMES if k in env_vars]
+        key_source = self._work_key_source()
+        reserved = ENV_RESERVED_NAMES + (AUTH_ENV_NAMES if key_source.kind in ("op", "error") else ())
+        legacy = [k for k in reserved if k in env_vars]
         if legacy:
-            env_vars = {k: v for k, v in env_vars.items() if k not in ENV_RESERVED_NAMES}
-            self._log("env (%s): ignoring reserved %s from the stored session env — romp sets the "
-                      "identity env itself (a reg from before the names were reserved)"
+            env_vars = {k: v for k, v in env_vars.items() if k not in reserved}
+            self._log("env (%s): ignoring reserved %s from the stored session env — romp manages "
+                      "identity and runtime authentication"
                       % (sess.name, ", ".join(legacy)), problem=True)
         fs = flag_settings_path(self.state_dir, sess.sid,
                                 ultracode=(sess.effort or "") == "ultracode", fast=sess.fast_opt,
                                 env=env_vars, log=self._log)
         if fs:
             kw["settings"] = fs
-        # Per-session auth (the user 2026-08-08): the work key was claimed OUT of this process's env at
-        # startup (work_api_key), so a login session's CLI inherits a clean environment and finds the
-        # login on its own; a key session gets the key injected here, explicitly. options.env merges
-        # OVER the inherited env in the SDK's transport, which is exactly the one-way door we need —
-        # inject or stay silent; never blank (an empty var reads as "API-key mode, no key" to the CLI).
-        # The key is read ONCE here, per connect, and the value the auth decision was made on is the
-        # value injected: the source is live now (a keyswap can land between two reads). An empty read
-        # decides login — blanking the var would leave the CLI in key-mode-without-a-key.
-        work_key, key_src = self._work_key_and_source()
-        launch_keyed = sess.effective_auth(work_key) == "key"
+        # Authentication is resolved only for a launch that selects API-key billing.
+        # Source presence is metadata; a provider failure cannot turn it into login.
+        launch_keyed = sess.auth == "key" or (sess.auth != "login" and key_source.configured)
+        work_key = ""
         if launch_keyed:
+            work_key, key_src = self._work_key_and_source(key_source)
+            if not work_key:
+                raise _keysrc.KeySourceError("API key billing selected but no API key source is configured")
             self._note_work_key(work_key, key_src)
             kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=work_key,
                              **key_fast_org_env(work_key, self._log))
-        elif sess.auth == "key":
-            # picked "key", but this manager's env carries none — falling to login silently would bill
-            # the wrong account with nothing to see; say so where the Log panel shows it.
-            self._log("auth (%s): session is set to the API key but the manager environment carries "
-                      "none (service.env) — launching on the login instead" % sess.name, problem=True)
+        else:
+            kw["env"] = dict(kw["env"], **startup_auth_env())
         sess._launched_keyed = launch_keyed
         sess._launched_key_fp = _keysrc.fingerprint(work_key) if launch_keyed else ""
         return ClaudeAgentOptions(**kw)
@@ -6111,8 +6160,10 @@ class SdkBackend:
             # the reserved identity names never cross the copy: a parent reg from before
             # ENV_RESERVED_NAMES existed carries them (the _options apply seam skips them there),
             # and the copy is where that legacy poison stops propagating into fresh regs
-            env = {k: v for k, v in parent["env"].items() if k not in ENV_RESERVED_NAMES}
-            dropped = [k for k in parent["env"] if k in ENV_RESERVED_NAMES]
+            reserved = ENV_RESERVED_NAMES + (AUTH_ENV_NAMES if self._work_key_source().kind
+                                              in ("op", "error") else ())
+            env = {k: v for k, v in parent["env"].items() if k not in reserved}
+            dropped = [k for k in parent["env"] if k in reserved]
             if dropped:
                 self._log("env (%s): dropping reserved %s from the inherited env — romp sets the "
                           "identity env itself (the parent reg predates the reserved names)"
@@ -7588,7 +7639,7 @@ class SdkBackend:
         next init confirms via apiKeySource (_note_auth_source flags a landing on the wrong side)."""
         if value not in ("login", "key"):
             return False
-        if value == "key" and not self.work_key:
+        if value == "key" and not self.work_key_configured:
             return False   # nothing to inject — the UI never offers this; refuse rather than half-apply
         if value == "login" and not self.login_ok():
             # the SAME bar the key side always had (T124: set_auth accepted 'login' unconditionally,
@@ -7622,9 +7673,9 @@ class SdkBackend:
         """The auth a session with no live SdkSession object would launch with — the dormant twin of
         SdkSession.effective_auth(), reading the same registry field with the same fallback."""
         a = (reg or {}).get("auth")
-        if a == "login":
-            return "login"
-        return "key" if self.work_key else "login"
+        if a in ("login", "key"):
+            return a
+        return "key" if self.work_key_configured else "login"
 
     def owns(self, sid: str) -> bool:
         return read_reg(self.state_dir, sid) is not None
@@ -8146,7 +8197,9 @@ class SdkBackend:
         # A missing dependency gets the REMEDY as its text, not the raw ModuleNotFoundError: "No module
         # named 'claude_agent_sdk'" tells a user nothing about what to run.
         dep = isinstance(exc, ImportError)
-        tail = "" if dep else sess.stderr_tail()   # what the CLI itself said before it exited
+        # A provider failure happened before a new CLI existed. The previous
+        # connection's stderr must not replace it or turn it into a quota hold.
+        tail = "" if dep or isinstance(exc, _keysrc.KeySourceError) else sess.stderr_tail()
         text = SDK_MISSING_TEXT if dep else launch_failure_text(exc, tail)
         rec = {"text": text, "at": int(time.time()), "limit": is_launch_limit(text), "dep": dep}
         try:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1549,7 +1549,7 @@ ENV_RESERVED_NAMES = ("ROMP_SID", "ROMP_SESSION_NAME")
 AUTH_ENV_NAMES = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
 
 
-def env_request_error(env) -> str:
+def env_request_error(env, auth: str = "") -> str:
     """Why `env` is NOT a valid per-session env payload — "" when it is (an empty dict is a valid,
     vacuous one). A payload is a dict of NAME → string-value pairs, names in the shell-identifier
     alphabet and outside the reserved identity names (ENV_RESERVED_NAMES): it lands in the per-sid
@@ -1566,7 +1566,7 @@ def env_request_error(env) -> str:
         if k in ENV_RESERVED_NAMES:
             return ("env: %s is reserved — romp sets the session's identity env "
                     "(ROMP_SID, ROMP_SESSION_NAME) itself" % k)
-        if k in AUTH_ENV_NAMES and work_api_key_source().kind in ("op", "error"):
+        if k in AUTH_ENV_NAMES and k in _keysrc.runtime_reserved_names(auth or "", work_api_key_source()):
             return "env: %s is reserved while runtime API key retrieval is configured" % k
         if not isinstance(v, str):
             return "env: the value for %r must be a string" % (k,)
@@ -1788,6 +1788,7 @@ def _cli_refusal(e: BaseException) -> bool:
 
 
 _WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
+_STARTUP_KEY_DISCARD_SAID = False   # the one-line "your startup key is ignored" notice, once per process
 _KEY_FILE_CHECKED = False      # the startup-vs-file agreement check (one line, once per process)
 _STARTUP_AUTH_ENV: dict | None = None
 _WORK_AUTH_LOCK = threading.RLock()
@@ -1826,6 +1827,7 @@ def startup_auth_env() -> dict:
         if _STARTUP_AUTH_ENV is None:
             _STARTUP_AUTH_ENV = {name: os.environ.pop(name)
                                  for name in AUTH_ENV_NAMES[1:] if name in os.environ}
+        _keysrc.claim_op_env()   # op's own credential: for the `op read` subprocess only, never a session's (2026-09-05)
         return dict(_STARTUP_AUTH_ENV)
 
 
@@ -1835,14 +1837,34 @@ def work_api_key_source():
     Once a file or runtime source takes over, discard the startup key. Removing that
     source must never restore a credential that the operator already replaced.
     """
-    global _WORK_KEY
+    global _WORK_KEY, _STARTUP_KEY_DISCARD_SAID
     with _WORK_AUTH_LOCK:
         startup = startup_api_key()
         source = _keysrc.select_source(startup)
         if source.kind == "file":
             _check_key_file_agrees(startup, source.value)
-        if source.kind in ("file", "op", "error"):
+        if source.kind in ("file", "op"):
+            # A real selection retires the startup key for good. Said ONCE when that key was non-empty:
+            # an operator who delivers the key through a systemd drop-in or a launchd plist rather than
+            # service.env would otherwise watch every session bill the login with nothing in the log
+            # (review find, 2026-09-05) — the silent fallback this module exists to end.
+            # (the standard install exports the file's own key line into the manager environment, so the
+            # SAME key on both sides is nothing to say; a DIFFERENT file key is _check_key_file_agrees's line)
+            discarded = source.kind == "op" or (source.kind == "file" and not source.value)
+            if startup and discarded and not _STARTUP_KEY_DISCARD_SAID:
+                _STARTUP_KEY_DISCARD_SAID = True
+                why = ("supervised managers read %s only" % _keysrc.service_env_path()
+                       if source.kind == "file" and os.environ.get("ROMP_SUPERVISED") == "1"
+                       else "%s selects the 1Password source" % _keysrc.REF_VAR if source.kind == "op"
+                       else "the env file's key line is empty")
+                sys.stderr.write("work key: the startup key (sha256:%s) is IGNORED — %s. Sessions without an "
+                                 "explicit Billing pick %s.\n"
+                                 % (_keysrc.fingerprint(startup), why,
+                                    "launch on the login" if not source.configured else "use that source"))
             _WORK_KEY = ""
+        # "error" (an unreadable or undecodable file) is not a selection: it fails the operation that asked
+        # while it lasts, and the startup key stays claimed so a transient permission blemish cannot
+        # quietly turn a keyed box into a login one once it clears (review find, 2026-09-05).
         return source
 
 
@@ -4856,7 +4878,8 @@ class SdkBackend:
                 src = "read from %s" % _keysrc.service_env_path()
             self._log("work key: sessions now launch on the key sha256:%s (%s)" % (fp, src))
 
-    def cycle_key(self, sid: str, expected_source_fp: str | None = None) -> str:
+    def cycle_key(self, sid: str, expected_source_fp: str | None = None, current_key_fp: str | None = None,
+                  probe: bool = False, resolve_error: str | None = None) -> str:
         """Re-present the CURRENT work key to one LIVE session by reconnecting it — the apply half of
         `romp keyswap --cycle` (the user 2026-09-04).
 
@@ -4887,6 +4910,14 @@ class SdkBackend:
         An optional source fingerprint binds the request to the CLI's preflight check. Check
         metadata again after provider retrieval, which can take time, before scheduling a reconnect.
         The actual launch still reads its source afresh; no credential is retained for that launch.
+        `current_key_fp` is the fingerprint of a key the CALLER resolved once for a whole request
+        (the /keycycle route, cycling many sessions): passed, this session is compared against it and
+        nothing is retrieved here — a dozen quiet sessions used to mean a dozen serial `op read`s on
+        one request thread (review find, 2026-09-05). `probe=True` classifies only — "unknown" /
+        "dormant" / "login" / "working", or "cycle" for a session that WOULD need the key — so the
+        caller can resolve once only when some session needs it; `resolve_error` is that request-level
+        failure, raised here at the point retrieval would have happened, so the rows that never needed
+        a key keep their own classification.
         """
         if not self.owns(sid):
             return "unknown"
@@ -4900,18 +4931,25 @@ class SdkBackend:
             live_work = len(s._subagents) + len(s._bg_tasks)
         if live_work or s.inflight > 0 or s._pending:
             return "working"
+        if probe:
+            return "cycle"
+        if resolve_error is not None:
+            raise _keysrc.KeySourceError(resolve_error)
         source.validate()
         source_fp = source.fingerprint()
         if expected_source_fp is not None and source_fp != expected_source_fp:
             raise _keysrc.KeySourceError("API key source changed; check it before cycling again")
-        key, _source = self._work_key_and_source(source)
-        if not key:
-            raise _keysrc.KeySourceError("API key billing selected but no API key source is configured")
-        current_source = self._work_key_source()
-        current_source.validate()
-        if current_source.fingerprint() != source_fp:
-            raise _keysrc.KeySourceError("API key source changed during retrieval; check it before cycling again")
-        fp = _keysrc.fingerprint(key)
+        if current_key_fp is not None:
+            fp = current_key_fp
+        else:
+            key, _source = self._work_key_and_source(source)
+            if not key:
+                raise _keysrc.KeySourceError("API key billing selected but no API key source is configured")
+            current_source = self._work_key_source()
+            current_source.validate()
+            if current_source.fingerprint() != source_fp:
+                raise _keysrc.KeySourceError("API key source changed during retrieval; check it before cycling again")
+            fp = _keysrc.fingerprint(key)
         if getattr(s, "_launched_key_fp", None) == fp:
             return "current"
         s.request_reconnect(defer=False)
@@ -5998,7 +6036,10 @@ class SdkBackend:
         # kernel's log wire and in the problem ring the dashboard's error center reads).
         env_vars = sess.env_vars
         key_source = self._work_key_source()
-        reserved = ENV_RESERVED_NAMES + (AUTH_ENV_NAMES if key_source.kind in ("op", "error") else ())
+        # Under runtime retrieval a per-session API key is always a competing credential; a login
+        # session's own token override is not (review find, 2026-09-05) — keysource.runtime_reserved_names
+        # is the one rule the doors, this launch and the fork copy share.
+        reserved = ENV_RESERVED_NAMES + _keysrc.runtime_reserved_names(sess.auth, key_source)
         legacy = [k for k in reserved if k in env_vars]
         if legacy:
             env_vars = {k: v for k, v in env_vars.items() if k not in reserved}
@@ -6035,7 +6076,7 @@ class SdkBackend:
             # refused OUTRIGHT rather than written into a reg every future connect would launch
             # with. The /new handler validates before calling; this raise is the backend's own
             # fail-loudly backstop for any other caller.
-            err = env_request_error(env)
+            err = env_request_error(env, auth or "")
             if err:
                 raise ValueError(err)
         sid = sid or str(uuid.uuid4())
@@ -6160,8 +6201,7 @@ class SdkBackend:
             # the reserved identity names never cross the copy: a parent reg from before
             # ENV_RESERVED_NAMES existed carries them (the _options apply seam skips them there),
             # and the copy is where that legacy poison stops propagating into fresh regs
-            reserved = ENV_RESERVED_NAMES + (AUTH_ENV_NAMES if self._work_key_source().kind
-                                              in ("op", "error") else ())
+            reserved = ENV_RESERVED_NAMES + _keysrc.runtime_reserved_names(reg.get("auth") or "", self._work_key_source())   # the launch rule, not a wider one (2026-09-05)
             env = {k: v for k, v in parent["env"].items() if k not in reserved}
             dropped = [k for k in parent["env"] if k in reserved]
             if dropped:
@@ -7613,9 +7653,9 @@ class SdkBackend:
         default (write_sdk_default): a var one session needed is not a seed for the next. No pending
         badge or chat chip yet — that surface ships with the env UI slice; the Log records the
         change (spawn-time slice, the user 2026-08-17)."""
-        if env_request_error(env):
-            return False
         reg = read_reg(self.state_dir, sid)
+        if env_request_error(env, (reg or {}).get("auth") or ""):
+            return False
         if not reg:
             return False
         env = dict(env)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,24 @@ os.environ["ROMP_SERVICE_ENV"] = _NO_SERVICE_ENV
 # inherited reference before module loading, so an auth test cannot resolve a developer's vault
 # merely because the isolated service.env is absent. Tests set synthetic references explicitly.
 os.environ.pop("ROMP_API_KEY_REF", None)
+# Every shell under a romp-managed session inherits ROMP_SUPERVISED=1 from the kernel (the service
+# unit exports it), and keysource gives that variable authority: a supervised manager reads the env
+# file only and ignores a startup key. Twenty-five tests that stage a startup key went red when the
+# suite ran from inside a romp session while CI stayed green (review find, 2026-09-05). The floor is
+# the unsupervised case; a test that wants supervision sets the variable itself.
+os.environ.pop("ROMP_SUPERVISED", None)
+
+
+def _reset_keysource_state():
+    """keysource remembers which path selected which source for the PROCESS (that is the resurrection
+    guard); under one pytest process that memory would leak between test modules. Every loaded copy of
+    the module (each SourceFileLoader name is its own module object) is reset."""
+    import sys
+    for name, m in list(sys.modules.items()):
+        if "keysource" in name and hasattr(m, "_AUTHORITATIVE_PATHS"):
+            m._AUTHORITATIVE_PATHS.clear()
+            getattr(m, "_ENV_PROVIDER_PATHS", set()).clear()
+            m._CACHE = ((), "")
 
 
 @pytest.fixture(autouse=True)
@@ -50,6 +68,8 @@ def _no_real_service_env():
     for var in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV"):
         os.environ[var] = _NO_SERVICE_ENV
     os.environ.pop("ROMP_API_KEY_REF", None)
+    os.environ.pop("ROMP_SUPERVISED", None)
+    _reset_keysource_state()
     yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,10 @@ os.environ["ROMP_MANAGER_PORT"] = "1"
 _NO_SERVICE_ENV = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
 os.environ["ROMP_SERVICE_ENV_FILE"] = _NO_SERVICE_ENV
 os.environ["ROMP_SERVICE_ENV"] = _NO_SERVICE_ENV
+# A runtime provider can also be selected directly from the manager's environment. Remove its
+# inherited reference before module loading, so an auth test cannot resolve a developer's vault
+# merely because the isolated service.env is absent. Tests set synthetic references explicitly.
+os.environ.pop("ROMP_API_KEY_REF", None)
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +49,7 @@ def _no_real_service_env():
     phase, before TestCase.run calls setUp) — so per-test intent still wins."""
     for var in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV"):
         os.environ[var] = _NO_SERVICE_ENV
+    os.environ.pop("ROMP_API_KEY_REF", None)
     yield
 
 

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -30,9 +30,12 @@ Synthetic sids only; the fixture key is an invented string; no real key material
 import json
 import os
 import tempfile
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -43,6 +46,9 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
+os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
+os.environ.pop("ROMP_API_KEY_REF", None)
 jd = SourceFileLoader("romp_judge_authbill", os.path.join(BIN, "romp-judge")).load_module()
 
 FAKE_KEY = "romp-test-fixture-key-not-real"   # nothing under test validates the shape, so no sk- prefix:
@@ -58,7 +64,11 @@ class _JudgeAuthBase(unittest.TestCase):
     def setUp(self):
         self._env_before = os.environ.pop("ANTHROPIC_API_KEY", None)
         self._fn_before = jd._WORK_KEY_FN
+        self._configured_before = jd._WORK_KEY_CONFIGURED_FN
+        self._login_before = jd._LOGIN_AUTH_ENV_FN
         jd._WORK_KEY_FN = None
+        jd._WORK_KEY_CONFIGURED_FN = None
+        jd._LOGIN_AUTH_ENV_FN = None
         jd._auth_cache[:] = [None, {}]
         jd.SDKDIR.mkdir(parents=True, exist_ok=True)
         for p in (jd.JUDGE_AUTH, jd.SDKDIR / (SID + ".json"),
@@ -70,10 +80,13 @@ class _JudgeAuthBase(unittest.TestCase):
 
     def tearDown(self):
         jd._WORK_KEY_FN = self._fn_before
+        jd._WORK_KEY_CONFIGURED_FN = self._configured_before
+        jd._LOGIN_AUTH_ENV_FN = self._login_before
         os.environ.pop("ANTHROPIC_API_KEY", None)
         if self._env_before is not None:
             os.environ["ANTHROPIC_API_KEY"] = self._env_before
         jd._judge_ctx.fsid = None
+        jd._judge_ctx.paused = False
         # leave NOTHING latched in the shared STATE: the suite runs every test file against one
         # XDG state home, and a leftover judge-auth.json row for the shared synthetic sid floors
         # OTHER files' build_feed cards to needs-you (25 stays-in-Working tests, found 2026-08-12)
@@ -99,9 +112,10 @@ class WorkKeyRead(_JudgeAuthBase):
         # never a second claimer: the variable is still there for sdk_backend's own pop
         self.assertEqual(os.environ.get("ANTHROPIC_API_KEY"), FAKE_KEY)
 
-    def test_a_broken_wire_reads_as_no_key_not_a_crash(self):
+    def test_a_broken_wire_propagates_instead_of_selecting_login(self):
         jd._WORK_KEY_FN = lambda: (_ for _ in ()).throw(RuntimeError("boom"))
-        self.assertEqual(jd._work_key(), "")
+        with self.assertRaises(RuntimeError):
+            jd._work_key()
 
 
 class JudgeBillingResolution(_JudgeAuthBase):
@@ -124,9 +138,11 @@ class JudgeBillingResolution(_JudgeAuthBase):
         self._reg("key")
         self.assertEqual(jd._judge_auth(SID), "key")
 
-    def test_a_key_pick_with_no_key_falls_to_login_like_the_session_itself(self):
-        self._reg("key")   # effective_auth logs the fall loudly and launches on login; judges mirror it
-        self.assertEqual(jd._judge_auth(SID), "login")
+    def test_a_key_pick_with_no_key_keeps_its_billing_intent(self):
+        self._reg("key")
+        self.assertEqual(jd._judge_auth(SID), "key")
+        with self.assertRaises(jd._keysrc.KeySourceError):
+            jd._judge_env("triage", "key")
 
 
 class JudgeEnvBilling(_JudgeAuthBase):
@@ -162,6 +178,120 @@ class JudgeEnvBilling(_JudgeAuthBase):
             self.assertEqual(jd._judge_env("index", "login", model="fable").get("MAX_THINKING_TOKENS"), "0")
         finally:
             os.environ.pop("TMUX", None)
+
+
+class RuntimeJudgeBilling(_JudgeAuthBase):
+    def test_runtime_reference_resolves_once_per_key_call(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "service.env")
+            with open(path, "w") as config:
+                config.write("ROMP_API_KEY_REF=op://test-vault/test-item/credential\n")
+            with patch.dict(os.environ, {"ROMP_SERVICE_ENV_FILE": path}), \
+                    patch.object(jd._keysrc.subprocess, "run", return_value=SimpleNamespace(
+                        returncode=0, stdout=FAKE_KEY.encode())) as provider:
+                for count in (1, 2):
+                    auth = jd._judge_auth(SID)
+                    self.assertEqual(provider.call_count, count - 1, "billing metadata never resolves")
+                    env = jd._judge_env("triage", auth)
+                    self.assertEqual(env["ANTHROPIC_API_KEY"], FAKE_KEY)
+                    self.assertEqual(provider.call_count, count)
+
+    def test_successful_key_call_resolves_the_provider_wire_once(self):
+        jd._WORK_KEY_FN = Mock(return_value=FAKE_KEY)
+        jd._WORK_KEY_CONFIGURED_FN = Mock(return_value=True)
+        jd._judge_ctx.fsid = SID
+        with patch.object(jd, "_judge_engine", return_value="claude"), \
+                patch.object(jd.subprocess, "run", return_value=SimpleNamespace(
+                    returncode=0, stderr="", stdout=json.dumps({"result": "ok"}))) as run:
+            self.assertEqual(jd._judge_run("sonnet", "SYS", "input", judge="planner"), "ok")
+        jd._WORK_KEY_FN.assert_called_once_with()
+        run.assert_called_once()
+        self.assertEqual(run.call_args.kwargs["env"]["ANTHROPIC_API_KEY"], FAKE_KEY)
+
+    def test_login_env_does_not_resolve_and_restores_claimed_login_tokens(self):
+        jd._WORK_KEY_FN = Mock(side_effect=RuntimeError("must not resolve"))
+        jd._LOGIN_AUTH_ENV_FN = lambda: {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-login-token"}
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "synthetic-ambient-key",
+                                     "ANTHROPIC_AUTH_TOKEN": "synthetic-ambient-bearer"}):
+            env = jd._judge_env("triage", "login")
+        jd._WORK_KEY_FN.assert_not_called()
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env)
+        self.assertEqual(env["CLAUDE_CODE_OAUTH_TOKEN"], "synthetic-login-token")
+
+    def test_exhausted_login_window_pauses_without_inspecting_or_resolving_a_key(self):
+        self._reg("login")
+        jd._WORK_KEY_FN = Mock(side_effect=RuntimeError("must not resolve"))
+        jd._WORK_KEY_CONFIGURED_FN = Mock(side_effect=RuntimeError("must not inspect"))
+        jd._judge_ctx.fsid = SID
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            (state / "usage.json").write_text(json.dumps({
+                "five_hour": {"pct": 100, "resets_at": int(time.time()) + 3600}}))
+            # Keep the usage fixture, limit latch, log, and in-memory gate state local to this test.
+            with patch.multiple(jd, STATE=state, JUDGE_LIMIT=state / "judge-limit.json",
+                                _limit_cache=[None, {}], _RATE_GATE_LOGGED={}), \
+                    patch.object(jd, "_judge_engine", return_value="claude"), \
+                    patch.object(jd.subprocess, "run") as run:
+                self.assertEqual(jd._judge_run("sonnet", "SYS", "input", judge="planner"), "")
+                run.assert_not_called()
+                jd._WORK_KEY_FN.assert_not_called()
+                jd._WORK_KEY_CONFIGURED_FN.assert_not_called()
+                self.assertTrue(jd._judge_ctx.paused)
+                self.assertEqual(jd._limit_down()["bucket"], "five_hour")
+                self.assertEqual(jd._auth_down_map(), {}, "a usage pause is not an auth failure")
+
+    def test_codex_call_never_selects_or_retrieves_an_anthropic_credential(self):
+        jd._WORK_KEY_FN = Mock(side_effect=RuntimeError("must not resolve"))
+        jd._WORK_KEY_CONFIGURED_FN = Mock(side_effect=RuntimeError("must not inspect"))
+        jd._judge_ctx.fsid = SID
+
+        def codex_reply(command, **kwargs):
+            with open(command[command.index("-o") + 1], "w") as output:
+                output.write("ok")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(jd, "_judge_engine", return_value="codex"), \
+                patch.dict(os.environ, {name: "synthetic-ambient-credential" for name in
+                           ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")}), \
+                patch.object(jd.subprocess, "run", side_effect=codex_reply) as run:
+            self.assertEqual(jd._judge_run("synthetic-model", "SYS", "input", judge="planner"), "ok")
+        jd._WORK_KEY_FN.assert_not_called()
+        jd._WORK_KEY_CONFIGURED_FN.assert_not_called()
+        run.assert_called_once()
+        for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+            self.assertNotIn(name, run.call_args.kwargs["env"])
+
+    def test_provider_failure_pauses_judging_and_never_falls_back_to_ambient_auth(self):
+        private_output = "synthetic-sensitive-provider-output"
+        jd._WORK_KEY_FN = Mock(side_effect=RuntimeError(private_output))
+        jd._WORK_KEY_CONFIGURED_FN = lambda: True
+        jd._judge_ctx.fsid = SID
+        with patch.object(jd, "_judge_engine", return_value="claude"), \
+                patch.dict(os.environ, {"ANTHROPIC_API_KEY": "synthetic-ambient-key",
+                                       "ANTHROPIC_AUTH_TOKEN": "synthetic-ambient-bearer"}), \
+                patch.object(jd.subprocess, "run") as run, \
+                patch.object(jd, "_log_judge_error") as log:
+            self.assertEqual(jd._judge_run("sonnet", "SYS", "input", judge="planner"), "")
+        run.assert_not_called()
+        jd._WORK_KEY_FN.assert_called_once_with()
+        self.assertTrue(jd._judge_ctx.paused, "configuration outages must not consume summary give-up attempts")
+        row = jd._auth_down_map()[SID]
+        self.assertEqual(row["mode"], "key")
+        self.assertEqual(row["note"], "API credential source failed")
+        self.assertNotIn(private_output, str(log.call_args))
+        self.assertNotIn(private_output, json.dumps(row))
+
+    def test_missing_explicit_key_pauses_the_call_and_reports_auth_down(self):
+        self._reg("key")
+        jd._WORK_KEY_FN = lambda: ""
+        jd._judge_ctx.fsid = SID
+        with patch.object(jd, "_judge_engine", return_value="claude"), \
+                patch.object(jd.subprocess, "run") as run:
+            self.assertEqual(jd._judge_run("sonnet", "SYS", "input", judge="planner"), "")
+        run.assert_not_called()
+        self.assertTrue(jd._judge_ctx.paused)
+        self.assertEqual(jd._auth_down_map()[SID]["mode"], "key")
 
 
 class AuthErrorClass(_JudgeAuthBase):

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -427,5 +427,99 @@ class KernelWiringAndFloorPins(unittest.TestCase):
         self.assertIn(".fask-jauth", css)
 
 
+class OpCredentialAndRetrievalGate(_JudgeAuthBase):
+    """Review finds of 2026-09-05, at the judge boundary."""
+
+    def test_a_judge_child_never_inherits_the_op_credential_when_romp_runs_op(self):
+        with patch.dict(os.environ, {"OP_SERVICE_ACCOUNT_TOKEN": "synthetic-op-token", "OP_SESSION_acct": "s",
+                                     "ROMP_API_KEY_REF": "op://test-vault/test-item/credential"}):
+            env = jd._judge_env("triage", auth="login")
+        self.assertNotIn("OP_SERVICE_ACCOUNT_TOKEN", env)
+        self.assertNotIn("OP_SESSION_acct", env)
+
+    def test_a_helper_box_keeps_op_in_its_judge_children(self):
+        """No reference configured: the sessions (and judges) may authenticate through a helper that runs op
+        itself, so romp leaves op's environment alone."""
+        with patch.dict(os.environ, {"OP_SERVICE_ACCOUNT_TOKEN": "synthetic-op-token"}), \
+             patch.object(jd._keysrc, "_OP_ENV", {}):
+            env = jd._judge_env("triage", auth="login")
+        self.assertEqual(env.get("OP_SERVICE_ACCOUNT_TOKEN"), "synthetic-op-token")
+
+    def test_a_failed_retrieval_is_not_retried_until_the_next_pass_or_a_new_source(self):
+        calls = []
+        def failing():
+            calls.append(1)
+            raise jd._keysrc.KeySourceError("1Password credential retrieval timed out; check op authentication")
+        jd._WORK_KEY_FN = failing
+        jd._WORK_KEY_CONFIGURED_FN = lambda: True
+        saved = dict(jd._KEY_GATE); saved_gen = jd._PASS_GEN[0]
+        try:
+            jd._KEY_GATE.update(fp=None, gen=None, note="")
+            jd.begin_pass_frame()                                  # a pass is running
+            with self.assertRaisesRegex(jd._keysrc.KeySourceError, "timed out"):
+                jd._judge_env("triage", auth="key")
+            with self.assertRaisesRegex(jd._keysrc.KeySourceError, "timed out"):
+                jd._judge_env("triage", auth="key")                # same pass, same source: fails at once
+            self.assertEqual(len(calls), 1, "one retrieval per pass, not one per call")
+            self.assertFalse(jd.begin_pass_frame(), "a tier joining the open pass…")
+            with self.assertRaises(jd._keysrc.KeySourceError):
+                jd._judge_env("triage", auth="key")
+            self.assertEqual(len(calls), 1, "…shares its gate: no retry mid-pass")
+            jd.end_pass_frame(); jd.begin_pass_frame()             # the NEXT pass is the deciding event
+            with self.assertRaises(jd._keysrc.KeySourceError):
+                jd._judge_env("triage", auth="key")
+            self.assertEqual(len(calls), 2)
+            jd._WORK_KEY_FN = lambda: FAKE_KEY                     # …and a retrieval that works clears nothing it need not
+            jd.end_pass_frame(); jd.begin_pass_frame()
+            self.assertEqual(jd._judge_env("triage", auth="key")["ANTHROPIC_API_KEY"], FAKE_KEY)
+        finally:
+            jd._KEY_GATE.update(saved); jd._PASS_GEN[0] = saved_gen
+            jd.end_pass_frame()
+
+    def test_the_first_retrieval_of_a_pass_gates_the_concurrent_wave(self):
+        """Six judge threads reach a pass's first key call together; the first retrieves, the rest wait for
+        its verdict instead of each spawning op and waiting out a timeout (review find, 2026-09-05)."""
+        import threading
+        calls, gate = [], threading.Event()
+        def slow_failing():
+            calls.append(1); gate.wait(2.0)
+            raise jd._keysrc.KeySourceError("1Password credential retrieval timed out; check op authentication")
+        jd._WORK_KEY_FN = slow_failing
+        saved = dict(jd._KEY_GATE); saved_gen = jd._PASS_GEN[0]
+        results = []
+        def worker():
+            try:
+                jd._judge_env("triage", auth="key"); results.append("ok")
+            except jd._keysrc.KeySourceError as e:
+                results.append(str(e))
+        try:
+            jd._KEY_GATE.update(fp=None, gen=None, note=""); jd.begin_pass_frame()
+            threads = [threading.Thread(target=worker) for _ in range(6)]
+            for th in threads: th.start()
+            time.sleep(0.3); gate.set()
+            for th in threads: th.join(5.0)
+            self.assertEqual(len(calls), 1, "one retrieval for the whole wave")
+            self.assertEqual(len(results), 6)
+            self.assertTrue(all("timed out" in r for r in results))
+        finally:
+            jd._KEY_GATE.update(saved); jd._PASS_GEN[0] = saved_gen; jd.end_pass_frame()
+
+    def test_standalone_callers_without_a_pass_frame_retry_every_call(self):
+        calls = []
+        def failing():
+            calls.append(1)
+            raise jd._keysrc.KeySourceError("1Password credential retrieval failed")
+        jd._WORK_KEY_FN = failing
+        saved = dict(jd._KEY_GATE); saved_gen = jd._PASS_GEN[0]
+        try:
+            jd._KEY_GATE.update(fp=None, gen=None, note=""); jd._PASS_GEN[0] = 0
+            for _ in range(2):
+                with self.assertRaises(jd._keysrc.KeySourceError):
+                    jd._judge_env("triage", auth="key")
+            self.assertEqual(len(calls), 2)
+        finally:
+            jd._KEY_GATE.update(saved); jd._PASS_GEN[0] = saved_gen
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_judge_rate_limit_gate.py
+++ b/tests/test_judge_rate_limit_gate.py
@@ -33,7 +33,9 @@ class RateLimitGate(unittest.TestCase):
         # the gate scopes to LOGIN-billed calls (2026-08-28) — pin the billing deterministically:
         # these tests always assumed login, which silently flipped to key on an env-keyed machine
         self._saved_key = jd._work_key
+        self._saved_key_configured = jd._work_key_configured
         jd._work_key = lambda: ""
+        jd._work_key_configured = lambda: bool(jd._work_key())
 
         class _FakeDone:
             stdout = '{"result": "the-model-reply"}'
@@ -46,6 +48,7 @@ class RateLimitGate(unittest.TestCase):
     def tearDown(self):
         jd.subprocess.run = self._saved_run
         jd._work_key = self._saved_key
+        jd._work_key_configured = self._saved_key_configured
         shutil.rmtree(self.td, ignore_errors=True)
 
     def _usage(self, pct, resets_in, bucket="five_hour"):

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -5,8 +5,8 @@ The manager's `ANTHROPIC_API_KEY` used to be claimed out of `os.environ` once at
 changing which org key the sessions billed meant restarting `romp-manager` — cutting every open turn
 and killing every subagent. Now:
 
-  * `kernel/keysource.py` reads the `ANTHROPIC_API_KEY=` line of the manager's env file LIVE, and
-    `sdk_backend.work_api_key` prefers it, falling back to the startup claim;
+  * `kernel/keysource.py` reads the configured API key source LIVE; a startup environment key
+    remains supported only until a file or runtime source takes over;
   * `_options` therefore injects the CURRENT key into every session it launches or revives;
   * `romp keyswap <name>` rewrites only that one line, atomically, from a sibling file;
   * `--cycle`/`--cycle-all` reconnect running sessions through `SdkBackend.cycle_key` so they
@@ -66,10 +66,11 @@ class _EnvFile(unittest.TestCase):
         self.d = tempfile.mkdtemp()
         self.path = os.path.join(self.d, "service.env")
         self._before = {v: os.environ.get(v) for v in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
-                                                       "ANTHROPIC_API_KEY")}
+                                                       "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF")}
         os.environ["ROMP_SERVICE_ENV_FILE"] = self.path
         os.environ["ROMP_SERVICE_ENV"] = self.path
         os.environ.pop("ANTHROPIC_API_KEY", None)
+        os.environ.pop("ROMP_API_KEY_REF", None)
         self.write_env(OLD_KEY)
         ks._CACHE = ((), "")          # the stat-identity cache is module-global
 
@@ -283,31 +284,27 @@ class LiveSpawnEnv(_Backend):
         src = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
         self.assertEqual(src.count("ANTHROPIC_API_KEY=work_key"), 1,
                          "one injection site only — a second would need its own live read")
-        self.assertIn("work_key, key_src = self._work_key_and_source()", src)
+        self.assertIn("work_key, key_src = self._work_key_and_source(key_source)", src)
 
     def test_the_key_is_read_once_per_connect_so_a_launch_cannot_straddle_a_swap(self):
         reads = []
-        orig = ks.read_key
+        orig = ks.read_source
 
         def counting(path=None):
             reads.append(path)
             return orig(path)
 
-        ks.read_key = counting
+        ks.read_source = counting
         try:
             self.be._options(self._sess(3, auth="key"), dict)
         finally:
-            ks.read_key = orig
+            ks.read_source = orig
         self.assertEqual(len(reads), 1, "two reads could return two different keys")
 
-    def test_an_empty_key_line_falls_to_login_rather_than_injecting_a_blank(self):
+    def test_an_empty_key_line_refuses_an_explicit_key_launch(self):
         self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
-        env = self._launch_env(4)
-        self.assertNotIn("ANTHROPIC_API_KEY", env,
-                         "an empty var reads as key-mode-without-a-key to the CLI — removal, never blanking")
-        texts = [p["text"] for p in self.be.problems(10)]
-        self.assertTrue(any("carries none" in t for t in texts),
-                        "a key session with no key to inject is a logged problem, not a silent fall")
+        with self.assertRaisesRegex(ks.KeySourceError, "no API key source"):
+            self._launch_env(4)
 
     def test_the_live_key_reaches_the_has_a_key_bool_and_the_auth_default(self):
         self.assertEqual(self.be.default_auth({}), "key")
@@ -327,21 +324,29 @@ class StartupFallback(_Backend):
 
     BOOT = BOOT_KEY
 
-    def test_a_file_with_no_key_line_falls_back_to_the_startup_claim(self):
+    def test_removing_a_previously_selected_file_key_does_not_restore_the_startup_key(self):
         with open(self.path, "w") as fh:                # genuinely no assignment, not an empty one
             fh.write("ROMP_PERF=1\n")
         ks._CACHE = ((), "")
-        self.assertEqual(self.be.work_key, BOOT_KEY)
-        self.assertEqual(self._launch_env(1).get("ANTHROPIC_API_KEY"), BOOT_KEY)
+        self.assertEqual(self.be.work_key, "")
+        with self.assertRaises(ks.KeySourceError):
+            self._launch_env(1)
 
-    def test_an_empty_key_line_falls_back_too(self):
+    def test_an_empty_key_line_does_not_restore_the_startup_key(self):
         self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
-        self.assertEqual(self.be.work_key, BOOT_KEY)
+        self.assertEqual(self.be.work_key, "")
 
-    def test_a_missing_file_falls_back_too(self):
+    def test_a_removed_file_does_not_restore_the_startup_key(self):
         os.unlink(self.path)
         ks._CACHE = ((), "")
+        self.assertEqual(self.be.work_key, "")
+
+    def test_a_never_configured_file_permits_a_shell_environment_key(self):
+        # A foreground installation that has never selected a file remains supported.
+        os.environ["ROMP_SERVICE_ENV_FILE"] = self.path + ".never-created"
+        sb._WORK_KEY = BOOT_KEY
         self.assertEqual(self.be.work_key, BOOT_KEY)
+        self.assertEqual(self._launch_env(1).get("ANTHROPIC_API_KEY"), BOOT_KEY)
 
     def test_the_file_wins_when_it_has_a_line(self):
         self.assertEqual(self.be.work_key, OLD_KEY,
@@ -361,6 +366,9 @@ class StartupFallback(_Backend):
         import io
         from contextlib import redirect_stderr
         sb._KEY_FILE_CHECKED = False
+        # This test starts before any file source has been selected.
+        ks._AUTHORITATIVE_PATHS.pop(self.path, None)
+        sb._WORK_KEY = self.BOOT
         with open(self.path, "w") as f:
             f.write("ROMP_PERF=1\n")                                  # no key line yet
         err = io.StringIO()
@@ -533,6 +541,12 @@ class KeyswapCli(_EnvFile):
 
     def setUp(self):
         super().setUp()
+        from unittest import mock
+        # Listing and selecting sources never resolve credentials, even when a provider profile
+        # is present. Only the stubbed kernel may do so; no test can invoke a real op session.
+        resolver = mock.patch.object(ks.KeySource, "resolve", side_effect=AssertionError("CLI resolved a secret"))
+        resolver.start()
+        self.addCleanup(resolver.stop)
         self.out = []
         self.posted = []
         self._kernel_before, self._post_before = cli._kernel, cli._post
@@ -593,7 +607,8 @@ class KeyswapCli(_EnvFile):
         self.assertEqual(rc, 0)
         self.assertEqual(self.posted[0][1:], ("/keycycle", {"sessions": []}), "the read comes first")
         self.assertEqual(self.posted[-1][1], "/keycycle")
-        self.assertEqual(self.posted[-1][2], {"sessions": ["web", "api"]})
+        self.assertEqual(self.posted[-1][2], {"sessions": ["web", "api"],
+                                             "expectedSourceFp": ks.fingerprint(NEW_KEY)})
         self.assertIn("history kept", said)
         self.assertIn("sha256:" + ks.fingerprint(NEW_KEY), said,
                       "the kernel's own fingerprint is how the operator confirms it re-read the file")
@@ -603,7 +618,8 @@ class KeyswapCli(_EnvFile):
         cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
             "ok": True, "keyFp": ks.fingerprint(NEW_KEY), "rows": []}
         rc, _ = self.run_cli("lowprio", "--cycle-all")
-        self.assertEqual([b for _u, _p, b in self.posted], [{"sessions": []}, {"all": True}],
+        self.assertEqual([b for _u, _p, b in self.posted],
+                         [{"sessions": []}, {"all": True, "expectedSourceFp": ks.fingerprint(NEW_KEY)}],
                          "the read, then the cycle — and never a session named by the CLI itself")
 
     def test_the_swap_still_lands_when_no_kernel_is_reachable(self):
@@ -662,10 +678,11 @@ class KeyswapCli(_EnvFile):
             "rows": [{"session": "web", "status": "working"}, {"session": "api", "status": "current"}]}
         rc, said = self.run_cli("lowprio", "--cycle", "web,api")
         self.assertEqual(rc, 0)
-        self.assertEqual([b for _u, _p, b in self.posted], [{"sessions": []}, {"sessions": ["web", "api"]}])
+        self.assertEqual([b for _u, _p, b in self.posted],
+                         [{"sessions": []}, {"sessions": ["web", "api"], "expectedSourceFp": ks.fingerprint(NEW_KEY)}])
         self.assertIn("skipped: a turn, subagents or background tasks are in flight", said)
         self.assertIn("already on this key", said)
-        self.assertIn("re-run the same --cycle", said)
+        self.assertIn("re-run --cycle for the skipped sessions", said)
 
     def test_the_probe_itself_honours_the_override_and_refuses_an_unusable_one(self):
         # _kernel() must USE _kernel_urls(): a revert of that one line passed every test (second review pass)
@@ -737,6 +754,167 @@ class KeyswapCli(_EnvFile):
         src = open(os.path.join(ROOT, "cli", "keyswap.py")).read()
         self.assertIn('"kernel" / "keysource.py"', src.replace("'", '"'),
                       "writer and reader must not carry two copies of the path or the parse rules")
+
+
+    def test_reference_profiles_are_listed_without_resolving_or_revealing_them(self):
+        ref = "op://test-vault/test-item/api-key"
+        self.sibling("vault", "ROMP_API_KEY_REF=%s\n" % ref)
+        before = open(self.path).read()
+        rc, said = self.run_cli()
+        self.assertEqual(rc, 0)
+        self.assertIn("vault", said)
+        self.assertIn("1Password reference", said)
+        self.assertIn(ks.KeySource("op", ref).fingerprint(), said)
+        self.assertNotIn(ref, said)
+        self.assertEqual(open(self.path).read(), before)
+
+    def test_selecting_a_reference_copies_only_the_reference_and_preserves_other_settings(self):
+        ref = "op://test-vault/test-item/api-key"
+        # A stale literal key in a profile must not be copied alongside its selected provider.
+        self.sibling("vault", "ANTHROPIC_API_KEY=%s\nROMP_API_KEY_REF=%s\n" % (NEW_KEY, ref))
+        rc, said = self.run_cli("vault")
+        self.assertEqual(rc, 0)
+        body = open(self.path).read()
+        self.assertIn("ROMP_API_KEY_REF=" + ref, body)
+        self.assertNotIn("ANTHROPIC_API_KEY=", body)
+        self.assertNotIn(OLD_KEY, body)
+        self.assertNotIn(NEW_KEY, body)
+        self.assertEqual(ks.read_source(self.path), ks.KeySource("op", ref))
+        for line in self.OTHER_LINES:
+            self.assertIn(line, body)
+        self.assertEqual(stat.S_IMODE(os.stat(self.path).st_mode), 0o600)
+        self.assertEqual(sorted(os.listdir(self.d)), ["service.env", "service.env.lowprio", "service.env.vault"])
+        self.assertIn("no key was copied to disk", said)
+        self.assertNotIn(ref, said)
+
+    def test_selecting_a_legacy_key_removes_the_reference(self):
+        ks.write_source(ks.KeySource("op", "op://test-vault/test-item/api-key"), self.path)
+        rc, _ = self.run_cli("lowprio")
+        self.assertEqual(rc, 0)
+        self.assertEqual(ks.read_key(self.path), NEW_KEY)
+        self.assertNotIn("ROMP_API_KEY_REF=", open(self.path).read())
+
+    def test_selecting_the_current_reference_removes_a_leftover_plaintext_key(self):
+        ref = "op://test-vault/test-item/api-key"
+        self.sibling("vault", "ROMP_API_KEY_REF=%s\n" % ref)
+        with open(self.path, "a") as fh:
+            fh.write("ROMP_API_KEY_REF=%s\n" % ref)
+        rc, _ = self.run_cli("vault")
+        self.assertEqual(rc, 0)
+        self.assertNotIn("ANTHROPIC_API_KEY=", open(self.path).read())
+        self.assertEqual(ks.read_source(self.path), ks.KeySource("op", ref))
+
+    def test_changing_references_takes_effect_in_the_same_file(self):
+        first = "op://test-vault/first/api-key"
+        second = "op://test-vault/second/api-key"
+        ks.write_source(ks.KeySource("op", first), self.path)
+        self.sibling("second", "ROMP_API_KEY_REF=%s\n" % second)
+        rc, _ = self.run_cli("second")
+        self.assertEqual(rc, 0)
+        self.assertEqual(ks.read_source(self.path), ks.KeySource("op", second))
+        self.assertNotIn(first, open(self.path).read())
+
+    def test_invalid_reference_profiles_refuse_to_fall_back_to_a_legacy_key(self):
+        import io
+        from contextlib import redirect_stderr
+        before = open(self.path).read()
+        for ref in ("", "not-an-op-reference", "op://"):
+            self.sibling("invalid", "ANTHROPIC_API_KEY=%s\nROMP_API_KEY_REF=%s\n" % (NEW_KEY, ref))
+            errors = io.StringIO()
+            with redirect_stderr(errors):
+                rc, said = self.run_cli("invalid")
+            self.assertEqual(rc, 2)
+            self.assertIn("invalid key source", errors.getvalue())
+            self.assertEqual(open(self.path).read(), before)
+            self.assertNotIn(NEW_KEY, errors.getvalue() + said)
+
+    def test_invalid_live_reference_is_an_error_even_when_the_kernel_is_down(self):
+        with open(self.path, "w") as fh:
+            fh.write("ROMP_API_KEY_REF=\n")
+        rc, said = self.run_cli()
+        self.assertEqual(rc, 1)
+        self.assertIn("configuration invalid", said)
+        self.assertEqual(self.posted, [])
+
+    def test_reference_cycle_compares_configuration_and_allows_rotation_behind_the_same_reference(self):
+        ref = "op://test-vault/test-item/api-key"
+        source = ks.KeySource("op", ref)
+        ks.write_source(source, self.path)
+        self.sibling("vault", "ROMP_API_KEY_REF=%s\n" % ref)
+        mtime = os.stat(self.path).st_mtime_ns
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "sourceFp": source.fingerprint(), "keyFp": ks.fingerprint(NEW_KEY),
+            "rows": [{"session": "web", "status": "cycling"}]}
+        rc, said = self.run_cli("vault", "--cycle", "web")
+        self.assertEqual(rc, 0)
+        self.assertEqual(os.stat(self.path).st_mtime_ns, mtime)
+        self.assertEqual([b for _, _, b in self.posted],
+                         [{"sessions": []}, {"sessions": ["web"], "expectedSourceFp": source.fingerprint()}])
+        self.assertIn("1Password reference matches", said)
+        self.assertIn("reconnecting now", said)
+        self.assertNotIn(ref, json.dumps(self.posted) + said)
+        self.assertNotIn(NEW_KEY, json.dumps(self.posted) + said)
+
+    def test_reference_cycle_refuses_old_kernels_and_mismatched_sources(self):
+        ref = "op://test-vault/test-item/api-key"
+        self.sibling("vault", "ROMP_API_KEY_REF=%s\n" % ref)
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        for fields, expected in (({}, "romp refresh"), ({"sourceFp": "op:wrong-source"}, "MISMATCH")):
+            self.posted.clear()
+            cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+                "ok": True, "keyFp": ks.fingerprint(NEW_KEY), "rows": [], **fields}
+            rc, said = self.run_cli("vault", "--cycle-all")
+            self.assertEqual(rc, 1)
+            self.assertIn(expected, said)
+            self.assertIn("NOT DONE", said)
+            self.assertEqual([b for _, _, b in self.posted], [{"sessions": []}])
+
+    def test_provider_failure_is_reported_without_reverting_the_selected_reference(self):
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        self.sibling("vault", "ROMP_API_KEY_REF=%s\n" % source.value)
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": False, "error": "1Password runtime key retrieval failed"}
+        rc, said = self.run_cli("vault", "--cycle-all")
+        self.assertEqual(rc, 1)
+        self.assertIn("FAILED", said)
+        self.assertIn("retrieval failed", said)
+        self.assertEqual(ks.read_source(self.path), source)
+        self.assertNotIn(OLD_KEY, open(self.path).read())
+        self.assertEqual([b for _, _, b in self.posted], [{"sessions": []}])
+
+    def test_a_provider_error_during_reconnect_exits_nonzero(self):
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        ks.write_source(source, self.path)
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+        cli._post = lambda u, p, b: self.posted.append((u, p, b)) or {
+            "ok": True, "sourceFp": source.fingerprint(),
+            "rows": ([{"session": "web", "status": "error: 1Password runtime key retrieval failed"}]
+                     if b.get("sessions") else [])}
+        rc, said = self.run_cli("--cycle", "web")
+        self.assertEqual(rc, 1)
+        self.assertIn("retrieval failed", said)
+
+
+    def test_a_changed_source_in_the_cycle_response_is_not_reported_as_success(self):
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        changed = ks.KeySource("op", "op://test-vault/other-item/api-key")
+        ks.write_source(source, self.path)
+        cli._kernel = lambda: "http://127.0.0.1:29855"
+
+        def respond(url, path, body):
+            self.posted.append((url, path, body))
+            if "expectedSourceFp" in body:
+                ks.write_source(changed, self.path)
+                return {"ok": True, "sourceFp": changed.fingerprint(), "rows": []}
+            return {"ok": True, "sourceFp": source.fingerprint(), "rows": []}
+
+        cli._post = respond
+        rc, said = self.run_cli("--cycle", "web")
+        self.assertEqual(rc, 1)
+        self.assertIn("source changed during the request", said)
+        self.assertEqual(self.posted[-1][2]["expectedSourceFp"], source.fingerprint())
 
 
 class KeycycleRoute(unittest.TestCase):
@@ -815,11 +993,12 @@ class KeycycleRoute(unittest.TestCase):
 
     def test_a_session_that_raises_is_reported_not_fatal(self):
         fake = self._Fake({})
-        fake.cycle_key = lambda sid: (_ for _ in ()).throw(RuntimeError("boom"))
+        fake.cycle_key = lambda sid: (_ for _ in ()).throw(RuntimeError("boom " + NEW_KEY))
         code, resp = self._with(fake, {"sessions": ["web", "api"]})
         self.assertEqual(code, 200)
         self.assertEqual(len(resp["rows"]), 2, "one bad session must not abandon the rest")
-        self.assertIn("boom", resp["rows"][0]["status"])
+        self.assertEqual(resp["rows"][0]["status"], "error: API credential source failed")
+        self.assertNotIn(NEW_KEY, json.dumps(resp))
 
     def test_an_empty_session_list_is_a_read_of_the_fingerprint_and_cycles_nothing(self):
         from unittest import mock
@@ -856,6 +1035,129 @@ class KeycycleRoute(unittest.TestCase):
             self.assertEqual(e.code, 403)
 
 
+    def _provider_backend(self, source):
+        """Exercise real cycle_key with an inert session and a synthetic provider descriptor."""
+        import threading
+        from types import SimpleNamespace
+        scheduled = []
+        session = SimpleNamespace(
+            name="web", effective_auth=lambda key=None: "key", _sub_lock=threading.Lock(),
+            _subagents={}, _bg_tasks={}, inflight=0, _pending=[],
+            _launched_key_fp=ks.fingerprint(OLD_KEY),
+            request_reconnect=lambda defer=True: scheduled.append(defer),
+        )
+        backend = SimpleNamespace(sessions={"s-web": session}, _log=lambda message: None)
+        backend.owns = lambda sid: sid in backend.sessions
+        backend._work_key_source = lambda: source
+        backend._work_key_and_source = lambda selected=None: ((selected or source).resolve(), source.kind)
+        backend.cycle_key = lambda sid, **kwargs: sb.SdkBackend.cycle_key(backend, sid, **kwargs)
+        return backend, scheduled
+
+    def test_provider_status_returns_source_identity_without_retrieving_a_key(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        with mock.patch.object(ks.KeySource, "resolve", side_effect=AssertionError("status retrieved a secret")) as resolve:
+            code, resp = self._with(backend, {"sessions": []})
+        self.assertEqual(code, 200)
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["sourceFp"], source.fingerprint())
+        self.assertEqual(resp["keyFp"], "")
+        self.assertEqual(resp["rows"], [])
+        self.assertEqual(scheduled, [])
+        resolve.assert_not_called()
+        self.assertNotIn(source.value, json.dumps(resp))
+
+    def test_invalid_provider_configuration_stops_the_route_before_retrieval_or_reconnect(self):
+        from unittest import mock
+        backend, scheduled = self._provider_backend(ks.KeySource("op", ""))
+        with mock.patch.object(ks.KeySource, "resolve", side_effect=AssertionError("invalid source resolved")) as resolve:
+            code, resp = self._with(backend, {"sessions": ["web"]})
+        self.assertEqual(code, 200)
+        self.assertFalse(resp["ok"])
+        self.assertIn("ROMP_API_KEY_REF", resp["error"])
+        self.assertEqual(scheduled, [])
+        resolve.assert_not_called()
+
+    def test_a_stale_expected_source_is_rejected_before_any_provider_or_reconnect(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        with mock.patch.object(ks.KeySource, "resolve", side_effect=AssertionError("stale source resolved")) as resolve:
+            code, resp = self._with(backend, {"sessions": ["web"], "expectedSourceFp": "stale-source"})
+        self.assertEqual(code, 409)
+        self.assertFalse(resp["ok"])
+        self.assertIn("source changed", resp["error"])
+        self.assertEqual(scheduled, [])
+        resolve.assert_not_called()
+
+    def test_a_source_change_during_provider_retrieval_does_not_schedule_reconnect(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        changed = ks.KeySource("op", "op://test-vault/other-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        selected = [source]
+        backend._work_key_source = lambda: selected[0]
+
+        def resolve_and_change():
+            selected[0] = changed
+            return NEW_KEY
+
+        with mock.patch.object(ks.KeySource, "resolve", side_effect=resolve_and_change) as resolve:
+            code, resp = self._with(backend, {"sessions": ["web"], "expectedSourceFp": source.fingerprint()})
+        self.assertEqual(code, 200)
+        self.assertIn("source changed during retrieval", resp["rows"][0]["status"])
+        self.assertEqual(scheduled, [])
+        resolve.assert_called_once_with()
+        self.assertNotIn(NEW_KEY, json.dumps(resp))
+
+    def test_a_rotated_key_behind_the_same_reference_reconnects_the_session(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        with mock.patch.object(ks.KeySource, "resolve", return_value=NEW_KEY) as resolve:
+            code, resp = self._with(backend, {"sessions": ["web"]})
+        self.assertEqual(code, 200)
+        self.assertEqual(resp["sourceFp"], source.fingerprint())
+        self.assertEqual(resp["rows"], [{"session": "web", "status": "cycling"}])
+        self.assertEqual(scheduled, [False])
+        resolve.assert_called_once_with()
+        self.assertNotIn(NEW_KEY, json.dumps(resp))
+
+    def test_provider_failure_does_not_reconnect_a_live_session(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        with mock.patch.object(ks.KeySource, "resolve", side_effect=ks.KeySourceError("1Password credential retrieval failed")):
+            code, resp = self._with(backend, {"sessions": ["web"]})
+        self.assertEqual(code, 200)
+        self.assertEqual(resp["rows"], [{"session": "web", "status": "error: 1Password credential retrieval failed"}])
+        self.assertEqual(scheduled, [])
+
+    def test_the_cli_reports_provider_failure_from_the_real_route_as_nonzero(self):
+        from unittest import mock
+        source = ks.KeySource("op", "op://test-vault/test-item/api-key")
+        backend, scheduled = self._provider_backend(source)
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "service.env")
+            ks.write_source(source, path)
+            said = []
+            with mock.patch.dict(os.environ, {"ROMP_SERVICE_ENV_FILE": path}), \
+                 mock.patch.object(cli, "_kernel", lambda: "http://127.0.0.1:%d" % self.port), \
+                 mock.patch.object(cli, "_token", lambda: self.km.TOKEN), \
+                 mock.patch.object(self.km, "_sdk", lambda: backend), \
+                 mock.patch.object(self.km, "_sid_of", lambda name: "s-" + name), \
+                 mock.patch.object(self.km, "_name_of", lambda sid: str(sid)[2:]), \
+                 mock.patch.object(self.km, "_push_soon", lambda: None), \
+                 mock.patch.object(ks.KeySource, "resolve", side_effect=ks.KeySourceError("1Password credential retrieval failed")) as resolve:
+                rc = cli.main(["--cycle", "web"], out=said.append)
+            self.assertEqual(rc, 1)
+            self.assertIn("1Password credential retrieval failed", "\n".join(said))
+            self.assertEqual(scheduled, [])
+            resolve.assert_called_once_with()
+            self.assertEqual(ks.read_source(path), source)
+
+
 class NothingLeaksTheKey(_Backend):
     """No key value in any log line, printed line, or wire payload. The fingerprint is the only
     rendered form — the same rule the browser side has always had for the key (2026-08-08)."""
@@ -883,6 +1185,7 @@ class NothingLeaksTheKey(_Backend):
         self.assertIn(ks.fingerprint(NEW_KEY), said[1])
 
     def test_the_announcement_names_the_startup_environment_when_the_file_has_no_line(self):
+        ks._AUTHORITATIVE_PATHS.pop(self.path, None)
         sb._WORK_KEY = OLD_KEY                                        # the boot claim (restored by tearDown)
         with open(self.path, "w") as f:
             f.write("ROMP_PERF=1\n")                                  # no key line: the startup claim is injected
@@ -920,7 +1223,8 @@ class NothingLeaksTheKey(_Backend):
 
     def test_the_problem_ring_the_dashboard_reads_never_carries_a_key(self):
         self.write_env("", lines=["ROMP_PERF=1"])       # a key pick with no key: the loudest path
-        self._launch_env(1)
+        with self.assertRaises(ks.KeySourceError):
+            self._launch_env(1)
         self.write_env(NEW_KEY)
         self._launch_env(2)
         for p in self.be.problems(50):

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -41,6 +41,7 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 # path that does not exist — so a bare non-pytest run of this file cannot read the real one either.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
+os.environ.pop("ROMP_SUPERVISED", None)  # a romp-managed shell inherits it; these tests stage the unsupervised startup-key case
 os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
 os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import threading
 import unittest
+from unittest.mock import Mock, patch
 import urllib.request
 from contextlib import redirect_stderr
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -210,6 +211,13 @@ class FetchAndFallback(unittest.TestCase):
         self._state = jd.STATE
         jd.STATE = Path(self.td.name)
         self._url, self._fn = km.MODELS_API_URL, getattr(jd, "_WORK_KEY_FN", None)
+        self._login_fn = jd._LOGIN_AUTH_ENV_FN
+        jd._LOGIN_AUTH_ENV_FN = None
+        self._source_env = {k: os.environ.get(k) for k in
+                            ("ROMP_SERVICE_ENV_FILE", "ROMP_API_KEY_REF", "ANTHROPIC_AUTH_TOKEN")}
+        os.environ["ROMP_SERVICE_ENV_FILE"] = str(Path(self.td.name) / "service.env")
+        os.environ.pop("ROMP_API_KEY_REF", None)
+        os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
         self._env_key = os.environ.get("ANTHROPIC_API_KEY")
         os.environ["ANTHROPIC_API_KEY"] = "synthetic-test-credential"   # the fake sees only this (never a key-shaped string: the pre-commit scanner)
         jd._WORK_KEY_FN = None
@@ -223,6 +231,12 @@ class FetchAndFallback(unittest.TestCase):
         _reset_catalog()
         km.MODELS_API_URL = self._url
         jd._WORK_KEY_FN = self._fn
+        jd._LOGIN_AUTH_ENV_FN = self._login_fn
+        for key, value in self._source_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
         if self._env_key is None:
             os.environ.pop("ANTHROPIC_API_KEY", None)
         else:
@@ -301,6 +315,41 @@ class FetchAndFallback(unittest.TestCase):
         self.assertIn("no API credential", km._catalog_status["lastError"])
         self.assertIn("no API credential the kernel can use", log)
         self.assertEqual(km.MODEL_VERSIONS["fable"][0]["value"], "claude-fable-5-1", "seed still serves")
+
+    def test_provider_failure_never_falls_back_to_an_ambient_key_or_token(self):
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = "synthetic-ambient-token"
+        jd._WORK_KEY_FN = Mock(side_effect=jd._keysrc.KeySourceError("1Password retrieval failed"))
+        started, log = self._refresh()
+        self.assertTrue(started)
+        jd._WORK_KEY_FN.assert_called_once_with()
+        self.assertEqual(_FakeModelsAPI.seen, [])
+        self.assertIn("1Password retrieval failed", km._catalog_status["lastError"])
+        self.assertNotIn("synthetic-ambient-token", log)
+        self.assertNotIn("synthetic-test-credential", log)
+        self.assertFalse(km._catalog_status["inflight"])
+
+    def test_runtime_reference_is_resolved_once_per_catalog_refresh_without_persistence(self):
+        ref = "op://test-vault/test-item/api-key"
+        os.environ["ROMP_API_KEY_REF"] = ref
+        with patch.object(jd._keysrc.subprocess, "run",
+                          return_value=Mock(returncode=0, stdout=b"synthetic-runtime-key")) as run:
+            self._refresh()
+            self.assertEqual(run.call_count, 1)
+            self._refresh()
+            self.assertEqual(run.call_count, 2)
+        self.assertTrue(_FakeModelsAPI.seen)
+        for file in Path(self.td.name).rglob("*"):
+            if file.is_file():
+                self.assertNotIn(b"synthetic-runtime-key", file.read_bytes())
+
+    def test_invalid_reference_prevents_requests_and_does_not_use_legacy_key(self):
+        Path(os.environ["ROMP_SERVICE_ENV_FILE"]).write_text("ROMP_API_KEY_REF=\n")
+        with patch.object(jd._keysrc.subprocess, "run") as run:
+            started, _ = self._refresh()
+        self.assertTrue(started)
+        run.assert_not_called()
+        self.assertEqual(_FakeModelsAPI.seen, [])
+        self.assertIn("ROMP_API_KEY_REF", km._catalog_status["lastError"])
 
     def test_a_fetch_that_adds_ids_tells_every_open_picker_to_re_read_models(self):
         # the refresh used to call _push_soon() here, its comment claiming the pickers re-read /models

--- a/tests/test_op_credential_boundary.py
+++ b/tests/test_op_credential_boundary.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Where op's own credential may and may not go (2026-09-05), pinned at the source across the four
+programs that spawn children: the kernel (claims first, scrubs the tmux server, strips revives), the
+manager (a scrubbed tmux server), the launcher (scrubs the server's globals before a pane exists), and the
+door (the request's auth decides which credential names are reserved). Synthetic throughout."""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+
+
+def _read(rel):
+    return open(os.path.join(ROOT, rel), encoding="utf-8").read()
+
+
+class KernelBoundary(unittest.TestCase):
+    def test_the_claim_is_the_kernels_first_act_and_scrubs_the_tmux_server(self):
+        src = _read("kernel/kernel.py")
+        main = src[src.rindex("\ndef main():"):]
+        claim = main.index("_claimed = jd._keysrc.claim_op_env()")
+        self.assertLess(claim, main.index("_ensure_bundles()"), "before the first child")
+        self.assertLess(claim, main.index("threading.Thread("), "before the first thread")
+        self.assertIn('jd._keysrc.tmux_unset_global(_claimed, os.environ.get("ROMP_TMUX_SOCKET", ""))', main)
+
+    def test_both_tmux_launch_paths_strip_the_credential(self):
+        src = _read("kernel/kernel.py")
+        self.assertIn("jd._keysrc.strip_op_env(env)     # op's credential stays with the kernel", src)
+        self.assertIn('env=jd._keysrc.strip_op_env(dict(os.environ)))', src, "the revive launch too")
+
+    def test_the_door_passes_the_requests_auth_to_the_one_rule(self):
+        src = _read("kernel/kernel.py")
+        self.assertIn('eerr = _env_error(env_req, str((b or {}).get("auth") or ""))', src)
+        self.assertIn("jd._keysrc.runtime_reserved_names(auth or \"\", jd._keysrc.select_source())", src)
+        sb = _read("kernel/sdk_backend.py")
+        self.assertIn('env_request_error(env, (reg or {}).get("auth") or "")', sb, "set_env knows the session's auth")
+        self.assertIn('err = env_request_error(env, auth or "")', sb, "spawn knows the pick")
+        self.assertIn("_keysrc.runtime_reserved_names(sess.auth, key_source)", sb, "the launch")
+        self.assertIn('_keysrc.runtime_reserved_names(reg.get("auth") or "", self._work_key_source())', sb, "the fork copy")
+
+
+class ManagerAndLauncher(unittest.TestCase):
+    def test_the_manager_starts_the_tmux_server_without_op_credentials_when_romp_runs_op(self):
+        src = _read("bin/romp-manager")
+        self.assertIn("function withoutOpCredentials(env)", src)
+        self.assertIn("if (!out.ROMP_API_KEY_REF) return out;", src, "a helper box keeps its environment")
+        self.assertRegex(src, r"k === 'OP_SERVICE_ACCOUNT_TOKEN' \|\| k === 'OP_CONNECT_HOST' \|\| k === 'OP_CONNECT_TOKEN' \|\| k === 'OP_ACCOUNT' \|\| k\.startsWith\('OP_SESSION_'\)")
+        self.assertIn("env: withoutOpCredentials(process.env) });", src)
+
+    def test_the_launcher_scrubs_the_servers_globals_before_the_pane_exists(self):
+        src = _read("bin/romp")
+        block = src[src.index('if [[ -n "${ROMP_API_KEY_REF:-}" ]]; then'):src.index('tmux new-session -d -s "$name" -c "$work_dir"')]
+        self.assertIn('tmux set-environment -gu "$op_var"', block)
+        self.assertIn("tmux show-environment -g", block)
+        self.assertIn("OP_SESSION_[A-Za-z0-9_]*", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_key_auth.py
+++ b/tests/test_runtime_key_auth.py
@@ -1,0 +1,180 @@
+"""Runtime credentials at the SDK boundary; all providers and sessions are synthetic."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+from importlib.machinery import SourceFileLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+_IMPORT_STATE = tempfile.mkdtemp(prefix="romp-runtime-auth-")
+os.environ["XDG_STATE_HOME"] = _IMPORT_STATE
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_SERVICE_ENV_FILE"] = _IMPORT_STATE + "/absent.env"
+os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
+os.environ.pop("ROMP_API_KEY_REF", None)
+sb = SourceFileLoader("romp_sdk_runtime_auth", str(ROOT / "kernel/sdk_backend.py")).load_module()
+ks = sb._keysrc
+REF = "op://test-vault/test-item/credential"
+KEY = "synthetic-runtime-credential"
+
+
+class RuntimeSdkAuth(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "service.env"
+        self.path.write_text("ROMP_API_KEY_REF=" + REF + "\n")
+        self.env = patch.dict(os.environ, {
+            "ROMP_SERVICE_ENV_FILE": str(self.path), "ROMP_SERVICE_ENV": str(self.path),
+            "ROMP_API_KEY_REF": "", "ANTHROPIC_API_KEY": "synthetic-old-startup-key",
+            "ANTHROPIC_AUTH_TOKEN": "synthetic-bearer", "CLAUDE_CODE_OAUTH_TOKEN": "synthetic-oauth",
+        })
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.addCleanup(patch.stopall)
+        patch.object(sb, "_WORK_KEY", None).start()
+        patch.object(sb, "_STARTUP_AUTH_ENV", None).start()
+        patch.object(sb, "_KEY_FILE_CHECKED", True).start()
+        patch.object(ks, "_CACHE", ((), ks.KeySource("none"))).start()
+        patch.object(ks, "_AUTHORITATIVE_PATHS", {}).start()
+        patch.object(sb, "_FAST_ORG_VERDICTS", {}).start()
+        patch.object(sb, "_fetch_key_fast_org", return_value=True).start()
+        self.provider = patch.object(ks.subprocess, "run", return_value=SimpleNamespace(
+            returncode=0, stdout=KEY.encode())).start()
+        fake_sdk = ModuleType("claude_agent_sdk")
+        fake_sdk.HookMatcher = lambda **kw: kw
+        fake_sdk.ClaudeAgentOptions = dict
+        fake_sdk.ClaudeSDKClient = unittest.mock.Mock()
+        for name in ("AssistantMessage", "ResultMessage", "SystemMessage"):
+            setattr(fake_sdk, name, type(name, (), {}))
+        self.client_factory = fake_sdk.ClaudeSDKClient
+        patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}).start()
+        self.logs = []
+        self.be = sb.SdkBackend(str(Path(self.tmp.name) / "state"), "/bin/true",
+                                lambda *a, **k: None, log=self.logs.append)
+
+    def session(self, auth="", **extra):
+        sid = self.be.spawn("synthetic", "/tmp", auth=auth)
+        reg = sb.read_reg(self.be.state_dir, sid)
+        reg.update(extra)
+        return sb.SdkSession(self.be, reg)
+
+    def test_ui_defaults_and_auth_selection_never_retrieve_a_key(self):
+        sess = self.session()
+        for _ in range(3):
+            self.assertTrue(self.be.work_key_configured)
+            self.assertEqual(self.be.work_key_source_fp(), ks.KeySource("op", REF).fingerprint())
+            self.assertEqual(self.be.default_auth({}), "key")
+            self.assertEqual(sess.effective_auth(), "key")
+            self.assertEqual(sess.snapshot()["auth"], "key")
+        self.assertTrue(self.be.set_auth(sess.sid, "key"))
+        self.provider.assert_not_called()
+        self.assertEqual(sb._WORK_KEY, "", "the replaced startup key is discarded")
+
+    def test_each_key_launch_resolves_once_and_keeps_secrets_out_of_files_and_caches(self):
+        self.provider.side_effect = [SimpleNamespace(returncode=0, stdout=KEY.encode()),
+                                    SimpleNamespace(returncode=0, stdout=b"synthetic-rotated-key")]
+        sess = self.session("key", env={"FEATURE_FLAG": "yes"})
+        first = self.be._options(sess, dict)
+        second = self.be._options(sess, dict)
+        self.assertEqual(first["env"]["ANTHROPIC_API_KEY"], KEY)
+        self.assertEqual(second["env"]["ANTHROPIC_API_KEY"], "synthetic-rotated-key")
+        self.assertEqual(self.provider.call_count, 2)
+        self.assertEqual(self.provider.call_args.args[0], ["op", "read", "--no-newline", REF])
+        for name in sb.AUTH_ENV_NAMES:
+            self.assertNotIn(name, os.environ)
+        for name in sb.AUTH_ENV_NAMES[1:]:
+            self.assertNotIn(name, first["env"])
+        self.assertEqual(sb._WORK_KEY, "")
+        self.assertNotIn(KEY, repr(sb._FAST_ORG_VERDICTS))
+        for file in Path(self.tmp.name).rglob("*"):
+            if file.is_file():
+                self.assertNotIn(KEY.encode(), file.read_bytes(), str(file))
+        self.assertNotIn(KEY, "\n".join(self.logs))
+
+    def test_login_does_not_invoke_a_broken_provider_and_restores_only_login_tokens(self):
+        self.provider.side_effect = FileNotFoundError()
+        options = self.be._options(self.session("login"), dict)
+        self.provider.assert_not_called()
+        self.assertNotIn("ANTHROPIC_API_KEY", options["env"])
+        self.assertEqual(options["env"]["ANTHROPIC_AUTH_TOKEN"], "synthetic-bearer")
+        self.assertEqual(options["env"]["CLAUDE_CODE_OAUTH_TOKEN"], "synthetic-oauth")
+
+    def test_failed_runtime_retrieval_never_constructs_a_client_and_records_launch_error(self):
+        self.provider.return_value = SimpleNamespace(returncode=1, stdout=b"provider-output-must-not-leak")
+        sess = self.session("key")
+        with patch.object(self.be, "_record_launch_error") as record:
+            with self.assertRaises(ks.KeySourceError):
+                asyncio.run(sess._amain())
+        record.assert_called_once()
+        self.client_factory.assert_not_called()
+        self.assertEqual(sess.effective_auth(), "key")
+        self.assertNotIn("provider-output", str(record.call_args))
+
+    def test_empty_explicit_key_refuses_login_fallback(self):
+        self.be.work_key = ""
+        sess = self.session("key")
+        self.assertEqual(sess.effective_auth(), "key")
+        with self.assertRaisesRegex(ks.KeySourceError, "no API key source"):
+            self.be._options(sess, dict)
+        self.provider.assert_not_called()
+
+    def test_provider_failure_record_does_not_reuse_a_previous_clis_stderr(self):
+        sess = self.session("key")
+        with patch.object(sess, "stderr_tail", return_value="old CLI output"):
+            self.be._record_launch_error(sess, ks.KeySourceError("1Password credential retrieval failed"))
+        error = sb.read_reg(self.be.state_dir, sess.sid)["launchError"]
+        self.assertIn("1Password credential retrieval failed", error["text"])
+        self.assertNotIn("old CLI output", error["text"])
+
+    def test_removed_runtime_reference_keeps_the_failure_explicit(self):
+        self.path.write_text("ROMP_PERF=1\n")
+        self.assertTrue(self.be.work_key_configured)
+        with self.assertRaises(ks.KeySourceError):
+            self.be._options(self.session(), dict)
+        self.provider.assert_not_called()
+
+    def test_runtime_mode_refuses_new_persisted_credentials_and_filters_legacy_settings(self):
+        for name in sb.AUTH_ENV_NAMES:
+            self.assertIn("reserved", sb.env_request_error({name: "synthetic-legacy-secret"}))
+            with self.assertRaisesRegex(ValueError, "reserved"):
+                self.be.spawn("bad", "/tmp", env={name: "synthetic-legacy-secret"})
+        sess = self.session("key", env={**{name: "synthetic-legacy-secret" for name in sb.AUTH_ENV_NAMES},
+                                        "FEATURE_FLAG": "yes"})
+        options = self.be._options(sess, dict)
+        saved_env = json.loads(Path(options["settings"]).read_text())["env"]
+        self.assertEqual(saved_env, {"FEATURE_FLAG": "yes"})
+
+    def test_cycles_skip_login_dormant_and_busy_sessions_before_retrieval(self):
+        login = self.session("login")
+        self.be.sessions[login.sid] = login
+        dormant = self.session("key")
+        busy = self.session("key")
+        self.be.sessions[busy.sid] = busy
+        busy.inflight = 1
+        self.assertEqual(self.be.cycle_key(login.sid), "login")
+        self.assertEqual(self.be.cycle_key(dormant.sid), "dormant")
+        self.assertEqual(self.be.cycle_key(busy.sid), "working")
+        self.provider.assert_not_called()
+
+    def test_cycle_resolves_once_for_currentness_and_logging(self):
+        sess = self.session("key")
+        self.be.sessions[sess.sid] = sess
+        with patch.object(sess, "request_reconnect") as reconnect:
+            self.assertEqual(self.be.cycle_key(sess.sid), "cycling")
+        reconnect.assert_called_once_with(defer=False)
+        self.assertEqual(self.provider.call_count, 1)
+        sess._launched_key_fp = ks.fingerprint(KEY)
+        with patch.object(sess, "request_reconnect") as reconnect:
+            self.assertEqual(self.be.cycle_key(sess.sid), "current")
+        reconnect.assert_not_called()
+        self.assertEqual(self.provider.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_key_auth.py
+++ b/tests/test_runtime_key_auth.py
@@ -139,16 +139,32 @@ class RuntimeSdkAuth(unittest.TestCase):
             self.be._options(self.session(), dict)
         self.provider.assert_not_called()
 
-    def test_runtime_mode_refuses_new_persisted_credentials_and_filters_legacy_settings(self):
-        for name in sb.AUTH_ENV_NAMES:
-            self.assertIn("reserved", sb.env_request_error({name: "synthetic-legacy-secret"}))
-            with self.assertRaisesRegex(ValueError, "reserved"):
-                self.be.spawn("bad", "/tmp", env={name: "synthetic-legacy-secret"})
+    def test_runtime_mode_refuses_a_persisted_api_key_and_filters_legacy_settings(self):
+        # A per-session API key competes with the runtime source: refused at the door, filtered at launch.
+        self.assertIn("reserved", sb.env_request_error({"ANTHROPIC_API_KEY": "synthetic-legacy-secret"}))
+        with self.assertRaisesRegex(ValueError, "reserved"):
+            self.be.spawn("bad", "/tmp", env={"ANTHROPIC_API_KEY": "synthetic-legacy-secret"})
         sess = self.session("key", env={**{name: "synthetic-legacy-secret" for name in sb.AUTH_ENV_NAMES},
                                         "FEATURE_FLAG": "yes"})
         options = self.be._options(sess, dict)
         saved_env = json.loads(Path(options["settings"]).read_text())["env"]
-        self.assertEqual(saved_env, {"FEATURE_FLAG": "yes"})
+        self.assertEqual(saved_env, {"FEATURE_FLAG": "yes"}, "a KEYED launch carries no competing credential of any kind")
+
+    def test_a_login_session_keeps_its_own_token_override_under_runtime_mode(self):
+        """A login session never touches the key source; its per-session OAuth token bills the account the
+        user chose for it. Stripping it re-billed the machine login with only a log line (review find,
+        2026-09-05). The door agrees: only the API key is reserved while runtime retrieval governs."""
+        for name in sb.AUTH_ENV_NAMES[1:]:
+            self.assertEqual(sb.env_request_error({name: "synthetic-second-login"}, "login"), "")
+            self.assertIn("reserved", sb.env_request_error({name: "synthetic-second-login"}, "key"))
+            self.assertIn("reserved", sb.env_request_error({name: "synthetic-second-login"}),
+                          "no pick with a configured source launches keyed, so the door refuses a competing token")
+        sess = self.session("login", env={"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-second-login", "FEATURE_FLAG": "yes"})
+        options = self.be._options(sess, dict)
+        saved_env = json.loads(Path(options["settings"]).read_text())["env"]
+        self.assertEqual(saved_env, {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-second-login", "FEATURE_FLAG": "yes"})
+        self.assertNotIn("ANTHROPIC_API_KEY", options["env"], "a login launch resolves no key")
+        self.provider.assert_not_called()
 
     def test_cycles_skip_login_dormant_and_busy_sessions_before_retrieval(self):
         login = self.session("login")
@@ -178,3 +194,162 @@ class RuntimeSdkAuth(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class OpCredentialAndDiscardNotice(unittest.TestCase):
+    """Review finds of 2026-09-05, at the SDK boundary."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "service.env"
+        self.path.write_text("ROMP_API_KEY_REF=" + REF + "\n")
+        self.env = patch.dict(os.environ, {
+            "ROMP_SERVICE_ENV_FILE": str(self.path), "ROMP_SERVICE_ENV": str(self.path),
+            "ROMP_API_KEY_REF": "", "ANTHROPIC_API_KEY": "synthetic-old-startup-key",
+            "OP_SERVICE_ACCOUNT_TOKEN": "synthetic-op-token", "OP_SESSION_acct": "synthetic-op-session",
+        })
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.addCleanup(patch.stopall)
+        os.environ.pop("ROMP_SUPERVISED", None)
+        patch.object(sb, "_WORK_KEY", None).start()
+        patch.object(sb, "_STARTUP_AUTH_ENV", None).start()
+        patch.object(sb, "_STARTUP_KEY_DISCARD_SAID", False).start()
+        patch.object(sb, "_KEY_FILE_CHECKED", True).start()
+        patch.object(ks, "_CACHE", ((), ks.KeySource("none"))).start()
+        patch.object(ks, "_AUTHORITATIVE_PATHS", {}).start()
+        patch.object(ks, "_OP_ENV", {}).start()
+        patch.object(sb, "_FAST_ORG_VERDICTS", {}).start()
+        patch.object(sb, "_fetch_key_fast_org", return_value=True).start()
+        self.provider = patch.object(ks.subprocess, "run", return_value=SimpleNamespace(
+            returncode=0, stdout=KEY.encode())).start()
+        fake_sdk = ModuleType("claude_agent_sdk")
+        fake_sdk.HookMatcher = lambda **kw: kw
+        fake_sdk.ClaudeAgentOptions = dict
+        fake_sdk.ClaudeSDKClient = unittest.mock.Mock()
+        for name in ("AssistantMessage", "ResultMessage", "SystemMessage"):
+            setattr(fake_sdk, name, type(name, (), {}))
+        patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}).start()
+        self.logs = []
+        self.err = patch("sys.stderr", new_callable=lambda: __import__("io").StringIO()).start()
+        self.be = sb.SdkBackend(str(Path(self.tmp.name) / "state"), "/bin/true",
+                                lambda *a, **k: None, log=self.logs.append)
+
+    def session(self, auth=""):
+        sid = self.be.spawn("synthetic", "/tmp", auth=auth)
+        return sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+
+    def test_op_credentials_never_reach_a_session_but_do_reach_op(self):
+        for name in ("OP_SERVICE_ACCOUNT_TOKEN", "OP_SESSION_acct"):
+            self.assertNotIn(name, os.environ, "claimed at backend init, like the token credentials")
+        options = self.be._options(self.session("key"), dict)
+        self.assertEqual(options["env"]["ANTHROPIC_API_KEY"], KEY)
+        for name in ("OP_SERVICE_ACCOUNT_TOKEN", "OP_SESSION_acct"):
+            self.assertNotIn(name, options["env"])
+        sub_env = self.provider.call_args.kwargs["env"]
+        self.assertEqual(sub_env["OP_SERVICE_ACCOUNT_TOKEN"], "synthetic-op-token")
+        self.assertEqual(sub_env["OP_SESSION_acct"], "synthetic-op-session")
+
+    def test_the_ignored_startup_key_is_said_once_with_its_fingerprint_never_its_value(self):
+        self.be._work_key_source(); self.be._work_key_source()
+        out = self.err.getvalue()
+        self.assertEqual(out.count("startup key (sha256:"), 1)
+        self.assertIn(ks.fingerprint("synthetic-old-startup-key"), out)
+        self.assertNotIn("synthetic-old-startup-key", out)
+        self.assertIn("1Password source", out)
+
+    def test_a_supervised_manager_names_the_file_only_rule_when_it_ignores_a_startup_key(self):
+        # a FRESH supervised kernel: no memory of a selected source (that memory is the resurrection guard,
+        # exercised elsewhere), the manager's inherited key still in the environment, no file line
+        self.path.unlink()
+        os.environ["ROMP_SUPERVISED"] = "1"
+        os.environ.pop("ROMP_API_KEY_REF", None)              # an (even empty) reference in the env is a selection
+        os.environ["ANTHROPIC_API_KEY"] = "synthetic-old-startup-key"
+        ks._CACHE = ((), ks.KeySource("none")); ks._AUTHORITATIVE_PATHS.clear()
+        sb._WORK_KEY = None; sb._STARTUP_KEY_DISCARD_SAID = False; self.err.truncate(0); self.err.seek(0)
+        src = sb.work_api_key_source()
+        self.assertEqual((src.kind, src.value, src.configured), ("file", "", False), "no file line: no key")
+        out = self.err.getvalue()
+        self.assertIn("supervised managers read", out); self.assertIn("launch on the login", out)
+        self.assertIn(ks.fingerprint("synthetic-old-startup-key"), out)
+
+    def test_an_unreadable_file_fails_loudly_but_discards_nothing(self):
+        if os.geteuid() == 0:
+            self.skipTest("root reads through chmod 0")
+        # a fresh kernel whose file is unreadable from the start: the startup key stays claimed
+        self.path.write_text("ROMP_API_KEY_REF=" + REF + "\n")
+        self.path.chmod(0)
+        self.addCleanup(lambda: self.path.chmod(0o600))
+        os.environ["ANTHROPIC_API_KEY"] = "synthetic-old-startup-key"
+        ks._CACHE = ((), ks.KeySource("none")); ks._AUTHORITATIVE_PATHS.clear(); sb._WORK_KEY = None
+        src = sb.work_api_key_source()
+        self.assertEqual(src.kind, "error")
+        with self.assertRaises(ks.KeySourceError):
+            src.resolve()
+        self.assertEqual(sb._WORK_KEY, "synthetic-old-startup-key", "a read error is not a selection")
+        self.path.chmod(0o600)
+        ks._CACHE = ((), ks.KeySource("none"))
+        self.assertEqual(sb.work_api_key_source().kind, "op", "…and the file governs again once readable")
+
+    def test_a_cycle_handed_the_requests_fingerprint_retrieves_nothing(self):
+        sess = self.session("key")
+        self.be.sessions[sess.sid] = sess
+        sess._launched_key_fp = ks.fingerprint(KEY)
+        self.provider.reset_mock()
+        self.assertEqual(self.be.cycle_key(sess.sid, current_key_fp=ks.fingerprint(KEY)), "current")
+        with patch.object(sess, "request_reconnect") as reconnect:
+            self.assertEqual(self.be.cycle_key(sess.sid, current_key_fp=ks.fingerprint("rotated")), "cycling")
+        reconnect.assert_called_once_with(defer=False)
+        self.provider.assert_not_called()
+
+    def test_the_standard_supervised_install_gets_no_ignored_key_notice(self):
+        """EnvironmentFile exports the file's own key line into the manager environment, so the same key on
+        both sides is the everyday case — nothing is ignored, nothing is said (review find, 2026-09-05)."""
+        self.path.write_text("ANTHROPIC_API_KEY=synthetic-old-startup-key\n")
+        os.environ["ROMP_SUPERVISED"] = "1"; os.environ.pop("ROMP_API_KEY_REF", None)
+        os.environ["ANTHROPIC_API_KEY"] = "synthetic-old-startup-key"
+        ks._CACHE = ((), ks.KeySource("none")); ks._AUTHORITATIVE_PATHS.clear()
+        sb._WORK_KEY = None; sb._STARTUP_KEY_DISCARD_SAID = False; self.err.truncate(0); self.err.seek(0)
+        for _ in range(2):
+            self.assertEqual(sb.work_api_key_source().kind, "file")
+        self.assertNotIn("IGNORED", self.err.getvalue())
+
+    def test_the_notice_names_the_reference_when_the_environment_selected_it(self):
+        self.path.unlink()
+        os.environ["ROMP_API_KEY_REF"] = REF; os.environ["ANTHROPIC_API_KEY"] = "synthetic-old-startup-key"
+        ks._CACHE = ((), ks.KeySource("none")); ks._AUTHORITATIVE_PATHS.clear(); ks._ENV_PROVIDER_PATHS.clear()
+        sb._WORK_KEY = None; sb._STARTUP_KEY_DISCARD_SAID = False; self.err.truncate(0); self.err.seek(0)
+        self.assertEqual(sb.work_api_key_source().kind, "op")
+        out = self.err.getvalue()
+        self.assertIn("ROMP_API_KEY_REF selects the 1Password source", out)
+        self.assertNotIn("env file", out)
+
+    def test_a_forked_login_session_keeps_its_parents_token_override(self):
+        parent = self.session("login")
+        reg = sb.read_reg(self.be.state_dir, parent.sid)
+        reg["env"] = {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-second-login", "FEATURE_FLAG": "yes"}
+        sb.write_reg(self.be.state_dir, parent.sid, reg)
+        child = self.be.fork("synthetic-child", parent.sid) if hasattr(self.be, "fork") else None
+        if child is None:
+            self.skipTest("this backend build has no fork")
+        creg = sb.read_reg(self.be.state_dir, child if isinstance(child, str) else child.sid)
+        self.assertEqual(creg.get("env"), {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-second-login", "FEATURE_FLAG": "yes"})
+        self.assertEqual(creg.get("auth"), "login")
+
+    def test_a_cycle_probe_classifies_without_retrieving_and_a_request_failure_lands_only_where_a_key_was_needed(self):
+        login = self.session("login"); self.be.sessions[login.sid] = login
+        keyed = self.session("key"); self.be.sessions[keyed.sid] = keyed
+        busy = self.session("key"); self.be.sessions[busy.sid] = busy; busy.inflight = 1
+        self.provider.reset_mock()
+        self.assertEqual(self.be.cycle_key(login.sid, probe=True), "login")
+        self.assertEqual(self.be.cycle_key(busy.sid, probe=True), "working")
+        self.assertEqual(self.be.cycle_key("11111111-2222-3333-4444-aaaaaaaaaaa9", probe=True), "unknown")
+        self.assertEqual(self.be.cycle_key(keyed.sid, probe=True), "cycle")
+        self.provider.assert_not_called()
+        self.assertEqual(self.be.cycle_key(login.sid, resolve_error="1Password credential retrieval failed"), "login",
+                         "a session that needs no key is not told the retrieval failed")
+        with self.assertRaisesRegex(ks.KeySourceError, "retrieval failed"):
+            self.be.cycle_key(keyed.sid, resolve_error="1Password credential retrieval failed")
+        self.provider.assert_not_called()
+

--- a/tests/test_runtime_keysource.py
+++ b/tests/test_runtime_keysource.py
@@ -497,3 +497,90 @@ def test_loading_a_consumer_preserves_prior_provider_removal(env, monkeypatch, c
         env.op.assert_not_called()
     finally:
         sys.modules.pop(module_name, None)
+
+
+def test_op_credentials_are_claimed_out_of_the_environment_and_reach_only_the_op_subprocess(env, monkeypatch):
+    """op's own credential (a service-account token, a signed-in session token) must reach the kernel for
+    headless use — and no child of the kernel: claim_op_env() takes the names out of os.environ once, and
+    resolve() gives them back to the `op read` subprocess alone (review find, 2026-09-05: they were inherited
+    by every Claude session and every judge call, a vault-wide credential in every agent's shell)."""
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "synthetic-op-token")
+    monkeypatch.setenv("OP_SESSION_my_account", "synthetic-op-session")
+    monkeypatch.setenv("OP_ACCOUNT", "my.1password.example")
+    monkeypatch.setenv("UNRELATED_VAR", "kept")
+    ks._OP_ENV.clear(); ks._OP_CLAIM_SAID = False
+    try:
+        # no reference anywhere: romp is not the op consumer (a session-side helper may be) → hands off
+        assert ks.claim_op_env() == {} and "OP_SERVICE_ACCOUNT_TOKEN" in os.environ
+        assert ks.strip_op_env({"OP_SERVICE_ACCOUNT_TOKEN": "x", "A": "1"}) == {"OP_SERVICE_ACCOUNT_TOKEN": "x", "A": "1"}
+        monkeypatch.setenv("ROMP_API_KEY_REF", REF)                  # now romp runs op itself
+        claimed = ks.claim_op_env()
+        assert set(claimed) == {"OP_SERVICE_ACCOUNT_TOKEN", "OP_SESSION_my_account", "OP_ACCOUNT"}
+        for name in claimed:
+            assert name not in os.environ, name
+        assert os.environ["UNRELATED_VAR"] == "kept"
+        # a value that appears later is claimed too, and the stash is idempotent
+        monkeypatch.setenv("OP_CONNECT_TOKEN", "synthetic-connect")
+        assert "OP_CONNECT_TOKEN" in ks.claim_op_env() and "OP_CONNECT_TOKEN" not in os.environ
+        env.op.side_effect = None
+        env.op.return_value = result(NEW_KEY.encode())
+        assert ks.KeySource("op", REF).resolve() == NEW_KEY
+        sub_env = env.op.call_args.kwargs["env"]
+        assert sub_env["OP_SERVICE_ACCOUNT_TOKEN"] == "synthetic-op-token"
+        assert sub_env["OP_SESSION_my_account"] == "synthetic-op-session"
+        assert sub_env["UNRELATED_VAR"] == "kept", "op still sees the ordinary environment (PATH, HOME, config)"
+        assert "OP_SERVICE_ACCOUNT_TOKEN" not in os.environ, "resolving hands nothing back to the process"
+        # a child env built before the claim is scrubbed the same way
+        child = {"OP_SERVICE_ACCOUNT_TOKEN": "x", "OP_SESSION_acct": "y", "PATH": "/bin", "OPTIONAL": "keep"}
+        assert ks.strip_op_env(child) == {"PATH": "/bin", "OPTIONAL": "keep"}
+        assert ks.is_op_env_name("OP_SESSION_anything") and not ks.is_op_env_name("OPTIONAL")
+    finally:
+        ks._OP_ENV.clear()
+
+
+def test_a_stray_byte_in_an_unrelated_line_does_not_turn_the_source_into_an_error(env):
+    env.path.write_bytes(b"# caf\xe9 note\nROMP_API_KEY_REF=" + REF.encode() + b"\n")
+    assert ks.read_source(str(env.path)) == ks.KeySource("op", REF)
+
+
+def test_the_claim_says_which_names_it_took_once_and_never_a_value(env, monkeypatch, capsys):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "synthetic-op-token-value")
+    ks._OP_ENV.clear(); ks._OP_CLAIM_SAID = False
+    try:
+        ks.claim_op_env(); ks.claim_op_env()
+        err = capsys.readouterr().err
+        assert err.count("op credentials claimed") == 1
+        assert "OP_SERVICE_ACCOUNT_TOKEN" in err and "synthetic-op-token-value" not in err
+    finally:
+        ks._OP_ENV.clear(); ks._OP_CLAIM_SAID = False
+
+
+def test_one_reserved_names_rule_for_the_doors_the_launch_and_the_fork():
+    op = ks.KeySource("op", REF); err = ks.KeySource("error", error="x"); plain = ks.KeySource("file", "k")
+    all3 = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+    assert ks.runtime_reserved_names("key", op) == all3
+    assert ks.runtime_reserved_names("", op) == all3, "no pick with a configured source launches keyed"
+    assert ks.runtime_reserved_names("login", op) == ("ANTHROPIC_API_KEY",), "a login session keeps its own token"
+    assert ks.runtime_reserved_names("login", err) == ("ANTHROPIC_API_KEY",)
+    assert ks.runtime_reserved_names("key", plain) == () and ks.runtime_reserved_names("", None) == ()
+
+
+def test_a_garbled_key_line_is_an_error_while_a_garbled_comment_is_not(env):
+    env.path.write_bytes(b"ANTHROPIC_API_KEY=sk-ant-TEST-\xff\xfe-garbled\n")
+    src = ks.read_source(str(env.path))
+    assert src.kind == "error" and "not valid UTF-8" in src.error and "ANTHROPIC_API_KEY" in src.error
+    env.path.write_bytes(b"# caf\xe9\nROMP_API_KEY_REF=" + REF.encode() + b"\n")
+    ks._CACHE = ((), "")
+    assert ks.read_source(str(env.path)) == ks.KeySource("op", REF)
+
+
+def test_tmux_server_scrub_runs_one_unset_per_credential_name(env):
+    with mock.patch.object(ks.subprocess, "run") as run:
+        ran = ks.tmux_unset_global(["OP_SERVICE_ACCOUNT_TOKEN", "OP_SESSION_acct", "PATH", "OP_ACCOUNT"], socket="probe")
+    assert ran == [["tmux", "-L", "probe", "set-environment", "-gu", "OP_ACCOUNT"],
+                   ["tmux", "-L", "probe", "set-environment", "-gu", "OP_SERVICE_ACCOUNT_TOKEN"],
+                   ["tmux", "-L", "probe", "set-environment", "-gu", "OP_SESSION_acct"]]
+    assert run.call_count == 3
+    with mock.patch.object(ks.subprocess, "run", side_effect=FileNotFoundError):
+        assert ks.tmux_unset_global(["OP_ACCOUNT"]) == [], "no tmux: nothing to do, nothing raised"

--- a/tests/test_runtime_keysource.py
+++ b/tests/test_runtime_keysource.py
@@ -1,0 +1,499 @@
+"""Runtime credential source contract, using synthetic secrets and mocked op only.
+
+These tests distinguish inspecting a configured reference from retrieving its value,
+and exercise source removal and failure without accessing the developer's credentials.
+"""
+import os
+import stat
+import subprocess
+import tempfile
+import traceback
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+ks = SourceFileLoader(
+    "romp_runtime_keysource_test", str(ROOT / "kernel" / "keysource.py")
+).load_module()
+
+REF = "op://test-vault/test-item/credential"
+OTHER_REF = "op://test-vault/other-item/credential"
+BOOT_KEY = "sk-ant-TEST-startup-do-not-reuse"
+OLD_KEY = "sk-ant-TEST-provider-old"
+NEW_KEY = "sk-ant-TEST-provider-new"
+SECRET_STDERR = "TEST-sensitive-provider-stderr"
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    path = tmp_path / "service.env"
+    monkeypatch.setenv("ROMP_SERVICE_ENV_FILE", str(path))
+    monkeypatch.setenv("ROMP_SERVICE_ENV", str(path))
+    monkeypatch.delenv("ROMP_API_KEY_REF", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ROMP_SUPERVISED", raising=False)
+    ks._CACHE = ((), "")
+    ks._AUTHORITATIVE_PATHS.clear()
+    ks._ENV_PROVIDER_PATHS.clear()
+    # Unexpected retrieval fails locally: no test may invoke the real executable.
+    with mock.patch.object(
+        ks.subprocess, "run", side_effect=AssertionError("unexpected credential retrieval")
+    ) as op:
+        yield SimpleNamespace(path=path, root=tmp_path, op=op)
+    ks._CACHE = ((), "")
+    ks._AUTHORITATIVE_PATHS.clear()
+    ks._ENV_PROVIDER_PATHS.clear()
+
+
+def result(value=OLD_KEY.encode(), returncode=0):
+    return subprocess.CompletedProcess(
+        ["op", "read", "--no-newline", REF], returncode,
+        stdout=value, stderr=SECRET_STDERR.encode(),
+    )
+
+
+def safe_failure(call, *hidden):
+    with pytest.raises(ks.KeySourceError) as caught:
+        call()
+    error = caught.value
+    rendered = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    for value in (OLD_KEY, NEW_KEY, BOOT_KEY, SECRET_STDERR, *hidden):
+        assert value not in str(error)
+        assert value not in repr(error)
+        assert value not in rendered
+    return error
+
+
+def test_metadata_and_legacy_reader_never_retrieve_provider(env):
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    source = ks.select_source(BOOT_KEY)
+
+    assert source.kind == "op"
+    assert source.configured
+    source.validate()
+    assert source.fingerprint()
+    assert source.fingerprint() == ks.read_source().fingerprint()
+    assert source == ks.parse_source(env.path.read_text())
+    assert REF not in repr(source)
+    assert ks.read_key() == ""
+    env.op.assert_not_called()
+
+
+def test_resolve_executes_literal_reference_with_bounded_noninteractive_io(env):
+    # Shell syntax and spaces must stay inside one argument, never be evaluated.
+    reference = "op://test vault/item;$(touch SHOULD_NOT_EXIST)/credential field"
+    env.op.side_effect = None
+    env.op.return_value = result()
+
+    assert ks.KeySource("op", reference).resolve() == OLD_KEY
+
+    args, kwargs = env.op.call_args
+    assert args == (["op", "read", "--no-newline", reference],)
+    assert not kwargs.get("shell", False)
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["stdout"] == subprocess.PIPE
+    assert kwargs["stderr"] == subprocess.DEVNULL
+    assert 0 < kwargs["timeout"] <= 30
+    assert kwargs["check"] is False
+    assert not (env.root / "SHOULD_NOT_EXIST").exists()
+
+
+def test_each_resolution_observes_rotation_without_caching_or_disk_writes(env):
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    source = ks.select_source(BOOT_KEY)
+    body = env.path.read_bytes()
+    names = sorted(env.root.iterdir())
+    env.op.side_effect = [result(OLD_KEY.encode()), result(NEW_KEY.encode())]
+
+    with mock.patch.object(ks, "open", create=True, side_effect=AssertionError("disk access")), \
+            mock.patch.object(ks.os, "open", side_effect=AssertionError("disk access")), \
+            mock.patch.object(ks.tempfile, "mkstemp", side_effect=AssertionError("disk access")):
+        assert source.resolve() == OLD_KEY
+        assert source.resolve() == NEW_KEY
+
+    assert env.op.call_count == 2
+    assert env.path.read_bytes() == body
+    assert sorted(env.root.iterdir()) == names
+    assert ks._CACHE[1].value == REF
+    assert source.value == REF
+    assert all(key not in repr(vars(ks)) for key in (OLD_KEY, NEW_KEY))
+
+
+@pytest.mark.parametrize("provider_failure", ["nonzero", "missing", "timeout", "oserror"])
+def test_provider_failures_are_safe_credential_errors(env, provider_failure):
+    env.op.side_effect = None
+    if provider_failure == "nonzero":
+        env.op.return_value = result(returncode=1)
+    elif provider_failure == "missing":
+        env.op.side_effect = FileNotFoundError(SECRET_STDERR)
+    elif provider_failure == "timeout":
+        env.op.side_effect = subprocess.TimeoutExpired(
+            ["op", "read", REF], 15, output=OLD_KEY.encode(), stderr=SECRET_STDERR.encode()
+        )
+    else:
+        env.op.side_effect = OSError(SECRET_STDERR)
+
+    safe_failure(ks.KeySource("op", REF).resolve)
+    assert env.op.call_count == 1
+
+
+@pytest.mark.parametrize("value", [
+    b"", b"\n", OLD_KEY.encode() + b"\n", OLD_KEY.encode() + b"\nsecond-line",
+    OLD_KEY.encode() + b"\x00", OLD_KEY.encode() + b" trailing-space",
+    b"\xff\xfe", b"x" * 16385,
+])
+def test_empty_malformed_or_oversized_provider_output_fails_safely(env, value):
+    env.op.side_effect = None
+    env.op.return_value = result(value)
+    safe_failure(ks.KeySource("op", REF).resolve)
+
+
+@pytest.mark.parametrize("reference", [
+    "", "not-a-reference", "op://", "op://vault/item", "op://vault//field",
+    "op://vault/item/", "op://vault/item/section/field/extra",
+    "op://vault/item/field\nPRIVATE_REF_MARKER", "op://vault/item/field\0PRIVATE_REF_MARKER",
+])
+def test_invalid_reference_never_runs_op_and_does_not_echo_input(env, reference):
+    source = ks.KeySource("op", reference)
+    assert source.configured  # Invalid explicit configuration cannot become login mode.
+    safe_failure(source.resolve, "PRIVATE_REF_MARKER")
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("body", [
+    f"ANTHROPIC_API_KEY={BOOT_KEY}\nROMP_API_KEY_REF={REF}\n",
+    f"ROMP_API_KEY_REF={REF}\nANTHROPIC_API_KEY={BOOT_KEY}\n",
+])
+def test_file_provider_wins_both_file_and_ambient_legacy_key(env, monkeypatch, body):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", BOOT_KEY)
+    env.path.write_text(body)
+    source = ks.select_source(BOOT_KEY)
+    assert (source.kind, source.value) == ("op", REF)
+    env.op.assert_not_called()
+
+
+def test_foreground_provider_wins_ambient_legacy_key(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", BOOT_KEY)
+    source = ks.select_source(BOOT_KEY)
+    assert (source.kind, source.value) == ("op", REF)
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("startup_key", ["", BOOT_KEY])
+def test_removing_foreground_provider_cannot_become_login_or_ambient_key(env, monkeypatch, startup_key):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(startup_key).kind == "op"
+    # Remembering selection must not block subsequent reads while it remains configured.
+    assert ks.select_source(startup_key).value == REF
+    monkeypatch.delenv("ROMP_API_KEY_REF")
+
+    source = ks.select_source(startup_key)
+    assert source.configured
+    assert source.kind == "error"
+    safe_failure(source.resolve)
+    env.op.assert_not_called()
+
+
+def test_empty_foreground_provider_stays_explicit_until_reconfigured(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    monkeypatch.setenv("ROMP_API_KEY_REF", "")
+    assert ks.select_source(BOOT_KEY).configured
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+    monkeypatch.setenv("ROMP_API_KEY_REF", OTHER_REF)
+    assert ks.select_source(BOOT_KEY).value == OTHER_REF
+    env.op.assert_not_called()
+
+
+def test_restoring_foreground_reference_recovers_from_removal(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(BOOT_KEY).value == REF
+    monkeypatch.delenv("ROMP_API_KEY_REF")
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+    monkeypatch.setenv("ROMP_API_KEY_REF", OTHER_REF)
+
+    assert ks.select_source(BOOT_KEY).value == OTHER_REF
+    env.op.assert_not_called()
+
+
+def test_foreground_provider_authority_is_isolated_by_service_file_path(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    monkeypatch.delenv("ROMP_API_KEY_REF")
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+
+    other_path = env.root / "other-service.env"
+    monkeypatch.setenv("ROMP_SERVICE_ENV_FILE", str(other_path))
+    assert ks.select_source(BOOT_KEY).resolve() == BOOT_KEY
+    monkeypatch.setenv("ROMP_SERVICE_ENV_FILE", str(env.path))
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+    env.op.assert_not_called()
+
+
+def test_explicit_file_key_can_replace_a_removed_foreground_provider(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    monkeypatch.delenv("ROMP_API_KEY_REF")
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+
+    ks.write_source(ks.KeySource("file", NEW_KEY))
+    assert ks.select_source(BOOT_KEY).resolve() == NEW_KEY
+    env.op.assert_not_called()
+
+
+def test_explicit_file_source_takes_priority_over_foreground_provider(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", OTHER_REF)
+    env.path.write_text(f"ANTHROPIC_API_KEY={OLD_KEY}\n")
+    source = ks.select_source(BOOT_KEY)
+    assert (source.kind, source.resolve()) == ("file", OLD_KEY)
+    env.op.assert_not_called()
+
+
+def test_removing_selected_file_provider_cannot_restore_foreground_provider(env, monkeypatch):
+    monkeypatch.setenv("ROMP_API_KEY_REF", OTHER_REF)
+    assert ks.select_source(BOOT_KEY).value == OTHER_REF
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    assert ks.select_source(BOOT_KEY).value == REF
+    env.path.unlink()
+
+    source = ks.select_source(BOOT_KEY)
+    assert source.configured
+    safe_failure(source.resolve)
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("credential", ["raw", "provider"])
+@pytest.mark.parametrize("edit", ["remove-file", "empty-file", "remove-assignment"])
+def test_supervised_kernel_restart_cannot_restore_removed_source(env, monkeypatch, credential, edit):
+    monkeypatch.setenv("ROMP_SUPERVISED", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", BOOT_KEY)
+    if credential == "provider":
+        monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+        env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+        assert ks.select_source(BOOT_KEY).value == REF
+    else:
+        env.path.write_text(f"ANTHROPIC_API_KEY={OLD_KEY}\n")
+        assert ks.select_source(BOOT_KEY).value == OLD_KEY
+    if edit == "remove-file":
+        env.path.unlink()
+    elif edit == "empty-file":
+        env.path.write_text("")
+    else:
+        env.path.write_text("ROMP_PERF=1\n")
+
+    # A fresh kernel under the still-running manager receives its original environment,
+    # but none of the previous kernel's authority maps or discarded startup-key state.
+    restarted = SourceFileLoader(
+        "romp_runtime_keysource_restarted_test", str(ROOT / "kernel" / "keysource.py")
+    ).load_module()
+    assert not restarted._AUTHORITATIVE_PATHS
+    assert not restarted._ENV_PROVIDER_PATHS
+    source = restarted.select_source(BOOT_KEY)
+    if credential == "provider":
+        assert source.kind == "error"
+        assert source.configured
+        with pytest.raises(restarted.KeySourceError) as caught:
+            source.resolve()
+        assert REF not in str(caught.value)
+        assert BOOT_KEY not in str(caught.value)
+        monkeypatch.delenv("ROMP_API_KEY_REF")
+        assert restarted.select_source("") == source
+    else:
+        assert source.kind == "file"
+        assert not source.configured
+        assert source.resolve() == ""
+        assert restarted.select_source("") == source
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("credential", ["raw", "provider"])
+def test_foreground_fresh_kernel_keeps_explicit_environment_auth(env, monkeypatch, credential):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", BOOT_KEY)
+    if credential == "provider":
+        monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    restarted = SourceFileLoader(
+        "romp_runtime_keysource_foreground_restart_test", str(ROOT / "kernel" / "keysource.py")
+    ).load_module()
+    source = restarted.select_source(BOOT_KEY)
+    if credential == "provider":
+        assert (source.kind, source.value) == ("op", REF)
+    else:
+        assert (source.kind, source.resolve()) == ("environment", BOOT_KEY)
+    env.op.assert_not_called()
+
+
+def test_supervised_service_without_key_source_still_allows_login(env, monkeypatch):
+    monkeypatch.setenv("ROMP_SUPERVISED", "1")
+    source = ks.select_source()
+    assert not source.configured
+    assert source.resolve() == ""
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    assert ks.select_source().value == REF
+    env.op.assert_not_called()
+
+
+def test_provider_failure_does_not_fall_back_to_competing_keys(env, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", BOOT_KEY)
+    env.path.write_text(f"ANTHROPIC_API_KEY={BOOT_KEY}\nROMP_API_KEY_REF={REF}\n")
+    env.op.side_effect = None
+    env.op.return_value = result(returncode=1)
+
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    assert env.op.call_count == 1
+
+
+def test_provider_failure_after_success_cannot_reuse_previous_resolved_key(env):
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    env.op.side_effect = [result(), result(returncode=1)]
+    assert ks.select_source(BOOT_KEY).resolve() == OLD_KEY
+
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+    assert env.op.call_count == 2
+
+
+@pytest.mark.parametrize("edit", ["remove-file", "remove-assignment", "empty-reference"])
+def test_removing_or_emptying_selected_provider_cannot_revive_startup_key(env, edit):
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    if edit == "remove-file":
+        env.path.unlink()
+    elif edit == "remove-assignment":
+        env.path.write_text("ROMP_PERF=1\n")
+    else:
+        env.path.write_text(f"ROMP_API_KEY_REF=\nANTHROPIC_API_KEY={BOOT_KEY}\n")
+
+    selected = ks.select_source(BOOT_KEY)
+    assert selected.configured
+    safe_failure(selected.resolve)
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("edit", ["remove-file", "remove-assignment", "empty-key"])
+def test_removing_or_emptying_legacy_source_cannot_revive_startup_key(env, edit):
+    env.path.write_text(f"ANTHROPIC_API_KEY={OLD_KEY}\n")
+    assert ks.select_source(BOOT_KEY).resolve() == OLD_KEY
+    if edit == "remove-file":
+        env.path.unlink()
+    elif edit == "remove-assignment":
+        env.path.write_text("ROMP_PERF=1\n")
+    else:
+        env.path.write_text("ANTHROPIC_API_KEY=\n")
+
+    assert ks.select_source(BOOT_KEY).resolve() == ""
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("file_source", [f"ROMP_API_KEY_REF={REF}", f"ANTHROPIC_API_KEY={OLD_KEY}"])
+@pytest.mark.parametrize("failure_at", ["stat", "open"])
+def test_unreadable_previously_selected_source_cannot_reuse_cached_value(env, file_source, failure_at):
+    env.path.write_text(file_source + "\n")
+    assert ks.select_source(BOOT_KEY).configured
+    if failure_at == "stat":
+        context = mock.patch.object(ks.os, "stat", side_effect=PermissionError(SECRET_STDERR))
+    else:
+        # Permission-only changes must invalidate the cache even if bytes/mtime are unchanged.
+        env.path.chmod(0o000)
+        context = mock.patch.object(ks, "open", create=True, side_effect=PermissionError(SECRET_STDERR))
+    with context:
+        selected = ks.select_source(BOOT_KEY)
+    assert selected.kind == "error"
+    assert selected.configured
+    safe_failure(selected.resolve)
+    env.op.assert_not_called()
+
+
+def test_explicit_new_source_recovers_from_removed_provider(env):
+    env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    env.path.unlink()
+    safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+
+    ks.write_source(ks.KeySource("op", OTHER_REF))
+    assert ks.select_source(BOOT_KEY).value == OTHER_REF
+    ks.write_source(ks.KeySource("file", NEW_KEY))
+    assert ks.select_source(BOOT_KEY).resolve() == NEW_KEY
+    env.op.assert_not_called()
+
+
+def test_atomic_reference_selection_removes_competing_keys_without_resolving(env):
+    original = (
+        f"# keep this comment\nANTHROPIC_API_KEY={OLD_KEY}\nROMP_PERF=1\n"
+        f"ROMP_API_KEY_REF={OTHER_REF}\nANTHROPIC_API_KEY={BOOT_KEY}\n"
+    )
+    env.path.write_text(original)
+    env.path.chmod(0o644)
+    real_replace = os.replace
+    replacements = []
+
+    def observe_replace(source_path, destination_path):
+        source_path = Path(source_path)
+        assert Path(destination_path) == env.path
+        assert source_path.parent == env.path.parent
+        assert env.path.read_text() == original  # Original survives until the atomic replace.
+        assert stat.S_IMODE(source_path.stat().st_mode) == 0o600
+        pending = source_path.read_text()
+        assert "ANTHROPIC_API_KEY=" not in pending
+        assert pending.count("ROMP_API_KEY_REF=") == 1
+        assert f"ROMP_API_KEY_REF={REF}" in pending
+        replacements.append(source_path)
+        real_replace(source_path, destination_path)
+
+    with mock.patch.object(ks.os, "replace", side_effect=observe_replace):
+        ks.write_source(ks.KeySource("op", REF))
+
+    assert len(replacements) == 1
+    assert stat.S_IMODE(env.path.stat().st_mode) == 0o600
+    assert env.path.read_text() == f"# keep this comment\nROMP_PERF=1\nROMP_API_KEY_REF={REF}\n"
+    assert sorted(env.root.iterdir()) == [env.path]
+    assert ks.select_source(BOOT_KEY).value == REF
+    env.op.assert_not_called()
+
+
+def test_failed_atomic_selection_preserves_old_configuration_and_cleans_temp_file(env):
+    original = f"ANTHROPIC_API_KEY={OLD_KEY}\nROMP_PERF=1\n"
+    env.path.write_text(original)
+    with mock.patch.object(ks.os, "replace", side_effect=OSError("synthetic rename failure")):
+        with pytest.raises(OSError, match="synthetic rename failure"):
+            ks.write_source(ks.KeySource("op", REF))
+    assert env.path.read_text() == original
+    assert sorted(env.root.iterdir()) == [env.path]
+    env.op.assert_not_called()
+
+
+@pytest.mark.parametrize("consumer,attribute", [
+    ("kernel/sdk_backend.py", "_keysrc"), ("cli/keyswap.py", "ks"),
+])
+@pytest.mark.parametrize("origin", ["file", "environment"])
+def test_loading_a_consumer_preserves_prior_provider_removal(env, monkeypatch, consumer, attribute, origin):
+    import sys
+    if origin == "file":
+        env.path.write_text(f"ROMP_API_KEY_REF={REF}\n")
+    else:
+        monkeypatch.setenv("ROMP_API_KEY_REF", REF)
+    assert ks.select_source(BOOT_KEY).kind == "op"
+    if origin == "file":
+        env.path.unlink()
+    else:
+        monkeypatch.delenv("ROMP_API_KEY_REF")
+
+    # The judge may select a provider before the SDK is loaded lazily. Loading a consumer must
+    # share that module, including its remembered authority, rather than re-execute and reset it.
+    monkeypatch.setitem(sys.modules, "romp_keysource", ks)
+    module_name = "romp_lazy_source_consumer_test"
+    try:
+        loaded = SourceFileLoader(module_name, str(ROOT / consumer)).load_module()
+        assert getattr(loaded, attribute) is ks
+        assert ks.select_source(BOOT_KEY).kind == "error"
+        safe_failure(lambda: ks.select_source(BOOT_KEY).resolve())
+        env.op.assert_not_called()
+    finally:
+        sys.modules.pop(module_name, None)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -37,6 +37,7 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ.pop("ROMP_SUPERVISED", None)  # a romp-managed shell inherits it; these tests stage the unsupervised startup-key case
 # The manager env file is a LIVE key source now (kernel/keysource.py), so floor it too: without this
 # a bare (non-pytest) run of this file on a machine with a real ~/.config/romp/service.env resolves
 # the developer's actual key instead of the fixture's. conftest.py holds the same floor for pytest.

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -42,6 +42,7 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 # the developer's actual key instead of the fixture's. conftest.py holds the same floor for pytest.
 os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
 os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
+os.environ.pop("ROMP_API_KEY_REF", None)
 sb = SourceFileLoader("romp_sdk_backend_auth", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 km = SourceFileLoader("romp_kernel_auth", os.path.join(BIN, "romp-kernel")).load_module()
 
@@ -118,10 +119,10 @@ class EffectiveAuth(_Keyed):
 class EffectiveAuthKeyless(_Keyed):
     KEY = ""
 
-    def test_everything_falls_to_login_when_no_key_exists(self):
+    def test_an_explicit_key_pick_never_becomes_login_when_no_key_exists(self):
         self.assertEqual(self._sess(1).effective_auth(), "login")
-        self.assertEqual(self._sess(2, auth="key").effective_auth(), "login",
-                         "'key' with nothing to inject launches on the login — loudly, via _options")
+        self.assertEqual(self._sess(2, auth="key").effective_auth(), "key")
+        self.assertEqual(self.be.default_auth({"auth": "key"}), "key")
 
 
 class _OptionsHarness(_Keyed):
@@ -166,10 +167,10 @@ class OptionsInjection(_OptionsHarness):
         self._options_kw(s2)
         self.assertFalse(s2._launched_keyed)
 
-    def test_a_key_pick_with_no_key_is_a_logged_problem_not_a_silent_fall(self):
-        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
-        self.assertIn("session is set to the API key but the manager environment carries", src)
-        self.assertIn('ANTHROPIC_API_KEY=work_key', src)
+    def test_a_key_pick_with_no_key_refuses_to_launch_on_the_login(self):
+        self.be.work_key = ""
+        with self.assertRaisesRegex(sb._keysrc.KeySourceError, "no API key source"):
+            self._options_kw(self._sess(3, auth="key"))
 
 
 class FastOrgPermissionFollowsBilling(_OptionsHarness):
@@ -424,7 +425,7 @@ class Availability(unittest.TestCase):
         km._sdk, km._claude_account, km._claude_account_label = self.real_sdk, self.real_acct, self.real_label
 
     def _world(self, key, acct, label="user@example.com"):
-        km._sdk = lambda: type("B", (), {"work_key": key})()
+        km._sdk = lambda: type("B", (), {"work_key_configured": bool(key)})()
         km._claude_account = lambda: acct
         km._claude_account_label = lambda: (label if acct else "")
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -456,6 +456,41 @@ class ValidatorLockstep(unittest.TestCase):
             self.assertEqual(km._env_error(payload), sb.env_request_error(payload),
                              "the copies must stay in lockstep — payload %r" % (payload,))
 
+    CREDENTIALS = ({"ANTHROPIC_API_KEY": "x"}, {"ANTHROPIC_AUTH_TOKEN": "x"}, {"CLAUDE_CODE_OAUTH_TOKEN": "x"})
+
+    def test_the_copies_agree_on_credentials_with_and_without_runtime_retrieval(self):
+        """Under runtime API-key retrieval a per-session API key is reserved (it competes with the source); a
+        login session's token override is not (review find, 2026-09-05). Both copies, both worlds."""
+        import tempfile
+        km = self._kernel()
+        for payload in self.CREDENTIALS:                       # no source configured: all three pass
+            self.assertEqual(km._env_error(payload), "")
+            self.assertEqual(sb.env_request_error(payload), "")
+        d = tempfile.mkdtemp()
+        path = os.path.join(d, "service.env")
+        with open(path, "w") as fh:
+            fh.write("ROMP_API_KEY_REF=op://test-vault/test-item/credential\n")
+        saved = {k: os.environ.get(k) for k in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV")}
+        try:
+            os.environ["ROMP_SERVICE_ENV_FILE"] = path; os.environ["ROMP_SERVICE_ENV"] = path
+            for m in (km.jd._keysrc, sb._keysrc):
+                m._CACHE = ((), ""); m._AUTHORITATIVE_PATHS.clear()
+            for auth in ("", "key", "login"):
+                verdicts = [(km._env_error(p, auth), sb.env_request_error(p, auth)) for p in self.CREDENTIALS]
+                for a, b in verdicts:
+                    self.assertEqual(a, b, "the copies must stay in lockstep under runtime retrieval (auth=%r)" % auth)
+                self.assertIn("reserved while runtime API key retrieval", verdicts[0][0], "the API key always competes")
+                if auth == "login":
+                    self.assertEqual(verdicts[1][0], ""); self.assertEqual(verdicts[2][0], "")   # its own token stays
+                else:
+                    self.assertIn("reserved", verdicts[1][0]); self.assertIn("reserved", verdicts[2][0])   # keyed: no competing token
+        finally:
+            for k, v in saved.items():
+                if v is None: os.environ.pop(k, None)
+                else: os.environ[k] = v
+            for m in (km.jd._keysrc, sb._keysrc):
+                m._CACHE = ((), ""); m._AUTHORITATIVE_PATHS.clear()
+
 
 class DrivePlumbing(unittest.TestCase):
     """The /new door rides the same park/drain path as the other per-session switches (source pins,

--- a/tests/test_supervised_floor.py
+++ b/tests/test_supervised_floor.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""The suite-wide ROMP_SUPERVISED floor (tests/conftest.py, 2026-09-05): every shell under a romp-managed
+session inherits ROMP_SUPERVISED=1 from the kernel (the service unit exports it), and kernel/keysource.py
+gives that variable authority — a supervised manager reads the env file only and ignores a startup key.
+Twenty-five tests that stage a startup key went red when the suite ran from inside a romp session while
+CI stayed green. conftest pops the variable at import and before every test, and resets keysource's
+per-process memory of which path selected which source so modules cannot leak selection state into each
+other. Source pins, in the style of test_model_catalog_floor.py, plus the floor observed from inside a test."""
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+
+
+class SupervisedFloor(unittest.TestCase):
+    def test_conftest_pops_the_variable_at_import_and_per_test(self):
+        src = open(os.path.join(HERE, "conftest.py")).read()
+        head, _, body = src.partition("@pytest.fixture(autouse=True)\ndef _no_real_service_env")
+        self.assertTrue(body, "the fixture header moved — re-anchor this pin")
+        self.assertIn('os.environ.pop("ROMP_SUPERVISED", None)', head, "the import-time floor")
+        self.assertIn('os.environ.pop("ROMP_SUPERVISED", None)', body, "the per-test re-assert")
+        self.assertIn("_reset_keysource_state()", body, "keysource memory is per test")
+        import re
+        self.assertRegex(src, r"_AUTHORITATIVE_PATHS\.clear\(\)")
+        self.assertRegex(src, r"_ENV_PROVIDER_PATHS.*\.clear\(\)")
+        self.assertRegex(src, r'_CACHE = \(\(\), ""\)')
+
+    def test_the_floor_holds_for_a_bare_run_under_a_supervised_shell(self):
+        """Independent of the sibling modules whose preambles also pop the variable: a subprocess with the
+        variable set runs only this module's behavioural check, which passes only if conftest's floor did."""
+        import subprocess, sys
+        env = dict(os.environ, ROMP_SUPERVISED="1")
+        r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+                            os.path.join(HERE, "test_supervised_floor.py") + "::SupervisedFloor::test_the_floor_holds_inside_a_test"],
+                           env=env, capture_output=True, text=True, timeout=120, cwd=os.path.dirname(HERE))
+        self.assertEqual(r.returncode, 0, r.stdout[-800:] + r.stderr[-400:])
+
+    def test_the_floor_holds_inside_a_test(self):
+        self.assertNotIn("ROMP_SUPERVISED", os.environ, "a romp-managed shell's export must not reach a test")

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -67,11 +67,13 @@ test("the gate, the clear, and the envelope mark all scope to LOGIN-billed calls
   // usage.json's windows are the login account's; a judge call bills the JUDGED session's account
   // (the 2026-08-12 rule) — so a key-billed call (pay-per-token, no windows) is never gated, its
   // success never clears the login latch, and its limit-shaped 429 never mints one.
-  assert.match(JUDGE, /auth = _judge_auth\(fsid\) {10,}# this call bills what the judged session bills\n    try:/,
-    "billing resolves BEFORE the gate");
-  assert.match(JUDGE, /json\.loads\(\(STATE \/ "usage\.json"\)\.read_text\(\)\) if auth == "login" else \{\}/);
-  assert.match(JUDGE, /if auth == "login":\s*\n\s*# only a LOGIN-billed success is evidence/);
-  assert.match(JUDGE, /if auth == "login":\s*\n\s{24}_limit_mark\("account", None, None, model\)/,
+  const run = JUDGE.slice(JUDGE.indexOf("def _judge_run(")).split("\ndef ", 1)[0];
+  const billing = run.indexOf('auth = "codex" if engine == "codex" else _judge_auth(fsid)');
+  const gate = run.indexOf('u = json.loads((STATE / "usage.json").read_text()) if auth == "login" else {}');
+  assert.ok(billing >= 0 && gate > billing,
+    "billing resolves BEFORE the login-only gate, including the Codex bypass");
+  assert.match(run, /if auth == "login":\s*\n\s*# only a LOGIN-billed success is evidence/);
+  assert.match(run, /if auth == "login":\s*\n\s{24}_limit_mark\("account", None, None, model\)/,
     "the envelope mark too (the manager's ruling: it carries no resets_at, so a false one sticks)");
 });
 


### PR DESCRIPTION
Romp's service key-switching path stores plaintext `ANTHROPIC_API_KEY` values in configuration files. This adds an optional runtime 1Password source:

```dotenv
ROMP_API_KEY_REF=op://vault/item/field
```

Romp stores and swaps the reference, then runs `op read --no-newline` when a Claude session launches, an API-key-billed judge runs, or the model catalog refreshes. UI/status checks inspect source metadata without invoking `op`. Resolved provider keys are neither written to disk nor cached for later operations. Existing static-key and explicit login configurations remain supported without requiring 1Password.

Credential failures stop the affected operation instead of falling back to another account. Explicit API-key billing with no key now fails instead of switching to login. Removing a configured source cannot resurrect the startup key, including after a supervised kernel restarts. Key-cycle requests check source identity before reconnecting, and runtime mode rejects competing per-session credential overrides.

The documentation covers service PATH/authentication prerequisites, migration, and rotation. 1Password authentication is configured separately; running Claude processes retain their launch credential until reconnecting.

Validation uses synthetic credentials and mocked provider responses; no live vault or paid model calls were used.

- Full Python regression suite passed locally; the focused judge authentication and rate-limit suite passes all 54 tests.
- Full shell suite: 389 passed.
- Full extension typecheck, test suite, and build passed locally.
- Python 3.10 syntax compatibility and shell syntax checks passed.
- `git diff --check` and Gitleaks secret scanning passed.



## Review rounds (2026-09-05)

Two adversarial reviews of this branch reproduced defects; the second commit closes them, each with a test:

- **`op`'s own credential stays with the kernel.** The headless route is a 1Password service-account token in `service.env`. When a reference is configured, the kernel claims `OP_SERVICE_ACCOUNT_TOKEN`, `OP_SESSION_*`, `OP_CONNECT_*` and `OP_ACCOUNT` out of its environment as its first act in `main()`, says which names it claimed, and hands them to the `op read` subprocess alone. The tmux server's global environment (what every pane inherits) is scrubbed at kernel start, by the manager when it starts the server, and by the launcher before a pane exists; judge children and revives are scrubbed too. A box whose sessions run `op` through Claude Code's `apiKeyHelper`, with no reference configured, is left alone. The docs name the route and state the scope honestly: inheritance hygiene, not isolation from a same-user process.
- **An ignored startup key is said once**, only when a different key is actually ignored (the standard install exports the file's own key into the manager environment; the same key on both sides is nothing to say). A supervised manager reads `service.env` only. An unreadable file is a loud error for the operation that asked, not a selection that discards the startup key; a garbled key line is an error with a readable note.
- **The suite is hermetic against `ROMP_SUPERVISED=1`**, which every shell under a romp-managed session inherits; 25 tests failed there while CI stayed green.
- **`romp keyswap --cycle-all` classifies first and resolves once**, only when some session needs the key; a failure lands only on those rows.
- **Judges retry a failed retrieval once per pass**, on a generation that advances only when a pass is created, and the first call of a pass gates the concurrent wave instead of six threads each spawning `op`.
- **One rule for credential overrides under runtime retrieval**: the API key always competes; a keyed launch carries no competing token; a login session keeps its own. The doors know the request's billing, the launch and the fork copy apply the same rule.

Full Python suite green with and without an inherited `ROMP_SUPERVISED`; shell and extension suites green.
