### PR TITLE
File viewer: the GitHub button says why when there is no link

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -28,7 +28,20 @@ passage, and repeat — each staged note remembers its quote and its place. **�
 everything you staged along with whatever is in the box, so the session applies the lot
 in one pass, and you never copy a line out of the document by hand. The line in each
 label is checked against the file at the moment you select, so numbers that moved under
-you are caught rather than quietly carried.
+you are caught rather than quietly carried. The title bar's **GitHub ↗** button opens the
+file on GitHub. While the check runs, the button waits dimmed with pulsing dots beside it.
+When there is nothing to open, the button stays in place, dimmed, and a caption beside it
+says why (the file is not in a git repository or not committed — untracked, staged but in no
+commit, or on a branch with no commits yet — the repository has no origin remote, its origin
+is not on GitHub, or the path is relative and no session's directory resolves it); the
+button's tooltip repeats the reason. A file on a branch that is not on origin keeps its link,
+drawn with a dashed border, and the caption says the branch is not on origin yet. That check
+trusts your clone's own refs: a branch deleted on GitHub reads as present until `git fetch
+--prune`, and one pushed from another clone reads as absent until a fetch. A branch that has
+never been pushed is asked of origin once and the answer kept until a push or fetch from this
+clone writes its tracking ref; where nothing local could refresh the answer (a
+`--single-branch` clone, or a branch on origin this clone has not fetched) origin is asked on
+each open.
 
 ### The feed
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28618,6 +28618,41 @@ def _git_out(args, cwd, timeout=5):
         return None
 
 
+def _git_net_out(args, cwd, timeout, env):
+    """_git_out for the one query that leaves the machine (ls-remote): git runs in its OWN session, and
+    the deadline kills the whole process group. subprocess.run's timeout kill reaches its direct child
+    alone, and the ssh git had spawned sat in its TCP connect for minutes after the viewer had already
+    been told "could not check" (reproduced 2026-09-05). A fresh session also has no controlling
+    terminal, so an ssh that wants a passphrase fails instead of waiting for one."""
+    try:
+        p = subprocess.Popen(["git", "-C", cwd] + args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                             stderr=subprocess.DEVNULL, text=True, start_new_session=True, env=env)
+    except OSError:
+        return None
+    try:
+        out, _ = p.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(p.pid, signal.SIGKILL)         # start_new_session: the child's pid is its pgid
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            p.communicate(timeout=5)
+        except Exception:
+            try:
+                p.kill()
+            except Exception:
+                pass
+        return None
+    except (OSError, subprocess.SubprocessError):
+        try:
+            p.kill()
+        except Exception:
+            pass
+        return None
+    return out.strip() if p.returncode == 0 else None
+
+
 # origin remote → the https://github.com/<owner>/<repo> base, for the spellings git actually writes:
 # scp-like ssh, ssh:// (with an optional port, and GitHub's own documented SSH-over-HTTPS host
 # ssh.github.com), https (with an explicit :443), .git suffix and all. Anchored, so
@@ -28627,20 +28662,153 @@ _GITHUB_REMOTE = re.compile(
     r"([\w.-]+)/([\w.-]+?)(?:\.git)?/?$")
 
 
-def _file_github_url(raw, sid):
-    """The GitHub web URL for a viewed file, or "" when there is none to give (the user 2026-08-15:
-    the viewer links to the file on GitHub when it is tracked there). Answered by the kernel that
-    OWNS the file — git on ITS disk is the authoritative source — and lazily, per viewer open, never
-    on the /file byte path (thumbnails must not pay three subprocesses each).
+# The no-link verdicts, as the viewer shows them (the user 2026-09-05, who could not tell an
+# uncommitted file from a broken link when the button simply never appeared). Plain phrases, a
+# fixed set: the viewer puts one in the disabled button's tooltip verbatim.
+GH_NO_REPO = "not in a git repository"
+GH_UNTRACKED = "not committed (untracked file)"
+GH_NO_COMMITS = "not committed (no commits yet)"
+GH_STAGED = "not committed (staged only)"
+GH_NO_ORIGIN = "no origin remote"
+GH_NOT_GITHUB = "the origin remote is not on GitHub"
+GH_NO_BASE = "relative path with no session directory to resolve it against"
+# ...and the two notes a link can carry anyway: the branch is real but GitHub has not seen it
+GH_NOT_ON_ORIGIN = "branch %s is not on origin"
+GH_ORIGIN_UNCHECKED = "could not check whether branch %s is on origin"
+GH_LS_REMOTE_S = 3          # the viewer is waiting on this reply; a remote that has not answered by then is "unchecked"
 
-    "" is a VERDICT, not an error: an untracked file, a non-repo path, or a non-GitHub origin all
-    honestly have no link, and the viewer simply never shows the button. The ref is the current
-    branch (what a human expects to read on GitHub), or the commit sha when HEAD is detached; a
-    branch that was never pushed 404s on GitHub's end, which is the truthful outcome for a file
-    that is not there yet."""
+
+# ls-remote's answers, memoized per (repo top, branch) — EVENT-keyed, no expiry: an entry holds until
+# the free local check (the tracking ref) changes its verdict, which is the event a push or fetch
+# produces. A never-pushed branch otherwise paid a network round trip on every viewer open, with as
+# many in flight as opens (2026-09-05). Only a False is kept, and only where the clone's fetch refspec
+# maps the branch onto that tracking ref (_origin_tracks), so that a push or a fetch CAN contradict
+# it. A True with no tracking ref has no drop event — a deletion on GitHub writes nothing here, and
+# `fetch --prune` has no ref to prune — and a False in a `--single-branch` clone would outlive the
+# push, since that push writes no tracking ref (both found in review, 2026-09-06); neither is stored,
+# and each open asks. "did not answer" is asked again next time. _ORIGIN_INFLIGHT dedupes concurrent
+# askers of one key: they wait on the leader's Event and share its answer, whatever it is, instead of
+# each paying the timeout in turn.
+_ORIGIN_MEMO = {}                       # (top, ref) -> False
+_ORIGIN_INFLIGHT = {}                   # (top, ref) -> [threading.Event, answer]
+_ORIGIN_LOCK = threading.Lock()
+
+
+def _refspec_match(pattern, name):
+    """What one side of a fetch refspec's single `*` stands for when `pattern` covers `name` ("" for an
+    exact match), or None when it does not cover it."""
+    if "*" not in pattern:
+        return "" if pattern == name else None
+    head, _, tail = pattern.partition("*")
+    if len(name) >= len(head) + len(tail) and name.startswith(head) and name.endswith(tail):
+        return name[len(head):len(name) - len(tail)]
+    return None
+
+
+def _origin_tracks(top, ref):
+    """Whether this clone's fetch refspecs for origin map refs/heads/<ref> onto refs/remotes/origin/<ref>
+    — so that a push of the branch from here (git updates the tracking ref a matching fetch refspec
+    names) or a fetch WRITES the ref _origin_has_branch reads for free. A default clone's
+    `+refs/heads/*:refs/remotes/origin/*` does; a `--single-branch` clone's
+    `+refs/heads/main:refs/remotes/origin/main` does for main alone; a negative refspec (^refs/heads/x)
+    excludes. Among the positive refspecs the FIRST one whose source covers the branch decides, as in
+    git: a push updates the tracking ref of the first match alone (remote.c query_refspecs), so with a
+    `refs/remotes/other/*` line ahead of the default one the push writes other's ref and not ours —
+    and a memo the earlier any-match reading kept would have outlived that push until the next fetch
+    (found in review). A source-only refspec (no destination) is skipped, as git skips it. A shape
+    not understood reads as untracked: the side that asks origin instead of trusting a memo nothing
+    could refresh."""
+    specs = _git_out(["config", "--get-all", "remote.origin.fetch"], top)
+    if not specs:
+        return False
+    src_ref, dst_ref = "refs/heads/" + ref, "refs/remotes/origin/" + ref
+    first = None                                    # the first positive match's verdict, once found
+    for spec in specs.splitlines():
+        spec = spec.strip()
+        if spec.startswith("^"):
+            if _refspec_match(spec[1:], src_ref) is not None:
+                return False                        # excluded from every fetch, wherever the line sits
+            continue
+        if first is not None:
+            continue                                # a later positive match never wins over the first
+        src, colon, dst = spec.lstrip("+").partition(":")
+        if not colon:
+            continue                                # source-only: fetched into FETCH_HEAD, writes no ref
+        star = _refspec_match(src, src_ref)
+        if star is not None:
+            first = dst.replace("*", star, 1) == dst_ref
+    return bool(first)
+
+
+def _origin_has_branch(top, ref):
+    """Whether origin carries branch `ref`: True / False / None (unknown — origin did not answer in
+    time, or refused). The local tracking ref answers first and for free (`refs/remotes/origin/<ref>`
+    exists once the branch has been pushed or fetched); only its absence pays one `ls-remote` — a
+    worktree branch never pushed has no tracking ref, and that is the case the note exists for. That
+    False is memoized, where the clone's fetch refspec maps the branch onto the tracking ref
+    (_origin_tracks), until the ref appears: the push from the session writes it (so does a fetch,
+    after a push from another clone), the free check sees it and drops the entry. What no local event
+    can contradict is asked again on every open: a True with the tracking ref absent (the branch was
+    pushed from another clone and never fetched here; a deletion on GitHub then writes nothing
+    locally), and any answer in a clone whose refspec leaves the branch untracked (`--single-branch`).
+    The verdict is as fresh as this clone's refs, then: a branch deleted on GitHub reads as present
+    until `fetch --prune`, one pushed from elsewhere as absent until a fetch. The query gets a short
+    timeout and no terminal prompt: the viewer must never hang on it. The pattern is the full ref and
+    the answer is matched on it exactly, because ls-remote patterns match a ref's TAIL (`main` would
+    also match `refs/heads/x/main`)."""
+    key = (top, ref)
+    if _git_out(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/" + ref], top):
+        with _ORIGIN_LOCK:
+            _ORIGIN_MEMO.pop(key, None)         # the free check answers now; its verdict changing re-asks
+        return True
+    with _ORIGIN_LOCK:
+        if key in _ORIGIN_MEMO:
+            return _ORIGIN_MEMO[key]
+        flight = _ORIGIN_INFLIGHT.get(key)
+        leader = flight is None
+        if leader:
+            flight = _ORIGIN_INFLIGHT[key] = [threading.Event(), None]
+    if not leader:
+        flight[0].wait()                        # the leader's finally always sets it
+        return flight[1]
+    on = None
+    try:
+        full = "refs/heads/" + ref
+        out = _git_net_out(["ls-remote", "--heads", "origin", full], top, timeout=GH_LS_REMOTE_S,
+                           env=dict(os.environ, GIT_TERMINAL_PROMPT="0"))
+        if out is not None:
+            on = any(line.split("\t")[-1] == full for line in out.splitlines())
+    finally:
+        keep = on is False and _origin_tracks(top, ref)    # a git read: outside the lock
+        with _ORIGIN_LOCK:
+            if keep:
+                _ORIGIN_MEMO[key] = False
+            _ORIGIN_INFLIGHT.pop(key, None)
+        flight[1] = on
+        flight[0].set()
+    return on
+
+
+def _file_github_link(raw, sid, check_origin=True):
+    """(url, reason) for a viewed file: the GitHub web URL when there is one to give, and otherwise
+    WHY there is none (the user 2026-08-15: the viewer links to the file on GitHub when it is tracked
+    there; the user 2026-09-05: when it cannot, it must say so). Answered by the kernel that OWNS the
+    file — git on ITS disk is the authoritative source — and lazily, per viewer open, never on the
+    /file byte path (thumbnails must not pay the git subprocesses).
+
+    An empty url is a VERDICT, not an error, and the reason names it: an untracked file, a non-repo
+    path, a file staged but in no commit, a repo with no origin, a non-GitHub origin, or a relative
+    path with no session cwd to place it all honestly have no link (GH_NO_REPO / GH_UNTRACKED /
+    GH_NO_COMMITS / GH_STAGED / GH_NO_ORIGIN / GH_NOT_GITHUB / GH_NO_BASE — a fixed set of plain
+    phrases the viewer shows verbatim). The ref is the current branch (what a human expects to read
+    on GitHub), or the commit sha when HEAD is detached. A branch that was never pushed 404s on
+    GitHub's end, so with check_origin the url still comes back (it is the right one, once pushed)
+    but carries GH_NOT_ON_ORIGIN as its reason — or GH_ORIGIN_UNCHECKED when origin did not answer in
+    time; a detached sha is never checked."""
     p = _resolve_open_path(str(raw or ""), sid)
     if not os.path.isabs(p):
-        return ""
+        return "", GH_NO_BASE                       # a relative path with no base can be placed in no repo —
+    #                                                 and no repo was consulted, so the verdict says THAT
     # realpath, not normpath (two executed repros): a lexical '..' collapse built a URL for a
     # DIFFERENT file than the bytes the viewer shows when the '..' followed a symlink — a wrong link,
     # strictly worse than none — and a symlinked path PREFIX made relpath escape the PHYSICAL toplevel
@@ -28649,29 +28817,58 @@ def _file_github_url(raw, sid):
     d = os.path.dirname(p)
     top = _git_out(["rev-parse", "--show-toplevel"], d)
     if not top:
-        return ""
+        return "", GH_NO_REPO
     rel = os.path.relpath(p, top)
     if rel == ".." or rel.startswith(".." + os.sep):
-        return ""                                   # escaped the repo — NOT a name-prefix test: a root
+        return "", GH_NO_REPO                       # escaped the repo — NOT a name-prefix test: a root
     #                                                 file literally named ..cfg is inside and links fine
     if _git_out(["ls-files", "--error-unmatch", "--", rel], top) is None:
-        return ""                                   # exists but untracked — no link to a thing not there
+        return "", GH_UNTRACKED                     # exists but untracked — no link to a thing not there
     remote = _git_out(["remote", "get-url", "origin"], top)
-    m = _GITHUB_REMOTE.match(remote or "")
+    if remote is None:
+        return "", GH_NO_ORIGIN                     # no remote by that name: a different fact from a
+    #                                                 non-GitHub one, and a different fix
+    m = _GITHUB_REMOTE.match(remote)
     if not m:
-        return ""
-    ref = _git_out(["rev-parse", "--abbrev-ref", "HEAD"], top)
-    if not ref:
-        return ""
-    if ref == "HEAD":                               # detached — the sha is the only honest ref
-        ref = _git_out(["rev-parse", "HEAD"], top) or ""
-        if not ref:
-            return ""
-    return "https://github.com/%s/%s/blob/%s/%s" % (
+        return "", GH_NOT_GITHUB
+    sha = _git_out(["rev-parse", "--verify", "--quiet", "HEAD"], top)
+    if not sha:
+        return "", GH_NO_COMMITS                    # staged into an unborn branch: in the index, on no commit
+    if _git_out(["cat-file", "-e", "HEAD:" + rel.replace(os.sep, "/")], top) is None:
+        return "", GH_STAGED                        # in the index, not in HEAD's tree: ls-files reads the
+    #                                                 INDEX, so a file staged on a branch with commits passed
+    #                                                 it and got a live URL at a path GitHub has on no ref —
+    #                                                 an enabled button that 404s (found in review). The
+    #                                                 commit HEAD names is what a push can put on GitHub
+    # `symbolic-ref -q HEAD` reads the branch HEAD names, NOT `rev-parse --abbrev-ref HEAD`: the latter
+    # spells a branch that shares its name with a tag as `heads/<branch>` to disambiguate, which GitHub
+    # 404s and which named a branch nobody has ("branch heads/main is not on origin") — reproduced
+    # 2026-09-05. Nor `branch --show-current`: git below 2.22 lacks it, and the failed query silently
+    # gave EVERY file a sha URL (found in review). Fails when HEAD is detached, and then the sha is the
+    # only honest ref.
+    head = _git_out(["symbolic-ref", "-q", "HEAD"], top) or ""
+    branch = head[len("refs/heads/"):] if head.startswith("refs/heads/") else None
+    ref = branch or sha
+    url = "https://github.com/%s/%s/blob/%s/%s" % (
         # safe="/" keeps a slashed branch name (feat/x) literal — the form GitHub's own UI writes;
         # GitHub resolves the ref/path ambiguity by longest match, exactly as it does for its users
         m.group(1), m.group(2), quote(ref, safe="/"),
         "/".join(quote(seg) for seg in rel.split(os.sep)))
+    reason = ""
+    if check_origin and branch:
+        on = _origin_has_branch(top, branch)
+        if on is False:
+            reason = GH_NOT_ON_ORIGIN % branch
+        elif on is None:
+            reason = GH_ORIGIN_UNCHECKED % branch
+    return url, reason
+
+
+def _file_github_url(raw, sid):
+    """The GitHub web URL for a viewed file, or "" when there is none — _file_github_link's url
+    alone, without the origin check (no network query for a caller that wants only the address).
+    Kept for callers that predate the reason; the viewer's op uses _file_github_link."""
+    return _file_github_link(raw, sid, check_origin=False)[0]
 
 
 # Inline-code spans that name an EXISTING file despite containing spaces (the user 2026-08-04: a note
@@ -36440,11 +36637,13 @@ class Handler(BaseHTTPRequestHandler):
             # kernel that OWNS the file — git on ITS disk is the authority, and a remote page's WS
             # already terminates on the owning kernel (the /remote/<host>/ws splice), so no relay
             # clause is needed; sid only resolves a relative path against that session's cwd. reqId
-            # is echoed for the stale-drop; an empty url is the no-link verdict and the viewer just
-            # never shows the button. Threaded: three git subprocesses must not block the recv loop.
+            # is echoed for the stale-drop; an empty url is the no-link verdict and `reason` says why,
+            # so the viewer shows the button disabled with the reason instead of hiding it (the user
+            # 2026-09-05); a url whose branch is not on origin carries the note in `reason` too.
+            # Threaded: the git subprocesses (and one possible ls-remote) must not block the recv loop.
             def _gl(c=client, m=msg):
-                _reply(c, {"type": "fileGitLink", "reqId": m.get("reqId"),
-                           "url": _file_github_url(m.get("path"), m.get("sid") or None)})
+                url, reason = _file_github_link(m.get("path"), m.get("sid") or None)
+                _reply(c, {"type": "fileGitLink", "reqId": m.get("reqId"), "url": url, "reason": reason})
             threading.Thread(target=_gl, daemon=True).start()
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -2,14 +2,19 @@
 """_file_github_url + the fileGitLink WS op — the viewer's GitHub link (the user 2026-08-15).
 
 An empty url is a VERDICT, not an error: untracked files, non-repo paths, and non-GitHub origins
-honestly have no link, and the viewer never shows the button. The ref is the current branch (what a
-human expects to read), or the sha when HEAD is detached. Real temp git repos, synthetic names only
-(TESTORG / notes-api — the demo world).
+honestly have no link — and since 2026-09-05 the verdict carries a REASON (_file_github_link returns
+(url, reason)), so the viewer shows the button disabled with the reason instead of hiding it; a branch
+that is not on origin keeps its url and carries a note. The ref is the current branch (what a human
+expects to read), or the sha when HEAD is detached. Real temp git repos, synthetic names only
+(TESTORG / notes-api — the demo world); the one network query (ls-remote) is served by a LOCAL bare
+repo through a stand-in ssh, so no test reaches GitHub.
 """
 import json
 import os
+import shutil
 import subprocess
 import tempfile
+import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -25,9 +30,86 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 km = SourceFileLoader("romp_kernel_github", os.path.join(BIN, "romp-kernel")).load_module()
 
 
+# The fixture repos ignore the developer's global and system git config: a global core.hooksPath or
+# LFS filter would otherwise run THEIR hooks on the fixture push below (on one dev box, git-lfs asked
+# the stand-in ssh for git-lfs-authenticate and failed the push). What the kernel itself runs is the
+# process environment's git, as in production — and the tests whose kernel call reaches origin pin
+# THAT environment the same way (_WithOrigin below). GIT_CONFIG_GLOBAL is honoured by git >= 2.32.
+_GIT_ENV = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+
+
 def _git(*args, cwd):
     subprocess.run(["git", "-c", "user.email=t@testhost", "-c", "user.name=t"] + list(args),
-                   cwd=cwd, check=True, capture_output=True)
+                   cwd=cwd, check=True, capture_output=True,
+                   env=dict(_GIT_ENV, GIT_SSH_COMMAND=os.environ.get("GIT_SSH_COMMAND", "ssh")))
+
+
+def _local_origin(repo):
+    """Serve `git@github.com:TESTORG/notes-api.git` from a LOCAL bare repo, no network. git runs
+    `$GIT_SSH_COMMAND [opts] git@github.com "git-upload-pack 'TESTORG/notes-api.git'"`; the stand-in
+    ignores everything but that last argument and runs it in a root that holds the bare repo at that
+    relative path — real git on both ends. The remote URL stays a GitHub one, so _GITHUB_REMOTE still
+    matches (a url.insteadOf rewrite would not do: `remote get-url` expands it). Pushes `repo`'s main,
+    so origin starts with that branch. Returns the root; the caller owns restoring GIT_SSH_COMMAND."""
+    root = tempfile.mkdtemp()
+    bare = os.path.join(root, "TESTORG", "notes-api.git")
+    os.makedirs(os.path.dirname(bare))
+    _git("init", "-q", "--bare", bare, cwd=root)
+    sh = os.path.join(root, "stand-in-ssh")
+    with open(sh, "w") as f:
+        f.write('#!/bin/sh\nfor a in "$@"; do cmd=$a; done\ncd "%s" && eval "$cmd"\n' % root)
+    os.chmod(sh, 0o755)
+    os.environ["GIT_SSH_COMMAND"] = sh
+    _git("push", "-q", "origin", "main", cwd=repo)
+    return root
+
+
+def _script(root, name, body):
+    p = os.path.join(root, name)
+    with open(p, "w") as f:
+        f.write("#!/bin/sh\n" + body)
+    os.chmod(p, 0o755)
+    return p
+
+
+def _restore_env_after(tc, *names):
+    """Register a cleanup that puts `names` back to their values NOW — addCleanup, not tearDown, so a
+    setUp that fails after changing one of them still restores it (a tearDown never runs then)."""
+    saved = {n: os.environ.get(n) for n in names}
+
+    def restore():
+        for n, v in saved.items():
+            if v is None:
+                os.environ.pop(n, None)
+            else:
+                os.environ[n] = v
+    tc.addCleanup(restore)
+
+
+def _git_version():
+    out = subprocess.run(["git", "--version"], capture_output=True, text=True).stdout
+    return tuple(int(x) for x in out.split()[2].split(".")[:2])
+
+
+def _alive(pid):
+    """Whether `pid` is still a running process. A zombie counts as gone: it has been killed and only
+    awaits its reaper (init, once its parent died with it)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    try:
+        with open("/proc/%d/stat" % pid) as f:
+            return f.read().rsplit(")", 1)[-1].split()[0] != "Z"
+    except OSError:
+        return True
+
+
+def _kill_quiet(pid):
+    try:
+        os.kill(pid, 9)
+    except OSError:
+        pass
 
 
 class _Repo(unittest.TestCase):
@@ -45,6 +127,45 @@ class _Repo(unittest.TestCase):
             f.write("untracked\n")
         _git("add", "src", cwd=self.tmp)
         _git("commit", "-q", "-m", "init", cwd=self.tmp)
+
+
+class _WithOrigin(_Repo):
+    """A repo whose origin is _local_origin's stand-in. The KERNEL's git runs with the PROCESS
+    environment (as in production), so for these tests that environment is pinned hermetic too:
+    GIT_CONFIG_GLOBAL=/dev/null (honoured by git >= 2.32) and GIT_CONFIG_NOSYSTEM=1. Without the pin
+    a developer's global `url."https://github.com/".insteadOf = git@github.com:` rewrote the fixture
+    origin under the kernel's ls-remote and the tests reached real github.com (reproduced 2026-09-05;
+    three went red). The kernel's memo of origin answers starts empty: every test begins unasked."""
+
+    URL = "https://github.com/TESTORG/notes-api/blob/%s/src/app.py"
+
+    def setUp(self):
+        _restore_env_after(self, "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM", "GIT_SSH_COMMAND")
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        km._ORIGIN_MEMO.clear()
+        km._ORIGIN_INFLIGHT.clear()
+        super().setUp()
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        self.root = _local_origin(self.tmp)          # origin has main; the push also wrote the tracking ref
+        self.ssh = os.path.join(self.root, "stand-in-ssh")
+
+    def counting_ssh(self, before=""):
+        """Point the kernel at a stand-in ssh that counts the queries that went out and runs `before`
+        (shell) ahead of each; returns the count reader. Counts the git-upload-pack calls only: a
+        GIT_SSH_COMMAND not named ssh also gets git's variant probe (`-G <host>`) before each one."""
+        log = os.path.join(self.root, "asked.log")
+        os.environ["GIT_SSH_COMMAND"] = _script(
+            self.root, "counting-ssh",
+            'case "$*" in *git-upload-pack*) echo x >> "%s";; esac\n%sexec "%s" "$@"\n'
+            % (log, before, self.ssh))
+
+        def asked():
+            if not os.path.exists(log):
+                return 0
+            with open(log) as f:
+                return f.read().count("x")
+        return asked
 
 
 class GitHubUrl(_Repo):
@@ -76,6 +197,14 @@ class GitHubUrl(_Repo):
         _git("checkout", "-q", sha, cwd=self.tmp)
         self.assertEqual(km._file_github_url(self.fp, None),
                          "https://github.com/TESTORG/notes-api/blob/%s/src/app.py" % sha)
+
+    def test_a_tag_named_like_the_branch_leaves_the_ref_alone(self):
+        # `rev-parse --abbrev-ref HEAD` disambiguates a branch/tag name clash as heads/main, and GitHub
+        # 404s that spelling (reproduced 2026-09-05); the branch name itself is what the URL wants
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        _git("tag", "main", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
 
     def test_a_symlinked_path_prefix_still_links(self):
         # executed repro: git reports the PHYSICAL toplevel, so a logical path through a symlink
@@ -119,13 +248,53 @@ class GitHubUrl(_Repo):
         self.assertEqual(km._file_github_url(dd, None),
                          "https://github.com/TESTORG/notes-api/blob/main/..cfg")
 
-    def test_no_link_verdicts_untracked_nonrepo_and_nongithub(self):
+    def test_no_link_verdicts_name_their_reason(self):
+        # the user 2026-09-05 could not tell an uncommitted file from a broken link: every no-link
+        # verdict now says which, in a plain phrase the viewer shows verbatim
         _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
-        self.assertEqual(km._file_github_url(os.path.join(self.tmp, "loose.txt"), None), "",
-                         "untracked file — no link to a thing not there")
-        self.assertEqual(km._file_github_url("/tmp", None), "", "not a repo")
+        self.assertEqual(km._file_github_link(os.path.join(self.tmp, "loose.txt"), None),
+                         ("", "not committed (untracked file)"), "untracked file — no link to a thing not there")
+        self.assertEqual(km._file_github_link(tempfile.mkdtemp(), None), ("", "not in a git repository"))
         _git("remote", "set-url", "origin", "git@gitlab.example.com:TESTORG/notes-api.git", cwd=self.tmp)
-        self.assertEqual(km._file_github_url(self.fp, None), "", "origin is not GitHub")
+        self.assertEqual(km._file_github_link(self.fp, None), ("", "the origin remote is not on GitHub"))
+        # the url-only caller keeps its "" verdict
+        self.assertEqual(km._file_github_url(self.fp, None), "")
+
+    def test_a_repo_with_no_origin_remote_says_that_not_not_on_github(self):
+        # `remote get-url origin` fails when there is no such remote; that used to read as "the origin
+        # remote is not on GitHub", which names a remote the repo does not have
+        self.assertEqual(km._file_github_link(self.fp, None), ("", "no origin remote"))
+        self.assertEqual(km._file_github_url(self.fp, None), "")
+
+    def test_a_file_staged_on_no_commit_is_not_committed(self):
+        # an unborn branch: ls-files sees the index entry, but HEAD names nothing to link
+        fresh = tempfile.mkdtemp()
+        _git("init", "-q", "-b", "main", cwd=fresh)
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=fresh)
+        fp = os.path.join(fresh, "new.py")
+        with open(fp, "w") as f:
+            f.write("pass\n")
+        _git("add", "new.py", cwd=fresh)
+        self.assertEqual(km._file_github_link(fp, None), ("", "not committed (no commits yet)"))
+
+    def test_a_file_staged_on_a_branch_with_commits_is_not_committed(self):
+        # the unborn case's sibling: HEAD is real, ls-files sees the index entry — and the URL that used
+        # to come back named a path GitHub has on no ref, so the viewer drew an enabled button that 404d
+        # (found in review). Only the tree HEAD names decides what a push can put on GitHub.
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        fp = os.path.join(self.tmp, "src", "new.py")
+        with open(fp, "w") as f:
+            f.write("pass\n")
+        _git("add", "src/new.py", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(fp, None), ("", "not committed (staged only)"))
+        self.assertEqual(km._file_github_url(fp, None), "")
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py",
+                         "its committed neighbour still links")
+        _git("commit", "-q", "-m", "new", cwd=self.tmp)
+        self.assertEqual(km._file_github_url(fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/new.py",
+                         "the commit is the event: nothing else changed")
 
     def test_a_relative_path_resolves_against_the_sessions_cwd(self):
         _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
@@ -134,18 +303,291 @@ class GitHubUrl(_Repo):
         try:
             self.assertEqual(km._file_github_url("src/app.py", "11111111-2222-3333-4444-000000000001"),
                              "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
-            self.assertEqual(km._file_github_url("src/app.py", None), "", "no sid, no base — no guess")
+            self.assertEqual(km._file_github_link("src/app.py", None),
+                             ("", "relative path with no session directory to resolve it against"),
+                             "no sid, no base — no guess; and the verdict names THAT, not a repository "
+                             "check the kernel never ran (found in review)")
         finally:
             km._cwd_of = real
 
 
-class GitLinkWire(_Repo):
+    def test_the_branch_name_needs_no_modern_git(self):
+        # `branch --show-current` arrived in git 2.22; below it the query fails, and a failed branch
+        # query silently gave EVERY file a commit-sha URL where the branch URL was right (found in
+        # review). The branch comes from `symbolic-ref -q HEAD` now, which every git has and which a
+        # same-named tag cannot bend either. Reproduced with a git that rejects the option and hands
+        # everything else on — first on PATH, which is where the kernel finds its git.
+        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
+        _git("tag", "main", cwd=self.tmp)
+        real = shutil.which("git")
+        _restore_env_after(self, "PATH")
+        old = tempfile.mkdtemp()
+        _script(old, "git",
+                'for a in "$@"; do [ "$a" = "--show-current" ] && '
+                '{ echo "error: unknown option \\`show-current\'" >&2; exit 129; }; done\n'
+                'exec "%s" "$@"\n' % real)
+        os.environ["PATH"] = old + os.pathsep + os.environ["PATH"]
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
+                             capture_output=True, text=True).stdout.strip()
+        _git("checkout", "-q", sha, cwd=self.tmp)
+        self.assertEqual(km._file_github_url(self.fp, None),
+                         "https://github.com/TESTORG/notes-api/blob/%s/src/app.py" % sha,
+                         "detached: the sha stays the only honest ref")
+
+
+class BranchOnOrigin(_WithOrigin):
+    """The branch note (the user 2026-09-05): a worktree branch never pushed 404s on GitHub, so the
+    url comes back WITH a reason. The local tracking ref answers first and free; only its absence
+    pays one ls-remote, served here by _local_origin's stand-in ssh — never the network."""
+
+    def test_the_kernels_git_reads_no_global_config_here(self):
+        # The fixture's pin, shown load-bearing (reproduced 2026-09-05 with a global insteadOf rewrite
+        # that sent the kernel's ls-remote to real github.com). Offline twin: a rewrite to another
+        # owner, which the stand-in has no repo for. With a developer's global config in force the
+        # kernel would build the wrong URL and fail the check; under the fixture's pin it never reads it.
+        if _git_version() < (2, 32):
+            self.skipTest("GIT_CONFIG_GLOBAL needs git >= 2.32")
+        cfg = os.path.join(self.root, "developer-gitconfig")
+        with open(cfg, "w") as f:
+            f.write('[url "git@github.com:OTHERORG/"]\n\tinsteadOf = git@github.com:TESTORG/\n')
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        os.environ["GIT_CONFIG_GLOBAL"] = cfg
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         ("https://github.com/OTHERORG/notes-api/blob/wip/src/app.py",
+                          "could not check whether branch wip is on origin"),
+                         "the leak, live: the kernel's git honours whatever global config the environment names")
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull    # the fixture's pin
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "branch wip is not on origin"))
+
+    def test_a_pushed_branch_carries_no_note_and_asks_origin_nothing(self):
+        os.environ["GIT_SSH_COMMAND"] = "false"       # any network query would come back "unchecked"
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "main", ""))
+
+    def test_a_missing_tracking_ref_falls_to_ls_remote(self):
+        # a clone that never fetched the ref: the local answer is absent, origin itself has the branch
+        _git("update-ref", "-d", "refs/remotes/origin/main", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "main", ""))
+
+    def test_a_branch_never_pushed_keeps_its_url_and_says_so(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "branch wip is not on origin"))
+
+    def test_a_tag_named_like_the_branch_never_bends_the_note(self):
+        # the heads/<branch> spelling would also have asked origin for a branch nobody has and said
+        # "branch heads/main is not on origin" about a branch that IS there (reproduced 2026-09-05)
+        _git("tag", "main", cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = "false"       # the tracking ref answers; nothing goes out
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "main", ""))
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        _git("tag", "wip", cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = self.ssh
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "branch wip is not on origin"))
+
+    def test_a_slashed_branch_is_matched_whole_not_by_tail(self):
+        # ls-remote patterns match a ref's TAIL: `wip` alone would also match refs/heads/x/wip
+        _git("checkout", "-q", "-b", "feat/wip", cwd=self.tmp)
+        _git("push", "-q", "origin", "feat/wip:refs/heads/other/feat/wip", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "feat/wip", "branch feat/wip is not on origin"))
+
+    def test_an_unreachable_origin_is_unchecked_not_asserted(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = "false"
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "could not check whether branch wip is on origin"))
+
+    def test_a_slow_origin_is_cut_off_because_the_viewer_is_waiting(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = _script(self.root, "slow-ssh", "sleep 5\n")
+        real = km.GH_LS_REMOTE_S
+        km.GH_LS_REMOTE_S = 0.3
+        try:
+            t0 = time.time()
+            self.assertEqual(km._file_github_link(self.fp, None),
+                             (self.URL % "wip", "could not check whether branch wip is on origin"))
+            self.assertLess(time.time() - t0, 2.0, "the timeout, not the remote, ends the wait")
+        finally:
+            km.GH_LS_REMOTE_S = real
+
+    def test_the_cut_kills_the_ssh_git_spawned_not_git_alone(self):
+        # subprocess.run's timeout kill reached git alone; the ssh it had spawned sat in its TCP connect
+        # for minutes after the viewer was told "could not check" (reproduced 2026-09-05). The query
+        # runs in its own session now and the deadline kills the whole group.
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        pidfile = os.path.join(self.root, "stuck-ssh.pid")
+        os.environ["GIT_SSH_COMMAND"] = _script(self.root, "stuck-ssh",
+                                                "echo $$ > '%s'\nexec sleep 30\n" % pidfile)
+        real = km.GH_LS_REMOTE_S
+        km.GH_LS_REMOTE_S = 0.3
+        try:
+            self.assertEqual(km._file_github_link(self.fp, None),
+                             (self.URL % "wip", "could not check whether branch wip is on origin"))
+        finally:
+            km.GH_LS_REMOTE_S = real
+        self.assertTrue(os.path.exists(pidfile), "the stand-in ssh ran before the cut")
+        pid = int(open(pidfile).read())
+        self.addCleanup(_kill_quiet, pid)
+        deadline = time.time() + 3
+        while _alive(pid) and time.time() < deadline:
+            time.sleep(0.02)
+        self.assertFalse(_alive(pid), "the ssh git spawned outlived the cut")
+
+    def test_a_detached_sha_is_never_checked(self):
+        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
+                             capture_output=True, text=True).stdout.strip()
+        _git("checkout", "-q", sha, cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = "false"
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % sha, ""))
+
+    def test_a_second_open_reuses_the_answer_instead_of_asking_origin_again(self):
+        # a never-pushed branch paid one round trip per viewer open (2026-09-05); the answer now holds
+        # until the local check changes its verdict — no clock on it
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        asked = self.counting_ssh()
+        for _ in range(2):
+            self.assertEqual(km._file_github_link(self.fp, None),
+                             (self.URL % "wip", "branch wip is not on origin"))
+        self.assertEqual(asked(), 1, "one ls-remote per (repo, branch)")
+        _git("checkout", "-q", "-b", "other", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None)[1], "branch other is not on origin")
+        self.assertEqual(asked(), 2, "another branch is another key")
+
+    def test_the_tracking_ref_appearing_flips_the_verdict_for_free(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        asked = self.counting_ssh()
+        self.assertEqual(km._file_github_link(self.fp, None)[1], "branch wip is not on origin")
+        # what a push from the session writes (the push itself would go through the counting ssh)
+        _git("update-ref", "refs/remotes/origin/wip", "HEAD", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", ""))
+        self.assertEqual(asked(), 1, "the tracking ref answered; no new ls-remote")
+        # ...and its disappearance (a fetch --prune after a deletion on GitHub) asks origin afresh
+        _git("update-ref", "-d", "refs/remotes/origin/wip", cwd=self.tmp)
+        self.assertEqual(km._file_github_link(self.fp, None)[1], "branch wip is not on origin")
+        self.assertEqual(asked(), 2, "the local verdict changed, so the memo was dropped")
+
+    def test_a_branch_on_origin_that_this_clone_never_fetched_is_asked_each_time(self):
+        # pushed from another clone: origin has it and this clone has no tracking ref. A True memoized
+        # here would have no drop event — a deletion on GitHub writes nothing locally, and `fetch
+        # --prune` has no ref to prune — and served a 404 link with no caption until the kernel
+        # restarted (found in review). So each open asks, until a fetch writes the tracking ref and
+        # the free check takes over.
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        _git("push", "-q", "origin", "wip", cwd=self.tmp)
+        _git("update-ref", "-d", "refs/remotes/origin/wip", cwd=self.tmp)   # as a clone that never fetched it
+        asked = self.counting_ssh()
+        for _ in range(2):
+            self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", ""))
+        self.assertEqual(asked(), 2, "a True with no tracking ref is not memoized: nothing local could contradict it")
+        _git("update-ref", "-d", "refs/heads/wip", cwd=os.path.join(self.root, "TESTORG", "notes-api.git"))
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "branch wip is not on origin"),
+                         "deleted on GitHub: the next open says so, no restart needed")
+
+    def test_a_clone_whose_refspec_leaves_the_branch_untracked_is_asked_each_time(self):
+        # `git clone --single-branch` writes +refs/heads/main:refs/remotes/origin/main, so a push of any
+        # OTHER branch from this clone writes no tracking ref. A memoized False would have outlived the
+        # push and captioned a working link as not on origin until restart (found in review). With no
+        # local event able to contradict it, nothing is memoized here; each open asks.
+        _git("config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main", cwd=self.tmp)
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        asked = self.counting_ssh()
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", "branch wip is not on origin"))
+        _git("push", "-q", "origin", "wip", cwd=self.tmp)
+        self.assertIsNone(km._git_out(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/wip"], self.tmp),
+                          "the fixture reproduces the gap: this push wrote no tracking ref")
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", ""),
+                         "the push is seen on the next open, not after a restart")
+        self.assertEqual(asked(), 2)
+
+    def test_a_refspec_ahead_of_the_default_takes_the_push_as_git_does(self):
+        # git updates the tracking ref of the FIRST fetch refspec that covers a pushed branch, and no
+        # other: with a `refs/remotes/other/*` line ahead of the default, the push writes other's ref.
+        # Reading any match as tracked memoized a False that push could not contradict, so the working
+        # link stayed captioned as not on origin until the next fetch (found in review).
+        _git("config", "--replace-all", "remote.origin.fetch", "+refs/heads/*:refs/remotes/other/*", cwd=self.tmp)
+        _git("config", "--add", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*", cwd=self.tmp)
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        asked = self.counting_ssh()
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", "branch wip is not on origin"))
+        _git("push", "-q", "origin", "wip", cwd=self.tmp)
+        self.assertIsNone(km._git_out(["rev-parse", "--verify", "--quiet", "refs/remotes/origin/wip"], self.tmp),
+                          "the fixture reproduces git's first-match rule: this push wrote no origin/wip")
+        self.assertTrue(km._git_out(["rev-parse", "--verify", "--quiet", "refs/remotes/other/wip"], self.tmp),
+                        "...it wrote other/wip, the first line's destination")
+        self.assertEqual(km._file_github_link(self.fp, None), (self.URL % "wip", ""),
+                         "the push is seen on the next open, not after the next fetch")
+        self.assertEqual(asked(), 2)
+
+    def test_the_fetch_refspec_decides_what_a_push_can_contradict(self):
+        # the memo's precondition, on the refspec shapes git writes: the default wildcard, a
+        # --single-branch exact ref (for that branch alone), a second remote's namespace, a negative
+        # refspec that excludes the branch, GitHub's pull-request refspec riding beside the default, a
+        # second namespace ahead of the default and behind it (the first positive match decides, as in
+        # git's push), and a source-only line ahead of the default (git skips a refspec with no
+        # destination; so does the read)
+        for specs, tracked in ((["+refs/heads/*:refs/remotes/origin/*"], True),
+                               (["+refs/heads/wip:refs/remotes/origin/wip"], True),
+                               (["+refs/heads/main:refs/remotes/origin/main"], False),
+                               (["+refs/heads/*:refs/remotes/upstream/*"], False),
+                               (["+refs/heads/*:refs/remotes/origin/*", "^refs/heads/wip"], False),
+                               (["^refs/heads/wip", "+refs/heads/*:refs/remotes/origin/*"], False),
+                               (["+refs/heads/*:refs/remotes/origin/*",
+                                 "+refs/pull/*/head:refs/remotes/origin/pr/*"], True),
+                               (["+refs/heads/*:refs/remotes/other/*", "+refs/heads/*:refs/remotes/origin/*"], False),
+                               (["+refs/heads/*:refs/remotes/origin/*", "+refs/heads/*:refs/remotes/other/*"], True),
+                               (["refs/heads/wip", "+refs/heads/*:refs/remotes/origin/*"], True)):
+            _git("config", "--replace-all", "remote.origin.fetch", specs[0], cwd=self.tmp)
+            for extra in specs[1:]:
+                _git("config", "--add", "remote.origin.fetch", extra, cwd=self.tmp)
+            self.assertEqual(km._origin_tracks(self.tmp, "wip"), tracked, specs)
+        _git("config", "--unset-all", "remote.origin.fetch", cwd=self.tmp)
+        self.assertFalse(km._origin_tracks(self.tmp, "wip"), "no refspec at all: nothing can write the ref")
+
+    def test_concurrent_opens_share_one_query(self):
+        # rapid opens used to put as many ls-remotes in flight as opens; askers of one key now wait
+        # for the one in flight and take its answer
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        asked = self.counting_ssh(before="sleep 0.3\n")
+        got = []
+        ts = [threading.Thread(target=lambda: got.append(km._file_github_link(self.fp, None)))
+              for _ in range(6)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(15)
+        self.assertEqual(got, [(self.URL % "wip", "branch wip is not on origin")] * 6)
+        self.assertEqual(asked(), 1)
+
+    def test_an_unanswered_query_is_asked_again_next_time(self):
+        # "could not check" is not an answer; memoizing it would make one blip permanent
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        os.environ["GIT_SSH_COMMAND"] = "false"
+        self.assertEqual(km._file_github_link(self.fp, None)[1],
+                         "could not check whether branch wip is on origin")
+        asked = self.counting_ssh()
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "branch wip is not on origin"))
+        self.assertEqual(asked(), 1)
+
+    def test_the_url_only_caller_never_asks_origin(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        marker = os.path.join(self.root, "asked")
+        os.environ["GIT_SSH_COMMAND"] = _script(self.root, "probe-ssh", "touch '%s'\nexit 255\n" % marker)
+        self.assertEqual(km._file_github_url(self.fp, None), self.URL % "wip")
+        self.assertFalse(os.path.exists(marker), "_file_github_url pays no network query")
+
+
+class GitLinkWire(_WithOrigin):
     """The WS op through the real dispatcher. The op answers on a THREAD (three git subprocesses must
     not block the recv loop), so the harness waits for the reply instead of reading it synchronously."""
 
     def setUp(self):
         super().setUp()
-        _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
         self.sent = []
         self.client = {"app": "feed", "alive": True,
                        "send": lambda s: self.sent.append(json.loads(s))}
@@ -164,11 +606,20 @@ class GitLinkWire(_Repo):
         self.assertEqual(r["type"], "fileGitLink")
         self.assertEqual(r["reqId"], 6, "echoed so a reply landing after a newer open is dropped")
         self.assertEqual(r["url"], "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
+        self.assertEqual(r["reason"], "", "a pushed branch has nothing to add")
 
-    def test_the_no_link_verdict_still_replies(self):
+    def test_the_no_link_verdict_still_replies_and_says_why(self):
         r = self.send_and_wait({"type": "fileGitLink", "path": os.path.join(self.tmp, "loose.txt"),
                                 "reqId": 7})
         self.assertEqual(r["url"], "", "an empty url is the verdict, never a dropped reply")
+        self.assertEqual(r["reason"], "not committed (untracked file)",
+                         "the reason rides the reply — the viewer shows it instead of hiding the button")
+
+    def test_a_branch_not_on_origin_keeps_the_url_and_carries_the_note(self):
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        r = self.send_and_wait({"type": "fileGitLink", "path": self.fp, "reqId": 8})
+        self.assertEqual(r["url"], "https://github.com/TESTORG/notes-api/blob/wip/src/app.py")
+        self.assertEqual(r["reason"], "branch wip is not on origin")
 
 
 if __name__ == "__main__":

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1397,9 +1397,24 @@ body.fileview-open { overflow: hidden; }
 .fileview-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
-/* an author `display` beats the UA's [hidden] rule — without this the anchor shows hrefless
-   before the kernel ever answers */
-a.fileview-btn[hidden] { display: none; }
+/* the GitHub action is one unit: the control and, when the kernel gave one, its reason as a caption
+   beside it — visible without hover (touch has none, and a disabled button takes no focus), and whole:
+   it wraps inside a bounded width rather than truncating, because nothing in the unit takes a tap,
+   click or focus that could finish a cut sentence; same size as the buttons it annotates, ragged edge
+   away from the control it precedes. */
+.fileview-gh { display: inline-flex; align-items: center; gap: 5px; min-width: 0; }
+.fileview-gh-why { font-size: 0.82em; line-height: 1.25; color: var(--dim); max-width: 18em; text-align: right; }
+/* pending: the kernel's check is on its way (up to 3 s when it must ask origin), so the slot holds the
+   dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
+   check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
+.fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
+/* no link: a real disabled button, greyed, hover inert — never hidden (an absent button read as
+   "broken" when the file was simply not committed yet, 2026-09-05) */
+.fileview-gh .fileview-btn:disabled { opacity: 0.55; cursor: default; }
+.fileview-gh .fileview-btn:disabled:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
+.fileview-gh .fileview-btn:disabled:active { transform: none; }
+/* a link whose branch is not on origin yet: dashed, the caption carries the note */
+a.fileview-gh-note { border-style: dashed; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
    and because they are a sibling element a selection of the code copies without dragging them along */

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -140,7 +140,7 @@ function dropMediaUrl(): void {
 // reshape freely. Anything acting on the OPEN file declares itself here instead of hand-wiring into
 // openFileView's action row, where every file-viewer change used to collide. mount() runs once per
 // open and returns the action's element for the row (or null to sit this file out); an action that
-// answers asynchronously (the GitHub link's kernel ask) mounts hidden and reveals itself when its
+// answers asynchronously (the GitHub link's kernel ask) mounts a placeholder and fills it in when its
 // reply lands. Ordering is registration order, after the built-ins.
 export interface FileViewActionCtx { path: string; sid: string | null; }
 export interface FileViewAction { id: string; mount: (ctx: FileViewActionCtx) => HTMLElement | null; }
@@ -150,31 +150,77 @@ export function registerFileViewAction(a: FileViewAction): void {
 }
 
 // ── the GitHub link (the user 2026-08-15) — the registry's first entry ─────────────────────────────
-// An anchor, not a button: the browser owns opening a new tab. Hidden until the OWNING kernel answers
-// the lazy fileGitLink ask with a real URL — an untracked file, a non-repo path, or a non-GitHub
-// origin all honestly have no link, and it simply never appears. One question per open, reqId-guarded.
+// One unit in the action row: the control and, when the kernel gave one, its reason as a caption
+// beside it. The OWNING kernel answers the lazy fileGitLink ask, and until it does the unit holds a
+// PLACEHOLDER — a dimmed disabled button and the loader's pulsing dots where the caption will go —
+// because the check takes up to 3 s when the kernel must ask origin, and an empty slot for that long
+// read as the old no-button state (found in review; the loading-state rule). The answer ALWAYS fills
+// the slot (the user 2026-09-05, who could not tell an uncommitted file from a broken link when the
+// button simply never appeared). A real URL is an anchor — the browser owns the new tab. No URL is
+// a real disabled <button>: assistive tech reads the state and the label, and there is no href to
+// follow or to go stale. The reason rides in the tooltip AND as the caption, because a tooltip alone
+// needs a mouse — touch has no hover, and a disabled button takes no focus — so the caption is what
+// makes the reason glanceable, and it is shown whole: the sheet wraps it inside a bounded width, since
+// nothing in the unit takes a tap, click or focus that could finish a truncated sentence. A URL
+// whose branch is not on origin stays an anchor, dashed, with the note as its caption, since GitHub
+// 404s it until the push. One question per open, reqId-guarded; a socket drop while it is out is
+// the one thing that loses the reply, and the shim's reconnect event re-asks (initFileView), so the
+// placeholder never outlives its wait. Exported for the DOM-shape test.
+const GH_REASONLESS = "this kernel predates link reasons; restart it after updating";
 let gitSeq = 0;
-let gitHooks: { reqId: number; apply: (url: string) => void } | null = null;
-registerFileViewAction({
+let gitHooks: { reqId: number; apply: (url: string, reason: string) => void; ask: () => void } | null = null;
+export const githubLinkAction: FileViewAction = {
   id: "github-link",
   mount({ path, sid }) {
-    const gh = el("a", "fileview-btn fileview-gh") as HTMLAnchorElement;
-    gh.textContent = "GitHub ↗";
-    gh.target = "_blank"; gh.rel = "noopener";
-    gh.hidden = true;
+    const unit = el("span", "fileview-gh");
+    // pending: a real disabled button (never an hrefless anchor, which has no role to read) and the
+    // loader's three dots in the caption's place; aria-busy names the wait for assistive tech
+    const wait = el("button", "fileview-btn") as HTMLButtonElement;
+    wait.type = "button"; wait.disabled = true; wait.textContent = "GitHub ↗";
+    wait.title = "Checking GitHub…"; wait.setAttribute("aria-label", wait.title);
+    const dots = el("span", "fileview-gh-dots");
+    for (let i = 0; i < 3; i++) dots.appendChild(el("i", "fileview-dot"));
+    unit.setAttribute("aria-busy", "true");
+    unit.appendChild(dots); unit.appendChild(wait);
+    const reqId = ++gitSeq;
+    const ask = () => post({ type: "fileGitLink", path, sid: sid || undefined, reqId });
     gitHooks = {
-      reqId: ++gitSeq,
-      apply: (url) => {
-        if (!url) return;
-        gh.href = url;
-        gh.title = url;                            // the full URL one hover away
-        gh.hidden = false;
+      reqId,
+      ask,
+      apply: (url, reason) => {
+        let ctl: HTMLElement;
+        if (url) {
+          const a = el("a", "fileview-btn") as HTMLAnchorElement;
+          a.href = url; a.target = "_blank"; a.rel = "noopener";
+          a.title = reason ? url + "\n" + reason : url;      // the full URL one hover away, and the note with it
+          if (reason) { a.classList.add("fileview-gh-note"); a.setAttribute("aria-label", "GitHub: " + reason); }
+          ctl = a;
+        } else {
+          // an older kernel answers without a reason — say what that means, rather than invent one
+          const b = el("button", "fileview-btn") as HTMLButtonElement;
+          b.type = "button"; b.disabled = true;
+          b.title = "No GitHub link: " + (reason || GH_REASONLESS);
+          b.setAttribute("aria-label", b.title);
+          ctl = b;
+        }
+        ctl.textContent = "GitHub ↗";
+        const why = reason || (url ? "" : GH_REASONLESS);
+        const parts: HTMLElement[] = [];
+        if (why) {
+          const cap = el("span", "fileview-gh-why");
+          cap.textContent = why;                             // whole, wrapped by the sheet — no tooltip to reach for
+          parts.push(cap);                                   // before the control: it annotates what follows
+        }
+        parts.push(ctl);
+        unit.replaceChildren(...parts);                      // the placeholder leaves with the wait
+        unit.removeAttribute("aria-busy");
       },
     };
-    post({ type: "fileGitLink", path, sid: sid || undefined, reqId: gitSeq });
-    return gh;
+    ask();
+    return unit;
   },
-});
+};
+registerFileViewAction(githubLinkAction);
 
 // ── quote a passage into the composer (the user 2026-08-23, the three-verbs consolidation) ────────
 // Selecting text in the viewer seeds the SAME labeled quote chip a VS Code editor highlight does:
@@ -862,7 +908,7 @@ export function initFileView(poster: (m: Record<string, unknown>) => void): void
       openFileView(m.path, typeof m.sid === "string" ? m.sid : null);
     } else if (m.type === "fileGitLink" && gitHooks && m.reqId === gitHooks.reqId) {
       const h = gitHooks; gitHooks = null;
-      h.apply(String(m.url || ""));
+      h.apply(String(m.url || ""), String(m.reason || ""));
     } else if (m.type === "fileSaved" && editHooks && m.reqId === editHooks.reqId) {
       const h = editHooks; editHooks = null;
       h.saved(String(m.mtimeNs || ""));
@@ -887,4 +933,9 @@ export function initFileView(poster: (m: Record<string, unknown>) => void): void
     h.failed("the connection dropped mid-save — it may or may not have landed; "
       + "Save again once the connection returns (a save that DID land will refuse as changed-on-disk)");
   });
+  // A drop while the GitHub ask is out loses its reply (the frame went; nothing re-sends it), and the
+  // placeholder would pulse for the rest of the open. The socket's RETURN is the event that re-asks —
+  // same reqId, so a first reply that was merely late and the second are one answer (the browse
+  // overlay's re-ask on romp:wsup is the precedent). A read-only query: asking twice costs nothing.
+  window.addEventListener("romp:wsup", () => { if (gitHooks) gitHooks.ask(); });
 }

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -16,7 +16,9 @@ const FEED = read("feed.css");
 const RULES = [
   "#romp-fileview {", ".fileview {", "body.fileview-open {", ".fileview-bar {", ".fileview-name {",
   ".fileview-dir {", ".fileview-base {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
-  "a.fileview-btn {", "a.fileview-btn[hidden] {", ".fileview-body {",
+  "a.fileview-btn {", ".fileview-gh {", ".fileview-gh-why {", ".fileview-gh-dots {",
+  ".fileview-gh .fileview-btn:disabled {", ".fileview-gh .fileview-btn:disabled:hover {",
+  ".fileview-gh .fileview-btn:disabled:active {", "a.fileview-gh-note {", ".fileview-body {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",
   ".fileview-imgbox {", ".fileview-img {", ".fileview-frame {",

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -1,6 +1,13 @@
 // The viewer's GitHub link (the user 2026-08-15): a lazy fileGitLink ask per open, answered by the
-// file-OWNING kernel (git on ITS disk is the authority), an anchor that appears only when a real
-// URL comes back. Source pins (no jsdom for these modules), the repo convention.
+// file-OWNING kernel (git on ITS disk is the authority). While the ask is out the unit holds a
+// placeholder — a disabled button and the loader's dots — so a slow check (the kernel's ls-remote can
+// take 3 s) reads as a wait, not as the old no-button state (found in review). The action shows on
+// EVERY answer (the user 2026-09-05): a real URL is an anchor; no URL is a real disabled button with
+// the kernel's reason as a caption beside it and in its tooltip; a URL whose branch is not on origin
+// is a dashed anchor with the note as its caption. The states run FOR REAL against a small DOM stand-in: the
+// module mounts through document.createElement and hears the reply off a window message, so plain
+// objects carrying the handful of DOM members it touches stand in for the page. What the DOM cannot
+// show (the CSS, the kernel's side) stays pinned at source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -10,10 +17,183 @@ const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui
 const VIEW = web("file-view.ts");
 const RENDER = web("render.ts");
 const CHAT_CSS = web("styles.css");
+const FEED_CSS = web("feed.css");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
+// ── a DOM stand-in: the members the GitHub action touches at mount and on the reply ───────────────
+class El {
+  id = ""; title = ""; hidden = false; type = ""; disabled = false; tabIndex = -1;
+  href = ""; target = ""; rel = "";
+  childNodes: Array<El | string> = [];
+  private attrs = new Map<string, string>();
+  private classes = new Set<string>();
+  classList = {
+    add: (...c: string[]) => { for (const x of c) this.classes.add(x); },
+    contains: (c: string) => this.classes.has(c),
+  };
+  constructor(public tagName: string) {}
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  get textContent(): string { return this.childNodes.map((c) => (typeof c === "string" ? c : c.textContent)).join(""); }
+  set textContent(v: string) { this.childNodes = v === "" ? [] : [v]; }
+  appendChild<T extends El>(c: T): T { this.childNodes.push(c); return c; }
+  replaceChildren(...cs: El[]): void { this.childNodes = [...cs]; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+const win: any = new EventTarget();       // window: the reply arrives as a message event
+win.parent = win;
+(globalThis as any).window = win;
+(globalThis as any).document = {
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => s,
+  getElementById: () => null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  body: new El("body"),
+};
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+const posted: any[] = [];
+const parts = (unit: El) => ({
+  cap: unit.childNodes.find((c) => c instanceof El && c.className === "fileview-gh-why") as El | undefined,
+  dots: unit.childNodes.find((c) => c instanceof El && c.className === "fileview-gh-dots") as El | undefined,
+  ctl: unit.childNodes.find((c) => c instanceof El && c.classList.contains("fileview-btn")) as El,
+});
+/** The unit as mounted, before any reply: the placeholder the states below all start from. */
+function assertPending(unit: El): void {
+  assert.equal(unit.className, "fileview-gh");
+  assert.equal(unit.hidden, false, "shown from the mount: the wait itself is visible");
+  assert.equal(unit.getAttribute("aria-busy"), "true", "and named as a wait for assistive tech");
+  const { cap, dots, ctl } = parts(unit);
+  assert.equal(ctl.tagName, "button", "a real disabled button holds the slot — never an hrefless anchor flash");
+  assert.equal(ctl.disabled, true); assert.equal(ctl.href, "");
+  assert.equal(ctl.textContent, "GitHub ↗");
+  assert.equal(ctl.title, "Checking GitHub…"); assert.equal(ctl.getAttribute("aria-label"), ctl.title);
+  assert.equal(cap, undefined, "no verdict yet, so no caption to mistake for one");
+  assert.ok(dots, "the loader's dots stand where the caption will go: a slow check reads as a wait");
+  assert.equal(dots!.childNodes.length, 3);
+  assert.ok(dots!.childNodes.every((c) => c instanceof El && c.tagName === "i" && c.className === "fileview-dot"));
+  assert.ok(unit.childNodes.indexOf(dots!) < unit.childNodes.indexOf(ctl), "dots before the button, as the caption will be");
+}
+async function mountAndAnswer(url: string, reason: string): Promise<El> {
+  const fv = await import("./file-view");
+  fv.initFileView((m) => posted.push(m));
+  const unit = fv.githubLinkAction.mount({ path: "/tmp/notes-api/src/app.py", sid: null }) as unknown as El;
+  assertPending(unit);
+  const ask = posted[posted.length - 1];
+  assert.deepEqual(ask, { type: "fileGitLink", path: "/tmp/notes-api/src/app.py", sid: undefined, reqId: ask.reqId });
+  win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId: ask.reqId, url, reason } }));
+  assert.equal(unit.hidden, false, "the answer always shows the action");
+  assert.equal(unit.hasAttribute("aria-busy"), false, "the answer ends the wait");
+  assert.equal(parts(unit).dots, undefined, "the placeholder leaves with it");
+  assert.equal(unit.childNodes.filter((c) => c instanceof El && c.classList.contains("fileview-btn")).length, 1,
+    "one control: the placeholder button is replaced, not joined");
+  return unit;
+}
+
+test("state 1 — a real URL: an anchor that opens a new tab, no caption, the URL as tooltip", async () => {
+  const url = "https://github.com/TESTORG/notes-api/blob/main/src/app.py";
+  const { cap, ctl } = parts(await mountAndAnswer(url, ""));
+  assert.equal(ctl.tagName, "a");
+  assert.equal(ctl.href, url); assert.equal(ctl.target, "_blank"); assert.equal(ctl.rel, "noopener");
+  assert.equal(ctl.textContent, "GitHub ↗");
+  assert.equal(ctl.title, url, "the full URL one hover away");
+  assert.equal(ctl.classList.contains("fileview-gh-note"), false);
+  assert.equal(cap, undefined, "nothing to say — no caption");
+});
+
+test("state 2 — no URL: a real disabled button, the reason visible beside it and in the tooltip", async () => {
+  // the user 2026-09-05 could not tell an uncommitted file from a broken feature when the button
+  // was simply absent; and a reason only a mouse could reach (the tooltip) left touch and keyboard
+  // users with the same question
+  const unit = await mountAndAnswer("", "the file is not committed");
+  const { cap, ctl } = parts(unit);
+  assert.equal(ctl.tagName, "button", "a real button: assistive tech exposes disabled and the label");
+  assert.equal(ctl.type, "button");
+  assert.equal(ctl.disabled, true);
+  assert.equal(ctl.href, "", "nothing to follow, nothing to go stale");
+  assert.equal(ctl.textContent, "GitHub ↗");
+  assert.equal(ctl.title, "No GitHub link: the file is not committed");
+  assert.equal(ctl.getAttribute("aria-label"), ctl.title);
+  assert.ok(cap, "the caption is the reason itself, without hover");
+  assert.equal(cap!.textContent, "the file is not committed");
+  assert.equal(cap!.title, "", "nothing waits behind a hover: the caption IS the whole reason (it wraps; a truncated "
+    + "sentence had no tap, click or focus to finish it — found in review)");
+  assert.ok(unit.childNodes.indexOf(cap!) < unit.childNodes.indexOf(ctl), "the caption annotates the control after it");
+});
+
+test("state 2b — a kernel that predates link reasons: the caption says so and what to do", async () => {
+  const { cap, ctl } = parts(await mountAndAnswer("", ""));
+  assert.equal(ctl.disabled, true);
+  assert.equal(cap!.textContent, "this kernel predates link reasons; restart it after updating");
+  assert.equal(ctl.title, "No GitHub link: this kernel predates link reasons; restart it after updating");
+});
+
+test("state 3 — a URL whose branch is not on origin: a dashed anchor with the note as its caption", async () => {
+  const url = "https://github.com/TESTORG/notes-api/blob/wip/src/app.py";
+  const { cap, ctl } = parts(await mountAndAnswer(url, "the branch has not been pushed"));
+  assert.equal(ctl.tagName, "a"); assert.equal(ctl.href, url);
+  assert.equal(ctl.classList.contains("fileview-gh-note"), true);
+  assert.equal(ctl.title, url + "\nthe branch has not been pushed");
+  assert.equal(ctl.getAttribute("aria-label"), "GitHub: the branch has not been pushed");
+  assert.equal(cap!.textContent, "the branch has not been pushed");
+});
+
+test("a reply for an older open lands nowhere — the newer open keeps waiting for its own", async () => {
+  const fv = await import("./file-view");
+  fv.initFileView((m) => posted.push(m));
+  const ctx = { path: "/tmp/notes-api/src/app.py", sid: null };
+  const first = fv.githubLinkAction.mount(ctx) as unknown as El;
+  const firstReq = posted[posted.length - 1].reqId;
+  const second = fv.githubLinkAction.mount(ctx) as unknown as El;   // a replace-open: its hooks supersede
+  win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId: firstReq,
+    url: "https://github.com/TESTORG/notes-api/blob/main/src/app.py", reason: "" } }));
+  assertPending(first);    // the superseded open hears nothing: still the placeholder it mounted with
+  assertPending(second);   // a stale reply is not the newer open's answer
+  win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId: posted[posted.length - 1].reqId,
+    url: "", reason: "the file is not committed" } }));
+  assert.equal(second.hasAttribute("aria-busy"), false); assert.equal(parts(second).ctl.disabled, true);
+  assert.equal(parts(second).cap!.textContent, "the file is not committed");
+});
+
+test("a socket drop while the ask is out: the reconnect re-asks with the same reqId, so the wait ends", async () => {
+  // the frame went and nothing re-sends it, so the reply is lost and the placeholder would pulse for
+  // the rest of the open. The shim's romp:wsup (its RECONNECT event; the first connect fires none) is
+  // the re-ask's trigger — an event, not a timer, as the browse overlay does.
+  const fv = await import("./file-view");
+  fv.initFileView((m) => posted.push(m));
+  const unit = fv.githubLinkAction.mount({ path: "/tmp/notes-api/src/app.py", sid: null }) as unknown as El;
+  const reqId = posted[posted.length - 1].reqId;
+  const before = posted.length;
+  win.dispatchEvent(new Event("romp:wsdown"));
+  assertPending(unit);     // the drop alone changes nothing: the answer may still come
+  win.dispatchEvent(new Event("romp:wsup"));
+  const again = posted.slice(before);
+  assert.ok(again.length >= 1, "the return re-asks");
+  assert.ok(again.every((m) => m.type === "fileGitLink" && m.reqId === reqId && m.path === "/tmp/notes-api/src/app.py"),
+    "the same question, same reqId: a late first reply and the second are one answer");
+  win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId, url: "", reason: "not committed (staged only)" } }));
+  assert.equal(unit.hasAttribute("aria-busy"), false);
+  assert.equal(parts(unit).cap!.textContent, "not committed (staged only)");
+  const settled = posted.length;
+  win.dispatchEvent(new Event("romp:wsup"));
+  assert.equal(posted.length, settled, "an answered open asks nothing more");
+});
+
+// ── what the DOM cannot show, pinned at source ─────────────────────────────────────────────────────
+
 test("the ask is lazy, per open, and sid-routed — never on the /file byte path", () => {
-  assert.match(VIEW, /post\(\{ type: "fileGitLink", path, sid: sid \|\| undefined, reqId: gitSeq \}\);/);
+  assert.match(VIEW, /const ask = \(\) => post\(\{ type: "fileGitLink", path, sid: sid \|\| undefined, reqId \}\);/);
   // thumbnails must not pay three git subprocesses each: /file itself is untouched
   assert.doesNotMatch(KERNEL, /_file_github_url\(fp/);
 });
@@ -22,24 +202,49 @@ test("the poster is bound at the boot of the document that hosts the viewer", ()
   assert.match(RENDER, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
 });
 
-test("the anchor appears only on a real URL, opens a new tab, and shows where it goes", () => {
-  assert.match(VIEW, /const gh = el\("a", "fileview-btn fileview-gh"\) as HTMLAnchorElement;/);
-  assert.match(VIEW, /gh\.target = "_blank"; gh\.rel = "noopener";/);
-  assert.match(VIEW, /gh\.hidden = true;/);
-  assert.match(VIEW, /if \(!url\) return;/, "an empty url is the no-link verdict — the button never appears");
-  assert.match(VIEW, /gh\.title = url;/, "the full URL one hover away");
-  assert.match(CHAT_CSS, /a\.fileview-btn \{ text-decoration: none;/);
+test("the sheets dress the unit: the caption at button size, the disabled button inert, the note dashed", () => {
+  // both sheets: the FEED hosts the same viewer (the file browser), so its unit dresses the same
+  for (const css of [CHAT_CSS, FEED_CSS]) {
+    assert.match(css, /a\.fileview-btn \{ text-decoration: none;/);
+    assert.match(css, /\.fileview-gh \{ display: inline-flex; align-items: center; gap: 5px; min-width: 0; \}/);
+    assert.doesNotMatch(css, /\.fileview-gh\[hidden\]/, "nothing hides the unit any more: the wait is shown, not skipped");
+    // the pending placeholder's dots are the pane's own loader dots (accent, pulsing), laid out inline
+    assert.match(css, /\.fileview-gh-dots \{ display: inline-flex; align-items: center; gap: 4px; \}/);
+    assert.match(css, /\.fileview-dot \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);\n  animation: fileview-pulse/);
+    // same size as the buttons it annotates (labels match labels), bounded in width and WRAPPING: the
+    // unit takes no tap, click or focus, so a truncated caption was a sentence nobody could finish
+    assert.match(css, /\.fileview-gh-why \{ font-size: 0\.82em; line-height: 1\.25; color: var\(--dim\); max-width: 18em; text-align: right; \}/);
+    const why = css.slice(css.indexOf(".fileview-gh-why {"), css.indexOf("}", css.indexOf(".fileview-gh-why {")));
+    assert.doesNotMatch(why, /nowrap|ellipsis|overflow: hidden/, "the caption wraps; it is never cut");
+    assert.match(css, /\.fileview-btn \{ font: inherit; font-size: 0\.82em;/);
+    assert.match(css, /\.fileview-gh \.fileview-btn:disabled \{ opacity: 0\.55; cursor: default; \}/);
+    assert.match(css, /\.fileview-gh \.fileview-btn:disabled:hover \{ border-color: var\(--card-border\); color: var\(--fg\); background: transparent; \}/);
+    assert.match(css, /\.fileview-gh \.fileview-btn:disabled:active \{ transform: none; \}/);
+    assert.match(css, /a\.fileview-gh-note \{ border-style: dashed; \}/);
+    assert.doesNotMatch(css, /aria-disabled="true"\]/, "the disabled state is the button's own, not an aria bit on an anchor");
+  }
 });
 
 test("replies are reqId-guarded and cannot touch a later open", () => {
   assert.match(VIEW, /m\.type === "fileGitLink" && gitHooks && m\.reqId === gitHooks\.reqId/);
+  assert.match(VIEW, /h\.apply\(String\(m\.url \|\| ""\), String\(m\.reason \|\| ""\)\);/, "the reply's reason travels with its url");
   // both the close and the replace path drop the hooks, so a late reply lands nowhere
   const closes = VIEW.match(/gitHooks = null;/g) || [];
   assert.ok(closes.length >= 2, "cleared on close AND on replace-open");
 });
 
 test("the kernel's answer is a verdict from git itself, threaded off the recv loop", () => {
+  // the phrases themselves are the kernel's (tests/test_file_github.py pins them); the viewer shows
+  // whatever string arrives
   assert.match(KERNEL, /def _file_github_url\(raw, sid\):/);
+  assert.match(KERNEL, /def _file_github_link\(raw, sid, check_origin=True\):/, "the (url, reason) sibling the op uses");
+  // ls-files reads the index; a staged-only file is checked against HEAD's tree before a URL is built
+  assert.match(KERNEL, /"cat-file", "-e", "HEAD:" \+ rel\.replace\(os\.sep, "\/"\)/, "no live button at a path GitHub has on no ref");
+  assert.match(KERNEL, /"url": url, "reason": reason\}\)/, "the reason rides the reply");
+  // the local tracking ref answers first; ls-remote is the fallback, short-timed, never a prompt
+  assert.match(KERNEL, /"refs\/remotes\/origin\/" \+ ref/);
+  assert.match(KERNEL, /"ls-remote", "--heads", "origin", full\], top, timeout=GH_LS_REMOTE_S/);
+  assert.match(KERNEL, /GIT_TERMINAL_PROMPT="0"/);
   assert.match(KERNEL, /elif msg and msg\.get\("type"\) == "fileGitLink":/);
   assert.match(KERNEL, /threading\.Thread\(target=_gl, daemon=True\)\.start\(\)/);
   // the spellings git actually writes for a GitHub origin — incl. ports and ssh.github.com
@@ -49,16 +254,13 @@ test("the kernel's answer is a verdict from git itself, threaded off the recv lo
   assert.match(KERNEL, /p = os\.path\.realpath\(p\)\n    d = os\.path\.dirname\(p\)/);
 });
 
-test("the hidden anchor stays hidden — an author display must not beat [hidden]", () => {
-  assert.match(CHAT_CSS, /a\.fileview-btn\[hidden\] \{ display: none; \}/);
-});
-
 test("the GitHub link is the action REGISTRY's first entry, not another hand-wired button", () => {
   // the registry (the user 2026-08-22): internal seam, no compatibility promise — actions on the
   // open file declare a mount() instead of editing openFileView, so viewer PRs stop colliding there
   assert.match(VIEW, /export function registerFileViewAction\(a: FileViewAction\): void \{/);
   assert.match(VIEW, /if \(!fileViewActions\.some\(\(x\) => x\.id === a\.id\)\) fileViewActions\.push\(a\);/, "same id registered twice mounts once");
-  assert.match(VIEW, /registerFileViewAction\(\{\n  id: "github-link",/);
+  assert.match(VIEW, /export const githubLinkAction: FileViewAction = \{\n  id: "github-link",/);
+  assert.match(VIEW, /registerFileViewAction\(githubLinkAction\);/);
   // openFileView renders registered actions by WALKING THE TABLE, after the built-ins
   assert.match(VIEW, /for \(const a of fileViewActions\) \{\n    const n = a\.mount\(\{ path, sid: sid \|\| null \}\);\n    if \(n\) acts\.appendChild\(n\);\n  \}/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3289,9 +3289,24 @@ body.fileview-open { overflow: hidden; }
 .fileview-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
-/* an author `display` beats the UA's [hidden] rule — without this the anchor shows hrefless
-   before the kernel ever answers */
-a.fileview-btn[hidden] { display: none; }
+/* the GitHub action is one unit: the control and, when the kernel gave one, its reason as a caption
+   beside it — visible without hover (touch has none, and a disabled button takes no focus), and whole:
+   it wraps inside a bounded width rather than truncating, because nothing in the unit takes a tap,
+   click or focus that could finish a cut sentence; same size as the buttons it annotates, ragged edge
+   away from the control it precedes. */
+.fileview-gh { display: inline-flex; align-items: center; gap: 5px; min-width: 0; }
+.fileview-gh-why { font-size: 0.82em; line-height: 1.25; color: var(--dim); max-width: 18em; text-align: right; }
+/* pending: the kernel's check is on its way (up to 3 s when it must ask origin), so the slot holds the
+   dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
+   check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
+.fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
+/* no link: a real disabled button, greyed, hover inert — never hidden (an absent button read as
+   "broken" when the file was simply not committed yet, 2026-09-05) */
+.fileview-gh .fileview-btn:disabled { opacity: 0.55; cursor: default; }
+.fileview-gh .fileview-btn:disabled:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
+.fileview-gh .fileview-btn:disabled:active { transform: none; }
+/* a link whose branch is not on origin yet: dashed, the caption carries the note */
+a.fileview-gh-note { border-style: dashed; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* the raw-mode editor: height: 100% (not flex) — .fileview-body above is a plain overflow block,
    not a flex container, so a flex basis on its child is inert and the textarea sat at the UA's


### PR DESCRIPTION
## What breaks

When the kernel decides a viewed file has no GitHub link (not in a repository, not committed, no origin remote, or an origin that is not on GitHub), the `fileGitLink` reply carries an empty `url` and the viewer hides the button. From the page, an uncommitted file is indistinguishable from a broken feature. Two smaller defects sit on the same path:

- `git rev-parse --abbrev-ref HEAD` spells a branch that shares its name with a tag as `heads/<branch>`, and GitHub 404s the URL built from it.
- A repository with no `origin` remote takes the same branch as a non-GitHub origin, so the only verdict available would name a remote the repository does not have.

## Reproduction

In a repository with a GitHub origin:

1. Open an untracked file in the viewer. No GitHub button appears and nothing says why.
2. On branch `main`, run `git tag main` and open a tracked file. The button links to `.../blob/heads/main/...`, which 404s.
3. Open a tracked file on a branch that was never pushed. The link 404s with no hint that a push would fix it.

## The fix

**Kernel.** `_file_github_link(raw, sid, check_origin=True)` returns `(url, reason)`, and the `fileGitLink` reply carries `reason` beside `url`. An empty url comes with one of a fixed set of plain phrases: `not in a git repository`, `not committed (untracked file)`, `not committed (no commits yet)`, `not committed (staged only)`, `no origin remote`, `the origin remote is not on GitHub`, and, for a relative path that no session directory resolves, `relative path with no session directory to resolve it against` (no repository check ran, so the verdict does not claim one). A file that is in the index but not in HEAD's tree gets the staged-only verdict from `git cat-file -e HEAD:<path>`, since `ls-files` reads the index and the URL would name a path GitHub has on no ref. `_file_github_url` keeps its url-only contract and never queries the network.

A branch that is not on origin keeps its url (it is the right one once pushed) and carries `branch X is not on origin`. `_origin_has_branch` reads the local tracking ref `refs/remotes/origin/X` first, which costs nothing; only its absence pays one `git ls-remote --heads origin refs/heads/X`, bounded at 3 s with `GIT_TERMINAL_PROMPT=0`. `_git_net_out` runs that query in its own session and kills the whole process group at the deadline: `subprocess.run`'s timeout kill reaches git alone, and the ssh git had spawned kept its TCP connect open for minutes after the viewer had been told "could not check". The pattern is the full ref and the match is exact, because ls-remote patterns match a ref's tail (`main` also matches `refs/heads/x/main`).

The answer is memoized per (repository, branch) with no clock, and the memo keeps only what a local event can later contradict: a False, and only where the clone's fetch refspec maps the branch onto `refs/remotes/origin/X`. `_origin_tracks` reads `remote.origin.fetch` for that: the default `+refs/heads/*:refs/remotes/origin/*` qualifies, a `--single-branch` clone's exact refspec qualifies for its one branch alone, a negative refspec excludes, the first positive match decides (git's push updates that refspec's tracking ref alone), a source-only refspec is skipped, and any shape it does not understand reads as untracked. Where the branch is tracked, a push from this clone or a fetch writes the tracking ref, the free check sees it and drops the entry. A True with no tracking ref has no drop event (a deletion on GitHub writes nothing locally, and `fetch --prune` has no ref to prune), and a False in a `--single-branch` clone would outlive the push, which writes no tracking ref there; neither is stored, and each open asks, with concurrent opens of one key still sharing one query. "could not check" is not memoized either. The verdict is therefore as fresh as the clone's own refs: a branch deleted on GitHub reads as present until `git fetch --prune`, and one pushed from another clone reads as absent until a fetch. The docstring and the guide state the same rule.

The branch name comes from `git symbolic-ref -q HEAD`, so a same-named tag no longer changes the ref to `heads/<branch>`, and the query works on any git: `branch --show-current` needs 2.22, and below that its failure silently gave every file a commit-sha URL. A repository with no origin remote reads `no origin remote`.

**Viewer.** The `github-link` registry entry mounts one unit. Until the kernel answers it holds a placeholder: a disabled button titled `Checking GitHub…` with the pane's three pulsing loader dots where the caption will go, and `aria-busy` on the unit, so a check that waits on `ls-remote` reads as a wait rather than as the old no-button state. A socket drop while the ask is out loses the reply, so the shim's reconnect event re-asks with the same reqId. With no url it renders a real disabled `<button>`, with the reason as a visible caption beside it and in the tooltip (`No GitHub link: ...`). With a url and a reason it renders a dashed anchor with the reason as its caption and aria-label. With a url alone it renders the anchor as before. The control is a disabled button because an hrefless anchor has no role for assistive tech to read; the reason is a caption as well as a tooltip because touch has no hover and a disabled button takes no focus. The caption wraps inside a bounded width (18em) rather than truncating: nothing in the unit takes a tap, click or focus, so a cut sentence would have had no way to finish. Both stylesheets carry the same rules.

**Compatibility.** The wire change is additive. An older viewer ignores `reason`. An older kernel's reasonless empty reply renders as a disabled button with the caption `this kernel predates link reasons; restart it after updating`.

**Docs.** The guide's "Reviewing a document" paragraph describes the three states, lists the reasons a file can have no link, and states what the branch check can and cannot see.

## From review

Folded before the merge, from the review at 7c064ac4:

- `_origin_has_branch` memoized a True while the tracking ref was absent, with no event to drop it, and a False that a `--single-branch` push could not contradict. Only a False is memoized now, and only under a refspec that maps the branch onto its tracking ref (`_origin_tracks`); everything else is asked on each open. The docstring, the guide and this body state the refresh rule as it is. Three tests cover the two states and the refspec shapes.
- The caption wraps instead of truncating at 18em with the full text in `title`; the exact CSS pin is updated and the caption's redundant tooltip is gone. Measured in headless Chromium at a 13px base: the two branch-bearing phrases and the 60-character fallback take two lines of a 192px box, none clipped; the short phrases stay on one line.
- `git symbolic-ref -q HEAD` replaces `git branch --show-current`. A test stands in an old git with a PATH wrapper that rejects `--show-current`, and checks the branch URL and the detached-HEAD sha URL under it.
- An unresolvable relative path is captioned `relative path with no session directory to resolve it against`, not `not in a git repository`; the guide's list includes it.
- The red-first count for the two UI test files below was wrong in the earlier body (8 of 12); it is 10 of 12.

Second round, from the review at fbfad515, folded by file into the same three commits:

- Kernel: a file staged on a branch with commits got a live URL and an empty reason, so the viewer drew an enabled button that 404s. After the sha check, `git cat-file -e HEAD:<path>` decides, and the verdict is `not committed (staged only)` (`GH_STAGED`). A test mirrors the unborn-branch one and checks that the committed neighbour still links and that the commit flips the verdict.
- Kernel: `_origin_tracks` accepted any matching fetch refspec, but git's push updates the tracking ref of the first match alone, so a `refs/remotes/other/*` line ahead of the default kept a memoized False the push could not contradict. The first positive match decides now; a source-only refspec is skipped as git skips it; a negative match still excludes wherever it sits. One test runs the two-line config end to end (the fixture's push writes `other/wip` and not `origin/wip`, and the next open sees the push); the refspec table gains both orderings and the source-only case.
- Viewer: the unit was hidden until the reply, so an open that waited on `ls-remote` showed no GitHub control for up to 3 s. It mounts a placeholder now (a disabled button, the loader dots, `aria-busy`), and the reply replaces it; the `[hidden]` rule and its pin are gone, both sheets gain `.fileview-gh-dots`, and the reconnect event re-asks a question whose reply a socket drop lost, so the placeholder cannot outlive its wait. The DOM test checks the placeholder before every state and the re-ask.
- Guide: the reasons list names a file staged but in no commit, and the paragraph says the button waits with pulsing dots while the check runs.

## Tests

`tests/test_file_github.py` (38 tests): a reason for every no-link verdict, the relative-path verdict among them; a file staged on a branch with commits and its committed neighbour; the same-named-tag case on both paths; the no-origin verdict; an old git without `branch --show-current` still names the branch and still links the sha when detached; the origin check served by a local bare repository through a stand-in ssh, so no test reaches the network; a pushed branch asks origin nothing; a missing tracking ref falls to ls-remote; a slashed branch is matched whole; an unreachable origin reads "could not check"; a slow origin is cut off and the spawned ssh dies with the cut; a detached sha is never checked; the memo, the in-flight sharing, the tracking-ref flip and the unanswered re-ask; a branch on origin that this clone never fetched is asked each time and its deletion on origin is seen on the next open; a `--single-branch` refspec is asked each time and the push is seen on the next open; a second namespace ahead of the default takes the push as git does and the next open sees it; the refspec shapes `_origin_tracks` reads, in both orders; the url-only caller never asks; the wire op carries `reason`. For the origin-backed tests the kernel's git runs with `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1` (git >= 2.32; one test self-skips below that), and one test shows the pin is load-bearing against a global `url.insteadOf` rewrite. The process-group test reads `/proc` to treat a zombie as gone, so that check is Linux-specific; the pytest job runs on ubuntu.

`ui/webview/github-link.test.ts` (12 tests): the placeholder at mount, the three states, the reasonless fallback, the stale-reply guard and the reconnect re-ask run against a small DOM stand-in; source pins cover the CSS (the caption rule, and that it carries no `nowrap`, `ellipsis` or `overflow: hidden`) and the kernel side. `fileview-parity.test.ts` covers the new rules in both sheets.

Before the change, 29 of the 38 Python tests fail against the old kernel (`_file_github_link` absent, the `heads/main` URL, the no-origin phrase, the memo's module state, the staged-only verdict), and 12 of the 13 tests in the two UI test files fail against the old viewer (measured in a scratch tree at fd2135c0 with the PR's test files).

Results: `pytest tests/test_file_github.py` 38 passed (with and without xdist); full `pytest -n 8` 7407 passed, 46 skipped, 0 failed. vscode-extension: `npm run typecheck` clean, `npm test` 2838 passed.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

