### PR TITLE
Turning Auto Nudge on acts at once again: the setAutoNudge handler re-ticks on a real apply

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5546,20 +5546,21 @@ def _compact_suggest_tick(sid, tm, now):
     with _NUDGE_LOCK:                                  # CLAIM BEFORE SEND (the double-send race,
         # 2026-09-01): the check above releases the lock before the fire-time gates, and this tick
         # has three concurrent entry points (the pusher's periodic pass, setAutoNudge's and
-        # setCompactSuggest's WS re-ticks) — latching only after the send let two entries pass the
-        # same unlatched check and inject the suggestion twice into one session. The latch write
-        # IS the claim: a fresh read under the lock re-derives what is still due (a concurrent
-        # entry may have claimed it in the gap), the winner latches and sends, the loser stands
-        # down right here. Same direction as the nudge machinery's own bookkeeping
-        # (_mark_auto_nudged records only after its send, so a failed send retries), inverted at
-        # this seam because the send must be single-shot — and the failure arm below rolls the
-        # claim back under the lock, so "never latch a fire that never went out" still holds
-        # durably: the next tick retries the same crossing. The claim (and the rollback) is
-        # durable against every OTHER ledger writer too: all of them hold _NUDGE_LOCK across
-        # their read-modify-write, and the ones with IO mid-span re-read fresh under the lock
-        # and mutate only their own keys — before that migration (2026-09-01), a debt reminder's
-        # pre-send snapshot written whole erased a concurrent claim (or resurrected a rolled-back
-        # one) and re-opened the double send through the side door.
+        # setCompactSuggest's WS re-ticks; single-flight since PR #943 via _AUTO_NUDGE_TICK_LOCK,
+        # but the latch is the SEND's own single-shot guarantee, so it stays) — latching only after
+        # the send let two entries pass the same unlatched check and inject the suggestion twice
+        # into one session. The latch write IS the claim: a fresh read under the lock re-derives
+        # what is still due (a concurrent entry may have claimed it in the gap), the winner latches
+        # and sends, the loser stands down right here. Same direction as the nudge machinery's own
+        # bookkeeping (_mark_auto_nudged records only after its send, so a failed send retries),
+        # inverted at this seam because the send must be single-shot — and the failure arm below
+        # rolls the claim back under the lock, so "never latch a fire that never went out" still
+        # holds durably: the next tick retries the same crossing. The claim (and the rollback) is
+        # durable against every OTHER ledger writer too: all of them hold _NUDGE_LOCK across their
+        # read-modify-write, and the ones with IO mid-span re-read fresh under the lock and mutate
+        # only their own keys — before that migration (2026-09-01), a debt reminder's pre-send
+        # snapshot written whole erased a concurrent claim (or resurrected a rolled-back one) and
+        # re-opened the double send through the side door.
         d = dict(_auto_nudge_data())                   # fresh read — a concurrent writer's blob is
         cs = dict(d.get("compactSuggested") or {})     # not clobbered
         held = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t]
@@ -5599,6 +5600,20 @@ def _compact_suggest_tick(sid, tm, now):
     return True
 
 
+# The tick is SINGLE-FLIGHT (PR #943 review): it has two concurrent entry points — the pusher's
+# periodic pass (0.5 s backstop) and the setAutoNudge / setCompactSuggest arms' act-now pass on the
+# WS handler thread — and the nudge send has no claim-before-send (_mark_auto_nudged records AFTER
+# the send so a failed send retries; _compact_suggest_tick's latch covers only its own seam), so two
+# passes that overlapped each derived the same due goal from the same store and injected the same
+# nudge twice into one session — reproduced from two threads at the 0.5 s cadence. A non-blocking
+# try-acquire, never a wait: the loser stands down whole, and loses nothing. The flag write precedes
+# the turn-on's tick, so a pass found in flight already reads the turned-on world (before the write
+# it would have returned at the enabled gate), and a pusher pass that meets the WS pass re-runs on
+# its own cadence — at worst an act-now degrades to the next cycle. A plain Lock, not an RLock: a
+# same-thread re-entry (a WS tick nested in a pass) must stand down the same way.
+_AUTO_NUDGE_TICK_LOCK = threading.Lock()
+
+
 def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     """One Auto-Nudge pass (from the periodic pusher). For each ALIVE, IDLE session (its turn ended) that
     isn't awaiting/compacting/api-error, isn't WAITING ON A LIVE PEER (a wait isn't a stall — the human's
@@ -5607,9 +5622,21 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
     is its considered verdict — a turn that ended by asking YOU a question is never nudged), inject the follow-up. RE-ARMS per stall episode, not once-ever: a goal is nudged again
     once a NEW GENUINE (work/user, not the agent's own nudge-response) ended turn leaves it still working, with
     a count that climbs each fire (surfaced on the timeline; no cap — the warning is the alert). A no-op unless
-    the user turned it on."""
+    the user turned it on, and single-flight (_AUTO_NUDGE_TICK_LOCK): a pass that finds another in
+    flight stands down without sending."""
     if not _auto_nudge_on():
         return
+    if not _AUTO_NUDGE_TICK_LOCK.acquire(blocking=False):
+        return                                            # a pass is in flight: it owns this world's sends
+    try:
+        _auto_nudge_pass(now, tmux, run_dead_wait)
+    finally:
+        _AUTO_NUDGE_TICK_LOCK.release()
+
+
+def _auto_nudge_pass(now, tmux, run_dead_wait):
+    """The body of one pass — the walk, the sweeps, the push. Only _auto_nudge_tick calls it, under
+    the single-flight guard (split out the way _pusher_cycle_jobs is from _pusher_cycle)."""
     nudged = dict(_auto_nudge_data().get("nudged", {}))   # {gid: {count, lastTurnId}}
     alive = list(_alive_sessions(now, tmux))
     alive_ids = {s["sid"] for s in alive}
@@ -35900,15 +35927,20 @@ class Handler(BaseHTTPRequestHandler):
             # apply — and no tick: a stood-down toggle is not new information), and the dashboard
             # that made the losing gesture hears it
             if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
-                # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the
-                # death transition has ONE observer (the pusher's tick; see _auto_nudge_tick), and
-                # this WS thread racing its prev-swap could spend a transition uncorroborated
-                _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+                # turn-ON acts at once instead of waiting out the pusher's 0.5 s backstop; turning off
+                # has nothing to act on (the tick is a no-op when off, so this also spares the WS
+                # thread the listing fork). The tick is single-flight against the pusher's pass
+                # (_AUTO_NUDGE_TICK_LOCK) and skips the dead-wait sweep: the death transition has ONE
+                # observer (the pusher's tick; see _auto_nudge_tick), and this WS thread racing its
+                # prev-swap could spend a transition uncorroborated
+                if msg["enabled"]:
+                    _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
             # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a
-            # real apply acts immediately on turn-on (don't wait 4s) — a stood-down toggle is not
+            # real apply acts at once on turn-on (instead of waiting out the pusher's 0.5 s backstop;
+            # single-flight against its pass, _AUTO_NUDGE_TICK_LOCK) — a stood-down toggle is not
             # new information — and the tick skips the dead-wait sweep: the death transition has
             # ONE observer (the pusher's tick; see _auto_nudge_tick), and this WS thread racing
             # its prev-swap could spend a transition uncorroborated

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5545,21 +5545,21 @@ def _compact_suggest_tick(sid, tm, now):
     #                                                    armed; a later tick re-checks the same gate
     with _NUDGE_LOCK:                                  # CLAIM BEFORE SEND (the double-send race,
         # 2026-09-01): the check above releases the lock before the fire-time gates, and this tick
-        # has two concurrent entry points (the pusher's periodic pass and the setCompactSuggest
-        # handler's act-now re-tick) — latching only after the send let two entries pass the same
-        # unlatched check and inject the suggestion twice into one session. The latch write IS
-        # the claim: a fresh read under the lock re-derives what is still due (a concurrent entry
-        # may have claimed it in the gap), the winner latches and sends, the loser stands down
-        # right here. Same direction as the nudge machinery's own bookkeeping (_mark_auto_nudged
-        # records only after its send, so a failed send retries), inverted at this seam because
-        # the send must be single-shot — and the failure arm below rolls the claim back under the
-        # lock, so "never latch a fire that never went out" still holds durably: the next tick
-        # retries the same crossing. The claim (and the rollback) is durable against every OTHER
-        # ledger writer too: all of them hold _NUDGE_LOCK across their read-modify-write, and the
-        # ones with IO mid-span re-read fresh under the lock and mutate only their own keys —
-        # before that migration (2026-09-01), a debt reminder's pre-send snapshot written whole
-        # erased a concurrent claim (or resurrected a rolled-back one) and re-opened the double
-        # send through the side door.
+        # has three concurrent entry points (the pusher's periodic pass, setAutoNudge's and
+        # setCompactSuggest's WS re-ticks) — latching only after the send let two entries pass the
+        # same unlatched check and inject the suggestion twice into one session. The latch write
+        # IS the claim: a fresh read under the lock re-derives what is still due (a concurrent
+        # entry may have claimed it in the gap), the winner latches and sends, the loser stands
+        # down right here. Same direction as the nudge machinery's own bookkeeping
+        # (_mark_auto_nudged records only after its send, so a failed send retries), inverted at
+        # this seam because the send must be single-shot — and the failure arm below rolls the
+        # claim back under the lock, so "never latch a fire that never went out" still holds
+        # durably: the next tick retries the same crossing. The claim (and the rollback) is
+        # durable against every OTHER ledger writer too: all of them hold _NUDGE_LOCK across
+        # their read-modify-write, and the ones with IO mid-span re-read fresh under the lock
+        # and mutate only their own keys — before that migration (2026-09-01), a debt reminder's
+        # pre-send snapshot written whole erased a concurrent claim (or resurrected a rolled-back
+        # one) and re-opened the double send through the side door.
         d = dict(_auto_nudge_data())                   # fresh read — a concurrent writer's blob is
         cs = dict(d.get("compactSuggested") or {})     # not clobbered
         held = [t for t in [int(x) for x in cs.get(sid, [])] if tokens >= t]
@@ -35897,8 +35897,14 @@ class Handler(BaseHTTPRequestHandler):
             _push_soon()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             # feed gear → server-side Auto Nudge on/off; a stale gesture stamp stands down (no
-            # apply), and the dashboard that made the losing gesture hears it
-            if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+            # apply — and no tick: a stood-down toggle is not new information), and the dashboard
+            # that made the losing gesture hears it
+            if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
+                # act immediately on turn-on (don't wait 4s) — but skip the dead-wait sweep: the
+                # death transition has ONE observer (the pusher's tick; see _auto_nudge_tick), and
+                # this WS thread racing its prev-swap could spend a transition uncorroborated
+                _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+            else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
             # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -7,6 +7,7 @@ event-triggered (the death transition; a boot catch-up sweep), once per stamp ep
 for restart cuts (the resume machinery owns those), and its why is a recognized procedural block.
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
 import contextlib
+import inspect
 import io
 import json
 import os
@@ -458,11 +459,20 @@ class DeadWaitOneObserver(_HermeticDeadWait):
         self.assertTrue(self._blocked(), "the pusher's own pass still completed its conversion")
 
     def test_the_setautonudge_call_site_skips_the_sweep(self):
-        # the ownership rule holds at the ONE other call site, pinned the way
-        # test_wake_goal_routes_its_dormant_branch_here pins its wiring
-        src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)",
-                      src)
+        # the ownership rule holds at every WS call site (setAutoNudge and setCompactSuggest),
+        # pinned the way test_wake_goal_routes_its_dormant_branch_here pins its wiring. The
+        # setAutoNudge arm is sliced out and checked on its own: a whole-source substring match
+        # stayed green while that arm's tick was missing, satisfied by setCompactSuggest's line
+        # (#846 inserted the new arm between the setter and its tick, re-parenting the tick).
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        arm = src[src.index('"setAutoNudge"'):src.index('"setCompactSuggest"')]
+        self.assertIn("_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)", arm,
+                      "setAutoNudge's own arm re-ticks, and skips the sweep")
+        calls = src.count("_auto_nudge_tick(int(time.time())")
+        self.assertGreaterEqual(calls, 2, "both WS arms re-tick")
+        self.assertEqual(calls, src.count("_auto_nudge_tick(int(time.time()), _tmux_sessions(), "
+                                          "run_dead_wait=False)"),
+                         "no WS call site runs the one-observer sweep")
 
 
 if __name__ == "__main__":

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -889,6 +889,93 @@ class AutoNudgeTurnOnActsNow(_Base):
         self.dispatch({"type": "setAutoNudge", "enabled": True})                 # older dashboard, no gt
         self.assertEqual(len(self.ticks), 1)
 
+    def test_a_real_turn_off_applies_and_fires_no_tick(self):
+        # turning OFF is a real apply too, with nothing to act on: the tick is a no-op when off, so
+        # firing it would only fork the session listing on the WS thread for nothing
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_OLD})
+        self.dispatch({"type": "setAutoNudge", "enabled": False, "gt": T_NEW})
+        self.assertFalse(km._auto_nudge_on(), "the turn-off applied")
+        self.assertEqual(len(self.ticks), 1, "only the turn-on ticked")
+
+
+SF_SID = "11111111-2222-4333-8444-555555555555"   # the single-flight tests' one fake alive session
+
+
+class AutoNudgeTickIsSingleFlight(_Base):
+    """_auto_nudge_tick has two concurrent entry points — the pusher's periodic pass (0.5 s
+    backstop) and the setAutoNudge arm's act-now pass on the WS handler thread — and the nudge
+    send has no claim-before-send (_compact_suggest_tick's latch covers only its own seam), so
+    two passes that overlap each derive the same due goal and inject the same nudge twice into
+    one session. The tick is single-flight (_AUTO_NUDGE_TICK_LOCK): a pass that finds another in
+    flight stands down whole, and loses nothing — the flag write precedes the turn-on's tick, so
+    a pass found in flight already reads the turned-on world, and the pusher re-runs on its own
+    cadence. Driven with the REAL tick; the per-session walk (which owns the send) is a recorder
+    that holds the first pass mid-send until the overlapping entry has been and gone, so the
+    interleave is deterministic, not a sleep."""
+
+    def setUp(self):
+        super().setUp()
+        km._auto_nudge_tick = self._saved["_auto_nudge_tick"]      # the real tick is the subject here
+        self._also = {n: getattr(km, n) for n in
+                      ("_alive_sessions", "_wait_for_graph", "_auto_nudge_session", "_compact_suggest_tick",
+                       "_debt_backstop_tick", "_dead_wait_sweep", "_awaiting_wake_outcomes", "_push_soon")}
+        self.sends = []                                            # the `now` of every pass that reached the send
+        self.entered, self.release = _real_threading.Event(), _real_threading.Event()
+        km._alive_sessions = lambda now, tmux: [{"sid": SF_SID, "path": "/nonexistent.jsonl"}]
+        km._wait_for_graph = lambda now, alive_ids: {}
+        km._auto_nudge_session = self._walk
+        km._compact_suggest_tick = lambda sid, tm, now: False
+        km._debt_backstop_tick = lambda now: None
+        km._dead_wait_sweep = lambda alive_ids, nudged, now: None
+        km._awaiting_wake_outcomes = lambda now, alive_ids: False
+        km._push_soon = lambda: None
+
+    def tearDown(self):
+        self.release.set()                                         # never leave a held pass behind
+        for n, v in self._also.items():
+            setattr(km, n, v)
+        super().tearDown()
+
+    def _walk(self, s, now, tmux, nudged, waitfor, alive_ids=None):
+        """The per-session walk standing in for the SEND: the first pass to reach it holds here,
+        mid-send, until the test releases it; every later pass records and returns at once."""
+        self.sends.append(now)
+        if len(self.sends) == 1:
+            self.entered.set()
+            self.release.wait(5)
+        return True
+
+    def _pass_in_flight(self, now, **kw):
+        t = _real_threading.Thread(target=km._auto_nudge_tick, args=(now, {}), kwargs=kw, daemon=True)
+        t.start()
+        self.assertTrue(self.entered.wait(5), "the first pass reached its send")
+        return t
+
+    def test_the_ws_arm_meeting_the_pusher_mid_pass_sends_nothing_more(self):
+        t = self._pass_in_flight(1000)                                          # the pusher's shape
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})   # a real apply: its act-now tick
+        self.release.set()
+        t.join(5)
+        self.assertEqual(self.sends, [1000], "one nudge, from the pass already in flight")
+
+    def test_the_pusher_meeting_the_ws_pass_mid_pass_stands_down_and_runs_next_cycle(self):
+        t = self._pass_in_flight(1000, run_dead_wait=False)                     # the WS arm's shape
+        km._auto_nudge_tick(1001, {})                                           # the pusher's pass: stands down
+        self.release.set()
+        t.join(5)
+        self.assertEqual(self.sends, [1000], "the overlapping pass sent nothing")
+        km._auto_nudge_tick(1002, {})                                           # its next cycle
+        self.assertEqual(self.sends, [1000, 1002], "a stood-down pass is retried next cycle, never lost")
+
+    def test_a_pass_that_raises_releases_the_guard(self):
+        self.release.set()                                                      # nothing holds in this test
+        km._alive_sessions = lambda now, tmux: 1 / 0
+        with self.assertRaises(ZeroDivisionError):                              # propagates as before (the
+            km._auto_nudge_tick(1000, {})                                       # pusher loop catches it)
+        km._alive_sessions = lambda now, tmux: [{"sid": SF_SID, "path": "/nonexistent.jsonl"}]
+        km._auto_nudge_tick(1001, {})
+        self.assertEqual(self.sends, [1001], "the guard is released on every exit, a raise included")
+
 
 class ThinkingSummariesSetting(_Base):
     """The thinking-summaries toggle (2026-09-01): a PER-INSTALL kernel setting — its own json under

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -811,9 +811,9 @@ class WiringPins(unittest.TestCase):
         import inspect
         self.src = inspect.getsource(km.Handler._dispatch_ws)
 
-    def test_auto_nudge_branch_passes_the_stamp(self):
-        self.assertIn('_set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None', self.src,
-                      "the branch hands the stamp over and gates on the apply")
+    def test_auto_nudge_branch_gates_on_the_stamp_and_skips_the_tick_on_stand_down(self):
+        self.assertIn('_set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None', self.src,
+                      "a stood-down toggle must not fire the nudge tick either — no new information")
 
     def test_file_editing_branch_passes_the_stamp(self):
         self.assertIn('_set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg))', self.src)
@@ -856,6 +856,38 @@ class WiringPins(unittest.TestCase):
         self.assertNotIn(".write_text(", src, "no raw write_text — a torn write must not tear the store")
         self.assertLess(src.index('fname + ".gt"'), src.index("_atomic_write(jd.STATE / fname,"),
                         "the sidecar publishes FIRST — a crash between the two errs toward stand-down")
+
+
+class AutoNudgeTurnOnActsNow(_Base):
+    """Turning Auto Nudge on acts in the same handler call instead of waiting for the pusher's
+    next pass — and ONLY a real apply does: a stale stamp and the gesture's own echo carry no
+    new information, so neither fires a tick (T208's setCompactSuggest arm has the same shape).
+    #846 inserted that arm between the auto-nudge setter and its act-now tick, which moved the
+    tick onto the new arm without changing the tick line — a source pin alone would not have
+    noticed, so the handler is driven here."""
+
+    def setUp(self):
+        super().setUp()
+        self.ticks = []
+        km._auto_nudge_tick = lambda *a, **k: self.ticks.append((a, k))   # restored by _Base.tearDown
+
+    def test_a_real_turn_on_ticks_once_without_the_dead_wait_sweep(self):
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})
+        self.assertEqual(len(self.ticks), 1, "a real apply acts now")
+        (now, tmux), kw = self.ticks[0]
+        self.assertIsInstance(now, int)
+        self.assertEqual(kw, {"run_dead_wait": False}, "the WS tick never runs the one-observer sweep")
+        self.assertEqual(tmux, {}, "the tick takes the listing the handler fetched (_tmux_sessions)")
+
+    def test_a_stale_stamp_and_an_echo_fire_no_tick(self):
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})
+        self.dispatch({"type": "setAutoNudge", "enabled": False, "gt": T_OLD})   # stale: stands down
+        self.dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})    # echo: the same pick again
+        self.assertEqual(len(self.ticks), 1, "only the applied gesture ticked")
+
+    def test_an_unstamped_toggle_applies_and_ticks(self):
+        self.dispatch({"type": "setAutoNudge", "enabled": True})                 # older dashboard, no gt
+        self.assertEqual(len(self.ticks), 1)
 
 
 class ThinkingSummariesSetting(_Base):


### PR DESCRIPTION
## What breaks

Turning Auto Nudge on from the gear no longer acts in the same handler call. Since #574 the `setAutoNudge` WS arm called `_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)` right after the setter, so the first nudge pass ran at once. At tip the arm only applies the setting (and answers a stale gesture), and the first pass waits for the pusher's next periodic tick.

## How it was lost

#846 (T208) added the `setCompactSuggest` arm by inserting its two lines between `_set_auto_nudge(bool(msg["enabled"]))` and the act-now comment and tick. The tick line itself did not change, so it stayed in the diff as context and became the new arm's body; a line-based blame shows no removal, and #846's description mentions no setAutoNudge change. #879 then re-derived the gt-gated arm as `if _set_auto_nudge(...) is None: _tell_stale_gesture(client)`, keeping that shape.

The tree still describes the missing caller. `_auto_nudge_tick`'s one-observer comment says setAutoNudge's WS-handler tick passes `run_dead_wait=False`, its ack-fast comment says the WS setAutoNudge op calls it directly on turn-on, and `DeadWaitOneObserver.test_the_setautonudge_call_site_skips_the_sweep` has been passing because its whole-file substring is satisfied by the setCompactSuggest line.

## Reproduction

Drive `Handler._dispatch_ws` with `_auto_nudge_tick` stubbed to record calls and send `{"type": "setAutoNudge", "enabled": true, "gt": <fresh stamp>}`. At tip the stub records nothing. `AutoNudgeTurnOnActsNow` in `tests/test_setting_gesture_order.py` is that reproduction: it fails on the base commit and passes with the fix.

## The fix

The setAutoNudge arm now mirrors the setCompactSuggest arm below it. When the setter returns a stamp (a real apply), the arm calls `_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)`; when it returns None (a stale stamp, the gesture's own echo, or a failed write) the arm fires no tick, and the stale case still answers the delivering socket with `settingStale`. `run_dead_wait=False` keeps the death transition's one observer, as before. `_compact_suggest_tick`'s claim-before-send comment now counts three concurrent entry points (the pusher and both WS re-ticks); #897's claim under `_NUDGE_LOCK` already makes the third entry safe.

Two notes for review:

- Turn-off no longer re-ticks: the second commit gates the arm's tick on `msg["enabled"]`, the one-line change offered in the first revision. The setCompactSuggest arm still ticks on any real apply.
- The two `_auto_nudge_tick` comments that describe the setAutoNudge caller are unchanged: they are accurate again with this fix, and #936 is editing that region.

## Re-entry guard (from review)

The branch is two commits, rebased onto main after #945. The first is the change above; its stale branch carries the two-argument `_tell_stale_gesture(client, msg)`.

The second commit makes `_auto_nudge_tick` single-flight. The tick has two concurrent entry points, the pusher's periodic pass (0.5 s backstop) and the act-now pass the WS arms run on the handler thread, and the nudge send has no claim-before-send, so a WS pass overlapping the pusher's injected the same nudge twice into one session. The tick now takes a module-level `Lock` with a non-blocking acquire and stands down whole when it is held. The body moves to `_auto_nudge_pass` (the `_pusher_cycle` / `_pusher_cycle_jobs` split), so the diff is the guard rather than a re-indented walk. The loser loses nothing: the flag write precedes the turn-on's tick, so a pass found in flight already reads the turned-on world, and a stood-down pusher pass re-runs on its next cycle. It is a plain `Lock`, not an `RLock`, so a same-thread re-entry stands down the same way. I kept the direct tick rather than setting `_pusher_wake`: the reviewed shape and the one-observer pins keep their meaning, and the guard also covers the setCompactSuggest arm's re-entry at main.

Also from the review: the arm ticks only on turn-on (`msg["enabled"]`), so a turn-off no longer forks the session listing on the WS thread for a tick that returns at the enabled gate, and both arms' "don't wait 4s" comments now name the 0.5 s cadence.

## Tests (red first)

With both commits' test changes applied on the base commit, seven tests fail (five from the first commit, two from the second); with the fix, all pass.

- `WiringPins.test_auto_nudge_branch_gates_on_the_stamp_and_skips_the_tick_on_stand_down` (replaces `test_auto_nudge_branch_passes_the_stamp`): the source pin flips from `is None` to `is not None`.
- `AutoNudgeTurnOnActsNow` (new, `tests/test_setting_gesture_order.py`): drives the real `_dispatch_ws` with the tick stubbed. A fresh stamped turn-on ticks once with `run_dead_wait=False` and the handler's `_tmux_sessions()` listing; a stale stamp and then the gesture's own echo add no tick; an unstamped toggle (an older dashboard) ticks once.
- `DeadWaitOneObserver.test_the_setautonudge_call_site_skips_the_sweep` (`tests/test_dead_wait_block.py`): slices the setAutoNudge arm out of `_dispatch_ws`'s source and requires the tick inside it, and requires `run_dead_wait=False` at every WS call site (the count of `_auto_nudge_tick(int(time.time())` calls equals the count carrying `run_dead_wait=False`).
- `AutoNudgeTickIsSingleFlight` (new, second commit, `tests/test_setting_gesture_order.py`): drives the real tick with the per-session walk replaced by a recorder that holds the first pass mid-send, then runs the other entry point against it in both interleaves: the pusher's pass in flight when a turn-on arrives through the real `_dispatch_ws`, and the WS pass in flight when the pusher's pass arrives. Each asserts exactly one send; the second also asserts that the stood-down pusher pass runs on its next cycle. Both failed on the first commit with two sends. A third test pins that a raising pass releases the guard; it failed against a variant without the `finally`.
- `AutoNudgeTurnOnActsNow.test_a_real_turn_off_applies_and_fires_no_tick` (second commit): failed on the first commit with two ticks.

Full `pytest tests` at the two-commit head: 7374 passed, 50 skipped under xdist. No shell or UI file changes.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
