### PR TITLE
A dropped dashboard socket is loud, the stale prompt keys on the heartbeat, and the Outline pane's ages run on the kernel's clock

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -339,6 +339,9 @@ own a direct path; the dashboard is then a plain URL on your tailnet.
     when a panel closes, so it never leaks connections, but under Remote or
     Tunnels the extension still relays each whole view payload to the local
     window as it changes. It does not yet take the deltas the browser panes do.
+    A pane that falls 16 MB behind is dropped and reconnects on its own; the
+    drop is logged in the kernel log and shows in the dashboard's bell, so a
+    link that cannot keep up reads as what it is rather than as a flaky network.
 
 ### From your phone
 

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -54,6 +54,31 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   **same served UI** over the **same protocol**, so the two front ends stay
   consistent by construction. Keeping the WS protocol stable is the compatibility
   contract.
+- **Liveness is a keepalive, and staleness is event-keyed.** The kernel sends a
+  `ka` frame to every socket every 10 s; the pane shim force-closes a socket that
+  has gone 30 s without any frame. After a reconnect the shim raises the "what you
+  see may be stale" prompt only on the SECOND `ka` arriving before the resync
+  frame — one full heartbeat period, bracketed by two kernel heartbeats on that
+  socket with no resync between them (a single `ka` can be a beat that was already
+  queued when the socket was accepted) — or on the reconnected socket closing
+  again before its resync; the first non-keepalive frame retires the prompt, never
+  a timer. A client that falls 16 MB behind is dropped by the kernel, loudly: one
+  `ws: dropping` line in the kernel log, written where the drop is decided so every
+  send path is covered, naming the pane, the dashboard, the backlog and the push
+  slot whose frame tipped the budget when a push did; and a row in the dashboard's
+  bell (at most five drop rows, none older than an hour, so they never crowd out a
+  backend problem). Every close of a socket that opened leaves a `wsclose`
+  breadcrumb (code, reason, socket age) in `client-diag.jsonl`; the redials an
+  outage refuses are counted and reported as one `wsconnfail` row on the next
+  open, and at most 20 breadcrumbs wait in the shim's queue for it.
+- **The Outline pane's ages run on the kernel's clock.** Its timestamps are the
+  kernel's, so the pane never reads the browser's clock against them: it anchors
+  on the frame's `now` paired with the moment that frame arrived from the wire
+  (`feed-age.ts`; federation stamps the merged frame it re-emits with `nowAt`, so a
+  re-emit on a view-order write or a remote host's frame never moves an age), and
+  every "(Xm ago)", the current goal's elapsed time and the recency cutoff move on
+  a 15 s refresh — skipped while the pane is hidden, with one catch-up render when
+  it is shown again — rather than only when a frame lands.
 - **Both judge tiers run continuously for any live session — no connection gate.**
   The kernel runs the index tier (captioner + archiver) AND the triage tier
   (planner → closer → courier → grouper → consolidator → distiller) in parallel,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30214,6 +30214,8 @@ def _shim(app, v=0):
     # pane sat silent through rebuilds).
     return """
 (function(){var queue=[],ws=null,everConnected=false;
+var queuedDiag=0,DIAG_QUEUE_MAX=20;   // clientDiag rows waiting in `queue` for a reconnect, capped (an outage must not pile up breadcrumbs); other queued messages are untouched
+var failedConnects=0,firstFailT=0;   // handshakes that never OPENED since the last open: reported as ONE wsconnfail row on the next open, never one wsclose per redial
 // This pane's DASHBOARD id. ?wid= when the host supplies one (the VS Code extension builds its own pane
 // URLs); otherwise the shell's per-tab id from sessionStorage, which is scoped to the browsing context and
 // shared with same-origin iframes — so every pane of one window agrees, a second window differs, and no
@@ -30250,7 +30252,7 @@ function selfStale(){selfBar("romp lost the live connection, so what you see may
 // the kernel's connect-time push has landed, which IS the resync the banner offers a reload for. Fires on
 // the first non-keepalive frame after a reconnect — the event, not a timer. A BUILD prompt is untouched:
 // new code is not delivered by a resync, so only a reload can answer that one.
-function clearStale(){if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}   // armed but never shown → nothing to see
+function clearStale(){stalePending="";   // armed but never shown → nothing to see
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
 else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}}
 // A pane the user cannot SEE never interrupts them about ITS OWN staleness (the user 2026-08-15: the
@@ -30273,14 +30275,24 @@ staleDiag("stale-raise",why);
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
 // ARM it rather than show it (the user 2026-08-01): the resync almost always lands within a beat of the
 // reconnect, so raising immediately made the prompt FLASH up and straight back down on nearly every
-// dashboard open — visual noise for a problem that fixed itself. A short arming window lets the common
-// case pass in silence, and clearStale below disarms it the moment the resync frame arrives.
-// Why a timer here, against the standing preference for events: the prompt asserts "your view MAY be
-// stale", and the only proof it is NOT is the resync landing — an event we key on. The only proof it IS
-// is that resync FAILING to arrive, which has no event to key on at all. So the window is exactly the
-// unavoidable minimum, and the event still wins whenever it exists.
-var staleTimer=0;
-function armStale(why){if(staleTimer)return;staleTimer=setTimeout(function(){staleTimer=0;raiseStale(why);},1000);}
+// dashboard open — visual noise for a problem that fixed itself. clearStale above disarms it the moment
+// the resync frame arrives. The arm used to be a 1s TIMER, on the argument that "the resync failed to
+// arrive" has no event of its own. It has two: the SECOND KEEPALIVE landing on the reconnected socket
+// while the resync is still pending — one full heartbeat period, bracketed by two kernel heartbeats on
+// this very socket with no resync between them: the kernel is alive and talking to it and has not
+// resynced it, exactly the state the prompt warns about — and the reconnected socket CLOSING again before
+// its resync — no frame is coming on it. Both fire in onmessage/onclose below. ONE keepalive is not the
+// event: the heartbeat thread can enqueue a beat the instant a socket is accepted, ahead of the connect
+// push, and raising on it flashed the banner exactly as the timer did. The timer was approximating all
+// this, and on a board of several hundred cards the connect push is a multi-megabyte frame that takes
+// longer than a second to land over a forwarded or tunnelled link, so it fired a beat BEFORE the resync
+// on nearly every reconnect. stalePending holds the PATH that armed ("reconnect"/"foreground") for the
+// breadcrumb; empty = not armed; staleKa counts the keepalives since the arm. pendingWhy carries the
+// foreground path's reason to the reconnect that arms for it; openSock/openT identify the socket that
+// last opened (the close rule applies to a socket that OPENED and armed, never to the one the foreground
+// path itself closes).
+var stalePending="",staleKa=0,pendingWhy="",openSock=null,openT=0;
+function armStale(why){stalePending=why;staleKa=0;}
 // BUILD drift (the user 2026-07-13): the keepalive carries the kernel's current dist token (dv); a page whose
 // baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
 // In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
@@ -30300,12 +30312,15 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];
+ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];queuedDiag=0;
+if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail",data:{app:APP,attempts:failedConnects,firstFailMs:Date.now()-firstFailT}});failedConnects=0;firstFailT=0;}   // the redials that never opened since the last open, as ONE row: how many, and how long ago the first failed
 if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
-if(!ann)armStale("reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; the resync-never-arrives case re-raises through the keepalive watchdog's forced second reconnect, which arms as always
-freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
+if(!ann)armStale(pendingWhy||"reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; a restart that never comes back stays loud through the disconnected state itself, and a SECOND reconnect arms as always
+pendingWhy="";freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
-if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
+if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();
+if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}   // the SECOND keepalive since the arm, no resync between: a full heartbeat period on THIS socket with the kernel alive, talking to it, and not resyncing it — the view IS stale. (One keepalive alone can be a beat queued at accept, ahead of the resync frame.)
+return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
 // T217: the kernel announces its own death (one final frame from the dying process). Latch it: the
 // imminent close is EXPECTED — onclose redials eagerly instead of on the blind cadence, and the
 // reconnect skips the stale-banner arm once (the resync is seconds away; a restart that never
@@ -30324,10 +30339,23 @@ else if(msg&&DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
-ws.onclose=function(){netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}
+// Every close of a socket that OPENED leaves a breadcrumb with the CLOSE CODE and reason: a kernel-side drop
+// (the client fell WS_QUEUE_BYTES behind — shutdown, no close frame → 1006), a clean kernel restart, a proxy
+// timeout and the watchdog's own close all looked identical from here, and a day of drops read as a flaky
+// network. send() queues while the socket is down, so the row rides the reconnect. A handshake that never
+// opened fires onclose too (every 1.5 s redial of an outage — an 8 h outage is ~19k of them, and their timings
+// would be the PREVIOUS socket's): those are counted and reported as one wsconnfail row on the next open,
+// never queued one by one.
+ws.onclose=function(ev){netState("down");
+if(openSock===this){try{send({type:"clientDiag",surface:"pane-shim",what:"wsclose",data:{app:APP,code:ev?ev.code:-1,reason:(ev&&ev.reason)||"",wasClean:!!(ev&&ev.wasClean),sinceOpenMs:openT?Date.now()-openT:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,everConnected:everConnected}});}catch(e){}}
+else{if(!failedConnects)firstFailT=Date.now();failedConnects++;}
+if(stalePending&&openSock===this){var cw=stalePending;stalePending="";raiseStale(cw+"-closed");}   // the reconnected socket died before its resync: nothing is coming on it, and the view IS stale
+try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}
 setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);};   // announced death → tight redial (the frame is the event; the blind 1.5s stays for unannounced drops)
 ws.onerror=function(){try{ws.close();}catch(e){}};}
-function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1)ws.send(s);else queue.push(s);}
+function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1){ws.send(s);return;}
+if(m&&m.type==="clientDiag"){if(queuedDiag>=DIAG_QUEUE_MAX)return;queuedDiag++;}   // breadcrumbs waiting for a reconnect are capped; everything else queues as before
+queue.push(s);}
 // The delta reassembler. DELTA_KINDS mirrors the kernel's _DELTA_SLOTS: which top-level collections of each
 // slot are keyed, and how — "dict" (an object keyed by its own keys), "byid" (a list keyed by item id),
 // "bykeys:a,b" (a list keyed by a composite of item fields), "dictlist:id" (an object of lists, each item keyed by its
@@ -30379,10 +30407,11 @@ if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}
 if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // visibility fast-path (the user 2026-07-05): a BACKGROUNDED tab has its timers throttled, so the 5s watchdog
 // above can lag and the browser may have quietly dropped the socket while it slept. The instant the tab is
-// foregrounded, if the socket isn't open or has gone quiet past the watchdog window, treat the view as stale —
-// prompt at once AND force a reconnect (which resyncs live), rather than leaving the user on a frozen frame.
+// foregrounded, if the socket isn't open or has gone quiet past the watchdog window, treat the view as stale:
+// force a reconnect (which resyncs live) and hand the reconnect its reason, so ITS arm reads "foreground" —
+// the prompt then follows the same two events as any reconnect, rather than leaving the user on a frozen frame.
 document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"||!everConnected)return;
-if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;
+if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;
 if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries
 if(!ws||ws.readyState===3)connect();}});})();
 """ % (app, int(v), app, app)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9928,6 +9928,12 @@ def _sdk_problem_rows(limit=20, cap=400):
             rows += [("be", r) for r in be.problems(limit)]
         except Exception:
             pass   # a fake/older backend without a usable ring: the boot problems still ride
+    # dropped dashboard sockets (_note_ws_drop) ride the same bell — a FEW, and RECENT: at most
+    # _WS_DROP_BELL_ROWS of them, none older than _WS_DROP_TTL_S, merged by time with the rest. Appended
+    # last and sliced positionally, twenty drops in a kernel's life would hide every later backend problem.
+    cutoff = time.time() - _WS_DROP_TTL_S
+    rows += [("ws", r) for r in _WS_DROPS if float(r.get("t") or 0) >= cutoff][-_WS_DROP_BELL_ROWS:]
+    rows.sort(key=lambda sr: float(sr[1].get("t") or 0))   # stable: same-t rows keep boot → backend → ws order
     out = []
     for src, r in rows[-limit:]:
         txt = _sdk_problem_text(r.get("text"), cap)
@@ -26866,8 +26872,11 @@ def _mk_ws_send(q, sock, client):
                 except OSError:
                     pass
                 # Raise: every caller already treats an exception from send as "mark this client dead".
-                raise OSError("ws client %s is %d bytes behind — dropping"
-                              % (client.get("app"), client["qbytes"]))
+                # Logged HERE, once per client (_note_ws_drop): the drop is loud whichever caller's frame
+                # tipped the budget — the ~60 direct client["send"] replies as much as the push paths.
+                why = "%d bytes behind" % client["qbytes"]
+                _note_ws_drop(client, why, len(s))
+                raise OSError("ws client %s is %s — dropping" % (client.get("app"), why))
             client["qbytes"] += len(s)
         q.put(s)                               # unbounded; the byte budget above is the real bound
     return send
@@ -27073,10 +27082,7 @@ def _send_to_app(app, msg):
     with _clients_lock:
         targets = [c for c in _clients if c["app"] == app]
     for c in targets:
-        try:
-            c["send"](s)
-        except Exception:
-            c["alive"] = False
+        _client_send(c, s)
 
 
 # WS heartbeat (the user 2026-06-29): the pusher DEDUPS — a quiet fleet sends no view frames for minutes — so a
@@ -27143,12 +27149,14 @@ def _keepalive_all(now=None):
             # not judged this beat — but still BEATEN: the ka must keep flowing to a client the kernel is
             # busy serving, or the shim's own silence watchdog closes a connection that is merely waiting
             # on a long build (review 2026-09-03, residual).
-        try:
-            c["send"](s)
-            if c.get("sock") is not None:
-                c["send"](_ws_ping_frame(str(int(now)).encode()))   # pingAt is stamped by the sender, on the wire
-        except Exception:
-            c["alive"] = False
+        # the beat goes through _client_send so a drop is logged where it is decided (_note_ws_drop, one
+        # line per client); the ping rides behind it on the same socket — pingAt is stamped by the sender,
+        # on the wire
+        if _client_send(c, s) and c.get("sock") is not None:
+            try:
+                c["send"](_ws_ping_frame(str(int(now)).encode()))
+            except Exception:
+                c["alive"] = False
 
 
 def _heartbeat():
@@ -27180,10 +27188,7 @@ def _send_to_view(app, msg, wid):
     with _clients_lock:
         targets = [c for c in _clients if c["app"] == app and (c.get("wid") or "") == wid]
     for c in targets:
-        try:
-            c["send"](s)
-        except Exception:
-            c["alive"] = False
+        _client_send(c, s)
 
 
 def _reveal_chat_for(client, focus_msg):
@@ -27401,6 +27406,65 @@ def _dedup_sig(msg, s):
         return json.dumps({k: v for k, v in msg.items() if k not in _DEDUP_VOLATILE},
                           sort_keys=True, default=str)
     return s
+
+
+# A dropped client is LOUD. _mk_ws_send raises when a client is WS_QUEUE_BYTES behind, and every caller
+# caught that with a bare `c["alive"] = False` — so a dashboard dropped every few minutes for a day (the
+# flashing "may be stale" prompt) left NO trace in the kernel log, the shim logged nothing on its side, and
+# it read as a flaky network. _drop_dead_ws_client already writes a line for the ping-timeout and
+# supersession drops; this is the same line for the budget drop, plus a row for the dashboard's bell (it
+# rides _sdk_problem_rows → the feed's `sdkNotices`, the existing kernel-problems channel), so the person at
+# the dashboard is told rather than left to wonder why the pane reloaded. Logged at the RAISE site
+# (_note_ws_drop from _mk_ws_send), so every caller is covered — the direct one-shot `client["send"]`
+# replies included, not only the push and keepalive paths that go through _client_send. Latched per client:
+# the sends after the first failure in the same cycle raise too, and would otherwise log the one drop
+# several times.
+_WS_DROPS = []           # {"seq", "t", "text"} rows, newest last, bounded — the bell's source
+_WS_DROP_SEQ = [0]
+_WS_DROP_BELL_ROWS = 5   # at most this many drop rows in the bell at once: they must not crowd a backend problem out
+_WS_DROP_TTL_S = 3600.0  # …and none older than this: a drop is news for an hour, then it is the log's business
+
+
+def _note_ws_drop(c, why, frame_len, key=None):
+    """Log one client's drop, once: the stderr line and — for the kernel's OWN drop (a client that fell
+    WS_QUEUE_BYTES behind; a socket that simply died is not news) — the bell row. `key` is the push slot
+    whose frame tipped the budget; the raise site (_mk_ws_send) has none of its own and reads the one
+    _client_send leaves on the client for the length of its call (`curSlot`), so the line names the frame
+    — a direct one-shot `client["send"]` finds it unset and the line reads `slot=-`, honestly."""
+    if c.get("dropLogged"):
+        return
+    c["dropLogged"] = True
+    if key is None:
+        key = c.get("curSlot")
+    try:
+        sys.stderr.write("ws: dropping %s client — %s (wid=%s slot=%s queued=%dB frame=%dB)\n"
+                         % (c.get("app"), why, c.get("wid") or "-", _perf_slot(key) if key else "-",
+                            int(c.get("qbytes") or 0), int(frame_len)))
+        if "bytes behind" in str(why):
+            _WS_DROP_SEQ[0] += 1
+            _WS_DROPS.append({"seq": _WS_DROP_SEQ[0], "t": time.time(),
+                              "text": "The %s pane's live connection was dropped: it had %.1f MB of "
+                                      "updates waiting and had stopped reading them. It reconnects on "
+                                      "its own." % (c.get("app") or "?", int(c.get("qbytes") or 0) / 1e6)})
+            del _WS_DROPS[:-20]
+    except Exception:
+        pass
+
+
+def _client_send(c, s, key=None):
+    """Enqueue one wire string on client `c`. A failure marks the client dead and logs the drop (once —
+    _mk_ws_send has usually logged it already, at the raise, naming the slot it finds in `curSlot`; see
+    _note_ws_drop). Returns whether the frame was accepted."""
+    c["curSlot"] = key
+    try:
+        c["send"](s)
+        return True
+    except Exception as e:
+        c["alive"] = False
+        _note_ws_drop(c, str(e), len(s), key)
+        return False
+    finally:
+        c.pop("curSlot", None)
 
 
 def _client_lock(c):
@@ -27682,10 +27746,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         _send_slot(c, ftype, payload, pre, sig)
         return
     _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0, delta=1)
-    try:
-        c["send"](s)
-    except Exception:
-        c["alive"] = False
+    if not _client_send(c, s, key):
         return
     st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
     for name, (ents, _order) in colls.items():
@@ -27721,10 +27782,7 @@ def _send_client(c, key, msg, pre=None, sig=None):
             return
         c["sent"][key] = (sig, now)
         _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
-        try:
-            c["send"](s)                              # enqueue only (never blocks): the lock is held for microseconds
-        except Exception:
-            c["alive"] = False
+        _client_send(c, s, key)                       # enqueue only (never blocks): the lock is held for microseconds
 
 
 def _send_chat(c, m, ms, change_from, led_changed):

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -29,8 +29,8 @@ class DisconnectBanner(unittest.TestCase):
         js = km._shim("chat")
         # reports up/down to the shell
         self.assertIn('postMessage({romp:"wsState",app:APP,state:s}', js)
-        self.assertIn('ws.onopen=function(){lastRecv=Date.now();netState("up");', js)   # lastRecv stamp → heartbeat watchdog
-        self.assertIn('ws.onclose=function(){netState("down");', js)   # reconnects on close (wsdown loader + retry follow)
+        self.assertIn('ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");', js)   # lastRecv stamp → heartbeat watchdog; openT/openSock → the close rule + wsclose breadcrumb
+        self.assertIn('ws.onclose=function(ev){netState("down");', js)   # reconnects on close (wsdown loader + retry follow)
         self.assertIn("setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);",
                       js, "T217: an ANNOUNCED death redials tight; the blind 1.5s stays for real drops")
         self.assertIn("ws.onerror=function(){try{ws.close();}catch(e){}};", js)
@@ -42,7 +42,7 @@ class DisconnectBanner(unittest.TestCase):
         # (the user 2026-08-01) — see test_the_connection_prompt_retires_when_the_resync_lands
         self.assertIn('if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;'
                       'restartAnnounced=0;', js)   # T217: the announced-restart latch spends inside the gate
-        self.assertIn('if(!ann)armStale("reconnect");', js)
+        self.assertIn('if(!ann)armStale(pendingWhy||"reconnect");', js)
         self.assertIn('try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
@@ -55,11 +55,11 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('window.parent.postMessage({romp:"wsStale"}', js, "embedded pane hands off to the shell banner")
         self.assertIn("function selfStale()", js, "standalone page (no shell) gets its own reload bar")
         self.assertIn("romp-stale-self", js)
-        # visibility fast-path: a foregrounded tab whose socket is dead/quiet ARMS the prompt at once (not
-        # after the throttled 5s watchdog), and forces a reconnect to resync — which disarms it again if the
-        # resync lands inside the arming window (the user 2026-08-01).
+        # visibility fast-path: a foregrounded tab whose socket is dead/quiet forces a reconnect to resync and
+        # hands that reconnect its reason; the reconnect's arm then follows the same two events as any other
+        # (a keepalive or a close before the resync), and the resync frame disarms it (the user 2026-08-01).
         self.assertIn('document.addEventListener("visibilitychange"', js)
-        self.assertIn('Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;', js)
+        self.assertIn('Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;', js)
 
     def test_a_hidden_pane_never_raises_the_stale_banner(self):
         # the user 2026-08-15, on the phone: the mobile shell shows ONE pane, hiding the rest with
@@ -85,8 +85,19 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('staleDiag("stale-raise",why);', js)
         self.assertIn('staleDiag("stale-suppressed-hidden",why);', js)
         self.assertIn('staleDiag("watchdog-close","quiet");', js)
-        self.assertIn('armStale("reconnect");', js)
-        self.assertIn('armStale("foreground");', js)
+        self.assertIn('armStale(pendingWhy||"reconnect");', js)
+        self.assertIn('pendingWhy="foreground";', js)
+        # …and every CLOSE leaves one too, with the close code/reason and the socket's age: a kernel-side
+        # drop (1006, no reason), a clean restart and a proxy timeout were indistinguishable
+        self.assertIn('if(openSock===this){try{send({type:"clientDiag",surface:"pane-shim",what:"wsclose",data:{app:APP,code:ev?ev.code:-1,'
+                      'reason:(ev&&ev.reason)||"",wasClean:!!(ev&&ev.wasClean),'
+                      'sinceOpenMs:openT?Date.now()-openT:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,everConnected:everConnected}', js)
+        # …for a socket that OPENED. A handshake that never opened fires onclose too — every redial of an
+        # outage, ~19k in 8 h — and those are counted and reported as ONE row on the next open, never queued
+        # one by one; queued breadcrumbs are capped besides. pane-shim-stale.test.ts runs both.
+        self.assertIn('else{if(!failedConnects)firstFailT=Date.now();failedConnects++;}', js)
+        self.assertIn('if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail",data:{app:APP,attempts:failedConnects,firstFailMs:Date.now()-firstFailT}});failedConnects=0;firstFailT=0;}', js)
+        self.assertIn('if(m&&m.type==="clientDiag"){if(queuedDiag>=DIAG_QUEUE_MAX)return;queuedDiag++;}', js)
 
     def test_shim_reconnect_loop_cannot_die(self):
         # The retry chain used to hang entirely off onclose, and the watchdog only ever closed OPEN
@@ -148,13 +159,24 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("freshPending=true", js, "a reconnect arms the retire")
         # …and the prompt is ARMED, not shown (the user 2026-08-01): raising it at once made it flash up
         # and straight back down on nearly every dashboard open, since the resync lands within a beat.
-        self.assertIn("staleTimer=setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js,
-                      "a one-second arming window, not an immediate raise")
-        self.assertIn('if(!ann)armStale("reconnect");', js,
+        # The arm is EVENT-keyed (it was a 1s timer, which fired a beat before the resync on nearly every
+        # reconnect once frames grew): it raises on the SECOND KEEPALIVE arriving while the resync is still
+        # pending — one full heartbeat period on this socket with the kernel alive, talking to it, and not
+        # resyncing it; a single keepalive can be a beat queued at accept, ahead of the resync frame — or on
+        # the reconnected socket CLOSING again before its resync. Nothing else. pane-shim-stale.test.ts RUNS
+        # the rule; these pins hold its text.
+        self.assertIn("function armStale(why){stalePending=why;staleKa=0;}", js, "arming records the path, shows nothing")
+        self.assertNotIn("setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js, "the timer is gone")
+        self.assertNotIn("staleTimer", js)
+        self.assertIn('if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}', js,
+                      "the second keepalive on the reconnected socket, resync still pending → raise")
+        self.assertIn('if(stalePending&&openSock===this){var cw=stalePending;stalePending="";raiseStale(cw+"-closed");}', js,
+                      "the reconnected socket closing before its resync → raise")
+        self.assertIn('if(!ann)armStale(pendingWhy||"reconnect");', js,
                       "the reconnect ARMS it — except the one an ANNOUNCED restart already explained (T217)")
         self.assertNotIn("if(wasReconn){raiseStale();", js, "…and never raises it outright")
-        self.assertIn("if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}", js,
-                      "a resync inside the window disarms it, so it never appears at all")
+        self.assertIn('function clearStale(){stalePending="";', js,
+                      "the resync disarms it, so it never appears at all")
         self.assertIn("if(freshPending){freshPending=false;clearStale();}", js,
                       "the first real frame after it fires the retire")
         # keepalives must NOT count as a resync — the ka branch returns before the retire line
@@ -171,7 +193,7 @@ class DisconnectBanner(unittest.TestCase):
         # a tab foregrounded onto a dead socket forces a reconnect and used to prompt immediately; that
         # reconnect resyncs like any other, so it arms the same window and disarms on the same frame
         js = km._shim("chat", 7777)
-        self.assertIn('Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;', js)
+        self.assertIn('Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;', js)
         self.assertNotIn("STALE_MS){raiseStale();", js)
 
     def test_a_standalone_page_retires_only_its_connection_bar(self):

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -82,8 +82,19 @@ class ShimWatchdogSourcePins(unittest.TestCase):
         self.assertNotIn("new WebSocket", km._TIMELINE_BOOT, "the timeline boot owns no socket of its own")
 
     def test_shim_ignores_the_keepalive_frame(self):
-        # the ka frame never reaches the bundles: the shim consumes it (build-drift check, then return)
-        self.assertIn('if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}', KSRC)
+        # the ka frame never reaches the bundles: the shim consumes it (build-drift check, the stale rule,
+        # then RETURN). Pinned as the exact branch text INCLUDING its return: a slice-to-the-next-`return;}`
+        # pin would stay green with the return deleted (the slice runs on to the next branch's return) while
+        # keepalives fell through to the resync retire and to the bundle. pane-shim-stale.test.ts RUNS the
+        # same rule and asserts no ka reaches the bundle.
+        head = ('if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();\n'
+                'if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}')
+        i = KSRC.index(head)
+        rest = KSRC[i + len(head):]
+        nl = rest.index("\n")                              # the rule line's trailing comment
+        third = rest[nl + 1:rest.index("\n", nl + 1)]
+        self.assertTrue(third.startswith("return;}"), "the ka branch RETURNS: %r" % third)
+        self.assertNotIn("dispatchEvent", head + rest[:nl + 1 + len(third)])
 
 
 class BuildDriftBanner(unittest.TestCase):

--- a/tests/test_restart_seam.py
+++ b/tests/test_restart_seam.py
@@ -172,7 +172,7 @@ class ShimSeam(unittest.TestCase):
     def test_the_announced_reconnect_skips_the_stale_arm_once(self):
         self.assertIn("var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;",
                       self.js, "the latch is one-shot: spent at the reconnect that consumes it")
-        self.assertIn('if(!ann)armStale("reconnect");', self.js)
+        self.assertIn('if(!ann)armStale(pendingWhy||"reconnect");', self.js)
         self.assertIn("freshPending=true;", self.js,
                       "…and the resync bookkeeping still runs, so the retire path is intact")
 
@@ -180,7 +180,7 @@ class ShimSeam(unittest.TestCase):
         # a restart that comes back SILENT re-raises through the keepalive watchdog's forced close →
         # second reconnect → latch already spent → armStale as always; and one that never comes back
         # stays loud through the disconnected state itself
-        self.assertIn('armStale("foreground")', self.js, "the foreground fast-path still arms")
+        self.assertIn('pendingWhy="foreground"', self.js, "the foreground fast-path still arms (through its reconnect)")
         self.assertIn("staleDiag(\"watchdog-close\",\"quiet\")", self.js, "the quiet watchdog still closes")
 
     def test_a_drop_over_content_shows_the_badge_not_the_sheet(self):

--- a/tests/test_ws_drop_loud.py
+++ b/tests/test_ws_drop_loud.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""A client the kernel drops for falling behind is LOUD — one stderr line and one bell row per drop.
+
+_mk_ws_send raises when a client is WS_QUEUE_BYTES behind (tests/test_ws_send_bounded.py owns that
+guarantee); every caller caught it with a bare `c["alive"] = False`. _drop_dead_ws_client writes a line for
+the ping-timeout and supersession drops, but the budget drop left NO trace in the kernel log, the shim
+logged nothing on its side, and a dashboard dropped and reconnected every few minutes read as a flaky
+network. Pinned: one line per drop naming the pane, dashboard id, backlog and — for a push-path drop — the
+slot whose frame tipped the budget (the raise site has no key of its own; _client_send leaves the slot in
+flight on the client for the length of its call, and a one-shot reply reads `slot=-`, honestly); a row for
+the bell via the kernel-problems channel (_sdk_problem_rows → feed sdkNotices); the log lives at the RAISE
+site (_mk_ws_send → _note_ws_drop), so the direct one-shot `client["send"]` replies are covered too, not
+only the push paths that go through _client_send; and the bell shows at most a few RECENT drop rows,
+merged by time with the backend's problems — twenty drops appended last and sliced positionally would hide
+every later backend problem for the rest of the kernel's life.
+
+Synthetic only: no session data.
+"""
+import io
+import json
+import os
+import queue
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wsdroploud", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+PREFIX = "ws: dropping"   # the prefix _drop_dead_ws_client already uses: one grep finds every kind of drop
+
+
+def _drop_lines(err):
+    return [l for l in err.getvalue().splitlines() if l.startswith(PREFIX)]
+
+
+class _Sock:
+    def shutdown(self, how):
+        pass
+
+
+def _budgeted(app, wid, behind=10):
+    """A client with the kernel's OWN send (_mk_ws_send), `behind` bytes under the drop budget: the next
+    frame that size or larger tips it."""
+    client = {"app": app, "wid": wid, "alive": True, "qbytes": km.WS_QUEUE_BYTES - behind,
+              "qlock": threading.Lock()}
+    client["send"] = km._mk_ws_send(queue.Queue(), _Sock(), client)
+    return client
+
+
+class DroppedClientsAreLoud(unittest.TestCase):
+    def _dropping(self):
+        def boom(_s):
+            raise OSError("ws client feed is 17000000 bytes behind — dropping")
+        return {"app": "feed", "alive": True, "wid": "w9", "qbytes": 17000000, "send": boom}
+
+    def test_one_stderr_line_per_drop_naming_pane_dashboard_and_backlog(self):
+        c = self._dropping()
+        err, old = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            km._send_client(c, ("feed",), {"type": "feed", "asks": []})
+            km._send_client(c, ("working",), {"type": "working"})   # the same cycle's next frame fails too
+        finally:
+            sys.stderr = old
+        lines = _drop_lines(err)
+        self.assertEqual(len(lines), 1, err.getvalue())
+        self.assertIn("dropping feed client", lines[0]); self.assertIn("wid=w9", lines[0])
+        self.assertIn("queued=17000000B", lines[0]); self.assertIn("17000000 bytes behind", lines[0])
+        self.assertFalse(c["alive"])
+
+    def test_the_drop_reaches_the_bell_through_the_kernel_problem_rows(self):
+        n0 = len(km._WS_DROPS)
+        old = sys.stderr; sys.stderr = io.StringIO()
+        try:
+            km._send_client(self._dropping(), ("feed",), {"type": "feed"})
+        finally:
+            sys.stderr = old
+        self.assertEqual(len(km._WS_DROPS), n0 + 1)
+        row = km._WS_DROPS[-1]
+        self.assertIn("feed pane", row["text"]); self.assertIn("17.0 MB", row["text"])
+        self.assertTrue(any(r["text"] == row["text"] and r["sig"].startswith("sdk|") and "|ws|" in r["sig"]
+                            for r in km._sdk_problem_rows()), "rides the feed's sdkNotices → the bell")
+
+    def test_a_drop_through_a_direct_send_is_loud_too(self):
+        # the RAISE site logs, so whichever caller's frame tips the budget — a one-shot reply through a
+        # bare client["send"], with no helper in sight — leaves the line and the bell row
+        client = _budgeted("chat", "w3")
+        n0 = len(km._WS_DROPS)
+        err, old = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            with self.assertRaises(OSError):
+                client["send"]('{"type":"renamed"}' + "x" * 100)
+            # the line is on stderr the moment the raise site fires — BEFORE any helper has run on this client
+            lines = _drop_lines(err)
+            self.assertEqual(len(lines), 1, err.getvalue())
+            self.assertIn("slot=-", lines[0], "a one-shot reply has no push slot, and the line says so")
+            self.assertEqual(len(km._WS_DROPS), n0 + 1)
+            km._client_send(client, "a later frame", ("chat", "x"))   # the helper on the same dead client: latched
+        finally:
+            sys.stderr = old
+        lines = _drop_lines(err)
+        self.assertEqual(len(lines), 1, "no second line for the same drop: " + err.getvalue())
+        self.assertIn("dropping chat client", lines[0]); self.assertIn("wid=w3", lines[0]); self.assertIn("bytes behind", lines[0])
+        self.assertFalse(client["alive"])
+        self.assertEqual(len(km._WS_DROPS), n0 + 1)
+        self.assertIn("chat pane", km._WS_DROPS[-1]["text"])
+
+    def test_a_push_path_drop_names_the_slot_whose_frame_tipped_the_budget(self):
+        # the raise site has no key of its own; _client_send leaves the slot in flight on the client for
+        # the length of the call, so the line names the frame — feed, a chat sid, the tab order — that did it
+        for key, named in ((("feed",), "slot=feed "), (("chat", SID), "slot=chat:11111111 "), (("taborder",), "slot=taborder ")):
+            client = _budgeted("feed", "w9")
+            err, old = io.StringIO(), sys.stderr
+            sys.stderr = err
+            try:
+                self.assertFalse(km._client_send(client, "x" * 100, key))
+            finally:
+                sys.stderr = old
+            lines = _drop_lines(err)
+            self.assertEqual(len(lines), 1, err.getvalue())
+            self.assertIn(named, lines[0], key)
+            self.assertNotIn("slot=-", lines[0])
+            self.assertIn("frame=100B", lines[0])
+            self.assertNotIn("curSlot", client, "the slot in flight is cleared after the call: a later one-shot reads `-`")
+        # a client whose push-path drop was logged: a later direct send raises again, latched, no second line
+        client = _budgeted("feed", "w9")
+        err, old = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            km._client_send(client, "x" * 100, ("feed",))
+            with self.assertRaises(OSError):
+                client["send"]("y" * 100)
+        finally:
+            sys.stderr = old
+        self.assertEqual(len(_drop_lines(err)), 1)
+
+    def test_a_drop_on_the_view_delta_path_is_loud_and_names_its_slot(self):
+        # the delta encoder's own send (the tail of _send_slot_delta) used to swallow the raise like the
+        # rest; a delta client that tips the budget on a delta frame leaves the same line, slot named
+        def feed(text):
+            asks = [{"itemId": "%s:g%d" % (SID, i), "sid": SID, "text": text if i == 0 else "card %d " % i * 40}
+                    for i in range(6)]
+            return {"type": "feed", "asks": asks, "now": 1000, "sessions": [{"sid": SID, "name": "web"}], "order": [SID]}
+        client = {"app": "feed", "wid": "w9", "alive": True, "qbytes": 0, "delta": True, "sock": object(),
+                  "qlock": threading.Lock()}
+        client["send"] = km._mk_ws_send(queue.Queue(), _Sock(), client)
+        first = feed("Wire the notes-api health route")
+        pre = json.dumps(first)
+        km._send_slot(client, "feed", first, pre, km._dedup_sig(first, pre))
+        self.assertIn("feed", client.get("dstate", {}), "the keyed full went, and the client is held as its base")
+        client["qbytes"] = km.WS_QUEUE_BYTES - 10                    # the next frame — a small delta — tips it
+        second = feed("Wire the notes-api health route, then its test")
+        pre2 = json.dumps(second)
+        err, old = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            km._send_slot(client, "feed", second, pre2, km._dedup_sig(second, pre2))
+        finally:
+            sys.stderr = old
+        lines = _drop_lines(err)
+        self.assertEqual(len(lines), 1, err.getvalue())
+        self.assertIn("dropping feed client", lines[0]); self.assertIn("slot=feed ", lines[0])
+        self.assertNotIn("view-delta feed:", err.getvalue(), "the drop is a drop, not an encoder failure")
+        self.assertFalse(client["alive"])
+        self.assertIn("feed pane", km._WS_DROPS[-1]["text"])
+
+    def test_drop_rows_never_crowd_a_backend_problem_out_of_the_bell(self):
+        class _Be:
+            def problems(self, limit=0):
+                return [{"seq": 7, "t": time.time(), "text": "sdk session web crashed"}]
+
+            def problem_seq(self):
+                return 7
+        saved = (list(km._WS_DROPS), km._sdk_backend)
+        old = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            km._WS_DROPS[:] = []
+            for _ in range(25):
+                km._send_client(self._dropping(), ("feed",), {"type": "feed"})
+            km._sdk_backend = _Be()
+            rows = km._sdk_problem_rows()
+            kinds = [r["sig"].split("|")[2] for r in rows]
+            self.assertIn("be", kinds, "the backend problem shows beside the drops: %r" % kinds)
+            self.assertLessEqual(kinds.count("ws"), km._WS_DROP_BELL_ROWS, "a few drop rows at most")
+            self.assertEqual([r["t"] for r in rows], sorted(r["t"] for r in rows), "merged by time")
+            for r in km._WS_DROPS:
+                r["t"] -= km._WS_DROP_TTL_S + 1
+            self.assertEqual([r["sig"].split("|")[2] for r in km._sdk_problem_rows()], ["be"],
+                             "an hour-old drop has left the bell (the log keeps it)")
+        finally:
+            sys.stderr = old
+            km._WS_DROPS[:] = saved[0]
+            km._sdk_backend = saved[1]
+
+    def test_every_send_path_goes_through_the_loud_helper(self):
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        body = src[src.index("def _send_to_app("):src.index("def _reveal_chat_for(")]
+        self.assertNotIn('except Exception:\n            c["alive"] = False', body,
+                         "_send_to_app / _keepalive_all / _send_to_view no longer swallow a drop")
+        self.assertEqual(body.count("_client_send(c, s)"), 3)
+        delta = src[src.index("def _send_slot_delta("):src.index("def _send_client(")]
+        self.assertIn("if not _client_send(c, s, key):\n        return", delta, "the delta encoder's send names its slot")
+        self.assertNotIn('c["send"](s)', delta)
+        per_client = src[src.index("def _send_client("):src.index("def _send_chat(")]
+        self.assertIn("_client_send(c, s, key)", per_client)
+        self.assertNotIn('c["send"](s)', per_client)
+        raise_site = src[src.index("def _mk_ws_send("):src.index("def _ws_send(")]
+        self.assertIn("_note_ws_drop(client, why, len(s))\n                raise OSError(", raise_site,
+                      "the raise site logs, so every direct caller is covered")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -315,11 +315,34 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
  *  remote's snapshot (both pushed ~every 2s) alternate and clobber each other, and the feed visibly flips
  *  back and forth ("repeatedly reloading"). Concatenate the arrays (items/asks/working) in hostSeq order
  *  (local first); keep the scalar chrome fields (now, dismissedCount, flags) from the LOCAL host, since the
- *  dashboard's own controls are local-authoritative. Ids are already prefixed by prefixInbound. */
+ *  dashboard's own controls are local-authoritative. Ids are already prefixed by prefixInbound.
+ *
+ *  A pane's clock anchor is a PAIR that travels with the frame: `now` (the emitting kernel's clock) and
+ *  `nowAt` (the local ms when that frame ARRIVED from the wire, `arrivedAt[host]`). The merge is emitted
+ *  not only on a wire arrival but on a view-order write, on every remote host's frame and on a detach, and
+ *  a pane that runs its ages on the kernel's clock (feed-age.ts liveNow) sets that clock from the frame it
+ *  is handed: anchoring `now` on the EMIT time would move every age back by however long the local board
+ *  had been quiet. The pair comes from the LOCAL host's frame; with no local frame yet, from the newest
+ *  remote arrival that carries a clock — the same host for both halves, so they always describe one frame.
+ *  Absent `arrivedAt` (a caller with no wire), no `nowAt` is set and the pane anchors on its own arrival. */
 export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[],
-                               view: readonly string[] = [], deadHosts: readonly string[] = []): any {
+                               view: readonly string[] = [], deadHosts: readonly string[] = [],
+                               arrivedAt: Record<string, number> = {}): any {
   const local = perHost[LOCAL] || {};
   const merged: any = { ...local, type: "feed", items: [], asks: [], working: [], awaiting: [], stateUnknown: [], order: [], sessions: [] };
+  let anchor = typeof local.now === "number" ? LOCAL : null;
+  if (anchor === null) {
+    for (const h of hostSeq) {
+      const f = perHost[h];
+      if (h === LOCAL || !f || typeof f.now !== "number" || typeof arrivedAt[h] !== "number") continue;
+      if (anchor === null || arrivedAt[h] > arrivedAt[anchor]) anchor = h;
+    }
+  }
+  if (anchor !== null) {
+    merged.now = perHost[anchor].now;
+    if (typeof arrivedAt[anchor] === "number") merged.nowAt = arrivedAt[anchor];
+    else delete merged.nowAt;
+  }
   // `ledgers` drives the FLEET pane (it rides the same feed message). Only include it once at least one host
   // has actually BUILT its ledgers — else the fleet's loader-gate (needs an array) would drop onto an empty
   // pane. Kept undefined until then so the loader holds, exactly like the single-kernel path.
@@ -608,6 +631,7 @@ export class FederationManager {
   private localViews: any = null;   // the LOCAL kernel's session-views blob, carried on merged tabOrder re-emits
   private perHostSids: Record<string, Set<string>> = {};
   private perHostFeed: Record<string, any> = {}; // last feed snapshot per host — merged so they don't clobber
+  private perHostFeedAt: Record<string, number> = {}; // host -> local ms its snapshot ARRIVED: the merged frame's clock anchor (mergeHostFeeds `nowAt`), so a re-emit anchors exactly as the arrival did
   private perHostTl: Record<string, any> = {}; //   last timeline lanes payload ({type:"data"}.data) per host
   private perHostTlBars: Record<string, any> = {}; // last timeline {type:"bars"} detail per host
   private hostSeq: string[] = [LOCAL]; // local first, then attach order — fixes the group order in the strip
@@ -732,6 +756,7 @@ export class FederationManager {
     }
     if (m && m.type === "feed") {
       this.perHostFeed[host] = m;
+      this.perHostFeedAt[host] = Date.now();   // the wire arrival: the one moment the frame's `now` was current
       this.ensureHost(host);
       this.emitMergedFeed();
       return;
@@ -777,7 +802,7 @@ export class FederationManager {
     }
     this.publishPending();
     const dead = this.deadHosts();
-    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead) }));
+    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view(), dead, this.perHostFeedAt) }));
   }
 
   // the hosts whose link is DOWN right now (this manager knows its sockets) — the merges' pendingDead input
@@ -1126,6 +1151,7 @@ export class FederationManager {
     delete this.perHostTabs[host];
     delete this.perHostSids[host];
     delete this.perHostFeed[host];
+    delete this.perHostFeedAt[host];
     const hadTl = host in this.perHostTl || host in this.perHostTlBars;
     delete this.perHostTl[host];
     delete this.perHostTlBars[host];

--- a/ui/webview/feed-age.test.ts
+++ b/ui/webview/feed-age.test.ts
@@ -1,0 +1,27 @@
+// The live clock a pane runs its ages on (feed-age.ts liveNow): the kernel's `now` on the last frame plus the
+// local time elapsed since that frame ARRIVED. Pure, so node --test runs it without a DOM.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { liveNow } from "./feed-age";
+
+test("liveNow adds only the local clock's DELTAS to the kernel's clock — skew between the two never enters", () => {
+  const hostNow = 1_000_000;                    // the kernel's clock, as of the frame (epoch s)
+  const arrivedMs = 9_000_000_000;              // the browser's clock when the frame landed — hours off the kernel's; irrelevant
+  assert.equal(liveNow(hostNow, arrivedMs, arrivedMs), hostNow, "at the arrival the kernel clock IS the frame's `now`");
+  assert.equal(liveNow(hostNow, arrivedMs, arrivedMs + 15_000), hostNow + 15, "15 s later, 15 s older");
+  assert.equal(liveNow(hostNow, arrivedMs, arrivedMs + 999), hostNow, "whole seconds only: ages never read ahead of the tick");
+  assert.equal(liveNow(hostNow, arrivedMs, arrivedMs - 5_000), hostNow, "a local clock that steps BACK cannot make an age negative");
+});
+
+test("the anchor is a (now, nowAt) pair that travels with the frame: a re-emit after a quiet hour reads the same live clock as the arrival", () => {
+  // federation re-emits the merged frame on a view-order write, on every remote host's frame and on a detach,
+  // and the pane sets its clock from whatever frame it is handed. The pair pins the anchor to the WIRE arrival:
+  // the same stored frame, re-emitted an hour later, anchors identically. Anchored on the emit instead, every
+  // age would go back by the quiet period.
+  const T = 1_000_000, arrivedMs = 5_000_000, hourLater = arrivedMs + 3_600_000;
+  const anchor = (m: { now: number; nowAt?: number }, handledMs: number) =>
+    liveNow(m.now, typeof m.nowAt === "number" ? m.nowAt : handledMs, handledMs);   // fleet.ts's rule
+  assert.equal(anchor({ now: T, nowAt: arrivedMs }, arrivedMs), T, "at the arrival");
+  assert.equal(anchor({ now: T, nowAt: arrivedMs }, hourLater), T + 3600, "the re-emit keeps the hour");
+  assert.equal(anchor({ now: T }, hourLater), T, "a frame with no pair anchors on the handling — the VS Code pipe's frames, which are never re-emitted");
+});

--- a/ui/webview/feed-age.ts
+++ b/ui/webview/feed-age.ts
@@ -1,0 +1,13 @@
+// The kernel's LIVE clock for a pane that rides the feed payload. Every age a pane shows — "Xm ago", the
+// current goal's elapsed time, a recency cutoff — is the difference between a timestamp the KERNEL wrote and
+// "now", and the browser's clock can sit minutes from the kernel's (a phone, a laptop back from sleep): read
+// against Date.now(), every age on the board is off by that skew. The payload carries the kernel's `now`, but
+// only as of the frame, and on the delta path a quiet board sends a pane nothing between the 60 s reposts.
+// So the pane keeps the kernel's clock moving itself: it records WHEN the frame arrived and adds the local
+// time elapsed since — skew between the two clocks never enters, only the local clock's deltas do. Pure:
+// node --test runs it without a DOM.
+
+/** The kernel clock now, in epoch seconds: the last payload's `now` plus the local time since it landed. */
+export function liveNow(hostNow: number, hostNowAtMs: number, nowMs: number): number {
+  return hostNow + Math.max(0, Math.floor((nowMs - hostNowAtMs) / 1000));
+}

--- a/ui/webview/feed-clock-anchor.test.ts
+++ b/ui/webview/feed-clock-anchor.test.ts
@@ -1,0 +1,100 @@
+// The merged feed frame's clock anchor travels with the frame. federation.ts re-emits the merged feed on a
+// view-order write (`storage` / VIEW_ORDER_EVENT → reorder → emitMergedFeed; view-order-wiring.test.ts pins
+// the wiring), on every remote host's frame and on a detach — and a pane that runs its ages on the kernel's
+// clock (fleet.ts, feed-age.ts liveNow) sets that clock from the frame it is handed. Anchored on the EMIT, a
+// re-emit after a quiet hour would take every age back by that hour (a tab drag in another pane, or an
+// attached kernel's 60 s repost, moving "1m ago" back to "<1m ago"). The anchor is the (now, nowAt) PAIR of
+// the local frame's wire arrival, so a re-emit anchors exactly as the arrival did. The real manager, a stub
+// window (emissions) and a stub clock; synthetic hosts and ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { mergeHostFeeds, FederationManager } from "./federation";
+import { liveNow } from "./feed-age";
+
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+const card = (i: number, extra: Record<string, unknown> = {}) => ({ itemId: "TESTSID:g" + i, sid: "TESTSID", text: "card " + i, t: 1000 + i, ...extra });
+
+function withFeedManager(fn: (fm: FederationManager, emitted: any[], clock: { ms: number }) => void): void {
+  const emitted: any[] = [];
+  const clock = { ms: 5_000_000 };
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  const realNow = Date.now;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: () => null, setItem: () => {} };
+  Date.now = () => clock.ms;
+  try {
+    fn(new FederationManager(), emitted, clock);
+  } finally {
+    Date.now = realNow;
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+const pair = (m: any) => [m.now, m.nowAt];
+
+test("the merged frame's clock anchor is the local frame's (now, nowAt) wire arrival: a re-emit after a quiet hour carries the same pair", () => {
+  withFeedManager((fm, emitted, clock) => {
+    const T = 1_000_000;
+    fm.inbound("", { type: "feed", asks: [card(0)], now: T, buildId: 1 });
+    assert.equal(emitted.length, 1);
+    assert.deepEqual(pair(emitted[0]), [T, 5_000_000], "stamped with the moment the frame arrived");
+    clock.ms += 3_600_000;                       // a quiet hour on the wire
+    (fm as any).emitMergedFeed();                // what a view-order write runs (reorder), with no new frame
+    assert.equal(emitted.length, 2);
+    assert.deepEqual(pair(emitted[1]), [T, 5_000_000], "the re-emit anchors exactly as the arrival did");
+    assert.equal(liveNow(emitted[1].now, emitted[1].nowAt, clock.ms), T + 3600, "so the pane's live clock keeps the hour");
+    assert.equal(liveNow(emitted[1].now, clock.ms, clock.ms), T, "anchored on the emit it would lose it — the bug");
+    assert.deepEqual(emitted[1].asks.map((a: any) => a.itemId), ["TESTSID:g0"], "the same board, unchanged");
+  });
+});
+
+test("a remote host's frame never moves the local anchor; the next local frame re-anchors on its own arrival", () => {
+  withFeedManager((fm, emitted, clock) => {
+    const T = 1_000_000;
+    fm.inbound("", { type: "feed", asks: [card(0)], now: T, buildId: 1 });
+    clock.ms += 3_600_000;
+    fm.inbound("TESTHOST", { type: "feed", asks: [], now: T + 7200, buildId: 9 });   // an attached kernel's 60 s repost, its clock 2 h ahead
+    assert.equal(emitted.length, 2);
+    assert.deepEqual(pair(emitted[1]), [T, 5_000_000], "the local pair, untouched by the remote's clock or arrival");
+    assert.equal(liveNow(emitted[1].now, emitted[1].nowAt, clock.ms), T + 3600);
+    clock.ms += 60_000;
+    fm.inbound("", { type: "feed", now: T + 3660, buildId: 2, asks: [card(0, { text: "changed" })] });
+    assert.equal(emitted.length, 3);
+    assert.deepEqual(pair(emitted[2]), [T + 3660, clock.ms], "new local information: the frame's clock, and when it arrived");
+    assert.equal(emitted[2].asks[0].text, "changed");
+    clock.ms += 30_000;
+    fm.inbound("TESTHOST", { type: "feed", asks: [], now: T + 7300, buildId: 10 });
+    assert.deepEqual(pair(emitted[3]), [T + 3660, clock.ms - 30_000], "…and the remote's next repost leaves it there");
+  });
+});
+
+test("with no local frame yet the pair comes from the newest REMOTE arrival — both halves from one host; no arrivals known → no nowAt", () => {
+  withFeedManager((fm, emitted, clock) => {
+    fm.inbound("HOSTA", { type: "feed", asks: [], now: 500 });
+    clock.ms += 10_000;
+    fm.inbound("HOSTB", { type: "feed", asks: [], now: 900 });
+    assert.deepEqual(pair(emitted[emitted.length - 1]), [900, 5_010_000], "HOSTB arrived last: its clock with its arrival");
+  });
+  const perHost = { HOSTA: { type: "feed", now: 500 }, HOSTB: { type: "feed", now: 900 } };
+  const older = mergeHostFeeds(perHost, ["", "HOSTA", "HOSTB"], [], [], { HOSTA: 9, HOSTB: 5 });
+  assert.deepEqual(pair(older), [500, 9], "the newest ARRIVAL wins, not the largest clock");
+  const local = mergeHostFeeds({ "": { type: "feed", now: 7 }, HOSTA: { type: "feed", now: 500 } }, ["", "HOSTA"], [], [], { "": 3, HOSTA: 9 });
+  assert.deepEqual(pair(local), [7, 3], "a local frame is the anchor whenever it exists, however old its arrival");
+  const bare = mergeHostFeeds({ "": { type: "feed", now: 7 } }, [""]);
+  assert.equal(bare.now, 7);
+  assert.equal("nowAt" in bare, false, "a caller with no wire (no arrivals) sets none: the pane anchors on its own arrival");
+  const none = mergeHostFeeds({ HOSTA: { type: "feed", asks: [] } }, ["", "HOSTA"], [], [], { HOSTA: 9 });
+  assert.equal("now" in none, false, "a frame with no clock (an older kernel) anchors nothing");
+});
+
+test("federation stamps the arrival beside the frame on the wire path, drops it with the host, and the merge is handed it", () => {
+  assert.match(FED, /private perHostFeedAt: Record<string, number> = \{\};/);
+  assert.match(FED, /this\.perHostFeed\[host\] = m;\n\s*this\.perHostFeedAt\[host\] = Date\.now\(\);/, "a frame's arrival");
+  assert.match(FED, /delete this\.perHostFeed\[host\];\n\s*delete this\.perHostFeedAt\[host\];/, "a detach forgets both");
+  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\), dead, this\.perHostFeedAt\)/, "every emit carries the arrivals");
+  assert.equal((FED.match(/perHostFeedAt\[host\] = Date\.now\(\)/g) || []).length, 1, "stamped where the frame comes off the wire and nowhere else — never on an emit");
+});

--- a/ui/webview/fleet-live-clock.test.ts
+++ b/ui/webview/fleet-live-clock.test.ts
@@ -1,0 +1,202 @@
+// The Outline pane on a LIVE clock. fleet.ts read Date.now() inside render(), and render() ran only on a
+// frame, a settings event or a click — so every "(Xm ago)", the current goal's elapsed time, the recency
+// cutoff and the slider range were off by whatever skew sat between the browser's clock and the kernel's
+// (the timestamps are the kernel's), and moved only when a frame arrived: on the delta path a quiet board
+// sends one every 60 s. The pane now anchors on the kernel's clock (feed-age.ts liveNow: the frame's `now`
+// plus the local time since its `nowAt` wire arrival) and re-renders every 15 s while visible.
+//
+// Run for real, not pinned at source: fleet.ts renders through document.createElement and reads frames off a
+// window message, so the page is stood in for by a small tree of plain objects carrying the handful of DOM
+// methods the render uses, under node:test's mock timers (Date and setInterval). The same harness runs the
+// clock's two anchors (a frame stamped `nowAt` by federation; one without, off the VS Code pipe, anchored at
+// its arrival), the refresh's visibility gate (a hidden document or a zero-size iframe skips the tick and the
+// pane catches up once on the way back), and the unreassembled-delta guard: a raw {type:"delta"} reaching the
+// pane is loud, asks for the whole slot, and applies nothing.
+import { test, mock } from "node:test";
+import * as assert from "node:assert/strict";
+
+// ── a DOM stand-in: the subset fleet.ts and its imports touch at load and in render() ──────────────
+class Txt {
+  nodeType = 3;
+  parentNode: El | null = null;
+  constructor(public textContent: string) {}
+}
+class El {
+  nodeType = 1;
+  id = ""; title = ""; hidden = false; value = ""; type = ""; checked = false; min = ""; max = ""; step = "";
+  innerHTML = ""; offsetWidth = 0; offsetHeight = 0;
+  parentNode: El | null = null;
+  childNodes: Array<El | Txt> = [];
+  dataset: Record<string, string | undefined> = {};
+  style: Record<string, string> = {};
+  private attrs = new Map<string, string>();
+  private classes = new Set<string>();
+  classList = {
+    add: (...c: string[]) => { for (const x of c) this.classes.add(x); },
+    remove: (...c: string[]) => { for (const x of c) this.classes.delete(x); },
+    toggle: (c: string, force?: boolean) => {
+      const on = force === undefined ? !this.classes.has(c) : force;
+      if (on) this.classes.add(c); else this.classes.delete(c);
+      return on;
+    },
+    contains: (c: string) => this.classes.has(c),
+  };
+  constructor(public tagName: string) {}
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  get textContent(): string { return this.childNodes.map((c) => c.textContent).join(""); }
+  set textContent(v: string) { this.replaceChildren(); if (v !== "") this.appendChild(new Txt(v)); }
+  appendChild<T extends El | Txt>(c: T): T { c.parentNode?.removeChild(c); c.parentNode = this; this.childNodes.push(c); return c; }
+  append(...cs: Array<El | Txt | string>): void { for (const c of cs) this.appendChild(typeof c === "string" ? new Txt(c) : c); }
+  replaceChildren(...cs: Array<El | Txt>): void { for (const c of this.childNodes) c.parentNode = null; this.childNodes = []; this.append(...cs); }
+  removeChild(c: El | Txt): void { const i = this.childNodes.indexOf(c); if (i >= 0) { this.childNodes.splice(i, 1); c.parentNode = null; } }
+  remove(): void { this.parentNode?.removeChild(this); }
+  contains(x: El | Txt | null): boolean { for (let n: El | Txt | null = x; n; n = n.parentNode) if (n === this) return true; return false; }
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  closest(): El | null { return null; }
+  getBoundingClientRect() { return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 }; }
+  focus(): void {}
+  *walk(): Generator<El> { for (const c of this.childNodes) if (c instanceof El) { yield c; yield* c.walk(); } }
+  byId(id: string): El | null { for (const e of this.walk()) if (e.id === id) return e; return null; }
+  byClass(c: string): El[] { return [...this.walk()].filter((e) => e.classList.contains(c)); }
+}
+
+const posted: any[] = [];                 // what the pane sends the kernel (acquireVsCodeApi().postMessage)
+const body = new El("body");
+const list = new El("div"); list.id = "fleet-list";
+const foot = new El("div"); foot.id = "fleet-foot";
+const search = new El("input"); search.id = "fleet-search";
+const clear = new El("button"); clear.id = "fleet-search-clear";
+body.append(list, foot, search, clear);
+const store = new Map<string, string>();
+const win: any = new EventTarget();       // window: message/storage listeners dispatch through EventTarget
+win.parent = win; win.top = win;          // not framed → no shell relays
+win.location = { hash: "", search: "" };
+win.innerWidth = 1200; win.innerHeight = 800;
+win.setTimeout = (...a: Parameters<typeof setTimeout>) => setTimeout(...a);
+win.clearTimeout = (t: ReturnType<typeof setTimeout>) => clearTimeout(t);
+win.acquireVsCodeApi = () => ({ postMessage: (m: any) => posted.push(m) });
+(globalThis as any).window = win;
+const doc: any = new EventTarget();       // document: visibilitychange dispatches through EventTarget; `hidden` is the Page Visibility bit
+Object.assign(doc, {
+  body, documentElement: new El("html"), hidden: false,
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => new Txt(s),
+  getElementById: (id: string) => body.byId(id),
+  querySelectorAll: () => [],
+  contains: (x: El) => body.contains(x),
+});
+(globalThis as any).document = doc;
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+// ── the clocks ─────────────────────────────────────────────────────────────────────────────────────
+const T0 = 1781100000;                    // the browser's clock at boot (synthetic epoch seconds)
+const K0 = T0 - 300;                      // the KERNEL's clock: five minutes behind — every age must follow it, never Date.now()
+const SID = "11111111-2222-3333-4444-555555555555";
+const frame = () => ({
+  type: "feed", now: K0, nowAt: T0 * 1000 - 10_000,   // arrived from the wire 10 s ago (a federation re-emit): the kernel clock reads K0 + 10 now
+  buildId: 1, asks: [],
+  ledgers: [{ sid: SID, name: "web", color: null, status: { state: "working" },
+    ledger: { current: { t: K0 - 10 }, tree: [
+      { id: "g1", text: "Wire the notes-api health route", depth: 0, done: false, blocked: false, t: K0 - 10, current: true },
+      { id: "g2", text: "Write the notes-api README", depth: 0, done: true, blocked: false, t: K0 - 60, mt: K0 - 30 },
+    ] } }],
+});
+const rows = () => Object.fromEntries(list.byClass("ledger-tnode").map((r) => [r.dataset.nid, r.byClass("ledger-ttime")[0]?.textContent ?? ""]));
+
+test("ages and the recency cutoff move on the kernel's live clock between frames — no frame, no movement, and a skewed browser clock were the bug", async () => {
+  mock.timers.enable({ apis: ["Date", "setInterval", "setTimeout"], now: T0 * 1000 });
+  store.set("romp:fleetShowDone", "1");   // the done top shows (fleet-roots gates it behind the toggle)
+  // the slider at its midpoint: cutoff = 60 s × (maxAge/60)^0.5, and maxAge floors at 120 s while every top is
+  // younger than that → an 84.85 s window. The done top starts inside it and ages out; the current one stays.
+  store.set("romp:fleetCutoffPos", "500");
+  await import("./fleet");                // module load: mounts the controls, installs the message listener and the 15 s refresh
+
+  win.dispatchEvent(new MessageEvent("message", { data: frame() }));
+  assert.deepEqual(rows(), { g1: "(20s)", g2: "(40s ago)" },
+    "anchored on the frame's `now` + its `nowAt` arrival: the browser clock (5 min ahead) would have read (5m)/(5m ago)");
+  const before = posted.length;
+
+  mock.timers.tick(15_000);               // one refresh, no frame
+  assert.deepEqual(rows(), { g1: "(35s)", g2: "(55s ago)" }, "15 s later both ages moved with nothing on the wire");
+  const g2 = list.byClass("ledger-tnode").find((r) => r.dataset.nid === "g2")!;
+  assert.equal(g2.byClass("ledger-ttime")[0].style.color, g2.byClass("ledger-ttext")[0].style.color,
+    "a done row's text takes its time's recency colour, repainted from the same clock");
+
+  mock.timers.tick(45_000);               // three more refreshes: 60 s after the frame
+  assert.deepEqual(rows(), { g1: "(1m)" },
+    "the done top (now 100 s old) aged out of the 84.85 s cutoff window and left the list; the current top (80 s) stays");
+  assert.equal(list.byClass("fl-session").length, 1, "its session stays: the filter is per top, not per session");
+  assert.equal(posted.length, before, "…all of it on the local clock: the pane asked the kernel for nothing");
+});
+
+test("a frame without `nowAt` (the VS Code pipe hands frames straight to the pane) anchors the clock at its arrival", () => {
+  // Federation stamps `nowAt` on the frames it re-emits; the extension's pipe hands the kernel's frame over
+  // unstamped, so the pane records the arrival itself and the ages count from the frame's own `now` from
+  // that moment. Still under the first test's mock timers: the browser clock reads T0 + 60 s here.
+  assert.equal(Date.now(), T0 * 1000 + 60_000, "the mock clock where the first test left it");
+  win.dispatchEvent(new MessageEvent("message", { data: { ...frame(), nowAt: undefined } }));
+  assert.deepEqual(rows(), { g1: "(10s)", g2: "(30s ago)" },
+    "anchored at arrival: the frame's `now` IS the kernel clock right now; the browser clock (6 min ahead) never enters");
+  mock.timers.tick(15_000);
+  assert.deepEqual(rows(), { g1: "(25s)", g2: "(45s ago)" }, "15 s later both ages moved 15 s, counted from the frame's `now`");
+});
+
+test("the 15 s refresh skips a hidden document and catches up once it is visible again", () => {
+  win.dispatchEvent(new MessageEvent("message", { data: { ...frame(), nowAt: Date.now() } }));   // a fresh anchor: (10s) / (30s ago)
+  const rebuilt = mock.method(list, "replaceChildren");   // render() starts with #fleet-list.replaceChildren(): every rebuild shows here
+  const shown = rows();
+  doc.hidden = true;
+  mock.timers.tick(30_000);               // two refreshes fall while hidden
+  assert.equal(rebuilt.mock.callCount(), 0, "no rebuild for a pane nobody can see");
+  assert.deepEqual(rows(), shown);
+  doc.hidden = false;
+  doc.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(rebuilt.mock.callCount(), 1, "one catch-up rebuild on the way back");
+  assert.deepEqual(rows(), { g1: "(40s)", g2: "(1m ago)" }, "…with the ages moved by the hidden 30 s");
+  mock.timers.tick(15_000);               // the cadence resumes
+  assert.equal(rebuilt.mock.callCount(), 2);
+  assert.deepEqual(rows(), { g1: "(55s)", g2: "(1m ago)" });
+  doc.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(rebuilt.mock.callCount(), 2, "a flip with no skipped tick owes nothing: the catch-up is once, not per flip");
+  rebuilt.mock.restore();
+});
+
+test("a pane the shell has hidden (a zero-size iframe, the shim's paneHidden test) skips too, and the resize it gets when shown catches up", () => {
+  win.dispatchEvent(new MessageEvent("message", { data: { ...frame(), nowAt: Date.now() } }));   // (10s) / (30s ago)
+  const rebuilt = mock.method(list, "replaceChildren");
+  win.innerWidth = 0;                     // display:none on the pane iframe: document.hidden stays false, the viewport is 0×0
+  mock.timers.tick(15_000);
+  assert.equal(rebuilt.mock.callCount(), 0, "no rebuild while the iframe has no size");
+  assert.deepEqual(rows(), { g1: "(10s)", g2: "(30s ago)" });
+  win.innerWidth = 1200;
+  win.dispatchEvent(new Event("resize"));  // what the iframe's window gets when the shell shows it again
+  assert.equal(rebuilt.mock.callCount(), 1);
+  assert.deepEqual(rows(), { g1: "(25s)", g2: "(45s ago)" }, "caught up by the hidden 15 s");
+  win.dispatchEvent(new Event("resize"));
+  assert.equal(rebuilt.mock.callCount(), 1, "an ordinary resize rebuilds nothing");
+  rebuilt.mock.restore();
+});
+
+test("a raw delta frame reaching the pane is loud, asks for the whole slot, and applies nothing", () => {
+  const err = mock.method(console, "error", () => {});
+  const shown = rows();
+  win.dispatchEvent(new MessageEvent("message", { data: { type: "delta", slot: "feed", base: 3, rev: 4,
+    rest: { now: K0 + 500, buildId: 9 }, coll: { asks: { set: {} } } } }));
+  assert.equal(err.mock.callCount(), 1);
+  assert.match(String(err.mock.calls[0].arguments[0]), /delta frame reached the pane unreassembled/);
+  assert.deepEqual(posted.filter((m) => m.type === "clientDiag"),
+    [{ type: "clientDiag", surface: "outline", what: "delta-unapplied", data: { slot: "feed", rev: 4 } }]);
+  assert.deepEqual(posted.filter((m) => m.type === "needSlot"), [{ type: "needSlot", slot: "feed" }],
+    "the re-base request the kernel answers with the whole slot — the shim's own message for a delta it cannot apply");
+  assert.deepEqual(rows(), shown, "the rows are as the last full frame left them: this pane applies no delta itself");
+  err.mock.restore();
+  mock.timers.reset();
+});

--- a/ui/webview/fleet.test.ts
+++ b/ui/webview/fleet.test.ts
@@ -15,6 +15,14 @@ test("fleet rides the FEED payload, reading its per-session `ledgers`", () => {
   assert.match(SRC, /sessions = m\.ledgers as FleetSession\[\]/);
 });
 
+test("fleet.ts applies no delta itself: the shim reassembles every {type:\"delta\"} frame before the bundle sees it — and one that arrives raw is loud, never dropped", () => {
+  // a host that hands the pane a kernel frame unreassembled would otherwise have every update fall through
+  // the `m.type !== "feed"` return in silence; the guard says so and asks for the whole slot with the
+  // message the shim itself uses (needSlot). Run for real in fleet-live-clock.test.ts.
+  assert.match(SRC, /if \(m\.type === "delta"\) \{[\s\S]*?"delta-unapplied"[\s\S]*?\{ type: "needSlot", slot: m\.slot \}[\s\S]*?return;\n\s*\}\n\s*if \(m\.type !== "feed"\) return;/);
+  assert.doesNotMatch(SRC, /applyDelta|from "\.\/feed-delta"/);
+});
+
 test("each session renders the real LEDGER TREE — .ledger-* nodes, marks, collapse, recency time", () => {
   assert.match(SRC, /el\("div", "ledger-tree"\)/);
   assert.match(SRC, /"ledger-tnode"/);

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -14,6 +14,7 @@ import { fleetVisibleRoots } from "./fleet-roots";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostPrefix } from "./host-prefix";
 import { ageColorReadable } from "./age-color";
+import { liveNow } from "./feed-age";
 import { TIP_GRACE_MS } from "./tip";
 
 type Color = { bg: string; fg: string } | null;
@@ -59,6 +60,15 @@ let provCards: ProvCard[] = [];
 // Full feed-card lookup by goal id (the SAME asks slice provCards reads): the hover card joins a top goal's
 // row to its feed card for the distiller BACKGROUND (cards carry it; ledger nodes don't — the user 2026-07-13).
 let asksById = new Map<string, { background?: string | null; summary?: string | null; blockSummary?: string | null }>();
+// The kernel's clock: `now` on the last frame, and WHEN that frame arrived (local ms). Every age on this pane
+// reads nowSec(), which adds the local time elapsed since (feed-age.ts liveNow), so the browser's own clock
+// never enters — read against Date.now(), every "(Xm ago)", the current goal's elapsed time and the recency
+// cutoff were off by whatever skew sat between the two clocks, and moved only when a frame arrived (a quiet
+// board on the delta path sends one every 60 s). `nowAt` is the WIRE arrival federation stamps on the merged
+// frame it re-emits (a re-emit after a quiet hour must not move an age); a frame without one (the VS Code
+// pipe hands frames straight to this pane) is arriving now.
+let hostNow = Math.floor(Date.now() / 1000), hostNowAt = Date.now();
+function nowSec(): number { return liveNow(hostNow, hostNowAt, Date.now()); }
 const DONE_KEY = "romp:fleetShowDone";
 function showDone(): boolean { try { return localStorage.getItem(DONE_KEY) === "1"; } catch { return false; } }
 function setShowDone(on: boolean) { try { localStorage.setItem(DONE_KEY, on ? "1" : "0"); } catch { /* ignore */ } }
@@ -392,7 +402,7 @@ function render() {
   const grouped = isGrouped();
   curFoldMode = foldMode();   // snapshot the sticky Collapse/Expand mode once for this render
   paintFoldButtons();
-  const now = Math.floor(Date.now() / 1000);
+  const now = nowSec();   // the kernel's clock, moving between frames (see hostNow)
   let any = false;
 
   // Adaptive cutoff range: the slider's right end tracks the OLDEST currently-eligible TOP goal (the user
@@ -664,7 +674,19 @@ function mountControls() {
 
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;
-  if (!m || m.type !== "feed") return;               // Fleet rides the FEED payload (proven channel); reads its `ledgers`
+  if (!m) return;
+  if (m.type === "delta") {
+    // The shim reassembles every {type:"delta"} frame into the whole message before a bundle sees it, and
+    // federation's remote sockets never dial for deltas — so one reaching this handler means a host handed
+    // the pane a kernel frame unreassembled. Say so and ask for the whole slot (needSlot: what the shim
+    // itself sends for a delta it cannot apply) rather than sit on the last frame while every update is
+    // dropped on the floor (fail loudly, never degrade). Run for real in fleet-live-clock.test.ts.
+    console.error("outline: a delta frame reached the pane unreassembled — asking the kernel for the whole slot");
+    vscodeApi?.postMessage({ type: "clientDiag", surface: "outline", what: "delta-unapplied", data: { slot: m.slot, rev: m.rev } });
+    vscodeApi?.postMessage({ type: "needSlot", slot: m.slot });
+    return;
+  }
+  if (m.type !== "feed") return;                     // the Outline rides the FEED payload (proven channel); reads its `ledgers`
   // "loaded" means the kernel actually BUILT the fleet's ledgers (the key is present, even if []) — NOT merely
   // that some feed message arrived. A feed push can reach us before the (cold) ledger build finishes; treating
   // that as loaded would drop the loader onto an empty pane (the user 2026-06-29). Until ledgers land, keep the
@@ -673,6 +695,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   // the attached-but-not-yet-merged hosts, from the merge itself (the ONLY writer; absent = none pending)
   pendingHosts = Array.isArray(m.pendingHosts) ? m.pendingHosts.filter((h: any) => typeof h === "string") : [];
   pendingDead = Array.isArray(m.pendingDead) ? m.pendingDead.filter((h: any) => typeof h === "string") : [];
+  if (typeof m.now === "number") {
+    hostNow = m.now;
+    hostNowAt = typeof m.nowAt === "number" ? m.nowAt : Date.now();   // the pair travels together: the frame's clock, and when THAT frame arrived
+  }
   if (!Array.isArray(m.ledgers)) return;
   loaded = true;
   sessions = m.ledgers as FleetSession[];
@@ -824,7 +850,7 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
   if (!s || !n) return;
   const byId = new Map([...(s.ledger?.tree || []), ...(s.ledger?.archivedTops || [])].map((x) => [x.id, x] as const));
   if (hoverCardEl) hoverCardEl.remove();
-  const card = buildHoverCard(s, n, byId, Math.floor(Date.now() / 1000));
+  const card = buildHoverCard(s, n, byId, nowSec());
   card.addEventListener("mouseenter", () => { if (hoverHideT) { clearTimeout(hoverHideT); hoverHideT = undefined; } });
   card.addEventListener("mouseleave", scheduleHideHover);
   document.body.appendChild(card);
@@ -910,6 +936,28 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
 mountControls();
 render();
 vscodeApi?.postMessage({ type: "ready" });   // ask the kernel to push the initial fleet state (like feed/timeline)
+
+// Keep every "(Xm ago)", the current goal's elapsed time, the recency cutoff and the slider's range honest
+// between frames: the clock-derived parts move on the local clock's deltas (nowSec) every 15 s, whatever the
+// wire is doing. A whole render(), not a per-element repaint: it is what every frame already runs, the ledgers
+// are small, and the cutoff filter has to be able to DROP a row as it ages out of the window — which no
+// repaint of the row's own text could do. Not for a pane nobody can see: a hidden tab (document.hidden) or a
+// pane the shell has hidden (display:none gives the iframe a ZERO viewport — the shim's paneHidden test;
+// document.hidden stays false for it) skips the tick, and the first visible moment catches up once
+// (visibilitychange, or the resize the iframe gets when it is shown again) — not on every flip, only after a
+// tick was skipped. Frames still render as they arrive.
+const paneHidden = () => document.hidden || window.innerWidth === 0 || window.innerHeight === 0;
+let tickSkipped = false;   // a refresh fell while hidden: the pane owes one catch-up render
+const refreshIfVisible = () => {
+  if (!loaded) return;
+  if (paneHidden()) { tickSkipped = true; return; }
+  tickSkipped = false;
+  render();
+};
+setInterval(refreshIfVisible, 15000);
+const catchUp = () => { if (tickSkipped) refreshIfVisible(); };
+document.addEventListener("visibilitychange", catchUp);
+window.addEventListener("resize", catchUp);
 
 // Hold the romp loader up until the ledgers actually land (the user 2026-06-29, who wanted the loading thing shown until
 // the tasks are ready to render). The shared _pane_spin loader has an 8s backstop that would otherwise hide

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -1,0 +1,260 @@
+// The pane shim's stale-banner rule, RUN rather than grepped. The shim is the JS the kernel inlines into
+// every pane page (kernel.py _shim); its template is lifted from the kernel source here, rendered as the
+// feed page renders it, and executed in a sandbox with a fake WebSocket, a fake clock and a fake shell. The
+// rule under test: after a reconnect, the "what you see may be stale" prompt is raised by the SECOND
+// KEEPALIVE arriving before the resync frame (one full heartbeat period, bracketed by two kernel heartbeats
+// on this socket with no resync between them — a single keepalive can be a beat that was already queued
+// when the socket was accepted), or by the reconnected socket CLOSING before it, and by nothing else — no
+// timer (every scenario runs the pending timers afterwards and asserts nothing fired, and asserts no timer
+// is armed on open); the first non-keepalive frame retires it; a keepalive never reaches the bundle. Also
+// run here: the close breadcrumbs (one `wsclose` per socket that OPENED; the redials an outage refused
+// coalesced into one `wsconnfail` row on the next open) and the cap on queued breadcrumbs.
+// Synthetic only (TESTHOST, no session data).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vm from "node:vm";
+
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+function shimJs(app: string): string {
+  const def = KERNEL.indexOf("def _shim(app, v=0):");
+  assert.ok(def > 0, "the shim renderer exists");
+  const start = KERNEL.indexOf('return """', def) + 'return """'.length;
+  const end = KERNEL.indexOf('""" % (app, int(v), app, app)', start);
+  assert.ok(end > start, "the template's format tuple is the one the test substitutes");
+  const args = [app, "5", app, app];
+  let i = 0;
+  return KERNEL.slice(start, end).replace(/%[sd]/g, () => args[i++]).replace(/%%/g, "%");
+}
+
+class Harness {
+  posted: any[] = [];          // what the pane told the shell (wsStale / wsFresh / wsState)
+  sent: any[] = [];            // what went up the socket (ready, clientDiag rows)
+  toBundle: any[] = [];        // frames the shim handed to the bundle
+  sockets: any[] = [];
+  timers: Array<() => void> = [];
+  visibility: Array<() => void> = [];
+  now = 1_000_000;
+  win: any;                    // the sandbox window (the shim hangs __rompLocalSend on it)
+  constructor(js: string) {
+    const h = this;
+    class FakeWS {
+      url: string; readyState = 0; onopen: any; onmessage: any; onclose: any; onerror: any;
+      constructor(url: string) { this.url = url; h.sockets.push(this); }
+      send(s: string) { h.sent.push(JSON.parse(s)); }
+      close() { if (this.readyState === 3) return; this.readyState = 3; this.onclose?.({ code: 1006, reason: "", wasClean: false }); }
+      open() { this.readyState = 1; this.onopen?.(); }
+      msg(o: any) { this.onmessage?.({ data: JSON.stringify(o) }); }
+    }
+    class FakeDate extends Date { static now() { return h.now; } }
+    const sandbox: any = {
+      window: {
+        parent: { postMessage: (m: any) => h.posted.push(m) },   // embedded: the shell owns the banner
+        sessionStorage: { getItem: () => "" },
+        dispatchEvent: (e: any) => { if (e && e.data !== undefined) h.toBundle.push(e.data); return true; },
+        addEventListener: () => {}, innerWidth: 800, innerHeight: 600,
+      },
+      document: {
+        addEventListener: (t: string, f: () => void) => { if (t === "visibilitychange") h.visibility.push(f); },
+        visibilityState: "visible", getElementById: () => null,
+      },
+      localStorage: { getItem: () => null, setItem: () => {} },
+      location: { protocol: "http:", host: "TESTHOST:29855", search: "" },
+      URLSearchParams: class { get() { return ""; } },
+      WebSocket: FakeWS, Date: FakeDate, JSON, console,
+      encodeURIComponent,
+      Event: class { type: string; constructor(t: string) { this.type = t; } },
+      MessageEvent: class { type: string; data: any; constructor(t: string, o: any) { this.type = t; this.data = o.data; } },
+      setTimeout: (f: () => void) => { h.timers.push(f); return h.timers.length; },
+      clearTimeout: () => {}, setInterval: () => 0,
+    };
+    sandbox.window.window = sandbox.window;
+    this.win = sandbox.window;
+    vm.runInNewContext(js, sandbox);
+  }
+  get ws() { return this.sockets[this.sockets.length - 1]; }
+  runTimers() { const t = this.timers.splice(0); for (const f of t) f(); }
+  stale() { return this.posted.filter((m) => m.romp === "wsStale" && !m.build).length; }
+  fresh() { return this.posted.filter((m) => m.romp === "wsFresh").length; }
+  diags(what: string) { return this.sent.filter((m) => m.type === "clientDiag" && m.what === what); }
+  kaReachedBundle() { return this.toBundle.some((m) => m && m.type === "ka"); }
+  /** the bundle has loaded and installed its listener: its own connect handshake goes through the shim's send() */
+  bundleReady() { this.win.__rompLocalSend({ type: "ready" }); }
+  /** connect, the bundle loads, deliver the first frame, then drop the socket and let the redial run: a RECONNECTED socket */
+  reconnected(): any {
+    this.ws.open(); this.bundleReady(); this.ws.msg({ type: "feed", asks: [] });
+    this.ws.close(); this.runTimers();
+    assert.equal(this.sockets.length, 2, "the close redialed");
+    this.ws.open();
+    assert.equal(this.timers.length, 0, "no timer is armed on open");
+    return this.ws;
+  }
+  /** the end of every scenario: whatever timers are pending fire, and the prompt count must not move */
+  settles(expectStale: number) {
+    this.runTimers();
+    assert.equal(this.stale(), expectStale, "nothing raises the prompt later — no timer does");
+  }
+}
+
+const FEED = () => new Harness(shimJs("feed"));
+
+test("the shim dials the page's socket as the kernel's connect handler expects it", () => {
+  const h = FEED();
+  assert.match(h.ws.url, /^ws:\/\/TESTHOST:29855\/ws\?app=feed&delta=1&iid=/);
+  h.settles(0);
+});
+
+test("resync first: a normal reconnect shows nothing, later keepalives are silent, and no timer is armed", () => {
+  const h = FEED();
+  const ws = h.reconnected();
+  assert.equal(h.stale(), 0, "arming shows nothing");
+  ws.msg({ type: "feed", asks: [] });
+  assert.equal(h.stale(), 0);
+  assert.equal(h.fresh(), 1, "the resync retires the (never shown) prompt");
+  ws.msg({ type: "ka", dv: 0 }); ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0, "keepalives after the resync are just keepalives");
+  assert.equal(h.toBundle.filter((m) => m.type === "feed").length, 2, "both frames reached the bundle");
+  assert.equal(h.kaReachedBundle(), false, "a keepalive never reaches the bundle");
+  h.settles(0);
+});
+
+test("one keepalive, then the resync: nothing shows — a single beat can be one already queued when the socket was accepted", () => {
+  const h = FEED();
+  const ws = h.reconnected();
+  ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0, "a single keepalive is not the event");
+  assert.equal(h.fresh(), 0, "…and it does not retire the arm either: it is not a resync");
+  ws.msg({ type: "feed", asks: [] });
+  assert.equal(h.stale(), 0);
+  assert.equal(h.fresh(), 1, "the resync retires it");
+  ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0, "the count died with the arm");
+  assert.equal(h.kaReachedBundle(), false);
+  h.settles(0);
+});
+
+test("two keepalives with no resync between them: the kernel is alive, talking to this socket and has not resynced it — raised", () => {
+  const h = FEED();
+  const ws = h.reconnected();
+  ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0);
+  ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 1, "the second heartbeat is the event");
+  assert.equal(h.diags("stale-raise")[0].data.why, "reconnect");
+  ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 1, "raised once, not per keepalive");
+  ws.msg({ type: "feed", asks: [] });
+  assert.equal(h.fresh(), 1, "the late resync still retires it");
+  assert.equal(h.kaReachedBundle(), false);
+  h.settles(1);
+});
+
+test("a delta frame the shim reassembles is the resync too: it retires the arm like a full frame", () => {
+  // the connect push to a pane that already holds the slot arrives as {type:"delta"} (the kernel's view
+  // deltas); the shim rebuilds the full message and hands THAT to the bundle — the resync, whatever its wire shape
+  const h = FEED();
+  const ws = h.reconnected();
+  ws.msg({ type: "ka", dv: 0 });
+  ws.msg({ type: "feed", asks: [{ itemId: "TESTSID:g1", text: "a" }], _keys: { asks: ["TESTSID:g1"] } });
+  assert.equal(h.fresh(), 1);
+  ws.close(); h.runTimers(); h.ws.open();
+  h.ws.msg({ type: "ka", dv: 0 });
+  h.ws.msg({ type: "delta", slot: "feed", base: 0, rev: 1, coll: { asks: { set: { "TESTSID:g1": { itemId: "TESTSID:g1", text: "b" } } } } });
+  assert.equal(h.stale(), 0);
+  assert.equal(h.fresh(), 2, "the reassembled delta retired the second arm");
+  assert.equal(h.toBundle[h.toBundle.length - 1].asks[0].text, "b", "…and the bundle got the full message");
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0);
+  h.settles(0);
+});
+
+test("the reconnected socket closing before its resync raises; the foreground path's own close does not", () => {
+  const h = FEED();
+  const ws = h.reconnected();
+  ws.close();
+  assert.equal(h.stale(), 1);
+  h.runTimers(); h.ws.open();   // the breadcrumb was queued on the dead socket; it flushes on the redial
+  assert.equal(h.timers.length, 0, "no timer is armed on open");
+  assert.equal(h.diags("stale-raise")[0].data.why, "reconnect-closed");
+  h.settles(1);
+  // foreground fast-path: a quiet socket is closed by the pane itself — no raise for that close; the
+  // reconnect it forces arms with why=foreground, and two keepalives before the resync raise as usual
+  const g = FEED();
+  g.ws.open(); g.ws.msg({ type: "feed", asks: [] });
+  g.now += 31_000;
+  for (const f of g.visibility) f();
+  assert.equal(g.stale(), 0, "closing a quiet socket is not a raise");
+  g.runTimers(); g.ws.open();
+  assert.equal(g.timers.length, 0, "no timer is armed on open");
+  g.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(g.stale(), 0);
+  g.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(g.stale(), 1);
+  assert.equal(g.diags("stale-raise")[0].data.why, "foreground");
+  g.settles(1);
+});
+
+test("an announced restart's reconnect skips the arm once (T217); a second reconnect arms as always", () => {
+  const h = FEED();
+  h.ws.open(); h.ws.msg({ type: "feed", asks: [] });
+  h.ws.msg({ type: "restarting" });
+  h.ws.close(); h.runTimers(); h.ws.open();
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0, "the announced restart explained this reconnect");
+  h.ws.msg({ type: "feed", asks: [] });
+  h.ws.close(); h.runTimers(); h.ws.open();
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 1, "the latch was one-shot");
+  h.settles(1);
+});
+
+test("every close of a socket that OPENED leaves a wsclose breadcrumb with the code, the socket's age and the quiet gap", () => {
+  const h = FEED();
+  h.ws.open(); h.now += 4_000; h.ws.msg({ type: "feed", asks: [] }); h.now += 2_500;
+  h.ws.close();
+  assert.equal(h.diags("wsclose").length, 0, "queued while the socket is down…");
+  h.runTimers(); h.ws.open();
+  const rows = h.diags("wsclose");
+  assert.equal(rows.length, 1, "…and delivered on the reconnect");
+  assert.equal(rows[0].surface, "pane-shim");
+  assert.deepEqual(rows[0].data, { app: "feed", code: 1006, reason: "", wasClean: false, sinceOpenMs: 6_500, quietMs: 2_500, everConnected: true });
+  assert.equal(h.diags("wsconnfail").length, 0, "no handshake failed");
+});
+
+test("the redials an outage refuses leave ONE coalesced row on the next open, never a wsclose each", () => {
+  const h = FEED();
+  h.ws.open(); h.bundleReady(); h.ws.msg({ type: "feed", asks: [] });
+  h.now += 1_000;
+  h.ws.close();                                    // the real drop: this socket had opened
+  const t0 = h.now;
+  for (let i = 0; i < 2400; i++) {                 // an hour of 1.5 s redials, every handshake refused
+    h.runTimers();                                 // the redial dials a new socket…
+    h.now += 1_500;
+    h.ws.close();                                  // …which the browser closes (1006) without it ever opening
+  }
+  h.runTimers(); h.ws.open();                      // the kernel is back
+  const closes = h.diags("wsclose");
+  assert.equal(closes.length, 1, "one wsclose: the socket that opened");
+  assert.equal(closes[0].data.sinceOpenMs, 1_000, "with ITS timings, not the outage's");
+  const fails = h.diags("wsconnfail");
+  assert.equal(fails.length, 1, "the refused handshakes are one row");
+  assert.deepEqual(fails[0].data, { app: "feed", attempts: 2400, firstFailMs: h.now - (t0 + 1_500) });
+  assert.deepEqual(h.sent.slice(-1), fails, "…sent on the open, after the flushed wsclose");
+  assert.equal(h.sent.filter((m) => m.type === "clientDiag").length, 2, "nothing else piled up");
+});
+
+test("queued breadcrumbs are capped while the socket is down; other queued messages are untouched", () => {
+  const h = FEED();                                // never opened yet: everything queues
+  for (let i = 0; i < 30; i++) h.win.__rompLocalSend({ type: "clientDiag", surface: "pane-shim", what: "probe", data: { i } });
+  h.win.__rompLocalSend({ type: "activeTab", id: "TESTSID" });
+  h.win.__rompLocalSend({ type: "clientDiag", surface: "pane-shim", what: "probe", data: { i: 30 } });
+  assert.equal(h.sent.length, 0, "nothing goes up before the open");
+  h.ws.open();
+  const diag = h.sent.filter((m) => m.type === "clientDiag");
+  assert.equal(diag.length, 20, "at most DIAG_QUEUE_MAX breadcrumbs ride the reconnect");
+  assert.deepEqual(diag.map((m) => m.data.i), [...Array(20).keys()], "the oldest are kept: the rows about the drop that started it");
+  assert.equal(h.sent.filter((m) => m.type === "activeTab").length, 1, "a non-diagnostic message is never dropped");
+  assert.equal(h.sent.length, 21);
+});

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -23,7 +23,7 @@ test("the arrangement is re-read per emit, never cached", () => {
   // surfaces arranged one way and this one's another until a reload
   assert.match(FED, /private view\(\): string\[\] \{\s*\n\s*return readViewOrder\(\);\s*\n\s*\}/);
   assert.match(FED, /mergeHostOrder\(this\.perHostOrder, this\.hostSeq, this\.view\(\)\)/);
-  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\), dead\)/);
+  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\), dead, this\.perHostFeedAt\)/);
   assert.match(FED, /mergeHostTimelines\(this\.perHostTl, this\.hostSeq, this\.view\(\)\)/);
 });
 


### PR DESCRIPTION
Three small fixes on top of the view-delta protocol that #914 and the #928 fold shipped. That protocol is what this builds on and nothing here changes it: the shim still dials `?delta=1`, `_send_slot`/`_send_slot_delta` still carry the feed and the bars, and the shim still reassembles every `{type:"delta"}` frame before a bundle sees it. What was left after it landed were three things that leave no trace or run on the wrong clock.

## 1. A client dropped for falling behind is silent

`_mk_ws_send` drops a client that has fallen `WS_QUEUE_BYTES` behind by raising, and every caller — `_send_client`, the tail of `_send_slot_delta`, `_send_to_app`, `_send_to_view`, the keepalive — catches it with a bare `c["alive"] = False`. `_drop_dead_ws_client` writes a `ws: dropping` line for the ping-timeout and supersession drops, but the budget drop writes nothing, so a dashboard dropped and reconnected every few minutes reads as a flaky network.

**Fix.** The raise site logs the drop (`_note_ws_drop`), once per client, with the same `ws: dropping` prefix the other two drops use, so one grep finds every kind: the pane, the dashboard id, the backlog, the frame that tipped it, and — for a push-path send — the slot whose frame it was. `_client_send` leaves the slot on the client for the length of its call, so the line reads `slot=feed`, `slot=chat:<sid>`, `slot=taborder`; a direct one-shot `client["send"]` reply reads `slot=-`. Every push and keepalive send goes through `_client_send`; the ~60 direct replies are covered by the raise site itself. The same drop rides the dashboard's bell through `_sdk_problem_rows` (the existing kernel-problems channel): at most five drop rows, none older than an hour, merged by time with the backend rows so they never crowd a backend problem out. Bell text is plain language for the person at the dashboard.

**Reproduce (before):** a client with the kernel's own `send` and `qbytes` ten bytes under the budget receives a 100-byte frame → `OSError`, `alive=False`, and nothing on stderr. `tests/test_ws_drop_loud.py` drives this on `_send_client`, on a direct `client["send"]`, and through `_send_slot` on a delta client whose second (delta) frame tips the budget.

## 2. The stale prompt is armed on a timer

After a reconnect the pane shim arms the "what you see may be stale" prompt on a one-second `setTimeout`. On a board of several hundred cards the connect push is a multi-megabyte frame that can take longer than a second to land over a forwarded or tunnelled link, so the prompt raises on reconnects that are resyncing normally, and a hidden pane's reconnect storm multiplies it.

**Fix.** The arm keys on two events. The prompt raises on the **second** keepalive arriving on the reconnected socket before any resync frame — one heartbeat period bracketed by two beats from a kernel that is alive, talking to this socket, and not resyncing it — or on the reconnected socket closing again before its resync. One keepalive is not the event: the heartbeat thread can enqueue a beat the instant a socket is accepted, ahead of the connect push. The first non-keepalive frame retires the arm as before (a delta the shim reassembles counts — the bundle receives the full message); the hidden-pane suppression, the announced-restart skip and the foreground path are unchanged in behaviour (the foreground path now hands its reason to the reconnect it forces, whose arm follows the same two events). Every close of a socket that opened leaves a `wsclose` clientDiag (code, reason, wasClean, socket age, quiet gap) — a kernel-side drop (1006, no close frame), a clean restart, a proxy timeout and the watchdog's own close were indistinguishable before; the redials an outage refuses are counted and reported as one `wsconnfail` row on the next open; at most 20 breadcrumbs wait in the shim's queue, other queued messages untouched.

**Design point to weigh.** A genuinely stale reconnect is now reported after 10–20 s of no resync rather than after one second. The trade is against a prompt that was raising on healthy reconnects.

## 3. The Outline pane's ages run on the browser's clock, and only when a frame lands

`fleet.ts` computed every "(Xm ago)", the current goal's elapsed time, the recency cutoff and the slider's range from `Date.now()` inside `render()`, against timestamps the **kernel** wrote — so every age is off by whatever skew sits between the browser's clock and the kernel's (minutes on a phone or a laptop back from sleep). And `render()` runs only on a frame, a settings event or a click; on the delta path a quiet board sends the pane one frame every 60 s (`_DEDUP_REPOST_S`), so the ages move in minute steps.

**Reproduce (before):** the new `fleet-live-clock.test.ts` runs `fleet.ts` for real under mock timers with the kernel clock five minutes behind the browser's. Two cards 20 s and 40 s old render as **no rows at all** — the browser clock reads them five minutes old and the recency cutoff drops them.

**Fix.** The pane anchors on the frame's `now` paired with the moment that frame arrived from the wire (`feed-age.ts` `liveNow`: the kernel's clock plus the local time elapsed since — only the local clock's deltas enter, never its offset), and re-renders every 15 s while visible. A whole `render()` rather than a per-element repaint, because the cutoff filter must be able to drop a row as it ages out. A hidden document or a zero-size iframe (the shell's `display:none` pane) skips the tick and catches up once when shown (`visibilitychange`, or the `resize` the iframe gets), not on every flip.

`federation.ts` stamps each host's feed frame with its wire arrival (`perHostFeedAt`) and `mergeHostFeeds` puts it beside `now` on the merged frame as `nowAt` — both from the local frame, or from the newest remote arrival when no local frame exists, so the pair always describes one frame. The merged frame is re-emitted on a view-order write, on every remote host's frame and on a detach; anchored on the emit instead, every age would move back by however long the local board had been quiet. `nowAt` is additive: `feed.ts` ignores it and is unchanged, and a frame without it (the VS Code pipe hands frames straight to the pane) anchors at its arrival.

A `{type:"delta"}` frame reaching the bundle unreassembled — the shim rebuilds every one before a bundle sees it, and federation's remote sockets never dial for deltas, so this means a host handed the pane a kernel frame raw — is loud (`console.error`, a clientDiag breadcrumb, a `needSlot` for the whole slot, the shim's own message for a delta it cannot apply) instead of falling through the `type !== "feed"` return with every later update dropped in silence.

## Tests

- Python: `tests/test_ws_drop_loud.py` (new, 7) — one stderr line per drop with its fields; the row reaches `_sdk_problem_rows`; a direct send's drop is loud; a push-path drop names its slot; a drop on the view-delta path is loud and named; drop rows never hide a backend problem; every send path goes through the helper (source pin). Shim pins in `test_kernel_disconnect_banner`, `test_kernel_ws_heartbeat` (the keepalive-branch pin now holds the branch's `return` explicitly) and `test_restart_seam` follow the new text.
- Node: `ui/webview/pane-shim-stale.test.ts` (new, 10) runs the shim's JavaScript, lifted from `kernel.py` and rendered as the feed page renders it, in a vm sandbox with fake sockets, timers and clock, and drives each rule (resync first; one keepalive; two keepalives; a reassembled delta as the resync; close before resync and the foreground path; announced restart; wsclose; wsconnfail; the queue cap). `fleet-live-clock.test.ts` (new, 5) runs `fleet.ts` against a small DOM stand-in under mock timers. `feed-clock-anchor.test.ts` (new, 4) drives the real `FederationManager` with a stub clock. `feed-age.test.ts` (new, 2) pins `liveNow`. One pin added to `fleet.test.ts`; `view-order-wiring.test.ts` follows the new `mergeHostFeeds` call.
- Every new or changed test was run against the unfixed code first and fails there (details in the commit messages). All fixtures are synthetic (placeholder ids, `TESTHOST`, the notes-api demo world).

Docs: one bullet each in `docs/read-side.md` for the keepalive-keyed prompt and the loud drop, and one for the Outline pane's clock; one sentence in `docs/guide.md`'s remote-access subsection.

Known follow-ups, not in this PR: the feed pane's own 15 s age tick still reads `Date.now()` (the same skew, bounded by the 60 s repost); `mergeHostFeeds` concatenates remote hosts' ledgers without rebasing their times onto the local clock, so a remote row's age is off by that host's skew.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)