### PR TITLE
A paste with nothing editable focused lands in the message box, so dictation works after selecting transcript text

### DIFF
--- a/tests/test_paste_to_focus_browser.py
+++ b/tests/test_paste_to_focus_browser.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Paste-to-focus, executed in a real browser (the user 2026-09-05/06): after selecting transcript text,
+a paste with nothing editable focused lands in the message box.
+
+The source pins in ui/webview/composer-paste-focus.test.ts say the window listener exists and reads the
+right gates; nothing there proves a TRUSTED paste on the bare page reaches it — the paste event's target
+is the element holding the selection start, not the body, and the shell installs capture keydown handlers
+into every pane document, either of which could have swallowed it unseen. This is the executed guard:
+a hermetic kernel serves the real /chat page and the real shell, a synthetic session renders a real
+transcript, the driver drag-selects inside a .turn (activeElement = body, the reply chip seeded), copies
+text the trusted way, presses Ctrl+V, and the box must hold the text with focus and the chip intact —
+on the bare chat page AND inside the shell's chat iframe. The type-to-focus sibling (a printable key
+from anywhere) is checked in the same breath, since both ride one gate list.
+
+Skips LOUDLY without the extension deps or a playwright browser (CI installs none); it executes on any
+dev box with the extension installed, which is where ships are gated. All fixtures synthetic.
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+REPLY = "The web session finished the notes-api login flow and every test passes now. Next up is the password reset path."
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+
+// runs inside the CHAT document: probes on the paste, read-only
+const PROBE = () => {
+  const w = window; w.__p = [];
+  w.addEventListener("paste", (e) => w.__p.push({ phase: "capture", inTurn: !!(e.target && e.target.closest && e.target.closest("#content .turn")),
+    target: e.target && (e.target.id || e.target.tagName), trusted: e.isTrusted, text: e.clipboardData ? e.clipboardData.getData("text/plain") : null }), true);
+  w.addEventListener("paste", (e) => w.__p.push({ phase: "bubble-late", defaultPrevented: e.defaultPrevented }));
+};
+const STATE = () => ({ active: document.activeElement ? (document.activeElement.id || document.activeElement.tagName) : null,
+  value: document.getElementById("composer-input").value, sel: String(getSelection()).slice(0, 30),
+  chip: (document.getElementById("composer-chips")?.textContent || "").slice(0, 60), pastes: window.__p });
+// the trusted way onto the clipboard: a temp box + execCommand("copy"), removed again so focus falls back to body
+const COPY = (t) => { const x = document.createElement("textarea"); document.body.appendChild(x); x.value = t; x.focus(); x.select();
+  const ok = document.execCommand("copy"); x.remove(); return ok; };
+const RESET = () => { const ta = document.getElementById("composer-input"); ta.value = ""; ta.blur(); getSelection().removeAllRanges(); window.__p = []; };
+
+async function selectReply(frame, page) {
+  // the user's gesture: a mouse drag across the assistant's sentence — focus goes to the body, selectionchange seeds the chip
+  const p = frame.locator("#content .turn p", { hasText: "finished the notes-api" }).first();   // the assistant's line, not the prompt that also says "login flow"
+  const b = await p.boundingBox();
+  await page.mouse.move(b.x + 4, b.y + b.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(b.x + Math.min(180, b.width - 4), b.y + b.height / 2, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(80);
+}
+async function run(label, frame, page) {
+  await frame.waitForSelector("#content .turn p", { timeout: 20000 });
+  await frame.waitForTimeout(300);
+  await frame.evaluate(PROBE);
+  const copied = await frame.evaluate(COPY, "dictated after selecting");
+  await selectReply(frame, page);
+  const selected = await frame.evaluate(STATE);
+  await page.keyboard.press("Control+v");
+  await page.waitForTimeout(150);
+  const pasted = await frame.evaluate(STATE);
+  // the sibling default: a printable key from the bare area lands in the box too
+  await frame.evaluate(RESET);
+  await selectReply(frame, page);
+  await page.keyboard.type("ok");
+  await page.waitForTimeout(80);
+  const typed = await frame.evaluate(STATE);
+  return { label, copied, selected, pasted, typed };
+}
+
+const out = {};
+const page = await browser.newPage({ viewport: { width: 1100, height: 720 } });
+await page.goto(cfg.chat);
+out.bare = await run("bare chat page", page.mainFrame(), page);
+
+const shell = await browser.newPage({ viewport: { width: 1400, height: 800 } });
+await shell.goto(cfg.landing);
+const chat = await (async () => { for (let i = 0; i < 200; i++) { const f = shell.frames().find((f) => /\/chat/.test(f.url())); if (f) return f; await shell.waitForTimeout(50); } return null; })();
+if (!chat) { console.error("no chat iframe in the shell"); process.exit(1); }
+await chat.waitForLoadState();
+await shell.waitForFunction(() => { const b = document.getElementById("romp-boot"); return !b || b.classList.contains("gone") || getComputedStyle(b).opacity === "0" || getComputedStyle(b).display === "none"; }, null, { timeout: 20000 }).catch(() => {});
+await shell.evaluate(() => { document.getElementById("romp-boot")?.remove(); });   // belt and braces: the splash must not eat the drag
+out.shell = await run("chat iframe in the shell", chat, shell);
+
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedPaste(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served paste needs them")
+        cls.lab = tempfile.mkdtemp(prefix="paste-to-focus-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        os.makedirs(proj, exist_ok=True)
+        # a CLOSED turn: an open one would invite the boot reconcile to resume it — no real CLI here
+        Path(proj, SID + ".jsonl").write_text(
+            json.dumps({"type": "user", "uuid": "11111111-2222-3333-4444-555555555555", "parentUuid": None,
+                        "timestamp": "2026-09-05T00:00:00.000Z", "sessionId": SID,
+                        "message": {"role": "user", "content": "Where do we stand on the login flow?"}}) + "\n" +
+            json.dumps({"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
+                        "parentUuid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": "2026-09-05T00:00:05.000Z", "sessionId": SID,
+                        "message": {"role": "assistant", "model": "claude-fable-5-1",
+                                    "content": [{"type": "text", "text": REPLY}],
+                                    "stop_reason": "end_turn"}}) + "\n")
+        cls.port = _free_port()
+        cls.token = "testtok-pastefocus"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist,
+                   ROMP_MODEL_CATALOG="off")   # hermetic: never reach the network
+        env.pop("ROMP_STATE_DIR", None)
+        cls.klog = open(os.path.join(cls.lab, "kernel.log"), "w")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=cls.klog, stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        if getattr(cls, "klog", None):
+            cls.klog.close()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        base = "http://127.0.0.1:%d" % self.port
+        with open(cfg, "w") as f:
+            json.dump({"chat": base + "/chat?token=" + self.token, "landing": base + "/?token=" + self.token}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served paste needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    def _check(self, r):
+        label = r["label"]
+        self.assertTrue(r["copied"], "%s: the trusted copy must land on the clipboard: %r" % (label, r))
+        # (a) the gesture: transcript text selected, nothing editable focused, the reply chip seeded
+        self.assertEqual(r["selected"]["active"], "BODY", "%s: the drag must leave focus on the body: %r" % (label, r["selected"]))
+        self.assertTrue(r["selected"]["sel"].startswith("The web session"), "%s: the drag must select the reply: %r" % (label, r["selected"]))
+        self.assertIn("The web session", r["selected"]["chip"], "%s: the selection seeds the reply chip: %r" % (label, r["selected"]))
+        self.assertEqual(r["selected"]["value"], "", "%s: nothing in the box before the paste: %r" % (label, r["selected"]))
+        # (b) the trusted paste: fired at the selection's element (inside a .turn), claimed by the window listener
+        pastes = r["pasted"]["pastes"]
+        cap = next((x for x in pastes if x["phase"] == "capture"), None)
+        self.assertIsNotNone(cap, "%s: a trusted Ctrl+V must dispatch a paste on the page: %r" % (label, r["pasted"]))
+        self.assertTrue(cap["trusted"] and cap["inTurn"], "%s: the paste targets the transcript node holding the selection: %r" % (label, cap))
+        self.assertEqual(cap["text"], "dictated after selecting", "%s: clipboardData carries the text: %r" % (label, cap))
+        late = next((x for x in pastes if x["phase"] == "bubble-late"), None)
+        self.assertTrue(late and late["defaultPrevented"], "%s: the window listener claims the paste (preventDefault): %r" % (label, pastes))
+        # (c) the outcome the user sees: text in the box, caret there, chip still armed for the send
+        self.assertEqual(r["pasted"]["value"], "dictated after selecting", "%s: the box holds the pasted text: %r" % (label, r["pasted"]))
+        self.assertEqual(r["pasted"]["active"], "composer-input", "%s: focus moved into the box: %r" % (label, r["pasted"]))
+        self.assertIn("The web session", r["pasted"]["chip"], "%s: the chip survives the paste: %r" % (label, r["pasted"]))
+        # the sibling default rides the same gates: a printable key from the bare area types into the box
+        self.assertEqual(r["typed"]["value"], "ok", "%s: type-to-focus still lands: %r" % (label, r["typed"]))
+        self.assertEqual(r["typed"]["active"], "composer-input", "%s: type-to-focus focuses the box: %r" % (label, r["typed"]))
+
+    def test_a_trusted_paste_after_selecting_transcript_text_lands_in_the_box(self):
+        out = self._drive()
+        self._check(out["bare"])     # the standalone /chat page
+        self._check(out["shell"])    # the same page as the shell's chat iframe, under the shell's capture chords
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -295,20 +295,24 @@ test("an unclaimed printable keystroke drops the cursor into the composer — na
   assert.ok(end > at, "the redirect focuses the box without jolting the transcript");
   const block = RENDER.slice(at, end);
   // gates, in the order the hazards were mapped: upstream handlers, chords, IME, non-printables,
-  // Space (ask-card toggle / scroll), a missing or read-only box, key repeat, typing targets, the
-  // live-ask card's number keys, open menus/dialogs, and the full-pane surfaces
+  // Space (ask-card toggle / scroll) — the KEY-specific ones stay in the handler…
   assert.match(block, /if \(e\.defaultPrevented \|\| e\.altKey \|\| e\.ctrlKey \|\| e\.metaKey\) return;/);
   assert.match(block, /if \(e\.isComposing \|\| e\.keyCode === 229\) return;/);
   assert.match(block, /if \(e\.key\.length !== 1 \|\| e\.key === " "\) return;/);
-  assert.match(block, /if \(!ta \|\| ta\.disabled \|\| document\.activeElement === ta\) return;/);
-  assert.match(block, /if \(isTypingTarget\(e\.target\) \|\| isTypingTarget\(document\.activeElement\)\) return;/);
+  // …and the rest — a missing or read-only box, key repeat, typing targets, the live-ask card's
+  // number keys, open menus/dialogs, the full-pane surfaces — live in typeFromAnywhereTarget, the
+  // ONE gate list this handler shares with paste-to-focus (2026-09-05; composer-paste-focus.test.ts)
+  assert.match(block, /const ta = typeFromAnywhereTarget\(e\);\s*\n\s*if \(!ta\) return;/);
+  const gates = RENDER.split("function typeFromAnywhereTarget(")[1].split("\n}")[0];
+  assert.match(gates, /if \(!ta \|\| ta\.disabled \|\| document\.activeElement === ta\) return null;/);
+  assert.match(gates, /if \(isTypingTarget\(e\.target\) \|\| isTypingTarget\(document\.activeElement\)\) return null;/);
   // the pane's own modals and meta menus own their keys, and a dropdown's type-ahead is typing: a
   // letter typed in the settings modal must never land in the hidden draft (review 2026-09-02)
-  assert.match(block, /document\.querySelector\("#rsettings:not\(\[hidden\]\), #ra-back:not\(\[hidden\]\), #rkeys-back, \.meta-menu"\)/);
+  assert.match(gates, /document\.querySelector\("#rsettings:not\(\[hidden\]\), #ra-back:not\(\[hidden\]\), #rkeys-back, \.meta-menu"\)/);
   assert.match(RENDER, /elm\.tagName === "SELECT"/, "SELECT is a typing target");
-  assert.match(block, /if \(activeId && liveAsks\.has\(activeId\)\) return;/);
-  assert.match(block, /if \(ctxMenuEl \|\| document\.querySelector\("\.picker-overlay"\)\) return;/);
-  assert.match(block, /romp-fileview[\s\S]*romp-filebrowse[\s\S]*romp-lightbox/);
+  assert.match(gates, /if \(activeId && liveAsks\.has\(activeId\)\) return null;/);
+  assert.match(gates, /if \(ctxMenuEl \|\| document\.querySelector\("\.picker-overlay"\)\) return null;/);
+  assert.match(gates, /romp-fileview[\s\S]*romp-filebrowse[\s\S]*romp-lightbox/);
   // NEVER preventDefault: the point is that the native keystroke inserts into the newly focused
   // box, so the composer's own input bookkeeping (draft, slash menu) sees ordinary typing
   assert.doesNotMatch(block, /preventDefault/);

--- a/ui/webview/composer-insert.ts
+++ b/ui/webview/composer-insert.ts
@@ -1,0 +1,20 @@
+// Put text into the message box the way a native paste would — at the caret, over the box's own
+// selection, caret left after it — and then tell the composer's bookkeeping about it. The box's
+// `input` listener (render.ts) owns everything that follows ordinary typing: autosize, the
+// per-tab draft and its persisted copy, the slash-command menu, the answering-vs-message cue. A
+// synthetic insertion that skipped that event would leave a draft the reload forgets and a box
+// that never grew. One owner here, so every non-native insertion stays in step with typing.
+//
+// Structural (not HTMLTextAreaElement) so a node test can hand it a plain object: the renderer
+// has no jsdom harness.
+export interface CaretBox {
+  selectionStart: number;
+  selectionEnd: number;
+  setRangeText(replacement: string, start: number, end: number, selectionMode?: "select" | "start" | "end" | "preserve"): void;
+  dispatchEvent(event: Event): boolean;
+}
+
+export function insertAtCaret(box: CaretBox, text: string): void {
+  box.setRangeText(text, box.selectionStart, box.selectionEnd, "end");
+  box.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/ui/webview/composer-paste-focus.test.ts
+++ b/ui/webview/composer-paste-focus.test.ts
@@ -1,0 +1,158 @@
+// Paste-to-focus (the user 2026-09-05): dictation tools land the whole utterance at once — a paste,
+// not keystrokes — so type-to-focus (composer-citation.test.ts, "SELECT → TYPE → ⌘⏎") never fired,
+// and after selecting transcript text nothing editable was focused: the dictated text went nowhere.
+// Focusing the box when the selection ends was ruled out (it collapses the page selection and breaks
+// plain copy). Instead a window-level, bubble-phase paste listener — the SAME gates as type-to-focus,
+// through one shared helper — takes a paste nobody claimed, focuses the box, inserts the text at the
+// caret and fires the input event the composer's bookkeeping listens for. A paste has already
+// dispatched at the body by the time it bubbles to window, so unlike the keystroke (whose native
+// insertion follows focus) this one must preventDefault and insert itself. No jsdom for this
+// renderer, so the wiring is pinned at source (the repo convention); the insertion helper is a pure
+// module and is exercised directly below.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { insertAtCaret, type CaretBox } from "./composer-insert";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const TYPE_MARK = "// SELECT → TYPE → ⌘⏎";
+const PASTE_MARK = "// SELECT → PASTE → ⌘⏎";
+
+// the paste handler's code: from its registration to the top-level close of its arrow function
+function pasteHandler(): { at: number; block: string; tail: string } {
+  const mark = RENDER.indexOf(PASTE_MARK);
+  assert.ok(mark > 0, "the paste-to-focus handler exists");
+  const at = RENDER.indexOf('window.addEventListener("paste"', mark);
+  assert.ok(at > mark, "the handler follows its design note");
+  const close = RENDER.indexOf("\n}", at);   // the body is indented, so the first column-0 brace closes the handler
+  return { at, block: RENDER.slice(at, close), tail: RENDER.slice(close, close + 5) };
+}
+function gates(): string {
+  return RENDER.split("function typeFromAnywhereTarget(")[1].split("\n}")[0];
+}
+
+test("the paste listener is window-level, bubble phase, installed once, beside type-to-focus", () => {
+  const { at, tail } = pasteHandler();
+  assert.equal(RENDER.match(/window\.addEventListener\("paste"/g)?.length, 1, "one window paste listener");
+  assert.equal(tail, "\n});\n", "no capture flag: bubble phase, so every element handler has already spoken");
+  assert.match(RENDER.slice(at), /^window\.addEventListener\("paste", \(e\) => \{\n/, "a plain listener on window, no options bag");
+  // it sits right after the type-to-focus handler — one keydown registration between the two notes
+  const typeAt = RENDER.indexOf(TYPE_MARK);
+  const pasteAt = RENDER.indexOf(PASTE_MARK);
+  assert.ok(typeAt > 0 && pasteAt > typeAt, "paste-to-focus follows type-to-focus");
+  const between = RENDER.slice(typeAt, pasteAt);
+  assert.equal(between.match(/window\.addEventListener\(/g)?.length, 1);
+  assert.match(between, /window\.addEventListener\("keydown"/);
+});
+
+test("both defaults run ONE gate list — typeFromAnywhereTarget — never a duplicated copy", () => {
+  assert.equal(RENDER.match(/function typeFromAnywhereTarget\(/g)?.length, 1, "the helper is defined once");
+  assert.match(RENDER, /function typeFromAnywhereTarget\(e: Event\): HTMLTextAreaElement \| null \{/);
+  const { block } = pasteHandler();
+  assert.match(block, /const ta = typeFromAnywhereTarget\(e\);\s*\n\s*if \(!ta\) return;/);
+  // the keystroke handler goes through the very same call
+  const typeAt = RENDER.indexOf(TYPE_MARK);
+  const keydown = RENDER.slice(RENDER.indexOf('window.addEventListener("keydown"', typeAt), RENDER.indexOf("\n}", typeAt));
+  assert.match(keydown, /const ta = typeFromAnywhereTarget\(e\);\s*\n\s*if \(!ta\) return;/);
+  // and neither re-implements a gate inline
+  const inline = /isTypingTarget|picker-overlay|romp-fileview|romp-filebrowse|romp-lightbox|rsettings|ra-back|rkeys-back|meta-menu|liveAsks|ctxMenuEl|composerNoteHolds|ta\.disabled/;
+  assert.doesNotMatch(block, inline, "the paste handler carries no gate of its own");
+  assert.doesNotMatch(keydown, inline, "the keydown handler carries no gate of its own");
+});
+
+test("it stands down when the box is focused, a typing target is active, or any surface owns the input", () => {
+  const { block } = pasteHandler();
+  assert.match(block, /^window\.addEventListener\("paste", \(e\) => \{\s*\n\s*if \(e\.defaultPrevented\) return;/, "an element handler that already acted wins");
+  const g = gates();
+  // the box itself: missing, read-only, or ALREADY focused — a paste into the focused box is native,
+  // and the composer's own paste handler (files, path-shaped text) keeps its default
+  assert.match(g, /if \(!ta \|\| ta\.disabled \|\| document\.activeElement === ta\) return null;/);
+  assert.match(RENDER, /ta\.addEventListener\("paste", \(e\) => \{\s*\n\s*const files = Array\.from\(e\.clipboardData\?\.files \|\| \[\]\);/, "the composer's own paste handler is untouched");
+  // a typing target (input, textarea, contenteditable, SELECT) keeps its paste
+  assert.match(g, /if \(isTypingTarget\(e\.target\) \|\| isTypingTarget\(document\.activeElement\)\) return null;/);
+  assert.match(RENDER, /elm\.tagName === "TEXTAREA" \|\| elm\.tagName === "INPUT" \|\| elm\.tagName === "SELECT" \|\| elm\.isContentEditable === true/);
+  // the live-ask card, an open context menu / #picker / #confirm, the full-pane surfaces, the pane's
+  // modals + meta menus, and the T236 hand-over note — each one a gate the keystroke already had
+  assert.match(g, /if \(activeId && liveAsks\.has\(activeId\)\) return null;/);
+  assert.match(g, /if \(ctxMenuEl \|\| document\.querySelector\("\.picker-overlay"\)\) return null;/);
+  assert.match(g, /document\.getElementById\("romp-fileview"\) \|\| document\.getElementById\("romp-filebrowse"\)\s*\n\s*\|\| document\.getElementById\("romp-lightbox"\)\) return null;/);
+  assert.match(g, /document\.querySelector\("#rsettings:not\(\[hidden\]\), #ra-back:not\(\[hidden\]\), #rkeys-back, \.meta-menu"\)\) return null;/);
+  assert.match(g, /if \(composerNoteHolds\(\)\) return null;/);
+  assert.match(g, /return ta;\s*$/, "the box comes back only once every gate has passed");
+});
+
+test("a plain-text paste is claimed: preventDefault, focus without scrolling, insert at the caret, input event", () => {
+  const { block } = pasteHandler();
+  assert.match(block, /const dt = e\.clipboardData;/);
+  assert.match(block, /const text = dt\.getData\("text\/plain"\);\s*\n\s*if \(!text\) return;/, "an empty paste changes nothing");
+  // the order matters: cancel the native (body-targeted) paste, focus, then insert through the one helper
+  assert.match(block, /e\.preventDefault\(\);\s*\n\s*ta\.focus\(\{ preventScroll: true \}\);\s*\n\s*insertAtCaret\(ta, text\);/);
+  assert.match(RENDER, /import \{ insertAtCaret \} from "\.\/composer-insert";/);
+  assert.doesNotMatch(block, /ta\.value\s*=|setRangeText|dispatchEvent/, "the insertion is the helper's, not a second copy");
+});
+
+test("the armed quote chip is never touched — it stages on ⌘⏎ exactly as after typing", () => {
+  // the focus collapses the page selection, and a collapse never clears the chip (the selectionchange
+  // pins in composer-citation.test.ts) — so this handler has no business with the citation state
+  const { block } = pasteHandler();
+  assert.doesNotMatch(block, /composerCitations|removeCitation|renderComposerChips|seedTranscriptQuote|clearEditorCitation|dropCitation|transcriptSelection/);
+  assert.doesNotMatch(block, /getSelection|removeAllRanges/, "the page selection is left to the focus call alone");
+});
+
+test("a clipboard carrying files stands down, on purpose and said so", () => {
+  const { block } = pasteHandler();
+  // the composer attaches files inline in its OWN paste handler (per-file: local path vs shipped bytes
+  // by host), not through a callable this branch could reuse — so a file paste from the bare area is
+  // left exactly as it was, rather than half-handled (a focus with nothing attached)
+  assert.match(block, /if \(!dt \|\| dt\.files\.length\) return;/);
+  assert.doesNotMatch(block, /shipFileToHost|addComposerFile/);
+  assert.match(block, /stay out of scope here/);
+});
+
+// ── insertAtCaret, the pure helper ────────────────────────────────────────────────────────────────
+// A fake box with the platform's setRangeText("end") semantics: replace [start, end) and park the
+// caret after the inserted text.
+class FakeBox implements CaretBox {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  calls: Array<[string, number, number, string | undefined]> = [];
+  events: Event[] = [];
+  constructor(value: string, start: number, end = start) { this.value = value; this.selectionStart = start; this.selectionEnd = end; }
+  setRangeText(replacement: string, start: number, end: number, mode?: "select" | "start" | "end" | "preserve"): void {
+    this.calls.push([replacement, start, end, mode]);
+    this.value = this.value.slice(0, start) + replacement + this.value.slice(end);
+    if (mode === "end") this.selectionStart = this.selectionEnd = start + replacement.length;
+  }
+  dispatchEvent(event: Event): boolean { this.events.push(event); return true; }
+}
+
+test("insertAtCaret puts the text at the caret and leaves the caret after it", () => {
+  const box = new FakeBox("hello world", 5);
+  insertAtCaret(box, ", dictated");
+  assert.equal(box.value, "hello, dictated world");
+  assert.equal(box.selectionStart, 15);
+  assert.equal(box.selectionEnd, 15);
+  assert.deepEqual(box.calls, [[", dictated", 5, 5, "end"]]);
+});
+
+test("insertAtCaret replaces the box's own selection, the way a native paste does", () => {
+  const box = new FakeBox("fix the typo", 4, 7);   // "the" selected
+  insertAtCaret(box, "every");
+  assert.equal(box.value, "fix every typo");
+  assert.equal(box.selectionStart, 9);
+  assert.equal(box.selectionEnd, 9);
+});
+
+test("insertAtCaret fires ONE bubbling input event, after the text is in place", () => {
+  const box = new FakeBox("", 0);
+  let seenAtDispatch: string | null = null;
+  box.dispatchEvent = (ev: Event) => { box.events.push(ev); seenAtDispatch = box.value; return true; };
+  insertAtCaret(box, "note to self");
+  assert.equal(box.events.length, 1);
+  assert.equal(box.events[0].type, "input");
+  assert.equal(box.events[0].bubbles, true);
+  assert.equal(seenAtDispatch, "note to self", "the composer's input listener reads the inserted text");
+});

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -312,8 +312,12 @@ test("an active tab torn down under the user: stash first, prune the fallback, b
 });
 
 test("while the note holds the box, the type-from-anywhere defaults stand down; a click into the box ends the hold", () => {
-  // the printable-key default: no focus steal into the survivor's box + flash (the handler stays preventDefault-free, as pinned by composer-citation.test.ts)
-  assert.match(RENDER, /if \(composerNoteHolds\(\)\) return;[^\n]*\n\s*ta\.focus\(\{ preventScroll: true \}\);/);
+  // the printable-key default (and, since 2026-09-05, the paste default with it): the hold is the LAST
+  // gate of their shared typeFromAnywhereTarget — no focus steal into the survivor's box + flash; both
+  // handlers focus only a box that helper returned (the keydown stays preventDefault-free, as pinned by
+  // composer-citation.test.ts)
+  assert.match(RENDER, /if \(composerNoteHolds\(\)\) return null;[^\n]*\n\s*return ta;\s*\n\}/);
+  assert.equal(RENDER.match(/const ta = typeFromAnywhereTarget\(e\);\s*\n\s*if \(!ta\) return;\s*\n(\s*e\.preventDefault\(\);\s*\n)?(?:[^\n]*\n)*?\s*ta\.focus\(\{ preventScroll: true \}\);/g)?.length, 2, "keydown and paste both focus through the shared gate");
   // bare-area Enter: stands down before focusComposerOrAsk
   assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(composerNoteHolds\(\)\) return;/);
   assert.match(RENDER, /function composerNoteHolds\(\): boolean \{\s*\n\s*if \(!composerNoteSid\) return false;\s*\n\s*flashComposerNote\(\);\s*\n\s*return true;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -43,6 +43,7 @@ import { openFileView } from "./file-view";
 import { initFileView } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
+import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
@@ -5412,6 +5413,22 @@ window.addEventListener("keydown", (e) => {
     if (focusComposerOrAsk()) e.preventDefault();   // the picker card if one's up, else the message box
   }
 });
+// The gates the two "from anywhere" defaults share — the printable keystroke below and the paste after
+// it. Returns the box to drop into, or null while something else owns the input. ONE list, so the two
+// can never disagree about what counts as "nobody claimed this": a surface that must keep its keys keeps
+// its pastes too.
+function typeFromAnywhereTarget(e: Event): HTMLTextAreaElement | null {
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (!ta || ta.disabled || document.activeElement === ta) return null;   // no box / read-only session / already in the box (covers key repeat; a paste there is native)
+  if (isTypingTarget(e.target) || isTypingTarget(document.activeElement)) return null;
+  if (activeId && liveAsks.has(activeId)) return null;   // the live-ask card owns input while it is up (digits are its number keys)
+  if (ctxMenuEl || document.querySelector(".picker-overlay")) return null;   // an open menu / #picker / #confirm owns the keys
+  if (document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse")
+      || document.getElementById("romp-lightbox")) return null;   // full-pane surfaces own their keys
+  if (document.querySelector("#rsettings:not([hidden]), #ra-back:not([hidden]), #rkeys-back, .meta-menu")) return null;   // the pane's own modals + meta menus own their keys (a letter typed there must never land in the draft)
+  if (composerNoteHolds()) return null;   // the box just changed hands under the user — no focus steal, the note flashes; a click re-binds (T236). Nothing to cancel either: a key on the bare body has nothing to insert into.
+  return ta;
+}
 // SELECT → TYPE → ⌘⏎ (the user 2026-09-02): a transcript selection already seeded the reply chip
 // (selectionchange), so the natural next act is just TYPING — the first printable keystroke drops
 // the cursor into the message box with the chip attached, no mouse round-trip, and ⌘⏎ stages as
@@ -5425,16 +5442,37 @@ window.addEventListener("keydown", (e) => {
   if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;   // chords are not typing (shift stays: capitals)
   if (e.isComposing || e.keyCode === 229) return;   // IME mid-composition — a focus steal aborts the composition
   if (e.key.length !== 1 || e.key === " ") return;  // printable only; Space stays a toggle/scroll key
-  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (!ta || ta.disabled || document.activeElement === ta) return;   // no box / read-only session / already typing (covers key repeat)
-  if (isTypingTarget(e.target) || isTypingTarget(document.activeElement)) return;
-  if (activeId && liveAsks.has(activeId)) return;   // digits belong to the live-ask card's number keys
-  if (ctxMenuEl || document.querySelector(".picker-overlay")) return;   // an open menu / #picker / #confirm owns the keys
-  if (document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse")
-      || document.getElementById("romp-lightbox")) return;   // full-pane surfaces own their keys
-  if (document.querySelector("#rsettings:not([hidden]), #ra-back:not([hidden]), #rkeys-back, .meta-menu")) return;   // the pane's own modals + meta menus own their keys (a letter typed there must never land in the draft)
-  if (composerNoteHolds()) return;   // the box just changed hands under the user — no focus steal, the note flashes; a click re-binds (T236). Nothing to cancel either: a key on the bare body has nothing to insert into.
+  const ta = typeFromAnywhereTarget(e);
+  if (!ta) return;
   ta.focus({ preventScroll: true });   // the native keystroke lands in the box; the chip survives (a collapse never clears it)
+});
+// SELECT → PASTE → ⌘⏎ (the user 2026-09-05): dictation tools land the whole utterance at once — a
+// paste, not keystrokes — so type-to-focus never fired and, with nothing editable focused after a
+// transcript selection, the dictated text went nowhere. (Focusing the box when the selection ends was
+// ruled out: it collapses the page selection and breaks plain copy.) Same gates as type-to-focus,
+// same bubble-phase-on-window stance: we take only a paste nobody claimed. The difference is
+// mechanical — a paste has ALREADY dispatched at the body by the time it bubbles here, so focusing
+// the box cannot re-target it the way a keydown's native insertion follows focus. So this one DOES
+// preventDefault and inserts the text itself, then fires the input event the box's own bookkeeping
+// (draft, autosize, slash menu) listens for — insertAtCaret. The armed quote chip is never touched:
+// the focus collapses the selection, and a collapse never clears it, so ⌘⏎ stages exactly as after
+// typing. A paste into the FOCUSED box never reaches this branch (typeFromAnywhereTarget), so the
+// composer's own paste handler (files, path-shaped text) keeps its native default.
+window.addEventListener("paste", (e) => {
+  if (e.defaultPrevented) return;   // an element handler already acted
+  const ta = typeFromAnywhereTarget(e);
+  if (!ta) return;
+  const dt = e.clipboardData;
+  // Files (a clipboard screenshot) stay out of scope here: the composer attaches them from its OWN
+  // paste handler, per-file and inline (path vs shipped bytes by host), not through a callable this
+  // branch could reuse — factoring that is its own change. Until then a file paste from the bare
+  // area does what it did before: nothing.
+  if (!dt || dt.files.length) return;
+  const text = dt.getData("text/plain");
+  if (!text) return;
+  e.preventDefault();
+  ta.focus({ preventScroll: true });
+  insertAtCaret(ta, text);
 });
 // Cmd/Ctrl+O and Cmd/Ctrl+Shift+O — the in-PAGE fallback, from anywhere including the composer, the
 // way Obsidian's quick switcher opens over the editor (the user 2026-08-08). Inside the romp shell


### PR DESCRIPTION
## The problem

The user dictates with a tool that drops the whole utterance into the page at once — as a paste, not keystrokes. The composer's type-to-focus default (SELECT → TYPE → ⌘⏎, 2026-09-02) keys on `keydown`, so it never saw the dictation; and after selecting transcript text nothing editable is focused, so the dictated text went nowhere.

Focusing the composer when the selection ends was considered and rejected: it would collapse the page selection and break ordinary copy.

## What this does

A window-level, bubble-phase `paste` listener installed once beside the keydown one. It takes only a paste nobody claimed, focuses the box (`preventScroll`), inserts the text at the caret / over the box's own selection, and fires the `input` event the composer's draft save, autosize and slash menu already listen for. Because the paste has already dispatched at the body by the time it bubbles to window, focusing cannot re-target it the way a keystroke's native insertion follows focus — so unlike type-to-focus this handler does `preventDefault` and inserts itself, through a new pure helper `insertAtCaret` (`ui/webview/composer-insert.ts`).

The armed quote/citation chip is not touched (the focus collapses the selection; a collapse never clears the chip), so ⌘⏎ stages exactly as after typing.

## Gates (shared, not duplicated)

Type-to-focus's non-key gates are factored into `typeFromAnywhereTarget(e)`, which both handlers call, so the two can never disagree about what "nobody claimed this" means. It stands down when:

- the composer textarea is missing, disabled, or already the active element (a paste into the focused box stays native — the composer's own paste handler for files and path-shaped text is unchanged);
- the event target or active element is a typing target (input, textarea, contenteditable, select);
- a live-ask card is up for the active session;
- a context menu or `.picker-overlay` (picker / confirm) is open;
- the file viewer, file browser or lightbox is up;
- the settings, analytics or shortcuts modal, or a meta menu, is open;
- the hand-over note holds the box (T236).

The paste handler additionally yields on `defaultPrevented`, on a clipboard carrying files, and on an empty `text/plain`.

**Files:** a clipboard with files (a screenshot) stands down, deliberately. The composer attaches files inline in its own paste handler (per-file: local path vs shipped bytes by host), not through a callable this branch could reuse; factoring that is its own change, and a half-behaviour (focus with nothing attached) would be worse than today's nothing. Said so in a code comment and pinned by a test.

## Verification

- `npm run typecheck` clean; `npm test` 2790/2790 (9 new in `composer-paste-focus.test.ts`); `npm run build` OK.
- The existing type-to-focus and hand-over-note pins (`composer-citation.test.ts`, `draft-teardown.test.ts`) follow the gates into the shared helper.
- No visual change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
