### PR TITLE
The views rebuild on exact inputs, the watched tab is served while nothing changed, and the per-cycle store readers answer from a stat

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -494,7 +494,9 @@ def _read_jsonl(path):
 # whole-parse cache contract. The cached list itself is never extended in place — a grown file stores a
 # NEW list — so a concurrent reader holding the old list is never surprised mid-iteration.
 _JSONL_CACHE = {}                 # path -> (mtime, size, offset, tail_bytes, records); dict order = LRU, hits reinsert
-_JSONL_CACHE_MAX = 384            # bounds MEMORY only — past the cap, evict the least-recently-USED entry, one per
+_JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-03: the per-session states,
+                                  # captions and the postal/nudge logs became tenants — a few KB each — and
+                                  # must never evict a live transcript's slot) — past the cap, evict the least-recently-USED entry, one per
                                   # insert, never clear(). The old clear-at-cap was sized to the session count, but
                                   # the working set is FILES, not sessions (every subagent writes its own transcript):
                                   # once more distinct files than slots passed through one push cycle, the clear

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -850,12 +850,21 @@ def pass_watermark(tier, fsid):
     return _PASS_DONE.get((str(tier), str(fsid)))
 _active_lock = threading.Lock()
 _active_seq = [0]
+_active_change = [0]      # bumped on EVERY begin and end — the exact "the set of in-flight judge calls
+#                            changed" event the kernel's view signature keys on (2026-09-03), so a
+#                            judging swirl lights and clears on the call itself, not on a pass cadence
+
+
+def active_change():
+    """Monotonic count of changes to the in-flight judge-call set (begins + ends)."""
+    return _active_change[0]
 
 
 def _active_begin(judge, fsid, sent):
     """Mark a judge call as running; returns a run id to pass to _active_end on completion."""
     with _active_lock:
         _active_seq[0] += 1
+        _active_change[0] += 1
         rid = _active_seq[0]
         _active[rid] = {"judge": judge, "fsid": fsid, "sent": sent}
         return rid
@@ -863,7 +872,8 @@ def _active_begin(judge, fsid, sent):
 
 def _active_end(rid):
     with _active_lock:
-        _active.pop(rid, None)
+        if _active.pop(rid, None) is not None:
+            _active_change[0] += 1
 
 
 def active_runs():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -592,6 +592,7 @@ def _version_info():
             "postalUnresolved": {"ids": len(_POSTAL_UNRESOLVED["seen"]),   # T234: unresolved postal ids
                                  "warned": _POSTAL_UNRESOLVED["warned"],    # (distinct pairs seen, lines
                                  "suppressed": _POSTAL_UNRESOLVED["suppressed"]},   # written, repeats held)
+            "views": dict(_VIEW_STATS),      # feed/timeline/chat rebuilt vs served from cache (2026-09-03)
             "drainRefused": dict(_DRAIN_REFUSED),   # T224: refused /busy?drain=1 arms — count (lifetime
             #                                          total), episodeCount (the current/last episode),
             #                                          open episode, last time; the silent degrade made visible
@@ -772,6 +773,9 @@ def iso(t):
         return ""
 
 
+_names_entry_memo = {}   # entry name -> ((mtime_ns, size, ino), parts) — see _names_snapshot
+
+
 def _names_snapshot():
     """{sid: tab-fields list} for every names-registry entry, read once. The pusher cycle publishes
     this as its names scope (_live_scope.names): build_session re-resolves every path token through
@@ -784,7 +788,15 @@ def _names_snapshot():
     try:
         for f in NAMES.iterdir():
             try:
-                snap[f.name] = f.read_text().rstrip("\n").split("\t")
+                # per-entry memo on (mtime_ns, size, inode) (2026-09-03): entries are published by
+                # os.replace, so any rewrite moves the key; an unchanged entry costs one stat, not a read
+                st = f.stat()
+                key = (st.st_mtime_ns, st.st_size, st.st_ino)
+                hit = _names_entry_memo.get(f.name)
+                if hit is None or hit[0] != key:
+                    hit = (key, f.read_text().rstrip("\n").split("\t"))
+                    _names_entry_memo[f.name] = hit
+                snap[f.name] = hit[1]
             except Exception:   # OSError, but ALSO UnicodeDecodeError on a torn/raw-bytes entry — the
                 continue        # per-call readers this replaces caught bare Exception, and this function
         #                         runs on the pusher thread's bare loop, so it must NEVER raise (review
@@ -792,6 +804,8 @@ def _names_snapshot():
         #                         good, and again on every restart while the file persisted)
     except Exception:
         pass
+    for gone in [n for n in _names_entry_memo if n not in snap]:
+        _names_entry_memo.pop(gone, None)              # a removed entry drops its memo
     return snap
 
 
@@ -4407,6 +4421,7 @@ def _set_retry_paused(paused, reason=""):
         if reason:
             d["reason"] = reason
     _atomic_write(jd.STATE / "retry-paused.json", json.dumps(d))
+    _mark_views_dirty()   # the queued bubble renders this hold; every writer publishes the flip (review 2026-09-05)
 
 
 def _retry_pause_reason():
@@ -5283,6 +5298,28 @@ def _pure_delegation_top(nodes, top_id, sid=None, path=None):
     return bool(leaves) and all(isinstance(nodes.get(nid, {}).get("handoff"), dict) for nid in leaves)
 
 
+def _states_rows(sid):
+    """Every parsed row of states/<sid>.jsonl, served APPEND-INCREMENTALLY from event_model's jsonl cache
+    (the transcripts' own reader: one stat per call while the file is quiet, only the appended bytes
+    when it grew). Upstream's _fold_records now serves most per-push readers; the three that remain on this
+    path (the busy hint, the nudge times, the state intervals) used to open the file and json.loads
+    every line on every call — per session per pusher cycle, on a log that only ever grows (≈5k rows /
+    1 MB on a long-lived session): ~2 full reads per second per session with NOTHING changed, measured
+    2026-09-03 as the largest steady-state read volume in the kernel (the states logs were the most-opened
+    files in a 12 s descriptor sample). Rows are the cache's own objects — read-only by contract, never
+    mutate them. Missing/unreadable file → [] (the readers' old OSError branches)."""
+    return em._read_jsonl_incremental(jd.STATE / "states" / ("%s.jsonl" % sid))
+
+
+def _messages_rows(path=None):
+    """Every parsed row of the postal log (timeline/messages.jsonl), append-incremental like _states_rows —
+    the feed's parked-handoff scan, the timeline's connector join, the postal index and the wait maps each
+    re-read and re-parsed the whole 5 MB log per build. Read-only rows; [] when absent. `path` defaults to
+    jd.MESSAGES; readers that historically derived the path from jd.STATE at call time pass it (in
+    production both name the same file; tests re-point one or the other)."""
+    return em._read_jsonl_incremental(path if path is not None else jd.MESSAGES)
+
+
 def _last_state(sid):
     """(value, t) of the most-recent STATE transition in states/<sid>.jsonl ('working'/'waiting'/'idle'/…),
     ignoring the interleaved awaiting overlays; ('', 0) when there's no state file yet. The Stop hook (tmux) and
@@ -5291,22 +5328,11 @@ def _last_state(sid):
     state recorded AFTER the parsed turn's end means the session is genuinely still working (a newer turn the
     parse hasn't caught up to); one recorded BEFORE it means the turn ended and the post-turn 'waiting' write
     was lost (e.g. a kernel restart) — a stale record that must not block the nudge forever."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
     val, vt = "", 0
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"state"' not in line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except ValueError:
-                    continue
-                if isinstance(rec, dict) and isinstance(rec.get("state"), str):
-                    val = rec["state"]
-                    vt = rec.get("t", vt)
-    except OSError:
-        return ("", 0)
+    for rec in _states_rows(sid):
+        if isinstance(rec, dict) and isinstance(rec.get("state"), str):
+            val = rec["state"]
+            vt = rec.get("t", vt)
     return (val, vt)
 
 
@@ -5752,6 +5778,26 @@ def _stamp_written_at(nd):
     return max(best, nd.get("awaitingAt") or 0)
 
 
+def _sid_inputs_fp(sid, path, extra=()):
+    """(stat, …) of the recorded inputs a per-session tick ruling reads — the goal store, its override
+    journal, the transcript, the postal log and the SDK reg — plus `extra` live facts. Equal tuples across
+    cycles mean the ruling's inputs did not move; None when nothing can be stat'd (then never skip)."""
+    out = []
+    for p in (jd.GOALDIR / (str(sid) + ".json"), jd.STATE / "overrides" / (str(sid) + ".jsonl"),
+              path or "", jd.STATE / "timeline" / "messages.jsonl", jd.STATE / "sdk" / (str(sid) + ".json")):
+        try:
+            st = os.stat(p) if p else None
+            out.append((st.st_mtime_ns, st.st_size, st.st_ino) if st else None)   # ino: an atomic republish
+        except OSError:                                                            # of equal size in one
+            out.append(None)                                                       # timestamp tick still moves
+    if all(x is None for x in out):
+        return None
+    return tuple(out) + tuple(extra)
+
+
+_lift_seen = {}   # sid -> the inputs fingerprint the awaiting lift last ruled on — see _lift_spent_awaiting
+
+
 def _lift_spent_awaiting(now, tmux):
     """Retire a goal's ⏳ awaiting stamp once the dispatches it was waiting on have RETURNED (the user
     2026-07-22). The closer's lift is bounded to the goals a turn actually WORKED ON (`touched`), which is
@@ -5781,7 +5827,27 @@ def _lift_spent_awaiting(now, tmux):
         try:
             if tmux.get(sid) is None:                 # dormant → its tasks died with the CLI, don't rule
                 continue
-            store = jd.load_goals(sid)
+            # Every fact this lift rules on is recorded somewhere that stats: the goal store and its
+            # override journal (the stamps), the transcript (the returns), the postal log (a peer's
+            # reply), the SDK reg (the CLI epoch) and the backend's live task set. Unchanged since the
+            # last cycle → the ruling is unchanged → skip the load (2026-09-03: this ran a full store
+            # load + journal replay per live session per 0.5 s cycle on a quiet board).
+            snap = tmux.get(sid) or {}
+            # …plus the two facts the ruling reads that no file records: the live subagent count, and
+            # for every dispatch the transcript pairs, WHETHER its recorded deadline has passed (a
+            # watcher past deadline+grace counts as returned — a clock fact, keyed as the boolean it
+            # resolves to, so the crossing itself re-examines the session; review 2026-09-03).
+            every = _bg_scan_all_cached(s["path"]) if s.get("path") else []
+            gate = _sid_inputs_fp(sid, s.get("path"),
+                                  extra=(tuple(sorted(str(t.get("toolUseId") or "") for t in (snap.get("bgTasks") or ())
+                                                      if isinstance(t, dict))),
+                                         len(snap.get("subagents") or ()),
+                                         tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
+                                                      for t in every if isinstance(t, dict) and t.get("status") == "running"))))
+            if gate is not None and _lift_seen.get(sid) == gate:
+                continue
+            _lift_seen[sid] = gate                    # recorded now; a ruling that RAISES forgets it below,
+            store = jd.load_goals(sid)                # so the next cycle retries instead of skipping
             nodes = store.get("nodes") or {}
             stamped = [nd for nd in nodes.values()
                        if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]
@@ -5966,7 +6032,9 @@ def _lift_spent_awaiting(now, tmux):
                 jd.rollup_status(store, False)
                 jd.save_goals(sid, store)
                 _mark_views_dirty()
+
         except Exception:
+            _lift_seen.pop(sid, None)                 # a raised ruling is not a ruling — re-run next cycle
             sys.stderr.write("awaiting-lift (session %s): %s\n" % (sid or "?", traceback.format_exc()))
 
 
@@ -8566,13 +8634,32 @@ def _comment_msg_text(rec):
     return "\n".join(p for p in parts if p).strip()
 
 
+_thread_reg_memo = {}   # tsid -> ((mtime_ns, size), reg dict) — see _thread_reg
+
+
 def _thread_reg(tsid):
-    """The thread's SDK registry entry (authoritative for cwd/lastSid/threadOf), {} when unreadable."""
+    """The thread's SDK registry entry (authoritative for cwd/lastSid/threadOf), {} when unreadable.
+    Memoized on the file's (mtime, size, inode) — thirteen callers, two of them per chat build, each decoded
+    the file afresh (2026-09-03). Returns a shallow copy so a caller's edit never leaks into the memo."""
+    p = jd.STATE / "sdk" / (tsid + ".json")
     try:
-        d = json.loads((jd.STATE / "sdk" / (tsid + ".json")).read_text())
-        return d if isinstance(d, dict) else {}
+        st = p.stat()
+        key = (st.st_mtime_ns, st.st_size, st.st_ino)
+    except OSError:
+        _thread_reg_memo.pop(tsid, None)
+        return {}
+    hit = _thread_reg_memo.get(tsid)
+    if hit is not None and hit[0] == key:
+        return dict(hit[1])
+    try:
+        d = json.loads(p.read_text())
+        d = d if isinstance(d, dict) else {}
     except (OSError, ValueError):
         return {}
+    if len(_thread_reg_memo) > 512:
+        _thread_reg_memo.pop(next(iter(_thread_reg_memo)))
+    _thread_reg_memo[tsid] = (key, d)
+    return dict(d)
 
 
 def _thread_transcript_path(reg, tsid):
@@ -17454,23 +17541,15 @@ def _states_awaiting_overlay(sid):
     signal is open_now OR awaiting, the timeline's is open_now alone, so a stale awaiting splits them). An
     idle/waiting state after an awaiting:true is consistent with awaiting (idle while the job runs) and does
     NOT supersede it. State records carry "state", overlay records carry "awaiting"; the two never overlap."""
-    p = jd.STATE / "states" / ("%s.jsonl" % sid)
     last = None
     working_after = False
-    try:
-        with open(p, errors="replace") as f:
-            for line in f:
-                if '"awaiting"' in line:
-                    try:
-                        o = json.loads(line)
-                    except Exception:
-                        continue
-                    if isinstance(o, dict) and "awaiting" in o:
-                        last, working_after = o, False     # a fresh overlay record resets the supersede flag
-                elif '"state"' in line and '"working"' in line:
-                    working_after = True                   # a real work turn resumed since the last overlay record
-    except OSError:
-        return None
+    for o in _states_rows(sid):
+        if not isinstance(o, dict):
+            continue
+        if "awaiting" in o:
+            last, working_after = o, False             # a fresh overlay record resets the supersede flag
+        elif o.get("state") == "working":
+            working_after = True                       # a real work turn resumed since the last overlay record
     if last is not None and last.get("awaiting") and working_after:
         return {"awaiting": False, "why": None}            # stale true — superseded by a later work turn
     return last
@@ -17494,21 +17573,16 @@ def _session_retrying(sid, tm):
         return None
     since = None
     try:
-        with open(jd.STATE / "states" / ("%s.jsonl" % sid), errors="replace") as f:
-            for line in f:
-                if '"state"' not in line:
-                    continue                               # overlay/recovery rows don't bound a stretch
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                st = o.get("state") if isinstance(o, dict) else None
-                if st == "retrying":
-                    if since is None:
-                        since = o.get("t")                 # first row of the current stretch
-                elif st:
-                    since = None                           # any real state transition ends the stretch
-    except OSError:
+        for o in _states_rows(sid):
+            st = o.get("state") if isinstance(o, dict) else None
+            if not st:
+                continue                                   # overlay/recovery rows don't bound a stretch
+            if st == "retrying":
+                if since is None:
+                    since = o.get("t")                     # first row of the current stretch
+            else:
+                since = None                               # any real state transition ends the stretch
+    except Exception:
         pass
     try:
         count = int(tm.get("retryCount") or 0)
@@ -18000,17 +18074,13 @@ def _ask_poll():
 
 
 def _captions(fsid):
+    """{unit id -> caption row} from captions/<fsid>.jsonl — append-incremental like the states logs
+    (2026-09-03): the chat build, the feed and the timeline each re-read and re-decoded the whole file
+    per build. Rows are the cache's objects: read-only."""
     out = {}
-    try:
-        for line in (jd.CAPDIR / (fsid + ".jsonl")).read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            if o.get("id"):
-                out[o["id"]] = o
-    except OSError:
-        pass
+    for o in em._read_jsonl_incremental(jd.CAPDIR / (fsid + ".jsonl")):
+        if isinstance(o, dict) and o.get("id"):
+            out[o["id"]] = o
     return out
 
 
@@ -18189,14 +18259,8 @@ def _postal_index():
     if hit is not None and hit[0] == key:
         return hit[1]
     idx = {}
-    try:
-        lines = p.read_text(errors="replace").splitlines()
-    except OSError:
-        return idx
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
+    for o in _messages_rows(p):                       # append-incremental rows (2026-09-03): a send no
+        if not isinstance(o, dict):                   # longer re-decodes the whole log on the active tab
             continue
         if o.get("ev") == "sent" and o.get("id"):
             idx[o["id"]] = {"id": o["id"], "from": o.get("from", "?"), "fromId": o.get("from_id", ""),
@@ -18520,11 +18584,24 @@ def _task_store_fp(fsid):
     if d is None:
         return None
     try:
-        ents = [(e.name, e.stat().st_mtime) for e in os.scandir(d)
-                if e.name.endswith(".json")]
+        ents = []
+        with os.scandir(d) as it:
+            for e in it:
+                if not e.name.endswith(".json"):
+                    continue
+                try:
+                    st = e.stat()
+                except OSError:
+                    continue                              # unlinked between readdir and stat → not in the store
+                ents.append((e.name, st.st_mtime_ns, st.st_size, st.st_ino))   # ns + size + inode: a same-size
+        #                                                    rename-publish inside one coarse timestamp tick
+        #                                                    still moves the key (review 2026-09-03)
     except OSError:
         return None
     return tuple(sorted(ents))
+
+
+_task_store_memo = {}   # store dir -> (per-file fingerprint, task list) — see _read_task_store
 
 
 def _read_task_store(fsid, fold=None):
@@ -18549,6 +18626,26 @@ def _read_task_store(fsid, fold=None):
     d = _task_store_resolve(fsid, fold)
     if d is None:
         return None                                       # store unlocatable → the caller surfaces an error
+    # Memoized on the resolved dir + every N.json's (name, mtime, size) (2026-09-03): the active tab's
+    # build listed and decoded every task file per cycle. The fingerprint is the same shape
+    # _task_store_fp already stats for the chat-build key. Callers get their own copy.
+    try:
+        fp = []
+        with os.scandir(d) as it:
+            for e in it:
+                if not e.name.endswith(".json"):
+                    continue
+                try:
+                    st = e.stat()
+                except OSError:
+                    continue                              # unlinked between readdir and stat → not part of the store
+                fp.append((e.name, st.st_mtime_ns, st.st_size, st.st_ino))
+        fp = tuple(sorted(fp))
+    except OSError:
+        return None                                       # store unreadable → the caller surfaces an error
+    hit = _task_store_memo.get(str(d))
+    if hit is not None and hit[0] == fp:
+        return [dict(t) for t in hit[1]]
     try:
         names = [n for n in os.listdir(d) if n.endswith(".json")]
     except OSError:
@@ -18568,8 +18665,12 @@ def _read_task_store(fsid, fold=None):
                       "status": str(t.get("status") or "pending"),
                       "_order": int(tid) if tid.isdigit() else (1 << 30)})
     tasks.sort(key=lambda t: (t["_order"], t["id"]))       # readable dir → authoritative (empty list included)
-    return [{"id": t["id"], "subject": t["subject"], "activeForm": t["activeForm"], "status": t["status"]}
-            for t in tasks]
+    out = [{"id": t["id"], "subject": t["subject"], "activeForm": t["activeForm"], "status": t["status"]}
+           for t in tasks]
+    if len(_task_store_memo) > 512:
+        _task_store_memo.pop(next(iter(_task_store_memo)))
+    _task_store_memo[str(d)] = (fp, out)
+    return [dict(t) for t in out]
 
 
 def _fold_tasks(session):
@@ -18622,11 +18723,54 @@ _parse_cache = {}                                # realpath → ((mtime, size, p
 # every 0.5s poll — a full transcript reshape into ChatEvent[] AND a json.dumps of the whole chat, per tab,
 # even when nothing changed. With transcripts now tens of MB, that pegged the kernel and starved the
 # webview. Cache each session's built payload + its serialized string, keyed on the transcript+states
-# (mtime,size) — the same trust model as _parse_cache. The ACTIVE tab(s) always rebuild (so what the user
-# is watching stays live, incl. SDK live-tail atoms that lead the disk); an unchanged BACKGROUND tab reuses
-# the cache → one stat() instead of a reshape+serialize. A real change (or switching to the tab) rebuilds.
-_built_chat = {}                                 # sid → (sig, payload_dict, serialized_str)
-_judge_gen = [0]                                 # bumped each producer pass → busts the cache when the judge
+# (mtime,size) — the same trust model as _parse_cache. The ACTIVE tab(s) are served while _active_chat_sig
+# is unchanged (its key carries what no file records: the owning backend's live tail and queue, the snapshot
+# facts, the side files, the clock predicates — 2026-09-03/05); an unchanged BACKGROUND tab reuses the
+# cache on its file-stat + snapshot key → one stat() instead of a reshape+serialize. A real change (or
+# switching to the tab) rebuilds.
+_built_chat = {}                                 # sid → (sig, payload_dict, serialized_str, active_sig, build_started_at)
+def _judge_store_fp():
+    """Fingerprint of every store a judge pass can WRITE — goal trees, captions, archives, the cleared
+    archive and the episode log: (dir, name, mtime_ns, size) per file, from one scandir each. Two equal
+    fingerprints around a pass prove the pass changed nothing a view reads; that is the exact event
+    _judge_gen now keys on (2026-09-03). Before, the generation bumped after EVERY producer pass (≤3 s
+    cadence), so the feed, the timeline and every background chat tab rebuilt every pass on a quiet
+    board — the dominant clock-like input to the view signatures, measured in the offline replay."""
+    out = []
+    for d in (jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.STATE / "goals-archive", jd.STATE / "episodes"):
+        try:
+            with os.scandir(d) as it:
+                for e in it:
+                    try:
+                        st = e.stat()
+                    except OSError:
+                        continue
+                    out.append((d.name, e.name, st.st_mtime_ns, st.st_size, st.st_ino))
+        except OSError:
+            continue
+    out.sort()
+    return tuple(out)
+
+
+_last_judge_fp = [None]   # the stores' fingerprint at the END of the last producer pass — see below
+
+
+def _bump_judge_gen_if_changed(before_fp=None):
+    """Advance the judge generation when the judge-written stores changed since the LAST time this looked
+    (the end of the previous pass) — not merely during the pass: a kernel-side save between passes (a
+    user's clear or resolve, the awaiting lift, a nudge verdict) moves a store too, and the background
+    chat tabs refresh on this generation alone (review 2026-09-03). `before_fp` is accepted for callers
+    that hold one but the comparison anchor is the previous look. Returns True when it advanced."""
+    cur = _judge_store_fp()
+    anchor = _last_judge_fp[0] if _last_judge_fp[0] is not None else before_fp
+    _last_judge_fp[0] = cur
+    if cur != anchor:
+        _judge_gen[0] += 1
+        return True
+    return False
+
+
+_judge_gen = [0]                                 # bumped when a producer pass CHANGED a store → busts the cache when the judge
                                                  # may have changed goal/caption state without a transcript write
 
 # ATOMIC JUDGE-PASS VISIBILITY (the user 2026-06-30): the triage judges (planner → closer → courier →
@@ -18714,6 +18858,178 @@ def _feed_goals(sid):
 # events holds the last-built events per session; _chat_diff finds the first index that differs from it — the
 # exact point content changed (a new event OR a tool output that just filled an earlier card). Diffing by
 # CONTENT (not a fixed window) is robust to _hydrate_postal turning one event into several cards mid-array.
+def _clock_predicates(sid, tm, now, path=None):
+    """The clock-derived facts build_session renders, as the booleans they resolve to — so a cache key
+    that carries them changes EXACTLY when the rendered payload would (the flip is the event), never on a
+    tick: the faded look at an hour idle (_idle_faded), an interrupt whose 120 s in-flight cap has run
+    out (_interrupting), a model switch whose 20 s cap has (_model_pending_now), a compaction whose 180 s
+    optimistic cap has (_compacting_optimistic), and each live background task past its recorded
+    deadline (em._bg_expired). These are the only reasons an identical-input build can differ."""
+    tm = tm or {}
+    since = tm.get("since") or 0
+    ic = _interrupt_clicked.get(sid)
+    mp = _model_switch_pending.get(sid) or {}
+    cc = _compact_clicked.get(sid)
+    # the live-task set AFTER the build's own expiry filter (_bg_live_norm joins each task's recorded
+    # deadline from the launch ledger and drops the expired ones) — a task expiring is a tid dropping
+    # out of this tuple. The raw snapshot rows carry no deadline, so a predicate over them could never
+    # flip (review 2026-09-03).
+    try:
+        live_ids = tuple(sorted(str(r.get("tid") or "") for r in _bg_live_norm(sid, path) if isinstance(r, dict)))
+    except Exception:
+        live_ids = None
+    return (bool(since) and bool(_idle_faded(tm.get("state") or "", since, now)),
+            bool(since) and (now - since > FADED_S),   # the hour mark itself: the build derives the chip's
+            #                                            state (a stuck 'compacting' overridden, "" → ready),
+            #                                            so key the flip whatever the raw state says
+            bool(ic) and (now - ic > 120),
+            bool(mp) and (now > (mp.get("until") or 0)),
+            bool(cc) and (now - cc > 180),
+            live_ids)
+
+
+_ACTIVE_SIG_FILES = ("sdk/{sid}.json", "sdk", "goals/{sid}.json", "overrides/{sid}.jsonl", "archive/{sid}.json",
+                     "goals-archive/{sid}.json", "captions/{sid}.jsonl", "episodes/{sid}.jsonl", "cleared.jsonl",
+                     "timeline/messages.jsonl", "colormap", "session-flags.json", "notify-cards.json",
+                     "retry-suppressed.json", "auto-nudge.json",
+                     "watches.json", "pr-watches.json",   # the kernel-owned watch set the awaiting box renders
+                     "usage.json",                        # the account limit hold behind the queued bubble
+                     "retry-paused.json")                 # the spend hold the queued bubble renders (review 2026-09-05)
+
+
+def _claudemd_paths(cwd):
+    """The CLAUDE.md files _claudemd_docs reads for `cwd`, in load order — the global file, then each project
+    file from the git root down to cwd. Shared with the active-tab key so an edit to any of them is a
+    keyed event, not a silent lag."""
+    out = [str(_GLOBAL_CLAUDE_MD)]
+    home = os.path.expanduser("~")
+    chain = []
+    d = os.path.abspath(os.path.expanduser(cwd)) if cwd else None
+    while d:
+        chain.append(d)
+        if os.path.isdir(os.path.join(d, ".git")):
+            break
+        parent = os.path.dirname(d)
+        if parent == d or d == home:
+            break
+        d = parent
+    out += [os.path.join(dd, "CLAUDE.md") for dd in reversed(chain)]
+    return out
+
+
+def _external_sig(sid, path=None):
+    """(stat, …) of the inputs OUTSIDE the state root that build_session renders: the account file the
+    billing badge reads; the HEAD files of the git trees its branch rows read — the registered cwd's
+    tree AND the tree of the last edited file (the per-session worktree, under this repo's convention),
+    both resolved through _tree_of exactly as the build does, so a subdirectory cwd keys its repo's
+    HEAD too; the CLAUDE.md chain (the docs card); and the output file of every running background
+    task, whose tail the task box shows live. cwd falls back to the transcript's own stamp when the
+    registry has none, as the build's does. These are external edits with no romp event; a stat is the
+    honest key (review 2026-09-03). Accepted lag, documented: a path token that becomes a link because a
+    PEER created the file it names re-resolves on the next keyed change, not on the file's creation."""
+    meta = _session_meta(path) if path else {}
+    cwd = _cwd_of(sid) or (meta.get("cwd") if isinstance(meta, dict) else "") or ""
+    paths = [os.path.expanduser("~/.claude.json")]
+    _ks = getattr(jd, "_keysrc", None)                  # the env file's key line decides authBoth (read live since b4ca13e7)
+    if _ks is not None:
+        try:
+            paths.append(_ks.service_env_path())
+        except Exception:
+            pass
+    tops = []
+    for d in (os.path.expanduser(cwd) if cwd else "",
+              os.path.dirname((meta.get("lastEditPath") if isinstance(meta, dict) else "") or "")):
+        if not d:
+            continue
+        try:
+            top = _tree_of(d)[0]
+        except Exception:
+            top = ""
+        if top and top not in tops:
+            tops.append(top)
+    for top in tops:
+        try:
+            hp = _git_head_file(top)
+        except Exception:
+            hp = ""
+        if hp:
+            paths.append(hp)
+    paths += _claudemd_paths(cwd) if cwd else [str(_GLOBAL_CLAUDE_MD)]
+    if path:
+        try:
+            for tk in _bg_scan_cached(path):
+                if isinstance(tk, dict) and tk.get("status") == "running" and tk.get("outputFile"):
+                    paths.append(os.path.expanduser(str(tk["outputFile"])))
+        except Exception:
+            pass
+    out = []
+    for p in paths:
+        try:
+            st = os.stat(p)
+            out.append((st.st_mtime_ns, st.st_size, st.st_ino))
+        except OSError:
+            out.append(None)
+    return tuple(out)
+
+
+def _active_chat_sig(sess, tm, now, base=None):
+    """The exact change key for the WATCHED chat tab (2026-09-03). The active tab used to rebuild on every
+    pusher cycle "by design" — its payload moves with inputs no file records: the SDK live tail, the
+    snapshot facts, the send queue, the compacting/clearing brackets, kernel-side stamps — so the
+    background tabs' file-stat signature could not serve it, and an 80 MB session cost ~0.4-0.9 s of
+    reshape per 0.5 s cycle whether or not anything moved (the offline replay). This key names each of
+    those inputs: _chat_build_sig (transcript/states/judge gen/task store/pending cut) + the backend's live
+    revision, queue, brackets + the snapshot row minus its volatile timestamp + the stat of every side file
+    the build reads + the names registry + the clock predicates that flip the rendered output + the
+    in-flight judge set. Kernel-side stamps that lack a stat are covered by _views_dirty at the serve
+    site (the _cached_feed idiom). None → never cache (no transcript, or an input we cannot key).
+    `base` is the pusher's already-computed _chat_build_sig for this tab (one stat pass, not two)."""
+    base = _chat_build_sig(sess, tm) if base is None else base
+    if base is None:
+        return None
+    sid = str(sess.get("sid") or "")
+    try:
+        snap = json.dumps({kk: vv for kk, vv in (tm or {}).items() if kk != "snapT"}, sort_keys=True, default=str)
+    except Exception:
+        return None
+    # The live tail of the backend that OWNS the session — not only the SDK's (review 2026-09-05: a tmux
+    # session's composer echo and a Codex session's queue live in their own stores, which the build renders
+    # but no file records; keyed on _sdk() alone the watched tmux tab served its last build with the send
+    # missing until some file moved). The SDK backend counts its mutations (live_rev); the others are
+    # digested from exactly what the build reads: each live atom's identity and dropped flag, the queue,
+    # the brackets and the launch error.
+    be = Sessions.backend_for(sid)
+    live = ()
+    if be is not None:
+        try:
+            if hasattr(be, "live_rev"):
+                live = (be.live_rev(sid), tuple(be.pending_queued(sid) or ()), be.compacting(sid), be.clearing(sid))
+            else:
+                atoms = tuple((str(a.get("uuid") or a.get("id") or ""), bool(a.get("dropped")), str(a.get("text") or "")[:64])
+                              for a in (be.live_atoms(sid) or ()) if isinstance(a, dict))
+                le = be.launch_error(sid) if hasattr(be, "launch_error") else None
+                live = (atoms, tuple(be.pending_queued(sid) or ()),
+                        be.compacting(sid) if hasattr(be, "compacting") else None,
+                        be.clearing(sid) if hasattr(be, "clearing") else None, bool(le))
+        except Exception:
+            return None
+    files = []
+    for rel in _ACTIVE_SIG_FILES:
+        try:
+            st = os.stat(jd.STATE / rel.format(sid=sid))
+            files.append((st.st_mtime_ns, st.st_size, st.st_ino))
+        except OSError:
+            files.append(None)
+    try:
+        ext = _external_sig(sid, sess.get("path"))
+    except Exception:
+        return None
+    names = getattr(_live_scope, "names", None)
+    names_key = hash(repr(sorted(names.items()))) if isinstance(names, dict) else None
+    return base + (snap, live, tuple(files), names_key, _clock_predicates(sid, tm, now, sess.get("path")),
+                   jd.active_change(), ext)
+
+
 _prev_chat_events = {}                           # sid → the events list from the previous build (to diff against)
 # ── the chat-payload FOLD (issue 903, 2026-09-03) ──────────────────────────────────────────────────
 # build_session reshaped a working session's WHOLE event list on every push (0.3-1 ms/event; 26k
@@ -18859,12 +19175,18 @@ def _chat_diff(prev, cur):
     return i
 
 
-def _chat_build_sig(sess):
+def _chat_build_sig(sess, tm=None):
     """A cheap (transcript mtime,size, states mtime,size) signature for the chat-build cache — busts on any
-    new content OR a state transition (idle/working), the two things that change a session's chat payload.
-    A new caption (TOC headline) lags for a background tab until its transcript next changes or it's opened,
-    which is acceptable for a tab the user isn't looking at. Returns None (→ never cache, always rebuild) if
-    the session has no transcript path or it can't be stat'd."""
+    new content OR a state transition (idle/working), the two things that change a session's chat payload,
+    plus the judge generation, the task store, the pending cut, and — when the caller hands the session's
+    snapshot row `tm` — the facts the build renders from it (state, model, ctx, effort, subagents, background
+    tasks, pending picks, retry count, connected, spawning). The judge generation used to advance every pass
+    and so rebuilt every background tab within ~3 s whatever changed; it now advances only when a judge-
+    written store moved, so the snapshot digest is what keeps a background tab's chips within one cycle of
+    the truth (review 2026-09-05). What still lags for a BACKGROUND tab until one of those inputs moves: the
+    side files only the active key stats (watches, usage, cleared cards, notify cards) — acceptable for a tab
+    the user isn't looking at; it is rebuilt the moment it becomes the active one. Returns None (→ never
+    cache, always rebuild) if the session has no transcript path or it can't be stat'd."""
     path = sess.get("path")
     if not path:
         return None
@@ -18896,6 +19218,13 @@ def _chat_build_sig(sess):
     # tail until the file next changes. Cheap: live SDK sessions answer from memory, no I/O.
     _be = _sdk()
     sig.append(_be.pending_cut(sess.get("sid") or "") if _be else "")
+    if tm is not None:
+        t = tm
+        sig.append((t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
+                    len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
+                    bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
+                    int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")),
+                    t.get("auth"), t.get("authLive")))
     return tuple(sig)
 
 
@@ -23447,11 +23776,9 @@ def _postal_wait_maps():
     try:
         rows = []
         alias = {}   # "host:name" -> sid, learned from every row a remote sender stamped
-        for line in jd.MESSAGES.read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
+        for o in _messages_rows():                    # append-incremental rows (2026-09-03); the fold
+            if not isinstance(o, dict):               # itself stays whole-log: aliases learned from LATER
+                continue                              # rows resolve EARLIER peer: rows
             rows.append(o)
             if o.get("from_host") and o.get("from") and o.get("from_id"):
                 alias[str(o["from_host"]) + ":" + str(o["from"])] = str(o["from_id"])
@@ -25514,14 +25841,8 @@ def _parked_handoffs(now, alive_sids):
     [{msgId, fromId, fromName, toId, toName, body, t}]. Best-effort []."""
     base = jd.STATE / "postal"
     out = []
-    try:
-        lines = jd.MESSAGES.read_text(errors="replace").splitlines()
-    except OSError:
-        return out
-    for line in lines:
-        try:
-            o = json.loads(line)
-        except Exception:
+    for o in _messages_rows():
+        if not isinstance(o, dict):
             continue
         mid, to_id, from_id = o.get("id"), o.get("to_id"), o.get("from_id")
         if not (o.get("park") and mid and to_id and from_id):
@@ -26488,16 +26809,9 @@ def _nudge_times():
     if hit is not None and hit[0] == key:
         return hit[1]
     idx = {}
-    try:
-        for line in p.read_text(errors="replace").splitlines():
-            try:
-                o = json.loads(line)
-            except Exception:
-                continue
-            if isinstance(o, dict) and o.get("gid") and o.get("t"):
-                idx.setdefault(o["gid"], []).append(int(o["t"]))
-    except OSError:
-        return {}
+    for o in em._read_jsonl_incremental(p):          # append-incremental (2026-09-03): the log grows on
+        if isinstance(o, dict) and o.get("gid") and o.get("t"):   # most nudge ticks; only new rows decode
+            idx.setdefault(o["gid"], []).append(int(o["t"]))
     _nudge_times_cache[str(p)] = (key, idx)
     return idx
 
@@ -29020,13 +29334,24 @@ def _push(targets, connect=False, tmux=None):
             build_order = sorted(chat_list, key=lambda s: 0 if s["sid"] in active
                                  or not os.path.exists(s["path"]) else 1)
             for s in build_order:
-                is_active = s["sid"] in active           # the watched tab(s) always rebuild → stay live
-                sig = _chat_build_sig(s)
+                is_active = s["sid"] in active           # the watched tab(s): rebuilt only when an input moved
+                sig = _chat_build_sig(s, tmux.get(s["sid"]))
                 hit = _built_chat.get(s["sid"])
-                if not is_active and hit is not None and sig is not None and hit[0] == sig:
-                    m, ms = hit[1], hit[2]               # unchanged background tab → reuse, no reshape/serialize
+                # The active tab is served from its last build when its EXACT key is unchanged and no
+                # kernel-side mutation postdates that build's start (2026-09-03; before, it rebuilt on
+                # every cycle by design — see _active_chat_sig). Background tabs keep their file-stat key.
+                asig = _active_chat_sig(s, tmux.get(s["sid"]), now, base=sig) if is_active else None
+                if is_active:
+                    fresh = (hit is not None and asig is not None and hit[3] == asig and _views_dirty[0] <= hit[4])
+                else:
+                    fresh = (hit is not None and sig is not None and hit[0] == sig)
+                if fresh:
+                    m, ms, asig, started = hit[1], hit[2], hit[3], hit[4]   # unchanged → reuse, no reshape/serialize
+                    _VIEW_STATS["chatServeActive" if is_active else "chatServeBg"] += 1
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
                 else:
+                    _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
+                    started = time.time()                # the _views_dirty floor for this build (start-keyed)
                     _t0 = time.monotonic()
                     m = build_session(s["sid"], now, tmux)
                     # The full serialization is LAZY (the 2026-08-10 CPU fix, round two): steady state
@@ -29075,9 +29400,9 @@ def _push(targets, connect=False, tmux=None):
                 # cache AFTER the sends, so a serialization a full send just paid for is kept — the next
                 # connect-push for this unchanged tab reuses it instead of dumping again
                 if sig is not None:
-                    if len(_built_chat) > 256:           # bounded by fleet size; a wholesale clear is fine
-                        _built_chat.clear()
-                    _built_chat[s["sid"]] = (sig, m, ms)
+                    while len(_built_chat) > 256:        # bounded by the session count; evict oldest-inserted, never clear
+                        _built_chat.pop(next(iter(_built_chat)))
+                    _built_chat[s["sid"]] = (sig, m, ms, asig, started)
             shown_sids = {s["sid"] for s in chat_list}
             for sid in list(_built_chat):                # drop cache for tabs no longer shown (closed/×-hidden)
                 if sid not in shown_sids:
@@ -29418,6 +29743,12 @@ def _producer_sig(browser):
 # dashboard re-does it every tick. Cache each payload, keyed on a fleet fingerprint; an UNCHANGED fleet (a
 # reload, an idle tick) reuses the last build instead of rebuilding.
 _built_feed = [None, None, 0.0, 0.0]              # [fleet_sig, payload, built_at, build_started_at]
+# How often each view is REBUILT vs SERVED from its cache — the pusher's cost, as numbers (2026-09-03).
+# Exposed on the version route beside the parse counters, so "the kernel is pegged" can be read as
+# "the timeline rebuilt 900 times in 30 min with 12 sessions idle" instead of inferred from top. A
+# rebuild is justified only by a changed input; a rising build count on a quiet board is a bug signature.
+_VIEW_STATS = {"feedBuild": 0, "feedServe": 0, "tlBuild": 0, "tlServe": 0,
+               "chatBuildActive": 0, "chatBuildBg": 0, "chatServeActive": 0, "chatServeBg": 0}
 _built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_at, build_started_at]
 # Wire-form caches for the two heavy shared payloads (the 2026-08-10 CPU fix, round three): the last
 # (source-identity key, serialized bytes, dedup sig) for the feed and the timeline bars, so an unchanged
@@ -29459,19 +29790,33 @@ def _fleet_view_sig(now, tmux):
     or a 5s time bucket so 'X ago'/elapsed keeps advancing when nothing else changes."""
     sig = _producer_sig(True)
     sig["__judge__"] = _judge_gen[0]
-    sig["__bucket__"] = now // 5
+    sig["__jrun__"] = jd.active_change()     # a judge call starting/ending → the card's judging swirl (exact event)
+    sig["__bucket__"] = now // 5             # the one remaining CLOCK input — kept until the age tints, the
+    #                                          hostNow ages and the timeline live edge tick client-side and the
+    #                                          build-time thresholds arm due marks (see the 2026-09-03 audit)
     sig["__sdkp__"] = _sdk_problem_count()   # a fresh SDK failure is its own event → rebuild now, don't wait
     sig["__syncn__"] = _sync_notice_count()  # …and so is a finished automatic sync
     for p, k in ((jd.STATE / "colormap", "__cmap__"), (jd.STATE / "session-flags.json", "__flags__"),
                  (jd.STATE / "session-order.json", "__order__"),
-                 (jd.STATE / "notify-cards.json", "__ncards__")):   # per-card bell arming → the card's menu state
+                 (jd.STATE / "notify-cards.json", "__ncards__"),   # per-card bell arming → the card's menu state
+                 (jd.STATE / "auto-nudge.json", "__nudge__"),      # stalled section, nudge counts/failed stamps
+                 (jd.STATE / "nudge-events.jsonl", "__nudgev__"),  # ⚡ marks
+                 (jd.STATE / "judge-auth.json", "__jauth__"),      # judge billing refusal latch
+                 (jd.STATE / "judge-limit.json", "__jlimit__")):   # judge quota latch
         try:
             sig[k] = os.stat(p).st_mtime
         except OSError:
             pass
     for s in sorted(tmux):
         t = tmux[s]
-        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"))
+        # the badge fields, plus the SDK snapshot facts the feed/timeline render that touch no file: live
+        # subagent and background-task counts (lane pill, awaiting box), an interrupt in flight, a model/
+        # effort/auth switch resolving, a retry storm. Without them a change here was visible only via
+        # the time bucket (the 2026-09-03 audit).
+        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
+                         len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
+                         bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
+                         int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")))
     return tuple(sorted(sig.items()))
 
 
@@ -29491,7 +29836,9 @@ def _cached_feed(now, tmux, sig, connect=False):
     # so back-to-back starts must not shrink its window.
     dirty = not connect and _views_dirty[0] > e[3]        # connect still serves the warmed build (never rebuilds)
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
+        _VIEW_STATS["feedServe"] += 1
         return e[1]
+    _VIEW_STATS["feedBuild"] += 1
     bid = _next_feed_build_id()          # claimed BEFORE the read, so an ack issued during this build outranks it
     started = time.time()                # …and the dirty floor for the NEXT check: mutations after this
     feed = build_feed(now, tmux)         # instant may be invisible to the build below → must rebuild
@@ -29909,7 +30256,9 @@ def _cached_timeline(now, tmux, sig, connect=False):
     e = _built_timeline
     dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
+        _VIEW_STATS["tlServe"] += 1
         return e[1]
+    _VIEW_STATS["tlBuild"] += 1
     started = time.time()
     tl = build_timeline(now, tmux)
     _built_timeline[:] = [sig, tl, time.time(), started]
@@ -29954,6 +30303,8 @@ def _producer():
                 _episode_boundary_tick(time.time())    # this same pass's planner/closer/nudge see a settled store
             except Exception:                          # instead of carrying dead cards into the fresh conversation
                 sys.stderr.write("episode: %s\n" % traceback.format_exc())
+            _pass_fp = _judge_store_fp() if _last_judge_fp[0] is None else None   # the first pass anchors on the
+                                                       # pre-pass look; later passes anchor on the previous look
             _begin_goals_pass()                        # snapshot PRE-pass goal stores → the feed serves them for the
                                                        # whole pass, so no half-applied intermediate ever shows
             _own_frame = jd.begin_pass_frame()         # ONE evidence frame for BOTH tiers and their worker pools:
@@ -29979,9 +30330,10 @@ def _producer():
                 sys.stderr.write("rearm-on-recovery: %s\n" % traceback.format_exc())
             _end_goals_pass()      # pass + compact done → drop the snapshot BEFORE bumping the gen, so the cache-
                                    # busting rebuild below reads the fully-applied (post-pass) state, not pre-pass.
-            _judge_gen[0] += 1     # a judge pass may have changed goal/caption state WITHOUT touching any
-                                   # transcript → bump the generation so the chat-build cache re-builds the
-                                   # background tabs once, keeping their Fleet status/ledger fresh (≤ this cadence).
+            _bump_judge_gen_if_changed(_pass_fp)   # a judge pass may have changed goal/caption state WITHOUT
+                                   # touching any transcript → bump the generation so the chat-build cache
+                                   # re-builds the background tabs once. Only when a store actually moved: a
+                                   # quiet pass leaves every view's signature alone (2026-09-03).
             try:                      # sessions with ARMED TIMERS need a LIVE CLI (the user 2026-08-28:
                 _sbe = _sdk()         # crons/wakeups never fired on dormant sessions — the CLI's scheduler
                 if _sbe and _sdk_ready():   # is in-process; see SdkBackend.ensure_scheduled)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4679,6 +4679,7 @@ class SdkBackend:
         #                                    the catalog lives in the kernel; the backend never imports it
         self._notify = notify              # notify(app, msg) -> push to clients (kernel._send_to_app)
         self._poke_cb = poke               # wake the kernel's producer/judges (optional)
+        self._owns_memo: dict = {}         # sid -> ((reg mtime_ns, size), owns?) — see owns()
         self._push_cb = push               # wake the kernel's PUSHER → immediate chat push (live tail)
         self._push_session_cb = push_session   # targeted ONE-session push (kernel _push_session_now) for
         #   per-session chip events (the connect handshake): a wake alone leaves the flip riding the next
@@ -4697,6 +4698,10 @@ class SdkBackend:
         #                                           writes come from kernel AND loop threads)
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
+        self._live_rev: dict[str, int] = {}       # sid -> count of changes to its live tail (add/edit/drop) —
+        #                                           the exact "the live tail moved" event the kernel's active-tab
+        #                                           cache keys on (2026-09-03); bumped by _touch_live at every
+        #                                           mutation site, never read as a value beyond equality
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
         self._drain_hold_until = 0.0              # deploy-drain lease (T121): RUNTIME-ONLY — a fresh boot starts clear by construction
         self._drain_hold_since = 0.0
@@ -6379,6 +6384,7 @@ class SdkBackend:
         if injected and "<!-- romp-auto -->" in text:
             echo["rompAuto"] = True                          # auto-nudge → romp-logo on the chat/timeline
         self._live.setdefault(sid, {})[key] = echo
+        self._touch_live(sid)
         self._persist_echoes(sid)                            # unlanded echoes survive a kernel restart (reg mirror)
         self._wake_push()
         return True
@@ -6425,6 +6431,7 @@ class SdkBackend:
                 if e.get("dropped"):
                     atom["dropped"] = True
                 self._live.setdefault(reg["sid"], {})[key] = atom
+                self._touch_live(reg["sid"])
             if self._live.get(reg["sid"]):
                 self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
 
@@ -6513,6 +6520,7 @@ class SdkBackend:
             if a["_echo_text"] in rekeyed:
                 continue                                   # now in the queue → renders as queued, prunes on landing
             a["dropped"] = True
+            self._touch_live(sid)
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                       "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
         self._persist_echoes(sid)
@@ -6561,6 +6569,7 @@ class SdkBackend:
                 continue
             if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
                 live.pop(k, None)
+                self._touch_live(sid)
                 if not live:
                     self._live.pop(sid, None)
                 self._persist_echoes(sid)
@@ -7627,7 +7636,23 @@ class SdkBackend:
         return "key" if self.work_key else "login"
 
     def owns(self, sid: str) -> bool:
-        return read_reg(self.state_dir, sid) is not None
+        """Whether this backend has a registry entry for `sid`. Memoized on the reg file's (mtime, size):
+        Sessions.backend_for asks this for every session in every pusher tick job — 130+ reg opens and
+        JSON decodes per cycle on a 17-session board with nothing changed (2026-09-03) — and the answer
+        can only change when the file does. A vanished file forgets its memo (the reg is gone)."""
+        p = _reg_path(self.state_dir, sid)
+        try:
+            st = p.stat()
+            key = (st.st_mtime_ns, st.st_size, st.st_ino)
+        except OSError:
+            self._owns_memo.pop(sid, None)
+            return False
+        hit = self._owns_memo.get(sid)
+        if hit is not None and hit[0] == key:
+            return hit[1]
+        ok = read_reg(self.state_dir, sid) is not None
+        self._owns_memo[sid] = (key, ok)
+        return ok
 
     def ensure_scheduled(self) -> int:
         """Keep a CLI process ALIVE for every session with ARMED SESSION TIMERS (reg sessionCrons, the
@@ -7879,6 +7904,7 @@ class SdkBackend:
         d = self._live.setdefault(sess.sid, {})
         d[atom["uuid"]] = atom
         _evict_live_overflow(d)                  # safety cap if no client ever drains/prunes — never an echo
+        self._touch_live(sess.sid)
         # The stream is the AUTHORITATIVE busy signal: a genuine WORK atom (streamed assistant/tool
         # output — not an input echo, not a /model-style command line) means the CLI is producing RIGHT
         # NOW, so re-assert 'working' if a prior state write settled ahead of it (e.g. a separate turn
@@ -7911,6 +7937,17 @@ class SdkBackend:
             except Exception as e:
                 self._log("session push (%s) failed: %s" % (sid, e))
         threading.Thread(target=run, name="sdk-push-session", daemon=True).start()
+
+    def _touch_live(self, sid: str) -> None:
+        """Record that `sid`'s live tail changed (see _live_rev)."""
+        revs = getattr(self, "_live_rev", None)          # a bare __new__ backend (tests drive prune_live on one)
+        if revs is None:                                 # has no counters yet: mint them rather than raise
+            revs = self._live_rev = {}
+        revs[sid] = revs.get(sid, 0) + 1
+
+    def live_rev(self, sid: str) -> int:
+        """How many times `sid`'s live tail has changed this process — equality means nothing moved."""
+        return getattr(self, "_live_rev", {}).get(sid, 0)
 
     def live_atoms(self, sid: str) -> list:
         """The session's in-memory live-tail atoms (newest last), for build_session to merge ahead of disk."""
@@ -7961,6 +7998,7 @@ class SdkBackend:
             if landed or stale_echo or stale_cmd:
                 echo_removed = echo_removed or bool(et and not a.get("command"))
                 del d[k]
+                self._touch_live(sid)
         if not d:
             self._live.pop(sid, None)
         if echo_removed:
@@ -8009,6 +8047,7 @@ class SdkBackend:
                         except Exception:
                             self._log("orphan-reply persist failed: %s" % traceback.format_exc())
                 del d[k]
+                self._touch_live(sid)
         if not d:
             self._live.pop(sid, None)
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2672,12 +2672,16 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(chat_order, ["NEW", "C", "A"],
                          "the transcript-less session shares the active tier (stable within it)")
 
-    def test_push_caches_unchanged_background_tabs_but_always_rebuilds_active(self):
+    def test_push_caches_unchanged_tabs_and_rebuilds_each_on_its_own_change(self):
         # the user 2026-06-24 (sluggish UI): the 0.5s pusher rebuilt EVERY open tab — a full transcript reshape
         # into ChatEvent[] AND a json.dumps of the whole chat, per tab, even when nothing changed — which pegged
         # the kernel on multi-MB transcripts and starved the webview. A BACKGROUND tab whose transcript+states
-        # are unchanged now reuses its built payload (one stat() instead of a reshape+serialize); the ACTIVE
-        # tab always rebuilds so what the user is watching stays live (incl. SDK live-tail atoms).
+        # are unchanged reuses its built payload (one stat() instead of a reshape+serialize). The ACTIVE tab
+        # used to rebuild on every push "to stay live"; since 2026-09-03 it too is served from its last build
+        # while its EXACT key (_active_chat_sig: file stats + live tail + snapshot + clock predicates) is
+        # unchanged and no kernel-side mutation postdates the build — so a watched 80 MB session no longer
+        # costs a reshape per 0.5 s cycle with nothing moving. Liveness is unchanged: any input that can
+        # move the payload is in the key, and _mark_views_dirty busts it for in-memory stamps.
         import tempfile
         d = tempfile.mkdtemp()
         pa, pb = os.path.join(d, "A.jsonl"), os.path.join(d, "B.jsonl")
@@ -2698,19 +2702,30 @@ class ViewBuilder(unittest.TestCase):
         client = {"app": "chat", "active": "A", "alive": True}
         try:
             km._push([client])                       # 1st: builds A + B
-            km._push([client])                       # 2nd: A rebuilt (active); B reused (unchanged)
+            km._push([client])                       # 2nd: nothing moved → A and B both served
             after_two = list(calls)
             with open(pb, "a") as f:                 # B's transcript grows → its signature busts
                 f.write("{}\n")
             os.utime(pb, None)
-            km._push([client])                       # 3rd: A rebuilt; B rebuilt (changed)
+            km._push([client])                       # 3rd: B rebuilt (changed); A still served
+            after_three = list(calls)
+            with open(pa, "a") as f:                 # A's transcript grows → the ACTIVE key busts
+                f.write("{}\n")
+            os.utime(pa, None)
+            km._push([client])                       # 4th: A rebuilt
+            after_four = list(calls)
+            km._mark_views_dirty()                   # a kernel-side mutation no file records
+            km._push([client])                       # 5th: A rebuilt (dirty postdates its build)
         finally:
             (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
              km.build_timeline, km._send_client) = saved
             km._built_chat.clear()
-        self.assertEqual(calls.count("A"), 3, "the ACTIVE tab rebuilds on every push (stays live)")
+        self.assertEqual(after_two.count("A"), 1, "an unchanged ACTIVE tab is served on the 2nd push")
         self.assertEqual(after_two.count("B"), 1, "an unchanged BACKGROUND tab is NOT rebuilt on the 2nd push")
-        self.assertEqual(calls.count("B"), 2, "the background tab rebuilds once its transcript actually changes")
+        self.assertEqual(after_three.count("B"), 2, "the background tab rebuilds once its transcript actually changes")
+        self.assertEqual(after_three.count("A"), 1, "…and that does not rebuild the active tab")
+        self.assertEqual(after_four.count("A"), 2, "the active tab rebuilds once ITS transcript changes")
+        self.assertEqual(calls.count("A"), 3, "a kernel-side mutation (views dirty) rebuilds the active tab")
 
     def _orphaned_goal(self, idle=True, closer_done=True, planned=True):
         # an idle (or still-open) session whose top goal still shows "working". closer_done puts the latest

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -54,6 +54,9 @@ class Redelivery(unittest.TestCase):
 
             def _wake_push(self):
                 pass
+
+            def _touch_live(self, sid):
+                pass                      # the live-tail revision hook (2026-09-03): a stub needs no counter
             _text_landed = sb.SdkBackend._text_landed if hasattr(sb, "SdkBackend") else None
         self.be = BE()
         # bind the real methods under test onto the stub

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -1,0 +1,760 @@
+#!/usr/bin/env python3
+"""The per-push readers of states/<sid>.jsonl and timeline/messages.jsonl are served append-
+incrementally (2026-09-03). Before, ten readers each opened the file and json.loads'd every line on
+every call — eight of them per session per pusher cycle — so an idle kernel re-read every session's
+states log about twice a second (the most-opened files in a live descriptor sample). Now they all
+consume event_model's jsonl cache: an unchanged file costs one stat, a grown file parses only the
+appended bytes, and every reader sees exactly the rows it saw before. Synthetic sids and rows only.
+"""
+import builtins
+import io
+import inspect
+import json
+import os
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-999999999901"     # private synthetic sid: this module owns its states file
+NOW = 1781100000
+
+
+class _StateSandbox(unittest.TestCase):
+    """Pin every judge-module store path to ONE fresh root for the test, and restore after. The kernel,
+    judge and event-model modules are process-wide singletons shared by every test module (same loader
+    name), and other modules re-point jd.STATE or jd.MESSAGES for their own cases — a reader that derives
+    its path from jd.STATE and one that reads jd.MESSAGES must agree here, or a full-suite run diverges
+    from a solo run (the ordering-dependent failure class the repo's CLAUDE.md warns about)."""
+
+    _PIN = ("STATE", "STATESDIR", "MESSAGES", "GOALDIR", "CAPDIR", "ARCHDIR")
+
+    def setUp(self):
+        from pathlib import Path
+        self._saved_paths = {k: getattr(jd, k) for k in self._PIN}
+        root = Path(tempfile.mkdtemp())
+        jd.STATE = root
+        jd.STATESDIR = root / "states"
+        jd.MESSAGES = root / "timeline" / "messages.jsonl"
+        jd.GOALDIR = root / "goals"
+        jd.CAPDIR = root / "captions"
+        jd.ARCHDIR = root / "archive"
+        for d in (jd.STATESDIR, jd.MESSAGES.parent, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, root / "sdk"):
+            d.mkdir(parents=True, exist_ok=True)
+        km._postal_index_memo[0] = None
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        self.addCleanup(self._restore_paths)
+
+    def _restore_paths(self):
+        for k, v in self._saved_paths.items():
+            setattr(jd, k, v)
+        km._postal_index_memo[0] = None
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+
+
+def _write_rows(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _append_rows(path, rows):
+    with open(path, "a") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+class _OpenCounter:
+    """Counts READ opens of ONE path — the proof that an unchanged file is served from cache. The tests'
+    own append writes to the same path are not counted."""
+
+    def __init__(self, path):
+        self.path, self.n, self._real = str(path), 0, builtins.open
+
+    def __enter__(self):
+        self._real_io = io.open
+
+        def hook(file, *a, **kw):
+            mode = a[0] if a else kw.get("mode", "r")
+            if str(file) == self.path and "r" in mode and "+" not in mode:
+                self.n += 1
+            return self._real_io(file, *a, **kw)
+        builtins.open = hook
+        io.open = hook          # pathlib's read_text/open call io.open, not the builtin (review 2026-09-03)
+        return self
+
+    def __exit__(self, *a):
+        builtins.open = self._real
+        io.open = self._real_io
+
+
+class StatesReaders(_StateSandbox):
+    ROWS = [
+        {"t": NOW - 900, "state": "working"},
+        {"t": NOW - 800, "awaiting": True, "why": "a build"},
+        {"t": NOW - 700, "retriesRecovered": 3},
+        {"t": NOW - 650, "cmdGesture": "/effort high"},
+        {"t": NOW - 640, "effortApplied": "high"},
+        {"t": NOW - 600, "state": "waiting"},
+        {"t": NOW - 500, "retriesGaveUp": 4, "errorKind": "overloaded"},
+        {"t": NOW - 400, "orphanReply": {"uuid": "u-1", "text": "the lost reply"}},
+        {"t": NOW - 300, "state": "compacting"},
+        {"t": NOW - 200, "state": "working"},
+        {"t": NOW - 100, "state": "idle"},
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.path = jd.STATE / "states" / (SID + ".jsonl")
+        em._JSONL_CACHE.pop(str(self.path), None)
+        _write_rows(self.path, self.ROWS)
+
+    def tearDown(self):
+        em._JSONL_CACHE.pop(str(self.path), None)
+        try:
+            os.unlink(self.path)
+        except OSError:
+            pass
+
+    def test_a_every_reader_sees_exactly_the_rows_it_saw_before(self):
+        self.assertEqual(km._last_state(SID), ("idle", NOW - 100))
+        self.assertEqual(km._last_state_value(SID), "idle")
+        # a later WORK turn supersedes the stale awaiting:true → not awaiting (the 2026-06-26 rule)
+        self.assertEqual(km._states_awaiting_overlay(SID), {"awaiting": False, "why": None})
+        self.assertEqual(km._retry_recoveries(SID), [{"t": NOW - 700, "retries": 3}])
+        self.assertEqual(km._retry_gaveups(SID), [{"t": NOW - 500, "retries": 4, "errorKind": "overloaded"}])
+        self.assertEqual(km._orphan_replies(SID), [{"t": NOW - 400, "uuid": "u-1", "text": "the lost reply"}])
+        self.assertEqual(km._effort_changes(SID), [{"t": NOW - 640, "effort": "high"}])
+        self.assertEqual(km._cmd_gestures(SID), [{"t": NOW - 650, "cmd": "/effort high"}])
+        # the compacting band runs from its transition to the next one
+        self.assertEqual(km._state_intervals(SID, "compacting", NOW), [[NOW - 300, NOW - 200]])
+        self.assertEqual(km._state_intervals(SID, ("permission", "picker"), NOW), [])
+
+    def test_a2_the_retrying_stretch_reads_from_the_same_rows(self):
+        _append_rows(self.path, [{"t": NOW - 60, "state": "retrying"}, {"t": NOW - 55, "awaiting": False},
+                                 {"t": NOW - 50, "state": "retrying"}])
+        tm = {"state": "retrying", "retryCount": 2, "retryInfo": {"max": 10, "status": 529}}
+        info = km._session_retrying(SID, tm)
+        self.assertEqual((info["since"], info["count"], info["max"], info["status"]), (NOW - 60, 2, 10, 529))
+        _append_rows(self.path, [{"t": NOW - 40, "state": "working"}])
+        self.assertIsNone(km._session_retrying(SID, tm)["since"], "a real transition ends the stretch")
+        self.assertIsNone(km._session_retrying(SID, {"state": "working"}), "not in a storm → no chip")
+
+    def test_b_an_awaiting_overlay_not_yet_superseded_stands(self):
+        _append_rows(self.path, [{"t": NOW - 50, "awaiting": True, "why": "an agent"}])
+        self.assertEqual(km._states_awaiting_overlay(SID), {"t": NOW - 50, "awaiting": True, "why": "an agent"})
+
+    def test_c_an_unchanged_file_is_never_reopened(self):
+        km._last_state(SID)                                   # warm the cache
+        with _OpenCounter(self.path) as c:
+            for _ in range(5):
+                km._last_state(SID); km._states_awaiting_overlay(SID); km._retry_recoveries(SID)
+                km._retry_gaveups(SID); km._orphan_replies(SID); km._effort_changes(SID)
+                km._cmd_gestures(SID); km._state_intervals(SID, "compacting", NOW)
+        self.assertEqual(c.n, 0, "eight readers x five calls on a quiet log: zero opens, one stat each")
+
+    def test_d_an_append_is_picked_up_from_the_appended_bytes_only(self):
+        km._last_state(SID)
+        with _OpenCounter(self.path) as c:
+            _append_rows(self.path, [{"t": NOW - 10, "state": "working"}])
+            self.assertEqual(km._last_state(SID), ("working", NOW - 10))
+            self.assertEqual(km._state_intervals(SID, "working", NOW)[-1], [NOW - 10, NOW])
+        self.assertEqual(c.n, 1, "the grown file is opened once, for its tail")
+
+    def test_e_a_missing_file_reads_as_before(self):
+        gone = "11111111-2222-3333-4444-999999999902"
+        self.assertEqual(km._last_state(gone), ("", 0))
+        self.assertIsNone(km._states_awaiting_overlay(gone))
+        self.assertEqual(km._retry_recoveries(gone), [])
+        self.assertEqual(km._state_intervals(gone, "compacting", NOW), [])
+
+    def test_f_a_garbled_line_is_skipped_not_fatal(self):
+        with open(self.path, "a") as f:
+            f.write("{not json\n")
+        _append_rows(self.path, [{"t": NOW - 5, "state": "waiting"}])
+        self.assertEqual(km._last_state(SID), ("waiting", NOW - 5))
+
+
+class PostalLogReaders(_StateSandbox):
+    A = "11111111-2222-3333-4444-999999999911"
+    B = "11111111-2222-3333-4444-999999999912"
+
+    def setUp(self):
+        super().setUp()
+        em._JSONL_CACHE.pop(str(jd.MESSAGES), None)
+        _write_rows(jd.MESSAGES, [
+            {"ev": "sent", "id": "m-1", "from_id": self.A, "to_id": self.B, "t": NOW - 100, "body": "please review", "park": True},
+            {"ev": "sent", "id": "m-2", "from_id": self.A, "to_id": self.B, "t": NOW - 90, "body": "and this"},
+            {"ev": "exec", "id": "m-2", "t": NOW - 80},
+        ])
+        (jd.STATE / "postal" / "mail" / self.B / "new").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "postal" / "mail" / self.B / "new" / "m-1").write_text("{}")
+
+    def tearDown(self):
+        em._JSONL_CACHE.pop(str(jd.MESSAGES), None)
+        try:
+            os.unlink(jd.MESSAGES)
+        except OSError:
+            pass
+
+    def test_a_parked_handoffs_and_connectors_read_the_same_rows(self):
+        parked = km._parked_handoffs(NOW, alive_sids=set())
+        self.assertEqual([h["msgId"] for h in parked], ["m-1"], parked)
+        self.assertEqual(km._parked_handoffs(NOW, alive_sids={self.B}), [], "a revived recipient consumed it")
+        conns = km._postal_messages(NOW, {self.A, self.B}, {self.A: "a", self.B: "b"})
+        self.assertTrue(any(c.get("id") == "m-2" for c in conns) or conns, conns)
+
+    def test_b_the_log_is_not_reopened_while_quiet(self):
+        km._parked_handoffs(NOW, alive_sids=set())
+        with _OpenCounter(jd.MESSAGES) as c:
+            for _ in range(3):
+                km._parked_handoffs(NOW, alive_sids=set())
+                km._postal_messages(NOW, {self.A, self.B}, {self.A: "a", self.B: "b"})
+        self.assertEqual(c.n, 0)
+
+
+class ViewCountersAreVisible(unittest.TestCase):
+    """The pusher's rebuild-vs-serve counts ride the version route beside the parse counters, so a kernel
+    that rebuilds a view every cycle on a quiet board is a NUMBER, not an inference from top."""
+
+    def test_a_an_unchanged_signature_is_served_and_counted(self):
+        before = dict(km._VIEW_STATS)
+        sig = ("stage0-test", 1)
+        km._built_feed[:] = [None, None, 0.0, 0.0]
+        km._cached_feed(NOW, {}, sig)                      # first: a build
+        km._cached_feed(NOW, {}, sig)                      # same sig: served
+        self.assertEqual(km._VIEW_STATS["feedBuild"] - before["feedBuild"], 1)
+        self.assertEqual(km._VIEW_STATS["feedServe"] - before["feedServe"], 1)
+        km._built_timeline[:] = [None, None, 0.0, 0.0]
+        km._cached_timeline(NOW, {}, sig)
+        km._cached_timeline(NOW, {}, sig)
+        self.assertEqual(km._VIEW_STATS["tlBuild"] - before["tlBuild"], 1)
+        self.assertEqual(km._VIEW_STATS["tlServe"] - before["tlServe"], 1)
+
+    def test_b_the_version_payload_carries_them(self):
+        fn = getattr(km, "_version_payload", None) or getattr(km, "_kernel_version_payload", None)
+        if fn is None:
+            src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py"), encoding="utf-8").read()
+            self.assertIn('"views": dict(_VIEW_STATS)', src)
+            return
+        self.assertEqual(set(fn()["views"]), set(km._VIEW_STATS))
+
+
+class BackendOwnsIsMemoized(unittest.TestCase):
+    """Sessions.backend_for asks the SDK backend `owns(sid)` for every session in every tick job; it read
+    and decoded the registry file each time. Now one stat answers while the file is unchanged."""
+
+    SID = "11111111-2222-3333-4444-999999999921"
+
+    def test_a_owns_reads_the_reg_once_per_file_version(self):
+        sb = SourceFileLoader("romp_sdk_backend_stage0", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        self.assertFalse(be.owns(self.SID), "no reg yet")
+        sb.write_reg(be.state_dir, self.SID, {"sid": self.SID, "name": "web", "cwd": "/tmp", "alive": True})
+        self.assertTrue(be.owns(self.SID))
+        reads = []
+        real = sb.read_reg
+        sb.read_reg = lambda *a, **k: (reads.append(1), real(*a, **k))[1]
+        try:
+            for _ in range(20):
+                self.assertTrue(be.owns(self.SID))
+            self.assertEqual(reads, [], "twenty asks on an unchanged reg: the file is not decoded again")
+            sb.write_reg(be.state_dir, self.SID, {"sid": self.SID, "name": "web", "cwd": "/tmp", "alive": False})
+            self.assertTrue(be.owns(self.SID))
+            self.assertEqual(len(reads), 1, "a rewritten reg is decoded once more")
+        finally:
+            sb.read_reg = real
+        os.unlink(sb._reg_path(be.state_dir, self.SID))
+        self.assertFalse(be.owns(self.SID), "a vanished reg is not owned")
+
+
+class ViewSignatureKeysOnExactInputs(_StateSandbox):
+    """The feed/timeline signature used to bust every ≤3 s because the judge generation advanced after
+    EVERY producer pass, changed store or not — and the per-session tuple missed the SDK snapshot facts the
+    views render (subagent counts, an interrupt, a switch resolving), so those surfaced only via the 5 s
+    time bucket. Now the generation moves only when a pass moved a store, a judge call starting or ending
+    is its own signature input, and the snapshot facts are in the tuple."""
+
+    SID = "11111111-2222-3333-4444-999999999931"
+
+    def test_a_a_quiet_pass_leaves_the_judge_generation_alone(self):
+        km._last_judge_fp[0] = None
+        fp = km._judge_store_fp()
+        km._bump_judge_gen_if_changed(fp)                    # anchor the "last look" on the current stores
+        g0 = km._judge_gen[0]
+        self.assertFalse(km._bump_judge_gen_if_changed(fp))
+        self.assertFalse(km._bump_judge_gen_if_changed(fp), "two quiet passes → no movement")
+        self.assertEqual(km._judge_gen[0], g0)
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (self.SID + ".json")).write_text(json.dumps({"rompUuid": self.SID, "nodes": {}}))
+        try:
+            # written BETWEEN passes (a user's clear, the awaiting lift): the next look sees it — the anchor is
+            # the previous look, not this pass's own start (review 2026-09-03)
+            self.assertTrue(km._bump_judge_gen_if_changed(km._judge_store_fp()), "a store moved since the last look → bump")
+            self.assertEqual(km._judge_gen[0], g0 + 1)
+            self.assertFalse(km._bump_judge_gen_if_changed(), "…and only once")
+        finally:
+            os.unlink(jd.GOALDIR / (self.SID + ".json"))
+            km._last_judge_fp[0] = None
+
+    def test_b_a_judge_call_starting_and_ending_are_signature_events(self):
+        c0 = jd.active_change()
+        rid = jd._active_begin("planner", self.SID, 0)
+        self.assertEqual(jd.active_change(), c0 + 1)
+        jd._active_end(rid)
+        self.assertEqual(jd.active_change(), c0 + 2)
+        jd._active_end(rid)                                  # a second end of the same run is not an event
+        self.assertEqual(jd.active_change(), c0 + 2)
+
+    def test_c_snapshot_facts_move_the_signature_without_a_file_or_the_clock(self):
+        now = NOW - (NOW % 5)                                 # inside one time bucket throughout
+        base = {"state": "working", "model": "m", "ctx": 10, "effort": "", "mode": "", "fast": "", "since": NOW - 60,
+                "subagents": [], "bgTasks": [], "interrupting": False, "modelPending": False, "retryCount": 0}
+        s1 = km._fleet_view_sig(now, {self.SID: dict(base)})
+        self.assertEqual(s1, km._fleet_view_sig(now + 1, {self.SID: dict(base)}), "same inputs, same bucket → same sig")
+        for k, v in (("subagents", [{"id": "a1"}]), ("bgTasks", [{"toolUseId": "t1"}]), ("interrupting", True),
+                     ("modelPending", True), ("retryCount", 3)):
+            changed = dict(base); changed[k] = v
+            self.assertNotEqual(s1, km._fleet_view_sig(now, {self.SID: changed}), k)
+        rid = jd._active_begin("closer", self.SID, 0)
+        try:
+            self.assertNotEqual(s1, km._fleet_view_sig(now, {self.SID: dict(base)}), "a judge call in flight")
+        finally:
+            jd._active_end(rid)
+
+
+class ActiveTabIsServedOnAnExactKey(_StateSandbox):
+    """The watched chat tab used to rebuild from all atoms on every pusher cycle "by design", because its
+    payload moves with inputs no file records. _active_chat_sig names every one of them, so an identical
+    world serves the last build and any moved input rebuilds. Synthetic session, private sid."""
+
+    SID = "11111111-2222-3333-4444-999999999941"
+
+    def setUp(self):
+        super().setUp()
+        self.path = jd.STATE / "states" / (self.SID + ".jsonl")
+        _write_rows(self.path, [{"t": NOW - 100, "state": "waiting"}])
+        self.tpath = jd.STATE / ("stage0-transcript-" + self.SID + ".jsonl")
+        self.tpath.write_text(json.dumps({"type": "user", "uuid": "u1", "timestamp": "2026-09-03T00:00:00Z",
+                                          "message": {"role": "user", "content": "hi"}}) + "\n")
+        self.sess = {"sid": self.SID, "path": str(self.tpath), "anchor": self.SID}
+        self.tm = {"state": "waiting", "since": NOW - 100, "model": "m", "subagents": [], "bgTasks": [], "snapT": NOW}
+        km._interrupt_clicked.pop(self.SID, None); km._model_switch_pending.pop(self.SID, None); km._compact_clicked.pop(self.SID, None)
+
+    def tearDown(self):
+        for p in (self.path, self.tpath):
+            try: os.unlink(p)
+            except OSError: pass
+        km._interrupt_clicked.pop(self.SID, None); km._model_switch_pending.pop(self.SID, None); km._compact_clicked.pop(self.SID, None)
+
+    def test_a_an_identical_world_yields_the_same_key_and_a_volatile_stamp_does_not_matter(self):
+        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+        self.assertIsNotNone(s1)
+        tm2 = dict(self.tm); tm2["snapT"] = NOW + 7
+        self.assertEqual(s1, km._active_chat_sig(self.sess, tm2, NOW + 1), "snapT and the clock alone move nothing")
+
+    def test_b_each_input_class_moves_the_key(self):
+        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+        tm = dict(self.tm); tm["state"] = "working"
+        self.assertNotEqual(s1, km._active_chat_sig(self.sess, tm, NOW), "a snapshot fact")
+        _append_rows(self.path, [{"t": NOW - 5, "state": "working"}])
+        s2 = km._active_chat_sig(self.sess, self.tm, NOW)
+        self.assertNotEqual(s1, s2, "a states row")
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        cap = jd.CAPDIR / (self.SID + ".jsonl")
+        try:
+            cap.write_text(json.dumps({"id": "seg-1", "gist": "did a thing"}) + "\n")
+            s3 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertNotEqual(s2, s3, "a caption landed")
+        finally:
+            try: os.unlink(cap)
+            except OSError: pass
+        rid = jd._active_begin("closer", self.SID, 0)
+        try:
+            self.assertNotEqual(s2, km._active_chat_sig(self.sess, self.tm, NOW), "a judge call in flight")
+        finally:
+            jd._active_end(rid)
+
+    def test_c_clock_predicates_flip_exactly_at_their_deadlines(self):
+        tm = {"state": "ready", "since": NOW - 3599, "bgTasks": []}
+        p0 = km._clock_predicates(self.SID, tm, NOW)
+        self.assertEqual(p0[:5], (False, False, False, False, False))
+        self.assertEqual(km._clock_predicates(self.SID, tm, NOW + 2)[0], True, "faded flips at the hour")
+        odd = dict(tm, state="")                          # the build derives 'ready' from an empty raw state
+        self.assertEqual(km._clock_predicates(self.SID, odd, NOW + 2)[1], True, "…keyed whatever the raw state says")
+        km._interrupt_clicked[self.SID] = NOW - 119
+        self.assertFalse(km._clock_predicates(self.SID, tm, NOW)[2])
+        self.assertTrue(km._clock_predicates(self.SID, tm, NOW + 2)[2], "the interrupt cap ran out")
+        s1 = km._active_chat_sig(self.sess, tm, NOW)
+        self.assertNotEqual(s1, km._active_chat_sig(self.sess, tm, NOW + 2), "…and the key follows the flip")
+
+
+    def test_d_a_live_task_expiring_moves_the_key_through_the_builds_own_filter(self):
+        """The raw snapshot rows carry no deadline; the build joins each task's recorded deadline from the
+        launch ledger and drops expired ones. The key carries that filtered set, so an expiry — a tid
+        dropping out — moves it exactly when the awaiting box would change (review 2026-09-03)."""
+        saved = km._bg_live_norm
+        rows = [{"tid": "t1", "desc": "watch", "t": NOW - 60}]
+        km._bg_live_norm = lambda sid, path: list(rows)
+        try:
+            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW + 1))
+            rows.clear()                                     # the watcher passed its deadline → filtered out
+            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW + 2))
+        finally:
+            km._bg_live_norm = saved
+
+    def test_d2_a_running_tasks_output_growing_moves_the_key(self):
+        """The task box shows a running task's output tail, read live from a file outside the state root; the
+        key stats that file so the tail keeps moving (review 2026-09-03)."""
+        out = jd.STATE / "task-out.log"; out.write_text("line 1\n")
+        saved = km._bg_scan_cached
+        km._bg_scan_cached = lambda path: [{"id": "toolu_1", "status": "running", "outputFile": str(out)}]
+        try:
+            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW))
+            with open(out, "a") as f:
+                f.write("line 2\n")
+            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "the tail grew")
+        finally:
+            km._bg_scan_cached = saved
+
+    def test_d3_the_branch_of_a_subdirectory_cwd_and_of_the_last_edited_files_tree_is_keyed(self):
+        """build_session reads the branch of the registered cwd's tree and of the last edited file's tree
+        (the per-session worktree); both HEADs are in the key, resolved through _tree_of like the build."""
+        import subprocess
+        repo = tempfile.mkdtemp()
+        subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+        sub = os.path.join(repo, "pkg"); os.makedirs(sub)
+        saved_cwd = km._cwd_of
+        km._cwd_of = lambda sid: sub                       # a cwd INSIDE the repo, not its top
+        try:
+            e1 = km._external_sig(self.SID, str(self.tpath))
+            self.assertTrue(any(x is not None for x in e1[1:2]), "the repo's HEAD is stat'd for a subdirectory cwd: %r" % (e1,))
+            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            subprocess.run(["git", "-C", repo, "checkout", "-q", "-b", "feature"], check=True)
+            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "a branch switch moves the key")
+        finally:
+            km._cwd_of = saved_cwd
+
+    def test_e_the_backend_leg_and_the_watch_files_move_the_key(self):
+        """A stub backend stands in for the SDK: the live-tail revision, the send queue and the brackets each
+        move the key; so does the kernel-owned watch registry's file (review 2026-09-03)."""
+        class Stub:
+            rev = 0; queue = []; comp = False; clr = False
+            def owns(self, sid): return True
+            def live_rev(self, sid): return self.rev
+            def pending_queued(self, sid): return list(self.queue)
+            def compacting(self, sid): return self.comp
+            def clearing(self, sid): return self.clr
+            def pending_cut(self, sid): return ""
+        stub = Stub(); saved = km._sdk
+        km._sdk = lambda: stub
+        try:
+            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW))
+            stub.rev += 1;  s2 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s1, s2, "a live atom")
+            stub.queue = ["x"]; s3 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s2, s3, "a queued send")
+            stub.comp = True;  s4 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s3, s4, "compacting")
+            (jd.STATE / "watches.json").write_text(json.dumps([{"sid": self.SID, "what": "a build"}]))
+            self.assertNotEqual(s4, km._active_chat_sig(self.sess, self.tm, NOW), "a watch armed")
+        finally:
+            km._sdk = saved
+
+
+    def test_f_the_owning_backends_live_tail_moves_the_key_for_a_tmux_session(self):
+        """Review 2026-09-05: the key read only the SDK backend's tail, so a tmux session's composer echo — a
+        kernel-side store the build renders — left the watched tab served stale until some file moved."""
+        saved_sdk = km._sdk
+        km._sdk = lambda: None                                    # this sid is tmux-owned
+        km._tmux_echo.pop(self.SID, None)
+        try:
+            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertIsNotNone(s1)
+            km._tmux_echo_add(self.SID, "please also fix the header")
+            s2 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertNotEqual(s1, s2, "the echo the build renders is in the key")
+            for a in km._tmux_echo.get(self.SID, {}).values():
+                a["dropped"] = True                               # the pane dropped the keystroke: rendered differently
+            s3 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertNotEqual(s2, s3, "…and so is its dropped flag")
+            km._tmux_echo.pop(self.SID, None)                     # dismissed
+            self.assertEqual(km._active_chat_sig(self.sess, self.tm, NOW), s1, "back to the world before the send")
+        finally:
+            km._sdk = saved_sdk
+            km._tmux_echo.pop(self.SID, None)
+
+    def test_g_the_background_key_carries_the_snapshot_facts_a_tabs_chips_render(self):
+        """The judge generation no longer advances every pass, so a background tab's chips (state, retrying,
+        subagents, pending picks…) are keyed on the snapshot row itself (review 2026-09-05)."""
+        b1 = km._chat_build_sig(self.sess, self.tm)
+        self.assertIsNotNone(b1)
+        tm2 = dict(self.tm); tm2["snapT"] = NOW + 30
+        self.assertEqual(b1, km._chat_build_sig(self.sess, tm2), "the volatile stamp alone moves nothing")
+        for k, v in (("state", "retrying"), ("subagents", ["a"]), ("retryCount", 3), ("modelPending", True),
+                     ("connected", True), ("spawning", True), ("model", "other"), ("auth", "key")):
+            tm3 = dict(self.tm); tm3[k] = v
+            self.assertNotEqual(b1, km._chat_build_sig(self.sess, tm3), k)
+        self.assertNotEqual(b1, km._chat_build_sig(self.sess), "no row handed → a different (row-less) key, never a false hit")
+
+    def test_h_the_spend_hold_moves_the_key_and_marks_the_views_dirty(self):
+        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+        before = km._views_dirty[0]
+        km._set_retry_paused(True, reason="spend")
+        try:
+            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "retry-paused.json is a keyed side file")
+            self.assertGreater(km._views_dirty[0], before, "every writer of the hold publishes the flip")
+        finally:
+            km._set_retry_paused(False)
+
+    def test_i_the_active_key_reuses_the_pushers_base(self):
+        base = km._chat_build_sig(self.sess, self.tm)
+        self.assertEqual(km._active_chat_sig(self.sess, self.tm, NOW, base=base), km._active_chat_sig(self.sess, self.tm, NOW))
+
+
+class PerBuildReadersAreCached(_StateSandbox):
+    SID = "11111111-2222-3333-4444-999999999951"
+
+    def test_a_captions_are_not_reopened_while_quiet(self):
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        cap = jd.CAPDIR / (self.SID + ".jsonl")
+        try:
+            _write_rows(cap, [{"id": "s1", "gist": "one"}, {"id": "s2", "gist": "two"}, {"id": "s1", "gist": "one, revised"}])
+            self.assertEqual({k: v["gist"] for k, v in km._captions(self.SID).items()}, {"s1": "one, revised", "s2": "two"}, "last wins")
+            with _OpenCounter(cap) as c:
+                for _ in range(4):
+                    km._captions(self.SID)
+            self.assertEqual(c.n, 0)
+        finally:
+            em._JSONL_CACHE.pop(str(cap), None)
+            try: os.unlink(cap)
+            except OSError: pass
+
+    def test_b_thread_reg_decodes_once_per_file_version_and_hands_out_copies(self):
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        reg = jd.STATE / "sdk" / (self.SID + ".json")
+        try:
+            reg.write_text(json.dumps({"sid": self.SID, "cwd": "/tmp", "threadOf": "parent"}))
+            d1 = km._thread_reg(self.SID)
+            self.assertEqual(d1.get("threadOf"), "parent")
+            d1["threadOf"] = "mutated by a caller"
+            with _OpenCounter(reg) as c:
+                d2 = km._thread_reg(self.SID)
+            self.assertEqual(c.n, 0, "an unchanged reg is one stat")
+            self.assertEqual(d2.get("threadOf"), "parent", "a caller's edit never reaches the memo")
+            reg.write_text(json.dumps({"sid": self.SID, "cwd": "/tmp", "threadOf": "other"}))
+            self.assertEqual(km._thread_reg(self.SID).get("threadOf"), "other", "a rewrite is seen")
+            os.unlink(reg)
+            self.assertEqual(km._thread_reg(self.SID), {}, "a vanished reg reads as before")
+        finally:
+            km._thread_reg_memo.pop(self.SID, None)
+            try: os.unlink(reg)
+            except OSError: pass
+
+    def test_c_the_live_tail_revision_moves_on_every_mutation(self):
+        sb = SourceFileLoader("romp_sdk_backend_stage0b", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        sid = self.SID
+        r0 = be.live_rev(sid)
+        be._live.setdefault(sid, {})["u1"] = {"uuid": "u1", "t": NOW, "type": "assistant"}
+        be._touch_live(sid)
+        self.assertEqual(be.live_rev(sid), r0 + 1)
+        be.prune_live(sid, {"u1"})                        # the transcript caught up → the atom is dropped
+        self.assertEqual(be.live_rev(sid), r0 + 2, "a prune is a mutation")
+        self.assertEqual(be.live_atoms(sid), [])
+        be.prune_live(sid, {"u1"})                        # nothing left to drop → no event
+        self.assertEqual(be.live_rev(sid), r0 + 2)
+
+
+class PerCycleStoreReadersAreCached(_StateSandbox):
+    """The pusher's tick jobs and builders re-read growing logs and small stores from disk every cycle.
+    Each now answers from a stat while its file is unchanged (2026-09-03)."""
+
+    SID = "11111111-2222-3333-4444-999999999961"
+
+    def test_a_last_state_is_the_literal_last_row_read_from_the_tail(self):
+        """Upstream's tail reader (c84165d4) superseded this branch's memoized one: every caller wants the
+        newest record, and it is read backwards from the end of the file rather than by a forward walk of a
+        log that only grows. Pinned here as the contract the liveness snapshot relies on."""
+        sb = SourceFileLoader("romp_sdk_backend_stage0c", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        sd = tempfile.mkdtemp()
+        p = os.path.join(sd, "states", self.SID + ".jsonl")
+        os.makedirs(os.path.dirname(p))
+        self.assertEqual(sb.last_state(sd, self.SID), {}, "no file → {}")
+        rows = [{"t": NOW - i, "state": "working" if i % 2 else "waiting"} for i in range(3000, 0, -1)]
+        rows.append({"t": NOW, "awaiting": True, "why": "x" * 6000})     # a big last row spans the first tail block
+        with open(p, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        self.assertEqual(sb.last_state(sd, self.SID), rows[-1], "the literal last row, overlay rows included")
+        self.assertIn("_lines_from_end", inspect.getsource(sb.last_state), "read from the tail, never a forward walk")
+
+    def test_b_machine_cut_is_read_once_per_file_version(self):
+        """Pins the contract, not the mechanism: upstream's _fold_records (97c0159e) superseded this branch's
+        shared-rows reader here, and it keeps the property that mattered — an unchanged file is never reopened."""
+        p = jd.STATE / "states" / (self.SID + ".jsonl")
+        try:
+            _write_rows(p, [{"t": NOW - 50, "state": "working"}, {"t": NOW - 40, "machineCut": "restart"},
+                            {"t": NOW - 30, "state": "waiting"}])
+            self.assertEqual(km._last_machine_cut(self.SID), (float(NOW - 40), "restart"))
+            km._last_machine_cut(self.SID)
+            with _OpenCounter(p) as c:
+                km._last_machine_cut(self.SID)
+            self.assertEqual(c.n, 0)
+        finally:
+            em._JSONL_CACHE.pop(str(p), None)
+            try: os.unlink(p)
+            except OSError: pass
+
+    def test_c_nudge_times_and_postal_index_fold_the_same_rows_incrementally(self):
+        nudge = jd.STATE / "nudge-events.jsonl"
+        try:
+            _write_rows(nudge, [{"gid": "g1", "t": NOW - 10}, {"gid": "g1", "t": NOW - 5}, {"gid": "g2", "t": NOW - 1}, {"nogid": 1}])
+            self.assertEqual(km._nudge_times(), {"g1": [NOW - 10, NOW - 5], "g2": [NOW - 1]})
+            _append_rows(nudge, [{"gid": "g2", "t": NOW}])
+            with _OpenCounter(nudge) as c:
+                self.assertEqual(km._nudge_times()["g2"], [NOW - 1, NOW])
+            self.assertEqual(c.n, 1, "the grown log is opened once, for its tail")
+        finally:
+            em._JSONL_CACHE.pop(str(nudge), None); km._nudge_times_cache.clear()
+            try: os.unlink(nudge)
+            except OSError: pass
+        msgs = jd.STATE / "timeline" / "messages.jsonl"
+        try:
+            _write_rows(msgs, [{"ev": "sent", "id": "m1", "from": "a", "from_id": "A", "to_id": "B", "body": "hi", "t": NOW - 3},
+                               {"ev": "exec", "id": "m1", "t": NOW - 2}])
+            km._postal_index_memo[0] = None
+            idx = km._postal_index()
+            self.assertEqual(set(idx), {"m1"}); self.assertEqual(idx["m1"]["body"], "hi")
+            with _OpenCounter(msgs) as c:
+                km._postal_index(); km._postal_wait_maps()
+            self.assertEqual(c.n, 0)
+        finally:
+            em._JSONL_CACHE.pop(str(msgs), None); km._postal_index_memo[0] = None
+            try: os.unlink(msgs)
+            except OSError: pass
+
+    def test_d_names_snapshot_reads_an_entry_once_per_version(self):
+        km.NAMES.mkdir(parents=True, exist_ok=True)
+        ent = km.NAMES / self.SID
+        try:
+            ent.write_text("web\t/tmp\t#abcdef\n")
+            self.assertEqual(km._names_snapshot()[self.SID][0], "web")
+            with _OpenCounter(ent) as c:
+                for _ in range(5):
+                    self.assertEqual(km._names_snapshot()[self.SID][0], "web")
+            self.assertEqual(c.n, 0, "an unchanged entry is one stat")
+            tmp = km.NAMES / (self.SID + ".tmp"); tmp.write_text("api\t/tmp\t#abcdef\n"); os.replace(tmp, ent)
+            self.assertEqual(km._names_snapshot()[self.SID][0], "api", "a replaced entry is re-read")
+            os.unlink(ent)
+            self.assertNotIn(self.SID, km._names_snapshot())
+            self.assertNotIn(self.SID, km._names_entry_memo, "a removed entry drops its memo")
+        finally:
+            km._names_entry_memo.pop(self.SID, None)
+            try: os.unlink(ent)
+            except OSError: pass
+
+    def test_e_task_store_is_decoded_once_per_fingerprint_and_handed_out_as_copies(self):
+        d = tempfile.mkdtemp()
+        (open(os.path.join(d, "1.json"), "w")).write(json.dumps({"id": "1", "subject": "first", "status": "pending"}))
+        (open(os.path.join(d, "2.json"), "w")).write(json.dumps({"id": "2", "subject": "second", "status": "completed"}))
+        saved = km._task_store_resolve
+        km._task_store_resolve = lambda fsid, fold=None: __import__("pathlib").Path(d)
+        try:
+            t1 = km._read_task_store(self.SID)
+            self.assertEqual([t["id"] for t in t1], ["1", "2"])
+            t1[0]["subject"] = "mutated by a caller"
+            with _OpenCounter(os.path.join(d, "1.json")) as c:
+                t2 = km._read_task_store(self.SID)
+            self.assertEqual(c.n, 0, "an unchanged store is stats only")
+            self.assertEqual(t2[0]["subject"], "first", "callers get copies")
+            with open(os.path.join(d, "2.json"), "w") as f:
+                f.write(json.dumps({"id": "2", "subject": "second", "status": "in_progress"}))
+            self.assertEqual(km._read_task_store(self.SID)[1]["status"], "in_progress", "a rewritten file is seen")
+        finally:
+            km._task_store_resolve = saved
+            km._task_store_memo.pop(str(d), None)
+
+    def test_e2_the_task_store_fingerprint_moves_on_a_same_size_republish_in_one_tick(self):
+        d = tempfile.mkdtemp()
+        f = os.path.join(d, "1.json")
+        open(f, "w").write(json.dumps({"id": "1", "subject": "a", "status": "pending"}))
+        st = os.stat(f)
+        saved = km._task_store_known
+        km._task_store_known = lambda fsid: __import__("pathlib").Path(d)
+        try:
+            fp1 = km._task_store_fp(self.SID)
+            tmp = os.path.join(d, "1.json.tmp")
+            open(tmp, "w").write(json.dumps({"id": "1", "subject": "b", "status": "pending"}))   # same length
+            os.utime(tmp, ns=(st.st_atime_ns, st.st_mtime_ns))                              # same stamp
+            os.replace(tmp, f)
+            self.assertNotEqual(fp1, km._task_store_fp(self.SID), "the inode moved even though size and mtime did not")
+        finally:
+            km._task_store_known = saved
+
+    def test_f_the_awaiting_lift_skips_a_session_whose_inputs_did_not_move(self):
+        sid = self.SID
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        gpath = jd.GOALDIR / (sid + ".json")
+        gpath.write_text(json.dumps({"rompUuid": sid, "seq": 0, "nodes": {}, "placements": {}, "status": {}}))
+        loads = []
+        real = jd.load_goals
+        jd.load_goals = lambda fsid: (loads.append(fsid), real(fsid))[1]
+        saved_alive = km._alive_sessions
+        km._alive_sessions = lambda now, tmux: [{"sid": sid, "path": str(gpath)}]
+        tmux = {sid: {"state": "waiting", "bgTasks": []}}
+        scan = []                                          # what the transcript pairs: a running watcher
+        saved_scan = km._bg_scan_all_cached
+        km._bg_scan_all_cached = lambda path: list(scan)
+        try:
+            km._lift_seen.pop(sid, None)
+            km._lift_spent_awaiting(NOW, tmux)
+            km._lift_spent_awaiting(NOW + 1, tmux)
+            km._lift_spent_awaiting(NOW + 2, tmux)
+            self.assertEqual(loads, [sid], "one load while nothing recorded moved")
+            tmp = gpath.with_suffix(".tmp")                  # published the way save_goals publishes: tmp + replace
+            tmp.write_text(json.dumps({"rompUuid": sid, "seq": 1, "nodes": {}, "placements": {}, "status": {}, "note": "longer"}))
+            os.replace(tmp, gpath)
+            km._lift_spent_awaiting(NOW + 3, tmux)
+            self.assertEqual(len(loads), 2, "a store write is re-examined")
+            tmux[sid]["bgTasks"] = [{"toolUseId": "t1", "status": "running"}]
+            km._lift_spent_awaiting(NOW + 4, tmux)
+            self.assertEqual(len(loads), 3, "a live task appearing is re-examined")
+            tmux[sid]["subagents"] = [{"id": "a1"}]
+            km._lift_spent_awaiting(NOW + 5, tmux)
+            self.assertEqual(len(loads), 4, "a subagent appearing is re-examined")
+            scan.append({"id": "toolu_1", "status": "running", "t": NOW, "deadline": NOW + 100})
+            km._lift_spent_awaiting(NOW + 6, tmux)
+            self.assertEqual(len(loads), 5, "a new dispatch is re-examined")
+            km._lift_spent_awaiting(NOW + 150, tmux)
+            self.assertEqual(len(loads), 5, "…and not again while its deadline has not passed")
+            km._lift_spent_awaiting(NOW + 100 + 121, tmux)
+            self.assertEqual(len(loads), 6, "the recorded deadline passing (plus grace) re-examines: the clock arm is keyed")
+            km._lift_spent_awaiting(NOW + 100 + 122, tmux)
+            self.assertEqual(len(loads), 6, "…once")
+            boom = [True]
+            jd.load_goals = lambda fsid: (loads.append(fsid), (_ for _ in ()).throw(RuntimeError("torn read")) if boom[0] else real(fsid))[1]
+            scan.append({"id": "toolu_2", "status": "running", "t": NOW + 300})
+            km._lift_spent_awaiting(NOW + 300, tmux)      # the ruling raises → not a ruling
+            self.assertEqual(len(loads), 7)
+            boom[0] = False
+            km._lift_spent_awaiting(NOW + 301, tmux)      # …so the next cycle retries on the same inputs
+            self.assertEqual(len(loads), 8, "a raised ruling is retried, not skipped")
+        finally:
+            jd.load_goals = real; km._alive_sessions = saved_alive; km._bg_scan_all_cached = saved_scan; km._lift_seen.pop(sid, None)
+            try: os.unlink(gpath)
+            except OSError: pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

Long-lived sessions grow transcripts without bound, and the kernel's push
cycle grew with them: on a seventeen-session board with an 80 MB transcript
the warm cycle took about 0.7 s with no dashboard open and 1.0 to 1.2 s with a
chat pane watching the largest session, most of it rebuilding views whose
inputs had not changed and re-reading small stores whose files had not moved.

Upstream has since folded the per-push transcript and states readers and the
chat payload build (97c0159e, c84165d4, 8925efad), which covered the first
part of this work; the readers here defer to those folds. What remains is the
other half, the decision of WHEN to rebuild at all:

- The judge generation advances only when a producer pass changed a
  judge-written store (goals, captions, archive, episodes), keyed on a
  fingerprint taken before and after the pass, instead of on every pass. A
  quiet pass leaves every view's signature alone.

- The board-view signature carries every input its rulings read: the judge
  run counter, the SDK snapshot facts (subagents, background tasks,
  interrupting, model and effort pending, auth pending, retry count,
  connected, spawning), and the auto-nudge, nudge-event, judge-auth and
  judge-limit stores. The time bucket stays, documented: removing it needs
  client-side age tints and a due-time heap for the build-time caps, Stage 1
  work.

- The ACTIVE chat tab, rebuilt on every cycle by design so the watched session
  stays live, is served from its last build while an exact key is unchanged:
  the chat signature, the snapshot digest minus its clock, the backend's live
  revision (bumped at seven mutation sites), its queue, compacting and
  clearing flags, fifteen side files, the names hash, the clock predicates
  resolved to the booleans they decide, and the external inputs the build
  reads (watches, PR watches, usage, the CLAUDE.md chain, both git trees'
  HEADs, running tasks' output files, the hour mark).

- Per-cycle readers of small stores answer from a stat while their files are
  unchanged: captions fold appends, the thread registry and names snapshot
  and task store memoize per entry on (mtime, size, inode), the backend's
  ownership check memoizes on the registry's stat, and the awaiting-lift gate
  skips a session whose inputs (goals, overrides, transcript, messages, SDK
  registry stats, live background-task ids) are unchanged. Two mechanisms are
  deliberately not gated: the awaiting-wake outcomes and the nudge walk carry
  a dead-man clock in their rulings.

- The version route counts how often each view was rebuilt versus served, so
  the next measurement does not need a replay harness.

Measured on an offline replay of the real board, seventeen sessions with a
41 MB transcript watched in the chat pane, against current upstream main with
its own folds in place: the warm push cycle 0.49 to 0.87 s on main, 0.27 to
0.31 s on this branch once the active tab is served from its last build (on
the older base the same change was 1.0 to 1.2 s down to 0.30 s; upstream's
folds took the rest). The cold first cycle, about 15 s of boot parse on both,
is Stage 2's subject; the timeline's O(all atoms) rebuild is Stage 1's.

Two adversarial review passes reproduced seven defects and two residuals in
the first cut, all fixed: the lift gate omitted its ruling's clock arm and
subagents and recorded itself before ruling; the clock-predicate expiry arm
was dead; the judge generation missed between-pass store writes; the active
key missed six side files and the CLAUDE.md chain; stat keys lacked the inode;
the task-store reader returned None on a mid-scan unlink; the tests' open
counter missed pathlib reads.

A third review, of the squash onto current main, found that the served active
tab keyed only the SDK backend's live tail: a tmux session's composer echo and
a Codex session's queue live in their own stores, which the build renders but
no file records, so the watched tmux tab served its last build with the send
missing until some file moved. The key now takes the OWNING backend's tail,
digested from exactly what the build reads. It also found that background
tabs had lost their implicit three-second refresh: the judge generation no
longer advances every pass, and nothing else keyed the snapshot facts a
background tab's chips render, so the background key now folds the same
per-session snapshot digest the board key uses. Smaller: the spend hold file
and the env file whose key line decides the Billing selector join the active
key, every writer of the spend hold marks the views dirty, the pre-pass judge
fingerprint is computed only on the first pass where it is consulted, and the
active key reuses the pusher's already-computed base instead of a second stat
pass.

Tests: tests/test_stage0_log_readers.py, with a private state sandbox per
class so the shared kernel singletons cannot leak between modules; the
redelivery stub models the live-revision hook.



Branch: one commit on current main, rebased today; three adversarial review rounds folded; full Python suite 7369 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
