### PR TITLE
Document what a typed /model or /effort does on each backend, and pin it

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -179,6 +179,26 @@ ghostty --working-directory={dir}   # Linux: Ghostty
 code {dir}                          # VS Code instead
 ```
 
+### Model and effort, from the statusline or a typed command
+
+Typing `/model X`, `/effort X`, or `/fast on|off` into the chat composer, or
+sending one with `romp send`, is the same setting change as a pick from the
+statusline's model and effort dropdowns: the kernel takes it through its own
+setters, so what it remembers (the value a reconnect relaunches with, the
+defaults new sessions start from) follows the switch. A bare `/model` (the
+CLI's own picker), a value the kernel cannot vouch for (a typo), or a longer
+message that merely opens with the command goes to the CLI verbatim, and the
+chat shows the CLI's own reply.
+
+The two backends apply the change differently. An SDK session switches model
+live but reloads to apply a new effort: the chat shows "Reloading session…"
+and the effort badge shows switching-dots until the reload completes, and a
+session that is mid-turn reloads when the turn ends. A terminal (tmux) session
+gets the CLI's own command typed into its pane. `/model` there asks for a
+confirmation, which the kernel accepts on your behalf so the pane is never
+left waiting on a keystroke the dashboard cannot send; `/effort` and `/fast`
+apply in place.
+
 ### Fast mode, from the chat statusline
 
 The statusline's badges — permission mode, model, effort — are each a small

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11345,7 +11345,7 @@ class TmuxBackend(sb.SessionBackend):
         return True, ""
 
     def set_model(self, sid, value):
-        _tmux_send(_name_of(sid) or sid, "/model " + value, model_cmd=True)   # /model opens a confirm → 2nd Enter
+        _tmux_send(_name_of(sid) or sid, "/model " + value, model_cmd=True)   # /model opens a confirm → the 2nd Enter accepts it for the user
         return True
 
     def set_mode(self, sid, mode):
@@ -20489,9 +20489,14 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     The CLI would execute the text (verified on 2.1.257), but that path bypasses romp: the registry,
     sdk-defaults.json, the pick memory and the reconnect's --model all kept the OLD value, so a switch
     typed into the composer silently reverted at the next reconnect or restart. The setters are also
-    what parks the change mid-compaction. Returns True when it took the command. Anything else —
-    another slash command, a bare "/model" (the CLI's own picker), plain text that merely contains one
-    — is the caller's to send verbatim: the CLI owns what executes. A refused fast toggle is told to
+    what parks the change mid-compaction. Returns True when it took the command. Whichever surface
+    typed it — the composer, the lane menu, POST /send — the command is one gesture with one outcome;
+    how the setter then LANDS it is the backend's: an SDK session switches model live but reconnects
+    to apply an effort change (SdkBackend.set_effort), a tmux session gets the CLI's own command typed
+    into its pane with /model's confirmation accepted for the user (TmuxBackend.set_model) — the
+    SessionBackend.set_model / set_effort docstrings hold the split. Anything else — another slash
+    command, a bare "/model" (the CLI's own picker), plain text that merely contains one — is the
+    caller's to send verbatim: the CLI owns what executes. A refused fast toggle is told to
     the client (fail loudly): a dormant SDK session has no live CLI to apply it, and the typed text
     used to at least draw the CLI's own refusal. `state`, when given, receives {"queued": bool} — whether
     the setter PARKED the change (they park under _ops_gate, read here) — so POST /send answers `queued`

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -115,14 +115,33 @@ class SessionBackend(ABC):
         return False
 
     @abstractmethod
-    def set_model(self, sid: str, value: str) -> bool: ...
+    def set_model(self, sid: str, value: str) -> bool:
+        """Switch the session's model. `value` is a family alias (opus — the CLI resolves it to the newest),
+        an explicit version id (a pin), or 'default'. Every surface lands here — the statusline picker, the
+        timeline lane menu, a '/model X' typed into the composer or sent by `romp send` (kernel
+        _route_meta_command) — so the registry and the remembered defaults never drift from what the CLI
+        runs. The SDK persists the value and applies it LIVE over the SDK's set_model control request, no
+        reconnect; a refusal reverts every layer (SdkBackend.set_model). tmux types the CLI's own '/model X'
+        into the pane and presses Enter once more to accept the confirmation the CLI asks for
+        (TmuxBackend.set_model, `_tmux_send(model_cmd=True)`): the dashboard cannot press it in the pane,
+        and the next send's clear-guard would refuse to paste over the open dialog.
+        False when it can't be applied (unknown sid, bad value) so the kernel can be loud instead of
+        pretending."""
 
     @abstractmethod
     def set_mode(self, sid: str, mode: str) -> bool:
         """Set the permission mode (auto/default/acceptEdits/plan/…)."""
 
     @abstractmethod
-    def set_effort(self, sid: str, value: str) -> bool: ...
+    def set_effort(self, sid: str, value: str) -> bool:
+        """Set the reasoning effort (one of the kernel's effort choices, 'low' through 'ultracode'). The two
+        backends land it differently from each other and from set_model: effort is a connect-time CLI flag
+        (--effort) with no SDK control request, so the SDK persists the value and RECONNECTS to apply it —
+        at once if the session is idle, at the end of the turn if it's busy — with `effortPending` driving
+        the badge's switching-dots and the chat's "Reloading session…" notice (SdkBackend.set_effort). tmux
+        types '/effort X' into the pane, which the TUI applies in place: no reconnect, no confirmation, so
+        no second Enter (TmuxBackend.set_effort). False when it can't be applied (unknown sid, bad value)
+        so the kernel can be loud instead of pretending."""
 
     @abstractmethod
     def set_fast(self, sid: str, value: str) -> bool:

--- a/tests/test_kernel_pane_clear.py
+++ b/tests/test_kernel_pane_clear.py
@@ -263,6 +263,29 @@ class SendAbortsWhenTmuxAnswersNonzero(unittest.TestCase):
         self.assertEqual(err, "")
 
 
+class TmuxSettersTypeTheClisOwnCommand(unittest.TestCase):
+    """TmuxBackend has no control channel: set_model and set_effort type the CLI's own command into the pane
+    (SessionBackend documents the per-backend split). The one asymmetry is pinned here. `/model X` opens a
+    confirmation in the TUI, so set_model asks _tmux_send for the second Enter (model_cmd=True): the
+    dashboard cannot press it in the pane, and the next send's clear-guard would refuse to paste over the
+    open dialog. `/effort X` applies in place and gets no such Enter. A recorder stands in
+    for _tmux_send (the real one sleeps before the confirm Enter), so this pins the call shape, not the
+    keystrokes; `**kw` keeps the recorder valid if the signature grows."""
+
+    def test_set_model_asks_for_the_confirm_enter_and_set_effort_does_not(self):
+        rec = []
+        saved_send, saved_name = km._tmux_send, km._name_of
+        km._tmux_send = lambda name, text, model_cmd=False, **kw: rec.append((name, text, model_cmd))
+        km._name_of = lambda sid: SESSION
+        try:
+            be = km.TmuxBackend()
+            self.assertTrue(be.set_model("sid-tmux", "opus"))
+            self.assertTrue(be.set_effort("sid-tmux", "high"))
+        finally:
+            km._tmux_send, km._name_of = saved_send, saved_name
+        self.assertEqual(rec, [(SESSION, "/model opus", True), (SESSION, "/effort high", False)])
+
+
 class CheckedPrimitivesReadTheExitCode(unittest.TestCase):
     """The contract of TmuxBackend's checked variants, on the real class: True iff tmux itself answered 0.
     An exec failure or a timeout (`_run` → None), a missing tmux (the same None) and a nonzero exit all read

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -119,6 +119,28 @@ class KernelWiring(unittest.TestCase):
             km._TMUX, km._name_of = saved, saved_name
             km._tmux_echo.pop("sid-tmux", None)                   # the optimistic echo wrote here — don't leak it
 
+    def test_a_typed_slash_model_or_effort_on_a_tmux_session_takes_the_setter_too(self):
+        # The routing is backend-agnostic: a typed "/model X" or "/effort X" on a tmux-owned sid reaches
+        # TmuxBackend's setters — which type the CLI's own command into the pane and, for /model, accept
+        # the confirmation the CLI asks for (SessionBackend.set_model) — never send() as literal text.
+        # The SDK-sid test below covers one door; this pins the other, so the two backends cannot drift
+        # apart at the router.
+        tm = FakeBackend(); tm._owned = set()
+        saved, saved_name = km._TMUX, km._name_of
+        km._TMUX = tm
+        km._name_of = lambda sid: "web"
+        try:
+            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-tmux", "text": "/model opus"}))
+            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-tmux", "text": "/effort high"}))
+            self.assertIn(("set_model", "sid-tmux", "opus"), tm.calls)
+            self.assertIn(("set_effort", "sid-tmux", "high"), tm.calls)
+            self.assertEqual([c for c in tm.calls if c[0] == "send"], [], "neither reaches the pane as text")
+            self.assertEqual(self.be.calls, [], "the SDK backend was untouched")
+        finally:
+            km._TMUX, km._name_of = saved, saved_name
+            km._tmux_echo.pop("sid-tmux", None)
+            km._model_switch_pending.pop("sid-tmux", None)        # the pick's switching-dots stamp — don't leak it
+
     def test_ui_op_falls_through_even_for_sdk_sid(self):
         # closeTab/openSession are backend-agnostic UI ops → never intercepted
         self.assertFalse(self._route({"type": "closeTab", "id": "sid-sdk"}))

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -71,6 +71,17 @@ class AbcContract(unittest.TestCase):
         for m in ABSTRACT:
             self.assertIn(m, defs, "SdkBackend must implement the SessionBackend method %s" % m)
 
+    def test_control_setters_document_their_per_backend_mechanics(self):
+        # set_model, set_effort and set_fast land DIFFERENTLY on the two backends — the SDK switches
+        # model live over its control request but RECONNECTS for effort; tmux types the CLI's own
+        # command into the pane and accepts /model's confirmation — and the contract is where a reader
+        # learns that, so each carries a docstring naming its mechanism. One distinctive word per
+        # method keeps the pin honest without freezing the prose.
+        for m, word in (("set_model", "control"), ("set_effort", "reconnect"), ("set_fast", "connect")):
+            doc = getattr(sb.SessionBackend, m).__doc__ or ""
+            self.assertTrue(doc.strip(), "SessionBackend.%s carries a docstring" % m)
+            self.assertIn(word, doc, "SessionBackend.%s's docstring names its mechanism (%r)" % (m, word))
+
 
 # quoted-literal markers — a raw `["tmux"` subprocess list, a tmux SUBCOMMAND string arg, or a tmux @-var
 # NAME string. Matching only QUOTED literals (not bare words) means prose in comments/docstrings that merely


### PR DESCRIPTION
Follow-up to the merge note on #882, which named two consequences of routing typed commands through the kernel's setters and asked for a line about each: the composer's `/effort` reconnects an SDK session, and a typed `/model` on a tmux session is auto-confirmed. Nothing at tip recorded either. This PR writes both down where they will be read, and pins them. No behavior changes.

## Why document rather than align

The SDK's control channel (claude-agent-sdk 0.2.132) offers `set_model` and `set_permission_mode` but no effort request, so a reconnect is the only way to apply an effort change that the registry, `sdk-defaults.json` and the next connect all agree on, which is the property #882 exists to hold. On tmux, the CLI's `/model X` opens a confirmation; the dashboard cannot press Enter in the pane, and the next send's clear-guard would refuse to paste over the open dialog, so the kernel accepts the confirmation for the user, as the lane menu's pick has since the model park was built. Both behaviors are right; they were undocumented.

## What changes

One commit, three parts:

- **The contract and the router say what each backend does.** `SessionBackend.set_model` and `set_effort` (`kernel/session_backend.py`) were bare `...` with no docstring, while the neighbouring `set_fast` spells out its per-backend mechanics. Both gain docstrings in that register: what the SDK does, what tmux does, when False comes back. `_route_meta_command`'s docstring (`kernel/kernel.py`) gains the sentence that a typed command and a picker click are one gesture, and that the landing is the backend's. Docstrings and one trailing comment only; every source-pinned line (the `_set_effort_or_park(be, sid, value)` park line, the `sendCommand` call the UI test pins) is untouched.
- **User-facing docs.** `docs/reference.md` gains "Model and effort, from the statusline or a typed command" beside "Fast mode": a typed `/model X`, `/effort X` or `/fast on|off` is a setting change (a bare `/model` or a value the kernel cannot vouch for stays the CLI's); an SDK session switches model live but reloads for effort ("Reloading session…", switching-dots, deferred to turn end while busy); a terminal session gets the CLI's own command typed into its pane with the `/model` confirmation accepted on the user's behalf.
- **Guard tests.**
  - `tests/test_session_api.py`: the ABC's control setters must carry a docstring naming their mechanism. Red on the unfixed base (`SessionBackend.set_model carries a docstring` fails with `''`), green with the docstrings.
  - `tests/test_sdk_kernel.py` (KernelWiring): a typed `/model opus` or `/effort high` on a tmux-owned sid reaches `TmuxBackend.set_model` / `set_effort`, never `send()`. The existing routing test covered SDK sids only.
  - `tests/test_kernel_pane_clear.py`: `TmuxBackend.set_model` calls `_tmux_send` with `model_cmd=True` and `set_effort` without it. A recorder stands in for `_tmux_send`, so the test pins the call shape and never enters the timed confirm wait.

## Verification

- `pytest -n 8 tests`: 7329 passed, 46 skipped. One failure in `tests/test_postal_relay_honesty.py` (xdist ordering, unrelated to this change); the module passes alone (30 passed).
- `vscode-extension`: `npm run typecheck` clean, `npm test` 2781/2781, `npm run build` ok.
- `git diff --check` clean.

## Out of scope

Claude Code 2.1.263 marks its non-interactive `/effort` descriptor `supportsNonInteractive`, so a literal `/effort` into the SDK stream would execute. A live-effort path that avoids the reconnect is possible in principle, but it is the registry-bypassing shape #882 closed, so it would be its own feature PR. The second Enter's timed wait predates this PR and is unchanged.

Tier: tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)