### PR TITLE
Tests: every temp directory the suite makes is removed when the run ends

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,8 +4,53 @@ resolve their state root at import time. conftest.py covers only pytest; without
 unittest run operated on the REAL ~/.local/state/romp (tests/test_kernel.py overwrote the real
 remotes.json that way today). Does NOT cover `cd tests && python -m unittest test_x` or a direct
 script run — the per-module preambles do, and tests/test_state_isolation_order.py enforces them."""
+import atexit
 import os
+import shutil
 import tempfile
+
+# Temp-directory hygiene (2026-09-06): the suite used to leak every directory it made. This floor and
+# conftest.py's each minted a state root per process and never removed it (two per pytest process:
+# eighteen for a `pytest -n 8` run), and about three hundred test modules call tempfile.mkdtemp with
+# no cleanup of their own. On a developer machine that ran the suite many times a day that left about
+# 1.9 million directories under the system temp directory, enough that listing it took minutes and
+# tens of gigabytes of memory, and the out-of-memory kills that followed took a running romp kernel
+# down. The fix is at the source: every tempfile.mkdtemp call made in this process is recorded, and
+# everything recorded is removed at interpreter exit (and, under pytest, at session end; see
+# conftest.py). Only directories this process created, and only under the system temp directory, are
+# ever removed. tempfile.TemporaryDirectory goes through the same mkdtemp and cleans itself first, so
+# the exit sweep finds nothing of it. This package imports before conftest.py (pytest imports
+# `tests.conftest` through the package), so conftest's own root is recorded too.
+_MADE_DIRS = []
+_REAL_MKDTEMP = tempfile.mkdtemp
+
+
+def _tracked_mkdtemp(*a, **k):
+    p = _REAL_MKDTEMP(*a, **k)
+    _MADE_DIRS.append(p)
+    return p
+
+
+_tracked_mkdtemp.romp_tracked = True          # tests/test_tempdir_hygiene.py asserts the hook is installed
+if not getattr(tempfile.mkdtemp, "romp_tracked", False):
+    tempfile.mkdtemp = _tracked_mkdtemp
+
+
+def remove_made_dirs():
+    """Remove every directory this process minted through tempfile.mkdtemp. Idempotent; registered
+    with atexit here and called again from conftest's pytest_sessionfinish."""
+    root = os.path.realpath(tempfile.gettempdir())
+    for p in reversed(list(_MADE_DIRS)):
+        try:
+            rp = os.path.realpath(p)
+            if rp != root and rp.startswith(root + os.sep) and os.path.isdir(rp) and not os.path.islink(p):
+                shutil.rmtree(rp, ignore_errors=True)
+        except Exception:
+            pass
+    _MADE_DIRS.clear()
+
+
+atexit.register(remove_made_dirs)
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,21 @@ import tempfile
 
 import pytest
 
-os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # recorded by tests/__init__.py's hook
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Temp-directory hygiene (2026-09-06, see tests/__init__.py): remove every directory this
+    process made through tempfile.mkdtemp, this state root included, when the session ends. Runs in
+    the controller and in every xdist worker, since each is its own pytest session. The package's
+    atexit hook does the same at interpreter exit; both are idempotent."""
+    try:
+        from tests import remove_made_dirs
+    except Exception:
+        return
+    remove_made_dirs()
+
 
 # No test may reach a REAL manager control port (2026-08-27): on a machine running a live romp,
 # every shell the manager tree spawns inherits ROMP_MANAGER_PORT, and any test kernel that dials

--- a/tests/test_tempdir_hygiene.py
+++ b/tests/test_tempdir_hygiene.py
@@ -1,0 +1,54 @@
+"""The suite removes every temp directory it makes (tests/__init__.py + tests/conftest.py, 2026-09-06).
+
+Three checks. In-process: the package's mkdtemp hook is installed, so a directory a test makes is
+recorded for the exit sweep. Two subprocess checks run this same module's in-process test as a child,
+once under pytest (conftest's session-end sweep) and once under unittest (the package's atexit sweep),
+with ROMP_HYGIENE_MARKER naming a file where the child writes the directory it made and its
+XDG_STATE_HOME root; the parent asserts both are gone once the child exits. That is the behaviour
+that ends the leak (over a million stale fixture directories on one machine before this)."""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MARKER_ENV = "ROMP_HYGIENE_MARKER"
+
+
+class Hygiene(unittest.TestCase):
+    def test_mkdtemp_is_tracked_in_process(self):
+        self.assertTrue(getattr(tempfile.mkdtemp, "romp_tracked", False),
+                        "the tests package's mkdtemp hook is not installed")
+        marker = os.environ.get(MARKER_ENV)
+        if marker:                                   # child mode: leave the evidence the parent checks
+            d = tempfile.mkdtemp(prefix="romp-hygiene-child-")
+            self.assertTrue(os.path.isdir(d))
+            with open(marker, "w") as fh:
+                fh.write(d + "\n" + os.environ["XDG_STATE_HOME"] + "\n")
+
+    def _run_child(self, argv):
+        scratch = tempfile.mkdtemp(prefix="romp-hygiene-")      # tracked: swept when THIS session ends
+        marker = os.path.join(scratch, "paths.txt")
+        env = dict(os.environ, **{MARKER_ENV: marker})
+        r = subprocess.run(argv, cwd=REPO, env=env, capture_output=True, text=True, timeout=300)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        with open(marker) as fh:
+            made, state_root = fh.read().split("\n")[:2]
+        self.assertTrue(made and state_root, "the child left no evidence")
+        self.assertFalse(os.path.exists(made), "the child's mkdtemp directory survived: " + made)
+        self.assertFalse(os.path.exists(state_root), "the child's state root survived: " + state_root)
+
+    @unittest.skipIf(os.environ.get(MARKER_ENV), "child mode")
+    def test_pytest_child_session_removes_its_dirs_and_state_root(self):
+        self._run_child([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+                         "tests/test_tempdir_hygiene.py::Hygiene::test_mkdtemp_is_tracked_in_process"])
+
+    @unittest.skipIf(os.environ.get(MARKER_ENV), "child mode")
+    def test_unittest_child_run_removes_its_dirs_and_state_root(self):
+        self._run_child([sys.executable, "-m", "unittest", "-q",
+                         "tests.test_tempdir_hygiene.Hygiene.test_mkdtemp_is_tracked_in_process"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The test suite never removed the temp directories it created. This PR records every `tempfile.mkdtemp` call the test process makes and removes those directories when the run ends. Tests and test infrastructure only; no product code changes.

## What breaks

`tests/__init__.py` and `tests/conftest.py` each create a state root per process with `tempfile.mkdtemp(prefix="romp-tests-state-")` and never remove it, so every pytest process (the controller and each xdist worker) leaves two behind. About 490 test modules carry the same module-level `XDG_STATE_HOME = tempfile.mkdtemp()` preamble, and 293 of the 503 modules that call `mkdtemp` have no cleanup anywhere in the file. A full run leaves thousands of directories in the system temp directory.

On one developer machine that runs the suite many times a day, about 1.9 million of these directories accumulated. Listing the temp directory took minutes and tens of gigabytes of memory, and the out-of-memory kills that followed took down a running romp kernel.

## Reproduction

At current `main`, with a fresh private temp root:

```
export TMPDIR=$(mktemp -d)
python -m pytest -q -n 4 tests/test_kernel.py tests/test_judge.py
ls "$TMPDIR" | wc -l    # 101
```

Ten of the 101 entries are `romp-tests-state-*` roots (five processes, two each); the rest are per-test `mkdtemp` directories. With this PR the same commands leave 1 entry, pytest's own `pytest-of-<user>` base for `tmp_path`, and repeating the run keeps it at 1.

## The fix

`tests/__init__.py` wraps `tempfile.mkdtemp` once (the wrapper is marked, so a second import does not double-wrap) to record every directory the process creates, and registers an `atexit` sweep that removes what was recorded. `tests/conftest.py` calls the same sweep from `pytest_sessionfinish`, which fires in the controller and in every xdist worker. The sweep is idempotent and removes a recorded path only if its realpath is strictly under the realpath of `tempfile.gettempdir()`, it is a directory, and it is not a symlink. `tempfile.TemporaryDirectory` goes through the same `mkdtemp` and cleans itself first, so the sweep finds nothing of it.

The ordering the design rests on: pytest imports the conftest as `tests.conftest` through the package (the repo has no pytest config file, so the default `prepend` import mode applies), so the package installs the hook before conftest mints its own root, and that root is recorded too. A bare `python -m unittest tests.test_x` is covered through the package import. A direct script run (`python tests/test_x.py`) is not, which is the boundary the existing state floor already has.

## Tests

`tests/test_tempdir_hygiene.py` makes three checks:

- the hook is installed (`tempfile.mkdtemp.romp_tracked`);
- a child `python -m pytest` session that runs the in-process test removes the directory it made and its `XDG_STATE_HOME` root (conftest's session-end sweep);
- a child `python -m unittest` run does the same (the package's atexit sweep).

The child writes the two paths to a marker file named by `ROMP_HYGIENE_MARKER`; the parent asserts both are gone once the child exits. All three fail on `main`: the first because the hook is absent, the two child runs because the child exits non-zero on that same assertion.

`tests/test_state_isolation_order.py` still passes; both floor lines are kept (the conftest line gains a trailing comment).

Verification: full suite with `-n 8` (7325 passed, 50 skipped, one failure in `test_postal_relay_honesty` that is a pre-existing xdist-ordering flake and passes alone) and the CI-style serial run of `test_tempdir_hygiene.py`, `test_state_isolation_order.py` and `test_kernel.py` (466 passed). The full run left no `romp-tests-state-*` or per-test directories in the private temp root.

## Not covered by this PR

- Temp files. `mkstemp` and `NamedTemporaryFile(delete=False)` create files, which the hook does not record. Most sites clean up in-file; the `_set_live` helper in `tests/test_postal_live_only.py` and `tests/test_postal_relay_honesty.py` does not, so a full run still leaves about 40 small `.json` files. That is a separate, smaller fix.
- Temp use by child processes and by shell `mktemp`. At tip none of it lands in the system temp directory: kernels spawned by tests write only inside the state root, and the bats suites `rm -rf` in teardown.
- `tests/manager-drain.test.js`, whose module-level `mkdtempSync` has no removal: one directory per `node --test` run.
- A run ended by pytest-timeout's `--timeout-method=thread`, which exits through `os._exit` and so skips both `atexit` and `pytest_sessionfinish`. A hung CI run leaks that run's directories, which is acceptable on an ephemeral runner.

A follow-on that would cover children and files as well is to point `TMPDIR` at one private root per run and remove it at session end. This PR takes the smaller, source-level step because it also covers bare unittest runs, which a pytest-only redirect would not.

Tier: tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)