### PR TITLE
The Awaiting box lists what a session waits on as rows grouped by kind, and the chip opens it

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2876,7 +2876,7 @@ def _parse_plan(raw, menu_len, allow_extend=False):
         elif do in ("done", "block", "awaiting"):
             g, r = _int(o, "goal"), _int(o, "ref")
             ak = str(o.get("kind") or "").strip().lower() if do == "awaiting" else ""
-            ak = {"kind": ak} if ak in AWAIT_KINDS else {}             # garbage/absent → kindless (legacy)
+            ak = {"kind": ak} if ak in AWAIT_KINDS_JUDGED else {}      # garbage/absent/"mixed" → kindless (legacy)
             if g and 1 <= g <= menu_len:
                 ops.append({"do": do, "why": why, "goal": g, **ak})
             elif r and r >= 1:
@@ -9171,7 +9171,15 @@ CLOSER_SYS = (
 # background task/watcher; an external job (cluster/CI/build); a peer session; a scheduled check-back.
 # The judge files one per awaiting verdict; a stamp without one (older judges, legacy stores) is
 # kindless and behaves exactly as before the enum existed.
-AWAIT_KINDS = ("agents", "task", "job", "peer", "timer")
+#
+# Two tuples since 2026-09-05 (plans/subagent-transcripts.md, slice 2): AWAIT_KINDS_JUDGED is what a
+# closer may FILE — the specific thing one goal waits on; AWAIT_KINDS adds "mixed", which only the
+# kernel's LIVE session read (_session_awaiting) produces when a session waits on several kinds at
+# once (an agent AND a background command AND a watch). A stamp is never "mixed": the parse sites
+# validate against the judged tuple, so an LLM emitting the word degrades to kindless like any other
+# off-enum kind, and every lift/supersede rule keyed on a stamp's kind keeps seeing a specific one.
+AWAIT_KINDS_JUDGED = ("agents", "task", "job", "peer", "timer")
+AWAIT_KINDS = AWAIT_KINDS_JUDGED + ("mixed",)
 
 # The PEER-kind write gate's evidence (the user 2026-08-24, after three reports of idle sessions
 # reading "awaiting a peer"): a kind=peer stamp requires an un-answered kind=question THIS session
@@ -9277,7 +9285,7 @@ def _parse_close(raw, menu_len):
                 why = " ".join(str(it.get("why", "")).split())[:300]
                 if kinds:
                     k = str(it.get("kind") or "").strip().lower()
-                    out[n] = {"why": why, "kind": k if k in AWAIT_KINDS else None}
+                    out[n] = {"why": why, "kind": k if k in AWAIT_KINDS_JUDGED else None}   # a closer files a specific kind, never "mixed"
                 else:
                     out[n] = why
         return out

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17527,6 +17527,13 @@ def _awaiting_kind_phrase(kind, n):
     return "%d timer%s" % (n, "" if n == 1 else "s")
 
 
+def _awaiting_join_items(agents, commands, watch):
+    """The awaited rows in display order — agents, then commands, then the watch dict's rows — the ONE
+    concatenation both the idle read (_awaiting_from_items) and the turn-agnostic read
+    (_session_background_items) use, so the two can never list a different set."""
+    return list(agents) + list(commands) + list((watch or {}).get("items") or [])
+
+
 def _awaiting_from_items(agents, commands, watch):
     """The awaiting answer DERIVED from the live rows — agents (source 0 + the pending agent launches),
     commands (the pending shell/monitor launches) and `watch` (_watch_awaiting's dict, or None). None when
@@ -17535,7 +17542,7 @@ def _awaiting_from_items(agents, commands, watch):
     count = every row, and a why that names each group ("waiting on 2 background agents, 1 background
     command and 1 armed watch"). `since` is the oldest row's own time; `tasks` the labels, so the
     payload's awaitingTasks fallback lists every awaited thing for consumers that still read that."""
-    items = list(agents) + list(commands) + list((watch or {}).get("items") or [])
+    items = _awaiting_join_items(agents, commands, watch)
     if not items:
         return None
     kinds = [k for k in _AWAIT_ITEM_KINDS if any(it["kind"] == k for it in items)]
@@ -17564,6 +17571,129 @@ def _awaiting_peer_items(peers):
             for p in (peers or [])]
 
 
+def _awaiting_live_rows(sid, path, live):
+    """The live awaited-row SOURCES for a session, assembled REGARDLESS of whether its turn is open →
+    (agents, commands, watch): the agent rows (the backend snapshot's live subagents ⋈ the pending agent
+    launches — one row per agent, matched on agentId), the command rows (the pending shell / Monitor
+    launches) and _watch_awaiting's dict (the armed kernel watches; None when there are none). `live` is
+    the session's backend snapshot (_tmux_sessions().get(sid)) or None for a dormant one.
+    Factored out of _session_awaiting on 2026-09-06 so the chat's #bg-tasks box can list the SAME rows
+    while the turn is open: with the rows gated on idleness alongside the chip, the box swapped between
+    the grouped rows and the legacy tasks list at every turn boundary of a session with agents in flight
+    — two presentations of one set of facts (the user 2026-09-06, who watched the box vanish on send and
+    come back when the turn ended). _session_awaiting still answers None mid-turn — the chip's Awaiting is
+    idle-only, by design — while the rows alone are turn-agnostic (_session_background_items). Every
+    source here is event-true: the hook set, the lifecycle stream / transcript pairing, the watch
+    registry; nothing about the open turn changes what they say."""
+    # Source 0 (the user 2026-07-05, jld_audit): the backend snapshot's LIVE subagent count — the designed
+    # SubagentStart/Stop signal, held in memory, independent of any turn. It outranks the overlay because
+    # the overlay's stale-supersede heuristic reads ANY later 'working' state row as proof awaiting ended —
+    # but a turn interleaving mid-wait (the auto-nudge asking for status) writes exactly that row while the
+    # agents are still running, falsely clearing the verdict; the API-error floor then painted a red
+    # "API error" + "stalled" card over a session with two agents mid-flight. Tmux sessions carry no
+    # subagents field → None → fall through unchanged.
+    tm = live or {}
+    agents, commands = [], []
+    seen_agent = {}   # agentId → its row: a background agent is in BOTH the hook set and the task stream
+    subs = tm.get("subagents")
+    for sub in subs or []:
+        # `subagents` is the snapshot's LIST of live agents ({"type","since","agentId"} — the hook's
+        # agent_id since slice 1); the original source-0 code formatted the list itself with %d (latent
+        # TypeError since 3325771, masked because a subagent normally runs inside an open turn →
+        # idle=False → this branch never ran). The type is the row's label until its launch row (below)
+        # brings the dispatch's own description.
+        if not isinstance(sub, dict):
+            continue
+        aid = sub.get("agentId")
+        it = _awaiting_item("agents", aid or "", sub.get("type") or "agent", sub.get("since"), agent_id=aid)
+        if aid:
+            seen_agent[str(aid)] = it
+        agents.append(it)
+    tasks = _bg_live_norm(sid, path)
+    pending = _bg_pending(sid, path, tasks) if tasks else []
+    meta = None   # the subagents sidecar map, read once and only if an agent launch lacks its agentId
+    for t in pending:
+        # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
+        # story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full rule).
+        # A dispatched agent/workflow is an AGENT row even through the task stream; a shell command or
+        # a Monitor is a COMMAND row. No collapse: two kinds present read as two groups, never "task".
+        is_agent = _bg_is_agent(t.get("type"))
+        if not is_agent:
+            commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
+            continue
+        aid = t.get("agentId")
+        if not aid and path and t.get("tid"):
+            meta = _subagent_meta_map(path) if meta is None else meta
+            aid = (meta.get(t["tid"]) or {}).get("agentId")
+        hit = seen_agent.get(str(aid)) if aid else None
+        if hit is not None:
+            # the SAME agent seen by the hook: one row, wearing the launch's id (Stop's handle), its
+            # description, and the earlier of the two start times (the launch's own time normally
+            # precedes the hook's stamp; until 2026-09-06 only a MISSING since was filled, so the later
+            # hook stamp won)
+            hit["id"] = t.get("tid") or hit["id"]
+            hit["label"] = t.get("desc") or hit["label"]
+            if t.get("t") and (not hit.get("since") or int(t["t"]) < hit["since"]):
+                hit["since"] = int(t["t"])
+            continue
+        agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
+    # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
+    # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
+    # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule
+    # (2026-08-30): ANY awaited thing shows — an idle session holding only a watch used to read plain
+    # ready, its wait visible nowhere but `romp watch --list`.
+    return agents, commands, _watch_awaiting(sid)
+
+
+def _session_background_items(sid, path):
+    """Every row a session has in flight in the background — the SAME rows _session_awaiting groups for
+    the idle Awaiting read (agents, commands, watches; _awaiting_join_items order), whether or not the turn
+    is open. [] when nothing runs. This is what the session-scoped surfaces ship as awaitingItems while
+    the session works (2026-09-06; see _awaiting_items_payload); peer waits and timers exist only through
+    the idle-gated arms, so they simply do not appear mid-turn."""
+    live = _tmux_sessions().get(str(sid))
+    agents, commands, watch = _awaiting_live_rows(sid, path, live)
+    return _awaiting_join_items(agents, commands, watch)
+
+
+class _serve_live(object):
+    """Serve `tmux` — a liveness map the caller already took — to every _tmux_sessions() read on this thread
+    for the block: the pusher cycle's own one-snapshot mechanism (_live_scope, the 2026-08-10 CPU fix), lent
+    to a build that was HANDED a snapshot outside a cycle (a WS handler's build_session / build_timeline), so
+    the nested reads underneath (_bg_live_norm's row lookup, the awaiting sources) never fork tmux or sweep
+    the registry again — tests/test_kernel_pusher_snapshot.py: a provided snapshot is enough. A scope already
+    active (the cycle's) is left alone; None means the caller holds none, and the block reads fresh as before."""
+    def __init__(self, tmux):
+        self.tmux, self.set = tmux, False
+
+    def __enter__(self):
+        if self.tmux is not None and getattr(_live_scope, "snapshot", None) is None:
+            _live_scope.snapshot = self.tmux
+            self.set = True
+        return self
+
+    def __exit__(self, *exc):
+        if self.set:
+            _live_scope.snapshot = None
+        return False
+
+
+def _awaiting_items_payload(aw, sid, path, tmux=None):
+    """The rows a session-scoped surface (the chat status, the timeline lane) ships as `awaitingItems`:
+    the wait's own rows when the session is idle-awaiting (`aw` = _session_awaiting's answer — for a
+    live-source wait these ARE the live rows; for a stamp, its peers; for an overlay row, nothing), else
+    everything in flight regardless of the turn. One expression, so the two surfaces can never disagree on
+    the set, and so the client contract holds under ONE key in both turn states: the box renders the rows
+    the same way either way and only its header follows awaitingWhy. `tmux` is the caller's liveness map
+    (build_session's / build_timeline's), served to the mid-turn read's nested lookups (_serve_live) so a
+    build handed a snapshot takes no fresh liveness read — the working path never did before this read
+    existed, and the pusher-snapshot test holds it to that."""
+    if aw:
+        return list(aw.get("items") or [])
+    with _serve_live(tmux):
+        return _session_background_items(sid, path)
+
+
 def _session_awaiting(sid, path, idle, stamp=False):
     """A session AWAITING dispatched/delegated background work (a WORKING flavor, the user 2026-06-22) →
     {"kind", "why", "since", "count", "items"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on
@@ -17573,7 +17703,9 @@ def _session_awaiting(sid, path, idle, stamp=False):
     say how long the wait has held (the user 2026-08-23: a stuck wait was invisible without a duration).
     `since` is None when the winning source carries no event time — the surfaces then show no duration
     rather than a guessed one. Falsy (None) when not awaiting, so truthiness callers read unchanged.
-    Only when IDLE — an actively producing turn is just 'working'. The EVENT-BASED sources, in order —
+    Only when IDLE — an actively producing turn is just 'working' (the ROWS alone are also readable
+    mid-turn through _session_background_items — the chat box lists them under a working header, 2026-09-06).
+    The EVENT-BASED sources, in order —
     though sources 0, 0.5/0.75 and 0.9 no longer short-circuit one another: each contributes ROWS
     (`items`, one per awaited thing, grouped agents / commands / watches — plans/subagent-transcripts.md
     slice 2) and the single kind/count/why are derived from the union (_awaiting_from_items; several
@@ -17624,68 +17756,13 @@ def _session_awaiting(sid, path, idle, stamp=False):
     MORE than the feed does. Postal peer-waits otherwise stay build_feed's."""
     if not idle:
         return None
-    # Source 0 (the user 2026-07-05, jld_audit): the backend snapshot's LIVE subagent count — the designed
-    # SubagentStart/Stop signal, held in memory, independent of any turn. It outranks the overlay because
-    # the overlay's stale-supersede heuristic reads ANY later 'working' state row as proof awaiting ended —
-    # but a turn interleaving mid-wait (the auto-nudge asking for status) writes exactly that row while the
-    # agents are still running, falsely clearing the verdict; the API-error floor then painted a red
-    # "API error" + "stalled" card over a session with two agents mid-flight. Tmux sessions carry no
-    # subagents field → None → fall through unchanged.
     live = _tmux_sessions().get(str(sid))    # None = not a live CLI (dormant); {}-like = live snapshot
-    tm = live or {}
     # Sources 0, 0.5/0.75 and 0.9 are COMBINED into rows (2026-09-05; see _awaiting_from_items): each
     # contributes what it knows, and the one answer is derived from all of them — the old first-source-
     # wins short-circuit is what made one situation read "agents" or "tasks" by accident of ordering.
-    agents, commands = [], []
-    seen_agent = {}   # agentId → its row: a background agent is in BOTH the hook set and the task stream
-    subs = tm.get("subagents")
-    for sub in subs or []:
-        # `subagents` is the snapshot's LIST of live agents ({"type","since","agentId"} — the hook's
-        # agent_id since slice 1); the original source-0 code formatted the list itself with %d (latent
-        # TypeError since 3325771, masked because a subagent normally runs inside an open turn →
-        # idle=False → this branch never ran). The type is the row's label until its launch row (below)
-        # brings the dispatch's own description.
-        if not isinstance(sub, dict):
-            continue
-        aid = sub.get("agentId")
-        it = _awaiting_item("agents", aid or "", sub.get("type") or "agent", sub.get("since"), agent_id=aid)
-        if aid:
-            seen_agent[str(aid)] = it
-        agents.append(it)
-    tasks = _bg_live_norm(sid, path)
-    pending = _bg_pending(sid, path, tasks) if tasks else []
-    meta = None   # the subagents sidecar map, read once and only if an agent launch lacks its agentId
-    for t in pending:
-        # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
-        # story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full rule).
-        # A dispatched agent/workflow is an AGENT row even through the task stream; a shell command or
-        # a Monitor is a COMMAND row. No collapse: two kinds present read as two groups, never "task".
-        is_agent = _bg_is_agent(t.get("type"))
-        if not is_agent:
-            commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
-            continue
-        aid = t.get("agentId")
-        if not aid and path and t.get("tid"):
-            meta = _subagent_meta_map(path) if meta is None else meta
-            aid = (meta.get(t["tid"]) or {}).get("agentId")
-        hit = seen_agent.get(str(aid)) if aid else None
-        if hit is not None:
-            # the SAME agent seen by the hook: one row, wearing the launch's id (Stop's handle), its
-            # description, and the earlier of the two start times (the launch's own time normally
-            # precedes the hook's stamp; until 2026-09-06 only a MISSING since was filled, so the later
-            # hook stamp won)
-            hit["id"] = t.get("tid") or hit["id"]
-            hit["label"] = t.get("desc") or hit["label"]
-            if t.get("t") and (not hit.get("since") or int(t["t"]) < hit["since"]):
-                hit["since"] = int(t["t"])
-            continue
-        agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
-    # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
-    # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
-    # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule
-    # (2026-08-30): ANY awaited thing shows — an idle session holding only a watch used to read plain
-    # ready, its wait visible nowhere but `romp watch --list`.
-    combined = _awaiting_from_items(agents, commands, _watch_awaiting(sid))
+    # The assembly itself is _awaiting_live_rows (2026-09-06), shared with the mid-turn read.
+    agents, commands, watch = _awaiting_live_rows(sid, path, live)
+    combined = _awaiting_from_items(agents, commands, watch)
     if combined:
         return combined
     ov = _states_awaiting_overlay(sid)
@@ -23768,16 +23845,20 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # (_session_awaiting returns None while open_now). Session-scoped chat-view chip → the durable stamp too,
     # so the composer's awaiting chip survives a kernel restart like the feed card.
     _aw = _session_awaiting(sid, sess["path"], not open_now, stamp=True)
-    # Armed kernel watches stay visible even MID-TURN (the user 2026-08-30, whose cluster-job watch
-    # showed only a chip tooltip while the box at the chat bottom stayed dark): _session_awaiting
-    # answers None while the turn is open BY DESIGN — the chip must keep reading "working" (the shared
-    # state formula is untouched) — but the awaited CONTENT still rides the payload, and the box keys
-    # on the fields' presence, never on the state. Idle sessions get watches through
-    # _session_awaiting's own source 0.9, which also stamps the awaitingBg chip.
-    if not _aw and open_now:
-        _aw = _watch_awaiting(sid)
     awaiting_why = _aw["why"] if _aw else None
     awaiting_kind = _aw["kind"] if _aw else None
+    # The in-flight ROWS ride the payload in BOTH turn states (2026-09-06): _session_awaiting answers
+    # None while the turn is open BY DESIGN — the chip must keep reading "working" (the shared state
+    # formula is untouched) — but what the session has running in the background does not change at a
+    # turn boundary, so the #bg-tasks box lists the same rows either way and only its header follows
+    # the chip ("Awaiting …" idle, "In the background …" working). This REPLACES the 2026-08-30 mid-turn
+    # arm that re-ran _watch_awaiting alone into awaitingWhy while the turn was open: it kept armed
+    # watches visible mid-turn (the user's rule then — anything awaited shows, even while working) but
+    # made the box read "Awaiting" under a Working chip and left every OTHER in-flight row to the legacy
+    # tasks list, so the box swapped presentations at every turn boundary of a session with agents in
+    # flight. Watches ride awaitingItems mid-turn like everything else now, and awaitingWhy means one
+    # thing on every surface: idle and waiting on these — the chip's Awaiting.
+    _aw_items = _awaiting_items_payload(_aw, sid, sess["path"], tmux)
     # API error → the session is BLOCKED until retried: a bottom card (renderApiError, a RED dot) AND the chip
     # flips to "blocked" below. Detected event-based from the transcript (isApiErrorMessage), so the exact
     # text (500 / timeout / model-not-found) doesn't matter (the user 2026-06-16). GATED on the session NOT
@@ -24016,10 +24097,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                   # number — a single agent is not "agents") — the chip and the box derive the word from
                   # this one number; None when the source cannot know (an untyped stamp, a bare overlay)
                   "awaitingCount": ((_aw or {}).get("count") if isinstance((_aw or {}).get("count"), int) else None),
-                  # …and the awaited ROWS themselves — [{kind, id, label, since, agentId?, detail?,
+                  # …and the in-flight ROWS themselves — [{kind, id, label, since, agentId?, detail?,
                   # watchId?}], grouped by the box and worded by the chip's tooltip (slice 2, 2026-09-05);
-                  # [] for a wait no source can enumerate (a judge stamp, a bare overlay row)
-                  "awaitingItems": (list((_aw or {}).get("items") or []) if awaiting_why else []),
+                  # shipped in BOTH turn states since 2026-09-06 (_aw_items above): the wait's rows when
+                  # idle-awaiting, everything running in the background otherwise; [] for a wait no
+                  # source can enumerate (a judge stamp, a bare overlay row) and when nothing runs
+                  "awaitingItems": _aw_items,
                   "awaitingTasks": (((_awaiting_task_descs(sid, sess["path"]) or
                                       (_aw or {}).get("tasks") or [])) if awaiting_why else []),
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
@@ -28373,7 +28456,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
             "awaitingKind": awaiting_kind,
             "awaitingCount": ((_aw_bg or {}).get("count") if isinstance((_aw_bg or {}).get("count"), int) else None),   # the lane badge agrees in number (T228)
-            "awaitingItems": (list((_aw_bg or {}).get("items") or []) if awaiting_bg else []),   # the awaited rows, same set as the chat box (slice 2)
+            "awaitingItems": (_awaiting_items_payload(_aw_bg, sid, s["path"], tmux) if live else []),   # the in-flight rows — the same set as the chat box, in both turn states (slice 2; turn-agnostic since 2026-09-06)
             "awaitingPeers": ((_aw_bg or {}).get("peers") or None),   # named identities for a peer wait (2026-08-26)
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the
             # idle-but-waiting stretch as a thin dashed segment whose hover lists exactly what's pending

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14438,23 +14438,34 @@ def _watch_awaiting(sid):
     is event-true at both ends (armed at registration, removed when the predicate fires, times out, or
     is cancelled), and it's kernel-owned, so this source survives restarts like the watches themselves.
     `tasks` lists each watch in the registrant's own words (the --note, else an elided predicate), so a
-    plural wait can enumerate them in the box's fold."""
+    plural wait can enumerate them in the box's fold. `items` is the same set as awaited ROWS
+    (_awaiting_item: kind "watches"), one per watch: a generic watch carries `watchId` — the handle the
+    box's Cancel button hands to cancel_watch, the same path `romp watch --cancel <id>` takes — and its
+    predicate as `detail`; a PR watch has no cancel path (nothing retires a pr-watch early today), so
+    it carries no watchId and the box offers no button for it."""
     sid = str(sid)
     with _watch_lock:
         rows = [dict(r) for r in _watches if str(r.get("sid")) == sid]
     prs = [dict(r) for r in _pr_watches if str(r.get("sid")) == sid]   # tick-thread idiom: copy, no lock
-    descs = []
+    descs, items = [], []
     for r in rows:
         note = (r.get("note") or "").strip()
         cmd = str(r.get("cmd") or "")
-        descs.append(note or "a kernel watch: %s" % (cmd if len(cmd) <= 80 else cmd[:77] + "…"))
+        clipped = cmd if len(cmd) <= 80 else cmd[:77] + "…"
+        descs.append(note or "a kernel watch: %s" % clipped)
+        it = _awaiting_item("watches", "watch:%s" % r.get("id"), note or clipped, r.get("at"), detail=cmd)
+        if r.get("id"):
+            it["watchId"] = str(r["id"])
+        items.append(it)
     for r in prs:
         descs.append("PR #%s (%s) to land" % (r.get("pr"), r.get("repo")))
+        items.append(_awaiting_item("watches", "pr:%s#%s" % (r.get("repo"), r.get("pr")),
+                                    "PR #%s (%s)" % (r.get("pr"), r.get("repo")), r.get("at")))
     if not descs:
         return None
     since = min([r.get("at") for r in rows + prs if r.get("at")] or [None])
     why = ("waiting on " + descs[0]) if len(descs) == 1 else         ("waiting on %d armed watches — %s, …" % (len(descs), descs[0]))
-    return {"kind": "job", "why": why, "since": since, "tasks": descs, "count": len(descs)}
+    return {"kind": "job", "why": why, "since": since, "tasks": descs, "count": len(descs), "items": items}
 
 
 def _watch_notice(kind, row, detail=""):
@@ -17473,16 +17484,101 @@ def _session_delegated_identities(sid):
     return sorted((_peer_identity(p) for p in peers), key=lambda d: d["name"])
 
 
+# ── awaited ROWS (plans/subagent-transcripts.md slice 2, the user 2026-09-05) ─────────────────────────
+# _session_awaiting used to answer with ONE kind chosen by source precedence: live subagents, else the
+# pending background launches (kind agents only if EVERY pending row was an agent, else the generic
+# "task"), else armed watches. So one situation read "agents" or "tasks" depending on which source spoke
+# first, a background shell command plus a background agent read "Awaiting 2 tasks" with the agent
+# silently absorbed, and nothing on screen listed what was awaited. The user's call: the kinds are
+# different things — show them as SEPARATE ROWS grouped by kind. Every live source now contributes
+# `items` — one row per awaited thing — and the legacy single kind/count/why are DERIVED from the rows:
+# one kind present → that kind's word (precedence only ever chose the word); several → kind "mixed",
+# count = every row. Rows wear the GROUP vocabulary (agents / commands / watches / peer / timer); the
+# legacy kind keys (agents / task / job / peer / timer) stay for every consumer that still reads them,
+# _AWAIT_ITEM_LEGACY_KIND bridging the two.
+_AWAIT_ITEM_KINDS = ("agents", "commands", "watches", "peer", "timer")       # the row groups, in display order
+_AWAIT_ITEM_LEGACY_KIND = {"agents": "agents", "commands": "task", "watches": "job", "peer": "peer", "timer": "timer"}
+
+
+def _awaiting_item(kind, iid, label, since, agent_id=None, detail=None):
+    """One awaited row: {kind, id, label, since} plus agentId (an agent row — the open-transcript arrow)
+    and detail (a watch's predicate) only when known, so every row without them is byte-identical to the
+    minimal shape. `since` is the row's OWN event time (a dispatch stamp, a hook's start, a watch's
+    registration) or None — never wall-clock now (the user 2026-08-23)."""
+    assert kind in _AWAIT_ITEM_KINDS, kind
+    it = {"kind": kind, "id": str(iid or ""), "label": str(label or "").strip(), "since": (int(since) if since else None)}
+    if agent_id:
+        it["agentId"] = str(agent_id)
+    if detail:
+        it["detail"] = str(detail)
+    return it
+
+
+def _awaiting_kind_phrase(kind, n):
+    """The counted noun phrase for one row group — the mixed why's building block."""
+    if kind == "agents":
+        return "%d background agent%s" % (n, "" if n == 1 else "s")
+    if kind == "commands":
+        return "%d background command%s" % (n, "" if n == 1 else "s")
+    if kind == "watches":
+        return "%d armed watch%s" % (n, "" if n == 1 else "es")
+    if kind == "peer":
+        return "%d peer%s" % (n, "" if n == 1 else "s")
+    return "%d timer%s" % (n, "" if n == 1 else "s")
+
+
+def _awaiting_from_items(agents, commands, watch):
+    """The awaiting answer DERIVED from the live rows — agents (source 0 + the pending agent launches),
+    commands (the pending shell/monitor launches) and `watch` (_watch_awaiting's dict, or None). None when
+    there are no rows. One kind present → its legacy kind word and the sentence that kind always wore
+    (byte-identical to the pre-rows whys, so nothing downstream re-learns them); several → kind "mixed",
+    count = every row, and a why that names each group ("waiting on 2 background agents, 1 background
+    command and 1 armed watch"). `since` is the oldest row's own time; `tasks` the labels, so the
+    payload's awaitingTasks fallback lists every awaited thing for consumers that still read that."""
+    items = list(agents) + list(commands) + list((watch or {}).get("items") or [])
+    if not items:
+        return None
+    kinds = [k for k in _AWAIT_ITEM_KINDS if any(it["kind"] == k for it in items)]
+    n = len(items)
+    since = min([it.get("since") for it in items if it.get("since")] or [None])
+    if kinds == ["agents"]:
+        why = "%d background agent%s still working" % (n, "" if n == 1 else "s")
+    elif kinds == ["commands"]:
+        d0 = commands[0]["label"]
+        why = ("waiting on a background command%s" % ((": " + d0) if d0 else "") if n == 1 else
+               "waiting on %d background commands%s" % (n, (" — " + d0 + ", …") if d0 else ""))
+    elif kinds == ["watches"]:
+        why = watch["why"]
+    else:
+        parts = [_awaiting_kind_phrase(k, sum(1 for it in items if it["kind"] == k)) for k in kinds]
+        why = "waiting on " + (", ".join(parts[:-1]) + " and " + parts[-1])
+    kind = _AWAIT_ITEM_LEGACY_KIND[kinds[0]] if len(kinds) == 1 else "mixed"
+    return {"kind": kind, "why": why, "since": since, "count": n, "items": items,
+            "tasks": [it["label"] or "background work" for it in items]}   # a label-less row keeps a kind-neutral word
+
+
+def _awaiting_peer_items(peers):
+    """Peer rows from the identities a stamp or the delegation graph names — label only (no sid: a nested
+    id would dodge federation's prefixing; the chip/box name and colour peers from awaitingPeers)."""
+    return [_awaiting_item("peer", "peer:%s" % (p.get("name") or ""), p.get("name") or "a peer", None)
+            for p in (peers or [])]
+
+
 def _session_awaiting(sid, path, idle, stamp=False):
     """A session AWAITING dispatched/delegated background work (a WORKING flavor, the user 2026-06-22) →
-    {"kind", "why", "since"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on
+    {"kind", "why", "since", "count", "items"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on
     (jd.AWAIT_KINDS, the user 2026-08-15 — kind rides as DATA so surfaces can word it and rules can scope
     by it; None = kindless, the legacy shape) plus WHEN the wait began — each source's own event time
     (a dispatch stamp, an overlay row's t, the judge's awaitingAt), never wall-clock now, so the chips can
     say how long the wait has held (the user 2026-08-23: a stuck wait was invisible without a duration).
     `since` is None when the winning source carries no event time — the surfaces then show no duration
     rather than a guessed one. Falsy (None) when not awaiting, so truthiness callers read unchanged.
-    Only when IDLE — an actively producing turn is just 'working'. The EVENT-BASED sources, in order:
+    Only when IDLE — an actively producing turn is just 'working'. The EVENT-BASED sources, in order —
+    though sources 0, 0.5/0.75 and 0.9 no longer short-circuit one another: each contributes ROWS
+    (`items`, one per awaited thing, grouped agents / commands / watches — plans/subagent-transcripts.md
+    slice 2) and the single kind/count/why are derived from the union (_awaiting_from_items; several
+    kinds present → kind "mixed"). The order below still ranks those three over the overlay and the
+    stamp-gated arms, which answer only when no live row exists:
       0. the backend snapshot's LIVE subagent count (SubagentStart/Stop) — genuine delegated Claude
          AGENTS in flight, held in memory, independent of any turn.
       0.5 the backend snapshot's LIVE bg-task set — the CLI's DESIGNED task lifecycle stream
@@ -17537,48 +17633,67 @@ def _session_awaiting(sid, path, idle, stamp=False):
     # subagents field → None → fall through unchanged.
     live = _tmux_sessions().get(str(sid))    # None = not a live CLI (dormant); {}-like = live snapshot
     tm = live or {}
+    # Sources 0, 0.5/0.75 and 0.9 are COMBINED into rows (2026-09-05; see _awaiting_from_items): each
+    # contributes what it knows, and the one answer is derived from all of them — the old first-source-
+    # wins short-circuit is what made one situation read "agents" or "tasks" by accident of ordering.
+    agents, commands = [], []
+    seen_agent = {}   # agentId → its row: a background agent is in BOTH the hook set and the task stream
     subs = tm.get("subagents")
-    if subs:
-        # `subagents` is the snapshot's LIST of live agents ({"type","since"}); the original source-0 code
-        # formatted the list itself with %d (latent TypeError since 3325771, masked because a subagent
-        # normally runs inside an open turn → idle=False → this branch never ran) — count via len().
-        n = len(subs)
-        return {"kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s"),
-                "count": n,   # how many are awaited — the chip/box word agrees in number with THIS (T225)
-                "since": min([s.get("since") for s in subs if s.get("since")] or [None])}   # the oldest live agent's start — the wait has held at least this long
+    for sub in subs or []:
+        # `subagents` is the snapshot's LIST of live agents ({"type","since","agentId"} — the hook's
+        # agent_id since slice 1); the original source-0 code formatted the list itself with %d (latent
+        # TypeError since 3325771, masked because a subagent normally runs inside an open turn →
+        # idle=False → this branch never ran). The type is the row's label until its launch row (below)
+        # brings the dispatch's own description.
+        if not isinstance(sub, dict):
+            continue
+        aid = sub.get("agentId")
+        it = _awaiting_item("agents", aid or "", sub.get("type") or "agent", sub.get("since"), agent_id=aid)
+        if aid:
+            seen_agent[str(aid)] = it
+        agents.append(it)
     tasks = _bg_live_norm(sid, path)
-    if tasks:
+    pending = _bg_pending(sid, path, tasks) if tasks else []
+    meta = None   # the subagents sidecar map, read once and only if an agent launch lacks its agentId
+    for t in pending:
         # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
         # story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full rule).
-        pending = _bg_pending(sid, path, tasks)
-        if pending:
-            d0 = pending[0]["desc"]
-            # a dispatched agent/workflow is kind agents even through the task stream; a mixed set
-            # (or plain shell work) is kind task — the generic word for in-harness background work
-            kind = ("agents" if all("agent" in (t.get("type") or "") or t.get("type") == "local_workflow"
-                                    for t in pending) else "task")
-            since = min([t.get("t") for t in pending if t.get("t")] or [None])   # the oldest pending dispatch
-            if len(pending) == 1:
-                return {"kind": kind, "since": since, "count": 1,
-                        "why": "waiting on a background task%s" % ((": " + d0) if d0 else "")}
-            return {"kind": kind, "since": since, "count": len(pending),
-                    "why": "waiting on %d background tasks%s"
-                           % (len(pending), (" — " + d0 + ", …") if d0 else "")}
+        # A dispatched agent/workflow is an AGENT row even through the task stream; a shell command or
+        # a Monitor is a COMMAND row. No collapse: two kinds present read as two groups, never "task".
+        is_agent = "agent" in (t.get("type") or "") or t.get("type") == "local_workflow"
+        if not is_agent:
+            commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
+            continue
+        aid = t.get("agentId")
+        if not aid and path and t.get("tid"):
+            meta = _subagent_meta_map(path) if meta is None else meta
+            aid = (meta.get(t["tid"]) or {}).get("agentId")
+        hit = seen_agent.get(str(aid)) if aid else None
+        if hit is not None:
+            # the SAME agent seen by the hook: one row, wearing the launch's id (Stop's handle), its
+            # description, and the earlier of the two start times
+            hit["id"] = t.get("tid") or hit["id"]
+            hit["label"] = t.get("desc") or hit["label"]
+            if t.get("t") and not hit.get("since"):
+                hit["since"] = int(t["t"])
+            continue
+        agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
     # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
     # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
     # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule
     # (2026-08-30): ANY awaited thing shows — an idle session holding only a watch used to read plain
     # ready, its wait visible nowhere but `romp watch --list`.
-    w = _watch_awaiting(sid)
-    if w:
-        return w
+    combined = _awaiting_from_items(agents, commands, _watch_awaiting(sid))
+    if combined:
+        return combined
     ov = _states_awaiting_overlay(sid)
     if ov is not None and ov.get("awaiting"):         # a producer wrote a LIVE awaiting:true → trust its why
         ovk = ov.get("kind")
         return {"kind": ovk if ovk in jd.AWAIT_KINDS else None,
                 "since": ov.get("t") or None,          # the overlay row's own stamp — when the hook declared the wait
                 "count": ov["count"] if isinstance(ov.get("count"), int) and ov["count"] > 0 else None,   # only when the producer said (no parsing the why)
-                "why": ov.get("why") or "waiting on dispatched work"}
+                "why": ov.get("why") or "waiting on dispatched work",
+                "items": []}                           # an overlay row names no rows — the box shows its why alone
     # An awaiting:false overlay row is NOT a veto — it says only that THIS channel has nothing to add.
     # The SDK Stop hook has written an unconditional false at every turn end since 2026-07-07 while
     # nothing writes true, so treating "most recent row is false" as the session's answer made source 2
@@ -17604,23 +17719,26 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # and nobody else's (the user 2026-08-08): the three surfaces answered one question two ways.
         y = _owned_yield_why(sid, path)
         if y:
-            return {"kind": "task", "why": y, "since": None, "count": 1}   # a live owned dispatch — in-harness work (no single event time to show)
+            return {"kind": "task", "why": y, "since": None, "count": 1, "items": []}   # a live owned dispatch — in-harness work (no single event time to show; the yield names no row)
         _gid, _at, st_why, st_kind, st_peers = _session_stamp_full(sid)
         if st_why:
             out = {"kind": st_kind, "why": st_why, "since": _at or None,   # the judge's own classification rides the stamp, with its awaitingAt
-                   "count": len(st_peers) if st_peers else None}   # a peer stamp knows its peers; other stamps carry no count
+                   "count": len(st_peers) if st_peers else None,   # a peer stamp knows its peers; other stamps carry no count
+                   "items": []}                                    # a stamp names no rows (a peer stamp names its peers, below)
             if st_kind == "peer" and st_peers:
                 # the stamp RECORDS who the wait is on (judge awaitPeers) — name them (2026-08-26);
                 # `peers` rides only when known, so every other arm's shape is byte-identical
                 out["peers"] = sorted((_peer_identity(p) for p in st_peers), key=lambda d_: d_["name"])
+                out["items"] = _awaiting_peer_items(out["peers"])
             return out
         d = _session_delegated_why(sid)
         if d:
-            out = {"kind": "peer", "why": d, "since": None}   # the courier handoff graph is peer by construction
+            out = {"kind": "peer", "why": d, "since": None, "items": []}   # the courier handoff graph is peer by construction
             pi = _session_delegated_identities(sid)
             if pi:
                 out["peers"] = pi
                 out["count"] = len(pi)
+                out["items"] = _awaiting_peer_items(pi)
             return out
     return None
 
@@ -17898,7 +18016,10 @@ def _owned_yield_why(sid, path):
         best = cand if best is None else max(best, cand)
     if best is None:
         return None
-    return "waiting on a background task%s" % ((": " + best[1]) if best[1] else "")
+    # worded "command" since 2026-09-05 (the awaiting vocabulary: agents / commands / watches — plans/
+    # subagent-transcripts.md slice 2): the owned dispatch is in-harness background work the chip words as
+    # a command; the kind stays the legacy "task" key every consumer already reads
+    return "waiting on a background command%s" % ((": " + best[1]) if best[1] else "")
 
 
 def _states_awaiting_overlay(sid):
@@ -23859,6 +23980,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                   # number — a single agent is not "agents") — the chip and the box derive the word from
                   # this one number; None when the source cannot know (an untyped stamp, a bare overlay)
                   "awaitingCount": ((_aw or {}).get("count") if isinstance((_aw or {}).get("count"), int) else None),
+                  # …and the awaited ROWS themselves — [{kind, id, label, since, agentId?, detail?,
+                  # watchId?}], grouped by the box and worded by the chip's tooltip (slice 2, 2026-09-05);
+                  # [] for a wait no source can enumerate (a judge stamp, a bare overlay row)
+                  "awaitingItems": (list((_aw or {}).get("items") or []) if awaiting_why else []),
                   "awaitingTasks": (((_awaiting_task_descs(sid, sess["path"]) or
                                       (_aw or {}).get("tasks") or [])) if awaiting_why else []),
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
@@ -24677,7 +24802,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
             "provisional": True, "judging": not turn_open, "tree": []}
 
 
-def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, count=None):
+def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, count=None, items=None):
     """A lightweight WORKING-column placeholder for a LIVE, IDLE session AWAITING a dispatched BACKGROUND
     TASK when there is NO open goal to floor to awaiting (the user 2026-07-13). The turn ended and every
     card is done/cleared/placed, so the goal loop has nothing to floor AND _provisional_card bows out (its
@@ -24700,9 +24825,9 @@ def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, 
             t = turns[-1].get("t", now)              # last activity → recency tint, sorts with the working column
     except Exception:
         pass
-    # _session_awaiting already phrases the why ("waiting on a background task: <desc>"); capitalize it for
+    # _session_awaiting already phrases the why ("waiting on a background command: <desc>"); capitalize it for
     # the headline. The task list rides `awaiting` for the pill, so the headline needn't repeat every task.
-    text = (why[:1].upper() + why[1:]) if why else "Waiting on a background task"
+    text = (why[:1].upper() + why[1:]) if why else "Waiting on a background command"
     return {"itemId": "awaiting:" + fsid, "sid": fsid, "name": name, "color": color, "text": text,
             "t": t, "live": live, "trgb": list(cm.age_rgb(now - t, _colormap())),
             "turnId": None, "origin": None, "followupPending": None,
@@ -24713,6 +24838,7 @@ def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, 
             # "Working…"/"Analyzing…" chip, carries the state (feed.ts defers the provisional chip when awaiting).
             "awaiting": {"why": why, "kind": kind, "since": since,
                          "count": count if isinstance(count, int) else None,   # the feed pill's word agrees in number (T225)
+                         "items": list(items or []),   # the awaited rows the pill lists, grouped (slice 2)
                          "tasks": _awaiting_task_descs(fsid, s["path"])},
             "provisional": True, "judging": False, "tree": []}
 
@@ -25406,6 +25532,7 @@ def build_feed(now, tmux=None):
         sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
         sess_awaiting_count = _sess_aw.get("count") if _sess_aw else None   # how many are awaited — the pill's word agrees in number (T225)
         sess_awaiting_peers = _sess_aw.get("peers") if _sess_aw else None   # named identities when the arm knows them (2026-08-26)
+        sess_awaiting_items = list(_sess_aw.get("items") or []) if _sess_aw else []   # the awaited rows (slice 2) — the pill lists them grouped
         if sess_awaiting_why and not who_working:
             awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
             #                                          same split _session_chip makes; feed/chat dots match the chip
@@ -25496,7 +25623,7 @@ def build_feed(now, tmux=None):
                 # the blocked card's own thread still proves the thread moved past the block.
                 _await_ok = bool(_own) and _own["since"] >= _blk_t
                 if _await_ok:
-                    _owned_why = "waiting on a background task%s" % (
+                    _owned_why = "waiting on a background command%s" % (   # the chip's word for in-harness work (2026-09-05)
                         (": " + _own["descs"][0]) if _own["descs"] else "")
                     _owned_since = _own["since"]           # the dispatch event that proved the yield
             # The JUDGE's durable ⏳ stamp (the closer's awaiting verdict, kernel/judge.py): this goal's
@@ -25593,14 +25720,15 @@ def build_feed(now, tmux=None):
             await_since = None                       # mirroring the or-chain exactly (a kindless winner
             await_peers = None                       # stays kindless; since = the wait's own event time).
             await_count = None                       # how many are awaited — the SAME number the chat chip words itself
+            await_items = []                         # the awaited ROWS the pill lists, grouped by kind (slice 2, 2026-09-05)
             if col == "awaiting":                    # from (T228, the user's one-count rule): the live snapshot's own
                 # count, the peers a stamp or delegation names, one owned dispatch; None when the arm cannot know
-                for _w, _k, _s, _p, _n in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count),
-                                           (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None)),
-                                           (_deleg_why, "peer", _deleg_since, _deleg_peers, (len(_deleg_peers) if _deleg_peers else None)),
-                                           (_owned_why, "task", _owned_since, None, 1)):
+                for _w, _k, _s, _p, _n, _it in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count, sess_awaiting_items),
+                                                (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None), _awaiting_peer_items(_stamp_peers)),
+                                                (_deleg_why, "peer", _deleg_since, _deleg_peers, (len(_deleg_peers) if _deleg_peers else None), _awaiting_peer_items(_deleg_peers)),
+                                                (_owned_why, "task", _owned_since, None, 1, [])):
                     if _w:
-                        await_kind, await_since, await_peers = _k, _s, _p
+                        await_kind, await_since, await_peers, await_items = _k, _s, _p, _it
                         await_count = _n if isinstance(_n, int) and _n > 0 else None
                         break
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
@@ -25890,6 +26018,7 @@ def build_feed(now, tmux=None):
                 "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
                               "count": await_count,   # the one number every surface words itself from (T228)
                               "peers": await_peers,   # delegation wait → [{name, host, sid, color}] for the identity-coloured box (the user 2026-08-23)
+                              "items": await_items,   # the awaited rows, grouped by the pill's expansion (slice 2)
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
@@ -26030,7 +26159,7 @@ def build_feed(now, tmux=None):
                 # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
                 asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
                                            kind=sess_awaiting_kind, since=sess_awaiting_since,
-                                           count=sess_awaiting_count))
+                                           count=sess_awaiting_count, items=sess_awaiting_items))
     # THE SERVING FOLD, commit side (T137): join each candidate's rows under its dispatch's
     # tracker row — a read-only render-time join across stores (the node itself stays in the
     # WORKER's store, where plan-sync completion, nudge freshness, and clears live; node ids are
@@ -28208,6 +28337,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
             "awaitingKind": awaiting_kind,
             "awaitingCount": ((_aw_bg or {}).get("count") if isinstance((_aw_bg or {}).get("count"), int) else None),   # the lane badge agrees in number (T228)
+            "awaitingItems": (list((_aw_bg or {}).get("items") or []) if awaiting_bg else []),   # the awaited rows, same set as the chat box (slice 2)
             "awaitingPeers": ((_aw_bg or {}).get("peers") or None),   # named identities for a peer wait (2026-08-26)
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the
             # idle-but-waiting stretch as a thin dashed segment whose hover lists exactly what's pending
@@ -38139,6 +38269,17 @@ class Handler(BaseHTTPRequestHandler):
                 sys.stderr.write("openSubagent %s/%s: %s\n" % (sid, aid, traceback.format_exc()))
                 client["send"](json.dumps({"type": "subagent", "id": sid, "agentId": aid,
                                            "error": "romp couldn't build this agent's transcript — the kernel log has the traceback."}))
+            return
+        if msg and msg.get("type") == "cancelWatch" and msg.get("watchId"):
+            # The awaiting box's Cancel on a generic `romp watch --cmd` row (slice 2, 2026-09-05): the SAME
+            # cancel_watch the CLI's `romp watch --cancel <id>` and POST /watch {"cancel"} reach — no new
+            # retire path, one more door to it. `id` (the session) rides only so federation routes the
+            # message to the kernel that owns the watch. LOUD on a miss (fail loudly, never degrade
+            # silently): the watch may have fired or been cancelled from the CLI a moment earlier.
+            if not cancel_watch(str(msg["watchId"]).strip()):
+                client["send"](json.dumps({"type": "warn",
+                                           "text": "Couldn't cancel that watch — it may have already fired or been cancelled."}))
+            _push_soon()
             return
         if msg and msg.get("type") == "setGlobalRetryPaused":
             _set_retry_paused(msg.get("value"))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17660,7 +17660,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full rule).
         # A dispatched agent/workflow is an AGENT row even through the task stream; a shell command or
         # a Monitor is a COMMAND row. No collapse: two kinds present read as two groups, never "task".
-        is_agent = "agent" in (t.get("type") or "") or t.get("type") == "local_workflow"
+        is_agent = _bg_is_agent(t.get("type"))
         if not is_agent:
             commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
             continue
@@ -17671,10 +17671,12 @@ def _session_awaiting(sid, path, idle, stamp=False):
         hit = seen_agent.get(str(aid)) if aid else None
         if hit is not None:
             # the SAME agent seen by the hook: one row, wearing the launch's id (Stop's handle), its
-            # description, and the earlier of the two start times
+            # description, and the earlier of the two start times (the launch's own time normally
+            # precedes the hook's stamp; until 2026-09-06 only a MISSING since was filled, so the later
+            # hook stamp won)
             hit["id"] = t.get("tid") or hit["id"]
             hit["label"] = t.get("desc") or hit["label"]
-            if t.get("t") and not hit.get("since"):
+            if t.get("t") and (not hit.get("since") or int(t["t"]) < hit["since"]):
                 hit["since"] = int(t["t"])
             continue
         agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
@@ -17743,12 +17745,36 @@ def _session_awaiting(sid, path, idle, stamp=False):
     return None
 
 
+def _bg_is_agent(kind):
+    """Is a task-stream / scan row a dispatched AGENT (Agent/Task or a Workflow run) rather than a shell
+    command or a Monitor? The one type test every bg-task consumer applies."""
+    return "agent" in (kind or "") or kind == "local_workflow"
+
+
+def _agent_task_label(desc, kind):
+    """The words a background AGENT row wears: the dispatch description alone. The CLI's task lifecycle
+    stream describes an Agent task as "Running <description>" — the STATUS word beside every row already
+    says running, so the prefix only doubled it (the user 2026-09-06, whose box read "Running Check…"
+    beside RUNNING). Stripped for agent rows only: a shell command's description is the user's own words,
+    and one that happens to start with "Running" must keep them."""
+    d = str(desc or "").strip()
+    if _bg_is_agent(kind) and d.startswith("Running "):
+        d = d[len("Running "):].strip()
+    return d
+
+
 def _bg_live_norm(sid, path):
-    """A session's LIVE background tasks, normalized to {tid, desc, t} across BOTH sources: the backend
-    snapshot's lifecycle set (source 0.5 — toolUseId/desc/since; a present-but-empty set is authoritative,
-    never overridden) or, for a live CLI carrying no lifecycle set (tmux; SDK mid-reattach), the
-    transcript's launch↔notification pairing ghost-gated by the CLI spawn stamp (source 0.75 — id/summary/
-    launch t). [] for a dormant session: its tasks died with its CLI."""
+    """A session's LIVE background tasks, normalized to {tid, desc, t, type} (+ agentId on agent rows)
+    across BOTH sources: the backend snapshot's lifecycle set (source 0.5 — toolUseId/desc/since; a
+    present-but-empty set is authoritative, never overridden) or, for a live CLI carrying no lifecycle set
+    (tmux; SDK mid-reattach), the transcript's launch↔notification pairing ghost-gated by the CLI spawn
+    stamp (source 0.75 — id/summary/launch t). [] for a dormant session: its tasks died with its CLI.
+    `agentId` is the agent's own id — the join key _session_awaiting uses to fold a stream row into the
+    SubagentStart hook's row for the same agent. It comes from the row's OWN record of the launch: the
+    lifecycle stream keys an Agent task by its agent id (`taskId`, probe-verified on 2.1.257), and the
+    transcript ack names it (`agentId`). Both are designed fields; the sidecar meta map is only the
+    fallback (its key is the ORIGINAL launch's toolUseId, which a resumed agent's task no longer carries —
+    the 2026-09-06 duplicate rows were exactly the agents that fallback could not resolve)."""
     live = _tmux_sessions().get(str(sid))
     if live is None:
         return []
@@ -17766,24 +17792,34 @@ def _bg_live_norm(sid, path):
         for t in live.get("bgTasks") or []:
             if not isinstance(t, dict):
                 continue
-            row = {"tid": t.get("toolUseId"), "desc": str(t.get("desc") or "").strip(),
-                   "t": int(t.get("since") or 0), "type": str(t.get("type") or "")}
+            kind = str(t.get("type") or "")
+            row = {"tid": t.get("toolUseId"), "desc": _agent_task_label(t.get("desc"), kind),
+                   "t": int(t.get("since") or 0), "type": kind}
             e = led.get(str(t.get("toolUseId")))
             if e and e.get("deadlineEpoch"):
                 row["deadline"] = float(e["deadlineEpoch"])
                 row["deadlineSrc"] = "hook"
-            if e and e.get("agentId"):
-                row["agentId"] = e["agentId"]
+            tid = str(t.get("taskId") or "")
+            if _bg_is_agent(kind) and _AGENT_ID_RE.match(tid):
+                row["agentId"] = tid       # the stream's own key for an Agent task is the agent's id
+            elif e and e.get("agentId"):
+                row["agentId"] = e["agentId"]   # the ledger's ACTING agent (a shell launched by a subagent)
             out.append(row)
         return [r for r in out if not em._bg_expired(r, time.time())]
     if not path:
         return []
     sp = _sdk_spawned_at(sid)
-    return [{"tid": tk.get("id"), "desc": str(tk.get("summary") or "").strip(), "t": int(tk.get("t") or 0),
-             "type": str(tk.get("type") or "")}
-            for tk in _bg_scan_cached(path)
-            if not (sp and tk.get("t") and tk["t"] < sp)
-            and not em._bg_expired(tk, time.time())]   # a monitor past its lifetime ceiling is not a live wait
+    out = []
+    for tk in _bg_scan_cached(path):
+        if (sp and tk.get("t") and tk["t"] < sp) or em._bg_expired(tk, time.time()):
+            continue                       # a ghost of the previous CLI / a monitor past its lifetime ceiling
+        kind = str(tk.get("type") or "")
+        row = {"tid": tk.get("id"), "desc": _agent_task_label(tk.get("summary"), kind),
+               "t": int(tk.get("t") or 0), "type": kind}
+        if tk.get("agentId"):
+            row["agentId"] = str(tk["agentId"])   # the async ack names the agent (em._scan_bg_tasks)
+        out.append(row)
+    return out
 
 
 def _bg_pending(sid, path, tasks):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17611,15 +17611,23 @@ def _awaiting_live_rows(sid, path, live):
         agents.append(it)
     tasks = _bg_live_norm(sid, path)
     pending = _bg_pending(sid, path, tasks) if tasks else []
+    pending_tids = {t.get("tid") for t in pending}
     meta = None   # the subagents sidecar map, read once and only if an agent launch lacks its agentId
-    for t in pending:
-        # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
-        # story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full rule).
-        # A dispatched agent/workflow is an AGENT row even through the task stream; a shell command or
-        # a Monitor is a COMMAND row. No collapse: two kinds present read as two groups, never "task".
+    for t in tasks:
+        # Sources 0.5/0.75 — a NEW row is added only for a PENDING task (launch not yet placed); a placed
+        # launch's story belongs to the judge's verdicts (see the docstring's 0.5 entry for the full
+        # rule). But the hook⋈stream JOIN runs over EVERY live agent task: once the judge places the
+        # launch turn (the ordinary idle-awaiting steady state) the launch left `pending`, the hook row
+        # never met its stream twin, and the row flapped between the hook's shape (id = agentId, label =
+        # the agent type) and the launch's (id = tid, label = the description) at each placement
+        # (review find on #938, 2026-09-07). A dispatched agent/workflow is an AGENT row even through the
+        # task stream; a shell command or a Monitor is a COMMAND row. No collapse: two kinds present read
+        # as two groups, never "task".
+        is_pending = t.get("tid") in pending_tids
         is_agent = _bg_is_agent(t.get("type"))
         if not is_agent:
-            commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
+            if is_pending:
+                commands.append(_awaiting_item("commands", t.get("tid") or "", t.get("desc") or "background command", t.get("t")))
             continue
         aid = t.get("agentId")
         if not aid and path and t.get("tid"):
@@ -17636,7 +17644,8 @@ def _awaiting_live_rows(sid, path, live):
             if t.get("t") and (not hit.get("since") or int(t["t"]) < hit["since"]):
                 hit["since"] = int(t["t"])
             continue
-        agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
+        if is_pending:   # unmatched by the hook set: a new row only while its launch is still unplaced
+            agents.append(_awaiting_item("agents", t.get("tid") or "", t.get("desc") or "background agent", t.get("t"), agent_id=aid))
     # Source 0.9 — ARMED KERNEL WATCHES this session registered (`romp watch --cmd` / `romp watch-pr`):
     # kernel-owned and restart-proof like the rows themselves, event-true at both ends (armed at
     # registration, cleared when the predicate fires or the watch cancels/times out). The user's rule

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4826,10 +4826,13 @@ class SdkSession:
         self.backend._poke()
 
     def _live_bg_tasks(self) -> list:
-        """The background tasks running RIGHT NOW: [{"desc","type","since","toolUseId","lastTool"}], oldest
-        first. Copied under the lock, like _live_subagents."""
+        """The background tasks running RIGHT NOW: [{"desc","type","since","toolUseId","lastTool","taskId"}],
+        oldest first. Copied under the lock, like _live_subagents. `taskId` is the CLI's own lifecycle key —
+        for an Agent task that IS the agent id (see _on_task_event), which is how the kernel joins this row
+        to the SubagentStart hook's: without it the same agent listed twice in the Awaiting box, once by
+        type and once as "Running <description>" (2026-09-06)."""
         with self._sub_lock:
-            return sorted((dict(v) for v in self._bg_tasks.values()), key=lambda d: d.get("since") or 0)
+            return sorted(({**v, "taskId": k} for k, v in self._bg_tasks.items()), key=lambda d: d.get("since") or 0)
 
     # ---- snapshot for live_sessions() ----
 

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -1,9 +1,10 @@
 # Subagent transcripts: open any agent's whole conversation from the dashboard
 
 **Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, PR #935, 2026-09-05; lands with that PR's
-merge commit). **Slice 2 BUILT** the same day on branch `awaiting-rows`, stacked on #935 — the Awaiting
-box lists what a session waits on as rows grouped by kind, and the chip opens it; its section is at the
-bottom.
+merge commit; a second cut the same day flattened the Agent head's fold — see "The head's fold").
+**Slice 2 BUILT** the same day on branch `awaiting-rows`, stacked on #935 — the Awaiting box lists what a
+session waits on as rows grouped by kind, and the chip opens it; its section is at the bottom. A 2026-09-06
+cut on the same branch made the box ONE presentation in both turn states (see "One presentation" there).
 
 Direction picked by the user (2026-09-05): a Claude Code subagent (the `Agent` tool, older
 transcripts say `Task`) should be readable in full from the dashboard — live while it runs and
@@ -89,18 +90,28 @@ the join (it also fills the bg-scan rows via `_bg_step`).
   anything else that wants to pair a result to its call).
 - `agentId` (or `null`) on every Agent/Task event.
 - `agentAsync: true` when the tool_result was an async launch ack.
+- on EVERY Agent/Task event with a readable agent file, running or finished: `agentSteps:
+  [{tool, desc, ts}, …]` — every tool call the agent has made so far, oldest first, capped at the
+  NEWEST `SUBAGENT_STEPS_CAP` (200) — and `stepsTotal`, the true count (so the label can say it and
+  the fold can note the cut). Folded append-incrementally from the agent's file (`em.fold_records`
+  on `_AGENT_GIST_CACHE`, keyed by the file's (mtime, size)): a growing file steps only its new
+  records, a finished file costs one read and then a stat per build (and its launch turn seals, so
+  the chat fold stops even that). `desc` is the head vocabulary: `input.description`, else the file
+  path, else the first line of the command, clipped. (2026-09-05, second cut: the first cut shipped
+  only `agentGist.recent`, the last three, and only while running; the fold lists them all now, so
+  `recent` left the wire — the client takes `steps.slice(-3)` for the preview.)
 - while a BACKGROUND agent runs: `agentRunning: true`, `output: ""` (the launch ack is not a
-  report — the client's existing "no output → amber dot" rule then reads it as running), and
-  `agentGist: {recent: [{tool, desc, ts}, …up to 3, newest last], calls, since, last}` folded
-  append-incrementally from the agent's file (`em.fold_records`, cached on the file's (mtime,
-  size)). `desc` is the head vocabulary: `input.description`, else the file path, else the first
-  line of the command, clipped.
+  report — the client's existing "no output → amber dot" rule then reads it as running), and the
+  preview's clock `agentGist: {calls, since, last}`. A FOREGROUND agent still mid-turn (no
+  tool_result yet) ships the clock too — the client reads its empty output as running, so the
+  preview needs it.
 - once the background agent's `<task-notification>` has landed in the parent transcript: `output`
   = the notification's `<result>` text (`_parse_task_notification` now captures it; the scan-all
   rows keep it, capped like the chat's own output cap) and `isError` from its status, so the head's
   report fold shows the closing summary instead of the launch ack. The task-notification notice
   card in the transcript stays as it was. A foreground agent's tool_result was always the report.
-- `agentGist` is absent once the agent has finished — the report fold is the endpoint then.
+- `agentGist` is absent once the agent has finished (no clock to show); `agentSteps` + `stepsTotal`
+  keep shipping — the fold lists what the agent did under its prompt and above its report.
 
 **The chat fold** (issue 903's sealed-prefix cache) treats a running agent the way it treats an
 undecided interrupt seam: the launch's turn is never sealed while the agent runs
@@ -141,11 +152,29 @@ rows are untouched.
 - **Arrow** (level 0): a house line-icon button on the Agent/Task head — and on agent bg-task
   rows — when `agentId` is present; tooltip "open transcript" (`setTip`), delegated through
   `actions.ts` (`data-act="openSubagent"`, click-safe across re-renders, `.romp-acted` pulse).
-- **Live preview** (level 0, only while running): up to three dim rows under the head, one per
-  recent tool call in the head vocabulary (`<tool> <desc>`), newest at the bottom, the last row
-  trailing `· N tool calls · <elapsed>`. It wears the tool-fold-toggle's 0.86em (no new size) and
-  lives INSIDE the tool turn, so a collapsed compact run hides it and an expanded run shows it.
-  Gone the moment the agent finishes.
+- **Live preview** (level 0, only while running AND the head's fold is closed): up to three dim rows
+  under the head, one per recent tool call in the head vocabulary (`<tool> <desc>`) — the newest
+  three of `agentSteps` — newest at the bottom, the last row trailing `· N tool calls · <elapsed>`.
+  It wears the tool-fold-toggle's 0.86em (no new size) and lives INSIDE the tool turn, so a
+  collapsed compact run hides it and an expanded run shows it. Gone the moment the agent finishes.
+  When the fold is OPEN the full list below replaces it: the render reads the fold's state from
+  `openFolds` under the fold's own key (no new state), and a CSS twin
+  (`.turn-tool.fold-open > .agent-preview`) hides it the instant the fold is clicked, before the
+  next push rebuilds the turn.
+- **The head's fold** (level 1, ONE click; same `tool:<uuid>` key as every tool fold, so an open fold
+  survives re-renders). Its label says what the click reveals, in order: `prompt · 12 tool calls`
+  while running, `prompt · 12 tool calls · report · 3 lines` once finished (singulars handled; the
+  tool-calls part is omitted at zero — `agentFoldLabel` in `subagent-view.ts`). Inside, all OPEN
+  and nothing nested: the prompt as markdown (the `prompt` field, the green-edged `.agent-report`
+  box); then EVERY shipped tool call, one dim row each in the preview's own classes
+  (`.agent-gist-row` / `-tool` / `-desc`), newest last, growing live on each push while the agent
+  runs (the last row trails the elapsed alone — the count is in the label), with a one-line
+  `N earlier calls not shown` note above when `stepsTotal > agentSteps.length`; then, once
+  finished, the report as markdown. The 2026-07-08 cut nested the prompt and the report as
+  collapsed caret boxes INSIDE the fold, so reading the prompt took two clicks — the user found that
+  odd (2026-09-05), hence the flat fold. The list is inline (no inner scroll box): the cap bounds
+  it at 200 rows, and a scroll-follow rule for a nested live list is more machinery than the case
+  earns; the arrow's viewer is where a long agent gets read properly.
 - **Peek tab viewer** (level 1): the arrow opens a peek tab (`peekId` / `.tab-peek` mechanics —
   `chatVisible()` says a subagent view is in the chat lens only when pinned) with id
   `sub:<sid>:<agentId>`, labelled by the sidecar's description (clipped) or agentType, wearing the
@@ -163,8 +192,9 @@ rows are untouched.
 ## Sizes and caps
 
 Per-block caps are the chat's own (`output` 16000 chars, `input` 4000, prompt/report markdown).
-`SUBAGENT_EVENT_CAP` bounds the shipped tail; the gist keeps 3 recent calls and two timestamps. The
-gist fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
+`SUBAGENT_EVENT_CAP` bounds the shipped tail; `SUBAGENT_STEPS_CAP` (200) bounds the steps on the
+head, with `stepsTotal` honest about the cut; the clock is a count and two timestamps. The steps
+fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
 
 ## Slice 2 (PR stacked on #935): the Awaiting box lists what a session waits on, by kind
 
@@ -273,6 +303,61 @@ delegate; grouped rows and per-kind affordances; Cancel → cancel_watch; the fe
 vocabulary), plus the updated pins in awaiting-state / awaiting-box-sync / awaiting-peer-name /
 bg-tasks-layout / feed-awaiting-swirl / spin-caption / timeline-awaiting / src/bg-tasks.
 Screenshot fixtures: `tools/ui-verify/fixtures/awaiting-rows-{chat,feed}.html`.
+
+### One presentation in both turn states (2026-09-06, same branch)
+**The flap, seen live:** a session with two background agents and a background command showed the grouped
+rows while idle ("Awaiting 3 · 2 agents · 1 command", the idle note). The moment the user sent a message the
+view vanished; when the turn ended it came back. Cause: `_session_awaiting` answers None unless the session
+is idle (by design — the chip's Awaiting is idle-only, a working session is Working), and the rows shipped
+ONLY through it, so mid-turn `awaitingItems` was empty and `renderBgTasks` fell to the LEGACY branch — the
+"N background tasks" list built from `s.bgTasks` (kernel `_bg_tasks`, never idle-gated) — or hid the box when
+that list was empty. Two presentations of one set of facts, swapped at every turn boundary. The chip was
+right and is untouched; the box must not flap.
+
+- **Kernel: the rows do not depend on idleness.** The live-source assembly (hook subagents ⋈ pending agent
+  launches on agentId, the pending commands, the armed watches — the slice-2 code, label rules included) is
+  `_awaiting_live_rows(sid, path, live)`, called by `_session_awaiting` for the idle read and by
+  `_session_background_items(sid, path)` for the turn-agnostic one; `_awaiting_join_items` is the ONE
+  concatenation both use. `_awaiting_items_payload(aw, sid, path, tmux)` is what the two session-scoped
+  surfaces ship as `awaitingItems` (the chat status and the timeline lane, under the SAME key): the wait's
+  own rows when `aw` (= `_session_awaiting`'s answer) exists — for a live-source wait these ARE the live
+  rows, for a peer stamp its peers, for an overlay row nothing — else everything in flight, read under the
+  build's own liveness map (`_serve_live` lends it to `_live_scope`, the pusher cycle's one-snapshot
+  mechanism): the working path never took a fresh liveness read and `test_kernel_pusher_snapshot.py`
+  holds it to that — the first cut forked tmux twice per build there. `awaitingWhy` / `awaitingKind`
+  / `awaitingCount` / `awaitingTasks` / `awaitingTaskIds` stay idle-gated exactly as before, so nothing
+  about WHEN the chip or a card moves changed; peer waits and timers exist only through the idle-gated arms
+  and simply do not appear mid-turn. The goal card and the placeholder keep their rows inside the card's
+  `awaiting` object (a wait only) — the feed pill already shows only for a wait.
+- **The 2026-08-30 mid-turn watch arm is retired.** The chat status used to re-run `_watch_awaiting` alone
+  into `awaitingWhy` while the turn was open, to keep armed watches visible mid-turn. That satisfied the
+  rule then but made the box read "Awaiting" (idle note included) under a Working chip, and left every OTHER
+  in-flight row to the legacy list. Watches ride `awaitingItems` mid-turn like everything else now, and
+  `awaitingWhy` means one thing on every surface: idle and waiting on these (⇔ the chip's Awaiting).
+  `tests/test_kernel.py::test_a_working_session_still_lists_its_armed_kernel_watches` pins the new shape.
+- **Client: one renderer.** `renderAwaitWhy` is folded into `renderBgTasks`; the legacy count-headed branch
+  is gone and the string "background tasks" no longer exists in the renderer. The box shows whenever there is
+  a wait, rows, or tracked tasks, and hides otherwise. Header: a wait (`awaitingWhy`) → today's
+  "Awaiting 3 · 2 agents · 1 command" / single-kind sentence / named peers, await-green dot, the idle note
+  closing the list; no wait → "In the background · 2 agents · 1 command" (singular forms fall out of
+  `awaitBreakdown`), the worst tracked status as the dot (a failed task stays glanceable while collapsed;
+  running-yellow otherwise), NO note. Row affordances are identical in both states (`bgRow` fed by
+  `awaitRowSpec` / `taskRowSpec`; `s.bgTasks` still lends command rows their output tail and Stop handle).
+  Tracked tasks the wait does not name list under "Also running" (was "Background tasks"); when the kernel
+  names no rows at all the working header counts them as the commands they are ("In the background · 1
+  command" for a dev server). The `bg-awaited` outline is one toggle: a wait, or a tracked task named in
+  `awaitingTaskIds` — the ids' presence, never the chip state; mid-turn the box wears its neutral border.
+  `bgFoldOpen` is only ever written by the header toggle and the chip click, so the status-only frame that
+  flips `awaitingWhy` (through `awaitKey`) finds the fold as it was.
+- **Tests:** kernel `tests/test_awaiting_rows.py::RowsDoNotDependOnIdleness` (same synthetic session idle vs
+  mid-turn → identical rows; the wait only when idle; watches mid-turn; a stamp's own rows; the shared join),
+  `test_awaiting_count.py` (the idle-only fields stay idle-only while the rows ride; the re-pinned ship
+  sites), `test_kernel_bg_tasks.py` (the same three joined rows on the real `_bg_live_norm` with the turn
+  open). UI `awaiting-rows.test.ts` ("one presentation" section: one renderer, the header rule per state
+  executed, no note working, no legacy string, the fold writers), plus the deliberately re-pinned
+  awaiting-state / awaiting-box-sync / awaiting-peer-name / bg-tasks-layout / src/bg-tasks pins, each with a
+  note saying why. The chat fixture (`tools/ui-verify/fixtures/awaiting-rows-chat.html`) now shows both
+  states one above the other.
 
 ### Left for later
 - Nested subagents' chain in the viewer header (parent → agent → agent) — slice-2 polish from the

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -189,7 +189,14 @@ the card at all.
   Workflow dispatches, `commands` for run_in_background Bash and Monitor), and the armed watches
   (`watches`; label = the `--note`, else the clipped predicate, else `PR #N (repo)`). A background agent
   seen by BOTH the hook set and the task stream is one row (matched on agentId), wearing the launch's id
-  (Stop's handle), its description, and the earlier start. `_awaiting_from_items` derives the legacy
+  (Stop's handle), its description, and the earlier start. **The stream row's agentId is the lifecycle
+  task's own id** (`taskId` on every bgTasks row since 2026-09-06 — the CLI keys an Agent task by its
+  agent id), or the async ack's `agentId` on the transcript-scan path; the sidecar meta map is only a
+  fallback. Before that fix the stream rows carried no key at all (the ledger is Bash/Monitor-only and
+  records the ACTING agent; the meta map is keyed on the original launch's toolUseId, which a resumed
+  agent's task no longer carries), so each agent listed twice — once by type with the arrow, once as
+  "Running <description>" without it — and the chip counted both. Agent rows also drop the CLI's
+  "Running " prefix from the lifecycle description (`_agent_task_label`): the STATUS word already says it. `_awaiting_from_items` derives the legacy
   `kind` / `count` / `why` / `since` / `tasks` from the union: one kind present → that kind's legacy key
   and the sentence it always wore; several → kind `"mixed"`, count = every row, and a why that names
   each group ("waiting on 2 background agents, 1 background command and 1 armed watch"). The all(...)

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -1,8 +1,9 @@
 # Subagent transcripts: open any agent's whole conversation from the dashboard
 
-**Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, 2026-09-05; lands with this PR's
-merge commit; second cut the same day flattened the Agent head's fold — see "The head's fold").
-Slice 2 (the Awaiting box by kind) is scoped at the bottom and is a separate PR.
+**Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, PR #935, 2026-09-05; lands with that PR's
+merge commit). **Slice 2 BUILT** the same day on branch `awaiting-rows`, stacked on #935 — the Awaiting
+box lists what a session waits on as rows grouped by kind, and the chip opens it; its section is at the
+bottom.
 
 Direction picked by the user (2026-09-05): a Claude Code subagent (the `Agent` tool, older
 transcripts say `Task`) should be readable in full from the dashboard — live while it runs and
@@ -88,28 +89,18 @@ the join (it also fills the bg-scan rows via `_bg_step`).
   anything else that wants to pair a result to its call).
 - `agentId` (or `null`) on every Agent/Task event.
 - `agentAsync: true` when the tool_result was an async launch ack.
-- on EVERY Agent/Task event with a readable agent file, running or finished: `agentSteps:
-  [{tool, desc, ts}, …]` — every tool call the agent has made so far, oldest first, capped at the
-  NEWEST `SUBAGENT_STEPS_CAP` (200) — and `stepsTotal`, the true count (so the label can say it and
-  the fold can note the cut). Folded append-incrementally from the agent's file (`em.fold_records`
-  on `_AGENT_GIST_CACHE`, keyed by the file's (mtime, size)): a growing file steps only its new
-  records, a finished file costs one read and then a stat per build (and its launch turn seals, so
-  the chat fold stops even that). `desc` is the head vocabulary: `input.description`, else the file
-  path, else the first line of the command, clipped. (2026-09-05, second cut: the first cut shipped
-  only `agentGist.recent`, the last three, and only while running; the fold lists them all now, so
-  `recent` left the wire — the client takes `steps.slice(-3)` for the preview.)
 - while a BACKGROUND agent runs: `agentRunning: true`, `output: ""` (the launch ack is not a
-  report — the client's existing "no output → amber dot" rule then reads it as running), and the
-  preview's clock `agentGist: {calls, since, last}`. A FOREGROUND agent still mid-turn (no
-  tool_result yet) ships the clock too — the client reads its empty output as running, so the
-  preview needs it.
+  report — the client's existing "no output → amber dot" rule then reads it as running), and
+  `agentGist: {recent: [{tool, desc, ts}, …up to 3, newest last], calls, since, last}` folded
+  append-incrementally from the agent's file (`em.fold_records`, cached on the file's (mtime,
+  size)). `desc` is the head vocabulary: `input.description`, else the file path, else the first
+  line of the command, clipped.
 - once the background agent's `<task-notification>` has landed in the parent transcript: `output`
   = the notification's `<result>` text (`_parse_task_notification` now captures it; the scan-all
   rows keep it, capped like the chat's own output cap) and `isError` from its status, so the head's
   report fold shows the closing summary instead of the launch ack. The task-notification notice
   card in the transcript stays as it was. A foreground agent's tool_result was always the report.
-- `agentGist` is absent once the agent has finished (no clock to show); `agentSteps` + `stepsTotal`
-  keep shipping — the fold lists what the agent did under its prompt and above its report.
+- `agentGist` is absent once the agent has finished — the report fold is the endpoint then.
 
 **The chat fold** (issue 903's sealed-prefix cache) treats a running agent the way it treats an
 undecided interrupt seam: the launch's turn is never sealed while the agent runs
@@ -150,29 +141,11 @@ rows are untouched.
 - **Arrow** (level 0): a house line-icon button on the Agent/Task head — and on agent bg-task
   rows — when `agentId` is present; tooltip "open transcript" (`setTip`), delegated through
   `actions.ts` (`data-act="openSubagent"`, click-safe across re-renders, `.romp-acted` pulse).
-- **Live preview** (level 0, only while running AND the head's fold is closed): up to three dim rows
-  under the head, one per recent tool call in the head vocabulary (`<tool> <desc>`) — the newest
-  three of `agentSteps` — newest at the bottom, the last row trailing `· N tool calls · <elapsed>`.
-  It wears the tool-fold-toggle's 0.86em (no new size) and lives INSIDE the tool turn, so a
-  collapsed compact run hides it and an expanded run shows it. Gone the moment the agent finishes.
-  When the fold is OPEN the full list below replaces it: the render reads the fold's state from
-  `openFolds` under the fold's own key (no new state), and a CSS twin
-  (`.turn-tool.fold-open > .agent-preview`) hides it the instant the fold is clicked, before the
-  next push rebuilds the turn.
-- **The head's fold** (level 1, ONE click; same `tool:<uuid>` key as every tool fold, so an open fold
-  survives re-renders). Its label says what the click reveals, in order: `prompt · 12 tool calls`
-  while running, `prompt · 12 tool calls · report · 3 lines` once finished (singulars handled; the
-  tool-calls part is omitted at zero — `agentFoldLabel` in `subagent-view.ts`). Inside, all OPEN
-  and nothing nested: the prompt as markdown (the `prompt` field, the green-edged `.agent-report`
-  box); then EVERY shipped tool call, one dim row each in the preview's own classes
-  (`.agent-gist-row` / `-tool` / `-desc`), newest last, growing live on each push while the agent
-  runs (the last row trails the elapsed alone — the count is in the label), with a one-line
-  `N earlier calls not shown` note above when `stepsTotal > agentSteps.length`; then, once
-  finished, the report as markdown. The 2026-07-08 cut nested the prompt and the report as
-  collapsed caret boxes INSIDE the fold, so reading the prompt took two clicks — the user found that
-  odd (2026-09-05), hence the flat fold. The list is inline (no inner scroll box): the cap bounds
-  it at 200 rows, and a scroll-follow rule for a nested live list is more machinery than the case
-  earns; the arrow's viewer is where a long agent gets read properly.
+- **Live preview** (level 0, only while running): up to three dim rows under the head, one per
+  recent tool call in the head vocabulary (`<tool> <desc>`), newest at the bottom, the last row
+  trailing `· N tool calls · <elapsed>`. It wears the tool-fold-toggle's 0.86em (no new size) and
+  lives INSIDE the tool turn, so a collapsed compact run hides it and an expanded run shows it.
+  Gone the moment the agent finishes.
 - **Peek tab viewer** (level 1): the arrow opens a peek tab (`peekId` / `.tab-peek` mechanics —
   `chatVisible()` says a subagent view is in the chat lens only when pinned) with id
   `sub:<sid>:<agentId>`, labelled by the sidecar's description (clipped) or agentType, wearing the
@@ -190,18 +163,113 @@ rows are untouched.
 ## Sizes and caps
 
 Per-block caps are the chat's own (`output` 16000 chars, `input` 4000, prompt/report markdown).
-`SUBAGENT_EVENT_CAP` bounds the shipped tail; `SUBAGENT_STEPS_CAP` (200) bounds the steps on the
-head, with `stepsTotal` honest about the cut; the clock is a count and two timestamps. The steps
-fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
+`SUBAGENT_EVENT_CAP` bounds the shipped tail; the gist keeps 3 recent calls and two timestamps. The
+gist fold state is bounded by the JSONL cache's LRU (384 files) like every other reader.
 
-## Slice 2 (separate PR): the Awaiting box lists what a session waits on, by kind
+## Slice 2 (PR stacked on #935): the Awaiting box lists what a session waits on, by kind
 
-- The bg-tasks / awaiting box groups pending rows in separate sections — **agents** (each with the
-  arrow above), **commands** (background Bash), **watches** (monitors) — instead of one flat list.
-- The statusline "Awaiting …" chip becomes clickable and opens that box.
-- The mixed-set label collapse goes away: `_session_awaiting`'s "kind is `agents` only if every
-  pending row is an agent, else `task`" is replaced by per-kind counts the chip can word honestly
-  ("2 agents · 1 command").
-- Nested subagents (an agent's own Agent calls, `spawnDepth` 2) already carry the arrow inside the
-  viewer since the meta map is per parent transcript; making the viewer's header show the chain
-  (parent → agent → agent) is slice-2 polish.
+**Status: built 2026-09-05** (branch `awaiting-rows`). The user's call, paraphrased: the three things a
+session can wait on — agents, background commands, kernel watches — are different things, so show them
+as SEPARATE ROWS grouped by kind, and make the chip clickable.
+
+### The defect it fixes (traced before the change)
+`_session_awaiting` answered with ONE kind chosen by source precedence: live SDK subagents → "agents";
+else the pending background launches → "agents" only if EVERY pending row was an agent, else the generic
+"task" (so a background shell command plus a background agent read "Awaiting 2 tasks" with the agent
+silently absorbed); else armed watches → "job", a word nothing else on screen explained. The same
+situation read "agents" or "tasks" depending on which source spoke first, and the statusline chip was a
+plain span — the one status word on the pane you could not click through. The feed's pill showed only
+when the legacy `tasks` list was non-empty, so a wait on live subagents had no clickable affordance on
+the card at all.
+
+### Kernel (`kernel/kernel.py`, `kernel/judge.py`)
+- `_session_awaiting` COMBINES its live sources instead of short-circuiting. Each contributes rows
+  (`_awaiting_item`): the backend snapshot's live subagents (kind `agents`, carrying the hook's
+  `agentId` so the slice-1 arrow works), the pending background launches (`agents` for Agent/Task/
+  Workflow dispatches, `commands` for run_in_background Bash and Monitor), and the armed watches
+  (`watches`; label = the `--note`, else the clipped predicate, else `PR #N (repo)`). A background agent
+  seen by BOTH the hook set and the task stream is one row (matched on agentId), wearing the launch's id
+  (Stop's handle), its description, and the earlier start. `_awaiting_from_items` derives the legacy
+  `kind` / `count` / `why` / `since` / `tasks` from the union: one kind present → that kind's legacy key
+  and the sentence it always wore; several → kind `"mixed"`, count = every row, and a why that names
+  each group ("waiting on 2 background agents, 1 background command and 1 armed watch"). The all(...)
+  collapse is gone. The overlay, owned-yield, judge-stamp and delegation arms ship `items: []` (they
+  name no live rows) except the peer arms, which list their peers as `peer` rows.
+- **The wire shape**, shipped wherever `awaitingKind`/`awaitingCount` ship — the chat status
+  (`awaitingItems`), the timeline lane (`awaitingItems`), the goal card and the placeholder card
+  (`awaiting.items`): `[{kind, id, label, since, agentId?, detail?, watchId?}]`, kind in
+  `agents | commands | watches | peer | timer`. `since` is the row's OWN event time or null, never now.
+  A generic watch row carries `watchId` (cancel_watch's handle) and its predicate as `detail`; a PR
+  watch carries neither.
+- `AWAIT_KINDS` gains `"mixed"`; the judge's parse sites (`_parse_close`, `_parse_plan`) validate
+  against `AWAIT_KINDS_JUDGED` (the five specific kinds), so a closer never FILES mixed — an LLM
+  emitting the word degrades to kindless like any other off-enum kind, and every lift/supersede rule
+  keyed on a stamp's kind keeps seeing a specific one. The overlay reader accepts mixed as data.
+- Vocabulary in the kernel's sentences: "waiting on a background command: X" / "waiting on 2 background
+  commands — X, …" (was "task(s)"), "waiting on 2 armed watches — X, …" (unchanged), "N background
+  agent(s) still working" (unchanged). The owned-yield arm and `_awaiting_card`'s fallback headline say
+  "command" too; the legacy kind KEYS (`task`, `job`) stay for every consumer that reads them.
+- A `cancelWatch` WS door: `{type: "cancelWatch", id: <sid>, watchId}` → the SAME `cancel_watch` that
+  `romp watch --cancel <id>` and `POST /watch {"cancel"}` reach; loud `warn` on a miss. **A cancel path
+  existed for generic watches only** — nothing retires a `romp watch-pr` early today, so PR-watch rows
+  carry no `watchId` and the box offers no button for them (not added here: it would be a new retire
+  path, out of this slice's scope).
+
+### Words (`ui/webview/spin-caption.ts`, `ui/romp-timeline-view.js`)
+`KIND_WORD` keeps the kernel's keys and changes the words: `task` → "command", `job` → "watch",
+`mixed` → no word; `kindWord` pluralizes "watch" → "watches". New shared helpers: `groupRows` (display
+order agents → commands → watches → peers → timers; an unknown group is kept, never dropped),
+`awaitBreakdown` ("2 agents · 1 command · 1 watch"), and `awaitWord` — the ONE label rule for the chip,
+the box gist and the feed pill: one row → its word ("agent" / "command" / "watch" / "timer"; a peer row →
+the peer's own name, swapped in by the caller); several of one kind → count + word ("3 agents");
+several kinds → the number alone ("4"); no rows (an older kernel, a stamp) → the legacy kind + count as
+before. The timeline's standalone twin mirrors the table (`tlKindWord`), and its badge goes through
+`tlAwaitSuffix` so a mixed wait reads "Awaiting 4" on the lane — the only timeline change.
+
+### Chat pane (`ui/webview/render.ts`, `styles.css`)
+- The statusline chip is a `<button class="chip chip-awaitingBg chip-btn" data-act="awaitingChip">`
+  on a delegate installed once on the stable `#statusline` (click-safe across the per-push rebuild; the
+  delegate's `.romp-acted` pulse acknowledges). Click → `bgFoldOpen.add(sid)` (the box's own fold
+  state), `renderBgTasks()`, `scrollIntoView`. Tip via `setTip`: the breakdown, the kernel's why, and
+  what the click does. Label per `awaitWord`; a single named peer keeps its coloured name.
+- `renderBgTasks` hands the box to `renderAwaitWhy` whenever a wait exists (tracked tasks join its
+  rows); the tasks-only path (no wait: a service the session keeps around) is unchanged. `renderAwaitWhy`
+  header: "Awaiting <n> · <breakdown>" for mixed, the single-kind sentence as before. Expanded: the rows
+  grouped by kind under `.bg-group-head` (shown only when 2+ groups, "Background tasks" counting as a
+  group for the tracked leftovers), then the plain-words note. ONE row renderer (`bgRow`, fed by
+  `awaitRowSpec` / `taskRowSpec`): agent rows → the slice-1 arrow + Stop while their launch is a live
+  tracked task, the prompt as the fold, NO output tail (the output file is the raw transcript; the arrow
+  is the way in — this also drops the raw JSONL fold from tracked agent rows in the tasks-only path);
+  command rows → status, Stop, the command + output-tail fold; watch rows → await-green dot, "armed",
+  "· 31m" since registration, Cancel when `watchId` rides, the predicate as the fold; peer rows → the
+  name in identity colour; a row with nothing to unfold is not a toggle. Per-row "· 12m" clocks tick
+  with the statusline timer from `data-since` (the box re-renders only on new fields; `awaitKey` now
+  includes `awaitingItems`). A wait with no rows (stamp / overlay) still expands to its full sentence.
+- No change to WHEN the chip flips or a card moves: `_session_chip`'s formula is untouched; only what
+  the surfaces say and what is clickable changed.
+
+### Feed (`ui/webview/feed.ts`, `feed.css`)
+The pill shows for ANY wait with rows (`awaiting.items`, or an older kernel's `tasks` read as rows of
+the legacy kind's group), reads by `awaitWord` (a single peer → its coloured name), opens by default
+like the bg-task pill did, and its expansion lists the rows grouped under `.ftask-group` headers when
+2+ groups — labels only (peer rows keep the identity colour + click-opens-session). `spinFor`'s
+say-it-once rule now stands the caption down under rows of ANY kind (`items` or `tasks`); a wait the
+kernel cannot enumerate keeps the boxed caption, the only place its why shows.
+
+### Tests
+Kernel: `tests/test_awaiting_rows.py` (all three sources at once → mixed; the shell + agent case is two
+rows of two kinds, never "task"; the hook/launch merge; single-kind sentences; watch rows' handles; the
+mixed kind's enum/parse rules; the cancel door), plus the existing pins updated with a note each
+(`test_awaiting_count.py` also pins that every surface ships the rows). UI: `ui/webview/awaiting-rows.
+test.ts` (the label rules executed; the three word maps agree on every kind × count; chip-as-button +
+delegate; grouped rows and per-kind affordances; Cancel → cancel_watch; the feed pill for any wait; the
+vocabulary), plus the updated pins in awaiting-state / awaiting-box-sync / awaiting-peer-name /
+bg-tasks-layout / feed-awaiting-swirl / spin-caption / timeline-awaiting / src/bg-tasks.
+Screenshot fixtures: `tools/ui-verify/fixtures/awaiting-rows-{chat,feed}.html`.
+
+### Left for later
+- Nested subagents' chain in the viewer header (parent → agent → agent) — slice-2 polish from the
+  original scoping, not done here.
+- An early-retire path for PR watches (then the watch row's Cancel appears for them too).
+- The owned-yield arm words every owned dispatch as a "command" (it carries no type); a placed agent
+  dispatch that outruns a block with no stamp is the one case that reads slightly off.

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -52,8 +52,10 @@ class SourcePins(unittest.TestCase):
             self.assertIn("if (awaitKey(s.status) !== before) renderBgTasks();", body, fn)
 
     def test_the_chip_and_the_gist_agree_in_number_from_one_count(self):
-        self.assertIn("kindWord(s.status.awaitingKind, s.status.awaitingCount)", RENDER)
-        self.assertIn("kindWord(s!.status.awaitingKind, s!.status.awaitingCount)", RENDER)
+        # since slice 2 (plans/subagent-transcripts.md, 2026-09-05) the ONE rule is awaitWord: the kernel's
+        # kind + count + the awaited ROWS word the chip and the gist alike ("agent", "3 agents", "4" for mixed)
+        self.assertIn("const chipWord = awaitWord(s.status.awaitingKind, s.status.awaitingCount, chipItems);", RENDER)
+        self.assertIn("const word = awaitWord(s!.status.awaitingKind, s!.status.awaitingCount, items);", RENDER)
 
 
 def _free_port():

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -55,7 +55,7 @@ class SourcePins(unittest.TestCase):
         # since slice 2 (plans/subagent-transcripts.md, 2026-09-05) the ONE rule is awaitWord: the kernel's
         # kind + count + the awaited ROWS word the chip and the gist alike ("agent", "3 agents", "4" for mixed)
         self.assertIn("const chipWord = awaitWord(s.status.awaitingKind, s.status.awaitingCount, chipItems);", RENDER)
-        self.assertIn("const word = awaitWord(s!.status.awaitingKind, s!.status.awaitingCount, items);", RENDER)
+        self.assertIn("const word = awaitWord(s.status.awaitingKind, s.status.awaitingCount, items);", RENDER)   # `s` narrowed by the one renderer's gate (2026-09-06)
 
 
 def _free_port():

--- a/tests/test_awaiting_card.py
+++ b/tests/test_awaiting_card.py
@@ -33,7 +33,7 @@ class AwaitingCard(unittest.TestCase):
     def tearDown(self):
         km._parse, km._awaiting_task_descs = self._parse, self._descs
 
-    def _card(self, why="waiting on a background task: watching CI run", live=True, now=2000):
+    def _card(self, why="waiting on a background command: watching CI run", live=True, now=2000):
         return km._awaiting_card({"sid": SID, "path": "/tmp/x"}, "docs", COLOR, SID, live, now, why)
 
     def test_shape_is_a_working_column_provisional_awaiting_card(self):
@@ -49,7 +49,7 @@ class AwaitingCard(unittest.TestCase):
     def test_awaiting_carries_the_live_task_descriptions_for_the_pill(self):
         c = self._card()
         self.assertEqual(c["awaiting"]["tasks"], ["watching CI run"])
-        self.assertEqual(c["awaiting"]["why"], "waiting on a background task: watching CI run")
+        self.assertEqual(c["awaiting"]["why"], "waiting on a background command: watching CI run")
 
     def test_awaiting_carries_the_waits_own_start_for_the_elapsed_readout(self):
         # the user 2026-08-23: Working shows how long it has been running, the awaiting states showed
@@ -60,10 +60,11 @@ class AwaitingCard(unittest.TestCase):
         self.assertIsNone(self._card()["awaiting"]["since"])   # absent → None: the UI shows no duration, never a guess
 
     def test_headline_capitalizes_the_why(self):
-        self.assertTrue(self._card()["text"].startswith("Waiting on a background task"))
+        self.assertTrue(self._card()["text"].startswith("Waiting on a background command"))
 
     def test_empty_why_falls_back_to_a_generic_headline(self):
-        self.assertEqual(self._card(why="")["text"], "Waiting on a background task")
+        # "command", not "task", since slice 2 (2026-09-05) — the awaiting vocabulary is agents / commands / watches
+        self.assertEqual(self._card(why="")["text"], "Waiting on a background command")
 
     def test_a_dead_session_gets_no_card(self):
         self.assertIsNone(self._card(live=False))

--- a/tests/test_awaiting_count.py
+++ b/tests/test_awaiting_count.py
@@ -77,6 +77,8 @@ class AwaitingCount(unittest.TestCase):
             aw = km._session_awaiting(SID, "/tmp/x", True)
             self.assertEqual((aw["kind"], aw["count"]), ("job", 3))
             self.assertEqual(len(aw["tasks"]), 3)
+            self.assertEqual(len(aw["items"]), 3, "one row per watch (slice 2)")
+            self.assertTrue(all(it["kind"] == "watches" for it in aw["items"]))
         finally:
             km._watches, km._pr_watches = saved
 
@@ -122,9 +124,20 @@ class AwaitingCount(unittest.TestCase):
         self.assertIn('"awaitingCount": ((_aw_bg or {}).get("count") if isinstance((_aw_bg or {}).get("count"), int) else None),',
                       src, "the timeline lane payload")
         self.assertIn('"count": await_count,', src, "the goal card's awaiting object")
-        self.assertIn('(_owned_why, "task", _owned_since, None, 1)', src, "one owned dispatch counts one")
-        self.assertIn('(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None))', src,
-                      "a stamp counts the peers it names")
+        # the or-chain tuples grew a sixth slot — the awaited ROWS (slice 2, 2026-09-05) — beside the count
+        self.assertIn('(_owned_why, "task", _owned_since, None, 1, [])', src, "one owned dispatch counts one (and names no row)")
+        self.assertIn('(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None), _awaiting_peer_items(_stamp_peers))', src,
+                      "a stamp counts the peers it names, and lists them as rows")
+
+    def test_every_surface_ships_the_rows_beside_the_count(self):
+        # slice 2 (plans/subagent-transcripts.md, 2026-09-05): wherever awaitingKind/awaitingCount ship,
+        # the awaited ROWS ship too — the chat status, the timeline lane, the goal card, the placeholder card
+        src = inspect.getsource(km)
+        self.assertIn('"awaitingItems": (list((_aw or {}).get("items") or []) if awaiting_why else []),', src, "the chat status payload")
+        self.assertIn('"awaitingItems": (list((_aw_bg or {}).get("items") or []) if awaiting_bg else []),', src, "the timeline lane payload")
+        self.assertIn('"items": await_items,', src, "the goal card's awaiting object")
+        self.assertIn('"items": list(items or []),', src, "the placeholder card's awaiting object")
+        self.assertIn('count=sess_awaiting_count, items=sess_awaiting_items))', src, "…threaded from the session read")
 
 
 if __name__ == "__main__":

--- a/tests/test_awaiting_count.py
+++ b/tests/test_awaiting_count.py
@@ -58,6 +58,21 @@ class AwaitingCount(unittest.TestCase):
         self.assertEqual(aw["count"], 3)
         self.assertIn("3 background agents", aw["why"])
 
+    def test_an_agent_seen_by_the_hook_and_the_stream_counts_once(self):
+        # 2026-09-06: two agents + one shell command read "Awaiting 5 · 4 agents · 1 command" because the
+        # hook row and the stream row for the same agent were never joined — the count is per awaited THING
+        a1, a2 = "a1111111111111111", "a2222222222222222"
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": a1},
+                                                         {"type": "general-purpose", "since": 105, "agentId": a2}]}}
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "toolu_01", "desc": "check the exporter", "t": 98, "type": "local_agent", "agentId": a1},
+            {"tid": "toolu_02", "desc": "rerun the harness", "t": 104, "type": "local_agent", "agentId": a2},
+            {"tid": "toolu_03", "desc": "build the docs", "t": 110, "type": "local_bash"}]
+        km._bg_pending = lambda sid, path, ts: ts
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 3))
+        self.assertEqual(aw["why"], "waiting on 2 background agents and 1 background command")
+
     def test_pending_tasks_count_the_pending_ones(self):
         tasks = [{"tid": "1", "desc": "watching CI", "t": 7, "type": "bash"},
                  {"tid": "2", "desc": "polling deploy", "t": 3, "type": "bash"}]

--- a/tests/test_awaiting_count.py
+++ b/tests/test_awaiting_count.py
@@ -146,13 +146,38 @@ class AwaitingCount(unittest.TestCase):
 
     def test_every_surface_ships_the_rows_beside_the_count(self):
         # slice 2 (plans/subagent-transcripts.md, 2026-09-05): wherever awaitingKind/awaitingCount ship,
-        # the awaited ROWS ship too — the chat status, the timeline lane, the goal card, the placeholder card
+        # the awaited ROWS ship too — the chat status, the timeline lane, the goal card, the placeholder card.
+        # Pins changed 2026-09-06: the two SESSION-scoped surfaces ship the rows in BOTH turn states now
+        # (_awaiting_items_payload: the wait's rows when idle-awaiting, everything in flight otherwise) —
+        # gating them on awaiting_why made the chat box swap presentations at every turn boundary. The
+        # goal card and the placeholder keep theirs inside the card's awaiting object (a wait only).
         src = inspect.getsource(km)
-        self.assertIn('"awaitingItems": (list((_aw or {}).get("items") or []) if awaiting_why else []),', src, "the chat status payload")
-        self.assertIn('"awaitingItems": (list((_aw_bg or {}).get("items") or []) if awaiting_bg else []),', src, "the timeline lane payload")
+        self.assertIn('_aw_items = _awaiting_items_payload(_aw, sid, sess["path"], tmux)', src, "the chat status payload (under the build's own snapshot)")
+        self.assertIn('"awaitingItems": _aw_items,', src, "the chat status payload")
+        self.assertIn('"awaitingItems": (_awaiting_items_payload(_aw_bg, sid, s["path"], tmux) if live else []),', src, "the timeline lane payload")
         self.assertIn('"items": await_items,', src, "the goal card's awaiting object")
         self.assertIn('"items": list(items or []),', src, "the placeholder card's awaiting object")
         self.assertIn('count=sess_awaiting_count, items=sess_awaiting_items))', src, "…threaded from the session read")
+
+    def test_mid_turn_the_count_kind_and_why_stay_idle_only_while_the_rows_ride(self):
+        # 2026-09-06: the chip's Awaiting (and the count/kind it words itself from) is idle-only BY DESIGN —
+        # a working session is Working. What changed is the ROWS: they are the same set either way, so the
+        # box that lists them no longer swaps presentations when a turn opens. The one-number contract holds
+        # in the idle state exactly as before; mid-turn there is no number, only the rows.
+        a1, a2 = "a1111111111111111", "a2222222222222222"
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": a1},
+                                                         {"type": "general-purpose", "since": 105, "agentId": a2}]}}
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "toolu_01", "desc": "check the exporter", "t": 98, "type": "local_agent", "agentId": a1},
+            {"tid": "toolu_02", "desc": "rerun the harness", "t": 104, "type": "local_agent", "agentId": a2},
+            {"tid": "toolu_03", "desc": "build the docs", "t": 110, "type": "local_bash"}]
+        km._bg_pending = lambda sid, path, ts: ts
+        idle = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((idle["kind"], idle["count"]), ("mixed", 3))
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", False), "mid-turn: no wait, no count, no kind, no why")
+        self.assertEqual(km._awaiting_items_payload(None, SID, "/tmp/x"), idle["items"],
+                         "…but the rows the surfaces ship are the SAME three, in the same order")
+        self.assertEqual(km._awaiting_items_payload(idle, SID, "/tmp/x"), idle["items"], "idle: the wait's own rows")
 
 
 if __name__ == "__main__":

--- a/tests/test_awaiting_rows.py
+++ b/tests/test_awaiting_rows.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""The awaited ROWS (plans/subagent-transcripts.md slice 2, the user 2026-09-05).
+
+_session_awaiting (bin/romp-kernel) used to answer with ONE kind chosen by source precedence — live
+subagents, else the pending background launches (kind "agents" only if EVERY pending row was an agent,
+else the generic "task"), else armed watches. So one situation read "agents" or "tasks" by accident of
+ordering, a background shell command plus a background agent read "Awaiting 2 tasks" with the agent
+silently absorbed, and nothing on screen listed what was awaited. The user's call: the kinds are
+different things — show them as SEPARATE ROWS grouped by kind. Now every live source contributes
+`items` (one row per awaited thing: {kind, id, label, since, agentId?, detail?, watchId?}, kind in
+agents / commands / watches / peer / timer), the legacy kind/count/why are DERIVED from the union, and
+several kinds at once make kind "mixed" (jd.AWAIT_KINDS) with count = every row.
+
+Synthetic inputs only; sources stubbed like test_awaiting_count.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_awaitrows", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-666666666666"
+AID = "a0123456789abcdef"          # a synthetic agent id (the hook's agent_id shape)
+
+
+class AwaitingRows(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_tmux_sessions", "_bg_live_norm", "_bg_pending", "_states_awaiting_overlay",
+                        "_owned_yield_why", "_session_stamp_full", "_session_delegated_why",
+                        "_session_delegated_identities", "_watches", "_pr_watches", "_peer_identity")}
+        km._tmux_sessions = lambda: {SID: {}}
+        km._bg_live_norm = lambda sid, path: []
+        km._bg_pending = lambda sid, path, tasks: tasks
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: None
+        km._session_stamp_full = lambda sid: (None, 0, None, None, ())
+        km._session_delegated_why = lambda sid: None
+        km._session_delegated_identities = lambda sid: []
+        km._watches, km._pr_watches = [], []
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+
+    # ---- all sources at once ----
+
+    def test_all_three_sources_contribute_rows_and_several_kinds_read_mixed(self):
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "explore", "since": 100, "agentId": AID}]}}
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "tu_agent2", "desc": "map the parser", "t": 120, "type": "local_agent", "agentId": "a1111111111111111"},
+            {"tid": "tu_bash1", "desc": "build the docs", "t": 130, "type": "local_bash"}]
+        km._watches = [{"id": "w1", "sid": SID, "cmd": "test -f /tmp/notes-api.done", "note": "the CI run", "at": 90}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"]), ("mixed", 4), "several kinds → mixed; every row counted")
+        self.assertEqual([it["kind"] for it in aw["items"]], ["agents", "agents", "commands", "watches"],
+                         "grouped in display order: agents, then commands, then watches")
+        self.assertEqual(aw["why"], "waiting on 2 background agents, 1 background command and 1 armed watch")
+        self.assertEqual(aw["since"], 90, "the oldest row's own event time")
+        self.assertEqual(aw["tasks"], ["explore", "map the parser", "build the docs", "the CI run"],
+                         "the legacy descriptions list every row, for consumers still reading tasks")
+
+    def test_a_shell_and_an_agent_pending_are_two_rows_never_the_collapse_word(self):
+        # the exact defect: a background shell command plus a background agent read "Awaiting 2 tasks"
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "tu_bash1", "desc": "build the docs", "t": 10, "type": "local_bash"},
+            {"tid": "tu_agent1", "desc": "audit the sampler", "t": 11, "type": "local_agent"}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["kind"], "mixed")
+        self.assertNotEqual(aw["kind"], "task")
+        self.assertEqual(sorted(it["kind"] for it in aw["items"]), ["agents", "commands"])
+        self.assertEqual(aw["count"], 2)
+        self.assertNotIn("task", aw["why"])
+
+    def test_a_hook_seen_agent_and_its_launch_row_merge_into_one_row(self):
+        # the same agent is in BOTH the hook set (SubagentStart) and the task stream (the launch ack):
+        # one row, wearing the launch's id (Stop's handle), its description, and the earliest start
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "explore", "since": 100, "agentId": AID}]}}
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "tu_agent1", "desc": "map the parser", "t": 95, "type": "local_agent", "agentId": AID}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"]), ("agents", 1))
+        self.assertEqual(aw["items"], [{"kind": "agents", "id": "tu_agent1", "label": "map the parser",
+                                        "since": 100, "agentId": AID}])
+        self.assertEqual(aw["why"], "1 background agent still working")
+
+    # ---- single-kind sentences (byte-identical to the pre-rows whys where the word did not change) ----
+
+    def test_single_kind_sentences_wear_the_plain_words(self):
+        km._bg_live_norm = lambda sid, path: [{"tid": "b1", "desc": "build the docs", "t": 10, "type": "local_bash"}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["why"]), ("task", "waiting on a background command: build the docs"))
+        km._bg_live_norm = lambda sid, path: [{"tid": "b1", "desc": "build the docs", "t": 10, "type": "local_bash"},
+                                              {"tid": "b2", "desc": "run the suite", "t": 12, "type": "local_bash"}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"], aw["why"]), ("task", 2, "waiting on 2 background commands — build the docs, …"))
+        km._bg_live_norm = lambda sid, path: []
+        km._watches = [{"id": "w1", "sid": SID, "cmd": "test -f /tmp/a", "note": "the CI run", "at": 90},
+                       {"id": "w2", "sid": SID, "cmd": "test -f /tmp/b", "at": 91}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual((aw["kind"], aw["count"], aw["why"]), ("job", 2, "waiting on 2 armed watches — the CI run, …"))
+        km._watches = km._watches[:1]
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["why"], "waiting on the CI run")
+        km._watches = []
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "a", "since": 1}, {"type": "b", "since": 2}]}}
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["why"], "2 background agents still working")
+
+    def test_a_monitor_is_a_command_row(self):
+        km._bg_live_norm = lambda sid, path: [{"tid": "m1", "desc": "watch the deploy log", "t": 10, "type": "local_monitor"}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual([it["kind"] for it in aw["items"]], ["commands"])
+
+    # ---- watch rows ----
+
+    def test_a_generic_watch_row_carries_its_cancel_handle_and_a_pr_watch_does_not(self):
+        km._watches = [{"id": "w1", "sid": SID, "cmd": "gh run view 12 --exit-status", "note": "the CI run", "at": 90}]
+        km._pr_watches = [{"sid": SID, "pr": 42, "repo": "notes-api/web", "at": 95}]
+        aw = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual(aw["items"], [
+            {"kind": "watches", "id": "watch:w1", "label": "the CI run", "since": 90,
+             "detail": "gh run view 12 --exit-status", "watchId": "w1"},   # cancel_watch's handle — the box's Cancel
+            {"kind": "watches", "id": "pr:notes-api/web#42", "label": "PR #42 (notes-api/web)", "since": 95}])   # no early-retire path today → no handle
+        self.assertEqual(aw["kind"], "job")
+
+    def test_the_awaiting_box_cancel_reaches_the_same_cancel_watch_as_the_cli(self):
+        # the WS door (slice 2) hands the row's watchId to cancel_watch — the path `romp watch --cancel`
+        # and POST /watch {"cancel"} already take; LOUD on a miss
+        src = inspect.getsource(km)
+        self.assertIn('msg.get("type") == "cancelWatch" and msg.get("watchId")', src)
+        self.assertIn('if not cancel_watch(str(msg["watchId"]).strip()):', src)
+        self.assertIn("Couldn't cancel that watch — it may have already fired or been cancelled.", src)
+        row, err = km.add_watch("test -f /tmp/notes-api.done", SID, note="the CI run")
+        self.assertIsNone(err)
+        self.assertEqual([it["watchId"] for it in km._watch_awaiting(SID)["items"]], [row["id"]])
+        self.assertTrue(km.cancel_watch(row["id"]))
+        self.assertIsNone(km._watch_awaiting(SID), "cancelled → the row is gone, so the wait is gone")
+        self.assertFalse(km.cancel_watch(row["id"]), "a second cancel is a miss the door reports loudly")
+
+    # ---- the row shape ----
+
+    def test_a_row_carries_agentId_and_detail_only_when_known(self):
+        self.assertEqual(km._awaiting_item("commands", "b1", " build ", None),
+                         {"kind": "commands", "id": "b1", "label": "build", "since": None})
+        self.assertEqual(km._awaiting_item("agents", "t1", "map", 5, agent_id=AID),
+                         {"kind": "agents", "id": "t1", "label": "map", "since": 5, "agentId": AID})
+        with self.assertRaises(AssertionError):
+            km._awaiting_item("task", "x", "legacy kind keys are not row kinds", None)
+
+    # ---- the arms that name no live rows ----
+
+    def test_arms_that_cannot_enumerate_ship_an_empty_row_list(self):
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "waiting on a build", "kind": "job", "t": 4321}
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True)["items"], [])
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: "waiting on a background command: the GPU batch"
+        self.assertEqual(km._session_awaiting(SID, "/tmp/x", True, stamp=True)["items"], [])
+
+    def test_a_peer_wait_lists_its_peers_as_rows(self):
+        km._peer_identity = lambda p: {"name": str(p), "host": "", "sid": str(p), "color": None}
+        km._session_stamp_full = lambda sid: ("g1", 8765, "delegated to two peers", "peer", ("api", "web"))
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertEqual(aw["items"], [{"kind": "peer", "id": "peer:api", "label": "api", "since": None},
+                                       {"kind": "peer", "id": "peer:web", "label": "web", "since": None}])
+        self.assertEqual(aw["count"], 2)
+
+
+class MixedKind(unittest.TestCase):
+    """"mixed" is a LIVE-read kind only: the enum every surface validates against accepts it, while the
+    judge's parse sites keep filing a specific kind — an LLM emitting "mixed" degrades to kindless."""
+
+    def test_the_enum_carries_mixed_and_the_judged_tuple_does_not(self):
+        self.assertIn("mixed", jd.AWAIT_KINDS)
+        self.assertNotIn("mixed", jd.AWAIT_KINDS_JUDGED)
+        self.assertEqual(jd.AWAIT_KINDS[:-1], jd.AWAIT_KINDS_JUDGED)
+
+    def test_a_closer_filing_mixed_is_kindless(self):
+        got = jd._parse_close('{"done": [], "block": [], "awaiting": [{"goal": 1, "why": "w", "kind": "mixed"},'
+                              '{"goal": 2, "why": "x", "kind": "job"}]}', 3)
+        self.assertEqual(got["awaiting"], {1: {"why": "w", "kind": None}, 2: {"why": "x", "kind": "job"}})
+
+    def test_a_nudge_planner_filing_mixed_is_kindless(self):
+        ops = jd._parse_plan('{"ops":[{"do":"awaiting","goal":1,"why":"w","kind":"mixed"}]}', 3)
+        self.assertEqual(ops, [{"do": "awaiting", "why": "w", "goal": 1}])
+
+    def test_an_overlay_row_saying_mixed_is_accepted_as_data(self):
+        saved = km._states_awaiting_overlay, km._tmux_sessions
+        km._tmux_sessions = lambda: {SID: {}}
+        km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "several things", "kind": "mixed", "t": 1, "count": 3}
+        try:
+            aw = km._session_awaiting(SID, "/tmp/x", True)
+        finally:
+            km._states_awaiting_overlay, km._tmux_sessions = saved
+        self.assertEqual((aw["kind"], aw["count"], aw["items"]), ("mixed", 3, []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_awaiting_rows.py
+++ b/tests/test_awaiting_rows.py
@@ -175,6 +175,122 @@ class AwaitingRows(unittest.TestCase):
         self.assertEqual(aw["count"], 2)
 
 
+class RowsDoNotDependOnIdleness(unittest.TestCase):
+    """The rows are the SAME set whether or not the turn is open (2026-09-06).
+
+    Seen live: a session with two background agents and a background command showed the grouped rows
+    ("Awaiting 3 · 2 agents · 1 command") while idle; the moment the user sent a message the view vanished,
+    and it came back when the turn ended. _session_awaiting answers None mid-turn BY DESIGN (a working
+    session is Working — the chip's Awaiting is idle-only), and the rows shipped only through it, so the
+    client fell to the legacy tasks list mid-turn: two presentations of one set of facts, swapped at every
+    turn boundary. Now the assembly is _awaiting_live_rows, turn-agnostic; _session_background_items joins
+    it, and _awaiting_items_payload is the one expression both session-scoped surfaces ship. The idle-only
+    fields (why / kind / count) are untouched — nothing about WHEN the chip flips changed.
+    Synthetic inputs, stubbed like the class above."""
+    A1, A2 = "a1111111111111111", "a2222222222222222"
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_tmux_sessions", "_bg_live_norm", "_bg_pending", "_states_awaiting_overlay",
+                        "_owned_yield_why", "_session_stamp_full", "_session_delegated_why",
+                        "_session_delegated_identities", "_watches", "_pr_watches", "_peer_identity")}
+        km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "general-purpose", "since": 100, "agentId": self.A1},
+                                                         {"type": "general-purpose", "since": 105, "agentId": self.A2}]}}
+        km._bg_live_norm = lambda sid, path: [
+            {"tid": "toolu_01", "desc": "Check the exporter for banned words", "t": 98, "type": "local_agent", "agentId": self.A1},
+            {"tid": "toolu_02", "desc": "Rerun the notes-api harness", "t": 104, "type": "local_agent", "agentId": self.A2},
+            {"tid": "toolu_03", "desc": "build the docs site", "t": 110, "type": "local_bash"}]
+        km._bg_pending = lambda sid, path, tasks: tasks
+        km._states_awaiting_overlay = lambda sid: None
+        km._owned_yield_why = lambda sid, path: None
+        km._session_stamp_full = lambda sid: (None, 0, None, None, ())
+        km._session_delegated_why = lambda sid: None
+        km._session_delegated_identities = lambda sid: []
+        km._watches, km._pr_watches = [], []
+
+    def tearDown(self):
+        for n, f in self._saved.items():
+            setattr(km, n, f)
+
+    def test_the_same_rows_idle_and_mid_turn_and_the_wait_only_when_idle(self):
+        idle = km._session_awaiting(SID, "/tmp/x", True)
+        self.assertEqual([(it["kind"], it["label"], it["id"]) for it in idle["items"]],
+                         [("agents", "Check the exporter for banned words", "toolu_01"),
+                          ("agents", "Rerun the notes-api harness", "toolu_02"),
+                          ("commands", "build the docs site", "toolu_03")])
+        self.assertEqual((idle["kind"], idle["count"]), ("mixed", 3))
+        self.assertEqual(idle["why"], "waiting on 2 background agents and 1 background command")
+        # the turn opens: no wait (the chip reads Working), the same rows
+        self.assertIsNone(km._session_awaiting(SID, "/tmp/x", False), "a working session is Working — unchanged")
+        self.assertEqual(km._session_background_items(SID, "/tmp/x"), idle["items"],
+                         "byte-identical rows in both turn states — the agentId join and the labels included")
+        self.assertEqual(km._awaiting_items_payload(None, SID, "/tmp/x"), idle["items"], "what the surfaces ship mid-turn")
+        self.assertEqual(km._awaiting_items_payload(idle, SID, "/tmp/x"), idle["items"], "…and idle: the wait's own rows")
+
+    def test_armed_watches_ride_the_rows_mid_turn_too(self):
+        # the 2026-08-30 rule (anything awaited shows even while working) now holds through the rows alone
+        # — the chat status no longer re-runs _watch_awaiting into awaitingWhy while the turn is open, which
+        # made the box read "Awaiting" under a Working chip
+        km._watches = [{"id": "w1", "sid": SID, "cmd": "test -f /tmp/notes-api.done", "note": "the CI run", "at": 90}]
+        rows = km._session_background_items(SID, "/tmp/x")
+        self.assertEqual([it["kind"] for it in rows], ["agents", "agents", "commands", "watches"])
+        self.assertEqual(rows[-1]["label"], "the CI run")
+        self.assertEqual(rows[-1]["watchId"], "w1", "Cancel's handle rides mid-turn as it does idle")
+        self.assertEqual(rows, km._session_awaiting(SID, "/tmp/x", True)["items"])
+
+    def test_a_stamp_wait_ships_its_own_rows_and_nothing_running_ships_none(self):
+        km._tmux_sessions = lambda: {SID: {}}
+        km._bg_live_norm = lambda sid, path: []
+        self.assertEqual(km._session_background_items(SID, "/tmp/x"), [])
+        self.assertEqual(km._awaiting_items_payload(None, SID, "/tmp/x"), [], "nothing in flight → no rows, no box")
+        km._peer_identity = lambda p: {"name": str(p), "host": "", "sid": str(p), "color": None}
+        km._session_stamp_full = lambda sid: ("g1", 8765, "delegated to two peers", "peer", ("api", "web"))
+        aw = km._session_awaiting(SID, "/tmp/x", True, stamp=True)
+        self.assertEqual([it["kind"] for it in km._awaiting_items_payload(aw, SID, "/tmp/x")], ["peer", "peer"],
+                         "an idle-gated arm's rows (a peer stamp) ship as the wait's rows — they exist only idle")
+        self.assertEqual(km._awaiting_items_payload({"why": "waiting on a build", "kind": "job", "items": []}, SID, "/tmp/x"), [],
+                         "a wait no source can enumerate ships none — never the live rows behind its back")
+
+    def test_a_build_handed_a_snapshot_takes_no_fresh_liveness_read_for_the_mid_turn_rows(self):
+        # caught by tests/test_kernel_pusher_snapshot.py on the first cut: the mid-turn read forked tmux /
+        # swept the registry twice per build_session (its own row lookup + _bg_live_norm's) on the WORKING
+        # path, which had never taken a liveness read. The caller's map is lent to _live_scope for the read
+        # (_serve_live) — the pusher cycle's own one-snapshot mechanism — and released after; a scope
+        # already active (the cycle's) is left untouched.
+        km._bg_live_norm = self._saved["_bg_live_norm"]   # the real normalizer, so its row lookup is exercised
+        reads = []
+        snap = {SID: {"subagents": [{"type": "explore", "since": 100, "agentId": self.A1}],
+                      "bgTasks": [{"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                                   "desc": "build the docs site", "lastTool": ""}]}}
+        km._tmux_sessions = self._saved["_tmux_sessions"]   # the real delegator: scope snapshot, else Sessions.live
+        saved_live, saved_scope = km.Sessions.live, getattr(km._live_scope, "snapshot", None)
+        km.Sessions.live = lambda: (reads.append(1), {})[1]
+        km._live_scope.snapshot = None
+        try:
+            rows = km._awaiting_items_payload(None, SID, None, snap)
+            self.assertEqual([(it["kind"], it["label"]) for it in rows], [("agents", "explore"), ("commands", "build the docs site")],
+                             "the rows come from the map the caller handed over")
+            self.assertEqual(reads, [], "a provided snapshot is enough — no fresh liveness read")
+            self.assertIsNone(km._live_scope.snapshot, "the lent scope is released with the read")
+            # inside a cycle (a scope already active) the cycle's snapshot wins and stays
+            km._live_scope.snapshot = snap
+            km._awaiting_items_payload(None, SID, None, {SID: {}})
+            self.assertIs(km._live_scope.snapshot, snap, "an active scope is left alone")
+            km._live_scope.snapshot = None
+            # no map at all → the read is fresh, as every un-scoped read is
+            km._awaiting_items_payload(None, SID, None)
+            self.assertEqual(len(reads), 2, "no snapshot handed over → fresh reads (the row lookup and the normalizer's)")
+        finally:
+            km.Sessions.live = saved_live
+            km._live_scope.snapshot = saved_scope
+
+    def test_the_join_is_one_concatenation_shared_by_both_reads(self):
+        src = inspect.getsource(km)
+        self.assertIn("    items = _awaiting_join_items(agents, commands, watch)\n    if not items:\n        return None", src)
+        self.assertIn("    return _awaiting_join_items(agents, commands, watch)", src)
+        self.assertIn("    agents, commands, watch = _awaiting_live_rows(sid, path, live)\n    combined = _awaiting_from_items(agents, commands, watch)", src)
+
+
 class MixedKind(unittest.TestCase):
     """"mixed" is a LIVE-read kind only: the enum every surface validates against accepts it, while the
     judge's parse sites keep filing a specific kind — an LLM emitting "mixed" degrades to kindless."""

--- a/tests/test_awaiting_rows.py
+++ b/tests/test_awaiting_rows.py
@@ -89,8 +89,10 @@ class AwaitingRows(unittest.TestCase):
             {"tid": "tu_agent1", "desc": "map the parser", "t": 95, "type": "local_agent", "agentId": AID}]
         aw = km._session_awaiting(SID, "/tmp/x", True)
         self.assertEqual((aw["kind"], aw["count"]), ("agents", 1))
+        # pin changed 2026-09-06: the joined row's since is the EARLIER of the hook's start and the launch's
+        # own time (the design said so; the code only ever filled a MISSING since, so the later hook stamp won)
         self.assertEqual(aw["items"], [{"kind": "agents", "id": "tu_agent1", "label": "map the parser",
-                                        "since": 100, "agentId": AID}])
+                                        "since": 95, "agentId": AID}])
         self.assertEqual(aw["why"], "1 background agent still working")
 
     # ---- single-kind sentences (byte-identical to the pre-rows whys where the word did not change) ----

--- a/tests/test_awaiting_since.py
+++ b/tests/test_awaiting_since.py
@@ -57,7 +57,7 @@ class SessionAwaitingSince(unittest.TestCase):
         km._bg_pending = lambda sid, path, ts: ts
         aw = km._session_awaiting(SID, "/tmp/x", True)
         self.assertEqual(aw["since"], 300)
-        self.assertIn("2 background tasks", aw["why"])
+        self.assertIn("2 background commands", aw["why"])   # "commands" since slice 2 (2026-09-05): shell launches are command rows
 
     def test_overlay_rides_its_own_rows_stamp(self):
         km._states_awaiting_overlay = lambda sid: {"awaiting": True, "why": "waiting on a build",

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1204,20 +1204,25 @@ class ViewBuilder(unittest.TestCase):
 
     def test_a_working_session_still_lists_its_armed_kernel_watches(self):
         # The user (2026-08-30, paraphrased): even while working, anything the session awaits shows
-        # at the chat bottom in the green box. Kernel half: the status payload carries the awaited
-        # content mid-turn while the chip formula stays untouched — state reads working, the box
-        # renders from the fields.
+        # at the chat bottom in the box. Kernel half: the status payload carries the awaited content
+        # mid-turn while the chip formula stays untouched — state reads working, the box renders from
+        # the fields. Pin changed 2026-09-06: the content rides the ROWS (awaitingItems), the same
+        # turn-agnostic set every in-flight thing rides, and awaitingWhy stays None mid-turn. The
+        # 2026-08-30 cut re-ran _watch_awaiting alone into awaitingWhy while the turn was open, which
+        # made the box read "Awaiting" under a Working chip and left every other in-flight row to the
+        # legacy tasks list — two presentations of one set of facts, swapped at every turn boundary.
         with self.tpath.open("a") as f:                  # an OPEN turn → the session reads working
             f.write(json.dumps(uline(NOW, "keep working on the strip", "uOpen", parent="a2")) + "\n")
         km._parse_cache.clear()
-        km.add_watch("test -f /tmp/synthetic-sentinel", SID, note="the cluster job's sentinel file")
+        row, _err = km.add_watch("test -f /tmp/synthetic-sentinel", SID, note="the cluster job's sentinel file")
         try:
             st = km.build_session(SID, NOW)["status"]
             self.assertEqual(st["state"], "working", "the shared chip formula is untouched")
-            self.assertIn("the cluster job's sentinel file", st["awaitingWhy"] or "")
-            self.assertEqual(st["awaitingKind"], "job")
-            self.assertEqual(st["awaitingTasks"], ["the cluster job's sentinel file"],
-                             "the box's fold lists each watch in the registrant's own words")
+            self.assertIsNone(st["awaitingWhy"], "awaitingWhy means idle-and-waiting — the chip's Awaiting — on every surface")
+            self.assertIsNone(st["awaitingKind"])
+            self.assertEqual([(it["kind"], it["label"], it.get("watchId")) for it in st["awaitingItems"]],
+                             [("watches", "the cluster job's sentinel file", row["id"])],
+                             "the watch is a row in the registrant's own words, Cancel's handle riding, while the turn is open")
         finally:
             self._clear_watches()
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1707,7 +1707,8 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(km._session_awaiting(SID, str(self.tpath), True),
                          {"kind": None, "since": 200,   # the overlay row's own stamp → the chips' elapsed readout (the user 2026-08-23)
                           "why": "Waiting on 2 background jobs it launched.",
-                          "count": None},   # a bare overlay row names no count — never parsed from the why (T225)
+                          "count": None,   # a bare overlay row names no count — never parsed from the why (T225)
+                          "items": []},    # …and names no rows (slice 2, 2026-09-05)
                          "the genuine awaiting badge still shows")
 
     def test_blocked_rolls_up_the_card_tree_so_a_buried_block_is_visible(self):
@@ -1797,26 +1798,42 @@ class ViewBuilder(unittest.TestCase):
             # source 0: real subagents in flight — the snapshot carries the live LIST (a {"type","since"}
             # per agent); the why counts via len() (the pre-fix code %d-formatted the list itself)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
+            # …each agent its own ROW since slice 2 (2026-09-05); a hook-only agent with no agentId has an
+            # empty row id and its type (here none → "agent") as the label until a launch row names it.
+            # The snapshot carries an EMPTY lifecycle set on purpose: since the sources are COMBINED, a
+            # live snapshot with no bgTasks key at all would let source 0.75 add the transcript's launch
+            # above as a command row beside the agents (a mixed read) — an SDK snapshot's empty set is
+            # authoritative and keeps this an agents-only read.
+            agent_row = {"kind": "agents", "id": "", "label": "agent", "since": T0}
+            km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}], "bgTasks": []}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "agents", "why": "2 background agents still working",
                               "since": T0,   # the oldest live agent's start → the chips' elapsed readout (the user 2026-08-23)
-                              "count": 2},   # the live agent count — the chip's number agreement rides it (T225)
+                              "count": 2,    # the live agent count — the chip's number agreement rides it (T225)
+                              "items": [agent_row, agent_row], "tasks": ["agent", "agent"]},
                              "a live subagent DOES leave an idle session awaiting (a working flavor)")
-            # source 0.5: the live bg-task set — one task shows its description verbatim
+            # source 0.5: the live bg-task set — one task shows its description verbatim (a COMMAND row;
+            # the sentence says "command" since slice 2)
+            desc = "20-minute timer for campaign-start check"
+            cmd_row = {"kind": "commands", "id": "tu_bg", "label": desc, "since": T0 + 9}
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task", "since": T0 + 9,   # the dispatch stamp (the user 2026-08-23)
-                              "why": "waiting on a background task: 20-minute timer for campaign-start check",
-                              "count": 1})
+                              "why": "waiting on a background command: " + desc,
+                              "count": 1, "items": [cmd_row], "tasks": [desc]})
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task", "since": T0 + 9,
-                              "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …",
-                              "count": 2})
-            # subagents outrank bg tasks when both run (they're the bigger dispatch)
+                              "why": "waiting on 2 background commands — " + desc + ", …",
+                              "count": 2, "items": [cmd_row, dict(cmd_row, label="power watcher")],
+                              "tasks": [desc, "power watcher"]})
+            # an agent AND a bg task at once: until 2026-09-05 the agents source short-circuited and the task
+            # vanished from the read; now both are rows of two kinds — kind "mixed", every row counted,
+            # the why naming each group (the user: they are different things, show them separately)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             {"kind": "agents", "why": "1 background agent still working", "since": T0, "count": 1})
+                             {"kind": "mixed", "why": "waiting on 1 background agent and 1 background command",
+                              "since": T0, "count": 2, "items": [agent_row, cmd_row], "tasks": ["agent", desc]})
         finally:
             km._tmux_sessions = saved
 
@@ -1832,7 +1849,8 @@ class ViewBuilder(unittest.TestCase):
         ]) + "\n")
         self.assertEqual(km._session_awaiting(SID, "/nonexistent", True),
                          {"kind": None, "why": "3 agents in flight",
-                          "since": T0 + 1, "count": None},   # the overlay row's own stamp (the user 2026-08-23)
+                          "since": T0 + 1, "count": None,   # the overlay row's own stamp (the user 2026-08-23)
+                          "items": []},                     # an overlay row names no rows (slice 2)
                          "the latest awaiting overlay (interleaved with state records) drives the badge")
         self.assertIsNone(km._session_awaiting(SID, "/nonexistent", False),
                           "a WORKING session is not 'awaiting' (idle=False short-circuits)")

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -73,7 +73,10 @@ class MergeCarriesBgTasks(unittest.TestCase):
         finally:
             km._tmux_sessions = saved_sessions
         self.assertEqual(why, {"kind": "task", "since": 1,   # the dispatch stamp → the chips' elapsed readout (the user 2026-08-23)
-                               "why": "waiting on a background task: 20-minute timer for campaign-start check", "count": 1})
+                               "why": "waiting on a background command: 20-minute timer for campaign-start check",   # "command" since slice 2 (2026-09-05)
+                               "count": 1,
+                               "items": [{"kind": "commands", "id": "tu1", "label": "20-minute timer for campaign-start check", "since": 1}],   # the one awaited row
+                               "tasks": ["20-minute timer for campaign-start check"]})
 
 
 class NudgeFailedRespectsAwaiting(unittest.TestCase):

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -156,7 +156,8 @@ class SessionLevelStamp(unittest.TestCase):
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": "job", "why": "slurm 4821 regenerating the parts",
                           "since": 200,   # the stamp's awaitingAt → the chips' elapsed readout (the user 2026-08-23)
-                          "count": None})   # a stamp naming no peers carries no count (T225)
+                          "count": None,   # a stamp naming no peers carries no count (T225)
+                          "items": []})    # …and names no rows (slice 2, 2026-09-05: every arm ships the awaited rows)
         self.assertEqual(km._session_stamp_full(SID),
                          ("g1", 200, "slurm 4821 regenerating the parts", "job", ()))
 
@@ -169,7 +170,8 @@ class SessionLevelStamp(unittest.TestCase):
         self._seed(("g1", "the watcher it armed; files the clip when it triggers", 200))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": None, "since": 200,
-                          "why": "the watcher it armed; files the clip when it triggers", "count": None})
+                          "why": "the watcher it armed; files the clip when it triggers", "count": None,
+                          "items": []})   # a stamp names no rows (slice 2)
 
     def test_stamp_false_stays_none_so_the_feed_scopes_per_goal(self):
         # the crux: the feed calls stamp=False, so the session-level signal is None for a stamp-only session
@@ -259,7 +261,10 @@ class SessionLevelDelegation(unittest.TestCase):
                          {"kind": "peer", "why": "delegated to probe; waiting on their result",
                           "since": None,   # the handoff graph has no single event time here → no duration
                           "peers": [{"name": "probe", "host": "", "sid": self.PEER, "color": None}],
-                          "count": 1})   # one identified peer → "Awaiting peer" (T225)
+                          "count": 1,   # one identified peer → "Awaiting peer" (T225)
+                          # the peers ALSO ride as rows (slice 2, 2026-09-05): label only — no sid, so
+                          # federation's prefixing has nothing to miss; the surfaces colour by awaitingPeers
+                          "items": [{"kind": "peer", "id": "peer:probe", "label": "probe", "since": None}]})
 
     def test_handoff_peer_identities_carry_name_host_and_colour_for_the_card(self):
         # the card's awaiting box names the peers the way the origin line does (the user 2026-08-23):
@@ -291,7 +296,8 @@ class SessionLevelDelegation(unittest.TestCase):
         nodes["g1"]["awaitingWhy"], nodes["g1"]["awaitingAt"] = "the sweep it launched", 200
         self._seed(nodes)
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "the sweep it launched", "since": 200, "count": None})
+                         {"kind": None, "why": "the sweep it launched", "since": 200, "count": None,
+                          "items": []})   # slice 2: every arm ships rows; a stamp names none
 
     def test_a_pure_delegation_top_stays_dark_matching_its_suppressed_card(self):
         # EVERY leaf a handoff → the feed suppresses the card in every column, so its dot never lights;
@@ -367,7 +373,7 @@ class KindScopedRules(unittest.TestCase):
     def test_a_peer_answer_supersedes_only_peer_waits(self):
         self._seed("job")
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": "job", "why": "the wait", "since": 200, "count": None},
+                         {"kind": "job", "why": "the wait", "since": 200, "count": None, "items": []},   # items: slice 2
                          "unrelated mail cannot end a wait on an external job")
         self._seed("peer")
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
@@ -436,14 +442,15 @@ class OverlayDoesNotVeto(unittest.TestCase):
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
                          {"kind": None, "why": "a dispatched release watch; tags when green",
-                          "since": 200, "count": None},
+                          "since": 200, "count": None, "items": []},   # items: slice 2
                          "the Stop hook's ambient false must not hide the judge's stamp")
 
     def test_a_live_true_row_still_wins_with_its_own_why(self):
         self._overlay({"t": 100, "awaiting": True, "why": "a job the hook reported"})
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         {"kind": None, "why": "a job the hook reported", "since": 100, "count": None},
+                         {"kind": None, "why": "a job the hook reported", "since": 100, "count": None,
+                          "items": []},   # an overlay row names no rows (slice 2)
                          "a positive overlay row keeps its channel")
 
     def test_false_row_and_no_stamp_is_plain_none(self):

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -413,16 +413,25 @@ class DurableAwaitingSource(unittest.TestCase):
     def _restore(self, saved):
         km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay = saved
 
-    def test_pending_agent_dispatches_read_kind_agents_not_task(self):
-        # dispatched agents/workflows are kind agents even through the task stream; a MIXED pending
-        # set (or plain shell work) is kind task — the generic word (the user 2026-08-15)
+    def test_pending_agent_and_shell_dispatches_are_two_rows_of_two_kinds(self):
+        # dispatched agents/workflows are AGENT rows even through the task stream; a shell launch is a
+        # COMMAND row. Until 2026-09-05 a mixed pending set collapsed to the generic kind "task" (the
+        # agent silently absorbed into "Awaiting 2 tasks"); the user's call (plans/subagent-transcripts.md
+        # slice 2): the kinds are different things — separate rows, kind "mixed", count = every row.
         rows = [{"toolUseId": "t1", "desc": "audit the sampler", "since": 5, "type": "local_agent"},
                 {"toolUseId": "t2", "desc": "notes-api sweep", "since": 6, "type": "local_workflow"}]
         saved = self._patched({self.SID: {"bgTasks": rows}})
         try:
-            self.assertEqual(km._session_awaiting(self.SID, None, True)["kind"], "agents")
+            aw = km._session_awaiting(self.SID, None, True)
+            self.assertEqual((aw["kind"], aw["count"]), ("agents", 2))
+            self.assertEqual([it["kind"] for it in aw["items"]], ["agents", "agents"])
             rows.append({"toolUseId": "t3", "desc": "mkdocs serve", "since": 7, "type": "local_bash"})
-            self.assertEqual(km._session_awaiting(self.SID, None, True)["kind"], "task")
+            aw = km._session_awaiting(self.SID, None, True)
+            self.assertEqual((aw["kind"], aw["count"]), ("mixed", 3), "two kinds present → mixed, every row counted")
+            self.assertEqual([(it["kind"], it["label"]) for it in aw["items"]],
+                             [("agents", "audit the sampler"), ("agents", "notes-api sweep"), ("commands", "mkdocs serve")])
+            self.assertNotIn("task", aw["why"], "the collapse word is gone: %r" % aw["why"])
+            self.assertEqual(aw["why"], "waiting on 2 background agents and 1 background command")
         finally:
             self._restore(saved)
 
@@ -434,8 +443,10 @@ class DurableAwaitingSource(unittest.TestCase):
         finally:
             self._restore(saved)
             os.unlink(path)
-        self.assertEqual(why, {"kind": "task", "why": "waiting on a background task: power watcher",
-                               "since": None, "count": 1})   # the transcript scan carries no dispatch stamp → no duration, never a guess
+        self.assertEqual(why, {"kind": "task", "why": "waiting on a background command: power watcher",   # "command" since slice 2 (2026-09-05)
+                               "since": None, "count": 1,   # the transcript scan carries no dispatch stamp → no duration, never a guess
+                               "tasks": ["power watcher"],
+                               "items": [{"kind": "commands", "id": TUSE, "label": "power watcher", "since": None}]})   # the one awaited row (slice 2)
 
     def test_the_notification_landing_ends_it(self):
         path = _write([_launch(), _notif_str(tid=TUSE)])

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -488,6 +488,99 @@ class DurableAwaitingSource(unittest.TestCase):
             os.unlink(path)
 
 
+class OneRowPerAgentAcrossTheHookAndTheStream(unittest.TestCase):
+    """A background agent is reported TWICE to _session_awaiting: by the SubagentStart hook set (source 0:
+    {type, since, agentId}) and by the CLI's task lifecycle stream (source 0.5: the bgTasks mirror, whose
+    rows carry the launch's toolUseId and the CLI's own description). The slice-2 join matched them on
+    agentId — but the stream rows never carried one: _live_bg_tasks dropped the lifecycle task_id (which IS
+    the agent id for an Agent task, probe-verified on 2.1.257 and already relied on by _on_task_event), the
+    launch ledger records Bash/Monitor only (its agentId is the ACTING agent), and the sidecar meta map is
+    keyed on the ORIGINAL launch's toolUseId, which a resumed agent's task no longer carries. Seen live on
+    2026-09-06: two agents and a shell command read "Awaiting 5 · 4 agents · 1 command" — each agent once by
+    type (with the open-transcript arrow) and once as "Running <description>" (no arrow). The join key is
+    the stream's own task_id (`taskId` on every bgTasks row), and an agent row's label is the dispatch
+    description with the CLI's "Running " prefix stripped (the STATUS word already says running).
+    SYNTHETIC: placeholder sid, invented agent ids and descriptions (the notes-api demo domain)."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    A1, A2 = "a1111111111111111", "a2222222222222222"
+
+    def setUp(self):
+        self._saved = (km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay, km._bg_pending)
+        km._sdk_spawned_at = lambda sid: None
+        km._states_awaiting_overlay = lambda sid: None
+        km._bg_pending = lambda sid, path, tasks: tasks     # nothing placed yet: every live row is pending
+
+    def tearDown(self):
+        km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay, km._bg_pending = self._saved
+
+    def _snap(self, subs, tasks):
+        km._tmux_sessions = lambda: {self.SID: {"subagents": subs, "bgTasks": tasks}}
+
+    def test_two_agents_seen_by_both_sources_and_a_shell_command_are_three_rows(self):
+        # the live defect, reproduced on the REAL _bg_live_norm: hook rows (type-labelled) + stream rows
+        # (the same two agents, the CLI's "Running <description>" wording, toolUseIds) + one shell task
+        self._snap([{"type": "general-purpose", "since": 100, "agentId": self.A1},
+                    {"type": "general-purpose", "since": 105, "agentId": self.A2}],
+                   [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                     "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                    {"toolUseId": "toolu_02", "taskId": self.A2, "type": "local_agent", "since": 104,
+                     "desc": "Running Rerun the notes-api harness", "lastTool": ""},
+                    {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                     "desc": "build the docs site", "lastTool": ""}])
+        aw = km._session_awaiting(self.SID, None, True)
+        self.assertEqual(aw["count"], 3, "one row per awaited thing — the same agent is never counted twice: %r" % aw["items"])
+        self.assertEqual([it["kind"] for it in aw["items"]], ["agents", "agents", "commands"])
+        self.assertEqual([it["label"] for it in aw["items"]],
+                         ["Check the exporter for banned words", "Rerun the notes-api harness", "build the docs site"],
+                         "the dispatch description, never the agent type and never the CLI's 'Running ' prefix")
+        self.assertEqual([it.get("agentId") for it in aw["items"]], [self.A1, self.A2, None],
+                         "every joined agent row keeps its agentId (the open-transcript arrow)")
+        self.assertEqual([it["id"] for it in aw["items"]], ["toolu_01", "toolu_02", "toolu_03"],
+                         "a joined row wears the launch's toolUseId — Stop's handle")
+        self.assertEqual([it["since"] for it in aw["items"]], [98, 104, 110], "the earlier of the two starts")
+        self.assertEqual((aw["kind"], aw["why"]), ("mixed", "waiting on 2 background agents and 1 background command"))
+        self.assertEqual(aw["tasks"], ["Check the exporter for banned words", "Rerun the notes-api harness", "build the docs site"])
+
+    def test_a_live_agent_the_stream_has_not_seen_keeps_its_type_as_the_label(self):
+        self._snap([{"type": "explore", "since": 100, "agentId": self.A1}], [])
+        aw = km._session_awaiting(self.SID, None, True)
+        self.assertEqual([(it["kind"], it["label"], it.get("agentId"), it["id"]) for it in aw["items"]],
+                         [("agents", "explore", self.A1, self.A1)])
+        self.assertEqual(aw["count"], 1)
+
+    def test_a_stream_agent_with_no_hook_row_is_one_row_by_description(self):
+        self._snap([], [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                         "desc": "Running Check the exporter for banned words", "lastTool": ""}])
+        aw = km._session_awaiting(self.SID, None, True)
+        self.assertEqual([(it["kind"], it["label"], it.get("agentId"), it["id"]) for it in aw["items"]],
+                         [("agents", "Check the exporter for banned words", self.A1, "toolu_01")])
+        self.assertEqual(aw["count"], 1)
+
+    def test_the_stream_row_carries_the_agent_id_and_the_plain_description(self):
+        # the normalized row itself, so every reader of _bg_live_norm (the chip's awaitingTasks, the
+        # feed pill, the nudge gates) sees one vocabulary
+        self._snap([], [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                         "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                        {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                         "desc": "Running the docs build", "lastTool": ""}])
+        rows = km._bg_live_norm(self.SID, None)
+        self.assertEqual([(r["tid"], r.get("agentId"), r["desc"]) for r in rows],
+                         [("toolu_01", self.A1, "Check the exporter for banned words"),
+                          ("toolu_03", None, "Running the docs build")],
+                         "only an AGENT row's desc wears the CLI's prefix; a shell task's description is the user's own words")
+
+    def test_the_transcript_scan_path_carries_the_acks_agent_id(self):
+        # source 0.75 (a live CLI with no lifecycle set — tmux): the async ack names the agent; the row
+        # must carry it so the same join works there
+        path = _write([_agent_tool_use(tid="tu_agent1", desc="Map the parser"), _agent_launch(tid="tu_agent1")])
+        km._tmux_sessions = lambda: {self.SID: {"name": "web"}}
+        try:
+            rows = km._bg_live_norm(self.SID, path)
+        finally:
+            os.unlink(path)
+        self.assertEqual([(r["tid"], r.get("agentId"), r["desc"]) for r in rows], [("tu_agent1", "a1", "Map the parser")])
+
+
 class AgentTasksAreNeverServices(unittest.TestCase):
     """_bg_split (the user 2026-07-27): a dispatched AGENT is work the session waits on by construction,
     never furniture — only shell tasks can be classified as services. A background agent was riding the

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -516,6 +516,23 @@ class OneRowPerAgentAcrossTheHookAndTheStream(unittest.TestCase):
     def _snap(self, subs, tasks):
         km._tmux_sessions = lambda: {self.SID: {"subagents": subs, "bgTasks": tasks}}
 
+    def test_a_placed_launch_still_joins_its_hook_row(self):
+        # the ordinary idle-awaiting steady state: the judge has PLACED the launch turn, so the launch is
+        # no longer pending — the hook row must still meet its stream twin (one row, the launch's id and
+        # description), not flap back to {id: agentId, label: agent type} (review find on #938, 2026-09-07)
+        km._bg_pending = lambda sid, path, tasks: []          # everything placed
+        self._snap([{"type": "general-purpose", "since": 100, "agentId": self.A1}],
+                   [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                     "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                    {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                     "desc": "build the docs site", "lastTool": ""}])
+        aw = km._session_awaiting(self.SID, None, True)
+        self.assertEqual(aw["count"], 1, "the placed command adds no row; the hook agent is one joined row: %r" % aw["items"])
+        it = aw["items"][0]
+        self.assertEqual((it["kind"], it["id"], it["label"], it.get("agentId"), it["since"]),
+                         ("agents", "toolu_01", "Check the exporter for banned words", self.A1, 98),
+                         "joined over EVERY live agent task, not only the pending ones")
+
     def test_two_agents_seen_by_both_sources_and_a_shell_command_are_three_rows(self):
         # the live defect, reproduced on the REAL _bg_live_norm: hook rows (type-labelled) + stream rows
         # (the same two agents, the CLI's "Running <description>" wording, toolUseIds) + one shell task

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -541,6 +541,24 @@ class OneRowPerAgentAcrossTheHookAndTheStream(unittest.TestCase):
         self.assertEqual((aw["kind"], aw["why"]), ("mixed", "waiting on 2 background agents and 1 background command"))
         self.assertEqual(aw["tasks"], ["Check the exporter for banned words", "Rerun the notes-api harness", "build the docs site"])
 
+    def test_the_same_three_rows_ride_while_the_turn_is_open(self):
+        # 2026-09-06, on the REAL _bg_live_norm: the joined rows are a turn-agnostic read
+        # (_session_background_items) — the chat box lists them under a working header instead of falling
+        # to the legacy tasks list, which is what made the box swap presentations at every turn boundary
+        self._snap([{"type": "general-purpose", "since": 100, "agentId": self.A1},
+                    {"type": "general-purpose", "since": 105, "agentId": self.A2}],
+                   [{"toolUseId": "toolu_01", "taskId": self.A1, "type": "local_agent", "since": 98,
+                     "desc": "Running Check the exporter for banned words", "lastTool": ""},
+                    {"toolUseId": "toolu_02", "taskId": self.A2, "type": "local_agent", "since": 104,
+                     "desc": "Running Rerun the notes-api harness", "lastTool": ""},
+                    {"toolUseId": "toolu_03", "taskId": "b3333", "type": "local_bash", "since": 110,
+                     "desc": "build the docs site", "lastTool": ""}])
+        idle_rows = km._session_awaiting(self.SID, None, True)["items"]
+        self.assertIsNone(km._session_awaiting(self.SID, None, False), "mid-turn there is no WAIT (the chip reads Working)")
+        self.assertEqual(km._session_background_items(self.SID, None), idle_rows, "…but the rows are the same three")
+        self.assertEqual([it["label"] for it in idle_rows],
+                         ["Check the exporter for banned words", "Rerun the notes-api harness", "build the docs site"])
+
     def test_a_live_agent_the_stream_has_not_seen_keeps_its_type_as_the_label(self):
         self._snap([{"type": "explore", "since": 100, "agentId": self.A1}], [])
         aw = km._session_awaiting(self.SID, None, True)

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -82,7 +82,8 @@ class OwnedYieldAwaiting(unittest.TestCase):
     def test_a_dispatch_that_outran_the_block_is_the_session_awaiting_why(self):
         self._store()
         why = km._owned_yield_why(SID, self.path)
-        self.assertEqual(why, "waiting on a background task: " + DESC,
+        # "command" since 2026-09-05 (slice 2 vocabulary: agents / commands / watches — "task" retired)
+        self.assertEqual(why, "waiting on a background command: " + DESC,
                          "the same why the card shows — one story, both surfaces")
 
     def test_a_dispatch_that_predates_the_block_proves_nothing(self):
@@ -113,9 +114,10 @@ class OwnedYieldAwaiting(unittest.TestCase):
     def test_the_session_surfaces_light_from_it_when_idle(self):
         self._store()
         self.assertEqual(km._session_awaiting(SID, self.path, True, stamp=True),
-                         {"kind": "task", "why": "waiting on a background task: " + DESC,
+                         {"kind": "task", "why": "waiting on a background command: " + DESC,   # "command" (slice 2 vocabulary); the kind KEY stays "task"
                           "since": None,   # the owned-yield read has no single event time → no duration
-                          "count": 1},   # one owned dispatch (T225)
+                          "count": 1,    # one owned dispatch (T225)
+                          "items": []},  # the yield names no row (slice 2); the tracked task itself lists in the box
                          "the lane/chip say awaiting instead of READY")
 
     def test_the_feed_path_is_unchanged_no_session_wide_floor(self):

--- a/tests/test_kernel_timeline_awaiting.py
+++ b/tests/test_kernel_timeline_awaiting.py
@@ -103,7 +103,7 @@ class TimelineAwaiting(unittest.TestCase):
                                            "context": None, "compactPct": None, "color": None, "mode": "",
                                            "bgTasks": [{"task_id": "t1", "desc": "Watch for round3 copy"}]}}
         lane = self._lane()
-        self.assertEqual(lane["awaitingBg"], "waiting on a background task: Watch for round3 copy")
+        self.assertEqual(lane["awaitingBg"], "waiting on a background command: Watch for round3 copy")   # "command" since slice 2 (2026-09-05)
         self.assertEqual(lane["awaitingTasks"], ["Watch for round3 copy"])
 
     def test_the_lane_ships_the_awaited_count_beside_the_kind(self):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -4164,6 +4164,19 @@ class BgTaskLifecycle(unittest.TestCase):
         self.assertEqual((snap[0]["desc"], snap[0]["lastTool"]), ("long build", "Bash"),
                          "a progress event for an id we never saw ADDS it (mid-task attach converges)")
 
+    def test_every_live_row_carries_its_lifecycle_task_id(self):
+        # the CLI keys an Agent task's lifecycle by the AGENT ID (probe-verified on 2.1.257; _on_task_event
+        # already retires the subagent by it). Shipping it on the row is what lets the kernel join the
+        # stream's row to the SubagentStart hook's — without it the same agent listed twice in the
+        # Awaiting box, once by type and once as "Running <description>" (2026-09-06).
+        s = self._sess()
+        self._feed(s, "task_started", {"task_id": "a1111111111111111", "description": "Running Map the parser",
+                                       "task_type": "local_agent", "tool_use_id": "toolu_01"})
+        self._feed(s, "task_started", {"task_id": "b2222", "description": "build the docs", "tool_use_id": "toolu_02"})
+        rows = s.snapshot()["bgTasks"]
+        self.assertEqual([(r["taskId"], r["toolUseId"]) for r in rows],
+                         [("a1111111111111111", "toolu_01"), ("b2222", "toolu_02")])
+
     def test_a_task_id_less_event_is_ignored(self):
         s = self._sess()
         self._feed(s, "task_started", {"description": "no id"})

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -5,8 +5,11 @@
      statusline beneath it with the Awaiting chip as a BUTTON reading "Awaiting 4". Invented content
      (notes-api demo domain), the DOM class for class as renderAwaitWhy / bgRow / updateStatusline emit it.
        tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/awaiting-rows-chat.html \
-           --out /tmp/awaiting-shots/chat-dark.png --size 760x330 --extra-css 'body{background:var(--bg);padding-top:10px}'
-       …and with --body-class "theme-light chat-theme-<name>" for the light theme.
+           --out /tmp/awaiting-shots/chat-dark.png --size 760x540 --extra-css 'body{background:var(--bg);padding-top:10px}'
+       …and with --body-class "theme-light chat-theme-<name>" for the light theme. The height matters: the
+       box caps at min(50vh, 340px), so a 330px-tall shot gives it 165px and clips the Watches group mid-row,
+       and 470px (235px) scrolls the closing note just out of view (the first two renders did exactly that);
+       the box's natural height here is ~262px, so 540px lets the whole box show as a real pane would.
 -->
 <div id="content" style="flex:0 0 auto"></div>
 <div id="bg-tasks" class="bg-awaited">

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -1,0 +1,35 @@
+<!-- SYNTHETIC fixture: the chat pane's awaiting box in the MIXED case (plans/subagent-transcripts.md
+     slice 2, 2026-09-05) — the #bg-tasks box expanded with its rows grouped by kind under small dim
+     headers (Agents / Commands / Watches), each row wearing its own kind's affordances (the agent rows'
+     open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel), and the
+     statusline beneath it with the Awaiting chip as a BUTTON reading "Awaiting 4". Invented content
+     (notes-api demo domain), the DOM class for class as renderAwaitWhy / bgRow / updateStatusline emit it.
+       tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/awaiting-rows-chat.html \
+           --out /tmp/awaiting-shots/chat-dark.png --size 760x330 --extra-css 'body{background:var(--bg);padding-top:10px}'
+       …and with --body-class "theme-light chat-theme-<name>" for the light theme.
+-->
+<div id="content" style="flex:0 0 auto"></div>
+<div id="bg-tasks" class="bg-awaited">
+  <div class="bg-fold-head bg-await open" data-act="bg-fold"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">Awaiting 4 · 2 agents · 1 command · 1 watch</span></div>
+  <div class="bg-list">
+    <div class="bg-group-head">Agents</div>
+    <div class="bg-task bg-running">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-task bg-running">
+      <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>
+    </div>
+    <div class="bg-group-head">Commands</div>
+    <div class="bg-task bg-running">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Build the docs site</span><span class="bg-since">· 9m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-group-head">Watches</div>
+    <div class="bg-task bg-armed">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">the CI run on web</span><span class="bg-since">· 31m</span><span class="bg-status">armed</span><button class="bg-stop bg-cancel">Cancel</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-await-note">The session is idle until this finishes; it picks back up on its own when the result lands.</div>
+  </div>
+</div>
+<div id="footer">
+  <div id="statusline" class="statusline"><button type="button" class="chip chip-awaitingBg chip-btn chip-awaiting-mixed" data-act="awaitingChip">Awaiting 4</button><span class="status-timer" id="work-timer">31:07</span><span class="sl-right"><span class="status-timer">web · main</span></span></div>
+</div>

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -4,6 +4,10 @@
      open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel), and the
      statusline beneath it with the Awaiting chip as a BUTTON reading "Awaiting 4". Invented content
      (notes-api demo domain), the DOM class for class as renderAwaitWhy / bgRow / updateStatusline emit it.
+     The two agent rows are the JOINED shape (2026-09-06): each background agent is reported by both the
+     SubagentStart hook and the CLI's task stream, and shows ONCE — labelled by its dispatch description
+     (no agent type, no "Running " prefix: the status word beside it already says running), with the
+     open-transcript arrow. Before the join the same box listed four agent rows for these two.
        tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/awaiting-rows-chat.html \
            --out /tmp/awaiting-shots/chat-dark.png --size 760x540 --extra-css 'body{background:var(--bg);padding-top:10px}'
        …and with --body-class "theme-light chat-theme-<name>" for the light theme. The height matters: the

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -1,21 +1,27 @@
-<!-- SYNTHETIC fixture: the chat pane's awaiting box in the MIXED case (plans/subagent-transcripts.md
-     slice 2, 2026-09-05) — the #bg-tasks box expanded with its rows grouped by kind under small dim
-     headers (Agents / Commands / Watches), each row wearing its own kind's affordances (the agent rows'
-     open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel), and the
-     statusline beneath it with the Awaiting chip as a BUTTON reading "Awaiting 4". Invented content
-     (notes-api demo domain), the DOM class for class as renderAwaitWhy / bgRow / updateStatusline emit it.
-     The two agent rows are the JOINED shape (2026-09-06): each background agent is reported by both the
-     SubagentStart hook and the CLI's task stream, and shows ONCE — labelled by its dispatch description
-     (no agent type, no "Running " prefix: the status word beside it already says running), with the
-     open-transcript arrow. Before the join the same box listed four agent rows for these two.
+<!-- SYNTHETIC fixture: the chat pane's #bg-tasks box in the MIXED case (plans/subagent-transcripts.md
+     slice 2, 2026-09-05), in BOTH turn states (2026-09-06), one above the other — the same four rows grouped
+     by kind under small dim headers (Agents / Commands / Watches), each row wearing its own kind's affordances
+     (the agent rows' open-transcript arrow + Stop, the command row's Stop + fold caret, the watch row's Cancel):
+       * IDLE: the box wears the await-green border and dot, the header reads "Awaiting 4 · 2 agents · 1 command
+         · 1 watch", the idle note closes the list, and the statusline beneath carries the Awaiting chip as a
+         BUTTON reading "Awaiting 4".
+       * WORKING: the SAME rows, the header reads "In the background · 2 agents · 1 command · 1 watch" over the
+         running-yellow dot, the box wears its neutral border, there is NO note, and the statusline reads
+         Working. Before 2026-09-06 this state showed a legacy "4 background tasks" list instead (or nothing),
+         so the box swapped views at every turn boundary.
+     Invented content (notes-api demo domain), the DOM class for class as renderBgTasks / bgRow /
+     updateStatusline emit it. The two agent rows are the JOINED shape (2026-09-06): each background agent is
+     reported by both the SubagentStart hook and the CLI's task stream, and shows ONCE — labelled by its
+     dispatch description (no agent type, no "Running " prefix: the status word beside it already says
+     running), with the open-transcript arrow. The small uppercase captions between the two are fixture-only.
        tools/ui-verify/shot.sh --css ui/webview/styles.css --body tools/ui-verify/fixtures/awaiting-rows-chat.html \
-           --out /tmp/awaiting-shots/chat-dark.png --size 760x540 --extra-css 'body{background:var(--bg);padding-top:10px}'
+           --out /tmp/awaiting-shots/chat-dark.png --size 760x700 --extra-css 'body{background:var(--bg);padding-top:10px}'
        …and with --body-class "theme-light chat-theme-<name>" for the light theme. The height matters: the
-       box caps at min(50vh, 340px), so a 330px-tall shot gives it 165px and clips the Watches group mid-row,
-       and 470px (235px) scrolls the closing note just out of view (the first two renders did exactly that);
-       the box's natural height here is ~262px, so 540px lets the whole box show as a real pane would.
+       box caps at min(50vh, 340px), so each box needs ~270px of viewport to show whole (the idle box's natural
+       height is ~262px, the working one ~240px); 700px shows both as a real pane would.
 -->
 <div id="content" style="flex:0 0 auto"></div>
+<div style="padding:2px 12px 0;font-size:10px;line-height:1.6;letter-spacing:.04em;text-transform:uppercase;font-weight:600;color:var(--dim)">idle — the chip reads Awaiting</div>
 <div id="bg-tasks" class="bg-awaited">
   <div class="bg-fold-head bg-await open" data-act="bg-fold"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">Awaiting 4 · 2 agents · 1 command · 1 watch</span></div>
   <div class="bg-list">
@@ -39,4 +45,28 @@
 </div>
 <div id="footer">
   <div id="statusline" class="statusline"><button type="button" class="chip chip-awaitingBg chip-btn chip-awaiting-mixed" data-act="awaitingChip">Awaiting 4</button><span class="status-timer" id="work-timer">31:07</span><span class="sl-right"><span class="status-timer">web · main</span></span></div>
+</div>
+<div style="padding:12px 12px 0;font-size:10px;line-height:1.6;letter-spacing:.04em;text-transform:uppercase;font-weight:600;color:var(--dim)">working — the same rows, the chip reads Working</div>
+<div id="bg-tasks">
+  <div class="bg-fold-head bg-running open" data-act="bg-fold"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">In the background · 2 agents · 1 command · 1 watch</span></div>
+  <div class="bg-list">
+    <div class="bg-group-head">Agents</div>
+    <div class="bg-task bg-running">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-task bg-running">
+      <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>
+    </div>
+    <div class="bg-group-head">Commands</div>
+    <div class="bg-task bg-running">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Build the docs site</span><span class="bg-since">· 9m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
+    </div>
+    <div class="bg-group-head">Watches</div>
+    <div class="bg-task bg-armed">
+      <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">the CI run on web</span><span class="bg-since">· 31m</span><span class="bg-status">armed</span><button class="bg-stop bg-cancel">Cancel</button><span class="bg-caret">▸</span></div>
+    </div>
+  </div>
+</div>
+<div id="footer">
+  <div id="statusline" class="statusline"><span class="chip chip-working"><span class="chip-pulse">Working</span></span><span class="status-timer" id="work-timer">0:42</span><span class="sl-right"><span class="status-timer">web · main</span></span></div>
 </div>

--- a/tools/ui-verify/fixtures/awaiting-rows-feed.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-feed.html
@@ -1,0 +1,35 @@
+<!-- SYNTHETIC fixture: a feed card whose Awaiting pill is pressed open on a MIXED wait
+     (plans/subagent-transcripts.md slice 2, 2026-09-05): the pill reads "Awaiting 4 · 12m" and the
+     checklist spot lists the awaited rows grouped under small dim headers (Agents / Commands / Watches),
+     labels only, the mini swirl as each row's mark. Invented content (notes-api demo domain), the DOM
+     class for class as applySections' renderTree emits it.
+       tools/ui-verify/shot.sh --css ui/webview/feed.css --body tools/ui-verify/fixtures/awaiting-rows-feed.html \
+           --out /tmp/awaiting-shots/feed-dark.png --size 520x300 --extra-css '#feed-list { min-height: 260px; }'
+-->
+<div id="feed-head"></div>
+<div id="feed-list">
+  <div class="feed-cols">
+    <div class="feed-col col-working">
+      <div class="feed-col-head"><span class="feed-col-name fcol-chip fcol-chip-working">Working</span><span class="feed-col-count">1</span></div>
+      <div class="feed-col-list">
+        <div class="fitem ask" style="background:rgba(66, 169, 176, 0.22);--card-r:66;--card-g:169;--card-b:176"><div class="fitem-main">
+          <div class="fask-row1"><div class="fcard-title nav">ship the notes-api exporter</div><span class="ftime">12m ago</span></div>
+          <div class="fask-row2"><div class="fask-id"><span class="fwork-dot await"></span><a class="fname" style="color:#E0A030">web</a></div></div>
+          <div class="fask-row3">
+            <button class="fask-secbtn fask-taskbtn on" aria-pressed="true"><span class="fask-awaiting-swirl" aria-hidden="true"></span><span class="fask-taskbtn-lbl">Awaiting 4 · 12m</span></button>
+            <button class="fask-secbtn">Sub-goals</button>
+          </div>
+          <div class="fask-checklist">
+            <div class="ftask-group">Agents</div>
+            <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Map the notes-api parser</span></div>
+            <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Audit the exporter's retries</span></div>
+            <div class="ftask-group">Commands</div>
+            <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">Build the docs site</span></div>
+            <div class="ftask-group">Watches</div>
+            <div class="fcheck ftask"><span class="fcheck-tri empty"></span><span class="fcheck-mark"><span class="fask-awaiting-swirl ftask-swirl"></span></span><span class="fcheck-text">the CI run on web</span></div>
+          </div>
+        </div></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -451,13 +451,23 @@ function idleGaps(merged, gapCT, now) {
 // "agent", never "agents"). This is the RESOLVED twin of ui/webview/spin-caption.ts kindWord()/KIND_WORD —
 // this file runs standalone (Obsidian too) and cannot import it, so the table and the rule are mirrored
 // here byte for byte and timeline-awaiting.test.ts holds the two together. An unknown count (an older
-// kernel ships none) keeps the plural default each kind always wore; an unknown kind stays "agents".
-const KIND_WORD = { agents: 'agents', task: 'task', job: 'job', peer: 'peer', timer: 'timer' };
+// kernel ships none) keeps the default each kind always wore; an unknown kind stays "agents". The WORDS
+// are the plain ones since 2026-09-05 (plans/subagent-transcripts.md slice 2): the kernel's "task" key
+// reads "command", "job" reads "watch", and "mixed" (several kinds at once) has no word — the badge
+// shows the count alone there (tlAwaitSuffix).
+const KIND_WORD = { agents: 'agents', task: 'command', job: 'watch', peer: 'peer', timer: 'timer', mixed: '' };
 function tlKindWord(kind, count) {
+  if (kind === 'mixed') return '';
   const base = KIND_WORD[kind || ''] || 'agents';
   if (typeof count !== 'number' || !Number.isFinite(count)) return base;
   if (count === 1) return base === 'agents' ? 'agent' : base;
-  return base === 'agents' ? base : base + 's';
+  return base === 'agents' ? base : (/ch$/.test(base) ? base + 'es' : base + 's');
+}
+// " agent" / " watches" after 'Awaiting'; a wordless mixed wait shows its count (" 4"); '' when neither is known.
+function tlAwaitSuffix(kind, count) {
+  const w = kind ? tlKindWord(kind, count) : '';
+  if (w) return ' ' + w;
+  return (kind === 'mixed' && typeof count === 'number' && count > 0) ? ' ' + count : '';
 }
 
 function badgeFor(s) {
@@ -483,7 +493,7 @@ function badgeFor(s) {
   // (The LEGACY lane state 'awaiting' above means blocked-on-you — this name dodges that.)
   // The KIND rides the label ('Awaiting job', the user 2026-08-15), worded by tlKindWord so one agent reads
   // 'Awaiting agent' (T228); an older kernel ships no awaitingKind and the badge reads plain 'Awaiting' as before.
-  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting' + (s.awaitingKind ? ' ' + tlKindWord(s.awaitingKind, s.awaitingCount) : ''), kind: 'awaitbg' };   // agrees in number with the chip (T228)
+  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting' + tlAwaitSuffix(s.awaitingKind, s.awaitingCount), kind: 'awaitbg' };   // agrees in number with the chip (T228); the plain words of slice 2
   else if (s.state === 'ready' || s.state === 'waiting' || s.state === 'idle') m = { label: 'Ready', kind: 'ready' };
   if (!m) return null;
   return { label: m.label, bg: BADGE[m.kind].bg, fg: BADGE[m.kind].fg };

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -50,7 +50,7 @@ test("a status-only frame re-renders the awaiting box when its fields change —
 test("the await key covers every field the box renders from, and nothing that ticks per second", () => {
   const key = RENDER.split("function awaitKey(")[1].split("\n}")[0];
   for (const f of ["st.state", "st.awaitingWhy", "st.awaitingKind", "st.awaitingCount", "st.awaitingTasks",
-                   "st.awaitingTaskIds", "st.awaitingPeers"]) {
+                   "st.awaitingTaskIds", "st.awaitingPeers", "st.awaitingItems"]) {   // awaitingItems: the rows the box groups (slice 2)
     assert.ok(key.includes(f), f + " must be in the key");
   }
   assert.doesNotMatch(key, /sinceEpoch|ctx\b|modelPending|effortPending/, "timer/ctx ticks must not rebuild the box");
@@ -64,25 +64,35 @@ test("the box's render condition is unchanged: awaited content present ⇒ box; 
 });
 
 test("the chip and the box gist take the kind word from ONE count (T225 rider)", () => {
-  assert.match(RENDER, /import \{ KIND_WORD, kindWord \} from "\.\/spin-caption";/);
+  // Since slice 2 (2026-09-05) the ONE rule is awaitWord (spin-caption.ts): it words the chip, the box
+  // gist and the feed pill from the kernel's kind + count + the awaited ROWS — "agent" for one, "3
+  // agents" for several, the bare number when the kinds are mixed. kindWord stays underneath for a
+  // payload with no rows (an older kernel), so the count still decides the number there.
+  assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow \} from "\.\/spin-caption";/);
   assert.match(RENDER, /awaitingCount\?: number \| null;/, "the Status shape carries the kernel's count");
-  assert.match(RENDER, /chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(kw \? " " \+ kindWord\(s\.status\.awaitingKind, s\.status\.awaitingCount\) : ""\);/);
-  assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(kw \? " " \+ kindWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount\) : ""\)/);
+  assert.match(RENDER, /awaitingItems\?: AwaitRow\[\];/, "…and the rows (slice 2)");
+  assert.match(RENDER, /const chipWord = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, chipItems\);/);
+  assert.match(RENDER, /chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(chipWord \? " " \+ chipWord : ""\);/);
+  assert.match(RENDER, /const word = awaitWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount, items\);/);
+  assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace/);
   // the feed pill and the spin caption derive their word the same way
-  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
-  assert.match(FEED, /kindWord\(awKind, 1\)/);
-  assert.match(FEED, /kindWord\(awKind, taskList\.length\)/);
+  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);
+  assert.match(FEED, /const pillWord = awaitWord\(awKind, \(it\.awaiting && it\.awaiting\.count\) \?\? taskRows\.length, taskRows\);/);
   assert.match(SPIN, /const word = kindWord\(aw\.kind, aw\.count\);/);
   assert.match(SPIN, /export function kindWord\(kind: string \| null \| undefined, count: number \| null \| undefined\): string \{/);
+  assert.match(SPIN, /export function awaitWord\(kind: string \| null \| undefined, count: number \| null \| undefined,\s*\n\s*items: readonly AwaitRow\[\] \| null \| undefined\): string \{/);
 });
 
 test("the kernel ships the count beside the kind, from every awaiting source", () => {
   assert.match(KERNEL, /"awaitingCount": \(\(_aw or \{\}\)\.get\("count"\) if isinstance\(\(_aw or \{\}\)\.get\("count"\), int\) else None\),/);
-  assert.match(KERNEL, /"why": "%d background agent%s still working" % \(n, "" if n == 1 else "s"\),\s*\n\s*"count": n,/,
-    "live subagents: the count is the live agent count");
-  assert.match(KERNEL, /"kind": kind, "since": since, "count": 1,/, "one pending task");
-  assert.match(KERNEL, /"kind": kind, "since": since, "count": len\(pending\),/, "several pending tasks");
-  assert.match(KERNEL, /"tasks": descs, "count": len\(descs\)\}/, "armed watches: one per row");
+  // since slice 2 (2026-09-05) the live sources are COMBINED into rows and the one count is derived
+  // from them — every row counted, whatever its kind (_awaiting_from_items); the watches' own read
+  // still counts one per row and now ships the rows too
+  assert.match(KERNEL, /why = "%d background agent%s still working" % \(n, "" if n == 1 else "s"\)/,
+    "live subagents: the sentence agrees in number with the row count");
+  assert.match(KERNEL, /return \{"kind": kind, "why": why, "since": since, "count": n, "items": items,/, "the count IS the row count");
+  assert.match(KERNEL, /kind = _AWAIT_ITEM_LEGACY_KIND\[kinds\[0\]\] if len\(kinds\) == 1 else "mixed"/, "one kind → its word; several → mixed");
+  assert.match(KERNEL, /"tasks": descs, "count": len\(descs\), "items": items\}/, "armed watches: one per row");
   assert.match(KERNEL, /"count": ov\["count"\] if isinstance\(ov\.get\("count"\), int\) and ov\["count"\] > 0 else None,/,
     "an overlay row carries a count only when its producer said so — never parsed from the why");
 });

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -56,11 +56,13 @@ test("the await key covers every field the box renders from, and nothing that ti
   assert.doesNotMatch(key, /sinceEpoch|ctx\b|modelPending|effortPending/, "timer/ctx ticks must not rebuild the box");
 });
 
-test("the box's render condition is unchanged: awaited content present ⇒ box; absent ⇒ hidden", () => {
-  const why = RENDER.split("function renderAwaitWhy(")[1].split("\n}")[0];
-  assert.match(why, /if \(!why \|\| !activeId\) \{ host\.style\.display = "none"; return; \}/,
-    "chip cleared (awaitingWhy gone) ⇒ the same status frame hides the box");
-  assert.match(why, /host\.style\.display = "";/);
+test("the box's render condition: in-flight content present ⇒ box; absent ⇒ hidden — a chip flip alone never hides it", () => {
+  // pin changed 2026-09-06: the rows ride in BOTH turn states now, so the box hides only when there is
+  // neither a wait, nor rows, nor tracked tasks. A chip flip Awaiting→Working with agents still in flight
+  // keeps the box (its header re-worded); a wait clearing with nothing left hides it in the same frame.
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
+  assert.match(body, /if \(!s \|\| !activeId \|\| \(!why && !items\.length && !tasks\.length\)\) \{ host\.style\.display = "none"; host\.classList\.remove\("bg-awaited"\); return; \}/);
+  assert.match(body, /host\.style\.display = "";/);
 });
 
 test("the chip and the box gist take the kind word from ONE count (T225 rider)", () => {
@@ -73,7 +75,7 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   assert.match(RENDER, /awaitingItems\?: AwaitRow\[\];/, "…and the rows (slice 2)");
   assert.match(RENDER, /const chipWord = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, chipItems\);/);
   assert.match(RENDER, /chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(chipWord \? " " \+ chipWord : ""\);/);
-  assert.match(RENDER, /const word = awaitWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount, items\);/);
+  assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/);   // `s` is narrowed by the one renderer's gate since 2026-09-06 (no `s!`)
   assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace/);
   // the feed pill and the spin caption derive their word the same way
   assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -53,9 +53,10 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
 });
 
 test("the kernel ships identities on every arm — the or-chain's hardcoded Nones are gone", () => {
-  assert.match(KERNEL, /\(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, \(len\(_stamp_peers\) if _stamp_peers else None\)\)/, "the judge-stamp arm (identities + their count, T228)");
-  assert.match(KERNEL, /\(sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count\)/,
-    "the session-snapshot arm");
+  // …plus, since slice 2 (2026-09-05), the peers as ROWS in the sixth slot, so the pill lists them
+  assert.match(KERNEL, /\(_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, \(len\(_stamp_peers\) if _stamp_peers else None\), _awaiting_peer_items\(_stamp_peers\)\)/, "the judge-stamp arm (identities + their count, T228; rows, slice 2)");
+  assert.match(KERNEL, /\(sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count, sess_awaiting_items\)/,
+    "the session-snapshot arm (its rows in the sixth slot, slice 2)");
   assert.match(KERNEL, /"awaitingPeers": \(\(_aw or \{\}\)\.get\("peers"\) or None\)/, "the chat status payload");
   assert.match(KERNEL, /"awaitingPeers": \(\(_aw_bg or \{\}\)\.get\("peers"\) or None\)/, "the timeline sessions payload");
   assert.match(KERNEL, /def _peer_identity\(psid\):/, "the ONE identity ladder");

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -33,7 +33,7 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
   assert.match(RENDER, /awaitingPeers\?: PeerIdent\[\] \| null;/, "the payload field beside awaitingKind");
   assert.match(RENDER, /type PeerIdent = \{ name: string; host\?: string; sid\?: string; color\?: \{ bg: string; fg: string \} \| null \};/,
     "named alias — the Status interface line stays brace-free for its other pins");
-  const boxAt = RENDER.indexOf("const awPeers = s!.status.awaitingPeers");
+  const boxAt = RENDER.indexOf("const awPeers = s.status.awaitingPeers");   // narrowed `s` since the one-renderer cut (2026-09-06)
   const box = RENDER.slice(boxAt, RENDER.indexOf("head.appendChild(lab);", boxAt));
   assert.match(box, /el\("span", "bg-await-peer"\)/);
   assert.match(box, /\(pr\.host \? pr\.host \+ ":" : ""\) \+ pr\.name/, "host-prefixed when cross-host");

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -1,0 +1,211 @@
+// The Awaiting chip is a button, and what it waits on shows as ROWS grouped by kind
+// (plans/subagent-transcripts.md slice 2, the user 2026-09-05).
+//
+// Before: the statusline's "Awaiting <word>" chip was a plain span — the one status word on the pane
+// you could not click through — and the word came from whichever kernel source spoke first (live
+// subagents → "agents"; the pending launches → "agents" only if EVERY row was an agent, else the generic
+// "tasks", so a shell command plus an agent read "Awaiting 2 tasks" with the agent silently absorbed;
+// armed watches → the mystery word "jobs"). Now every awaited thing is its own row (kernel
+// awaitingItems: {kind, id, label, since, agentId?, detail?, watchId?}), the chip words itself from
+// the rows by ONE rule shared with the box gist and the feed pill (awaitWord), the chip opens the box,
+// and the box lists the rows under small dim group headers when more than one kind is present —
+// agent rows with the open-transcript arrow + Stop, command rows with the output fold + Stop, watch
+// rows with the label, how long armed, and Cancel when the kernel has a handle.
+//
+// The label rules are EXECUTED (spin-caption exports them); the DOM wiring is pinned at the source
+// (no jsdom for the chat renderer), the same harness every other awaiting pin uses.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { awaitWord, awaitBreakdown, groupRows, rowWord, kindWord, spinFor, GROUP_TITLE, ROW_KIND_OF_LEGACY,
+         type AwaitRow } from "./spin-caption";
+
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = W("render.ts");
+const FEED = W("feed.ts");
+const STYLES = W("styles.css");
+const FEEDCSS = W("feed.css");
+const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+const agent = (label: string, agentId = "a0123456789abcdef"): AwaitRow => ({ kind: "agents", id: "tu_" + label, label, since: 100, agentId });
+const command = (label: string): AwaitRow => ({ kind: "commands", id: "b_" + label, label, since: 120 });
+const watch = (label: string, watchId: string | null = "w1"): AwaitRow => ({ kind: "watches", id: "watch:" + label, label, since: 90, detail: "test -f /tmp/" + label, watchId });
+const peer = (name: string): AwaitRow => ({ kind: "peer", id: "peer:" + name, label: name });
+
+// --- the label rules, executed ------------------------------------------------------------------------
+test("awaitWord: one row reads its kind's word; several of one kind read the count and the word", () => {
+  assert.equal(awaitWord("agents", 1, [agent("map the parser")]), "agent");
+  assert.equal(awaitWord("task", 1, [command("build the docs")]), "command");
+  assert.equal(awaitWord("job", 1, [watch("the CI run")]), "watch");
+  assert.equal(awaitWord("peer", 1, [peer("web")]), "peer", "a single peer's word; the surfaces swap in the peer's own name");
+  assert.equal(awaitWord(null, null, [{ kind: "timer", id: "t1", label: "20 minutes" }]), "timer");
+  assert.equal(awaitWord("agents", 3, [agent("a"), agent("b"), agent("c")]), "3 agents");
+  assert.equal(awaitWord("task", 2, [command("a"), command("b")]), "2 commands");
+  assert.equal(awaitWord("job", 2, [watch("a"), watch("b")]), "2 watches");
+});
+
+test("awaitWord: several KINDS read the bare number — the breakdown is the tooltip's job", () => {
+  const rows = [agent("a"), agent("b"), command("c"), watch("d")];
+  assert.equal(awaitWord("mixed", 4, rows), "4");
+  assert.equal(awaitBreakdown(rows), "2 agents · 1 command · 1 watch");
+  assert.equal(awaitBreakdown([command("c")]), "1 command");
+  assert.equal(awaitBreakdown([]), "");
+});
+
+test("awaitWord: with no rows (an older kernel, a judge stamp) the legacy kind + count still word it", () => {
+  assert.equal(awaitWord("agents", 1, []), "agent");
+  assert.equal(awaitWord("agents", 2, []), "2 agents");
+  assert.equal(awaitWord("task", null, []), "command", "no count → the kind's default word, no number");
+  assert.equal(awaitWord("job", 2, null), "2 watches");
+  assert.equal(awaitWord("mixed", 4, []), "4", "a mixed overlay row with a count → the number");
+  assert.equal(awaitWord("mixed", null, []), "", "…and with none, no word at all: the chip reads plain Awaiting");
+  assert.equal(awaitWord(null, null, []), "agents", "kindless keeps the historic default");
+});
+
+test("groupRows: display order agents → commands → watches → peers → timers; unknown kinds kept, never dropped", () => {
+  const g = groupRows([peer("web"), watch("w"), command("c"), agent("a"), { kind: "future", id: "f", label: "x" }]);
+  assert.deepEqual(g.map((x) => x.kind), ["agents", "commands", "watches", "peer", "other"]);
+  assert.deepEqual(groupRows([]), []);
+  assert.deepEqual(groupRows(null), []);
+  for (const k of ["agents", "commands", "watches", "peer", "timer"]) assert.ok(GROUP_TITLE[k], "every group has a header title: " + k);
+  assert.equal(rowWord("watches", 1), "watch"); assert.equal(rowWord("watches", 2), "watches");
+  assert.equal(ROW_KIND_OF_LEGACY.task, "commands"); assert.equal(ROW_KIND_OF_LEGACY.job, "watches");
+});
+
+test("the three word maps agree on every legacy kind × count: kindWord, the timeline twin, and awaitWord with no rows", () => {
+  const table = TL.match(/const KIND_WORD = \{[^}]*\};/);
+  const fn = TL.match(/function tlKindWord\(kind, count\) \{[\s\S]*?\n\}/);
+  const suffix = TL.match(/function tlAwaitSuffix\(kind, count\) \{[\s\S]*?\n\}/);
+  assert.ok(table && fn && suffix, "the timeline carries the table, tlKindWord and tlAwaitSuffix");
+  const tl = new Function(table![0] + "\n" + fn![0] + "\nreturn tlKindWord;")() as (k: unknown, c: unknown) => string;
+  const tlSuffix = new Function(table![0] + "\n" + fn![0] + "\n" + suffix![0] + "\nreturn tlAwaitSuffix;")() as (k: unknown, c: unknown) => string;
+  for (const k of ["agents", "task", "job", "peer", "timer", "mixed", "", null, "nonsense"]) {
+    for (const c of [null, 0, 1, 2, 5]) {
+      assert.equal(tl(k, c), kindWord(k as any, c as any), `twin: kind=${String(k)} count=${String(c)}`);
+      const w = kindWord(k as any, c as any);
+      // awaitWord with no rows is kindWord with the count in front once it is known and plural
+      const expect = (typeof c === "number" && c > 1 && w) ? c + " " + w : (k === "mixed" ? (c ? String(c) : "") : w);
+      assert.equal(awaitWord(k as any, c as any, []), expect, `awaitWord: kind=${String(k)} count=${String(c)}`);
+    }
+  }
+  assert.equal(tlSuffix("job", 1), " watch");
+  assert.equal(tlSuffix("mixed", 4), " 4", "the lane badge shows a mixed wait's count");
+  assert.equal(tlSuffix("mixed", null), "");
+  assert.equal(tlSuffix(null, 3), "", "an older kernel ships no kind → plain Awaiting, as before");
+});
+
+test("the card caption stands down under rows of ANY kind, and still speaks when the kernel names none", () => {
+  const under = spinFor({ awaiting: { why: "1 background agent still working", kind: "agents", count: 1, items: [agent("a")] }, column: "working", sessState: "quiet" }, false, false);
+  assert.equal(under.caption, null, "the pill + its open list are the one awaiting read (the 2026-08-23 rule, now for every enumerable wait)");
+  const alone = spinFor({ awaiting: { why: "waiting on the test suite", kind: "task", items: [] }, column: "working" }, false, false);
+  assert.equal(alone.caption, "Waiting on the test suite", "a judge stamp names no rows → the caption is the only place its why shows");
+});
+
+// --- the chat statusline chip -------------------------------------------------------------------------
+test("the Awaiting chip is a BUTTON on the stable statusline delegate, acknowledged, that opens the box", () => {
+  const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
+  assert.match(branch, /const chip = el\("button", "chip chip-awaitingBg chip-btn"\) as HTMLButtonElement;/);
+  assert.match(branch, /chip\.type = "button";/);
+  assert.match(branch, /chip\.dataset\.act = "awaitingChip";/, "keyed for the delegate — never a listener on the rebuilt node");
+  // the tooltip: the per-kind breakdown, the kernel's why, and what the click does (setTip, one line each)
+  assert.match(branch, /setTip\(chip, \[awaitBreakdown\(chipItems\), s\.status\.awaitingWhy \|\| "idle, waiting on background work it dispatched",\s*\n\s*"click to see what it's waiting on"\]\.filter\(Boolean\)\.join\("\\n"\)\);/);
+  assert.doesNotMatch(branch, /chip\.title =/, "styled tip only — never the native title beside it");
+  // installed ONCE on #statusline (updateStatusline rebuilds its children every push); the handler opens the
+  // box's own fold state, re-renders it, and scrolls it into view
+  assert.match(RENDER, /const sl = document\.getElementById\("statusline"\);\s*\n\s*if \(!sl\) return;\s*\n\s*delegate\(sl, \{\s*\n\s*"awaitingChip": \(\) => \{\s*\n\s*if \(!activeId\) return;\s*\n\s*bgFoldOpen\.add\(activeId\);[^\n]*\n\s*renderBgTasks\(\);\s*\n\s*document\.getElementById\("bg-tasks"\)\?\.scrollIntoView\(\{ block: "nearest" \}\);/);
+  // a button's UA chrome is reset so it wears the chip exactly; hover/active feedback; the .romp-acted pulse is the delegate's
+  assert.match(STYLES, /button\.chip \{ font-family: inherit; line-height: normal; border: 0; cursor: pointer;/);
+  assert.match(STYLES, /button\.chip:hover \{ filter: brightness\(1\.08\); \}/);
+  assert.match(STYLES, /\.romp-acted \{ animation: romp-acted-pulse/);
+});
+
+test("the chip's label: a single named peer keeps its coloured name; every other wait wears awaitWord", () => {
+  const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
+  assert.match(branch, /if \(chipPeers\.length && groupRows\(chipItems\)\.every\(\(g\) => g\.kind === "peer"\)\) \{/, "the name path only when every row is a peer — a peer beside an agent is a mixed wait");
+  assert.match(branch, /\} else chip\.append\(chipWord \|\| chipPeers\.length \+ " peers"\);/);
+  assert.match(branch, /\} else chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(chipWord \? " " \+ chipWord : ""\);/);
+});
+
+// --- the box: rows grouped by kind, per-kind affordances ------------------------------------------------
+test("the box groups the rows by kind, headers only when more than one group shows, tracked services trailing", () => {
+  const body = RENDER.split("function renderAwaitWhy(")[1].split("\nfunction ")[0];
+  assert.match(body, /const groups = groupRows\(items\);/);
+  assert.match(body, /const leftovers = tasks\.filter\(\(t\) => !itemIds\.has\(t\.id\)\);/, "tracked tasks the wait does not name still list");
+  assert.match(body, /const headers = groups\.length \+ \(leftovers\.length \? 1 : 0\) >= 2;/);
+  assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
+  assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = "Background tasks"; list\.appendChild\(gh\); \}/);
+  // the header: mixed → "Awaiting <n> · <breakdown>"; one kind → the sentence as before
+  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/);
+  // the no-rows fallback still expands to the full sentence — never a dead end
+  assert.match(body, /if \(!groups\.length && !leftovers\.length\) \{[\s\S]*?const w = el\("div", "bg-await-why"\); w\.textContent = why;/);
+  // the header vocabulary is .bg-status's (10px uppercase), dim
+  assert.match(STYLES, /\.bg-group-head \{ flex: 0 0 auto; padding: 6px 9px 2px; font-size: 10px; text-transform: uppercase; letter-spacing: \.04em; font-weight: 600; color: var\(--dim\); \}/);
+});
+
+test("per-kind affordances on ONE row shape: agent → arrow + Stop; command → output fold + Stop; watch → armed-since + Cancel", () => {
+  const spec = RENDER.split("function awaitRowSpec(")[1].split("\nfunction ")[0];
+  assert.match(spec, /if \(it\.kind === "agents"\) \{[\s\S]*?agentId: it\.agentId \|\| \(tracked && tracked\.agentId\) \|\| null[\s\S]*?stopId: running \? tracked!\.id : null[\s\S]*?output: null \};/,
+    "an agent row: the arrow's id, Stop while its launch is live, NO output tail (its file is the transcript)");
+  assert.match(spec, /if \(it\.kind === "commands"\) \{[\s\S]*?stopId: running \? tracked!\.id : null[\s\S]*?output: tracked \? \(tracked\.output \|\| "\(no output captured\)"\) : null \};/);
+  assert.match(spec, /if \(it\.kind === "watches"\) \{[\s\S]*?status: "armed", caption: "armed"[\s\S]*?watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/);
+  assert.match(spec, /if \(it\.kind === "peer"\) \{[\s\S]*?peer: peerByName\.get\(it\.label \|\| ""\) \|\| null \};/);
+  const row = RENDER.split("function bgRow(")[1].split("\nfunction ")[0];
+  assert.match(row, /if \(t\.agentId\) \{[\s\S]*?const open = agentOpenButton\(t\.agentId, null, sid\);\s*\n\s*open\.classList\.add\("bg-open-agent"\);/);
+  assert.match(row, /if \(t\.since && t\.since > 0\) \{[\s\S]*?w\.dataset\.since = String\(t\.since\);[\s\S]*?workingFor\(Date\.now\(\) \/ 1000 - t\.since\)/, "how long the row has been waited on, from its OWN event time");
+  assert.match(row, /if \(t\.watchId\) \{[\s\S]*?cancel\.dataset\.act = "bg-cancel-watch"; cancel\.dataset\.id = t\.watchId;[\s\S]*?cancel\.textContent = "Cancel"; setTip\(cancel, "cancel this watch"\);/);
+  assert.match(row, /const foldable = !!\(t\.command \|\| t\.output\);/);
+  assert.match(row, /if \(foldable\) \{ rh\.dataset\.act = "bg-toggle"; rh\.dataset\.id = t\.id; \}/, "a row with nothing to unfold is not a toggle");
+  // the per-row clocks tick with the statusline timer (the box re-renders only on new fields)
+  assert.match(RENDER, /document\.querySelectorAll<HTMLElement>\("#bg-tasks \.bg-since\[data-since\]"\)/);
+  // armed watches and peer/timer waits wear the await-green dot: nothing is computing HERE
+  assert.match(STYLES, /\.bg-task\.bg-armed, \.bg-task\.bg-waiting \{ --bgt: var\(--st-awaitbg-bg\); \}/);
+});
+
+test("Cancel rides the box's stable delegate, acknowledges, and reaches the kernel's one cancel_watch", () => {
+  assert.match(RENDER, /"bg-cancel-watch": \(el\) => \{[\s\S]*?btn\.disabled = true; btn\.textContent = "Cancelling…";[\s\S]*?vscodeApi\?\.postMessage\(\{ type: "cancelWatch", id: activeId, watchId: id \}\);/);
+  // kernel: the SAME cancel_watch `romp watch --cancel` and POST /watch {"cancel"} reach; LOUD on a miss
+  assert.match(KERNEL, /if msg and msg\.get\("type"\) == "cancelWatch" and msg\.get\("watchId"\):/);
+  assert.match(KERNEL, /if not cancel_watch\(str\(msg\["watchId"\]\)\.strip\(\)\):\s*\n\s*client\["send"\]\(json\.dumps\(\{"type": "warn",/);
+  // a PR watch has no early-retire path today → the kernel ships no watchId → no button (bgRow keys on it)
+  assert.match(KERNEL, /a PR watch has no cancel path \(nothing retires a pr-watch early today\), so\s*\n\s*it carries no watchId and the box offers no button for it/);
+});
+
+test("the box re-renders on a rows change like any other awaiting field, and every surface ships the rows", () => {
+  const key = RENDER.split("function awaitKey(")[1].split("\n}")[0];
+  assert.ok(key.includes("st.awaitingItems"), "awaitingItems is in the await key");
+  assert.match(KERNEL, /"awaitingItems": \(list\(\(_aw or \{\}\)\.get\("items"\) or \[\]\) if awaiting_why else \[\]\),/, "chat status");
+  assert.match(KERNEL, /"awaitingItems": \(list\(\(_aw_bg or \{\}\)\.get\("items"\) or \[\]\) if awaiting_bg else \[\]\),/, "timeline lane");
+  assert.match(KERNEL, /"items": await_items,/, "the goal card");
+  assert.match(KERNEL, /"items": list\(items or \[\]\),/, "the placeholder card");
+});
+
+// --- the feed pill ------------------------------------------------------------------------------------
+test("the feed pill shows for ANY wait with rows, words itself by the same rule, and lists the rows grouped", () => {
+  const sec = FEED.split("function applySections(")[1].split("\nfunction ")[0];
+  assert.match(sec, /const awItems: AwaitRow\[\] = \(\(it\.awaiting && it\.awaiting\.items\) \|\| \[\]\)\.filter\(\(r\) => r && r\.kind\);/);
+  assert.match(sec, /const taskRows: AwaitRow\[\] = awItems\.length \? awItems\s*\n\s*: taskList\.map\(\(d\) => \(\{ kind: ROW_KIND_OF_LEGACY\[awKind\] \|\| "commands", label: d \}\)\);/,
+    "an older kernel's descriptions read as rows of the legacy kind's group");
+  assert.match(sec, /const hasTasks = taskRows\.length > 0;/);
+  assert.match(sec, /taskBtn\.style\.display = hasTasks \? "" : "none";/, "rows of any kind → the pill; no rows → none (the caption speaks)");
+  assert.match(sec, /const pillWord = awaitWord\(awKind, \(it\.awaiting && it\.awaiting\.count\) \?\? taskRows\.length, taskRows\);/);
+  assert.match(sec, /if \(pillPeers\.length === 1 && taskRows\.every\(\(r\) => r\.kind === "peer"\)\) \{/, "a single named peer → its name in identity colour");
+  // the expansion: grouped, dim headers only when more than one group, labels only (the chat box carries the controls)
+  assert.match(sec, /if \(choice === "tasks"\) \{[\s\S]*?const groups = groupRows\(taskRows\);[\s\S]*?if \(groups\.length > 1\) \{ const gh = el\("div", "ftask-group"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; cl\.appendChild\(gh\); \}/);
+  assert.match(sec, /\} else txt\.textContent = r\.label \|\| r\.kind;/);
+  assert.doesNotMatch(sec.split('if (choice === "tasks") {')[1].split("return;")[0], /bg-stop|Cancel|agentOpenButton/, "labels only on the card");
+  assert.match(FEEDCSS, /\.ftask-group \{ font-size: 0\.72em; text-transform: uppercase; letter-spacing: 0\.06em; color: var\(--dim\); margin: 4px 0 1px; \}/);
+});
+
+// --- vocabulary: the plain words everywhere, and no card moves --------------------------------------------
+test("the user-visible words are agent / command / watch / <peer> / timer; the kernel's why sentences match", () => {
+  assert.match(KERNEL, /return "%d background command%s" % \(n, "" if n == 1 else "s"\)/);
+  assert.match(KERNEL, /return "%d armed watch%s" % \(n, "" if n == 1 else "es"\)/);
+  assert.match(KERNEL, /why = \("waiting on a background command%s" % \(\(": " \+ d0\) if d0 else ""\) if n == 1 else\s*\n\s*"waiting on %d background commands%s"/);
+  assert.match(KERNEL, /"waiting on %d armed watches — %s, …"/);
+  assert.doesNotMatch(KERNEL.split("def _awaiting_from_items")[1].split("\ndef ")[0], /background task/, "the collapse word is gone from the derived sentences");
+  // the state formula that MOVES a card/chip is untouched: awaiting still keys on awaiting_why alone
+  assert.match(KERNEL, /"awaitingBg" if awaiting_why else "ready"\)/);
+});

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -131,12 +131,17 @@ test("the chip's label: a single named peer keeps its coloured name; every other
 
 // --- the box: rows grouped by kind, per-kind affordances ------------------------------------------------
 test("the box groups the rows by kind, headers only when more than one group shows, tracked services trailing", () => {
-  const body = RENDER.split("function renderAwaitWhy(")[1].split("\nfunction ")[0];
+  // since 2026-09-06 the one renderer is renderBgTasks (renderAwaitWhy folded into it — see the
+  // "one presentation" tests below); the grouping is unchanged
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /const groups = groupRows\(items\);/);
   assert.match(body, /const leftovers = tasks\.filter\(\(t\) => !itemIds\.has\(t\.id\)\);/, "tracked tasks the wait does not name still list");
   assert.match(body, /const headers = groups\.length \+ \(leftovers\.length \? 1 : 0\) >= 2;/);
   assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
-  assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = "Background tasks"; list\.appendChild\(gh\); \}/);
+  // the trailing group's title (pin changed 2026-09-06): "Background tasks" was the legacy list's word and the
+  // renderer must not say it anywhere; a tracked task the wait does not name is simply also running
+  assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = BG_LEFTOVER_TITLE; list\.appendChild\(gh\); \}/);
+  assert.match(RENDER, /const BG_LEFTOVER_TITLE = "Also running";/);
   // the header: mixed → "Awaiting <n> · <breakdown>"; one kind → the sentence as before
   assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
@@ -176,8 +181,10 @@ test("Cancel rides the box's stable delegate, acknowledges, and reaches the kern
 test("the box re-renders on a rows change like any other awaiting field, and every surface ships the rows", () => {
   const key = RENDER.split("function awaitKey(")[1].split("\n}")[0];
   assert.ok(key.includes("st.awaitingItems"), "awaitingItems is in the await key");
-  assert.match(KERNEL, /"awaitingItems": \(list\(\(_aw or \{\}\)\.get\("items"\) or \[\]\) if awaiting_why else \[\]\),/, "chat status");
-  assert.match(KERNEL, /"awaitingItems": \(list\(\(_aw_bg or \{\}\)\.get\("items"\) or \[\]\) if awaiting_bg else \[\]\),/, "timeline lane");
+  // pins changed 2026-09-06: the session-scoped surfaces ship the rows in BOTH turn states (the wait's own rows
+  // idle-awaiting, everything in flight otherwise — _awaiting_items_payload), not gated on awaiting_why
+  assert.match(KERNEL, /_aw_items = _awaiting_items_payload\(_aw, sid, sess\["path"\], tmux\)[\s\S]*?"awaitingItems": _aw_items,/, "chat status");
+  assert.match(KERNEL, /"awaitingItems": \(_awaiting_items_payload\(_aw_bg, sid, s\["path"\], tmux\) if live else \[\]\),/, "timeline lane");
   assert.match(KERNEL, /"items": await_items,/, "the goal card");
   assert.match(KERNEL, /"items": list\(items or \[\]\),/, "the placeholder card");
 });
@@ -211,6 +218,75 @@ test("every row — agent, command, watch, peer — is ONE line: label, then arr
                  at('el("span", "bg-caret")')];
   assert.deepEqual([...order].sort((a, b) => a - b), order, "label → arrow → elapsed → status → Stop → Cancel → caret");
   assert.match(STYLES, /\.bg-sum \{ flex: 0 1 auto; min-width: 0;/);
+});
+
+// --- one presentation in both turn states (the user 2026-09-06) -------------------------------------------
+// Seen live: a session with two background agents and a background command showed the grouped rows while
+// idle ("Awaiting 3 · 2 agents · 1 command", the idle note); the moment the user sent a message the view
+// vanished, and it came back when the turn ended. The kernel shipped the rows only while idle (alongside the
+// chip's idle-only Awaiting), so mid-turn the client fell to the legacy "N background tasks" list built from
+// s.bgTasks — two presentations of one set of facts, swapped at every turn boundary. Now the rows ride in both
+// states and ONE renderer draws them; only the header follows awaitingWhy (idle-and-waiting ⇔ the chip's
+// Awaiting). The chip itself still flips exactly when it did.
+test("ONE renderer: the grouped rows render whenever rows exist, idle or not; the legacy count list and its words are gone", () => {
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
+  assert.ok(!RENDER.includes("function renderAwaitWhy"), "the two-branch split is gone — one code path");
+  assert.doesNotMatch(body, /background tasks/i, "the legacy header string is gone from the renderer");
+  assert.doesNotMatch(RENDER, /count \+ " background tasks"/);
+  assert.doesNotMatch(RENDER, /"Background task · "/);
+  // the render gate is CONTENT: rows (awaitingItems, shipped in both states), a wait's why, or tracked tasks
+  assert.match(body, /const items = \(\(s && s\.status\.awaitingItems\) \|\| \[\]\)\.filter\(\(it\) => it && it\.kind\);/);
+  assert.match(body, /if \(!s \|\| !activeId \|\| \(!why && !items\.length && !tasks\.length\)\) \{ host\.style\.display = "none"; host\.classList\.remove\("bg-awaited"\); return; \}/);
+  // the same row renderer for every row in either state — tracked tasks still lend the command rows their
+  // output tail and Stop handle (awaitRowSpec's `tracked`), and list on their own when the wait names none
+  assert.match(body, /const taskById = new Map<string, BgTask>\(tasks\.map\(\(t\) => \[t\.id, t\]\)\);/);
+  assert.match(body, /for \(const it of g\.rows\) list\.appendChild\(bgRow\(awaitRowSpec\(it, taskById\.get\(it\.id \|\| ""\), peerByName\), sid\)\);/);
+  assert.match(body, /for \(const t of leftovers\) list\.appendChild\(bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)\);/);
+  // the awaited outline keys on the wait / the awaited ids' presence as before — never the chip state
+  assert.match(body, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
+  assert.doesNotMatch(body, /status\.state/, "nothing in the renderer reads the chip state");
+});
+
+test("the header follows the wait: idle → 'Awaiting …' + the idle note; working → 'In the background · <breakdown>' and NO note", () => {
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
+  assert.match(body, /if \(why\) \{[\s\S]*?const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "idle: today's label, agreeing in number with the chip");
+  assert.match(body, /\} else \{[\s\S]*?const counted: AwaitRow\[\] = items\.length \? items : leftovers\.map\(\(t\) => \(\{ kind: "commands", id: t\.id, label: t\.summary \}\)\);\s*\n\s*lab\.textContent = "In the background · " \+ awaitBreakdown\(counted\);/,
+    "working: the same rows, worded as what they are; a tracked service with no awaited row counts as the command it is");
+  // the idle note is appended under a wait only — once at the end of the list, once in the no-rows fallback
+  assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
+  assert.match(body, /det\.appendChild\(bgIdleNote\(\)\);/);
+  assert.equal((body.match(/bgIdleNote\(\)/g) || []).length, 2, "no other note anywhere in the renderer");
+  assert.doesNotMatch(RENDER, /keeps working meanwhile/, "the working-state sentence is gone: 'In the background' says it");
+  assert.match(RENDER, /function bgIdleNote\(\): HTMLElement \{[\s\S]*?"The session is idle until this finishes; it picks back up on its own when the result lands\."/);
+  // the header dot: await-green under a wait (like the chip), else the worst tracked status — a failed task
+  // stays glanceable while collapsed, running-yellow otherwise (never completed-blue for a box of live rows)
+  assert.match(body, /const head = el\("div", "bg-fold-head " \+ \(why \? "bg-await" : "bg-" \+ worst\) \+ \(open \? " open" : ""\)\);/);
+  assert.match(body, /const worst = tasks\.reduce\(\(w, t\) => \(BG_RANK\[t\.status\] \|\| 0\) > \(BG_RANK\[w\] \|\| 0\) \? t\.status : w, "running"\);/);
+  // the words, EXECUTED: the same rows word both headers, singular and plural
+  const rows = [agent("a"), agent("b"), command("c")];
+  assert.equal("Awaiting " + awaitWord("mixed", 3, rows) + " · " + awaitBreakdown(rows), "Awaiting 3 · 2 agents · 1 command");
+  assert.equal("In the background · " + awaitBreakdown(rows), "In the background · 2 agents · 1 command");
+  assert.equal("In the background · " + awaitBreakdown([agent("a")]), "In the background · 1 agent");
+  assert.equal("In the background · " + awaitBreakdown([command("c"), command("d")]), "In the background · 2 commands");
+  assert.equal("In the background · " + awaitBreakdown([watch("w")]), "In the background · 1 watch", "an armed watch shows mid-turn too (the 2026-08-30 rule, through the rows)");
+  assert.equal("In the background · " + awaitBreakdown([{ kind: "commands", id: "b1", label: "serve the docs" }]), "In the background · 1 command");
+});
+
+test("the box's fold state survives the idle↔working flip: the renderer only READS bgFoldOpen; the two clicks are its only writers", () => {
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
+  assert.match(body, /const open = bgFoldOpen\.has\(sid\);/);
+  assert.doesNotMatch(body, /bgFoldOpen\.(add|delete|clear)\(/, "the renderer never writes the fold state");
+  const writers = (RENDER.match(/bgFoldOpen\.(add|delete|clear)\([^)]*\)/g) || []).sort();
+  assert.deepEqual(writers, ["bgFoldOpen.add(activeId)", "bgFoldOpen.add(id)", "bgFoldOpen.delete(id)"],
+    "the header toggle and the chip click, nothing else — a status-only frame that flips awaitingWhy re-renders through awaitKey and finds the fold as it was");
+  const key = RENDER.split("function awaitKey(")[1].split("\n}")[0];
+  assert.ok(key.includes("st.awaitingWhy") && key.includes("st.awaitingItems"), "the flip and the rows both re-render the box");
+  // …and the kernel ships the SAME rows in both states, so only the header changes on the flip
+  assert.match(KERNEL, /def _awaiting_live_rows\(sid, path, live\):/);
+  assert.match(KERNEL, /def _session_background_items\(sid, path\):/);
+  assert.match(KERNEL, /def _awaiting_items_payload\(aw, sid, path, tmux=None\):[\s\S]*?if aw:\s*\n\s*return list\(aw\.get\("items"\) or \[\]\)\s*\n\s*with _serve_live\(tmux\):\s*\n\s*return _session_background_items\(sid, path\)/,
+    "the wait's own rows, else everything in flight — read under the caller's snapshot (no fresh liveness read on the working path)");
+  assert.match(KERNEL, /def _awaiting_join_items\(agents, commands, watch\):/, "one concatenation for the idle read and the turn-agnostic read");
 });
 
 // --- vocabulary: the plain words everywhere, and no card moves --------------------------------------------

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -199,6 +199,20 @@ test("the feed pill shows for ANY wait with rows, words itself by the same rule,
   assert.match(FEEDCSS, /\.ftask-group \{ font-size: 0\.72em; text-transform: uppercase; letter-spacing: 0\.06em; color: var\(--dim\); margin: 4px 0 1px; \}/);
 });
 
+test("every row — agent, command, watch, peer — is ONE line: label, then arrow · elapsed · status · Stop/Cancel · caret, inline (the user 2026-09-05)", () => {
+  // The cluster used to sit at the row's right edge (the label grew to fill); on a wide desktop the user
+  // missed it. One row builder (bgRow) serves every kind, so the DOM order pinned here IS the reading
+  // order for all of them, and styles.css's .bg-sum (0 1 auto, min-width 0) keeps the cluster right after
+  // the label — bg-tasks-layout.test.ts pins the CSS half.
+  const row = RENDER.split("function bgRow(")[1].split("\nfunction ")[0];
+  const at = (s: string) => { const i = row.indexOf(s); assert.ok(i >= 0, "found " + s); return i; };
+  const order = [at('el("span", "bg-sum")'), at('open.classList.add("bg-open-agent")'), at('el("span", "bg-since")'),
+                 at('el("span", "bg-status")'), at('el("button", "bg-stop")'), at('el("button", "bg-stop bg-cancel")'),
+                 at('el("span", "bg-caret")')];
+  assert.deepEqual([...order].sort((a, b) => a - b), order, "label → arrow → elapsed → status → Stop → Cancel → caret");
+  assert.match(STYLES, /\.bg-sum \{ flex: 0 1 auto; min-width: 0;/);
+});
+
 // --- vocabulary: the plain words everywhere, and no card moves --------------------------------------------
 test("the user-visible words are agent / command / watch / <peer> / timer; the kernel's why sentences match", () => {
   assert.match(KERNEL, /return "%d background command%s" % \(n, "" if n == 1 else "s"\)/);

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -75,18 +75,21 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
   assert.doesNotMatch(branch, /sl-await-why/);
   assert.doesNotMatch(STYLES, /sl-await-why/);
-  // …and the #bg-tasks box renders it when no tracked tasks claim the box: the same fold treatment
-  // (await-green dot, verb-stripped header), expanding to the full why, the awaited items when there are
-  // several, and a plain-words note on what the state means. No Stop — nothing untracked is killable.
-  assert.match(RENDER, /\{ renderAwaitWhy\(host, s \|\| null\); return; \}/);
+  // …and the #bg-tasks box renders it — since slice 2 (2026-09-05) whenever a wait exists, the tracked
+  // tasks joining its rows: the same fold treatment (await-green dot, verb-stripped header), expanding
+  // to the awaited ROWS grouped by kind, or to the full why when the kernel names none, and a
+  // plain-words note on what the state means. Stop rides only a row backed by a LIVE tracked task
+  // (bgRow's stopId) — an untracked wait (a peer's PR, a watch) still has no process to kill.
+  assert.match(RENDER, /if \(why \|\| !count \|\| !tasks\.length\) \{ renderAwaitWhy\(host, s \|\| null, tasks\); return; \}/);
   assert.match(RENDER, /"bg-fold-head bg-await"/);
-  assert.match(RENDER, /"Awaiting" \+ \(kw \? " " \+ kindWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount\) : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
   // …the kind word rides the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
-  assert.match(RENDER, /KIND_WORD\[\(s!\.status\.awaitingKind \|\| ""\)\]/);
+  assert.match(RENDER, /const word = awaitWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount, items\);/);
   assert.match(RENDER, /chip-awaiting-" \+ \(s\.status\.awaitingKind \|\| "untyped"\)/);
-  assert.match(RENDER, /if \(items\.length > 1\)/);
+  assert.match(RENDER, /if \(descs\.length > 1\)/);   // the no-rows fallback lists the legacy descriptions only when there are several
   assert.match(RENDER, /bg-await-note/);
-  assert.doesNotMatch(RENDER.split("function renderAwaitWhy")[1].split("\n}")[0], /bg-stop/);
+  assert.match(RENDER, /stopId: running \? tracked!\.id : null/);
+  assert.match(RENDER, /return \{ id, status: "armed", caption: "armed", label: it\.label \|\| "a watch", since: it\.since,\s*\n\s*watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/, "a watch row: Cancel when the kernel has a handle, never Stop");
   assert.match(STYLES, /\.bg-fold-head\.bg-await \{ --bgt: var\(--st-awaitbg-bg\); \}/);
 });
 
@@ -100,7 +103,8 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   assert.match(RENDER, /awaitingTaskIds\?: string\[\];/);
   assert.match(RENDER, /const awaited = new Set<string>\(s!\.status\.awaitingTaskIds \|\| \[\]\);/);   // ids' presence, never the chip state (2026-08-30: awaited things show even while working)
   assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
-  assert.match(RENDER, /\(awaited\.has\(t\.id\) \? " bg-awaited" : ""\)/);
+  assert.match(RENDER, /bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)/);   // the row spec carries the match (slice 2's one row renderer)
+  assert.match(RENDER, /\(t\.awaited \? " bg-awaited" : ""\)/);
   // …the untracked-wait box (renderAwaitWhy) IS the awaited thing, so it wears the border whole
   assert.match(RENDER, /host\.classList\.add\("bg-awaited"\);/);
   // the outline is the chip's await-green — the border/outline only; the status DOT rules are untouched
@@ -123,7 +127,9 @@ test("awaited things show even while WORKING, and kernel watches feed the box (t
   // 2. kernel watches are an awaiting SOURCE (idle: flips the chip like any wait; the rows are
   // kernel-owned and event-true at both ends — armed at registration, cleared on fire/cancel)
   assert.match(KERNEL, /def _watch_awaiting\(sid\):/);
-  assert.match(KERNEL, /w = _watch_awaiting\(sid\)\s*\n\s*if w:\s*\n\s*return w/);
+  // …COMBINED with the live agents and pending launches since slice 2 (2026-09-05) — no source
+  // short-circuits another; the one answer is derived from every row
+  assert.match(KERNEL, /combined = _awaiting_from_items\(agents, commands, _watch_awaiting\(sid\)\)\s*\n\s*if combined:\s*\n\s*return combined/);
   // 3. mid-turn, the CONTENT rides the payload while the shared state formula stays untouched —
   // the chip keeps reading working, the box renders from the fields
   assert.match(KERNEL, /if not _aw and open_now:\s*\n\s*_aw = _watch_awaiting\(sid\)/);

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -75,16 +75,18 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
   assert.doesNotMatch(branch, /sl-await-why/);
   assert.doesNotMatch(STYLES, /sl-await-why/);
-  // …and the #bg-tasks box renders it — since slice 2 (2026-09-05) whenever a wait exists, the tracked
-  // tasks joining its rows: the same fold treatment (await-green dot, verb-stripped header), expanding
-  // to the awaited ROWS grouped by kind, or to the full why when the kernel names none, and a
-  // plain-words note on what the state means. Stop rides only a row backed by a LIVE tracked task
-  // (bgRow's stopId) — an untracked wait (a peer's PR, a watch) still has no process to kill.
-  assert.match(RENDER, /if \(why \|\| !count \|\| !tasks\.length\) \{ renderAwaitWhy\(host, s \|\| null, tasks\); return; \}/);
-  assert.match(RENDER, /"bg-fold-head bg-await"/);
+  // …and the #bg-tasks box renders it — since slice 2 (2026-09-05) as the header over the awaited ROWS
+  // grouped by kind, the tracked tasks joining them (or the full why when the kernel names none), with a
+  // plain-words note on what the state means. Since 2026-09-06 ONE renderer (renderBgTasks) draws the
+  // box in both turn states from the same rows; the wait's why picks the header's words and its
+  // await-green dot (pin changed: the two-branch split into a legacy tasks list is gone). Stop rides
+  // only a row backed by a LIVE tracked task (bgRow's stopId) — an untracked wait (a peer's PR, a
+  // watch) still has no process to kill.
+  assert.ok(!RENDER.includes("function renderAwaitWhy"), "one renderer");
+  assert.match(RENDER, /const head = el\("div", "bg-fold-head " \+ \(why \? "bg-await" : "bg-" \+ worst\) \+ \(open \? " open" : ""\)\);/);
   assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
   // …the kind word rides the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
-  assert.match(RENDER, /const word = awaitWord\(s!\.status\.awaitingKind, s!\.status\.awaitingCount, items\);/);
+  assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/);
   assert.match(RENDER, /chip-awaiting-" \+ \(s\.status\.awaitingKind \|\| "untyped"\)/);
   assert.match(RENDER, /if \(descs\.length > 1\)/);   // the no-rows fallback lists the legacy descriptions only when there are several
   assert.match(RENDER, /bg-await-note/);
@@ -99,14 +101,16 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   assert.match(KERNEL, /"awaitingTaskIds": \(_awaiting_task_ids\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
   assert.match(KERNEL, /def _awaiting_task_ids\(sid, path\):/);
   assert.match(KERNEL, /return \[t\["tid"\] for t in awaited if t\.get\("tid"\)\]/);
-  // client: rows are marked from awaitingTaskIds only while the chip is awaitingBg…
+  // client: rows are marked from awaitingTaskIds — the ids' presence, never the chip state (2026-08-30:
+  // awaited things show even while working)…
   assert.match(RENDER, /awaitingTaskIds\?: string\[\];/);
-  assert.match(RENDER, /const awaited = new Set<string>\(s!\.status\.awaitingTaskIds \|\| \[\]\);/);   // ids' presence, never the chip state (2026-08-30: awaited things show even while working)
-  assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
+  assert.match(RENDER, /const awaited = new Set<string>\(s\.status\.awaitingTaskIds \|\| \[\]\);/);
+  // …and the box wears the border whole while the session WAITS on its rows (the wait IS the box) or
+  // whenever a tracked task is named awaited — one toggle since the one-renderer cut (2026-09-06; the
+  // kernel ships the ids only with a wait, so mid-turn the box wears its neutral border under a Working chip)
+  assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
   assert.match(RENDER, /bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)/);   // the row spec carries the match (slice 2's one row renderer)
   assert.match(RENDER, /\(t\.awaited \? " bg-awaited" : ""\)/);
-  // …the untracked-wait box (renderAwaitWhy) IS the awaited thing, so it wears the border whole
-  assert.match(RENDER, /host\.classList\.add\("bg-awaited"\);/);
   // the outline is the chip's await-green — the border/outline only; the status DOT rules are untouched
   assert.match(STYLES, /#bg-tasks\.bg-awaited \{ border-color: var\(--st-awaitbg-bg\); \}/);
   assert.match(STYLES, /\.bg-task\.bg-awaited \{ box-shadow: inset 0 0 0 1px var\(--st-awaitbg-bg\); border-radius: 5px; \}/);
@@ -116,23 +120,32 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
 test("awaited things show even while WORKING, and kernel watches feed the box (the user 2026-08-30)", () => {
   // Their requirement, paraphrased: even mid-turn, anything the session awaits — jobs, watches,
   // pending externals — shows at the chat bottom in the green box. Three legs, pinned where they live:
-  // 1. the box keys on awaited CONTENT, never the chip state (the old state gate was the defect)
+  // 1. the box keys on in-flight CONTENT, never the chip state (the old state gate was the defect)
   assert.match(RENDER, /const why = \(s && \(s\.status\.awaitingWhy \|\| ""\)\.trim\(\)\) \|\| "";/);
-  assert.doesNotMatch(RENDER.split("function renderAwaitWhy")[1].split("\n}")[0],
-    /state === "awaitingBg" &&/);
-  // …with the fold's plain-words note adapting to the chip: idle keeps the historic sentence,
-  // working says the session keeps going and is told when the wait lands
-  assert.match(RENDER, /s!\.status\.state === "awaitingBg"\s*\n\s*\? "The session is idle until this finishes/);
-  assert.match(RENDER, /: "The session keeps working meanwhile; it's told when this lands\."/);
+  const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
+  assert.doesNotMatch(body, /state === "awaitingBg"/);
+  // …with the fold's plain-words note under a WAIT only (pin changed 2026-09-06): the header now says
+  // which state the box is in — "Awaiting …" idle, "In the background …" working — so the working
+  // state needs no sentence; the old two-note switch keyed on the chip state is gone with it
+  assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
+  assert.doesNotMatch(RENDER, /The session keeps working meanwhile/);
+  assert.match(RENDER, /function bgIdleNote\(\): HTMLElement \{[\s\S]*?"The session is idle until this finishes; it picks back up on its own when the result lands\."/);
   // 2. kernel watches are an awaiting SOURCE (idle: flips the chip like any wait; the rows are
   // kernel-owned and event-true at both ends — armed at registration, cleared on fire/cancel)
   assert.match(KERNEL, /def _watch_awaiting\(sid\):/);
   // …COMBINED with the live agents and pending launches since slice 2 (2026-09-05) — no source
-  // short-circuits another; the one answer is derived from every row
-  assert.match(KERNEL, /combined = _awaiting_from_items\(agents, commands, _watch_awaiting\(sid\)\)\s*\n\s*if combined:\s*\n\s*return combined/);
-  // 3. mid-turn, the CONTENT rides the payload while the shared state formula stays untouched —
-  // the chip keeps reading working, the box renders from the fields
-  assert.match(KERNEL, /if not _aw and open_now:\s*\n\s*_aw = _watch_awaiting\(sid\)/);
+  // short-circuits another; the one answer is derived from every row — by _awaiting_live_rows, the
+  // assembly the mid-turn read shares (2026-09-06)
+  assert.match(KERNEL, /agents, commands, watch = _awaiting_live_rows\(sid, path, live\)\s*\n\s*combined = _awaiting_from_items\(agents, commands, watch\)\s*\n\s*if combined:\s*\n\s*return combined/);
+  assert.match(KERNEL, /return agents, commands, _watch_awaiting\(sid\)/);
+  // 3. mid-turn, the CONTENT rides the payload while the shared state formula stays untouched — the
+  // chip keeps reading working, the box renders from the fields. Pin changed 2026-09-06: the content
+  // is the ROWS (awaitingItems, the same set in both turn states), not a watch-only re-run into
+  // awaitingWhy — that arm made the box read "Awaiting" under a Working chip and left every other
+  // in-flight row to the legacy list; awaitingWhy now means idle-and-waiting on every surface
+  assert.doesNotMatch(KERNEL, /if not _aw and open_now:/);
+  assert.match(KERNEL, /_aw_items = _awaiting_items_payload\(_aw, sid, sess\["path"\], tmux\)/);   // under the build's own snapshot — no fresh liveness read on the working path
+  assert.match(KERNEL, /"awaitingItems": _aw_items,/);
   assert.match(KERNEL, /"working" if open_now else\n/);   // the state formula's ordering is intact
 });
 

--- a/ui/webview/bg-tasks-layout.test.ts
+++ b/ui/webview/bg-tasks-layout.test.ts
@@ -44,8 +44,11 @@ test("status dots are SOLID — the pulsating yellow animation is gone", () => {
 test("each RUNNING task row has a Stop button riding the stable delegate (the user 2026-08-04)", () => {
   // the button posts the SDK's designed stop_task control request, keyed by the id the box shows;
   // gated on status so a finished row never grows a dead control
-  assert.match(RENDER, /if \(\(t\.status \|\| "running"\) === "running"\) \{/);
-  assert.match(RENDER, /stop\.dataset\.act = "bg-stop"; stop\.dataset\.id = t\.id;/);
+  // since slice 2 (2026-09-05) the row SPEC decides: a tracked task's Stop handle is its id while it
+  // runs (taskRowSpec / awaitRowSpec), and bgRow renders the button from that handle
+  assert.match(RENDER, /stopId: status === "running" \? t\.id : null/);
+  assert.match(RENDER, /if \(t\.stopId\) \{/);
+  assert.match(RENDER, /stop\.dataset\.act = "bg-stop"; stop\.dataset\.id = t\.stopId;/);
   // click-safe: handled on the SAME delegate as the fold toggles, never a per-render listener…
   assert.match(RENDER, /"bg-stop": \(el\) => \{/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "stopTask", id: activeId, taskId: id \}\);/);

--- a/ui/webview/bg-tasks-layout.test.ts
+++ b/ui/webview/bg-tasks-layout.test.ts
@@ -56,3 +56,23 @@ test("each RUNNING task row has a Stop button riding the stable delegate (the us
   // own terminal lifecycle event) is the real confirmation, and a re-render restores a live task's button
   assert.match(RENDER, /btn\.disabled = true; btn\.textContent = "Stopping…";/);
 });
+
+test("a row's trailing cluster sits INLINE after the label, left-aligned — never pushed to the right edge (the user 2026-09-05)", () => {
+  // Before: .bg-sum grew (flex 1 1 auto) to fill the row, so the arrow, elapsed, status word, Stop and caret
+  // hugged the far right — on a wide desktop pane the user missed them entirely. The label now takes only its
+  // own width, shrinking with an ellipsis when long (0 1 auto + min-width 0), and the cluster follows it at
+  // the existing 8px gap. Every cluster item is 0 0 auto so a long label can never push it off-screen, and
+  // nothing in the row uses a spacer, margin-left:auto or space-between.
+  const SUM = (CSS.match(/\.bg-sum \{[^}]*\}/) || [""])[0];
+  assert.match(SUM, /flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);
+  assert.doesNotMatch(SUM, /flex: 1 1 auto/);
+  const ROWHEAD = (CSS.match(/\.bg-head \{[^}]*\}/) || [""])[0];
+  assert.match(ROWHEAD, /display: flex; align-items: center; gap: 8px;/);
+  assert.doesNotMatch(ROWHEAD, /justify-content|space-between/);
+  for (const sel of [".bg-since", ".bg-status", ".bg-caret", ".bg-stop", ".tool-open-agent, .sub-head-pin"]) {
+    const rule = (CSS.match(new RegExp(sel.replace(/[.,]/g, (c) => "\\" + c) + " \\{[^}]*\\}")) || [""])[0];
+    assert.match(rule, /flex: 0 0 auto;/, sel + " holds its width");
+    assert.doesNotMatch(rule, /margin-left: auto/, sel + " is not a spacer");
+  }
+  assert.doesNotMatch(CSS, /\.bg-head [^{]*\{[^}]*margin-left: auto/, "no cluster item is pushed right");
+});

--- a/ui/webview/bg-tasks-layout.test.ts
+++ b/ui/webview/bg-tasks-layout.test.ts
@@ -1,5 +1,5 @@
 // Background-task box (the user 2026-07-07): ONE dedicated full-width rounded box just above the statusline.
-// The "N background tasks" header BAR sits at the TOP of the box; clicking it expands the list DOWNWARD
+// The one-line header BAR ("Awaiting …" idle / "In the background …" working) sits at the TOP of the box; clicking it expands the list DOWNWARD
 // beneath the header inside the SAME box (a normal flex-direction: column, reading top-to-bottom), so nothing
 // spills below the box — the earlier design let a shrink-1 box get squeezed and its rows clipped behind the
 // composer. It HOLDS its content (flex 0 0 auto), is capped so it never crowds the composer, and the inner

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,7 +21,7 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // the rows' vocabulary too (slice 2)
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote \} from "\.\/distiller-line";/);
@@ -35,10 +35,13 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /"bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none"/);
   // "Awaiting task", never "Waiting on task": one word per state across every surface — the chat chip
   // and timeline badge already say Awaiting for this exact state (the user 2026-08-13)
-  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ \(awKind \? kindWord\(awKind, 1\) : kw\)\s*\n?\s*: "Awaiting " \+ taskList\.length \+ " "/);
+  // …worded by the ONE rule the chat chip and box use (awaitWord, slice 2 2026-09-05): "Awaiting
+  // agent" / "Awaiting 3 agents" / "Awaiting 4" for mixed kinds; a single named peer → its name
+  assert.match(FEED, /pillLbl\.replaceChildren\("Awaiting "\);/);
+  assert.match(FEED, /\} else pillLbl\.append\(pillWord\);/);
   assert.doesNotMatch(FEED, /"Waiting on task"/);
   // the pill carries the wait's elapsed time, same readout as the awaiting box (the user 2026-08-23)
-  assert.match(FEED, /\+ pillWaited;/);
+  assert.match(FEED, /pillLbl\.append\(pillWaited\);/);   // appended after the (possibly coloured) word since slice 2
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark
   assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask"\)[\s\S]*?ftask-swirl/);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -609,6 +609,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fask-taskbtn { display: inline-flex; align-items: center; gap: 5px; }
 .fask-taskbtn .fask-awaiting-swirl { width: 10px; height: 10px; }
 .ftask-swirl.fask-awaiting-swirl { display: inline-block; width: 11px; height: 11px; vertical-align: -1px; }
+/* the expanded list grouped by KIND (slice 2, 2026-09-05): a small dim caps header per group, in the
+   .fmodal-warn-cap vocabulary, shown only when more than one group is on the card */
+.ftask-group { font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--dim); margin: 4px 0 1px; }
+.ftask-group:first-child { margin-top: 1px; }
 
 /* "Followed up" — optimistic reopen pending the judge's re-file (judges delegation, 2026-06-17); blue pill */
 .fask-followedup { flex: 0 0 auto; font-size: 0.66em; font-weight: 700; letter-spacing: 0.04em;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -8,7 +8,7 @@
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
-import { spinFor, KIND_WORD, kindWord, waitedSuffix } from "./spin-caption";
+import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
@@ -118,7 +118,8 @@ interface AskItem {
   satellite?: boolean | null;                        // tracked delegation (the user 2026-08-24): this card is the recipient-side copy of a delegator-homed primary — off the default board; the session filter still reaches it (nothing runs in secret)
   delegTracked?: { name: string; host?: string; sid: string; color?: { bg: string; fg: string } | null }[] | null;  // tracked delegation PRIMARY: the recipient identities whose live status this one card carries  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string; since?: number } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25). since = when the unanswered ask was sent → the chip's elapsed readout (the user 2026-08-23)
-  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; tasks?: string[] | null;
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; count?: number | null; tasks?: string[] | null;
+               items?: AwaitRow[] | null;   // the awaited ROWS grouped by kind (slice 2, 2026-09-05) — the pill lists them; count = how many (T225)
                peers?: { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null }[] | null } | null;   // peers: delegation wait → the box names them in identity colour (the user 2026-08-23)   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why. since = the wait's own event time → the box/pill elapsed readout (the user 2026-08-23)
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
@@ -1450,7 +1451,15 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // live background tasks (the user 2026-07-13): when the card is AWAITING on tasks, the compact
   // "Awaiting task" pill joins the section toggles and expands this list (the old boxed caption is gone)
   const taskList = ((it.awaiting && it.awaiting.tasks) || []).filter(Boolean);
-  const hasTasks = taskList.length > 0;
+  // …and since slice 2 (2026-09-05) the awaited ROWS, grouped by kind — agents, commands, watches,
+  // peers — so the pill shows for ANY wait the kernel can enumerate, not only a bg-task one (a wait on
+  // live subagents had no clickable affordance on the card). An older kernel ships descriptions only;
+  // they read as rows of the legacy kind's group, so the list never goes blank on a mixed deployment.
+  const awKind = (it.awaiting && it.awaiting.kind) || "";
+  const awItems: AwaitRow[] = ((it.awaiting && it.awaiting.items) || []).filter((r) => r && r.kind);
+  const taskRows: AwaitRow[] = awItems.length ? awItems
+    : taskList.map((d) => ({ kind: ROW_KIND_OF_LEGACY[awKind] || "commands", label: d }));
+  const hasTasks = taskRows.length > 0;
   // resolve the selection (default = summary open), falling back to "none" if the chosen section is empty
   // the stall note (the user 2026-07-23) — shown whenever the kernel says romp is holding this card, with
   // or without a judge-written note, since `why` alone already answers "why is nothing happening"
@@ -1527,16 +1536,24 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // Awaiting, and two words for one state read as two states (the user 2026-08-13).
   const taskBtn = a._taskBtn as HTMLElement;
   taskBtn.style.display = hasTasks ? "" : "none";
-  // the KIND words the pill (the user 2026-08-15): "Awaiting job", "Awaiting 3 agents" — the wait's
-  // class in the visible label (tooltips are dead on the touch PWA); kindless keeps the classic "task"
-  const awKind = (it.awaiting && it.awaiting.kind) || "";
-  const kw = KIND_WORD[awKind] || "task";
+  // the KIND words the pill (the user 2026-08-15): "Awaiting watch", "Awaiting 3 agents" — the wait's
+  // class in the visible label (tooltips are dead on the touch PWA). ONE rule with the chat chip and
+  // the awaiting box (awaitWord, slice 2): one row → its word, several of a kind → count + word, mixed
+  // kinds → the number alone ("Awaiting 4"); a single named peer → its name in identity colour.
   // the wait's elapsed time rides the pill exactly as it rides the awaiting box and the working
   // narration — a stuck wait must be glanceable everywhere the state shows (the user 2026-08-23)
   const pillWaited = waitedSuffix(it.awaiting && it.awaiting.since, Date.now() / 1000);
-  (a._taskLbl as HTMLElement).textContent =
-    (taskList.length === 1 ? "Awaiting " + (awKind ? kindWord(awKind, 1) : kw)
-                           : "Awaiting " + taskList.length + " " + (awKind ? kindWord(awKind, taskList.length) : kw + "s")) + pillWaited;   // one number-agreeing vocabulary (T225)
+  const pillPeers = (it.awaiting && it.awaiting.peers) || [];
+  const pillWord = awaitWord(awKind, (it.awaiting && it.awaiting.count) ?? taskRows.length, taskRows);
+  const pillLbl = a._taskLbl as HTMLElement;
+  pillLbl.replaceChildren("Awaiting ");
+  if (pillPeers.length === 1 && taskRows.every((r) => r.kind === "peer")) {
+    const nm = el("span", "fask-waiton-name");
+    nm.replaceChildren(...hostPartsNodes(pillPeers[0].host, pillPeers[0].name));
+    if (pillPeers[0].color && pillPeers[0].color.bg) nm.style.color = pillPeers[0].color.bg;
+    pillLbl.appendChild(nm);
+  } else pillLbl.append(pillWord);
+  pillLbl.append(pillWaited);
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";
@@ -1557,14 +1574,34 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
     // the TASK list (the user 2026-07-13): same view/spot as the sub-goal checklist — one row per live
     // background task, a small spinning swirl as its mark (in flight), the task's own description as text
     if (choice === "tasks") {
-      for (const d of taskList) {
-        const row = el("div", "fcheck ftask");
-        const tri = el("span", "fcheck-tri empty");
-        const mark = el("span", "fcheck-mark");
-        mark.appendChild(el("span", "fask-awaiting-swirl ftask-swirl"));
-        const txt = el("span", "fcheck-text"); txt.textContent = d;
-        row.append(tri, mark, txt);
-        cl.appendChild(row);
+      // …grouped by KIND since slice 2 (2026-09-05): a small dim header per group when more than one
+      // shows (agents / commands / watches / peers), labels only — the chat's box carries the controls
+      const groups = groupRows(taskRows);
+      const peerByName = new Map(pillPeers.map((p) => [p.name, p]));
+      for (const g of groups) {
+        if (groups.length > 1) { const gh = el("div", "ftask-group"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; cl.appendChild(gh); }
+        for (const r of g.rows) {
+          const row = el("div", "fcheck ftask");
+          const tri = el("span", "fcheck-tri empty");
+          const mark = el("span", "fcheck-mark");
+          mark.appendChild(el("span", "fask-awaiting-swirl ftask-swirl"));
+          const txt = el("span", "fcheck-text");
+          const p = r.kind === "peer" ? peerByName.get(r.label || "") : undefined;
+          if (p) {
+            // a peer row names the session the way the awaiting box does: identity colour, quiet host prefix,
+            // click opens the session (the standard session-chip gesture)
+            txt.replaceChildren(...hostPartsNodes(p.host, p.name));
+            if (p.color && p.color.bg) txt.style.color = p.color.bg;
+            if (p.sid) {
+              const sid = p.sid;
+              txt.title = "waiting on " + p.name + " — click opens the session";
+              txt.style.cursor = "pointer";
+              txt.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: sid }); };
+            }
+          } else txt.textContent = r.label || r.kind;
+          row.append(tri, mark, txt);
+          cl.appendChild(row);
+        }
       }
       cl.style.display = cl.children.length ? "" : "none";
       return;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -232,7 +232,7 @@ interface TodoTask { id: string; subject: string; activeForm?: string; status: s
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -240,7 +240,7 @@ interface Color { bg: string; fg: string; }
 // carries the full ask — the Agent prompt / the Workflow script — so the row's detail level says what the
 // work IS, not a generic label over an empty block (the user 2026-08-15).
 interface BgTask { id: string; status: string; summary: string; command?: string; output?: string; agentId?: string; }   // agentId: an AGENT row (its own transcript is openable — plans/subagent-transcripts.md); absent on shell tasks
-// The box payload: count (total to surface → the "N background tasks" header) + up to 16 tasks (the list).
+// The box payload: count (the true total of tracked tasks) + up to 16 tasks (the rows the #bg-tasks box joins to the kernel's in-flight rows).
 interface BgTasks { count: number; tasks: BgTask[]; }
 // events is a contiguous TAIL of the transcript: global indices [headFrom, headTotal). On a fresh load the
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
@@ -9778,19 +9778,29 @@ function renderLedger() {
   if (host) { host.replaceChildren(); host.style.display = "none"; }
 }
 
-// Background-task box (#bg-tasks) between the transcript and the composer (the user 2026-06-26). Three-level
-// disclosure, like a tool-use fold — and COLLAPSED by default so a busy session (e.g. many running training
-// tasks) doesn't fill the box:
-//   1. a count HEADER — "Background task · <name>" for one, "N background tasks" for many (+ a worst-status
-//      dot so a failure is glanceable while collapsed). Click → toggle the list.
-//   2. the LIST — one row per task (status dot + summary), scrollable (~5 visible). Click a row → details.
-//   3. per-task DETAILS — the command + its output, each in its own scrollable block.
-// Both fold levels persist across the per-push re-render (keyed by session id / task id); every toggle is
-// DELEGATED to the stable #bg-tasks container so a rebuild mid-click never drops it. textContent only
-// (command/output are untrusted).
-const bgExpanded = new Set<string>();   // task ids whose details are open
+// The in-flight box (#bg-tasks) between the transcript and the composer (the user 2026-06-26): everything
+// the active session has running in the background — dispatched agents, background commands, armed kernel
+// watches, the peers a wait names — as rows grouped by kind (slice 2, plans/subagent-transcripts.md).
+// Three-level disclosure, like a tool-use fold, and COLLAPSED by default so a busy session doesn't fill it:
+//   1. a one-line HEADER — "Awaiting 3 · 2 agents · 1 command" while the session is idle waiting on the
+//      rows (the chip's Awaiting), "In the background · 2 agents · 1 command" while it works — with a status
+//      dot (await-green idle; the worst tracked status working, so a failure is glanceable while collapsed).
+//      Click → toggle the list.
+//   2. the LIST — one row per thing (bgRow), under small dim group headers when more than one kind shows.
+//      Click a row → details.
+//   3. per-row DETAILS — an agent's prompt, a command's command line + output tail, a watch's predicate.
+// ONE presentation in both turn states (2026-09-06): the rows come from the kernel's awaitingItems, which
+// ships the same set whether or not the turn is open; only the header follows awaitingWhy. Before this the
+// rows shipped only while idle and the box fell to a legacy count-headed tasks list mid-turn, so it
+// swapped views at every turn boundary of a session with agents in flight (the user 2026-09-06, who watched
+// it vanish on send and come back when the turn ended). Both fold levels persist across the per-push
+// re-render (keyed by session id / row id — renderBgTasks never writes them, so the idle↔working flip
+// cannot close an open box); every toggle is DELEGATED to the stable #bg-tasks container so a rebuild
+// mid-click never drops it. textContent only (command/output are untrusted).
+const bgExpanded = new Set<string>();   // row ids whose details are open
 const bgFoldOpen = new Set<string>();   // session ids whose list is expanded
 const BG_RANK: Record<string, number> = { failed: 3, running: 2, completed: 1 };
+const BG_LEFTOVER_TITLE = "Also running";   // tracked tasks the wait does not name (a dev server the session keeps around)
 // ── SUBAGENT VIEWER (plans/subagent-transcripts.md, 2026-09-05) ─────────────────────────────────
 // The arrow on an Agent head (or an agent bg-task row) opens the agent's whole transcript as a PEEK tab:
 // a client-only pseudo-session in `sessions`/`order` with id `<parentId>/agent/<agentId>`, fed by the
@@ -9930,41 +9940,106 @@ function renderBgTasks() {
   if (!host) return;
   host.replaceChildren();
   const s = activeId ? sessions.get(activeId) : null;
-  const box = s && s.bgTasks;
-  const tasks = (box && box.tasks) || [];
-  const count = box ? box.count : 0;
-  host.classList.remove("bg-awaited");   // re-derived below from THIS payload (renderAwaitWhy adds its own)
-  // An awaited WAIT owns the box (slice 2, 2026-09-05): its rows, grouped by kind, with the tracked
-  // background tasks joined in — a session waiting on an agent AND a build AND a watch used to show the
-  // tasks list alone (the watch invisible, the header saying "2 background tasks"). No tracked tasks and
-  // no wait → renderAwaitWhy hides the box.
+  const tasks: BgTask[] = (s && s.bgTasks && s.bgTasks.tasks) || [];
+  // Keyed on CONTENT, never the chip state (the user 2026-08-30, paraphrased: even while working, anything
+  // the session has in flight shows at the chat bottom). The rows ride awaitingItems in both turn states;
+  // awaitingWhy rides only while the session is idle waiting on them (⇔ the chip's Awaiting) and picks the
+  // header's words; the tracked tasks (s.bgTasks) lend the command rows their output tail and Stop handle,
+  // and list on their own when the wait does not name them (a service the session keeps around).
   const why = (s && (s.status.awaitingWhy || "").trim()) || "";
-  if (why || !count || !tasks.length) { renderAwaitWhy(host, s || null, tasks); return; }
+  const items = ((s && s.status.awaitingItems) || []).filter((it) => it && it.kind);
+  if (!s || !activeId || (!why && !items.length && !tasks.length)) { host.style.display = "none"; host.classList.remove("bg-awaited"); return; }
   host.style.display = "";
-  // the AWAITED rows (the user 2026-08-19): when the chip waits on specific tasks, those rows — and
-  // the box holding them — wear a thin outline in the chip's green (awaitingTaskIds, the kernel's
-  // exact launch-id match); the status DOT keeps its meaning (yellow = the task is running). Keyed on
-  // the ids' PRESENCE, never the chip state (the user 2026-08-30: awaited things show even while the
-  // session is working — the kernel only ships ids when something genuinely awaits them).
-  const awaited = new Set<string>(s!.status.awaitingTaskIds || []);
-  host.classList.toggle("bg-awaited", tasks.some((t) => awaited.has(t.id)));
-  const sid = activeId as string;
+  const sid = activeId;
+  // the AWAITED outline (the user 2026-08-19): the box wears the chip's await-green while the session waits
+  // on its rows (the wait IS the box), and whenever the kernel names tracked tasks as awaited
+  // (awaitingTaskIds — an exact launch-id match; the ids' PRESENCE, never the chip state); the status DOT
+  // keeps its own meaning (yellow = the row is running)
+  const awaited = new Set<string>(s.status.awaitingTaskIds || []);
+  host.classList.toggle("bg-awaited", !!why || tasks.some((t) => awaited.has(t.id)));
   const open = bgFoldOpen.has(sid);
-  // worst status among the shown tasks → the header dot color (so a failure shows even while collapsed)
-  const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, "completed");
-  const head = el("div", "bg-fold-head bg-" + worst + (open ? " open" : ""));
+  const groups = groupRows(items);
+  const awPeers = s.status.awaitingPeers || [];
+  const itemIds = new Set<string>(items.map((it) => it.id || "").filter(Boolean));
+  const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
+  // the header dot: await-green while waiting, like the chip; otherwise the worst tracked status, so a
+  // failed task is glanceable while collapsed (running-yellow when nothing tracked has failed)
+  const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, "running");
+  const head = el("div", "bg-fold-head " + (why ? "bg-await" : "bg-" + worst) + (open ? " open" : ""));
   head.dataset.act = "bg-fold"; head.dataset.id = sid;
   const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);   // ▸ closed → ▾ open (expands DOWNWARD beneath the header)
   head.appendChild(el("span", "bg-dot"));
   const lab = el("span", "bg-fold-label");
-  lab.textContent = count === 1 ? "Background task · " + (tasks[0].summary || "running")
-    : count + " background tasks";
+  if (why) {
+    // IDLE, waiting on the rows — the chip reads Awaiting and the header agrees with it in number: ONE rule
+    // words both (awaitWord). The kernel's why leads with the verb ("waiting on a background command: …");
+    // strip it so the labeled header doesn't stutter. The expanded body carries the rows (or the sentence).
+    const word = awaitWord(s.status.awaitingKind, s.status.awaitingCount, items);
+    if (awPeers.length && groups.every((g) => g.kind === "peer")) {
+      // a peer-kind wait NAMES the actual session (the user 2026-08-26) — identity colour, quiet
+      // host: prefix, the feed box's own treatment; the why tail keeps the wait's verb without
+      // restating the names ("delegated to X; " is the names, already rendered)
+      lab.append("Awaiting ");
+      awPeers.forEach((pr, i) => {
+        if (i) lab.append(", ");
+        const nm = el("span", "bg-await-peer");
+        nm.textContent = (pr.host ? pr.host + ":" : "") + pr.name;
+        if (pr.color && pr.color.bg) nm.style.color = pr.color.bg;
+        lab.appendChild(nm);
+      });
+      lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
+    } else if (groups.length > 1) {
+      lab.textContent = "Awaiting " + word + " · " + awaitBreakdown(items);   // mixed kinds: the number, then the breakdown
+    } else {
+      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+    }
+  } else {
+    // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded
+    // as what they are, no idle note. The breakdown counts the in-flight rows, or the tracked tasks when
+    // the kernel names none (they are shell tasks by construction — _bg_split never makes an agent a service).
+    const counted: AwaitRow[] = items.length ? items : leftovers.map((t) => ({ kind: "commands", id: t.id, label: t.summary }));
+    lab.textContent = "In the background · " + awaitBreakdown(counted);
+  }
   head.appendChild(lab);
   host.appendChild(head);
   if (!open) return;
+  if (!groups.length && !leftovers.length) {
+    // nothing enumerable (a judge stamp, an overlay row, an older kernel): the full sentence, the legacy
+    // descriptions when there are several, the note — never a dead end (only a wait reaches here: with no
+    // why, no rows and no tasks the box is hidden above)
+    const det = el("div", "bg-detail bg-await-detail");
+    const w = el("div", "bg-await-why"); w.textContent = why; det.appendChild(w);
+    const descs = s.status.awaitingTasks || [];
+    if (descs.length > 1) {   // a single description is already the why — list only a real plurality
+      for (const d of descs) { const r = el("div", "bg-await-task"); r.textContent = "· " + d; det.appendChild(r); }
+    }
+    det.appendChild(bgIdleNote());
+    host.appendChild(det);
+    return;
+  }
+  const taskById = new Map<string, BgTask>(tasks.map((t) => [t.id, t]));
+  const peerByName = new Map<string, PeerIdent>(awPeers.map((p) => [p.name, p]));
+  const headers = groups.length + (leftovers.length ? 1 : 0) >= 2;   // group headers only when there is more than one group to tell apart
   const list = el("div", "bg-list");
-  for (const t of tasks) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
+  for (const g of groups) {
+    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; list.appendChild(gh); }
+    for (const it of g.rows) list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
+  }
+  if (leftovers.length) {
+    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = BG_LEFTOVER_TITLE; list.appendChild(gh); }
+    for (const t of leftovers) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
+  }
+  // the plain-words note on what the state means — for the idle wait only, where the state is not obvious
+  // from the header; "In the background" says all a working session needs (2026-09-06)
+  if (why) list.appendChild(bgIdleNote());
   host.appendChild(list);
+}
+
+// The one sentence under an idle wait's rows: what the state means, in plain words.
+function bgIdleNote(): HTMLElement {
+  const note = el("div", "bg-await-note");
+  note.textContent = "The session is idle until this finishes; it picks back up on its own when the result lands.";
+  return note;
 }
 
 // One ROW of the box, whatever it is (slice 2, 2026-09-05) — the awaited things are different kinds,
@@ -10079,94 +10154,6 @@ function bgRow(t: BgRowSpec, sid: string): HTMLElement {
     row.appendChild(det);
   }
   return row;
-}
-
-// The Awaiting session's box (the user 2026-08-13: the reason spent a few hours beside the statusline
-// chip — PR #350 — and crowded the composer area; this box between transcript and composer is where
-// dispatched work has always surfaced). Same fold treatment as the task header: one await-green-dotted
-// line — "Awaiting <word> · <why>" for one kind, "Awaiting <n> · <breakdown>" when the kinds are mixed
-// — and, expanded, the awaited ROWS grouped by kind (slice 2, 2026-09-05): a small dim header per group
-// when several groups show, each row with its own kind's affordances (bgRow), the tracked background
-// tasks the wait does not name trailing under "Background tasks", and a plain-words note on what the
-// state means. A wait the kernel cannot enumerate (a judge stamp, an overlay row, an older kernel)
-// expands to its full sentence instead — never a dead end.
-function renderAwaitWhy(host: HTMLElement, s: Session | null, tasks: BgTask[] = []) {
-  // Keyed on awaited CONTENT, never the chip state (the user 2026-08-30, their words paraphrased:
-  // even while working, anything the session awaits shows at the chat bottom in the green box). The
-  // kernel ships awaitingWhy whenever something is genuinely awaited — armed kernel watches included,
-  // mid-turn included — so the fields' presence IS the render condition; the chip keeps its meaning.
-  const why = (s && (s.status.awaitingWhy || "").trim()) || "";
-  if (!why || !activeId) { host.style.display = "none"; return; }
-  host.style.display = "";
-  host.classList.add("bg-awaited");   // this whole box IS the awaited thing — the chip's green border
-  const sid = activeId;
-  const open = bgFoldOpen.has(sid);
-  const items = (s!.status.awaitingItems || []).filter((it) => it && it.kind);
-  const groups = groupRows(items);
-  const awPeers = s!.status.awaitingPeers || [];
-  const head = el("div", "bg-fold-head bg-await" + (open ? " open" : ""));
-  head.dataset.act = "bg-fold"; head.dataset.id = sid;
-  const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);
-  head.appendChild(el("span", "bg-dot"));
-  const lab = el("span", "bg-fold-label");
-  // the kernel's why leads with the verb ("waiting on a background command: …") — strip it so the
-  // labeled header doesn't stutter; the expanded body carries the rows (or the full sentence)
-  const word = awaitWord(s!.status.awaitingKind, s!.status.awaitingCount, items);
-  if (awPeers.length && groups.every((g) => g.kind === "peer")) {
-    // a peer-kind wait NAMES the actual session (the user 2026-08-26) — identity colour, quiet
-    // host: prefix, the feed box's own treatment; the why tail keeps the wait's verb without
-    // restating the names ("delegated to X; " is the names, already rendered)
-    lab.append("Awaiting ");
-    awPeers.forEach((pr, i) => {
-      if (i) lab.append(", ");
-      const nm = el("span", "bg-await-peer");
-      nm.textContent = (pr.host ? pr.host + ":" : "") + pr.name;
-      if (pr.color && pr.color.bg) nm.style.color = pr.color.bg;
-      lab.appendChild(nm);
-    });
-    lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
-  } else if (groups.length > 1) {
-    lab.textContent = "Awaiting " + word + " · " + awaitBreakdown(items);   // mixed kinds: the number, then the breakdown
-  } else {
-    lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
-  }
-  head.appendChild(lab);
-  host.appendChild(head);
-  if (!open) return;
-  const note = el("div", "bg-await-note");
-  note.textContent = s!.status.state === "awaitingBg"
-    ? "The session is idle until this finishes; it picks back up on its own when the result lands."
-    : "The session keeps working meanwhile; it's told when this lands.";
-  const itemIds = new Set<string>(items.map((it) => it.id || "").filter(Boolean));
-  const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
-  if (!groups.length && !leftovers.length) {
-    // nothing enumerable (a judge stamp, an overlay row, an older kernel): the full sentence, the legacy
-    // descriptions when there are several, the note
-    const det = el("div", "bg-detail bg-await-detail");
-    const w = el("div", "bg-await-why"); w.textContent = why; det.appendChild(w);
-    const descs = s!.status.awaitingTasks || [];
-    if (descs.length > 1) {   // a single description is already the why — list only a real plurality
-      for (const d of descs) { const r = el("div", "bg-await-task"); r.textContent = "· " + d; det.appendChild(r); }
-    }
-    det.appendChild(note);
-    host.appendChild(det);
-    return;
-  }
-  const awaited = new Set<string>(s!.status.awaitingTaskIds || []);
-  const taskById = new Map<string, BgTask>(tasks.map((t) => [t.id, t]));
-  const peerByName = new Map<string, PeerIdent>(awPeers.map((p) => [p.name, p]));
-  const headers = groups.length + (leftovers.length ? 1 : 0) >= 2;   // group headers only when there is more than one group to tell apart
-  const list = el("div", "bg-list");
-  for (const g of groups) {
-    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; list.appendChild(gh); }
-    for (const it of g.rows) list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
-  }
-  if (leftovers.length) {
-    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = "Background tasks"; list.appendChild(gh); }
-    for (const t of leftovers) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
-  }
-  list.appendChild(note);
-  host.appendChild(list);
 }
 
 // ---- live "awaiting your input" widgets (structured: radio / checkbox / submit / text) ----
@@ -11350,7 +11337,7 @@ function updateStatusline() {
     timer.id = "work-timer";
     timer.textContent = elapsedMs(s.status.sinceEpoch);
     sl.appendChild(timer);
-    // The WHY renders in the #bg-tasks box between transcript and composer (renderAwaitWhy), not
+    // The WHY renders in the #bg-tasks box between transcript and composer (renderBgTasks), not
     // here — a reason line beside the chip crowded the composer area (the user 2026-08-13, on the
     // same day's PR #350 that first surfaced it here).
   } else if (s.status.state === "compacting") {
@@ -12663,7 +12650,7 @@ function requestOlder(sid: string, v: View, content: HTMLElement): void {
   vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.headFrom });
 }
 
-// The awaiting fields the #bg-tasks box renders from (renderAwaitWhy / the awaited-row outline) — one
+// The awaiting fields the #bg-tasks box renders from (renderBgTasks — the header words, the rows, the awaited-row outline) — one
 // key per status, so a status-only frame re-renders the box exactly when THESE change (the chip's own
 // flip is one of them) and never on the per-second ticks that touch nothing the box shows.
 function awaitKey(st: Status | undefined): string {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -25,7 +25,7 @@ import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { senderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
-import { KIND_WORD, kindWord } from "./spin-caption";
+import { awaitWord, awaitBreakdown, groupRows, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
@@ -232,7 +232,7 @@ interface TodoTask { id: string; subject: string; activeForm?: string; status: s
 
 type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -9934,7 +9934,12 @@ function renderBgTasks() {
   const tasks = (box && box.tasks) || [];
   const count = box ? box.count : 0;
   host.classList.remove("bg-awaited");   // re-derived below from THIS payload (renderAwaitWhy adds its own)
-  if (!count || !tasks.length) { renderAwaitWhy(host, s || null); return; }
+  // An awaited WAIT owns the box (slice 2, 2026-09-05): its rows, grouped by kind, with the tracked
+  // background tasks joined in — a session waiting on an agent AND a build AND a watch used to show the
+  // tasks list alone (the watch invisible, the header saying "2 background tasks"). No tracked tasks and
+  // no wait → renderAwaitWhy hides the box.
+  const why = (s && (s.status.awaitingWhy || "").trim()) || "";
+  if (why || !count || !tasks.length) { renderAwaitWhy(host, s || null, tasks); return; }
   host.style.display = "";
   // the AWAITED rows (the user 2026-08-19): when the chip waits on specific tasks, those rows — and
   // the box holding them — wear a thin outline in the chip's green (awaitingTaskIds, the kernel's
@@ -9958,53 +9963,134 @@ function renderBgTasks() {
   host.appendChild(head);
   if (!open) return;
   const list = el("div", "bg-list");
-  for (const t of tasks) {
-    const tOpen = bgExpanded.has(t.id);
-    const row = el("div", "bg-task bg-" + (t.status || "running") + (awaited.has(t.id) ? " bg-awaited" : "") + (tOpen ? " open" : ""));
-    const rh = el("div", "bg-head");
-    rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id;   // the row header toggles; clicks in the detail body don't collapse it
-    rh.appendChild(el("span", "bg-dot"));
-    const sum = el("span", "bg-sum"); sum.textContent = t.summary || "Background task"; rh.appendChild(sum);
-    if (t.agentId) {
-      // an AGENT row: the same open-transcript arrow the Agent tool head wears (plans/subagent-transcripts.md).
-      // Nested inside the bg-toggle row; the body delegate's closest-[data-act] lookup finds the arrow first,
-      // so a click opens the viewer without toggling the row.
-      const open = agentOpenButton(t.agentId, null, sid);
-      open.classList.add("bg-open-agent");
-      rh.appendChild(open);
-    }
-    const st = el("span", "bg-status"); st.textContent = t.status || "running"; rh.appendChild(st);
-    if ((t.status || "running") === "running") {
-      // Stop this ONE task (the SDK's stop_task control request — the user 2026-08-04). Rides the same
-      // stable delegate as the fold toggles (click-safe across re-renders); the click acknowledges by
-      // disabling + relabeling ITSELF, and the row's disappearance (the task's own terminal lifecycle
-      // event) is the real confirmation — a task still running at the next render gets a fresh button.
-      const stop = el("button", "bg-stop");
-      stop.dataset.act = "bg-stop"; stop.dataset.id = t.id;
-      stop.textContent = "Stop"; stop.title = "stop this background task";
-      rh.appendChild(stop);
-    }
-    const rc = el("span", "bg-caret"); rc.textContent = tOpen ? "▾" : "▸"; rh.appendChild(rc);
-    row.appendChild(rh);
-    if (tOpen) {
-      const det = el("div", "bg-detail");
-      if (t.command) { const cmd = el("pre", "bg-cmd"); cmd.textContent = t.command; det.appendChild(cmd); }
-      const out = el("pre", "bg-out"); out.textContent = t.output || "(no output captured)"; det.appendChild(out);
-      row.appendChild(det);
-    }
-    list.appendChild(row);
-  }
+  for (const t of tasks) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
   host.appendChild(list);
 }
 
-// The Awaiting session's WHY, in the same box when NO tracked tasks claim it (the user 2026-08-13:
-// the reason spent a few hours beside the statusline chip — PR #350 — and crowded the composer area;
-// this box between transcript and composer is where dispatched work has always surfaced). Same fold
-// treatment as the task header: one await-green-dotted line, click → the full why, each awaited item when
-// there are several, and a plain-words note on what the state means. No Stop here — an untracked wait
-// (a peer's PR, a build) has no process to kill; tracked run_in_background tasks take the list path
-// above, which carries one Stop per running row.
-function renderAwaitWhy(host: HTMLElement, s: Session | null) {
+// One ROW of the box, whatever it is (slice 2, 2026-09-05) — the awaited things are different kinds,
+// so each keeps its own affordances on ONE row shape: an AGENT row carries the open-transcript arrow
+// (agentId, plans/subagent-transcripts.md) and Stop while its launch is a live task; a COMMAND row
+// keeps the output-tail fold and Stop; an armed WATCH row shows its label, how long it has been armed,
+// and Cancel when the kernel has a handle for it (a generic `romp watch`; a PR watch has no early-retire
+// path, so no button); a PEER row names the session in its identity colour; a tracked background task
+// the wait does not name (a service the session keeps around) is the row it always was.
+interface BgRowSpec {
+  id: string;                 // the fold key: the launch id, the watch handle, or the row's own id
+  status: string;             // running | armed | waiting | completed | failed → the dot's tint
+  caption?: string | null;    // the small uppercase state word beside the row ("running", "armed"); none for a peer
+  label: string;
+  awaited?: boolean;          // wears the chip's green outline (the tasks-only path: awaitingTaskIds)
+  agentId?: string | null;
+  since?: number | null;      // the row's own event time → a live "· 12m" (ticked by the statusline timer)
+  stopId?: string | null;     // a live task's id → Stop
+  watchId?: string | null;    // a generic watch's id → Cancel
+  command?: string | null;    // the fold: an agent's prompt, a command's command line, a watch's predicate
+  output?: string | null;     // the fold: a command's output tail (never an agent's — its output file IS the transcript; the arrow is the way in)
+  peer?: PeerIdent | null;    // a peer row: the name in identity colour
+}
+
+function taskRowSpec(t: BgTask, awaited: boolean): BgRowSpec {
+  const status = t.status || "running";
+  return { id: t.id, status, caption: status, label: t.summary || "Background task", awaited,
+           agentId: t.agentId || null, stopId: status === "running" ? t.id : null,
+           command: t.command || null, output: t.agentId ? null : (t.output || "(no output captured)") };
+}
+
+// An awaited row joined to its tracked task (the same launch id — _bg_tasks "id" / the lifecycle set's
+// toolUseId), which lends the command line, the output tail, the live status and Stop's handle.
+function awaitRowSpec(it: AwaitRow, tracked: BgTask | undefined, peerByName: Map<string, PeerIdent>): BgRowSpec {
+  const running = !!tracked && (tracked.status || "running") === "running";
+  const id = it.id || it.agentId || "";
+  if (it.kind === "agents") {
+    return { id, status: "running", caption: "running", label: it.label || (tracked && tracked.summary) || "background agent",
+             agentId: it.agentId || (tracked && tracked.agentId) || null, since: it.since,
+             stopId: running ? tracked!.id : null, command: (tracked && tracked.command) || null, output: null };
+  }
+  if (it.kind === "commands") {
+    const status = (tracked && tracked.status) || "running";
+    return { id, status, caption: status, label: it.label || (tracked && tracked.summary) || "background command", since: it.since,
+             stopId: running ? tracked!.id : null, command: (tracked && tracked.command) || null,
+             output: tracked ? (tracked.output || "(no output captured)") : null };
+  }
+  if (it.kind === "watches") {
+    return { id, status: "armed", caption: "armed", label: it.label || "a watch", since: it.since,
+             watchId: it.watchId || null, command: it.detail || null };
+  }
+  if (it.kind === "peer") {
+    return { id, status: "waiting", label: it.label || "a peer", peer: peerByName.get(it.label || "") || null };
+  }
+  return { id, status: "waiting", caption: it.kind === "timer" ? "timer" : null, label: it.label || it.kind, since: it.since };
+}
+
+function bgRow(t: BgRowSpec, sid: string): HTMLElement {
+  const tOpen = bgExpanded.has(t.id);
+  const foldable = !!(t.command || t.output);
+  const row = el("div", "bg-task bg-" + (t.status || "running") + (t.awaited ? " bg-awaited" : "") + (tOpen && foldable ? " open" : ""));
+  const rh = el("div", "bg-head" + (foldable ? "" : " bg-flat"));
+  if (foldable) { rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id; }   // the row header toggles; clicks in the detail body don't collapse it
+  rh.appendChild(el("span", "bg-dot"));
+  const sum = el("span", "bg-sum");
+  if (t.peer) {
+    // the HOUSE session-reference idiom: host prefix quiet, the NAME in the peer's identity colour
+    sum.replaceChildren(...hostPartsNodes(t.peer.host, t.peer.name));
+    if (t.peer.color && t.peer.color.bg) sum.style.color = t.peer.color.bg;
+  } else sum.textContent = t.label || "Background task";
+  rh.appendChild(sum);
+  if (t.agentId) {
+    // an AGENT row: the same open-transcript arrow the Agent tool head wears (plans/subagent-transcripts.md).
+    // Nested inside the bg-toggle row; the body delegate's closest-[data-act] lookup finds the arrow first,
+    // so a click opens the viewer without toggling the row.
+    const open = agentOpenButton(t.agentId, null, sid);
+    open.classList.add("bg-open-agent");
+    rh.appendChild(open);
+  }
+  if (t.since && t.since > 0) {
+    // how long this row has been waited on, from its OWN event time (a dispatch stamp, a watch's
+    // registration) — the statusline tick keeps it live (the box itself re-renders only on new fields)
+    const w = el("span", "bg-since"); w.dataset.since = String(t.since);
+    w.textContent = "· " + workingFor(Date.now() / 1000 - t.since);
+    rh.appendChild(w);
+  }
+  if (t.caption) { const st = el("span", "bg-status"); st.textContent = t.caption; rh.appendChild(st); }
+  if (t.stopId) {
+    // Stop this ONE task (the SDK's stop_task control request — the user 2026-08-04). Rides the same
+    // stable delegate as the fold toggles (click-safe across re-renders); the click acknowledges by
+    // disabling + relabeling ITSELF, and the row's disappearance (the task's own terminal lifecycle
+    // event) is the real confirmation — a task still running at the next render gets a fresh button.
+    const stop = el("button", "bg-stop");
+    stop.dataset.act = "bg-stop"; stop.dataset.id = t.stopId;
+    stop.textContent = "Stop"; setTip(stop, "stop this background task");
+    rh.appendChild(stop);
+  }
+  if (t.watchId) {
+    // Cancel this ONE armed watch — the kernel's cancel_watch, the very path `romp watch --cancel` takes;
+    // same acknowledge-then-vanish contract as Stop (the registry drops the row, the next push drops it here)
+    const cancel = el("button", "bg-stop bg-cancel");
+    cancel.dataset.act = "bg-cancel-watch"; cancel.dataset.id = t.watchId;
+    cancel.textContent = "Cancel"; setTip(cancel, "cancel this watch");
+    rh.appendChild(cancel);
+  }
+  if (foldable) { const rc = el("span", "bg-caret"); rc.textContent = tOpen ? "▾" : "▸"; rh.appendChild(rc); }
+  row.appendChild(rh);
+  if (tOpen && foldable) {
+    const det = el("div", "bg-detail");
+    if (t.command) { const cmd = el("pre", "bg-cmd"); cmd.textContent = t.command; det.appendChild(cmd); }
+    if (t.output) { const out = el("pre", "bg-out"); out.textContent = t.output; det.appendChild(out); }
+    row.appendChild(det);
+  }
+  return row;
+}
+
+// The Awaiting session's box (the user 2026-08-13: the reason spent a few hours beside the statusline
+// chip — PR #350 — and crowded the composer area; this box between transcript and composer is where
+// dispatched work has always surfaced). Same fold treatment as the task header: one await-green-dotted
+// line — "Awaiting <word> · <why>" for one kind, "Awaiting <n> · <breakdown>" when the kinds are mixed
+// — and, expanded, the awaited ROWS grouped by kind (slice 2, 2026-09-05): a small dim header per group
+// when several groups show, each row with its own kind's affordances (bgRow), the tracked background
+// tasks the wait does not name trailing under "Background tasks", and a plain-words note on what the
+// state means. A wait the kernel cannot enumerate (a judge stamp, an overlay row, an older kernel)
+// expands to its full sentence instead — never a dead end.
+function renderAwaitWhy(host: HTMLElement, s: Session | null, tasks: BgTask[] = []) {
   // Keyed on awaited CONTENT, never the chip state (the user 2026-08-30, their words paraphrased:
   // even while working, anything the session awaits shows at the chat bottom in the green box). The
   // kernel ships awaitingWhy whenever something is genuinely awaited — armed kernel watches included,
@@ -10015,16 +10101,18 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
   host.classList.add("bg-awaited");   // this whole box IS the awaited thing — the chip's green border
   const sid = activeId;
   const open = bgFoldOpen.has(sid);
+  const items = (s!.status.awaitingItems || []).filter((it) => it && it.kind);
+  const groups = groupRows(items);
+  const awPeers = s!.status.awaitingPeers || [];
   const head = el("div", "bg-fold-head bg-await" + (open ? " open" : ""));
   head.dataset.act = "bg-fold"; head.dataset.id = sid;
   const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);
   head.appendChild(el("span", "bg-dot"));
   const lab = el("span", "bg-fold-label");
-  // the kernel's why leads with the verb ("waiting on a background task: …") — strip it so the
-  // labeled header doesn't stutter; the expanded body keeps the full sentence
-  const kw = KIND_WORD[(s!.status.awaitingKind || "")] || "";
-  const awPeers = s!.status.awaitingPeers || [];
-  if (awPeers.length) {
+  // the kernel's why leads with the verb ("waiting on a background command: …") — strip it so the
+  // labeled header doesn't stutter; the expanded body carries the rows (or the full sentence)
+  const word = awaitWord(s!.status.awaitingKind, s!.status.awaitingCount, items);
+  if (awPeers.length && groups.every((g) => g.kind === "peer")) {
     // a peer-kind wait NAMES the actual session (the user 2026-08-26) — identity colour, quiet
     // host: prefix, the feed box's own treatment; the why tail keeps the wait's verb without
     // restating the names ("delegated to X; " is the names, already rendered)
@@ -10037,24 +10125,48 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
       lab.appendChild(nm);
     });
     lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
+  } else if (groups.length > 1) {
+    lab.textContent = "Awaiting " + word + " · " + awaitBreakdown(items);   // mixed kinds: the number, then the breakdown
   } else {
-    lab.textContent = "Awaiting" + (kw ? " " + kindWord(s!.status.awaitingKind, s!.status.awaitingCount) : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+    lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
   }
   head.appendChild(lab);
   host.appendChild(head);
   if (!open) return;
-  const det = el("div", "bg-detail bg-await-detail");
-  const w = el("div", "bg-await-why"); w.textContent = why; det.appendChild(w);
-  const items = s!.status.awaitingTasks || [];
-  if (items.length > 1) {   // a single description is already the why — list only a real plurality
-    for (const t of items) { const r = el("div", "bg-await-task"); r.textContent = "· " + t; det.appendChild(r); }
-  }
   const note = el("div", "bg-await-note");
   note.textContent = s!.status.state === "awaitingBg"
     ? "The session is idle until this finishes; it picks back up on its own when the result lands."
     : "The session keeps working meanwhile; it's told when this lands.";
-  det.appendChild(note);
-  host.appendChild(det);
+  const itemIds = new Set<string>(items.map((it) => it.id || "").filter(Boolean));
+  const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
+  if (!groups.length && !leftovers.length) {
+    // nothing enumerable (a judge stamp, an overlay row, an older kernel): the full sentence, the legacy
+    // descriptions when there are several, the note
+    const det = el("div", "bg-detail bg-await-detail");
+    const w = el("div", "bg-await-why"); w.textContent = why; det.appendChild(w);
+    const descs = s!.status.awaitingTasks || [];
+    if (descs.length > 1) {   // a single description is already the why — list only a real plurality
+      for (const d of descs) { const r = el("div", "bg-await-task"); r.textContent = "· " + d; det.appendChild(r); }
+    }
+    det.appendChild(note);
+    host.appendChild(det);
+    return;
+  }
+  const awaited = new Set<string>(s!.status.awaitingTaskIds || []);
+  const taskById = new Map<string, BgTask>(tasks.map((t) => [t.id, t]));
+  const peerByName = new Map<string, PeerIdent>(awPeers.map((p) => [p.name, p]));
+  const headers = groups.length + (leftovers.length ? 1 : 0) >= 2;   // group headers only when there is more than one group to tell apart
+  const list = el("div", "bg-list");
+  for (const g of groups) {
+    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; list.appendChild(gh); }
+    for (const it of g.rows) list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
+  }
+  if (leftovers.length) {
+    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = "Background tasks"; list.appendChild(gh); }
+    for (const t of leftovers) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
+  }
+  list.appendChild(note);
+  host.appendChild(list);
 }
 
 // ---- live "awaiting your input" widgets (structured: radio / checkbox / submit / text) ----
@@ -11195,13 +11307,23 @@ function updateStatusline() {
   } else if (s.status.state === "awaitingBg") {
     // idle main thread, waiting on background work it dispatched (the user 2026-07-13): its own await-green
     // chip — no pulse (nothing is computing HERE), but the elapsed timer stays so the wait has a clock
-    const chip = el("span", "chip chip-awaitingBg");
+    // …and a BUTTON since slice 2 (plans/subagent-transcripts.md, the user 2026-09-05): click opens the
+    // #bg-tasks box below and scrolls it into view — the chip used to be the one status word on the
+    // pane you could not click through. data-act on the stable #statusline delegate (click-safe across
+    // the per-push rebuild); the delegate's .romp-acted pulse acknowledges the press.
+    const chip = el("button", "chip chip-awaitingBg chip-btn") as HTMLButtonElement;
+    chip.type = "button";
+    chip.dataset.act = "awaitingChip";
     // the KIND rides the label so a glance says WHAT is awaited (the user 2026-08-15) — tooltips are
-    // dead on the touch PWA, so the word must be visible; the subject stays in the #bg-tasks box
-    const kw = KIND_WORD[s.status.awaitingKind || ""] || "";
+    // dead on the touch PWA, so the word must be visible; the subject stays in the #bg-tasks box. ONE
+    // rule words it (awaitWord): "Awaiting agent" / "Awaiting command" / "Awaiting watch" for one,
+    // "Awaiting 3 agents" for several of a kind, "Awaiting 4" when the kinds are mixed — the
+    // breakdown ("2 agents · 1 command · 1 watch") rides the tooltip.
+    const chipItems = s.status.awaitingItems || [];
     chip.classList.add("chip-awaiting-" + (s.status.awaitingKind || "untyped"));   // per-kind hook, one hue today
     const chipPeers = s.status.awaitingPeers || [];
-    if (chipPeers.length) {
+    const chipWord = awaitWord(s.status.awaitingKind, s.status.awaitingCount, chipItems);
+    if (chipPeers.length && groupRows(chipItems).every((g) => g.kind === "peer")) {
       // the pill names the actual session (the user 2026-08-26): "Awaiting <name>", the NAME itself
       // in the peer's identity colour — the dot it launched with retired the same day (round two:
       // it read stupid). The name sits on an always-on ~85% black backing (.chip-peer-name), mostly
@@ -11218,10 +11340,11 @@ function updateStatusline() {
         nm.replaceChildren(...hostPartsNodes(chipPeers[0].host, chipPeers[0].name));
         if (chipPeers[0].color && chipPeers[0].color.bg) nm.style.color = chipPeers[0].color.bg;
         chip.appendChild(nm);
-      } else chip.append(chipPeers.length + " peers");
-    } else chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kindWord(s.status.awaitingKind, s.status.awaitingCount) : "");   // "Awaiting agent" for one, "agents" for more (T225)
-    chip.title = (s.status.awaitingWhy || "idle, waiting on background work it dispatched")
-               + " — clears when the result lands";
+      } else chip.append(chipWord || chipPeers.length + " peers");
+    } else chip.textContent = CHIP_LABEL.awaitingBg + (chipWord ? " " + chipWord : "");   // agrees in number (T225); the plain words of slice 2
+    // the tip: the per-kind breakdown when there are rows, the kernel's why, and what the click does
+    setTip(chip, [awaitBreakdown(chipItems), s.status.awaitingWhy || "idle, waiting on background work it dispatched",
+                  "click to see what it's waiting on"].filter(Boolean).join("\n"));
     sl.appendChild(chip);
     const timer = el("span", "status-timer");
     timer.id = "work-timer";
@@ -12546,7 +12669,7 @@ function requestOlder(sid: string, v: View, content: HTMLElement): void {
 function awaitKey(st: Status | undefined): string {
   if (!st) return "";
   return JSON.stringify([st.state, st.awaitingWhy || "", st.awaitingKind || "", st.awaitingCount ?? null,
-                         st.awaitingTasks || [], st.awaitingTaskIds || [],
+                         st.awaitingTasks || [], st.awaitingTaskIds || [], st.awaitingItems || [],
                          (st.awaitingPeers || []).map((p) => [p.host || "", p.name || ""])]);
 }
 
@@ -13199,6 +13322,12 @@ setInterval(() => {
     const timer = document.getElementById("work-timer");
     if (timer) timer.textContent = elapsedMs(s.status.sinceEpoch);
     else updateStatusline();
+  }
+  // the awaiting box's per-row clocks (slice 2): the box re-renders only when its fields change, so each
+  // row's "· 12m" ticks here, from the row's own event time it carries in data-since
+  for (const w of Array.from(document.querySelectorAll<HTMLElement>("#bg-tasks .bg-since[data-since]"))) {
+    const since = Number(w.dataset.since);
+    if (since > 0) w.textContent = "· " + workingFor(Date.now() / 1000 - since);
   }
   const ct = document.getElementById("cmt-work-timer");
   if (ct) {
@@ -14029,6 +14158,27 @@ setupSettings();
       const btn = el as HTMLButtonElement;
       btn.disabled = true; btn.textContent = "Stopping…";   // immediate acknowledgement, before the round-trip
       vscodeApi?.postMessage({ type: "stopTask", id: activeId, taskId: id });
+    },
+    "bg-cancel-watch": (el) => {   // retire this ONE armed watch (kernel cancel_watch — the `romp watch --cancel` path); the row goes when the registry drops it
+      const id = el.dataset.id; if (!id || !activeId) return;
+      const btn = el as HTMLButtonElement;
+      btn.disabled = true; btn.textContent = "Cancelling…";   // immediate acknowledgement, before the round-trip
+      vscodeApi?.postMessage({ type: "cancelWatch", id: activeId, watchId: id });
+    },
+  });
+})();
+(() => {
+  // The statusline's Awaiting chip (slice 2, 2026-09-05): a click opens the awaiting box and brings it
+  // into view. Delegated to the stable #statusline (updateStatusline rebuilds its children on every
+  // push), so the press always lands; the delegate's flash acknowledges it before the box re-renders.
+  const sl = document.getElementById("statusline");
+  if (!sl) return;
+  delegate(sl, {
+    "awaitingChip": () => {
+      if (!activeId) return;
+      bgFoldOpen.add(activeId);   // the box's own fold state — the chip and the header toggle share it
+      renderBgTasks();
+      document.getElementById("bg-tasks")?.scrollIntoView({ block: "nearest" });
     },
   });
 })();

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -47,10 +47,11 @@ test("AWAITING outranks everything and wears the box", () => {
   assert.match(s.tip, /Not on you|not on you/);
 });
 
-test("the kind words the box: 'Awaiting job' for an external computation, per KIND_WORD", () => {
-  // the wait's CLASS in the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
+test("the kind words the box: 'Awaiting watch' for an armed watch, per KIND_WORD", () => {
+  // the wait's CLASS in the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA.
+  // The kernel's "job" key reads "watch" since slice 2 (2026-09-05): the plain word for what it is
   assert.equal(spinFor({ awaiting: { why: "", kind: "job" }, column: "working" }, false, false).caption,
-               "Awaiting job");
+               "Awaiting watch");
   assert.equal(spinFor({ awaiting: { why: "", kind: "timer" }, column: "working" }, false, false).caption,
                "Awaiting timer");
   assert.equal(spinFor({ awaiting: { why: "", kind: "banana" }, column: "working" }, false, false).caption,
@@ -166,7 +167,7 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor, KIND_WORD, kindWord, waitedSuffix \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow \} from "\.\/spin-caption";/);   // slice 2: the rows' vocabulary rides the same import
   // the elapsed readout reaches the OTHER two awaiting surfaces through the same helper: the
   // "Awaiting task" pill and the "Awaiting <peer>" chip (the user 2026-08-23)
   assert.match(FEED, /const pillWaited = waitedSuffix\(it\.awaiting && it\.awaiting\.since, Date\.now\(\) \/ 1000\);/);
@@ -287,19 +288,23 @@ test("kindWord: exactly one agent is 'agent'; two or more are 'agents'", () => {
   assert.equal(kindWord("agents", 7), "agents");
 });
 
-test("kindWord: the other kinds pluralize by count too", () => {
-  assert.equal(kindWord("task", 1), "task");
-  assert.equal(kindWord("task", 3), "tasks");
-  assert.equal(kindWord("job", 2), "jobs");
+test("kindWord: the other kinds pluralize by count too — in the plain words of slice 2 (2026-09-05)", () => {
+  // the kernel's KEYS stay (task / job); the WORDS are what the thing is: a background command, an armed
+  // watch. "watch" pluralizes to "watches", not "watchs".
+  assert.equal(kindWord("task", 1), "command");
+  assert.equal(kindWord("task", 3), "commands");
+  assert.equal(kindWord("job", 1), "watch");
+  assert.equal(kindWord("job", 2), "watches");
   assert.equal(kindWord("peer", 1), "peer");
   assert.equal(kindWord("peer", 2), "peers");
   assert.equal(kindWord("timer", 4), "timers");
+  assert.equal(kindWord("mixed", 4), "", "several kinds at once have no word — the number is the label");
 });
 
 test("kindWord: an unknown count keeps the surfaces' historic default; an unknown kind stays agents", () => {
   assert.equal(kindWord("agents", null), "agents");
   assert.equal(kindWord("agents", undefined), "agents");
-  assert.equal(kindWord("task", null), "task");
+  assert.equal(kindWord("task", null), "command");
   assert.equal(kindWord(null, 1), "agent");
   assert.equal(kindWord("", 2), "agents");
   assert.equal(kindWord("nonsense", 2), "agents");

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -35,9 +35,18 @@
 // only branches that fire in that window, so the swirl is the sole thing saying the card is in motion and
 // still blocked underneath. Gating either on a brief would leave it silent.
 
+/** One awaited ROW (kernel _awaiting_item, plans/subagent-transcripts.md slice 2, 2026-09-05): kind is
+ *  the row GROUP — agents | commands | watches | peer | timer — never a legacy kind key. agentId rides
+ *  on an agent row (the open-transcript arrow), detail on a watch row (its predicate), watchId on a
+ *  generic watch (the Cancel handle; a PR watch has no early-retire path and carries none). */
+export interface AwaitRow {
+  kind: string; id?: string; label?: string; since?: number | null;
+  agentId?: string | null; detail?: string | null; watchId?: string | null;
+}
+
 /** The card fields the ladder reads. Structural, so the test can pass plain objects. */
 export interface SpinItem {
-  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; count?: number | null; tasks?: unknown[] | null } | null;   // count = how many things are awaited (T225: the label agrees in number)   // since = the wait's own event time (kernel or-chain / _session_awaiting; the user 2026-08-23)
+  awaiting?: { why?: string | null; kind?: string | null; since?: number | null; count?: number | null; tasks?: unknown[] | null; items?: AwaitRow[] | null } | null;   // count = how many things are awaited (T225: the label agrees in number)   // since = the wait's own event time (kernel or-chain / _session_awaiting; the user 2026-08-23)   // items = the awaited rows (slice 2); present → the pill lists them and the caption stands down
   waitingOn?: unknown;
   provisional?: boolean;
   column?: string;
@@ -60,22 +69,93 @@ export interface Spin {
 
 const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
 
-/** The awaiting KIND's one label word (kernel jd.AWAIT_KINDS; the user 2026-08-15). Kindless (an older
- *  kernel, an untyped legacy stamp) falls back to "agents" — the word this box has always defaulted to. */
+/** The awaiting KIND's one label word (kernel jd.AWAIT_KINDS; the user 2026-08-15). The KEYS are the
+ *  kernel's legacy kind keys (agents / task / job / peer / timer, plus "mixed" since slice 2); the WORDS
+ *  are the plain ones the user asked for on 2026-09-05 (plans/subagent-transcripts.md slice 2): "task"
+ *  reads "command" (a run_in_background Bash or Monitor), "job" reads "watch" (an armed `romp watch`),
+ *  and "mixed" — several kinds at once — has NO word: the number alone is the label ("Awaiting 4").
+ *  Kindless (an older kernel, an untyped legacy stamp) falls back to "agents" — the word this box has
+ *  always defaulted to. The timeline mirrors this table byte for byte (tlKindWord). */
 export const KIND_WORD: Record<string, string> = {
-  agents: "agents", task: "task", job: "job", peer: "peer", timer: "timer",
+  agents: "agents", task: "command", job: "watch", peer: "peer", timer: "timer", mixed: "",
 };
+
+/** English plural for the kind words: "watch" → "watches", everything else + "s". */
+function pluralWord(w: string): string {
+  return /ch$/.test(w) ? w + "es" : w + "s";
+}
 
 /** The kind word AGREEING IN NUMBER with how many things are awaited (T225; the user 2026-09-02,
  *  who wants one awaited agent labelled as one, not as "agents"). One helper feeds the
  *  chat chip, the awaiting box gist, the feed pill and the spin caption, so every surface derives the
  *  word from the same count. An unknown count (null/undefined — an older kernel, a kindless stamp)
- *  keeps the plural KIND_WORD default the surfaces have always worn; an unknown kind stays "agents". */
+ *  keeps the KIND_WORD default the surfaces have always worn (plural "agents", singular otherwise);
+ *  an unknown kind stays "agents"; "mixed" is wordless whatever the count. */
 export function kindWord(kind: string | null | undefined, count: number | null | undefined): string {
+  if (kind === "mixed") return "";
   const base = KIND_WORD[kind || ""] || "agents";
   if (typeof count !== "number" || !Number.isFinite(count)) return base;
   if (count === 1) return base === "agents" ? "agent" : base;
-  return base === "agents" ? base : base + "s";
+  return base === "agents" ? base : pluralWord(base);
+}
+
+// ── the awaited ROWS' vocabulary (slice 2) ──────────────────────────────────────────────────────────
+/** Row groups in DISPLAY order — the kernel's _AWAIT_ITEM_KINDS, mirrored. */
+export const ROW_KINDS = ["agents", "commands", "watches", "peer", "timer"] as const;
+/** singular / plural per row group. */
+const ROW_WORD: Record<string, [string, string]> = {
+  agents: ["agent", "agents"], commands: ["command", "commands"], watches: ["watch", "watches"],
+  peer: ["peer", "peers"], timer: ["timer", "timers"],
+};
+/** The small dim header over each group when several groups show. */
+export const GROUP_TITLE: Record<string, string> = {
+  agents: "Agents", commands: "Commands", watches: "Watches", peer: "Peers", timer: "Timers",
+};
+/** legacy kind key → row group, for an older kernel's payload that ships descriptions but no rows. */
+export const ROW_KIND_OF_LEGACY: Record<string, string> = {
+  agents: "agents", task: "commands", job: "watches", peer: "peer", timer: "timer",
+};
+
+/** One group's word, agreeing in number: rowWord("watches", 2) → "watches"; rowWord("agents", 1) → "agent". */
+export function rowWord(kind: string, n: number): string {
+  const w = ROW_WORD[kind] || ROW_WORD.commands;
+  return n === 1 ? w[0] : w[1];
+}
+
+/** The rows bucketed by group, in display order; empty groups omitted. */
+export function groupRows(items: readonly AwaitRow[] | null | undefined): { kind: string; rows: AwaitRow[] }[] {
+  const out: { kind: string; rows: AwaitRow[] }[] = [];
+  for (const k of ROW_KINDS) {
+    const rows = (items || []).filter((it) => it && it.kind === k);
+    if (rows.length) out.push({ kind: k, rows });
+  }
+  const known = new Set<string>(ROW_KINDS);
+  const other = (items || []).filter((it) => it && !known.has(it.kind));   // a newer kernel's group this build doesn't know: shown, never dropped
+  if (other.length) out.push({ kind: "other", rows: other });
+  return out;
+}
+
+/** "2 agents · 1 command · 1 watch" — the tooltip breakdown; "" with no rows. */
+export function awaitBreakdown(items: readonly AwaitRow[] | null | undefined): string {
+  return groupRows(items).map((g) => g.rows.length + " " + rowWord(g.kind, g.rows.length)).join(" · ");
+}
+
+/** The text after "Awaiting" on the chat chip, the box gist and the feed pill — ONE rule (the user
+ *  2026-09-05): one row → its word ("agent", "command", "watch", "timer"; a peer row → "peer", which
+ *  the callers swap for the peer's own name); several of ONE group → the count and the word ("3
+ *  agents"); several GROUPS → the number alone ("4"), the breakdown riding the tooltip. With no rows
+ *  (an older kernel, a judge stamp, an overlay row) the legacy kind + count word it as before, the count
+ *  leading when it is known and plural ("3 agents"); kind "mixed" with no rows is the bare count. */
+export function awaitWord(kind: string | null | undefined, count: number | null | undefined,
+                          items: readonly AwaitRow[] | null | undefined): string {
+  const groups = groupRows(items);
+  const n = (items || []).length;
+  if (groups.length > 1) return String(n);
+  if (groups.length === 1) return n === 1 ? rowWord(groups[0].kind, 1) : n + " " + rowWord(groups[0].kind, n);
+  const known = typeof count === "number" && Number.isFinite(count) && count > 0;
+  if (kind === "mixed") return known ? String(count) : "";
+  const w = kindWord(kind, count);
+  return known && count! > 1 ? count + " " + w : w;
 }
 
 /** dCompleted/dBlocked come from distillInputs(distillState, column) — the GENUINE resolution state, not
@@ -101,13 +181,18 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
   // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Awaiting task" pill
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
   const awTasks = ((aw && aw.tasks) || []).filter(Boolean);
+  // …and since slice 2 (2026-09-05) the awaited ROWS: any wait the kernel can enumerate — agents,
+  // commands, watches, peers — ships them, and the pill lists them grouped, so the same say-it-once
+  // rule holds for every such wait, not only the bg-task one. A wait with NEITHER (a judge stamp, an
+  // overlay row, an older kernel) keeps the boxed caption below — it is the only place its why shows.
+  const awRows = awTasks.length + ((aw && aw.items) || []).length;
   // A bg-TASK wait says it ONCE (the user 2026-08-23, second screenshot of the day): the "Awaiting
   // task" pill + its open-by-default list are the whole read. The first cut of today's fix named the
   // first task in a caption here — and with the list now open by default, one card said the same
   // wait three times (pill, caption, list row). No caption, then; the floor guards below keep the
   // quiet/unknown lines from contradicting the pill instead (that contradiction is what the caption
   // was for).
-  if (aw && !it.waitingOn && !awTasks.length) {
+  if (aw && !it.waitingOn && !awRows) {
     // AWAITING — the session is held, waiting on work it dispatched. It keeps its own read: a boxed
     // "Awaiting <kind-word>" label, the kind carried as DATA from the kernel (the user 2026-08-15) so
     // the box says WHAT is awaited — agents, a job on a cluster, a timer — not one word for five
@@ -220,7 +305,7 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // say what this card is doing, and the quiet/unknown lines below would either contradict them
     // ("Paused — nothing is in motion" under in-flight tasks — the morning's screenshot) or repeat
     // them. An OPEN turn still narrates: the session working WHILE tasks run is new information.
-    if (awTasks.length && it.sessState !== "open") return NONE;
+    if (awRows && it.sessState !== "open") return NONE;
     if (it.sessState === "open") {
       return {
         caption: "Working…",

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -813,6 +813,7 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
   padding: 7px 11px; cursor: pointer; user-select: none; font-size: 12px; }
 .bg-fold-head.open { border-bottom: 1px solid var(--box-border); }
 .bg-fold-head:hover { background: rgba(255, 255, 255, 0.04); }
+/* Stop (a live task) and Cancel (an armed watch — slice 2, 2026-09-05) wear ONE button treatment */
 .bg-stop { flex: 0 0 auto; font-size: var(--btn-fs-sm); padding: var(--btn-pad-sm); border-radius: 9px; cursor: pointer;
   border: 1px solid color-mix(in srgb, var(--fg) 25%, transparent); background: transparent; color: var(--fg);
   transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease, transform 0.08s ease; }
@@ -829,6 +830,18 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .bg-task { --bgt: var(--st-working-bg); }
 .bg-task.bg-failed { --bgt: var(--st-blocked-bg); }
 .bg-task.bg-completed { --bgt: var(--st-ready-bg); }
+/* an armed watch / a peer or timer wait: nothing is computing HERE — the dot wears the await-green (slice 2) */
+.bg-task.bg-armed, .bg-task.bg-waiting { --bgt: var(--st-awaitbg-bg); }
+/* the rows grouped by KIND (slice 2, 2026-09-05): a small dim header per group, in the .bg-status
+   vocabulary (10px uppercase), shown only when more than one group is on screen */
+.bg-group-head { flex: 0 0 auto; padding: 6px 9px 2px; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; font-weight: 600; color: var(--dim); }
+.bg-group-head + .bg-group-head { padding-top: 2px; }
+/* a row with nothing to unfold (a hook-only agent, a PR watch, a peer) is not a toggle: no hand, no hover wash */
+.bg-head.bg-flat { cursor: default; }
+.bg-head.bg-flat:hover { background: none; }
+/* how long a row has been waited on (its own event time; the statusline tick keeps it live) */
+.bg-since { flex: 0 0 auto; font-size: 11px; color: var(--dim); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.bg-list > .bg-await-note { padding: 2px 9px 4px; }
 /* AWAITED (the user 2026-08-19): the session's await-green chip is waiting on THIS task — the box
    border + the row's thin outline take the chip's green; the dot keeps meaning the task's own status */
 #bg-tasks.bg-awaited { border-color: var(--st-awaitbg-bg); }
@@ -1171,6 +1184,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    #fff default = the no-identity (cross-host) name stays legible on the dark backing. */
 .chip-peer-name { background: rgba(0, 0, 0, 0.85); color: #fff; border-radius: 7px; padding: 0 5px; margin-left: 1px; }
 .chip-awaitingBg { background: var(--st-awaitbg-bg); color: var(--st-awaitbg-fg); }
+/* the Awaiting chip is a BUTTON (slice 2, 2026-09-05): click opens the awaiting box below. The UA
+   button chrome is reset so it wears the chip exactly (.chip supplies size, weight, padding, radius);
+   hover lifts it a touch, :active presses, and the delegate's .romp-acted pulse acknowledges the click. */
+button.chip { font-family: inherit; line-height: normal; border: 0; cursor: pointer; transition: filter 0.12s ease, transform 0.08s ease; }
+button.chip:hover { filter: brightness(1.08); }
+button.chip:active { transform: scale(0.96); }
+button.chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 /* retrying = a SOFT 'blocked on the API' (rate-limit / overload auto-retry) — not a hang, not working. Amber/
    orange, deliberately distinct from working-yellow and blocked-red (the user via api 2026-06-23). */
 .chip-retrying { background: #e67e22; color: #2a1500; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -851,7 +851,12 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* SOLID status dot — no pulse (the user 2026-07-07: the pulsating yellow was distracting; a running dot is
    just solid working-yellow, like the rest of the dashboard's status dots). */
 .bg-dot { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%; background: var(--bgt); }
-.bg-sum { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; color: var(--fg); }
+/* the row reads LEFT TO RIGHT as one line — label, then its cluster (arrow · elapsed · STATUS · Stop · caret)
+   INLINE right after it (the user 2026-09-05: with the label growing to fill, the cluster sat at the far
+   right edge and a wide desktop pane lost it entirely). The label takes only its own width and shrinks with
+   an ellipsis when too long (flex 0 1 auto, min-width 0); every cluster item is 0 0 auto, so the label can
+   never push them off-screen; no spacer, no margin-left:auto, no space-between. */
+.bg-sum { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; color: var(--fg); }
 .bg-status { flex: 0 0 auto; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; font-weight: 600; color: var(--bgt); }
 .bg-caret { flex: 0 0 auto; color: var(--dim); font-size: 10px; width: 10px; }
 /* level 3: a task's command + output, each its own scrollable block, indented under the line (overscroll-

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -807,8 +807,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 #bg-tasks { flex: 0 0 auto; min-height: 0; max-height: min(50vh, 340px); overflow: hidden;
   box-sizing: border-box; margin: 8px 10px 6px; border: 1px solid var(--box-border); border-radius: 8px;
   background: var(--box-bg); display: flex; flex-direction: column; }
-/* level 1: the header BAR at the top of the box ("N background tasks" / "Background task · name"). No own
-   border/radius — the box provides them; a bottom border appears when expanded, separating it from the list below. */
+/* level 1: the header BAR at the top of the box ("Awaiting 3 · 2 agents · 1 command" idle, "In the background ·
+   2 agents · 1 command" working — 2026-09-06). No own border/radius — the box provides them; a bottom border
+   appears when expanded, separating it from the list below. */
 .bg-fold-head { --bgt: var(--st-working-bg); flex: 0 0 auto; display: flex; align-items: center; gap: 7px;
   padding: 7px 11px; cursor: pointer; user-select: none; font-size: 12px; }
 .bg-fold-head.open { border-bottom: 1px solid var(--box-border); }

--- a/ui/webview/timeline-awaiting.test.ts
+++ b/ui/webview/timeline-awaiting.test.ts
@@ -17,7 +17,9 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 test("an awaitingBg lane renders an Awaiting badge in the romp brand green (the user 2026-07-22)", () => {
   // keyed on the chip state (the shared _session_chip split) OR the legacy why-field (older remote kernels)
   // the kind word agrees in NUMBER with the kernel's count (T228) — via the standalone twin of kindWord()
-  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting' \+ \(s\.awaitingKind \? ' ' \+ tlKindWord\(s\.awaitingKind, s\.awaitingCount\) : ''\), kind: 'awaitbg' \};/);
+  // …through tlAwaitSuffix since slice 2 (2026-09-05): the twin's word when it has one, the bare count for a mixed wait
+  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting' \+ tlAwaitSuffix\(s\.awaitingKind, s\.awaitingCount\), kind: 'awaitbg' \};/);
+  assert.match(TL, /const w = kind \? tlKindWord\(kind, count\) : '';\s*\n\s*if \(w\) return ' ' \+ w;/);
   // brand green, matching --st-awaitbg-bg in styles.css (this file loads standalone, so the hex is mirrored)
   assert.match(TL, /awaitbg: \{ bg: '#54B204', fg: '#0c1a00' \}/);
   // an awaitingBg lane still reads ACTIVE (full opacity / ongoing treatment), like working/compacting/clearing
@@ -71,7 +73,10 @@ test("the timeline's tlKindWord twin agrees with spin-caption's kindWord on ever
   }
   assert.equal(tl("agents", 1), "agent", "one awaited agent reads singular on the lane, as on the chip");
   assert.equal(tl("agents", 2), "agents");
-  assert.equal(tl("task", 3), "tasks");
+  assert.equal(tl("task", 3), "commands", "the plain words of slice 2 (2026-09-05): a task row is a command");
+  assert.equal(tl("job", 1), "watch");
+  assert.equal(tl("job", 2), "watches");
+  assert.equal(tl("mixed", 4), "", "a mixed wait has no word on the lane either");
   assert.equal(tl("agents", null), "agents", "an older kernel with no count keeps the historic plural");
 });
 

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -32,7 +32,10 @@ test("three-level disclosure: header fold, then per-task detail, both keyed so t
   assert.match(SRC, /rh\.dataset\.act = "bg-toggle"; rh\.dataset\.id = t\.id;/);
   // detail body = command + output, textContent only (untrusted)
   assert.match(SRC, /cmd\.textContent = t\.command;/);
-  assert.match(SRC, /out\.textContent = t\.output \|\| "\(no output captured\)";/);
+  // the fallback moved into the row spec (slice 2, 2026-09-05: one bgRow renderer for every kind of row);
+  // an AGENT row carries no output — its output file IS its transcript, and the arrow is the way in
+  assert.match(SRC, /output: t\.agentId \? null : \(t\.output \|\| "\(no output captured\)"\)/);
+  assert.match(SRC, /if \(t\.output\) \{ const out = el\("pre", "bg-out"\); out\.textContent = t\.output; det\.appendChild\(out\); \}/);
 });
 
 test("the worst status drives the collapsed header dot so a failure is glanceable", () => {

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -17,9 +17,14 @@ test("the box payload is {count, tasks} and rides on the session across pushes",
   assert.match(SRC, /bgTasks: \("bgTasks" in msg\) \? msg\.bgTasks : \(prev \? prev\.bgTasks : undefined\)/);
 });
 
-test("the header collapses to a count: one → 'Background task · name', many → 'N background tasks'", () => {
-  assert.match(SRC, /count === 1 \? "Background task · " \+ \(tasks\[0\]\.summary \|\| "running"\)/);
-  assert.match(SRC, /: count \+ " background tasks"/);
+test("the header is ONE line worded from the rows — 'Awaiting …' idle, 'In the background · …' working; the legacy count header is gone", () => {
+  // pin changed 2026-09-06: the "N background tasks" / "Background task · name" header was the legacy branch
+  // the box fell to whenever the kernel shipped no awaited rows — mid-turn, every time — so the box swapped
+  // presentations at each turn boundary; one renderer now words the header from the same rows in both states
+  assert.doesNotMatch(SRC, /count \+ " background tasks"/);
+  assert.doesNotMatch(SRC, /"Background task · "/);
+  assert.match(SRC, /lab\.textContent = "In the background · " \+ awaitBreakdown\(counted\);/);
+  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/);
   // collapsed by default: when the fold isn't open, only the header renders
   assert.match(SRC, /const open = bgFoldOpen\.has\(sid\);/);
   assert.match(SRC, /if \(!open\) return;/);


### PR DESCRIPTION
**Stacked on #935 (slice 1); the first four commits are that PR's and this diff should be read after it merges.** Slice 2 of `plans/subagent-transcripts.md` — the five commits from `8336e6a2` on, plus one fixture-note fix.

## What and why

A session can wait on three different things — background agents, background commands (`run_in_background` Bash / Monitor), and armed kernel watches — and the dashboard used to fold them into one word chosen by which source spoke first. A background agent plus a background shell command read "Awaiting 2 tasks" with the agent silently absorbed; an armed watch read "job", a word nothing else on screen explained; and the statusline chip was the one status word on the pane you could not click. This PR makes the three kinds separate rows, grouped, and makes the chip the way in.

- **Kernel: every awaited thing is its own row.** `_session_awaiting` now COMBINES its live sources (SDK subagent hooks, pending background launches, armed watches) into `items` — `[{kind, id, label, since, agentId?, detail?, watchId?}]`, kind in `agents | commands | watches | peer | timer` — and derives the legacy `kind` / `count` / `why` / `tasks` from that union. One kind present → the word and sentence it always wore (byte-identical); several → kind `"mixed"`, count = every row, a why that names each group. The old `all(...)`-collapse-to-"task" is gone. A background agent seen by both the hook set and the task stream is one row. `items` ships wherever `awaitingKind`/`awaitingCount` ship: the chat status, the timeline lane, the goal card and the placeholder card. The stamp / overlay / owned-yield arms ship `items: []`; peer arms list their peers as rows. A `cancelWatch` WS door reaches the same `cancel_watch` the CLI does (loud `warn` on a miss). `AWAIT_KINDS_JUDGED` keeps `"mixed"` out of what a closer may file.
- **Words.** `task` → "command", `job` → "watch" (`KIND_WORD`, the timeline's `tlKindWord` twin, `kindWord` pluralizes "watches"); `mixed` has no word, so the badge reads "Awaiting 4". One shared label rule (`awaitWord`) for the chip, the box gist and the feed pill: one row → its word, several of one kind → count + word, several kinds → the number alone with the breakdown ("2 agents · 1 command · 1 watch") in the tooltip.
- **Chat pane.** The Awaiting chip is a `<button data-act="awaitingChip">` delegated once on the stable `#statusline` (click-safe across the per-push rebuild, `.romp-acted` acknowledges); click opens the `#bg-tasks` box and scrolls to it, `setTip` carries the breakdown and the why. The box lists rows grouped by kind under small dim headers (only when 2+ groups): agent rows keep slice 1's open-transcript arrow + Stop while their launch is a live tracked task; command rows keep Stop + the command/output-tail fold; watch rows wear the await-green dot, "armed", a since clock, and Cancel only where a cancel path exists (generic `romp watch` rows carry `watchId`; PR watches have no early-retire path today, so no button). A row with nothing to unfold is not a toggle.
- **Feed.** The pill shows for ANY wait with rows (or an older kernel's `tasks` read as rows of the legacy kind's group), reads by the same `awaitWord`, and its expansion lists the labels grouped under `.ftask-group` headers. `spinFor`'s say-it-once rule stands the caption down under rows of any kind.
- **Card movement timing is unchanged** — `_session_chip`'s formula is untouched; only what the surfaces say and what is clickable changed.

## How verified

- `vscode-extension`: `npm run typecheck` clean, `npm test` 2810 pass / 0 fail, `npm run build` clean.
- Python: `pytest tests/` (minus the live codex smoke) 7372 passed, 40 skipped, 0 failed.
- New tests: `tests/test_awaiting_rows.py` (all three sources at once → mixed; shell + agent is two rows of two kinds, never "task"; the hook/launch merge; single-kind sentences byte-identical to before; watch rows' handles; the mixed kind's enum/parse rules; the cancel door) and `ui/webview/awaiting-rows.test.ts` (the label rules; the three word maps agree on every kind × count; chip-as-button + delegate; grouped rows and per-kind affordances; Cancel → `cancel_watch`; the feed pill for any wait; the vocabulary). Existing pins updated deliberately, each with a note: `test_awaiting_count.py` (also pins that every surface ships the rows), `test_awaiting_card.py`, `test_awaiting_since.py`, `test_awaiting_box_sync.py`, `test_kernel.py`, `test_kernel_awaiting_merge.py`, `test_kernel_awaiting_stamp.py`, `test_kernel_bg_tasks.py`, `test_kernel_owned_yield_awaiting.py`, `test_kernel_timeline_awaiting.py`; UI: awaiting-state, awaiting-box-sync, awaiting-peer-name, bg-tasks-layout, feed-awaiting-swirl, spin-caption, timeline-awaiting, src/bg-tasks.
- Headless screenshots via `tools/ui-verify/shot.sh` from the two synthetic fixtures added here (`tools/ui-verify/fixtures/awaiting-rows-{chat,feed}.html`), dark and light, eyeballed:
  - **Chat:** the expanded box headed "Awaiting 4 · 2 agents · 1 command · 1 watch"; three groups under dim caps headers (AGENTS / COMMANDS / WATCHES); the first agent row with the open-transcript arrow, "· 12m", RUNNING, Stop and a fold caret, the second (hook-only) with the arrow and RUNNING alone; the command row with Stop + caret; the watch row with a green dot, "· 31m", ARMED, Cancel and a caret; the closing note beneath; the statusline below with the green "Awaiting 4" chip rendered as a button. Light theme identical in its own palette.
  - **Feed:** a Working-column card with the pill pressed open reading "Awaiting 4 · 12m", and beneath it the four labels grouped under AGENTS / COMMANDS / WATCHES headers. (The swirl glyph is absent in the headless shots only because the sheet's `url(../media/…)` cannot resolve from the harness's temp dir.)
  - The chat fixture's usage note first asked for a 330px-tall shot, which clipped the box at its 50vh cap; the last commit corrects the note to 540px and says why.

## Left for later (as the plan records)

- An early-retire path for PR watches (then their rows get Cancel too).
- The nested-subagent chain in the viewer header.
- The owned-yield arm words every owned dispatch as a "command" since it carries no type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
