### PR TITLE
A notification tap comes back to the romp already open and lands on the session and card that buzzed

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29499,14 +29499,16 @@ def _cached_feed(now, tmux, sig, connect=False):
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
     _fired = _feed_notifications(feed)                    # armed bells: fresh builds are the transition event
-    for _t, _b, _sid in _fired:
+    for _t, _b, _sid, _iid in _fired:
         _system_notify(_t, _b)
-        _push_notify(_t, _b, _sid, _badge)                # same events to subscribed phones (plans/ios-app.md)
+        # same events to subscribed phones (plans/ios-app.md); kind + card id are what the tap acts on
+        _push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)
     if _fired:
         # …and to trusted peers' devices (plans/federated-push.md): the phone subscribed at the
         # always-on box must buzz for THIS kernel's cards too — which kernel detected an event is
         # romp's business, never the user's.
-        _push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])
+        _push_forward([{"title": _t, "body": _b, "sid": _sid, "kind": "card", "cardId": _iid}
+                       for _t, _b, _sid, _iid in _fired])
     _badge_push(_badge)                                   # app-icon count for installed shells (proposal 3)
     return feed
 
@@ -29538,11 +29540,12 @@ def _system_notify(title, body):
 
 
 def _feed_notifications(feed):
-    """Diff this feed build against the last; return [(title, body, sid)] for every ARMED card that
-    newly entered needs_input or completed (including a card appearing already there — work can
-    surface blocked). Also advances the prev map and prunes armed ids whose card left the feed.
-    sid rides along so a push notification's tap can land ON the session that fired (the user
-    2026-08-08, whose first real push opened the app on a different session)."""
+    """Diff this feed build against the last; return [(title, body, sid, itemId)] for every ARMED
+    card that newly entered needs_input or completed (including a card appearing already there —
+    work can surface blocked). Also advances the prev map and prunes armed ids whose card left the
+    feed. sid rides along so a push notification's tap can land ON the session that fired (the
+    user 2026-08-08, whose first real push opened the app on a different session); itemId joined
+    it 2026-09-06 so the same tap can also scroll the feed to the card itself."""
     prev = _NOTIFY_PREV[0]
     cur = {}
     for a in feed.get("asks") or []:
@@ -29565,7 +29568,7 @@ def _feed_notifications(feed):
         txt = str(a.get("text") or "").strip()
         out.append(("romp: %s" % (a.get("name") or "session"),
                     "%s: %s" % (what, txt[:140] if txt else "a task changed state"),
-                    str(a.get("sid") or "")))
+                    str(a.get("sid") or ""), iid))
     return out
 
 
@@ -29737,15 +29740,54 @@ def _push_send_one(sub, payload):
         return True
 
 
-def _push_notify(title, body, sid="", badge=None):
+def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host=""):
+    """The JSON one web push carries — the ONE builder every push kind goes through, so a tap on
+    any of them lands the same way (the user 2026-09-06, who wants a tap to focus the romp
+    window they already have open and put them on the session — and card — that buzzed).
+
+    Content is the gist and nothing more: title + body. Everything else is ROUTING metadata the
+    service worker acts on, never text it shows:
+      sid   — top level, for a worker of the previous build still installed on some phone (it
+              read d.sid; a worker updates on the next push or app open, not before);
+      tag   — one notification per SESSION: a second push for the same session replaces the
+              first on the lock screen instead of stacking (renotify keeps the buzz), and a
+              sid-less push wears a fixed tag so tests collapse too;
+      badge — the needs-you count the worker paints on the app icon while the app is closed;
+              None OMITS the key and the worker leaves the count alone — the shape a mirrored
+              federated event wears, because the origin's count is not ours;
+      data  — {sid, host, kind, cardId, url}: what the worker hands the shell on a tap (or puts
+              in the URL it opens when no window exists). kind names the leg that fired ("card":
+              a card entered needs-you/completed; "turn": a turn ended; "test": the popover's
+              probe, no sid, nowhere to land); cardId (a card kind only) is the goal id the feed
+              scrolls to; url is the same-origin deep link the shell already parses at boot
+              (?push-reveal=<sid>, plus &push-card=<id> for a card) — "/" when there is no
+              session to land on. host is the origin kernel of a relayed event ("" = local);
+              the sid already wears it as a prefix (host:sid, the merged dashboard's own tab
+              address), so this is a courtesy copy, not a second source of truth."""
+    import urllib.parse
+    sid, card_id, kind = str(sid or ""), str(card_id or ""), str(kind or "card")
+    host = str(host or "") or (sid.split(":", 1)[0] if ":" in sid else "")
+    url = "/"
+    if sid:
+        q = [("push-reveal", sid)] + ([("push-card", card_id)] if card_id else [])
+        url = "/?" + urllib.parse.urlencode(q)
+    d = {"title": str(title), "body": str(body), "sid": sid,
+         "tag": "romp:" + (sid or kind),
+         "data": {"sid": sid, "host": host, "kind": kind, "cardId": card_id, "url": url}}
+    if badge is not None:
+        d["badge"] = int(badge or 0)
+    return d
+
+
+def _push_notify(title, body, sid="", badge=None, kind="card", card_id="", host=""):
     """_system_notify's sibling sink: the same (title, body) — the card's gist and nothing more —
-    to every subscribed device, plus two pieces of ROUTING metadata, not content: sid, so tapping
-    the notification lands on the session that fired (the user 2026-08-08), and badge, the
-    needs-you count the service worker paints on the app icon while the app is closed. badge=None
-    OMITS the key and the worker leaves the icon's count alone — the shape a mirrored federated
-    event wears, because the origin kernel's count is not this kernel's count
-    (plans/federated-push.md). Runs on the pusher thread, so all network work moves to a daemon
-    thread (the _refresh_remote_prices discipline) and this never blocks or raises."""
+    to every subscribed device, plus the ROUTING metadata _push_payload documents: sid, so
+    tapping the notification lands on the session that fired (the user 2026-08-08); badge, the
+    needs-you count for the app icon (None omits it — the mirrored federated shape,
+    plans/federated-push.md); and kind/card_id/host, so the tap can also scroll the feed to the
+    card and name the origin of a relayed event. Runs on the pusher thread, so all network work
+    moves to a daemon thread (the _refresh_remote_prices discipline) and this never blocks or
+    raises."""
     subs = _push_subs()
     if not subs:
         return
@@ -29755,10 +29797,7 @@ def _push_notify(title, body, sid="", badge=None):
         print("romp: web push: %d subscription(s) on file but the python 'cryptography' package "
               "is missing — notification not delivered" % len(subs), file=sys.stderr)
         return
-    d = {"title": str(title), "body": str(body), "sid": str(sid or "")}
-    if badge is not None:
-        d["badge"] = int(badge or 0)
-    payload = json.dumps(d).encode()
+    payload = json.dumps(_push_payload(title, body, sid, badge, kind, card_id, host)).encode()
 
     def run():
         dead = []
@@ -29777,8 +29816,9 @@ def _push_notify(title, body, sid="", badge=None):
 def _push_forward(events):
     """The federated half of the push sink (plans/federated-push.md; the user 2026-08-08, who wants
     one device subscription to buzz for EVERY connected kernel): hand this kernel's fresh bell
-    events — [{title, body, sid}] — to every attached TRUSTED peer, and each peer delivers them to
-    the devices subscribed to IT. Rides the channel every kernel-to-kernel control call already
+    events — [{title, body, sid, kind, cardId}] — to every attached TRUSTED peer, and each peer
+    delivers them to the devices subscribed to IT (kind/cardId ride so a tap on the mirrored
+    notification lands on the card, not just the session; a peer of an older build ignores them). Rides the channel every kernel-to-kernel control call already
     rides (_peer_call: the pair's tunnel + the token exchanged at attach) — no new legs, no new
     trust surface. Only events THIS kernel detected are ever forwarded, and /push/relay mirrors to
     devices only, never onward, so a cycle of attachments cannot echo an event back. Fire-and-forget
@@ -29820,8 +29860,14 @@ self.addEventListener('install',function(e){self.skipWaiting();});
 self.addEventListener('activate',function(e){e.waitUntil(clients.claim());});
 self.addEventListener('push',function(e){
 var d={};try{d=e.data?e.data.json():{};}catch(err){}
-var work=[self.registration.showNotification(d.title||'romp',
-{body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',data:{sid:d.sid||''}})];
+// data = the ROUTING block the kernel built (_push_payload: sid, host, kind, cardId, url) — what the
+// tap below acts on; a payload from an older kernel carries only a flat sid, so that is the fallback.
+// tag: one notification per session — a second buzz for the same session REPLACES the first on the
+// lock screen instead of stacking (renotify keeps it audible); the kernel picks the tag.
+var opts={body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',
+data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}};
+if(d.tag){opts.tag=d.tag;opts.renotify=true;}
+var work=[self.registration.showNotification(d.title||'romp',opts)];
 // the app-icon count, kept current while the app is CLOSED (the open shell re-paints it live over
 // its own WS). setAppBadge exists in the SW only where badging works at all (iOS installed apps).
 // Numeric-only on purpose: a mirrored federated event omits badge (the ORIGIN kernel's count is
@@ -29831,15 +29877,25 @@ if('setAppBadge' in self.navigator&&typeof d.badge==='number')work.push(self.nav
 e.waitUntil(Promise.all(work));
 });
 // Land ON the thing that notified (the user 2026-08-08, whose first push opened a different
-// session): a live window gets focus + the sid over postMessage (the shell relays it into the
-// chat pane); no window -> open one with the sid in the URL, and the shell asks the kernel to
-// aim the focus at it once its chat pane connects (POST /reveal).
+// session; 2026-09-06, who wants the tap to come back to the romp they already have open): the
+// notification closes; then the window the user last had in front (matchAll orders most-recently-
+// focused first) is focused and handed the routing block over postMessage — the shell turns that
+// into the chat focus + the feed's card reveal. No window at all -> open one on the deep link the
+// kernel built (the shell parses it at boot). focus() can REJECT (an installed iOS app has refused
+// it) — then the tap still lands: fall through to openWindow rather than dropping it. Everything
+// rides waitUntil, so the worker is kept alive until the tap has landed; no timers anywhere.
 self.addEventListener('notificationclick',function(e){
 e.notification.close();
-var sid=(e.notification.data&&e.notification.data.sid)||'';
+var d=e.notification.data||{};var sid=d.sid||'';
+var url=d.url||(sid?'/?push-reveal='+encodeURIComponent(sid):'/');
+var msg={romp:'notificationClick',sid:sid,host:d.host||'',kind:d.kind||'',cardId:d.cardId||''};
+function open(){return clients.openWindow(url);}
 e.waitUntil(clients.matchAll({type:'window',includeUncontrolled:true}).then(function(ws){
-if(ws.length)return ws[0].focus().then(function(w){try{(w||ws[0]).postMessage({romp:'pushReveal',sid:sid});}catch(err){}});
-return clients.openWindow(sid?'/?push-reveal='+encodeURIComponent(sid):'/');}));
+if(!ws.length)return open();
+var w=ws[0];
+return Promise.resolve().then(function(){return w.focus();}).then(function(fw){
+try{(fw||w).postMessage(msg);}catch(err){}},open);
+}));
 });
 """
 
@@ -32360,26 +32416,52 @@ return want?devSub(perm):devUnsub();
 }).then(function(){done();},function(e){fail(e);done();});
 });});
 })();
-// Landing a push tap on the session that fired (the user 2026-08-08). Two arrivals:
-//  - live window: the SW focused us and posted {romp:'pushReveal',sid} — relay a focus straight
-//    into the chat iframe. Its own handler does the rest (tab select, come forward on mobile via
-//    revealSelfPane), same as a kernel-sent focus — the shim delivers those over postMessage too.
-//  - cold start: the SW opened '/?push-reveal=sid' — the chat pane's WS does not exist yet, so
-//    ask the kernel to park the focus for OUR wid (POST /reveal, consumed on the pane's ready).
-//    The param is then stripped so a later manual reload does not replay the jump.
-// Separate IIFE from the bell on purpose: the bell bails where the Push API is missing, but a
-// pushReveal can only ever arrive where it exists, and this block must not ride that bail.
+"""
+
+
+# Landing a notification tap on what fired (the user 2026-08-08, whose first push opened a different
+# session; 2026-09-06, who wants the tap to come back to the romp already open and put them on the
+# session — and the card — that buzzed). Two arrivals, ONE activation path: both ask the KERNEL to
+# aim the chat focus at THIS dashboard (POST /reveal {sid, wid}) — never a focus posted straight
+# into the chat iframe, which could only ever address a tab that is already there. The kernel
+# answers a live session with the focus (chat pane connected → delivered now; not yet → parked for
+# that wid and consumed on the pane's ready — the exact event, no delay heuristics) and a dead or
+# unknown one with the revive prompt (_reveal_msg), so no sid ever ends in a silent no-op.
+#  - live window: the SW focused us and posted {romp:'notificationClick', sid, host, kind, cardId}.
+#  - cold start: the SW opened the kernel's deep link '/?push-reveal=<sid>[&push-card=<id>]'. The
+#    params are stripped (history.replaceState) the moment they are read, so a manual reload later
+#    does not replay the jump.
+# A card kind ALSO scrolls the feed to its card: {romp:'revealCard'} into the feed iframe — the same
+# message the Log's bell entries post — but only once the feed has its cards, which it announces
+# with {romp:'ready', app:'feed'} after its first payload renders (before that the iframe may have
+# no listener yet, or nothing to scroll to); a tap that arrives earlier waits for exactly that
+# message. A sid-less tap (a test notification) has nowhere to land: the SW's focus/openWindow was
+# the whole action. A /reveal the kernel refuses lands in the Log rather than vanishing.
+# Its own <script>, like every shell behaviour (test_kernel_mobile's count pin): a throw in the
+# bell's script must not strand a tap, and a bell that bails where the Push API is missing must
+# not take the deep-link half with it.
+_LANDING_REVEAL_JS = """
 (function(){
-function reveal(sid){if(!sid)return;var f=document.getElementById('f-chat');
-try{f&&f.contentWindow&&f.contentWindow.postMessage({type:'focus',id:sid,live:true},'*');}catch(e){}}
-if('serviceWorker' in navigator&&navigator.serviceWorker.addEventListener){
-navigator.serviceWorker.addEventListener('message',function(ev){
-var m=ev.data;if(m&&m.romp==='pushReveal'&&m.sid)reveal(m.sid);});}
-var u=new URL(location.href),pr=u.searchParams.get('push-reveal');
-if(pr){var wid='';try{wid=sessionStorage.getItem('romp:wid')||'';}catch(e){}
-fetch('/reveal',{method:'POST',body:JSON.stringify({sid:pr,wid:wid})})['catch'](function(e){});
-u.searchParams['delete']('push-reveal');
-try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():''));}catch(e){}}
+function wid(){try{return sessionStorage.getItem('romp:wid')||'';}catch(e){return '';}}
+function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Could not open the session this notification was about: '+((e&&e.message)||e));}catch(err){}}
+var feedReady=false,pendingCard=null;
+function revealCard(itemId,sid){if(!feedReady){pendingCard={itemId:itemId,sid:sid};return;}
+var f=document.getElementById('f-feed');
+try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'revealCard',itemId:itemId,sid:sid},'*');}catch(e){}}
+window.addEventListener('message',function(e){var m=e&&e.data;
+if(!(m&&m.romp==='ready'&&m.app==='feed'))return;
+feedReady=true;if(pendingCard){var c=pendingCard;pendingCard=null;revealCard(c.itemId,c.sid);}});
+function land(sid,kind,cardId){
+if(sid)fetch('/reveal',{method:'POST',body:JSON.stringify({sid:sid,wid:wid()})}).then(function(r){
+if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});})['catch'](fail);
+if(sid&&kind==='card'&&cardId)revealCard(cardId,sid);}
+if('serviceWorker' in navigator&&navigator.serviceWorker&&navigator.serviceWorker.addEventListener){
+navigator.serviceWorker.addEventListener('message',function(ev){var m=ev&&ev.data;
+if(m&&m.romp==='notificationClick')land(String(m.sid||''),String(m.kind||''),String(m.cardId||''));});}
+var u=new URL(location.href),pr=u.searchParams.get('push-reveal'),pc=u.searchParams.get('push-card');
+if(pr||pc){land(pr||'',pc?'card':'',pc||'');
+u.searchParams['delete']('push-reveal');u.searchParams['delete']('push-card');
+try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():'')+u.hash);}catch(e){}}
 })();
 """
 
@@ -33622,6 +33704,7 @@ def _landing():
             "<script>" + _LANDING_REMOTES_JS + "</script>"
             "<script>" + _LANDING_MOBILE_JS + "</script>"
             "<script>" + _LANDING_PUSH_JS + "</script>"
+            "<script>" + _LANDING_REVEAL_JS + "</script>"
             "<script>" + _LANDING_COLLAPSE_JS + "</script>"
             # the command palette (Cmd/Ctrl+P) and the session quick-switcher hotkey (Cmd/Ctrl+O):
             # a dist bundle (ui/webview/palette-main.ts) like age-color-global above. Loaded last —
@@ -34551,7 +34634,12 @@ class Handler(BaseHTTPRequestHandler):
                         sid = "%s:%s" % (origin, sid)
                     if t.startswith("romp: "):
                         t = "romp: %s:%s" % (origin, t[len("romp: "):])
-                    _push_notify(t, b, sid)       # badge omitted: the origin's count is not ours
+                    # badge omitted: the origin's count is not ours. kind/cardId pass through
+                    # (an older peer sends neither → the card default, which is all it had);
+                    # the card id is a goal id, globally unique and never host-prefixed
+                    # (federation.ts), so the merged feed finds it as-is.
+                    _push_notify(t, b, sid, kind=str(ev.get("kind") or "card"),
+                                 card_id=str(ev.get("cardId") or ""), host=origin)
                     n += 1
                 return self._send(200, json.dumps({"ok": True, "mirrored": n}), "application/json")
             if u.path == "/reveal":

--- a/plans/ios-app.md
+++ b/plans/ios-app.md
@@ -6,11 +6,17 @@ end — `/sw.js`, `/push/*`, VAPID, the `_push_notify` sink beside `_system_noti
 bell), live-verified on a real iPhone on 2026-08-07; then 3 plus tap-to-open on 2026-08-08, after
 the first real push opened the app on a session OTHER than the one that fired it — the bug that
 motivated the routing metadata below. A push now carries the firing card's sid and the
-needs-you count as routing metadata: the notification tap lands on that session (live window →
-SW postMessage → focus into the chat pane; cold start → `/?push-reveal=` → `POST /reveal` parks a
-wid-aimed focus consumed on that window's chat `ready` — an exact event, no delay heuristics),
-and the app icon wears the count (`navigator.setAppBadge` — the SW paints it while the app is
-closed, the shell trues it up over its WS on connect and on every change).
+needs-you count as routing metadata — and, since 2026-09-06, a `data` block `{sid, host, kind,
+cardId, url}` plus a per-session `tag` (`_push_payload`). The notification tap lands on that
+session: the SW closes the notification, focuses the window the user last had in front and posts
+`{romp:'notificationClick', …}` to it (a refused `focus()` falls through to `openWindow` on the
+deep link, all inside `waitUntil`); with no window it opens `url` (`/?push-reveal=<sid>
+[&push-card=<id>]`). Either way the shell asks the kernel for the focus (`POST /reveal`, wid-aimed,
+parked until that window's chat `ready` when the pane is not up yet — an exact event, no delay
+heuristics; a dead sid gets the revive prompt, never a silent miss) and, for a card, posts
+`revealCard` into the feed once it has announced its first payload; the URL params are stripped
+with `replaceState`. The app icon wears the count (`navigator.setAppBadge` — the SW paints it while
+the app is closed, the shell trues it up over its WS on connect and on every change).
 Implementation notes that amend this sketch:
 - The shell background is `#1e1e1e`, not the `#101418` guessed below (that is the login page);
   the manifest and theme-color use `#1e1e1e`.

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -180,7 +180,9 @@ class LandingShell(unittest.TestCase):
         # ios-standalone viewport flip and the push bell 2026-08-07, plans/ios-app.md; + the shared
         # Escape-closes-the-topmost-modal block 2026-08-09; + the release-update banner 2026-08-09).
         html = km._landing()
-        self.assertEqual(html.count("<script>"), 17)   # +1 2026-08-28: the theme reader right after <body>
+        # +1 2026-08-28: the theme reader right after <body>; +1 2026-09-06: the notification-tap landing
+        # script (_LANDING_REVEAL_JS) — its own script so a throw in the bell's cannot strand a tap
+        self.assertEqual(html.count("<script>"), 18)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -124,16 +124,124 @@ class ServiceWorkerRoute(unittest.TestCase):
         self.assertIn("clients.claim()", js)
 
     def test_sw_click_lands_on_the_session_that_fired(self):
-        # the user 2026-08-08: the first real push opened the app on a DIFFERENT session. The sid
-        # rides the notification's data; a live window gets it over postMessage, a cold start gets
-        # it in the URL for the shell's POST /reveal.
+        # the user 2026-08-08: the first real push opened the app on a DIFFERENT session. The
+        # kernel's routing block rides the notification's data; a live window gets it over
+        # postMessage, a cold start gets the kernel's deep link (ServiceWorkerExecutes runs it).
         _, body = _serve_get("/sw.js", headers={"X-Romp-Token": km.TOKEN})
         js = body.decode()
-        self.assertIn("data:{sid:", js)
-        self.assertIn("pushReveal", js)
-        self.assertIn("/?push-reveal=", js)
+        self.assertIn("data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}", js,
+                      "the routing block verbatim; an older kernel's flat sid still lands")
+        self.assertIn("opts.tag=d.tag;opts.renotify=true", js, "one notification per session, still audible")
+        self.assertIn("romp:'notificationClick'", js)
+        self.assertIn("clients.openWindow(url)", js)
+        self.assertIn("/?push-reveal=", js)              # the fallback deep link for a data block without one
+        self.assertNotIn("setTimeout", js)                # event-based end to end — no timers in the worker
         # ...and the closed-app badge count comes from the payload
         self.assertIn("setAppBadge", js)
+
+
+# The worker, EXECUTED (the test_error_center.py pattern): node runs _SW_JS against stubs of the
+# ServiceWorker globals and the driver replays a push and four taps, logging every call in order.
+# A source pin says the words are there; this says the sequence is right: close → matchAll →
+# focus + postMessage, openWindow only when no window exists or focus() refused, all under waitUntil.
+_SW_HARNESS = r"""
+'use strict';
+const H = {};            // event name -> the worker's handler
+const LOG = [];          // every call the worker makes, in order
+global.self = {
+  addEventListener: (k, f) => { H[k] = f; },
+  skipWaiting: () => {},
+  registration: { showNotification: (title, opts) => { LOG.push(['show', title, opts]); return Promise.resolve(); } },
+  navigator: {},         // no setAppBadge here: the numeric-only badge rule has its own pin
+};
+global.clients = {
+  claim: () => Promise.resolve(),
+  matchAll: (q) => { LOG.push(['matchAll', q]); return Promise.resolve([]); },
+  openWindow: (u) => { LOG.push(['openWindow', u]); return Promise.resolve({}); },
+};
+"""
+_SW_DRIVER = r"""
+function win(focusOk) {
+  const w = { focus: () => { LOG.push(['focus']); return focusOk ? Promise.resolve(w) : Promise.reject(new Error('refused')); },
+              postMessage: (m) => LOG.push(['post', m]) };
+  return w;
+}
+async function tap(data, windows) {
+  LOG.length = 0;
+  const waited = [];
+  global.clients.matchAll = (q) => { LOG.push(['matchAll', q]); return Promise.resolve(windows); };
+  H.notificationclick({ notification: { close: () => LOG.push(['close']), data }, waitUntil: (p) => waited.push(p) });
+  for (const p of waited) await p;
+  return { log: LOG.slice(), waited: waited.length };
+}
+(async () => {
+  const out = {};
+  const data = { sid: 'S1', host: '', kind: 'card', cardId: 'S1:g1', url: '/?push-reveal=S1&push-card=S1%3Ag1' };
+  H.push({ data: { json: () => ({ title: 'romp: web', body: 'Needs you: x', sid: 'S1', tag: 'romp:S1', badge: 2, data }) },
+           waitUntil: () => { out.pushWaited = true; } });
+  out.push = LOG.slice();
+  LOG.length = 0;
+  H.push({ data: { json: () => ({ title: 't', body: 'b', sid: 'S9' }) }, waitUntil: () => {} });   // an older kernel's flat payload
+  out.pushLegacy = LOG.slice();
+  out.live = await tap(data, [win(true)]);
+  out.cold = await tap(data, []);
+  out.refused = await tap(data, [win(false)]);
+  out.test = await tap({ sid: '', host: '', kind: 'test', cardId: '', url: '/' }, []);
+  out.legacyTap = await tap({ sid: 'S7' }, []);            // a notification an older worker showed: flat sid, no url
+  console.log(JSON.stringify(out));
+})();
+"""
+
+
+class ServiceWorkerExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import subprocess, tempfile as _tf
+        with _tf.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(_SW_HARNESS + km._SW_JS + _SW_DRIVER)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the worker threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    MATCH = ["matchAll", {"type": "window", "includeUncontrolled": True}]
+    MSG = {"romp": "notificationClick", "sid": "S1", "host": "", "kind": "card", "cardId": "S1:g1"}
+    URL = "/?push-reveal=S1&push-card=S1%3Ag1"
+
+    def test_push_shows_the_gist_and_keeps_the_routing_block_verbatim(self):
+        show = self.out["push"][0]
+        self.assertEqual(show[:2], ["show", "romp: web"])
+        opts = show[2]
+        self.assertEqual(opts["body"], "Needs you: x")
+        self.assertEqual(opts["data"], {"sid": "S1", "host": "", "kind": "card", "cardId": "S1:g1", "url": self.URL})
+        self.assertEqual((opts["tag"], opts["renotify"]), ("romp:S1", True), "same session → replaces, still buzzes")
+        self.assertTrue(self.out["pushWaited"])
+        # an older kernel's flat payload still lands on its sid, and wears no tag it did not send
+        legacy = self.out["pushLegacy"][0][2]
+        self.assertEqual(legacy["data"], {"sid": "S9"})
+        self.assertNotIn("tag", legacy)
+
+    def test_a_live_window_is_focused_and_told_never_reopened(self):
+        live = self.out["live"]
+        self.assertEqual(live["waited"], 1, "the whole tap rides one waitUntil")
+        self.assertEqual(live["log"], [["close"], self.MATCH, ["focus"], ["post", self.MSG]])
+
+    def test_no_window_opens_the_deep_link(self):
+        self.assertEqual(self.out["cold"]["log"], [["close"], self.MATCH, ["openWindow", self.URL]])
+        self.assertEqual(self.out["cold"]["waited"], 1)
+
+    def test_a_refused_focus_falls_through_to_open_window(self):
+        # the installed-app case: focus() rejects — the tap must still land somewhere
+        self.assertEqual(self.out["refused"]["log"], [["close"], self.MATCH, ["focus"], ["openWindow", self.URL]])
+
+    def test_a_test_notification_just_opens_romp(self):
+        self.assertEqual(self.out["test"]["log"], [["close"], self.MATCH, ["openWindow", "/"]])
+
+    def test_a_notification_from_the_previous_worker_still_lands(self):
+        self.assertEqual(self.out["legacyTap"]["log"][-1], ["openWindow", "/?push-reveal=S7"])
 
 
 @unittest.skipUnless(HAVE_CRYPTO, "python 'cryptography' not installed")
@@ -313,7 +421,7 @@ class PushSink(unittest.TestCase):
         import inspect
         src = inspect.getsource(km._cached_feed)
         self.assertIn("_system_notify(_t, _b)", src)
-        self.assertIn("_push_notify(_t, _b, _sid, _badge)", src)
+        self.assertIn('_push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)', src)
         self.assertIn("_badge_push(_badge)", src)
 
     def test_no_subscriptions_means_no_work(self):
@@ -351,11 +459,49 @@ class PushSink(unittest.TestCase):
         self.assertEqual(set(km._push_subs()), {"https://push.example.net/send/live"},
                          "404/410 prunes; success stays")
         body = json.loads(list(seen.values())[0].decode())
-        # the plan's privacy note, pinned: the payload is the card's gist (title + body) plus two
-        # pieces of ROUTING metadata — the sid the tap should land on and the badge count — and
-        # nothing more (no brief, no transcript), even though the content is E2E-encrypted
-        self.assertEqual(set(body), {"title", "body", "sid", "badge"})
+        # the plan's privacy note, pinned: the payload is the card's gist (title + body) plus
+        # ROUTING metadata — where the tap lands (sid, the data block), how it stacks (tag) and the
+        # badge count — and nothing more (no brief, no transcript), even though the content is
+        # E2E-encrypted. Every routing value is an id or a fixed word, never text.
+        self.assertEqual(set(body), {"title", "body", "sid", "badge", "tag", "data"})
         self.assertEqual((body["title"], body["sid"], body["badge"]), ("romp: web", "SID-web", 3))
+        self.assertEqual(set(body["data"]), {"sid", "host", "kind", "cardId", "url"})
+
+
+class PushPayloadShape(unittest.TestCase):
+    """_push_payload: the ONE builder every push kind goes through (the user 2026-09-06, who wants
+    a tap to focus the romp already open and land on the session — and card — that buzzed)."""
+
+    def test_a_card_push_carries_the_card_and_a_deep_link_the_shell_parses(self):
+        d = km._push_payload("romp: web", "Needs you: pick one", "SID-web", 2, kind="card",
+                             card_id="SID-web:g3")
+        self.assertEqual(d["data"], {"sid": "SID-web", "host": "", "kind": "card", "cardId": "SID-web:g3",
+                                     "url": "/?push-reveal=SID-web&push-card=SID-web%3Ag3"})
+        self.assertEqual(d["tag"], "romp:SID-web", "one notification per session")
+        self.assertEqual(d["sid"], "SID-web", "…and flat, for a worker of the previous build")
+        self.assertEqual(d["badge"], 2)
+
+    def test_a_turn_push_names_its_kind_and_carries_no_card(self):
+        d = km._push_payload("web", "finished a turn", "SID-web", kind="turn")
+        self.assertEqual((d["data"]["kind"], d["data"]["cardId"], d["data"]["url"]),
+                         ("turn", "", "/?push-reveal=SID-web"))
+        self.assertNotIn("badge", d, "None omits the key — the worker leaves the count alone")
+
+    def test_a_test_push_has_no_session_and_lands_on_romp_itself(self):
+        # the popover's probe (PR #937's _push_test builds its payload here once it lands): kind
+        # "test", no sid, so the tap can only ever focus or open romp — and every test collapses
+        # into one notification rather than stacking on the lock screen
+        d = km._push_payload("romp", "Test notification", kind="test")
+        self.assertEqual(d["data"], {"sid": "", "host": "", "kind": "test", "cardId": "", "url": "/"})
+        self.assertEqual(d["tag"], "romp:test")
+
+    def test_a_relayed_push_keeps_the_origin_in_sid_and_host(self):
+        # a federated event's sid already wears its host prefix (the merged dashboard's own tab
+        # address); host is the courtesy copy, from the relay's origin or read off the prefix
+        d = km._push_payload("romp: boxa:web", "b", "boxa:11111111-2222", host="boxa", card_id="11111111-2222:g1")
+        self.assertEqual((d["data"]["sid"], d["data"]["host"]), ("boxa:11111111-2222", "boxa"))
+        self.assertEqual(d["data"]["url"], "/?push-reveal=boxa%3A11111111-2222&push-card=11111111-2222%3Ag1")
+        self.assertEqual(km._push_payload("t", "b", "boxb:S")["data"]["host"], "boxb")
 
     def test_missing_crypto_with_subscriptions_says_so(self):
         km._save_push_subs({"https://push.example.net/send/x": {
@@ -515,16 +661,114 @@ class Badge(unittest.TestCase):
 class LandingRevealPins(unittest.TestCase):
     def test_shell_carries_both_halves_of_the_tap(self):
         html = km._landing()
-        self.assertIn("pushReveal", html)          # live window: SW message → focus into the chat iframe
-        self.assertIn("push-reveal", html)         # cold start: URL param → POST /reveal {sid, wid}
-        self.assertIn("'/reveal'", html)
-        self.assertIn("romp:wid", html)            # aimed by the shell's own per-window id
+        self.assertIn("m.romp==='notificationClick'", html)   # live window: the SW's message
+        self.assertIn("searchParams.get('push-reveal')", html)  # cold start: the deep link's params…
+        self.assertIn("searchParams.get('push-card')", html)
+        self.assertIn("searchParams['delete']('push-reveal')", html)   # …stripped once read
+        self.assertIn("history.replaceState", html)
+        self.assertIn("fetch('/reveal'", html)     # ONE activation path: the kernel aims the focus…
+        self.assertIn("romp:wid", html)            # …at the shell's own per-window id
+        self.assertIn("romp:'revealCard'", html)   # a card kind also scrolls the feed to the card…
+        self.assertIn("m.romp==='ready'&&m.app==='feed'", html)   # …once the feed has its cards
+        self.assertNotIn("type:'focus',id:sid", html, "no focus posted straight into the chat iframe any more")
+        self.assertNotIn("setTimeout", km._LANDING_REVEAL_JS, "event-based: the feed's ready, never a timer")
 
     def test_shell_ws_trues_up_the_badge(self):
         html = km._landing()
         self.assertIn("{type:'ready'}", html)      # connect → the kernel answers with the current count
         self.assertIn("setAppBadge", html)
         self.assertIn("clearAppBadge", html)       # zero clears, never leaves a stale number
+
+
+# The shell's reveal script, EXECUTED (the test_error_center.py pattern): node runs
+# _LANDING_REVEAL_JS against stubs of the few browser globals it touches, booting on a deep link
+# and then replaying the worker's messages. Pins the routing, not the words: /reveal is asked
+# with the shell's wid, the URL is stripped, the card waits for the FEED's ready (not the
+# timeline's), a turn kind reveals no card, a sid-less tap does nothing, a refused /reveal is loud.
+_REVEAL_HARNESS = r"""
+'use strict';
+const FETCHES = [], POSTED = [], NOTES = [], REPLACED = [], WIN = [], SW = [];
+let fetchOk = true;
+const feedWin = { postMessage: (m) => POSTED.push(m) };
+global.window = global;
+global.document = { getElementById: (id) => (id === 'f-feed' ? { contentWindow: feedWin } : null) };
+global.sessionStorage = { getItem: (k) => (k === 'romp:wid' ? 'W-test' : null) };
+global.addEventListener = (k, f) => { if (k === 'message') WIN.push(f); };
+Object.defineProperty(global, 'navigator', { configurable: true,   // a getter-only global in node 22
+  value: { serviceWorker: { addEventListener: (k, f) => { if (k === 'message') SW.push(f); } } } });
+global.history = { replaceState: (s, t, u) => REPLACED.push(u) };
+global.location = { href: 'http://localhost:7777/?push-reveal=S1&push-card=S1%3Ag1&keep=1#frag' };
+global.fetch = (path, init) => { FETCHES.push([path, JSON.parse(init.body)]);
+  return Promise.resolve(fetchOk ? { ok: true } : { ok: false, status: 400, text: () => Promise.resolve('missing sid') }); };
+global.__rompNotify = (kind, text) => NOTES.push([kind, text]);
+"""
+_REVEAL_DRIVER = r"""
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const swMsg = (m) => SW.forEach((f) => f({ data: m }));
+const winMsg = (m) => WIN.forEach((f) => f({ data: m }));
+(async () => {
+  const out = { boot: { fetches: FETCHES.slice(), replaced: REPLACED.slice(), postedBeforeReady: POSTED.length } };
+  winMsg({ romp: 'ready' });                              // the timeline's ready: not the feed's
+  out.boot.postedAfterTimelineReady = POSTED.length;
+  winMsg({ romp: 'ready', app: 'feed' });
+  out.boot.postedAfterFeedReady = POSTED.slice();
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S2', host: '', kind: 'card', cardId: 'S2:g4' });
+  out.live = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S3', host: '', kind: 'turn', cardId: '' });
+  out.turn = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  FETCHES.length = 0; POSTED.length = 0;
+  swMsg({ romp: 'notificationClick', sid: '', host: '', kind: 'test', cardId: '' });
+  out.test = { fetches: FETCHES.slice(), posted: POSTED.slice() };
+  fetchOk = false; FETCHES.length = 0;
+  swMsg({ romp: 'notificationClick', sid: 'S-bad', kind: 'turn' });
+  await tick(); await tick();
+  out.refused = { notes: NOTES.slice() };
+  console.log(JSON.stringify(out));
+})();
+"""
+
+
+class LandingRevealExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import subprocess, tempfile as _tf
+        with _tf.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(_REVEAL_HARNESS + km._LANDING_REVEAL_JS + _REVEAL_DRIVER)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the reveal script threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_a_cold_start_asks_the_kernel_at_once_and_strips_the_link(self):
+        b = self.out["boot"]
+        self.assertEqual(b["fetches"], [["/reveal", {"sid": "S1", "wid": "W-test"}]])
+        self.assertEqual(b["replaced"], ["/?keep=1#frag"], "only OUR params go; a reload must not replay the jump")
+
+    def test_the_card_waits_for_the_feeds_own_ready(self):
+        b = self.out["boot"]
+        self.assertEqual(b["postedBeforeReady"], 0, "no listener yet, nothing to scroll to")
+        self.assertEqual(b["postedAfterTimelineReady"], 0, "another pane's ready is not the feed's")
+        self.assertEqual(b["postedAfterFeedReady"], [{"romp": "revealCard", "itemId": "S1:g1", "sid": "S1"}])
+
+    def test_a_live_tap_routes_the_same_way(self):
+        live = self.out["live"]
+        self.assertEqual(live["fetches"], [["/reveal", {"sid": "S2", "wid": "W-test"}]])
+        self.assertEqual(live["posted"], [{"romp": "revealCard", "itemId": "S2:g4", "sid": "S2"}])
+
+    def test_a_turn_focuses_without_a_card_and_a_test_lands_nowhere(self):
+        self.assertEqual(len(self.out["turn"]["fetches"]), 1)
+        self.assertEqual(self.out["turn"]["posted"], [])
+        self.assertEqual(self.out["test"], {"fetches": [], "posted": []})
+
+    def test_a_refused_reveal_is_loud(self):
+        self.assertEqual(self.out["refused"]["notes"],
+                         [["error", "Could not open the session this notification was about: missing sid"]])
+
 
 
 class RailBell(unittest.TestCase):

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -170,7 +170,7 @@ class RelayRoute(unittest.TestCase):
         # the origin rides the sid AND the title, the way every federated surface wears it —
         # and badge is OMITTED (positional call, default None): the origin's count is not ours
         pn.assert_called_once_with("romp: boxa:web", "Needs you: fix the login flow",
-                                   "boxa:11111111-2222")
+                                   "boxa:11111111-2222", kind="card", card_id="", host="boxa")
         self.assertEqual(err, "")
 
     def test_title_and_sid_surgery_is_tolerant(self):
@@ -180,7 +180,23 @@ class RelayRoute(unittest.TestCase):
         status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": evs})
         self.assertEqual(status, 200)
         self.assertEqual(parsed["mirrored"], 1)
-        pn.assert_called_once_with("Custom shape", "b", "already:prefixed")
+        pn.assert_called_once_with("Custom shape", "b", "already:prefixed", kind="card", card_id="", host="boxa")
+
+    def test_kind_and_card_pass_through_with_the_origin_as_host(self):
+        # the card id is a goal id — globally unique, never host-prefixed (federation.ts) — so the
+        # merged feed finds it as-is; the sid wears the prefix and host names the origin outright
+        _seed_remote("boxa", "trusted")
+        ev = {"title": "romp: web", "body": "Needs you: x", "sid": "11111111-2222",
+              "kind": "card", "cardId": "11111111-2222:g1"}
+        status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": [ev]})
+        self.assertEqual(parsed["mirrored"], 1)
+        pn.assert_called_once_with("romp: boxa:web", "Needs you: x", "boxa:11111111-2222",
+                                   kind="card", card_id="11111111-2222:g1", host="boxa")
+        # …and the payload that reaches the phone carries both, the deep link included
+        d = km._push_payload("romp: boxa:web", "Needs you: x", "boxa:11111111-2222",
+                             kind="card", card_id="11111111-2222:g1", host="boxa")["data"]
+        self.assertEqual((d["sid"], d["host"], d["cardId"]), ("boxa:11111111-2222", "boxa", "11111111-2222:g1"))
+        self.assertEqual(d["url"], "/?push-reveal=boxa%3A11111111-2222&push-card=11111111-2222%3Ag1")
 
     def test_a_remembered_trusted_host_counts(self):
         # trust is judged by origin, attached or not — the remembered table is the origin store
@@ -188,7 +204,7 @@ class RelayRoute(unittest.TestCase):
         status, parsed, pn, _, _ = self._relay(
             {"origin": "boxb", "events": [{"title": "romp: api", "body": "Completed: done", "sid": "S2"}]})
         self.assertEqual(parsed, {"ok": True, "mirrored": 1})
-        pn.assert_called_once_with("romp: boxb:api", "Completed: done", "boxb:S2")
+        pn.assert_called_once_with("romp: boxb:api", "Completed: done", "boxb:S2", kind="card", card_id="", host="boxb")
 
     def test_below_trusted_drops_loudly_and_never_buzzes(self):
         _seed_remote("boxa", "directed")
@@ -266,7 +282,7 @@ class ForwardWiring(unittest.TestCase):
         # and local pushes consumed — never a second diff that could disagree
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("_fired = _feed_notifications(feed)", src)
-        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])',
+        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid, "kind": "card", "cardId": _iid}',
                       src)
 
 

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -120,7 +120,7 @@ class NotifyCardStore(unittest.TestCase):
 
 
 class FeedNotifications(unittest.TestCase):
-    """The diff detector: [(title, body)] per armed card newly in needs_input/completed."""
+    """The diff detector: [(title, body, sid, itemId)] per armed card newly in needs_input/completed."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -223,6 +223,7 @@ class FeedNotifications(unittest.TestCase):
                                            _card("OTHERSID:g1", "OTHERSID", "needs_input")))
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0][2], "OTHERSID", "only the unmuted session's card notifies")
+        self.assertEqual(out[0][3], "OTHERSID:g1", "the card's own id rides along for the tap to land on")
 
     def test_a_card_arm_overrides_its_sessions_mute(self):
         # most-specific-wins: card > session > master
@@ -305,7 +306,7 @@ class NotifyWiring(unittest.TestCase):
         # (the sid joined the tuple 2026-08-08 so the push sink can aim its tap-to-open; the list
         # got a name the same day so the federated forward rides the SAME events, never a re-diff)
         self.assertIn("_fired = _feed_notifications(feed)", self.src)
-        self.assertIn("for _t, _b, _sid in _fired:", self.src)
+        self.assertIn("for _t, _b, _sid, _iid in _fired:", self.src)   # itemId: the tap scrolls the feed to the card
         self.assertIn("_system_notify(_t, _b)", self.src)
         self.assertIn("_push_forward([{", self.src)   # trusted peers hear the same transition
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -253,6 +253,7 @@ const pendingMoveKind = new Map<string, MoveKind>();
 // trail instead of unreproducible archaeology. Ids only, no card text.
 const shownCol = new Map<string, string>();            // itemId → column as last RENDERED (post-prediction)
 let lastFeedEvent = "init";                            // the input change the next render reflects
+let feedAnnounced = false;                             // {romp:'ready'} posted to the shell once, on the first payload's render
 let lastPayloadBuildId = 0;
 function auditShownColumns(list: AskItem[]) {
   const seen = new Set<string>();
@@ -5108,6 +5109,13 @@ function applyFeedPayload(m: any): void {
   if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
   if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;
   render();
+  if (!feedAnnounced) {
+    feedAnnounced = true;
+    // First content is on screen → tell the shell, the way the timeline does: the boot splash's cue, and the
+    // exact event a notification tap's card reveal waits for — the shell holds its {romp:'revealCard'} until
+    // the feed has cards to scroll to (kernel.py _LANDING_REVEAL_JS). Standalone page: no parent, nothing to say.
+    try { if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "ready", app: "feed" }, "*"); } catch { /* no shell */ }
+  }
 }
 
 
@@ -5117,9 +5125,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.romp === "paneFocus") { kbEnterCards(); return; }   // the shell handed us keyboard focus → arm card nav
   if (m.romp === "revealCard") {
-    // a bell-entry click jumps back to the card it was minted from (the user 2026-07-28): scroll it
-    // into view and pulse it accent so the eye lands on the right card. A card that no longer exists
-    // under its own key (cleared, or folded into a group) falls back to opening the session.
+    // a bell-entry click (the user 2026-07-28) or a notification tap (2026-09-06) jumps to the card it was
+    // minted from: scroll it into view and pulse it accent so the eye lands on the right card. A card in a
+    // FOLDED thread has no element yet — unfold first (the same rule revealCards follows: the navigation wins
+    // over the disclosure). A card that no longer exists under its own key (cleared, or folded into a group)
+    // falls back to opening the session.
+    unfoldThreadsFor(new Set(["a:" + String(m.itemId || "")]));
     const target = document.querySelector(`[data-key="a:${String(m.itemId || "")}"]`) as HTMLElement | null;
     if (target) {
       target.scrollIntoView({ block: "center", behavior: "smooth" });
@@ -5364,20 +5375,23 @@ function applyExtHover() {
 // exactly the cards a hover would have outlined. The class is removed and re-added across a forced
 // reflow, or a second click on the same card would re-add a class it already has and CSS would replay
 // nothing — the "clicked again and it didn't flash" bug this shape avoids.
-function revealCards(keys: Set<string>) {
-  // A target inside a FOLDED thread has no element to scroll to, and a jump that lands on nothing is the
-  // silent no-op a collapse must never cause (the user 2026-07-31). Unfold the owning thread(s) and render
-  // before looking: the navigation wins over the disclosure, and the thread stays open afterwards so you
-  // can see where you were taken.
-  if (collapsedThreads.size) {
-    let opened = false;
-    for (const a of asks) {
-      if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
-        collapsedThreads.delete(a.sid); opened = true;
-      }
+// A target inside a FOLDED thread has no element to scroll to, and a jump that lands on nothing is the
+// silent no-op a collapse must never cause (the user 2026-07-31). Unfold the owning thread(s) and render
+// before looking: the navigation wins over the disclosure, and the thread stays open afterwards so you
+// can see where you were taken. Shared by every "take me to this card" entry (revealCards, revealCard).
+function unfoldThreadsFor(keys: Set<string>): void {
+  if (!collapsedThreads.size) return;
+  let opened = false;
+  for (const a of asks) {
+    if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
+      collapsedThreads.delete(a.sid); opened = true;
     }
-    if (opened) render();
   }
+  if (opened) render();
+}
+
+function revealCards(keys: Set<string>) {
+  unfoldThreadsFor(keys);
   const hits = Array.from(document.querySelectorAll<HTMLElement>("[data-key]"))
     .filter((c) => extHoverMatches(c.dataset.key, keys));
   if (!hits.length) return;

--- a/ui/webview/notify-click-reveal.test.ts
+++ b/ui/webview/notify-click-reveal.test.ts
@@ -1,0 +1,37 @@
+// A notification tap lands on the session AND the card that buzzed (the user 2026-09-06). The feed's
+// half of that, pinned from both sides of the iframe boundary: the feed announces its first content
+// so the shell knows when a {romp:'revealCard'} has something to land on, and the reveal itself never
+// dead-ends on a folded thread. Source pins against feed.ts + kernel.py (the render path has no jsdom
+// harness), like card-notify's; the shell script itself is EXECUTED by tests/test_kernel_webpush.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the feed announces its FIRST payload's render to the shell, once, the way the timeline does", () => {
+  assert.match(SRC, /let feedAnnounced = false;/);
+  // after render() inside applyFeedPayload — the cards are in the DOM when this leaves the frame
+  assert.match(SRC, /render\(\);\n  if \(!feedAnnounced\) \{\n    feedAnnounced = true;/);
+  assert.match(SRC, /window\.parent\.postMessage\(\{ romp: "ready", app: "feed" \}, "\*"\)/);
+  assert.equal(SRC.match(/romp: "ready", app: "feed"/g)?.length, 1, "one announcement, one place");
+});
+
+test("the shell's reveal script waits for exactly that message, never another pane's ready", () => {
+  // the two sides of the contract share the words: app:'feed' is what the shell keys on
+  assert.match(KERNEL, /m\.romp==='ready'&&m\.app==='feed'/);
+  assert.match(KERNEL, /pendingCard=\{itemId:itemId,sid:sid\};return;/, "a tap before the feed is up is held, not dropped");
+  assert.doesNotMatch(KERNEL.slice(KERNEL.indexOf("_LANDING_REVEAL_JS = "), KERNEL.indexOf("_LANDING_REVEAL_JS = ") + 2600),
+    /setTimeout/, "event-based: the feed's own ready, no timer");
+});
+
+test("revealCard unfolds a collapsed thread before looking for the card (no silent miss on a fold)", () => {
+  assert.match(SRC, /function unfoldThreadsFor\(keys: Set<string>\): void \{/);
+  // both "take me to this card" entries share it: the bell-entry/notification jump and the chat-dot jump
+  assert.match(SRC, /unfoldThreadsFor\(new Set\(\["a:" \+ String\(m\.itemId \|\| ""\)\]\)\);\n    const target = document\.querySelector/);
+  assert.match(SRC, /function revealCards\(keys: Set<string>\) \{\n  unfoldThreadsFor\(keys\);/);
+  // and the existing fallback stands: a card gone from the feed still opens its session
+  assert.match(SRC, /\} else if \(m\.sid\) \{\n      vscodeApi\?\.postMessage\(\{ type: "openSession", id: String\(m\.sid\) \}\);/);
+});


### PR DESCRIPTION
## What a tap does now

Tapping a romp web-push notification (phone PWA or desktop browser):

1. **Focuses the romp window you already have open** instead of opening a new one — the service worker's `notificationclick` closes the notification, `matchAll`s same-origin windows, focuses the most recently used one and posts `{romp:'notificationClick', sid, host, kind, cardId}` to it.
2. **Lands on the session that buzzed** — the shell asks the kernel for the focus (`POST /reveal`, aimed at its own window id). A live session gets its chat tab activated on the live tail; a dead or unknown one gets the revive prompt, never a silent no-op; a refused `/reveal` lands in the Log.
3. **For a card notification, scrolls the feed to that card** (`revealCard` into the feed iframe, the same message the Log's bell entries use), once the feed has announced its first payload. The feed's `revealCard` now unfolds a collapsed thread before looking.
4. **No window open** (or `focus()` refused, as an installed iOS app can): `openWindow` on the kernel's deep link `/?push-reveal=<sid>[&push-card=<id>]`; the shell parks the focus with the kernel until its chat pane is ready (the existing event-based park) and strips the params with `replaceState` so a reload does not replay the jump.
5. A test notification (no sid) just focuses/opens romp.

Everything rides `waitUntil`; no timers anywhere in the worker or the shell script.

## Payload

Built by one shared `_push_payload`, which every push kind goes through:

```
{ title, body, sid, tag: "romp:<sid>" | "romp:test", badge?,
  data: { sid, host, kind: "card"|"turn"|"test", cardId, url } }
```

- `tag` collapses repeated pushes for one session (`renotify` keeps them audible); there was no tag before.
- `sid` stays at the top level for a worker of the previous build still installed somewhere.
- The card leg passes `kind="card"` + its goal id. The federation forward and `/push/relay` carry `kind`/`cardId` through; the relay stamps the origin as `host` (the sid already wears it as the `host:sid` prefix the merged dashboard routes; the card id is a goal id and never prefixed).
- PR #937's turn leg and test push are not on main yet; once it lands, `_turn_notify_tick` passes `kind="turn"` and `_push_test` builds its payload with `_push_payload(..., kind="test")` — one argument each.

## Before / after in the worker

Before: `close → matchAll → ws[0].focus().then(postMessage {romp:'pushReveal', sid})`, else `openWindow('/?push-reveal=sid')`; a rejected `focus()` dropped the tap; the shell posted a bare `focus` straight into the chat iframe on the live path (no dead-session check, no card).

After: focus-first with the routing block, `openWindow(url)` on no window **or** refused focus, and both arrivals routed through `/reveal` + the feed's card reveal.

## Desktop

`_system_notify` (osascript `display notification` / `notify-send`) has no cheap click hook — macOS offers none, and `notify-send --action` blocks on the reply. Left as is.

## Verified

- `tests/test_kernel_webpush.py`: the worker and the shell's reveal script are **executed under node** against stubs — close → matchAll → focus + postMessage; openWindow on no window / refused focus; legacy flat-sid payloads; the card waits for the *feed's* ready, not the timeline's; turn/test kinds; loud failure. Payload shape per kind.
- `tests/test_kernel_webpush_federation.py`: forward keeps kind + cardId; relay passes them through with the origin as host; the mirrored deep link.
- `tests/test_notify_bells.py`, `tests/test_kernel_mobile.py` (script-count pin +1), `ui/webview/notify-click-reveal.test.ts` (feed-side pins).
- `npm run typecheck && npm test` (2784 pass) `&& npm run build`; full Python suite: 7348 passed, 40 skipped.
- **Real-device verification is your tap on the phone**: install the current build, arm the bell, tap a needs-you push with the app open and again with it closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
