### PR TITLE
A job stamp over in-harness work lifts when the last background item ends, and its dead-man runs with nudges off

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -434,7 +434,11 @@ permission/API-error floors: one interrupt at a time, the present event first.
   cross-host peers, legacy kindless stamps, hung-forever agents/tasks, and
   prose-declared timer check-backs; every observable ending (a notification
   pairing, the restart epoch, a tool's declared deadline, a peer's answer or
-  death) retires its wait as an event, with no clock at all.
+  death) retires its wait as an event, with no clock at all. A task/job stamp
+  whose launches the planner placed under another card lifts the same way once
+  the session's live registry is empty and the last in-harness item ended after
+  the stamp. The wake runs from the pusher whether or not auto-nudge is on: the
+  toggle scopes the nudge, not the dead-man.
 
 ## Where responsibilities overlap
 

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -437,8 +437,8 @@ permission/API-error floors: one interrupt at a time, the present event first.
   death) retires its wait as an event, with no clock at all. A task/job stamp
   whose launches the planner placed under another card lifts the same way once
   the session's live registry is empty and the last in-harness item ended after
-  the stamp. The wake runs from the pusher whether or not auto-nudge is on: the
-  toggle scopes the nudge, not the dead-man.
+  the stamp. The dead-man runs from the pusher whether or not auto-nudge is on;
+  with it off, a due wait files its lift (no injected check-in) instead.
 
 ## Where responsibilities overlap
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9122,7 +9122,10 @@ CLOSER_SYS = (
     "and still needs answered. Work handed OFF to a peer is the peer's own — ownership transferred, "
     "not a wait; omit it. The kind boundaries are strict: job means an external computation the "
     "session ITSELF launched (a cluster job, CI, a build) — another SESSION's work is never a job, "
-    "however long it runs; agents means background agents this session dispatched and still out; "
+    "however long it runs; and job is only for compute the session cannot watch from inside the "
+    "harness (a CI run, a deploy, a remote queue): a wait on its own background command, Monitor, "
+    "or subagent is task or agents, never job; agents means background agents this session "
+    "dispatched and still out; "
     "timer means a scheduled check-back that actually EXISTS at turn end — never one the turn "
     "canceled. Waiting for INBOUND mail (the manager's next dispatch, a peer's next message) is not "
     "a wait at all: an idle recipient reads idle — omit it. Never relabel a wait to a different "
@@ -9169,6 +9172,10 @@ CLOSER_SYS = (
 # The awaiting KINDS — what a wait is on, as data (the user 2026-08-15, who wanted the surfaces to
 # say WHAT is awaited, and the rules scoped by it): agents/subagents dispatched in-harness; a
 # background task/watcher; an external job (cluster/CI/build); a peer session; a scheduled check-back.
+# The task/job line matters mechanically (2026-09-05): task and agents end on events romp observes
+# (the lifecycle registry, notification pairing), so their stamps lift exactly; job is compute the
+# session cannot watch from inside the harness, whose stamp has only the 6h dead-man — a closer that
+# files an in-harness Monitor or background command as job trades an exact lift for a clock.
 # The judge files one per awaiting verdict; a stamp without one (older judges, legacy stores) is
 # kindless and behaves exactly as before the enum existed.
 AWAIT_KINDS = ("agents", "task", "job", "peer", "timer")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5817,8 +5817,10 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     ending romp cannot observe (kind=job). Behind the toggle it was unreachable: a kind=job stamp stood 17
     hours over nothing pending because this tick returned before its goal walk. So the walk runs in
     WAKE-ONLY mode when nudges are off — same session gates, only the awaiting branch of the goal loop —
-    the way _interrupt_block_tick runs every push independent of the toggle. The plain nudge, the
-    compaction suggestion, the debt ladder and the dormant-owner sweep keep the toggle as before."""
+    the way _interrupt_block_tick runs every push independent of the toggle; and in that mode a due
+    dead-man INJECTS NOTHING (the user said no unprompted messages): it files the stamp's lift instead,
+    the row the orphan lift files (see _wake_goal). The plain nudge, the compaction suggestion, the debt
+    ladder and the dormant-owner sweep keep the toggle as before."""
     if not _AUTO_NUDGE_TICK_LOCK.acquire(blocking=False):
         return                                            # a pass is in flight: it owns this world's sends
     try:
@@ -6671,7 +6673,7 @@ def _file_wake_answer(store, sid, gid, now):
     return False
 
 
-def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
+def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=False):
     """The AWAITING branch of _auto_nudge_session's goal walk — one stamped top goal. The stamp is a
     judged wait, so the plain status nudge stays off; but a wait is not an exemption from the ladder
     (the user 2026-08-11): fire the check-in past the backstop, track its outcome through the same record
@@ -6688,7 +6690,17 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
                 what made the one-shot design terminal).
       silent    no response within the same window (from the FIRE, rec["at"]) → _mark_nudge_failed(wake=True):
                 the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
-                genuinely NEW stamp episode (anchor newer than the one that failed)."""
+                genuinely NEW stamp episode (anchor newer than the one that failed).
+    `wake_only` (auto-nudge OFF, 2026-09-05): the user turned unprompted messages off, so the due
+    dead-man injects NOTHING. It files instead the row _lift_spent_awaiting's orphan branch files — a
+    romp/awaiting LIFT at the stamp's anchor: romp withdraws a wait it can no longer vouch for, the
+    card returns to plain Working (the same shape every other stalled card wears with nudges off,
+    nothing hidden behind a claimed wait), and the lift row re-nominates the closer's filed-since
+    gate so the next audited turn can re-stamp a still-real wait. No block: every procedural block
+    copy asserts something untrue here (a check-in that got no answer, a follow-up, a dead session),
+    and the lift is the one existing filing whose words hold. Once per stamp by construction — the
+    lifted stamp no longer reads as a stamp, so this branch is never re-entered for it — and the
+    in-flight/outcome legs above still run for a wake that fired while nudges were on."""
     at, why = stamp[0], stamp[1]
     kind = stamp[2] if len(stamp) > 2 else None
     if tmux.get(sid) is None:
@@ -6759,6 +6771,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
     _defer = _revivers_pending(sid, store, turns, gid)
     if _defer and not _nudge_deferred_ok(gid, _defer, now, sid):
         return False
+    _fresh = None
     try:
         # last-moment fresh-store re-read (the judges run concurrently with this tick): the wake's whole
         # justification is "the stamp stands and the goal is open" — re-key on the store as written
@@ -6768,6 +6781,22 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
             return False
     except Exception:
         pass
+    if wake_only:
+        # AUTO-NUDGE OFF: no injection (docstring). File the orphan branch's lift on the FRESH store
+        # (a judge pass holding the tick's snapshot across its model call would otherwise be
+        # clobbered), on the node that carries THIS stamp; an unreadable fresh store files nothing
+        # and the next tick re-asks — never a write off stale evidence.
+        if _fresh is None:
+            return False
+        _sn = next((n for n in _fresh.get("nodes", {}).values()
+                    if n.get("awaitingWhy") and n.get("awaitingAt") == at and not n.get("rolledUp")), None)
+        if _sn is None or not jd.record_verdict(_fresh, _sn, "romp", "awaiting", at, lift=True):
+            return False
+        jd.rollup_status(_fresh, False)
+        jd.save_goals(sid, _fresh)
+        _mark_views_dirty()
+        _drop_auto_nudge_rec(gid)                    # the spent episode's residue goes with the wait
+        return True
     Sessions.backend_for(sid).send(sid, _followup_body(gid, None, AWAITING_BACKSTOP_TEXT,
                                                        injected=True, auto=True, wake=True))
     _nudge_deferred_ok(gid, "", now, sid)            # the hold is over — drop any deferral record
@@ -7331,8 +7360,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     failures per session (see the tick's loop). Mutates `nudged` (the tick's in-memory mirror);
     returns True when it fired a nudge or stamped a failure — the tick pushes once at the end.
     `wake_only` (auto-nudge OFF, 2026-09-05): the same session gates, but the goal loop takes only
-    its awaiting branch — the dead-man wake and its outcome leg — and never the plain nudge, the
-    stall escalation or the debt reminder (see the tick's docstring).
+    its awaiting branch — the dead-man (which then files a lift, never an injection) and the wake
+    outcome leg — and never the plain nudge, the stall escalation or the debt reminder (see the
+    tick's and _wake_goal's docstrings).
     Same-tick fires COALESCE: every goal due this tick goes out as ONE bundled message (see
     _nudge_bundle_body), after a last-moment store re-read drops any goal the judges resolved
     while the tick was deciding (_nudge_fire_list — the user 2026-07-24). After the goal walk,
@@ -7483,7 +7513,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
             # done / block / user reply / a peer's answer superseding the stamp). But a wait is not an
             # exemption from the ladder (the user 2026-08-11): past the backstop the goal takes a WAKE —
             # same records, same response gates, same escalation, its own copy (see _wake_goal).
-            fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux) or fired
+            fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux, wake_only) or fired
             continue
         if wake_only:
             continue                                 # auto-nudge OFF: the dead-man was the whole errand

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5807,11 +5807,18 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     has an orphaned 'working' top goal, AND whose latest turn the closer has already classified (so 'working'
     is its considered verdict — a turn that ended by asking YOU a question is never nudged), inject the follow-up. RE-ARMS per stall episode, not once-ever: a goal is nudged again
     once a NEW GENUINE (work/user, not the agent's own nudge-response) ended turn leaves it still working, with
-    a count that climbs each fire (surfaced on the timeline; no cap — the warning is the alert). A no-op unless
-    the user turned it on, and single-flight (_AUTO_NUDGE_TICK_LOCK): a pass that finds another in
-    flight stands down without sending."""
-    if not _auto_nudge_on():
-        return
+    a count that climbs each fire (surfaced on the timeline; no cap — the warning is the alert). Single-flight
+    (_AUTO_NUDGE_TICK_LOCK): a pass that finds another in flight stands down without sending. The NUDGE
+    legs are a no-op unless the user turned it on.
+
+    THE AWAITING DEAD-MAN RUNS REGARDLESS OF THE TOGGLE (2026-09-05). The toggle is the user opting out of
+    injected status checks; the 6h wake in _wake_goal is the reachability floor every Working card is
+    promised (the 2026-08-22 rule: nudged/woken until it lands) and the ONLY mechanism for a wait whose
+    ending romp cannot observe (kind=job). Behind the toggle it was unreachable: a kind=job stamp stood 17
+    hours over nothing pending because this tick returned before its goal walk. So the walk runs in
+    WAKE-ONLY mode when nudges are off — same session gates, only the awaiting branch of the goal loop —
+    the way _interrupt_block_tick runs every push independent of the toggle. The plain nudge, the
+    compaction suggestion, the debt ladder and the dormant-owner sweep keep the toggle as before."""
     if not _AUTO_NUDGE_TICK_LOCK.acquire(blocking=False):
         return                                            # a pass is in flight: it owns this world's sends
     try:
@@ -5840,7 +5847,9 @@ def _ws_act_now_tick():
 
 def _auto_nudge_pass(now, tmux, run_dead_wait):
     """The body of one pass — the walk, the sweeps, the push. Only _auto_nudge_tick calls it, under
-    the single-flight guard (split out the way _pusher_cycle_jobs is from _pusher_cycle)."""
+    the single-flight guard (split out the way _pusher_cycle_jobs is from _pusher_cycle). `on` is the auto-nudge toggle:
+    off, the walk runs WAKE-ONLY — the awaiting dead-man still fires (see _auto_nudge_tick)."""
+    on = _auto_nudge_on()
     nudged = dict(_auto_nudge_data().get("nudged", {}))   # {gid: {count, lastTurnId}}
     alive = list(_alive_sessions(now, tmux))
     alive_ids = {s["sid"] for s in alive}
@@ -5853,7 +5862,7 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
         # ticks over two days before anyone noticed; every session after the bad one in the
         # iteration lost its nudges. The failure still logs loudly, per session.
         try:
-            r = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids)
+            r = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids, wake_only=not on)
             fired = (r is True) or fired
             # the walk->sweep handoff journal (the user 2026-08-24): a session gate names itself as
             # the return value; the sweep owns gate-held records by the GATE'S CLASS, never by age
@@ -5864,13 +5873,15 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
             # the compaction suggestion rides the same walk (contract at _compact_suggest_tick).
             # Deliberately INSIDE the auto-nudge toggle: a user who turned injected follow-ups
             # off has said no unprompted messages, and this is exactly that class.
-            fired = _compact_suggest_tick(s["sid"], tmux.get(s["sid"]), now) or fired
+            if on:
+                fired = _compact_suggest_tick(s["sid"], tmux.get(s["sid"]), now) or fired
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
     try:
-        _debt_backstop_tick(now)                       # reminder outcomes for debtors the walk can't reach
-        if run_dead_wait:
+        if on:
+            _debt_backstop_tick(now)                   # reminder outcomes for debtors the walk can't reach
+        if run_dead_wait and on:
             # THE DEATH TRANSITION HAS ONE OBSERVER: _dead_wait_sweep's prev-swap (_PREV_ALIVE)
             # is a lock-free read-modify-write, safe only because exactly one caller — the
             # pusher's periodic tick — ever runs it. setAutoNudge's WS-handler tick passes
@@ -6009,6 +6020,25 @@ def _lift_ev_t(nd, now):
     newest ruling winning, not a flap. This is the diary's standing evidence-time rule (see
     judge.record_verdict) — a `now` row outranks the judges on the in-flight segment forever."""
     return nd.get("awaitingAt") or now
+
+
+def _bg_ended_after(every, tombs, sp, anchor, now):
+    """Did some in-harness background item END after `anchor`? The watermark for the dispatch-less
+    task/job lift in _lift_spent_awaiting: the registry says nothing runs NOW, and this says the
+    emptiness ARRIVED after the stamp — so the stamp stood over live work that has since ended, rather
+    than over a world already empty when the judge stamped (a wait on something outside the harness).
+    Every source is a recorded event, never a clock: a task's terminal record (`endT`), a Monitor's
+    recorded ceiling passing (its kill moment — em._bg_expired, deadline past the anchor), a launch-
+    ledger stop tombstone (`at`; a TaskStop suppresses the notification the transcript would pair), or
+    the CLI respawn `sp` that killed everything the stamp could have watched."""
+    if sp > anchor:
+        return True
+    for t in every:
+        if (t.get("endT") or 0) > anchor:
+            return True
+        if t.get("status") == "running" and em._bg_expired(t, now) and (t.get("deadline") or 0) > anchor:
+            return True
+    return any((e.get("at") or 0) > anchor for e in tombs if isinstance(e, dict))
 
 
 def _stamp_written_at(nd):
@@ -6165,6 +6195,9 @@ def _lift_spent_awaiting(now, tmux):
             reg_ids = ({str(t.get("toolUseId") or "") for t in snap.get("bgTasks") or []
                         if isinstance(t, dict)} if "bgTasks" in snap else None)
             sp = _sdk_spawned_at(sid) or 0
+            # the launch ledger's stop tombstones (sdk_backend's bgLedgerEnded): a TaskStop suppresses
+            # the task notification, so the transcript never learns the Monitor ended — the hook did
+            tombs = ((_thread_reg(sid).get("bgLedgerEnded") or []) if reg_ids is not None else [])
             if not every and reg_ids is None:
                 if changed:
                     jd.rollup_status(store, False)
@@ -6211,21 +6244,37 @@ def _lift_spent_awaiting(now, tmux):
                     elif born <= (t.get("t") or 0) <= horizon:
                         own.append(t)
                 if not own:                           # nothing dispatched → not a background wait; leave it
-                    # …EXCEPT a kind=agents stamp standing over an authoritatively EMPTY lifecycle
-                    # set with no live subagents and nothing running in the transcript (the user
-                    # 2026-08-24): an agents-kind wait ends with task notifications, and with no
-                    # dispatch recorded ANYWHERE no such event can ever arrive — the shape a closer
-                    # mints when it misreads peer sessions as agents, orphaned for good the moment a
-                    # restart clears the world it described. Same evidence-postdates-anchor rule as
-                    # every lift: the (re)spawn must be newer than the stamp's anchor.
-                    if (nd.get("awaitingKind") == "agents" and reg_ids is not None and not reg_ids
-                            and not snap.get("subagents") and not running
-                            and (sp > (nd.get("awaitingAt") or 0)
-                                 # …or the transcript itself shows NOTHING running at all (2026-08-25
-                                 # audit): the closer stamped agents over a world with zero live
-                                 # dispatches — the misread-peer-as-agents shape needs no respawn to
-                                 # prove the notification can never arrive; the pairing already did
-                                 or not any(t.get("status") == "running" for t in every))):
+                    # …EXCEPT a stamp standing over an authoritatively EMPTY in-harness world: the
+                    # backend's lifecycle set present and empty, no live subagents, nothing running in
+                    # the transcript. Two shapes, one writer:
+                    #  - kind=agents (the user 2026-08-24): an agents-kind wait ends with task
+                    #    notifications, and with no dispatch recorded ANYWHERE no such event can ever
+                    #    arrive — the shape a closer mints when it misreads peer sessions as agents,
+                    #    orphaned for good the moment a restart clears the world it described. Same
+                    #    evidence-postdates-anchor rule as every lift: the (re)spawn must be newer than
+                    #    the stamp's anchor — or the transcript itself shows NOTHING running at all
+                    #    (2026-08-25 audit: the misread-peer-as-agents shape needs no respawn to prove
+                    #    the notification can never arrive; the pairing already did).
+                    #  - kind=task/job (2026-09-05): a closer stamped a top kind=job for a Monitor plus
+                    #    a background command the session ITSELF was running, the planner placed both
+                    #    launches on a sibling top, and this skip kept the stamp 17 hours over an empty
+                    #    registry with nothing pending anywhere (the wake below it never reached it —
+                    #    nudges off, top all-delegated). The deciding event is the LAST in-harness item
+                    #    ENDING after the stamp (_bg_ended_after: a terminal record, a Monitor's recorded
+                    #    ceiling, the launch ledger's stop tombstone, or the CLI respawn that killed
+                    #    everything) — a world already empty when the judge stamped is a wait on
+                    #    something the registry cannot see (a CI run), and stays the dead-man's. An
+                    #    ARMED kernel watch for this sid (a PR watch) is a carrier still running: its
+                    #    delivery is the ending, so the stamp stands. The owned-dispatch job rule below
+                    #    ("the watcher dying is the carrier going") is untouched: it needs a dispatch of
+                    #    the goal's OWN to protect, and this branch has none.
+                    _kind, _anchor0 = nd.get("awaitingKind"), nd.get("awaitingAt") or 0
+                    _empty = reg_ids is not None and not reg_ids and not snap.get("subagents") and not running
+                    if _empty and (
+                            (_kind == "agents"
+                             and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)))
+                            or (_kind in ("task", "job") and not _kernel_watch_armed(sid)
+                                and _bg_ended_after(every, tombs, sp, _anchor0, now))):
                         if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                             changed = True
                             _drop_auto_nudge_rec(top)
@@ -7276,11 +7325,14 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     return True, resp
 
 
-def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
+def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False):
     """One session's slice of the auto-nudge tick: the session-level gates, then the fire/stamp
     walk over its still-'working' top goals. Split from _auto_nudge_tick so the tick isolates
     failures per session (see the tick's loop). Mutates `nudged` (the tick's in-memory mirror);
     returns True when it fired a nudge or stamped a failure — the tick pushes once at the end.
+    `wake_only` (auto-nudge OFF, 2026-09-05): the same session gates, but the goal loop takes only
+    its awaiting branch — the dead-man wake and its outcome leg — and never the plain nudge, the
+    stall escalation or the debt reminder (see the tick's docstring).
     Same-tick fires COALESCE: every goal due this tick goes out as ONE bundled message (see
     _nudge_bundle_body), after a last-moment store re-read drops any goal the judges resolved
     while the tick was deciding (_nudge_fire_list — the user 2026-07-24). After the goal walk,
@@ -7407,14 +7459,23 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             continue                                 # top-level, live goals only
         if status.get(gid, "working") != "working":
             continue                                 # blocked/completed → the session resolved it; not orphaned
-        if _all_outstanding_delegated(nodes, gid):
-            _put_walk_gate(gid, "all-delegated", now)   # a wake record here is walk-unreachable → the sweep owns it
-            continue                                 # all open work handed to peers → nothing for THIS session
-        if sid in waitfor and nd.get("t", 0) <= waitfor[sid]["since"]:
-            _put_walk_gate(gid, "awaiting-peer", now)   # same: journaled so the sweep can evaluate its outcome
-            continue                                 # awaiting a live peer's reply to a question this goal predates
-        _pop_walk_gate(gid)                          # the walk reaches this goal — any per-goal hold is over
         _stamp = _goal_awaiting_stamp_full(nodes, gid, _kids, answered_at=_peer_answered(sid))
+        # THE SESSION'S OWN WAIT OUTRANKS THE PEER GATES (2026-09-05): the two skips below exist to
+        # suppress the plain status nudge for work that is a PEER's — all open leaves delegated, or
+        # a question to a live peer this goal predates. A job/agents/task/timer stamp is not that: it
+        # is a wait the session itself set running, and its dead-man (the wake branch below) is its
+        # only reviver — behind these gates a kind=job stamp on a top whose children had completed
+        # under a courier handoff stood 17 hours. A peer-kind or kindless stamp (which may well be a
+        # peer wait — the enum postdates it) keeps the gates, exactly as before.
+        _own_wait = bool(_stamp) and _stamp[2] in ("job", "agents", "task", "timer")
+        if not _own_wait:
+            if _all_outstanding_delegated(nodes, gid):
+                _put_walk_gate(gid, "all-delegated", now)   # a wake record here is walk-unreachable → the sweep owns it
+                continue                             # all open work handed to peers → nothing for THIS session
+            if sid in waitfor and nd.get("t", 0) <= waitfor[sid]["since"]:
+                _put_walk_gate(gid, "awaiting-peer", now)   # same: journaled so the sweep can evaluate its outcome
+                continue                             # awaiting a live peer's reply to a question this goal predates
+        _pop_walk_gate(gid)                          # the walk reaches this goal — any per-goal hold is over
         if _stamp:
             # The judge's durable ⏳ stamp (closer awaiting verdict): the goal's latest audited turn ended
             # waiting on async work it dispatched — not a stall, so the status nudge stays off. Restart-
@@ -7424,6 +7485,8 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             # same records, same response gates, same escalation, its own copy (see _wake_goal).
             fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux) or fired
             continue
+        if wake_only:
+            continue                                 # auto-nudge OFF: the dead-man was the whole errand
         # PARK GATE (the user 2026-08-30, the parked-tick round): a goal whose record holds the full
         # memo pair is PARKED — the ruling already said this exact world doesn't warrant a fire — so
         # it must not be re-evaluated (or logged) at every pass: 98.5% of a day's nudge-events rows
@@ -7720,7 +7783,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                          ev_t=recent_ts)             # it survived (the 2026-08-25 instrumentation)
         nudged[gid] = {"count": count, "lastTurnId": arm_id}   # mirror in-memory for the rest of this tick
         fired = True
-    if not fired:
+    if not fired and not wake_only:
         # DEBT REMINDER (the user 2026-07-26): this idle session asked for nothing itself, but it may
         # OWE a reply that is silently parking a peer ("Awaiting <us>" on their cards, which the goal
         # nudge deliberately skips). Same gates as the goal nudge (we only reach here idle, judged,
@@ -14151,6 +14214,15 @@ def _pr_watches_load():
         # boot re-arm (the reconnect-intent precedent): fresh counters, poll immediately
         for r in _pr_watches:
             r["_next"], r["_fails"], r["_busy"] = 0, 0, False
+
+
+def _kernel_watch_armed(sid):
+    """Is the kernel itself still watching something FOR this session — an armed PR watch whose
+    delivery will end the session's wait? The awaiting-stamp lift asks before retiring a job/task
+    stamp over an empty in-harness registry: a kernel-side carrier is exactly the external wait
+    whose ending IS observable (the watch's mail), so the stamp stands while it is armed."""
+    with _pr_watch_lock:
+        return any(str(r.get("sid")) == str(sid) for r in _pr_watches)
 
 
 def _pr_watches_save():
@@ -32217,8 +32289,9 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _deferral_sweep_tick(now)         # the walk, independent of the nudge toggle (the stall/swirl
     except Exception:                     # surfaces read these records regardless)
         sys.stderr.write("deferral-sweep: %s\n" % traceback.format_exc())
-    try:                                  # Auto Nudge runs server-side even with no browser open (cheap when
-        _auto_nudge_tick(now, tmux)       # off); the awaiting WAKE rides its goal walk (see _wake_goal)
+    try:                                  # Auto Nudge runs server-side even with no browser open; the awaiting
+        _auto_nudge_tick(now, tmux)       # WAKE rides its goal walk (see _wake_goal) and runs even when the
+    #                                       nudge is OFF — the toggle scopes the nudge legs, not the dead-man
     except Exception:
         sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
     try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6024,7 +6024,7 @@ def _lift_ev_t(nd, now):
     return nd.get("awaitingAt") or now
 
 
-def _bg_ended_after(every, tombs, sp, anchor, now):
+def _bg_ended_after(every, tombs, sp, anchor, now, kind="task"):
     """Did some in-harness background item END after `anchor`? The watermark for the dispatch-less
     task/job lift in _lift_spent_awaiting: the registry says nothing runs NOW, and this says the
     emptiness ARRIVED after the stamp — so the stamp stood over live work that has since ended, rather
@@ -6032,13 +6032,18 @@ def _bg_ended_after(every, tombs, sp, anchor, now):
     Every source is a recorded event, never a clock: a task's terminal record (`endT`), a Monitor's
     recorded ceiling passing (its kill moment — em._bg_expired, deadline past the anchor), a launch-
     ledger stop tombstone (`at`; a TaskStop suppresses the notification the transcript would pair), or
-    the CLI respawn `sp` that killed everything the stamp could have watched."""
-    if sp > anchor:
+    the CLI respawn `sp` that killed everything the stamp could have watched.
+
+    `kind` is the stamp's awaitingKind. For a JOB stamp (compute the kernel cannot observe: a CI run,
+    a remote queue) a CLI respawn and a Monitor's ceiling are CARRIER deaths, not the job ending — a
+    routine kernel restart alone used to lift a correctly-labelled job stamp that owned nothing (review
+    find on #936, 2026-09-07). A job lifts only on a real terminal record or a ledger stop tombstone."""
+    if kind != "job" and sp > anchor:
         return True
     for t in every:
         if (t.get("endT") or 0) > anchor:
             return True
-        if t.get("status") == "running" and em._bg_expired(t, now) and (t.get("deadline") or 0) > anchor:
+        if kind != "job" and t.get("status") == "running" and em._bg_expired(t, now) and (t.get("deadline") or 0) > anchor:
             return True
     return any((e.get("at") or 0) > anchor for e in tombs if isinstance(e, dict))
 
@@ -6276,7 +6281,11 @@ def _lift_spent_awaiting(now, tmux):
                             (_kind == "agents"
                              and (sp > _anchor0 or not any(t.get("status") == "running" for t in every)))
                             or (_kind in ("task", "job") and not _kernel_watch_armed(sid)
-                                and _bg_ended_after(every, tombs, sp, _anchor0, now))):
+                                # endings are measured from the stamp's WRITE time (_stamp_written_at), not
+                                # the audited turn's trigger: an item that returned mid-turn, before the
+                                # closer even wrote the stamp, is not the world emptying after it (review
+                                # find on #936, 2026-09-07)
+                                and _bg_ended_after(every, tombs, sp, _stamp_written_at(nd), now, kind=_kind))):
                         if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                             changed = True
                             _drop_auto_nudge_rec(top)

--- a/tests/test_awaiting_audit_classes.py
+++ b/tests/test_awaiting_audit_classes.py
@@ -143,6 +143,13 @@ class KindBoundaries(_Base):
 
     def test_the_kind_boundaries_are_stated(self):
         for phrase in ("another SESSION's work is never a job",
+                       # 2026-09-05: a closer stamped kind=job for a Monitor plus a background
+                       # command the session itself was running — "job" is for compute the session
+                       # cannot watch from inside the harness; its own commands/watchers/subagents
+                       # are task/agents. The dead-man for job waits is a 6h clock, so a
+                       # mislabelled in-harness wait costs hours the exact lifts would have saved.
+                       "cannot watch from inside the harness",
+                       "own background command, Monitor, or subagent is task or agents, never job",
                        "never one the turn "
                        "canceled",
                        "an idle recipient reads idle",

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -3279,7 +3279,7 @@ class ViewBuilder(unittest.TestCase):
         km._write_auto_nudge({"enabled": True, "nudged": {}})
         seen = []
 
-        def boom(s, now, tmux, nudged, waitfor, alive_ids=None):
+        def boom(s, now, tmux, nudged, waitfor, alive_ids=None, **kw):   # kw: wake_only (2026-09-05)
             if s["sid"] == "bad-session":
                 raise TypeError("%d format: a real number is required, not list")
             seen.append(s["sid"])

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -618,3 +618,185 @@ class LiftKeepsLiveLedgerRecords(unittest.TestCase):
                     self.assertNotIn(gid, left, "spent latches still drop (the 2026-08-16 fix)")
             finally:
                 km.jd.STATE = saved
+
+
+class InHarnessWaitLift(unittest.TestCase):
+    """A task/job stamp whose dispatches sit on ANOTHER top lifts when the in-harness world it stood
+    over goes EMPTY after the stamp (2026-09-05). The live specimen: the closer stamped a top kind=job
+    for a Monitor plus a background command the session itself was running; the planner placed both
+    launches on a sibling top, so the stamp owned nothing (`own == []`) and the dispatch-less skip
+    kept it — for 17 hours, over an authoritatively empty registry, nothing pending anywhere. The
+    agents-kind orphan rule already lifts that shape; task/job now take the same lift, keyed on the
+    same authority (the backend's present-and-empty lifecycle set, no live subagents, no armed kernel
+    watch) plus the watermark the whole sweep uses: the LAST in-harness item's ending — a terminal
+    record, a Monitor's recorded ceiling, the launch ledger's stop tombstone, or the CLI respawn that
+    killed everything — must postdate the stamp's anchor. A world already empty when the closer
+    stamped is a wait on something the registry cannot see (a CI run): the dead-man's, untouched.
+
+    SYNTHETIC fixtures; a PRIVATE sid (the goal-store fixture rule: load_goals replays the per-sid
+    override journal, and the shared placeholder sid's journal is written by other modules)."""
+
+    PSID = "44444444-5555-6666-7777-888888888888"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = {k: getattr(km, k) for k in
+                      ("_alive_sessions", "_mark_views_dirty", "_sdk_spawned_at", "_bg_placed_tops")}
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        (td / "sdk").mkdir()
+        self.path = str(td / (self.PSID + ".jsonl"))
+        km._alive_sessions = lambda now, tmux: [{"sid": self.PSID, "path": self.path}]
+        km._mark_views_dirty = lambda *a, **k: None
+        km._sdk_spawned_at = lambda sid: self.spawn
+        self.spawn = STAMP - 50                       # default: the CLI predates the stamp — no respawn story
+        self.gid, self.other = self.PSID + ":g1", self.PSID + ":g2"
+        # the planner placed every launch on the SIBLING top: this goal owns no dispatch
+        km._bg_placed_tops = lambda sid, path, tids: {t: self.other for t in tids}
+        self._saved_watches = list(km._pr_watches)
+        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km._pr_watches[:] = self._saved_watches
+        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
+        km._SESSION_STAMP_CACHE.clear(); km._bgall_cache.clear(); km._bgtasks_cache.clear()
+        try:
+            (km.jd._overrides_dir() / (self.PSID + ".jsonl")).unlink()
+        except OSError:
+            pass
+        self.td.cleanup()
+
+    def _transcript(self, recs):
+        with open(self.path, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        km._bgall_cache.clear(); km._bgtasks_cache.clear()
+
+    def _seed(self, kind, anchor=STAMP, why="watching the rebuild; will pick the result up when it lands"):
+        nd = {"id": self.gid, "text": "rebuild the notes-api index", "parentId": None,
+              "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+              "awaitingWhy": why, "awaitingAt": anchor,
+              **({"awaitingKind": kind} if kind else {}),
+              "log": [{"ev_t": anchor, "src": "closer", "kind": "awaiting", "why": why,
+                       **({"awaitKind": kind} if kind else {}), "at": anchor}]}
+        sib = {"id": self.other, "text": "wire the web session's watcher", "parentId": None,
+               "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+               "log": []}
+        (km.jd.GOALDIR / (self.PSID + ".json")).write_text(json.dumps(
+            {"rompUuid": self.PSID, "seq": 1, "placements": {}, "status": {},
+             "nodes": {self.gid: nd, self.other: sib}}))
+
+    def _reg(self, **fields):
+        (km.jd.STATE / "sdk" / (self.PSID + ".json")).write_text(json.dumps(fields))
+
+    def _node(self):
+        return json.loads((km.jd.GOALDIR / (self.PSID + ".json")).read_text())["nodes"][self.gid]
+
+    def _stamp(self):
+        return self._node().get("awaitingWhy") or None
+
+    def _tick(self, snap, now=BACK + 100):
+        km._lift_spent_awaiting(now, {self.PSID: snap} if snap is not None else {})
+
+    def test_a_job_stamp_over_dispatches_placed_elsewhere_lifts_when_the_world_empties_after_it(self):
+        # the specimen: the background command returned AFTER the stamp; the registry is present and
+        # empty; the goal owns nothing (placed on the sibling) — the wait it described is over
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("job")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp(), "nothing in-harness runs any more, and it ended after the stamp")
+
+    def test_the_lift_is_the_agents_lift_exactly(self):
+        # same writer, same row: a romp/awaiting LIFT anchored at the stamp (never wall-clock)
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("task")
+        self._tick({"state": "", "bgTasks": []})
+        row = [e for e in self._node()["log"] if e.get("kind") == "awaiting"][-1]
+        self.assertEqual((row.get("src"), row.get("lift"), row.get("ev_t")), ("romp", True, STAMP))
+
+    def test_a_task_stamp_takes_the_same_lift(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("task")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp())
+
+    def test_one_live_registry_entry_keeps_the_stamp(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK), _launch("t2", LAUNCH + 1)])
+        self._seed("job")
+        self._tick({"state": "", "bgTasks": [{"toolUseId": "t2", "desc": "x", "since": LAUNCH + 1}]})
+        self.assertIsNotNone(self._stamp(), "something is still running in-harness — the wait stands")
+
+    def test_live_subagents_keep_the_stamp(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("task")
+        self._tick({"state": "", "bgTasks": [], "subagents": [{"type": "Task", "since": BACK}]})
+        self.assertIsNotNone(self._stamp())
+
+    def test_no_authoritative_registry_means_no_move(self):
+        # a tmux CLI carries no lifecycle set: registry-absent is not evidence of anything
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("job")
+        self._tick({"state": ""})
+        self.assertIsNotNone(self._stamp(), "no authoritative source → no move")
+        # …and a DORMANT session is skipped outright (its tasks died with its CLI; the death owns it)
+        self._seed("job")
+        self._tick(None)
+        self.assertIsNotNone(self._stamp())
+
+    def test_emptiness_that_predates_the_stamp_is_not_the_waits_ending(self):
+        # the closer stamped AFTER the last return, knowing it — the wait is about something the
+        # registry cannot see (a CI run); the dead-man owns it, this sweep does not
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("job", anchor=BACK + 100)
+        self._tick({"state": "", "bgTasks": []}, now=BACK + 500)
+        self.assertIsNotNone(self._stamp(), "the world was already empty when the judge stamped")
+
+    def test_nothing_ever_dispatched_keeps_a_job_stamp(self):
+        # a genuinely external job with no in-harness carrier at all: no ending event exists here
+        self._transcript([])
+        self._seed("job")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNotNone(self._stamp(), "no item ended after the stamp — nothing to key on")
+
+    def test_a_respawn_after_the_stamp_is_a_sufficient_ending(self):
+        # the sibling's launch has no terminal record (killed with the process); the CLI epoch is
+        # newer than the stamp, so everything the stamp could have watched died at that moment
+        self._transcript([_launch("t1", LAUNCH)])
+        self._seed("task")
+        self.spawn = STAMP + 50
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp())
+
+    def test_a_ledger_stop_tombstone_after_the_stamp_is_the_ending_event(self):
+        # a Monitor called off with TaskStop suppresses its notification — the transcript never
+        # learns — but the launch ledger journals the stop; that tombstone is the exact event
+        self._transcript([_monitor("m1", LAUNCH, timeout_ms=30_000_000)])
+        self._seed("job")
+        self._reg(bgLedgerEnded=[{"tid": "m1", "why": "stopped", "at": BACK}])
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp())
+        self._seed("job")
+        self._reg(bgLedgerEnded=[{"tid": "m1", "why": "stopped", "at": STAMP - 10}])
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNotNone(self._stamp(), "a stop the judge already knew about is not new information")
+
+    def test_an_armed_kernel_watch_keeps_a_job_stamp(self):
+        # a PR watch is the kernel's own carrier of an external wait: its delivery IS the ending
+        # event, so the stamp stands while the watch is armed for this session
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed("job")
+        km._pr_watches.append({"pr": 7, "repo": "notes-api/notes-api", "sid": self.PSID, "at": LAUNCH,
+                               "_next": 0, "_fails": 0, "_busy": False})
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNotNone(self._stamp(), "the kernel is still watching something for this session")
+
+    def test_a_kindless_stamp_keeps_the_conservative_skip(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(None)
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNotNone(self._stamp(), "a kindless stamp may be a peer wait — untouched, as before")

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -461,13 +461,13 @@ class RestartReconcile(unittest.TestCase):
                 f.write(json.dumps(r) + "\n")
         km._bgall_cache.clear(); km._bgtasks_cache.clear()
 
-    def _seed(self, kind, why="waiting on a dispatched investigation", anchor=STAMP):
+    def _seed(self, kind, why="waiting on a dispatched investigation", anchor=STAMP, written=None):
         nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
               "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
               "awaitingWhy": why, "awaitingAt": anchor,
               **({"awaitingKind": kind} if kind else {}),
               "log": [{"ev_t": anchor, "src": "closer", "kind": "awaiting", "why": why,
-                       **({"awaitKind": kind} if kind else {}), "at": anchor}]}
+                       **({"awaitKind": kind} if kind else {}), "at": anchor if written is None else written}]}
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
             {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
 
@@ -508,6 +508,35 @@ class RestartReconcile(unittest.TestCase):
         self._seed("job")
         self._tick({"state": "", "bgTasks": []})
         self.assertIsNotNone(self._stamp(), "the slurm job may run on — only its terminal record lifts")
+
+    def test_a_restart_alone_does_not_lift_a_dispatchless_job_stamp(self):
+        # a JOB stamp names compute the kernel cannot observe (a CI run, a remote queue). A CLI respawn
+        # is the CARRIER dying, not the job ending — yet a routine kernel restart alone lifted a
+        # correctly-labelled job stamp that owned nothing (review find on #936, 2026-09-07). The same
+        # shape with kind=task DOES lift: an in-harness task died with its process.
+        self._transcript([])                              # nothing dispatched anywhere
+        self._seed("job", why="slurm 4821 regenerating the parts; verifies when done")
+        self.spawn = BACK                                 # the backend respawned AFTER the stamp
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNotNone(self._stamp(), "a restart is not the external job returning")
+        self._seed("task", why="the background build finishing")
+        self._tick({"state": "", "bgTasks": []})
+        self.assertIsNone(self._stamp(), "an in-harness task stamp: the respawn killed what it watched")
+
+    def test_a_return_before_the_stamp_was_written_is_not_the_world_emptying_after_it(self):
+        # the dispatch-less branch measures endings from the stamp's WRITE time, not the audited turn's
+        # trigger: a background item that returned mid-turn, before the closer even wrote the stamp,
+        # used to lift it within one pusher cycle of its write (review find on #936, 2026-09-07)
+        self.spawn = STAMP - 50                           # no respawn after the stamp
+        # launched BEFORE the goal was born, so the stamp owns no dispatch and the dispatch-less branch
+        # (not the owned-dispatch rule) is what decides
+        self._transcript([_launch("t1", BORN - 50), _notification("t1", BACK)])   # returned at BACK…
+        self._seed("task", anchor=STAMP, written=BACK + 50)                        # …the stamp written AFTER it
+        self._tick({"state": "", "bgTasks": []}, now=BACK + 200)
+        self.assertIsNotNone(self._stamp(), "the return predates the stamp's write — not an ending after it")
+        self._seed("task", anchor=STAMP, written=STAMP)                         # written BEFORE the return
+        self._tick({"state": "", "bgTasks": []}, now=BACK + 200)
+        self.assertIsNone(self._stamp(), "a return after the write is the ending the stamp waited on")
 
     def test_a_dispatchless_agents_stamp_over_an_empty_registry_lifts(self):
         # the live 2026-08-24 shape: a closer misread peer sessions as agents and stamped kind=agents

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -986,7 +986,7 @@ class AutoNudgeTickIsSingleFlight(_Base):
             setattr(km, n, v)
         super().tearDown()
 
-    def _walk(self, s, now, tmux, nudged, waitfor, alive_ids=None):
+    def _walk(self, s, now, tmux, nudged, waitfor, alive_ids=None, wake_only=False):   # #936 adds the kwarg (toggle off → wake-only walk)
         """The per-session walk standing in for the SEND: the first pass to reach it holds here,
         mid-send, until the test releases it; every later pass records and returns at once."""
         self.sends.append(now)

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""The awaiting dead-man runs whether or not auto-nudge is on, and reaches a stamped top the
+all-delegated gate would otherwise skip (2026-09-05).
+
+The 6h wake in _wake_goal is the designed backstop for waits whose ending romp cannot observe
+(kind=job: external compute). It was unreachable twice over for the live specimen — a kind=job
+stamp that stood 17 hours over nothing pending: (a) _auto_nudge_tick returned before the goal walk
+because the user had auto-nudge OFF, and (b) even with it on, the walk skipped the top via
+_all_outstanding_delegated (its children complete, the top carrying a courier `handoff`), a gate
+that exists to suppress the plain status nudge for peer work — a job/agents/task/timer wait is the
+session's OWN wait, not delegated work. The toggle governs the nudge (an injected status check the
+user opted out of); the dead-man is the reachability floor every Working card is promised, so it
+runs from the pusher's tick regardless, the way _interrupt_block_tick does. It fires once per stamp
+episode (the shared `nudged` ledger's wake record), never again per tick. SYNTHETIC fixtures only;
+a PRIVATE sid (goal-store fixture rule)."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wdt", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "55555555-6666-7777-8888-999999999999"     # private to this module (the fixture rule)
+NOW = 1_787_900_000
+H = 3600
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, sid, body):
+        self.sent.append((sid, body))
+
+    def pending_queued(self, sid):
+        return []
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = {k: getattr(km, k) for k in (
+            "_alive_sessions", "_wait_for_graph", "_session_flag", "_compacting_now", "_api_error",
+            "_session_working", "_interrupt_suppresses_nudge", "_backend_rewind_pending", "_last_state",
+            "_session_awaiting", "_turn_romp_injected", "_closer_settled", "_revivers_pending",
+            "_pending_ops", "_log_nudge_event", "_push_all", "_mark_views_dirty", "_path_of",
+            "_debt_backstop_tick", "_PREV_ALIVE")}
+        self.saved_jd = {k: getattr(jd, k) for k in ("STATE", "GOALDIR", "parsed_session", "_segs", "plan_units")}
+        self.saved_backend = km.Sessions.backend_for
+        jd.STATE = td
+        jd.GOALDIR = td / "goals"; jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        self.fb = _FakeBackend()
+        km.Sessions.backend_for = lambda sid: self.fb
+        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": "/nonexistent.jsonl"}]
+        km._wait_for_graph = lambda now, sids: {}
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        km._session_working = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="": False
+        km._backend_rewind_pending = lambda sid: False
+        km._last_state = lambda sid: ("", 0)
+        km._session_awaiting = lambda *a, **k: None
+        km._turn_romp_injected = lambda tn: False
+        km._closer_settled = lambda *a: True
+        km._revivers_pending = lambda *a, **k: ""
+        km._pending_ops = {}
+        km._log_nudge_event = lambda *a, **k: None
+        km._push_all = lambda *a, **k: None
+        km._mark_views_dirty = lambda *a, **k: None
+        km._path_of = lambda sid, now=None: "/nonexistent.jsonl"
+        km._debt_backstop_tick = lambda now: None
+        km._PREV_ALIVE = {SID}                       # no death transition pending
+        jd._segs = lambda tn, store: []
+        jd.plan_units = lambda session, store: []
+        self.turns = [{"id": "t1", "ended": True, "end": NOW - 8 * H, "t": NOW - 8 * H - 10, "atoms": []}]
+        jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+        self.gid = SID + ":g1"
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        for k, v in self.saved_jd.items():
+            setattr(jd, k, v)
+        km.Sessions.backend_for = self.saved_backend
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()
+        except OSError:
+            pass
+        self.td.cleanup()
+
+    def _toggle(self, enabled):
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps({"enabled": enabled, "nudged": {}}))
+        km._autonudge_cache.clear()
+
+    def _seed(self, kind="job", age=7 * H, delegated=True, stamped=True):
+        """A working top whose only open leaf is a courier handoff (all-delegated), carrying a stamp."""
+        at = NOW - age
+        why = "the index rebuild is still running; picking the result up when it lands"
+        top = {"id": self.gid, "text": "rebuild the notes-api index", "parentId": None,
+               "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": 100, "mt": 100,
+               "log": []}
+        if stamped:
+            top.update({"awaitingWhy": why, "awaitingAt": at, **({"awaitingKind": kind} if kind else {})})
+            top["log"].append({"ev_t": at, "src": "closer", "kind": "awaiting", "why": why,
+                               **({"awaitKind": kind} if kind else {}), "at": at})
+        nodes = {self.gid: top}
+        if delegated:
+            kid = self.gid + "c"
+            nodes[kid] = {"id": kid, "text": "web session: wire the watcher", "parentId": self.gid,
+                          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                          "t": 100, "mt": 100, "log": [],
+                          "handoff": {"to": "web", "msgId": "11111111-2222-3333-4444-000000000001"}}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {self.gid: "working"}, "nodes": nodes}))
+        km._SESSION_STAMP_CACHE.clear()
+
+    def _tick(self, now=NOW):
+        km._auto_nudge_tick(now, {SID: {"state": ""}})
+
+    def _wakes(self):
+        return [b for _s, b in self.fb.sent if km.AWAITING_BACKSTOP_TEXT in b]
+
+
+class DeadmanIgnoresTheToggle(_Base):
+    def test_a_7h_job_stamp_on_an_all_delegated_top_fires_with_nudges_off(self):
+        self._toggle(False)
+        self._seed(kind="job", age=7 * H)
+        self._tick()
+        self.assertEqual(len(self._wakes()), 1, "the dead-man is the reachability floor, not a nudge feature")
+        rec = km._auto_nudge_data()["nudged"][self.gid]
+        self.assertTrue(rec.get("wake"), "…recorded as a wake episode in the shared ledger")
+        self.assertEqual(rec.get("anchor"), NOW - 7 * H)
+
+    def test_a_second_cycle_does_not_fire_again(self):
+        self._toggle(False)
+        self._seed(kind="job", age=7 * H)
+        self._tick()
+        self._tick(NOW + 5)
+        self._tick(NOW + 60)
+        self.assertEqual(len(self._wakes()), 1, "once per stamp episode — keyed on the wake record, never per build")
+
+    def test_a_5h_stamp_is_still_patient(self):
+        self._toggle(False)
+        self._seed(kind="job", age=5 * H)
+        self._tick()
+        self.assertEqual(self.fb.sent, [], "the 6h constant stands")
+
+    def test_the_toggle_still_governs_the_plain_nudge(self):
+        # an unstamped working top with nudges off: nothing fires — the opt-out is the nudge's
+        self._toggle(False)
+        self._seed(stamped=False, delegated=False)
+        self._tick()
+        self.assertEqual(self.fb.sent, [], "no injected status check while auto-nudge is off")
+
+    def test_the_kinds_take_the_same_path(self):
+        for kind in ("agents", "task", "timer"):
+            self.fb.sent.clear()
+            self._toggle(False)
+            self._seed(kind=kind, age=7 * H)
+            self._tick()
+            self.assertEqual(len(self._wakes()), 1, "kind=%s is the session's own wait" % kind)
+
+
+class OwnWaitOutranksTheDelegatedGate(_Base):
+    def test_with_nudges_on_the_all_delegated_top_still_takes_its_wake(self):
+        self._toggle(True)
+        self._seed(kind="job", age=7 * H)
+        self._tick()
+        self.assertEqual(len(self._wakes()), 1)
+        self.assertNotIn(self.gid, km._auto_nudge_data().get("walkGates", {}),
+                         "the walk reached the goal — no all-delegated hold is journaled for it")
+
+    def test_a_peer_stamp_keeps_the_gate(self):
+        # a peer wait IS the delegated shape the gate exists for — it stays behind it
+        self._toggle(True)
+        self._seed(kind="peer", age=7 * H)
+        self._tick()
+        self.assertEqual(self.fb.sent, [])
+        self.assertEqual(km._auto_nudge_data()["walkGates"][self.gid]["gate"], "all-delegated")
+
+    def test_a_kindless_stamp_keeps_the_gate(self):
+        self._toggle(True)
+        self._seed(kind=None, age=7 * H)
+        self._tick()
+        self.assertEqual(self.fb.sent, [], "a kindless stamp may be a peer wait — conservative, as before")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -10,9 +10,12 @@ _all_outstanding_delegated (its children complete, the top carrying a courier `h
 that exists to suppress the plain status nudge for peer work — a job/agents/task/timer wait is the
 session's OWN wait, not delegated work. The toggle governs the nudge (an injected status check the
 user opted out of); the dead-man is the reachability floor every Working card is promised, so it
-runs from the pusher's tick regardless, the way _interrupt_block_tick does. It fires once per stamp
-episode (the shared `nudged` ledger's wake record), never again per tick. SYNTHETIC fixtures only;
-a PRIVATE sid (goal-store fixture rule)."""
+runs from the pusher's tick regardless, the way _interrupt_block_tick does — but with nudges OFF it
+injects NOTHING (romp interrupts only when the human is the bottleneck, and the user said no
+unprompted messages): it files the stamp's lift, the exact row the orphan lift files, so the card
+returns to plain Working and the closer is re-nominated. With nudges ON the injected check-in is
+unchanged. Either way it acts once per stamp episode (the wake record / the lifted stamp), never
+again per tick. SYNTHETIC fixtures only; a PRIVATE sid (goal-store fixture rule)."""
 import json
 import os
 import tempfile
@@ -135,30 +138,42 @@ class _Base(unittest.TestCase):
     def _wakes(self):
         return [b for _s, b in self.fb.sent if km.AWAITING_BACKSTOP_TEXT in b]
 
+    def _node(self):
+        return jd.load_goals(SID)["nodes"][self.gid]
+
+    def _lifts(self):
+        return [e for e in self._node().get("log") or [] if e.get("kind") == "awaiting" and e.get("lift")]
+
 
 class DeadmanIgnoresTheToggle(_Base):
-    def test_a_7h_job_stamp_on_an_all_delegated_top_fires_with_nudges_off(self):
+    def test_a_7h_job_stamp_on_an_all_delegated_top_files_a_lift_and_injects_nothing(self):
         self._toggle(False)
         self._seed(kind="job", age=7 * H)
         self._tick()
-        self.assertEqual(len(self._wakes()), 1, "the dead-man is the reachability floor, not a nudge feature")
-        rec = km._auto_nudge_data()["nudged"][self.gid]
-        self.assertTrue(rec.get("wake"), "…recorded as a wake episode in the shared ledger")
-        self.assertEqual(rec.get("anchor"), NOW - 7 * H)
+        self.assertEqual(self.fb.sent, [], "nudges off: no unprompted message, whatever the clock says")
+        self.assertIsNone(self._node().get("awaitingWhy"), "the wait romp cannot vouch for is withdrawn")
+        row = self._lifts()[-1]
+        self.assertEqual((row.get("src"), row.get("ev_t")), ("romp", NOW - 7 * H),
+                         "the orphan lift's exact row: romp/awaiting/lift at the stamp's anchor")
+        self.assertEqual(jd.load_goals(SID)["status"].get(self.gid, "working"), "working",
+                         "no block — every procedural block copy would misstate what happened")
+        self.assertNotIn(self.gid, km._auto_nudge_data()["nudged"], "no injection → no wake record")
 
-    def test_a_second_cycle_does_not_fire_again(self):
+    def test_a_second_cycle_does_not_file_again(self):
         self._toggle(False)
         self._seed(kind="job", age=7 * H)
         self._tick()
         self._tick(NOW + 5)
         self._tick(NOW + 60)
-        self.assertEqual(len(self._wakes()), 1, "once per stamp episode — keyed on the wake record, never per build")
+        self.assertEqual(len(self._lifts()), 1, "once per stamp — the lifted stamp no longer reads as one")
+        self.assertEqual(self.fb.sent, [])
 
     def test_a_5h_stamp_is_still_patient(self):
         self._toggle(False)
         self._seed(kind="job", age=5 * H)
         self._tick()
         self.assertEqual(self.fb.sent, [], "the 6h constant stands")
+        self.assertIsNotNone(self._node().get("awaitingWhy"), "…and nothing is filed either")
 
     def test_the_toggle_still_governs_the_plain_nudge(self):
         # an unstamped working top with nudges off: nothing fires — the opt-out is the nudge's
@@ -169,21 +184,37 @@ class DeadmanIgnoresTheToggle(_Base):
 
     def test_the_kinds_take_the_same_path(self):
         for kind in ("agents", "task", "timer"):
-            self.fb.sent.clear()
             self._toggle(False)
             self._seed(kind=kind, age=7 * H)
             self._tick()
-            self.assertEqual(len(self._wakes()), 1, "kind=%s is the session's own wait" % kind)
+            self.assertEqual(len(self._lifts()), 1, "kind=%s is the session's own wait" % kind)
+            self.assertEqual(self.fb.sent, [])
 
 
-class OwnWaitOutranksTheDelegatedGate(_Base):
+class NudgesOnKeepTheCheckIn(_Base):
     def test_with_nudges_on_the_all_delegated_top_still_takes_its_wake(self):
         self._toggle(True)
         self._seed(kind="job", age=7 * H)
         self._tick()
-        self.assertEqual(len(self._wakes()), 1)
+        self.assertEqual(len(self._wakes()), 1, "nudges on: today's injected check-in, unchanged")
+        self.assertIsNotNone(self._node().get("awaitingWhy"), "the check-in is the action — the stamp stands")
+        self.assertEqual(self._lifts(), [])
+        rec = km._auto_nudge_data()["nudged"][self.gid]
+        self.assertTrue(rec.get("wake"), "…recorded as a wake episode in the shared ledger")
+        self.assertEqual(rec.get("anchor"), NOW - 7 * H)
         self.assertNotIn(self.gid, km._auto_nudge_data().get("walkGates", {}),
                          "the walk reached the goal — no all-delegated hold is journaled for it")
+
+    def test_a_second_cycle_is_silent_with_nudges_on(self):
+        self._toggle(True)
+        self._seed(kind="job", age=7 * H)
+        self._tick()
+        self._tick(NOW + 5)
+        self._tick(NOW + 60)
+        self.assertEqual(len(self._wakes()), 1, "once per stamp episode — keyed on the wake record")
+
+
+class OwnWaitOutranksTheDelegatedGate(_Base):
 
     def test_a_peer_stamp_keeps_the_gate(self):
         # a peer wait IS the delegated shape the gate exists for — it stays behind it


### PR DESCRIPTION
## The bug

A session's card read "Awaiting job" for about 17 hours while nothing was pending. Diagnosed read-only on the live machine (2026-09-05). Three links in the chain, all in `kernel/kernel.py` and `kernel/judge.py`:

1. The closer stamped a top `awaitingKind: "job"` for a wait that was in fact in-harness work: a Monitor plus a background Bash the session itself was running. `job` is meant for compute the kernel cannot observe.
2. The planner placed both launches on a sibling top, so `_lift_spent_awaiting` found the stamped goal owned no dispatch (`own == []`) and skipped it. The only dispatch-less exception was the `agents` kind; a `job`/`task` stamp fell through unlifted even after the SDK registry's `bgTasks` (authoritative) went empty and the Monitor and Bash had ended.
3. The designed backstop, the 6h dead-man in `_wake_goal`, was unreachable twice over: `_auto_nudge_tick` returned early because auto-nudge was off, and even with it on, `_auto_nudge_session` skipped the top through `_all_outstanding_delegated` (children complete, a courier `handoff` on the top). `_dead_wait_sweep` cannot help a parked-but-alive SDK session.

## The fix (three parts, each keyed on an event)

**A. Event-based lift for in-harness waits** (`_lift_spent_awaiting`, new `_bg_ended_after`, `_kernel_watch_armed`). A `task`/`job` stamp with no owned dispatch takes the same lift as the `agents` orphan rule when the backend's lifecycle set is present and empty, no subagents live, no kernel PR watch is armed for the sid, AND the last in-harness item ended after the stamp's anchor. The ending sources are all recorded events: a task's terminal record (`endT`), a Monitor's recorded ceiling passing, the launch ledger's stop tombstone (`bgLedgerEnded`, the hook's record of a TaskStop that suppresses the notification), or the CLI respawn epoch. A world already empty when the judge stamped is a wait on something outside the harness and stays the dead-man's. No registry (tmux, dormant) means no move. The lift row is the agents branch's exactly: `romp`/`awaiting`/`lift` at the anchor, plus the spent-ledger drop.

**B. Dead-man independent of the toggle** (`_auto_nudge_tick`, `_auto_nudge_session`, `_wake_goal`). The tick now runs its goal walk in `wake_only` mode when auto-nudge is off: same session gates, only the awaiting branch (`_wake_goal` and its outcome leg); the plain nudge, compaction suggestion, debt ladder and dormant-owner sweep keep the toggle as before, the way `_interrupt_block_tick` already runs independently. In that mode a due dead-man injects NOTHING (the user turned unprompted messages off, and this is not a case where the human is the bottleneck): it files the row `_lift_spent_awaiting`'s orphan branch files, a `romp`/`awaiting` lift at the stamp's anchor on a fresh store read, so the card returns to plain Working and the lift row re-nominates the closer. No block, because every existing procedural block copy would misstate what happened (a check-in that got no answer, a follow-up, a dead session) and new copy was out of scope. With nudges on, today's injected check-in (`AWAITING_BACKSTOP_TEXT`) is unchanged. In the goal loop, a `job`/`agents`/`task`/`timer` stamp is evaluated before the all-delegated and awaiting-peer gates (which exist to suppress the plain nudge for a peer's work); `peer` and kindless stamps keep the gates. The 6h constant is unchanged; either action happens once per stamp (the wake record / the lifted stamp) and never re-fires per build.

**C. Closer wording** (`CLOSER_SYS`, the `AWAIT_KINDS` comment). `job` is only compute the session cannot watch from inside the harness (a CI run, a deploy, a remote queue); a wait on its own background command, Monitor, or subagent is `task`/`agents`, never `job`. One sentence, pinned.

## Verification

- New: `tests/test_kernel_awaiting_lift.py::InHarnessWaitLift` (13 tests: the lift for job and task, the exact row, live registry / live subagents / armed PR watch hold, no registry and dormant untouched, emptiness predating the stamp untouched, nothing-ever-dispatched untouched, respawn-after-stamp lifts, ledger tombstone before/after, kindless untouched); `tests/test_wake_deadman_toggle.py` (10 tests: nudges off + 7h job stamp files the lift with no message, no block and no wake record; second cycle files nothing; 5h stays patient; toggle still governs the plain nudge; every own-wait kind; nudges on: the injection as before with the stamp standing, second cycle silent; gate reorder; peer and kindless keep the gate); `KindBoundaries` pin for the wording.
- Updated: `tests/test_kernel.py` isolation test's stub accepts the new keyword.
- Reproduced first: the 10 positive cases failed before the change, the hold cases passed.
- Full suite: `uv run --quiet --with pytest --with cryptography -- pytest tests/ -q --ignore=tests/smoke_codex_live.py` — 7350 passed, 44 skipped.
- Fixtures are synthetic (placeholder uuids, the notes-api demo domain), private sids with journals cleaned in tearDown.

## Left out, deliberately

`_dead_wait_sweep` (dormant owners' stamped cards → procedural block) stays inside the auto-nudge toggle. It is the same class of needs-you rule and arguably belongs outside the toggle too, but it carries the `_PREV_ALIVE` one-observer semantics and a boot catch-up sweep, so moving it is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

