### PR TITLE
Model pickers: the learned-version scan re-parses a reg only when its file changed

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -893,6 +893,18 @@ _VERSION_FAMILY = {v["value"]: fam for fam, vs in MODEL_VERSIONS.items() for v i
 MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pref all surfaces read, like colormap
 _model_picks_lock = threading.Lock()   # its read-modify-writes run on the WS-handler, producer AND SDK-loop threads
 _learned_announced = set()   # ids already announced on stderr as outside the catalog (once per process)
+# The learned-version scan runs on the pickers' hot paths — every /models read (one per picker open and per
+# models frame), every pick (_note_model_pick → _version_family falls through to it for any value the
+# catalog does not list, the bare alias a family click sends included), the typed /model vouch, the judge
+# tier setters and the SDK loop's refusal hook — and re-opening and JSON-parsing every reg per call was the
+# cost. The file is the truth, so the key is exactly what changes when the file does: (mtime_ns, size,
+# inode), the key list_regs' _REG_CACHE uses (write_reg's os.replace mints a new inode, so a same-size
+# same-instant rewrite still misses). Only the one reported string is cached, never the derived rows: the
+# derivation must run against the LIVE catalog snapshot every call (a catalog that catches up drops the
+# mark; _note_unknown_model must see each sighting). Unlocked on purpose: dict get/set/pop are atomic, two
+# threads racing on a changed file both parse it and store equal tuples, and holding _catalog_lock around
+# file I/O would stall the catalog refresh thread.
+_learned_reg_cache = {}   # str(path) -> ((mtime_ns, size, ino), liveModelId or "") — see _reported_model_ids
 # Bumps on every pick-memory change and every catalog growth; rides the models frame (_models_changed) AND
 # the /models payload, so a picker can drop a response older than one it has applied. Seeded from the clock
 # rather than 0: the counter is per process, and a kernel restart must never hand a page that kept its
@@ -1221,6 +1233,46 @@ def _model_id_label(value):
     return "%s %d" % (fam.capitalize(), maj) + (".%d" % minor if minor else "")
 
 
+def _reported_model_ids():
+    """[liveModelId, …] across every reg under STATE/sdk (the same files _thread_reg reads), in reg-name
+    order, re-parsing only a reg whose file changed since it was last parsed (_learned_reg_cache, keyed
+    on the file's content-stat). Unreadable, non-JSON and non-dict regs and regs with no liveModelId
+    contribute nothing — exactly what the uncached scan skipped; a failed read or parse is not cached,
+    so the next call retries it, and a reg that vanished leaves the cache on the next scan."""
+    try:
+        entries = sorted(os.scandir(jd.STATE / "sdk"), key=lambda e: e.name)   # the glob was sorted: same order
+    except OSError:                              # a missing sdk/ dir included — no regs yet
+        return []
+    out, seen = [], set()
+    for de in entries:
+        if not de.name.endswith(".json"):        # write_reg's <sid>.json.<pid>.<hex>.tmp never counted
+            continue
+        seen.add(de.path)
+        try:
+            st = de.stat()
+        except OSError:
+            continue
+        key = (st.st_mtime_ns, st.st_size, st.st_ino)
+        hit = _learned_reg_cache.get(de.path)
+        if hit is not None and hit[0] == key:
+            mid = hit[1]
+        else:
+            try:
+                reg = json.loads(Path(de.path).read_text())
+            except (OSError, ValueError):
+                _learned_reg_cache.pop(de.path, None)
+                continue
+            mid = reg.get("liveModelId") if isinstance(reg, dict) else None
+            mid = mid if isinstance(mid, str) else ""
+            _learned_reg_cache[de.path] = (key, mid)
+        if mid:
+            out.append(mid)
+    for p in list(_learned_reg_cache):           # deleted regs leave the cache
+        if p not in seen:
+            _learned_reg_cache.pop(p, None)
+    return out
+
+
 def _learned_versions():
     """{family: [{"value", "label", "learned": True}, …]} — every model id a session's CLI has actually
     REPORTED (reg.liveModelId, persisted by the SDK backend's _learn_model from the init / assistant
@@ -1231,24 +1283,16 @@ def _learned_versions():
     kernel life, spent only when it actually starts), so the catalog catches up and the row's mark
     drops. A dated snapshot of a known version shares its label and adds nothing (the dateless alias
     covers it); provider-prefixed and synthetic ids are not the shape the pickers send and are
-    skipped. Reads the same reg files _thread_reg does. A first sighting is announced once on stderr —
-    and the pickers mark the row — so an unlisted model is LOUD, never a silent gap behind a stale
-    menu (the fail-loudly rule)."""
+    skipped. The reg scan re-parses a reg only when its file changed (_reported_model_ids); the
+    derivation against the catalog runs every call, so a catalog that catches up drops the mark at
+    once. A first sighting is announced once on stderr — and the pickers mark the row — so an
+    unlisted model is LOUD, never a silent gap behind a stale menu (the fail-loudly rule)."""
     out = {}
     fams = {c["value"] for c in MODEL_CHOICES}
     with _catalog_lock:                          # the catalog is rebuilt in place on its own thread
         known = set(_VERSION_FAMILY)
         labels = {fam: {v["label"].lower() for v in vs} for fam, vs in MODEL_VERSIONS.items()}
-    try:
-        regs = sorted((jd.STATE / "sdk").glob("*.json"))
-    except OSError:
-        return out
-    for p in regs:
-        try:
-            reg = json.loads(p.read_text())
-        except (OSError, ValueError):
-            continue
-        mid = reg.get("liveModelId") if isinstance(reg, dict) else None
+    for mid in _reported_model_ids():
         parts = _model_id_parts(mid)
         if not parts or parts[0] not in fams:
             continue

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -894,16 +894,16 @@ MODEL_PICKS_FILE_NAME = "model-picks.json"   # {family: full-id} — a viewer pr
 _model_picks_lock = threading.Lock()   # its read-modify-writes run on the WS-handler, producer AND SDK-loop threads
 _learned_announced = set()   # ids already announced on stderr as outside the catalog (once per process)
 # The learned-version scan runs on the pickers' hot paths — every /models read (one per picker open and per
-# models frame), every pick (_note_model_pick → _version_family falls through to it for any value the
-# catalog does not list, the bare alias a family click sends included), the typed /model vouch, the judge
-# tier setters and the SDK loop's refusal hook — and re-opening and JSON-parsing every reg per call was the
-# cost. The file is the truth, so the key is exactly what changes when the file does: (mtime_ns, size,
-# inode), the key list_regs' _REG_CACHE uses (write_reg's os.replace mints a new inode, so a same-size
-# same-instant rewrite still misses). Only the one reported string is cached, never the derived rows: the
-# derivation must run against the LIVE catalog snapshot every call (a catalog that catches up drops the
-# mark; _note_unknown_model must see each sighting). Unlocked on purpose: dict get/set/pop are atomic, two
-# threads racing on a changed file both parse it and store equal tuples, and holding _catalog_lock around
-# file I/O would stall the catalog refresh thread.
+# models frame), every pick (_note_model_pick → _version_family falls through to it for any version-shaped
+# value the catalog does not list), the typed /model vouch, the judge tier setters and the SDK loop's
+# refusal hook — and re-opening and JSON-parsing every reg per call was the cost. The file is the truth,
+# so the key is exactly what changes when the file does: (mtime_ns, size, inode), the key list_regs'
+# _REG_CACHE uses (write_reg's os.replace mints a new inode, so a same-size same-instant rewrite still
+# misses). Only the one reported string is cached, never the derived rows: the derivation must run against
+# the LIVE catalog snapshot every call (a catalog that catches up drops the mark; _note_unknown_model must
+# see each sighting). Unlocked on purpose: dict get/set/pop are atomic, two threads racing on a changed
+# file both parse it and store equal tuples, and holding _catalog_lock around file I/O would stall the
+# catalog refresh thread.
 _learned_reg_cache = {}   # str(path) -> ((mtime_ns, size, ino), liveModelId or "") — see _reported_model_ids
 # Bumps on every pick-memory change and every catalog growth; rides the models frame (_models_changed) AND
 # the /models payload, so a picker can drop a response older than one it has applied. Seeded from the clock
@@ -1338,12 +1338,16 @@ def _version_family(value, learned=None):
     """The family a VERSION id belongs to — a catalog id (the seed table, or one the Models API fetch
     added to it), or one a session's CLI has reported (learned) — and '' for anything else: a family
     alias, 'default', a never-seen id. This is what makes a value a pin the pick memory may record;
-    read at CALL time, so an id the catalog learned after boot is a pin from that moment on."""
+    read at CALL time, so an id the catalog learned after boot is a pin from that moment on. A value
+    that is not even version-shaped is answered before the reg scan: a learned row's value is always
+    a first-party version id, so the bare alias every family click sends can match none."""
     v = str(value or "")
     with _catalog_lock:
         fam = _VERSION_FAMILY.get(v)
     if fam:
         return fam
+    if not _model_id_parts(v):                   # an alias, 'default', a typo: no learned row can equal it
+        return ""
     for f, vs in (_learned_versions() if learned is None else learned).items():
         if any(x["value"] == v for x in vs):
             return f

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -429,6 +429,81 @@ class LearnedVersions(_ModelsServer):
         self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
         self.assertEqual(km._model_picks(), {"opus": "claude-opus-5-1", "sonnet": "claude-sonnet-4-6"})
 
+    def _replace_reg(self, sid, **fields):
+        # the SDK backend's write_reg shape — tmp + os.replace, a NEW inode per write. A test that
+        # REWRITES a reg uses this, not _reg: an in-place write_text keeps the inode, and a same-size
+        # rewrite inside one timestamp tick would leave (mtime_ns, size, ino) unchanged
+        d = jd.STATE / "sdk"
+        tmp = d / (sid + ".json.tmp")
+        tmp.write_text(json.dumps({"sid": sid, "name": "web", "cwd": "/tmp", "alive": True, **fields}))
+        os.replace(tmp, d / (sid + ".json"))
+
+    @contextlib.contextmanager
+    def _counting_reg_reads(self):
+        """The reg files under STATE/sdk the kernel READS while held — only those: the /models route
+        also reads the pick store, the CLI-block file and the catalog cache, so an unfiltered counter
+        is never zero."""
+        reads, real, sdk = [], Path.read_text, str(jd.STATE / "sdk") + os.sep
+
+        def read_text(p, *a, **k):
+            if str(p).startswith(sdk):
+                reads.append(p.name)
+            return real(p, *a, **k)
+        with mock.patch.object(Path, "read_text", read_text):
+            yield reads
+
+    def test_a_warm_scan_re_reads_no_reg_whose_file_is_unchanged(self):
+        # THE COST: the scan runs on the pickers' hot paths — every /models read (one per picker open
+        # and per models frame), every pick via _version_family, the SDK loop's refusal hook — and
+        # re-opened and JSON-parsed every reg per call. A reg whose file has not changed is parsed once.
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        self._reg("11111111-2222-3333-4444-555555555502", liveModelId="claude-sonnet-5-1")
+        self._reg("11111111-2222-3333-4444-555555555503", liveModelId="claude-haiku-5")
+        first = km._learned_versions()
+        self.assertEqual(sorted(first), ["haiku", "opus", "sonnet"])
+        with self._counting_reg_reads() as reads:
+            second = km._learned_versions()
+        self.assertEqual(reads, [], "nothing changed → nothing re-read")
+        self.assertEqual(second, first)
+
+    def test_a_changed_or_new_reg_is_seen_and_a_deleted_one_drops_on_the_next_call(self):
+        # the file is the truth, so the cache keys on exactly what changes when the file does —
+        # (mtime_ns, size, inode), the key list_regs' _REG_CACHE uses; write_reg's os.replace mints
+        # a new inode per write, so a rewrite is never mistaken for the file it replaced
+        sid1, sid2 = "11111111-2222-3333-4444-555555555501", "11111111-2222-3333-4444-555555555502"
+        self._reg(sid1, liveModelId="claude-opus-5-1")
+        self.assertEqual([v["value"] for v in km._learned_versions()["opus"]], ["claude-opus-5-1"])
+        self._replace_reg(sid1, liveModelId="claude-opus-5-2")          # the session's CLI moved on
+        self.assertEqual([v["value"] for v in km._learned_versions()["opus"]], ["claude-opus-5-2"],
+                         "rewritten → re-read, the old id gone with the old file")
+        self._reg(sid2, liveModelId="claude-sonnet-5-1")                 # a new session
+        learned = km._learned_versions()
+        self.assertEqual([v["value"] for v in learned["sonnet"]], ["claude-sonnet-5-1"], "new → seen")
+        self.assertEqual([v["value"] for v in learned["opus"]], ["claude-opus-5-2"])
+        (jd.STATE / "sdk" / (sid1 + ".json")).unlink()                    # the session is gone
+        self.assertNotIn("opus", km._learned_versions(), "deleted → dropped")
+        self.assertNotIn(str(jd.STATE / "sdk" / (sid1 + ".json")), km._learned_reg_cache, "…and its entry with it")
+
+    def test_a_garbled_or_non_dict_reg_is_skipped_and_a_failed_parse_is_retried(self):
+        # exactly what the uncached scan skipped: a file json.loads cannot parse, a JSON value that
+        # is not a dict, a dict with no liveModelId — each contributes nothing and the good reg still
+        # lands. A failed read or parse is NOT cached (the next call retries it, so a healed file gets
+        # its turn); a parsed non-dict is (its answer cannot change until the file does)
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        self._reg("11111111-2222-3333-4444-555555555502")                 # no liveModelId yet
+        d = jd.STATE / "sdk"
+        (d / "broken.json").write_text("{not json")
+        (d / "list.json").write_text("[]")
+        learned = km._learned_versions()
+        self.assertEqual({f: [v["value"] for v in vs] for f, vs in learned.items()}, {"opus": ["claude-opus-5-1"]})
+        rows = {m["value"]: m for m in self._models()["models"]}
+        self.assertEqual(rows["opus"]["versions"][0]["value"], "claude-opus-5-1",
+                         "the route still answers, learned row included")
+        self.assertNotIn(str(d / "broken.json"), km._learned_reg_cache, "a failed parse is not cached")
+        with self._counting_reg_reads() as reads:
+            km._learned_versions()
+        self.assertEqual(reads, ["broken.json"], "the retry is the ONLY re-read: every parsed reg, dict or not, is warm")
+
 
 class AliasMigration(unittest.TestCase):
     """One-time boot pass, mirroring the CLI's own 2.1.257 `migration_fable5_to_fable_alias`: a stored

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -504,6 +504,20 @@ class LearnedVersions(_ModelsServer):
             km._learned_versions()
         self.assertEqual(reads, ["broken.json"], "the retry is the ONLY re-read: every parsed reg, dict or not, is warm")
 
+    def test_a_bare_family_alias_never_scans_the_regs(self):
+        # every bare family click sends the alias ('fable'); _note_model_pick asks _version_family
+        # whether that is a pin, and an alias is never a catalog id — so the lookup fell through to
+        # the reg scan on every click. A learned row's value is always a first-party VERSION id, so a
+        # value _model_id_parts rejects can match none: answered before the scan.
+        self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
+        with mock.patch.object(km, "_learned_versions", wraps=km._learned_versions) as scan:
+            self.assertEqual(km._version_family("fable"), "")
+            self.assertEqual(km._version_family("default"), "")
+            self.assertEqual(km._version_family("total-nonsense"), "")
+            self.assertEqual(scan.call_count, 0, "no version shape → no scan")
+            self.assertEqual(km._version_family("claude-opus-5-1"), "opus", "a version-shaped value still consults the regs")
+            self.assertEqual(scan.call_count, 1)
+
 
 class AliasMigration(unittest.TestCase):
     """One-time boot pass, mirroring the CLI's own 2.1.257 `migration_fable5_to_fable_alias`: a stored


### PR DESCRIPTION
`_learned_versions` re-read and JSON-parsed every session reg under `STATE/sdk` on every call, and it sits on the pickers' hot paths. This change caches the reg scan per file, keyed on the file's content-stat, and keeps the derivation against the catalog per call. Follow-up to the note on #882.

## What it cost

Each call ran one glob plus one read and one JSON parse per reg. The callers:

- `GET /models`: once per picker open and per models-frame re-fetch (every open picker re-reads on `_models_changed`).
- Every pick: `_note_model_pick` asks `_version_family`, which short-circuits only on catalog ids and otherwise falls through to the scan. The bare family alias a family click sends took that path on every click.
- The typed `/model` vouch (`_vouched_model`), the judge tier setters (`_judge_model_values`), and the SDK loop's refusal hook (`_model_pick_refused`).

Reproduction at 2b9db2be: with three regs under `STATE/sdk`, a second `_learned_versions()` call reads all three files again. `test_a_warm_scan_re_reads_no_reg_whose_file_is_unchanged` counts the reads and expects zero; at that tip it sees three.

## The fix (commit 1)

The scan moves into `_reported_model_ids`, which caches each reg's reported `liveModelId` keyed on `(mtime_ns, size, inode)`. That is the key `list_regs`' `_REG_CACHE` already uses for the liveness sweep: `write_reg`'s `os.replace` creates a new inode per write, so a same-size same-instant rewrite still misses. Per call: one `scandir` plus one `stat` per reg.

Only the reported string is cached, never the derived rows. The derivation against the live catalog snapshot (the `_catalog_lock` snapshot of `_VERSION_FAMILY` and labels, the dateless-alias fold, `_note_unknown_model`, the one-time stderr announce) still runs every call, so both T222 properties hold: a catalog that catches up drops the `learned` mark from an id already scanned, and a sighting after an inflight refresh lands still asks for its own refresh (the `_note_unknown_model` docstring relies on the list being re-derived per read).

Failure semantics are unchanged. An unreadable, non-JSON or non-dict reg, or one without `liveModelId`, contributes nothing. A failed read or parse is not cached, so the next call retries it. Regs that vanished leave the cache on the next scan. Scan order stays reg-name order, as the sorted glob was.

Two placement choices. It stays in kernel.py rather than routing through `list_regs`, because the SDK backend module loads lazily inside `_sdk_locked()` and the picker paths (and their tests) run without a backend constructed. The cache is an unlocked module dict: get/set/pop are atomic, two threads racing on a changed file store equal tuples, and holding `_catalog_lock` around file I/O would stall the catalog refresh thread.

## Commit 2, separable

`_version_family` returns `''` before scanning when `_model_id_parts` rejects the value. A learned row's value is always a first-party version id, so an alias, `default` or a typo can match none. The result is identical for every input (a `[1m]`-tagged or dated spelling still passes the parts check, still scans, and still misses the dateless learned values); only the scan is avoided, so the family-click path no longer touches the regs. Drop this commit if you would rather keep the lookup's shape.

## Tests (red first at 2b9db2be)

In `tests/test_model_versions.py`, class `LearnedVersions`:

- A warm second scan performs zero reg reads and returns the same rows (three reads at the previous tip).
- A rewritten reg (new inode, via tmp + `os.replace`, the `write_reg` shape), a new reg and a deleted reg are each reflected on the next call; the deleted one's cache entry goes with it.
- A garbled and a non-dict reg are skipped and `/models` still answers with the learned row; the garbled one is retried on the next call, the parsed one stays warm.
- Commit 2: a bare alias, `default` and a typo resolve to `''` without a call into the learned-version scan; a version-shaped value still consults it.

Existing learned-version, catalog-union and refresh-dedup tests are untouched and green. Full `tests/` sweep: 7327 passed, 50 skipped. bats: 389/389. Synthetic regs only (placeholder sids, session name `web`).

## Not included

`_model_alias_boot_pass`'s own one-time reg pass, `_thread_reg`, and anything in `sdk_backend.py`.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)