### PR TITLE
Index judges: a bare alias is checked against the model the CLI actually served, and the tier-pick pin that bound nothing is gone

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -194,8 +194,14 @@ _EFFORT_FLOOR = {"fable": (5, 0), "mythos": (5, 0), "opus": (4, 6), "sonnet": (4
 #   family -> first (major, minor) the CLI treats as adaptive; below it is its denylist. The catalog knows
 #   no Haiku past 4.5, so haiku's floor marks where the denylist ends, not a version that exists.
 _ALIAS_HEAD = {"fable": (5, 1), "opus": (5, 0), "sonnet": (5, 0), "haiku": (4, 5)}   # the catalog's aliases block
+#   as read from the 2.1.257 / 2.1.258 binaries. 2.1.263 resolves alias targets at run time from a published
+#   catalog, falling back to its compiled table, so this can go stale with no CLI upgrade: _note_served_model
+#   checks it against the id each call actually served, and _ALIAS_SERVED outranks it once a call has answered.
 _MODEL_FAMILIES = tuple(_EFFORT_FLOOR)
 _UNKNOWN_MODEL_LOGGED = set()   # ids already announced as unplaceable (one stderr line each)
+_ALIAS_SERVED = {}              # family -> (major, minor) the CLI served for the BARE alias this process, read off
+                                #   result envelopes (_note_served_model); _adaptive_thinking asks it before the table
+_ALIAS_DRIFT_LOGGED = set()     # (family, served id) pairs already announced as off the table (one stderr line each)
 
 
 def _model_family_version(model):
@@ -233,7 +239,8 @@ def _model_family_version(model):
 def _adaptive_thinking(model):
     """True when `model` runs adaptive thinking under CLI 2.1.257 / 2.1.258 — the models whose index-tier
     cost lever is `--effort` (_EFFORT_FLOOR: Fable and Mythos, every version; Opus >= 4.6; Sonnet >= 4.6;
-    a bare alias is the version the catalog resolves it to, _ALIAS_HEAD — `haiku` is Haiku 4.5, so False).
+    a bare alias is the version the CLI has been SEEN to serve for it this process — _ALIAS_SERVED, read off
+    the result envelopes — else the table's head, _ALIAS_HEAD: `haiku` is Haiku 4.5, so False).
     False is the CLI's denylist — Haiku 4.5 and older, Sonnet 4.5 and older, Opus 4.5 and older, every
     claude-3 — the models where MAX_THINKING_TOKENS=0 is honored and is the lever. An id this cannot
     place — no family it knows, or a family with no readable version — gets the CLI's own answer for an
@@ -251,9 +258,52 @@ def _adaptive_thinking(model):
                              "otherwise) and leaves the thinking-off env var unset; extend _EFFORT_FLOOR "
                              "when the CLI's catalog places it\n" % (model, INDEX_EFFORT_DEFAULT))
         return True
-    if ver is None:                                # a bare alias: the version the catalog resolves it to
-        ver = _ALIAS_HEAD.get(fam, _EFFORT_FLOOR[fam])
+    if ver is None:                                # a bare alias: the version the CLI served for it, else the
+        ver = _ALIAS_SERVED.get(fam) or _ALIAS_HEAD.get(fam, _EFFORT_FLOOR[fam])   # catalog head we assume
     return ver >= _EFFORT_FLOOR[fam]
+
+
+def _note_served_model(model, wrap):
+    """After a successful claude-engine call: compare the id the CLI SERVED — the result envelope's
+    `modelUsage`, which the CLI keys by model id (a dated `claude-haiku-4-5-20251001`) — with what
+    _ALIAS_HEAD assumes for a BARE family alias. The served version is recorded (_ALIAS_SERVED) so
+    _adaptive_thinking follows the CLI from the next call, and a mismatch is announced once per (alias,
+    served id): the table is a copy of the CLI's catalog, and the envelope is that catalog answering.
+    The same-family entry with the most output tokens is the model that wrote the reply (a side call's
+    entry cannot move the alias). Quiet when they agree, when `model` is a versioned id (a pin is a
+    pin, never remapped), and when the envelope names no same-family model — that carries no evidence
+    either way, so the table's answer stands exactly as it did before this check. Every tier feeds the
+    record; only the index tier's lever reads it. Best-effort, never raises (mirrors _log_judge_usage —
+    bookkeeping must not cost the reply)."""
+    try:
+        fam, ver = _model_family_version(model)
+        if fam is None or ver is not None:
+            return
+        mu = wrap.get("modelUsage") if isinstance(wrap, dict) else None
+        if not isinstance(mu, dict):
+            return
+        best = None                               # (output tokens, served id, served version)
+        for mid, u in mu.items():
+            sfam, sver = _model_family_version(mid)
+            if sfam != fam or not sver:
+                continue
+            out = u.get("outputTokens") if isinstance(u, dict) else None
+            out = out if isinstance(out, (int, float)) else 0
+            if best is None or out > best[0]:
+                best = (out, mid, sver)
+        if best is None:
+            return
+        _, mid, served = best
+        _ALIAS_SERVED[fam] = served
+        head = _ALIAS_HEAD.get(fam, _EFFORT_FLOOR[fam])
+        if served != head and (fam, mid) not in _ALIAS_DRIFT_LOGGED:
+            _ALIAS_DRIFT_LOGGED.add((fam, mid))
+            sys.stderr.write("romp-judge: the CLI serves the bare %s alias as %s (%d.%d), not the %d.%d "
+                             "_ALIAS_HEAD assumes — the index tier's lever for %s follows the served version "
+                             "from here; move _ALIAS_HEAD when the CLI's catalog does\n"
+                             % (fam, mid, served[0], served[1], head[0], head[1], fam))
+    except Exception:
+        pass
 
 
 # The DISTILLING tier (the user 2026-08-14): the card-prose writers — distiller, briefer, staller — get
@@ -1520,6 +1570,8 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             if isinstance(wrap, dict) and isinstance(wrap.get("result"), str):
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
+                _note_served_model(model, wrap)       # the envelope names the model a bare alias resolved to;
+                                                      # the alias table is checked against it (one line per drift)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
                 if auth == "login":
                     # only a LOGIN-billed success is evidence the login window reset early — a

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -255,8 +255,9 @@ def _adaptive_thinking(model):
             sys.stderr.write("romp-judge: model %r is not one I can place (family + version) — the CLI "
                              "treats an unlisted model as adaptive and drops thinking:disabled for it, so "
                              "the index tier passes --effort (%s unless the gear's Indexing effort says "
-                             "otherwise) and leaves the thinking-off env var unset; extend _EFFORT_FLOOR "
-                             "when the CLI's catalog places it\n" % (model, INDEX_EFFORT_DEFAULT))
+                             "otherwise); the thinking-off env var rides the tier regardless, a no-op the "
+                             "CLI drops for such a model; extend _EFFORT_FLOOR when the CLI's catalog places "
+                             "it\n" % (model, INDEX_EFFORT_DEFAULT))
         return True
     if ver is None:                                # a bare alias: the version the CLI served for it, else the
         ver = _ALIAS_SERVED.get(fam) or _ALIAS_HEAD.get(fam, _EFFORT_FLOOR[fam])   # catalog head we assume
@@ -1229,25 +1230,23 @@ def _codex_effort(effort, tier):
 
 def _judge_env(tier, auth="login", model=None):
     """The subprocess env for ONE judge call. Drops the TMUX vars (so the child isn't taken for a live
-    pane) and trips the Stop-hook recursion guard. For the INDEX tier it also applies the cost lever the
-    MODEL can take (2026-09-01): on a model WITHOUT adaptive thinking (Haiku, Sonnet 4.5, Opus 4.5 and
-    older — _adaptive_thinking, the CLI's own denylist) it disables extended thinking
-    (MAX_THINKING_TOKENS=0): the captioner + archiver do mechanical one-shot summarization, where the
-    default thinking is pure waste — a Haiku probe showed a ~385-token thinking block emitted before a
-    ~15-token caption (722 -> 24 output tokens, 7.1s -> 0.9s per call, ~92% cheaper, identical caption).
-    On a model WITH adaptive thinking (Fable, Mythos, Opus 4.6+, Sonnet 4.6+, and any model the CLI does
-    not place) the env var is NOT set and `--effort low` is the lever (_judge_run, INDEX_EFFORT_DEFAULT,
-    the gear's Indexing effort pick overriding): the CLI (2.1.257 and 2.1.258) drops the thinking parameter
-    for a model carrying its `rejects_disabled_thinking` capability — Fable and Mythos, and its first-party
-    default grants it to every unlisted model (the API refuses thinking:disabled on them) — so there the
-    var was a silent no-op and every "thinking-off" call ran FULL-COST adaptive thinking. (Opus 4.6+ and
-    Sonnet 4.6+ do honor the var; the tier still takes effort on them — one lever for every adaptive
-    model, the gear pick the knob.) `model` is the call's model; None resolves the tier's configured pick
-    (_index_model), so a bare _judge_env("index") answers about the tier as configured rather than
-    assuming Haiku. TRIAGE keeps thinking on every model: the planner / closer / grouper / distiller make
-    real placement + closure judgments. Output is the expensive half (Haiku $5/Mtok out) AND the latency
-    driver (~58 tok/s, serial), so this is the captioner's biggest single lever — and it's what makes any
-    future batching latency-safe.
+    pane) and trips the Stop-hook recursion guard. For the INDEX tier it also disables extended thinking
+    (MAX_THINKING_TOKENS=0), on EVERY model (2026-09-01; unconditional since the PR #880 review): the
+    captioner + archiver do mechanical one-shot summarization, where the default thinking is pure waste —
+    a Haiku probe showed a ~385-token thinking block emitted before a ~15-token caption (722 -> 24 output
+    tokens, 7.1s -> 0.9s per call, ~92% cheaper, identical caption). Where the CLI (2.1.257 and 2.1.258)
+    honors thinking:disabled — Haiku, Sonnet/Opus 4.5 and older, and Sonnet/Opus 4.6+, which run adaptive
+    thinking yet still take it — the var is the lever; where it drops the parameter for a model carrying
+    its `rejects_disabled_thinking` capability — Fable and Mythos, and every unlisted model under its
+    first-party default (the API refuses thinking:disabled on them) — the var is a harmless no-op and
+    `--effort low` in _judge_run (INDEX_EFFORT_DEFAULT, the gear's Indexing effort pick overriding;
+    _adaptive_thinking decides which models) is the lever that lands. Both ride together; neither can
+    hurt the other. `model` is the call's model, accepted for the call shape and not consulted here since
+    the var became unconditional — the model-keyed half of the lever lives in _judge_run. TRIAGE keeps
+    thinking on every model: the planner / closer / grouper / distiller make real placement + closure
+    judgments. Output is the expensive half (Haiku $5/Mtok out) AND the latency driver (~58 tok/s,
+    serial), so this is the captioner's biggest single lever — and it's what makes any future batching
+    latency-safe.
 
     `auth` is the call's resolved billing (_judge_auth). The ambient ANTHROPIC_API_KEY is stripped
     unconditionally — in the kernel process the SDK backend already claimed it out of os.environ, and

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6389,14 +6389,13 @@ class JudgeUsageLog(unittest.TestCase):
 
 
 class JudgeEnv(unittest.TestCase):
-    """The INDEX tier (captioner + archiver) keeps its cost lever, but the lever follows the MODEL
-    (2026-09-01) — by GENERATION, read from the CLI's (2.1.257 / 2.1.258) adaptive-thinking rule, not by
-    family. A model without adaptive thinking (Haiku, Sonnet 4.5, Opus 4.5 and older) otherwise emits a
-    long thinking block before the trivial caption — pure output waste — so it runs with
-    MAX_THINKING_TOKENS=0. A model with it (Fable, Opus 4.6+, Sonnet 4.6+) takes `--effort low` instead
-    (IndexTierLever below) and the env var is NOT set: on Fable the CLI drops the thinking parameter
-    outright (its rejects_disabled_thinking capability), so the var was a silent no-op that ran full-cost
-    thinking. TRIAGE keeps thinking on every model."""
+    """The INDEX tier (captioner + archiver) runs with MAX_THINKING_TOKENS=0 on EVERY model (2026-09-01;
+    unconditional since the PR #880 review). A model without adaptive thinking (Haiku, Sonnet 4.5, Opus
+    4.5 and older — the CLI's 2.1.257 / 2.1.258 denylist) otherwise emits a long thinking block before the
+    trivial caption — pure output waste — and Sonnet/Opus 4.6+ honor the var too. Where the CLI drops the
+    parameter outright (Fable, Mythos: its rejects_disabled_thinking capability) the var is a harmless
+    no-op and `--effort low` is the lever that lands (IndexTierLever below). The model-keyed half of the
+    lever lives in _judge_run; _judge_env reads no model. TRIAGE keeps thinking on every model."""
 
     def test_index_tier_sets_thinking_off_for_every_model(self):
         self.assertEqual(jd._judge_env("index", model="haiku").get("MAX_THINKING_TOKENS"), "0",
@@ -6422,14 +6421,6 @@ class JudgeEnv(unittest.TestCase):
             # 4.6+ honors thinking:disabled too — withholding the var there traded a measured thinking-off
             # path for unmeasured adaptive-low; it rides everywhere now, effort decides the rest
             self.assertEqual(jd._judge_env("index", model=m).get("MAX_THINKING_TOKENS"), "0", m)
-
-    def test_index_tier_with_no_model_resolves_the_tier_pick(self):
-        # the tier's configured model decides (INDEX_MODEL is haiku out of the box); a bare
-        # _judge_env("index") answers about that pick rather than assuming Haiku
-        jd._state_cache.clear()
-        self.assertEqual(jd._index_model(), jd.INDEX_MODEL)
-        self.assertEqual(jd._judge_env("index").get("MAX_THINKING_TOKENS"), "0",
-                         "the var rides the index tier whatever the pick resolves to")
 
     def test_every_tier_disables_prompt_caching(self):
         # One-shot judge calls never read the cache back — the per-call security mark re-rolls the
@@ -6536,10 +6527,11 @@ class IndexTierLever(unittest.TestCase):
     and effort is the lever those models honor. _judge_run resolves the tier's model first, then: no
     adaptive thinking (Haiku, Sonnet 4.5, Opus 4.5 and older) → MAX_THINKING_TOKENS=0 and no --effort
     flag; adaptive thinking (Fable, Mythos, Opus 4.6+, Sonnet 4.6+, and any model the CLI's catalog does
-    not place — its first-party default) → `--effort <index-effort setting, default low>` and NO env
-    var. The gear's existing Indexing effort pick (STATE/index-effort) is the configurability; the tier
-    logs which lever applied, once per model. The subprocess is stubbed and its argv + env captured —
-    nothing runs."""
+    not place — its first-party default) → `--effort <index-effort setting, default low>`, with the env
+    var riding beside it (unconditional on the index tier since the PR #880 review: honored on 4.6+
+    Sonnet/Opus, a no-op where the CLI drops it). The gear's existing Indexing effort pick
+    (STATE/index-effort) is the configurability; the tier logs which lever applied, once per model. The
+    subprocess is stubbed and its argv + env captured — nothing runs."""
 
     def setUp(self):
         self.calls = []

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6676,6 +6676,157 @@ class IndexTierLever(unittest.TestCase):
         self.assertIsNone(env.get("MAX_THINKING_TOKENS"))
 
 
+class AliasHeadDrift(unittest.TestCase):
+    """_ALIAS_HEAD is a guess about the CLI's catalog — its aliases block as read from the 2.1.257 / 2.1.258
+    binaries — and 2.1.263 resolves alias targets at run time from a published catalog, so the table can
+    go stale with no CLI upgrade. The CLI's own answer rides every successful call: the result envelope's
+    `modelUsage` is keyed by the model id that actually served (a dated claude-haiku-4-5-20251001).
+    _note_served_model reads it after each call on a BARE alias, records the served version
+    (_ALIAS_SERVED), and _adaptive_thinking consults that ahead of the table from then on; a served
+    version the table disagrees with is announced once per (alias, served id). Quiet when they agree, on
+    a versioned pin (never remapped), and when the envelope names no same-family model — no evidence
+    either way, so the table's answer stands exactly as before. The subprocess is stubbed and its argv +
+    env captured — nothing runs."""
+
+    def setUp(self):
+        self.calls = []
+        self.stdout = json.dumps({"result": "a caption", "usage": {}})
+        self._saved_usage = jd.USAGE
+        self._td = Path(tempfile.mkdtemp())
+        jd.USAGE = self._td / "judge-usage.jsonl"
+        (jd.STATE / "index-effort").unlink(missing_ok=True)
+        self._reset()
+        os.environ.pop("MAX_THINKING_TOKENS", None)
+
+        def fake_run(cmd, **kw):
+            self.calls.append((cmd, kw.get("env") or {}))
+            return mock.Mock(stdout=self.stdout, stderr="", returncode=0)
+
+        self._patch = mock.patch.object(jd.subprocess, "run", side_effect=fake_run)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        (jd.STATE / "index-effort").unlink(missing_ok=True)
+        self._reset()   # again, deliberately: a drifted head left behind would flip EffortCapability's
+        jd.USAGE = self._saved_usage   # `haiku -> False` pin in whichever worker runs it next
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _reset(self):
+        jd._state_cache.clear()
+        jd._LEVER_LOGGED.clear()
+        jd._ALIAS_SERVED.clear()
+        jd._ALIAS_DRIFT_LOGGED.clear()
+
+    def _run(self, model, model_usage=None, tier="index", judge="captioner"):
+        """One stubbed call; the envelope carries `model_usage` under modelUsage when given (None: the
+        envelope names no model, the IndexTierLever stub's shape). Returns (argv, env, stderr text)."""
+        self.calls.clear()
+        wrap = {"result": "a caption", "usage": {}}
+        if model_usage is not None:
+            wrap["modelUsage"] = model_usage
+        self.stdout = json.dumps(wrap)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            reply = jd._judge_run(model, "SYS", "payload", judge=judge, tier=tier)
+        self.assertEqual(len(self.calls), 1, "exactly one subprocess call")
+        self.assertEqual(reply, "a caption", "the reply comes back whatever the envelope says about the model")
+        cmd, env = self.calls[0]
+        return cmd, env, err.getvalue()
+
+    def _effort_of(self, cmd):
+        return cmd[cmd.index("--effort") + 1] if "--effort" in cmd else None
+
+    @staticmethod
+    def _drift_lines(err):
+        return [ln for ln in err.splitlines() if "_ALIAS_HEAD" in ln]
+
+    def test_a_served_version_that_matches_the_table_is_quiet(self):
+        cmd, env, err = self._run("haiku", {"claude-haiku-4-5-20251001": {"inputTokens": 100, "outputTokens": 15}})
+        self.assertEqual(self._drift_lines(err), [], "the table agrees with the CLI: nothing to say")
+        self.assertIn("MAX_THINKING_TOKENS=0", err, "the lever line is the only line")
+        self.assertNotIn("--effort", cmd)
+        # .get() rather than assertNotIn(..., env), here and below: a failure must not print the whole
+        # environment (a copy of os.environ, credentials included) into the log
+        self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+        self.assertEqual(jd._ALIAS_SERVED.get("haiku"), (4, 5), "an agreeing answer is recorded all the same")
+
+    def test_a_moved_alias_is_announced_once_and_the_lever_follows(self):
+        moved = {"claude-haiku-4-6-20260301": {"inputTokens": 100, "outputTokens": 15}}
+        cmd, env, err = self._run("haiku", moved)
+        self.assertNotIn("--effort", cmd, "the first call runs under the table's answer: the envelope arrives after it")
+        self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+        lines = self._drift_lines(err)
+        self.assertEqual(len(lines), 1, "one drift line, got: %r" % err)
+        for s in ("haiku", "claude-haiku-4-6-20260301", "4.6", "4.5"):
+            self.assertIn(s, lines[0], "the line names the alias, the served id and both versions")
+        self.assertTrue(jd._adaptive_thinking("haiku"), "the served version places the alias from here")
+        cmd, env, err = self._run("haiku", moved)
+        self.assertEqual(self._effort_of(cmd), "low", "the second call carries the lever for the served version")
+        self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0", "…and the var still rides")
+        self.assertIn("--effort low", err, "the lever change is re-announced by the existing per-model line")
+        self.assertEqual(self._drift_lines(err), [], "the drift is said once per (alias, served id)")
+        _cmd, _env, err = self._run("haiku", moved)
+        self.assertEqual(err, "", "a third call: same lever, same served id — nothing new to say")
+
+    def test_the_reply_writer_decides_when_two_same_family_ids_appear(self):
+        _cmd, _env, err = self._run("haiku", {"claude-haiku-4-6-20260301": {"outputTokens": 40},
+                                              "claude-haiku-4-5-20251001": {"outputTokens": 3}})
+        self.assertEqual(jd._ALIAS_SERVED.get("haiku"), (4, 6), "the model that wrote the reply is the served one")
+        self.assertEqual(len(self._drift_lines(err)), 1)
+        self._reset()
+        _cmd, _env, err = self._run("haiku", {"claude-haiku-4-6-20260301": {"outputTokens": 3},
+                                              "claude-haiku-4-5-20251001": {"outputTokens": 40}})
+        self.assertEqual(jd._ALIAS_SERVED.get("haiku"), (4, 5))
+        self.assertEqual(self._drift_lines(err), [], "a side call's id does not move the alias")
+
+    def test_only_the_alias_family_speaks(self):
+        _cmd, _env, err = self._run("sonnet", {"claude-sonnet-5-20260201": {"outputTokens": 30},
+                                               "claude-haiku-4-6-20260301": {"outputTokens": 5}})
+        self.assertEqual(jd._ALIAS_SERVED.get("sonnet"), (5, 0))
+        self.assertNotIn("haiku", jd._ALIAS_SERVED, "another family's entry never speaks for haiku")
+        self.assertFalse(jd._adaptive_thinking("haiku"))
+        self.assertEqual(self._drift_lines(err), [], "sonnet's served 5.0 is the table's head")
+
+    def test_a_versioned_pin_is_never_remapped(self):
+        _cmd, _env, err = self._run("claude-haiku-4-5", {"claude-haiku-4-6-20260301": {"outputTokens": 15}})
+        self.assertEqual(jd._ALIAS_SERVED, {}, "a pin is a pin: only a bare alias is subject to resolution")
+        self.assertEqual(self._drift_lines(err), [])
+        self.assertFalse(jd._adaptive_thinking("claude-haiku-4-5"))
+
+    def test_every_tier_feeds_the_record_and_only_the_index_lever_reads_it(self):
+        # a triage call on the alias reveals its head just as well; triage's own levers are untouched
+        cmd, env, err = self._run("haiku", {"claude-haiku-4-6-20260301": {"outputTokens": 200}},
+                                  tier="triage", judge="planner")
+        self.assertNotIn("--effort", cmd, "triage keeps its own default")
+        self.assertIsNone(env.get("MAX_THINKING_TOKENS"))
+        self.assertEqual(len(self._drift_lines(err)), 1)
+        self.assertEqual(jd._ALIAS_SERVED.get("haiku"), (4, 6))
+        cmd, env, err = self._run("haiku")
+        self.assertEqual(self._effort_of(cmd), "low", "the index tier's lever follows what triage learned")
+        self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+
+    def test_an_envelope_naming_no_model_is_quiet(self):
+        # absence carries no evidence of drift: the table's answer stands exactly as before this check
+        # existed (and IndexTierLever's stub, which names no model, keeps its empty-stderr assertion)
+        for mu in (None, {}):
+            self._reset()
+            cmd, env, err = self._run("haiku", mu)
+            self.assertEqual(self._drift_lines(err), [], "modelUsage=%r" % (mu,))
+            self.assertEqual(jd._ALIAS_SERVED, {})
+            self.assertNotIn("--effort", cmd)
+            self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+
+    def test_a_malformed_entry_cannot_cost_the_reply(self):
+        # best-effort like _log_judge_usage: the reply is the call's product, the check is bookkeeping
+        for mu in ({"claude-haiku-4-6-20260301": "not a dict"},
+                   {"claude-haiku-4-6-20260301": {"outputTokens": "many"}},
+                   {"claude-haiku-4-6-20260301": None, "<synthetic>": {"outputTokens": 0}},
+                   "not a dict at all", 7):
+            self._reset()
+            self._run("haiku", mu)                    # asserts the reply came back
+
+
 class GistLlm(unittest.TestCase):
     """gist_llm: the captioner's present-focused sibling for an in-progress prompt (the feed's
     'Analyzing: …' placeholder). The model call is stubbed; this pins the prompt/model + cleanup."""


### PR DESCRIPTION
This picks up the two no-gate notes from the #880 review: the bare `haiku` alias pinned to 4.5 in `_ALIAS_HEAD` with no drift signal if the catalog moves it, and `test_index_tier_with_no_model_resolves_the_tier_pick` passing against main too. Two commits, one per note.

## What breaks

`_adaptive_thinking` places a bare family alias (`haiku`, `sonnet`, ...) by `_ALIAS_HEAD`, a table copied from the 2.1.257/258 binaries, and nothing checks the table against what the CLI serves. The CLI at 2.1.263 resolves alias targets at run time from a published catalog and falls back to its compiled table (its own log lines name a `[publishedCatalog]` fallback to compiled behavior), so the head can move with no CLI upgrade. When it does, the index tier keeps choosing the lever for the old version, with nothing in the log. For `haiku` that is the failure #880 fixed, returning through the alias: a Haiku the CLI treats as adaptive gets no `--effort`, and if it also rejects `thinking: disabled`, runs full-cost thinking silently. The fold narrowed this (the variable rides regardless), but the effort default and the lever line still answer from the table.

## Reproduction

Stub `subprocess.run` to return `{"result": "a caption", "usage": {}, "modelUsage": {"claude-haiku-4-6-20260301": {"outputTokens": 15}}}` and call `_judge_run("haiku", ..., tier="index")` twice. Before this change: no `--effort` on either call, nothing on stderr beyond the lever line, and `_adaptive_thinking("haiku")` still False. `AliasHeadDrift.test_a_moved_alias_is_announced_once_and_the_lever_follows` is that reproduction; it fails before the change.

## The fix

Every judge call already receives the CLI's answer. The `-p --output-format json` envelope carries `modelUsage`, keyed by the model id that actually served, beside the `usage` and `total_cost_usd` that `_log_judge_usage` reads; `_judge_run` ignored it. Confirmed live on 2.1.263: a `--model haiku` call returns one `modelUsage` key, `claude-haiku-4-5-20251001`, with `outputTokens` in it.

`_note_served_model(model, wrap)` runs after every successful claude-engine call. When the call's model was a bare alias, it reads the same-family entry of `modelUsage` (the one with the most output tokens: the model that wrote the reply), records the served version in `_ALIAS_SERVED`, and `_adaptive_thinking` consults that ahead of `_ALIAS_HEAD` from then on. When the served version differs from the table, one stderr line per (alias, served id) names both versions and says the lever follows the served one; the existing per-model lever line then re-announces the new lever on the next call. Versioned ids are never remapped. Nothing changes while the table agrees, which it does on 2.1.263 (`latest_per_family`: fable 5.1, opus 5, sonnet 5, haiku 4.5).

Design points a reviewer may want to weigh:

- The first call on a moved alias still runs under the table's answer, because the envelope arrives after the call; the second call is corrected.
- An envelope naming no same-family model is quiet. Absence carries no evidence of drift, so the table's answer stands exactly as before; a test pins this. A once-per-process line there is a three-line change, but `IndexTierLever`'s empty-stderr assertion would then need its stub to carry `modelUsage`.
- If you prefer signal only, with no self-correction, the `_ALIAS_SERVED.get(fam) or` lookup in `_adaptive_thinking` is the one line to drop; the drift line stands on its own, and the lever-follow assertions go with it.
- Every tier feeds `_ALIAS_SERVED` (a triage call on `sonnet` reveals its head just as well); only the index lever reads it.
- The check is best-effort like `_log_judge_usage`: a malformed entry cannot cost the reply.

## The second note

`_judge_env` reads no model since the fold made the variable unconditional, so a test named for `_judge_env("index")` resolving the tier's pick has no behavior to bind: it asserted the default pick's name and the unconditional variable, both true on any main. It is removed rather than rewritten; the tier-pick contract is pinned where it lives (`ModelTiers` for the captioner/archiver calling `_index_model()`, `IndexTierLever` for what `_judge_run` does with the model).

The prose around it still described the shape the review reversed. `_judge_env`'s docstring said the variable is NOT set on adaptive models and that `None` resolves the tier's pick; the `JudgeEnv` and `IndexTierLever` class docstrings said effort replaces the variable; the stranger's stderr line said the variable is left unset. All four now state the unconditional contract: the variable rides every index call, honored where the CLI takes `thinking: disabled` and a harmless no-op where it drops it, with `--effort` landing beside it. The `model` parameter stays, since `_judge_run` and the existing pins pass it and dropping it would rewrite the fold's own tests for no behavior gain; say the word and a follow-up drops it.

## Tests

`tests/test_judge.py`, new class `AliasHeadDrift` (subprocess stubbed; argv and env captured, read with `.get()` so a failure never prints the environment):

- an agreeing served version is quiet, and recorded
- a moved alias is announced once; the first call runs under the table, the second carries `--effort low` with the variable still riding and a fresh lever line, the third is silent
- the reply writer decides between two same-family ids
- another family's entry never speaks for `haiku`
- a versioned pin is never remapped
- every tier feeds the record; only the index lever reads it
- an envelope naming no model is quiet
- a malformed entry cannot cost the reply

Red before the change: all eight error on the missing `_ALIAS_SERVED`; with only the two module-level names added, the five behavioral cases fail (no drift line, nothing recorded, no `--effort` on the second call) and the three quiet pins pass. `tests/test_judge.py` ran three times under `-n 8` (the new class clears `_ALIAS_SERVED` in setUp and tearDown, so `EffortCapability`'s `haiku -> False` pin never sees a drifted head in a shared worker). Full pytest suite green twice. No shell or UI surface is touched.

## Scope

First-party auth, as in #880. Bedrock/Vertex alias targets are not modeled; the served id would still be read correctly there, but the denylist and floors remain first-party. A CLI older than the `modelUsage` field yields no signal and the previous behavior.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)