### PR TITLE
To-do card: a TaskCreate the CLI rejected is not a checklist item

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2768,12 +2768,14 @@ def declared_plan(session):
     [{key, text, activeForm, status}] — the FALLBACK behind task_store_plan for a session with no
     live task store, so downstream (the judge's plan-sync) sees a generic 'declared plan' shape
     instead of raw tool calls. Mirrors the kernel's _fold_tasks, with the same blind spots: only the
-    MAIN agent's TaskCreate/TaskUpdate calls, and only those on the transcript's live chain.
+    MAIN agent's TaskCreate/TaskUpdate calls, and only those on the transcript's live chain — and the
+    same skip: a TaskCreate the CLI rejected (its paired tool_result carries is_error) is not a step.
     `key` is the stable `Task #N` id lifted from TaskCreate's
     result text (a creation-order `cN` fallback if the result is unreadable); `status` rides each
     TaskUpdate. Only TaskCreate/TaskUpdate are folded — plain TodoWrite (no durable ids) is not
     used by romp. Empty list if the session declared no plan."""
     results = {}                                           # tool_use_id → result text (carries 'Task #N')
+    rejected = set()                                       # tool_use_ids whose result came back is_error
     for turn in session["turns"]:
         for a in turn["atoms"]:
             if a.get("type") != "user":
@@ -2782,6 +2784,8 @@ def declared_plan(session):
                 if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
                     c = b.get("content")
                     results[b["tool_use_id"]] = c if isinstance(c, str) else json.dumps(c)
+                    if b.get("is_error"):
+                        rejected.add(b["tool_use_id"])
     tasks, order = {}, 0
     for turn in session["turns"]:
         for a in turn["atoms"]:
@@ -2792,6 +2796,13 @@ def declared_plan(session):
                     continue
                 inp = b.get("input") or {}
                 if b.get("name") == "TaskCreate":
+                    # A TaskCreate the CLI rejected (a malformed call — no `subject`, or a {tasks: [...]}
+                    # batch — answered by an is_error tool_result naming the missing field) created no task,
+                    # so it is not a declared step. Folded, it became a keyless item with empty text that
+                    # _sync_declared_plan minted as a standalone open "(declared step)" card no TaskUpdate
+                    # could ever close. Keyed on the result's is_error, as the kernel's fold is.
+                    if b.get("id") in rejected:
+                        continue
                     m = re.search(r"Task #(\d+)", results.get(b.get("id"), "") or "")
                     key = m.group(1) if m else "c%d" % order
                     af = inp.get("activeForm")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18640,6 +18640,7 @@ def _fold_tasks(session):
     order, or None if there were none. The webview renders this as a todo card (kind:'todo') and hides the
     raw Task* calls (ACK_TOOLS) — so the kernel emits the folded card and skips the raw tool events."""
     out = {}                                              # tool_use_id → result text (carries 'Task #N')
+    rejected = set()                                      # tool_use_ids whose result came back is_error
     for turn in session["turns"]:
         for a in turn["atoms"]:
             if a.get("type") != "user":
@@ -18648,6 +18649,8 @@ def _fold_tasks(session):
                 if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
                     c = b.get("content")
                     out[b["tool_use_id"]] = c if isinstance(c, str) else json.dumps(c)
+                    if b.get("is_error"):
+                        rejected.add(b["tool_use_id"])
     tasks, order = {}, 0
     for turn in session["turns"]:
         for a in turn["atoms"]:
@@ -18658,6 +18661,18 @@ def _fold_tasks(session):
                     continue
                 inp = b.get("input") or {}
                 if b.get("name") == "TaskCreate":
+                    # A TaskCreate the CLI REJECTED is not a checklist item. A malformed call — no `subject`
+                    # ({agent_hint, prompt}), or a {tasks: [...]} batch — draws a paired tool_result with
+                    # is_error set and an InputValidationError naming the missing field: nothing was created,
+                    # nothing launched, and nothing renders it (the chat skips every raw TaskCreate row).
+                    # Folded as a pending task it gave a session whose only TaskCreate was rejected a phantom
+                    # open item, which tripped the card's "can't read the task store" error the moment the
+                    # store was unresolvable. The skip keys on the result's is_error — the event that says no
+                    # task exists — not on the input's key names, which would miss every other rejected
+                    # shape. A create whose result has not landed yet still folds under its creation-order
+                    # id, as before.
+                    if b.get("id") in rejected:
+                        continue
                     m = re.search(r"Task #(\d+)", out.get(b.get("id"), "") or "")
                     tid = m.group(1) if m else "c%d" % order
                     af = inp.get("activeForm")

--- a/tests/test_judge_authoritative_plan_sync.py
+++ b/tests/test_judge_authoritative_plan_sync.py
@@ -4,7 +4,8 @@ Code's Task tool) is mirrored DETERMINISTICALLY into the goal graph as `agentTas
 agent-declared-OPEN item is authoritative — its open state trumps a judge/rollup 'done'.
 
 Covers:
-- em.declared_plan   — folding TaskCreate/TaskUpdate (+ results) into ordered {key,text,status}.
+- em.declared_plan   — folding TaskCreate/TaskUpdate (+ results) into ordered {key,text,status};
+                       a TaskCreate the CLI rejected (is_error result) is not a step.
 - em.task_store_plan — the AUTHORITATIVE live task store read the sync prefers over the fold.
 - jd._sync_declared_plan — find-or-create by stable Task id; idempotent; status refresh; reopen;
                        store-first sourcing (fold only when no store dir; unreadable store = loud skip).
@@ -85,10 +86,19 @@ def tupdate(t, uuid, parent, task_id, status, tool_id):
                                      "input": {"taskId": task_id, "status": status}}]}}
 
 
-def tres(t, uuid, parent, tool_use_id, text):
+def tcreate_raw(t, uuid, parent, inp, tool_id):
+    """A TaskCreate with an arbitrary input — the malformed shapes the CLI rejects."""
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "stop_reason": "tool_use",
+                        "content": [{"type": "tool_use", "id": tool_id, "name": "TaskCreate", "input": inp}]}}
+
+
+def tres(t, uuid, parent, tool_use_id, text, is_error=False):
+    b = {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
+    if is_error:
+        b["is_error"] = True
     return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
-            "message": {"role": "user",
-                        "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": text}]}}
+            "message": {"role": "user", "content": [b]}}
 
 
 def build_session(records, now=NOW, rompuuid=SID):
@@ -119,6 +129,29 @@ def plan_session(items, now=NOW):
     return build_session(recs, now=now)
 
 
+REJECTED = ("InputValidationError: TaskCreate failed due to the following issue:\n"
+            "The required parameter `subject` is missing")
+
+
+def rejected_plan_session(accepted=True):
+    """A session whose TaskCreate calls the CLI REJECTED — a subject-less {agent_hint, prompt} call and a
+    {tasks: [...]} batch, each answered by an is_error tool_result naming the missing field, so no task
+    exists for either — after one accepted create (Task #1) unless `accepted` is False."""
+    recs = [uline(T0, "run the migration", "u1")]
+    parent, t = "u1", T0 + 5
+    if accepted:
+        recs.append(tcreate(t, "ac1", parent, "Design v3", "Designing v3", "tc1")); t += 1
+        recs.append(tres(t, "rc1", "ac1", "tc1", "Task #1 created successfully. Use TaskUpdate to update it.")); t += 1
+        parent = "rc1"
+    recs.append(tcreate_raw(t, "ax1", parent, {"agent_hint": "overnight pipeline", "prompt": "run the thing"},
+                            "tx1")); t += 1
+    recs.append(tres(t, "rx1", "ax1", "tx1", REJECTED, is_error=True)); t += 1
+    recs.append(tcreate_raw(t, "ax2", "rx1", {"tasks": [{"subject": "Rewire store"}]}, "tx2")); t += 1
+    recs.append(tres(t, "rx2", "ax2", "tx2", REJECTED, is_error=True)); t += 1
+    recs.append(aline(t + 1, "On it.", "aend", "rx2", stop="end_turn"))
+    return build_session(recs)
+
+
 def fresh_store():
     return {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
 
@@ -146,6 +179,16 @@ class DeclaredPlanAdapter(unittest.TestCase):
     def test_empty_when_no_task_tool(self):
         s = build_session([uline(T0, "hi", "u1"), aline(T0 + 5, "hello", "a1", "u1")])
         self.assertEqual(em.declared_plan(s), [])
+
+    def test_a_rejected_taskcreate_is_not_a_declared_step(self):
+        """A TaskCreate the CLI rejected — its paired tool_result carries is_error and an InputValidationError
+        naming the missing `subject` — created nothing, so it is not a step of the plan: neither the
+        subject-less {agent_hint, prompt} call nor the {tasks: [...]} batch. Without the skip each folded
+        to a keyless item with empty text (mirroring the kernel's _fold_tasks skip)."""
+        self.assertEqual(em.declared_plan(rejected_plan_session(accepted=False)), [])
+        items = em.declared_plan(rejected_plan_session())
+        self.assertEqual([(it["key"], it["text"]) for it in items], [("1", "Design v3")],
+                         "the accepted create (its result carries Task #N) still folds")
 
 
 class SyncFindOrCreate(unittest.TestCase):
@@ -230,6 +273,21 @@ class SyncFindOrCreate(unittest.TestCase):
         s = plan_session([("Phase 1 (already done)", "Doing", [("completed",)])])
         self.assertTrue(jd._sync_declared_plan(store, s, "s1", T0 + 10))
         self.assertEqual(agent_nodes(store), {}, "the born-done backlog node is self-healed away")
+
+    def test_a_rejected_taskcreate_mints_no_placeholder_card(self):
+        """What the fold-path leak cost: an item with empty text is minted as a standalone open card reading
+        "(declared step)" that no TaskUpdate can ever close — no task with that key exists — so it holds
+        the session working and re-mints after every clear. A rejected create must mint nothing."""
+        store = fresh_store()
+        changed = jd._sync_declared_plan(store, rejected_plan_session(accepted=False), "seg1", T0 + 50)
+        self.assertEqual([nd["text"] for nd in store["nodes"].values()], [],
+                         "rejected-only session: no mirror, no placeholder card")
+        self.assertFalse(changed)
+        store = fresh_store()
+        self.assertTrue(jd._sync_declared_plan(store, rejected_plan_session(), "seg1", T0 + 50))
+        self.assertEqual({k: nd["text"] for k, nd in agent_nodes(store).items()}, {"1": "Design v3"},
+                         "only the accepted create is mirrored")
+        self.assertNotIn("(declared step)", [nd["text"] for nd in store["nodes"].values()])
 
     def test_open_backlog_node_is_adopted_not_deleted(self):
         """A pre-fix OPEN agentTask node (marker absent) is ADOPTED (marker added), never deleted — so it

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -386,6 +386,70 @@ class ViewBuilder(unittest.TestCase):
             (km._read_task_store, km._fold_tasks) = saved
         self.assertNotIn("todo", kinds, "authoritative-empty store → no card (the fold does not override it)")
 
+    def test_fold_ignores_a_rejected_taskcreate(self):
+        # A TaskCreate the CLI REJECTED is not a checklist item. A malformed call — no `subject`
+        # ({agent_hint, prompt}), or a {tasks: [...]} batch — draws a paired tool_result with is_error set
+        # and an InputValidationError naming the missing field: nothing was created, nothing launched, and
+        # nothing renders it. Folded as a pending task it gave a session whose only TaskCreate was rejected
+        # a phantom open item, which tripped the card's "can't read the task store" error whenever the
+        # store was unresolvable. The skip keys on the result's is_error, not on the input's key names; the
+        # {tasks} batch (no prompt/agent_hint key) pins that — a guard re-keyed on input names lets it through.
+        def _tu(name, inp, rid):
+            return {"type": "tool_use", "id": rid, "name": name, "input": inp}
+        def _tr(rid, text, is_error=False):
+            b = {"type": "tool_result", "tool_use_id": rid, "content": text}
+            if is_error:
+                b["is_error"] = True
+            return {"type": "user", "message": {"content": [b]}}
+        def _asst(*blocks):
+            return {"type": "assistant", "message": {"content": list(blocks)}}
+        rejected = ("InputValidationError: TaskCreate failed due to the following issue:\n"
+                    "The required parameter `subject` is missing")
+        # a session whose only TaskCreate carried {agent_hint, prompt} and was rejected → no checklist at all
+        bg = {"turns": [{"atoms": [
+            _asst(_tu("TaskCreate", {"agent_hint": "overnight pipeline", "prompt": "run the thing"}, "toolu_TEST0001")),
+            _tr("toolu_TEST0001", rejected, is_error=True),
+        ]}]}
+        self.assertIsNone(km._fold_tasks(bg), "a rejected TaskCreate is not a checklist item")
+        # the {tasks: [...]} batch is rejected the same way, and carries neither prompt nor agent_hint
+        batch = {"turns": [{"atoms": [
+            _asst(_tu("TaskCreate", {"tasks": [{"subject": "vet the pairs"}, {"subject": "run the sweep"}]},
+                      "toolu_TEST0002")),
+            _tr("toolu_TEST0002", rejected, is_error=True),
+        ]}]}
+        self.assertIsNone(km._fold_tasks(batch), "a rejected {tasks} batch is not a checklist item either")
+        # a mixed session keeps the accepted create (its result carries "Task #N") and drops the rejected ones
+        mixed = {"turns": [{"atoms": [
+            _asst(_tu("TaskCreate", {"subject": "vet the pairs"}, "toolu_TEST0003")),
+            _tr("toolu_TEST0003", "Task #1 created successfully. Use TaskUpdate to update it."),
+            _asst(_tu("TaskCreate", {"agent_hint": "bg", "prompt": "go"}, "toolu_TEST0004")),
+            _tr("toolu_TEST0004", rejected, is_error=True),
+            _asst(_tu("TaskCreate", {"tasks": [{"subject": "run the sweep"}]}, "toolu_TEST0005")),
+            _tr("toolu_TEST0005", rejected, is_error=True),
+        ]}]}
+        folded = km._fold_tasks(mixed)
+        self.assertEqual([(t["id"], t["subject"]) for t in folded], [("1", "vet the pairs")],
+                         "only the accepted create folds")
+        # and the card raises NO error for a rejected-only session with an unresolvable store. The REAL fold
+        # runs over each synthetic transcript through build_session (the fixture transcript itself has no
+        # Task calls); the mixed transcript is the control that proves the path is live — its accepted
+        # create still trips the unreadable-store error.
+        real_fold = km._fold_tasks
+        saved = (km._read_task_store, km._fold_tasks)
+        km._read_task_store = lambda fsid, fold=None: None            # store unresolvable, as in the repro
+        try:
+            km._fold_tasks = lambda session: real_fold(bg)
+            kinds = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
+            km._fold_tasks = lambda session: real_fold(batch)
+            kinds_batch = [e["kind"] for e in km.build_session(SID, NOW)["events"]]
+            km._fold_tasks = lambda session: real_fold(mixed)
+            todo = [e for e in km.build_session(SID, NOW)["events"] if e["kind"] == "todo"]
+        finally:
+            (km._read_task_store, km._fold_tasks) = saved
+        self.assertNotIn("todo", kinds, "rejected-only session → no phantom to-do card, no error")
+        self.assertNotIn("todo", kinds_batch, "rejected {tasks} batch → no phantom to-do card, no error")
+        self.assertTrue(todo and todo[0].get("error"), "control: an accepted create still surfaces the error")
+
     def test_fully_completed_store_drops_the_todo_card(self):
         # a done list is not a live to-do (the user 2026-06-10). At `track`'s screenshot time the store was
         # already all-completed, so the store-based card is correctly ABSENT — not a stale "3/5".


### PR DESCRIPTION
## What breaks

A session whose only `TaskCreate` calls were rejected by the CLI showed the To-do card's error state on every build ("Can't read Claude's task store (~/.claude/tasks) for this session, so the to-do list can't be shown accurately"), although it had no to-do list at all.

## Cause

`_fold_tasks` (kernel/kernel.py) treated every `TaskCreate` tool_use as a checklist create. The CLI rejects a malformed call: the paired `tool_result` carries `is_error` and an `InputValidationError` naming the missing `subject`. Two such shapes appear in real transcripts, `{agent_hint, prompt}` with no `subject` and a `{tasks: [...]}` batch. No task was created and nothing was launched. The earlier revision of this PR called the first shape a background-agent launch; no installed Claude Code build has one, and that diagnosis was wrong. The fold still minted a pending item with an empty subject and a creation-order id (`c0`). The card then saw open tasks in the transcript and no readable store, the condition its fail-loudly branch reports.

`event_model.declared_plan`, the judge's mirror of the same fold, had the same hole: the rejected create folded to a keyless item with empty text, which `_sync_declared_plan` minted as a standalone open card reading "(declared step)" that no `TaskUpdate` could ever close.

## Reproduction

Fold a transcript whose one `TaskCreate` is `{"agent_hint": "...", "prompt": "..."}` or `{"tasks": [...]}` and whose paired result has `is_error` set, with an `InputValidationError` naming the missing `subject`:

```
>>> _fold_tasks(rejected_only)
[{'id': 'c0', 'subject': '', 'activeForm': None, 'status': 'pending'}]
>>> [nd["text"] for nd in store["nodes"].values()]   # after _sync_declared_plan over the same transcript
['(declared step)', '(declared step)']
```

Through `build_session` with the store unreadable, the phantom item produces a `todo` event carrying the error. The tests reproduce each of these.

## Fix

Both folds record, in the result pass they already make, the `tool_use_id` of every `tool_result` with `is_error` set, and the `TaskCreate` branch skips a create whose id is in that set. The skip keys on the CLI's rejection, the event that says no task exists, so every rejected shape is covered, including the `{tasks}` batch. An accepted create (its result carries `Task #N`) folds as before, a create whose result has not landed yet still folds under its creation-order id, `TaskUpdate` handling is unchanged, and the card's error branch is untouched: with no phantom task, it fires only when the transcript shows outstanding checklist work.

This revision answers the review hold, which found the earlier diagnosis not real and two sibling paths open. The four items folded:

1. `kernel/kernel.py`, `_fold_tasks`: the skip is keyed on the paired result's `is_error`, replacing the guard keyed on `prompt`/`agent_hint` in the input.
2. The comment there now says a `TaskCreate` the CLI rejected is not a checklist item. The launch and the bgTasks/TaskStop rendering it described do not happen.
3. `kernel/event_model.py`, `declared_plan`: the same skip, so `_sync_declared_plan` mints no placeholder card, with tests in `tests/test_judge_authoritative_plan_sync.py`.
4. `tests/test_kernel.py`: the fixture results carry `is_error` with validation-style text, and a `{tasks}` case pins the re-keyed guard.

## Tests

`tests/test_kernel.py`, `ViewBuilder.test_fold_ignores_a_rejected_taskcreate`, next to the existing todo-store tests. Fixture data is synthetic.

1. `_fold_tasks` over a rejected-only transcript (`{agent_hint, prompt}`) returns `None`.
2. `_fold_tasks` over a rejected `{tasks: [...]}` batch returns `None`.
3. A mixed transcript folds to only the accepted create, `[("1", "vet the pairs")]`.
4. Through `build_session` with `_read_task_store` patched to return `None` and the real fold driven over each transcript: both rejected-only transcripts yield no `todo` event, and the mixed transcript still yields the error card (the control that proves the card path is exercised).

`tests/test_judge_authoritative_plan_sync.py`, beside the existing `declared_plan` and `_sync_declared_plan` tests:

5. `DeclaredPlanAdapter.test_a_rejected_taskcreate_is_not_a_declared_step`: a rejected-only session folds to `[]`; with one accepted create the fold is `[("1", "Design v3")]`.
6. `SyncFindOrCreate.test_a_rejected_taskcreate_mints_no_placeholder_card`: a rejected-only session mints no node and returns `False`; with one accepted create only key `1` is mirrored and no node reads "(declared step)".

Red first, each against the code it pins:

- Without any guard (`_fold_tasks` at the base commit): (1) fails with `[{'id': 'c0', 'subject': '', ...}] is not None`.
- Under the earlier revision's guard keyed on input names: (1) passes and (2) fails with the same `c0` item. The `{tasks}` case is what a guard keyed on input names lets through.
- `declared_plan` without the skip: (5) fails with two items, `{'key': 'c0', 'text': ''}` and `{'key': 'c1', 'text': ''}`; (6) fails with `['(declared step)', '(declared step)'] != []`.

All six pass with the skips.

Verification: `pytest tests/test_kernel.py -n 8` 462 passed; `pytest tests/test_judge_authoritative_plan_sync.py -n 8` 28 passed; `pytest tests -n 8` 7370 passed, 50 skipped.

## Out of scope

The chat drops every raw `TaskCreate`/`TaskUpdate` tool_use before rendering (they are folded into the one checklist card), and a `tool_result` with no tool event to attach to is dropped with it, so a rejected `TaskCreate` and its error never appear in the chat: the user has no sign the model's call failed. That predates this PR. Surfacing a rejected create is a separate change if wanted.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
