### PR TITLE
The #879 follow-ups: gesture stamps climb above every stamp seen, a stood-down pick can be applied anyway, and the federation queue's edges are journaled, cleared per entry, and toasted once per refused flush

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -633,6 +633,11 @@ def _version_info():
                          "commentModel": jd._state_str("comment-model", "session"),
                          "commentEffort": jd._state_str("comment-effort", "session"),
                          "commentFast": jd._state_str("comment-fast", "session")},
+            # every gt-gated store's last-applied gesture stamp (epoch-ms ints, nothing path-shaped):
+            # the gear stamps its next gesture above these instead of trusting the device clock.
+            # Top-level, not lifted into /tunnels rows — a remote's newer stamp reaches the dashboard
+            # through its settingStale frame, and Apply anyway is the designed path from there.
+            "settingsGt": _settings_gt(),
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
             "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
@@ -28070,7 +28075,44 @@ def _setting_kept_value(name):
     return jd._state_str(name, "")   # the judge-tier stores are bare value files
 
 
-def _tell_stale_gesture(client):
+# Every gt-gated store, by the name _setting_stale is called with — the vocabulary the settingStale
+# frame and the gear's STALE_LABELS already share, so /version's settingsGt speaks the same one.
+_GT_STORES = ("auto-nudge", "compact-suggest", "file-editing", "update-mode", "thinking-summaries",
+              "judge-model", "index-model", "judge-effort", "index-effort",
+              "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast")
+
+
+def _setting_stored_gt(name):
+    """The last-APPLIED gesture stamp a store holds — _setting_kept_value's switch, for the stamp
+    beside the value. Absent file, absent field or garbled content all read 0 (nothing to outrank),
+    the same defensive shape the setters use for `prev`."""
+    if name == "auto-nudge":
+        return _gt_int(_auto_nudge_data().get("gt"))
+    if name == "compact-suggest":
+        return _gt_int(_auto_nudge_data().get("compactSuggestGt"))
+    if name == "update-mode":
+        return _update_mode_gt()
+    if name in ("file-editing", "thinking-summaries"):
+        try:
+            d = json.loads((jd.STATE / (THINKING_SUMMARIES_FILE if name == "thinking-summaries"
+                                        else "file-editing.json")).read_text())
+            return _gt_int(d.get("gt")) if isinstance(d, dict) else 0
+        except Exception:
+            return 0
+    return _judge_state_gt(name)   # the judge-tier stores keep theirs in a `<name>.gt` sidecar
+
+
+def _settings_gt():
+    """/version's `settingsGt`: every gt-gated store's last-applied gesture stamp, keyed by the
+    store name the settingStale frame uses (PR #879 follow-up). Gesture stamps are minted on the
+    DEVICE, so a clock running ahead used to stamp every store into the future and lock every
+    correctly-clocked device out until the skew elapsed; a dashboard that reads this on open stamps
+    its next gesture at max(Date.now(), gt + 1) instead of trusting its own wall clock
+    (ui/webview/gesture-clock.js). Epoch-ms integers only — fine for the auth-exempt route."""
+    return {n: _setting_stored_gt(n) for n in _GT_STORES}
+
+
+def _tell_stale_gesture(client, msg):
     """A gt-gated setter just refused: if that refusal was a stale STAND-DOWN (recorded on this
     thread by _setting_stale), answer the DELIVERING socket with a small settingStale frame — the
     same targeted _reply idiom the saveFile acks use, never a broadcast. Without it the refusal
@@ -28078,12 +28120,17 @@ def _tell_stale_gesture(client):
     pick as applied (the gear fills only on open), and with the mesh AGREEING on the kept value
     the mixed marks showed nothing. The gear toasts the frame and re-fills if open — event-keyed,
     the frame IS the deciding event; no polling. A refusal for any other cause (invalid value,
-    OSError) records no notice and sends nothing."""
+    OSError) records no notice and sends nothing.
+    The frame echoes `gesture`: the refused message itself, WITHOUT its stamp, so the toast can
+    offer to re-issue it as a new gesture (a fresh click is legitimate new information) stamped
+    above the stored one. The stamp is dropped on purpose — a re-issue can never reuse the stale
+    one — and the gear only re-issues a type that matches the setting the frame names."""
     st = _pop_stale_notice()
     if not st:
         return
     _reply(client, {"type": "settingStale", "setting": st["setting"],
-                    "storedGt": st["storedGt"], "kept": _setting_kept_value(st["setting"])})
+                    "storedGt": st["storedGt"], "kept": _setting_kept_value(st["setting"]),
+                    "gesture": {k: v for k, v in msg.items() if k != "gt"}})
 
 
 # ---- pasted-image hydration + dropped-file handling (ported from the old TS kernel chat-view/src/
@@ -35709,7 +35756,7 @@ class Handler(BaseHTTPRequestHandler):
             # feed gear → server-side Auto Nudge on/off; a stale gesture stamp stands down (no
             # apply), and the dashboard that made the losing gesture hears it
             if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
             # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a
             # real apply acts immediately on turn-on (don't wait 4s) — a stood-down toggle is not
@@ -35719,23 +35766,23 @@ class Handler(BaseHTTPRequestHandler):
             if _set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
                 _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
             # feed gear → how romp handles new releases at boot; gt-gated like every queued setting
             if _set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg)) is None:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setFileEditing" and msg.get("enabled") is not None:
             # The viewer's Edit consent popup (the user 2026-08-22) — a kernel-side setting like
             # setAutoNudge, broadcast by federation.ts KERNEL_SETTING so one yes answers the mesh.
             # A stale gesture stamp stands down (a queued flush must not undo a newer choice).
             if _set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setThinkingSummaries" and msg.get("enabled") is not None:
             # The gear's Thinking summaries checkbox (2026-09-01) — kernel-side like setFileEditing but
             # PER-INSTALL (not a KERNEL_SETTING: nothing to propagate), gt-gated all the same; the SDK
             # backend reads the store at each session's next connect, so nothing else to do here.
             if _set_thinking_summaries(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the
             # goal is gone, so following up on it makes no sense. Chips can cite a SUB-goal of the card
@@ -36224,63 +36271,63 @@ class Handler(BaseHTTPRequestHandler):
                 threading.Thread(target=_propagate_judge_settings,   # …and every linked kernel's judges with it
                                  args=({"judgeModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setIndexModel" and msg.get("model"):
             _jgt = _set_index_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Indexing model" dropdown
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"indexModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setJudgeEffort":
             _jgt = _set_judge_effort(str(msg.get("effort") or ""), gt=_gesture_ms(msg))   # gear "Triage effort" ("" = default/none)
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"judgeEffort": str(msg.get("effort") or ""), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setIndexEffort":
             _jgt = _set_index_effort(str(msg.get("effort") or ""), gt=_gesture_ms(msg))   # gear "Indexing effort"
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"indexEffort": str(msg.get("effort") or ""), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setDistillModel" and msg.get("model"):
             _jgt = _set_distill_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Distilling model" ("triage" = follow the triage pick)
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"distillModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setDistillEffort" and msg.get("effort"):
             _jgt = _set_distill_effort(str(msg["effort"]), gt=_gesture_ms(msg))   # gear "Distilling effort" ("triage" = follow; "none" = pinned no-flag)
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"distillEffort": str(msg["effort"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCommentModel" and msg.get("model"):
             _jgt = _set_comment_model(str(msg["model"]), gt=_gesture_ms(msg))   # gear "Comment model" ("session" = same as the session)
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"commentModel": str(msg["model"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCommentEffort" and msg.get("effort"):
             _jgt = _set_comment_effort(str(msg["effort"]), gt=_gesture_ms(msg))   # gear "Comment effort"
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"commentEffort": str(msg["effort"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCommentFast" and msg.get("fast"):
             _jgt = _set_comment_fast(str(msg["fast"]), gt=_gesture_ms(msg))     # gear "Fast comment threads" ("on" / "session")
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"commentFast": str(msg["fast"]), "gt": _jgt},), daemon=True).start()
             else:
-                _tell_stale_gesture(client)
+                _tell_stale_gesture(client, msg)
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3324,7 +3324,7 @@ def _setting_stale(name, gt, applied_gt):
     _stale_seen.last = None
     if gt is None or gt > applied_gt:
         return False
-    _stale_seen.last = {"setting": name, "storedGt": applied_gt}
+    _stale_seen.last = {"setting": name, "storedGt": applied_gt, "gt": gt}
     sys.stderr.write("setting %s: stale gesture stood down (gesture %d <= applied %d) — "
                      "no apply, no propagation\n" % (name, gt, applied_gt))
     return True
@@ -28124,12 +28124,15 @@ def _tell_stale_gesture(client, msg):
     The frame echoes `gesture`: the refused message itself, WITHOUT its stamp, so the toast can
     offer to re-issue it as a new gesture (a fresh click is legitimate new information) stamped
     above the stored one. The stamp is dropped on purpose — a re-issue can never reuse the stale
-    one — and the gear only re-issues a type that matches the setting the frame names."""
+    one — and the gear only re-issues a type that matches the setting the frame names.
+    It also carries `gt`, the refused gesture's OWN stamp: a dashboard's broadcast reaches every
+    linked kernel, so one stale flush draws one refusal per kernel — all sharing this stamp — and
+    the gear folds them into one toast naming the refusing hosts (setting + gt is the fold key)."""
     st = _pop_stale_notice()
     if not st:
         return
     _reply(client, {"type": "settingStale", "setting": st["setting"],
-                    "storedGt": st["storedGt"], "kept": _setting_kept_value(st["setting"]),
+                    "storedGt": st["storedGt"], "gt": st["gt"], "kept": _setting_kept_value(st["setting"]),
                     "gesture": {k: v for k, v in msg.items() if k != "gt"}})
 
 

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -560,8 +560,9 @@ class Wiring(unittest.TestCase):
         for opt in ("value=ask", "value=auto", "value=off"):
             self.assertIn(opt, self.gear)
         # the post is gesture-stamped (2026-08-29): setUpdateMode rides federation's queued
-        # KERNEL_SETTING class, so the kernel orders applies by the click's own time
-        self.assertIn("post({ type: 'setUpdateMode', mode: upm.value, gt: Date.now() })", self.gear)
+        # KERNEL_SETTING class, so the kernel orders applies by the click's own time — minted through
+        # the gesture clock (ui/webview/gesture-clock.js), above every stamp the page has seen
+        self.assertIn("post({ type: 'setUpdateMode', mode: upm.value, gt: gclock.stamp('update-mode') })", self.gear)
         # fill() renders through setShow now (2026-09-01): the same silent write, plus the
         # honest marked-option injection when a stored value is off this page's list
         self.assertIn("setShow(upm, v.updateMode)", self.gear)

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -629,6 +629,8 @@ class StaleGestureAnswersTheDeliveringSocket(_Base):
         self.assertEqual(frames[0]["setting"], "judge-model")
         self.assertEqual(frames[0]["storedGt"], T_NEW)
         self.assertEqual(frames[0]["kept"], "fable", "the kept value rides along (cheap: one store read)")
+        self.assertEqual(frames[0]["gt"], T_OLD, "the refused gesture's own stamp rides the frame — the "
+                         "dashboard folds N kernels' refusals of one flush by it")
 
     def test_the_frame_echoes_the_refused_gesture_without_its_stamp(self):
         # the toast's Apply anyway re-issues exactly this echo with a FRESH stamp (PR #879 follow-up):
@@ -679,6 +681,7 @@ class StaleGestureAnswersTheDeliveringSocket(_Base):
             self.assertEqual(len(frames), 1, store)
             self.assertEqual(frames[0]["setting"], store)
             self.assertEqual(frames[0]["storedGt"], T_NEW)
+            self.assertEqual(frames[0]["gt"], T_OLD, store)
             self.assertEqual(frames[0]["kept"], kept, store)
             self.assertEqual(frames[0]["gesture"], older, "the refused message echoes back minus its gt (%s)" % store)
 

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -630,6 +630,20 @@ class StaleGestureAnswersTheDeliveringSocket(_Base):
         self.assertEqual(frames[0]["storedGt"], T_NEW)
         self.assertEqual(frames[0]["kept"], "fable", "the kept value rides along (cheap: one store read)")
 
+    def test_the_frame_echoes_the_refused_gesture_without_its_stamp(self):
+        # the toast's Apply anyway re-issues exactly this echo with a FRESH stamp (PR #879 follow-up):
+        # the refused message rides back minus its gt, so a re-issue can never reuse the stale one
+        self.dispatch_rec({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})
+        sent = self.dispatch_rec({"type": "setJudgeModel", "model": "opus", "gt": T_OLD})
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(frames[0]["gesture"], {"type": "setJudgeModel", "model": "opus"})
+        self.assertNotIn("gt", frames[0]["gesture"], "the stale stamp is dropped on purpose")
+        # a boolean toggle echoes the same way
+        self.dispatch_rec({"type": "setAutoNudge", "enabled": False, "gt": T_NEW})
+        sent = self.dispatch_rec({"type": "setAutoNudge", "enabled": True, "gt": T_OLD})
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(frames[0]["gesture"], {"type": "setAutoNudge", "enabled": True})
+
     def test_every_gt_gated_setting_answers(self):
         cases = [({"type": "setAutoNudge", "enabled": False}, {"type": "setAutoNudge", "enabled": True},
                   "auto-nudge", False),
@@ -666,12 +680,123 @@ class StaleGestureAnswersTheDeliveringSocket(_Base):
             self.assertEqual(frames[0]["setting"], store)
             self.assertEqual(frames[0]["storedGt"], T_NEW)
             self.assertEqual(frames[0]["kept"], kept, store)
+            self.assertEqual(frames[0]["gesture"], older, "the refused message echoes back minus its gt (%s)" % store)
 
     def test_no_frame_for_invalid_or_unstamped(self):
         sent = self.dispatch_rec({"type": "setJudgeModel", "model": "gpt-99", "gt": T_NEW})
         self.assertEqual(sent, [], "a refused VALUE is not a stale gesture — no frame")
         sent = self.dispatch_rec({"type": "setJudgeModel", "model": "haiku"})
         self.assertEqual(sent, [], "the unstamped compat path applies — no frame")
+
+
+class VersionReportsEveryStoredStamp(_Base):
+    """/version carries `settingsGt`: every gt-gated store's last-applied stamp, keyed by the store
+    name the settingStale frame uses (PR #879 follow-up). The gear reads /version on every open and
+    stamps its next gesture at max(Date.now(), gt + 1) — the maintainer's proposed shape — instead of
+    trusting the device's wall clock. Integers only: the route is auth-exempt."""
+
+    def test_a_fresh_install_reports_every_store_at_zero(self):
+        gts = km._version_info()["settingsGt"]
+        self.assertEqual(set(gts), set(km._GT_STORES), "one key per gt-gated store, no more, no less")
+        self.assertEqual(len(km._GT_STORES), 14, "five toggles/modes + nine judge-tier stores")
+        self.assertEqual(set(gts.values()), {0}, "nothing applied yet reads 0 — nothing to outrank")
+        self.assertEqual(json.loads(json.dumps(gts)), gts, "plain JSON — ints, no paths, nothing to redact")
+
+    def test_each_setter_s_stamp_is_reported_under_its_store_and_nothing_else_moves(self):
+        self.assertEqual(km._set_judge_model("fable", gt=T_NEW), T_NEW)
+        self.assertEqual(km._set_auto_nudge(False, gt=T_OLD), T_OLD)
+        self.assertEqual(km._set_compact_suggest(True, gt=T_NEW + 5), T_NEW + 5)
+        self.assertEqual(km._set_file_editing(True, gt=T_NEW + 6), T_NEW + 6)
+        self.assertEqual(km._set_update_mode("auto", gt=T_NEW + 7), T_NEW + 7)
+        self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW + 8), T_NEW + 8)
+        self.assertEqual(km._set_comment_fast("on", gt=T_NEW + 9), T_NEW + 9)
+        gts = km._version_info()["settingsGt"]
+        want = {"judge-model": T_NEW, "auto-nudge": T_OLD, "compact-suggest": T_NEW + 5,
+                "file-editing": T_NEW + 6, "update-mode": T_NEW + 7, "thinking-summaries": T_NEW + 8,
+                "comment-fast": T_NEW + 9}
+        for store, gt in want.items():
+            self.assertEqual(gts[store], gt, store)
+        for store in set(km._GT_STORES) - set(want):
+            self.assertEqual(gts[store], 0, "%s was never set and stays 0" % store)
+        # the two checkboxes that share auto-nudge.json keep separate clocks in the report too
+        self.assertNotEqual(gts["auto-nudge"], gts["compact-suggest"])
+
+    def test_an_unstamped_apply_reports_its_arrival_time(self):
+        before = int(time.time() * 1000)
+        km._set_index_effort("high")
+        got = km._version_info()["settingsGt"]["index-effort"]
+        self.assertGreaterEqual(got, before, "the compat path's arrival stamp is what the store holds")
+
+    def test_the_frames_setting_names_are_exactly_the_report_s_keys(self):
+        # the completeness cross-check: every store a settingStale frame can name is reported, so the
+        # gear's clock (which learns from BOTH) has one vocabulary
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        newer = [{"type": "setAutoNudge", "enabled": False}, {"type": "setCompactSuggest", "enabled": True},
+                 {"type": "setFileEditing", "enabled": True}, {"type": "setUpdateMode", "mode": "auto"},
+                 {"type": "setThinkingSummaries", "enabled": True}, {"type": "setJudgeModel", "model": "fable"},
+                 {"type": "setIndexModel", "model": "fable"}, {"type": "setJudgeEffort", "effort": "high"},
+                 {"type": "setIndexEffort", "effort": "high"}, {"type": "setDistillModel", "model": "haiku"},
+                 {"type": "setDistillEffort", "effort": "high"}, {"type": "setCommentModel", "model": "haiku"},
+                 {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"}]
+        older = [{"type": "setAutoNudge", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
+                 {"type": "setFileEditing", "enabled": False}, {"type": "setUpdateMode", "mode": "off"},
+                 {"type": "setThinkingSummaries", "enabled": False}, {"type": "setJudgeModel", "model": "opus"},
+                 {"type": "setIndexModel", "model": "opus"}, {"type": "setJudgeEffort", "effort": "low"},
+                 {"type": "setIndexEffort", "effort": "low"}, {"type": "setDistillModel", "model": "triage"},
+                 {"type": "setDistillEffort", "effort": "low"}, {"type": "setCommentModel", "model": "session"},
+                 {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"}]
+        with contextlib.redirect_stderr(io.StringIO()):
+            for n, o in zip(newer, older):
+                km.Handler._dispatch_ws(types.SimpleNamespace(), dict(n, gt=T_NEW), client)
+                km.Handler._dispatch_ws(types.SimpleNamespace(), dict(o, gt=T_OLD), client)
+        named = {m["setting"] for m in sent if m.get("type") == "settingStale"}
+        self.assertEqual(named, set(km._version_info()["settingsGt"]), "frames and the report share one vocabulary")
+        self.assertEqual(len(named), 14)
+
+
+class ASkewedClockCannotLockTheStore(_Base):
+    """The maintainer's scenario on #879: a device whose clock runs ahead stamps a store into the
+    future, and every correctly-clocked device is refused until the skew elapses — no gesture from
+    them can win. With the frame echoing the refused gesture and reporting the stamp it lost to, the
+    dashboard re-issues the same pick stamped max(now, storedGt + 1): applied, propagated with that
+    stamp, no frame. The re-issue is a new user gesture — new information, not a clock heuristic."""
+
+    def dispatch_rec(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        return sent
+
+    def test_the_echoed_gesture_re_issued_above_the_stored_stamp_wins(self):
+        self.dispatch_rec({"type": "setJudgeModel", "model": "fable", "gt": T_NEW})   # the fast clock's pick
+        self.propagated.clear()
+        sent = self.dispatch_rec({"type": "setJudgeModel", "model": "opus", "gt": T_OLD})   # the honest clock's, refused
+        frame = [m for m in sent if m.get("type") == "settingStale"][0]
+        self.assertEqual(frame["storedGt"], T_NEW)
+        self.assertEqual(km.jd._state_str("judge-model", ""), "fable", "refused: the store still holds the future stamp's pick")
+        self.assertEqual(self.propagated, [], "a refusal fans nothing out")
+        # what the toast's Apply anyway sends: the echo plus max(Date.now(), storedGt + 1) — the
+        # device's clock says T_OLD, so the learned stamp wins
+        retry = dict(frame["gesture"], gt=max(T_OLD, frame["storedGt"] + 1))
+        sent = self.dispatch_rec(retry)
+        self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [], "the re-issue is not refused")
+        self.assertEqual(km.jd._state_str("judge-model", ""), "opus", "the correctly-clocked device's pick applied")
+        self.assertEqual(km._judge_state_gt("judge-model"), T_NEW + 1, "the store holds the re-issue's stamp")
+        self.assertEqual(self.propagated[-1], {"judgeModel": "opus", "gt": T_NEW + 1},
+                         "…and the fan-out carries it, so every receiver orders the same way")
+        self.assertEqual(km._version_info()["settingsGt"]["judge-model"], T_NEW + 1)
+
+    def test_a_toggle_climbs_the_same_way(self):
+        self.dispatch_rec({"type": "setFileEditing", "enabled": False, "gt": T_NEW})
+        sent = self.dispatch_rec({"type": "setFileEditing", "enabled": True, "gt": T_OLD})
+        frame = [m for m in sent if m.get("type") == "settingStale"][0]
+        self.assertFalse(km._file_editing_on())
+        sent = self.dispatch_rec(dict(frame["gesture"], gt=max(T_OLD, frame["storedGt"] + 1)))
+        self.assertEqual(sent, [])
+        self.assertTrue(km._file_editing_on(), "the re-issued consent applied")
+        self.assertEqual(km._setting_stored_gt("file-editing"), T_NEW + 1)
 
 
 class WiringPins(unittest.TestCase):
@@ -698,9 +823,13 @@ class WiringPins(unittest.TestCase):
         self.assertIn('_set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg))', self.src)
 
     def test_every_stood_down_branch_tells_the_delivering_socket(self):
-        self.assertGreaterEqual(self.src.count("_tell_stale_gesture(client)"), 14,
+        self.assertGreaterEqual(self.src.count("_tell_stale_gesture(client, msg)"), 14,
                                 "all fourteen gt-gated branches (five toggles + nine judge tiers) "
-                                "answer the delivering socket on a stand-down")
+                                "answer the delivering socket on a stand-down, handing over the "
+                                "refused message so the frame can echo it")
+        self.assertNotIn("_tell_stale_gesture(client)\n", self.src,
+                         "no branch still calls the echo-less form — the toast's Apply anyway "
+                         "re-issues what the frame echoes")
 
     def test_the_docstring_names_all_three_none_causes(self):
         doc = km._set_judge_state.__doc__ or ""

--- a/ui/webview/federation-send-queue.test.ts
+++ b/ui/webview/federation-send-queue.test.ts
@@ -262,6 +262,88 @@ test("a setting queued on a CLOSED socket survives the watchdog's lost-timer red
   });
 });
 
+// ── the queue's edges (the #879 review's smaller notes): queueing is journaled, and a flush that
+// throws part-way clears only what it delivered.
+
+test("a setting queued for a down host leaves a sendqueue breadcrumb: host, type, stamp, socket state", () => {
+  withFed((fm, _win, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");           // CONNECTING: the window a send used to drop in
+    fm.outbound({ type: "setJudgeModel", model: "m1", gt: 1000 });
+    const q = diags(localSends, "sendqueue");
+    assert.equal(q.length, 1, "one line per queued gesture per down host");
+    assert.deepEqual(q[0].data, { host: "TESTHOSTA", msgType: "setJudgeModel", gt: 1000, rs: 0 });
+    assert.equal(diags(localSends, "senddrop").length, 0, "queued, not dropped");
+    // the user picks again while the host is still down: the replaced pick is named
+    fm.outbound({ type: "setJudgeModel", model: "m2", gt: 2000 });
+    const q2 = diags(localSends, "sendqueue");
+    assert.equal(q2.length, 2);
+    assert.deepEqual(q2[1].data, { host: "TESTHOSTA", msgType: "setJudgeModel", gt: 2000, rs: 0, superseded: 1000 });
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)), [{ type: "setJudgeModel", model: "m2", gt: 2000 }],
+      "the flush itself is unchanged: latest per type, stamp intact");
+  });
+});
+
+test("a live send is not a queue event: no sendqueue breadcrumb on an OPEN socket", () => {
+  withFed((fm, _win, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");
+    sock.open();
+    fm.outbound({ type: "setJudgeModel", model: "m1", gt: 1000 });
+    assert.deepEqual(sock.types(), ["setJudgeModel"], "delivered live");
+    assert.equal(diags(localSends, "sendqueue").length, 0);
+  });
+});
+
+test("a CLOSED socket queues with rs 3; an unstamped message records gt 0 and supersedes as `true`", () => {
+  withFed((fm, _win, localSends) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;                                // the relay dropped under us
+    fm.outbound({ type: "setAutoNudge", enabled: false });   // an older emitter: no stamp
+    fm.outbound({ type: "setAutoNudge", enabled: true, gt: 5 });
+    const q = diags(localSends, "sendqueue").map((d) => d.data);
+    assert.deepEqual(q, [{ host: "TESTHOSTA", msgType: "setAutoNudge", gt: 0, rs: 3 },
+                         { host: "TESTHOSTA", msgType: "setAutoNudge", gt: 5, rs: 3, superseded: true }]);
+  });
+});
+
+/** A socket whose Nth send throws — the mid-flush failure the per-entry clear exists for. */
+class FlakySocket extends FakeSocket {
+  static failAt = 2;
+  n = 0;
+  send(s: string): void {
+    if (++this.n === FlakySocket.failAt) throw new Error("send failed mid-flush");
+    super.send(s);
+  }
+}
+
+test("a send that throws mid-flush clears only the delivered entries: the held one flushes on the redial, nothing replays", () => {
+  withFed((fm, _win, localSends) => {
+    (globalThis as any).WebSocket = FlakySocket;      // withFed restores the global in its finally
+    const sock = attach(fm, "TESTHOSTA") as FlakySocket;
+    fm.outbound({ type: "setFileEditing", enabled: true, gt: 10 });
+    fm.outbound({ type: "setJudgeModel", model: "m1", gt: 20 });
+    sock.open();                                      // the first send lands, the second throws
+    assert.deepEqual(sock.types(), ["setFileEditing"]);
+    assert.deepEqual([...fm.conns.get("TESTHOSTA").pending.keys()], ["setJudgeModel"],
+      "the delivered entry is gone from the queue; the undelivered one is held");
+    const halt = diags(localSends, "hostconn").filter((d) => d.data.ev === "flush-halt");
+    assert.equal(halt.length, 1, "a partial flush is never silent");
+    assert.deepEqual(halt[0].data, { host: "TESTHOSTA", ev: "flush-halt", flushed: ["setFileEditing"], held: ["setJudgeModel"] });
+    const open = diags(localSends, "hostconn").filter((d) => d.data.ev === "open").pop();
+    assert.deepEqual(open.data, { host: "TESTHOSTA", ev: "open", flushed: ["setFileEditing"] },
+      "the open breadcrumb names what actually went, and the open handler ran on past the halt");
+    // the redial: only the held entry rides the fresh socket
+    (globalThis as any).WebSocket = FakeSocket;
+    sock.readyState = 3;
+    const s2 = redial(fm, "TESTHOSTA");
+    s2.open();
+    assert.deepEqual(s2.sent.map((s) => JSON.parse(s)), [{ type: "setJudgeModel", model: "m1", gt: 20 }],
+      "the delivered entry is not replayed — a replay is one gesture delivered twice");
+    assert.equal(fm.conns.get("TESTHOSTA").pending.size, 0);
+  });
+});
+
 // Source pins, in the federation-remote-gate.test.ts style: the properties above hold only while
 // every remote send routes through the ONE queue-aware helper, and the flush hangs on the open
 // event itself — a raw `ws.send` site or a timer-based flush would reopen the hole quietly.

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -103,6 +103,11 @@ export function prefixInbound(host: string, msg: any): any {
   // prefixed), but its buildId only means something on THAT kernel's counter — stamp the host so the
   // feed pane compares it against the same host's frame in the merged payload, never the local counter
   if (out.type === "cardMoveAck" || out.type === "cardPredict") out.host = host;
+  // a remote kernel's stand-down reply to a settings gesture (settingStale) cannot name its own host;
+  // the gear folds one flush's N refusals into one toast and names the refusing machines. The local
+  // host ("") took the identity exit above, so a local frame has no host key: the gear words it as
+  // this machine. The echoed `gesture` inside passes through untouched — it is re-issued as-is.
+  if (out.type === "settingStale") out.host = host;
   if (out.type === "sessionList" && Array.isArray(out.items)) {
     out.items = out.items.map((it: any) => (it && typeof it === "object" && typeof it.id === "string"
       ? { ...it, id: prefixId(host, it.id),
@@ -924,7 +929,9 @@ export class FederationManager {
   //   frozen, so every KERNEL_SETTING carries `gt` (epoch ms minted at the user's gesture, where
   //   the message is built) and the KERNEL orders applies by it, standing stale flushes down. The
   //   queue's contract here is to deliver the message UNCHANGED — never re-stamp at send or flush
-  //   time, which would forge freshness onto an hours-old pick;
+  //   time, which would forge freshness onto an hours-old pick. Queueing is journaled (`sendqueue`),
+  //   so a later disagreement between machines is attributable to this tab holding the pick while
+  //   the host was down, and to the older pick of the same type it replaced;
   // - anything else keeps its behavior (replaying an arbitrary action minutes later can be worse
   //   than dropping it — a deliberate non-goal) but the drop lands a client-diag breadcrumb naming
   //   the type and host, beside the existing warn toast: a drop is never silent.
@@ -935,7 +942,15 @@ export class FederationManager {
       return;
     }
     if (c && msg && typeof msg.type === "string" && KERNEL_SETTING.has(msg.type)) {
-      c.pending.set(msg.type, msg); // not dropped — it rides the next open, so no toast here
+      // not dropped — it rides the next open, so no toast; but never silent either: the breadcrumb
+      // names the host, the type, the gesture's own stamp, the socket's state at queue time (rs; -1
+      // = not dialed) and, when it replaced an older queued pick of the same type, that pick's stamp
+      // (superseded). The kernel stamps the journal line's time — nothing is minted here.
+      const prev = c.pending.get(msg.type);
+      c.pending.set(msg.type, msg);
+      this.diag("sendqueue", { host, msgType: msg.type, gt: typeof msg.gt === "number" ? msg.gt : 0,
+                               rs: c.ws ? c.ws.readyState : -1,
+                               ...(prev ? { superseded: typeof prev.gt === "number" ? prev.gt : true } : {}) });
       return;
     }
     this.diag("senddrop", { host, msgType: (msg && msg.type) || "" });
@@ -946,13 +961,28 @@ export class FederationManager {
    *  synchronously, so they precede ANY post-reconnect traffic. The file viewer's consent flow relies
    *  on exactly that: its setFileEditing broadcast must land before the save that follows the yes
    *  (the same-socket ordering the save route's gate assumes), now across a down-socket window too.
-   *  Returns the flushed types for the open breadcrumb. */
+   *  Each entry clears AS IT IS DELIVERED: a send that throws mid-flush leaves only the undelivered
+   *  ones for the next open. A whole-map clear after the loop would replay the delivered ones too,
+   *  and a replay is one gesture delivered twice (a kernel without gesture ordering applies it twice;
+   *  a current one logs an echo or stand-down line per copy). The halt is journaled in the hostconn
+   *  family (`flush-halt`, naming what went and what is held) because a partial flush is never
+   *  silent; the catch swallows on purpose so the open handler still stamps lastRecv and dispatches
+   *  romp:hostRelayUp, and the dead socket's own onclose redials. Returns the flushed types for the
+   *  open breadcrumb. */
   private flushPending(conn: Conn): string[] {
     if (!conn.pending.size || !conn.ws || conn.ws.readyState !== 1) return [];
-    const types = [...conn.pending.keys()];
-    for (const m of conn.pending.values()) conn.ws.send(JSON.stringify(m));
-    conn.pending.clear();
-    return types;
+    const flushed: string[] = [];
+    for (const [t, m] of conn.pending) {   // deleting the current entry mid-iteration is spec-safe on a Map
+      try {
+        conn.ws.send(JSON.stringify(m));
+      } catch (e) {
+        this.diag("hostconn", { host: conn.host, ev: "flush-halt", flushed: [...flushed], held: [...conn.pending.keys()] });
+        break;
+      }
+      conn.pending.delete(t);
+      flushed.push(t);
+    }
+    return flushed;
   }
 
   // A route to a host whose socket isn't open would otherwise VANISH — creating a session on an

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -35,8 +35,9 @@ test("the banner is build-once, acknowledges, and offers Opus only for the Fable
     "built once — the button survives re-renders (click-safety)");
   assert.match(FEED, /btn\.textContent = "Switching…";\s*\n\s*\/\/ ?.*|btn\.textContent = "Switching…";/,
     "acknowledges before the kernel round-trip");
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus", gt: Date\.now\(\) \}\)/,
-    "the switch is a settings gesture like any gear pick — stamped so the kernel can order it");
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus", gt: gclock\.stamp\("judge-model"\) \}\)/,
+    "the switch is a settings gesture like any gear pick — stamped through the gesture clock so the kernel can order it");
+  assert.match(FEED, /const gclock = require\("\.\/gesture-clock\.js"\);/, "the feed loads the clock the gear stamps with");
   assert.match(FEED, /btn\.style\.display = fable \? "" : "none";/, "the switch offer is Fable-specific");
   assert.match(FEED, /The account's usage window is full/, "general exhaustion states it plainly");
   assert.match(FEED, /paintJudgeLimit\(\);   \/\/ the usage-limit banner above the columns/,

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -444,6 +444,10 @@ const vscodeApi =
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { initGear } = require("./gear.js");
 initGear((m: Record<string, unknown>) => vscodeApi?.postMessage(m));
+// the gesture clock the gear stamps its settings posts with — one module graph per document, so
+// the gear's learning (each store's stamp from /version on open) serves the banner below too
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const gclock = require("./gesture-clock.js");
 
 // The romp strip (VS Code only — the host opts in via __rompShowStrip): usage
 // bars + the gear button, docked below #feed-foot. The gear raises the modal
@@ -4252,8 +4256,10 @@ function ensureJudgeLimit(): HTMLElement {
   btn.onclick = () => {
     btn.disabled = true;
     btn.textContent = "Switching…";                      // acknowledge before the round-trip
-    // gt: a settings gesture like any gear pick — stamped at the click so the kernel can order it
-    vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus", gt: Date.now() });
+    // gt: a settings gesture like any gear pick — stamped at the click, through the gesture clock, so
+    // the kernel can order it (with the gear never opened in this document the clock has learned
+    // nothing and this is the wall clock; a refusal then offers Apply anyway)
+    vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus", gt: gclock.stamp("judge-model") });
   };
   b.appendChild(btn);
   const sess = el("span", "jl-sess"); b.appendChild(sess);   // who the window actually touches (2026-08-28)

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -362,7 +362,10 @@ test("Edit is consent-gated, and the gate is the KERNEL's flag, not the button (
   // — stamped with the gesture's own time, so a copy queued for a down host and flushed hours
   // later can never outrank a newer pick at the kernel (the store orders applies by gt)
   assert.match(VIEW, /window\.confirm\(\s*\n?\s*"Allow editing files from the dashboard\?/);
-  assert.match(VIEW, /post\(\{ type: "setFileEditing", enabled: true, gt: Date\.now\(\) \}\);/);
+  assert.match(VIEW, /post\(\{ type: "setFileEditing", enabled: true, gt: gclock\.stamp\("file-editing"\) \}\);/,
+    "…minted through the gesture clock, above every stamp the /version read just reported");
+  assert.match(VIEW, /const gclock = require\("\.\/gesture-clock\.js"\);/, "the viewer loads the clock");
+  assert.match(VIEW, /gclock\.learnAll\(v\.settingsGt\);/, "the consent check's /version read teaches the clock");
   // the popup's promise of a gear off-switch is real, and the save route refuses server-side
   const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
   assert.ok(GEAR.includes("'setFileEditing'"), "the gear can turn it back off");

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -21,6 +21,8 @@ import DOMPurify from "dompurify";
 import { fileUrl } from "./preview";
 import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const gclock = require("./gesture-clock.js");   // the gesture clock every settings post stamps through
 
 // hljs is registered per-bundle. Same language set (and grammar registrations) the chat's fence
 // highlighting uses, dup-guarded, so importing this module alongside render.ts costs nothing.
@@ -335,16 +337,21 @@ export function openFileView(path: string, sid?: string | null): void {
   // wrongly-granted yes here can do is draw one refused save with its plain-words error.
   async function editingAllowed(): Promise<boolean> {
     let on = false;
-    try { on = !!(await (await fetch(kernelUrl("/version"), { cache: "no-store" })).json()).fileEditing; } catch { /* ask below */ }
+    try {
+      const v = await (await fetch(kernelUrl("/version"), { cache: "no-store" })).json();
+      on = !!v.fileEditing;
+      gclock.learnAll(v.settingsGt);   // the same read teaches the clock every store's current stamp
+    } catch { /* ask below */ }
     if (on) return true;
     if (!window.confirm(
       "Allow editing files from the dashboard?\n\n" +
       "Saves write straight to disk on the file's machine — and this applies on every machine " +
       "connected here. A session working in that folder is told when you edit under it.\n\n" +
       "You can turn this off later in the settings gear.")) return false;
-    // gt = the consent's own click time: federation queues this per host across a down socket, and
-    // the kernel orders applies by the stamp — a flush hours later must not outrank a newer gesture
-    post({ type: "setFileEditing", enabled: true, gt: Date.now() });
+    // gt = the consent's own click, stamped through the gesture clock (above every stamp the read
+    // above reported): federation queues this per host across a down socket, and the kernel orders
+    // applies by the stamp — a flush hours later must not outrank a newer gesture
+    post({ type: "setFileEditing", enabled: true, gt: gclock.stamp("file-editing") });
     return true;
   }
   editBtn.addEventListener("click", () => {

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -173,6 +173,13 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
   color: var(--text-muted, #9aa0a6);
   font-size: 11px; line-height: 1.4; padding: 2px 4px; border-radius: 8px; }
 .rs-stale-toast-x:hover { color: var(--fg, #fff); background: rgba(255, 255, 255, 0.08); }
+/* the toast's one action (Apply anyway): the gear's small bordered button (#rs-keys-btn's dress), in
+   this sheet's literal palette because the gear's hosts load only this sheet */
+.rs-stale-toast-act { flex: 0 0 auto; cursor: pointer; font: inherit; font-size: 11px; line-height: 1.4;
+  padding: 2px 8px; border-radius: 5px; border: 1px solid var(--hairline, #3a3a3a);
+  background: var(--btn-bg, #2a2a2a); color: var(--fg, #ccc); white-space: nowrap; }
+.rs-stale-toast-act:hover { border-color: var(--accent, #9cd2ff); color: var(--accent, #9cd2ff);
+  background: var(--accent-wash, rgba(156, 210, 255, 0.12)); }
 .rs-stale-toast.fade { opacity: 0; }
 
 /* the login paste-code MODAL (the user 2026-08-30): the panel treatment — centered card over a

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -830,12 +830,24 @@ function initGear(post) {
     setTimeout(function () { t.remove(); }, 12000);   // …then the self-clearing backstop; a click/Esc dismisses sooner
     return t;
   }
-  // The copy names the setting and the value in force and says the pick was not applied. It does
-  // NOT say who or where changed it: the kernel knows only that it holds a larger stamp, and with
-  // device clocks in the mix that is not the same as "someone changed it after you" (#879 review).
-  function staleText(label, kept) {
-    return label + ': not applied. A later pick' + (kept ? ' (' + kept + ')' : '') + ' is already in place.';
+  // The copy names the setting, the kernels that refused, and the value in force, and says the pick
+  // was not applied. It does NOT say who or where changed it: the kernel knows only that it holds a
+  // larger stamp, and with device clocks in the mix that is not the same as "someone changed it
+  // after you" (#879 review). The hosts ARE known: each refusal came from one of them.
+  function staleText(label, kept, hosts) {
+    return label + ': not applied on ' + hosts.join(', ') + '. A later pick'
+      + (kept ? ' (' + kept + ')' : '') + ' is already in place.';
   }
+  // One toast per refused GESTURE, not per refusing kernel: a dashboard's broadcast reaches every
+  // linked kernel, so one stale flush used to draw N identical toasts naming no host. The fold key
+  // is the gesture's identity — setting + its own gt, which the frame carries — an event key, never
+  // a time window: N kernels refusing one flush share it, two different gestures never do. A frame
+  // without gt (an older kernel) keeps one toast per frame. Liveness is the node's parentNode at
+  // lookup, so a dismissed or expired toast never absorbs a later frame and no cleanup rides the
+  // timers. A remote kernel's frame arrives host-stamped (federation.ts prefixInbound); the local
+  // kernel's has no host and reads as this machine, the name the gear already uses for it.
+  var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...] } while the toast is up
+  function staleHost(m) { return (typeof m.host === 'string' && m.host) ? m.host : 'this machine'; }
   // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
   // page has seen (the frame's storedGt included, learned just before): a fresh click is legitimate
   // new information, the event the ordering rule wants — never a clock heuristic. Offered only when
@@ -852,7 +864,16 @@ function initGear(post) {
     var label = STALE_LABELS[m.setting] || String(m.setting || 'A setting');
     var kept = m.kept === true ? 'on' : m.kept === false ? 'off'
       : (typeof m.kept === 'string' && m.kept ? m.kept : '');
-    staleToast(staleText(label, kept), staleAction(m));
+    var key = typeof m.gt === 'number' ? m.setting + ':' + m.gt : '';
+    var live = key && staleOpen[key] && staleOpen[key].t.parentNode ? staleOpen[key] : null;
+    var where = staleHost(m);
+    if (live) {   // the same gesture, refused by one more kernel: add the host to the toast on screen
+      if (live.hosts.indexOf(where) < 0) live.hosts.push(where);
+      live.t.querySelector('.rs-stale-toast-msg').textContent = staleText(label, kept, live.hosts);
+    } else {
+      var t = staleToast(staleText(label, kept, [where]), staleAction(m));
+      if (key) staleOpen[key] = { t: t, hosts: [where] };
+    }
     if (!p.hidden) fill();   // the open modal re-reads the kernel's values so it stops showing the refused pick
   });
   // The model/effort <option>s come from /models — the same single source the

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -20,6 +20,7 @@
 // Model/effort <option>s come from GET /models at open (they were server-baked
 // into the HTML before — /models was already the single source of truth).
 
+var gclock = require('./gesture-clock.js');   // every `gt` below is minted here (see that file)
 function kb() { return (typeof window !== 'undefined' && window.__rompKernelBase) || ''; }
 function ku(path) {
   var tok = (typeof window !== 'undefined' && window.__rompKernelToken) || '';
@@ -437,28 +438,32 @@ function initGear(post) {
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
   if (ao) ao.addEventListener('change', function () { var s = load(); s.activeOnly = ao.checked; save(s); });
   if (fc) fc.addEventListener('change', function () { var s = load(); s.collapsed = fc.checked; save(s); });
-  // Thinking summaries is kernel-side but PER-INSTALL (2026-09-01): the post goes to the LOCAL kernel
-  // only — it is deliberately not in federation's KERNEL_SETTING set, so it never queues for or
-  // reaches another machine. Stamped with the gesture time all the same (two dashboards on one
-  // kernel still race, and the kernel orders every setting by `gt`; see the block below).
-  if (ths) ths.addEventListener('change', function () { post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: Date.now() }); });
+  // Every gt-stamped post below mints its stamp through the gesture clock (gesture-clock.js): epoch
+  // ms at the click, lifted above the highest stamp this page has seen for that store — fill()
+  // learns each store's current stamp from /version, the settingStale listener from the frame that
+  // refused a gesture — so a device whose clock runs behind another's still outranks every stamp it
+  // knows of. Federation queues KERNEL_SETTING posts per host while a socket is down and flushes
+  // them on reconnect, so a delayed copy must carry the ORIGINAL gesture's stamp — the kernel orders
+  // applies by it and stands a stale flush down instead of walking the mesh back to an hours-old
+  // pick (a frozen tab's flush did exactly that). Stamp in the message literal, never at send/flush
+  // time.
+  // Thinking summaries and Suggest /compact are kernel-side but PER-INSTALL: each post goes to the
+  // LOCAL kernel only — deliberately not in federation's KERNEL_SETTING set (gear.test.ts pins the
+  // membership), so neither queues for or reaches another machine. Stamped all the same: two
+  // dashboards on one kernel still race, and the kernel orders every setting by `gt`.
+  if (ths) ths.addEventListener('change', function () { post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: gclock.stamp('thinking-summaries') }); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
   // Each attached kernel keeps its own copy, so the post goes to all of them
   // (federation.ts KERNEL_SETTING) — which is also what resolves a split box:
   // the click picks one answer and every machine takes it.
-  // Every KERNEL_SETTING post carries `gt`: epoch ms minted HERE, at the click. Federation queues
-  // these per host while a socket is down and flushes them on reconnect, so a delayed copy must
-  // carry the ORIGINAL gesture's time — the kernel orders applies by it and stands a stale flush
-  // down instead of walking the mesh back to an hours-old pick (a frozen tab's flush did exactly
-  // that). Stamp in the message literal, never at send/flush time.
   if (an) an.addEventListener('change', function () {
     clearAutoNudgeSplit();
-    post({ type: 'setAutoNudge', enabled: an.checked, gt: Date.now() });
+    post({ type: 'setAutoNudge', enabled: an.checked, gt: gclock.stamp('auto-nudge') });
   });
-  if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked, gt: Date.now() }); });
+  if (fe) fe.addEventListener('change', function () { post({ type: 'setFileEditing', enabled: fe.checked, gt: gclock.stamp('file-editing') }); });
   if (cvm) cvm.addEventListener('change', function () { post({ type: 'setConserve', enabled: cvm.checked }); });
-  if (csg) csg.addEventListener('change', function () { post({ type: 'setCompactSuggest', enabled: csg.checked, gt: Date.now() }); });
+  if (csg) csg.addEventListener('change', function () { post({ type: 'setCompactSuggest', enabled: csg.checked, gt: gclock.stamp('compact-suggest') }); });
   // ── the in-dashboard LOGIN flow (T157): the dashboard is already on the phone over Tailscale,
   // so streaming the CLI's paste-code OAuth URL here IS the phone login. The code input is a pure
   // pass-through to the kernel's PTY — nothing is stored or logged on any side.
@@ -531,7 +536,7 @@ function initGear(post) {
   });
   if (lgI) lgI.addEventListener('keydown', function (e) { if (e.key === 'Enter' && lgSend) lgSend.click(); });
   if (lgX) lgX.addEventListener('click', function () { lgModal(false); post({ type: 'loginCancel' }); if (lgTimer) { clearTimeout(lgTimer); lgTimer = null; } lgRender({ login: { state: '' } }); });
-  if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value, gt: Date.now() }); });
+  if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value, gt: gclock.stamp('update-mode') }); });
   // The judge MODEL pickers mirror the session pickers (the user 2026-08-25): families top-level,
   // clicking a family sends its /models `default` (the user's remembered version), hover or
   // ArrowRight reveals a side submenu of versions. The native select stays (hidden) as the VALUE
@@ -686,12 +691,12 @@ function initGear(post) {
     versionMenu(cmm, [{ value: 'session', label: 'Same as the session', versions: [] },
                       { value: 'default', label: 'Default', versions: [] }]);
   });
-  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value, gt: Date.now() }); });
-  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: Date.now() }); });
-  if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value, gt: Date.now() }); });
-  if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value, gt: Date.now() }); });
-  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: Date.now() }); });
-  if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value, gt: Date.now() }); });
+  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value, gt: gclock.stamp('judge-model') }); });
+  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: gclock.stamp('index-model') }); });
+  if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value, gt: gclock.stamp('judge-effort') }); });
+  if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value, gt: gclock.stamp('index-effort') }); });
+  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: gclock.stamp('distill-model') }); });
+  if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value, gt: gclock.stamp('distill-effort') }); });
   // Fast is an Opus-only research preview (render.ts fastAvailable, the same rule): a pinned
   // non-Opus comment model makes the box a dead control, so it disables — and a model pick that
   // strands a checked box also unchecks it, visibly, as part of the user's own gesture (never a
@@ -704,12 +709,12 @@ function initGear(post) {
     cmf.disabled = !can;
     if (!can && cmf.checked && fromModelPick) {
       cmf.checked = false;
-      post({ type: 'setCommentFast', fast: 'session', gt: Date.now() });
+      post({ type: 'setCommentFast', fast: 'session', gt: gclock.stamp('comment-fast') });
     }
   }
-  if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value, gt: Date.now() }); cmtFastGate(true); });
-  if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value, gt: Date.now() }); });
-  if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session', gt: Date.now() }); });
+  if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value, gt: gclock.stamp('comment-model') }); cmtFastGate(true); });
+  if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value, gt: gclock.stamp('comment-effort') }); });
+  if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session', gt: gclock.stamp('comment-fast') }); });
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
@@ -774,13 +779,22 @@ function initGear(post) {
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
     'comment-fast': 'Fast comment threads', 'thinking-summaries': 'Thinking summaries' };
+  // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
+  // may re-issue the one setting it names, nothing else) and the completeness pin's map
+  // (gear.test.ts checks every emitter stamps through the clock under its own store name)
+  var STALE_TYPE = { 'auto-nudge': 'setAutoNudge', 'compact-suggest': 'setCompactSuggest',
+    'file-editing': 'setFileEditing', 'update-mode': 'setUpdateMode', 'thinking-summaries': 'setThinkingSummaries',
+    'judge-model': 'setJudgeModel', 'judge-effort': 'setJudgeEffort',
+    'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort',
+    'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
+    'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast' };
   // Dismissal is the warn-toast FAMILY treatment (the user 2026-08-25: a notice with no visible
   // way out gets in the way — worst on touch, and this toast's mint site is a frozen phone tab
   // flushing on recovery): a visible ✕ in the chip-✕ dress, the whole toast still click-dismisses,
   // Escape clears the stack, and the fade precedes the auto-remove. COPIED from the family home
   // (render.ts warnToast + styles.css .warn-toast-x) because the gear is its own document, loaded
   // by panes that ship only this sheet — keep the two in step (setting-stale.test.ts pins this copy).
-  function staleToast(text) {
+  function staleToast(text, act) {
     var box = document.getElementById('rs-stale-toasts');
     if (!box) {   // created once; dismissal delegated to the STABLE container (click-safe rule)
       box = document.createElement('div'); box.id = 'rs-stale-toasts';
@@ -800,22 +814,45 @@ function initGear(post) {
     t.className = 'rs-stale-toast'; t.setAttribute('role', 'status'); t.title = 'click to dismiss';
     var txt = document.createElement('span');
     txt.className = 'rs-stale-toast-msg'; txt.textContent = text;
+    t.appendChild(txt);
+    if (act) {   // the toast's one action: a real button whose click also bubbles to the container's
+      var b = document.createElement('button');   // delegated dismiss, so acting clears the toast too
+      b.type = 'button'; b.className = 'rs-stale-toast-act'; b.textContent = act.label;
+      b.addEventListener('click', act.run);
+      t.appendChild(b);
+    }
     var x = document.createElement('button');
     x.className = 'rs-stale-toast-x'; x.setAttribute('aria-label', 'Dismiss'); x.title = 'dismiss (Esc)';
     x.textContent = '✕';   // clicks bubble to the container's delegated dismiss, like the family's
-    t.appendChild(txt); t.appendChild(x);
+    t.appendChild(x);
     box.appendChild(t);
     setTimeout(function () { t.classList.add('fade'); }, 11000);   // the family fade first…
     setTimeout(function () { t.remove(); }, 12000);   // …then the self-clearing backstop; a click/Esc dismisses sooner
+    return t;
+  }
+  // The copy names the setting and the value in force and says the pick was not applied. It does
+  // NOT say who or where changed it: the kernel knows only that it holds a larger stamp, and with
+  // device clocks in the mix that is not the same as "someone changed it after you" (#879 review).
+  function staleText(label, kept) {
+    return label + ': not applied. A later pick' + (kept ? ' (' + kept + ')' : '') + ' is already in place.';
+  }
+  // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
+  // page has seen (the frame's storedGt included, learned just before): a fresh click is legitimate
+  // new information, the event the ordering rule wants — never a clock heuristic. Offered only when
+  // the echo's type is the setting the frame names, so a frame from any linked kernel may re-issue
+  // that one setting and nothing else; an older kernel sends no echo and the toast shows without it.
+  function staleAction(m) {
+    if (!m.gesture || typeof m.gesture !== 'object' || STALE_TYPE[m.setting] !== m.gesture.type) return null;
+    return { label: 'Apply anyway', run: function () { post(Object.assign({}, m.gesture, { gt: gclock.stamp(m.setting) })); } };
   }
   window.addEventListener('message', function (e) {
     var m = e.data;
     if (!m || m.type !== 'settingStale') return;
+    gclock.learn(m.setting, m.storedGt);   // the frame IS new information about that store's clock
     var label = STALE_LABELS[m.setting] || String(m.setting || 'A setting');
     var kept = m.kept === true ? 'on' : m.kept === false ? 'off'
       : (typeof m.kept === 'string' && m.kept ? m.kept : '');
-    staleToast(label + ' changed more recently somewhere else — keeping the newer choice'
-      + (kept ? ' (' + kept + ')' : '') + '.');
+    staleToast(staleText(label, kept), staleAction(m));
     if (!p.hidden) fill();   // the open modal re-reads the kernel's values so it stops showing the refused pick
   });
   // The model/effort <option>s come from /models — the same single source the
@@ -972,6 +1009,7 @@ function initGear(post) {
   // setShow — fill()'s write path for every kernel-backed select below — sits beside paintChoices, which
   // shares it.
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
+    gclock.learnAll(v.settingsGt);   // each store's last-applied stamp: the clock climbs above them (an older kernel sends none)
     // ONE /tunnels fetch feeds every cross-machine comparison: the autoNudge box and the select marks.
     // A failed /tunnels leaves the local answers standing, unmarked — same fallback as before.
     fetch(ku('/tunnels'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -61,11 +61,22 @@ test("EVERY queued-class kernel setting is emitted with its gesture time (comple
   // stale flush takes the no-stamp compat path, records a forged-fresh arrival stamp, and the
   // judge tiers fan that stamp mesh-wide over genuinely newer gestures. Adding a member without
   // a stamped emitter goes red here: zero emitters found, or an emitter literal without gt.
+  // The stamp is minted through the gesture clock (gesture-clock.js) under the emitter's own STORE
+  // name — stamp('judge-model') for setJudgeModel — so it lands above every stamp the page has seen
+  // for that store; a bare Date.now() is the bug the clock replaced (a device whose clock runs ahead
+  // stamps every store into the future and locks every other device out until the skew elapses).
+  // STALE_TYPE (gear.js) is the store→type map, the same one the stale toast's Apply anyway trusts.
   const FED = read("ui", "webview", "federation.ts");
   const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
   assert.ok(setSrc, "federation.ts's KERNEL_SETTING set located");
   const members = Array.from(setSrc![1].matchAll(/"([A-Za-z]+)"/g)).map((m) => m[1]);
   assert.ok(members.length >= 9, `the set parsed (${members.length} members)`);
+  const typeSrc = GEAR.match(/var STALE_TYPE = \{([\s\S]*?)\};/);
+  assert.ok(typeSrc, "gear.js's STALE_TYPE map located");
+  const storeType: Record<string, string> = {};
+  for (const m of typeSrc![1].matchAll(/'([a-z-]+)':\s*'(set[A-Za-z]+)'/g)) storeType[m[1]] = m[2];
+  for (const type of members)
+    assert.ok(Object.values(storeType).includes(type), `STALE_TYPE names a store for ${type}`);
   // scan every webview source that could emit one (the gear, the file viewer's consent post,
   // the feed's judge-limit switch, and any future emitter under ui/webview)
   const srcDir = path.join(ROOT, "ui", "webview");
@@ -78,8 +89,10 @@ test("EVERY queued-class kernel setting is emitted with its gesture time (comple
       const re = new RegExp(`\\{\\s*type:\\s*['"]${type}['"][^}]*\\}`, "g");
       for (const lit of text.match(re) || []) {
         emitters++;
-        assert.match(lit, /\bgt:\s*Date\.now\(\)/,
-          `${f} must stamp the gesture time inside the ${type} message literal itself: ${lit}`);
+        const stamp = lit.match(/\bgt:\s*gclock\.stamp\(['"]([a-z-]+)['"]\)/);
+        assert.ok(stamp, `${f} must stamp the gesture through the clock inside the ${type} message literal itself: ${lit}`);
+        assert.equal(storeType[stamp![1]], type, `${f} stamps ${type} under its own store name: ${lit}`);
+        assert.doesNotMatch(lit, /Date\.now\(\)/, `${f}: the bare wall clock is the bug the clock replaced: ${lit}`);
       }
     }
     assert.ok(emitters >= 1,
@@ -184,7 +197,7 @@ test("the /compact suggestion is a real settings checkbox beside Auto Nudge (the
   assert.ok(GEAR.indexOf("id=rs-autonudge") < at && at < GEAR.indexOf("id=rs-conserve"),
     "…directly after Auto Nudge, where the user asked for it");
   assert.ok(/csg\.addEventListener\('change'/.test(GEAR)
-    && GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked, gt: Date.now() })"),
+    && GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked, gt: gclock.stamp('compact-suggest') })"),
     "the click posts the kernel's designed setCompactSuggest message — gesture-stamped, like "
     + "every kernel-side setting the gear emits");
   assert.ok(GEAR.includes("csg.checked = !!v.compactSuggest"),

--- a/ui/webview/gesture-clock.js
+++ b/ui/webview/gesture-clock.js
@@ -1,0 +1,40 @@
+// The gesture clock — where every kernel-setting message mints its `gt` (PR #879 follow-up).
+// Gesture stamps order the kernel's settings stores (a stamp at or below the stored one stands
+// down), and they used to be the device's bare wall clock: a laptop ten minutes ahead picked a
+// judge model and stamped every store ten minutes into the future, so for ten minutes every pick
+// from a correctly-clocked phone was refused and no gesture from it could win. The stamp is a
+// per-store LOGICAL clock seeded by the wall clock now: stamp(store) = max(Date.now(), the
+// highest stamp this page has seen for that store + 1). A page learns stamps from /version's
+// settingsGt (the gear reads it on every open; the file viewer on its consent check) and from
+// the settingStale frame that refuses a gesture (storedGt IS the number to climb above) — so a
+// device whose clock runs behind still outranks every stamp it has seen. Event over clock: the
+// user's gesture is the new information, and its stamp says only "after everything I know of".
+// Plain CJS like gear.js — one module graph per document (the feed pane and the chat pane each
+// load their own), bundled wherever it is required, no build-list entry.
+var seen = {};   // store name → the highest stamp this page has seen for it (learned or minted)
+
+// Record a stamp the kernel reported for `store` (from /version or a settingStale frame). Only a
+// higher number moves the clock; garbage (a non-string store, 0, NaN, a non-number) is ignored, so
+// an older kernel that sends nothing, or a malformed frame, can never lower or corrupt it.
+function learn(store, gt) {
+  gt = Number(gt);
+  if (typeof store !== 'string' || !store || !(gt > 0) || !isFinite(gt)) return;
+  if (gt > (seen[store] || 0)) seen[store] = gt;
+}
+
+// Fold a whole /version `settingsGt` dict; anything but a plain object is a no-op.
+function learnAll(map) {
+  if (!map || typeof map !== 'object' || Array.isArray(map)) return;
+  for (var k in map) if (Object.prototype.hasOwnProperty.call(map, k)) learn(k, map[k]);
+}
+
+// The stamp for a gesture on `store`, minted at the click. Records its own result, so stamps are
+// strictly increasing per store on this page even when the wall clock steps back, and two clicks
+// on one setting within a millisecond no longer collide as an equal-stamp-different-value refusal.
+function stamp(store) {
+  var s = Math.max(Date.now(), (seen[store] || 0) + 1);
+  seen[store] = s;
+  return s;
+}
+
+module.exports = { learn: learn, learnAll: learnAll, stamp: stamp };

--- a/ui/webview/gesture-clock.test.ts
+++ b/ui/webview/gesture-clock.test.ts
@@ -1,0 +1,108 @@
+// The gesture clock (ui/webview/gesture-clock.js), exercised for real. Every kernel-setting
+// message stamps `gt` through it, and the kernel orders each store's applies by that stamp
+// (tests/test_setting_gesture_order.py) — so the stamp used to be the device's bare wall clock, and
+// a laptop ten minutes ahead locked every correctly-clocked device out of a setting for ten
+// minutes (no gesture from them could outrank the future stamp it had stored). The clock is a
+// per-store logical clock seeded by the wall clock: it learns the stamps the kernel reports
+// (/version's settingsGt, a settingStale frame's storedGt) and stamps above the highest it has
+// seen. BEHAVIORAL: the module is required and driven with Date.now stubbed — no source pins.
+// Module state is per bundle, so each test uses store names of its own.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { learn, learnAll, stamp } = require("./gesture-clock.js");
+
+/** Run `fn` with Date.now pinned to `now` (or to a sequence of values); always restored. */
+function withNow<T>(now: number | number[], fn: () => T): T {
+  const real = Date.now;
+  const seq = Array.isArray(now) ? [...now] : [now];
+  Date.now = () => (seq.length > 1 ? seq.shift()! : seq[0]);
+  try { return fn(); } finally { Date.now = real; }
+}
+
+test("with nothing learned, the stamp is the wall clock", () => {
+  assert.equal(withNow(5000, () => stamp("t1-store")), 5000);
+});
+
+test("a learned stamp at or above the wall clock lifts the next stamp to learned + 1", () => {
+  learn("t2-store", 9000);                       // a store stamped by a device whose clock ran ahead
+  assert.equal(withNow(5000, () => stamp("t2-store")), 9001, "above the future stamp, not the wall clock");
+  learn("t2-store", 9001);                       // exactly what the clock already holds — no lift
+  assert.equal(withNow(5000, () => stamp("t2-store")), 9002, "still strictly increasing");
+});
+
+test("a learned stamp below the wall clock changes nothing — the wall clock already outranks it", () => {
+  learn("t3-store", 100);
+  assert.equal(withNow(5000, () => stamp("t3-store")), 5000);
+});
+
+test("two stamps within one millisecond are strictly increasing (no equal-stamp collision)", () => {
+  const [a, b, c] = withNow(7000, () => [stamp("t4-store"), stamp("t4-store"), stamp("t4-store")]);
+  assert.deepEqual([a, b, c], [7000, 7001, 7002]);
+});
+
+test("a wall clock that steps back cannot lower the clock: stamps stay above every stamp minted here", () => {
+  const a = withNow(8000, () => stamp("t5-store"));
+  const b = withNow(7000, () => stamp("t5-store"));   // NTP correction between two clicks
+  assert.equal(a, 8000);
+  assert.equal(b, 8001, "the second click still orders after the first");
+});
+
+test("stamps are per store: learning one store's stamp lifts no other", () => {
+  learn("t6-judge", 9_000_000);
+  assert.equal(withNow(5000, () => stamp("t6-nudge")), 5000, "another store's clock is untouched");
+  assert.equal(withNow(5000, () => stamp("t6-judge")), 9_000_001);
+});
+
+test("learn ignores garbage: a lower stamp, zero, NaN, a non-number, an empty or non-string store", () => {
+  learn("t7-store", 6000);
+  learn("t7-store", 5999);                        // lower — ignored
+  learn("t7-store", 0);
+  learn("t7-store", NaN);
+  learn("t7-store", "not a number");
+  learn("t7-store", Infinity);
+  learn("t7-store", null);
+  learn("t7-store", undefined);
+  learn("", 10_000_000);                          // no store name — ignored, and nothing else is lifted
+  learn(42 as any, 10_000_000);
+  learn(null as any, 10_000_000);
+  assert.equal(withNow(1000, () => stamp("t7-store")), 6001, "only the valid 6000 moved the clock");
+  assert.equal(withNow(1000, () => stamp("")), 1000, "the empty name learned nothing");
+});
+
+test("learn takes a numeric string too (a kernel that serialized the int as text)", () => {
+  learn("t8-store", "7000" as any);
+  assert.equal(withNow(1000, () => stamp("t8-store")), 7001);
+});
+
+test("learnAll folds a /version settingsGt dict and ignores anything that is not a plain object", () => {
+  learnAll({ "t9-a": 4000, "t9-b": 0, "t9-c": "x", "t9-d": 3000 });
+  assert.equal(withNow(1000, () => stamp("t9-a")), 4001);
+  assert.equal(withNow(1000, () => stamp("t9-b")), 1000, "0 taught nothing");
+  assert.equal(withNow(1000, () => stamp("t9-c")), 1000, "a non-number taught nothing");
+  assert.equal(withNow(1000, () => stamp("t9-d")), 3001);
+  for (const bad of [undefined, null, 7, "gt", [5000], true])   // an older kernel sends no dict at all
+    assert.doesNotThrow(() => learnAll(bad));
+  assert.equal(withNow(1000, () => stamp("0")), 1000, "an array's index never became a store");
+});
+
+test("the maintainer's scenario end to end: a future stamp learned from a refusal is outranked by the next click", () => {
+  // a laptop ten minutes ahead stamped the store at T+600s; this correctly-clocked device's click at
+  // T is refused, the frame reports storedGt, and the re-issue must climb above it
+  const T = 1_700_000_000_000, skew = 600_000;
+  const first = withNow(T, () => stamp("t10-judge"));
+  assert.equal(first, T, "the first click knows nothing and trusts the wall clock");
+  learn("t10-judge", T + skew);                   // the settingStale frame's storedGt
+  const retry = withNow(T + 1, () => stamp("t10-judge"));
+  assert.equal(retry, T + skew + 1, "Apply anyway stamps above the future stamp, not ten minutes later");
+});
+
+test("every gt emitter under ui/webview stamps through this module (the sources load it)", () => {
+  const dir = path.resolve(process.cwd(), "..", "ui", "webview");
+  for (const f of ["gear.js", "feed.ts", "file-view.ts"])
+    assert.ok(/require\(['"]\.\/gesture-clock\.js['"]\)/.test(fs.readFileSync(path.join(dir, f), "utf8")),
+      `${f} requires the gesture clock`);
+});

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -155,6 +155,15 @@ test("routeOutbound: dropFile routes by its session id — attachment bytes reac
   assert.deepEqual(prefixInbound("gpu1", reply), reply);
 });
 
+test("prefixInbound: a remote kernel's settingStale frame is host-stamped (the gear names the refusing machines)", () => {
+  const f = { type: "settingStale", setting: "judge-model", storedGt: 2000, gt: 1000, kept: "m",
+              gesture: { type: "setJudgeModel", model: "x" } };
+  const out = prefixInbound("gpu1", f);
+  assert.equal(out.host, "gpu1");
+  assert.deepEqual(out.gesture, f.gesture, "the echoed gesture passes through untouched — it is re-issued as-is");
+  assert.deepEqual(prefixInbound("", f), f, "the local kernel's frame has no host key (the gear words it as this machine)");
+});
+
 test("prefixInbound: glowTurns groups get sid-prefixed so the merged chat finds the remote pane", () => {
   // The return leg of the same highlight: the owning kernel answers with glowTurns keyed by its own
   // bare sids, but the merged chat page keys its views "host:sid" — unprefixed groups matched nothing.

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -1,0 +1,159 @@
+// The stale-settings toast folds one refused gesture's N refusals into ONE notice naming the
+// refusing kernels (the #879 review's note: N kernels refusing one stale flush drew N identical
+// toasts naming no host). BEHAVIORAL, the gear-models-frame.test.ts way: the toast block of gear.js
+// (STALE_LABELS through the settingStale listener) is lifted out and run against stand-ins for
+// window/document/setTimeout and the closure names it reads (p, fill, post, gclock), then driven
+// with frames the way federation hands them to the gear — a remote kernel's frame host-stamped by
+// prefixInbound, the local kernel's without a host. Synthetic hosts only (the notes-api demo world).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+
+// A minimal DOM: what staleToast and the fold touch — className/id/textContent/title, children with
+// parentNode, appendChild/remove, setAttribute, classList, querySelector by class, click listeners.
+type Node = {
+  tag: string; id: string; className: string; textContent: string; title: string; type: string;
+  children: Node[]; parentNode: Node | null; clicks: Array<(e: any) => void>;
+  appendChild(c: Node): void; remove(): void; setAttribute(k: string, v: string): void;
+  classList: { add(c: string): void; contains(c: string): boolean };
+  querySelector(sel: string): Node | null; addEventListener(type: string, fn: (e: any) => void): void;
+};
+function node(tag: string): Node {
+  const n: Node = {
+    tag, id: "", className: "", textContent: "", title: "", type: "", children: [], parentNode: null, clicks: [],
+    appendChild(c) { c.parentNode = n; n.children.push(c); },
+    remove() { if (n.parentNode) { const p = n.parentNode; p.children.splice(p.children.indexOf(n), 1); n.parentNode = null; } },
+    setAttribute() { /* role/aria — not under test */ },
+    classList: { add(c) { n.className += " " + c; }, contains(c) { return n.className.split(" ").includes(c); } },
+    querySelector(sel) { return n.children.find((c) => c.className.split(" ").includes(sel.slice(1))) || null; },
+    addEventListener(type, fn) { if (type === "click") n.clicks.push(fn); },
+  };
+  return n;
+}
+
+function lift() {
+  const start = GEAR.indexOf("  var STALE_LABELS");
+  const at = GEAR.indexOf("m.type !== 'settingStale'", start);
+  const stop = GEAR.indexOf("\n  });\n", at) + "\n  });\n".length;
+  assert.ok(start > 0 && at > start && stop > at, "anchors not found — the gear's stale-toast block moved; re-anchor");
+  const src = GEAR.slice(start, stop);
+  const listeners: Array<(e: any) => void> = [];
+  const win = { addEventListener: (type: string, fn: (e: any) => void) => { if (type === "message") listeners.push(fn); } };
+  const body = node("body");
+  const byId: Record<string, Node> = {};
+  const doc = {
+    body,
+    getElementById: (id: string) => byId[id] || null,
+    createElement: (tag: string) => node(tag),
+    addEventListener: () => { /* the Escape handler — not under test */ },
+  };
+  // ids register when appended to body (the container is created once, then found by id)
+  body.appendChild = (c: Node) => { c.parentNode = body; body.children.push(c); if (c.id) byId[c.id] = c; };
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  const setTimeout = (fn: () => void, ms: number) => { timers.push({ fn, ms }); return timers.length; };
+  const p = { hidden: true };
+  let fills = 0;
+  const fill = () => { fills++; };
+  const posts: any[] = [];
+  const post = (m: any) => posts.push(m);
+  const learned: Array<[string, number]> = [];
+  const gclock = { learn: (s: string, gt: number) => learned.push([s, gt]), stamp: (s: string) => { learned.push([s, -1]); return 7777; } };
+  const fn = new Function("window", "document", "p", "fill", "post", "gclock", "setTimeout", src);
+  fn(win, doc, p, fill, post, gclock, setTimeout);
+  const frame = (m: any) => listeners.forEach((l) => l({ data: m }));
+  const box = () => byId["rs-stale-toasts"];
+  const texts = () => (box() ? box().children.map((t) => t.querySelector(".rs-stale-toast-msg")!.textContent) : []);
+  return { frame, box, texts, timers, p, fills: () => fills, posts, learned };
+}
+
+const REFUSED = { type: "settingStale", setting: "judge-model", storedGt: 2000, gt: 1000, kept: "fable",
+                  gesture: { type: "setJudgeModel", model: "opus" } };
+
+test("three kernels refusing one gesture draw ONE toast that names all three", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  g.frame({ ...REFUSED, host: "api" });
+  g.frame({ ...REFUSED });                         // the local kernel: no host key
+  assert.equal(g.box().children.length, 1, "one toast for one refused gesture");
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web, api, this machine. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.learned.filter(([, gt]) => gt > 0), [["judge-model", 2000], ["judge-model", 2000], ["judge-model", 2000]],
+    "every frame teaches the clock the stamp it lost to");
+});
+
+test("the same host refusing twice is named once; a different gesture gets its own toast", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  g.frame({ ...REFUSED, host: "web" });            // a duplicate delivery
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place."]);
+  g.frame({ ...REFUSED, gt: 999, host: "web" });   // an older click of the same setting — its own identity
+  assert.equal(g.box().children.length, 2);
+  g.frame({ ...REFUSED, setting: "auto-nudge", kept: false, gesture: { type: "setAutoNudge", enabled: true }, host: "web" });
+  assert.equal(g.box().children.length, 3);
+  assert.equal(g.texts()[2], "Auto Nudge: not applied on web. A later pick (off) is already in place.", "booleans read as on/off");
+});
+
+test("a frame without gt (an older kernel) keeps one toast per frame — no key, no fold", () => {
+  const g = lift();
+  const { gt: _gt, ...old } = REFUSED;
+  g.frame({ ...old, host: "web" });
+  g.frame({ ...old, host: "api" });
+  assert.equal(g.box().children.length, 2);
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place.",
+                               "Triage model: not applied on api. A later pick (fable) is already in place."]);
+});
+
+test("a dismissed or expired toast never absorbs a later frame: liveness is the node's presence, not a window", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  const first = g.box().children[0];
+  first.remove();                                  // click-dismissed (the container's delegated handler)
+  g.frame({ ...REFUSED, host: "api" });
+  assert.equal(g.box().children.length, 1, "a fresh toast, not a resurrection");
+  assert.deepEqual(g.texts(), ["Triage model: not applied on api. A later pick (fable) is already in place."]);
+  // the self-clearing backstop: run the 12000ms callbacks, then the same key again
+  g.timers.filter((t) => t.ms === 12000).forEach((t) => t.fn());
+  assert.equal(g.box().children.length, 0, "expired");
+  g.frame({ ...REFUSED, host: "web" });
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place."]);
+});
+
+test("the folded toast keeps its Apply anyway: one click re-issues the echo with a fresh stamp", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  g.frame({ ...REFUSED, host: "api" });
+  const t = g.box().children[0];
+  const btn = t.children.find((c) => c.className === "rs-stale-toast-act")!;
+  assert.ok(btn, "the action button rides the folded toast");
+  assert.equal(btn.textContent, "Apply anyway");
+  assert.equal(btn.type, "button");
+  btn.clicks.forEach((fn) => fn({}));
+  assert.deepEqual(g.posts, [{ type: "setJudgeModel", model: "opus", gt: 7777 }],
+    "the echoed gesture, stamped through the clock (which has learned both refusals' storedGt)");
+  assert.deepEqual(g.learned[g.learned.length - 1], ["judge-model", -1], "stamp('judge-model') minted it");
+  assert.ok(t.children.findIndex((c) => c.className === "rs-stale-toast-act") < t.children.findIndex((c) => c.className === "rs-stale-toast-x"),
+    "the action sits before the ✕");
+});
+
+test("no action when the echo's type is not the setting's, or when there is no echo (an older kernel)", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web", gesture: { type: "setAutoNudge", enabled: true } });
+  const { gesture: _g, ...noEcho } = REFUSED;
+  g.frame({ ...noEcho, gt: 1001, host: "web" });
+  assert.equal(g.box().children.length, 2);
+  for (const t of g.box().children)
+    assert.equal(t.children.find((c) => c.className === "rs-stale-toast-act"), undefined, "no Apply anyway");
+});
+
+test("the open modal re-fills once per frame; a closed one never does", () => {
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  g.frame({ ...REFUSED, host: "api" });
+  assert.equal(g.fills(), 0, "closed: fill() runs on the next open anyway");
+  g.p.hidden = false;
+  g.frame({ ...REFUSED, host: "gpu1" });
+  g.frame({ ...REFUSED, gt: 5, host: "gpu1" });
+  assert.equal(g.fills(), 2, "open: the frame IS the event — one re-read per frame, folded or not");
+});

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -67,8 +67,8 @@ test("the gear hears the frame: a plain-words toast, and a re-fill only while th
 test("the toast's copy names the setting and the kept value and never claims another device acted", () => {
   // the kernel knows only that it holds a larger stamp — with device clocks minting the stamps,
   // "changed more recently somewhere else" asserted a fact it could not know (#879 review)
-  assert.match(GEAR, /return label \+ ': not applied\. A later pick' \+ \(kept \? ' \(' \+ kept \+ '\)' : ''\) \+ ' is already in place\.';/,
-    "the copy: what was not applied, and what is in force");
+  assert.match(GEAR, /return label \+ ': not applied on ' \+ hosts\.join\(', '\) \+ '\. A later pick'\s*\n\s*\+ \(kept \? ' \(' \+ kept \+ '\)' : ''\) \+ ' is already in place\.';/,
+    "the copy: what was not applied, on which kernels, and what is in force");
   const copy = GEAR.slice(GEAR.indexOf("function staleText("), GEAR.indexOf("if (!p.hidden) fill();"));
   assert.ok(copy.length > 0 && copy.length < 3000, "the copy helper and the listener located");
   for (const claim of ["somewhere else", "another device", "elsewhere", "changed more recently"])
@@ -132,6 +132,22 @@ test("the toast wears the family dismissal: a visible ✕ in the chip-✕ dress,
   assert.match(GEAR_CSS, /\.rs-stale-toast-x:hover \{ color: var\(--fg, #fff\); background: rgba\(255, 255, 255, 0\.08\); \}/);
   assert.match(GEAR_CSS, /\.rs-stale-toast\.fade \{ opacity: 0; \}/, "the fade class actually fades");
   assert.match(GEAR_CSS, /\.rs-stale-toast \{[^}]*transition: opacity/, "…through a real transition");
+});
+
+test("one toast per refused gesture, naming the refusing hosts: the fold key is setting + the gesture's own gt", () => {
+  // N kernels refusing one stale flush used to draw N identical toasts naming no host (#879
+  // review). The frame now carries the refused gesture's own stamp, a remote kernel's frame arrives
+  // host-stamped, and the gear folds by (setting, gt) — an event key, never a time window.
+  // setting-stale-fold.test.ts drives the lifted block; these pin the three-file wiring.
+  assert.match(KERNEL, /_stale_seen\.last = \{"setting": name, "storedGt": applied_gt, "gt": gt\}/, "the stand-down records the refused stamp");
+  assert.ok(KERNEL.includes('"gt": st["gt"],'), "…and the frame carries it");
+  const FED = read("ui", "webview", "federation.ts");
+  assert.ok(FED.includes('if (out.type === "settingStale") out.host = host;'), "a remote kernel's frame is host-stamped on the way in");
+  assert.match(GEAR, /var key = typeof m\.gt === 'number' \? m\.setting \+ ':' \+ m\.gt : '';/, "the fold key; no gt (an older kernel) → no fold");
+  assert.match(GEAR, /staleOpen\[key\]\.t\.parentNode \? staleOpen\[key\] : null/, "liveness is the node's parentNode at lookup — no cleanup on the timers");
+  assert.match(GEAR, /return \(typeof m\.host === 'string' && m\.host\) \? m\.host : 'this machine';/, "the local kernel's frame reads as this machine");
+  assert.doesNotMatch(GEAR.slice(GEAR.indexOf("var staleOpen"), GEAR.indexOf("if (!p.hidden) fill();")), /Date\.now\(|setTimeout|setInterval/,
+    "the fold keys on the gesture, never on a clock or a window");
 });
 
 test("the kept value rides when cheap, and reads as words (booleans become on/off)", () => {

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -4,11 +4,14 @@
 // gear kept displaying the refused pick as applied (fill() runs only on openSettings), and since
 // the mesh then AGREES on the kept value, the mixed marks show nothing either. Event-keyed fix,
 // no polling: the WS branch that stands a gesture down answers the DELIVERING socket with a
-// small {type:"settingStale", setting, storedGt, kept} frame (the same targeted _reply idiom the
-// saveFile acks use), and the gear — the shared module both hosts load — toasts it in plain
-// words and re-fills itself if it is open. The kernel-side semantics are behavior-tested in
-// test_setting_gesture_order.py; no jsdom harness for these renderers, so the wiring is pinned
-// at the source (the repo convention).
+// small {type:"settingStale", setting, storedGt, kept, gesture} frame (the same targeted _reply
+// idiom the saveFile acks use), and the gear — the shared module both hosts load — toasts it in
+// plain words and re-fills itself if it is open. The toast (PR #879 follow-up) learns the stamp
+// it lost to, says the pick was not applied WITHOUT claiming another device acted (the kernel
+// knows only that it holds a larger stamp), and offers Apply anyway: the frame's echoed gesture
+// re-issued with a fresh stamp above everything this page has seen. The kernel-side semantics are
+// behavior-tested in test_setting_gesture_order.py; no jsdom harness for these renderers, so the
+// wiring is pinned at the source (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -20,14 +23,33 @@ const GEAR_CSS = read("ui", "webview", "gear.css");
 const KERNEL = read("kernel", "kernel.py");
 
 test("the kernel answers the delivering socket with a settingStale frame — the _reply idiom", () => {
-  assert.match(KERNEL, /def _tell_stale_gesture\(client\)/, "the reply helper exists");
+  assert.match(KERNEL, /def _tell_stale_gesture\(client, msg\)/, "the reply helper exists and sees the refused message");
   assert.ok(KERNEL.includes('"type": "settingStale"'), "the frame is the settingStale type");
-  const helper = KERNEL.slice(KERNEL.indexOf("def _tell_stale_gesture"), KERNEL.indexOf("def _tell_stale_gesture") + 2000);
+  const helper = KERNEL.slice(KERNEL.indexOf("def _tell_stale_gesture"), KERNEL.indexOf("def _tell_stale_gesture") + 2600);
   assert.match(helper, /_reply\(client,/, "targeted reply on ONE socket — never a broadcast");
+  // the echo the toast's Apply anyway re-issues: the refused message minus its stamp (a re-issue
+  // can never reuse the stale one)
+  assert.match(helper, /"gesture": \{k: v for k, v in msg\.items\(\) if k != "gt"\}/, "the frame echoes the refused gesture without its gt");
   // every queued-class WS branch answers on its stand-down path (9 = autoNudge, fileEditing,
   // updateMode + the six judge tiers)
-  const sites = KERNEL.match(/_tell_stale_gesture\(client\)/g) || [];
+  const sites = KERNEL.match(/_tell_stale_gesture\(client, msg\)/g) || [];
   assert.ok(sites.length >= 9, `every gt-gated branch tells the delivering socket (got ${sites.length})`);
+  assert.equal((KERNEL.match(/_tell_stale_gesture\(client\)/g) || []).length, 0, "no branch still calls the echo-less form");
+});
+
+test("/version reports every gt-gated store's last-applied stamp, and the gear stamps above them", () => {
+  // the maintainer's follow-up on #879: gesture stamps were the device's bare wall clock, so a
+  // laptop ten minutes ahead locked every correctly-clocked device out for ten minutes. The gear
+  // already read /version on every open; now it learns each store's stamp there and mints every
+  // gesture at max(Date.now(), seen + 1) (ui/webview/gesture-clock.js; gesture-clock.test.ts drives
+  // the module). The kernel side is behavior-tested in test_setting_gesture_order.py.
+  assert.match(KERNEL, /"settingsGt": _settings_gt\(\),/, "/version carries the stamps (ints only — the route is auth-exempt)");
+  assert.match(KERNEL, /def _settings_gt\(\):/);
+  assert.match(KERNEL, /def _setting_stored_gt\(name\):/, "one switch mirrors _setting_kept_value's");
+  assert.match(GEAR, /var gclock = require\('\.\/gesture-clock\.js'\);/, "the gear loads the clock");
+  const fill = GEAR.slice(GEAR.indexOf("function fill() {"), GEAR.indexOf("function fill() {") + 600);
+  assert.match(fill, /gclock\.learnAll\(v\.settingsGt\);/, "every open teaches the clock the kernel's current stamps");
+  assert.ok(!/gt: Date\.now\(\)/.test(GEAR), "no gear emitter stamps with the bare wall clock");
 });
 
 test("the gear hears the frame: a plain-words toast, and a re-fill only while the modal is open", () => {
@@ -36,8 +58,44 @@ test("the gear hears the frame: a plain-words toast, and a re-fill only while th
   const seg = GEAR.slice(GEAR.indexOf("'settingStale'") - 600, GEAR.indexOf("'settingStale'") + 1600);
   assert.match(seg, /if \(!p\.hidden\) fill\(\);/, "an OPEN gear re-reads the kernel's actual values; a closed one fills on its next open anyway");
   assert.doesNotMatch(seg, /setInterval|setTimeout\(fill/, "no polling — the frame IS the event");
-  assert.ok(GEAR.includes("changed more recently"), "the toast says what happened in plain words");
   assert.ok(GEAR.includes("staleToast"), "the dropWarn-style toast renderer exists");
+  // the frame is new information about that store's clock: learned BEFORE anything else, so the
+  // toast's Apply anyway (and the next ordinary click) stamps above the stamp this gesture lost to
+  assert.match(seg, /gclock\.learn\(m\.setting, m\.storedGt\);/, "the listener learns storedGt");
+});
+
+test("the toast's copy names the setting and the kept value and never claims another device acted", () => {
+  // the kernel knows only that it holds a larger stamp — with device clocks minting the stamps,
+  // "changed more recently somewhere else" asserted a fact it could not know (#879 review)
+  assert.match(GEAR, /return label \+ ': not applied\. A later pick' \+ \(kept \? ' \(' \+ kept \+ '\)' : ''\) \+ ' is already in place\.';/,
+    "the copy: what was not applied, and what is in force");
+  const copy = GEAR.slice(GEAR.indexOf("function staleText("), GEAR.indexOf("if (!p.hidden) fill();"));
+  assert.ok(copy.length > 0 && copy.length < 3000, "the copy helper and the listener located");
+  for (const claim of ["somewhere else", "another device", "elsewhere", "changed more recently"])
+    assert.ok(!copy.includes(claim), `the toast no longer says "${claim}"`);
+  assert.ok(!GEAR.includes("changed more recently"), "the old copy is gone from the file");
+});
+
+test("Apply anyway re-issues the echoed gesture with a fresh stamp, and only for the setting the frame names", () => {
+  // a new user gesture is legitimate new information — the event the ordering rule wants. The
+  // stamp is minted through the clock, which has just learned storedGt, so the re-issue outranks
+  // the stamp this pick lost to; the echo's type must match the frame's setting (STALE_TYPE), so a
+  // frame from any linked kernel can re-issue that one setting and nothing else
+  assert.match(GEAR, /STALE_TYPE\[m\.setting\] !== m\.gesture\.type\) return null;/, "the whitelist");
+  assert.match(GEAR, /post\(Object\.assign\(\{\}, m\.gesture, \{ gt: gclock\.stamp\(m\.setting\) \}\)\)/, "the re-issue: the echo plus a fresh stamp");
+  assert.ok(GEAR.includes("label: 'Apply anyway'"), "the action's label");
+  assert.match(GEAR, /if \(!m\.gesture \|\| typeof m\.gesture !== 'object'/, "an older kernel sends no echo: the toast shows without the action");
+  // the button: a real <button type=button>, appended before the ✕; its click bubbles to the
+  // container's delegated dismiss (no stopPropagation), so applying also clears the toast
+  assert.match(GEAR, /b\.type = 'button'; b\.className = 'rs-stale-toast-act'; b\.textContent = act\.label;/);
+  assert.match(GEAR, /b\.addEventListener\('click', act\.run\);/);
+  const toast = GEAR.slice(GEAR.indexOf("function staleToast(text, act)"), GEAR.indexOf("function staleText("));
+  assert.ok(toast.length > 0, "staleToast(text, act) located");
+  assert.doesNotMatch(toast, /\.stopPropagation\(/, "the action's click still dismisses the toast");
+  assert.ok(toast.indexOf("rs-stale-toast-act") < toast.indexOf("x.className = 'rs-stale-toast-x'"), "the action sits before the ✕");
+  assert.match(toast, /return t;\n  \}/, "the toast node is returned");
+  assert.ok(GEAR_CSS.includes(".rs-stale-toast-act {"), "gear.css dresses the button (the gear's hosts load only this sheet)");
+  assert.ok(GEAR_CSS.includes(".rs-stale-toast-act:hover {"), "…with a hover");
 });
 
 test("the toast is click-safe and self-clearing, styled by the gear's own sheet (both hosts load it)", () => {

--- a/ui/webview/thinking-summaries.test.ts
+++ b/ui/webview/thinking-summaries.test.ts
@@ -64,7 +64,7 @@ test("the gear has a Thinking summaries checkbox among the kernel-side toggles, 
     "the copy says the toggle also turns adaptive thinking on where it was off");
   assert.ok(/Compact transcript still hides them/.test(row),
     "…and that the compact view (default on) keeps hiding thinking, summaries included");
-  assert.ok(GEAR.includes("post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: Date.now() })"),
+  assert.ok(GEAR.includes("post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: gclock.stamp('thinking-summaries') })"),
     "the click posts the kernel's designed message with the gesture stamp minted in the literal");
   assert.ok(GEAR.includes("ths.checked = !!v.thinkingSummaries"),
     "the box always shows the kernel's persisted answer, never a page default");


### PR DESCRIPTION
Follow-up to the review note on #879, built as proposed there: stamp gestures as `max(Date.now(), lastSeenGt + 1)` with the gear learning each store's current `gt` from `/version`, an explicit "apply anyway" action on the toast, and copy that does not claim another device acted. The three smaller notes from the same review ride as a second commit: the queue-time breadcrumb, the per-entry clear in `flushPending`, and one host-named toast per refused flush. The `setCompactSuggest` note is a comment fix only: it stays out of `KERNEL_SETTING` by design (per-install), and the comment above the per-install toggles in gear.js now says so.

## What breaks

**Clock skew locks a setting.** Gesture stamps were the device's bare wall clock. A laptop ten minutes ahead picks a triage model; every kernel stores a stamp ten minutes in the future. For the next ten minutes every pick of that setting from a correctly-clocked phone is refused (`gt <= applied_gt`), the phone's gear toasts that the setting "changed more recently somewhere else" (which the kernel cannot know; it only knows it holds a larger number), and no gesture from the phone can win.

**Queue edges.** A setting queued for a host whose socket was down left nothing in the client-diag journal (only the non-setting drop path did), so a later disagreement between machines was not attributable. `flushPending` sent every queued entry and then cleared the map once, so a send that threw mid-flush left the delivered entries in the map and the next open replayed them. A stale flush refused by N kernels drew N identical toasts naming no host.

## Reproduction

All synthetic, in the existing harnesses:

- `tests/test_setting_gesture_order.py::ASkewedClockCannotLockTheStore`: a store holding a future stamp refuses a correctly-clocked pick; on the base commit nothing lets the dashboard climb above it.
- `ui/webview/federation-send-queue.test.ts`: a `FlakySocket` whose second send throws; on the base commit the redial re-sends the delivered entry and the queue still holds both.
- `ui/webview/setting-stale-fold.test.ts`: three frames for one gesture, from `web`, `api` and the local kernel; on the base commit, three toasts and no host text.

## The fix

### Commit 1: the gesture clock and Apply anyway

**Kernel.** `/version` gains `settingsGt`: every gt-gated store's last-applied stamp, keyed by the store names the `settingStale` frame already uses (14 keys, epoch-ms integers; nothing path-shaped, so still fine on the auth-exempt route). The `settingStale` frame gains `gesture`: the delivering socket's own refused message echoed back without its stamp, so the dashboard can re-issue it as a new gesture; the stamp is dropped on purpose so a re-issue can never reuse the stale one. `_tell_stale_gesture(client)` becomes `_tell_stale_gesture(client, msg)` at its 14 call sites.

**Webview clock.** A small shared CJS module, `ui/webview/gesture-clock.js`, keeps a per-store logical clock seeded by the wall clock: `stamp(store) = max(Date.now(), seen[store] + 1)`, recording its own result. Every emitter (the gear's fifteen literals, the feed's judge-limit switch, the file viewer's consent) mints its stamp through it at the click, still inside the message literal; the queue's deliver-unchanged contract is untouched. The gear learns each store's stamp from `/version` on every open (it fetched it already), the viewer from the `/version` read it already makes before asking consent, and the `settingStale` listener from the frame's `storedGt`. Side effect: two clicks on one setting within one millisecond no longer collide as an equal-stamp refusal.

**Toast.** It names the setting and the kept value, says the pick was not applied because a later pick is already in place, no longer says where or by whom, and offers **Apply anyway**: the echoed gesture re-issued with a fresh stamp above everything this page has seen. A new user gesture is legitimate new information, the event the ordering rule asks for. The action is offered only when the echo's type matches the setting the frame names (`STALE_TYPE`), so a frame from any linked kernel can re-issue that one setting and nothing else.

### Commit 2: the queue's edges

- `sendRemote` emits a `sendqueue` breadcrumb `{host, msgType, gt, rs, superseded?}` on the queue branch: `rs` is the socket's `readyState` at queue time (-1 if not dialed), `superseded` the replaced entry's `gt`. Nothing mints a timestamp in the send path; the kernel stamps the journal line.
- `flushPending` deletes each entry as its send succeeds; a throw halts the loop, leaves the rest queued for the next open, and posts a `hostconn` `flush-halt` breadcrumb naming flushed and held types. The open breadcrumb on a complete flush is unchanged.
- The `settingStale` frame gains the refused gesture's own `gt`; `prefixInbound` stamps `host` on a remote kernel's `settingStale` as it does for `cardMoveAck`; the gear folds frames by `(setting, gt)`, the refused gesture's identity (an event key, never a time window), into one toast that lists the refusing kernels: "Triage model: not applied on web, api, this machine. A later pick (fable) is already in place." A frame without `gt` (an older kernel) keeps one toast per frame. Liveness of the folded toast is checked at lookup, so a dismissed or expired toast never absorbs a later frame; the dismissal treatment and timings are untouched.

## Compatibility

Additive on both sides. An older kernel sends no `settingsGt`, no `gesture` and no `gt` in the frame: the clock falls back to the wall clock, the toast shows without the action, and refusals are toasted one per frame. An older dashboard keeps stamping `Date.now()` and is refused exactly as today. No store format changes. Two gear documents on one page (feed pane and chat pane) each keep their own clock; each learns on its own open and from the frames it receives, and either can apply anyway. The judge-limit banner in feed.ts has no `/version` read of its own: with the gear never opened in that document it stamps with the wall clock and relies on the refusal plus Apply anyway.

## Tests

Every new test fails on the base commit without the code hunks (checked by reverting the source files and re-running: 10 pytest and 11 node failures for commit 1, 2 pytest and 10 node failures for commit 2, all in the new or changed tests).

Kernel, `tests/test_setting_gesture_order.py`: `VersionReportsEveryStoredStamp` (fresh stores read 0, each setter's stamp is reported, an unstamped apply reports its arrival time, the frames' setting names equal the report's keys), `ASkewedClockCannotLockTheStore` (refused at the skew, applied and propagated at `storedGt + 1`, no frame), the frame's `gesture` echo without `gt` and its `gt` on every gt-gated setting, and the wiring pin on the new signature.

Webview: `gesture-clock.test.ts` drives the module with `Date.now` stubbed (monotonic per store, learned + 1, a stepped-back clock, garbage ignored, the skew scenario end to end). `gear.test.ts`'s completeness pin now requires every `KERNEL_SETTING` emitter to stamp through the clock under its own store name and rejects a bare `Date.now()`. `setting-stale.test.ts` pins the new copy and the absence of the old claim, the learn, the whitelist, the action and its re-issue shape, and the fold's three-file wiring. `setting-stale-fold.test.ts` lifts the gear's toast block the way `gear-models-frame.test.ts` lifts its models block and drives frames through it. `federation-send-queue.test.ts` covers the breadcrumb and the mid-flush throw. `multi-kernel-merge.test.ts` covers the host stamp. The verbatim literal pins in `thinking-summaries.test.ts`, `file-view.test.ts`, `feed-limit-banner.test.ts` and `tests/test_kernel_update.py` follow the emitters.

Full suites on the branch: pytest 7334 passed (46 skipped), `npm test` 2808 passed, `npm run typecheck` and `npm run build` clean, bats 389 passed.

Not in scope: `/tunnels` rows do not lift peers' stamps; a remote's newer stamp reaches the dashboard through the refusal frame, and Apply anyway is the designed path from there.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)