### PR TITLE
The bell opens a popover with separate switches and a test button, and a turn end can buzz the phone

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -418,6 +418,39 @@ internet and your agents, with no device check in front of it.
     standing between other members and your agents. Either keep the tailnet to
     your own devices, or write an ACL restricting the kernel machine to them.
 
+#### Notifications on your phone
+
+Romp can buzz your phone when a session needs you or finishes a task, so you can
+put the phone down while the sessions work. On an iPhone, first add Romp to the
+Home Screen (share sheet, then **Add to Home Screen**) and open it from there:
+iOS only lets an installed app receive notifications, so in a plain Safari tab
+the option stays off and says so. On Android and on a desktop browser the page
+itself can receive them.
+
+Then tap the bell. On a phone it sits in the bar along the bottom; on a desktop
+it is in the bottom-right cluster. A small card opens with three switches and a
+button:
+
+- **All devices** is the main switch. It turns notifications on for every task,
+  on every device you have set up and on the desktop of every machine you have
+  attached. The bells on individual sessions and cards then work as mutes.
+- **This device** turns them on for the phone or browser you are holding. The
+  first time, the browser asks for permission. If you refuse, the row goes grey
+  and tells you where to allow it again (on an iPhone, Settings, then
+  Notifications, then Romp; in a desktop browser, the site permission beside the
+  address). Turning this off silences only this device.
+- **Also when a turn finishes** adds a notification every time any session
+  finishes a turn, with the session's name and the first line of what it said.
+  With many sessions running this is a lot of buzzing, so it is off unless you
+  want it. A turn that ends by asking you something buzzes once, not twice.
+- **Send a test notification** sends one notification to the device you are
+  holding and prints the push service's answer under the button, so you can see
+  at once whether the phone is set up or why it is not.
+
+The bell itself shows the state of the device you are looking at: lit when the
+main switch is on and this device is set up, and crossed out otherwise. Its
+tooltip says which of the two is off.
+
 ## Security and trust
 
 Romp drives agents that run tools and shell commands as you, so reaching its API

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -428,24 +428,31 @@ the option stays off and says so. On Android and on a desktop browser the page
 itself can receive them.
 
 Then tap the bell. On a phone it sits in the bar along the bottom; on a desktop
-it is in the bottom-right cluster. A small card opens with three switches and a
-button:
+it is in the bottom-right cluster. A small card opens with a main switch, two
+switches indented under it, and a button:
 
-- **All devices** is the main switch. It turns notifications on for every task,
-  on every device you have set up and on the desktop of every machine you have
-  attached. The bells on individual sessions and cards then work as mutes.
-- **This device** turns them on for the phone or browser you are holding. The
-  first time, the browser asks for permission. If you refuse, the row goes grey
-  and tells you where to allow it again (on an iPhone, Settings, then
-  Notifications, then Romp; in a desktop browser, the site permission beside the
-  address). Turning this off silences only this device.
-- **Also when a turn finishes** adds a notification every time any session
-  finishes a turn, with the session's name and the first line of what it said.
-  With many sessions running this is a lot of buzzing, so it is off unless you
-  want it. A turn that ends by asking you something buzzes once, not twice.
+- **Notifications** is the main switch. Off silences every device and the
+  desktop of every machine you have attached; the bells on individual sessions
+  and cards are mutes under it. While it is off, the two switches beneath it are
+  dimmed but still work, so you can set a phone up first and switch everything
+  on when you are ready.
+- **This device**, under it, turns them on for the phone or browser you are
+  holding. The first time, the browser asks for permission. If you refuse, the
+  row goes grey and tells you where to allow it again (on an iPhone, Settings,
+  then Notifications, then Romp; in a desktop browser, the site permission
+  beside the address). Turning this off silences only this device. With the
+  main switch off, the row says the device is set up but nothing arrives until
+  the main switch is on.
+- **Also when a turn finishes**, also under it, adds a notification every time
+  any session finishes a turn, with the session's name and the first line of
+  what it said. With many sessions running this is a lot of buzzing, so it is
+  off unless you want it. A turn that ends by asking you something buzzes once,
+  not twice.
 - **Send a test notification** sends one notification to the device you are
-  holding and prints the push service's answer under the button, so you can see
-  at once whether the phone is set up or why it is not.
+  holding, whatever the switches say, and prints the push service's answer under
+  the button, so you can see at once whether the phone is set up or why it is
+  not. With the main switch off, the answer adds that real notifications will
+  not arrive until it is on.
 
 The bell itself shows the state of the device you are looking at: lit when the
 main switch is on and this device is set up, and crossed out otherwise. Its

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -451,8 +451,11 @@ switches indented under it, and a button:
 - **Send a test notification** sends one notification to the device you are
   holding, whatever the switches say, and prints the push service's answer under
   the button, so you can see at once whether the phone is set up or why it is
-  not. With the main switch off, the answer adds that real notifications will
-  not arrive until it is on.
+  not. The test is addressed to the session you were looking at when you
+  pressed the button, so you can switch to another session or another browser
+  tab, tap the notification, and check that it brings you back. With the main
+  switch off, the answer adds that real notifications will not arrive until it
+  is on.
 
 The bell itself shows the state of the device you are looking at: lit when the
 main switch is on and this device is set up, and crossed out otherwise. Its

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3104,6 +3104,15 @@ def _set_session_flag(sid, flag, value):
 # whose card left the feed are pruned on write (the card is gone; a fresh card is a fresh id), so
 # the file tracks the live feed instead of growing forever.
 NOTIFY_ALL_KEY = "*"
+# "*turns" is the SECOND reserved key (2026-09-05): the kernel-wide "also when a turn finishes" switch
+# behind the bell popover. It lives in this file rather than a sibling on purpose — it is read on the
+# same fire path as the master (both gate one push), so one cached read answers both; it rides the
+# same atomic write, the same mtime cache, and the same `__ncards__` watch that busts the feed sig
+# and repaints every dashboard when either flips. Off by default, and a real key only while on
+# (the master's own delete-on-off discipline). A card id can never collide with it: ids are
+# "<sid>:<node>" and the sid is a uuid.
+NOTIFY_TURNS_KEY = "*turns"
+_NOTIFY_RESERVED = frozenset((NOTIFY_ALL_KEY, NOTIFY_TURNS_KEY))
 _notify_cards_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
@@ -3137,6 +3146,22 @@ def _set_notify_all(value):
         cur[NOTIFY_ALL_KEY] = True
     else:
         cur.pop(NOTIFY_ALL_KEY, None)
+    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+
+
+def _notify_turns_on():
+    """The turn-finished switch (bell popover, 2026-09-05): on = every session's turn end buzzes the
+    subscribed phones — gated by the master at the FIRE (see _turn_notify_tick), never here, so the
+    popover can show the row's own state while the master is off."""
+    return bool(_notify_cards().get(NOTIFY_TURNS_KEY))
+
+
+def _set_notify_turns(value):
+    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
+    if value:
+        cur[NOTIFY_TURNS_KEY] = True
+    else:
+        cur.pop(NOTIFY_TURNS_KEY, None)
     _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
 
 
@@ -3193,11 +3218,12 @@ def _set_notify_session(sid, value):
 def _prune_notify_cards(live_ids):
     """Drop armed ids whose card is no longer in the feed (cleared/archived — the id never comes back).
     Called from the feed-diff detector, so the write happens only on the event of a card leaving.
-    The master key is not a card and never prunes; values are kept as stored (False = a mute)."""
+    The reserved keys (the master, the turn-finished switch) are not cards and never prune; values
+    are kept as stored (False = a mute)."""
     cur = _notify_cards()
-    gone = [i for i in cur if i not in live_ids and i != NOTIFY_ALL_KEY]
+    gone = [i for i in cur if i not in live_ids and i not in _NOTIFY_RESERVED]
     if gone:
-        kept = {i: cur[i] for i in cur if i in live_ids or i == NOTIFY_ALL_KEY}
+        kept = {i: cur[i] for i in cur if i in live_ids or i in _NOTIFY_RESERVED}
         _atomic_write(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
 
 
@@ -29499,14 +29525,23 @@ def _cached_feed(now, tmux, sig, connect=False):
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
     _fired = _feed_notifications(feed)                    # armed bells: fresh builds are the transition event
+    _buzzed = []
     for _t, _b, _sid in _fired:
         _system_notify(_t, _b)
+        # ONE phone buzz per session per turn end (the 2026-09-05 rule, see _buzz_claim): a card
+        # moving because its session just stopped shares that stop with the turn-finished push —
+        # whichever of the two files first buzzes, the other yields. The desktop notice above and
+        # the badge below are not the buzz and never yield.
+        if not _buzz_claim(_sid, _turn_end_key(_sid), "bell"):
+            continue
         _push_notify(_t, _b, _sid, _badge)                # same events to subscribed phones (plans/ios-app.md)
-    if _fired:
+        _buzzed.append({"title": _t, "body": _b, "sid": _sid})
+    if _buzzed:
         # …and to trusted peers' devices (plans/federated-push.md): the phone subscribed at the
         # always-on box must buzz for THIS kernel's cards too — which kernel detected an event is
-        # romp's business, never the user's.
-        _push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])
+        # romp's business, never the user's. Only what buzzed HERE travels, so a peer's phone
+        # hears each turn end once too.
+        _push_forward(_buzzed)
     _badge_push(_badge)                                   # app-icon count for installed shells (proposal 3)
     return feed
 
@@ -29718,10 +29753,17 @@ def _vapid_auth(endpoint):
     return "vapid t=%s.%s, k=%s" % (signing.decode(), _b64u(r.to_bytes(32, "big") + s.to_bytes(32, "big")), pub)
 
 
-def _push_send_one(sub, payload):
-    """POST one encrypted notification to one subscription. Returns False only when the push
-    service says the subscription is DEAD (404/410 — the sole prune signal, per the plan); a
-    network blip keeps it."""
+_PUSH_DEAD_STATUSES = (404, 410)   # the push service's "this subscription is gone" — the sole prune signal
+
+
+def _push_post(sub, payload):
+    """POST one encrypted notification to one subscription and report what the push service SAID:
+    (status, detail). status is the HTTP status (a 2xx = accepted — Apple/Google answer 201), or 0
+    when the request never got an answer (DNS, timeout, TLS), with the error in detail. Never
+    raises on the network path: the caller decides what an outcome means — _push_send_one turns
+    it into keep/prune for the fan-out, /push/test hands it to the user verbatim (2026-09-05, the
+    popover's test button: before it, every failure short of a dead subscription was swallowed as
+    success and a phone that never buzzed had nothing to show for it)."""
     import urllib.request, urllib.error
     req = urllib.request.Request(
         sub["endpoint"], method="POST",
@@ -29729,12 +29771,50 @@ def _push_send_one(sub, payload):
         headers={"Authorization": _vapid_auth(sub["endpoint"]),
                  "Content-Encoding": "aes128gcm", "TTL": "86400", "Urgency": "high"})
     try:
-        urllib.request.urlopen(req, timeout=10).read()
-        return True
+        with urllib.request.urlopen(req, timeout=10) as r:
+            r.read()
+            return int(r.status or 200), str(r.reason or "accepted")
     except urllib.error.HTTPError as e:
-        return e.code not in (404, 410)
-    except Exception:
-        return True
+        try:
+            body = e.read().decode("utf-8", "replace").strip()
+        except Exception:
+            body = ""
+        detail = str(e.reason or "")
+        if body:
+            detail = ("%s: %s" % (detail, body[:200])) if detail else body[:200]
+        return int(e.code), detail or ("HTTP %d" % e.code)
+    except Exception as e:
+        return 0, ("%s: %s" % (type(e).__name__, e)).strip(": ")
+
+
+def _push_send_one(sub, payload):
+    """POST one encrypted notification to one subscription. Returns False only when the push
+    service says the subscription is DEAD (404/410 — the sole prune signal, per the plan); a
+    network blip keeps it. Built on _push_post, which keeps the status for the callers that need
+    it; the fan-out only needs keep-or-prune."""
+    status, _detail = _push_post(sub, payload)
+    return status not in _PUSH_DEAD_STATUSES
+
+
+def _push_test(endpoint):
+    """The popover's "Send a test notification" (2026-09-05): ONE plain notification to ONE
+    subscription — the asking device's — and the push service's answer back to it as
+    {ok, status, detail}. Synchronous on purpose: the whole point is to show the user what the
+    service said. An endpoint nobody subscribed answers ok:false with the reason (the shell shows
+    it under the button); a dead subscription (404/410) is pruned exactly as the fan-out would
+    prune it, and the detail says so. Raises RuntimeError when the crypto dependency is missing —
+    the route turns that into the same loud 500 /push/subscribe gives."""
+    sub = _push_subs().get(str(endpoint or ""))
+    if not sub:
+        return {"ok": False, "status": 0, "detail": "this device isn't subscribed yet"}
+    _vapid_keys()                                          # RuntimeError without cryptography → the route's 500
+    payload = json.dumps({"title": "romp", "body": "Test notification — this device is set up."}).encode()
+    status, detail = _push_post(sub, payload)
+    ok = 200 <= status < 300
+    if status in _PUSH_DEAD_STATUSES:
+        _del_push_sub(sub["endpoint"])
+        detail = "%s — the push service says this subscription is gone, so it was removed; turn This device off and on again" % detail
+    return {"ok": ok, "status": status, "detail": detail}
 
 
 def _push_notify(title, body, sid="", badge=None):
@@ -29803,6 +29883,94 @@ def _push_forward(events):
                 pass                               # one unreachable peer must not block the rest
 
     threading.Thread(target=run, daemon=True).start()
+
+
+# ── the turn-finished push (the bell popover's third row, 2026-09-05) ─────────────────────────────
+# With the master AND the turn switch on, every session's turn end buzzes the subscribed phones:
+# {title: the session's name, body: the first line of what it said, sid}. The EVENT is the session's
+# recorded settle — the Stop hook's `lastStopAt` stamp (SDK sessions) or the states/ 'waiting'/'idle'
+# transition the Stop hook writes (tmux) — read per pusher cycle, which the very same settle wakes
+# (/tick, the backend's poke). No timer, no transcript-mtime inference. The first sight of a session
+# is a silent baseline (existing state is status, not news — the _NOTIFY_PREV policy), and a session
+# the user muted (its own bell off) stays quiet here too: the master's "on unless muted" model.
+#
+# ONE BUZZ PER TURN END (the no-double-buzz rule): a turn that ends by asking a question also moves
+# its card into needs_input a few seconds later, once the judges rule — a bell event. Both writers
+# claim (sid, turn-end key) through _buzz_claim; whoever files first buzzes and the other yields.
+# Within one cycle the feed builds before this tick, so when the judges have already ruled the more
+# informative bell event wins; across cycles the turn push usually lands first and the later bell
+# event yields on the phone (the desktop notice and the badge still fire — they are not the buzz).
+# Bell events never yield to EACH OTHER: two cards of one session moving in one build buzz twice,
+# exactly as before this rule existed.
+_TURN_PREV = {}      # sid -> turn-end key at the last tick; absent = baseline pending
+_PUSH_BUZZED = {}    # sid -> (turn-end key, "turn"|"bell") of the last phone buzz filed for it
+_TURN_BODY_CAP = 120
+
+
+def _turn_end_key(sid):
+    """The session's newest TURN-END as an opaque key, 0 when there is no settle evidence. Like
+    _settle_event_key, the Stop hook's lastStopAt is primary; the fallback is stricter — only a
+    STOPPED states/ transition ('waiting'/'idle') counts, because _last_state also moves when a
+    turn STARTS and a start must never read as an end here."""
+    try:
+        t = int((_thread_reg(sid) or {}).get("lastStopAt") or 0)
+    except Exception:
+        t = 0
+    if t:
+        return t
+    val, vt = _last_state(sid)
+    return (vt or 0) if val in ("waiting", "idle") else 0
+
+
+def _buzz_claim(sid, key, kind):
+    """File a phone buzz for (sid, key) from `kind` ("turn" | "bell"). True = go ahead; False = a
+    buzz for this same turn end already went out and this one yields. A bell event yields only to a
+    TURN claim (bell events never suppress each other); a turn push yields to any claim. A sid-less
+    event (a card with no session) has nothing to share a turn with and always passes."""
+    if not sid:
+        return True
+    cur = _PUSH_BUZZED.get(sid)
+    if cur is not None and cur[0] == key and (kind == "turn" or cur[1] == "turn"):
+        return False
+    if cur is None or cur[0] != key or kind == "turn":
+        _PUSH_BUZZED[sid] = (key, kind)
+    return True
+
+
+def _first_line(text, cap=_TURN_BODY_CAP):
+    """The first non-empty line of a reply, clipped to `cap` characters with an ellipsis."""
+    for line in str(text or "").splitlines():
+        s = line.strip()
+        if s:
+            return s if len(s) <= cap else s[:cap - 1].rstrip() + "…"
+    return ""
+
+
+def _turn_notify_tick(now, tmux):
+    """One pusher-cycle pass over the live sessions: a session whose turn-end key MOVED since the
+    last pass finished a turn. Fires only with both switches on and the session unmuted; every
+    sighting advances the memo regardless, so switching the row on later never replays old ends."""
+    fired = []
+    for s in _alive_sessions(now, tmux):
+        sid = str(s.get("sid") or "")
+        if not sid:
+            continue
+        key = _turn_end_key(sid)
+        prev = _TURN_PREV.get(sid)
+        _TURN_PREV[sid] = key
+        if prev is None or key == prev or not key:
+            continue                                     # baseline / nothing new / no settle evidence
+        if not (_notify_all_on() and _notify_turns_on() and _notify_session_effective(sid)):
+            continue
+        if not _buzz_claim(sid, key, "turn"):
+            continue                                     # a bell event already buzzed for this turn end
+        body = _first_line(_last_assistant_text(s.get("path") or "")) or "finished a turn"
+        title = str(s.get("name") or _name_of(sid) or sid[:8])
+        _push_notify(title, body, sid)                   # badge omitted: the count rides its own push
+        fired.append({"title": title, "body": body, "sid": sid})
+    if fired:
+        _push_forward(fired)                             # peers' phones hear it too, the bell-event way
+    return fired
 
 
 # The whole service worker. Push delivery ONLY — deliberately NO fetch handler: romp is useless
@@ -30050,6 +30218,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         sys.stderr.write("pending-ops: %s\n" % traceback.format_exc())   # never behind a judge pass (2026-09-03)
     if any_client:
         _push_all(tmux=tmux)
+    try:                                  # the turn-finished push (bell popover): AFTER the feed build above,
+        _turn_notify_tick(now, tmux)      # so a bell event the same settle produced files its buzz first
+    except Exception:
+        sys.stderr.write("turn-notify: %s\n" % traceback.format_exc())
     # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
     try:                                  # EXACT retraction first: dispatches returned → the stamp is spent,
         _lift_spent_awaiting(now, tmux)   # so the nudge tick below never wakes a wait that already ended
@@ -31095,8 +31267,10 @@ else{var ru=document.getElementById('ru-back');
 if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
 else{var er=document.getElementById('rerr-back');
 if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;}
+else{var bp=document.getElementById('rbell-back');
+if(bp&&!bp.hidden&&window.__rompCloseBellPop){window.__rompCloseBellPop();closed=true;}
 else{var nt=document.getElementById('rnet-back');
-if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}
+if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}}
 if(closed){e.preventDefault();e.stopPropagation();}}
 document.addEventListener('keydown',onEsc,true);
 ['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
@@ -32300,6 +32474,7 @@ else if(m&&m.type==='badge'&&'setAppBadge' in navigator){
 try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function(e){});}catch(e){}}
 // the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
 else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);
+else if(m&&m.type==='notifyTurns'&&window.__rompNotifyTurnsPaint)window.__rompNotifyTurnsPaint(!!m.on);
 // the boot check found a newer romp release — raise the update banner on every open dashboard
 else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'',m.drift||'',m.boot||'',m.state||'');};
 ws.onclose=function(){setTimeout(shellWS,2000);};}catch(e){}}
@@ -32309,37 +32484,64 @@ var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}
 """
 
 
-# The bell in the bottom bar's action cluster / mobile tab bar: the MASTER notification switch
-# (the user 2026-08-09, who expected the bottom-right bell to turn notifications on for every task,
-# with per-item bells as the way to mute some — not a switch that arms nothing by itself). ON = the
-# kernel arms every card by default (notify-cards.json "*", POST /notify-all) and the session/card
-# bells read as mutes; the same tap also opts THIS device into the web pushes where the Push API
-# exists (plans/ios-app.md proposal 2 — on iOS that means the installed home-screen app), so one
-# gesture buys the arming and the delivery together. The bell paints from the KERNEL's state (GET
-# /notify-all at boot, a {type:'notifyAll'} shell push on every toggle) — never from the device
-# subscription, so every device's bell agrees. The push-subscribe leg is best-effort ON TOP of the
-# master flip: a denied permission lands in the Log but leaves notifications on (the kernel box
-# still speaks, other devices still buzz). Notification.requestPermission runs synchronously in the
-# tap (iOS voids the gesture across an await), which is why it is kicked off BEFORE the /notify-all
-# round-trip rather than chained after it.
+# The bell in the bottom bar's action cluster / mobile tab bar opens the NOTIFICATION POPOVER
+# (2026-09-05). Before it, one tap did two jobs at once: it flipped the kernel-wide master switch
+# (the user 2026-08-09's model — on = every task notifies, the session/card bells read as mutes;
+# notify-cards.json "*", POST /notify-all) AND subscribed or unsubscribed THIS device's Web Push
+# (plans/ios-app.md proposal 2) — so turning the bell off on a phone silenced every device, a denied
+# permission left the master on with only a Log line to show for it, and nothing ever told the user
+# whether the push service had accepted a subscription at all. The popover pulls the two apart as
+# rows — "All devices" (the master, kernel-authoritative: GET /notify-all at boot, a {type:'notifyAll'}
+# shell push on every toggle so every dashboard agrees) and "This device" (this browser's
+# subscription; Notification.requestPermission still runs synchronously in the tap's own stack
+# because iOS voids the gesture across an await) — adds the turn-finished switch (/notify-turns,
+# its own {type:'notifyTurns'} push), and a test button that POSTs /push/test with this device's
+# endpoint and shows the push service's answer as one sentence under itself. The bell GLYPH now
+# reflects this device: lit only when the master is on AND this browser is subscribed; a browser
+# with no Push API has no subscription half to reflect, so the master alone paints it there. The
+# tooltip names which half is off. Where push is blocked or unavailable the This-device row is
+# disabled and its sub-line says why and how to fix it — never a silent no-op.
 _LANDING_PUSH_JS = """
 (function(){var bells=[].slice.call(document.querySelectorAll('#mbell,#rail-bell'));if(!bells.length)return;
 bells.forEach(function(b){b.hidden=false;});
 var canPush=('serviceWorker' in navigator)&&('PushManager' in window)&&('Notification' in window);
-var isOn=false,busy=false;
-function paint(){bells.forEach(function(b){b.classList.toggle('on',isOn);
-var t=isOn?'Notifications on for every task — tap to turn off':'Notify when any task needs you or completes';
-b.setAttribute('title',t);b.setAttribute('aria-label',t);});}
-window.__rompNotifyAllPaint=function(on){isOn=!!on;paint();};   // the shell WS repaints every open dashboard on a toggle
+var back=document.getElementById('rbell-back'),pop=document.getElementById('rbell-pop');if(!back||!pop)return;
+var rows={};['all','dev','turns'].forEach(function(k){rows[k]=pop.querySelector('[data-act='+k+']');});
+var devSubEl=document.getElementById('rbp-dev-sub'),testBtn=document.getElementById('rbp-test'),testOut=document.getElementById('rbp-test-out');
+var isOn=false,turnsOn=false,devOn=false,busy={};
+function perm(){return canPush?Notification.permission:'';}
+function sw(k,on,ok){var r=rows[k];if(!r)return;r.classList.toggle('off',!ok);r.setAttribute('aria-checked',on?'true':'false');
+r.setAttribute('aria-disabled',ok?'false':'true');var s=r.querySelector('.rbp-sw');if(s)s.classList.toggle('on',!!on);}
+function paint(){
+var devOk=canPush&&perm()!=='denied';
+var lit=isOn&&(canPush?devOn:true);   // the glyph is THIS device's truth: master AND its subscription
+var t;
+if(lit)t='Notifications on — tap for options';
+else if(!isOn&&canPush&&!devOn)t='Notifications off — for all devices, and on this device';
+else if(!isOn)t='Notifications off for all devices';
+else t='Notifications off on this device';
+bells.forEach(function(b){b.classList.toggle('on',lit);b.setAttribute('title',t);b.setAttribute('aria-label',t);});
+sw('all',isOn,true);sw('dev',devOn,devOk);sw('turns',turnsOn,true);
+var sub;
+if(!canPush)sub="Push isn't available in this browser. On iPhone, add romp to the Home Screen first and open it from there.";
+else if(perm()==='denied')sub="Notifications are blocked for this site. On iPhone: Settings, then Notifications, then Romp. In a desktop browser: the site permission beside the address.";
+else if(devOn)sub="This browser gets a notification when a session needs you or finishes.";
+else sub="Turn on to get them on this device.";
+if(devSubEl)devSubEl.textContent=sub;}
+window.__rompNotifyAllPaint=function(on){isOn=!!on;paint();};     // the shell WS repaints every open dashboard on a toggle
+window.__rompNotifyTurnsPaint=function(on){turnsOn=!!on;paint();};
 fetch('/notify-all').then(function(r){return r.json();}).then(function(d){isOn=!!(d&&d.on);paint();}).catch(function(e){});
-function sub(){return navigator.serviceWorker.getRegistration('/').then(function(r){return r?r.pushManager.getSubscription():null;});}
+fetch('/notify-turns').then(function(r){return r.json();}).then(function(d){turnsOn=!!(d&&d.on);paint();}).catch(function(e){});
+function sub(){if(!canPush)return Promise.resolve(null);
+return navigator.serviceWorker.getRegistration('/').then(function(r){return r?r.pushManager.getSubscription():null;}).catch(function(e){return null;});}
+sub().then(function(s){devOn=!!s;paint();});
 function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Notifications: '+((e&&e.message)||e));}catch(err){}}
 function post(path,obj){return fetch(path,{method:'POST',body:JSON.stringify(obj)}).then(function(r){
-if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});});}
+if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});
+return r.json().catch(function(){return {};});});}
 function b64u(s){var raw=atob((s+'==='.slice((s.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/'));
 var a=new Uint8Array(raw.length);for(var i=0;i<raw.length;i++)a[i]=raw.charCodeAt(i);return a;}
-function done(){busy=false;bells.forEach(function(b){b.classList.remove('busy');});}
-function devSub(perm){return perm.then(function(p){
+function devSubscribe(permP){return permP.then(function(p){
 if(p!=='granted')throw new Error('push not allowed on this device');
 return navigator.serviceWorker.register('/sw.js');
 }).then(function(){return fetch('/push/vapid-key').then(function(r){
@@ -32347,18 +32549,36 @@ if(!r.ok)return r.text().then(function(t){throw new Error(t||'no server key');})
 }).then(function(k){return navigator.serviceWorker.ready.then(function(reg){
 return reg.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:b64u(k.key)});});
 }).then(function(s){return post('/push/subscribe',s.toJSON());});}
-function devUnsub(){return sub().then(function(s){var ep=s?s.endpoint:'';
+function devUnsubscribe(){return sub().then(function(s){var ep=s?s.endpoint:'';
 return (s?s.unsubscribe():Promise.resolve()).then(function(){return ep?post('/push/unsubscribe',{endpoint:ep}):null;});});}
-bells.forEach(function(bl){bl.addEventListener('click',function(){
-if(busy)return;busy=true;bells.forEach(function(b){b.classList.add('busy');});   // acknowledge the tap before any round-trip
-var want=!isOn;
-var perm=(want&&canPush)?Notification.requestPermission():null;   // in the tap's own stack, before any await
-post('/notify-all',{on:want}).then(function(){
-isOn=want;paint();                       // the master flipped — the bell says so even if the push leg fails below
-if(!canPush)return;
-return want?devSub(perm):devUnsub();
-}).then(function(){done();},function(e){fail(e);done();});
-});});
+function place(anchor){var r=anchor.getBoundingClientRect();   // beside the rail bell / above the tab bar: both sit at the bottom edge
+pop.style.bottom=Math.max(8,window.innerHeight-r.top+6)+'px';pop.style.right=Math.max(8,window.innerWidth-r.right)+'px';}
+function open(anchor){place(anchor);back.hidden=false;}
+function close(){back.hidden=true;}
+window.__rompCloseBellPop=close;                                  // Escape (the shell's shared chain) closes it like every panel
+back.addEventListener('click',function(e){if(e.target===back)close();});   // an outside tap: the backdrop is everything outside the card
+bells.forEach(function(bl){bl.addEventListener('click',function(){if(!back.hidden){close();return;}open(bl);});});
+function setBusy(k,on){busy[k]=on;var r=rows[k];if(r)r.classList.toggle('busy',on);}   // acknowledge the tap before any round-trip
+pop.addEventListener('click',function(e){var el=e.target;
+while(el&&el!==pop&&!(el.getAttribute&&el.getAttribute('data-act')))el=el.parentNode;
+if(!el||el===pop)return;var act=el.getAttribute('data-act');
+if(act==='all'){if(busy.all)return;setBusy('all',true);var want=!isOn;
+post('/notify-all',{on:want}).then(function(){isOn=want;paint();},fail).then(function(){setBusy('all',false);});}
+else if(act==='dev'){if(busy.dev||el.classList.contains('off'))return;setBusy('dev',true);var wantD=!devOn;
+var perm0=(wantD&&canPush)?Notification.requestPermission():null;   // in the tap's own stack, before any await
+(wantD?devSubscribe(perm0):devUnsubscribe()).then(function(){devOn=wantD;},function(e){fail(e);return sub().then(function(s){devOn=!!s;});})
+.then(function(){setBusy('dev',false);paint();});}
+else if(act==='turns'){if(busy.turns)return;setBusy('turns',true);var wantT=!turnsOn;
+post('/notify-turns',{on:wantT}).then(function(){turnsOn=wantT;paint();},fail).then(function(){setBusy('turns',false);});}
+else if(act==='test'){if(!testBtn||testBtn.disabled)return;testBtn.disabled=true;var label=testBtn.textContent;testBtn.textContent='Sending…';
+testOut.className='rbp-sub';testOut.textContent='';
+sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};return post('/push/test',{endpoint:s.endpoint});}).then(function(d){
+var ok=!!(d&&d.ok);testOut.classList.toggle('bad',!ok);
+testOut.textContent=ok?'The push service accepted it.':(d&&d.nosub?"This device isn't subscribed yet.":
+(d&&d.status?('The push service refused it: '+d.status+' '+(d.detail||'')+'.'):('Could not reach the push service: '+((d&&d.detail)||'no answer')+'.')));
+},function(e){testOut.classList.add('bad');testOut.textContent='Test failed: '+((e&&e.message)||e)+'.';})
+.then(function(){testBtn.disabled=false;testBtn.textContent=label;});}
+});
 })();
 // Landing a push tap on the session that fired (the user 2026-08-08). Two arrivals:
 //  - live window: the SW focused us and posted {romp:'pushReveal',sid} — relay a focus straight
@@ -32809,6 +33029,11 @@ def _landing():
             "<meta name=theme-color id=meta-theme content='#1e1e1e'>"
             "<link rel=icon type=image/svg+xml href=/media/romp-swirl-glyph.svg><title>Romp</title><style>"
             ":root{--accent:#9cd2ff;--accent-fg:#0c1a2e}"
+            # The menu vocabulary's tokens (CLAUDE.md "Menus and dropdowns wear ONE vocabulary"), defined
+            # HERE because the shell loads no sheet: the bell popover reads them, with the same dark
+            # literals as var() fallbacks in its rules. Byte-equal to styles.css's :root values.
+            ":root{--menu-bg:#252526;--menu-fg:#cccccc;--menu-border:rgba(255,255,255,0.12);--menu-hover:rgba(255,255,255,0.09);"
+            "--radius-menu:6px;--shadow-menu:0 4px 12px rgba(0,0,0,0.35);--check-bg:#1EA1EB}"
             # Inter loads PER DOCUMENT (2026-08-27, PR-730 review): the shell names 'Inter' in every
             # sans stack below, but @font-face never crosses an iframe boundary — without these two
             # rules the panes rendered Inter while the shell around them silently kept the system
@@ -32915,6 +33140,40 @@ def _landing():
             # pixel-identical (the user 2026-09-02)
             ".bell-slash{display:none}"
             "#rail-bell:not(.on) .bell-slash,#mbell:not(.on) .bell-slash{display:block}"
+            # ── the bell popover (2026-09-05): the bell's tap opens this instead of flipping anything.
+            # The house menu dress through the menu TOKENS (defined in the shell's :root / theme-light
+            # blocks), each with its dark literal as the var() fallback (menu-theme-tokens.test.ts
+            # bans a raw hex anywhere else). Anchored by _LANDING_PUSH_JS at open time — bottom/right
+            # measured from the tapped bell — so it sits beside the rail bell on desktop and above the
+            # tab bar on a phone; the transparent full-window backdrop is what catches an outside tap
+            # (a tap on an iframe never reaches this document otherwise). z 205: above the network
+            # panel (200), below the Log (210) — the Escape chain closes topmost first. Global scope on
+            # purpose: the bell state rules further down sit inside the mobile media block.
+            "#rbell-back{position:fixed;inset:0;z-index:205;background:transparent}#rbell-back[hidden]{display:none}"
+            "#rbell-pop{position:fixed;width:min(320px,calc(100vw - 16px));box-sizing:border-box;padding:4px;"
+            "background:var(--menu-bg,#252526);color:var(--menu-fg,#cccccc);border:1px solid var(--menu-border,rgba(255,255,255,0.12));"
+            "border-radius:var(--radius-menu,6px);box-shadow:var(--shadow-menu,0 4px 12px rgba(0,0,0,0.35));"
+            "font:12px/1.45 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;text-align:left}"
+            ".rbp-row{display:flex;flex-direction:column;gap:2px;padding:7px 10px;border-radius:4px;cursor:pointer;user-select:none;"
+            "-webkit-tap-highlight-color:transparent}"
+            ".rbp-row:hover{background:var(--menu-hover,rgba(255,255,255,0.09))}"
+            ".rbp-row.off{opacity:.55;cursor:default}.rbp-row.off:hover{background:none}"   # a switch that cannot be flipped here
+            ".rbp-row.busy{opacity:.55}"                                                     # the tap's acknowledgement
+            ".rbp-head{display:flex;align-items:center;justify-content:space-between;gap:10px;font-weight:600}"
+            ".rbp-sub{font-size:0.82em;opacity:.6}"                                          # every sub-line: one size, one weight
+            ".rbp-sw{flex:0 0 auto;width:26px;height:14px;border-radius:7px;background:rgba(127,127,127,0.35);position:relative;"
+            "transition:background .15s}"
+            ".rbp-sw::after{content:'';position:absolute;top:2px;left:2px;width:10px;height:10px;border-radius:50%;"
+            "background:var(--menu-fg,#cccccc);transition:transform .15s}"
+            ".rbp-sw.on{background:var(--accent)}.rbp-sw.on::after{background:var(--accent-fg);transform:translateX(12px)}"
+            ".rbp-div{height:1px;background:var(--menu-border,rgba(255,255,255,0.12));margin:3px 6px}"
+            ".rbp-act{cursor:default}.rbp-act:hover{background:none}"
+            "#rbp-test{display:block;width:100%;box-sizing:border-box;background:none;border:1px solid var(--menu-border,rgba(255,255,255,0.12));"
+            "border-radius:4px;color:var(--menu-fg,#cccccc);font:inherit;font-weight:600;padding:5px 10px;cursor:pointer;text-align:left}"
+            "#rbp-test:hover{background:var(--menu-hover,rgba(255,255,255,0.09))}"
+            "#rbp-test[disabled]{opacity:.55;cursor:default}"
+            "#rbp-test-out{padding-top:4px}#rbp-test-out:empty{display:none}"
+            "#rbp-test-out.bad{color:#e5484d;opacity:1}"    # a refusal is a STATUS, so it wears the status red, not the accent
             # Per-node fleet colour on the network glyph (the user 2026-07-29). The nodes carry their own
             # fill, so they override the icon's currentColor: accent = connected and on this build,
             # grey = attached but not answering (romp is dialing), red = needs you (drift, no kernel, or
@@ -33354,6 +33613,10 @@ def _landing():
             # so the dark rendering is byte-identical. Accent goes clay (#C2410C) via the same --accent var
             # every accent consumer already reads.
             "body.theme-light{--accent:#C2410C;--accent-fg:#FFF8F2;background:#F1EAE2}"
+            # the light theme's menu tokens — the values styles.css's body.theme-light block resolves
+            # them to, so the bell popover is the same cream card every other menu is
+            "body.theme-light{--menu-bg:#FBF6EF;--menu-fg:#1F1E1D;--menu-border:rgba(0,0,0,0.12);--menu-hover:rgba(0,0,0,0.06);"
+            "--shadow-menu:0 4px 12px rgba(31,26,20,0.16);--check-bg:#C2410C}"
             # the html element keeps its dark background otherwise (body.theme-light can't reach an
             # ancestor without :has); body covers the viewport, but paint the canvas right too
             "html:has(> body.theme-light){background:#F1EAE2}"
@@ -33411,7 +33674,24 @@ def _landing():
             "</style></head><body class='po-chat po-feed po-timeline'>"
             + _THEME_READER +
             "<div id=romp-boot>" + _loader_inner() + "</div>"
-            # the notification popover (hidden until the bell is clicked; backdrop click closes). No
+            # the bell popover (2026-09-05; driven by _LANDING_PUSH_JS): the two switches that ONE bell
+            # tap used to flip together — the kernel-wide master and this device's push subscription —
+            # as separate rows, plus the turn-finished switch and a test button that shows the push
+            # service's answer. Sub-lines are the one-sentence "why"; the This-device sub-line is
+            # rewritten by the JS to say what this browser can and cannot do. Hidden until the bell is
+            # tapped; the transparent backdrop closes it, as does Escape (_LANDING_ESC_JS).
+            "<div id=rbell-back hidden><div id=rbell-pop role=dialog aria-label='Notification settings'>"
+            "<div class=rbp-row data-act=all role=switch aria-checked=false><div class=rbp-head>All devices<span class=rbp-sw></span></div>"
+            "<div class=rbp-sub>Arms every device, and the desktop of every machine you've attached.</div></div>"
+            "<div class=rbp-row data-act=dev role=switch aria-checked=false><div class=rbp-head>This device<span class=rbp-sw></span></div>"
+            "<div class=rbp-sub id=rbp-dev-sub>Turn on to get them on this device.</div></div>"
+            "<div class=rbp-row data-act=turns role=switch aria-checked=false><div class=rbp-head>Also when a turn finishes<span class=rbp-sw></span></div>"
+            "<div class=rbp-sub>Buzzes every time any session finishes a turn. With many sessions running, that is a lot of buzzing.</div></div>"
+            "<div class=rbp-div></div>"
+            "<div class='rbp-row rbp-act'><button id=rbp-test data-act=test>Send a test notification</button>"
+            "<div class=rbp-sub id=rbp-test-out></div></div>"
+            "</div></div>"
+            # the Log popover (hidden until the triangle is clicked; backdrop click closes). No
             # Reload button (the user 2026-07-27: redundant next to the rail's own restart/refresh —
             # and a dead page is one browser-refresh away regardless).
             "<div id=rerr-back hidden><div id=rerr-panel>"
@@ -34332,6 +34612,10 @@ class Handler(BaseHTTPRequestHandler):
                 # blocks on you or completes, unless its session/card bell mutes it. The shell
                 # paints the bottom-right bell from this at boot.
                 return self._send(200, json.dumps({"on": _notify_all_on()}), "application/json", cache="no-cache")
+            if p == "/notify-turns":
+                # the popover's turn-finished switch (2026-09-05): its OWN state, ungated by the
+                # master, so the row can show what it is set to while the master is off
+                return self._send(200, json.dumps({"on": _notify_turns_on()}), "application/json", cache="no-cache")
             if p == "/push/vapid-key":
                 # the public key the shell subscribes with (applicationServerKey). Gated like every
                 # page fetch; the 500 carries the missing-package message for the bell to surface.
@@ -34482,6 +34766,32 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
                 _send_to_app("shell", {"type": "notifyAll", "on": _on})
                 return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")
+            if u.path == "/notify-turns":
+                # the popover's turn-finished switch (2026-09-05): kernel-authoritative like the
+                # master, its own shell push so every open dashboard's row agrees. No dirty mark —
+                # the feed carries nothing that reads it.
+                try:
+                    _on = bool(json.loads(raw_body or b"{}").get("on"))
+                except (ValueError, AttributeError):
+                    return self._send(400, "bad json", "text/plain")
+                _set_notify_turns(_on)
+                _send_to_app("shell", {"type": "notifyTurns", "on": _on})
+                return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")
+            if u.path == "/push/test":
+                # the popover's test button (2026-09-05): one notification to THIS device's
+                # subscription, the push service's answer back verbatim — {ok, status, detail}.
+                # Missing crypto is the same loud 500 the subscribe route gives.
+                try:
+                    _ep = str(json.loads(raw_body or b"{}").get("endpoint") or "")
+                except (ValueError, AttributeError):
+                    return self._send(400, "bad json", "text/plain")
+                if not _ep:
+                    return self._send(400, "missing endpoint", "text/plain")
+                try:
+                    _res = _push_test(_ep)
+                except RuntimeError as e:
+                    return self._send(500, str(e), "text/plain")
+                return self._send(200, json.dumps(_res), "application/json")
             if u.path == "/push/subscribe":
                 # A device opting into the bell pushes (plans/ios-app.md proposal 2): body is the
                 # browser's own PushSubscription JSON, stored keyed by endpoint — so re-subscribing

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32491,12 +32491,17 @@ var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}
 # (plans/ios-app.md proposal 2) — so turning the bell off on a phone silenced every device, a denied
 # permission left the master on with only a Log line to show for it, and nothing ever told the user
 # whether the push service had accepted a subscription at all. The popover pulls the two apart as
-# rows — "All devices" (the master, kernel-authoritative: GET /notify-all at boot, a {type:'notifyAll'}
-# shell push on every toggle so every dashboard agrees) and "This device" (this browser's
-# subscription; Notification.requestPermission still runs synchronously in the tap's own stack
-# because iOS voids the gesture across an await) — adds the turn-finished switch (/notify-turns,
+# rows — "Notifications" (the master, kernel-authoritative: GET /notify-all at boot, a {type:'notifyAll'}
+# shell push on every toggle so every dashboard agrees) and, nested under it, "This device" (this
+# browser's subscription; Notification.requestPermission still runs synchronously in the tap's own
+# stack because iOS voids the gesture across an await) — adds the turn-finished switch (/notify-turns,
 # its own {type:'notifyTurns'} push), and a test button that POSTs /push/test with this device's
-# endpoint and shows the push service's answer as one sentence under itself. The bell GLYPH now
+# endpoint and shows the push service's answer as one sentence under itself. The master's paint
+# also dims the nested rows (#rbell-pop.master-off) while it is off and the device sub-line says the
+# device is set up but nothing arrives — the same kernel bit, so the dim follows every notifyAll
+# push with no polling; the rows stay operable. The test button ignores the switches on purpose
+# (it answers "is this phone wired up?"), so with the master off its result adds one sentence
+# saying real notifications will not arrive until the main switch is on. The bell GLYPH now
 # reflects this device: lit only when the master is on AND this browser is subscribed; a browser
 # with no Push API has no subscription half to reflect, so the master alone paints it there. The
 # tooltip names which half is off. Where push is blocked or unavailable the This-device row is
@@ -32522,9 +32527,11 @@ else if(!isOn)t='Notifications off for all devices';
 else t='Notifications off on this device';
 bells.forEach(function(b){b.classList.toggle('on',lit);b.setAttribute('title',t);b.setAttribute('aria-label',t);});
 sw('all',isOn,true);sw('dev',devOn,devOk);sw('turns',turnsOn,true);
+pop.classList.toggle('master-off',!isOn);   // the rows under the master dim while it is off — same kernel bit as its pill, same repaint
 var sub;
 if(!canPush)sub="Push isn't available in this browser. On iPhone, add romp to the Home Screen first and open it from there.";
 else if(perm()==='denied')sub="Notifications are blocked for this site. On iPhone: Settings, then Notifications, then Romp. In a desktop browser: the site permission beside the address.";
+else if(devOn&&!isOn)sub="This device is set up, but nothing arrives until the main switch is on.";
 else if(devOn)sub="This browser gets a notification when a session needs you or finishes.";
 else sub="Turn on to get them on this device.";
 if(devSubEl)devSubEl.textContent=sub;}
@@ -32576,6 +32583,7 @@ sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};ret
 var ok=!!(d&&d.ok);testOut.classList.toggle('bad',!ok);
 testOut.textContent=ok?'The push service accepted it.':(d&&d.nosub?"This device isn't subscribed yet.":
 (d&&d.status?('The push service refused it: '+d.status+' '+(d.detail||'')+'.'):('Could not reach the push service: '+((d&&d.detail)||'no answer')+'.')));
+if(!isOn)testOut.textContent+=" Real notifications won't arrive until the main switch is on.";   // the test ignores the switches on purpose; say so
 },function(e){testOut.classList.add('bad');testOut.textContent='Test failed: '+((e&&e.message)||e)+'.';})
 .then(function(){testBtn.disabled=false;testBtn.textContent=label;});}
 });
@@ -33166,6 +33174,12 @@ def _landing():
             ".rbp-sw::after{content:'';position:absolute;top:2px;left:2px;width:10px;height:10px;border-radius:50%;"
             "background:var(--menu-fg,#cccccc);transition:transform .15s}"
             ".rbp-sw.on{background:var(--accent)}.rbp-sw.on::after{background:var(--accent-fg);transform:translateX(12px)}"
+            # the switches under the master: one indent and one hairline — the popover's own hairline
+            # token, at the master label's left edge — so the hierarchy is visible, not just implied
+            ".rbp-nest{margin-left:10px;padding-left:4px;border-left:1px solid var(--menu-border,rgba(255,255,255,0.12))}"
+            # master off: the nested rows dim in the wash .off and .busy already wear — but keep their
+            # cursor and hover, because they still take a tap (set the phone up first, switch on later)
+            "#rbell-pop.master-off .rbp-nest>.rbp-row{opacity:.55}"
             ".rbp-div{height:1px;background:var(--menu-border,rgba(255,255,255,0.12));margin:3px 6px}"
             ".rbp-act{cursor:default}.rbp-act:hover{background:none}"
             "#rbp-test{display:block;width:100%;box-sizing:border-box;background:none;border:1px solid var(--menu-border,rgba(255,255,255,0.12));"
@@ -33680,13 +33694,22 @@ def _landing():
             # service's answer. Sub-lines are the one-sentence "why"; the This-device sub-line is
             # rewritten by the JS to say what this browser can and cannot do. Hidden until the bell is
             # tapped; the transparent backdrop closes it, as does Escape (_LANDING_ESC_JS).
+            # The master is NAMED as the master and the other two switches NEST under it (.rbp-nest):
+            # its first label, "All devices", sat beside "This device" and read as a scope choice — and
+            # with the master off the device row still painted ON, since it reads only this browser's
+            # subscription (the user 2026-09-05, confused by exactly that pair). The nest dims while the
+            # master is off (#rbell-pop.master-off, painted by the JS) but its rows stay operable, so a
+            # phone can be set up before anything is switched on.
             "<div id=rbell-back hidden><div id=rbell-pop role=dialog aria-label='Notification settings'>"
-            "<div class=rbp-row data-act=all role=switch aria-checked=false><div class=rbp-head>All devices<span class=rbp-sw></span></div>"
-            "<div class=rbp-sub>Arms every device, and the desktop of every machine you've attached.</div></div>"
+            "<div class=rbp-row data-act=all role=switch aria-checked=false><div class=rbp-head>Notifications<span class=rbp-sw></span></div>"
+            "<div class=rbp-sub>The main switch: off silences every device, and the desktop of every machine you've attached. "
+            "The bells on sessions and cards are mutes under it.</div></div>"
+            "<div class=rbp-nest>"
             "<div class=rbp-row data-act=dev role=switch aria-checked=false><div class=rbp-head>This device<span class=rbp-sw></span></div>"
             "<div class=rbp-sub id=rbp-dev-sub>Turn on to get them on this device.</div></div>"
             "<div class=rbp-row data-act=turns role=switch aria-checked=false><div class=rbp-head>Also when a turn finishes<span class=rbp-sw></span></div>"
             "<div class=rbp-sub>Buzzes every time any session finishes a turn. With many sessions running, that is a lot of buzzing.</div></div>"
+            "</div>"
             "<div class=rbp-div></div>"
             "<div class='rbp-row rbp-act'><button id=rbp-test data-act=test>Send a test notification</button>"
             "<div class=rbp-sub id=rbp-test-out></div></div>"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29798,25 +29798,48 @@ def _push_send_one(sub, payload):
     return status not in _PUSH_DEAD_STATUSES
 
 
-def _push_test(endpoint):
+def _push_test(endpoint, sid="", host=""):
     """The popover's "Send a test notification" (2026-09-05): ONE plain notification to ONE
     subscription — the asking device's — and the push service's answer back to it as
     {ok, status, detail}. Synchronous on purpose: the whole point is to show the user what the
     service said. An endpoint nobody subscribed answers ok:false with the reason (the shell shows
     it under the button); a dead subscription (404/410) is pruned exactly as the fan-out would
     prune it, and the detail says so. Raises RuntimeError when the crypto dependency is missing —
-    the route turns that into the same loud 500 /push/subscribe gives."""
+    the route turns that into the same loud 500 /push/subscribe gives.
+
+    ADDRESSED TO A SESSION (the user 2026-09-06, who wants to try the tap for real: press the
+    button while looking at one session, switch to another session and another browser tab, tap
+    the notification, and be brought back to the first). `sid` is the session the shell had in
+    front when the button was pressed — the chat pane's active tab, host-prefixed for a federated
+    one — and `host` the courtesy copy _push_payload documents. It rides the payload's routing
+    block under kind "test", so the tap lands exactly the way a turn's does (the shell POSTs
+    /reveal for any sid; only a card kind adds the card scroll), and the body names the session so
+    the lock screen says where the tap goes. The name is the local registry's; a federated
+    session's name lives at its origin kernel, so it falls back to the short id there. The answer
+    carries `sid` and `name` back so the popover's result line says the same thing in the same
+    words. With no session active the shell sends no sid and the test is what it was: a sid-less
+    probe that just brings romp forward."""
     sub = _push_subs().get(str(endpoint or ""))
     if not sub:
         return {"ok": False, "status": 0, "detail": "this device isn't subscribed yet"}
     _vapid_keys()                                          # RuntimeError without cryptography → the route's 500
-    payload = json.dumps(_push_payload("romp", "Test notification — this device is set up.", kind="test")).encode()
+    sid, host, name = str(sid or ""), str(host or ""), ""
+    if sid:
+        bare = sid.split(":", 1)[1] if ":" in sid else sid
+        name = _name_of(bare) or bare[:8]
+        body = "Test notification — tap to come back to %s." % name
+    else:
+        body = "Test notification — this device is set up."
+    payload = json.dumps(_push_payload("romp", body, sid=sid, kind="test", host=host)).encode()
     status, detail = _push_post(sub, payload)
     ok = 200 <= status < 300
     if status in _PUSH_DEAD_STATUSES:
         _del_push_sub(sub["endpoint"])
         detail = "%s — the push service says this subscription is gone, so it was removed; turn This device off and on again" % detail
-    return {"ok": ok, "status": status, "detail": detail}
+    res = {"ok": ok, "status": status, "detail": detail}
+    if sid:
+        res["sid"], res["name"] = sid, name
+    return res
 
 
 def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host=""):
@@ -29837,7 +29860,9 @@ def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host
       data  — {sid, host, kind, cardId, url}: what the worker hands the shell on a tap (or puts
               in the URL it opens when no window exists). kind names the leg that fired ("card":
               a card entered needs-you/completed; "turn": a turn ended; "test": the popover's
-              probe, no sid, nowhere to land); cardId (a card kind only) is the goal id the feed
+              probe, carrying the session the user was looking at when they pressed the button —
+              2026-09-06 — so its tap comes back there like a turn's; sid-less, and nowhere to
+              land, only when no session was in front); cardId (a card kind only) is the goal id the feed
               scrolls to; url is the same-origin deep link the shell already parses at boot
               (?push-reveal=<sid>, plus &push-card=<id> for a card) — "/" when there is no
               session to land on. host is the origin kernel of a relayed event ("" = local);
@@ -32551,7 +32576,10 @@ var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}
 # browser's subscription; Notification.requestPermission still runs synchronously in the tap's own
 # stack because iOS voids the gesture across an await) — adds the turn-finished switch (/notify-turns,
 # its own {type:'notifyTurns'} push), and a test button that POSTs /push/test with this device's
-# endpoint and shows the push service's answer as one sentence under itself. The master's paint
+# endpoint AND the session the chat pane has in front (2026-09-06: the test is addressed to it, so
+# its tap brings the user back there — read off the chat iframe's active tab at the press, the same
+# same-origin DOM the mobile header's current-session chip mirrors, no second channel) and shows
+# the push service's answer as one sentence under itself, plus where the tap goes. The master's paint
 # also dims the nested rows (#rbell-pop.master-off) while it is off and the device sub-line says the
 # device is set up but nothing arrives — the same kernel bit, so the dim follows every notifyAll
 # push with no polling; the rows stay operable. The test button ignores the switches on purpose
@@ -32613,6 +32641,13 @@ return reg.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:b64u
 }).then(function(s){return post('/push/subscribe',s.toJSON());});}
 function devUnsubscribe(){return sub().then(function(s){var ep=s?s.endpoint:'';
 return (s?s.unsubscribe():Promise.resolve()).then(function(){return ep?post('/push/unsubscribe',{endpoint:ep}):null;});});}
+// the session the user is LOOKING AT: the chat pane's active tab, read off the same-origin iframe's DOM — the very
+// nodes the mobile header's current-session chip mirrors (_CHAT_MOBILE_JS reads #tabs .tab.active), so one truth and
+// no second channel. A federated tab's id is already host-prefixed (host:sid); the host rides along as the payload's
+// courtesy copy. No tab in front → no sid, and the test is the plain probe it always was.
+function activeSession(){var t=null;try{var f=document.getElementById('f-chat'),d=f&&f.contentDocument;t=d&&d.querySelector('#tabs .tab.active[data-id]');}catch(e){}
+var id=t?String(t.getAttribute('data-id')||''):'';var i=id.indexOf(':');
+return {sid:id,host:i>0?id.slice(0,i):''};}
 function place(anchor){var r=anchor.getBoundingClientRect();   // beside the rail bell / above the tab bar: both sit at the bottom edge
 pop.style.bottom=Math.max(8,window.innerHeight-r.top+6)+'px';pop.style.right=Math.max(8,window.innerWidth-r.right)+'px';}
 function open(anchor){place(anchor);back.hidden=false;}
@@ -32634,10 +32669,12 @@ else if(act==='turns'){if(busy.turns)return;setBusy('turns',true);var wantT=!tur
 post('/notify-turns',{on:wantT}).then(function(){turnsOn=wantT;paint();},fail).then(function(){setBusy('turns',false);});}
 else if(act==='test'){if(!testBtn||testBtn.disabled)return;testBtn.disabled=true;var label=testBtn.textContent;testBtn.textContent='Sending…';
 testOut.className='rbp-sub';testOut.textContent='';
-sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};return post('/push/test',{endpoint:s.endpoint});}).then(function(d){
+var at=activeSession();   // read AT the press, before any await: the session you were looking at, not the one you switch to while it sends
+sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};return post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host});}).then(function(d){
 var ok=!!(d&&d.ok);testOut.classList.toggle('bad',!ok);
 testOut.textContent=ok?'The push service accepted it.':(d&&d.nosub?"This device isn't subscribed yet.":
 (d&&d.status?('The push service refused it: '+d.status+' '+(d.detail||'')+'.'):('Could not reach the push service: '+((d&&d.detail)||'no answer')+'.')));
+if(ok&&d.name)testOut.textContent+=' Tapping it brings you back to '+d.name+'.';   // addressed to a session: say where the tap goes, in the kernel's words (the body names it the same way)
 if(!isOn)testOut.textContent+=" Real notifications won't arrive until the main switch is on.";   // the test ignores the switches on purpose; say so
 },function(e){testOut.classList.add('bad');testOut.textContent='Test failed: '+((e&&e.message)||e)+'.';})
 .then(function(){testBtn.disabled=false;testBtn.textContent=label;});}
@@ -32662,8 +32699,11 @@ if(!isOn)testOut.textContent+=" Real notifications won't arrive until the main s
 # message the Log's bell entries post — but only once the feed has its cards, which it announces
 # with {romp:'ready', app:'feed'} after its first payload renders (before that the iframe may have
 # no listener yet, or nothing to scroll to); a tap that arrives earlier waits for exactly that
-# message. A sid-less tap (a test notification) has nowhere to land: the SW's focus/openWindow was
-# the whole action. A /reveal the kernel refuses lands in the Log rather than vanishing.
+# message. ANY sid lands, whatever the kind: a test notification carries the session the user was
+# looking at when they pressed the button (2026-09-06) and comes back to it exactly like a turn's;
+# only a card kind adds the card scroll. A sid-less tap (a test pressed with no session in front)
+# has nowhere to land: the SW's focus/openWindow was the whole action. A /reveal the kernel refuses
+# lands in the Log rather than vanishing.
 # Its own <script>, like every shell behaviour (test_kernel_mobile's count pin): a throw in the
 # bell's script must not strand a tap, and a bell that bails where the Push API is missing must
 # not take the deep-link half with it.
@@ -34885,15 +34925,21 @@ class Handler(BaseHTTPRequestHandler):
             if u.path == "/push/test":
                 # the popover's test button (2026-09-05): one notification to THIS device's
                 # subscription, the push service's answer back verbatim — {ok, status, detail}.
-                # Missing crypto is the same loud 500 the subscribe route gives.
+                # Since 2026-09-06 addressed to the session the shell had in front (sid, host-
+                # prefixed for a federated one, plus host), so the tap comes back to it; no sid is
+                # the plain probe. Missing crypto is the same loud 500 the subscribe route gives.
                 try:
-                    _ep = str(json.loads(raw_body or b"{}").get("endpoint") or "")
+                    _tb = json.loads(raw_body or b"{}")
+                    _ep = str(_tb.get("endpoint") or "")
+                    _tsid, _thost = _tb.get("sid") or "", _tb.get("host") or ""
                 except (ValueError, AttributeError):
                     return self._send(400, "bad json", "text/plain")
                 if not _ep:
                     return self._send(400, "missing endpoint", "text/plain")
+                if not isinstance(_tsid, str) or not isinstance(_thost, str):
+                    return self._send(400, "bad sid", "text/plain")
                 try:
-                    _res = _push_test(_ep)
+                    _res = _push_test(_ep, _tsid, _thost)
                 except RuntimeError as e:
                     return self._send(500, str(e), "text/plain")
                 return self._send(200, json.dumps(_res), "application/json")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13569,9 +13569,12 @@ def list_remotes():
         return [_remote_public(r) for r in _remotes.values()]
 
 
-def _poll_remote_sids(r):
-    """GET the remote kernel's /sessions THROUGH the -L tunnel; return its session ids (for the wake-router's
-    host↔sid map). None on any failure — leave the last-known map in place.
+def _poll_remote_sessions(r):
+    """GET the remote kernel's /sessions THROUGH the -L tunnel; return its id-bearing rows (each `{id, name,
+    …}` — the same unified list _session_rows serves here). None on any failure — leave the last-known
+    snapshot in place. The supervisor reads BOTH the ids (the wake-router's host↔sid map) and the names
+    (_remote_names: the kernel's own copy of what that host calls each session, so a notification about a
+    remote session can be named without a round-trip — 2026-09-06) off ONE poll.
 
     Also files HOW it failed in r["_probe"], because the shape of the failure is the one thing that tells a
     live tunnel with no romp behind it apart from an ssh that is still holding its listener over a transport
@@ -13595,7 +13598,7 @@ def _poll_remote_sids(r):
             return None
         rows = json.loads(data.decode("utf-8"))
         r["_probe"] = "ok"
-        return [x.get("id") for x in rows if isinstance(x, dict) and x.get("id")]
+        return [x for x in rows if isinstance(x, dict) and x.get("id")]
     except (socket.timeout, TimeoutError):
         r["_probe"] = "timeout"
         return None
@@ -13609,6 +13612,30 @@ def _poll_remote_sids(r):
         # a malformed body still proves the far side spoke, so this is never a dead transport
         r["_probe"] = "refused"
         return None
+
+
+def _poll_remote_sids(r):
+    """The remote's session ids, off _poll_remote_sessions (None on failure, same verdict in r["_probe"])."""
+    rows = _poll_remote_sessions(r)
+    return None if rows is None else [x.get("id") for x in rows]
+
+
+def _remote_names(rows):
+    """{sid: name} from a host's /sessions rows — a string name only; a row without one files nothing
+    (never a coined name, so a miss stays a miss and the caller falls back on purpose)."""
+    return {str(x["id"]): x["name"] for x in (rows or [])
+            if isinstance(x, dict) and x.get("id") and isinstance(x.get("name"), str) and x["name"]}
+
+
+def _remote_name_of(host, sid):
+    """What the attached host `host` calls session `sid` (a BARE id), from the supervisor's last successful
+    poll of its /sessions — the kernel's authoritative local copy of that host's registry, the same
+    snapshot _host_for_sid routes by. None when this kernel has no such copy: the host never polled, a row
+    from before names were filed, or an id that host does not list."""
+    with _remotes_lock:
+        r = _remotes.get(str(host or ""))
+        names = (r or {}).get("names") or {}
+        return names.get(str(sid or "")) or None
 
 
 def _host_for_sid(sid):
@@ -15414,7 +15441,8 @@ def _tunnel_supervisor():
                 if skip:
                     continue
                 up = _port_open(r["local_port"])              # outside the lock (socket round-trip)
-                sids = _poll_remote_sids(r) if up else None
+                rows = _poll_remote_sessions(r) if up else None   # its session rows: ids for the wake-router, names for notifications
+                sids = None if rows is None else [x.get("id") for x in rows]
                 rver = _poll_remote_version(r) if up else None   # the code the remote is running (drift check)
                 rsha = (rver or {}).get("sha")
                 # …and which Claude account it burns, so the rail can draw a second set of bars when it is
@@ -15504,6 +15532,7 @@ def _tunnel_supervisor():
                         # _start_remote wrote it (the user 2026-07-11)
                     if sids is not None:
                         r["sids"] = sids
+                        r["names"] = _remote_names(rows)   # what that host calls each of them (_remote_name_of)
                     if rver and rver.get("pid"):
                         r["hub_pid"] = rver["pid"]   # the peer kernel's incarnation — a restart changes it (auto-reconnect 2026-08-24)
                     if rsha is not None:
@@ -26976,6 +27005,7 @@ def _note_ws_inbound(client, now=None):
     else:
         client["lastIn"] = now if now is not None else _ws_clock()
         client["pingAt"] = None
+    _reveal_proven(client)     # a push tap handed to this socket while it was unproven has landed (2026-09-06)
 
 
 def _drop_dead_ws_client(client, why):
@@ -29798,7 +29828,10 @@ def _push_send_one(sub, payload):
     return status not in _PUSH_DEAD_STATUSES
 
 
-def _push_test(endpoint, sid="", host=""):
+PUSH_LABEL_MAX = 80    # the shell's tab label, as a last-resort session name: display text, clipped
+
+
+def _push_test(endpoint, sid="", host="", label=""):
     """The popover's "Send a test notification" (2026-09-05): ONE plain notification to ONE
     subscription — the asking device's — and the push service's answer back to it as
     {ok, status, detail}. Synchronous on purpose: the whole point is to show the user what the
@@ -29814,19 +29847,33 @@ def _push_test(endpoint, sid="", host=""):
     one — and `host` the courtesy copy _push_payload documents. It rides the payload's routing
     block under kind "test", so the tap lands exactly the way a turn's does (the shell POSTs
     /reveal for any sid; only a card kind adds the card scroll), and the body names the session so
-    the lock screen says where the tap goes. The name is the local registry's; a federated
-    session's name lives at its origin kernel, so it falls back to the short id there. The answer
-    carries `sid` and `name` back so the popover's result line says the same thing in the same
-    words. With no session active the shell sends no sid and the test is what it was: a sid-less
-    probe that just brings romp forward."""
+    the lock screen says where the tap goes. The answer carries `sid` and `name` back so the
+    popover's result line says the same thing in the same words. With no session active the shell
+    sends no sid and the test is what it was: a sid-less probe that just brings romp forward.
+
+    THE NAME, in order of authority (the user 2026-09-06, whose test for a session on another
+    machine named its short id): a local session's is the names registry's (_name_of); a federated
+    one's is what its host calls it in the tunnel supervisor's snapshot of that host's /sessions
+    (_remote_name_of), worn host-prefixed the way the merged dashboard shows it. When the kernel
+    truly has no name — a host not polled yet, a kernel too old to file names — the shell's
+    `label` stands in: the active tab's own text, the user's UI text and nothing more, so it is
+    clipped and flattened here and never consulted ahead of the kernel's own copy. Neither → the
+    short id, as before."""
     sub = _push_subs().get(str(endpoint or ""))
     if not sub:
         return {"ok": False, "status": 0, "detail": "this device isn't subscribed yet"}
     _vapid_keys()                                          # RuntimeError without cryptography → the route's 500
     sid, host, name = str(sid or ""), str(host or ""), ""
+    label = " ".join(str(label or "").split())[:PUSH_LABEL_MAX]
     if sid:
-        bare = sid.split(":", 1)[1] if ":" in sid else sid
-        name = _name_of(bare) or bare[:8]
+        if ":" in sid:
+            pfx, bare = sid.split(":", 1)
+            rn = _remote_name_of(pfx, bare)
+            name = ("%s:%s" % (pfx, rn)) if rn else ""
+        else:
+            bare = sid
+            name = _name_of(bare) or ""
+        name = name or label or bare[:8]
         body = "Test notification — tap to come back to %s." % name
     else:
         body = "Test notification — this device is set up."
@@ -30076,15 +30123,23 @@ e.waitUntil(Promise.all(work));
 // kernel built (the shell parses it at boot). focus() can REJECT (an installed iOS app has refused
 // it) — then the tap still lands: fall through to openWindow rather than dropping it. Everything
 // rides waitUntil, so the worker is kept alive until the tap has landed; no timers anywhere.
+// TOP-LEVEL windows only (the user 2026-09-06, whose tap on the phone did nothing): the dashboard's
+// panes are same-origin iframes under this worker's scope, and matchAll lists each of them as a
+// window client too (frameType 'nested') — most recently FOCUSED first, which after a tap in the
+// chat pane's session picker is the chat iframe. Only the shell (the top-level document) carries
+// the reveal listener; posting into a pane dropped the tap on the floor. A client that reports no
+// frameType is treated as a window rather than dropped.
 self.addEventListener('notificationclick',function(e){
 e.notification.close();
 var d=e.notification.data||{};var sid=d.sid||'';
 var url=d.url||(sid?'/?push-reveal='+encodeURIComponent(sid):'/');
 var msg={romp:'notificationClick',sid:sid,host:d.host||'',kind:d.kind||'',cardId:d.cardId||''};
 function open(){return clients.openWindow(url);}
+function shell(w){return !w.frameType||w.frameType==='top-level'||w.frameType==='auxiliary';}
 e.waitUntil(clients.matchAll({type:'window',includeUncontrolled:true}).then(function(ws){
-if(!ws.length)return open();
-var w=ws[0];
+var tops=ws.filter(shell);
+if(!tops.length)return open();
+var w=tops[0];
 return Promise.resolve().then(function(){return w.focus();}).then(function(fw){
 try{(fw||w).postMessage(msg);}catch(err){}},open);
 }));
@@ -30099,7 +30154,9 @@ try{(fw||w).postMessage(msg);}catch(err){}},open);
 # for: that window's chat pane saying "ready" (matched by wid — the per-dashboard id the shell
 # mints and every same-window pane shares — so a second dashboard's reload cannot steal it). One
 # slot, latest wins: two taps before a boot completes should land on the newer notification.
-_PENDING_REVEAL = [None]                     # {"sid": ..., "wid": ...} or None
+# `sent` (2026-09-06): the clients a LIVE tap was already handed to while unproven — see
+# _reveal_request; a pong from one of them retires the slot, a redial's ready consumes it.
+_PENDING_REVEAL = [None]                     # {"sid": ..., "wid": ...[, "sent": [clients]]} or None
 
 
 def _reveal_msg(sid):
@@ -30118,22 +30175,51 @@ def _reveal_msg(sid):
     return {"type": "focus", "id": sid, "live": True}
 
 
-def _reveal_request(sid, wid):
+def _reveal_request(sid, wid, boot=False):
     """POST /reveal: aim the focus at the dashboard whose wid asked. Its chat pane already
     connected → deliver now; not yet (the cold-start norm — the shell's fetch beats the iframe's
-    WS) → park for _consume_pending_reveal. Returns whether it was delivered immediately."""
+    WS) → park for _consume_pending_reveal. Returns whether it was delivered immediately.
+
+    Two ways a same-wid chat socket the kernel holds is NOT the pane this tap is for (the user
+    2026-09-06, whose tap on the phone did nothing — the phone is where sockets die without a
+    close: a suspended app, a VPN link that dropped with the screen):
+      boot  — the shell says the page is BOOTING (the deep-link arrival: iOS opens the installed
+              app's one window on the link, or the app comes back from a kill). Its own chat pane
+              cannot be connected yet, so a socket wearing its wid is the PREVIOUS page's
+              (sessionStorage keeps the wid across a reload) — dead, and the ping timeout has up to
+              WS_DEAD_S to say so. Park only; "delivering" there parked nothing and the new pane's
+              ready found nothing to consume.
+      unproven — a live tap, but the target has a ping on the wire nobody has answered (pingAt set:
+              the peer is unproven since the last heartbeat). Deliver as before AND keep a copy
+              parked, tagged with who it went to: the pong that proves that socket alive retires it
+              (_note_ws_inbound — the focus frame is ordered behind the ping it answers); a dead
+              socket never pongs, the pane redials, and its ready consumes the copy instead of
+              finding nothing. A socket with no ping outstanding is proven: nothing parked, so a
+              later ready never replays a landed tap."""
     with _clients_lock:
-        targets = [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid]
-    delivered = False
+        targets = [] if boot else [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid]
+    delivered, sent = False, []
     for c in targets:
         try:
             c["send"](json.dumps(_reveal_msg(sid)))
             delivered = True
+            if c.get("pingAt") is not None:
+                sent.append(c)
         except Exception:
             pass
     if not delivered:
         _PENDING_REVEAL[0] = {"sid": str(sid), "wid": str(wid or "")}
+    elif sent:
+        _PENDING_REVEAL[0] = {"sid": str(sid), "wid": str(wid or ""), "sent": sent}
     return delivered
+
+
+def _reveal_proven(client):
+    """A pong or message from `client`: if the parked reveal was HANDED to it while unproven, the
+    socket is alive and the focus frame ahead of this pong has landed — retire the copy."""
+    p = _PENDING_REVEAL[0]
+    if p and any(c is client for c in (p.get("sent") or ())):
+        _PENDING_REVEAL[0] = None
 
 
 def _consume_pending_reveal(client):
@@ -32644,10 +32730,13 @@ return (s?s.unsubscribe():Promise.resolve()).then(function(){return ep?post('/pu
 // the session the user is LOOKING AT: the chat pane's active tab, read off the same-origin iframe's DOM — the very
 // nodes the mobile header's current-session chip mirrors (_CHAT_MOBILE_JS reads #tabs .tab.active), so one truth and
 // no second channel. A federated tab's id is already host-prefixed (host:sid); the host rides along as the payload's
-// courtesy copy. No tab in front → no sid, and the test is the plain probe it always was.
+// courtesy copy. No tab in front → no sid, and the test is the plain probe it always was. The tab's LABEL rides
+// along too (2026-09-06): the kernel names the session from its own registry or its snapshot of the owning host and
+// falls back to this — the user's own UI text, display-only, clipped here as well as there.
 function activeSession(){var t=null;try{var f=document.getElementById('f-chat'),d=f&&f.contentDocument;t=d&&d.querySelector('#tabs .tab.active[data-id]');}catch(e){}
 var id=t?String(t.getAttribute('data-id')||''):'';var i=id.indexOf(':');
-return {sid:id,host:i>0?id.slice(0,i):''};}
+var lab=t&&t.querySelector('.tab-label');
+return {sid:id,host:i>0?id.slice(0,i):'',label:String((lab&&lab.textContent)||'').replace(/\\s+/g,' ').trim().slice(0,80)};}
 function place(anchor){var r=anchor.getBoundingClientRect();   // beside the rail bell / above the tab bar: both sit at the bottom edge
 pop.style.bottom=Math.max(8,window.innerHeight-r.top+6)+'px';pop.style.right=Math.max(8,window.innerWidth-r.right)+'px';}
 function open(anchor){place(anchor);back.hidden=false;}
@@ -32670,7 +32759,7 @@ post('/notify-turns',{on:wantT}).then(function(){turnsOn=wantT;paint();},fail).t
 else if(act==='test'){if(!testBtn||testBtn.disabled)return;testBtn.disabled=true;var label=testBtn.textContent;testBtn.textContent='Sending…';
 testOut.className='rbp-sub';testOut.textContent='';
 var at=activeSession();   // read AT the press, before any await: the session you were looking at, not the one you switch to while it sends
-sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};return post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host});}).then(function(d){
+sub().then(function(s){if(!s)return {ok:false,status:0,detail:'',nosub:true};return post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host,label:at.label});}).then(function(d){
 var ok=!!(d&&d.ok);testOut.classList.toggle('bad',!ok);
 testOut.textContent=ok?'The push service accepted it.':(d&&d.nosub?"This device isn't subscribed yet.":
 (d&&d.status?('The push service refused it: '+d.status+' '+(d.detail||'')+'.'):('Could not reach the push service: '+((d&&d.detail)||'no answer')+'.')));
@@ -32694,7 +32783,11 @@ if(!isOn)testOut.textContent+=" Real notifications won't arrive until the main s
 #  - live window: the SW focused us and posted {romp:'notificationClick', sid, host, kind, cardId}.
 #  - cold start: the SW opened the kernel's deep link '/?push-reveal=<sid>[&push-card=<id>]'. The
 #    params are stripped (history.replaceState) the moment they are read, so a manual reload later
-#    does not replay the jump.
+#    does not replay the jump. This arrival POSTs boot:true — the page is booting, so its chat pane
+#    is not connected yet, and the kernel must park for it rather than hand the focus to a same-wid
+#    socket the previous page left behind (the phone, 2026-09-06: iOS reopens the installed app's
+#    one window on the link and sessionStorage keeps the wid; the old pane's socket died without a
+#    close and sat in the kernel's client list until the ping timeout).
 # A card kind ALSO scrolls the feed to its card: {romp:'revealCard'} into the feed iframe — the same
 # message the Log's bell entries post — but only once the feed has its cards, which it announces
 # with {romp:'ready', app:'feed'} after its first payload renders (before that the iframe may have
@@ -32718,15 +32811,16 @@ try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'revealCard',itemId:it
 window.addEventListener('message',function(e){var m=e&&e.data;
 if(!(m&&m.romp==='ready'&&m.app==='feed'))return;
 feedReady=true;if(pendingCard){var c=pendingCard;pendingCard=null;revealCard(c.itemId,c.sid);}});
-function land(sid,kind,cardId){
-if(sid)fetch('/reveal',{method:'POST',body:JSON.stringify({sid:sid,wid:wid()})}).then(function(r){
+function land(sid,kind,cardId,boot){
+var body={sid:sid,wid:wid()};if(boot)body.boot=true;   // booting: our chat pane is not connected yet — park for it
+if(sid)fetch('/reveal',{method:'POST',body:JSON.stringify(body)}).then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});})['catch'](fail);
 if(sid&&kind==='card'&&cardId)revealCard(cardId,sid);}
 if('serviceWorker' in navigator&&navigator.serviceWorker&&navigator.serviceWorker.addEventListener){
 navigator.serviceWorker.addEventListener('message',function(ev){var m=ev&&ev.data;
-if(m&&m.romp==='notificationClick')land(String(m.sid||''),String(m.kind||''),String(m.cardId||''));});}
+if(m&&m.romp==='notificationClick')land(String(m.sid||''),String(m.kind||''),String(m.cardId||''),false);});}
 var u=new URL(location.href),pr=u.searchParams.get('push-reveal'),pc=u.searchParams.get('push-card');
-if(pr||pc){land(pr||'',pc?'card':'',pc||'');
+if(pr||pc){land(pr||'',pc?'card':'',pc||'',true);
 u.searchParams['delete']('push-reveal');u.searchParams['delete']('push-card');
 try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():'')+u.hash);}catch(e){}}
 })();
@@ -34928,18 +35022,23 @@ class Handler(BaseHTTPRequestHandler):
                 # Since 2026-09-06 addressed to the session the shell had in front (sid, host-
                 # prefixed for a federated one, plus host), so the tap comes back to it; no sid is
                 # the plain probe. Missing crypto is the same loud 500 the subscribe route gives.
+                # `label` (2026-09-06): the active tab's text, the fallback name when this kernel
+                # holds none for the id — a string, clipped in _push_test, or a 400.
                 try:
                     _tb = json.loads(raw_body or b"{}")
                     _ep = str(_tb.get("endpoint") or "")
                     _tsid, _thost = _tb.get("sid") or "", _tb.get("host") or ""
+                    _tlabel = _tb.get("label") or ""
                 except (ValueError, AttributeError):
                     return self._send(400, "bad json", "text/plain")
                 if not _ep:
                     return self._send(400, "missing endpoint", "text/plain")
                 if not isinstance(_tsid, str) or not isinstance(_thost, str):
                     return self._send(400, "bad sid", "text/plain")
+                if not isinstance(_tlabel, str):
+                    return self._send(400, "bad label", "text/plain")
                 try:
-                    _res = _push_test(_ep, _tsid, _thost)
+                    _res = _push_test(_ep, _tsid, _thost, _tlabel)
                 except RuntimeError as e:
                     return self._send(500, str(e), "text/plain")
                 return self._send(200, json.dumps(_res), "application/json")
@@ -35024,15 +35123,19 @@ class Handler(BaseHTTPRequestHandler):
                 # The cold-start half of a push tap (see _PENDING_REVEAL): the freshly opened
                 # shell asks for the focus its ?push-reveal= URL named, aimed by its own wid so
                 # no other open dashboard gets dragged along (the 2026-07-29 rule).
+                # `boot` (2026-09-06): the deep-link arrival — the page is booting, so its own chat
+                # pane is not connected yet; the kernel parks for it and never counts a same-wid
+                # socket the previous page left behind as delivery (_reveal_request has the why).
                 try:
                     body = json.loads(raw_body or b"{}")
                     sid = str(body.get("sid") or "")
                     wid = str(body.get("wid") or "")
+                    boot = bool(body.get("boot"))
                 except (ValueError, AttributeError):
                     return self._send(400, "bad json", "text/plain")
                 if not sid:
                     return self._send(400, "missing sid", "text/plain")
-                now_ = _reveal_request(sid, wid)
+                now_ = _reveal_request(sid, wid, boot=boot)
                 return self._send(200, json.dumps({"ok": True, "delivered": now_}), "application/json")
             if u.path == "/tick":
                 # Event-driven wake: the Stop / UserPromptSubmit / PostCompact hooks (and the postal drain) poke

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29499,14 +29499,16 @@ def _cached_feed(now, tmux, sig, connect=False):
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
     _fired = _feed_notifications(feed)                    # armed bells: fresh builds are the transition event
-    for _t, _b, _sid in _fired:
+    for _t, _b, _sid, _iid in _fired:
         _system_notify(_t, _b)
-        _push_notify(_t, _b, _sid, _badge)                # same events to subscribed phones (plans/ios-app.md)
+        # same events to subscribed phones (plans/ios-app.md); kind + card id are what the tap acts on
+        _push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)
     if _fired:
         # …and to trusted peers' devices (plans/federated-push.md): the phone subscribed at the
         # always-on box must buzz for THIS kernel's cards too — which kernel detected an event is
         # romp's business, never the user's.
-        _push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])
+        _push_forward([{"title": _t, "body": _b, "sid": _sid, "kind": "card", "cardId": _iid}
+                       for _t, _b, _sid, _iid in _fired])
     _badge_push(_badge)                                   # app-icon count for installed shells (proposal 3)
     return feed
 
@@ -29538,11 +29540,12 @@ def _system_notify(title, body):
 
 
 def _feed_notifications(feed):
-    """Diff this feed build against the last; return [(title, body, sid)] for every ARMED card that
-    newly entered needs_input or completed (including a card appearing already there — work can
-    surface blocked). Also advances the prev map and prunes armed ids whose card left the feed.
-    sid rides along so a push notification's tap can land ON the session that fired (the user
-    2026-08-08, whose first real push opened the app on a different session)."""
+    """Diff this feed build against the last; return [(title, body, sid, itemId)] for every ARMED
+    card that newly entered needs_input or completed (including a card appearing already there —
+    work can surface blocked). Also advances the prev map and prunes armed ids whose card left the
+    feed. sid rides along so a push notification's tap can land ON the session that fired (the
+    user 2026-08-08, whose first real push opened the app on a different session); itemId joined
+    it 2026-09-06 so the same tap can also scroll the feed to the card itself."""
     prev = _NOTIFY_PREV[0]
     cur = {}
     for a in feed.get("asks") or []:
@@ -29565,7 +29568,7 @@ def _feed_notifications(feed):
         txt = str(a.get("text") or "").strip()
         out.append(("romp: %s" % (a.get("name") or "session"),
                     "%s: %s" % (what, txt[:140] if txt else "a task changed state"),
-                    str(a.get("sid") or "")))
+                    str(a.get("sid") or ""), iid))
     return out
 
 
@@ -29737,15 +29740,54 @@ def _push_send_one(sub, payload):
         return True
 
 
-def _push_notify(title, body, sid="", badge=None):
+def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host=""):
+    """The JSON one web push carries — the ONE builder every push kind goes through, so a tap on
+    any of them lands the same way (the user 2026-09-06, who wants a tap to focus the romp
+    window they already have open and put them on the session — and card — that buzzed).
+
+    Content is the gist and nothing more: title + body. Everything else is ROUTING metadata the
+    service worker acts on, never text it shows:
+      sid   — top level, for a worker of the previous build still installed on some phone (it
+              read d.sid; a worker updates on the next push or app open, not before);
+      tag   — one notification per SESSION: a second push for the same session replaces the
+              first on the lock screen instead of stacking (renotify keeps the buzz), and a
+              sid-less push wears a fixed tag so tests collapse too;
+      badge — the needs-you count the worker paints on the app icon while the app is closed;
+              None OMITS the key and the worker leaves the count alone — the shape a mirrored
+              federated event wears, because the origin's count is not ours;
+      data  — {sid, host, kind, cardId, url}: what the worker hands the shell on a tap (or puts
+              in the URL it opens when no window exists). kind names the leg that fired ("card":
+              a card entered needs-you/completed; "turn": a turn ended; "test": the popover's
+              probe, no sid, nowhere to land); cardId (a card kind only) is the goal id the feed
+              scrolls to; url is the same-origin deep link the shell already parses at boot
+              (?push-reveal=<sid>, plus &push-card=<id> for a card) — "/" when there is no
+              session to land on. host is the origin kernel of a relayed event ("" = local);
+              the sid already wears it as a prefix (host:sid, the merged dashboard's own tab
+              address), so this is a courtesy copy, not a second source of truth."""
+    import urllib.parse
+    sid, card_id, kind = str(sid or ""), str(card_id or ""), str(kind or "card")
+    host = str(host or "") or (sid.split(":", 1)[0] if ":" in sid else "")
+    url = "/"
+    if sid:
+        q = [("push-reveal", sid)] + ([("push-card", card_id)] if card_id else [])
+        url = "/?" + urllib.parse.urlencode(q)
+    d = {"title": str(title), "body": str(body), "sid": sid,
+         "tag": "romp:" + (sid or kind),
+         "data": {"sid": sid, "host": host, "kind": kind, "cardId": card_id, "url": url}}
+    if badge is not None:
+        d["badge"] = int(badge or 0)
+    return d
+
+
+def _push_notify(title, body, sid="", badge=None, kind="card", card_id="", host=""):
     """_system_notify's sibling sink: the same (title, body) — the card's gist and nothing more —
-    to every subscribed device, plus two pieces of ROUTING metadata, not content: sid, so tapping
-    the notification lands on the session that fired (the user 2026-08-08), and badge, the
-    needs-you count the service worker paints on the app icon while the app is closed. badge=None
-    OMITS the key and the worker leaves the icon's count alone — the shape a mirrored federated
-    event wears, because the origin kernel's count is not this kernel's count
-    (plans/federated-push.md). Runs on the pusher thread, so all network work moves to a daemon
-    thread (the _refresh_remote_prices discipline) and this never blocks or raises."""
+    to every subscribed device, plus the ROUTING metadata _push_payload documents: sid, so
+    tapping the notification lands on the session that fired (the user 2026-08-08); badge, the
+    needs-you count for the app icon (None omits it — the mirrored federated shape,
+    plans/federated-push.md); and kind/card_id/host, so the tap can also scroll the feed to the
+    card and name the origin of a relayed event. Runs on the pusher thread, so all network work
+    moves to a daemon thread (the _refresh_remote_prices discipline) and this never blocks or
+    raises."""
     subs = _push_subs()
     if not subs:
         return
@@ -29755,10 +29797,7 @@ def _push_notify(title, body, sid="", badge=None):
         print("romp: web push: %d subscription(s) on file but the python 'cryptography' package "
               "is missing — notification not delivered" % len(subs), file=sys.stderr)
         return
-    d = {"title": str(title), "body": str(body), "sid": str(sid or "")}
-    if badge is not None:
-        d["badge"] = int(badge or 0)
-    payload = json.dumps(d).encode()
+    payload = json.dumps(_push_payload(title, body, sid, badge, kind, card_id, host)).encode()
 
     def run():
         dead = []
@@ -29777,8 +29816,9 @@ def _push_notify(title, body, sid="", badge=None):
 def _push_forward(events):
     """The federated half of the push sink (plans/federated-push.md; the user 2026-08-08, who wants
     one device subscription to buzz for EVERY connected kernel): hand this kernel's fresh bell
-    events — [{title, body, sid}] — to every attached TRUSTED peer, and each peer delivers them to
-    the devices subscribed to IT. Rides the channel every kernel-to-kernel control call already
+    events — [{title, body, sid, kind, cardId}] — to every attached TRUSTED peer, and each peer
+    delivers them to the devices subscribed to IT (kind/cardId ride so a tap on the mirrored
+    notification lands on the card, not just the session; a peer of an older build ignores them). Rides the channel every kernel-to-kernel control call already
     rides (_peer_call: the pair's tunnel + the token exchanged at attach) — no new legs, no new
     trust surface. Only events THIS kernel detected are ever forwarded, and /push/relay mirrors to
     devices only, never onward, so a cycle of attachments cannot echo an event back. Fire-and-forget
@@ -29820,8 +29860,14 @@ self.addEventListener('install',function(e){self.skipWaiting();});
 self.addEventListener('activate',function(e){e.waitUntil(clients.claim());});
 self.addEventListener('push',function(e){
 var d={};try{d=e.data?e.data.json():{};}catch(err){}
-var work=[self.registration.showNotification(d.title||'romp',
-{body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',data:{sid:d.sid||''}})];
+// data = the ROUTING block the kernel built (_push_payload: sid, host, kind, cardId, url) — what the
+// tap below acts on; a payload from an older kernel carries only a flat sid, so that is the fallback.
+// tag: one notification per session — a second buzz for the same session REPLACES the first on the
+// lock screen instead of stacking (renotify keeps it audible); the kernel picks the tag.
+var opts={body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',
+data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}};
+if(d.tag){opts.tag=d.tag;opts.renotify=true;}
+var work=[self.registration.showNotification(d.title||'romp',opts)];
 // the app-icon count, kept current while the app is CLOSED (the open shell re-paints it live over
 // its own WS). setAppBadge exists in the SW only where badging works at all (iOS installed apps).
 // Numeric-only on purpose: a mirrored federated event omits badge (the ORIGIN kernel's count is
@@ -29831,15 +29877,25 @@ if('setAppBadge' in self.navigator&&typeof d.badge==='number')work.push(self.nav
 e.waitUntil(Promise.all(work));
 });
 // Land ON the thing that notified (the user 2026-08-08, whose first push opened a different
-// session): a live window gets focus + the sid over postMessage (the shell relays it into the
-// chat pane); no window -> open one with the sid in the URL, and the shell asks the kernel to
-// aim the focus at it once its chat pane connects (POST /reveal).
+// session; 2026-09-06, who wants the tap to come back to the romp they already have open): the
+// notification closes; then the window the user last had in front (matchAll orders most-recently-
+// focused first) is focused and handed the routing block over postMessage — the shell turns that
+// into the chat focus + the feed's card reveal. No window at all -> open one on the deep link the
+// kernel built (the shell parses it at boot). focus() can REJECT (an installed iOS app has refused
+// it) — then the tap still lands: fall through to openWindow rather than dropping it. Everything
+// rides waitUntil, so the worker is kept alive until the tap has landed; no timers anywhere.
 self.addEventListener('notificationclick',function(e){
 e.notification.close();
-var sid=(e.notification.data&&e.notification.data.sid)||'';
+var d=e.notification.data||{};var sid=d.sid||'';
+var url=d.url||(sid?'/?push-reveal='+encodeURIComponent(sid):'/');
+var msg={romp:'notificationClick',sid:sid,host:d.host||'',kind:d.kind||'',cardId:d.cardId||''};
+function open(){return clients.openWindow(url);}
 e.waitUntil(clients.matchAll({type:'window',includeUncontrolled:true}).then(function(ws){
-if(ws.length)return ws[0].focus().then(function(w){try{(w||ws[0]).postMessage({romp:'pushReveal',sid:sid});}catch(err){}});
-return clients.openWindow(sid?'/?push-reveal='+encodeURIComponent(sid):'/');}));
+if(!ws.length)return open();
+var w=ws[0];
+return Promise.resolve().then(function(){return w.focus();}).then(function(fw){
+try{(fw||w).postMessage(msg);}catch(err){}},open);
+}));
 });
 """
 
@@ -32360,26 +32416,52 @@ return want?devSub(perm):devUnsub();
 }).then(function(){done();},function(e){fail(e);done();});
 });});
 })();
-// Landing a push tap on the session that fired (the user 2026-08-08). Two arrivals:
-//  - live window: the SW focused us and posted {romp:'pushReveal',sid} — relay a focus straight
-//    into the chat iframe. Its own handler does the rest (tab select, come forward on mobile via
-//    revealSelfPane), same as a kernel-sent focus — the shim delivers those over postMessage too.
-//  - cold start: the SW opened '/?push-reveal=sid' — the chat pane's WS does not exist yet, so
-//    ask the kernel to park the focus for OUR wid (POST /reveal, consumed on the pane's ready).
-//    The param is then stripped so a later manual reload does not replay the jump.
-// Separate IIFE from the bell on purpose: the bell bails where the Push API is missing, but a
-// pushReveal can only ever arrive where it exists, and this block must not ride that bail.
+"""
+
+
+# Landing a notification tap on what fired (the user 2026-08-08, whose first push opened a different
+# session; 2026-09-06, who wants the tap to come back to the romp already open and put them on the
+# session — and the card — that buzzed). Two arrivals, ONE activation path: both ask the KERNEL to
+# aim the chat focus at THIS dashboard (POST /reveal {sid, wid}) — never a focus posted straight
+# into the chat iframe, which could only ever address a tab that is already there. The kernel
+# answers a live session with the focus (chat pane connected → delivered now; not yet → parked for
+# that wid and consumed on the pane's ready — the exact event, no delay heuristics) and a dead or
+# unknown one with the revive prompt (_reveal_msg), so no sid ever ends in a silent no-op.
+#  - live window: the SW focused us and posted {romp:'notificationClick', sid, host, kind, cardId}.
+#  - cold start: the SW opened the kernel's deep link '/?push-reveal=<sid>[&push-card=<id>]'. The
+#    params are stripped (history.replaceState) the moment they are read, so a manual reload later
+#    does not replay the jump.
+# A card kind ALSO scrolls the feed to its card: {romp:'revealCard'} into the feed iframe — the same
+# message the Log's bell entries post — but only once the feed has its cards, which it announces
+# with {romp:'ready', app:'feed'} after its first payload renders (before that the iframe may have
+# no listener yet, or nothing to scroll to); a tap that arrives earlier waits for exactly that
+# message. A sid-less tap (a test notification) has nowhere to land: the SW's focus/openWindow was
+# the whole action. A /reveal the kernel refuses lands in the Log rather than vanishing.
+# Its own <script>, like every shell behaviour (test_kernel_mobile's count pin): a throw in the
+# bell's script must not strand a tap, and a bell that bails where the Push API is missing must
+# not take the deep-link half with it.
+_LANDING_REVEAL_JS = """
 (function(){
-function reveal(sid){if(!sid)return;var f=document.getElementById('f-chat');
-try{f&&f.contentWindow&&f.contentWindow.postMessage({type:'focus',id:sid,live:true},'*');}catch(e){}}
-if('serviceWorker' in navigator&&navigator.serviceWorker.addEventListener){
-navigator.serviceWorker.addEventListener('message',function(ev){
-var m=ev.data;if(m&&m.romp==='pushReveal'&&m.sid)reveal(m.sid);});}
-var u=new URL(location.href),pr=u.searchParams.get('push-reveal');
-if(pr){var wid='';try{wid=sessionStorage.getItem('romp:wid')||'';}catch(e){}
-fetch('/reveal',{method:'POST',body:JSON.stringify({sid:pr,wid:wid})})['catch'](function(e){});
-u.searchParams['delete']('push-reveal');
-try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():''));}catch(e){}}
+function wid(){try{return sessionStorage.getItem('romp:wid')||'';}catch(e){return '';}}
+function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Could not open the session this notification was about: '+((e&&e.message)||e));}catch(err){}}
+var feedReady=false,pendingCard=null;
+function revealCard(itemId,sid){if(!feedReady){pendingCard={itemId:itemId,sid:sid};return;}
+var f=document.getElementById('f-feed');
+try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'revealCard',itemId:itemId,sid:sid},'*');}catch(e){}}
+window.addEventListener('message',function(e){var m=e&&e.data;
+if(!(m&&m.romp==='ready'&&m.app==='feed'))return;
+feedReady=true;if(pendingCard){var c=pendingCard;pendingCard=null;revealCard(c.itemId,c.sid);}});
+function land(sid,kind,cardId){
+if(sid)fetch('/reveal',{method:'POST',body:JSON.stringify({sid:sid,wid:wid()})}).then(function(r){
+if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});})['catch'](fail);
+if(sid&&kind==='card'&&cardId)revealCard(cardId,sid);}
+if('serviceWorker' in navigator&&navigator.serviceWorker&&navigator.serviceWorker.addEventListener){
+navigator.serviceWorker.addEventListener('message',function(ev){var m=ev&&ev.data;
+if(m&&m.romp==='notificationClick')land(String(m.sid||''),String(m.kind||''),String(m.cardId||''));});}
+var u=new URL(location.href),pr=u.searchParams.get('push-reveal'),pc=u.searchParams.get('push-card');
+if(pr||pc){land(pr||'',pc?'card':'',pc||'');
+u.searchParams['delete']('push-reveal');u.searchParams['delete']('push-card');
+try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():'')+u.hash);}catch(e){}}
 })();
 """
 
@@ -33622,6 +33704,7 @@ def _landing():
             "<script>" + _LANDING_REMOTES_JS + "</script>"
             "<script>" + _LANDING_MOBILE_JS + "</script>"
             "<script>" + _LANDING_PUSH_JS + "</script>"
+            "<script>" + _LANDING_REVEAL_JS + "</script>"
             "<script>" + _LANDING_COLLAPSE_JS + "</script>"
             # the command palette (Cmd/Ctrl+P) and the session quick-switcher hotkey (Cmd/Ctrl+O):
             # a dist bundle (ui/webview/palette-main.ts) like age-color-global above. Loaded last —
@@ -34551,7 +34634,12 @@ class Handler(BaseHTTPRequestHandler):
                         sid = "%s:%s" % (origin, sid)
                     if t.startswith("romp: "):
                         t = "romp: %s:%s" % (origin, t[len("romp: "):])
-                    _push_notify(t, b, sid)       # badge omitted: the origin's count is not ours
+                    # badge omitted: the origin's count is not ours. kind/cardId pass through
+                    # (an older peer sends neither → the card default, which is all it had);
+                    # the card id is a goal id, globally unique and never host-prefixed
+                    # (federation.ts), so the merged feed finds it as-is.
+                    _push_notify(t, b, sid, kind=str(ev.get("kind") or "card"),
+                                 card_id=str(ev.get("cardId") or ""), host=origin)
                     n += 1
                 return self._send(200, json.dumps({"ok": True, "mirrored": n}), "application/json")
             if u.path == "/reveal":

--- a/plans/ios-app.md
+++ b/plans/ios-app.md
@@ -6,11 +6,17 @@ end — `/sw.js`, `/push/*`, VAPID, the `_push_notify` sink beside `_system_noti
 bell), live-verified on a real iPhone on 2026-08-07; then 3 plus tap-to-open on 2026-08-08, after
 the first real push opened the app on a session OTHER than the one that fired it — the bug that
 motivated the routing metadata below. A push now carries the firing card's sid and the
-needs-you count as routing metadata: the notification tap lands on that session (live window →
-SW postMessage → focus into the chat pane; cold start → `/?push-reveal=` → `POST /reveal` parks a
-wid-aimed focus consumed on that window's chat `ready` — an exact event, no delay heuristics),
-and the app icon wears the count (`navigator.setAppBadge` — the SW paints it while the app is
-closed, the shell trues it up over its WS on connect and on every change).
+needs-you count as routing metadata — and, since 2026-09-06, a `data` block `{sid, host, kind,
+cardId, url}` plus a per-session `tag` (`_push_payload`). The notification tap lands on that
+session: the SW closes the notification, focuses the window the user last had in front and posts
+`{romp:'notificationClick', …}` to it (a refused `focus()` falls through to `openWindow` on the
+deep link, all inside `waitUntil`); with no window it opens `url` (`/?push-reveal=<sid>
+[&push-card=<id>]`). Either way the shell asks the kernel for the focus (`POST /reveal`, wid-aimed,
+parked until that window's chat `ready` when the pane is not up yet — an exact event, no delay
+heuristics; a dead sid gets the revive prompt, never a silent miss) and, for a card, posts
+`revealCard` into the feed once it has announced its first payload; the URL params are stripped
+with `replaceState`. The app icon wears the count (`navigator.setAppBadge` — the SW paints it while
+the app is closed, the shell trues it up over its WS on connect and on every change).
 Implementation notes that amend this sketch:
 - The shell background is `#1e1e1e`, not the `#101418` guessed below (that is the login page);
   the manifest and theme-color use `#1e1e1e`.

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -180,7 +180,9 @@ class LandingShell(unittest.TestCase):
         # ios-standalone viewport flip and the push bell 2026-08-07, plans/ios-app.md; + the shared
         # Escape-closes-the-topmost-modal block 2026-08-09; + the release-update banner 2026-08-09).
         html = km._landing()
-        self.assertEqual(html.count("<script>"), 17)   # +1 2026-08-28: the theme reader right after <body>
+        # +1 2026-08-28: the theme reader right after <body>; +1 2026-09-06: the notification-tap landing
+        # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap
+        self.assertEqual(html.count("<script>"), 18)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""The bell popover (2026-09-05): the bell's tap opens a small anchored card whose rows are the
+switches ONE tap used to flip together, plus the turn-finished switch and a test button.
+
+What these pin, by layer:
+
+  * the store — "*turns" is a second reserved key in notify-cards.json: GET/POST /notify-turns
+    read and flip it, its own shell push repaints every dashboard, and the prune that drops ids
+    whose card left the feed keeps BOTH reserved keys.
+  * the test button — POST /push/test sends ONE notification to the asking device's subscription
+    and returns the push service's answer {ok, status, detail}; an unknown endpoint says so; a
+    dead one (404/410) is pruned exactly like the fan-out prunes it; missing crypto is the same
+    loud 500 the subscribe route gives. _push_post is the one HTTP path under both; _push_send_one
+    keeps its prune semantics (False on 404/410 ONLY) on top of it.
+  * the turn-finished push — _turn_notify_tick fires on a session's turn-end KEY moving (the Stop
+    hook's lastStopAt, or a STOPPED states/ transition), only with the master AND the switch on
+    and the session unmuted, with a silent first-sight baseline; the event travels to trusted
+    peers the bell-event way.
+  * the one-buzz-per-turn-end rule — _buzz_claim: the bell event and the turn push both claim
+    (sid, turn-end key); the first to file buzzes and the other yields; bell events never
+    suppress each other; a sid-less event always passes.
+  * the shell — the popover markup (four rows), the menu TOKENS with their dark fallbacks, the
+    theme blocks that define them, the Escape chain, the WS repaint, and the bell glyph reading
+    THIS device (master AND subscribed).
+
+Synthetic only: placeholder sids, the notes-api demo sessions (web/api), invented reply text.
+"""
+import io
+import json
+import os
+import threading
+import time
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+import tempfile
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads (the webpush test's 2026-08-08 lesson: a raw run must never
+# touch the live push store or rotate the real VAPID key).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+from pathlib import Path
+_STATE_TD = tempfile.TemporaryDirectory()
+jd.STATE = Path(_STATE_TD.name)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_notify_popover", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID_WEB = "11111111-2222-4333-8444-555555555501"
+SID_API = "11111111-2222-4333-8444-555555555502"
+
+
+def _serve_get(path, headers=None):
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    h.headers = dict(headers or {})
+    h.path = path
+    h.command = "GET"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = io.BytesIO()
+    h.close_connection = True
+    captured = {}
+    h.send_response = lambda code, *a: captured.__setitem__("status", code)
+    h.send_header = lambda k, v: None
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_GET()
+    return captured.get("status"), h.wfile.getvalue()
+
+
+def _reset_store():
+    for name in ("notify-cards.json", "push-subscriptions.json", "session-flags.json"):
+        try:
+            (jd.STATE / name).unlink()
+        except OSError:
+            pass
+    km._notify_cards_cache.clear()
+    km._TURN_PREV.clear()
+    km._PUSH_BUZZED.clear()
+
+
+class _LoopbackMixin:
+    @classmethod
+    def setUpClass(cls):
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def _post(self, path, body, token=True, raw=None):
+        import urllib.request, urllib.error
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["X-Romp-Token"] = km.TOKEN
+        data = raw if raw is not None else json.dumps(body).encode()
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path),
+                                     method="POST", data=data, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, r.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+
+class TurnSwitchStore(_LoopbackMixin, unittest.TestCase):
+    """GET/POST /notify-turns — the turn-finished switch's kernel half, a second reserved key
+    beside the master in notify-cards.json."""
+
+    def setUp(self):
+        _reset_store()
+
+    def test_default_off_and_gated(self):
+        status, _ = _serve_get("/notify-turns")
+        self.assertEqual(status, 403, "behind the serve token like every page")
+        status, body = _serve_get("/notify-turns", headers={"X-Romp-Token": km.TOKEN})
+        self.assertEqual((status, json.loads(body)), (200, {"on": False}))
+        self.assertFalse(km._notify_turns_on())
+
+    def test_post_flips_persists_and_broadcasts_its_own_message(self):
+        sent = []
+        with mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append((app, m))):
+            code, body = self._post("/notify-turns", {"on": True})
+        self.assertEqual((code, json.loads(body)), (200, {"ok": True, "on": True}))
+        self.assertTrue(km._notify_turns_on())
+        self.assertEqual(json.loads((jd.STATE / "notify-cards.json").read_text()), {"*turns": True},
+                         "persisted beside the master, as its own key")
+        self.assertIn(("shell", {"type": "notifyTurns", "on": True}), sent,
+                      "every open dashboard's row repaints — a distinct message, so the master's stays as it was")
+        # the master is untouched by the turn switch, in both directions
+        self.assertFalse(km._notify_all_on())
+        code, _ = self._post("/notify-turns", {"on": False})
+        self.assertEqual(code, 200)
+        self.assertFalse(km._notify_turns_on())
+        self.assertEqual(km._notify_cards(), {}, "off deletes the key rather than pinning False")
+
+    def test_post_requires_token_and_refuses_garbage(self):
+        code, _ = self._post("/notify-turns", {"on": True}, token=False)
+        self.assertEqual(code, 403)
+        code, _ = self._post("/notify-turns", None, raw=b"not json")
+        self.assertEqual(code, 400)
+        self.assertFalse(km._notify_turns_on())
+
+    def test_prune_keeps_both_reserved_keys(self):
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        km._set_notify_card("%s:g1" % SID_WEB, False, SID_WEB)     # a mute, kept while its card lives
+        km._prune_notify_cards({"%s:g1" % SID_WEB})
+        self.assertEqual(km._notify_cards(), {"*": True, "*turns": True, "%s:g1" % SID_WEB: False})
+        km._prune_notify_cards(set())                              # the card left the feed
+        self.assertEqual(km._notify_cards(), {"*": True, "*turns": True},
+                         "neither reserved key is a card; only card ids prune")
+
+    def test_the_turn_key_never_reads_as_a_card(self):
+        km._set_notify_turns(True)
+        cards = km._notify_cards()
+        # the master is off, so no card is effectively armed — the turn key must not leak into that
+        self.assertFalse(km._notify_card_effective(cards, "%s:g1" % SID_WEB, SID_WEB))
+
+
+class PushPost(unittest.TestCase):
+    """_push_post against a real loopback push service double — status and detail as the caller
+    would see them; _push_send_one's prune rule on top."""
+
+    @classmethod
+    def setUpClass(cls):
+        from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+        cls.script = {"status": 201, "body": b""}
+
+        class Svc(BaseHTTPRequestHandler):
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(n)
+                self.send_response(cls.script["status"])
+                self.send_header("Content-Length", str(len(cls.script["body"])))
+                self.end_headers()
+                self.wfile.write(cls.script["body"])
+
+            def log_message(self, *a):
+                pass
+
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), Svc)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def _sub(self):
+        return {"endpoint": "http://127.0.0.1:%d/send/dev-1" % self.port,
+                "keys": {"p256dh": "k", "auth": "a"}}
+
+    def _post(self, status, body=b""):
+        type(self).script = {"status": status, "body": body}
+        with mock.patch.object(km, "_webpush_encrypt", return_value=b"ciphertext"), \
+             mock.patch.object(km, "_vapid_auth", return_value="vapid t=x, k=y"):
+            return km._push_post(self._sub(), b"{}")
+
+    def test_accepted_reports_the_2xx(self):
+        status, detail = self._post(201)
+        self.assertEqual(status, 201)
+        self.assertTrue(detail)
+
+    def test_a_refusal_carries_status_and_the_services_reason(self):
+        status, detail = self._post(403, b'{"reason":"BadJwtToken"}')
+        self.assertEqual(status, 403)
+        self.assertIn("BadJwtToken", detail, "the service's own reason reaches the user")
+
+    def test_no_answer_is_status_zero_with_the_error(self):
+        with mock.patch.object(km, "_webpush_encrypt", return_value=b"x"), \
+             mock.patch.object(km, "_vapid_auth", return_value="vapid t=x, k=y"):
+            status, detail = km._push_post({"endpoint": "http://127.0.0.1:1/x",
+                                            "keys": {"p256dh": "k", "auth": "a"}}, b"{}")
+        self.assertEqual(status, 0)
+        self.assertTrue(detail)
+
+    def test_send_one_prunes_on_404_and_410_only(self):
+        # the fan-out's contract, unchanged by the refactor: False = dead subscription, and NOTHING
+        # else — a 5xx, a 403, a timeout all keep the subscription
+        outcomes = {404: False, 410: False, 201: True, 403: True, 500: True, 0: True}
+        for status, keep in outcomes.items():
+            with mock.patch.object(km, "_push_post", return_value=(status, "x")):
+                self.assertEqual(km._push_send_one(self._sub(), b"{}"), keep, status)
+
+
+class PushTestRoute(_LoopbackMixin, unittest.TestCase):
+    """POST /push/test over the real handler: one notification to the asking device, the push
+    service's answer back."""
+
+    def setUp(self):
+        _reset_store()
+        self.ep = "https://push.example.net/send/dev-test"
+        km._save_push_subs({self.ep: {"endpoint": self.ep, "keys": {"p256dh": "k", "auth": "a"}}})
+
+    def _test(self, outcome):
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=outcome) as pp:
+            code, body = self._post("/push/test", {"endpoint": self.ep})
+        return code, json.loads(body), pp
+
+    def test_accepted(self):
+        code, res, pp = self._test((201, "Created"))
+        self.assertEqual(code, 200)
+        self.assertEqual(res, {"ok": True, "status": 201, "detail": "Created"})
+        # ONE send, to THIS subscription, a plain title and one sentence
+        (sub, payload), _ = pp.call_args
+        self.assertEqual(sub["endpoint"], self.ep)
+        d = json.loads(payload.decode())
+        self.assertEqual(d["title"], "romp")
+        self.assertTrue(d["body"])
+        self.assertEqual(set(d), {"title", "body"}, "a test carries no sid to jump to and no badge")
+
+    def test_a_refusal_comes_back_verbatim(self):
+        code, res, _ = self._test((403, "Forbidden: {\"reason\":\"BadJwtToken\"}"))
+        self.assertEqual(code, 200)
+        self.assertEqual(res["ok"], False)
+        self.assertEqual(res["status"], 403)
+        self.assertIn("BadJwtToken", res["detail"])
+        self.assertIn(self.ep, km._push_subs(), "a refusal short of dead keeps the subscription")
+
+    def test_a_dead_subscription_is_pruned_and_says_so(self):
+        code, res, _ = self._test((410, "Gone"))
+        self.assertEqual((code, res["ok"], res["status"]), (200, False, 410))
+        self.assertIn("removed", res["detail"])
+        self.assertNotIn(self.ep, km._push_subs(), "the same prune the fan-out applies")
+
+    def test_no_answer_is_status_zero(self):
+        _, res, _ = self._test((0, "URLError: timed out"))
+        self.assertEqual((res["ok"], res["status"]), (False, 0))
+        self.assertIn("timed out", res["detail"])
+
+    def test_an_unknown_endpoint_says_not_subscribed(self):
+        with mock.patch.object(km, "_push_post") as pp:
+            code, body = self._post("/push/test", {"endpoint": "https://push.example.net/send/other"})
+        self.assertEqual(code, 200)
+        res = json.loads(body)
+        self.assertEqual((res["ok"], res["status"]), (False, 0))
+        self.assertIn("isn't subscribed", res["detail"])
+        pp.assert_not_called()
+
+    def test_missing_crypto_is_the_loud_500(self):
+        with mock.patch.object(km, "_PUSH_CRYPTO", [False]):
+            code, body = self._post("/push/test", {"endpoint": self.ep})
+        self.assertEqual(code, 500)
+        self.assertIn("cryptography", body)
+
+    def test_gated_and_validated(self):
+        code, _ = self._post("/push/test", {"endpoint": self.ep}, token=False)
+        self.assertEqual(code, 403)
+        code, _ = self._post("/push/test", {})
+        self.assertEqual(code, 400)
+        code, _ = self._post("/push/test", None, raw=b"nope")
+        self.assertEqual(code, 400)
+
+
+def _stamp_stop(sid, t):
+    """The Stop hook's ledger stamp — the SDK session's authoritative turn-end fact."""
+    d = jd.STATE / "sdk"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / (sid + ".json")).write_text(json.dumps({"lastStopAt": int(t)}))
+
+
+def _append_state(sid, state, t):
+    d = jd.STATE / "states"
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / (sid + ".jsonl"), "a") as f:
+        f.write(json.dumps({"t": int(t), "state": state}) + "\n")
+
+
+def _transcript(sid, text):
+    p = jd.STATE / ("transcript-%s.jsonl" % sid[-2:])
+    rec = {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}
+    p.write_text(json.dumps({"type": "user", "message": {"content": "hi"}}) + "\n" + json.dumps(rec) + "\n")
+    return str(p)
+
+
+class TurnFinishedPush(unittest.TestCase):
+    """_turn_notify_tick: a session's turn-end key moving is the event; both switches gate it."""
+
+    def setUp(self):
+        _reset_store()
+        for p in (jd.STATE / "sdk", jd.STATE / "states"):
+            for f in p.glob("*") if p.exists() else []:
+                f.unlink()
+        self.path = _transcript(SID_WEB, "Done: the login flow now redirects to the notes list.\n\nDetails below.")
+        self.alive = [{"sid": SID_WEB, "name": "web", "path": self.path}]
+        self.tmux = {SID_WEB: {"state": "waiting"}}
+
+    def _tick(self):
+        pushed, fwd = [], []
+        with mock.patch.object(km, "_alive_sessions", return_value=self.alive), \
+             mock.patch.object(km, "_push_notify", side_effect=lambda *a, **k: pushed.append((a, k))), \
+             mock.patch.object(km, "_push_forward", side_effect=lambda evs: fwd.append(evs)):
+            fired = km._turn_notify_tick(time.time(), self.tmux)
+        return fired, pushed, fwd
+
+    def test_first_sight_is_a_silent_baseline_then_a_new_end_fires(self):
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        _stamp_stop(SID_WEB, 1000)
+        fired, pushed, fwd = self._tick()
+        self.assertEqual((fired, pushed, fwd), ([], [], []), "existing state is status, not news")
+        _stamp_stop(SID_WEB, 1001)
+        fired, pushed, fwd = self._tick()
+        self.assertEqual(fired, [{"title": "web", "body": "Done: the login flow now redirects to the notes list.",
+                                  "sid": SID_WEB}])
+        (args, kw), = pushed
+        self.assertEqual(args, ("web", "Done: the login flow now redirects to the notes list.", SID_WEB))
+        self.assertNotIn("badge", kw, "the count rides its own push")
+        self.assertEqual(fwd, [fired], "the same event travels to trusted peers, the bell-event way")
+        # the same key again is nothing new
+        self.assertEqual(self._tick()[0], [])
+
+    def test_both_switches_must_be_on(self):
+        _stamp_stop(SID_WEB, 1000)
+        self._tick()                                       # baseline
+        for master, turns in ((False, False), (True, False), (False, True)):
+            km._set_notify_all(master)
+            km._set_notify_turns(turns)
+            _stamp_stop(SID_WEB, 1001 + int(master) + 2 * int(turns))
+            self.assertEqual(self._tick()[0], [], (master, turns))
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        _stamp_stop(SID_WEB, 1010)
+        self.assertEqual(len(self._tick()[0]), 1, "…and with both on the next end fires")
+
+    def test_switching_on_later_never_replays_old_ends(self):
+        _stamp_stop(SID_WEB, 1000)
+        self._tick()
+        _stamp_stop(SID_WEB, 1001)                          # an end that happened while off
+        self._tick()
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        self.assertEqual(self._tick()[0], [], "the memo advanced while off; nothing to replay")
+
+    def test_a_muted_session_stays_quiet(self):
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        km._set_notify_session(SID_WEB, False)              # its own bell off = a mute under the master
+        _stamp_stop(SID_WEB, 1000)
+        self._tick()
+        _stamp_stop(SID_WEB, 1001)
+        self.assertEqual(self._tick()[0], [])
+
+    def test_an_empty_reply_gets_a_plain_body(self):
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        self.alive[0]["path"] = str(jd.STATE / "no-such-transcript.jsonl")
+        _stamp_stop(SID_WEB, 1000)
+        self._tick()
+        _stamp_stop(SID_WEB, 1001)
+        self.assertEqual(self._tick()[0][0]["body"], "finished a turn")
+
+    def test_the_fallback_key_counts_only_stopped_transitions(self):
+        # a tmux session: no Stop-hook ledger; states/ is the record — and a turn STARTING (working)
+        # must never read as an end
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        _append_state(SID_WEB, "waiting", 1000)
+        self.assertEqual(km._turn_end_key(SID_WEB), 1000)
+        self._tick()                                        # baseline
+        _append_state(SID_WEB, "working", 1001)
+        self.assertEqual(km._turn_end_key(SID_WEB), 0, "a start is not an end")
+        self.assertEqual(self._tick()[0], [])
+        _append_state(SID_WEB, "waiting", 1002)
+        self.assertEqual(len(self._tick()[0]), 1, "the stop after it is")
+
+    def test_wired_into_the_pusher_cycle_after_the_feed_build(self):
+        import inspect
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_turn_notify_tick(now, tmux)", src)
+        self.assertLess(src.index("_push_all(tmux=tmux)"), src.index("_turn_notify_tick(now, tmux)"),
+                        "the feed builds first, so a same-settle bell event files its buzz first")
+
+
+class FirstLine(unittest.TestCase):
+    def test_first_non_empty_line_clipped(self):
+        self.assertEqual(km._first_line("\n\n  Shipped it.  \nmore"), "Shipped it.")
+        self.assertEqual(km._first_line(""), "")
+        long = "x" * 200
+        out = km._first_line(long)
+        self.assertEqual(len(out), 120)
+        self.assertTrue(out.endswith("…"))
+
+
+class OneBuzzPerTurnEnd(unittest.TestCase):
+    """The no-double-buzz rule, both orders."""
+
+    def setUp(self):
+        _reset_store()
+        for f in (jd.STATE / "sdk").glob("*") if (jd.STATE / "sdk").exists() else []:
+            f.unlink()
+
+    def test_turn_first_then_the_bell_event_yields(self):
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "turn"))
+        self.assertFalse(km._buzz_claim(SID_WEB, 1001, "bell"), "the phone already buzzed for this stop")
+        self.assertTrue(km._buzz_claim(SID_WEB, 1002, "bell"), "a later turn end is new information")
+
+    def test_bell_first_then_the_turn_push_yields(self):
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "bell"))
+        self.assertFalse(km._buzz_claim(SID_WEB, 1001, "turn"))
+        self.assertTrue(km._buzz_claim(SID_WEB, 1002, "turn"))
+
+    def test_bell_events_never_suppress_each_other(self):
+        # two cards of one session moving in one build buzz twice — exactly as before the rule
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "bell"))
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "bell"))
+        self.assertFalse(km._buzz_claim(SID_WEB, 1001, "turn"), "…and the turn push still yields to them")
+
+    def test_sessions_are_independent_and_sidless_always_passes(self):
+        self.assertTrue(km._buzz_claim(SID_WEB, 1001, "turn"))
+        self.assertTrue(km._buzz_claim(SID_API, 1001, "bell"))
+        self.assertTrue(km._buzz_claim("", 0, "bell"))
+        self.assertTrue(km._buzz_claim("", 0, "bell"))
+
+    def test_the_tick_yields_to_a_bell_claim(self):
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        path = _transcript(SID_WEB, "Which migration should I keep?")
+        alive = [{"sid": SID_WEB, "name": "web", "path": path}]
+        with mock.patch.object(km, "_alive_sessions", return_value=alive), \
+             mock.patch.object(km, "_push_notify") as pn, \
+             mock.patch.object(km, "_push_forward") as pf:
+            _stamp_stop(SID_WEB, 1000)
+            km._turn_notify_tick(time.time(), {SID_WEB: {}})            # baseline
+            _stamp_stop(SID_WEB, 1001)
+            # the judges ruled inside the same cycle: the card moved and its bell event filed first
+            self.assertTrue(km._buzz_claim(SID_WEB, km._turn_end_key(SID_WEB), "bell"))
+            self.assertEqual(km._turn_notify_tick(time.time(), {SID_WEB: {}}), [])
+            pn.assert_not_called()
+            pf.assert_not_called()
+
+    def test_the_feed_path_claims_before_it_pushes(self):
+        import inspect
+        src = inspect.getsource(km._cached_feed)
+        self.assertIn('_buzz_claim(_sid, _turn_end_key(_sid), "bell")', src)
+        self.assertLess(src.index("_buzz_claim("), src.index("_push_notify(_t, _b, _sid, _badge)"))
+        self.assertLess(src.index("_system_notify(_t, _b)"), src.index("_buzz_claim("),
+                        "the desktop notice is not the buzz and never yields")
+
+
+class RelayOfTurnEvents(unittest.TestCase):
+    def test_a_turn_shaped_event_mirrors_with_the_origin_on_its_sid(self):
+        # the relay's tolerant surgery (the federation test's contract): a session-named title
+        # passes as composed, the sid gains the origin so a tap routes through the merged dashboard
+        with km._remotes_lock:
+            km._remotes["boxa"] = {"host": "boxa", "kernel_port": 1, "local_port": 1, "token": "tok",
+                                   "proc": None, "status": "up", "trust": "trusted"}
+        try:
+            raw = json.dumps({"origin": "boxa", "events": [{"title": "web", "body": "Done: shipped.", "sid": SID_WEB}]}).encode()
+            h = km.Handler.__new__(km.Handler)
+            h.client_address = ("127.0.0.1", 0)
+            h.headers = {"X-Romp-Token": km.TOKEN, "Content-Length": str(len(raw))}
+            h.path = "/push/relay"
+            h.command = "POST"
+            h.request_version = "HTTP/1.1"
+            h.wfile = io.BytesIO()
+            h.rfile = io.BytesIO(raw)
+            h.close_connection = True
+            h.send_response = lambda code, *a: None
+            h.send_header = lambda k, v: None
+            h.end_headers = lambda: None
+            h.log_message = lambda *a: None
+            with mock.patch.object(km, "_push_notify") as pn:
+                h.do_POST()
+            pn.assert_called_once_with("web", "Done: shipped.", "boxa:" + SID_WEB)
+        finally:
+            with km._remotes_lock:
+                km._remotes.pop("boxa", None)
+
+
+class ShellPopover(unittest.TestCase):
+    """The rendered landing: the popover's markup and skin, the wiring around it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = km._landing()
+
+    def test_the_four_rows(self):
+        h = self.html
+        self.assertIn("id=rbell-back hidden", h)
+        self.assertIn("id=rbell-pop role=dialog", h)
+        for act in ("data-act=all", "data-act=dev", "data-act=turns"):
+            self.assertIn("class=rbp-row %s role=switch" % act, h)
+        self.assertIn(">All devices<", h)
+        self.assertIn(">This device<", h)
+        self.assertIn(">Also when a turn finishes<", h)
+        self.assertIn("id=rbp-test data-act=test>Send a test notification<", h)
+        # the one-sentence "why" under each switch
+        self.assertIn("Arms every device, and the desktop of every machine you've attached.", h)
+        self.assertIn("Buzzes every time any session finishes a turn. With many sessions running, that is a lot of buzzing.", h)
+        self.assertIn("id=rbp-test-out", h)
+
+    def test_the_bell_opens_it_and_the_rows_are_the_switches(self):
+        js = km._LANDING_PUSH_JS
+        self.assertIn("open(bl)", js)
+        self.assertNotIn("post('/notify-all',{on:want}).then(function(){\nisOn=want;paint();                       // the master flipped", js,
+                         "the bell's own tap no longer flips the master")
+        self.assertIn("if(act==='all')", js)
+        self.assertIn("post('/notify-all',{on:want})", js)
+        self.assertIn("if(act==='dev')", js)
+        self.assertIn("Notification.requestPermission():null", js)      # still inside the tap's own stack
+        self.assertIn("devSubscribe(perm0):devUnsubscribe()", js)
+        self.assertIn("if(act==='turns')", js)
+        self.assertIn("post('/notify-turns',{on:wantT})", js)
+        self.assertIn("if(act==='test')", js)
+        self.assertIn("post('/push/test',{endpoint:s.endpoint})", js)
+        # the test button acknowledges at once and self-restores; the answer lands under it
+        self.assertIn("testBtn.disabled=true", js)
+        self.assertIn("testBtn.textContent='Sending…'", js)
+        self.assertIn("testBtn.disabled=false;testBtn.textContent=label", js)
+        self.assertIn("'The push service accepted it.'", js)
+        self.assertIn("This device isn't subscribed yet.", js)
+        self.assertIn("'The push service refused it: '+d.status", js)
+
+    def test_the_glyph_reflects_this_device_and_the_tooltip_names_the_off_half(self):
+        js = km._LANDING_PUSH_JS
+        self.assertIn("var lit=isOn&&(canPush?devOn:true)", js)
+        self.assertIn("b.classList.toggle('on',lit)", js)
+        self.assertIn("'Notifications off for all devices'", js)
+        self.assertIn("'Notifications off on this device'", js)
+        self.assertIn("'Notifications off — for all devices, and on this device'", js)
+        # blocked / unavailable push is SAID, in the row, with the way back
+        self.assertIn("perm()==='denied'", js)
+        self.assertIn("Notifications are blocked for this site.", js)
+        self.assertIn("add romp to the Home Screen first", js)
+        self.assertIn("el.classList.contains('off'))return", js, "a blocked row does not fire the request")
+
+    def test_dismissal_and_repaint_wiring(self):
+        h = self.html
+        self.assertIn("window.__rompCloseBellPop=close", h)
+        self.assertIn("if(bp&&!bp.hidden&&window.__rompCloseBellPop){window.__rompCloseBellPop();closed=true;}", h,
+                      "Escape closes it through the shell's shared chain")
+        self.assertIn("if(e.target===back)close()", h, "an outside tap lands on the backdrop and closes")
+        self.assertIn("m.type==='notifyTurns'&&window.__rompNotifyTurnsPaint", h)
+        self.assertIn("fetch('/notify-turns')", h)
+        self.assertIn("z-index:205", h)
+
+    def test_the_menu_tokens_with_their_dark_fallbacks(self):
+        h = self.html
+        # the shell defines the tokens (it loads no sheet) — dark byte-equal to styles.css's :root,
+        # the light block in the light palette
+        self.assertIn(":root{--menu-bg:#252526;--menu-fg:#cccccc;--menu-border:rgba(255,255,255,0.12);"
+                      "--menu-hover:rgba(255,255,255,0.09);--radius-menu:6px;--shadow-menu:0 4px 12px rgba(0,0,0,0.35);"
+                      "--check-bg:#1EA1EB}", h)
+        self.assertIn("body.theme-light{--menu-bg:#FBF6EF;--menu-fg:#1F1E1D;--menu-border:rgba(0,0,0,0.12);"
+                      "--menu-hover:rgba(0,0,0,0.06);--shadow-menu:0 4px 12px rgba(31,26,20,0.16);--check-bg:#C2410C}", h)
+        pop = h[h.index("#rbell-pop{"):h.index("#rbp-test-out{")]
+        self.assertIn("background:var(--menu-bg,#252526)", pop)
+        self.assertIn("color:var(--menu-fg,#cccccc)", pop)
+        self.assertIn("border:1px solid var(--menu-border,rgba(255,255,255,0.12))", pop)
+        self.assertIn("border-radius:var(--radius-menu,6px)", pop)
+        self.assertIn("box-shadow:var(--shadow-menu,0 4px 12px rgba(0,0,0,0.35))", pop)
+        self.assertIn("background:var(--menu-hover,rgba(255,255,255,0.09))", pop)
+        self.assertIn("font:12px/1.45 'Inter'", pop)
+        self.assertIn(".rbp-sub{font-size:0.82em;opacity:.6}", pop)
+        # no raw dark literal outside a var() fallback slot
+        import re
+        bare = re.sub(r"var\((--[\w-]+)\s*,\s*(?:[^()]|\([^()]*\))*\)", r"var(\1)", pop)
+        for lit in ("#252526", "#cccccc", "rgba(255,255,255", "rgba(0,0,0,0.35)", "#1EA1EB"):
+            self.assertNotIn(lit, bare, lit)
+        self.assertIn("background:var(--accent)", pop, "the on-state pill is accent chrome")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -291,8 +291,9 @@ class PushTestRoute(_LoopbackMixin, unittest.TestCase):
         self.assertNotIn("badge", d, "the count rides its own push")
 
     def test_a_federated_session_keeps_its_prefix_and_falls_back_to_the_short_id(self):
-        # a remote session's name lives at its origin kernel; ours knows only the id and says so
-        # rather than inventing one — the prefixed id and the host ride the routing block as-is
+        # a remote session's name lives at its origin kernel; with no snapshot of that kernel's
+        # list and no label from the shell, ours knows only the id and says so rather than
+        # inventing one — the prefixed id and the host ride the routing block as-is
         with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
              mock.patch.object(km, "_push_post", return_value=(201, "Created")) as pp, \
              mock.patch.object(km, "_name_of", return_value=None):
@@ -303,6 +304,63 @@ class PushTestRoute(_LoopbackMixin, unittest.TestCase):
         d = json.loads(pp.call_args[0][1].decode())
         self.assertEqual(d["body"], "Test notification — tap to come back to %s." % SID_API[:8])
         self.assertEqual((d["data"]["sid"], d["data"]["host"], d["data"]["kind"]), ("boxa:" + SID_API, "boxa", "test"))
+
+    def _snapshot(self, host, names):
+        """Seed the supervisor's per-host snapshot the way its poll files it (sids + names)."""
+        with km._remotes_lock:
+            km._remotes[host] = {"host": host, "kernel_port": 1, "local_port": 1, "status": "up",
+                                 "sids": list(names), "names": dict(names)}
+        self.addCleanup(lambda: km._remotes.pop(host, None))
+
+    def test_a_remote_sessions_name_comes_from_the_kernels_own_snapshot_of_that_host(self):
+        # the user 2026-09-06, whose test notification for a session on another machine named its
+        # short id: the kernel DOES know that name — the tunnel supervisor polls every attached
+        # host's /sessions (id + name) for the wake-router's map — so the notification and the
+        # popover's result line read it from there, host-prefixed the way the dashboard shows it.
+        # The shell's label is display text of last resort and loses to the kernel's own copy.
+        self._snapshot("boxa", {SID_API: "api"})
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")) as pp, \
+             mock.patch.object(km, "_name_of", return_value=None):
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "host": "boxa",
+                                                   "label": "boxa:stale-label"})
+        self.assertEqual(code, 200)
+        res = json.loads(body)
+        self.assertEqual((res["sid"], res["name"]), ("boxa:" + SID_API, "boxa:api"))
+        d = json.loads(pp.call_args[0][1].decode())
+        self.assertEqual(d["body"], "Test notification — tap to come back to boxa:api.")
+
+    def test_the_shells_label_stands_in_when_the_kernel_has_no_name_for_the_id(self):
+        # no snapshot for that host (never polled, or a kernel too old to file names): the tab's own
+        # label — the user's UI text, display-only — beats a bare short id
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")) as pp, \
+             mock.patch.object(km, "_name_of", return_value=None):
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "host": "boxa",
+                                                   "label": "  boxa:api\n(paused) "})
+        self.assertEqual(code, 200)
+        self.assertEqual(json.loads(body)["name"], "boxa:api (paused)", "trimmed and flattened, otherwise verbatim")
+        d = json.loads(pp.call_args[0][1].decode())
+        self.assertEqual(d["body"], "Test notification — tap to come back to boxa:api (paused).")
+        # a local session keeps the registry's name even when the label disagrees (the registry is authoritative)
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")), \
+             mock.patch.object(km, "_name_of", side_effect=lambda s: "web" if s == SID_WEB else None):
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": SID_WEB, "host": "", "label": "renamed"})
+        self.assertEqual(json.loads(body)["name"], "web")
+
+    def test_the_label_is_a_capped_string_or_a_400(self):
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")), \
+             mock.patch.object(km, "_name_of", return_value=None):
+            code, _ = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "label": 5})
+            self.assertEqual(code, 400)
+            code, _ = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "label": ["x"]})
+            self.assertEqual(code, 400)
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "label": "x" * 500})
+        self.assertEqual(code, 200)
+        self.assertEqual(json.loads(body)["name"], "x" * km.PUSH_LABEL_MAX, "long UI text is clipped, not refused")
+        self.assertLessEqual(km.PUSH_LABEL_MAX, 80)
 
     def test_without_a_sid_the_probe_is_what_it_was(self):
         code, res, pp = self._test((201, "Created"))
@@ -358,6 +416,61 @@ class PushTestRoute(_LoopbackMixin, unittest.TestCase):
         self.assertEqual(code, 400)
         code, _ = self._post("/push/test", None, raw=b"nope")
         self.assertEqual(code, 400)
+
+
+class RemoteNames(unittest.TestCase):
+    """Where the kernel's copy of a remote session's name comes from (2026-09-06): the tunnel
+    supervisor already GETs each attached host's /sessions through the -L tunnel every pass for the
+    wake-router's host↔sid map; the same rows carry `name`, so the poll files both beside each
+    other on the host's row and _remote_name_of reads that snapshot."""
+
+    def _serve_rows(self, rows):
+        from http.server import HTTPServer, BaseHTTPRequestHandler
+        body = json.dumps(rows).encode()
+
+        class Svc(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *a):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", 0), Svc)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.shutdown)
+        return srv.server_address[1]
+
+    def test_the_poll_returns_the_rows_and_the_ids_are_read_off_them(self):
+        port = self._serve_rows([{"id": SID_API, "name": "api", "state": "ready"},
+                                 {"id": SID_WEB, "name": "web"}, {"nope": 1}, "junk"])
+        r = {"host": "boxa", "local_port": port, "token": ""}
+        rows = km._poll_remote_sessions(r)
+        self.assertEqual([x["id"] for x in rows], [SID_API, SID_WEB], "id-bearing dict rows only")
+        self.assertEqual(r["_probe"], "ok")
+        self.assertEqual(km._poll_remote_sids(r), [SID_API, SID_WEB], "the sid list is unchanged for its callers")
+        self.assertEqual(km._remote_names(rows), {SID_API: "api", SID_WEB: "web"})
+        self.assertEqual(km._remote_names([{"id": SID_API, "name": 7}, {"id": SID_WEB}]), {},
+                         "a row without a string name files nothing — never a coined one")
+
+    def test_the_supervisor_files_names_beside_sids(self):
+        import inspect
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn('r["sids"] = sids', src)
+        self.assertIn('r["names"] = _remote_names(rows)', src, "same poll, same locked write as the sids")
+        self.assertIn("rows = _poll_remote_sessions(r) if up else None", src, "ONE GET per pass, not a second one for names")
+
+    def test_remote_name_of_reads_the_snapshot_and_says_nothing_otherwise(self):
+        with km._remotes_lock:
+            km._remotes["boxa"] = {"host": "boxa", "sids": [SID_API], "names": {SID_API: "api"}}
+            km._remotes["boxb"] = {"host": "boxb", "sids": [SID_WEB]}          # an older row: no names filed
+        self.addCleanup(lambda: (km._remotes.pop("boxa", None), km._remotes.pop("boxb", None)))
+        self.assertEqual(km._remote_name_of("boxa", SID_API), "api")
+        self.assertIsNone(km._remote_name_of("boxa", SID_WEB))
+        self.assertIsNone(km._remote_name_of("boxb", SID_WEB))
+        self.assertIsNone(km._remote_name_of("nohost", SID_WEB))
 
 
 def _stamp_stop(sid, t):
@@ -662,13 +775,18 @@ class ShellPopover(unittest.TestCase):
         self.assertIn("function activeSession(){", js)
         self.assertIn("document.getElementById('f-chat')", js)
         self.assertIn("d.querySelector('#tabs .tab.active[data-id]')", js)
-        # a federated tab's id is host:sid, so the host is its prefix; a bare local id has none
-        self.assertIn("var i=id.indexOf(':');\nreturn {sid:id,host:i>0?id.slice(0,i):''};", js)
+        # a federated tab's id is host:sid, so the host is its prefix; a bare local id has none.
+        # The tab's LABEL rides along too (2026-09-06): the kernel names the session from its own
+        # registry or its snapshot of the owning host, and falls back to this — the user's own UI
+        # text, display-only, clipped here as well as there
+        self.assertIn("var i=id.indexOf(':');\nvar lab=t&&t.querySelector('.tab-label');\nreturn {sid:id,host:i>0?id.slice(0,i):'',label:", js)
+        self.assertIn(".replace(/\\s+/g,' ').trim().slice(0,80)}", js)   # flattened + clipped at the same cap the kernel applies
+        self.assertEqual(km.PUSH_LABEL_MAX, 80)
         handler = js[js.index("if(act==='test')"):]
         # read AT the press, before the subscription lookup's await: the session you were looking
         # at, not the one you switch to while it sends
         self.assertLess(handler.index("var at=activeSession();"), handler.index("sub().then("))
-        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host})", handler)
+        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host,label:at.label})", handler)
         # on success with a session, ONE sentence says where the tap goes — in the kernel's words
         # (d.name, the name the notification body carries) — after the outcome, before the master-off note
         line = "if(ok&&d.name)testOut.textContent+=' Tapping it brings you back to '+d.name+'.';"
@@ -691,8 +809,9 @@ class ShellPopover(unittest.TestCase):
         self.assertIn("post('/notify-turns',{on:wantT})", js)
         self.assertIn("if(act==='test')", js)
         # the test is addressed to the session in front (2026-09-06): the endpoint AND the active
-        # tab's sid/host ride the POST, so its tap comes back to that session
-        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host})", js)
+        # tab's sid/host ride the POST, so its tap comes back to that session — plus the tab's label,
+        # the fallback name when the kernel holds none for the id
+        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host,label:at.label})", js)
         # the test button acknowledges at once and self-restores; the answer lands under it
         self.assertIn("testBtn.disabled=true", js)
         self.assertIn("testBtn.textContent='Sending…'", js)

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -11,7 +11,10 @@ What these pin, by layer:
     and returns the push service's answer {ok, status, detail}; an unknown endpoint says so; a
     dead one (404/410) is pruned exactly like the fan-out prunes it; missing crypto is the same
     loud 500 the subscribe route gives. _push_post is the one HTTP path under both; _push_send_one
-    keeps its prune semantics (False on 404/410 ONLY) on top of it.
+    keeps its prune semantics (False on 404/410 ONLY) on top of it. Since 2026-09-06 the test is
+    ADDRESSED to the session the shell had in front (sid + host, the chat pane's active tab): the
+    payload carries it under kind test so the tap comes back there like a turn's, the body names
+    it, and the answer echoes sid + name for the popover's result line; no sid is the old probe.
   * the turn-finished push — _turn_notify_tick fires on a session's turn-end KEY moving (the Stop
     hook's lastStopAt, or a STOPPED states/ transition), only with the master AND the switch on
     and the session unmuted, with a silent first-sight baseline; the event travels to trusted
@@ -264,6 +267,55 @@ class PushTestRoute(_LoopbackMixin, unittest.TestCase):
         self.assertEqual(d["data"]["kind"], "test")
         self.assertFalse(d["data"].get("sid"))
         self.assertNotIn("badge", d)
+
+    def test_addressed_to_the_session_you_were_looking_at(self):
+        # the user 2026-09-06: press the button on one session, switch away, tap, come back to it.
+        # The shell sends the chat pane's active tab; the payload carries it under kind test, the
+        # body names it, and the answer echoes sid + name for the popover's result line
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")) as pp, \
+             mock.patch.object(km, "_name_of", side_effect=lambda s: "web" if s == SID_WEB else None):
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": SID_WEB, "host": ""})
+        self.assertEqual(code, 200)
+        self.assertEqual(json.loads(body), {"ok": True, "status": 201, "detail": "Created", "sid": SID_WEB, "name": "web"})
+        (sub, payload), _ = pp.call_args
+        self.assertEqual(sub["endpoint"], self.ep)
+        d = json.loads(payload.decode())
+        self.assertEqual(d["title"], "romp")
+        self.assertEqual(d["body"], "Test notification — tap to come back to web.")
+        self.assertEqual(d["sid"], SID_WEB)
+        self.assertEqual(d["tag"], "romp:" + SID_WEB)
+        # a turn's routing shape under kind test: the shell POSTs /reveal for the sid, no card to scroll to
+        self.assertEqual(d["data"], {"sid": SID_WEB, "host": "", "kind": "test", "cardId": "",
+                                     "url": "/?push-reveal=" + SID_WEB})
+        self.assertNotIn("badge", d, "the count rides its own push")
+
+    def test_a_federated_session_keeps_its_prefix_and_falls_back_to_the_short_id(self):
+        # a remote session's name lives at its origin kernel; ours knows only the id and says so
+        # rather than inventing one — the prefixed id and the host ride the routing block as-is
+        with mock.patch.object(km, "_vapid_keys", return_value=(None, "pub")), \
+             mock.patch.object(km, "_push_post", return_value=(201, "Created")) as pp, \
+             mock.patch.object(km, "_name_of", return_value=None):
+            code, body = self._post("/push/test", {"endpoint": self.ep, "sid": "boxa:" + SID_API, "host": "boxa"})
+        self.assertEqual(code, 200)
+        res = json.loads(body)
+        self.assertEqual((res["sid"], res["name"]), ("boxa:" + SID_API, SID_API[:8]))
+        d = json.loads(pp.call_args[0][1].decode())
+        self.assertEqual(d["body"], "Test notification — tap to come back to %s." % SID_API[:8])
+        self.assertEqual((d["data"]["sid"], d["data"]["host"], d["data"]["kind"]), ("boxa:" + SID_API, "boxa", "test"))
+
+    def test_without_a_sid_the_probe_is_what_it_was(self):
+        code, res, pp = self._test((201, "Created"))
+        self.assertEqual(res, {"ok": True, "status": 201, "detail": "Created"}, "no session, no sid or name echoed")
+        d = json.loads(pp.call_args[0][1].decode())
+        self.assertEqual(d["body"], "Test notification — this device is set up.")
+        self.assertEqual(d["data"]["url"], "/", "nowhere to land: the tap just brings romp forward")
+
+    def test_a_sid_or_host_that_is_not_a_string_is_a_400(self):
+        code, _ = self._post("/push/test", {"endpoint": self.ep, "sid": 5})
+        self.assertEqual(code, 400)
+        code, _ = self._post("/push/test", {"endpoint": self.ep, "sid": SID_WEB, "host": ["boxa"]})
+        self.assertEqual(code, 400)
 
     def test_a_refusal_comes_back_verbatim(self):
         code, res, _ = self._test((403, "Forbidden: {\"reason\":\"BadJwtToken\"}"))
@@ -603,6 +655,28 @@ class ShellPopover(unittest.TestCase):
         self.assertLess(handler.index("'The push service accepted it.'"), handler.index(line))
         self.assertLess(handler.index(line), handler.index("},function(e){testOut.classList.add('bad')"))
 
+    def test_the_test_is_addressed_to_the_session_in_front(self):
+        js = km._LANDING_PUSH_JS
+        # the shell reads the chat pane's ACTIVE TAB off the same-origin iframe's own DOM — the nodes
+        # the mobile header's #mcur chip mirrors — rather than growing a second channel for one fact
+        self.assertIn("function activeSession(){", js)
+        self.assertIn("document.getElementById('f-chat')", js)
+        self.assertIn("d.querySelector('#tabs .tab.active[data-id]')", js)
+        # a federated tab's id is host:sid, so the host is its prefix; a bare local id has none
+        self.assertIn("var i=id.indexOf(':');\nreturn {sid:id,host:i>0?id.slice(0,i):''};", js)
+        handler = js[js.index("if(act==='test')"):]
+        # read AT the press, before the subscription lookup's await: the session you were looking
+        # at, not the one you switch to while it sends
+        self.assertLess(handler.index("var at=activeSession();"), handler.index("sub().then("))
+        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host})", handler)
+        # on success with a session, ONE sentence says where the tap goes — in the kernel's words
+        # (d.name, the name the notification body carries) — after the outcome, before the master-off note
+        line = "if(ok&&d.name)testOut.textContent+=' Tapping it brings you back to '+d.name+'.';"
+        self.assertIn(line, handler)
+        self.assertEqual(js.count("Tapping it brings you back to"), 1, "one sentence, appended once")
+        self.assertLess(handler.index("'The push service accepted it.'"), handler.index(line))
+        self.assertLess(handler.index(line), handler.index("if(!isOn)testOut.textContent+="))
+
     def test_the_bell_opens_it_and_the_rows_are_the_switches(self):
         js = km._LANDING_PUSH_JS
         self.assertIn("open(bl)", js)
@@ -616,7 +690,9 @@ class ShellPopover(unittest.TestCase):
         self.assertIn("if(act==='turns')", js)
         self.assertIn("post('/notify-turns',{on:wantT})", js)
         self.assertIn("if(act==='test')", js)
-        self.assertIn("post('/push/test',{endpoint:s.endpoint})", js)
+        # the test is addressed to the session in front (2026-09-06): the endpoint AND the active
+        # tab's sid/host ride the POST, so its tap comes back to that session
+        self.assertIn("post('/push/test',{endpoint:s.endpoint,sid:at.sid,host:at.host})", js)
         # the test button acknowledges at once and self-restores; the answer lands under it
         self.assertIn("testBtn.disabled=true", js)
         self.assertIn("testBtn.textContent='Sending…'", js)

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -532,14 +532,68 @@ class ShellPopover(unittest.TestCase):
         self.assertIn("id=rbell-pop role=dialog", h)
         for act in ("data-act=all", "data-act=dev", "data-act=turns"):
             self.assertIn("class=rbp-row %s role=switch" % act, h)
-        self.assertIn(">All devices<", h)
+        # the master is labelled as the master (was "All devices", which beside "This device" read as
+        # a scope choice rather than the switch the other two sit under — the user 2026-09-05)
+        self.assertIn(">Notifications<", h)
+        self.assertNotIn(">All devices<", h)
         self.assertIn(">This device<", h)
         self.assertIn(">Also when a turn finishes<", h)
         self.assertIn("id=rbp-test data-act=test>Send a test notification<", h)
-        # the one-sentence "why" under each switch
-        self.assertIn("Arms every device, and the desktop of every machine you've attached.", h)
+        # the "why" under each switch — the master's in two sentences: what off does, what the bells are
+        self.assertIn("The main switch: off silences every device, and the desktop of every machine you've attached. "
+                      "The bells on sessions and cards are mutes under it.", h)
         self.assertIn("Buzzes every time any session finishes a turn. With many sessions running, that is a lot of buzzing.", h)
         self.assertIn("id=rbp-test-out", h)
+
+    def test_the_device_and_turn_rows_nest_under_the_master(self):
+        h = self.html
+        pop = h[h.index("<div id=rbell-pop"):h.index("<div class=rbp-div>")]
+        # the nest opens right after the master row and closes right before the divider, holding
+        # exactly the device and turns rows — a visible hierarchy, not three peers
+        self.assertIn("</div></div><div class=rbp-nest><div class=rbp-row data-act=dev", pop)
+        self.assertTrue(pop.endswith("</div></div></div>"), "the nest closes before the divider")
+        self.assertEqual(pop.count("<div class=rbp-nest>"), 1)
+        self.assertLess(pop.index("data-act=all"), pop.index("<div class=rbp-nest>"))
+        self.assertLess(pop.index("<div class=rbp-nest>"), pop.index("data-act=dev"))
+        self.assertLess(pop.index("data-act=dev"), pop.index("data-act=turns"))
+        # one indent + one hairline, the popover's own hairline token (with its dark fallback, as
+        # every token in this block carries — the token test below sweeps the same slice)
+        self.assertIn(".rbp-nest{margin-left:10px;padding-left:4px;border-left:1px solid var(--menu-border,rgba(255,255,255,0.12))}", h)
+
+    def test_master_off_dims_the_nested_rows_but_leaves_them_operable(self):
+        js, h = km._LANDING_PUSH_JS, self.html
+        # the class the JS toggles, from INSIDE paint() — the one function the boot fetch and the
+        # kernel's notifyAll push both run, so the dim follows the master's live state with no
+        # polling and no second source of truth
+        paint = js[js.index("function paint(){"):js.index("window.__rompNotifyAllPaint=")]
+        self.assertIn("pop.classList.toggle('master-off',!isOn)", paint)
+        self.assertIn("window.__rompNotifyAllPaint=function(on){isOn=!!on;paint();}", js)
+        # …and the rule it drives: the nested rows wear the wash .off and .busy already wear
+        self.assertIn("#rbell-pop.master-off .rbp-nest>.rbp-row{opacity:.55}", h)
+        self.assertIn(".rbp-row.off{opacity:.55;", h)
+        self.assertIn(".rbp-row.busy{opacity:.55}", h)
+        # dimmed is not disabled: no cursor or hover suppression on the dimmed rows, and no tap guard
+        # reads master-off — a phone can be set up before the main switch goes on
+        self.assertNotIn("master-off .rbp-nest>.rbp-row:hover", h)
+        self.assertNotIn("master-off .rbp-nest>.rbp-row{opacity:.55;cursor", h)
+        self.assertNotIn("master-off", js.replace("pop.classList.toggle('master-off',!isOn)", ""))
+        # the device sub-line says the device is set up but nothing arrives — the devOn-and-master-off
+        # branch, ahead of the plain devOn line so it wins while the master is off
+        self.assertIn('else if(devOn&&!isOn)sub="This device is set up, but nothing arrives until the main switch is on.";', js)
+        self.assertLess(js.index("else if(devOn&&!isOn)sub="), js.index('else if(devOn)sub="This browser gets a notification'))
+
+    def test_the_test_result_adds_that_the_master_is_off(self):
+        js = km._LANDING_PUSH_JS
+        # the test ignores the switches on purpose (it asks "is this phone wired up?"); with the master
+        # off, ONE sentence rides the result so a working test is not read as notifications working
+        handler = js[js.index("if(act==='test')"):]
+        line = "if(!isOn)testOut.textContent+=\" Real notifications won't arrive until the main switch is on.\";"
+        self.assertIn(line, handler)
+        self.assertEqual(js.count("Real notifications won't arrive"), 1, "one sentence, appended once")
+        # appended AFTER the result line, inside the same then-handler, so every answer the push
+        # service can give carries it
+        self.assertLess(handler.index("'The push service accepted it.'"), handler.index(line))
+        self.assertLess(handler.index(line), handler.index("},function(e){testOut.classList.add('bad')"))
 
     def test_the_bell_opens_it_and_the_rows_are_the_switches(self):
         js = km._LANDING_PUSH_JS

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -528,9 +528,11 @@ class LandingRevealPins(unittest.TestCase):
 
 
 class RailBell(unittest.TestCase):
-    """The desktop rail carries the same bell as the mobile tab bar (the user 2026-08-08), and the
-    pair is the MASTER notification switch (the user 2026-08-09): on = every task notifies unless
-    its own bell mutes it, with the device push subscription a best-effort leg on top."""
+    """The desktop rail carries the same bell as the mobile tab bar (the user 2026-08-08). Since
+    2026-09-05 the pair OPENS THE POPOVER (tests/test_kernel_notify_popover.py) whose rows are the
+    switches: the kernel-wide master (the user 2026-08-09's model: on = every task notifies unless
+    its own bell mutes it) and this device's push subscription, pulled apart so a phone turning
+    itself off no longer silences every device."""
 
     def test_shell_serves_both_bells_and_one_flow_drives_them(self):
         status, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
@@ -555,22 +557,29 @@ class RailBell(unittest.TestCase):
         self.assertIn(".bell-slash{display:none}", page)
         self.assertIn("#rail-bell:not(.on) .bell-slash,#mbell:not(.on) .bell-slash{display:block}", page)
 
-    def test_the_bell_is_the_master_switch_not_a_device_toggle(self):
+    def test_the_bell_opens_the_popover_whose_rows_are_the_switches(self):
+        # (2026-09-05: was "the bell is the master switch, not a device toggle" — the tap now opens
+        # the popover, and the All-devices row is the master while This-device is the subscription)
         _, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
         page = body.decode()
-        # kernel-authoritative paint: state comes from GET /notify-all at boot and the shell WS
-        # push on every toggle — never from this device's push subscription
+        # kernel-authoritative paint of the master: GET /notify-all at boot and the shell WS push
+        # on every toggle, so every dashboard's row agrees
         self.assertIn("fetch('/notify-all')", page)
         self.assertIn("window.__rompNotifyAllPaint", page)
         self.assertIn("m.type==='notifyAll'", page, "the shell WS repaints every open dashboard")
         self.assertIn("post('/notify-all',{on:want})", page)
+        self.assertIn("id=rbell-pop", page)
+        self.assertIn("data-act=all", page)
+        self.assertIn("data-act=dev", page)
         # the bell shows everywhere — the master matters even where the Push API is missing (the
-        # kernel box still gets osascript, other devices still buzz); only the subscribe leg gates
+        # kernel box still gets osascript, other devices still buzz); only the device row gates
         self.assertNotIn("('Notification' in window))return", page,
                          "the old whole-bell capability bail is gone")
         self.assertIn("var canPush=", page)
         # the permission ask still runs in the tap's own stack (iOS voids the gesture across awaits)
         self.assertIn("Notification.requestPermission():null", page)
+        # the glyph is THIS device's truth now: master AND subscribed (tests/test_kernel_notify_popover.py)
+        self.assertIn("var lit=isOn&&(canPush?devOn:true)", page)
 
 
 class MasterBellRoute(unittest.TestCase):

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -162,8 +162,17 @@ global.clients = {
 """
 _SW_DRIVER = r"""
 function win(focusOk) {
-  const w = { focus: () => { LOG.push(['focus']); return focusOk ? Promise.resolve(w) : Promise.reject(new Error('refused')); },
+  const w = { frameType: 'top-level',
+              focus: () => { LOG.push(['focus']); return focusOk ? Promise.resolve(w) : Promise.reject(new Error('refused')); },
               postMessage: (m) => LOG.push(['post', m]) };
+  return w;
+}
+// a TAGGED client, for the dashboard's shape: the shell (top-level) plus its same-origin pane iframes,
+// which the browser lists as window clients too (frameType 'nested'), most-recently-focused first
+function frame(tag, frameType) {
+  const w = { frameType,
+              focus: () => { LOG.push(['focus', tag]); return Promise.resolve(w); },
+              postMessage: (m) => LOG.push(['post', tag, m]) };
   return w;
 }
 async function tap(data, windows) {
@@ -191,6 +200,12 @@ async function tap(data, windows) {
   out.testLive = await tap(testSid, [win(true)]);
   out.testCold = await tap(testSid, []);
   out.legacyTap = await tap({ sid: 'S7' }, []);            // a notification an older worker showed: flat sid, no url
+  // the phone (2026-09-06): the user last tapped INSIDE the chat pane (the mobile session picker), so the
+  // chat iframe is the most recently focused client — ahead of the shell that carries the reveal listener
+  const fed = { sid: 'boxa:S8', host: 'boxa', kind: 'test', cardId: '', url: '/?push-reveal=boxa%3AS8' };
+  out.nested = await tap(fed, [frame('chat', 'nested'), frame('feed', 'nested'), frame('shell', 'top-level')]);
+  out.nestedOnly = await tap(fed, [frame('chat', 'nested')]);   // a pane with no shell above it: nothing to post to
+  out.untyped = await tap(fed, [frame('old', undefined)]);       // a browser that reports no frameType is a window
   console.log(JSON.stringify(out));
 })();
 """
@@ -253,6 +268,19 @@ class ServiceWorkerExecutes(unittest.TestCase):
 
     def test_a_notification_from_the_previous_worker_still_lands(self):
         self.assertEqual(self.out["legacyTap"]["log"][-1], ["openWindow", "/?push-reveal=S7"])
+
+    def test_the_tap_is_posted_to_the_shell_never_into_a_pane_iframe(self):
+        # the user 2026-09-06, on the phone: the tap did nothing. matchAll lists the dashboard's
+        # same-origin pane iframes as window clients too, most-recently-focused first — and the
+        # chat pane the user had just switched sessions in was first. Only the top-level shell
+        # listens for the worker's message; posting into the pane dropped the tap on the floor.
+        msg = {"romp": "notificationClick", "sid": "boxa:S8", "host": "boxa", "kind": "test", "cardId": ""}
+        self.assertEqual(self.out["nested"]["log"],
+                         [["close"], self.MATCH, ["focus", "shell"], ["post", "shell", msg]])
+        # no top-level client at all → the deep link, exactly as with no window
+        self.assertEqual(self.out["nestedOnly"]["log"], [["close"], self.MATCH, ["openWindow", "/?push-reveal=boxa%3AS8"]])
+        # a client that reports no frameType is treated as a window, never dropped
+        self.assertEqual(self.out["untyped"]["log"][-1], ["post", "old", msg])
 
 
 @unittest.skipUnless(HAVE_CRYPTO, "python 'cryptography' not installed")
@@ -599,6 +627,55 @@ class RevealAiming(unittest.TestCase):
             km._consume_pending_reveal(c)
         self.assertEqual(got[0]["id"], "S")
 
+    def test_a_booting_page_parks_past_the_previous_pages_socket(self):
+        # the deep-link arrival (2026-09-06, the phone): the page is BOOTING, so its own chat pane
+        # cannot be connected yet — a same-wid chat socket the kernel still holds is the PREVIOUS
+        # page's (sessionStorage keeps the wid across a reload; a suspended phone never sent its
+        # close, and the ping timeout has up to WS_DEAD_S to notice). "Delivering" there parked
+        # nothing, and the new pane's ready found nothing to consume.
+        twin, twin_got = self._register("chat", "W-phone")
+        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+            self.assertFalse(km._reveal_request("S", "W-phone", boot=True))
+            self.assertEqual(twin_got, [], "a booting page's tap is never aimed at a socket that predates it")
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "S", "wid": "W-phone"})
+            fresh, fresh_got = _fake_ws_client("chat", "W-phone")
+            km._consume_pending_reveal(fresh)
+        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
+        self.assertIsNone(km._PENDING_REVEAL[0])
+
+    def test_a_live_tap_to_an_unproven_socket_keeps_a_copy_until_the_pong_or_the_redial(self):
+        # the live half of the same hole: the pane's socket has a ping on the wire nobody has
+        # answered yet (pingAt set — the peer is unproven since the last heartbeat). The focus goes
+        # out as before, AND stays parked: the pong that proves the socket alive retires the copy
+        # (the frame is ordered behind the ping it answers); a dead socket never pongs, the pane
+        # redials, and its ready consumes the copy instead of finding nothing.
+        c, got = self._register("chat", "W1")
+        c["pingAt"] = 100.0
+        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+            self.assertTrue(km._reveal_request("S", "W1"))
+        self.assertEqual(got, [{"type": "focus", "id": "S", "live": True}], "still delivered at once")
+        self.assertEqual((km._PENDING_REVEAL[0] or {}).get("sid"), "S", "…and kept until the socket proves itself")
+        # another window's pane pongs: not this tap's socket, the copy stays
+        other, _ = self._register("chat", "W2")
+        other["pingAt"] = 100.0
+        km._note_ws_inbound(other, now=101.0)
+        self.assertIsNotNone(km._PENDING_REVEAL[0])
+        # the delivered-to socket pongs → proven → the copy is retired, and a later ready replays nothing
+        km._note_ws_inbound(c, now=101.0)
+        self.assertIsNone(km._PENDING_REVEAL[0])
+        c["pingAt"] = None
+        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+            self.assertTrue(km._reveal_request("S", "W1"))
+        self.assertIsNone(km._PENDING_REVEAL[0], "a socket with no ping outstanding is proven — nothing parked")
+        # the dead case: never pongs; the pane's redial says ready and takes the copy
+        c["pingAt"] = 100.0
+        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+            km._reveal_request("S", "W1")
+            fresh, fresh_got = _fake_ws_client("chat", "W1")
+            km._consume_pending_reveal(fresh)
+        self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
+        self.assertIsNone(km._PENDING_REVEAL[0])
+
 
 class RevealRoute(unittest.TestCase):
     """POST /reveal over the real handler (the ServeSecurity pattern)."""
@@ -642,6 +719,22 @@ class RevealRoute(unittest.TestCase):
         code, _ = self._post("/reveal", {"wid": "W"})
         self.assertEqual(code, 400)
         self.assertIsNone(km._PENDING_REVEAL[0])
+
+    def test_a_boot_flagged_reveal_parks_even_past_a_connected_same_wid_pane(self):
+        # the deep-link arrival says it is booting; the kernel parks for the pane that is about to
+        # connect and never counts the previous page's socket as delivery (RevealAiming has the why)
+        twin, twin_got = _fake_ws_client("chat", "W-x")
+        with km._clients_lock:
+            km._clients.append(twin)
+        try:
+            code, body = self._post("/reveal", {"sid": "SID-x", "wid": "W-x", "boot": True})
+        finally:
+            with km._clients_lock:
+                km._clients.remove(twin)
+        self.assertEqual(code, 200)
+        self.assertFalse(json.loads(body)["delivered"])
+        self.assertEqual(twin_got, [])
+        self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-x", "wid": "W-x"})
 
 
 class Badge(unittest.TestCase):
@@ -761,7 +854,9 @@ class LandingRevealExecutes(unittest.TestCase):
 
     def test_a_cold_start_asks_the_kernel_at_once_and_strips_the_link(self):
         b = self.out["boot"]
-        self.assertEqual(b["fetches"], [["/reveal", {"sid": "S1", "wid": "W-test"}]])
+        # boot:true — this page is booting, so its own chat pane is not connected yet; the kernel
+        # parks for it rather than aiming at a same-wid socket the previous page left behind
+        self.assertEqual(b["fetches"], [["/reveal", {"sid": "S1", "wid": "W-test", "boot": True}]])
         self.assertEqual(b["replaced"], ["/?keep=1#frag"], "only OUR params go; a reload must not replay the jump")
 
     def test_the_card_waits_for_the_feeds_own_ready(self):

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -187,6 +187,9 @@ async function tap(data, windows) {
   out.cold = await tap(data, []);
   out.refused = await tap(data, [win(false)]);
   out.test = await tap({ sid: '', host: '', kind: 'test', cardId: '', url: '/' }, []);
+  const testSid = { sid: 'S5', host: '', kind: 'test', cardId: '', url: '/?push-reveal=S5' };   // a test addressed to the session in front (2026-09-06)
+  out.testLive = await tap(testSid, [win(true)]);
+  out.testCold = await tap(testSid, []);
   out.legacyTap = await tap({ sid: 'S7' }, []);            // a notification an older worker showed: flat sid, no url
   console.log(JSON.stringify(out));
 })();
@@ -238,7 +241,15 @@ class ServiceWorkerExecutes(unittest.TestCase):
         self.assertEqual(self.out["refused"]["log"], [["close"], self.MATCH, ["focus"], ["openWindow", self.URL]])
 
     def test_a_test_notification_just_opens_romp(self):
+        # …when it carries no session: the button was pressed with no session in front
         self.assertEqual(self.out["test"]["log"], [["close"], self.MATCH, ["openWindow", "/"]])
+
+    def test_a_test_addressed_to_a_session_lands_on_it_like_a_turn(self):
+        # the user 2026-09-06: the test carries the session the button was pressed on. The worker
+        # does not branch on kind — the same focus + routing block live, the same deep link cold
+        msg = {"romp": "notificationClick", "sid": "S5", "host": "", "kind": "test", "cardId": ""}
+        self.assertEqual(self.out["testLive"]["log"], [["close"], self.MATCH, ["focus"], ["post", msg]])
+        self.assertEqual(self.out["testCold"]["log"], [["close"], self.MATCH, ["openWindow", "/?push-reveal=S5"]])
 
     def test_a_notification_from_the_previous_worker_still_lands(self):
         self.assertEqual(self.out["legacyTap"]["log"][-1], ["openWindow", "/?push-reveal=S7"])
@@ -684,7 +695,8 @@ class LandingRevealPins(unittest.TestCase):
 # _LANDING_REVEAL_JS against stubs of the few browser globals it touches, booting on a deep link
 # and then replaying the worker's messages. Pins the routing, not the words: /reveal is asked
 # with the shell's wid, the URL is stripped, the card waits for the FEED's ready (not the
-# timeline's), a turn kind reveals no card, a sid-less tap does nothing, a refused /reveal is loud.
+# timeline's), a turn kind reveals no card, a test addressed to a session reveals it the same way,
+# a sid-less tap does nothing, a refused /reveal is loud.
 _REVEAL_HARNESS = r"""
 'use strict';
 const FETCHES = [], POSTED = [], NOTES = [], REPLACED = [], WIN = [], SW = [];
@@ -721,6 +733,9 @@ const winMsg = (m) => WIN.forEach((f) => f({ data: m }));
   FETCHES.length = 0; POSTED.length = 0;
   swMsg({ romp: 'notificationClick', sid: '', host: '', kind: 'test', cardId: '' });
   out.test = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S5', host: '', kind: 'test', cardId: '' });   // a test addressed to the session in front (2026-09-06)
+  out.testSid = { fetches: FETCHES.slice(), posted: POSTED.slice() };
   fetchOk = false; FETCHES.length = 0;
   swMsg({ romp: 'notificationClick', sid: 'S-bad', kind: 'turn' });
   await tick(); await tick();
@@ -760,10 +775,14 @@ class LandingRevealExecutes(unittest.TestCase):
         self.assertEqual(live["fetches"], [["/reveal", {"sid": "S2", "wid": "W-test"}]])
         self.assertEqual(live["posted"], [{"romp": "revealCard", "itemId": "S2:g4", "sid": "S2"}])
 
-    def test_a_turn_focuses_without_a_card_and_a_test_lands_nowhere(self):
+    def test_a_turn_focuses_without_a_card_and_a_sidless_test_lands_nowhere(self):
         self.assertEqual(len(self.out["turn"]["fetches"]), 1)
         self.assertEqual(self.out["turn"]["posted"], [])
         self.assertEqual(self.out["test"], {"fetches": [], "posted": []})
+
+    def test_a_test_addressed_to_a_session_reveals_it_like_a_turn(self):
+        # the user 2026-09-06: ANY sid lands, whatever the kind; only a card adds the card scroll
+        self.assertEqual(self.out["testSid"], {"fetches": [["/reveal", {"sid": "S5", "wid": "W-test"}]], "posted": []})
 
     def test_a_refused_reveal_is_loud(self):
         self.assertEqual(self.out["refused"]["notes"],

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -124,16 +124,124 @@ class ServiceWorkerRoute(unittest.TestCase):
         self.assertIn("clients.claim()", js)
 
     def test_sw_click_lands_on_the_session_that_fired(self):
-        # the user 2026-08-08: the first real push opened the app on a DIFFERENT session. The sid
-        # rides the notification's data; a live window gets it over postMessage, a cold start gets
-        # it in the URL for the shell's POST /reveal.
+        # the user 2026-08-08: the first real push opened the app on a DIFFERENT session. The
+        # kernel's routing block rides the notification's data; a live window gets it over
+        # postMessage, a cold start gets the kernel's deep link (ServiceWorkerExecutes runs it).
         _, body = _serve_get("/sw.js", headers={"X-Romp-Token": km.TOKEN})
         js = body.decode()
-        self.assertIn("data:{sid:", js)
-        self.assertIn("pushReveal", js)
-        self.assertIn("/?push-reveal=", js)
+        self.assertIn("data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}", js,
+                      "the routing block verbatim; an older kernel's flat sid still lands")
+        self.assertIn("opts.tag=d.tag;opts.renotify=true", js, "one notification per session, still audible")
+        self.assertIn("romp:'notificationClick'", js)
+        self.assertIn("clients.openWindow(url)", js)
+        self.assertIn("/?push-reveal=", js)              # the fallback deep link for a data block without one
+        self.assertNotIn("setTimeout", js)                # event-based end to end — no timers in the worker
         # ...and the closed-app badge count comes from the payload
         self.assertIn("setAppBadge", js)
+
+
+# The worker, EXECUTED (the test_error_center.py pattern): node runs _SW_JS against stubs of the
+# ServiceWorker globals and the driver replays a push and four taps, logging every call in order.
+# A source pin says the words are there; this says the sequence is right: close → matchAll →
+# focus + postMessage, openWindow only when no window exists or focus() refused, all under waitUntil.
+_SW_HARNESS = r"""
+'use strict';
+const H = {};            // event name -> the worker's handler
+const LOG = [];          // every call the worker makes, in order
+global.self = {
+  addEventListener: (k, f) => { H[k] = f; },
+  skipWaiting: () => {},
+  registration: { showNotification: (title, opts) => { LOG.push(['show', title, opts]); return Promise.resolve(); } },
+  navigator: {},         // no setAppBadge here: the numeric-only badge rule has its own pin
+};
+global.clients = {
+  claim: () => Promise.resolve(),
+  matchAll: (q) => { LOG.push(['matchAll', q]); return Promise.resolve([]); },
+  openWindow: (u) => { LOG.push(['openWindow', u]); return Promise.resolve({}); },
+};
+"""
+_SW_DRIVER = r"""
+function win(focusOk) {
+  const w = { focus: () => { LOG.push(['focus']); return focusOk ? Promise.resolve(w) : Promise.reject(new Error('refused')); },
+              postMessage: (m) => LOG.push(['post', m]) };
+  return w;
+}
+async function tap(data, windows) {
+  LOG.length = 0;
+  const waited = [];
+  global.clients.matchAll = (q) => { LOG.push(['matchAll', q]); return Promise.resolve(windows); };
+  H.notificationclick({ notification: { close: () => LOG.push(['close']), data }, waitUntil: (p) => waited.push(p) });
+  for (const p of waited) await p;
+  return { log: LOG.slice(), waited: waited.length };
+}
+(async () => {
+  const out = {};
+  const data = { sid: 'S1', host: '', kind: 'card', cardId: 'S1:g1', url: '/?push-reveal=S1&push-card=S1%3Ag1' };
+  H.push({ data: { json: () => ({ title: 'romp: web', body: 'Needs you: x', sid: 'S1', tag: 'romp:S1', badge: 2, data }) },
+           waitUntil: () => { out.pushWaited = true; } });
+  out.push = LOG.slice();
+  LOG.length = 0;
+  H.push({ data: { json: () => ({ title: 't', body: 'b', sid: 'S9' }) }, waitUntil: () => {} });   // an older kernel's flat payload
+  out.pushLegacy = LOG.slice();
+  out.live = await tap(data, [win(true)]);
+  out.cold = await tap(data, []);
+  out.refused = await tap(data, [win(false)]);
+  out.test = await tap({ sid: '', host: '', kind: 'test', cardId: '', url: '/' }, []);
+  out.legacyTap = await tap({ sid: 'S7' }, []);            // a notification an older worker showed: flat sid, no url
+  console.log(JSON.stringify(out));
+})();
+"""
+
+
+class ServiceWorkerExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import subprocess, tempfile as _tf
+        with _tf.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(_SW_HARNESS + km._SW_JS + _SW_DRIVER)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the worker threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    MATCH = ["matchAll", {"type": "window", "includeUncontrolled": True}]
+    MSG = {"romp": "notificationClick", "sid": "S1", "host": "", "kind": "card", "cardId": "S1:g1"}
+    URL = "/?push-reveal=S1&push-card=S1%3Ag1"
+
+    def test_push_shows_the_gist_and_keeps_the_routing_block_verbatim(self):
+        show = self.out["push"][0]
+        self.assertEqual(show[:2], ["show", "romp: web"])
+        opts = show[2]
+        self.assertEqual(opts["body"], "Needs you: x")
+        self.assertEqual(opts["data"], {"sid": "S1", "host": "", "kind": "card", "cardId": "S1:g1", "url": self.URL})
+        self.assertEqual((opts["tag"], opts["renotify"]), ("romp:S1", True), "same session → replaces, still buzzes")
+        self.assertTrue(self.out["pushWaited"])
+        # an older kernel's flat payload still lands on its sid, and wears no tag it did not send
+        legacy = self.out["pushLegacy"][0][2]
+        self.assertEqual(legacy["data"], {"sid": "S9"})
+        self.assertNotIn("tag", legacy)
+
+    def test_a_live_window_is_focused_and_told_never_reopened(self):
+        live = self.out["live"]
+        self.assertEqual(live["waited"], 1, "the whole tap rides one waitUntil")
+        self.assertEqual(live["log"], [["close"], self.MATCH, ["focus"], ["post", self.MSG]])
+
+    def test_no_window_opens_the_deep_link(self):
+        self.assertEqual(self.out["cold"]["log"], [["close"], self.MATCH, ["openWindow", self.URL]])
+        self.assertEqual(self.out["cold"]["waited"], 1)
+
+    def test_a_refused_focus_falls_through_to_open_window(self):
+        # the installed-app case: focus() rejects — the tap must still land somewhere
+        self.assertEqual(self.out["refused"]["log"], [["close"], self.MATCH, ["focus"], ["openWindow", self.URL]])
+
+    def test_a_test_notification_just_opens_romp(self):
+        self.assertEqual(self.out["test"]["log"], [["close"], self.MATCH, ["openWindow", "/"]])
+
+    def test_a_notification_from_the_previous_worker_still_lands(self):
+        self.assertEqual(self.out["legacyTap"]["log"][-1], ["openWindow", "/?push-reveal=S7"])
 
 
 @unittest.skipUnless(HAVE_CRYPTO, "python 'cryptography' not installed")
@@ -313,7 +421,7 @@ class PushSink(unittest.TestCase):
         import inspect
         src = inspect.getsource(km._cached_feed)
         self.assertIn("_system_notify(_t, _b)", src)
-        self.assertIn("_push_notify(_t, _b, _sid, _badge)", src)
+        self.assertIn('_push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)', src)
         self.assertIn("_badge_push(_badge)", src)
 
     def test_no_subscriptions_means_no_work(self):
@@ -351,11 +459,49 @@ class PushSink(unittest.TestCase):
         self.assertEqual(set(km._push_subs()), {"https://push.example.net/send/live"},
                          "404/410 prunes; success stays")
         body = json.loads(list(seen.values())[0].decode())
-        # the plan's privacy note, pinned: the payload is the card's gist (title + body) plus two
-        # pieces of ROUTING metadata — the sid the tap should land on and the badge count — and
-        # nothing more (no brief, no transcript), even though the content is E2E-encrypted
-        self.assertEqual(set(body), {"title", "body", "sid", "badge"})
+        # the plan's privacy note, pinned: the payload is the card's gist (title + body) plus
+        # ROUTING metadata — where the tap lands (sid, the data block), how it stacks (tag) and the
+        # badge count — and nothing more (no brief, no transcript), even though the content is
+        # E2E-encrypted. Every routing value is an id or a fixed word, never text.
+        self.assertEqual(set(body), {"title", "body", "sid", "badge", "tag", "data"})
         self.assertEqual((body["title"], body["sid"], body["badge"]), ("romp: web", "SID-web", 3))
+        self.assertEqual(set(body["data"]), {"sid", "host", "kind", "cardId", "url"})
+
+
+class PushPayloadShape(unittest.TestCase):
+    """_push_payload: the ONE builder every push kind goes through (the user 2026-09-06, who wants
+    a tap to focus the romp already open and land on the session — and card — that buzzed)."""
+
+    def test_a_card_push_carries_the_card_and_a_deep_link_the_shell_parses(self):
+        d = km._push_payload("romp: web", "Needs you: pick one", "SID-web", 2, kind="card",
+                             card_id="SID-web:g3")
+        self.assertEqual(d["data"], {"sid": "SID-web", "host": "", "kind": "card", "cardId": "SID-web:g3",
+                                     "url": "/?push-reveal=SID-web&push-card=SID-web%3Ag3"})
+        self.assertEqual(d["tag"], "romp:SID-web", "one notification per session")
+        self.assertEqual(d["sid"], "SID-web", "…and flat, for a worker of the previous build")
+        self.assertEqual(d["badge"], 2)
+
+    def test_a_turn_push_names_its_kind_and_carries_no_card(self):
+        d = km._push_payload("web", "finished a turn", "SID-web", kind="turn")
+        self.assertEqual((d["data"]["kind"], d["data"]["cardId"], d["data"]["url"]),
+                         ("turn", "", "/?push-reveal=SID-web"))
+        self.assertNotIn("badge", d, "None omits the key — the worker leaves the count alone")
+
+    def test_a_test_push_has_no_session_and_lands_on_romp_itself(self):
+        # the popover's probe (PR #937's _push_test builds its payload here once it lands): kind
+        # "test", no sid, so the tap can only ever focus or open romp — and every test collapses
+        # into one notification rather than stacking on the lock screen
+        d = km._push_payload("romp", "Test notification", kind="test")
+        self.assertEqual(d["data"], {"sid": "", "host": "", "kind": "test", "cardId": "", "url": "/"})
+        self.assertEqual(d["tag"], "romp:test")
+
+    def test_a_relayed_push_keeps_the_origin_in_sid_and_host(self):
+        # a federated event's sid already wears its host prefix (the merged dashboard's own tab
+        # address); host is the courtesy copy, from the relay's origin or read off the prefix
+        d = km._push_payload("romp: boxa:web", "b", "boxa:11111111-2222", host="boxa", card_id="11111111-2222:g1")
+        self.assertEqual((d["data"]["sid"], d["data"]["host"]), ("boxa:11111111-2222", "boxa"))
+        self.assertEqual(d["data"]["url"], "/?push-reveal=boxa%3A11111111-2222&push-card=11111111-2222%3Ag1")
+        self.assertEqual(km._push_payload("t", "b", "boxb:S")["data"]["host"], "boxb")
 
     def test_missing_crypto_with_subscriptions_says_so(self):
         km._save_push_subs({"https://push.example.net/send/x": {
@@ -515,16 +661,114 @@ class Badge(unittest.TestCase):
 class LandingRevealPins(unittest.TestCase):
     def test_shell_carries_both_halves_of_the_tap(self):
         html = km._landing()
-        self.assertIn("pushReveal", html)          # live window: SW message → focus into the chat iframe
-        self.assertIn("push-reveal", html)         # cold start: URL param → POST /reveal {sid, wid}
-        self.assertIn("'/reveal'", html)
-        self.assertIn("romp:wid", html)            # aimed by the shell's own per-window id
+        self.assertIn("m.romp==='notificationClick'", html)   # live window: the SW's message
+        self.assertIn("searchParams.get('push-reveal')", html)  # cold start: the deep link's params…
+        self.assertIn("searchParams.get('push-card')", html)
+        self.assertIn("searchParams['delete']('push-reveal')", html)   # …stripped once read
+        self.assertIn("history.replaceState", html)
+        self.assertIn("fetch('/reveal'", html)     # ONE activation path: the kernel aims the focus…
+        self.assertIn("romp:wid", html)            # …at the shell's own per-window id
+        self.assertIn("romp:'revealCard'", html)   # a card kind also scrolls the feed to the card…
+        self.assertIn("m.romp==='ready'&&m.app==='feed'", html)   # …once the feed has its cards
+        self.assertNotIn("type:'focus',id:sid", html, "no focus posted straight into the chat iframe any more")
+        self.assertNotIn("setTimeout", km._LANDING_REVEAL_JS, "event-based: the feed's ready, never a timer")
 
     def test_shell_ws_trues_up_the_badge(self):
         html = km._landing()
         self.assertIn("{type:'ready'}", html)      # connect → the kernel answers with the current count
         self.assertIn("setAppBadge", html)
         self.assertIn("clearAppBadge", html)       # zero clears, never leaves a stale number
+
+
+# The shell's reveal script, EXECUTED (the test_error_center.py pattern): node runs
+# _LANDING_REVEAL_JS against stubs of the few browser globals it touches, booting on a deep link
+# and then replaying the worker's messages. Pins the routing, not the words: /reveal is asked
+# with the shell's wid, the URL is stripped, the card waits for the FEED's ready (not the
+# timeline's), a turn kind reveals no card, a sid-less tap does nothing, a refused /reveal is loud.
+_REVEAL_HARNESS = r"""
+'use strict';
+const FETCHES = [], POSTED = [], NOTES = [], REPLACED = [], WIN = [], SW = [];
+let fetchOk = true;
+const feedWin = { postMessage: (m) => POSTED.push(m) };
+global.window = global;
+global.document = { getElementById: (id) => (id === 'f-feed' ? { contentWindow: feedWin } : null) };
+global.sessionStorage = { getItem: (k) => (k === 'romp:wid' ? 'W-test' : null) };
+global.addEventListener = (k, f) => { if (k === 'message') WIN.push(f); };
+Object.defineProperty(global, 'navigator', { configurable: true,   // a getter-only global in node 22
+  value: { serviceWorker: { addEventListener: (k, f) => { if (k === 'message') SW.push(f); } } } });
+global.history = { replaceState: (s, t, u) => REPLACED.push(u) };
+global.location = { href: 'http://localhost:7777/?push-reveal=S1&push-card=S1%3Ag1&keep=1#frag' };
+global.fetch = (path, init) => { FETCHES.push([path, JSON.parse(init.body)]);
+  return Promise.resolve(fetchOk ? { ok: true } : { ok: false, status: 400, text: () => Promise.resolve('missing sid') }); };
+global.__rompNotify = (kind, text) => NOTES.push([kind, text]);
+"""
+_REVEAL_DRIVER = r"""
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const swMsg = (m) => SW.forEach((f) => f({ data: m }));
+const winMsg = (m) => WIN.forEach((f) => f({ data: m }));
+(async () => {
+  const out = { boot: { fetches: FETCHES.slice(), replaced: REPLACED.slice(), postedBeforeReady: POSTED.length } };
+  winMsg({ romp: 'ready' });                              // the timeline's ready: not the feed's
+  out.boot.postedAfterTimelineReady = POSTED.length;
+  winMsg({ romp: 'ready', app: 'feed' });
+  out.boot.postedAfterFeedReady = POSTED.slice();
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S2', host: '', kind: 'card', cardId: 'S2:g4' });
+  out.live = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S3', host: '', kind: 'turn', cardId: '' });
+  out.turn = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: '', host: '', kind: 'test', cardId: '' });
+  out.test = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  fetchOk = false; FETCHES.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S-bad', kind: 'turn' });
+  await tick(); await tick();
+  out.refused = { notes: NOTES.slice() };
+  console.log(JSON.stringify(out));
+})();
+"""
+
+
+class LandingRevealExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import subprocess, tempfile as _tf
+        with _tf.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(_REVEAL_HARNESS + km._LANDING_REVEAL_JS + _REVEAL_DRIVER)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the reveal script threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_a_cold_start_asks_the_kernel_at_once_and_strips_the_link(self):
+        b = self.out["boot"]
+        self.assertEqual(b["fetches"], [["/reveal", {"sid": "S1", "wid": "W-test"}]])
+        self.assertEqual(b["replaced"], ["/?keep=1#frag"], "only OUR params go; a reload must not replay the jump")
+
+    def test_the_card_waits_for_the_feeds_own_ready(self):
+        b = self.out["boot"]
+        self.assertEqual(b["postedBeforeReady"], 0, "no listener yet, nothing to scroll to")
+        self.assertEqual(b["postedAfterTimelineReady"], 0, "another pane's ready is not the feed's")
+        self.assertEqual(b["postedAfterFeedReady"], [{"romp": "revealCard", "itemId": "S1:g1", "sid": "S1"}])
+
+    def test_a_live_tap_routes_the_same_way(self):
+        live = self.out["live"]
+        self.assertEqual(live["fetches"], [["/reveal", {"sid": "S2", "wid": "W-test"}]])
+        self.assertEqual(live["posted"], [{"romp": "revealCard", "itemId": "S2:g4", "sid": "S2"}])
+
+    def test_a_turn_focuses_without_a_card_and_a_test_lands_nowhere(self):
+        self.assertEqual(len(self.out["turn"]["fetches"]), 1)
+        self.assertEqual(self.out["turn"]["posted"], [])
+        self.assertEqual(self.out["test"], {"fetches": [], "posted": []})
+
+    def test_a_refused_reveal_is_loud(self):
+        self.assertEqual(self.out["refused"]["notes"],
+                         [["error", "Could not open the session this notification was about: missing sid"]])
+
 
 
 class RailBell(unittest.TestCase):

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -531,8 +531,10 @@ class RailBell(unittest.TestCase):
     """The desktop rail carries the same bell as the mobile tab bar (the user 2026-08-08). Since
     2026-09-05 the pair OPENS THE POPOVER (tests/test_kernel_notify_popover.py) whose rows are the
     switches: the kernel-wide master (the user 2026-08-09's model: on = every task notifies unless
-    its own bell mutes it) and this device's push subscription, pulled apart so a phone turning
-    itself off no longer silences every device."""
+    its own bell mutes it), labelled "Notifications", and nested under it this device's push
+    subscription — pulled apart so a phone turning itself off no longer silences every device, and
+    nested so the master reads as the master, not as a scope beside "This device" (the user
+    2026-09-05)."""
 
     def test_shell_serves_both_bells_and_one_flow_drives_them(self):
         status, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
@@ -559,7 +561,9 @@ class RailBell(unittest.TestCase):
 
     def test_the_bell_opens_the_popover_whose_rows_are_the_switches(self):
         # (2026-09-05: was "the bell is the master switch, not a device toggle" — the tap now opens
-        # the popover, and the All-devices row is the master while This-device is the subscription)
+        # the popover; the Notifications row is the master and This-device, nested under it, is the
+        # subscription. The pin moved from "All devices" the same day: that label read as a scope
+        # choice, not the switch the rest sit under)
         _, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
         page = body.decode()
         # kernel-authoritative paint of the master: GET /notify-all at boot and the shell WS push

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -263,11 +263,15 @@ class FederatedReveal(unittest.TestCase):
 class ForwardWiring(unittest.TestCase):
     def test_the_forward_rides_the_same_fired_events(self):
         # the one choke point: the forward consumes the SAME _feed_notifications result the bells
-        # and local pushes consumed — never a second diff that could disagree
+        # and local pushes consumed — never a second diff that could disagree. Since 2026-09-05
+        # (the one-buzz-per-turn-end rule, tests/test_kernel_notify_popover.py) the forward carries
+        # the events that BUZZED here — `_buzzed`, the fired list minus the ones that yielded to a
+        # turn-finished push — so a peer's phone hears each turn end once, exactly like ours.
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("_fired = _feed_notifications(feed)", src)
-        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])',
-                      src)
+        self.assertIn('_buzzed.append({"title": _t, "body": _b, "sid": _sid})', src)
+        self.assertIn("_push_forward(_buzzed)", src)
+        self.assertNotIn("_push_forward([{", src, "no second list is built from a second diff")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -170,7 +170,7 @@ class RelayRoute(unittest.TestCase):
         # the origin rides the sid AND the title, the way every federated surface wears it —
         # and badge is OMITTED (positional call, default None): the origin's count is not ours
         pn.assert_called_once_with("romp: boxa:web", "Needs you: fix the login flow",
-                                   "boxa:11111111-2222")
+                                   "boxa:11111111-2222", kind="card", card_id="", host="boxa")
         self.assertEqual(err, "")
 
     def test_title_and_sid_surgery_is_tolerant(self):
@@ -180,7 +180,23 @@ class RelayRoute(unittest.TestCase):
         status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": evs})
         self.assertEqual(status, 200)
         self.assertEqual(parsed["mirrored"], 1)
-        pn.assert_called_once_with("Custom shape", "b", "already:prefixed")
+        pn.assert_called_once_with("Custom shape", "b", "already:prefixed", kind="card", card_id="", host="boxa")
+
+    def test_kind_and_card_pass_through_with_the_origin_as_host(self):
+        # the card id is a goal id — globally unique, never host-prefixed (federation.ts) — so the
+        # merged feed finds it as-is; the sid wears the prefix and host names the origin outright
+        _seed_remote("boxa", "trusted")
+        ev = {"title": "romp: web", "body": "Needs you: x", "sid": "11111111-2222",
+              "kind": "card", "cardId": "11111111-2222:g1"}
+        status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": [ev]})
+        self.assertEqual(parsed["mirrored"], 1)
+        pn.assert_called_once_with("romp: boxa:web", "Needs you: x", "boxa:11111111-2222",
+                                   kind="card", card_id="11111111-2222:g1", host="boxa")
+        # …and the payload that reaches the phone carries both, the deep link included
+        d = km._push_payload("romp: boxa:web", "Needs you: x", "boxa:11111111-2222",
+                             kind="card", card_id="11111111-2222:g1", host="boxa")["data"]
+        self.assertEqual((d["sid"], d["host"], d["cardId"]), ("boxa:11111111-2222", "boxa", "11111111-2222:g1"))
+        self.assertEqual(d["url"], "/?push-reveal=boxa%3A11111111-2222&push-card=11111111-2222%3Ag1")
 
     def test_a_remembered_trusted_host_counts(self):
         # trust is judged by origin, attached or not — the remembered table is the origin store
@@ -188,7 +204,7 @@ class RelayRoute(unittest.TestCase):
         status, parsed, pn, _, _ = self._relay(
             {"origin": "boxb", "events": [{"title": "romp: api", "body": "Completed: done", "sid": "S2"}]})
         self.assertEqual(parsed, {"ok": True, "mirrored": 1})
-        pn.assert_called_once_with("romp: boxb:api", "Completed: done", "boxb:S2")
+        pn.assert_called_once_with("romp: boxb:api", "Completed: done", "boxb:S2", kind="card", card_id="", host="boxb")
 
     def test_below_trusted_drops_loudly_and_never_buzzes(self):
         _seed_remote("boxa", "directed")
@@ -266,7 +282,7 @@ class ForwardWiring(unittest.TestCase):
         # and local pushes consumed — never a second diff that could disagree
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("_fired = _feed_notifications(feed)", src)
-        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])',
+        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid, "kind": "card", "cardId": _iid}',
                       src)
 
 

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -307,7 +307,10 @@ class NotifyWiring(unittest.TestCase):
         self.assertIn("_fired = _feed_notifications(feed)", self.src)
         self.assertIn("for _t, _b, _sid in _fired:", self.src)
         self.assertIn("_system_notify(_t, _b)", self.src)
-        self.assertIn("_push_forward([{", self.src)   # trusted peers hear the same transition
+        # trusted peers hear the same transition — since 2026-09-05 the events that BUZZED here
+        # (`_buzzed`: the fired list minus those that yielded to a turn-finished push for the same
+        # turn end, tests/test_kernel_notify_popover.py), never a list built from a second diff
+        self.assertIn("_push_forward(_buzzed)", self.src)
 
 
 if __name__ == "__main__":

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -120,7 +120,7 @@ class NotifyCardStore(unittest.TestCase):
 
 
 class FeedNotifications(unittest.TestCase):
-    """The diff detector: [(title, body)] per armed card newly in needs_input/completed."""
+    """The diff detector: [(title, body, sid, itemId)] per armed card newly in needs_input/completed."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -223,6 +223,7 @@ class FeedNotifications(unittest.TestCase):
                                            _card("OTHERSID:g1", "OTHERSID", "needs_input")))
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0][2], "OTHERSID", "only the unmuted session's card notifies")
+        self.assertEqual(out[0][3], "OTHERSID:g1", "the card's own id rides along for the tap to land on")
 
     def test_a_card_arm_overrides_its_sessions_mute(self):
         # most-specific-wins: card > session > master
@@ -305,7 +306,7 @@ class NotifyWiring(unittest.TestCase):
         # (the sid joined the tuple 2026-08-08 so the push sink can aim its tap-to-open; the list
         # got a name the same day so the federated forward rides the SAME events, never a re-diff)
         self.assertIn("_fired = _feed_notifications(feed)", self.src)
-        self.assertIn("for _t, _b, _sid in _fired:", self.src)
+        self.assertIn("for _t, _b, _sid, _iid in _fired:", self.src)   # itemId: the tap scrolls the feed to the card
         self.assertIn("_system_notify(_t, _b)", self.src)
         self.assertIn("_push_forward([{", self.src)   # trusted peers hear the same transition
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -253,6 +253,7 @@ const pendingMoveKind = new Map<string, MoveKind>();
 // trail instead of unreproducible archaeology. Ids only, no card text.
 const shownCol = new Map<string, string>();            // itemId → column as last RENDERED (post-prediction)
 let lastFeedEvent = "init";                            // the input change the next render reflects
+let feedAnnounced = false;                             // {romp:'ready'} posted to the shell once, on the first payload's render
 let lastPayloadBuildId = 0;
 function auditShownColumns(list: AskItem[]) {
   const seen = new Set<string>();
@@ -5108,6 +5109,13 @@ function applyFeedPayload(m: any): void {
   if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
   if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;
   render();
+  if (!feedAnnounced) {
+    feedAnnounced = true;
+    // First content is on screen → tell the shell, the way the timeline does: the boot splash's cue, and the
+    // exact event a notification tap's card reveal waits for — the shell holds its {romp:'revealCard'} until
+    // the feed has cards to scroll to (kernel.py _LANDING_REVEAL_JS). Standalone page: no parent, nothing to say.
+    try { if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "ready", app: "feed" }, "*"); } catch { /* no shell */ }
+  }
 }
 
 
@@ -5117,9 +5125,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.romp === "paneFocus") { kbEnterCards(); return; }   // the shell handed us keyboard focus → arm card nav
   if (m.romp === "revealCard") {
-    // a bell-entry click jumps back to the card it was minted from (the user 2026-07-28): scroll it
-    // into view and pulse it accent so the eye lands on the right card. A card that no longer exists
-    // under its own key (cleared, or folded into a group) falls back to opening the session.
+    // a bell-entry click (the user 2026-07-28) or a notification tap (2026-09-06) jumps to the card it was
+    // minted from: scroll it into view and pulse it accent so the eye lands on the right card. A card in a
+    // FOLDED thread has no element yet — unfold first (the same rule revealCards follows: the navigation wins
+    // over the disclosure). A card that no longer exists under its own key (cleared, or folded into a group)
+    // falls back to opening the session.
+    unfoldThreadsFor(new Set(["a:" + String(m.itemId || "")]));
     const target = document.querySelector(`[data-key="a:${String(m.itemId || "")}"]`) as HTMLElement | null;
     if (target) {
       target.scrollIntoView({ block: "center", behavior: "smooth" });
@@ -5364,20 +5375,23 @@ function applyExtHover() {
 // exactly the cards a hover would have outlined. The class is removed and re-added across a forced
 // reflow, or a second click on the same card would re-add a class it already has and CSS would replay
 // nothing — the "clicked again and it didn't flash" bug this shape avoids.
-function revealCards(keys: Set<string>) {
-  // A target inside a FOLDED thread has no element to scroll to, and a jump that lands on nothing is the
-  // silent no-op a collapse must never cause (the user 2026-07-31). Unfold the owning thread(s) and render
-  // before looking: the navigation wins over the disclosure, and the thread stays open afterwards so you
-  // can see where you were taken.
-  if (collapsedThreads.size) {
-    let opened = false;
-    for (const a of asks) {
-      if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
-        collapsedThreads.delete(a.sid); opened = true;
-      }
+// A target inside a FOLDED thread has no element to scroll to, and a jump that lands on nothing is the
+// silent no-op a collapse must never cause (the user 2026-07-31). Unfold the owning thread(s) and render
+// before looking: the navigation wins over the disclosure, and the thread stays open afterwards so you
+// can see where you were taken. Shared by every "take me to this card" entry (revealCards, revealCard).
+function unfoldThreadsFor(keys: Set<string>): void {
+  if (!collapsedThreads.size) return;
+  let opened = false;
+  for (const a of asks) {
+    if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
+      collapsedThreads.delete(a.sid); opened = true;
     }
-    if (opened) render();
   }
+  if (opened) render();
+}
+
+function revealCards(keys: Set<string>) {
+  unfoldThreadsFor(keys);
   const hits = Array.from(document.querySelectorAll<HTMLElement>("[data-key]"))
     .filter((c) => extHoverMatches(c.dataset.key, keys));
   if (!hits.length) return;

--- a/ui/webview/menu-theme-tokens.test.ts
+++ b/ui/webview/menu-theme-tokens.test.ts
@@ -114,6 +114,9 @@ const SURFACES: Array<[string, string]> = [
   ["feed.css .feed-sessmenu .fsm-row:hover", FEED.slice(FEED.indexOf("\n.feed-sessmenu .fsm-row:hover {"), FEED.indexOf("}", FEED.indexOf("\n.feed-sessmenu .fsm-row:hover {")))],
   ["styles.css .ctx-swatch.sel", CHAT.slice(CHAT.indexOf("\n.ctx-swatch.sel {"), CHAT.indexOf("}", CHAT.indexOf("\n.ctx-swatch.sel {")))],
   ["kernel.py mobile session picker (#mlist)", KERNEL.slice(KERNEL.indexOf('"#mlist{display:none;'), KERNEL.indexOf('".mrow.ph'))],
+  // the shell's bell popover (2026-09-05): rows + switch pills + the test button, up to the status-red
+  // refusal line (a STATUS colour, outside the menu vocabulary by the CLAUDE.md accent/status split)
+  ["kernel.py bell popover (#rbell-pop)", KERNEL.slice(KERNEL.indexOf('"#rbell-back{'), KERNEL.indexOf('"#rbp-test-out.bad{'))],
   ["tag-menu.ts openTagMenu", slice(MENU, "export function openTagMenu", "export function tagMenuButton")],
   ["timeline menuStyleFor/menuCheckStyleFor", slice(TIMELINE, "const menuStyleFor", "let MENU_STYLE")],
 ];
@@ -207,3 +210,34 @@ test("the sheets' reference menu rules wear the tokens too — one card, one hov
   assert.match(mob, /border:1px solid var\(--hairline,#3a3a3a\)/, "#mlist hairline (dark #3a3a3a byte-identical)");
   assert.match(KERNEL, /body\.theme-light #mlist\{/, "the light block re-skins the mobile picker");
 });
+
+test("the shell DEFINES the menu tokens (it loads no sheet) and the bell popover reads them with the dark fallbacks", () => {
+  // the shell's two theme blocks resolve the tokens to the SAME values the sheets' blocks do —
+  // dark byte-for-byte the CLAUDE.md literals, light the cream card — so the popover is one more
+  // wearer of the one vocabulary, not a third skin (2026-09-05)
+  const dark = KERNEL.slice(KERNEL.indexOf('":root{--menu-bg:'), KERNEL.indexOf('}"', KERNEL.indexOf('":root{--menu-bg:')));
+  for (const [tok, val] of Object.entries(DARK)) {
+    if (tok === "--menu-ring" || tok === "--check-ring") continue;          // the popover draws no swatch grid
+    assert.ok(norm(dark).includes(norm(`${tok}:${innermostOf(val)}`)), `shell :root ${tok} = ${innermostOf(val)}`);
+  }
+  const light = KERNEL.slice(KERNEL.indexOf('"body.theme-light{--menu-bg:'), KERNEL.indexOf('}"', KERNEL.indexOf('"body.theme-light{--menu-bg:')));
+  for (const [tok, val] of Object.entries(LIGHT)) {
+    if (tok === "--menu-ring" || tok === "--check-ring") continue;
+    assert.ok(norm(light).includes(norm(`${tok}:${val}`)), `shell body.theme-light ${tok} = ${val}`);
+  }
+  const pop = KERNEL.slice(KERNEL.indexOf('"#rbell-pop{'), KERNEL.indexOf('"#rbp-test-out.bad{'));
+  assert.match(pop, /background:var\(--menu-bg,#252526\)/, "popover card");
+  assert.match(pop, /color:var\(--menu-fg,#cccccc\)/, "popover text");
+  assert.match(pop, /border:1px solid var\(--menu-border,rgba\(255,255,255,0\.12\)\)/, "popover hairline");
+  assert.match(pop, /border-radius:var\(--radius-menu,6px\)/, "popover radius");
+  assert.match(pop, /box-shadow:var\(--shadow-menu,0 4px 12px rgba\(0,0,0,0\.35\)\)/, "popover shadow");
+  assert.match(pop, /background:var\(--menu-hover,rgba\(255,255,255,0\.09\)\)/, "row hover");
+  // fallback parity, the same check the inline menus get: every fallback IS the dark token value
+  const GEOMETRY: Record<string, string> = { "--radius-menu": "6px", "--shadow-menu": "0 4px 12px rgba(0, 0, 0, 0.35)" };
+  for (const m of pop.matchAll(/var\((--menu-[\w-]+|--check-bg|--radius-menu|--shadow-menu),\s*((?:[^()]|\([^()]*\))*)\)/g)) {
+    const tok: string = m[1], fb = m[2];
+    const want = GEOMETRY[tok] ?? innermostOf(DARK[tok as keyof typeof DARK]);
+    assert.equal(norm(fb), norm(want), `${tok} fallback ${fb} must equal the dark token value ${want}`);
+  }
+});
+function innermostOf(v: string): string { const m = v.startsWith("var(") ? v.match(/,\s*(.+)\)\s*$/) : null; return m ? m[1] : v; }

--- a/ui/webview/notify-click-reveal.test.ts
+++ b/ui/webview/notify-click-reveal.test.ts
@@ -35,3 +35,26 @@ test("revealCard unfolds a collapsed thread before looking for the card (no sile
   // and the existing fallback stands: a card gone from the feed still opens its session
   assert.match(SRC, /\} else if \(m\.sid\) \{\n      vscodeApi\?\.postMessage\(\{ type: "openSession", id: String\(m\.sid\) \}\);/);
 });
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("a reveal outranks the persisted-tab restore: the focus handler retires wantActive", () => {
+  // the federated cold start (the user 2026-09-06, on the phone): the kernel parks the tap's focus
+  // and delivers it on the chat pane's ready — BEFORE any remote host has relayed its sessions. The
+  // focus sets the active tab; then the persisted tab (a remote one, arriving later over its own
+  // socket) matched wantActive and setActive'd itself over the reveal. An explicit reveal is newer
+  // information than a restore of where the page last was.
+  const focusBlock = (RENDER.match(/else if \(m\.type === "focus"\) \{[\s\S]*?\n  \}/) || [""])[0];
+  assert.ok(focusBlock.length > 100, "found the focus handler");
+  assert.match(focusBlock, /\n    wantActive = null;/);
+  // …and the restore itself is still the one-shot it was: consumed on arrival, or retired here
+  assert.match(RENDER, /if \(wantActive && msg\.id === wantActive\) \{ wantActive = null; setActive\(msg\.id\); \}/);
+});
+
+test("a focus on a federated session its host has not relayed yet shows the loader, not 'No session open'", () => {
+  // the tab exists nowhere on the client until the owning host's relay lands; the id's host prefix
+  // says one is coming, so the wait wears the romp loader (CLAUDE.md: loading states) instead of the
+  // empty-dashboard copy, which read as the tap having done nothing
+  assert.match(RENDER, /if \(activeId && \(tabMeta\.has\(activeId\) \|\| hostOf\(activeId\)\)\) \{/);
+  assert.match(RENDER, /: \(hostOf\(activeId\) \? "a session on " \+ hostOf\(activeId\) : "“session”"\);/);
+});

--- a/ui/webview/notify-click-reveal.test.ts
+++ b/ui/webview/notify-click-reveal.test.ts
@@ -1,0 +1,37 @@
+// A notification tap lands on the session AND the card that buzzed (the user 2026-09-06). The feed's
+// half of that, pinned from both sides of the iframe boundary: the feed announces its first content
+// so the shell knows when a {romp:'revealCard'} has something to land on, and the reveal itself never
+// dead-ends on a folded thread. Source pins against feed.ts + kernel.py (the render path has no jsdom
+// harness), like card-notify's; the shell script itself is EXECUTED by tests/test_kernel_webpush.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the feed announces its FIRST payload's render to the shell, once, the way the timeline does", () => {
+  assert.match(SRC, /let feedAnnounced = false;/);
+  // after render() inside applyFeedPayload — the cards are in the DOM when this leaves the frame
+  assert.match(SRC, /render\(\);\n  if \(!feedAnnounced\) \{\n    feedAnnounced = true;/);
+  assert.match(SRC, /window\.parent\.postMessage\(\{ romp: "ready", app: "feed" \}, "\*"\)/);
+  assert.equal(SRC.match(/romp: "ready", app: "feed"/g)?.length, 1, "one announcement, one place");
+});
+
+test("the shell's reveal script waits for exactly that message, never another pane's ready", () => {
+  // the two sides of the contract share the words: app:'feed' is what the shell keys on
+  assert.match(KERNEL, /m\.romp==='ready'&&m\.app==='feed'/);
+  assert.match(KERNEL, /pendingCard=\{itemId:itemId,sid:sid\};return;/, "a tap before the feed is up is held, not dropped");
+  assert.doesNotMatch(KERNEL.slice(KERNEL.indexOf("_LANDING_REVEAL_JS = "), KERNEL.indexOf("_LANDING_REVEAL_JS = ") + 2600),
+    /setTimeout/, "event-based: the feed's own ready, no timer");
+});
+
+test("revealCard unfolds a collapsed thread before looking for the card (no silent miss on a fold)", () => {
+  assert.match(SRC, /function unfoldThreadsFor\(keys: Set<string>\): void \{/);
+  // both "take me to this card" entries share it: the bell-entry/notification jump and the chat-dot jump
+  assert.match(SRC, /unfoldThreadsFor\(new Set\(\["a:" \+ String\(m\.itemId \|\| ""\)\]\)\);\n    const target = document\.querySelector/);
+  assert.match(SRC, /function revealCards\(keys: Set<string>\) \{\n  unfoldThreadsFor\(keys\);/);
+  // and the existing fallback stands: a card gone from the feed still opens its session
+  assert.match(SRC, /\} else if \(m\.sid\) \{\n      vscodeApi\?\.postMessage\(\{ type: "openSession", id: String\(m\.sid\) \}\);/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8931,11 +8931,16 @@ function showActive() {
     // A KNOWN-LOADING tab (its meta arrived, its payload hasn't — the clicked placeholder): the
     // thread area holds the pane-local romp loader, and the first session frame renders in place —
     // you're already there (the user 2026-08-25). Everything else keeps the no-sessions copy.
+    // A FEDERATED id nothing here knows yet counts as loading too (2026-09-06): a push tap's focus
+    // lands on this pane's ready, before the owning host has relayed its tab list, and the id's
+    // host prefix says one is coming — the no-sessions copy read as the tap having done nothing.
     document.getElementById("tab-loading")?.remove();
-    if (activeId && tabMeta.has(activeId)) {
+    if (activeId && (tabMeta.has(activeId) || hostOf(activeId))) {
       const wait = el("div", "tab-loading-wait");
       wait.id = "tab-loading";
-      wait.appendChild(rompLoaderInner("opening “" + (tabMeta.get(activeId)?.name || "session") + "”…"));
+      const meta = tabMeta.get(activeId);
+      const what = meta?.name ? "“" + meta.name + "”" : (hostOf(activeId) ? "a session on " + hostOf(activeId) : "“session”");
+      wait.appendChild(rompLoaderInner("opening " + what + "…"));
       content.appendChild(wait);
       if (empty) empty.style.display = "none";
     } else if (!empty) {
@@ -12468,6 +12473,11 @@ window.addEventListener("message", (e: MessageEvent) => {
     revealSelfPane();   // every focus is someone jumping HERE — on mobile, come forward (incl. from a remote kernel)
     closingTabs.delete(m.id);   // an explicit reveal outranks a pending close-suppression: closing a tab and
     //                             reopening it from the picker inside the ack window must show it at once
+    // …and outranks the persisted-tab restore (the user 2026-09-06, on the phone): a push tap's focus is
+    // delivered on this pane's ready, BEFORE any remote host has relayed its sessions — so when the tab
+    // this page last showed was a remote one, its later arrival matched wantActive and setActive'd
+    // itself straight over the reveal. A reveal is newer information than where the page last was.
+    wantActive = null;
     if (revivePending && m.id === revivePending) clearReviveLoader();   // the revive landed — the loader's success event
     assertPeekFor(m.id);   // an out-of-view focus peeks even on the already-active fast path below (setActive is skipped there)
     // `live` (the user 2026-07-08): land on the LIVE TAIL. A blocked card's picker/permission prompt IS the

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -39,8 +39,10 @@ test("makePlaceholderTab draws name + identity color, and is CLICKABLE while loa
   assert.match(fn, /tab\.addEventListener\("keydown", onTabKey\);/);
   assert.ok(!/close|draggable/.test(fn), "no close ✕, no drag — the only new power is selection");
   // …and the ACTIVE loading tab's thread area holds the pane-local romp loader until frames land in place
-  assert.match(RENDER, /if \(activeId && tabMeta\.has\(activeId\)\) \{/);
-  assert.match(RENDER, /wait\.appendChild\(rompLoaderInner\("opening “" \+ \(tabMeta\.get\(activeId\)\?\.name \|\| "session"\) \+ "”…"\)\);/);
+  // (a federated id no host has relayed yet counts as loading too — notify-click-reveal.test.ts)
+  assert.match(RENDER, /if \(activeId && \(tabMeta\.has\(activeId\) \|\| hostOf\(activeId\)\)\) \{/);
+  assert.match(RENDER, /const what = meta\?\.name \? "“" \+ meta\.name \+ "”" : /);
+  assert.match(RENDER, /wait\.appendChild\(rompLoaderInner\("opening " \+ what \+ "…"\)\);/);
   assert.match(RENDER, /document\.getElementById\("tab-loading"\)\?\.remove\(\);   \/\/ the payload landed — the real view takes over in place/);
 });
 


### PR DESCRIPTION
Stacked on #940 (notify-click-open): merged in so the two push PRs no longer collide; land #940 first.

## The problem

One tap on the notification bell did two jobs at once: it flipped the kernel-wide master switch and it subscribed or unsubscribed this device's Web Push. So turning the bell off on a phone silenced every device; a denied permission threw a line into the Log while leaving the master on, with no way back; nothing ever told the user whether the push service had accepted a subscription; and a turn finishing never buzzed unless the judges happened to move its card.

## What is now true

- Tapping either bell (desktop rail or mobile tab bar) opens a small anchored popover in the house menu dress. The shell now defines the menu tokens in its own `:root` / `body.theme-light` blocks (it loads no sheet), and the popover's rules read them with the dark literals as `var()` fallbacks. Escape and an outside tap close it like every other shell panel.
- Rows: **All devices** (the master, `/notify-all`), **This device** (this browser's subscription, permission still requested inside the tap's own stack; when the site is blocked the row is disabled and says how to re-enable; where the Push API is missing it says so), **Also when a turn finishes** (new, `/notify-turns`, off by default), and **Send a test notification** (acknowledges at once, self-restores, shows the push service's answer as one sentence under itself).
- The bell glyph reflects THIS device: lit only when the master is on AND this browser is subscribed; slashed otherwise. A browser without the Push API has no subscription half to reflect, so the master alone paints it there. The tooltip names which half is off.
- `"*turns"` is a second reserved key beside the master in `notify-cards.json` (same fire path, same cache, same `__ncards__` watch; prune keeps both reserved keys).

## `/push/test` contract

`POST /push/test {endpoint}` sends ONE notification (title `romp`, one plain sentence) to that subscription only and returns the push service's answer as `{ok, status, detail}`: `ok` is a 2xx; `status` is the HTTP status, or `0` when the request never got an answer (with the error in `detail`); a refusal carries the service's own reason in `detail`. An endpoint nobody subscribed answers `ok:false` with `detail` "this device isn't subscribed yet". A dead subscription (404/410) is pruned exactly as the fan-out prunes it, and `detail` says so. Missing crypto is the same loud 500 `/push/subscribe` gives. Underneath, `_push_post` is the one HTTP path returning `(status, detail)`; `_push_send_one` keeps its prune semantics (False on 404/410 only, everything else keeps the subscription) on top of it.

## The turn-complete rule

`_turn_notify_tick` runs in the pusher cycle right after the feed build. The event is the session's turn-end key moving: the Stop hook's `lastStopAt` stamp (SDK sessions), else a STOPPED `states/` transition (`waiting`/`idle`, so a turn starting never reads as an end). It fires only with the master AND the turn switch on and the session unmuted, pushing `{title: <session name>, body: first line of the reply clipped to 120 chars, sid}` through `_push_notify` and forwarding to trusted peers the bell-event way. The first sighting of a session is a silent baseline, and the memo advances while the switch is off, so turning it on later never replays old ends.

## The no-double-buzz rule

One phone buzz per session per turn end. The bell event (a card entering needs_input/completed) and the turn-finished push both claim `(sid, turn-end key)` through `_buzz_claim`; whichever files first buzzes and the other yields. Within one cycle the feed builds first, so when the judges have already ruled the more informative bell event wins; across cycles the turn push usually lands first and the later bell event yields on the phone. Bell events never suppress each other (two cards of one session moving in one build still buzz twice), the desktop notification and the badge are outside the rule, and only what buzzed locally is forwarded to peers, so their phones hear each turn end once too.

## Verification

- Python: full suite green, 7369 passed / 40 skipped (run in two halves under the tool's time cap). New `tests/test_kernel_notify_popover.py` covers the store and `/notify-turns`, `/push/test` on the real handler with each outcome, `_push_post` against a loopback push-service double, the prune rule, the tick (baseline, both switches, mute, fallback key, wiring order), the claim in both orders, the relay, and the shell markup/tokens. Three existing pins updated deliberately (federation forward, notify-bells forward, RailBell model), each with a comment.
- TypeScript: `npm run typecheck`, `npm test` (2782 passed; `menu-theme-tokens.test.ts` gains the popover as a surface plus a shell-defines-tokens test), `npm run build`.
- Screenshots (headless, synthetic fixture): desktop dark and light show the card anchored above the rail bell with two lit pills, one off, and the accepted sentence under the button; phone-width dark and light show it above the tab bar with the This-device row disabled and its blocked-site sub-line, and a red refusal line under the button. Tokens resolve to the dark card and the cream card respectively; text and pills line up. The first desktop render caught the popover CSS sitting inside the mobile media block, which is now fixed (the rules are global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

