### PR TITLE
Tests: bats suites that reach tmux get a private socket directory, and the ones that bind ports pick free ones

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,26 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
 - **`*.bats`** — the shell surfaces: `bin/romp`, the launch chain, hooks,
   postal CLI. Keep them GNU/BSD-portable (CI runs bats on ubuntu).
   Run: `bats tests/*.bats`.
+  Any test whose subject shells out to tmux must isolate the tmux socket
+  directory: `load tmux-private`, `tmux_private_socket_dir "$TEST_DIR"` in
+  setup (it exports `TMUX_TMPDIR` under the test dir and creates it first;
+  tmux 3.4 silently uses the machine's default socket directory when
+  `TMUX_TMPDIR` names a missing one), and `tmux_private_kill && rm -rf
+  "$TEST_DIR"` as the last line of teardown (the kill fails when the
+  directory is already gone, since a server started under it has then
+  leaked; it has to be teardown's final status, because bats swallows a
+  failing command mid-teardown). A tmux mock on PATH
+  covers only the tests that install one: on 2026-09-06 a full bats run
+  ran `romp-manager-ensure.bats` while the machine's default tmux server
+  was down, the real manager it starts ran `tmux start-server` on the
+  default socket, and for the rest of the day the machine's tmux server was
+  the test's, carrying the run's environment inside the service's cgroup.
+  Any test whose subject binds a loopback port picks it with `load
+  free-port` + `free_port VAR...`, never a literal: a literal shared by two
+  files collided within one run (`romp-manager-ensure.bats` once used
+  `romp-manager-origin.bats`'s control port), and any literal collides when
+  two checkouts run bats at once on one machine. The helper picks below
+  the ephemeral range, so a transient source port cannot hold the pick.
 - **node suites** — live beside their sources in `ui/webview/*.test.ts` and
   `vscode-extension/src/*.test.ts`, run with `npm test` from
   `vscode-extension/`. Many pin lines of `kernel/kernel.py` as strings — run

--- a/tests/free-port.bash
+++ b/tests/free-port.bash
@@ -1,0 +1,68 @@
+# tests/free-port.bash: loopback TCP ports nothing is bound to, for the bats suites whose subject
+# binds one (the ones that start a real bin/romp-manager).
+#
+# Use from a bats file: `load free-port` at the top, then `free_port CPORT MPORT` in setup() or a
+# test (`local cport mport; free_port cport mport` inside a test). Each named variable is assigned a
+# distinct port. The function fails, with a `free-port:` line on stderr, when python3 is missing or
+# no port is found, and bats then fails the test right there: an empty port would otherwise reach
+# bin/romp-manager as `Number('') || 7432`, the default control port, where a developer's live manager
+# may be listening.
+#
+# Why not a literal: a literal shared by two files collides within one run (romp-manager-ensure.bats
+# once ran `up` on romp-manager-origin.bats's control port, and a manager SIGTERM'd there outlives
+# the kill by shutdownAll's exit grace, so `up` exited "already running" and never called tmux), and
+# any literal collides when two checkouts run bats at once on one machine.
+#
+# Ports come from 20000-24999: below Linux's ephemeral range (32768-60999) and macOS's (49152-65535),
+# so a transient outgoing connection cannot hold the pick as its SOURCE port between the pick and the
+# subject's bind (the lesson tests/romp-postal.bats's header records), and below the project's own
+# defaults (the postal bus's 25302, the postal tests' 27200-28300, the kernel's 29855; the manager's
+# 7432 sits under the band). The probe is a plain bind with no SO_REUSEADDR: a port in TIME_WAIT from
+# an earlier test reads busy and is skipped (node's listen would bind it anyway, so skipping is the safe
+# side). What remains is the window between the pick and the subject's bind, milliseconds long, while
+# bats runs files one after another; a second bats run on the same machine competes on a random pick
+# out of 5000, where a literal collided every time.
+#
+# The locals carry a prefix because bash scopes dynamically: with plain names, `local name; free_port
+# name` would assign the helper's own local and hand the caller an empty string, the exact failure the
+# helper exists to prevent.
+
+free_port() {   # free_port VAR...: assigns each VAR a distinct free loopback port
+    local _fp_ports _fp_picks _fp_i=0 _fp_name
+    if [ $# -eq 0 ]; then
+        echo "free-port: usage: free_port VAR..." >&2
+        return 1
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "free-port: python3 not found on PATH; cannot probe for a free port" >&2
+        return 1
+    fi
+    _fp_ports="$(python3 - "$#" <<'PY'
+import random, socket, sys
+n = int(sys.argv[1])
+picked = []
+for _ in range(500):
+    p = random.randint(20000, 24999)
+    if p in picked:
+        continue
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", p))
+    except OSError:
+        continue
+    finally:
+        s.close()
+    picked.append(p)
+    if len(picked) == n:
+        break
+if len(picked) < n:
+    sys.exit(1)
+print(" ".join(str(p) for p in picked))
+PY
+)" || { echo "free-port: no free loopback port in 20000-24999 after 500 tries" >&2; return 1; }
+    read -ra _fp_picks <<< "$_fp_ports"
+    for _fp_name in "$@"; do
+        printf -v "$_fp_name" '%s' "${_fp_picks[_fp_i]}"
+        _fp_i=$((_fp_i + 1))
+    done
+}

--- a/tests/free-port.bats
+++ b/tests/free-port.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+# tests/free-port.bash picks loopback ports nothing is bound to, for the suites that start a real
+# bin/romp-manager. These cases pin its contract: the band, distinct picks, and a loud failure where a
+# silent one would send the subject to the manager's default port. Nothing below runs tmux or node.
+
+load free-port
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "free_port assigns a port in 20000-24999 that a bind then succeeds on" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    local port=""
+    free_port port
+    [[ "$port" =~ ^[0-9]+$ ]]
+    [ "$port" -ge 20000 ]
+    [ "$port" -le 24999 ]
+    python3 -c "import socket; socket.socket().bind(('127.0.0.1', $port))"
+}
+
+@test "free_port assigns every named variable a distinct port" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    local a="" b="" c=""
+    free_port a b c
+    [[ "$a" =~ ^[0-9]+$ ]] && [[ "$b" =~ ^[0-9]+$ ]] && [[ "$c" =~ ^[0-9]+$ ]]
+    [ "$a" != "$b" ] && [ "$b" != "$c" ] && [ "$a" != "$c" ]
+}
+
+@test "free_port assigns a caller's variable even when it is named like one of the helper's locals" {
+    # bash scopes dynamically: a `local` in the caller is what the helper's own `local` of the same name
+    # would shadow, so plain local names in the helper hand such a caller an empty string, and an empty
+    # port reaches bin/romp-manager as its default control port.
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    local name="" i="" ports="" picks=""
+    free_port name i ports picks
+    [[ "$name" =~ ^[0-9]+$ ]] && [[ "$i" =~ ^[0-9]+$ ]]
+    [[ "$ports" =~ ^[0-9]+$ ]] && [[ "$picks" =~ ^[0-9]+$ ]]
+}
+
+@test "free_port fails loudly without python3" {
+    # An empty pick would reach bin/romp-manager as its default control port, so the helper must fail
+    # the test at the pick, not hand back nothing.
+    mkdir "$TEST_DIR/empty"
+    PATH="$TEST_DIR/empty" run free_port port
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"free-port:"* ]]
+    [[ "$output" == *"python3"* ]]
+}
+
+@test "free_port with no variable names is a usage error" {
+    run free_port
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"free-port:"* ]]
+}

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -4,6 +4,8 @@
 # (romp-manager-ensure.sh) calls it so romp usage brings up the supervisor.
 # It must be idempotent (no second manager) and non-blocking (spawns detached).
 
+load free-port
+
 setup() {
     TEST_DIR="$(mktemp -d)"
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
@@ -12,7 +14,7 @@ setup() {
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"
     chmod +x "$FAKE"
-    CPORT=7561 MPORT=7562
+    free_port CPORT MPORT   # fresh per test, never a literal (tests/free-port.bash)
 }
 
 teardown() {
@@ -64,9 +66,12 @@ teardown() {
     printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\nexit 0\n' "$CALLS" > "$BIN/tmux"
     chmod +x "$BIN/tmux"
 
-    # Run `up` directly on a UNIQUE port (so it doesn't no-op against the other test's manager); the
-    # manager calls startTmuxServer() at startup, before it ever binds the control port.
-    env PATH="$BIN:$PATH" ROMP_MANAGER_PORT=7571 ROMP_SERVE_PORT=7572 ROMP_SERVE_BIN="$FAKE" node "$MGR" up >/dev/null 2>&1 &
+    # Run `up` directly on this test's own ports (setup picks fresh ones per test, so it cannot no-op
+    # against another test's manager); the manager calls startTmuxServer() at startup, before it ever
+    # binds the control port. A literal here once duplicated romp-manager-origin.bats's control port,
+    # and a manager SIGTERM'd there outlives the kill by shutdownAll's exit grace, so a combined run
+    # found `up` exiting "already running" without ever calling tmux.
+    env PATH="$BIN:$PATH" ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" node "$MGR" up >/dev/null 2>&1 &
     MGR_PID=$!
     local i
     for i in $(seq 1 50); do [ -f "$CALLS" ] && break; sleep 0.1; done
@@ -89,12 +94,12 @@ teardown() {
     printf '#!/usr/bin/env bash\nenv > "%s"\nexec sleep 30\n' "$envdump" > "$FAKE"
     chmod +x "$FAKE"
     env TMUX="/tmp/tmux-000/default,99999,7" TMUX_PANE="%7" \
-        ROMP_MANAGER_PORT=7581 ROMP_SERVE_PORT=7582 ROMP_SERVE_BIN="$FAKE" \
+        ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" \
         node "$MGR" up >/dev/null 2>&1 &
     MGR_PID=$!
     local i
     for i in $(seq 1 50); do [ -s "$envdump" ] && break; sleep 0.1; done
-    curl -fsS -X POST "http://127.0.0.1:7581/stop" >/dev/null 2>&1 || true
+    curl -fsS -X POST "http://127.0.0.1:$CPORT/stop" >/dev/null 2>&1 || true
     [ -s "$envdump" ]
     # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
     run grep -q '^TMUX=' "$envdump"
@@ -132,20 +137,20 @@ PYEOF
     chmod +x "$FAKEK"
 
     env BUSY_FILE="$BUSY" SPAWN_LOG="$SPAWNS" ROMP_QUIET_POLL_MS=200 \
-        ROMP_MANAGER_PORT=7591 ROMP_SERVE_PORT=7592 ROMP_SERVE_BIN="$FAKEK" \
+        ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKEK" \
         node "$MGR" up >/dev/null 2>&1 &
     MGR_PID=$!
     local i
     for i in $(seq 1 50); do
-        curl -fsS "http://127.0.0.1:7591/status" >/dev/null 2>&1 && [ -s "$SPAWNS" ] && break
+        curl -fsS "http://127.0.0.1:$CPORT/status" >/dev/null 2>&1 && [ -s "$SPAWNS" ] && break
         sleep 0.1
     done
     [ "$(grep -c spawn "$SPAWNS")" -eq 1 ]
 
     # Two quiet-mode refreshes while turns are in flight: both defer, the second coalesces.
-    run curl -fsS -X POST "http://127.0.0.1:7591/restart-all?when=quiet"
+    run curl -fsS -X POST "http://127.0.0.1:$CPORT/restart-all?when=quiet"
     [[ "$output" == *'"deferred":true'* ]]
-    run curl -fsS -X POST "http://127.0.0.1:7591/restart-all?when=quiet"
+    run curl -fsS -X POST "http://127.0.0.1:$CPORT/restart-all?when=quiet"
     [[ "$output" == *'"coalesced":2'* ]]
 
     # Still busy after several poll cycles -> no bounce happened.
@@ -156,5 +161,5 @@ PYEOF
     echo 0 > "$BUSY"
     for i in $(seq 1 60); do [ "$(grep -c spawn "$SPAWNS")" -ge 2 ] && break; sleep 0.1; done
     [ "$(grep -c spawn "$SPAWNS")" -eq 2 ]
-    curl -fsS -X POST "http://127.0.0.1:7591/stop" >/dev/null 2>&1 || true
+    curl -fsS -X POST "http://127.0.0.1:$CPORT/stop" >/dev/null 2>&1 || true
 }

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -5,10 +5,31 @@
 # It must be idempotent (no second manager) and non-blocking (spawns detached).
 
 load free-port
+load tmux-private
 
 setup() {
     TEST_DIR="$(mktemp -d)"
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
+    # Every test here starts a REAL manager, and startManager() runs `tmux start-server` before it does
+    # anything else. Two layers keep that off the machine's tmux server (tests/tmux-private.bash has the
+    # 2026-09-06 incident this file caused): a recording fake tmux on PATH for the WHOLE file (the
+    # detached manager that `ensure` spawns inherits PATH too), and a socket directory private to the
+    # test, for any tmux call that reaches the real binary. The fake appends each call's argv to
+    # FAKE_TMUX_CALLS and writes the socket directory it was handed to FAKE_TMUX_ENV.
+    BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
+    export FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" FAKE_TMUX_ENV="$TEST_DIR/tmux-env"
+    cat > "$BIN/tmux" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_TMUX_CALLS"
+{
+    printf 'TMUX_TMPDIR=%s\n' "${TMUX_TMPDIR-}"
+    if [ -d "${TMUX_TMPDIR:-/nonexistent}" ]; then echo 'TMUX_TMPDIR_IS_DIR=1'; else echo 'TMUX_TMPDIR_IS_DIR=0'; fi
+} > "$FAKE_TMUX_ENV"
+exit 0
+FAKE
+    chmod +x "$BIN/tmux"
+    export PATH="$BIN:$PATH"
+    tmux_private_socket_dir "$TEST_DIR"
     # Fake kernel launcher: stay alive without binding a real port (we assert on the
     # manager's control endpoint, not a live kernel).
     FAKE="$TEST_DIR/fake-serve"
@@ -21,7 +42,9 @@ teardown() {
     # Graceful stop, then reap the detached manager (it is orphaned, not our child).
     curl -fsS -X POST "http://127.0.0.1:${CPORT:-0}/stop" >/dev/null 2>&1 || true
     [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null || true
-    rm -rf "$TEST_DIR"
+    # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
+    # its failure is teardown's status: bats swallows a failing command mid-teardown.
+    tmux_private_kill && rm -rf "$TEST_DIR"
 }
 
 @test "ensure: idempotent, non-blocking auto-start of the supervisor" {
@@ -58,29 +81,102 @@ teardown() {
 @test "manager bootstraps a tmux server (launchd-rooted) with exit-empty off" {
     command -v node >/dev/null 2>&1 || skip "node not available"
 
-    # Fake tmux on PATH that records its args — so we assert WHAT the manager asks of tmux at startup,
-    # without touching the real tmux server. (The fix: a launchd-rooted server so new sessions don't
+    # setup()'s fake tmux records its args, so we assert WHAT the manager asks of tmux at startup
+    # without touching a real tmux server. (The fix: a launchd-rooted server so new sessions don't
     # inherit a terminal's TCC identity → the "VS Code wants to access" prompt.)
-    BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
-    CALLS="$TEST_DIR/tmux-calls"
-    printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\nexit 0\n' "$CALLS" > "$BIN/tmux"
-    chmod +x "$BIN/tmux"
-
+    #
     # Run `up` directly on this test's own ports (setup picks fresh ones per test, so it cannot no-op
     # against another test's manager); the manager calls startTmuxServer() at startup, before it ever
     # binds the control port. A literal here once duplicated romp-manager-origin.bats's control port,
     # and a manager SIGTERM'd there outlives the kill by shutdownAll's exit grace, so a combined run
     # found `up` exiting "already running" without ever calling tmux.
-    env PATH="$BIN:$PATH" ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" node "$MGR" up >/dev/null 2>&1 &
+    env ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" node "$MGR" up >/dev/null 2>&1 &
     MGR_PID=$!
     local i
-    for i in $(seq 1 50); do [ -f "$CALLS" ] && break; sleep 0.1; done
+    for i in $(seq 1 50); do [ -f "$FAKE_TMUX_CALLS" ] && break; sleep 0.1; done
     kill "$MGR_PID" 2>/dev/null || true
 
     # startManager() → startTmuxServer() ran our fake tmux with start-server + exit-empty off.
-    [ -f "$CALLS" ]
-    grep -q "start-server" "$CALLS"
-    grep -q "exit-empty off" "$CALLS"
+    [ -f "$FAKE_TMUX_CALLS" ]
+    grep -q "start-server" "$FAKE_TMUX_CALLS"
+    grep -q "exit-empty off" "$FAKE_TMUX_CALLS"
+}
+
+@test "the manager's tmux call is handed a socket directory private to the test, and it already exists" {
+    command -v node >/dev/null 2>&1 || skip "node not available"
+    command -v curl >/dev/null 2>&1 || skip "curl not available"
+
+    # The 2026-09-06 incident, on the path that caused it: `ensure` spawns a DETACHED manager, whose
+    # `tmux start-server` ran on the machine's default socket. The manager inherits the test's
+    # environment, so the fake tmux records the socket directory it was handed. It must be the test's
+    # own, and it must EXIST at that moment: tmux 3.4 silently uses the default socket directory when
+    # TMUX_TMPDIR names a missing one, so an export without the mkdir isolates nothing. The manager
+    # sits on setup's per-test CPORT, so teardown's /stop reaps it like every other.
+    run env ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" node "$MGR" ensure
+    [ "$status" -eq 0 ]
+    # Wait for the control port, not the env file: startManager() runs tmux (which writes the file) a few
+    # milliseconds BEFORE it binds the port, and teardown's /stop needs the port. A test that returned on
+    # the file could hand teardown a manager that is not yet listening, and the /stop would miss it.
+    local i
+    for i in $(seq 1 50); do
+        curl -fsS "http://127.0.0.1:$CPORT/status" >/dev/null 2>&1 && break
+        sleep 0.1
+    done
+    run curl -fsS "http://127.0.0.1:$CPORT/status"
+    [ "$status" -eq 0 ]
+    MGR_PID="$(printf '%s' "$output" | grep -oE '"pid":[ ]*[0-9]+' | head -1 | grep -oE '[0-9]+')"
+    [ -s "$FAKE_TMUX_ENV" ]
+    grep -qxF "TMUX_TMPDIR=$TEST_DIR/tmux" "$FAKE_TMUX_ENV"
+    grep -qxF "TMUX_TMPDIR_IS_DIR=1" "$FAKE_TMUX_ENV"
+}
+
+@test "with the real tmux, the server the manager starts lives inside the test directory" {
+    command -v node >/dev/null 2>&1 || skip "node not available"
+    command -v curl >/dev/null 2>&1 || skip "curl not available"
+    # The fake tmux leaves PATH for this test alone: the machine's tmux takes the manager's call, and the
+    # private socket directory is the ONLY thing between that call and the machine's default server.
+    local path="${PATH#"$BIN:"}"
+    PATH="$path" command -v tmux >/dev/null 2>&1 || skip "tmux not available"
+
+    # Refuse to run a real tmux unless the isolation is in place: a regression in setup() must fail
+    # here, not reproduce the incident on the machine's server.
+    [[ "$TMUX_TMPDIR" == "$TEST_DIR/"* ]]
+    [ -d "$TMUX_TMPDIR" ]
+
+    # The server sources a tmux.conf at start-server, and the manager's call cannot be given -f from here
+    # (nor would -f on the helper's own kill/show calls help: a client passes -f only to a server it
+    # starts, and neither command starts one). So the developer's config is kept out by pointing HOME
+    # and XDG_CONFIG_HOME at the test dir, where no tmux.conf exists. The socket path does not depend on
+    # HOME (TMUX_TMPDIR alone decides it), so the pin below is unchanged; the manager's own use of HOME
+    # is its state dir, which this also keeps out of the developer's. /etc/tmux.conf, if a box has one,
+    # is still read; nothing short of -f avoids that.
+    local home="$TEST_DIR/home"; mkdir -p "$home"
+    env PATH="$path" HOME="$home" XDG_CONFIG_HOME="$home/.config" \
+        ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" \
+        node "$MGR" up >/dev/null 2>&1 &
+    MGR_PID=$!
+    # startManager() runs tmux before it binds the control port, so a live port means the call is done.
+    local i
+    for i in $(seq 1 50); do curl -fsS "http://127.0.0.1:$CPORT/status" >/dev/null 2>&1 && break; sleep 0.1; done
+    kill "$MGR_PID" 2>/dev/null || true
+
+    # tmux places the socket at $TMUX_TMPDIR/tmux-<uid>/default: under the test directory, nowhere else.
+    local sock="$TMUX_TMPDIR/tmux-$(id -u)/default"
+    [ -S "$sock" ]
+    [ "$(ls -A "$TMUX_TMPDIR")" = "tmux-$(id -u)" ]
+    [ ! -e "$TEST_DIR/default" ]
+    # A live server answers on it, set up the way the manager asked (exit-empty off is what keeps an
+    # empty server alive). -S names the socket, so this reaches no other server, and the tmux is the
+    # machine's, found past the fake (which answers anything with exit 0 and no output).
+    local tmux; tmux="$(tmux_private_real_tmux)"
+    run "$tmux" -S "$sock" show -g exit-empty
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit-empty off"* ]]
+    # The teardown kill reaches that server too (the first run of this isolation leaked one: PATH
+    # handed kill-server to the fake). After it, nothing answers on the socket.
+    tmux_private_kill
+    run "$tmux" -S "$sock" show -g exit-empty
+    [ "$status" -ne 0 ]
 }
 
 @test "a leaked \$TMUX never reaches the manager or its kernels" {

--- a/tests/romp-manager-origin.bats
+++ b/tests/romp-manager-origin.bats
@@ -6,6 +6,8 @@
 # kill the user's kernels. Server-side clients (the kernel's Restart proxy, the
 # `romp on` CLI) send no Origin and must keep working.
 
+load free-port
+
 setup() {
     TEST_DIR="$(mktemp -d)"
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
@@ -13,7 +15,7 @@ setup() {
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"
     chmod +x "$FAKE"
-    CPORT=7571; MPORT=7572
+    free_port CPORT MPORT   # fresh per test, never a literal (tests/free-port.bash)
 }
 
 teardown() {

--- a/tests/romp-manager-origin.bats
+++ b/tests/romp-manager-origin.bats
@@ -7,10 +7,20 @@
 # `romp on` CLI) send no Origin and must keep working.
 
 load free-port
+load tmux-private
 
 setup() {
     TEST_DIR="$(mktemp -d)"
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
+    # The manager under test is REAL, and startManager() runs `tmux start-server` before it binds the
+    # control port: a call this file has no interest in, which must still never reach the machine's
+    # tmux server (tests/tmux-private.bash has the 2026-09-06 incident). A no-op tmux on PATH absorbs
+    # it; the private socket directory catches any call that reaches the real binary anyway.
+    BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/tmux"
+    chmod +x "$BIN/tmux"
+    export PATH="$BIN:$PATH"
+    tmux_private_socket_dir "$TEST_DIR"
     # Fake kernel launcher: stays alive without binding a real port.
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"
@@ -20,7 +30,9 @@ setup() {
 
 teardown() {
     [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null || true
-    rm -rf "$TEST_DIR"
+    # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
+    # its failure is teardown's status: bats swallows a failing command mid-teardown.
+    tmux_private_kill && rm -rf "$TEST_DIR"
 }
 
 @test "manager rejects cross-site Origin, allows no-Origin clients" {

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -111,7 +111,13 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     # roulette on a loaded runner) killed the bind, the bus died, and the whole test failed in
     # setup with a shifting identity. postal_spawn_bus must step past the squatter — and say so.
     kill "$BUS_PID" 2>/dev/null; wait "$BUS_PID" 2>/dev/null || true   # this test drives its own spawn
-    local squat=$((ROMP_POSTAL_PORT + 7000))
+    # +2000 puts the squat at 29200+N (N this test's number): it and both retry candidates (+500, +1000)
+    # stay below the 32768 ephemeral floor the header warns about, and clear of the per-test band
+    # (27200-28300) and the kernel's default 29855. The old +7000 sat at 34200+N, inside the range, and
+    # on 2026-09-03 a CI run's squatter ITSELF failed to bind (Address already in use) when a transient
+    # source port held it: the flake this file exists to prevent.
+    local squat=$((ROMP_POSTAL_PORT + 2000))
+    [ $((squat + 1000)) -lt 32768 ]   # squat and every retry candidate stay below the ephemeral floor
     python3 -c "import socket,sys,time
 s=socket.socket(); s.bind(('127.0.0.1',$squat)); s.listen(1)
 print('bound', flush=True); time.sleep(30)" > "$TEST_DIR/squat.log" &

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -4,6 +4,7 @@
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
 load free-port
+load tmux-private
 
 setup() {
     TEST_DIR="$(mktemp -d)"
@@ -80,6 +81,11 @@ MOCK
     _stub_claude "2.1.226"
 
     export PATH="$MOCK_DIR:$PATH"
+    # The romp-manager tests below start a REAL bin/romp-manager, whose startup runs `tmux start-server`,
+    # and `romp new -t` runs `tmux new-session`: the mock above takes both, and the private socket
+    # directory keeps any call that reaches the real binary off the machine's tmux server
+    # (tests/tmux-private.bash has the 2026-09-06 incident).
+    tmux_private_socket_dir "$TEST_DIR"
     unset TMUX            # default: outside tmux → attach-session branch
     # Hermetic HOME: bin/romp probes $HOME/.claude/romp-postal.mcp.json (would
     # nondeterministically append --mcp-config on a dev machine) and writes the
@@ -94,7 +100,9 @@ teardown() {
     # Tests that launch a background romp-manager record its pid in MGR_PID so we
     # always reap it (and its child kernels), even if an assertion aborted the test.
     [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null
-    rm -rf "$TEST_DIR"
+    # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
+    # its failure is teardown's status: bats swallows a failing command mid-teardown.
+    tmux_private_kill && rm -rf "$TEST_DIR"
 }
 
 # Helper — runs romp with merged stdout+stderr so BATS captures errors

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -3,6 +3,8 @@
 # Resolve path to the romp script under test
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
+load free-port
+
 setup() {
     TEST_DIR="$(mktemp -d)"
     WORK_DIR="$TEST_DIR/myproject"
@@ -1016,7 +1018,8 @@ MOCK
     command -v node >/dev/null 2>&1 || skip "node not available"
     local mgr; mgr="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
     # port nothing is listening on → the control client must fail fast with a clear message
-    run env ROMP_MANAGER_PORT=7531 node "$mgr" status
+    local port; free_port port
+    run env ROMP_MANAGER_PORT=$port node "$mgr" status
     [ "$status" -eq 1 ]
     [[ "$output" == *"not running"* ]]
 }
@@ -1032,7 +1035,7 @@ MOCK
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$fake"
     chmod +x "$fake"
 
-    local cport=7541 mport=7542 kport=7543
+    local cport mport kport; free_port cport mport kport
     # Launch the manager in the background; it auto-spawns 'main' on mport via the fake launcher.
     ROMP_MANAGER_PORT=$cport ROMP_SERVE_PORT=$mport ROMP_SERVE_BIN="$fake" \
         node "$mgr" up >/dev/null 2>&1 &
@@ -1075,7 +1078,7 @@ MOCK
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$fake"
     chmod +x "$fake"
 
-    local cport=7551 mport=7552 kport=7553
+    local cport mport kport; free_port cport mport kport
     ROMP_MANAGER_PORT=$cport ROMP_SERVE_PORT=$mport ROMP_SERVE_BIN="$fake" \
         node "$mgr" up >/dev/null 2>&1 &
     MGR_PID=$!

--- a/tests/tmux-private.bash
+++ b/tests/tmux-private.bash
@@ -1,0 +1,81 @@
+# tests/tmux-private.bash: a tmux socket directory private to one bats test.
+#
+# Use from a bats file: `load tmux-private` at the top, `tmux_private_socket_dir "$TEST_DIR"` in
+# setup(), and `tmux_private_kill && rm -rf "$TEST_DIR"` as the LAST line of teardown(). The kill must
+# run before the rm (see tmux_private_kill), and its failure must be teardown's own status: bats runs
+# teardown with errexit and the ERR trap off, so a failing command in the middle of it is swallowed
+# and the test passes; only teardown's return status can fail it.
+#
+# Why (2026-09-06): a bats sweep ran tests/romp-manager-ensure.bats ninety seconds after a stray
+# `tmux kill-server` elsewhere had removed the machine's default tmux server. That file starts a REAL
+# detached bin/romp-manager, whose startManager() runs `tmux start-server` on the DEFAULT socket, at
+# the one moment no server existed there. The machine's tmux server was then the test's: it carried
+# the sweep's environment (BATS_*, the sweep session's ROMP_SID, a fake-serve path under a temp dir
+# already deleted) and sat in the service's cgroup. A tmux mock on PATH covers only the tests that
+# install one; TMUX_TMPDIR covers every tmux the subject reaches, mock or real.
+#
+# The directory MUST exist before tmux runs. tmux 3.4 falls back to the default socket directory
+# silently when TMUX_TMPDIR names a missing one (verified: with TMUX_TMPDIR set to a missing path,
+# `#{socket_path}` reads /tmp/tmux-<uid>/default), so an export without the mkdir isolates nothing.
+# tmux puts its socket at $TMUX_TMPDIR/tmux-<uid>/default, creating the tmux-<uid> level itself.
+
+tmux_private_socket_dir() {   # $1 = the test's temp dir, removed in teardown
+    TMUX_PRIVATE_TEST_DIR="$1"
+    TMUX_PRIVATE_DIR="$1/tmux"
+    mkdir -p "$TMUX_PRIVATE_DIR"
+    export TMUX_TMPDIR="$TMUX_PRIVATE_DIR"
+}
+
+# The machine's tmux: the first `tmux` on PATH that is NOT under the test directory, where every suite
+# here keeps its mocks. A mock on PATH answers `kill-server` with exit 0 and kills nothing (the first
+# run of the isolation leaked a server that way), so the kill below never goes through PATH.
+# Prints the path. Exit 1 when there is none (a box without tmux started no server either); exit 2,
+# with a message, when tmux_private_socket_dir was never called: with TMUX_PRIVATE_TEST_DIR unset the
+# exclusion pattern would read `/*` and skip EVERY absolute PATH entry, so the search would report "no
+# tmux" on a box that has one, and a caller would take that for a box with nothing to kill.
+tmux_private_real_tmux() {
+    local dir dirs
+    if [ -z "${TMUX_PRIVATE_TEST_DIR:-}" ]; then
+        echo "tmux-private: TMUX_PRIVATE_TEST_DIR is unset (tmux_private_socket_dir not called); refusing to pick a tmux" >&2
+        return 2
+    fi
+    IFS=: read -ra dirs <<< "$PATH"
+    for dir in "${dirs[@]}"; do
+        [ -n "$dir" ] || continue
+        case "$dir" in "$TMUX_PRIVATE_TEST_DIR"|"$TMUX_PRIVATE_TEST_DIR"/*) continue ;; esac
+        [ -x "$dir/tmux" ] && { printf '%s\n' "$dir/tmux"; return 0; }
+    done
+    return 1
+}
+
+# Kill every tmux server whose socket sits under the private directory: a `start-server` outlives its
+# client, and the manager that ran it, so without this a server (kept alive by the manager's
+# `exit-empty off`) would leak past the test. -S names the socket outright (no TMUX_TMPDIR lookup, so
+# this can never resolve to the machine's server), and it runs before the directory is removed:
+# afterwards a bare `tmux kill-server` WOULD fall back to the machine's (the silent fallback above).
+# kill-server never starts a server, so a stale socket is inert.
+#
+# Exit 0 when tmux_private_socket_dir was never called (nothing was armed, so nothing can have leaked;
+# a teardown that runs after a setup failed early must not add a second error). Exit 1, with a message,
+# when it WAS called and the directory is already gone: the sockets went with it, so any server started
+# under it is now unreachable by -S and has leaked. That is the teardown ordering bug this guards
+# (an `rm -rf "$TEST_DIR"` before the kill), and a silent exit 0 there would hide it.
+tmux_private_kill() {
+    local sock tmux rc
+    [ -n "${TMUX_PRIVATE_DIR:-}" ] || return 0
+    if [ ! -d "$TMUX_PRIVATE_DIR" ]; then
+        echo "tmux-private: $TMUX_PRIVATE_DIR is gone before tmux_private_kill ran; a server started under it has leaked (call tmux_private_kill before the rm -rf)" >&2
+        return 1
+    fi
+    tmux="$(tmux_private_real_tmux)" && rc=0 || rc=$?
+    case "$rc" in
+        0) ;;
+        1) return 0 ;;    # no tmux on the box: no server was started
+        *) return 1 ;;    # refused (message already printed)
+    esac
+    for sock in "$TMUX_PRIVATE_DIR"/tmux-*/*; do
+        [ -S "$sock" ] || continue
+        "$tmux" -S "$sock" kill-server 2>/dev/null || true
+    done
+    return 0
+}

--- a/tests/tmux-private.bats
+++ b/tests/tmux-private.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+# tests/tmux-private.bash gives a bats file a tmux socket directory private to the test. These cases
+# pin the helper's own contract, above all where it must FAIL rather than fall through: every silent
+# return here is a server that could outlive a test on the machine's tmux. Nothing below runs tmux.
+
+load tmux-private
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "tmux_private_socket_dir creates the directory and exports TMUX_TMPDIR under the test dir" {
+    tmux_private_socket_dir "$TEST_DIR"
+    [ "$TMUX_TMPDIR" = "$TEST_DIR/tmux" ]
+    [ -d "$TMUX_TMPDIR" ]
+    [ "$TMUX_PRIVATE_DIR" = "$TEST_DIR/tmux" ]
+    [ "$TMUX_PRIVATE_TEST_DIR" = "$TEST_DIR" ]
+}
+
+@test "tmux_private_kill fails loudly when the private directory is already gone" {
+    # The teardown ordering bug: an `rm -rf "$TEST_DIR"` before the kill takes the sockets with it, so a
+    # server started under the directory can no longer be reached by -S. Exit 0 there would hide a leak.
+    tmux_private_socket_dir "$TEST_DIR"
+    rm -rf "$TMUX_PRIVATE_DIR"
+    run tmux_private_kill
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tmux-private:"* ]]
+    [[ "$output" == *"$TMUX_PRIVATE_DIR"* ]]
+    [[ "$output" == *"leaked"* ]]
+}
+
+@test "tmux_private_kill is a silent no-op when nothing was armed" {
+    # A teardown after a setup that failed before tmux_private_socket_dir ran: nothing could have leaked,
+    # and a second error would only bury the first.
+    unset TMUX_PRIVATE_DIR TMUX_PRIVATE_TEST_DIR
+    run tmux_private_kill
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "tmux_private_real_tmux refuses when the test dir variable is unset" {
+    # With TMUX_PRIVATE_TEST_DIR unset the exclusion pattern reads `/*`, which skips every absolute PATH
+    # entry: the search would report "no tmux" on a box that has one, and tmux_private_kill would take
+    # that for a box with nothing to kill.
+    unset TMUX_PRIVATE_TEST_DIR
+    run tmux_private_real_tmux
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"tmux-private:"* ]]
+    [[ "$output" == *"TMUX_PRIVATE_TEST_DIR"* ]]
+}
+
+@test "tmux_private_real_tmux skips a tmux under the test dir and finds one outside it" {
+    # The kill must reach the machine's tmux, never a suite's PATH mock (a mock answered kill-server with
+    # exit 0 and the first run of the isolation leaked a server). Both binaries here are stand-ins: the
+    # one outside the test dir lives in its own temp dir, so the case holds on a box without tmux.
+    tmux_private_socket_dir "$TEST_DIR"
+    local mock="$TEST_DIR/bin" real; mkdir -p "$mock"
+    real="$(mktemp -d)"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$mock/tmux"; chmod +x "$mock/tmux"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$real/tmux"; chmod +x "$real/tmux"
+    PATH="$mock:$real:$PATH" run tmux_private_real_tmux
+    rm -rf "$real"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$real/tmux" ]
+}
+
+@test "under bats, the teardown line fails the test when the rm ran before the kill" {
+    # bats calls teardown with errexit and the ERR trap off, so a failing tmux_private_kill in the MIDDLE
+    # of teardown is swallowed and the test passes; only teardown's return status counts. The line the
+    # header prescribes, `tmux_private_kill && rm -rf "$TEST_DIR"`, makes the kill's failure that status.
+    # Two one-test files under a nested bats: that line after a premature rm fails the test, and the
+    # same line with no rm before it passes. No server is started, so nothing runs tmux. (The nested
+    # files are assembled with printf: a line of THIS file starting with the test keyword would be read
+    # as one of its own tests by the bats preprocessor, heredoc or not.)
+    command -v bats >/dev/null 2>&1 || skip "bats not on PATH"
+    local helper; helper="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/tmux-private.bash"
+    local f
+    for f in rm-first kill-first; do
+        {
+            printf 'load "%s"\n' "$helper"
+            printf 'setup() { TEST_DIR="$(mktemp -d)"; tmux_private_socket_dir "$TEST_DIR"; }\n'
+            if [ "$f" = rm-first ]; then
+                printf 'teardown() { rm -rf "$TEST_DIR"; tmux_private_kill && rm -rf "$TEST_DIR"; }\n'
+            else
+                printf 'teardown() { tmux_private_kill && rm -rf "$TEST_DIR"; }\n'
+            fi
+            printf '@%s "the body passes" { true; }\n' test
+        } > "$TEST_DIR/$f.bats"
+    done
+    run bats --print-output-on-failure "$TEST_DIR/rm-first.bats"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not ok 1"* ]]
+    [[ "$output" == *"leaked"* ]]
+    run bats "$TEST_DIR/kill-first.bats"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok 1"* ]]
+}

--- a/tests/tmux-status-hook.bats
+++ b/tests/tmux-status-hook.bats
@@ -3,6 +3,8 @@
 # Resolve path to the hook script under test
 HOOK_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks" && pwd)/tmux-status.sh"
 
+load tmux-private
+
 setup() {
     TEST_DIR="$(mktemp -d)"
     MOCK_DIR="$TEST_DIR/mock"
@@ -46,6 +48,10 @@ MOCK
     chmod +x "$MOCK_DIR/romp-idle-dots"
 
     export PATH="$MOCK_DIR:$PATH"
+    # The hook shells out to `tmux` by name on every event; the mock takes those calls, and the private
+    # socket directory keeps any that reach the real binary off the machine's tmux server
+    # (tests/tmux-private.bash has the 2026-09-06 incident).
+    tmux_private_socket_dir "$TEST_DIR"
     export TMUX="fake"
     export MOCK_SESSION_NAME="test"
     export MOCK_IS_ROMP=1
@@ -58,7 +64,9 @@ MOCK
 }
 
 teardown() {
-    rm -rf "$TEST_DIR"
+    # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
+    # its failure is teardown's status: bats swallows a failing command mid-teardown.
+    tmux_private_kill && rm -rf "$TEST_DIR"
 }
 
 # Helper — runs the hook with JSON on stdin


### PR DESCRIPTION
## What breaks

Three test-only problems in the bats suites; no product code is touched.

**1. Real managers run `tmux start-server` on the developer's default socket.** `tests/romp-manager-ensure.bats` and `tests/romp-manager-origin.bats` start a real `bin/romp-manager`, whose `startManager()` runs `tmux start-server ; set -g exit-empty off` before it binds the control port. Only the tmux-bootstrap test put a fake tmux on PATH, so on any machine with tmux the other tests' managers ran that against the default socket. Usually a no-op, because a server is already up. With none up, the test's manager created the machine's tmux server, and for the rest of the day that server carried the test's environment (`BATS_*` variables, a fake-serve path under a temp dir already deleted). CI does not see it: both runners are ephemeral, so a server a test leaves behind dies with the job.

**2. Fixed loopback ports collide.** ensure.bats's tmux-bootstrap test used 7571/7572, the same literals as origin.bats's control and serve ports. A manager SIGTERM'd in origin.bats outlives the kill by `shutdownAll`'s exit grace, so `bats tests/romp-manager-origin.bats tests/romp-manager-ensure.bats` finds `up` exiting "already running" without ever calling tmux (2 of 3 runs here). Any literal also collides when two checkouts run bats at once on one machine (reproduced: both runs red at the base).

**3. The postal squat port sits inside the ephemeral range.** The red Shell check on #897's first CI attempt (2026-09-03) was not a manager-suite collision. `tests/romp-postal.bats` "the bus spawn survives a taken port" binds its squatter at `ROMP_POSTAL_PORT + 7000` = 34200+N, inside the 32768-60999 range the file's own header says to stay below, and the squatter itself failed to bind (`Address already in use`) when a transient source port held it.

## The fix

Three commits.

**`tests/free-port.bash`** (commit 1). `free_port VAR...` assigns each named variable a distinct loopback port nothing is bound to, probed by a plain bind (no `SO_REUSEADDR`, so a TIME_WAIT port reads busy and is skipped), chosen at random from 20000-24999: below Linux's (32768-60999) and macOS's (49152-65535) ephemeral ranges, so a transient outgoing connection cannot hold the pick as a source port between the pick and the subject's bind (the rule romp-postal.bats's header already records), and clear of the project's own defaults (7432, 29855, the postal tests' band). It fails loudly without python3 or a free port: an empty port would reach the manager as `Number('') || 7432`, the default control port, where a developer's live manager may be listening, and bats fails the test at the pick. Every fixed bind in romp-manager-ensure, romp-manager-origin and romp.bats now picks (including romp.bats's dead-port probe, which wants exactly an unbound port). ensure.bats's tests share setup's per-test picks, so teardown's `/stop` reaps every manager the same way and the per-test literals are gone.

**`tests/tmux-private.bash`** (commit 2). `tmux_private_socket_dir "$TEST_DIR"` exports `TMUX_TMPDIR` under the test dir and creates it first: tmux 3.4 silently uses the default socket directory when `TMUX_TMPDIR` names a missing one (`make_label()` expands the candidates with errors ignored; the same code is in 3.5a; verified on 3.4 via `#{socket_path}`), so an export without the mkdir isolates nothing. `tmux_private_kill && rm -rf "$TEST_DIR"` ends teardown: it kills every server whose socket sits under the private directory, addressing the socket with `-S` (so it can never resolve to the machine's server) through the first tmux on PATH outside the test dir (a PATH mock answered `kill-server` with exit 0 and leaked a server on the first try), fails when the directory is already gone (a server started under it has then leaked), and refuses when the helper was never armed. It has to be teardown's final status: bats runs teardown with errexit and the ERR trap off, so a failing command mid-teardown is swallowed and the test passes. Wired into the four suites whose subject shells out to tmux: romp-manager-ensure (its recording fake tmux now covers the whole file, since the detached manager that `ensure` spawns inherits PATH), romp-manager-origin (a no-op tmux), romp, and tmux-status-hook. `tests/README.md` records both rules.

**`tests/romp-postal.bats`** (commit 3). The squat moves to +2000 (29200+N), which keeps it and both retry candidates (+500, +1000) below 32768 and clear of the per-test band and the kernel's default port; an arithmetic pin holds the band.

## Tests

- `tests/tmux-private.bats` (6, none runs tmux): the directory is created and exported; the kill fails loudly when the directory is gone; it is a silent no-op when never armed; the real-tmux lookup refuses when unarmed and skips a tmux under the test dir; and under a nested bats, the prescribed teardown line fails a test whose `rm -rf` ran before the kill and passes one where it did not.
- `tests/free-port.bats` (5): a pick is in band and bindable; picks are distinct; a caller's variable is assigned even when it is named like one of the helper's locals; loud failure without python3; usage error with no names.
- Two pins in `tests/romp-manager-ensure.bats`: the `ensure`-spawned detached manager's tmux is handed a `TMUX_TMPDIR` under the test dir that already exists (fake tmux; runs on every CI OS); and with the real tmux, the server socket appears only under the private directory, answers `show -g exit-empty` with `off`, and is gone after the teardown kill. That one skips where tmux is absent; the ubuntu runner image ships one, so on the Linux bats job it ran as `ok 144` rather than skipping; `HOME` and `XDG_CONFIG_HOME` point at the test dir so the developer's tmux.conf is not sourced (`/etc/tmux.conf` is still read; nothing short of `-f` avoids that, and the manager's call cannot carry one).
- Red-first: with the helper's `mkdir` removed, both ensure pins and the helper's create test fail (the real-tmux pin at its `[ -d "$TMUX_TMPDIR" ]` guard, before any tmux runs), and so does every test in the four wired suites, at teardown's `tmux_private_kill` guard, which reads the never-created directory as gone; with `rm -rf` moved before the kill, all six ensure tests fail with the leak message. The 7571 collision reproduced at the base (2 of 3 reverse-order runs; both of two concurrent runs) and not after (0 of 3; 0 of 2). The squat pin fails with +7000 and passes with +2000.
- Full `bats tests/*.bats`: 402/402, real-tmux pin `ok`; no tmux server or manager left behind after any run. Full pytest and `node --test tests/manager-*.test.js`: unchanged surface (no `.py` or `.js` touched).

## Not in this PR

Installing tmux on the Linux bats job (the workflow deliberately installs only bats, and the ubuntu runner image already ships one, so the real-tmux pin runs there anyway; the fake-tmux pin carries the coverage on a runner without tmux). Two pre-existing flakes seen while running romp.bats, both present at the base and untouched here: its curl mock exits without draining the `--config -` stdin that `bin/romp` pipes in, so under load a kernel-API test fails with "kernel not reachable" (passes alone); and six temp dirs per run survive teardown with `home/.local/state/romp/serve-token` written after the `rm -rf`.

One risk to note: macOS caps Unix socket paths at 104 bytes, and `mktemp -d` there plus `/tmux/tmux-<uid>/default` lands near 94. If the manual macOS bats job ever fails in the real-tmux pin on socket creation, shorten the private dir.

Tier: tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)