### PR TITLE
Open any subagent's whole transcript from the dashboard, live while it runs

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -42,11 +42,12 @@ MESSAGES_LOG = STATE / "timeline" / "messages.jsonl"
 # Mid-turn the model stops with `tool_use` (a tool cycle) — that does NOT end the turn.
 END_STOPS = ("end_turn", "stop_sequence")
 # The toolUseResult keys a consumer actually reads (Edit's structuredPatch → diffRows,
-# AskUserQuestion's answers map → the answered box). The atom carry is GATED on one of these
-# being present: an unconditional dict carry held every Read result's full file bytes in the
-# parse cache by reference — ~a fifth of transcript bytes on read-heavy sessions — for shapes
-# nothing reads. Widen this set when a new consumer appears; never revert to carry-all.
-TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch"))
+# AskUserQuestion's answers map → the answered box, the Agent tool's agentId / isAsync → the
+# subagent join + the background-launch flag, plans/subagent-transcripts.md). The atom carry is
+# GATED on one of these being present: an unconditional dict carry held every Read result's full
+# file bytes in the parse cache by reference — ~a fifth of transcript bytes on read-heavy sessions —
+# for shapes nothing reads. Widen this set when a new consumer appears; never revert to carry-all.
+TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch", "agentId", "isAsync"))
 # romp's own postal marker, injected into a delivered message body. It is the ONLY
 # postal signal — never the generic "Stop hook feedback:" prefix (any blocking Stop
 # hook produces that). The sender rompUuid is resolved from timeline/messages.jsonl
@@ -210,8 +211,17 @@ def _parse_task_notification(txt):
     # has_status: whether <status> was PRESENT, distinct from the "completed" default. A Monitor's
     # per-EVENT notification carries no status tag (only its terminal one does) — without this bit the
     # default would let a wrapped event read as "completed" and end a watch that is still live.
+    # result: an AGENT's closing message (the <result> body) — the report the parent's Agent tool head
+    # shows once a background agent has come to rest (plans/subagent-transcripts.md); a command's
+    # notification carries none. Capped like the chat's own tool output.
     return {"status": (st or "completed").lower(), "has_status": bool(st), "summary": fld("summary"),
-            "output_file": fld("output-file"), "tool_use_id": fld("tool-use-id")}
+            "output_file": fld("output-file"), "tool_use_id": fld("tool-use-id"),
+            "result": fld("result")[:_RESULT_CAP]}
+
+
+# A background agent's <result> text kept on its scan row (the want_all view) — the same 16000-char cap
+# build_session puts on every tool's output, so the report fold and the scan row can never disagree.
+_RESULT_CAP = 16000
 
 
 # A non-persistent Monitor records its own lifetime ceiling at launch (timeout_ms — the harness kills
@@ -306,6 +316,8 @@ def _bg_step(state, o):
                 return                     # a monitor EVENT (no <status> tag) — the watch is still live
             tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                               summary=note["summary"] or tasks[tid]["summary"])
+            if note.get("result"):         # an agent's closing message → the Agent head's report fold
+                tasks[tid]["result"] = note["result"]
             if end_t:                      # WHEN the result landed — the awaiting-stamp lift keys the
                 tasks[tid]["endT"] = end_t  # "returned after the stamp was written" test on it (2026-08-16)
             _bg_forget_terminal(state, tid)
@@ -391,6 +403,8 @@ def _bg_step(state, o):
                                   "outputFile": tur.get("outputFile") or ""}
                     if tur.get("taskType") or d.get("type"):
                         tasks[tid]["type"] = tur.get("taskType") or d["type"]
+                    if tur.get("agentId"):   # the ack names the agent whose own transcript this launch writes
+                        tasks[tid]["agentId"] = str(tur["agentId"])   # (plans/subagent-transcripts.md)
                     order.append(tid)
                     continue
                 if async_launch and tid in tasks and not b.get("is_error") \
@@ -402,6 +416,8 @@ def _bg_step(state, o):
                     tk["outputFile"] = tk["outputFile"] or tur.get("outputFile") or ""
                     if tur.get("taskType"):
                         tk["type"] = tur["taskType"]
+                    if tur.get("agentId") and not tk.get("agentId"):
+                        tk["agentId"] = str(tur["agentId"])
                     if not tk["command"]:
                         tk["command"] = _clip_detail(tur.get("prompt") or "")
                     continue
@@ -411,6 +427,8 @@ def _bg_step(state, o):
                         continue               # a wrapped monitor EVENT — not a terminal (see _mark)
                     tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                                       summary=note["summary"] or tasks[tid]["summary"])
+                    if note.get("result"):
+                        tasks[tid]["result"] = note["result"]
                     et = parse_z(o.get("timestamp"))
                     if et:                     # the return's moment (see _mark)
                         tasks[tid]["endT"] = et

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17738,10 +17738,358 @@ def _bg_tasks(path, spawned_at=None, live=None):
     elif spawned_at:
         scan = [tk for tk in scan if not (tk.get("t") and tk["t"] < spawned_at)]
     out = []
+    meta = None                                   # the subagents sidecar map, read once and only if an agent row needs it
     for tk in scan[:30]:    # show up to 30 lines (the flat list scrolls); count below reports the true total
-        out.append({"id": tk["id"], "status": tk["status"], "summary": tk["summary"], "command": tk["command"],
-                    "output": _read_task_output(tk["outputFile"])})
+        row = {"id": tk["id"], "status": tk["status"], "summary": tk["summary"], "command": tk["command"],
+               "output": _read_task_output(tk["outputFile"])}
+        # an AGENT row names the agent whose own transcript it writes, so the box can offer the same
+        # open-transcript arrow the Agent tool head has (plans/subagent-transcripts.md). Three sources,
+        # any one suffices: the launch ack's agentId, the sidecar map, the output symlink's basename.
+        # Shell tasks (`b…` ids, plain-text output) get no agentId and keep their treatment.
+        if tk.get("type") in ("local_agent", None) or tk.get("agentId"):
+            aid = tk.get("agentId")
+            if not aid:
+                meta = _subagent_meta_map(path) if meta is None else meta
+                aid = (meta.get(tk["id"]) or {}).get("agentId") or _agent_id_of_output(tk.get("outputFile"))
+            if aid and _AGENT_ID_RE.match(str(aid)):
+                row["agentId"] = str(aid)
+        out.append(row)
     return {"count": len(scan), "tasks": out}
+
+
+# ───────────────────────── subagent transcripts (plans/subagent-transcripts.md, 2026-09-05) ─────────────────────────
+# Claude Code writes every subagent (the Agent tool; older transcripts say Task) its OWN complete JSONL
+# beside the parent transcript — <proj>/<fsid>/subagents/agent-<agentId>.jsonl — plus a sidecar
+# agent-<agentId>.meta.json whose toolUseId is the parent's tool_use block id. The dashboard reads THAT
+# file (the authoritative copy; the background task's /tmp output file is a symlink to it) rather than
+# un-dropping the SDK's sidechain stream, which the backend deliberately filters out of the parent's
+# conversation (tests/test_sidechain_atoms.py). Everything below is event-based: directory mtimes, file
+# (mtime, size) keys, the transcript's own launch↔notification pairing, and the SDK's live sets.
+_AGENT_ID_RE = re.compile(r"^a[0-9a-f]{16}$")
+_SUBAGENT_META_CACHE = {}       # subagents dir -> (dir mtime_ns, {toolUseId: {agentId, agentType, description, spawnDepth}})
+_AGENT_GIST_CACHE = {}          # agent jsonl path -> em.fold_records entry (the live preview's fold state)
+_AGENT_LAUNCH_CACHE = {}        # parent jsonl path -> em.fold_records entry (foreground launches + their settles)
+_SUBAGENT_FRAMES = {}           # (sid, agentId) -> (change key, frame, serialized) — shared by every client with it open
+SUBAGENT_EVENT_CAP = 300        # events shipped per viewer frame — a bounded TAIL, honest about the cut (the episode fold's rule)
+SUBAGENT_RECENT = 3             # tool calls the live preview shows under the Agent head
+
+
+def _subagents_dir(path):
+    """The subagents directory for a transcript file: <dir>/<file stem>/subagents."""
+    return Path(str(path)).with_suffix("") / "subagents"
+
+
+def _subagent_meta_map(path):
+    """toolUseId → {agentId, agentType, description, spawnDepth} for every agent-*.meta.json beside the
+    transcript at `path`, cached on the DIRECTORY's mtime (a sidecar landing changes it — a stat, never a
+    timer). {} when the directory does not exist (older CLIs wrote no subagent files)."""
+    d = _subagents_dir(path)
+    try:
+        key = os.stat(d).st_mtime_ns
+    except OSError:
+        _SUBAGENT_META_CACHE.pop(str(d), None)
+        return {}
+    hit = _SUBAGENT_META_CACHE.get(str(d))
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    out = {}
+    try:
+        names = sorted(os.listdir(d))
+    except OSError:
+        names = []
+    for nm in names:
+        if not (nm.startswith("agent-") and nm.endswith(".meta.json")):
+            continue
+        aid = nm[len("agent-"):-len(".meta.json")]
+        if not _AGENT_ID_RE.match(aid):
+            continue
+        try:
+            meta = json.loads((d / nm).read_text())
+        except (OSError, ValueError):
+            continue
+        if not isinstance(meta, dict) or not meta.get("toolUseId"):
+            continue
+        out[str(meta["toolUseId"])] = {"agentId": aid, "agentType": meta.get("agentType") or "",
+                                       "description": meta.get("description") or "",
+                                       "spawnDepth": meta.get("spawnDepth")}
+    if len(_SUBAGENT_META_CACHE) > 256:
+        _SUBAGENT_META_CACHE.clear()
+    _SUBAGENT_META_CACHE[str(d)] = (key, out)
+    return out
+
+
+def _subagent_meta(path, agent_id):
+    """One agent's sidecar (agentType, description, spawnDepth, toolUseId) read directly; {} when absent."""
+    mp = _subagents_dir(path) / ("agent-%s.meta.json" % agent_id)
+    try:
+        meta = json.loads(mp.read_text())
+    except (OSError, ValueError):
+        return {}
+    return meta if isinstance(meta, dict) else {}
+
+
+def _subagent_file(path, agent_id):
+    """The agent's own transcript beside the parent transcript `path`, or — when the sidecar dir has moved
+    under a /clear fork's fsid — the one file of that name anywhere in the project dir. None when missing."""
+    if not path or not _AGENT_ID_RE.match(str(agent_id or "")):
+        return None
+    ap = _subagents_dir(path) / ("agent-%s.jsonl" % agent_id)
+    if ap.exists():
+        return ap
+    try:
+        for cand in Path(str(path)).parent.glob("*/subagents/agent-%s.jsonl" % agent_id):
+            return cand
+    except OSError:
+        pass
+    return None
+
+
+def _agent_id_of_output(output_file):
+    """The agent id a background task's output path names (…/tasks/<agentId>.output), else None."""
+    stem = os.path.splitext(os.path.basename(str(output_file or "")))[0]
+    return stem if _AGENT_ID_RE.match(stem) else None
+
+
+def _tool_gist_desc(name, inp):
+    """A tool call's one-line gist in the chat head's own vocabulary: input.description, else the file
+    path, else the command's first line, then a search's pattern/query before its scope path (the
+    pattern says what was looked for; the path only where), then url/skill/prompt — clipped."""
+    if not isinstance(inp, dict):
+        return ""
+    for k in ("description", "file_path", "command", "pattern", "query", "path", "url", "skill", "prompt"):
+        v = inp.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip().splitlines()[0][:80]
+    return ""
+
+
+def _gist_fresh():
+    return {"recent": [], "calls": 0, "since": None, "last": None}
+
+
+def _gist_step(state, o):
+    ts = o.get("timestamp") if isinstance(o.get("timestamp"), str) else None
+    if ts:
+        state["since"] = state["since"] or ts
+        state["last"] = ts
+    if o.get("type") == "assistant":
+        c = (o.get("message") or {}).get("content")
+        if isinstance(c, list):
+            for b in c:
+                if isinstance(b, dict) and b.get("type") == "tool_use":
+                    state["calls"] += 1
+                    state["recent"] = (state["recent"] + [{"tool": b.get("name") or "tool",
+                                                           "desc": _tool_gist_desc(b.get("name"), b.get("input")),
+                                                           "ts": ts}])[-SUBAGENT_RECENT:]
+    return state
+
+
+def _agent_gist(agent_path):
+    """The live preview under a running Agent head: its last SUBAGENT_RECENT tool calls (newest last),
+    the tool-call count so far, and the first/last record stamps — folded append-incrementally over the
+    agent's own file (em.fold_records: a growing file steps only its new records). None when unreadable."""
+    try:
+        st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step)
+    except Exception:
+        return None
+    if not st["since"]:
+        return None
+    return {"recent": [dict(r) for r in st["recent"]], "calls": st["calls"], "since": st["since"], "last": st["last"]}
+
+
+def _launch_fresh():
+    return {"launched": {}, "settled": set()}
+
+
+def _launch_step(state, o):
+    """FOREGROUND agent launches (a tool_use named Agent/Task) and the tool_results that settle them — an
+    async ack is a launch acknowledgement, not a settle, and leaves the id open for the bg scan's pairing."""
+    t = o.get("type")
+    c = (o.get("message") or {}).get("content")
+    if t == "assistant" and isinstance(c, list):
+        for b in c:
+            if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") in ("Agent", "Task") and b.get("id"):
+                state["launched"].setdefault(b["id"], em.parse_z(o.get("timestamp")))
+    elif t == "user" and isinstance(c, list):
+        tur = o.get("toolUseResult")
+        tur = tur if isinstance(tur, dict) else {}
+        if tur.get("isAsync") or tur.get("status") == "async_launched":
+            return state
+        for b in c:
+            if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id") in state["launched"]:
+                state["settled"].add(b["tool_use_id"])
+    return state
+
+
+def _agent_launch_state(path):
+    return em.fold_records(_AGENT_LAUNCH_CACHE, str(path), _launch_fresh, _launch_step)
+
+
+def _agent_alive(row, agent_id, tm, spawned_at):
+    """Is a launched agent still running? `row` is its bg-scan row ({id, status, t, …}; a foreground launch
+    passes a synthetic running row) — the transcript's own pairing says whether a result has landed. The
+    live gate then says whether the CLI that would deliver one is still around: an SDK session's snapshot
+    carries the SubagentStart/Stop set (agent ids) and the task-lifecycle set (tool-use ids) — the agent is
+    alive iff either names it; a tmux or dormant session falls to the spawned-at ghost gate _bg_tasks
+    applies (a launch older than the current CLI epoch died with the previous CLI). Never a clock."""
+    if not row or row.get("status") != "running":
+        return False
+    if tm is not None and ("subagents" in tm or "bgTasks" in tm):
+        live_agents = {str(x.get("agentId")) for x in (tm.get("subagents") or []) if x.get("agentId")}
+        live_tools = {str(x.get("toolUseId")) for x in (tm.get("bgTasks") or []) if x.get("toolUseId")}
+        return (str(agent_id) in live_agents) or (str(row.get("id")) in live_tools)
+    return not (spawned_at and row.get("t") and row["t"] < spawned_at)
+
+
+def _agent_running_for(parent_path, tool_use_id, agent_id, tm, spawned_at):
+    """The viewer's `running` flag for one agent, from the parent transcript: a background launch is read
+    off the bg scan's pairing (its notification ends it), a foreground one off its own tool_result."""
+    if not tool_use_id:
+        return False
+    rows = {r["id"]: r for r in _bg_scan_all_cached(parent_path)}
+    row = rows.get(tool_use_id)
+    if row is not None:
+        return _agent_alive(row, agent_id, tm, spawned_at)
+    st = _agent_launch_state(parent_path)
+    if tool_use_id not in st["launched"] or tool_use_id in st["settled"]:
+        return False
+    return _agent_alive({"id": tool_use_id, "status": "running", "t": st["launched"][tool_use_id]}, agent_id, tm, spawned_at)
+
+
+def _stamp_agents(by_tool, scan_path, tm, spawned_at, meta_path=None):
+    """Post-pass over one build's Agent/Task tool events (plans/subagent-transcripts.md): every one gets
+    toolUseId + agentId (from the ack's toolUseResult or the sidecar map); a BACKGROUND launch that is
+    still running drops its launch-ack output (the ack is not a report — the client's existing no-output
+    rule then reads it as running), takes agentRunning and the live agentGist preview; one whose
+    <task-notification> has landed takes the notification's <result> as its output, so the head's report
+    fold shows the closing summary instead of the ack. A foreground agent's tool_result was always the
+    report and is left alone. Returns {toolUseId: "sync"|"running"|"report"|"pending"} for the fold's
+    sealed-agent gate (pending = launched, no result, and not alive — the ack stays as the honest output)."""
+    meta = None
+    rows = None
+    out = {}
+    for tid, ev in by_tool.items():
+        if ev.get("name") not in ("Agent", "Task"):
+            continue
+        if meta is None:
+            meta = _subagent_meta_map(meta_path or scan_path)
+        aid = ev.get("agentId") or (meta.get(tid) or {}).get("agentId")
+        ev["agentId"] = str(aid) if aid else None
+        if not ev.get("agentAsync"):
+            out[tid] = "sync"
+            continue
+        if rows is None:
+            rows = {r["id"]: r for r in _bg_scan_all_cached(scan_path)}
+        row = rows.get(tid)
+        if row is not None and row.get("status") != "running":
+            if row.get("result"):
+                ev["output"] = row["result"]
+                ev["isError"] = row["status"] not in ("completed", "done", "success")
+            out[tid] = "report"
+        elif _agent_alive(row, aid, tm, spawned_at):
+            ev["output"] = ""
+            ev["agentRunning"] = True
+            ap = _subagent_file(meta_path or scan_path, aid) if aid else None
+            g = _agent_gist(ap) if ap is not None else None
+            if g:
+                ev["agentGist"] = g
+            out[tid] = "running"
+        else:
+            out[tid] = "pending"
+    return out
+
+
+def _chat_agent_open_at(events, lo):
+    """Index of the first RUNNING Agent card at/after `lo` — a launch turn the chat fold must not seal
+    while the agent runs (its preview and eventual report are rebuilt live in the tail). None when every
+    agent in range has settled. The undecided-seam rule's twin (see _chat_seam_open_at)."""
+    for i in range(lo, len(events)):
+        if events[i].get("kind") == "tool" and events[i].get("agentRunning"):
+            return i
+    return None
+
+
+def _chat_agents_moved(agents, path, tm, spawned_at):
+    """The fold's sealed-agent gate: True when a sealed Agent card would render differently now — a
+    launch sealed with no agent id has gained its sidecar, or a background launch sealed WITHOUT its
+    report (pending) has come to rest or is alive again. `agents` = [(toolUseId, agentId, pending)]."""
+    meta = None
+    rows = None
+    for tid, aid, pending in agents:
+        if aid is None:
+            meta = _subagent_meta_map(path) if meta is None else meta
+            if tid in meta:
+                return True
+        if pending:
+            rows = {r["id"]: r for r in _bg_scan_all_cached(path)} if rows is None else rows
+            row = rows.get(tid)
+            if row is not None and (row.get("status") != "running" or _agent_alive(row, aid, tm, spawned_at)):
+                return True
+    return False
+
+
+def build_subagent(sid, agent_id, now, tmux=None):
+    """The {type:"subagent"} viewer frame for one agent of session `sid`: its sidecar meta, whether it is
+    still running, and its transcript rendered through build_session's override mode — the SAME renderer
+    the chat uses, in sidechain mode (no parent side-store notes) — as a capped tail. FAIL LOUDLY (the
+    repo rule): a missing file is an `error` sentence the pane shows, never a blank."""
+    base = {"type": "subagent", "id": sid, "agentId": agent_id}
+    if not _AGENT_ID_RE.match(str(agent_id or "")):
+        return {**base, "error": "That is not a subagent id, so there is no transcript to open."}
+    tmux = _tmux_sessions() if tmux is None else tmux
+    ppath = _path_of(sid, now)
+    if not ppath:
+        return {**base, "error": "This session's transcript can't be found, so its agents can't be opened."}
+    apath = _subagent_file(ppath, agent_id)
+    if apath is None:
+        return {**base, "error": "The transcript file for agent %s is missing beside this session's transcript "
+                                 "(subagents/agent-%s.jsonl), so it can't be shown." % (agent_id, agent_id)}
+    meta = _subagent_meta(ppath, agent_id)
+    full = build_session(sid, now, tmux, path_override=str(apath), sidechain=True, meta_path=ppath)
+    if not full:
+        return {**base, "error": "This session isn't known to romp any more, so its agent can't be shown."}
+    evs = full.get("events") or []
+    return {**base,
+            "meta": {"agentType": meta.get("agentType") or "", "description": meta.get("description") or "",
+                     "spawnDepth": meta.get("spawnDepth"), "toolUseId": meta.get("toolUseId") or ""},
+            "running": _agent_running_for(ppath, meta.get("toolUseId"), agent_id, tmux.get(str(sid)), _sdk_spawned_at(sid)),
+            "events": evs[-SUBAGENT_EVENT_CAP:], "truncated": len(evs) > SUBAGENT_EVENT_CAP}
+
+
+def _subagent_frame_cached(sid, agent_id, now, tmux=None):
+    """(frame, serialized) for an OPEN viewer, rebuilt only when its change key moved: the agent file's
+    (mtime, size), the running flag, and whether the sidecar exists. Shared across clients; the per-client
+    dedup slot ("subagent", sid, agentId) absorbs an unchanged re-send."""
+    tmux = _tmux_sessions() if tmux is None else tmux
+    ppath = _path_of(sid, now)
+    apath = _subagent_file(ppath, agent_id) if ppath else None
+    meta = _subagent_meta(ppath, agent_id) if ppath else {}
+    running = (_agent_running_for(ppath, meta.get("toolUseId"), agent_id, tmux.get(str(sid)), _sdk_spawned_at(sid))
+               if ppath else False)
+    key = (ppath, _chat_stat_key(str(apath)) if apath is not None else None, running, bool(meta))
+    hit = _SUBAGENT_FRAMES.get((sid, agent_id))
+    if hit is not None and hit[0] == key:
+        return hit[1], hit[2]
+    fr = build_subagent(sid, agent_id, now, tmux)
+    pre = json.dumps(fr)
+    if len(_SUBAGENT_FRAMES) > 64:
+        _SUBAGENT_FRAMES.clear()
+    _SUBAGENT_FRAMES[(sid, agent_id)] = (key, fr, pre)
+    return fr, pre
+
+
+def _push_subagents(clients, now, tmux):
+    """Re-push every OPEN subagent viewer on these chat clients (client["subagents"], set by openSubagent,
+    cleared by closeSubagent or the socket going away). Rides the pusher's existing per-cycle chat pass —
+    no polling loop of its own — and costs a stat per open viewer when nothing changed."""
+    for c in clients:
+        for (ssid, aid) in list((c.get("subagents") or {}).keys()):
+            try:
+                fr, pre = _subagent_frame_cached(ssid, aid, now, tmux)
+            except Exception:
+                sys.stderr.write("subagent frame failed for %s/%s: %s\n" % (ssid, aid, traceback.format_exc()))
+                continue
+            _send_client(c, ("subagent", ssid, aid), fr, pre=pre)
 
 
 # The MONTHLY SPEND CAP error (the user 2026-07-14): a billing limit ("You've hit your monthly spend
@@ -21440,9 +21788,14 @@ def _stamp_interrupt_causes(events):
     return events
 
 
-def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
+def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, sidechain=False, meta_path=None):
     """A {type:"session"} message the render.js bundle consumes: the event tree reshaped to
     ChatEvent[], plus the TOC ledger (archiver headline + turn captions) and a status chip.
+
+    sidechain (build_subagent, plans/subagent-transcripts.md): the override file is a SUBAGENT's own
+    transcript — render it through the same pipeline, but keep the parent's side-store notes (retry
+    recoveries, orphan replies, effort/gesture chips — all sid-keyed) out of a conversation they never
+    belonged to. meta_path names the PARENT transcript whose subagents/ sidecars join nested Agent calls.
 
     path_override (build_episode, the user 2026-07-27): parse THAT transcript instead of the session's
     current one — the single sid→path resolution point the episode plan reserved (plans/clear-episodes.md).
@@ -21557,6 +21910,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # retry that re-replied must not double. Match exact, and either-way prefix (a partial stream vs its full
     # retry). NB: build the disk-text set from the SAME session["turns"] atoms this loop renders.
     orphans = _past_floor(_orphan_replies(sid)); _oi = 0
+    if sidechain:
+        # a subagent's transcript carries none of the parent's side-store notes (see the docstring)
+        recoveries, gaveups, efforts, gestures, orphans = [], [], [], [], []
     _disk_texts = set()
     _turn_texts = {}                          # turn index → that turn's disk texts (built on demand, see the fold)
     def _texts_of_turn(_i):
@@ -21615,6 +21971,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 _fold_why = "gesture"                 # a gesture chip the live tail pruned now renders durably
             elif _fe["orphan_uuids"] & _landed_uuids:
                 _fold_why = "landed"                  # an interleaved orphan reply landed on some branch after all
+            elif _fe.get("agents") and _chat_agents_moved(_fe["agents"], sess["path"], tm0, _sdk_spawned_at(sid)):
+                _fold_why = "agent"                   # a sealed Agent card's report landed / sidecar appeared / liveness flipped
             else:
                 _k = _fe["n"]
                 _tail_tr = set()
@@ -21770,6 +22128,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             ev["output"] = (c if isinstance(c, str) else json.dumps(c))[:16000]
                             ev["isError"] = bool(tr.get("is_error"))
                             ev["resultUuid"] = a.get("uuid")
+                            if tur and ev.get("name") in ("Agent", "Task"):
+                                # the ack names the agent whose own transcript this launch writes, and
+                                # says whether it was a BACKGROUND launch (the ack is then not the
+                                # report — _stamp_agents fills the real one when the notification lands)
+                                if tur.get("agentId"):
+                                    ev["agentId"] = str(tur["agentId"])
+                                if tur.get("isAsync") or tur.get("status") == "async_launched":
+                                    ev["agentAsync"] = True
                             # Edit/MultiEdit: Claude Code records a structuredPatch (toolUseResult) carrying REAL
                             # file line numbers + context — turn it into numbered diff rows so the chat shows a
                             # true line-number gutter (the user 2026-06-29). filePath-matched so the right result
@@ -21955,6 +22321,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                               "desc": str(inp.get("description") or "")[:200],
                               "input": json.dumps(inp) if _full else json.dumps(inp)[:4000], "output": "", "isError": False,
                               "uuid": a.get("uuid"), "ts": ts,
+                              "toolUseId": b.get("id"),   # the tool_use BLOCK id (uuid is the record's) — the join
+                              #   key a subagent's sidecar / a task-notification names (plans/subagent-transcripts.md)
                               "file": inp.get("file_path") or inp.get("path") or "",
                               "diff": _edit_diff(inp) if b.get("name") in ("Edit", "MultiEdit", "Write") else ""}
                         if b.get("name") == "AskUserQuestion":
@@ -21991,6 +22359,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 events.append({"kind": "modelFallback", "uuid": a.get("uuid"), "ts": ts,
                                "from": a.get("fallback_from") or "", "to": a.get("fallback_to") or "",
                                "md": a.get("content") or ""})
+    # Agent/Task cards: the agent join, the running preview, the landed report (plans/subagent-transcripts.md).
+    # Tail events only in fold mode — the sealed prefix's cards are gated by _chat_agents_moved and held
+    # open by _chat_agent_open_at below.
+    _agent_states = _stamp_agents(by_tool, sess["path"], tm0, _sdk_spawned_at(sid), meta_path=meta_path)
     _flush_recoveries(tail_cap_t)                       # a recovery on the still-open tail turn (t past the last atom) → bottom of the flow
     #                                                     (tail_cap_t: an episode render stops at its /clear — later notes belong to the next episode)
     # The post-passes run over the TAIL only (issue 903): the prefix was hydrated, stamped and tlId'd
@@ -22034,6 +22406,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 _b = next((_i for _i in range(_pref_len, len(events)) if _turn_of(events[_i]) >= _np),
                           len(events))
                 _open = _chat_seam_open_at(events[:_b], _pref_len)   # an undecided seam holds the boundary
+                if _open is None:
+                    _open = _chat_agent_open_at(events[:_b], _pref_len)   # …and so does a RUNNING agent's launch turn
                 if _open is None:
                     break
                 _np = _turn_of(events[_open])   # may equal _fk: the next pass then finds _b == _pref_len and no
@@ -22099,7 +22473,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                     "open_tools": _open_tools, "skill_unfilled": _skill_unf,
                     "postal_raw": _praw, "postal_cards": _pcards,
                     "postal_key": _pk, "judge_gen": _judge_gen[0], "pl_pending": _plp,
-                    "task_outs": _touts})
+                    "task_outs": _touts,
+                    # the sealed Agent cards, for _chat_agents_moved: (toolUseId, agentId, pending) —
+                    # pending = a background launch sealed without its report (the ack stands as output)
+                    "agents": (list(_fe["agents"]) if _fold_ok and _fe.get("agents") else [])
+                              + [(_e.get("toolUseId"), _e.get("agentId"),
+                                  _agent_states.get(_e.get("toolUseId")) == "pending")
+                                 for _e in _newpart if _e.get("kind") == "tool" and _e.get("name") in ("Agent", "Task")]})
             _chat_fold_last.info["prefix_next"] = _b
         except Exception:
             with _chat_fold_lock:
@@ -29102,6 +29482,9 @@ def _push(targets, connect=False, tmux=None):
                 if fr:
                     for c in chat_clients:
                         _send_client(c, ("comments", s["sid"]), fr)
+            # OPEN SUBAGENT VIEWERS (plans/subagent-transcripts.md): each rides its own per-client dedup slot
+            # like the comment frames, rebuilt only when the agent's file or liveness moved.
+            _push_subagents(chat_clients, now, tmux)
         fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
         feed_src = _cached_feed(now, tmux, fsig, connect) if want_feed else None
         feed = feed_src
@@ -35580,6 +35963,26 @@ class Handler(BaseHTTPRequestHandler):
                 client["send"](json.dumps(build_episode(str(msg["id"]), int(time.time()))))
             except Exception:
                 sys.stderr.write("loadEpisode: %s\n" % traceback.format_exc())
+            return
+        if msg and msg.get("type") in ("openSubagent", "closeSubagent") and msg.get("id") and msg.get("agentId"):
+            # A subagent viewer opened/closed (plans/subagent-transcripts.md): openSubagent answers NOW with
+            # the frame and registers the viewer on this client, so the pusher's chat pass re-sends it while
+            # the agent's file changes (_push_subagents); closeSubagent unregisters it. The dedup slot is
+            # dropped on both, so a reopen of an UNCHANGED agent is never swallowed as a duplicate.
+            sid, aid = str(msg["id"]), str(msg["agentId"])
+            with _client_lock(client):
+                client.setdefault("sent", {}).pop(("subagent", sid, aid), None)
+            if msg["type"] == "closeSubagent":
+                (client.get("subagents") or {}).pop((sid, aid), None)
+                return
+            client.setdefault("subagents", {})[(sid, aid)] = True
+            try:
+                fr, pre = _subagent_frame_cached(sid, aid, int(time.time()))
+                _send_client(client, ("subagent", sid, aid), fr, pre=pre)
+            except Exception:
+                sys.stderr.write("openSubagent %s/%s: %s\n" % (sid, aid, traceback.format_exc()))
+                client["send"](json.dumps({"type": "subagent", "id": sid, "agentId": aid,
+                                           "error": "romp couldn't build this agent's transcript — the kernel log has the traceback."}))
             return
         if msg and msg.get("type") == "setGlobalRetryPaused":
             _set_retry_paused(msg.get("value"))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17767,11 +17767,11 @@ def _bg_tasks(path, spawned_at=None, live=None):
 # (mtime, size) keys, the transcript's own launch↔notification pairing, and the SDK's live sets.
 _AGENT_ID_RE = re.compile(r"^a[0-9a-f]{16}$")
 _SUBAGENT_META_CACHE = {}       # subagents dir -> (dir mtime_ns, {toolUseId: {agentId, agentType, description, spawnDepth}})
-_AGENT_GIST_CACHE = {}          # agent jsonl path -> em.fold_records entry (the live preview's fold state)
+_AGENT_GIST_CACHE = {}          # agent jsonl path -> em.fold_records entry (the Agent head's steps fold state)
 _AGENT_LAUNCH_CACHE = {}        # parent jsonl path -> em.fold_records entry (foreground launches + their settles)
 _SUBAGENT_FRAMES = {}           # (sid, agentId) -> (change key, frame, serialized) — shared by every client with it open
 SUBAGENT_EVENT_CAP = 300        # events shipped per viewer frame — a bounded TAIL, honest about the cut (the episode fold's rule)
-SUBAGENT_RECENT = 3             # tool calls the live preview shows under the Agent head
+SUBAGENT_STEPS_CAP = 200        # tool calls shipped on the Agent head (agentSteps) — the newest; stepsTotal says the true count
 
 
 def _subagents_dir(path):
@@ -17864,7 +17864,7 @@ def _tool_gist_desc(name, inp):
 
 
 def _gist_fresh():
-    return {"recent": [], "calls": 0, "since": None, "last": None}
+    return {"steps": [], "calls": 0, "since": None, "last": None}
 
 
 def _gist_step(state, o):
@@ -17878,23 +17878,35 @@ def _gist_step(state, o):
             for b in c:
                 if isinstance(b, dict) and b.get("type") == "tool_use":
                     state["calls"] += 1
-                    state["recent"] = (state["recent"] + [{"tool": b.get("name") or "tool",
-                                                           "desc": _tool_gist_desc(b.get("name"), b.get("input")),
-                                                           "ts": ts}])[-SUBAGENT_RECENT:]
+                    state["steps"] = (state["steps"] + [{"tool": b.get("name") or "tool",
+                                                         "desc": _tool_gist_desc(b.get("name"), b.get("input")),
+                                                         "ts": ts}])[-SUBAGENT_STEPS_CAP:]
     return state
 
 
-def _agent_gist(agent_path):
-    """The live preview under a running Agent head: its last SUBAGENT_RECENT tool calls (newest last),
-    the tool-call count so far, and the first/last record stamps — folded append-incrementally over the
-    agent's own file (em.fold_records: a growing file steps only its new records). None when unreadable."""
+def _agent_steps(agent_path):
+    """The Agent head's view of the agent's own file: every tool call so far in order (`steps`, the newest
+    SUBAGENT_STEPS_CAP of them), the true count (`calls`), and the first/last record stamps — folded
+    append-incrementally over the file (em.fold_records: a growing file steps only its new records; a
+    finished file costs one read, then a stat per build). None when unreadable or empty. Shipped on the
+    event as agentSteps + stepsTotal whether the agent runs or has finished (the fold shows the list
+    either way); the running preview's clock (agentGist: calls/since/last) rides only while it runs."""
     try:
         st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step)
     except Exception:
         return None
     if not st["since"]:
         return None
-    return {"recent": [dict(r) for r in st["recent"]], "calls": st["calls"], "since": st["since"], "last": st["last"]}
+    return st
+
+
+def _stamp_steps(ev, st):
+    ev["agentSteps"] = [dict(r) for r in st["steps"]]
+    ev["stepsTotal"] = st["calls"]
+
+
+def _gist_of(st):
+    return {"calls": st["calls"], "since": st["since"], "last": st["last"]}
 
 
 def _launch_fresh():
@@ -17960,10 +17972,11 @@ def _stamp_agents(by_tool, scan_path, tm, spawned_at, meta_path=None):
     """Post-pass over one build's Agent/Task tool events (plans/subagent-transcripts.md): every one gets
     toolUseId + agentId (from the ack's toolUseResult or the sidecar map); a BACKGROUND launch that is
     still running drops its launch-ack output (the ack is not a report — the client's existing no-output
-    rule then reads it as running), takes agentRunning and the live agentGist preview; one whose
+    rule then reads it as running), takes agentRunning and the live agentGist clock; one whose
     <task-notification> has landed takes the notification's <result> as its output, so the head's report
     fold shows the closing summary instead of the ack. A foreground agent's tool_result was always the
-    report and is left alone. Returns {toolUseId: "sync"|"running"|"report"|"pending"} for the fold's
+    report and is left alone. Every one with a readable agent file carries agentSteps (its tool calls,
+    the newest SUBAGENT_STEPS_CAP) + stepsTotal, running or finished. Returns {toolUseId: "sync"|"running"|"report"|"pending"} for the fold's
     sealed-agent gate (pending = launched, no result, and not alive — the ack stays as the honest output)."""
     meta = None
     rows = None
@@ -17975,7 +17988,16 @@ def _stamp_agents(by_tool, scan_path, tm, spawned_at, meta_path=None):
             meta = _subagent_meta_map(meta_path or scan_path)
         aid = ev.get("agentId") or (meta.get(tid) or {}).get("agentId")
         ev["agentId"] = str(aid) if aid else None
+        # the agent's tool calls ride the head running OR finished — the fold lists them either way
+        ap = _subagent_file(meta_path or scan_path, aid) if aid else None
+        st = _agent_steps(ap) if ap is not None else None
+        if st:
+            _stamp_steps(ev, st)
         if not ev.get("agentAsync"):
+            # a FOREGROUND agent still mid-turn (no tool_result yet) reads as running on the client (no
+            # output), so its preview clock ships too; its landed tool_result is the report
+            if st and not ev.get("resultUuid"):
+                ev["agentGist"] = _gist_of(st)
             out[tid] = "sync"
             continue
         if rows is None:
@@ -17989,10 +18011,8 @@ def _stamp_agents(by_tool, scan_path, tm, spawned_at, meta_path=None):
         elif _agent_alive(row, aid, tm, spawned_at):
             ev["output"] = ""
             ev["agentRunning"] = True
-            ap = _subagent_file(meta_path or scan_path, aid) if aid else None
-            g = _agent_gist(ap) if ap is not None else None
-            if g:
-                ev["agentGist"] = g
+            if st:
+                ev["agentGist"] = _gist_of(st)
             out[tid] = "running"
         else:
             out[tid] = "pending"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -495,7 +495,8 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
 # The toolUseResult keys a consumer actually reads — MIRRORS event_model.TUR_CONSUMED_KEYS (this
 # module loads standalone, so it cannot import the event model; a drift pin in test_sdk_backend.py
 # holds the two sets equal). Widen both together when a new consumer appears; never carry-all.
-TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch"))
+TUR_CONSUMED_KEYS = frozenset(("answers", "structuredPatch", "agentId", "isAsync"))   # + the Agent tool's
+#   join/background flag (plans/subagent-transcripts.md, 2026-09-05) — widened in step with event_model
 
 TYPE_SOMETHING = "Type something"   # meta-option label the webview turns into the inline "add your own" field
 
@@ -4256,10 +4257,12 @@ class SdkSession:
         return {}
 
     def _live_subagents(self) -> list:
-        """The Task subagents running RIGHT NOW: [{"type","since"}], oldest first. Copied under the lock (hooks
-        mutate on the loop thread; snapshot() reads on the kernel thread)."""
+        """The Task subagents running RIGHT NOW: [{"type","since","agentId"}], oldest first. Copied under the
+        lock (hooks mutate on the loop thread; snapshot() reads on the kernel thread). agentId is the hook's
+        agent_id — the same `a…` id the CLI names the agent's own transcript file after, so the kernel can
+        say WHICH launch is alive, not only how many (plans/subagent-transcripts.md, 2026-09-05)."""
         with self._sub_lock:
-            return sorted((dict(v) for v in self._subagents.values()), key=lambda d: d.get("since") or 0)
+            return sorted(({**v, "agentId": k} for k, v in self._subagents.items()), key=lambda d: d.get("since") or 0)
 
     def _drop_live_work(self, reason: str):
         """The CLI process is gone — a reconnect (an effort/fast/auth switch) abandons the old client — so

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -1,0 +1,177 @@
+# Subagent transcripts: open any agent's whole conversation from the dashboard
+
+**Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, 2026-09-05; lands with this PR's
+merge commit). Slice 2 (the Awaiting box by kind) is scoped at the bottom and is a separate PR.
+
+Direction picked by the user (2026-09-05): a Claude Code subagent (the `Agent` tool, older
+transcripts say `Task`) should be readable in full from the dashboard — live while it runs and
+after it finishes — the way the desktop app lets you open one. Paraphrased: the two endpoints romp
+shows today are not enough to tell what an agent is doing or why it took the turn it did.
+
+## The problem (traced 2026-09-05, before the fix)
+
+romp showed exactly two points of a subagent's life, both on the parent's Agent tool head
+(`renderTool`, pinned by `ui/webview/render-agent.test.ts`): the kickoff **prompt** and the final
+**report**, as collapsed folds. Everything in between — the agent's own reasoning, its tool calls,
+the files it read, the commands it ran — was invisible. Three concrete defects fell out of that:
+
+- **No progress while running.** A background agent's head showed an amber dot for minutes with
+  nothing to say about what it was on. The bg-tasks box (`renderBgTasks` / kernel `_bg_tasks`)
+  had a row, but its expansion showed only the clipped prompt and the last 8 KB of an output file
+  that is, for an agent, a raw JSONL — the ugly launch record, not a transcript.
+- **The report fold lied for background agents.** The tool_result of a `run_in_background` Agent
+  is only the launch acknowledgement ("async agent launched…"), and that is what the fold showed
+  forever. The real closing summary landed later as a `<task-notification>` user turn, rendered
+  as its own notice card (`renderAgentNotif`) with no link back to the head.
+- **The Awaiting word confusion.** The statusline's "Awaiting agents" chip collapses to a generic
+  "task" wording as soon as one pending row is not an agent (`_session_awaiting`: kind is
+  `agents` only if EVERY pending row is one), so a session waiting on two agents and one build
+  reads as waiting on "tasks", and nothing on screen lists which. (Slice 2.)
+
+## Verified data facts (read-only survey of this machine; nothing real is copied here)
+
+- Claude Code writes ONE complete JSONL per subagent beside the parent transcript:
+  `~/.claude/projects/<proj-slug>/<parent-sid>/subagents/agent-<agentId>.jsonl`, plus a sidecar
+  `agent-<agentId>.meta.json` with keys `agentType`, `description`, `spawnDepth`, `toolUseId`
+  (optional `name`, `isFork`, `stoppedByUser`, `parentAgentId`). `agentId` is `a` + 16 lowercase
+  hex. **`meta.toolUseId` equals the parent's Agent `tool_use` block id** — the join key.
+- The records are the same shape as a normal transcript (`user` / `assistant` / `attachment`,
+  `message.content` blocks of text / thinking / tool_use / tool_result), tagged
+  `isSidechain: true`, `agentId`, `sessionId` = the PARENT sid, `parentUuid` chaining within the
+  file. So the FileAdapter parse that builds the chat already understands them.
+- The background Agent tool's output file (`/tmp/claude-<uid>/<slug>/<sid>/tasks/<agentId>.output`)
+  is a SYMLINK to that same JSONL — the projects dir is the single authoritative copy. Background
+  BASH tasks (`b` + 9 alphanumerics) are plain text and are not subagents; their treatment is
+  unchanged.
+- Parent linkage: the assistant record's `tool_use` block `{id, name: "Agent"|"Task", input:
+  {description, prompt, subagent_type, run_in_background?}}`; the matching user record's top-level
+  `toolUseResult` carries `agentId` (the async variant also `isAsync`, `status`, `outputFile`; the
+  sync variant the final `content`, `usage`, `totalDurationMs`…). A background agent's report
+  lands later as a `<task-notification>…<result>` user turn (`origin.kind == "task-notification"`).
+- Sizes: median agent file ~400 KB / ~116 records; the largest seen ~22 MB, dominated by a few
+  giant tool_result blobs. Per-block truncation (the chat's existing caps) matters more than
+  pagination; the shipped event list is a capped TAIL with a `truncated` flag.
+
+## Decision: read the file, do not un-drop the stream
+
+The SDK backend deliberately DROPS live stream messages tagged `parent_tool_use_id`
+(`kernel/sdk_backend.py` `msg_to_atom`, pinned by `tests/test_sidechain_atoms.py`): a subagent's
+kickoff prompt used to leak into the parent chat as a giant expanded box. That stays exactly as it
+is. This feature reads the agent's ON-DISK file instead, which:
+
+- keeps the parent stream clean (no sidechain atoms to filter per push);
+- works for dormant and revived sessions and for tmux sessions, which have no SDK stream at all;
+- reads the authoritative store (the file the CLI itself writes), never a reconstruction.
+
+Liveness is event-based, never a clock: for an SDK session the backend's SubagentStart/Stop set
+(`SdkSession._subagents`, now shipped WITH each agent's id) and its task-lifecycle set
+(`bgTasks`, keyed by tool-use id) say what is in flight; for a tmux or dormant session, "running"
+means the parent transcript has no final result for that tool-use id yet (a sync tool_result, or a
+task-notification for the launch) and the launch postdates the current CLI epoch — the same ghost
+gate `_bg_tasks` already applies, so the head's dot, the gist, the viewer and the box can never
+disagree.
+
+## What ships in slice 1
+
+### Kernel
+
+**Discovery + join.** `_subagent_meta_map(parent_path)` enumerates
+`<proj>/<fsid>/subagents/agent-*.meta.json` into `toolUseId → {agentId, agentType, description,
+spawnDepth}`, cached per directory on the directory's mtime (a new sidecar changes it — a stat, not
+a timer). The parent's `toolUseResult.agentId` on the tool_result record is the second source of
+the join (it also fills the bg-scan rows via `_bg_step`).
+
+**The Agent tool event** (`build_session`, the `kind:"tool"` event) now carries:
+- `toolUseId` — the tool_use BLOCK id. Verified: the event's `uuid` was the RECORD uuid, so the
+  block id was not on the wire before. Every tool event carries it now (cheap; the join key for
+  anything else that wants to pair a result to its call).
+- `agentId` (or `null`) on every Agent/Task event.
+- `agentAsync: true` when the tool_result was an async launch ack.
+- while a BACKGROUND agent runs: `agentRunning: true`, `output: ""` (the launch ack is not a
+  report — the client's existing "no output → amber dot" rule then reads it as running), and
+  `agentGist: {recent: [{tool, desc, ts}, …up to 3, newest last], calls, since, last}` folded
+  append-incrementally from the agent's file (`em.fold_records`, cached on the file's (mtime,
+  size)). `desc` is the head vocabulary: `input.description`, else the file path, else the first
+  line of the command, clipped.
+- once the background agent's `<task-notification>` has landed in the parent transcript: `output`
+  = the notification's `<result>` text (`_parse_task_notification` now captures it; the scan-all
+  rows keep it, capped like the chat's own output cap) and `isError` from its status, so the head's
+  report fold shows the closing summary instead of the launch ack. The task-notification notice
+  card in the transcript stays as it was. A foreground agent's tool_result was always the report.
+- `agentGist` is absent once the agent has finished — the report fold is the endpoint then.
+
+**The chat fold** (issue 903's sealed-prefix cache) treats a running agent the way it treats an
+undecided interrupt seam: the launch's turn is never sealed while the agent runs
+(`_chat_agent_open_at` holds the boundary), so the gist and the eventual report are rebuilt live
+with no per-push gate. Sealed Agent events are remembered in the entry (`agents`: tool-use id,
+agent id, pending flag) and one cheap gate — `_chat_agents_moved` — demotes to a full build when a
+sealed pending agent's row turns terminal or comes alive again, or a sealed null `agentId` gains
+its sidecar.
+
+**Open/close protocol.** Client → kernel `{type:"openSubagent", id:<sid>, agentId}` and
+`{type:"closeSubagent", id, agentId}`. The kernel answers, and re-pushes while the viewer is open,
+`{type:"subagent", id, agentId, meta:{agentType, description, spawnDepth, toolUseId}, running,
+events:[…], truncated}` — `events` built through the SAME `build_session` path the chat uses
+(`path_override` = the agent file, plus `sidechain=True`, which keeps the parent's side-store
+notes — retry recoveries, orphan replies, effort/gesture chips — out of a transcript they do not
+belong to). Capped at `SUBAGENT_EVENT_CAP` tail events with `truncated: true` when cut (the
+`/clear` episode fold's precedent). A missing or unreadable file pushes
+`{type:"subagent", …, error:"<plain sentence>"}` — loud, never blank. Open viewers live on the
+client record (`client["subagents"]`); the pusher's existing per-cycle chat pass re-sends a frame
+only when its change key — the agent file's (mtime, size) and the running flag — moved, and the
+per-client dedup slot `("subagent", sid, agentId)` absorbs the rest; a close or a disconnect
+ends the pushes. No new polling loop.
+
+**Federation.** Nothing bespoke: the request carries the parent `id`, so `routeOutbound` sends it
+to the owning host and strips the prefix, and `prefixInbound` re-prefixes the frame's `id` — the
+same path a comment-thread request takes. The client's tab id is `<parentId>/agent/<agentId>`
+(`ui/webview/subagent-view.ts`), NOT the `sub:<sid>:<agentId>` shape first sketched: host-prefix.ts
+reads the FIRST colon of an id as the host marker, so a `sub:` prefix would have named a phantom
+host everywhere `hostOf()` is consulted (offline marks, strip dimming, outbound routing). A
+colon-free suffix keeps `hostOf(subId) === hostOf(parentId)` with no special case.
+
+**bg-tasks rows** carry `agentId` when the launch is an agent (from the ack's `agentId`, the
+sidecar map, or the output symlink's basename), so the box can offer the same arrow. Shell-task
+rows are untouched.
+
+### UI (`ui/webview/render.ts` + `ui/webview/subagent-view.ts`)
+
+- **Arrow** (level 0): a house line-icon button on the Agent/Task head — and on agent bg-task
+  rows — when `agentId` is present; tooltip "open transcript" (`setTip`), delegated through
+  `actions.ts` (`data-act="openSubagent"`, click-safe across re-renders, `.romp-acted` pulse).
+- **Live preview** (level 0, only while running): up to three dim rows under the head, one per
+  recent tool call in the head vocabulary (`<tool> <desc>`), newest at the bottom, the last row
+  trailing `· N tool calls · <elapsed>`. It wears the tool-fold-toggle's 0.86em (no new size) and
+  lives INSIDE the tool turn, so a collapsed compact run hides it and an expanded run shows it.
+  Gone the moment the agent finishes.
+- **Peek tab viewer** (level 1): the arrow opens a peek tab (`peekId` / `.tab-peek` mechanics —
+  `chatVisible()` says a subagent view is in the chat lens only when pinned) with id
+  `sub:<sid>:<agentId>`, labelled by the sidecar's description (clipped) or agentType, wearing the
+  parent's colour. Its header reads "subagent of <parent> · <agentType> · running|finished" with
+  the parent name a link back to the tool head (setActive with the head's uuid as the anchor, the
+  chat's own scroll-to-uuid), a pin control ("keep this tab") that converts it to a regular tab
+  that stays until closed, and a "earlier part not shown" note when `truncated`. The transcript
+  renders through the SAME `displayItems` / `renderEvent` path as the chat (Compact transcript
+  applies), read-only: the composer is disabled, no ask controls. Live pushes replace the events in
+  place with the chat's own scroll rule (follow the bottom only when already there). The romp loader
+  holds the pane until the first frame; an `error` frame shows its sentence in the pane. Pinned
+  subagent tabs do not survive a reload in this slice (a code comment says so).
+- Feed and timeline: no changes.
+
+## Sizes and caps
+
+Per-block caps are the chat's own (`output` 16000 chars, `input` 4000, prompt/report markdown).
+`SUBAGENT_EVENT_CAP` bounds the shipped tail; the gist keeps 3 recent calls and two timestamps. The
+gist fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
+
+## Slice 2 (separate PR): the Awaiting box lists what a session waits on, by kind
+
+- The bg-tasks / awaiting box groups pending rows in separate sections — **agents** (each with the
+  arrow above), **commands** (background Bash), **watches** (monitors) — instead of one flat list.
+- The statusline "Awaiting …" chip becomes clickable and opens that box.
+- The mixed-set label collapse goes away: `_session_awaiting`'s "kind is `agents` only if every
+  pending row is an agent, else `task`" is replaced by per-kind counts the chip can word honestly
+  ("2 agents · 1 command").
+- Nested subagents (an agent's own Agent calls, `spawnDepth` 2) already carry the arrow inside the
+  viewer since the meta map is per parent transcript; making the viewer's header show the chain
+  (parent → agent → agent) is slice-2 polish.

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -1,7 +1,8 @@
 # Subagent transcripts: open any agent's whole conversation from the dashboard
 
 **Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, 2026-09-05; lands with this PR's
-merge commit). Slice 2 (the Awaiting box by kind) is scoped at the bottom and is a separate PR.
+merge commit; second cut the same day flattened the Agent head's fold — see "The head's fold").
+Slice 2 (the Awaiting box by kind) is scoped at the bottom and is a separate PR.
 
 Direction picked by the user (2026-09-05): a Claude Code subagent (the `Agent` tool, older
 transcripts say `Task`) should be readable in full from the dashboard — live while it runs and
@@ -87,18 +88,28 @@ the join (it also fills the bg-scan rows via `_bg_step`).
   anything else that wants to pair a result to its call).
 - `agentId` (or `null`) on every Agent/Task event.
 - `agentAsync: true` when the tool_result was an async launch ack.
+- on EVERY Agent/Task event with a readable agent file, running or finished: `agentSteps:
+  [{tool, desc, ts}, …]` — every tool call the agent has made so far, oldest first, capped at the
+  NEWEST `SUBAGENT_STEPS_CAP` (200) — and `stepsTotal`, the true count (so the label can say it and
+  the fold can note the cut). Folded append-incrementally from the agent's file (`em.fold_records`
+  on `_AGENT_GIST_CACHE`, keyed by the file's (mtime, size)): a growing file steps only its new
+  records, a finished file costs one read and then a stat per build (and its launch turn seals, so
+  the chat fold stops even that). `desc` is the head vocabulary: `input.description`, else the file
+  path, else the first line of the command, clipped. (2026-09-05, second cut: the first cut shipped
+  only `agentGist.recent`, the last three, and only while running; the fold lists them all now, so
+  `recent` left the wire — the client takes `steps.slice(-3)` for the preview.)
 - while a BACKGROUND agent runs: `agentRunning: true`, `output: ""` (the launch ack is not a
-  report — the client's existing "no output → amber dot" rule then reads it as running), and
-  `agentGist: {recent: [{tool, desc, ts}, …up to 3, newest last], calls, since, last}` folded
-  append-incrementally from the agent's file (`em.fold_records`, cached on the file's (mtime,
-  size)). `desc` is the head vocabulary: `input.description`, else the file path, else the first
-  line of the command, clipped.
+  report — the client's existing "no output → amber dot" rule then reads it as running), and the
+  preview's clock `agentGist: {calls, since, last}`. A FOREGROUND agent still mid-turn (no
+  tool_result yet) ships the clock too — the client reads its empty output as running, so the
+  preview needs it.
 - once the background agent's `<task-notification>` has landed in the parent transcript: `output`
   = the notification's `<result>` text (`_parse_task_notification` now captures it; the scan-all
   rows keep it, capped like the chat's own output cap) and `isError` from its status, so the head's
   report fold shows the closing summary instead of the launch ack. The task-notification notice
   card in the transcript stays as it was. A foreground agent's tool_result was always the report.
-- `agentGist` is absent once the agent has finished — the report fold is the endpoint then.
+- `agentGist` is absent once the agent has finished (no clock to show); `agentSteps` + `stepsTotal`
+  keep shipping — the fold lists what the agent did under its prompt and above its report.
 
 **The chat fold** (issue 903's sealed-prefix cache) treats a running agent the way it treats an
 undecided interrupt seam: the launch's turn is never sealed while the agent runs
@@ -139,11 +150,29 @@ rows are untouched.
 - **Arrow** (level 0): a house line-icon button on the Agent/Task head — and on agent bg-task
   rows — when `agentId` is present; tooltip "open transcript" (`setTip`), delegated through
   `actions.ts` (`data-act="openSubagent"`, click-safe across re-renders, `.romp-acted` pulse).
-- **Live preview** (level 0, only while running): up to three dim rows under the head, one per
-  recent tool call in the head vocabulary (`<tool> <desc>`), newest at the bottom, the last row
-  trailing `· N tool calls · <elapsed>`. It wears the tool-fold-toggle's 0.86em (no new size) and
-  lives INSIDE the tool turn, so a collapsed compact run hides it and an expanded run shows it.
-  Gone the moment the agent finishes.
+- **Live preview** (level 0, only while running AND the head's fold is closed): up to three dim rows
+  under the head, one per recent tool call in the head vocabulary (`<tool> <desc>`) — the newest
+  three of `agentSteps` — newest at the bottom, the last row trailing `· N tool calls · <elapsed>`.
+  It wears the tool-fold-toggle's 0.86em (no new size) and lives INSIDE the tool turn, so a
+  collapsed compact run hides it and an expanded run shows it. Gone the moment the agent finishes.
+  When the fold is OPEN the full list below replaces it: the render reads the fold's state from
+  `openFolds` under the fold's own key (no new state), and a CSS twin
+  (`.turn-tool.fold-open > .agent-preview`) hides it the instant the fold is clicked, before the
+  next push rebuilds the turn.
+- **The head's fold** (level 1, ONE click; same `tool:<uuid>` key as every tool fold, so an open fold
+  survives re-renders). Its label says what the click reveals, in order: `prompt · 12 tool calls`
+  while running, `prompt · 12 tool calls · report · 3 lines` once finished (singulars handled; the
+  tool-calls part is omitted at zero — `agentFoldLabel` in `subagent-view.ts`). Inside, all OPEN
+  and nothing nested: the prompt as markdown (the `prompt` field, the green-edged `.agent-report`
+  box); then EVERY shipped tool call, one dim row each in the preview's own classes
+  (`.agent-gist-row` / `-tool` / `-desc`), newest last, growing live on each push while the agent
+  runs (the last row trails the elapsed alone — the count is in the label), with a one-line
+  `N earlier calls not shown` note above when `stepsTotal > agentSteps.length`; then, once
+  finished, the report as markdown. The 2026-07-08 cut nested the prompt and the report as
+  collapsed caret boxes INSIDE the fold, so reading the prompt took two clicks — the user found that
+  odd (2026-09-05), hence the flat fold. The list is inline (no inner scroll box): the cap bounds
+  it at 200 rows, and a scroll-follow rule for a nested live list is more machinery than the case
+  earns; the arrow's viewer is where a long agent gets read properly.
 - **Peek tab viewer** (level 1): the arrow opens a peek tab (`peekId` / `.tab-peek` mechanics —
   `chatVisible()` says a subagent view is in the chat lens only when pinned) with id
   `sub:<sid>:<agentId>`, labelled by the sidecar's description (clipped) or agentType, wearing the
@@ -161,8 +190,9 @@ rows are untouched.
 ## Sizes and caps
 
 Per-block caps are the chat's own (`output` 16000 chars, `input` 4000, prompt/report markdown).
-`SUBAGENT_EVENT_CAP` bounds the shipped tail; the gist keeps 3 recent calls and two timestamps. The
-gist fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
+`SUBAGENT_EVENT_CAP` bounds the shipped tail; `SUBAGENT_STEPS_CAP` (200) bounds the steps on the
+head, with `stepsTotal` honest about the cut; the clock is a count and two timestamps. The steps
+fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
 
 ## Slice 2 (separate PR): the Awaiting box lists what a session waits on, by kind
 

--- a/tests/test_subagent_transcripts.py
+++ b/tests/test_subagent_transcripts.py
@@ -1,0 +1,520 @@
+"""Subagent transcripts (plans/subagent-transcripts.md, 2026-09-05): the whole conversation of any
+Agent/Task subagent is openable from the dashboard, live and after.
+
+Kernel half, pinned here:
+  - discovery + join: the subagents/ sidecar map (toolUseId -> agentId, dir-mtime cached) and the
+    launch ack's toolUseResult.agentId both name the agent on the parent's Agent tool event;
+  - the Agent tool event carries toolUseId + agentId; a RUNNING background agent drops its launch-ack
+    output and takes agentRunning + the agentGist preview (last 3 tool calls, count, stamps); a landed
+    <task-notification> puts its <result> in the event's output (the report fold) and the gist goes;
+  - build_subagent renders the agent's own file through build_session's pipeline (sidechain mode), a
+    capped tail with `truncated`, `running` from the parent's pairing + the live sets, and a LOUD
+    error for a missing file;
+  - openSubagent / closeSubagent register a viewer on the client; the pusher pass re-sends only when
+    the file changed, and stops after close;
+  - a bg-tasks row carries agentId only when the launch is an agent;
+  - the chat fold never seals a running agent's launch turn, and folds byte-identically to a full build.
+Synthetic data only: placeholder ids, TESTHOST-free paths, the notes-api demo world."""
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_subagents", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+em = km.em
+
+SID = "11111111-2222-3333-4444-555555555555"
+AID_BG = "a1111111111111111"      # the background agent
+AID_FG = "a2222222222222222"      # the foreground agent
+TU_BG = "toolu_bg_0001"
+TU_FG = "toolu_fg_0001"
+NOW = int(time.time())
+T0 = NOW - 600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def urec(t, uuid, content, parent=None, **extra):
+    r = {"type": "user", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t), "sessionId": SID,
+         "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main",
+         "message": {"role": "user", "content": content}}
+    r.update(extra)
+    return r
+
+
+def arec(t, uuid, blocks, parent, stop="end_turn"):
+    return {"type": "assistant", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t), "sessionId": SID,
+            "cwd": "/tmp/notes-api", "version": "2.1.0", "gitBranch": "main",
+            "message": {"role": "assistant", "model": "claude-opus-5", "content": blocks, "stop_reason": stop}}
+
+
+def tool_use(tid, name, inp):
+    return {"type": "tool_use", "id": tid, "name": name, "input": inp}
+
+
+def tool_result(tid, content, is_error=False):
+    return {"type": "tool_result", "tool_use_id": tid, "content": content, "is_error": is_error}
+
+
+def notif_text(tid, status, result, aid=AID_BG):
+    return ("<task-notification>\n<task-id>%s</task-id>\n<tool-use-id>%s</tool-use-id>\n"
+            "<output-file>/tmp/claude-1000/-tmp-notes-api/%s/tasks/%s.output</output-file>\n"
+            "<status>%s</status>\n<summary>Agent \"check the api tests\" came to rest</summary>\n"
+            "<result>%s</result>\n</task-notification>" % (aid, tid, SID, aid, status, result))
+
+
+def write_jsonl(path, rows):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+def append_jsonl(path, rows):
+    with open(path, "a") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    os.utime(path, None)
+
+
+class World(unittest.TestCase):
+    """A notes-api session `web` whose transcript launches one BACKGROUND agent (its ack is async) and one
+    FOREGROUND agent (its tool_result is the report), each with its own file under subagents/."""
+
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        self.cwd = os.path.realpath(os.path.join(self._td, "notes-api"))
+        os.makedirs(self.cwd, exist_ok=True)
+        self.proj = jd._proj_dir(self.cwd)
+        self.proj.mkdir(parents=True)
+        (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "names" / SID).write_text("web\t" + self.cwd)
+        self.tpath = self.proj / (SID + ".jsonl")
+        self.subdir = self.proj / SID / "subagents"
+        self.subdir.mkdir(parents=True)
+        # ── the parent transcript: turn 1 launches the background agent, turn 2 runs a foreground one
+        ack = {"isAsync": True, "status": "async_launched", "agentId": AID_BG, "description": "check the api tests",
+               "outputFile": "/tmp/claude-1000/-tmp-notes-api/%s/tasks/%s.output" % (SID, AID_BG),
+               "taskType": "local_agent"}
+        self.parent = [
+            urec(T0, "u1", "check the api tests in the background, then tidy the readme"),
+            arec(T0 + 2, "a1", [{"type": "text", "text": "Dispatching an agent for the tests."},
+                                tool_use(TU_BG, "Agent", {"description": "check the api tests",
+                                                          "prompt": "Run the notes-api test suite and report failures.",
+                                                          "subagent_type": "general-purpose", "run_in_background": True})],
+                 "u1", stop="tool_use"),
+            urec(T0 + 3, "r1", [tool_result(TU_BG, "Async agent launched. Agent ID: %s. Output file: %s"
+                                            % (AID_BG, ack["outputFile"]))], "a1", toolUseResult=ack),
+            arec(T0 + 4, "a2", [{"type": "text", "text": "The agent is running; I'll tidy the readme meanwhile."}], "r1"),
+            urec(T0 + 60, "u2", "now have a subagent summarise the readme", "a2"),
+            arec(T0 + 62, "a3", [tool_use(TU_FG, "Agent", {"description": "summarise the readme",
+                                                           "prompt": "Read README.md and summarise it in three lines.",
+                                                           "subagent_type": "general-purpose"})], "u2", stop="tool_use"),
+            urec(T0 + 90, "r3", [tool_result(TU_FG, "README summary: the notes-api serves notes over HTTP.")], "a3",
+                 toolUseResult={"agentId": AID_FG, "content": [{"type": "text", "text": "README summary…"}],
+                                "totalDurationMs": 28000}),
+            arec(T0 + 92, "a4", [{"type": "text", "text": "Summary in hand."}], "r3"),
+        ]
+        write_jsonl(self.tpath, self.parent)
+        self.last = "a4"                 # the transcript's leaf uuid — every append chains onto it (a null
+        #                                  parent would read as a /clear fork and drop the earlier turns)
+        # ── sidecars + agent files
+        (self.subdir / ("agent-%s.meta.json" % AID_BG)).write_text(json.dumps(
+            {"agentType": "general-purpose", "description": "check the api tests", "spawnDepth": 1, "toolUseId": TU_BG}))
+        (self.subdir / ("agent-%s.meta.json" % AID_FG)).write_text(json.dumps(
+            {"agentType": "general-purpose", "description": "summarise the readme", "spawnDepth": 1, "toolUseId": TU_FG}))
+        self.bg_file = self.subdir / ("agent-%s.jsonl" % AID_BG)
+        self.fg_file = self.subdir / ("agent-%s.jsonl" % AID_FG)
+        write_jsonl(self.bg_file, self._agent_records(AID_BG, T0 + 5, [
+            ("Read", {"file_path": "/tmp/notes-api/tests/test_api.py"}, "def test_list(): ..."),
+            ("Bash", {"command": "uv run pytest -q tests/", "description": "run the api tests"}, "3 passed, 1 failed"),
+            ("Grep", {"pattern": "def test_", "path": "/tmp/notes-api/tests"}, "tests/test_api.py:1"),
+            ("Read", {"file_path": "/tmp/notes-api/api/notes.py"}, "def list_notes(): ..."),
+        ]))
+        write_jsonl(self.fg_file, self._agent_records(AID_FG, T0 + 63, [
+            ("Read", {"file_path": "/tmp/notes-api/README.md"}, "# notes-api\n…"),
+        ], closing="README summary: the notes-api serves notes over HTTP."))
+        self.tm = {}                     # dormant: no live CLI snapshot → the spawned-at ghost gate
+        # an SDK snapshot as the status build reads it (model/effort/context keys), for the Liveness tests
+        self.live = {"state": "waiting", "since": T0, "model": "", "effort": "", "context": None,
+                     "compactPct": None, "color": None, "backend": "sdk"}
+        km._tmux_sessions = lambda: self.tm
+        for cache in (km._chat_fold, km._parse_cache, km._SUBAGENT_META_CACHE, km._AGENT_GIST_CACHE,
+                      km._AGENT_LAUNCH_CACHE, km._SUBAGENT_FRAMES, km._bgtasks_cache, km._bgall_cache):
+            cache.clear()
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _agent_records(self, aid, t, calls, closing="All four tests pass now; one flaky case was re-run."):
+        recs = [dict(urec(t, "%s-u0" % aid, "Do the delegated work.", None), isSidechain=True, agentId=aid)]
+        prev = "%s-u0" % aid
+        for i, (name, inp, out) in enumerate(calls):
+            a = "%s-a%d" % (aid, i)
+            r = "%s-r%d" % (aid, i)
+            recs.append(dict(arec(t + 2 * i + 1, a, [tool_use("%s-tu%d" % (aid, i), name, inp)], prev, stop="tool_use"),
+                             isSidechain=True, agentId=aid))
+            recs.append(dict(urec(t + 2 * i + 2, r, [tool_result("%s-tu%d" % (aid, i), out)], a), isSidechain=True, agentId=aid))
+            prev = r
+        recs.append(dict(arec(t + 2 * len(calls) + 3, "%s-fin" % aid, [{"type": "text", "text": closing}], prev),
+                         isSidechain=True, agentId=aid))
+        return recs
+
+    def _events(self):
+        m = km.build_session(SID, NOW, self.tm)
+        self.assertIsNotNone(m)
+        return m["events"]
+
+    def _agent_events(self):
+        return {e["toolUseId"]: e for e in self._events() if e.get("kind") == "tool" and e.get("name") == "Agent"}
+
+    def _land_notification(self, status="completed", result="All four tests pass now; one flaky case was re-run."):
+        append_jsonl(self.tpath, [urec(T0 + 400, "n1", notif_text(TU_BG, status, result), self.last)])
+        self.last = "n1"
+
+    def _follow_ups(self, n):
+        """n small complete turns appended after the launch, chained onto the leaf."""
+        for i in range(n):
+            u, a = "u%d" % (10 + i), "a%d" % (10 + i)
+            append_jsonl(self.tpath, [urec(T0 + 300 + 10 * i, u, "small follow-up %d" % i, self.last),
+                                      arec(T0 + 302 + 10 * i, a, [{"type": "text", "text": "ok %d" % i}], u)])
+            self.last = a
+
+
+class DiscoveryAndJoin(World):
+    def test_sidecar_map_joins_tool_use_id_to_agent_id_and_is_cached_on_the_dir_mtime(self):
+        m = km._subagent_meta_map(str(self.tpath))
+        self.assertEqual(m[TU_BG]["agentId"], AID_BG)
+        self.assertEqual(m[TU_BG]["agentType"], "general-purpose")
+        self.assertEqual(m[TU_BG]["description"], "check the api tests")
+        self.assertEqual(m[TU_FG]["agentId"], AID_FG)
+        self.assertIs(km._subagent_meta_map(str(self.tpath)), m, "an unchanged directory serves the cached map")
+        # a THIRD sidecar lands: the directory's mtime moves and the map re-reads (event-based, no timer)
+        (self.subdir / "agent-a3333333333333333.meta.json").write_text(json.dumps({"toolUseId": "toolu_x", "agentType": "Explore"}))
+        os.utime(self.subdir, (time.time() + 5, time.time() + 5))
+        m2 = km._subagent_meta_map(str(self.tpath))
+        self.assertEqual(m2["toolu_x"]["agentId"], "a3333333333333333")
+        # a malformed name or a non-agent id never enters the map
+        self.assertNotIn("", m2)
+        self.assertEqual(km._subagent_meta_map(str(self.proj / "nope.jsonl")), {}, "no subagents dir → empty, no raise")
+
+    def test_the_agent_tool_event_carries_the_block_id_and_the_agent_id_from_both_sources(self):
+        evs = self._agent_events()
+        self.assertEqual(set(evs), {TU_BG, TU_FG}, "toolUseId is the tool_use BLOCK id, distinct from the record uuid")
+        self.assertEqual(evs[TU_BG]["uuid"], "a1", "uuid stays the record's")
+        self.assertEqual(evs[TU_BG]["agentId"], AID_BG)
+        self.assertEqual(evs[TU_FG]["agentId"], AID_FG)
+        # the join survives the sidecar going missing: the ack's toolUseResult.agentId is the second source
+        (self.subdir / ("agent-%s.meta.json" % AID_FG)).unlink()
+        os.utime(self.subdir, (time.time() + 5, time.time() + 5))
+        km._parse_cache.clear(); km._chat_fold.clear()
+        self.assertEqual(self._agent_events()[TU_FG]["agentId"], AID_FG)
+
+    def test_every_tool_event_carries_its_block_id(self):
+        # the join key is generic — nothing else on the wire named the tool_use block
+        self.assertTrue(all(e.get("toolUseId") for e in self._events() if e.get("kind") == "tool"))
+
+
+class RunningPreview(World):
+    def test_a_running_background_agent_drops_the_ack_and_shows_the_last_three_calls(self):
+        ev = self._agent_events()[TU_BG]
+        self.assertTrue(ev.get("agentAsync"))
+        self.assertTrue(ev.get("agentRunning"))
+        self.assertEqual(ev["output"], "", "the launch ack is not a report — an empty output reads as running")
+        self.assertFalse(ev["isError"])
+        g = ev["agentGist"]
+        self.assertEqual(g["calls"], 4)
+        self.assertEqual([r["tool"] for r in g["recent"]], ["Bash", "Grep", "Read"], "the last 3, newest LAST")
+        self.assertEqual(g["recent"][0]["desc"], "run the api tests", "input.description wins")
+        self.assertEqual(g["recent"][1]["desc"], "def test_", "else the pattern")
+        self.assertEqual(g["recent"][2]["desc"], "/tmp/notes-api/api/notes.py", "else the file path")
+        self.assertEqual(g["since"], iso(T0 + 5))
+        self.assertEqual(g["last"], iso(T0 + 5 + 2 * 4 + 3))
+        self.assertTrue(all(r.get("ts") for r in g["recent"]))
+
+    def test_the_preview_follows_the_agent_file_as_it_grows(self):
+        self._agent_events()
+        append_jsonl(self.bg_file, [dict(arec(T0 + 40, "%s-a9" % AID_BG,
+                                              [tool_use("%s-tu9" % AID_BG, "Edit", {"file_path": "/tmp/notes-api/api/notes.py"})],
+                                              "%s-fin" % AID_BG, stop="tool_use"), isSidechain=True, agentId=AID_BG)])
+        km._parse_cache.clear(); km._chat_fold.clear()
+        g = self._agent_events()[TU_BG]["agentGist"]
+        self.assertEqual(g["calls"], 5)
+        self.assertEqual(g["recent"][-1]["tool"], "Edit")
+
+    def test_a_foreground_agent_keeps_its_report_and_shows_no_preview(self):
+        ev = self._agent_events()[TU_FG]
+        self.assertNotIn("agentGist", ev)
+        self.assertNotIn("agentRunning", ev)
+        self.assertNotIn("agentAsync", ev)
+        self.assertIn("README summary", ev["output"], "the sync tool_result IS the report")
+
+    def test_the_gist_desc_rule_is_the_head_vocabulary(self):
+        self.assertEqual(km._tool_gist_desc("Bash", {"command": "ls -la\nwc -l", "description": "list files"}), "list files")
+        self.assertEqual(km._tool_gist_desc("Bash", {"command": "ls -la\nwc -l"}), "ls -la")
+        self.assertEqual(km._tool_gist_desc("Edit", {"file_path": "/tmp/notes-api/x.py", "old_string": "a"}), "/tmp/notes-api/x.py")
+        self.assertEqual(km._tool_gist_desc("Read", "not a dict"), "")
+        self.assertEqual(len(km._tool_gist_desc("Bash", {"command": "x" * 500})), 80, "clipped")
+
+
+class LandedReport(World):
+    def test_the_landed_notification_becomes_the_report_and_the_preview_goes(self):
+        self._land_notification()
+        km._parse_cache.clear(); km._chat_fold.clear()
+        ev = self._agent_events()[TU_BG]
+        self.assertEqual(ev["output"], "All four tests pass now; one flaky case was re-run.",
+                         "the <result> text replaces the launch ack in the report fold")
+        self.assertFalse(ev["isError"])
+        self.assertNotIn("agentGist", ev)
+        self.assertNotIn("agentRunning", ev)
+        self.assertEqual(ev["agentId"], AID_BG, "the join stays after the report lands")
+        # the task-notification notice card in the transcript is untouched: the user turn still carries it
+        notes = [e for e in self._events() if e.get("kind") == "user" and any("<result>" in r for r in (e.get("reminders") or []))]
+        self.assertEqual(len(notes), 1)
+
+    def test_a_failed_notification_marks_the_report_as_an_error(self):
+        self._land_notification(status="failed", result="The suite could not start: missing dependency.")
+        km._parse_cache.clear(); km._chat_fold.clear()
+        ev = self._agent_events()[TU_BG]
+        self.assertTrue(ev["isError"])
+        self.assertIn("missing dependency", ev["output"])
+
+    def test_the_notification_parser_captures_the_result(self):
+        n = em._parse_task_notification(notif_text(TU_BG, "completed", "done: 4/4"))
+        self.assertEqual(n["result"], "done: 4/4")
+        self.assertEqual(n["tool_use_id"], TU_BG)
+        self.assertEqual(em._parse_task_notification("<task-notification><status>completed</status></task-notification>")["result"], "")
+
+
+class Liveness(World):
+    def test_sdk_live_sets_decide_running_for_a_background_agent(self):
+        # the SDK snapshot names the live agents (SubagentStart/Stop) → running while listed …
+        self.tm = {SID: dict(self.live, subagents=[{"type": "general-purpose", "since": T0, "agentId": AID_BG}], bgTasks=[])}
+        ev = self._agent_events()[TU_BG]
+        self.assertTrue(ev.get("agentRunning"))
+        # … and NOT running the moment neither live set names it, even with no notification landed:
+        # the ack stands as the honest output (nothing will come back), no preview
+        self.tm = {SID: dict(self.live, subagents=[], bgTasks=[])}
+        km._chat_fold.clear()
+        ev = self._agent_events()[TU_BG]
+        self.assertNotIn("agentRunning", ev)
+        self.assertNotIn("agentGist", ev)
+        self.assertIn("Async agent launched", ev["output"])
+        # the task-lifecycle set (tool-use id) is the other live source
+        self.tm = {SID: dict(self.live, subagents=[], bgTasks=[{"toolUseId": TU_BG, "desc": "x"}])}
+        km._chat_fold.clear()
+        self.assertTrue(self._agent_events()[TU_BG].get("agentRunning"))
+
+    def test_a_dormant_session_uses_the_cli_epoch_ghost_gate(self):
+        # a launch OLDER than the current CLI epoch died with the previous CLI: not running
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"sid": SID, "spawnedAt": T0 + 100}))
+        ev = self._agent_events()[TU_BG]
+        self.assertNotIn("agentRunning", ev)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"sid": SID, "spawnedAt": T0 - 100}))
+        km._chat_fold.clear()
+        self.assertTrue(self._agent_events()[TU_BG].get("agentRunning"))
+
+
+class Viewer(World):
+    def test_build_subagent_renders_the_agent_file_through_the_chat_pipeline(self):
+        fr = km.build_subagent(SID, AID_BG, NOW, self.tm)
+        self.assertEqual(fr["type"], "subagent")
+        self.assertEqual((fr["id"], fr["agentId"]), (SID, AID_BG))
+        self.assertNotIn("error", fr)
+        self.assertEqual(fr["meta"], {"agentType": "general-purpose", "description": "check the api tests",
+                                      "spawnDepth": 1, "toolUseId": TU_BG})
+        self.assertTrue(fr["running"])
+        self.assertFalse(fr["truncated"])
+        kinds = [e["kind"] for e in fr["events"]]
+        self.assertIn("user", kinds)
+        self.assertIn("tool", kinds)
+        self.assertIn("assistant", kinds)
+        tools = [e for e in fr["events"] if e["kind"] == "tool"]
+        self.assertEqual([t["name"] for t in tools], ["Read", "Bash", "Grep", "Read"])
+        self.assertEqual(tools[1]["output"], "3 passed, 1 failed", "tool_results fill the same way the chat's do")
+        self.assertTrue(all(t.get("toolUseId") for t in tools))
+        self.assertIn("one flaky case", fr["events"][-1]["md"])
+        # the parent's side-store notes never leak into the agent's render (sidechain mode)
+        self.assertFalse(any(e["kind"] in ("retried", "retryGaveUp", "effortApplied", "cmdGesture") for e in fr["events"]))
+
+    def test_running_flips_when_the_notification_lands_and_a_foreground_agent_reads_finished(self):
+        self.assertTrue(km.build_subagent(SID, AID_BG, NOW, self.tm)["running"])
+        self.assertFalse(km.build_subagent(SID, AID_FG, NOW, self.tm)["running"], "its tool_result settled it")
+        self._land_notification()
+        km._parse_cache.clear()
+        self.assertFalse(km.build_subagent(SID, AID_BG, NOW, self.tm)["running"])
+
+    def test_a_foreground_agent_mid_turn_reads_running(self):
+        # cut the parent transcript before the foreground agent's tool_result landed
+        write_jsonl(self.tpath, self.parent[:6])
+        km._parse_cache.clear()
+        self.assertTrue(km.build_subagent(SID, AID_FG, NOW, self.tm)["running"])
+
+    def test_the_shipped_tail_is_capped_and_says_so(self):
+        saved = km.SUBAGENT_EVENT_CAP
+        try:
+            km.SUBAGENT_EVENT_CAP = 3
+            fr = km.build_subagent(SID, AID_BG, NOW, self.tm)
+            self.assertTrue(fr["truncated"])
+            self.assertEqual(len(fr["events"]), 3)
+            self.assertIn("one flaky case", fr["events"][-1]["md"], "a TAIL — the newest events survive the cut")
+        finally:
+            km.SUBAGENT_EVENT_CAP = saved
+
+    def test_a_missing_file_is_a_loud_error_never_a_blank(self):
+        self.bg_file.unlink()
+        fr = km.build_subagent(SID, AID_BG, NOW, self.tm)
+        self.assertIn("error", fr)
+        self.assertIn("missing", fr["error"])
+        self.assertNotIn("events", fr)
+        self.assertIn("error", km.build_subagent(SID, "not-an-agent", NOW, self.tm))
+        self.assertIn("error", km.build_subagent("99999999-0000-0000-0000-000000000000", AID_BG, NOW, self.tm))
+
+    def test_the_file_is_found_under_a_forked_fsid_dir(self):
+        # after a /clear fork the parent transcript is a NEW file, but the agent's dir keeps the old fsid
+        moved = self.proj / "66666666-7777-8888-9999-000000000000"
+        shutil.move(str(self.proj / SID), str(moved))
+        km._SUBAGENT_META_CACHE.clear()
+        self.assertEqual(km._subagent_file(str(self.tpath), AID_BG), moved / "subagents" / ("agent-%s.jsonl" % AID_BG))
+        self.assertIsNone(km._subagent_file(str(self.tpath), "a9999999999999999"))
+
+
+class _Client(dict):
+    """A ws client record as _dispatch_ws sees it: frames land in `out`."""
+
+    def __init__(self):
+        super().__init__()
+        self.out = []
+        self.update({"app": "chat", "wid": "w1", "alive": True, "sent": {}, "dlock": __import__("threading").RLock(),
+                     "send": lambda s: self.out.append(json.loads(s))})
+
+
+class OpenClose(World):
+    def _dispatch(self, client, msg):
+        km.Handler._dispatch_ws(object.__new__(km.Handler), msg, client)
+
+    def test_open_answers_now_and_registers_the_viewer_then_close_stops_the_pushes(self):
+        c = _Client()
+        self._dispatch(c, {"type": "openSubagent", "id": SID, "agentId": AID_BG})
+        self.assertEqual(len(c.out), 1)
+        fr = c.out[0]
+        self.assertEqual((fr["type"], fr["agentId"]), ("subagent", AID_BG))
+        self.assertTrue(fr["running"])
+        self.assertIn((SID, AID_BG), c["subagents"])
+        # the pusher pass: an UNCHANGED agent re-sends nothing (the dedup slot) …
+        km._push_subagents([c], NOW, self.tm)
+        self.assertEqual(len(c.out), 1)
+        # … a grown file re-sends the fresh frame …
+        append_jsonl(self.bg_file, [dict(arec(T0 + 40, "%s-a9" % AID_BG, [{"type": "text", "text": "Nearly done."}],
+                                              "%s-fin" % AID_BG), isSidechain=True, agentId=AID_BG)])
+        km._parse_cache.clear()
+        km._push_subagents([c], NOW, self.tm)
+        self.assertEqual(len(c.out), 2)
+        self.assertEqual(c.out[1]["events"][-1]["md"], "Nearly done.")
+        # … and a landed notification re-sends too (the running flag is part of the change key)
+        self._land_notification()
+        km._parse_cache.clear()
+        km._push_subagents([c], NOW, self.tm)
+        self.assertEqual(len(c.out), 3)
+        self.assertFalse(c.out[2]["running"])
+        # close: unregistered, and no further frames however the file moves
+        self._dispatch(c, {"type": "closeSubagent", "id": SID, "agentId": AID_BG})
+        self.assertNotIn((SID, AID_BG), c["subagents"])
+        append_jsonl(self.bg_file, [dict(arec(T0 + 50, "%s-a10" % AID_BG, [{"type": "text", "text": "Really done."}],
+                                              "%s-a9" % AID_BG), isSidechain=True, agentId=AID_BG)])
+        km._parse_cache.clear()
+        km._push_subagents([c], NOW, self.tm)
+        self.assertEqual(len(c.out), 3)
+        # a REOPEN of the unchanged agent is answered again (the dedup slot was dropped on close)
+        self._dispatch(c, {"type": "openSubagent", "id": SID, "agentId": AID_BG})
+        self.assertEqual(len(c.out), 4)
+
+    def test_open_on_a_missing_file_pushes_the_error_frame(self):
+        c = _Client()
+        self.bg_file.unlink()
+        self._dispatch(c, {"type": "openSubagent", "id": SID, "agentId": AID_BG})
+        self.assertEqual(len(c.out), 1)
+        self.assertIn("missing", c.out[0]["error"])
+
+
+class BgRows(World):
+    def test_an_agent_row_carries_its_agent_id_and_a_shell_row_does_not(self):
+        # add a background shell command beside the agent launch
+        append_jsonl(self.tpath, [
+            arec(T0 + 100, "a5", [tool_use("toolu_sh_1", "Bash", {"command": "uv run pytest -q", "run_in_background": True,
+                                                                   "description": "run the suite"})], self.last, stop="tool_use"),
+            urec(T0 + 101, "r5", [tool_result("toolu_sh_1", "Command running in background with ID: b12345abc")], "a5",
+                 toolUseResult={"isAsync": True, "status": "async_launched",
+                                "outputFile": "/tmp/claude-1000/-tmp-notes-api/%s/tasks/b12345abc.output" % SID}),
+        ])
+        box = km._bg_tasks(str(self.tpath))
+        rows = {r["id"]: r for r in box["tasks"]}
+        self.assertEqual(rows[TU_BG]["agentId"], AID_BG)
+        self.assertNotIn("agentId", rows["toolu_sh_1"], "a shell task is not a subagent")
+
+    def test_the_output_symlink_basename_is_the_third_join_source(self):
+        self.assertEqual(km._agent_id_of_output("/tmp/claude-1000/x/%s/tasks/%s.output" % (SID, AID_BG)), AID_BG)
+        self.assertIsNone(km._agent_id_of_output("/tmp/claude-1000/x/%s/tasks/b12345abc.output" % SID))
+        self.assertIsNone(km._agent_id_of_output(""))
+
+
+class Fold(World):
+    def _n(self):
+        e = km._chat_fold_get(SID)
+        return e["n"] if e else 0
+
+    def test_a_running_agents_launch_turn_is_never_sealed_and_the_fold_matches_a_full_build(self):
+        # three turns after the launch: the boundary stays before turn 1 while the agent runs
+        self._follow_ups(3)
+        km._parse_cache.clear()
+        inc = self._events()
+        self.assertLessEqual(self._n(), 1, "the launch turn (index 0) holds the seal boundary while its agent runs")
+        km._chat_fold.clear()
+        ref = self._events()
+        self.assertEqual(json.dumps(inc, sort_keys=True), json.dumps(ref, sort_keys=True))
+        # the notification lands: the agent's turn seals like any other, and the sealed card shows the report
+        self._land_notification()
+        km._parse_cache.clear()
+        self._events(); self._events()
+        self.assertGreaterEqual(self._n(), 2, "settled → sealed")
+        ev = self._agent_events()[TU_BG]
+        self.assertIn("one flaky case", ev["output"])
+        inc2 = self._events()
+        km._chat_fold.clear()
+        self.assertEqual(json.dumps(inc2, sort_keys=True), json.dumps(self._events(), sort_keys=True))
+
+    def test_a_sealed_pending_agent_demotes_when_its_report_lands(self):
+        # dormant + the ghost gate says the launch is dead → sealed as PENDING (ack stands); a late
+        # notification must still reach the sealed card
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"sid": SID, "spawnedAt": T0 + 100}))
+        self._follow_ups(2)
+        self._events(); self._events()
+        self.assertGreaterEqual(self._n(), 2, "a dead launch does not hold the seal")
+        self.assertTrue(any(a[0] == TU_BG and a[2] for a in km._chat_fold_get(SID)["agents"]), "remembered as pending")
+        self.assertIn("Async agent launched", self._agent_events()[TU_BG]["output"])
+        self._land_notification()
+        km._parse_cache.clear()
+        ev = self._agent_events()[TU_BG]
+        self.assertIn("one flaky case", ev["output"], "the sealed card was rebuilt with the landed report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subagent_transcripts.py
+++ b/tests/test_subagent_transcripts.py
@@ -4,9 +4,11 @@ Agent/Task subagent is openable from the dashboard, live and after.
 Kernel half, pinned here:
   - discovery + join: the subagents/ sidecar map (toolUseId -> agentId, dir-mtime cached) and the
     launch ack's toolUseResult.agentId both name the agent on the parent's Agent tool event;
-  - the Agent tool event carries toolUseId + agentId; a RUNNING background agent drops its launch-ack
-    output and takes agentRunning + the agentGist preview (last 3 tool calls, count, stamps); a landed
-    <task-notification> puts its <result> in the event's output (the report fold) and the gist goes;
+  - the Agent tool event carries toolUseId + agentId, and — running or finished — agentSteps (every
+    tool call so far in order, the newest SUBAGENT_STEPS_CAP) + stepsTotal, folded once per file
+    change; a RUNNING background agent drops its launch-ack output and takes agentRunning + the
+    agentGist clock (calls, since, last — the preview derives its three rows from the steps); a landed
+    <task-notification> puts its <result> in the event's output (the report fold) and the clock goes;
   - build_subagent renders the agent's own file through build_session's pipeline (sidechain mode), a
     capped tail with `truncated`, `running` from the parent's pairing + the live sets, and a LOUD
     error for a missing file;
@@ -232,38 +234,92 @@ class DiscoveryAndJoin(World):
 
 
 class RunningPreview(World):
-    def test_a_running_background_agent_drops_the_ack_and_shows_the_last_three_calls(self):
+    def test_a_running_background_agent_drops_the_ack_and_ships_its_steps_and_clock(self):
         ev = self._agent_events()[TU_BG]
         self.assertTrue(ev.get("agentAsync"))
         self.assertTrue(ev.get("agentRunning"))
         self.assertEqual(ev["output"], "", "the launch ack is not a report — an empty output reads as running")
         self.assertFalse(ev["isError"])
+        # every tool call so far, in order (the fold lists them; the preview takes the last three client-side)
+        steps = ev["agentSteps"]
+        self.assertEqual([r["tool"] for r in steps], ["Read", "Bash", "Grep", "Read"], "all of them, oldest first")
+        self.assertEqual(steps[1]["desc"], "run the api tests", "input.description wins")
+        self.assertEqual(steps[2]["desc"], "def test_", "else the pattern")
+        self.assertEqual(steps[3]["desc"], "/tmp/notes-api/api/notes.py", "else the file path")
+        self.assertTrue(all(r.get("ts") for r in steps))
+        self.assertEqual(ev["stepsTotal"], 4)
+        # the clock: count + first/last stamps; no `recent` — the steps carry the rows now (2026-09-05)
         g = ev["agentGist"]
-        self.assertEqual(g["calls"], 4)
-        self.assertEqual([r["tool"] for r in g["recent"]], ["Bash", "Grep", "Read"], "the last 3, newest LAST")
-        self.assertEqual(g["recent"][0]["desc"], "run the api tests", "input.description wins")
-        self.assertEqual(g["recent"][1]["desc"], "def test_", "else the pattern")
-        self.assertEqual(g["recent"][2]["desc"], "/tmp/notes-api/api/notes.py", "else the file path")
-        self.assertEqual(g["since"], iso(T0 + 5))
-        self.assertEqual(g["last"], iso(T0 + 5 + 2 * 4 + 3))
-        self.assertTrue(all(r.get("ts") for r in g["recent"]))
+        self.assertEqual(g, {"calls": 4, "since": iso(T0 + 5), "last": iso(T0 + 5 + 2 * 4 + 3)})
 
-    def test_the_preview_follows_the_agent_file_as_it_grows(self):
+    def test_the_steps_follow_the_agent_file_as_it_grows(self):
         self._agent_events()
         append_jsonl(self.bg_file, [dict(arec(T0 + 40, "%s-a9" % AID_BG,
                                               [tool_use("%s-tu9" % AID_BG, "Edit", {"file_path": "/tmp/notes-api/api/notes.py"})],
                                               "%s-fin" % AID_BG, stop="tool_use"), isSidechain=True, agentId=AID_BG)])
         km._parse_cache.clear(); km._chat_fold.clear()
-        g = self._agent_events()[TU_BG]["agentGist"]
-        self.assertEqual(g["calls"], 5)
-        self.assertEqual(g["recent"][-1]["tool"], "Edit")
+        ev = self._agent_events()[TU_BG]
+        self.assertEqual(ev["agentGist"]["calls"], 5)
+        self.assertEqual(ev["stepsTotal"], 5)
+        self.assertEqual(ev["agentSteps"][-1]["tool"], "Edit", "newest LAST")
 
-    def test_a_foreground_agent_keeps_its_report_and_shows_no_preview(self):
+    def test_the_steps_are_capped_at_the_newest_and_the_total_says_the_true_count(self):
+        # 200 calls is the cap: a 210-call agent ships the last 200 and stepsTotal 210
+        n = km.SUBAGENT_STEPS_CAP + 10
+        write_jsonl(self.bg_file, self._agent_records(AID_BG, T0 + 5, [
+            ("Read", {"file_path": "/tmp/notes-api/f%d.py" % i}, "…") for i in range(n)]))
+        km._AGENT_GIST_CACHE.clear()
+        ev = self._agent_events()[TU_BG]
+        self.assertEqual(ev["stepsTotal"], n)
+        self.assertEqual(len(ev["agentSteps"]), km.SUBAGENT_STEPS_CAP)
+        self.assertEqual(ev["agentSteps"][0]["desc"], "/tmp/notes-api/f10.py", "the OLDEST ten fell off")
+        self.assertEqual(ev["agentSteps"][-1]["desc"], "/tmp/notes-api/f%d.py" % (n - 1))
+        self.assertEqual(ev["agentGist"]["calls"], n)
+
+    def test_the_steps_fold_is_cached_on_the_file_and_an_unchanged_file_folds_nothing(self):
+        steps = []
+        real = km._gist_step
+        km._gist_step = lambda st, o: steps.append(o) or real(st, o)
+        try:
+            first = km._agent_steps(self.bg_file)
+            self.assertEqual(first["calls"], 4)
+            folded = len(steps)
+            self.assertGreater(folded, 0)
+            # same mtime and size → the cached state answers; not one record is stepped again
+            again = km._agent_steps(self.bg_file)
+            self.assertEqual(again["calls"], 4)
+            self.assertEqual(len(steps), folded, "an unchanged file is a stat, never a re-fold")
+            # a grown file steps ONLY its new records (append-incremental)
+            append_jsonl(self.bg_file, [dict(arec(T0 + 40, "%s-a9" % AID_BG,
+                                                  [tool_use("%s-tu9" % AID_BG, "Edit", {"file_path": "/tmp/notes-api/api/notes.py"})],
+                                                  "%s-fin" % AID_BG, stop="tool_use"), isSidechain=True, agentId=AID_BG)])
+            grown = km._agent_steps(self.bg_file)
+            self.assertEqual(grown["calls"], 5)
+            self.assertEqual(len(steps), folded + 1)
+        finally:
+            km._gist_step = real
+
+    def test_a_finished_foreground_agent_keeps_its_report_and_its_steps_but_no_clock(self):
         ev = self._agent_events()[TU_FG]
-        self.assertNotIn("agentGist", ev)
+        self.assertNotIn("agentGist", ev, "the clock is the running preview's; a finished head has none")
         self.assertNotIn("agentRunning", ev)
         self.assertNotIn("agentAsync", ev)
         self.assertIn("README summary", ev["output"], "the sync tool_result IS the report")
+        # the steps keep shipping after the finish: the fold lists prompt, steps, report in one click
+        self.assertEqual([r["tool"] for r in ev["agentSteps"]], ["Read"])
+        self.assertEqual(ev["agentSteps"][0]["desc"], "/tmp/notes-api/README.md")
+        self.assertEqual(ev["stepsTotal"], 1)
+
+    def test_a_foreground_agent_mid_turn_ships_the_clock_too(self):
+        # the parent transcript cut before the foreground agent's tool_result: no output → the client
+        # reads it as running, so the preview's clock and the steps both ride the head
+        write_jsonl(self.tpath, self.parent[:6])
+        km._parse_cache.clear(); km._chat_fold.clear()
+        ev = self._agent_events()[TU_FG]
+        self.assertEqual(ev["output"], "")
+        self.assertEqual(ev["agentGist"]["calls"], 1)
+        self.assertEqual(ev["stepsTotal"], 1)
+        self.assertNotIn("agentRunning", ev, "a sync launch's run-state stays the client's no-output rule")
 
     def test_the_gist_desc_rule_is_the_head_vocabulary(self):
         self.assertEqual(km._tool_gist_desc("Bash", {"command": "ls -la\nwc -l", "description": "list files"}), "list files")
@@ -284,6 +340,9 @@ class LandedReport(World):
         self.assertNotIn("agentGist", ev)
         self.assertNotIn("agentRunning", ev)
         self.assertEqual(ev["agentId"], AID_BG, "the join stays after the report lands")
+        self.assertEqual([r["tool"] for r in ev["agentSteps"]], ["Read", "Bash", "Grep", "Read"],
+                         "the steps keep shipping after the finish — the fold lists them under the prompt")
+        self.assertEqual(ev["stepsTotal"], 4)
         # the task-notification notice card in the transcript is untouched: the user turn still carries it
         notes = [e for e in self._events() if e.get("kind") == "user" and any("<result>" in r for r in (e.get("reminders") or []))]
         self.assertEqual(len(notes), 1)
@@ -316,6 +375,7 @@ class Liveness(World):
         self.assertNotIn("agentRunning", ev)
         self.assertNotIn("agentGist", ev)
         self.assertIn("Async agent launched", ev["output"])
+        self.assertEqual(ev["stepsTotal"], 4, "what it did before it died still lists in the fold")
         # the task-lifecycle set (tool-use id) is the other live source
         self.tm = {SID: dict(self.live, subagents=[], bgTasks=[{"toolUseId": TU_BG, "desc": "x"}])}
         km._chat_fold.clear()

--- a/tools/ui-verify/fixtures/agent-head.html
+++ b/tools/ui-verify/fixtures/agent-head.html
@@ -1,0 +1,77 @@
+<!-- SYNTHETIC fixture: the Agent tool head in its three states (plans/subagent-transcripts.md, 2026-09-05),
+     class for class what renderTool emits — the running head with its fold CLOSED (the three-row preview
+     shows), the running head with its fold OPEN (prompt + every tool call; the preview yields via the
+     .fold-open CSS twin), and a FINISHED head with its fold open (prompt, tool calls, report; the arrow
+     still there). Invented content (notes-api demo domain). Run, both themes:
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/agent-head.html \
+           --out /tmp/agent-fold-shots/dark.png --size 720x760 --extra-css 'body{display:block;padding:10px 20px}'
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/agent-head.html \
+           --out /tmp/agent-fold-shots/light.png --size 720x760 --extra-css 'body{display:block;padding:10px 20px}' \
+           --body-class "theme-light chat-theme-yatharth"
+-->
+<!-- 1. running, fold closed: head + the level-0 preview -->
+<div class="turn turn-tool">
+  <span class="dot working"></span>
+  <div class="tool-head">
+    <span class="tool-name">Agent</span><span class="tool-desc">check the api tests</span>
+    <span class="tool-fold-toggle" title="click to expand">prompt · 4 tool calls</span>
+    <span class="tool-open-agent" role="button" tabindex="0"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span>
+  </div>
+  <div class="agent-gist agent-preview">
+    <div class="agent-gist-row"><span class="agent-gist-tool">Bash</span><span class="agent-gist-desc">run the api tests</span></div>
+    <div class="agent-gist-row"><span class="agent-gist-tool">Grep</span><span class="agent-gist-desc">def test_</span></div>
+    <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/api/notes.py</span><span class="agent-gist-meta">· 4 tool calls · 40s</span></div>
+  </div>
+  <div class="agent-folds tool-fold-body">
+    <div class="agent-report md"><p>Run the notes-api test suite and report failures.</p></div>
+    <div class="agent-gist agent-steps">
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/tests/test_api.py</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Bash</span><span class="agent-gist-desc">run the api tests</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Grep</span><span class="agent-gist-desc">def test_</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/api/notes.py</span><span class="agent-gist-meta">· 40s</span></div>
+    </div>
+  </div>
+</div>
+<div class="turn"><div class="assistant md"><p>The agent is running; I'll tidy the readme meanwhile.</p></div></div>
+<!-- 2. running, fold OPEN: prompt + every call; the preview is in the DOM but the .fold-open twin hides it -->
+<div class="turn turn-tool fold-open">
+  <span class="dot working"></span>
+  <div class="tool-head">
+    <span class="tool-name">Agent</span><span class="tool-desc">summarise the readme</span>
+    <span class="tool-fold-toggle" title="click to expand">prompt · 7 tool calls</span>
+    <span class="tool-open-agent" role="button" tabindex="0"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span>
+  </div>
+  <div class="agent-gist agent-preview">
+    <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/docs/usage.md</span><span class="agent-gist-meta">· 7 tool calls · 1m 12s</span></div>
+  </div>
+  <div class="agent-folds tool-fold-body">
+    <div class="agent-report md"><p>Read <code>README.md</code> and summarise it in three lines. Mention the export endpoint if the docs cover it.</p></div>
+    <div class="agent-gist agent-steps">
+      <div class="agent-steps-note">2 earlier calls not shown</div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/README.md</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Grep</span><span class="agent-gist-desc">export</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Glob</span><span class="agent-gist-desc">docs/**/*.md</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/docs/export.md</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/docs/usage.md</span><span class="agent-gist-meta">· 1m 12s</span></div>
+    </div>
+  </div>
+</div>
+<div class="turn"><div class="assistant md"><p>Both agents are out; I'll wait for the summary before touching the docs.</p></div></div>
+<!-- 3. finished, fold open: prompt, tool calls, report; green dot; the arrow stays -->
+<div class="turn turn-tool fold-open">
+  <span class="dot green"></span>
+  <div class="tool-head">
+    <span class="tool-name">Agent</span><span class="tool-desc">list the failing fixtures</span>
+    <span class="tool-fold-toggle" title="click to expand">prompt · 3 tool calls · report · 3 lines</span>
+    <span class="tool-open-agent" role="button" tabindex="0"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span>
+  </div>
+  <div class="agent-folds tool-fold-body">
+    <div class="agent-report md"><p>Find every fixture under <code>tests/fixtures/</code> that the exporter suite still fails on, and name the assertion each one trips.</p></div>
+    <div class="agent-gist agent-steps">
+      <div class="agent-gist-row"><span class="agent-gist-tool">Glob</span><span class="agent-gist-desc">tests/fixtures/*.csv</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Bash</span><span class="agent-gist-desc">run the exporter suite</span></div>
+      <div class="agent-gist-row"><span class="agent-gist-tool">Read</span><span class="agent-gist-desc">/tmp/notes-api/tests/fixtures/legacy-header.csv</span></div>
+    </div>
+    <div class="agent-report md"><p>Two fixtures fail, both on the header row:</p><ul><li><code>legacy-header.csv</code> — the old three-column header trips <code>assert_columns</code>.</li><li><code>empty-notes.csv</code> — no rows at all; the exporter asserts at least one.</li></ul></div>
+  </div>
+</div>

--- a/ui/webview/fold-persist.test.ts
+++ b/ui/webview/fold-persist.test.ts
@@ -36,7 +36,10 @@ test("the other collapsibles pass stable keys (reminders, tool folds, thinking)"
   assert.match(RENDER, /"rem:" \+ ev\.uuid/, "system reminders key on the user turn uuid");
   assert.match(RENDER, /const fkey = ev\.uuid \? "tool:" \+ ev\.uuid : undefined;/, "tool folds key on the tool uuid");
   assert.match(RENDER, /"think:" \+ ev\.uuid/, "thinking clamp keys on the thinking uuid");
-  // the whole agent dispatch (prompt + report) collapses under ONE fold with one stable key, so a single
-  // click expands both halves together (the user 2026-06-22)
-  assert.match(RENDER, /fkey \+ ":agent"/);
+  // the whole agent dispatch (prompt, tool calls, report) collapses under ONE fold with one stable key,
+  // so a single click expands all of it together (the user 2026-06-22). The key is the tool's own fkey:
+  // the ":agent"-suffixed sub-keys went with the nested prompt/report boxes (2026-09-05 — everything
+  // inside the fold is open now, so there is nothing left to key separately).
+  assert.match(RENDER, /inlineFold\(head, turn, label, body, fkey\);/);
+  assert.doesNotMatch(RENDER, /fkey \+ ":agent"/, "no nested agent sub-folds to key");
 });

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -16,7 +16,10 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("peek OPEN: every activation routes the peek decision — setActive derives peek-vs-normal from the CURRENT views", () => {
   // the single entry: setActive (tab clicks, the focus handler, jumpSession, cycleTab and
   // nav-history's apply all land here), before its already-active early-return
-  assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,400}?if \(activeId === id && anchor == null && anchorT == null\) return;/);
+  // the window between the derivation and the early return widened on 2026-09-05: the subagent viewer's
+  // two lines sit there (pruneSubViews — an activation is the event that closes an unpinned viewer — and the
+  // reopen of a viewer id whose tab is gone), both BEFORE the return by design, see plans/subagent-transcripts.md
+  assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,900}?if \(activeId === id && anchor == null && anchorT == null\) return;/);
   // the derivation: in-view → no peek; out-of-view → THIS session is the peek
   assert.match(RENDER, /const next = chatVisible\(id\) \? null : id;\s*\n\s*if \(next !== peekId\) \{ peekId = next; renderTabs\(\); \}/);
 });
@@ -34,7 +37,10 @@ test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no
   // views-arrival paths): setActive (every activation), the focus fast path (already-active),
   // captureViews (kernel-pushed views), postViews (local optimistic edit). Nothing else derives.
   const sites = RENDER.match(/assertPeekFor\(/g) || [];
-  assert.equal(sites.length, 6, "definition + 5 call sites: setActive, focus fast path, captureViews, postViews, and the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame)");
+  // 6 → 7 on 2026-09-05: the subagent viewer's PIN control re-derives its own tab (pinned → in the chat
+  // lens → sheds the peek dress; unpinned → back to a peek) through the same derivation — no second
+  // peek mechanism (plans/subagent-transcripts.md; chatVisible() answers pinnedSubs for a viewer id)
+  assert.equal(sites.length, 7, "definition + 6 call sites: setActive, focus fast path, captureViews, postViews, the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame), and the subagent viewer's pin toggle (2026-09-05)");
 });
 
 test("a view change that excludes the ACTIVE session converts it into the peek — never a bounce (the user 2026-08-24)", () => {

--- a/ui/webview/render-agent.test.ts
+++ b/ui/webview/render-agent.test.ts
@@ -1,9 +1,15 @@
 // Subagent (Task/Agent) display, disclosed progressively (the user 2026-07-17: default compact, click to
-// go deeper): level 0 is ONE head row (Task + description + the run-state rail dot); the head's inline
-// fold reveals the PROMPT and REPORT as their own collapsed caret boxes (the user 2026-07-08 — markdown-
-// rendered, the prompt field not the tool JSON); opening either box is level 2. Unlike the pre-07-08
-// head toggle, level 1 reveals fold LABELS, never the prompt itself, so nothing renders twice. No jsdom
-// harness for the chat renderer, so — like the other webview tests — pin it at the source level.
+// go deeper): level 0 is ONE head row (Agent + description + the run-state rail dot) plus, while the
+// agent runs, a three-row preview of its latest tool calls; level 1 — ONE click on the head's inline
+// fold — reveals everything, all OPEN and in the label's order: the prompt as markdown (the prompt
+// field, not the tool JSON — the user 2026-07-08), the full list of tool calls, then the report as
+// markdown once the agent has finished.
+//
+// PINS MOVED DELIBERATELY (2026-09-05): the 2026-07-08 cut nested the prompt and the report as
+// collapsed caret boxes INSIDE the fold, so reading the prompt took two clicks — the user found that
+// odd. The fold now carries the rest in one click, with nothing nested, and its label says what the
+// click reveals ("prompt · 12 tool calls" / "… · report · 3 lines"). No jsdom harness for the chat
+// renderer, so — like the other webview tests — pin it at the source level.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -12,33 +18,69 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the PROMPT gets its own collapsed, markdown-rendered caret fold (not a plain <pre> behind the head toggle)", () => {
+// the Agent branch of renderTool, from `if (signal) {` to the `} else if (!ev.output) {` that follows it
+const AGENT = (RENDER.match(/if \(signal\) \{[\s\S]*?\n    \} else if \(!ev\.output\) \{/) || [""])[0];
+
+test("the PROMPT is the prompt field, markdown-rendered into an agent-report box, OPEN inside the fold (no nested caret box)", () => {
+  assert.ok(AGENT.length > 500, "found the Agent branch");
   // the prompt shown is the actual prompt field (not the raw tool JSON)…
-  assert.match(RENDER, /try \{ const o = JSON\.parse\(ev\.input\); if \(o && typeof o\.prompt === "string"\) promptText = o\.prompt; \}/);
+  assert.match(AGENT, /try \{ const o = JSON\.parse\(ev\.input\); if \(o && typeof o\.prompt === "string"\) promptText = o\.prompt; \}/);
   // …rendered as markdown into an agent-report box (the "nicer font" — no more preEl(promptText))…
-  assert.match(RENDER, /const box = el\("div", "agent-report md"\); box\.innerHTML = md\(promptText\); highlight\(box\);/);
-  // …wrapped in its OWN keyed, collapsed-by-default caret fold labeled "prompt".
-  assert.match(RENDER, /halves\.appendChild\(foldable\("prompt", box, akey \? akey \+ ":prompt" : undefined\)\);/);
-  // the prompt is NOT rendered as a monospace <pre> anymore
+  assert.match(AGENT, /const box = el\("div", "agent-report md"\); box\.innerHTML = md\(promptText\); highlight\(box\);\s*\n\s*body\.appendChild\(box\);/);
+  // …appended DIRECTLY to the fold body: no foldable() wrapper anywhere in the branch (2026-09-05 — the
+  // nested "prompt" / "report · N lines" caret boxes cost a second click)
+  assert.doesNotMatch(AGENT, /foldable\(/, "nothing nested inside the Agent fold");
+  assert.doesNotMatch(AGENT, /fkey \+ ":agent"/, "no sub-keys — one fold, one key");
   assert.doesNotMatch(RENDER, /body\.appendChild\(preEl\(promptText\)\)/, "the plain <pre> prompt is gone");
   assert.doesNotMatch(RENDER, /el\("div", "agent-fold"\)/, "the shared agent-fold body wrapper is gone");
 });
 
-test("level 0 is ONE head row: both halves fold behind the head's inline toggle (the user 2026-07-17)", () => {
-  // both caret boxes live in a shared wrapper that hangs off the HEAD fold — one row by default
-  assert.match(RENDER, /const halves = el\("div", "agent-folds"\);/);
-  assert.match(RENDER, /const label = ev\.output \? `prompt \+ report · \$\{countLines\(ev\.output\)\} line\$\{countLines\(ev\.output\) === 1 \? "" : "s"\}` : "prompt";/);
-  assert.match(RENDER, /if \(halves\.childElementCount\) \{/);
-  assert.match(RENDER, /inlineFold\(head, turn, label, halves, fkey\);/);
+test("level 0 is ONE head row: the fold hangs off the head's inline toggle under the tool's own key", () => {
+  assert.match(AGENT, /const body = el\("div", "agent-folds"\);/);
+  assert.match(AGENT, /if \(body\.childElementCount\) \{/);
+  assert.match(AGENT, /inlineFold\(head, turn, label, body, fkey\);/, "the same fkey as before, so an open fold survives re-renders");
 });
 
-test("the REPORT gets its own caret fold, line-count in the label, still the green-edged sub-transcript", () => {
-  assert.match(RENDER, /halves\.appendChild\(foldable\(`report · \$\{countLines\(ev\.output\)\} lines`, box, akey \? akey \+ ":report" : undefined\)\);/);
+test("the fold LABEL says what one click reveals: prompt · N tool calls [· report · N lines]", () => {
+  assert.match(AGENT, /const label = agentFoldLabel\(\{ stepsTotal: ev\.stepsTotal \?\? steps\.length, reportLines: ev\.output \? countLines\(ev\.output\) : null \}\);/);
+  // the old two-shape label is gone
+  assert.doesNotMatch(RENDER, /`prompt \+ report · /);
+});
+
+test("the fold's CONTENT order is prompt, then every tool call (one dim row each, the preview's classes), then the report", () => {
+  const iPrompt = AGENT.indexOf("md(promptText)");
+  const iSteps = AGENT.indexOf('el("div", "agent-gist agent-steps")');
+  const iReport = AGENT.indexOf("md(ev.output)");
+  assert.ok(iPrompt > 0 && iSteps > iPrompt && iReport > iSteps, `order: prompt ${iPrompt} < steps ${iSteps} < report ${iReport}`);
+  // the steps list: the shared row builder over stepLines (every step, the clock's elapsed on the last row while running)
+  assert.match(AGENT, /appendGistRows\(list, stepLines\(steps, ev\.agentGist, Date\.now\(\)\)\);/);
+  assert.match(AGENT, /const steps = ev\.agentSteps \|\| \[\];/);
+  // the cap note, one line, only when the kernel cut the oldest calls
+  assert.match(AGENT, /const note = stepsNote\(steps\.length, ev\.stepsTotal\);\s*\n\s*if \(note\) \{ const n = el\("div", "agent-steps-note"\); n\.textContent = note; list\.appendChild\(n\); \}/);
+  // the report: markdown in the same green-edged box, appended last, no caret box
+  assert.match(AGENT, /const box = el\("div", "agent-report md"\); box\.innerHTML = md\(ev\.output\); highlight\(box\);\s*\n\s*body\.appendChild\(box\);/);
   assert.match(CSS, /\.agent-report \{[^}]*border-left: 2px solid rgba\(87, 181, 15/);
+  // the list wears the preview's classes and size — no new font-size; the note rides the same block
+  assert.match(CSS, /\.agent-folds > \.agent-steps \{ margin: [^}]*\}/);
+  assert.match(CSS, /\.agent-steps-note \{[^}]*\}/);
+  assert.doesNotMatch(CSS, /\.agent-steps[^{]*\{[^}]*font-size/, "the steps list inherits .agent-gist's 0.86em");
   // the old per-section uppercase label + the 300px preview clamp are both gone
-  assert.doesNotMatch(RENDER, /agent-fold-label/, "the per-section labels are gone (the caret fold labels them)");
+  assert.doesNotMatch(RENDER, /agent-fold-label/, "the per-section labels are gone");
   assert.doesNotMatch(CSS, /\.agent-fold-label \{/, "the .agent-fold-label rule is gone");
   assert.doesNotMatch(RENDER, /el\("div", "io-clamp agent-clamp"\)/, "the 300px report clamp block is removed");
+});
+
+test("the level-0 preview shows only while RUNNING with the fold CLOSED; a FINISHED head still carries the open-transcript arrow", () => {
+  const tail = (RENDER.match(/if \(\(ev\.name === "Task" \|\| ev\.name === "Agent"\) && ev\.agentId\) \{[\s\S]*?\n  \}\n  return turn;/) || [""])[0];
+  assert.ok(tail.length > 200, "found the arrow/preview block");
+  // the arrow is gated on agentId alone — nothing about output, clock or run-state (the user asked that a
+  // finished agent keep its arrow, 2026-09-05)
+  assert.match(tail, /head\.appendChild\(agentOpenButton\(ev\.agentId, ev\.uuid \|\| null, renderingOwnerSid \|\| renderingSid \|\| null\)\);/);
+  assert.doesNotMatch(tail.split("agentOpenButton")[0], /agentGist|agentRunning|ev\.output|agentSteps/);
+  // the preview: the clock ships only while running (kernel: agentGist goes at finish), and the fold's
+  // open state comes from openFolds under the fold's own key — closed → preview, open → the full list
+  assert.match(tail, /if \(ev\.agentGist && !\(fkey && openFolds\.has\(fkey\)\)\) head\.insertAdjacentElement\("afterend", renderAgentGist\(ev\.agentSteps, ev\.agentGist\)\);/);
+  assert.match(CSS, /\.turn-tool\.fold-open > \.agent-preview \{ display: none; \}/, "the click itself hides it, before the next rebuild");
 });
 
 test("a still-running agent (dispatched, no report yet) reads as RUNNING — amber working dot, not green ✓ (the user 2026-06-24)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -37,6 +37,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional 
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
+import { subTabId, isSubId, subParts, subLabel, gistLines, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist } from "./subagent-view";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
@@ -120,6 +121,16 @@ type ChatEvent = (
       // Skill only: the skill's full instructions markdown (the isMeta content record / its live-stream
       // twin, joined by the kernel) → the tool's collapsed-by-default fold body (the user 2026-07-08).
       skillMd?: string;
+      // Subagent transcripts (plans/subagent-transcripts.md): the tool_use BLOCK id (uuid is the record's);
+      // for Agent/Task the agent the launch wrote (null when no sidecar/ack names one), whether the launch
+      // was a background one, whether it is still running, and — only while running — the live preview
+      // of its last few tool calls. The kernel clears `output` while a background agent runs (the launch
+      // ack is not a report) and fills it with the notification's <result> once it lands.
+      toolUseId?: string;
+      agentId?: string | null;
+      agentAsync?: boolean;
+      agentRunning?: boolean;
+      agentGist?: AgentGist;
     }
   | {
       kind: "postal-service";
@@ -236,14 +247,19 @@ interface Color { bg: string; fg: string; }
 // agent/workflow, `summary` is the dispatch's description (or the workflow meta's summary) and `command`
 // carries the full ask — the Agent prompt / the Workflow script — so the row's detail level says what the
 // work IS, not a generic label over an empty block (the user 2026-08-15).
-interface BgTask { id: string; status: string; summary: string; command?: string; output?: string; }
+interface BgTask { id: string; status: string; summary: string; command?: string; output?: string; agentId?: string; }   // agentId: an AGENT row (its own transcript is openable — plans/subagent-transcripts.md); absent on shell tasks
 // The box payload: count (total to surface → the "N background tasks" header) + up to 16 tasks (the list).
 interface BgTasks { count: number; tasks: BgTask[]; }
 // events is a contiguous TAIL of the transcript: global indices [headFrom, headTotal). On a fresh load the
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
+// A SUBAGENT VIEWER pseudo-session (plans/subagent-transcripts.md): a read-only tab whose events are one
+// agent's own transcript, fed by {type:"subagent"} frames. Client-only — the kernel never lists it in
+// tabOrder (reconcileTabOrder keeps a known, never-kernel-seen id), so it lives exactly as long as the
+// viewer. anchorUuid = the parent's Agent tool head, for the header's link back.
+interface SubInfo { parentId: string; agentId: string; meta: SubMeta | null; running: boolean; truncated: boolean; error: string | null; loaded: boolean; anchorUuid: string | null; }
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -528,9 +544,16 @@ let peekId: string | null = null;
 // the CHAT surface keys on its own lens (per-surface selections, the user 2026-08-25) — the scalar
 // viewVisible stays for legacy callers; tabs and peeks decide through actives.chat
 function chatVisible(id: string): boolean {
+  // a subagent viewer is in the chat lens only once PINNED (its header's pin control): unpinned it is
+  // the peek — assertPeekFor's own derivation then dresses it .tab-peek and drops it on the next
+  // activation, with no second peek mechanism (plans/subagent-transcripts.md)
+  if (isSubId(id)) return pinnedSubs.has(id);
   const v = effViews();
   return lensVisible(surfaceLens(v, "chat"), viewTagUnion(v), id);
 }
+// Pinned subagent viewers ("keep this tab"). Client state like peekId: a pinned viewer does NOT survive
+// a reload in this slice (deliberate — the kernel has no tab-order entry to restore it from; see plan).
+const pinnedSubs = new Set<string>();
 function assertPeekFor(id: string): void {
   const next = chatVisible(id) ? null : id;
   if (next !== peekId) { peekId = next; renderTabs(); }
@@ -3816,7 +3839,44 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
   // No right-side status glyph: the LEFT rail dot already carries the outcome — a green ✓
   // disc on success, a red ✗ disc on error (the user 2026-06-13). The old in-head ✓/✗ sat
   // right beside an identical dot, so it was pure duplication.
+  if ((ev.name === "Task" || ev.name === "Agent") && ev.agentId) {
+    // Subagent transcripts (plans/subagent-transcripts.md): the arrow opens the agent's WHOLE
+    // conversation as a peek tab (level 1); while the agent runs, the preview under the head shows
+    // its last few tool calls (level 0). Both live inside this turn, so a collapsed compact run hides
+    // them with the head and an expanded run shows them.
+    head.appendChild(agentOpenButton(ev.agentId, ev.uuid || null, renderingOwnerSid || renderingSid || null));
+    if (ev.agentGist) head.insertAdjacentElement("afterend", renderAgentGist(ev.agentGist));
+  }
   return turn;
+}
+
+// The house line-icon button that opens a subagent's transcript. Delegated (data-act on the stable
+// document.body delegate below), never a per-node listener: the tool head rebuilds on every push.
+function agentOpenButton(agentId: string, anchorUuid: string | null, ownerSid: string | null): HTMLElement {
+  const b = el("span", "tool-open-agent");
+  b.dataset.act = "openSubagent";
+  b.dataset.agent = agentId;
+  if (ownerSid) b.dataset.sid = ownerSid;
+  if (anchorUuid) b.dataset.uuid = anchorUuid;
+  b.innerHTML = openIconSvg();
+  b.setAttribute("role", "button"); b.tabIndex = 0;
+  setTip(b, "open transcript");
+  return b;
+}
+
+// The running agent's preview: up to three dim rows in the head vocabulary (`<tool> <desc>`), newest
+// last, the last row trailing "· N tool calls · elapsed". Wears the tool-fold-toggle's size (0.86em) —
+// no new font-size on the tool head. Gone once the kernel stops shipping the gist (the agent finished).
+function renderAgentGist(g: AgentGist): HTMLElement {
+  const box = el("div", "agent-gist");
+  for (const line of gistLines(g, Date.now())) {
+    const row = el("div", "agent-gist-row");
+    const t = el("span", "agent-gist-tool"); t.textContent = line.tool; row.appendChild(t);
+    if (line.desc) { const d = el("span", "agent-gist-desc"); d.textContent = line.desc; row.appendChild(d); }
+    if (line.meta) { const m = el("span", "agent-gist-meta"); m.textContent = line.meta; row.appendChild(m); }
+    box.appendChild(row);
+  }
+  return box;
 }
 
 
@@ -4562,8 +4622,9 @@ function renderTabs() {
     tab.dataset.id = id;
     tab.dataset.act = "select";  // click → setActive, via the stable #tabs delegate (./actions), not a per-node handler
     tab.addEventListener("keydown", onTabKey);
-    // drag-to-reorder (synced with the timeline via the shared session-order file)
-    tab.draggable = true;
+    // drag-to-reorder (synced with the timeline via the shared session-order file). A subagent viewer
+    // stays put: it is client-only, and a reorder would post its id into the kernel's order.
+    tab.draggable = !s.sub;
     // Exactly ONE thing on screen may look like the dragged tab (T133, the user 2026-08-27: the
     // native drag image following the pointer PLUS the dimmed in-flow tab read as a ghost
     // duplicate — "not how most softwares show it"). The native image is blanked, and the dimmed
@@ -4666,15 +4727,18 @@ function renderTabs() {
     }
     // Rich hover tooltip (custom DOM — a native title can't colour/bold): backend in its own colour, the
     // full dir path, and mode/model/effort/context each on a line (the user 2026-06-23). See showTabTip.
-    tab.addEventListener("mouseenter", () => showTabTip(tab, s));
-    tab.addEventListener("mouseleave", hideTabTip);
+    if (!s.sub) {   // the rich tip reads a real session's dir/branch/model; a viewer has none of them
+      tab.addEventListener("mouseenter", () => showTabTip(tab, s));
+      tab.addEventListener("mouseleave", hideTabTip);
+    }
     const close = el("span", "tab-close");
     close.textContent = "×";
     // A dead (closed) session has nothing to end, so its ✕ just removes the read-only tab — no
     // "End session?" confirm (the user 2026-06-16). A live session still routes through the host's
-    // Close-tab / End-session confirm (closeSession → confirmClose).
+    // Close-tab / End-session confirm (closeSession → confirmClose). A subagent viewer likewise
+    // just closes (the tabs delegate's close handler routes it by isSubId).
     const dead = st === "closed";
-    close.title = dead ? "Close tab" : "End session";
+    close.title = dead || s.sub ? "Close tab" : "End session";
     // Click-safe (see ./actions): renderTabs() does `#tabs`.replaceChildren() on every kernel push, so a
     // handler hung on this ✕ is destroyed mid-click and the click is dropped (the "had to click End session
     // several times" bug). The action lives on the stable #tabs delegate instead; this node just declares it.
@@ -4684,8 +4748,8 @@ function renderTabs() {
     tab.appendChild(close);
     // double-click a tab to show/hide the ledger overview — same as the strip's caret
     tab.addEventListener("dblclick", (e) => { e.preventDefault(); toggleLedgerCollapsed(); });
-    // right-click → context menu; "Rename" edits the title in place
-    tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, id); });
+    // right-click → context menu; "Rename" edits the title in place (not for a viewer: nothing to rename/hide/end)
+    if (!s.sub) tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, id); });
     bar.appendChild(tab);
   }
   const add = el("div", "tab tab-add");
@@ -8452,6 +8516,8 @@ function syncViewInner(id: string, atBottom?: boolean): View {
   // non-append sync).
   renderingSid = id;          // so renderSystem can key the pinned card's persisted open-state by session
   renderingOwnerSid = id;     // preview/image URLs bake THIS session's id (host prefix included), never activeId's
+  const subOf = subParts(id);
+  if (subOf) renderingOwnerSid = subOf.parentId;   // …except a subagent VIEWER, whose files belong to its PARENT session
   const v = ensureView(id);
   const s = sessions.get(id);
   if (!s) return v;
@@ -8474,6 +8540,16 @@ function syncViewInner(id: string, atBottom?: boolean): View {
       if (failedRevives.has(id)) {
         ph.textContent = failedRevives.get(id) || "";
         ph.classList.add("tx-revive-failed");
+      } else if (s.sub && s.sub.error) {
+        // the kernel could not open the agent's file: its sentence, loud, in the pane (never a blank)
+        ph.textContent = s.sub.error;
+        ph.classList.add("tx-revive-failed");
+      } else if (s.sub && !s.sub.loaded) {
+        // the viewer's first frame is in flight → the romp loader holds the pane (the wait-state rule)
+        ph.classList.add("tx-starting");
+        ph.appendChild(rompLoaderInner("opening the agent's transcript…"));
+      } else if (s.sub) {
+        ph.textContent = "This agent has written nothing yet.";
       } else if (isProvisionalId(id) && failedProvisionals.has(id)) {
         ph.textContent = "This session couldn't start. What you typed is kept in the box below; "
           + "✕ on the tab discards both.";
@@ -8928,6 +9004,7 @@ function showActive() {
   const s = activeId ? sessions.get(activeId) : null;
   if (!s) {
     for (const v of views.values()) v.el.style.display = "none";
+    renderSubHead();   // no active viewer → the header goes
     // A KNOWN-LOADING tab (its meta arrived, its payload hasn't — the clicked placeholder): the
     // thread area holds the pane-local romp loader, and the first session frame renders in place —
     // you're already there (the user 2026-08-25). Everything else keeps the no-sessions copy.
@@ -8958,10 +9035,12 @@ function showActive() {
     // a FAILED provisional wears the closed treatment on its tab, but its composer stays LIVE: it holds
     // the only copy of what was typed, which must stay editable/copyable (the send path refuses loudly)
     const closed = s.status.state === "closed" && !failedProvisionals.has(activeId!);
-    composer.disabled = closed;
+    const viewer = !!s.sub;   // a SUBAGENT VIEWER is read-only by nature: there is no session behind it to message
+    composer.disabled = closed || viewer;
     composer.placeholder = closed ? "Session closed — read-only" : composerRestingPlaceholder();
+    if (viewer) composer.placeholder = "Subagent transcript — read-only";
     const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
-    if (sendBtn) sendBtn.disabled = closed;   // read-only session → the explicit send button is dead too
+    if (sendBtn) sendBtn.disabled = closed || viewer;   // read-only session/viewer → the explicit send button is dead too
   }
   // tint the whole-window border with the active session's identity color
   if (s.color && s.color.bg) document.body.style.setProperty("--active-accent", s.color.bg);
@@ -8982,6 +9061,7 @@ function showActive() {
     v.rendered = 0; v.winStart = 0; v.avgTurnH = undefined; v.stick = true;   // → firstBuild rebuilds the tail, lands at bottom
   }
   for (const [vid, vv] of views) vv.el.style.display = vid === activeId ? "" : "none";
+  renderSubHead();   // the viewer's header above its transcript (hidden for every real session)
   updateStatusline();
   // The transcript BUILD is the only expensive part of a switch. A view already built for the current
   // events renders instantly (cache / incremental); an UNBUILT one (first visit), or a compact view whose
@@ -9612,6 +9692,117 @@ function renderLedger() {
 const bgExpanded = new Set<string>();   // task ids whose details are open
 const bgFoldOpen = new Set<string>();   // session ids whose list is expanded
 const BG_RANK: Record<string, number> = { failed: 3, running: 2, completed: 1 };
+// ── SUBAGENT VIEWER (plans/subagent-transcripts.md, 2026-09-05) ─────────────────────────────────
+// The arrow on an Agent head (or an agent bg-task row) opens the agent's whole transcript as a PEEK tab:
+// a client-only pseudo-session in `sessions`/`order` with id `<parentId>/agent/<agentId>`, fed by the
+// kernel's {type:"subagent"} frames (openSubagent → first frame now, then a re-push whenever the agent's
+// file or liveness moves; closeSubagent stops them). Rendered through the SAME syncView/displayItems/
+// renderEvent path as the chat — Compact transcript, folds, day dividers, all of it — read-only. Peek
+// mechanics are the chat's own: chatVisible() says a viewer is in the lens only when pinned, so
+// assertPeekFor dresses it .tab-peek and pruneSubViews (from setActive) closes it on the next activation.
+function openSubagentView(parentId: string, agentId: string, anchorUuid: string | null): void {
+  const id = subTabId(parentId, agentId);
+  const parent = sessions.get(parentId);
+  const cur = sessions.get(id);
+  if (!cur) {
+    sessions.set(id, {
+      id, name: subLabel(null), color: parent?.color || null, events: [],
+      status: { state: "idle", sinceEpoch: null, backend: "sub" },
+      cwd: parent?.cwd,
+      sub: { parentId, agentId, meta: null, running: false, truncated: false, error: null, loaded: false, anchorUuid },
+    });
+    if (!order.includes(id)) order.push(id);
+    vscodeApi?.postMessage({ type: "openSubagent", id: parentId, agentId });
+  } else if (anchorUuid && cur.sub) cur.sub.anchorUuid = anchorUuid;
+  setActive(id);
+}
+
+function closeSubagentView(id: string): void {
+  const p = subParts(id);
+  if (p) vscodeApi?.postMessage({ type: "closeSubagent", id: p.parentId, agentId: p.agentId });
+  pinnedSubs.delete(id);
+  dismissSession(id, "close");
+}
+
+// Every UNPINNED viewer other than `keep` closes — the peek rule, applied at the one event that ends
+// a peek (an activation), never on a timer. A pinned viewer stays until its ✕.
+function pruneSubViews(keep: string): void {
+  for (const id of Array.from(sessions.keys())) {
+    if (id !== keep && isSubId(id) && !pinnedSubs.has(id)) closeSubagentView(id);
+  }
+}
+
+// A {type:"subagent"} frame: replace the viewer's events in place (the chat's own append/scroll rule
+// via appendActive when it is the active tab — follow the bottom only when already there), refresh the
+// header and the tab label. A frame for a viewer that is no longer open tells the kernel to stop.
+function applySubagentFrame(m: any): void {
+  const parentId = String(m.id || ""), agentId = String(m.agentId || "");
+  if (!parentId || !agentId) return;
+  const id = subTabId(parentId, agentId);
+  const s = sessions.get(id);
+  if (!s || !s.sub) { vscodeApi?.postMessage({ type: "closeSubagent", id: parentId, agentId }); return; }
+  s.sub.loaded = true;
+  s.sub.error = m.error ? String(m.error) : null;
+  s.sub.running = !!m.running;
+  s.sub.truncated = !!m.truncated;
+  if (m.meta && typeof m.meta === "object") s.sub.meta = m.meta as SubMeta;
+  s.name = subLabel(s.sub.meta);
+  if (!s.sub.error) s.events = Array.isArray(m.events) ? (m.events as ChatEvent[]) : [];
+  else s.events = [];
+  renderTabs();
+  if (activeId === id) {
+    const v = views.get(id);
+    const first = !v || v.rendered === 0;   // the pane held the loader/placeholder — this is the FIRST content
+    if (v && s.events.length === 0) { v.rendered = 0; v.stale = true; }   // placeholder → loader/error/empty re-derives
+    // the first content lands at the NEWEST end like a fresh tab (showActive → landActive); every later
+    // frame is an append that keeps the reader's spot (appendActive's follow-only-when-at-bottom rule)
+    if (first) { if (v) { v.stick = true; v.rendered = 0; } showActive(); }
+    else appendActive();
+    renderSubHead();
+  } else {
+    const v = views.get(id);
+    if (v) v.stale = true;
+  }
+}
+
+// The viewer's header, a sticky line above its transcript inside #content: "subagent of <parent> ·
+// <type> · running|finished", the parent name a link back to the Agent tool head (setActive with the
+// head's uuid as the anchor — the chat's own scroll-to-uuid), the pin control, and the "earlier part
+// not shown" note when the kernel cut the tail. Hidden whenever the active tab is a real session.
+function renderSubHead(): void {
+  const content = document.getElementById("content");
+  if (!content) return;
+  let host = document.getElementById("sub-head");
+  const s = activeId ? sessions.get(activeId) : null;
+  if (!s || !s.sub) { if (host) host.remove(); return; }
+  if (!host) { host = el("div", "sub-head"); host.id = "sub-head"; content.insertBefore(host, content.firstChild); }
+  host.replaceChildren();
+  const line = el("div", "sub-head-line");
+  const kicker = el("span", "sub-head-kicker"); kicker.textContent = "subagent of"; line.appendChild(kicker);
+  const parentName = sessions.get(s.sub.parentId)?.name || tabMeta.get(s.sub.parentId)?.name || "its session";
+  const link = el("span", "sub-head-parent");
+  link.dataset.act = "subParent"; link.dataset.sid = s.sub.parentId;
+  if (s.sub.anchorUuid) link.dataset.uuid = s.sub.anchorUuid;
+  link.replaceChildren(...hostNameNodes(parentName, s.sub.parentId));
+  setTip(link, "back to the launch in the parent session");
+  line.appendChild(link);
+  const parts = subHeadParts(s.sub.meta, s.sub.running);
+  const typ = el("span", "sub-head-type"); typ.textContent = "· " + parts.type; line.appendChild(typ);
+  const state = el("span", "sub-head-state " + parts.state); state.textContent = "· " + parts.state; line.appendChild(state);
+  const pin = el("span", "sub-head-pin" + (pinnedSubs.has(s.id) ? " pinned" : ""));
+  pin.dataset.act = "pinSubagent"; pin.dataset.id = s.id;
+  pin.innerHTML = pinIconSvg();
+  pin.setAttribute("role", "button"); pin.tabIndex = 0;
+  setTip(pin, pinnedSubs.has(s.id) ? "kept — click to let this tab close on its own" : "keep this tab");
+  line.appendChild(pin);
+  host.appendChild(line);
+  if (s.sub.truncated && !s.sub.error) {
+    const note = el("div", "sub-head-note");
+    note.textContent = "earlier part not shown";
+    host.appendChild(note);
+  }
+}
+
 function renderBgTasks() {
   const host = document.getElementById("bg-tasks");
   if (!host) return;
@@ -9652,6 +9843,14 @@ function renderBgTasks() {
     rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id;   // the row header toggles; clicks in the detail body don't collapse it
     rh.appendChild(el("span", "bg-dot"));
     const sum = el("span", "bg-sum"); sum.textContent = t.summary || "Background task"; rh.appendChild(sum);
+    if (t.agentId) {
+      // an AGENT row: the same open-transcript arrow the Agent tool head wears (plans/subagent-transcripts.md).
+      // Nested inside the bg-toggle row; the body delegate's closest-[data-act] lookup finds the arrow first,
+      // so a click opens the viewer without toggling the row.
+      const open = agentOpenButton(t.agentId, null, sid);
+      open.classList.add("bg-open-agent");
+      rh.appendChild(open);
+    }
     const st = el("span", "bg-status"); st.textContent = t.status || "running"; rh.appendChild(st);
     if ((t.status || "running") === "running") {
       // Stop this ONE task (the SDK's stop_task control request — the user 2026-08-04). Rides the same
@@ -10848,6 +11047,14 @@ function updateStatusline() {
   }
   if (!s) return;
   sl.replaceChildren();
+  if (s.sub) {
+    // a subagent viewer has no session state, model or context to show — the header above the
+    // transcript says what it is; the statusline just says the pane is read-only
+    const ro = el("span", "sub-status-line");
+    ro.textContent = "read-only · a subagent's transcript";
+    sl.appendChild(ro);
+    return;
+  }
   // Left: the state chip — WORKING gets a sine color-pulse + elapsed timer; idle
   // states get the plain chip (no timer). Right: model + effort · ctx%, always.
   if (s.status.state === "working") {
@@ -11814,6 +12021,13 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   // drops it. Before the already-active early-return, so a re-focus of a hidden session re-asserts
   // its peek even when nothing else changes.
   assertPeekFor(id);
+  pruneSubViews(id);   // an unpinned subagent viewer is a peek: any other activation closes it (and its kernel pushes)
+  if (isSubId(id) && !sessions.has(id)) {
+    // a viewer id from the nav trail / a stale state whose tab is gone → reopen it (openSubagentView
+    // lands back here with the pseudo-session in place)
+    const p = subParts(id);
+    if (p) { openSubagentView(p.parentId, p.agentId, null); return; }
+  }
   if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
   navHist.record();   // every real navigation records the spot being LEFT (the user 2026-08-14: Ctrl+M / Ctrl+, walk the trail)
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
@@ -12462,6 +12676,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "chatTail") chatTail(m);
   else if (m.type === "chatHead") chatHead(m);
   else if (m.type === "chatEpisode") chatEpisode(m);
+  else if (m.type === "subagent") applySubagentFrame(m);
   else if (m.type === "update") update(m);
   else if (m.type === "status") statusOnly(m);
   else if (m.type === "focus") {
@@ -13716,6 +13931,23 @@ setupSettings();
     document.addEventListener("click", dismiss);
   });
   delegate(document.body, {
+    // Subagent transcripts (plans/subagent-transcripts.md): the arrow on an Agent head / agent bg row
+    // opens the viewer; the viewer header's parent link jumps back to the tool head; its pin keeps the tab.
+    openSubagent: (el) => {
+      const agentId = el.dataset.agent; if (!agentId) return;
+      const owner = el.dataset.sid || activeId; if (!owner) return;
+      openSubagentView(owner, agentId, el.dataset.uuid || null);
+    },
+    subParent: (el) => {
+      const sid = el.dataset.sid; if (!sid) return;
+      setActive(sid, el.dataset.uuid || undefined);
+    },
+    pinSubagent: (el) => {
+      const id = el.dataset.id; if (!id) return;
+      if (pinnedSubs.has(id)) pinnedSubs.delete(id); else pinnedSubs.add(id);
+      assertPeekFor(id);   // pinned → in the chat lens → sheds the peek dress; unpinned → back to a peek
+      renderSubHead();
+    },
     openFolder: (el) => {
       const cwd = el.dataset.cwd; if (!cwd || !vscodeApi) return;
       const id = el.dataset.id;
@@ -13908,6 +14140,7 @@ setupSettings();
     select: (el) => { const id = el.dataset.id; if (id) { setActive(id); focusActiveTab(); } },
     close: (el) => {
       const id = el.dataset.id;
+      if (id && isSubId(id)) { closeSubagentView(id); return; }   // a subagent viewer: nothing to end, just close
       if (!id || !vscodeApi) return;
       // dead → just drop the read-only tab (optimistically too: it's the same kernel round-trip to wait
       // on). A failed provisional is local-only — the kernel never knew its id, so nothing to post.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9038,9 +9038,12 @@ function showActive() {
     const viewer = !!s.sub;   // a SUBAGENT VIEWER is read-only by nature: there is no session behind it to message
     composer.disabled = closed || viewer;
     composer.placeholder = closed ? "Session closed — read-only" : composerRestingPlaceholder();
-    if (viewer) composer.placeholder = "Subagent transcript — read-only";
     const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
     if (sendBtn) sendBtn.disabled = closed || viewer;   // read-only session/viewer → the explicit send button is dead too
+    // ONE read-only cue for the viewer: the statusline's dim line. The whole message box (input + send)
+    // goes, so the pane never says it twice and the transcript gets the vertical space back.
+    const composerBox = document.getElementById("composer");
+    if (composerBox) composerBox.style.display = viewer ? "none" : "";
   }
   // tint the whole-window border with the active session's identity color
   if (s.color && s.color.bg) document.body.style.setProperty("--active-accent", s.color.bg);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -37,7 +37,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional 
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
-import { subTabId, isSubId, subParts, subLabel, gistLines, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist } from "./subagent-view";
+import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
@@ -123,13 +123,17 @@ type ChatEvent = (
       skillMd?: string;
       // Subagent transcripts (plans/subagent-transcripts.md): the tool_use BLOCK id (uuid is the record's);
       // for Agent/Task the agent the launch wrote (null when no sidecar/ack names one), whether the launch
-      // was a background one, whether it is still running, and — only while running — the live preview
-      // of its last few tool calls. The kernel clears `output` while a background agent runs (the launch
-      // ack is not a report) and fills it with the notification's <result> once it lands.
+      // was a background one, whether it is still running, its tool calls so far (agentSteps: oldest
+      // first, the newest 200; stepsTotal the true count — shipped running OR finished, the fold lists
+      // them either way) and — only while running — the preview's clock (agentGist). The kernel clears
+      // `output` while a background agent runs (the launch ack is not a report) and fills it with the
+      // notification's <result> once it lands.
       toolUseId?: string;
       agentId?: string | null;
       agentAsync?: boolean;
       agentRunning?: boolean;
+      agentSteps?: AgentGistRow[];
+      stepsTotal?: number;
       agentGist?: AgentGist;
     }
   | {
@@ -3791,28 +3795,37 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
     const signal = ev.name === "Task" || ev.name === "Agent";
     if (signal) {
       // Subagent (Task/Agent) = a delegated mini-conversation, disclosed PROGRESSIVELY (the user
-      // 2026-07-17: default compact, click to go deeper — everywhere). Level 0 is ONE head row (Task +
-      // its description, the amber/green rail dot carrying run-state); level 1 (the head's inline fold)
-      // reveals the PROMPT and REPORT as their own collapsed caret boxes; level 2 opens either box —
-      // each markdown-rendered (the user 2026-07-08; the prompt is the prompt field, not the tool JSON).
-      // Unlike the pre-07-08 head toggle this reveals fold LABELS, not the prompt itself, so nothing
-      // renders twice.
-      const akey = fkey ? fkey + ":agent" : undefined;
-      const halves = el("div", "agent-folds");
+      // 2026-07-17: default compact, click to go deeper — everywhere). Level 0 is ONE head row (Agent +
+      // its description, the amber/green rail dot carrying run-state) plus, while it runs, the three-row
+      // preview below. Level 1 — ONE click on the head's inline fold — reveals everything, all OPEN and
+      // in the label's order: the PROMPT as markdown (the prompt field, not the tool JSON — the user
+      // 2026-07-08), the FULL list of tool calls (one dim row each, the preview's own vocabulary, newest
+      // last, growing live while the agent runs), then the REPORT as markdown once it has finished. The
+      // 2026-07-08 cut nested prompt and report as collapsed caret boxes inside the fold, so reading the
+      // prompt took two clicks; the user found that odd (2026-09-05), hence one fold, nothing nested.
+      // The label says what the click reveals: "prompt · 12 tool calls" / "… · report · 3 lines".
+      const body = el("div", "agent-folds");
       if (ev.input) {
         let promptText = ev.input;   // ev.input is the tool's full JSON; show just the prompt the agent was given
         try { const o = JSON.parse(ev.input); if (o && typeof o.prompt === "string") promptText = o.prompt; } catch { /* truncated JSON → show raw */ }
         const box = el("div", "agent-report md"); box.innerHTML = md(promptText); highlight(box);
-        halves.appendChild(foldable("prompt", box, akey ? akey + ":prompt" : undefined));
+        body.appendChild(box);
+      }
+      const steps = ev.agentSteps || [];
+      if (steps.length) {
+        const list = el("div", "agent-gist agent-steps");
+        const note = stepsNote(steps.length, ev.stepsTotal);
+        if (note) { const n = el("div", "agent-steps-note"); n.textContent = note; list.appendChild(n); }
+        appendGistRows(list, stepLines(steps, ev.agentGist, Date.now()));
+        body.appendChild(list);
       }
       if (ev.output) {
-        // the report is the meatier half → its line count rides the fold label (else just "report")
         const box = el("div", "agent-report md"); box.innerHTML = md(ev.output); highlight(box);
-        halves.appendChild(foldable(`report · ${countLines(ev.output)} lines`, box, akey ? akey + ":report" : undefined));
+        body.appendChild(box);
       }
-      if (halves.childElementCount) {
-        const label = ev.output ? `prompt + report · ${countLines(ev.output)} line${countLines(ev.output) === 1 ? "" : "s"}` : "prompt";
-        inlineFold(head, turn, label, halves, fkey);
+      if (body.childElementCount) {
+        const label = agentFoldLabel({ stepsTotal: ev.stepsTotal ?? steps.length, reportLines: ev.output ? countLines(ev.output) : null });
+        inlineFold(head, turn, label, body, fkey);
       }
     } else if (!ev.output) {
       // No result text yet, OR a command that finished with no output (mkdir, git add, …). Keep the command
@@ -3841,11 +3854,15 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
   // right beside an identical dot, so it was pure duplication.
   if ((ev.name === "Task" || ev.name === "Agent") && ev.agentId) {
     // Subagent transcripts (plans/subagent-transcripts.md): the arrow opens the agent's WHOLE
-    // conversation as a peek tab (level 1); while the agent runs, the preview under the head shows
-    // its last few tool calls (level 0). Both live inside this turn, so a collapsed compact run hides
-    // them with the head and an expanded run shows them.
+    // conversation as a peek tab — running or finished, whenever the agent is known. While the agent
+    // runs (the kernel ships its clock), the preview under the head shows its last three tool calls
+    // (level 0) — but only while the head's fold is CLOSED: an open fold lists every call, so the
+    // preview would repeat its tail. The fold's state is read from the same store that keeps it across
+    // re-renders (openFolds, keyed by fkey) — no new state; the CSS twin (.fold-open hides
+    // .agent-preview) covers the click itself, before the next push rebuilds the turn. Everything here
+    // lives inside this turn, so a collapsed compact run hides it with the head.
     head.appendChild(agentOpenButton(ev.agentId, ev.uuid || null, renderingOwnerSid || renderingSid || null));
-    if (ev.agentGist) head.insertAdjacentElement("afterend", renderAgentGist(ev.agentGist));
+    if (ev.agentGist && !(fkey && openFolds.has(fkey))) head.insertAdjacentElement("afterend", renderAgentGist(ev.agentSteps, ev.agentGist));
   }
   return turn;
 }
@@ -3866,17 +3883,22 @@ function agentOpenButton(agentId: string, anchorUuid: string | null, ownerSid: s
 
 // The running agent's preview: up to three dim rows in the head vocabulary (`<tool> <desc>`), newest
 // last, the last row trailing "· N tool calls · elapsed". Wears the tool-fold-toggle's size (0.86em) —
-// no new font-size on the tool head. Gone once the kernel stops shipping the gist (the agent finished).
-function renderAgentGist(g: AgentGist): HTMLElement {
-  const box = el("div", "agent-gist");
-  for (const line of gistLines(g, Date.now())) {
+// no new font-size on the tool head. Gone once the kernel stops shipping the clock (the agent finished).
+function renderAgentGist(steps: AgentGistRow[] | undefined, g: AgentGist): HTMLElement {
+  const box = el("div", "agent-gist agent-preview");
+  appendGistRows(box, gistLines(steps, g, Date.now()));
+  return box;
+}
+
+// One dim row per tool call — the preview and the fold's full list share the rows, so they read alike.
+function appendGistRows(box: HTMLElement, lines: GistLine[]): void {
+  for (const line of lines) {
     const row = el("div", "agent-gist-row");
     const t = el("span", "agent-gist-tool"); t.textContent = line.tool; row.appendChild(t);
     if (line.desc) { const d = el("span", "agent-gist-desc"); d.textContent = line.desc; row.appendChild(d); }
     if (line.meta) { const m = el("span", "agent-gist-meta"); m.textContent = line.meta; row.appendChild(m); }
     box.appendChild(row);
   }
-  return box;
 }
 
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2248,6 +2248,32 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .notice-dot-clear { border-color: var(--dim); }
 .clear-loading { display: inline-flex; align-items: center; gap: 8px; }
 .clear-truncated { color: var(--dim); padding: 4px 0 6px; }
+
+/* ── SUBAGENT TRANSCRIPTS (plans/subagent-transcripts.md, 2026-09-05) ──────────────────────────────
+   The open-transcript arrow on an Agent head / agent bg row and the viewer header's pin share ONE
+   button dress (dim line icon, accent on hover — the house icon-button treatment); the running
+   preview under the head wears the tool-fold-toggle's 0.86em (no new size on the tool head); the
+   viewer header is a sticky dim line above the transcript, tokens only so both themes read. */
+.tool-open-agent, .sub-head-pin { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 4px; color: var(--dim); cursor: pointer; flex: 0 0 auto; align-self: center; }
+.tool-open-agent:hover, .sub-head-pin:hover { color: var(--accent); background: var(--accent-wash); }
+.tool-open-agent svg, .sub-head-pin svg { display: block; }
+.tool-open-agent.bg-open-agent { margin-left: 2px; }
+.sub-head-pin.pinned { color: var(--accent); }
+.agent-gist { display: flex; flex-direction: column; gap: 1px; margin: 1px 0 3px; color: var(--dim); font-size: 0.86em; }
+.agent-gist-row { display: flex; align-items: baseline; gap: 6px; min-width: 0; }
+.agent-gist-tool { flex: 0 0 auto; font-weight: 600; }
+.agent-gist-desc { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-gist-meta { flex: 0 0 auto; white-space: nowrap; opacity: 0.8; }
+#sub-head { position: sticky; top: 0; z-index: 2; background: var(--bg); border-bottom: 1px solid var(--box-border); color: var(--dim); font-size: 0.86em; }
+.sub-head-line { display: flex; align-items: center; gap: 6px; padding: 6px 12px; min-width: 0; }
+.sub-head-parent { color: var(--fg); cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; }
+.sub-head-parent:hover { text-decoration: underline; }
+.sub-head-type { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.sub-head-state.running { color: var(--st-working-bg); }
+.sub-head-state.finished { color: var(--st-ready-bg); }
+.sub-head-pin { margin-left: auto; }
+.sub-head-note { padding: 0 12px 6px; }
+.sub-status-line { color: var(--dim); }
 /* the nested pre-clear transcript: same renderers as the live chat, scoped so its rail hugs the card */
 .clear-episode { border-top: 1px solid var(--box-border); margin-top: 4px; padding-top: 4px; }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2264,6 +2264,11 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .agent-gist-tool { flex: 0 0 auto; font-weight: 600; }
 .agent-gist-desc { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .agent-gist-meta { flex: 0 0 auto; white-space: nowrap; opacity: 0.8; }
+/* the head's fold lists EVERY call (same rows); the level-0 preview yields to it the instant the fold
+   opens — this rule covers the click, the render-time openFolds check covers every rebuild after */
+.turn-tool.fold-open > .agent-preview { display: none; }
+.agent-folds > .agent-steps { margin: 6px 0 6px 2px; }
+.agent-steps-note { opacity: 0.8; font-style: italic; margin-bottom: 2px; }
 #sub-head { position: sticky; top: 0; z-index: 2; background: var(--bg); border-bottom: 1px solid var(--box-border); color: var(--dim); font-size: 0.86em; }
 .sub-head-line { display: flex; align-items: center; gap: 6px; padding: 6px 12px; min-width: 0; }
 .sub-head-parent { color: var(--fg); cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; }

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -1,0 +1,178 @@
+// Subagent transcripts (plans/subagent-transcripts.md, 2026-09-05): the UI half. The pure module
+// (ids, labels, the running preview's rows, the elapsed clock) is exercised directly; the DOM wiring in
+// render.ts has no jsdom harness, so — like every other webview test — it is pinned at the source level:
+// the arrow appears only with an agentId, the preview lives INSIDE the tool turn (so a collapsed compact
+// run hides it), the viewer is a peek tab through the chat's own derivation (chatVisible answers
+// pinnedSubs), read-only, with a header back-link + pin, an error sentence, a truncated note.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { subTabId, isSubId, subParts, subLabel, gistLines, elapsedSince, subHeadParts, openIconSvg, pinIconSvg, SUB_SEP } from "../../ui/webview/subagent-view";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+// ── the pure module ─────────────────────────────────────────────────────────────────────────────
+test("the viewer tab id is the parent id plus a COLON-FREE suffix, so hostOf(subId) === hostOf(parentId)", () => {
+  const local = subTabId("11111111-2222-3333-4444-555555555555", "a1111111111111111");
+  assert.equal(local, "11111111-2222-3333-4444-555555555555/agent/a1111111111111111");
+  assert.ok(isSubId(local));
+  assert.deepEqual(subParts(local), { parentId: "11111111-2222-3333-4444-555555555555", agentId: "a1111111111111111" });
+  // federation: the parent id already carries "host:" — the first colon stays the host marker
+  const remote = subTabId("TESTHOST:11111111-2222-3333-4444-555555555555", "a1111111111111111");
+  assert.equal(remote.indexOf(":"), "TESTHOST".length, "the only colon is the host marker");
+  assert.equal(subParts(remote)!.parentId, "TESTHOST:11111111-2222-3333-4444-555555555555");
+  assert.ok(!SUB_SEP.includes(":"), "the suffix never introduces a colon");
+  // not a viewer id
+  assert.ok(!isSubId("11111111-2222-3333-4444-555555555555"));
+  assert.equal(subParts("11111111-2222-3333-4444-555555555555"), null);
+  assert.equal(subParts("/agent/a1"), null, "an empty parent is not a viewer id");
+  assert.equal(subParts("x/agent/"), null, "an empty agent id is not a viewer id");
+});
+
+test("the tab label is the description (clipped), else the agent type, never the hex id", () => {
+  assert.equal(subLabel({ description: "check the api tests", agentType: "general-purpose" }), "check the api tests");
+  assert.equal(subLabel({ description: "", agentType: "Explore" }), "Explore");
+  assert.equal(subLabel(null), "subagent");
+  const long = subLabel({ description: "run the whole notes-api suite and write up every failure" });
+  assert.ok(long.length <= 28 && long.endsWith("…"), long);
+});
+
+test("gistLines: newest LAST, the head vocabulary per row, count + elapsed trailing the last row only", () => {
+  const now = Date.parse("2026-09-05T10:01:00.000Z");
+  const g = { recent: [{ tool: "Bash", desc: "run the api tests" }, { tool: "Grep", desc: "def test_" }, { tool: "Read", desc: "/tmp/notes-api/api/notes.py" }],
+              calls: 12, since: "2026-09-05T10:00:20.000Z", last: "2026-09-05T10:00:58.000Z" };
+  const lines = gistLines(g, now);
+  assert.equal(lines.length, 3);
+  assert.deepEqual(lines.map((l) => l.tool), ["Bash", "Grep", "Read"]);
+  assert.equal(lines[0].meta, "", "only the last row carries the count/elapsed");
+  assert.equal(lines[1].meta, "");
+  assert.equal(lines[2].meta, "· 12 tool calls · 40s");
+  // one call reads singular; a longer run reads m/s like the statusline timer
+  assert.equal(gistLines({ recent: [{ tool: "Read", desc: "x" }], calls: 1, since: "2026-09-05T09:58:55.000Z" }, now)[0].meta, "· 1 tool call · 2m 5s");
+  // more than three recent rows are clipped to the newest three (defensive: the kernel ships three)
+  assert.equal(gistLines({ recent: [1, 2, 3, 4].map((i) => ({ tool: "T" + i, desc: "" })), calls: 4 }, now).map((l) => l.tool).join(","), "T2,T3,T4");
+  // no gist / nothing recent → nothing to draw (the caller renders no box)
+  assert.deepEqual(gistLines(null, now), []);
+  assert.deepEqual(gistLines({ recent: [], calls: 0 }, now), []);
+});
+
+test("elapsedSince prints the statusline timer's shapes and is empty for an unreadable stamp", () => {
+  const now = Date.parse("2026-09-05T12:00:00.000Z");
+  assert.equal(elapsedSince("2026-09-05T11:59:30.000Z", now), "30s");
+  assert.equal(elapsedSince("2026-09-05T11:57:55.000Z", now), "2m 5s");
+  assert.equal(elapsedSince("2026-09-05T10:57:00.000Z", now), "1h 3m");
+  assert.equal(elapsedSince("garbage", now), "");
+  assert.equal(elapsedSince(null, now), "");
+});
+
+test("the header parts: type falls back to 'agent'; state is running|finished", () => {
+  assert.deepEqual(subHeadParts({ agentType: "Explore" }, true), { type: "Explore", state: "running" });
+  assert.deepEqual(subHeadParts(null, false), { type: "agent", state: "finished" });
+});
+
+test("both icons wear the house line-icon style: 16-unit viewBox, currentColor, stroke 1.4, round caps", () => {
+  for (const svg of [openIconSvg(), pinIconSvg()]) {
+    assert.match(svg, /viewBox="0 0 16 16"/);
+    assert.match(svg, /stroke="currentColor"/);
+    assert.match(svg, /stroke-width="1\.4"/);
+    assert.match(svg, /stroke-linecap="round" stroke-linejoin="round"/);
+    assert.doesNotMatch(svg, /#[0-9a-fA-F]{3,6}/, "no hardcoded colour — the button's CSS tints it");
+  }
+});
+
+// ── render.ts wiring (source pins) ──────────────────────────────────────────────────────────────
+test("the arrow rides the Agent/Task head ONLY when the event carries an agentId, and the preview only with a gist", () => {
+  assert.match(RENDER, /if \(\(ev\.name === "Task" \|\| ev\.name === "Agent"\) && ev\.agentId\) \{[\s\S]{0,700}?head\.appendChild\(agentOpenButton\(ev\.agentId, ev\.uuid \|\| null, renderingOwnerSid \|\| renderingSid \|\| null\)\);\s*\n\s*if \(ev\.agentGist\) head\.insertAdjacentElement\("afterend", renderAgentGist\(ev\.agentGist\)\);/);
+  // the running-dot rule the older pin holds is untouched: the kernel clears a running background
+  // agent's output, so "no output" still reads as running
+  assert.match(RENDER, /const agentRunning = \(ev\.name === "Task" \|\| ev\.name === "Agent"\) && !ev\.output && !ev\.isError;/);
+});
+
+test("the arrow is click-safe: a data-act on the stable body delegate, a setTip tooltip, the house icon", () => {
+  assert.match(RENDER, /function agentOpenButton\(agentId: string, anchorUuid: string \| null, ownerSid: string \| null\): HTMLElement \{[\s\S]{0,600}?b\.dataset\.act = "openSubagent";[\s\S]{0,400}?b\.innerHTML = openIconSvg\(\);[\s\S]{0,200}?setTip\(b, "open transcript"\);/);
+  assert.match(RENDER, /delegate\(document\.body, \{[\s\S]{0,600}?openSubagent: \(el\) => \{/);
+  assert.match(RENDER, /subParent: \(el\) => \{[\s\S]{0,200}?setActive\(sid, el\.dataset\.uuid \|\| undefined\);/);
+  assert.match(RENDER, /pinSubagent: \(el\) => \{[\s\S]{0,300}?assertPeekFor\(id\);/);
+  assert.doesNotMatch(RENDER, /tool-open-agent"\)[\s\S]{0,300}?addEventListener\("click"/, "never a per-node click handler on a rebuilt head");
+});
+
+test("the preview renders INSIDE the tool turn in the fold-toggle's size — a collapsed compact run hides it; the collapsed line never draws it", () => {
+  assert.match(RENDER, /function renderAgentGist\(g: AgentGist\): HTMLElement \{[\s\S]{0,300}?for \(const line of gistLines\(g, Date\.now\(\)\)\) \{/);
+  assert.match(RENDER, /const row = el\("div", "agent-gist-row"\);[\s\S]{0,400}?"agent-gist-tool"[\s\S]{0,200}?"agent-gist-desc"[\s\S]{0,200}?"agent-gist-meta"/);
+  // the collapsed toolgroup line knows nothing of the gist — only the per-tool renderTool (run when expanded) does
+  const group = (RENDER.match(/function renderToolGroup\([\s\S]*?\n\}\n/) || [""])[0];
+  assert.ok(group.length > 200, "found renderToolGroup");
+  assert.doesNotMatch(group, /agentGist|renderAgentGist/);
+  assert.match(CSS, /\.agent-gist \{[^}]*font-size: 0\.86em;/);
+  assert.match(CSS, /\.tool-fold-toggle \{[^}]*font-size: 0\.86em;/, "the SAME size the tool head already uses");
+  assert.match(CSS, /\.agent-gist-desc \{[^}]*text-overflow: ellipsis;[^}]*white-space: nowrap;/);
+  assert.match(CSS, /\.agent-gist-meta \{[^}]*white-space: nowrap;/, "the trailing count/elapsed always fits — the desc shrinks");
+});
+
+test("the bg-tasks box puts the same arrow on an AGENT row only (shell rows keep their treatment)", () => {
+  assert.match(RENDER, /if \(t\.agentId\) \{[\s\S]{0,500}?const open = agentOpenButton\(t\.agentId, null, sid\);\s*\n\s*open\.classList\.add\("bg-open-agent"\);/);
+  assert.match(RENDER, /interface BgTask \{[^}]*agentId\?: string;/);
+});
+
+test("the viewer is a PEEK through the chat's own derivation: chatVisible answers pinnedSubs for a viewer id", () => {
+  assert.match(RENDER, /function chatVisible\(id: string\): boolean \{[\s\S]{0,600}?if \(isSubId\(id\)\) return pinnedSubs\.has\(id\);/);
+  assert.match(RENDER, /const pinnedSubs = new Set<string>\(\);/);
+  // opening: a client-only pseudo-session in sessions/order, the kernel asked once, then setActive
+  assert.match(RENDER, /function openSubagentView\(parentId: string, agentId: string, anchorUuid: string \| null\): void \{[\s\S]{0,1200}?vscodeApi\?\.postMessage\(\{ type: "openSubagent", id: parentId, agentId \}\);[\s\S]{0,200}?setActive\(id\);/);
+  // the peek closes on the next activation (pruneSubViews in setActive), telling the kernel to stop
+  assert.match(RENDER, /assertPeekFor\(id\);\s*\n\s*pruneSubViews\(id\);/);
+  assert.match(RENDER, /function closeSubagentView\(id: string\): void \{[\s\S]{0,300}?postMessage\(\{ type: "closeSubagent", id: p\.parentId, agentId: p\.agentId \}\);[\s\S]{0,100}?pinnedSubs\.delete\(id\);[\s\S]{0,50}?dismissSession\(id, "close"\);/);
+  assert.match(RENDER, /if \(id !== keep && isSubId\(id\) && !pinnedSubs\.has\(id\)\) closeSubagentView\(id\);/);
+  // a pinned viewer does not survive a reload in this slice — stated where the set lives
+  assert.match(RENDER, /a pinned viewer does NOT survive\s*\n?\s*\/\/ a reload in this slice/);
+});
+
+test("the viewer is READ-ONLY: composer and send disabled, its own placeholder, no meta menus in the statusline", () => {
+  assert.match(RENDER, /const viewer = !!s\.sub;[^\n]*\n\s*composer\.disabled = closed \|\| viewer;/);
+  assert.match(RENDER, /if \(viewer\) composer\.placeholder = "Subagent transcript — read-only";/);
+  assert.match(RENDER, /if \(sendBtn\) sendBtn\.disabled = closed \|\| viewer;/);
+  assert.match(RENDER, /if \(s\.sub\) \{[\s\S]{0,400}?ro\.textContent = "read-only · a subagent's transcript";[\s\S]{0,100}?return;/);
+  // the tab: no drag (a reorder would post the id into the kernel's order), no rename menu, ✕ = Close tab
+  assert.match(RENDER, /tab\.draggable = !s\.sub;/);
+  assert.match(RENDER, /if \(!s\.sub\) tab\.addEventListener\("contextmenu"/);
+  assert.match(RENDER, /close\.title = dead \|\| s\.sub \? "Close tab" : "End session";/);
+  assert.match(RENDER, /if \(id && isSubId\(id\)\) \{ closeSubagentView\(id\); return; \}/);
+});
+
+test("the header: 'subagent of <parent>' links back to the launch (setActive + the head's uuid), type, state, pin", () => {
+  assert.match(RENDER, /function renderSubHead\(\): void \{[\s\S]{0,2500}?kicker\.textContent = "subagent of";[\s\S]{0,600}?link\.dataset\.act = "subParent"; link\.dataset\.sid = s\.sub\.parentId;[\s\S]{0,100}?if \(s\.sub\.anchorUuid\) link\.dataset\.uuid = s\.sub\.anchorUuid;/);
+  assert.match(RENDER, /link\.replaceChildren\(\.\.\.hostNameNodes\(parentName, s\.sub\.parentId\)\);/, "the house session-reference idiom");
+  assert.match(RENDER, /const parts = subHeadParts\(s\.sub\.meta, s\.sub\.running\);/);
+  assert.match(RENDER, /pin\.dataset\.act = "pinSubagent"; pin\.dataset\.id = s\.id;\s*\n\s*pin\.innerHTML = pinIconSvg\(\);/);
+  assert.match(RENDER, /setTip\(pin, pinnedSubs\.has\(s\.id\) \? "kept — click to let this tab close on its own" : "keep this tab"\);/);
+  // the truncated note, one line, only when the kernel cut the tail and there is no error
+  assert.match(RENDER, /if \(s\.sub\.truncated && !s\.sub\.error\) \{[\s\S]{0,200}?note\.textContent = "earlier part not shown";/);
+  // the header lives in #content and is removed for every real session
+  assert.match(RENDER, /if \(!s \|\| !s\.sub\) \{ if \(host\) host\.remove\(\); return; \}/);
+  assert.match(CSS, /#sub-head \{ position: sticky; top: 0;[^}]*font-size: 0\.86em;/);
+});
+
+test("frames: events replace in place through appendActive (the chat's scroll rule); error → the sentence in the pane; loader first", () => {
+  assert.match(RENDER, /else if \(m\.type === "subagent"\) applySubagentFrame\(m\);/);
+  assert.match(RENDER, /function applySubagentFrame\(m: any\): void \{[\s\S]{0,1500}?if \(activeId === id\) \{[\s\S]{0,900}?else appendActive\(\);\s*\n\s*renderSubHead\(\);/);
+  // the FIRST content lands at the newest end like a fresh tab; later frames append and keep the reader's spot
+  assert.match(RENDER, /const first = !v \|\| v\.rendered === 0;[\s\S]{0,600}?if \(first\) \{ if \(v\) \{ v\.stick = true; v\.rendered = 0; \} showActive\(\); \}/);
+  // a frame for a viewer that is gone tells the kernel to stop pushing
+  assert.match(RENDER, /if \(!s \|\| !s\.sub\) \{ vscodeApi\?\.postMessage\(\{ type: "closeSubagent", id: parentId, agentId \}\); return; \}/);
+  // the empty-transcript placeholder: error sentence (loud), else the romp loader until the first frame
+  assert.match(RENDER, /\} else if \(s\.sub && s\.sub\.error\) \{[\s\S]{0,200}?ph\.textContent = s\.sub\.error;/);
+  assert.match(RENDER, /\} else if \(s\.sub && !s\.sub\.loaded\) \{[\s\S]{0,300}?ph\.appendChild\(rompLoaderInner\("opening the agent's transcript…"\)\);/);
+  // file/preview URLs bake the PARENT's id for a viewer
+  assert.match(RENDER, /const subOf = subParts\(id\);\s*\n\s*if \(subOf\) renderingOwnerSid = subOf\.parentId;/);
+});
+
+test("the new CSS uses theme tokens only — no raw hex in the subagent rules", () => {
+  const block = (CSS.match(/\/\* ── SUBAGENT TRANSCRIPTS[\s\S]*?\.sub-status-line \{[^}]*\}\n/) || [""])[0];
+  assert.ok(block.length > 500, "found the subagent CSS block");
+  assert.doesNotMatch(block, /#[0-9a-fA-F]{3,6}\b/);
+  for (const tok of ["--dim", "--accent", "--accent-wash", "--bg", "--box-border", "--st-working-bg", "--st-ready-bg"]) {
+    assert.ok(block.includes("var(" + tok + ")"), "uses " + tok);
+  }
+});

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -129,9 +129,12 @@ test("the viewer is a PEEK through the chat's own derivation: chatVisible answer
   assert.match(RENDER, /a pinned viewer does NOT survive\s*\n?\s*\/\/ a reload in this slice/);
 });
 
-test("the viewer is READ-ONLY: composer and send disabled, its own placeholder, no meta menus in the statusline", () => {
+test("the viewer is READ-ONLY: the message box is hidden, send disabled, one dim statusline line, no meta menus", () => {
   assert.match(RENDER, /const viewer = !!s\.sub;[^\n]*\n\s*composer\.disabled = closed \|\| viewer;/);
-  assert.match(RENDER, /if \(viewer\) composer\.placeholder = "Subagent transcript — read-only";/);
+  // ONE read-only cue: the message box (input + send) is hidden outright in the viewer; the statusline
+  // line below carries the word — never both (the placeholder once doubled it, 2026-09-05)
+  assert.match(RENDER, /if \(composerBox\) composerBox\.style\.display = viewer \? "none" : "";/);
+  assert.doesNotMatch(RENDER, /Subagent transcript — read-only/);
   assert.match(RENDER, /if \(sendBtn\) sendBtn\.disabled = closed \|\| viewer;/);
   assert.match(RENDER, /if \(s\.sub\) \{[\s\S]{0,400}?ro\.textContent = "read-only · a subagent's transcript";[\s\S]{0,100}?return;/);
   // the tab: no drag (a reorder would post the id into the kernel's order), no rename menu, ✕ = Close tab

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { subTabId, isSubId, subParts, subLabel, gistLines, elapsedSince, subHeadParts, openIconSvg, pinIconSvg, SUB_SEP } from "../../ui/webview/subagent-view";
+import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, elapsedSince, subHeadParts, openIconSvg, pinIconSvg, SUB_SEP, PREVIEW_ROWS } from "../../ui/webview/subagent-view";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
@@ -39,23 +39,58 @@ test("the tab label is the description (clipped), else the agent type, never the
   assert.ok(long.length <= 28 && long.endsWith("…"), long);
 });
 
-test("gistLines: newest LAST, the head vocabulary per row, count + elapsed trailing the last row only", () => {
+// The preview's rows come from the STEPS now (2026-09-05: the kernel ships every call as agentSteps and
+// the fold lists them all, so the three-row preview is steps.slice(-3) client-side — the old
+// `gist.recent` field is gone from the wire). The pins below moved from `recent` to `steps` for that.
+const STEPS = [{ tool: "Read", desc: "/tmp/notes-api/tests/test_api.py" }, { tool: "Bash", desc: "run the api tests" },
+               { tool: "Grep", desc: "def test_" }, { tool: "Read", desc: "/tmp/notes-api/api/notes.py" }];
+const CLOCK = { calls: 12, since: "2026-09-05T10:00:20.000Z", last: "2026-09-05T10:00:58.000Z" };
+
+test("gistLines: the newest THREE steps, newest LAST, the head vocabulary per row, count + elapsed trailing the last row only", () => {
   const now = Date.parse("2026-09-05T10:01:00.000Z");
-  const g = { recent: [{ tool: "Bash", desc: "run the api tests" }, { tool: "Grep", desc: "def test_" }, { tool: "Read", desc: "/tmp/notes-api/api/notes.py" }],
-              calls: 12, since: "2026-09-05T10:00:20.000Z", last: "2026-09-05T10:00:58.000Z" };
-  const lines = gistLines(g, now);
-  assert.equal(lines.length, 3);
+  const lines = gistLines(STEPS, CLOCK, now);
+  assert.equal(PREVIEW_ROWS, 3);
+  assert.equal(lines.length, 3, "four steps → the newest three");
   assert.deepEqual(lines.map((l) => l.tool), ["Bash", "Grep", "Read"]);
   assert.equal(lines[0].meta, "", "only the last row carries the count/elapsed");
   assert.equal(lines[1].meta, "");
   assert.equal(lines[2].meta, "· 12 tool calls · 40s");
   // one call reads singular; a longer run reads m/s like the statusline timer
-  assert.equal(gistLines({ recent: [{ tool: "Read", desc: "x" }], calls: 1, since: "2026-09-05T09:58:55.000Z" }, now)[0].meta, "· 1 tool call · 2m 5s");
-  // more than three recent rows are clipped to the newest three (defensive: the kernel ships three)
-  assert.equal(gistLines({ recent: [1, 2, 3, 4].map((i) => ({ tool: "T" + i, desc: "" })), calls: 4 }, now).map((l) => l.tool).join(","), "T2,T3,T4");
-  // no gist / nothing recent → nothing to draw (the caller renders no box)
-  assert.deepEqual(gistLines(null, now), []);
-  assert.deepEqual(gistLines({ recent: [], calls: 0 }, now), []);
+  assert.equal(gistLines([{ tool: "Read", desc: "x" }], { calls: 1, since: "2026-09-05T09:58:55.000Z" }, now)[0].meta, "· 1 tool call · 2m 5s");
+  // no clock (the agent finished) / no steps → nothing to draw (the caller renders no preview)
+  assert.deepEqual(gistLines(STEPS, null, now), [], "a finished agent has no preview");
+  assert.deepEqual(gistLines([], CLOCK, now), []);
+  assert.deepEqual(gistLines(null, CLOCK, now), []);
+});
+
+test("stepLines: EVERY step in order for the fold; the elapsed alone trails the last row while running, nothing when finished", () => {
+  const now = Date.parse("2026-09-05T10:01:00.000Z");
+  const running = stepLines(STEPS, CLOCK, now);
+  assert.equal(running.length, 4);
+  assert.deepEqual(running.map((l) => l.tool), ["Read", "Bash", "Grep", "Read"], "oldest first, newest LAST");
+  assert.deepEqual(running.map((l) => l.meta), ["", "", "", "· 40s"], "the count lives in the fold label, not the row");
+  const finished = stepLines(STEPS, null, now);
+  assert.deepEqual(finished.map((l) => l.meta), ["", "", "", ""]);
+  assert.equal(finished[1].desc, "run the api tests");
+  assert.deepEqual(stepLines([], CLOCK, now), []);
+  assert.deepEqual(stepLines(undefined, null, now), []);
+});
+
+test("stepsNote: names the calls the kernel's cap cut, singular handled, empty when every call is on the wire", () => {
+  assert.equal(stepsNote(200, 257), "57 earlier calls not shown");
+  assert.equal(stepsNote(200, 201), "1 earlier call not shown");
+  assert.equal(stepsNote(4, 4), "");
+  assert.equal(stepsNote(4, undefined), "");
+  assert.equal(stepsNote(4, 3), "", "never negative");
+});
+
+test("agentFoldLabel: running 'prompt · N tool calls'; finished adds '· report · N lines'; zero calls omits the part; singulars", () => {
+  assert.equal(agentFoldLabel({ stepsTotal: 12, reportLines: null }), "prompt · 12 tool calls");
+  assert.equal(agentFoldLabel({ stepsTotal: 12, reportLines: 3 }), "prompt · 12 tool calls · report · 3 lines");
+  assert.equal(agentFoldLabel({ stepsTotal: 0, reportLines: null }), "prompt");
+  assert.equal(agentFoldLabel({ stepsTotal: 0, reportLines: 1 }), "prompt · report · 1 line");
+  assert.equal(agentFoldLabel({ stepsTotal: 1, reportLines: 1 }), "prompt · 1 tool call · report · 1 line");
+  assert.equal(agentFoldLabel({ reportLines: null }), "prompt", "no steps shipped at all reads like zero");
 });
 
 test("elapsedSince prints the statusline timer's shapes and is empty for an unreadable stamp", () => {
@@ -83,8 +118,20 @@ test("both icons wear the house line-icon style: 16-unit viewBox, currentColor, 
 });
 
 // ── render.ts wiring (source pins) ──────────────────────────────────────────────────────────────
-test("the arrow rides the Agent/Task head ONLY when the event carries an agentId, and the preview only with a gist", () => {
-  assert.match(RENDER, /if \(\(ev\.name === "Task" \|\| ev\.name === "Agent"\) && ev\.agentId\) \{[\s\S]{0,700}?head\.appendChild\(agentOpenButton\(ev\.agentId, ev\.uuid \|\| null, renderingOwnerSid \|\| renderingSid \|\| null\)\);\s*\n\s*if \(ev\.agentGist\) head\.insertAdjacentElement\("afterend", renderAgentGist\(ev\.agentGist\)\);/);
+test("the arrow rides the Agent/Task head whenever the event carries an agentId — running OR finished; the preview only with the clock AND a closed fold", () => {
+  // the arrow: gated on agentId alone — a FINISHED agent (output landed, no clock) still carries it, so
+  // its whole transcript stays one click away after the fact (the user asked, 2026-09-05)
+  const block = (RENDER.match(/if \(\(ev\.name === "Task" \|\| ev\.name === "Agent"\) && ev\.agentId\) \{[\s\S]*?\n  \}\n  return turn;/) || [""])[0];
+  assert.ok(block.length > 200, "found the arrow/preview block");
+  assert.match(block, /head\.appendChild\(agentOpenButton\(ev\.agentId, ev\.uuid \|\| null, renderingOwnerSid \|\| renderingSid \|\| null\)\);/);
+  assert.doesNotMatch(block.split("agentOpenButton")[0], /agentGist|agentRunning|ev\.output/, "nothing about run-state gates the arrow");
+  // the preview (2026-09-05): shown while the kernel ships the clock (running) AND the head's fold is
+  // CLOSED — an open fold lists every call, so the preview steps aside. The fold's state is read from
+  // openFolds under the same fkey the fold persists with; no new state.
+  assert.match(block, /if \(ev\.agentGist && !\(fkey && openFolds\.has\(fkey\)\)\) head\.insertAdjacentElement\("afterend", renderAgentGist\(ev\.agentSteps, ev\.agentGist\)\);/);
+  // …and the CSS twin hides it the instant the fold opens, before the next push rebuilds the turn
+  assert.match(CSS, /\.turn-tool\.fold-open > \.agent-preview \{ display: none; \}/);
+  assert.match(RENDER, /const box = el\("div", "agent-gist agent-preview"\);/);
   // the running-dot rule the older pin holds is untouched: the kernel clears a running background
   // agent's output, so "no output" still reads as running
   assert.match(RENDER, /const agentRunning = \(ev\.name === "Task" \|\| ev\.name === "Agent"\) && !ev\.output && !ev\.isError;/);
@@ -99,8 +146,10 @@ test("the arrow is click-safe: a data-act on the stable body delegate, a setTip 
 });
 
 test("the preview renders INSIDE the tool turn in the fold-toggle's size — a collapsed compact run hides it; the collapsed line never draws it", () => {
-  assert.match(RENDER, /function renderAgentGist\(g: AgentGist\): HTMLElement \{[\s\S]{0,300}?for \(const line of gistLines\(g, Date\.now\(\)\)\) \{/);
-  assert.match(RENDER, /const row = el\("div", "agent-gist-row"\);[\s\S]{0,400}?"agent-gist-tool"[\s\S]{0,200}?"agent-gist-desc"[\s\S]{0,200}?"agent-gist-meta"/);
+  // (2026-09-05) the preview's rows come from the steps: renderAgentGist takes (steps, clock) and both it
+  // and the fold's full list append rows through ONE builder, so the two read alike
+  assert.match(RENDER, /function renderAgentGist\(steps: AgentGistRow\[\] \| undefined, g: AgentGist\): HTMLElement \{[\s\S]{0,300}?appendGistRows\(box, gistLines\(steps, g, Date\.now\(\)\)\);/);
+  assert.match(RENDER, /function appendGistRows\(box: HTMLElement, lines: GistLine\[\]\): void \{[\s\S]{0,200}?const row = el\("div", "agent-gist-row"\);[\s\S]{0,400}?"agent-gist-tool"[\s\S]{0,200}?"agent-gist-desc"[\s\S]{0,200}?"agent-gist-meta"/);
   // the collapsed toolgroup line knows nothing of the gist — only the per-tool renderTool (run when expanded) does
   const group = (RENDER.match(/function renderToolGroup\([\s\S]*?\n\}\n/) || [""])[0];
   assert.ok(group.length > 200, "found renderToolGroup");

--- a/ui/webview/subagent-view.ts
+++ b/ui/webview/subagent-view.ts
@@ -1,0 +1,87 @@
+// Subagent transcripts (plans/subagent-transcripts.md, 2026-09-05): the pure half of the viewer —
+// tab ids, labels, the live-preview rows and the two line icons. render.ts owns the DOM (the arrow on
+// the Agent head and the bg-task row, the peek-tab viewer, the header) and the kernel protocol
+// (openSubagent / closeSubagent ↔ {type:"subagent"} frames); this module is what the source pins and
+// the executable tests exercise without a DOM.
+//
+// The viewer TAB ID is `<parentId>/agent/<agentId>` — the parent's id (host-prefixed under federation,
+// "host:sid") plus a colon-free suffix. host-prefix.ts reads the FIRST colon as the host marker, so a
+// `sub:<sid>:<agentId>` shape would have named a phantom host "sub" everywhere hostOf() is consulted
+// (the offline mark, the strip's host dimming, outbound routing); a suffix keeps hostOf(subId) ===
+// hostOf(parentId) for free. The suffix never reaches the kernel as a session id (openSubagent carries
+// the parent id + agentId), and a bare "/agent/" cannot occur in a uuid or a host name.
+
+export const SUB_SEP = "/agent/";
+
+export function subTabId(parentId: string, agentId: string): string { return parentId + SUB_SEP + agentId; }
+export function isSubId(id: string | null | undefined): boolean { return typeof id === "string" && id.includes(SUB_SEP); }
+export function subParts(id: string): { parentId: string; agentId: string } | null {
+  if (typeof id !== "string") return null;
+  const i = id.indexOf(SUB_SEP);
+  if (i <= 0) return null;
+  const agentId = id.slice(i + SUB_SEP.length);
+  return agentId ? { parentId: id.slice(0, i), agentId } : null;
+}
+
+export interface SubMeta { agentType?: string; description?: string; spawnDepth?: number | null; toolUseId?: string; }
+export interface AgentGistRow { tool: string; desc: string; ts?: string; }
+export interface AgentGist { recent: AgentGistRow[]; calls: number; since?: string | null; last?: string | null; }
+
+// The tab label: the sidecar's description (what the parent asked for), clipped to a tab's worth; else
+// the agent type; else the bare word. Never the agent id — a hex string says nothing at a glance.
+export const SUB_LABEL_MAX = 28;
+export function subLabel(meta: SubMeta | null | undefined): string {
+  const d = (meta?.description || "").trim();
+  if (d) return d.length > SUB_LABEL_MAX ? d.slice(0, SUB_LABEL_MAX - 1).trimEnd() + "…" : d;
+  const t = (meta?.agentType || "").trim();
+  return t || "subagent";
+}
+
+// Elapsed since an ISO stamp, in the statusline timer's own vocabulary ("40s", "2m 5s", "1h 3m") —
+// the same shape elapsedMs() prints beside the working chip, so the preview's clock reads like the
+// pane's other clocks. "" when the stamp is unreadable.
+export function elapsedSince(iso: string | null | undefined, nowMs: number): string {
+  const t = iso ? Date.parse(iso) : NaN;
+  if (!isFinite(t)) return "";
+  const s = Math.max(0, Math.floor((nowMs - t) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+// The preview's rows: the agent's recent tool calls in the head vocabulary (`<tool> <desc>`), newest
+// LAST (the kernel ships them oldest→newest), with the trailing count/elapsed on the last row —
+// "· 12 tool calls · 40s". Only while the kernel ships a gist (the agent is running); the caller shows
+// nothing otherwise. Pure, so the shape is testable without a DOM.
+export interface GistLine { tool: string; desc: string; meta: string; }
+export function gistLines(g: AgentGist | null | undefined, nowMs: number): GistLine[] {
+  if (!g || !Array.isArray(g.recent) || !g.recent.length) return [];
+  const rows = g.recent.slice(-3);
+  const n = Math.max(0, g.calls | 0);
+  const parts: string[] = [];
+  if (n) parts.push(`${n} tool call${n === 1 ? "" : "s"}`);
+  const el = elapsedSince(g.since, nowMs);
+  if (el) parts.push(el);
+  const meta = parts.length ? "· " + parts.join(" · ") : "";
+  return rows.map((r, i) => ({ tool: String(r.tool || "tool"), desc: String(r.desc || ""), meta: i === rows.length - 1 ? meta : "" }));
+}
+
+// The viewer header's one line: "subagent of <parent> · <agentType> · running|finished". The parent
+// name is rendered by the caller as a link (hostNameNodes), so this returns the pieces, not a string.
+export function subHeadParts(meta: SubMeta | null | undefined, running: boolean): { type: string; state: "running" | "finished" } {
+  return { type: (meta?.agentType || "").trim() || "agent", state: running ? "running" : "finished" };
+}
+
+// The two line icons, in the house style every glyph in render.ts wears (16-unit viewBox, currentColor
+// stroke 1.4, round caps/joins): the OPEN arrow (a corner box with an arrow leaving it — "open this
+// elsewhere") and the PIN (a pushpin: head, collar, needle). Trusted constant markup.
+const ICON_OPEN = '<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" '
+  + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">'
+  + '<path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/>'
+  + '<path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg>';
+const ICON_PIN = '<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" '
+  + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">'
+  + '<path d="M6 2.5h4v4.2l1.8 2.3H4.2L6 6.7z"/><path d="M8 9v4.5"/></svg>';
+export function openIconSvg(): string { return ICON_OPEN; }
+export function pinIconSvg(): string { return ICON_PIN; }

--- a/ui/webview/subagent-view.ts
+++ b/ui/webview/subagent-view.ts
@@ -1,5 +1,5 @@
 // Subagent transcripts (plans/subagent-transcripts.md, 2026-09-05): the pure half of the viewer —
-// tab ids, labels, the live-preview rows and the two line icons. render.ts owns the DOM (the arrow on
+// tab ids, labels, the Agent head's preview rows, fold label and full steps list, and the two line icons. render.ts owns the DOM (the arrow on
 // the Agent head and the bg-task row, the peek-tab viewer, the header) and the kernel protocol
 // (openSubagent / closeSubagent ↔ {type:"subagent"} frames); this module is what the source pins and
 // the executable tests exercise without a DOM.
@@ -24,8 +24,14 @@ export function subParts(id: string): { parentId: string; agentId: string } | nu
 }
 
 export interface SubMeta { agentType?: string; description?: string; spawnDepth?: number | null; toolUseId?: string; }
+// One tool call the agent made (the kernel's agentSteps row): the tool name and its one-line gist in the
+// head vocabulary. The kernel ships every call so far, oldest first, capped at the NEWEST 200
+// (SUBAGENT_STEPS_CAP) with stepsTotal saying the true count.
 export interface AgentGistRow { tool: string; desc: string; ts?: string; }
-export interface AgentGist { recent: AgentGistRow[]; calls: number; since?: string | null; last?: string | null; }
+// The running preview's clock: the call count and the agent's first/last record stamps. Ships only
+// while the agent runs; the preview's three rows come from the steps (no `recent` on the wire since
+// 2026-09-05 — the fold lists the same steps, so one field feeds both).
+export interface AgentGist { calls: number; since?: string | null; last?: string | null; }
 
 // The tab label: the sidecar's description (what the parent asked for), clipped to a tab's worth; else
 // the agent type; else the bare word. Never the agent id — a hex string says nothing at a glance.
@@ -50,21 +56,57 @@ export function elapsedSince(iso: string | null | undefined, nowMs: number): str
   return `${Math.floor(m / 60)}h ${m % 60}m`;
 }
 
-// The preview's rows: the agent's recent tool calls in the head vocabulary (`<tool> <desc>`), newest
-// LAST (the kernel ships them oldest→newest), with the trailing count/elapsed on the last row —
-// "· 12 tool calls · 40s". Only while the kernel ships a gist (the agent is running); the caller shows
-// nothing otherwise. Pure, so the shape is testable without a DOM.
+// The level-0 preview's rows: the agent's LAST THREE tool calls in the head vocabulary (`<tool> <desc>`),
+// newest LAST (the kernel ships the steps oldest→newest), with the trailing count/elapsed on the last
+// row — "· 12 tool calls · 40s". Only while the kernel ships the clock (the agent is running); the
+// caller shows nothing otherwise. Pure, so the shape is testable without a DOM.
+export const PREVIEW_ROWS = 3;
 export interface GistLine { tool: string; desc: string; meta: string; }
-export function gistLines(g: AgentGist | null | undefined, nowMs: number): GistLine[] {
-  if (!g || !Array.isArray(g.recent) || !g.recent.length) return [];
-  const rows = g.recent.slice(-3);
+function stepLine(r: AgentGistRow, meta: string): GistLine {
+  return { tool: String(r.tool || "tool"), desc: String(r.desc || ""), meta };
+}
+function clockMeta(g: AgentGist | null | undefined, nowMs: number, withCount: boolean): string {
+  if (!g) return "";
   const n = Math.max(0, g.calls | 0);
   const parts: string[] = [];
-  if (n) parts.push(`${n} tool call${n === 1 ? "" : "s"}`);
+  if (withCount && n) parts.push(`${n} tool call${n === 1 ? "" : "s"}`);
   const el = elapsedSince(g.since, nowMs);
   if (el) parts.push(el);
-  const meta = parts.length ? "· " + parts.join(" · ") : "";
-  return rows.map((r, i) => ({ tool: String(r.tool || "tool"), desc: String(r.desc || ""), meta: i === rows.length - 1 ? meta : "" }));
+  return parts.length ? "· " + parts.join(" · ") : "";
+}
+export function gistLines(steps: AgentGistRow[] | null | undefined, g: AgentGist | null | undefined, nowMs: number): GistLine[] {
+  if (!g || !Array.isArray(steps) || !steps.length) return [];
+  const rows = steps.slice(-PREVIEW_ROWS);
+  const meta = clockMeta(g, nowMs, true);
+  return rows.map((r, i) => stepLine(r, i === rows.length - 1 ? meta : ""));
+}
+
+// The fold's FULL list: every shipped step, same vocabulary and order; while the agent runs (a clock
+// ships) the last row trails the elapsed alone — the count already sits in the fold label. A finished
+// agent's rows carry no meta.
+export function stepLines(steps: AgentGistRow[] | null | undefined, g: AgentGist | null | undefined, nowMs: number): GistLine[] {
+  if (!Array.isArray(steps) || !steps.length) return [];
+  const meta = clockMeta(g, nowMs, false);
+  return steps.map((r, i) => stepLine(r, i === steps.length - 1 ? meta : ""));
+}
+
+// The one line above the list when the kernel's cap cut the oldest steps: "57 earlier calls not shown".
+// "" when every call is on the wire.
+export function stepsNote(shown: number, total: number | null | undefined): string {
+  const n = Math.max(0, (total || 0) - shown);
+  return n ? `${n} earlier call${n === 1 ? "" : "s"} not shown` : "";
+}
+
+// The Agent head's fold label — what ONE click reveals, in the order it appears: the prompt, the tool
+// calls (omitted at zero), and — once the agent has finished — the report with its line count.
+//   running:  "prompt · 12 tool calls"
+//   finished: "prompt · 12 tool calls · report · 3 lines"
+export function agentFoldLabel(o: { stepsTotal?: number | null; reportLines?: number | null }): string {
+  const parts = ["prompt"];
+  const n = Math.max(0, o.stepsTotal || 0);
+  if (n) parts.push(`${n} tool call${n === 1 ? "" : "s"}`);
+  if (o.reportLines != null) parts.push(`report · ${o.reportLines} line${o.reportLines === 1 ? "" : "s"}`);
+  return parts.join(" · ");
 }
 
 // The viewer header's one line: "subagent of <parent> · <agentType> · running|finished". The parent


### PR DESCRIPTION
## What

A Claude Code subagent (the `Agent` tool; older transcripts say `Task`) used to show two points of its life on the parent's tool head: the kickoff prompt and the final report. Everything between was invisible, a running background agent had nothing to say for minutes, and a background agent's report fold showed the launch acknowledgement forever. Now:

- **Level 0, on the Agent head** (and on agent rows of the background-tasks box): an open-transcript arrow whenever the launch names an agent; while the agent runs, a preview of its last three tool calls in the head's own `<tool> <desc>` vocabulary, the last row trailing `· N tool calls · elapsed`. Inside the tool turn, so a collapsed compact run hides it. Gone when the agent finishes.
- **Level 1, the viewer:** the arrow opens the agent's WHOLE conversation as a peek tab wearing the parent's colour, rendered through the chat's own renderers (Compact transcript, folds, day dividers), read-only. Header: "subagent of <parent> · <type> · running|finished", the parent name a link back to the launch, a pin that keeps the tab, an "earlier part not shown" note when the tail was cut. Live frames update it in place with the chat's follow-only-at-bottom rule; the romp loader holds the pane until the first frame; a missing file shows its error sentence in the pane.
- **The report fold is now the real report** for a background agent: once its `<task-notification>` lands, the notification's `<result>` fills the head's output (and `isError` follows the status) instead of the launch ack. The notice card in the transcript is unchanged.

Plan doc: `plans/subagent-transcripts.md` (problem, verified data facts, decisions, wire contract, caps, and the slice-2 scope — the Awaiting box grouped by kind — which is NOT in this PR).

## Why read the file rather than un-drop the stream

The SDK backend deliberately drops live stream messages tagged `parent_tool_use_id` (`tests/test_sidechain_atoms.py` pins it) — that stays. Claude Code writes every subagent its own complete JSONL beside the parent transcript (`<proj>/<fsid>/subagents/agent-<agentId>.jsonl` + a `.meta.json` sidecar whose `toolUseId` is the parent's tool_use block id; the background task's `/tmp` output file is a symlink to it). Reading that file keeps the parent stream clean, works for dormant/revived and tmux sessions, and reads the authoritative store. Liveness is event-based: the SDK's SubagentStart/Stop set (now shipped with agent ids) and its task-lifecycle set for SDK sessions, the CLI-epoch ghost gate otherwise — the same gate the bg-tasks box already applies, so head, preview, viewer and box agree.

## Wire contract

- Every `kind:"tool"` event carries `toolUseId` (the tool_use BLOCK id; `uuid` was and is the record's). Agent/Task events add `agentId` (or `null`), `agentAsync` (a background launch); while a background agent runs: `agentRunning: true`, `output: ""`, `agentGist: {recent: [{tool, desc, ts}] (≤3, newest last), calls, since, last}`; once its notification lands: `output` = the `<result>` text, `isError` from the status, no gist.
- bg-tasks rows: `agentId` on agent rows only.
- Client → kernel `{type:"openSubagent", id:<sid>, agentId}` / `{type:"closeSubagent", id, agentId}`. Kernel → client `{type:"subagent", id, agentId, meta:{agentType, description, spawnDepth, toolUseId}, running, events:[…chat events…], truncated}` or `{…, error:"<sentence>"}`. First frame on open, re-pushed by the pusher's chat pass only when the agent file's (mtime,size) or the running flag moved; stops on close/disconnect. Federation: routed by the parent `id` like a comment-thread request; the client's tab id is `<parentId>/agent/<agentId>` (colon-free suffix, so `hostOf()` keeps working).
- The chat fold never seals a running agent's launch turn (the undecided-seam rule's twin); a sealed pending agent demotes when its report lands or its sidecar appears. `TUR_CONSUMED_KEYS` widened with `agentId`/`isAsync` (event model + SDK mirror, in step).

## Verified

- `uv run … pytest tests/` — 7357 passed, 40 skipped (new: `tests/test_subagent_transcripts.py`, 24 tests: sidecar/ack join, tool-event stamps, gist shape, landed report + failed status, liveness from live sets and the ghost gate, viewer build/cap/error/forked-dir lookup, open/close/re-push, bg rows, fold hold + equivalence).
- `cd vscode-extension && npm run typecheck && npm test && npm run build` — 2796 passed (new: `ui/webview/subagent-view.test.ts`, 15 tests; two `peek-tab.test.ts` pins moved deliberately with a comment saying why; `render-agent.test.ts` untouched and green; `tests/test_sidechain_atoms.py` untouched and green).
- Headless screenshots (both themes, synthetic notes-api fixtures, not committed): the Agent head with the running preview + arrow beside a finished Agent head with `prompt + report`; the viewer as a peek tab with header, transcript and the single dim read-only footer line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)