### PR TITLE
The boot orphan reaper matches under systemd (orphaned = parent is not a live kernel, not ppid 1) and reads ps with -ww

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1239,26 +1239,53 @@ def _cli_carries_sid(cmd: str, sids) -> bool:
     return False
 
 
+def _is_kernel_cmd(cmd: str) -> bool:
+    """Does this `ps` command text name a romp kernel? The manager runs `romp-serve`, which execs
+    `<python> <repo>/bin/romp-kernel` (bin/romp-serve's last line), so a kernel shows as
+    `/usr/bin/python3.12 …/bin/romp-kernel`; a hand-run one is `bin/romp-kernel` or
+    `python3 kernel/kernel.py`. Matched on argv TOKENS — the basename `romp-kernel`, or a
+    `kernel/kernel.py` path — never on a substring, so `tail -f …/romp-kernel.log` is not a kernel."""
+    for tok in cmd.split():
+        base = tok.rsplit("/", 1)[-1]
+        if base == "romp-kernel":
+            return True
+        if tok in ("kernel.py", "kernel/kernel.py") or tok.endswith("/kernel/kernel.py"):
+            return True
+    return False
+
+
 def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
     """PIDs of ORPHANED SDK-driven `claude` CLIs holding one of OUR sessions (--resume/--session-id
-    in either flag spelling, + the stream-json mark — see _cli_carries_sid). Orphaned = re-parented
-    to launchd (ppid 1): a live SDK CLI is always a child of the kernel that spawned it, so only a
-    dead kernel's leftover — a zombie writer that would fight the resume for the transcript —
-    reaches ppid 1. The parent check is load-bearing: matching on the command line alone let a
-    duplicate backend's reconcile reap freshly-resumed LIVE sessions mid-turn (2026-07-06). Pure
+    in either flag spelling, + the stream-json mark — see _cli_carries_sid). Orphaned = its PARENT
+    is not a live romp kernel (absent from the listing, or a process that is not a kernel): a live
+    SDK CLI is always a child of the kernel that spawned it, so only a dead kernel's leftover — a
+    zombie writer that would fight the resume for the transcript — has any other parent. The parent
+    check is load-bearing: matching on the command line alone let a duplicate backend's reconcile
+    reap freshly-resumed LIVE sessions mid-turn (2026-07-06); and a CLI parented to a DIFFERENT live
+    kernel is that kernel's, never reaped here.
+
+    Until 2026-09-05 "orphaned" meant ppid 1 (macOS: an orphan re-parents to launchd). Under
+    `systemd --user` that never happens: the user manager sets PR_SET_CHILD_SUBREAPER, so a CLI left
+    behind by a kernel that died without a drain (a crash respawn, a SIGKILL at the service's stop
+    timeout) re-parents to the `systemd --user` pid (verified on a Linux box that day: ppid = the user
+    manager, never 1), and this reaper had matched nothing on Linux under the service all along; only
+    a full service restart, which empties the unit's cgroup (systemd's default KillMode=control-group),
+    ever ended such a CLI. The definition now names the property the ppid-1 check approximated. Pure
     (takes `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
-    out = []
+    procs: dict[int, tuple[int, str]] = {}    # pid -> (ppid, command), in listing order
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
         if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
             continue
-        pid, ppid, cmd = int(parts[0]), int(parts[1]), parts[2]
-        if ppid != 1:
+        procs[int(parts[0])] = (int(parts[1]), parts[2])
+    out = []
+    for pid, (ppid, cmd) in procs.items():
+        if _SDK_CLI_MARK not in cmd or not _cli_carries_sid(cmd, lastsids):
             continue
-        if _SDK_CLI_MARK not in cmd:
-            continue
-        if _cli_carries_sid(cmd, lastsids):
-            out.append(pid)
+        parent = procs.get(ppid)
+        if parent is not None and _is_kernel_cmd(parent[1]):
+            continue    # a live kernel's child — ours or another kernel's, either way not an orphan
+        out.append(pid)
     return out
 
 
@@ -1267,8 +1294,8 @@ def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> i
     The interrupt escalation's (and the drain reap's) target: same signature match as
     find_orphan_clis (_cli_carries_sid + the stream-json mark) but the OPPOSITE parent check — it
     may only signal our own child, never a tmux CLI (no mark), never another kernel's, never an
-    orphan (ppid 1, the reaper's territory). Pure (takes `ps -axo pid=,ppid=,command=` lines) so
-    tests need no live processes."""
+    orphan (a CLI whose parent is no live kernel — the reaper's territory). Pure (takes
+    `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
         if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
@@ -4895,8 +4922,9 @@ class SdkBackend:
     def _boot_reconcile(self, regs: list[dict]) -> None:
         """The kernel just booted — reconcile what the previous kernel's death left behind. Event-keyed
         on the boot itself plus each session's state tail, never on ages or timers:
-          * REAP orphaned SDK CLIs still resuming our sessions: a dead kernel's children re-parent to
-            launchd and keep writing the transcript, so a resume would give the conversation two writers.
+          * REAP orphaned SDK CLIs still resuming our sessions: a dead kernel's children re-parent
+            (to launchd on macOS, to the `systemd --user` subreaper on Linux) and keep writing the
+            transcript, so a resume would give the conversation two writers.
           * A session whose state tail is 'working' had its turn CUT by the kernel death — a user
             interrupt writes 'idle', a finished turn 'waiting'; only a kill leaves 'working' — so resume
             it with a visible continuation nudge (BOOT_RESUME_NUDGE) ahead of its restored queue. The

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1220,6 +1220,15 @@ def task_death_notice(tasks: list, cause: str = "a restart or crash") -> str:
 # interactive `claude --resume` never has it, so the orphan reap can never touch a tmux CLI.
 _SDK_CLI_MARK = "--input-format stream-json"
 
+# The `ps` listing the boot reaper (find_orphan_clis) and the interrupt escalation (find_session_cli)
+# read. `-ww` is load-bearing: without it procps truncates every line to $COLUMNS whenever that
+# variable is exported (BSD ps does the same by default), and the sid an SDK CLI carries sits about
+# 2 KB into its argv, behind --append-system-prompt — so a kernel started from a shell that exported
+# COLUMNS matched nothing and reaped nothing, with no error. Verified on procps-ng 4.0.4 (2026-09-05):
+# `COLUMNS=80 ps -axo …` cut a 3200-character argv at 80 columns, `-axwwo` printed it whole. `-ww`
+# means unlimited width on procps and BSD ps alike.
+PS_ARGV = ["ps", "-axwwo", "pid=,ppid=,command="]
+
 
 def _cli_carries_sid(cmd: str, sids) -> bool:
     """True when this CLI's argv names one of OUR conversation ids. The Agent SDK has spelled the
@@ -1271,7 +1280,7 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
     manager, never 1), and this reaper had matched nothing on Linux under the service all along; only
     a full service restart, which empties the unit's cgroup (systemd's default KillMode=control-group),
     ever ended such a CLI. The definition now names the property the ppid-1 check approximated. Pure
-    (takes `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
+    (takes PS_ARGV's `ps -axwwo pid=,ppid=,command=` lines) so tests need no live processes."""
     procs: dict[int, tuple[int, str]] = {}    # pid -> (ppid, command), in listing order
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
@@ -1295,7 +1304,7 @@ def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> i
     find_orphan_clis (_cli_carries_sid + the stream-json mark) but the OPPOSITE parent check — it
     may only signal our own child, never a tmux CLI (no mark), never another kernel's, never an
     orphan (a CLI whose parent is no live kernel — the reaper's territory). Pure (takes
-    `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
+    PS_ARGV's `ps -axwwo pid=,ppid=,command=` lines) so tests need no live processes."""
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
         if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
@@ -4910,8 +4919,7 @@ class SdkBackend:
         find_session_cli matcher, so the signal can only ever land on our own child. None (logged by
         the caller) when no such process exists."""
         try:
-            ps = subprocess.run(["ps", "-axo", "pid=,ppid=,command="],
-                                capture_output=True, text=True, timeout=10)
+            ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10)
             reg = read_reg(self.state_dir, session.sid) or {}
             sids = [session.sid, str(reg.get("lastSid") or "")]
             return find_session_cli(ps.stdout.splitlines(), sids, os.getpid())
@@ -4948,8 +4956,7 @@ class SdkBackend:
             lastsids = [str(r.get("lastSid") or "") for r in alive if r.get("lastSid")]
             if lastsids:
                 try:
-                    ps = subprocess.run(["ps", "-axo", "pid=,ppid=,command="],
-                                        capture_output=True, text=True, timeout=10).stdout
+                    ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10).stdout
                     for pid in find_orphan_clis(ps.splitlines(), lastsids):
                         if pid == os.getpid():
                             continue

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -20,11 +20,16 @@ All deterministic: no SDK import, no real claude processes (ps/os.kill are patch
 """
 import json
 import os
+import shutil
+import subprocess
+import sys
 import tempfile
 import signal
 import threading
 import time
+import types
 import unittest
+import uuid
 from pathlib import Path
 from unittest import mock
 from importlib.machinery import SourceFileLoader
@@ -185,6 +190,83 @@ class QueuePersistence(unittest.TestCase):
                          "restores strings only — junk entries never wedge delivery")
 
 
+def _procps() -> bool:
+    """Whether this box's ps is procps (Linux; BSD ps has no --version). The truncation control below
+    pins procps behaviour, so it runs only there."""
+    try:
+        return "procps" in subprocess.run(["ps", "--version"], capture_output=True, text=True, timeout=10).stdout
+    except Exception:
+        return False
+
+
+class PsArgv(unittest.TestCase):
+    """The `ps` both process scans run. `-ww` is the point: procps truncates every line to $COLUMNS
+    when that variable is exported (BSD ps does by default), and an SDK CLI's sid sits ~2 KB into its
+    argv behind --append-system-prompt, so a kernel started with COLUMNS exported reaped nothing and
+    could not find its own child to signal, silently (2026-09-05; `COLUMNS=80 ps -axo` cut a 3200-char
+    argv at 80 columns on procps-ng 4.0.4, `-axwwo` printed it whole). The first three tests pin the
+    argv and its two call sites through mocks; the last two run this box's ps against a real long argv,
+    on Linux only, so the width property itself has an executable check."""
+
+    def test_the_argv_asks_for_unlimited_width(self):
+        self.assertEqual(sb.PS_ARGV, ["ps", "-axwwo", "pid=,ppid=,command="])
+
+    # GNU sleep rejects a non-numeric argument, so the sleeper with the >3000-character argv is this
+    # interpreter, given the marker as an argument it ignores; it is killed on the way out. The marker is
+    # minted per test so nothing else on the box (this process's own argv included) can carry it.
+    def _sleeper_with_a_long_argv(self):
+        marker = "romp-ps-ww-tail-" + uuid.uuid4().hex
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)", "x" * 3000 + marker],
+                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(child.wait, timeout=10)
+        self.addCleanup(child.kill)
+        return child, marker
+
+    def _ps_line_for(self, pid, argv):
+        out = subprocess.run(argv, env={**os.environ, "COLUMNS": "80"}, capture_output=True, text=True,
+                             timeout=10).stdout
+        mine = [ln for ln in out.splitlines() if ln.split()[:1] == [str(pid)]]
+        self.assertEqual(len(mine), 1, "one line for the sleeper's pid: %r" % (mine,))
+        return mine[0]
+
+    @unittest.skipUnless(sys.platform.startswith("linux") and shutil.which("ps"), "a real ps on Linux")
+    def test_a_real_ps_under_columns_80_prints_a_3000_character_argv_whole(self):
+        child, marker = self._sleeper_with_a_long_argv()
+        line = self._ps_line_for(child.pid, sb.PS_ARGV)
+        self.assertIn(marker, line, "the argv's tail survived COLUMNS=80 (line is %d chars)" % len(line))
+        self.assertGreater(len(line), 3000)
+
+    @unittest.skipUnless(sys.platform.startswith("linux") and _procps(), "procps ps on Linux")
+    def test_without_ww_the_same_ps_cuts_the_argv_at_columns(self):
+        # the control: the argv PS_ARGV replaced (-axo) loses the marker on procps, so the test above
+        # passes because of -ww and not because this box's ps never truncates
+        child, marker = self._sleeper_with_a_long_argv()
+        line = self._ps_line_for(child.pid, ["ps", "-axo", "pid=,ppid=,command="])
+        self.assertNotIn(marker, line)
+        self.assertLessEqual(len(line), 80)
+
+    def test_the_interrupt_escalation_reads_ps_with_it(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        sid = "11111111-aaaa-0000-0000-00000000000f"
+        _reg(d, sid)
+        # our own child (ppid = this process), its sid 2 KB into the argv — what -ww keeps intact
+        ps = "  4242 %d /x/claude --append-system-prompt %s --resume %s --input-format stream-json\n" % (
+            os.getpid(), "p" * 2100, sid)
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)) as run:
+            pid = be._session_cli_pid(types.SimpleNamespace(sid=sid, name="web"))
+        self.assertEqual(pid, 4242)
+        self.assertEqual(run.call_args_list[0][0][0], sb.PS_ARGV)
+
+    def test_the_boot_reaper_reads_ps_with_it(self):
+        # the reaper's own reap test (BootReconcile.test_reaps_orphans_but_never_tmux) pins the same
+        # argv on its call; this one pins that the two sites share ONE constant, so neither can drift
+        with open(sb.__file__) as f:
+            src = f.read()
+        self.assertNotIn('"-axo"', src, "every ps scan goes through PS_ARGV (-ww)")
+        self.assertEqual(src.count("subprocess.run(PS_ARGV"), 2, "the reaper and the escalation")
+
+
 class BootReconcile(unittest.TestCase):
     def _setup(self):
         d = tempfile.mkdtemp()
@@ -298,12 +380,13 @@ class BootReconcile(unittest.TestCase):
               "  557 90210 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
               ) % (sid, sid, sid)
         killed = []
-        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)), \
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)) as run, \
              mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
             be._boot_reconcile([sb.read_reg(Path(d), sid)])
         self.assertEqual(killed, [(555, sb.signal.SIGTERM)],
                          "the SDK orphan is reaped; the tmux CLI and the live (parented) CLI "
                          "on the same sid are untouched")
+        self.assertEqual(run.call_args_list[0][0][0], sb.PS_ARGV, "the listing is read with PS_ARGV")
 
     def test_reconcile_is_opt_in(self):
         # Constructing the backend plain (tests, ad-hoc) must NOT spawn a reconcile thread; the

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -7,7 +7,8 @@ Covers the backend half:
     re-seeded from it, so a kernel death can DELAY queued turns but never lose them;
   * last_state_value — the cut-turn discriminator reads the last STATE record through the
     interleaved awaiting overlays (the boot heal itself appends one);
-  * find_orphan_clis — matches only ORPHANED (ppid 1) SDK-driven CLIs (--resume <ours> +
+  * find_orphan_clis — matches only ORPHANED SDK-driven CLIs, i.e. whose parent is no live romp
+    kernel (ppid 1 on macOS; the `systemd --user` subreaper on Linux, 2026-09-05) (--resume <ours> +
     stream-json), never a tmux session's interactive `claude --resume` and never a LIVE CLI still
     parented to a kernel (2026-07-06: a duplicate backend's reconcile reaped live sessions);
   * _boot_reconcile — resumes exactly the cut-turn / queued sessions (a user-interrupted or
@@ -81,14 +82,65 @@ class FindOrphanClis(unittest.TestCase):
         self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [4242])
 
     def test_live_children_are_never_orphans(self):
-        # Same command line as a true orphan, but still parented to a running kernel (ppid != 1):
-        # a LIVE session's CLI. Reaping these was the 2026-07-06 kill storm — a duplicate backend's
-        # reconcile SIGTERM'd freshly-resumed sessions mid-turn (exit 143).
+        # Same command line as a true orphan, but still parented to a running kernel (the kernel's
+        # own line is in the listing): a LIVE session's CLI. Reaping these was the 2026-07-06 kill
+        # storm — a duplicate backend's reconcile SIGTERM'd freshly-resumed sessions mid-turn (exit 143).
         lines = [
+            " 38438 901 /usr/bin/python3.12 /x/romp/bin/romp-kernel",
             " 4242 38438 /x/claude --output-format stream-json --resume %s --input-format stream-json" % self.SID,
             " 4245 1 /x/claude --output-format stream-json --resume %s --input-format stream-json" % self.SID,
         ]
         self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [4245])
+
+    # Orphaned = the parent is not a live romp kernel (2026-09-05). Until then the check was ppid 1,
+    # which is what an orphan gets under launchd — and never under `systemd --user`, whose
+    # PR_SET_CHILD_SUBREAPER re-parents an orphan to the user manager's pid, so the reap had matched
+    # nothing on Linux under the service.
+    def _cli(self, pid, ppid):
+        return " %d %d /x/claude --output-format stream-json --resume=%s --input-format stream-json" % (pid, ppid, self.SID)
+
+    def test_orphan_reparented_to_launchd(self):
+        # macOS: pid 1 is launchd, present in the listing and not a kernel
+        lines = [" 1 0 /sbin/launchd", self._cli(700, 1)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [700])
+
+    def test_orphan_reparented_to_the_systemd_user_manager(self):
+        # Linux under the service: the orphan's ppid is the `systemd --user` pid, never 1
+        lines = [" 1 0 /sbin/init", " 901 1 /usr/lib/systemd/systemd --user", self._cli(701, 901)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [701])
+
+    def test_orphan_whose_parent_is_absent_from_the_listing(self):
+        # the parent died between the CLI's line and its own (ps is not atomic) — an orphan
+        lines = [self._cli(702, 65000)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [702])
+
+    def test_a_live_cli_parented_to_a_romp_kernel_is_never_reaped(self):
+        for kernel in (" 500 901 /usr/bin/python3.12 /x/romp/bin/romp-kernel",
+                       " 500 901 python3 bin/romp-kernel",
+                       " 500 901 python3 kernel/kernel.py",
+                       " 500 901 /usr/bin/python3 /x/romp/kernel/kernel.py"):
+            lines = [" 901 1 /usr/lib/systemd/systemd --user", kernel, self._cli(703, 500)]
+            self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [], kernel)
+
+    def test_a_cli_parented_to_a_different_live_kernel_is_that_kernels(self):
+        # another kernel (an aux port, a second install) owns this CLI — not ours to reap, whatever
+        # sid it carries; the orphan next to it, parented to the user manager, still is
+        lines = [" 901 1 /usr/lib/systemd/systemd --user",
+                 " 600 901 /usr/bin/python3.12 /elsewhere/romp/bin/romp-kernel",
+                 self._cli(704, 600), self._cli(705, 901)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [705])
+
+    def test_kernel_match_is_on_argv_tokens_not_substrings(self):
+        self.assertTrue(sb._is_kernel_cmd("/usr/bin/python3.12 /x/romp/bin/romp-kernel"))
+        self.assertTrue(sb._is_kernel_cmd("python3 kernel/kernel.py"))
+        self.assertTrue(sb._is_kernel_cmd("python3 kernel.py"))
+        # a process merely mentioning the kernel is not one: its child would be an orphan
+        self.assertFalse(sb._is_kernel_cmd("tail -f /x/state/romp/romp-kernel.log"))
+        self.assertFalse(sb._is_kernel_cmd("node /x/romp/bin/romp-manager up"))
+        self.assertFalse(sb._is_kernel_cmd("/usr/lib/systemd/systemd --user"))
+        self.assertFalse(sb._is_kernel_cmd("python3 other/kernel.py"))
+        lines = [" 800 1 tail -f /x/state/romp/romp-kernel.log", self._cli(706, 800)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [706])
 
     def test_empty_sids_match_nothing(self):
         lines = [" 1 1 claude --resume  --input-format stream-json"]
@@ -242,6 +294,7 @@ class BootReconcile(unittest.TestCase):
         sb.append_state(Path(d), sid, "working")
         ps = ("  555 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
               "  556 1 claude --resume %s --name termsess\n"
+              "  90210 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
               "  557 90210 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
               ) % (sid, sid, sid)
         killed = []


### PR DESCRIPTION
Two bugs made `find_orphan_clis` match nothing, with no error, and the second one also blinded the interrupt escalation's process scan. Both live in `kernel/sdk_backend.py`; each commit fixes one and carries tests that fail before it.

## What breaks

**1. Under `systemd --user`, the boot reaper never matched.** `find_orphan_clis` called an SDK CLI orphaned only when its ppid was 1, which describes launchd on macOS. Under the Linux install (`romp-service` writes a `systemd --user` unit) the user manager is a child subreaper, so a CLI left behind by a kernel that died without a drain (a crash respawn, a SIGKILL at the service's stop timeout, a kernel killed by hand) re-parents to the user manager's pid, never to 1. The reap has matched nothing on Linux under the service since it was written. The one thing that ended such a CLI was a full service restart: the unit sets no `KillMode`, so systemd's default empties the whole cgroup. Until then the orphan kept writing the transcript the resumed session was also writing.

**2. Both process scans ran `ps -axo`, which truncates.** procps cuts every output line to an exported `$COLUMNS` (BSD ps does so by default), and the sid an SDK CLI carries sits about 2 KB into its argv, behind `--append-system-prompt`. A kernel started from a shell that exported `COLUMNS` neither reaped orphans nor found its own child to signal (`_session_cli_pid`, the interrupt escalation).

## Reproduction

Both observed on a Linux install under the service (procps-ng 4.0.4):

- `ps -axwwo pid=,ppid=,command= | grep -- '--input-format stream-json'` lists every live SDK CLI with the kernel's pid as ppid. After a kernel dies without a drain (the manager respawns it), the same listing shows the leftover CLIs with the `systemd --user` pid as ppid, not 1, so the old `ppid != 1` test skipped them and the new kernel's boot reconcile logged `reaped 0 orphaned CLI(s)`.
- `COLUMNS=80 ps -axo pid=,ppid=,command= | grep -c -- '--input-format stream-json'` prints 0 while `-axwwo` on the same box prints the live count (20 at the time); every `-axo` line is exactly 80 characters.

## The fix

- `find_orphan_clis` builds a pid -> (ppid, command) map from the listing and calls an SDK-marked CLI holding one of our sids orphaned when its parent is absent from the listing or is not a romp kernel. `_is_kernel_cmd` decides on argv tokens (a token with basename `romp-kernel`, or a `kernel/kernel.py` path), never on substrings, so a `tail -f .../romp-kernel.log` parent is not a kernel. The parent check stays load-bearing: a CLI parented to any live kernel, another instance's included, is left alone (the 2026-07-06 duplicate-backend reap of live sessions stays prevented), and tmux-run interactive CLIs are untouched as before (no stream-json mark). The caller, `_boot_reconcile`, is unchanged.
- One constant, `PS_ARGV = ["ps", "-axwwo", "pid=,ppid=,command="]`, serves both scans. `-ww` is unlimited width on procps and on BSD ps (verified on procps; read from the man page for BSD, not run).

## Tests (`tests/test_sdk_lifecycle_hardening.py`)

Commit 1, `FindOrphanClis`: an orphan under launchd; an orphan under the systemd user manager; an orphan whose parent is absent from the listing; a live CLI under four kernel spellings, never reaped; a CLI under a different live kernel left alone while its neighbour under the user manager is reaped; the token-vs-substring pin for `_is_kernel_cmd`. The two existing fixtures that encoded "ppid != 1 means live" gain the parent kernel's own line. Four of the six new tests fail on the base (the launchd case and the four-spellings case hold under both definitions and stay as regression guards).

Commit 2, `PsArgv`: pins the argv; both call sites through mocks (the escalation finds a child whose sid sits 2 KB into the argv; the reap test asserts the argv it ran); a source scan that no `"-axo"` remains and both sites share the one constant (deliberately brittle: a third ps site in the module must update it); and two Linux-only tests that run the real `ps` with `COLUMNS=80` against a process whose argv carries a marker past its 3000th character. With `PS_ARGV` the marker survives; with the old `-axo` argv the line is cut at 80 columns. The second is the control (procps only) and passes before and after by design; every other PsArgv test fails on the base. The real-ps tests skip where `ps` is absent or not procps, so the macOS job skips them and the ubuntu job runs them.

## Boundaries worth a look

- A live SDK CLI whose direct parent is not a kernel process is reaped at the next boot. The Agent SDK spawns the CLI directly, so a stock install has no such process; a non-exec wrapper script installed as `claude` would create one.
- `_is_kernel_cmd` recognizes what `romp-serve` runs (`exec <python> .../bin/romp-kernel`) and a hand-run `python3 kernel/kernel.py`. A kernel launched another way (`python -m kernel.kernel`) is not recognized, which matters only with two kernels running at once. A process whose command text merely contains such a token (a shell whose command line names the kernel path) counts as a kernel and shields its children; that is the safe direction, since a false "kernel" prevents a reap and never causes one.
- The reaper still sends SIGTERM only, as before.
- The separate `ps -axo pid=,command=` in `kernel/kernel.py` (ssh tunnel cleanup) is untouched: short argv, different matcher. It could route through the same constant in a follow-up.
- No docs change: the reference does not describe the reaper.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)