### PR TITLE
Session CLIs and the manager's tmux server run in their own systemd scopes, so a service restart no longer kills session work

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -23,6 +23,7 @@ no separate implementation to point at.
 | `romp-node-launch` | POSIX sh | Runs the manager under a romp-owned copy of node (`romp-node`) so macOS TCC permissions can be granted to romp alone. |
 | `romp-manager` | Node | The kernel **supervisor**: spawns kernels via `romp-serve`, respawns on crash, `up/ensure/restart-all/status/down`. Reached via `romp up` / `romp refresh` / `romp status`. |
 | `romp-serve` | Bash | The manager→kernel seam: maps the manager's spawn contract onto the kernel's env, picks the python, then `exec`s the kernel (PID preserved for the supervisor; the kernel self-builds stale UI bundles). |
+| `romp-cli-scope` | POSIX sh | Linux + systemd only: the kernel spawns each session's `claude` CLI through it, and it `exec`s `systemd-run --user --scope` in place, so the CLI (and every tool shell, `setsid` child and tmux server it later starts) runs in a transient scope of its own instead of the manager service's cgroup, which a service restart empties. PID, parent and argv preserved; `ROMP_CLI_SCOPE=0`, or no `ROMP_SID` (a probe, not a session), runs the CLI directly, and so does a failed pre-flight scope, with one stderr line saying why, which the kernel logs as a problem at once. |
 | `romp-sdk-setup` | Bash | Provisions the Agent SDK venv for the SDK backend. Run by `install.sh`. |
 
 ## Symlinks → `kernel/` (the always-on core)

--- a/bin/romp-cli-scope
+++ b/bin/romp-cli-scope
@@ -1,0 +1,88 @@
+#!/bin/sh
+# romp-cli-scope — run one session's `claude` CLI inside its own transient systemd scope.
+#
+# WHY: on Linux the manager runs as a systemd user service that relies on systemd's default
+# KillMode=control-group (the unit sets no KillMode line, on purpose: it is what guarantees a wedged
+# kernel or postal bus still holding its port dies on a service restart). Every process the service
+# tree starts lands in the service's cgroup, and that includes each session's CLI, its tool shells,
+# their setsid children and any tmux server a session starts — so a service restart on 2026-09-05
+# (`systemctl --user restart romp-manager`) killed sessions' tmux servers and setsid jobs along with
+# the kernel. Only kernel-only restarts (`romp refresh`), which never touch the service, had left
+# them running. `systemd-run --scope` moves the CLI, and so everything it later spawns, into a scope
+# of its own outside the service cgroup.
+#
+# WHY exec-in-place matters: the kernel's interrupt escalation (find_session_cli in sdk_backend.py)
+# finds the CLI as a DIRECT CHILD of the kernel, and the boot orphan reaper (find_orphan_clis) reads
+# `--input-format stream-json` and the sid from the argv and treats a CLI whose parent is no live
+# romp kernel as orphaned. Both hold only if the CLI ends up with this wrapper's pid, its parent and
+# the argv tail the SDK passed: `exec` here hands our pid to systemd-run, and systemd-run in --scope
+# mode moves itself into the new scope and then execs the command in place, so the CLI keeps the pid
+# the SDK spawned and its parent stays the kernel. (An orphan re-parents to the `systemd --user`
+# subreaper, never to pid 1, scope or no scope — which is why the reaper keys on the parent not
+# being a kernel rather than on ppid 1.)
+#
+# The scope name carries the first 8 characters of the session id, this pid (the pid the CLI will
+# run as) and a start time, so `systemctl --user list-units 'romp-session-*'` doubles as a pid
+# record. systemd refuses a duplicate unit name ("already loaded"), and a previous CLI's scope can
+# outlive that CLI (a tmux server it started keeps the scope loaded), so once pids wrap a pid alone
+# could collide; the time component makes the name unique.
+#
+# Two direct-exec paths, no scope: no ROMP_SID (a process with no session identity is a probe — the
+# SDK's per-connect `claude -v` version check — not a session, and must not get a scope of its own),
+# and a failed pre-flight (`systemd-run … -- true`: the user bus gone, scopes refused), where one
+# stderr line names the reason and the CLI runs directly rather than not at all.
+#
+# Every stderr line this wrapper writes starts with `romp-cli-scope:`, and its second word says which
+# of the two messages it is, so the kernel tells them apart without reading the prose
+# (SdkSession._on_cli_stderr):
+#   `romp-cli-scope: fallback: …` — the failed pre-flight above; the CLI runs directly. The kernel logs
+#     this line the moment it arrives, as a problem naming the session. On this path the CLI starts,
+#     so no launch failure ever drains the stderr tail; without that the line would never have been
+#     read and the boot verdict would keep saying scopes are on. The launch-error card drops these
+#     lines from a failed CLI's stderr tail, since the log already has them.
+#   `romp-cli-scope: refused: …` — ROMP_CLI_REAL unset, exit 127, no CLI at all. The kernel logs no
+#     fallback for it: the launch fails, and the launch-error path reports the line on its own.
+# The rest of the CLI's stderr the kernel only buffers, for a launch that fails.
+#
+# Environment: ROMP_CLI_REAL (required) — the real CLI; ROMP_SID — the session id (kernel-set);
+# ROMP_CLI_SCOPE=0 — run the CLI directly, no scope. Arguments pass through verbatim.
+set -u
+
+if [ -z "${ROMP_CLI_REAL:-}" ]; then
+    echo "romp-cli-scope: refused: ROMP_CLI_REAL is unset or empty; it must name the real claude CLI, and this wrapper does not guess one" >&2
+    exit 127
+fi
+
+sid="${ROMP_SID:-}"
+if [ "${ROMP_CLI_SCOPE:-}" = "0" ] || [ -z "$sid" ] || ! command -v systemd-run >/dev/null 2>&1; then
+    exec "$ROMP_CLI_REAL" "$@"
+fi
+
+# Pre-flight: can this user manager start a scope right now? The kernel probed once at its own start,
+# but the bus can go away later, and a launch that fails outright is worse than one in the wrong cgroup.
+# Bounded to 10 s when `timeout` (coreutils) is on PATH: a bus that accepts the connection and never
+# answers holds systemd-run for its own 90 s default, past the SDK's 60 s initialize timeout, so the
+# fallback below would never engage in the case it exists for. Any non-zero exit, 124 (the bound hit)
+# included, is a failed pre-flight. Without `timeout` the pre-flight runs unbounded, as it did before.
+if command -v timeout >/dev/null 2>&1; then
+    err="$(timeout 10 systemd-run --user --scope --quiet --collect -- true 2>&1)"; rc=$?
+    [ "$rc" -eq 124 ] && err="the pre-flight scope did not finish within 10 s"
+else
+    err="$(systemd-run --user --scope --quiet --collect -- true 2>&1)"; rc=$?
+fi
+if [ "$rc" -ne 0 ]; then
+    nl='
+'
+    err="${err%%"$nl"*}"
+    echo "romp-cli-scope: fallback: systemd-run cannot start a transient scope (${err:-no detail}) — running the CLI directly, outside a scope; a service restart will take its background work down" >&2
+    exec "$ROMP_CLI_REAL" "$@"
+fi
+
+t="$(date +%s%N 2>/dev/null)"
+case "$t" in
+    ''|*[!0-9]*) t="$(date +%s)" ;;    # a date without %N prints the letter; seconds still separate pid reuse in time
+esac
+unit="romp-session-$(printf '%.8s' "$sid")-$$-$t"
+
+exec systemd-run --user --scope --quiet --collect --unit="$unit" \
+    --description="romp session $sid" -- "$ROMP_CLI_REAL" "$@"

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -549,11 +549,95 @@ function runManager() {
 // prompt "Visual Studio Code wants to access…" — even with VS Code closed (its helpers linger). Starting
 // the server here at login fixes it permanently. `exit-empty off` keeps the (initially empty) server alive
 // until real sessions join; it's a no-op if a server is already running (the user 2026-06-16).
+//
+// Under the Linux service the server goes into a transient systemd scope of its own (2026-09-05). The
+// manager runs as a systemd user service that relies on systemd's default KillMode=control-group (the
+// unit sets no KillMode line), so a server started here lands in the service's cgroup and `systemctl
+// --user restart romp-manager` kills it, with every session's tmux jobs inside — a service restart that
+// day killed two sessions' tmux servers and setsid jobs along with the kernel. `systemd-run --scope`
+// starts the daemon outside the service cgroup; a session's later `tmux new-session` joins that server
+// and survives a service restart. The tmux CLIENT still exits at once (it only starts the daemon), so
+// execFileSync's semantics are unchanged, and when a server already runs the call is the same no-op and
+// the scope collects itself. Any failure of the scoped path falls back to the bare call. The macOS path
+// is as it was: launchd owns the lineage there and the TCC rationale above still applies.
+const TMUX_START_ARGV = ['tmux', 'start-server', ';', 'set', '-g', 'exit-empty', 'off'];
+
+// Is `name` an executable on the env's PATH? (Node has no `which`.)
+function commandOnPath(name, env = process.env) {
+  for (const dir of (env.PATH || '').split(path.delimiter)) {
+    if (!dir) continue;
+    try { fs.accessSync(path.join(dir, name), fs.constants.X_OK); return true; } catch { /* next dir */ }
+  }
+  return false;
+}
+
+// The PURE choice of how to start the server — exported for unit tests. null when tmux is not on PATH:
+// nothing to start and nothing to say (the behaviour before the scopes; a tmux-less box must not log a
+// scope failure at every start). Scoped exactly when the kernel scopes session CLIs (cli_scope_supported
+// in kernel/sdk_backend.py, the same switch): ROMP_CLI_SCOPE=1, or under the supervised service
+// (ROMP_SUPERVISED, what bin/romp-service's unit sets) unless ROMP_CLI_SCOPE=0 — so a terminal-run
+// manager scopes nothing unless asked — and then only on Linux with systemd-run on PATH. The unit name
+// carries a timestamp: systemd refuses a duplicate name ("already loaded") and the last scope may
+// still be alive with the server in it.
+function tmuxStartArgv({ platform = process.platform, env = process.env, onPath = commandOnPath, now = Date.now } = {}) {
+  if (!onPath('tmux', env)) return null;
+  const want = env.ROMP_CLI_SCOPE;
+  const wanted = want === '1' || (Boolean(env.ROMP_SUPERVISED) && want !== '0');
+  if (platform !== 'linux' || !wanted || !onPath('systemd-run', env)) {
+    return { argv: TMUX_START_ARGV.slice(), scoped: false };
+  }
+  return { argv: ['systemd-run', '--user', '--scope', '--quiet', '--collect', `--unit=romp-tmux-${now()}`,
+                  '--', ...TMUX_START_ARGV], scoped: true };
+}
+
+const TMUX_START_TIMEOUT_MS = 5000;
+const FAILURE_LINE_MAX = 200;
+
+// What a failed scoped start says in the log, from execFileSync's error: the tool that failed, and its
+// first stderr line, bounded. systemd-run in --scope mode execs the command in place, so a non-zero exit
+// is either systemd-run's own — no user bus, a refused unit name; its logger prefixes every line
+// "Failed to …" — or tmux's, failing inside a scope that did start ("error connecting to …"). The line
+// names whichever wrote the message. With nothing on stderr it names systemd-run, the command that ran,
+// and says how it ended. Exported for the node suite.
+function scopedStartFailure(e) {
+  const first = String((e && e.stderr) || '').split('\n').map((s) => s.trim()).find(Boolean) || '';
+  const tool = first && !/^Failed to /.test(first) ? 'tmux' : 'systemd-run';
+  let detail = first;
+  if (!detail) {
+    if (e && e.code === 'ETIMEDOUT') detail = `timed out after ${TMUX_START_TIMEOUT_MS / 1000} s`;
+    else if (e && e.signal) detail = `killed by ${e.signal}`;
+    else if (e && typeof e.status === 'number') detail = `exit ${e.status}, nothing on stderr`;
+    else detail = String(e && e.message || e).split('\n')[0];   // a spawn error: "spawnSync systemd-run ENOENT"
+  }
+  if (detail.length > FAILURE_LINE_MAX) detail = detail.slice(0, FAILURE_LINE_MAX - 1) + '…';
+  return { tool, detail };
+}
+
 function startTmuxServer() {
+  const pick = tmuxStartArgv();
+  if (!pick) return;   // no tmux on PATH: nothing to start, and nothing to log (as before the scopes)
+  // stderr is piped on the scoped call, for the failure line below: with stdio 'ignore' the error carried
+  // "Command failed: <argv>" and nothing about why. The pipe closes when tmux's client exits — its server
+  // daemonizes onto /dev/null — so it holds nothing open. The bare call keeps 'ignore': nothing reads it.
+  const stdio = pick.scoped ? ['ignore', 'ignore', 'pipe'] : 'ignore';
   try {
-    execFileSync('tmux', ['start-server', ';', 'set', '-g', 'exit-empty', 'off'], { stdio: 'ignore', timeout: 5000 });
-    log('tmux server ensured (launchd-rooted) — new sessions won\'t inherit a terminal\'s TCC identity');
-  } catch (e) { /* tmux not installed, or a server is already up — nothing to do */ }
+    execFileSync(pick.argv[0], pick.argv.slice(1), { stdio, timeout: TMUX_START_TIMEOUT_MS });
+    log(pick.scoped
+      ? 'tmux server ensured in its own transient scope (romp-tmux-*) — a service restart leaves it and its sessions\' jobs alive'
+      : 'tmux server ensured (launchd-rooted) — new sessions won\'t inherit a terminal\'s TCC identity');
+    return;
+  } catch (e) {
+    if (!pick.scoped) return;   // a server is already up, or tmux itself failed — nothing more to do
+    // Say what failed and where the server will land: this may be a terminal run with no service cgroup.
+    const { tool, detail } = scopedStartFailure(e);
+    log(tool === 'tmux'
+      ? `tmux failed inside the scope systemd-run started for it (${detail}) — starting it the plain way instead`
+      : `systemd-run could not start the tmux server in a scope (${detail}) — starting it the plain way instead`);
+  }
+  try {
+    execFileSync(TMUX_START_ARGV[0], TMUX_START_ARGV.slice(1), { stdio: 'ignore', timeout: TMUX_START_TIMEOUT_MS });
+    log('tmux server ensured without a scope — under the service, a service restart will take it down');
+  } catch (e) { /* a server is already up, or tmux itself failed — nothing to do */ }
 }
 
 function startManager() {
@@ -663,7 +747,8 @@ function ensureUp() {
 // Exported for unit tests (restartGate = the pure storm-cap decision). The CLI dispatch runs only when this
 // file is executed directly, so require()-ing it from a test has no side effects.
 module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp,
-                   kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet };
+                   kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet,
+                   tmuxStartArgv, scopedStartFailure, commandOnPath, TMUX_START_ARGV };
 if (require.main === module) {
   const cmd = process.argv[2];
   // `restart-all` (the `romp refresh` deploy path) bounces IMMEDIATELY by default (T160, the user

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -420,6 +420,52 @@ one file; a service installed before that carries only the default. `romp
 keyswap` asks the running kernel which key it reads and says `MISMATCH` when
 that is not the file's — the check to make after a swap.
 
+### What survives a restart
+
+A kernel restart ends every session's CLI. On `romp refresh`, the manager's
+restart-all or a service stop, the kernel receives SIGTERM and drains: it
+closes each CLI, and a CLI still running when the drain's bound expires gets
+SIGTERM, then SIGKILL. A crash respawn has no drain: the kernel died without
+running one, its CLIs are orphaned, and the next kernel's boot reaper
+terminates them (see below). The CLI's harness background tasks do not all end
+with it. Its timers and monitors live inside the CLI process and end when it
+does. A background shell is a separate process the CLI started, and a CLI
+killed by SIGKILL runs no cleanup, so its shells are re-parented and may keep
+running. The session resumes with its history and is told what was cut: its
+in-flight turn, if it had one, and each background task, with a request to
+check whether each is still running before relaunching it. A kernel restart has
+never touched work a session deliberately detached: tmux servers, `setsid`
+children and other processes that outlive their shell.
+
+A service restart (`systemctl --user restart romp-manager`, or the machine's
+own service management) kills everything in the service's cgroup, so on Linux
+under systemd Romp runs each session's CLI, and the default tmux server the
+manager starts, in a transient systemd scope of its own, outside that cgroup
+(`systemctl --user list-units 'romp-session-*' 'romp-tmux-*'` lists them). A
+session's tmux servers, `setsid` children and other detached work live in the
+session's scope, and a service restart leaves them alive as a kernel restart
+does; before 2026-09-05 they were in the service's cgroup and died with it. The
+CLI itself still ends: the kernel receives the service's SIGTERM and runs the
+same drain. A scoped CLI outlives a service restart only when the drain does not
+reach it: a kernel killed before its drain finishes (SIGKILL at the service's
+stop timeout), or a CLI the drain could not find. The reaper handles that case:
+at the next kernel boot, an SDK-driven CLI holding one of the kernel's sessions
+whose parent is not a live romp kernel is treated as orphaned and terminated.
+Under `systemd --user` an orphan re-parents to the user manager, not to pid 1,
+so a ppid check alone would miss it and did, before 2026-09-05.
+
+One-time caveat when this lands: the first service restart after it still
+empties the current cgroup, tmux servers included, because the running manager
+and its tmux server predate the change and are still inside the service's
+cgroup. The guarantee holds from the following restart on.
+
+`ROMP_CLI_SCOPE=0` in the service environment turns the scopes off, for
+session CLIs and the tmux server alike. A manager run outside the service
+(`romp up`) scopes nothing unless `ROMP_CLI_SCOPE=1` is set, which turns both
+on. The kernel logs which it chose at start (`cli scope: on` or `off`, with the
+reason). The macOS launchd path is unchanged: there is no cgroup kill there,
+and the tmux server keeps its launchd lineage.
+
 ## Where things live
 
 State is written under `${XDG_STATE_HOME:-~/.local/state}/romp/`. Transcripts

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -463,7 +463,10 @@ cgroup. The guarantee holds from the following restart on.
 session CLIs and the tmux server alike. A manager run outside the service
 (`romp up`) scopes nothing unless `ROMP_CLI_SCOPE=1` is set, which turns both
 on. The kernel logs which it chose at start (`cli scope: on` or `off`, with the
-reason). The macOS launchd path is unchanged: there is no cgroup kill there,
+reason); when the scopes were wanted on Linux and the box cannot provide them
+(no `systemd-run`, or a user manager that refuses to start one), that verdict
+also appears in the dashboard's error center, since every session then runs
+inside the service cgroup. The macOS launchd path is unchanged: there is no cgroup kill there,
 and the tmux server keeps its launchd lineage.
 
 ## Where things live

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -59,6 +60,92 @@ def _bin_on_path_env(environ) -> dict:
     if rbin in cur.split(os.pathsep):
         return {}
     return {"PATH": (rbin + os.pathsep + cur) if cur else rbin}
+
+
+# Per-session transient systemd scopes (Linux, 2026-09-05). Under the systemd user service every
+# process the service tree starts shares the service's cgroup, and the unit relies on systemd's
+# default KillMode=control-group (it sets no KillMode line; a wedged kernel or bus still holding its
+# port must die on a service restart), which empties that cgroup on `systemctl --user restart
+# romp-manager` — each session's CLI, its tool shells, their setsid children and any tmux server a
+# session started included. A service restart on 2026-09-05 killed sessions' tmux servers and setsid
+# jobs along with the kernel; only kernel-only restarts (`romp refresh`), which never touch the
+# service, had left them running. So, when supported, the CLI is spawned through bin/romp-cli-scope,
+# which execs `systemd-run --user --scope` in place: the CLI keeps the spawned pid, parent and argv
+# (find_session_cli still finds it as this kernel's child; find_orphan_clis still reads its argv) but
+# runs in a scope of its own, and everything it later spawns goes with it. What the scopes take away
+# is the cgroup kill as a backstop for the boot reaper: an orphaned CLI now outlives a service
+# restart too, and under `systemd --user` (a child subreaper) it re-parents to the user manager,
+# never to pid 1 — which is why find_orphan_clis keys on "parent is not a live romp kernel", not on
+# ppid 1.
+CLI_SCOPE_PROBE = ["systemd-run", "--user", "--scope", "--quiet", "--collect", "--", "true"]
+CLI_SCOPE_PROBE_TIMEOUT = 10.0
+# What every line bin/romp-cli-scope writes to stderr starts with. The wrapper writes only when the
+# CLI did NOT get its scope, and the line's second word says which of its two messages it is:
+#   CLI_SCOPE_FALLBACK_PREFIX — the pre-flight scope failed and it ran the CLI directly. The CLI starts,
+#     so no launch failure ever drains the stderr tail; SdkSession._on_cli_stderr logs the line the
+#     moment it arrives, as a problem (_note_cli_scope_fallback). launch_failure_text drops these lines
+#     from a failed launch's stderr tail, since the log already has them.
+#   CLI_SCOPE_REFUSAL_PREFIX — ROMP_CLI_REAL was unset and it refused (exit 127). No CLI started, so this
+#     is a launch failure on its own, reported by _record_launch_error like any other; it is not a
+#     fallback and is not logged as one.
+CLI_SCOPE_NOTICE_PREFIX = "romp-cli-scope:"
+CLI_SCOPE_FALLBACK_PREFIX = CLI_SCOPE_NOTICE_PREFIX + " fallback:"
+CLI_SCOPE_REFUSAL_PREFIX = CLI_SCOPE_NOTICE_PREFIX + " refused:"
+
+
+def cli_scope_wrapper() -> str:
+    """The wrapper's absolute path: the repo's bin/, located the same way _bin_on_path_env finds it."""
+    return str(Path(__file__).resolve().parent.parent / "bin" / "romp-cli-scope")
+
+
+def cli_scope_supported(environ=None, which=shutil.which, run=subprocess.run, log=None,
+                        platform=None) -> bool:
+    """Whether this backend should spawn CLIs through the scope wrapper. Decided ONCE per backend, at
+    construction, from the process environment and a one-shot probe — never per session, so a flaky
+    probe cannot leave sessions in mixed states. Pure on its inputs (environ/which/run/platform
+    injectable) so the truth table is testable without a real systemd-run, on any OS.
+
+    On when ROMP_CLI_SCOPE=1, or under the supervised service (ROMP_SUPERVISED, what bin/romp-service's
+    unit sets) unless ROMP_CLI_SCOPE=0 — so the default is on under the service and off from a
+    terminal or in tests. Then only on Linux (transient scopes are a systemd feature; the macOS launchd
+    plist sets ROMP_SUPERVISED too, and without this check every kernel start there logged
+    "systemd-run is not on PATH" as if something were missing), only if `systemd-run` is on PATH, and
+    only if a probe scope actually starts (a user manager that cannot start scopes would otherwise
+    fail every session start). `log`, when given, receives the one-line verdict either way."""
+    env = os.environ if environ is None else environ
+    plat = sys.platform if platform is None else platform
+    want = env.get("ROMP_CLI_SCOPE", "")
+    ok, reason = False, ""
+    if want == "1" or (env.get("ROMP_SUPERVISED") and want != "0"):
+        if not plat.startswith("linux"):
+            reason = "not Linux (transient scopes are a systemd feature)"
+        elif not which("systemd-run"):
+            reason = "systemd-run is not on PATH"
+        else:
+            try:
+                r = run(CLI_SCOPE_PROBE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                        timeout=CLI_SCOPE_PROBE_TIMEOUT)
+            except Exception as e:      # timeout, missing binary raced away, anything else
+                reason = "the probe (%s) failed: %s" % (" ".join(CLI_SCOPE_PROBE), e)
+            else:
+                if r.returncode == 0:
+                    ok = True
+                else:
+                    err = (r.stderr or b"")
+                    err = err.decode("utf-8", "replace") if isinstance(err, bytes) else str(err)
+                    reason = "the probe (%s) exited %s%s" % (" ".join(CLI_SCOPE_PROBE), r.returncode,
+                                                             (": " + err.strip()) if err.strip() else "")
+    elif want == "0":
+        reason = "ROMP_CLI_SCOPE=0"
+    else:
+        reason = "not under the supervised service (ROMP_SUPERVISED unset) and ROMP_CLI_SCOPE is not 1"
+    if log:
+        if ok:
+            log("cli scope: on — each session's CLI runs in its own transient systemd scope; a manager "
+                "restart leaves session-spawned tmux/setsid work alive")
+        else:
+            log("cli scope: off — %s" % reason)
+    return ok
 
 
 def pick_identity_color(sid: str, state_dir=None) -> tuple[str, str]:
@@ -1169,19 +1256,34 @@ SDK_STDERR_PLACEHOLDER = "Check stderr output for details"
 STDERR_TAIL_LINES = 40
 
 
+def _without_scope_fallback_notices(text: str) -> str:
+    """`text` less every line of the scope wrapper's fallback notice (CLI_SCOPE_FALLBACK_PREFIX). On a
+    fallback launch that notice is the FIRST line of the CLI's stderr, about 230 characters of it, and
+    _note_cli_scope_fallback logged it the moment it arrived; left in, it led the launch-error card of a
+    CLI that then failed at start and pushed the CLI's own reason past the card's 600-character cut. The
+    wrapper's exit-127 refusal (CLI_SCOPE_REFUSAL_PREFIX) is kept: it IS that launch's reason, and
+    nothing else reports it."""
+    return "\n".join(ln for ln in text.splitlines() if not ln.startswith(CLI_SCOPE_FALLBACK_PREFIX))
+
+
 def launch_failure_text(exc: BaseException, tail: str = "") -> str:
     """The most SPECIFIC human text a failed CLI launch carries. The SDK's ProcessError keeps the CLI's
     own stderr on the exception (the class that actually names the cause); `tail` is what romp captured
     off the child's stderr itself, used when the exception carries only the SDK's placeholder; everything
-    else falls back to the exception's own text. Truncated, since a stderr dump can run long and this
-    lands in a chat card."""
+    else falls back to the exception's own text. The scope wrapper's fallback notice is dropped from
+    every captured stderr part first (_without_scope_fallback_notices: the log already has it, and it
+    crowded the CLI's reason out). Truncated, since a stderr dump can run long and this lands in a chat
+    card."""
     parts = []
     for attr in ("stderr", "stdout"):
         v = getattr(exc, attr, None)
         if isinstance(v, bytes):
             v = v.decode("utf-8", "replace")
-        if isinstance(v, str) and v.strip() and SDK_STDERR_PLACEHOLDER not in v:
-            parts.append(v.strip())
+        if isinstance(v, str) and SDK_STDERR_PLACEHOLDER not in v:
+            v = _without_scope_fallback_notices(v)
+            if v.strip():
+                parts.append(v.strip())
+    tail = _without_scope_fallback_notices(tail)
     if tail.strip():
         parts.append(tail.strip())
     parts.append(("%s: %s" % (type(exc).__name__, exc)).strip())
@@ -1201,20 +1303,29 @@ def is_launch_limit(text: str) -> bool:
 
 
 def task_death_notice(tasks: list, cause: str = "a restart or crash") -> str:
-    """The visible romp notice for BACKGROUND TASKS that died with their claude process. Bg tasks are
-    the CLI's children, so a kernel restart or CLI crash silently kills a session's timers/watchers —
-    and a session idle-waiting on one would wait FOREVER for a completion notification that can never
-    arrive (nimbus's dead campaign watcher, the user 2026-07-11). The notice names what was lost (the
-    task descriptions from the lifecycle stream) so the session can relaunch exactly what still
-    matters. Enqueued by _on_session_gone (CLI died, kernel alive), the boot reconcile (kernel died;
-    read from the reg's bgTasks mirror), and _drop_live_work (a settings switch reconnected the CLI —
-    `cause` names that, so the session is told the truth about why its work vanished)."""
+    """The visible romp notice for BACKGROUND TASKS a session lost when its claude process ended. Bg
+    tasks are the CLI's children, so a kernel restart or CLI crash cuts a session off from its
+    timers/watchers — and a session idle-waiting on one would wait FOREVER for a completion
+    notification that can never arrive (nimbus's dead campaign watcher, the user 2026-07-11). The
+    notice names what was lost (the task descriptions from the lifecycle stream) so the session can
+    relaunch exactly what still matters. Enqueued by _on_session_gone (CLI died, kernel alive), the
+    boot reconcile (kernel died; read from the reg's bgTasks mirror), and _drop_live_work (a settings
+    switch reconnected the CLI; `cause` names that, so the session is told why its work was cut off).
+
+    It says "cut off", not "died" (2026-09-05): under the per-session scopes (cli_scope_supported) a
+    task's tool shell can outlive the CLI — the process may well still be running, and the session
+    that relaunches it without checking runs two. So the ask is to check first. The voice is the person the
+    session works for; the only romp noun is the sanctioned [romp] prefix (test_injected_voice)."""
     n = len(tasks)
     descs = "; ".join(d for d in ((t.get("desc") or "").strip() for t in tasks[:4]) if d)
+    one = n == 1
     return ("<!-- romp-injected --><!-- romp-system -->[romp] %d background task%s this session had "
-            "running died with its claude process (%s)%s. Their completion "
-            "notifications will never arrive — relaunch any that are still needed, or carry on if "
-            "they aren't." % (n, "" if n == 1 else "s", cause, (": " + descs) if descs else ""))
+            "running %s cut off from the session when its claude process ended (%s)%s. "
+            "%s completion notification%s will never arrive. Check whether %s still running before "
+            "relaunching %s; if %s needed, carry on."
+            % (n, "" if one else "s", "was" if one else "were", cause, (": " + descs) if descs else "",
+               "Its" if one else "Their", "" if one else "s", "it is" if one else "each is",
+               "it", "it isn't" if one else "they aren't"))
 
 # The marker only SDK-driven claude CLIs carry (the kernel drives them over stdin); a tmux session's
 # interactive `claude --resume` never has it, so the orphan reap can never touch a tmux CLI.
@@ -3304,11 +3415,26 @@ class SdkSession:
         session would drown the kernel log. The tail is drained where it matters — _record_launch_error
         logs it and puts it on the session's error card.
 
+        One line IS logged at once: the scope wrapper's fallback notice (CLI_SCOPE_FALLBACK_PREFIX, from
+        bin/romp-cli-scope), which says this CLI is running directly, without its transient scope,
+        after the pre-flight scope failed. On that path the CLI starts, so no launch failure ever drains
+        the tail, and until 2026-09-05 the line was never read: the boot verdict kept saying scopes were
+        on while the session's work sat in the service cgroup, where a service restart kills it. So the
+        line goes to the backend's problem log immediately, naming the session
+        (_note_cli_scope_fallback) — as well as being buffered like any other line. The wrapper's other
+        line, the exit-127 refusal (CLI_SCOPE_REFUSAL_PREFIX, ROMP_CLI_REAL unset), is only buffered: no
+        CLI started, so the launch fails and _record_launch_error reports the line from the tail.
+        Logging it here as well reported the one event twice, and the first time as a CLI "started
+        outside a scope" when none had started.
+
         Called from the SDK's stderr reader task; it isolates exceptions per line, but keep it total
         anyway (a raise here would lose the very diagnostics this exists to keep)."""
         try:
             if line and line.strip():
-                self._stderr_tail.append(line.rstrip("\n"))
+                text = line.rstrip("\n")
+                self._stderr_tail.append(text)
+                if text.startswith(CLI_SCOPE_FALLBACK_PREFIX):
+                    self.backend._note_cli_scope_fallback(self, text)
         except Exception:
             pass
 
@@ -4762,6 +4888,19 @@ class SdkBackend:
         if self._sdk_missing and log:
             self._log("claude_agent_sdk is NOT importable — every SDK session will report itself unable to "
                       "start (run bin/romp-sdk-setup). tmux sessions are unaffected.", problem=True)
+        # Per-session transient scopes (see cli_scope_supported): ONE verdict per backend, cached here;
+        # _options reads it at every connect. The probe runs here, never per session.
+        self.cli_scope = cli_scope_supported(log=self._log)
+        if self.cli_scope:
+            # The SDK's per-connect minimum-version check spawns `[cli_path, "-v"]` with the KERNEL's
+            # environment, not options.env (claude_agent_sdk 0.2.132, _check_claude_version), so the
+            # wrapper must find ROMP_CLI_REAL here too — without it the probe exited 127, the SDK
+            # swallowed that, and the version warning was silently off while every connect forked a
+            # probe that failed. One value per backend; the per-session entry in _options stays (the
+            # session's own launch reads it). ROMP_SID is unset for it, so the wrapper runs the probe
+            # directly, unscoped.
+            os.environ["ROMP_CLI_REAL"] = self.claude_bin
+        self._cli_scope_wrapper_logged = False    # the missing-wrapper fallback is reported once per backend
         self._heal_attempts: dict[str, int] = {}  # sid -> crash-resume attempts since its last COMPLETED turn
         #                                           (bounds _heal_cut_session to one resume per cut; a completed
         #                                           turn resets it, so a crash LOOP can't respawn forever)
@@ -5820,6 +5959,17 @@ class SdkBackend:
             rows = list(self._problems)
         return rows[-limit:] if limit else rows
 
+    def _note_cli_scope_fallback(self, sess, text: str) -> None:
+        """The scope wrapper wrote its fallback notice on `sess`'s stderr (SdkSession._on_cli_stderr,
+        CLI_SCOPE_FALLBACK_PREFIX): this CLI is running directly, inside the service cgroup, after the
+        pre-flight scope failed. Logged at once as a problem (the error center shows it; a launch that
+        succeeds never drains the stderr tail, so nothing else would), so a reader of the log can tell
+        that the boot verdict "cli scope: on" stopped holding. The wrapper's exit-127 refusal
+        (CLI_SCOPE_REFUSAL_PREFIX) never reaches here: no CLI started, and the launch-error path
+        reports it."""
+        self._log("cli scope: session %s (%s) started its CLI outside a scope — %s"
+                  % (sess.name, str(sess.sid)[:8], text), problem=True)
+
     def _poke(self):
         if self._poke_cb:
             try:
@@ -5883,6 +6033,21 @@ class SdkBackend:
             effort=("xhigh" if (sess.effort or DEFAULT_EFFORT) == "ultracode" else (sess.effort or DEFAULT_EFFORT)),
             max_buffer_size=SDK_MAX_BUFFER,   # a >1MB stdout message would crash the receive loop → kill any live picker
         )
+        # Per-session transient scope (cli_scope_supported): cli_path becomes the exec-in-place wrapper
+        # and ROMP_CLI_REAL carries the real CLI to it. The SDK spawns `[cli_path, *args]`, and the
+        # wrapper execs systemd-run, which execs the CLI, so the pid and argv the SDK sees ARE the
+        # CLI's. A missing or non-executable wrapper is a packaging bug, reported once and loudly —
+        # the session still starts on the direct path, inside the service cgroup.
+        if self.cli_scope:
+            wrapper = cli_scope_wrapper()
+            if os.access(wrapper, os.X_OK):
+                kw["cli_path"] = wrapper
+                kw["env"]["ROMP_CLI_REAL"] = self.claude_bin
+            elif not self._cli_scope_wrapper_logged:
+                self._cli_scope_wrapper_logged = True
+                self._log("cli scope: the wrapper %s is missing or not executable (a packaging bug) — "
+                          "sessions start with the CLI directly, inside the service cgroup, until it is "
+                          "restored" % wrapper, problem=True)
         # Thinking summaries (the kernel's per-install gear toggle, 2026-09-01). On the SDK's stream-json
         # path the CLI requests NO thinking display: it uses an explicit --thinking-display when given,
         # consults the showThinkingSummaries settings key only when interactive, and forces "omitted" only

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -111,22 +111,30 @@ def cli_scope_supported(environ=None, which=shutil.which, run=subprocess.run, lo
     plist sets ROMP_SUPERVISED too, and without this check every kernel start there logged
     "systemd-run is not on PATH" as if something were missing), only if `systemd-run` is on PATH, and
     only if a probe scope actually starts (a user manager that cannot start scopes would otherwise
-    fail every session start). `log`, when given, receives the one-line verdict either way."""
+    fail every session start).
+
+    `log`, when given, receives the one-line verdict either way, as `log(line, problem=<bool>)` —
+    SdkBackend._log's signature. `problem` is True only when the switch was WANTED on Linux and could
+    not be honoured (systemd-run missing, or the probe failing): every session this backend starts
+    then runs inside the service cgroup, which the error center should show the way the launch-time
+    fallbacks (_note_cli_scope_fallback, the missing-wrapper line in _options) already do; a log line
+    nobody tails is not a report (2026-09-06). The other off verdicts are ordinary — the environment
+    asked for off, or the platform has no systemd — and stay plain lines."""
     env = os.environ if environ is None else environ
     plat = sys.platform if platform is None else platform
     want = env.get("ROMP_CLI_SCOPE", "")
-    ok, reason = False, ""
+    ok, reason, problem = False, "", False
     if want == "1" or (env.get("ROMP_SUPERVISED") and want != "0"):
         if not plat.startswith("linux"):
             reason = "not Linux (transient scopes are a systemd feature)"
         elif not which("systemd-run"):
-            reason = "systemd-run is not on PATH"
+            reason, problem = "systemd-run is not on PATH", True
         else:
             try:
                 r = run(CLI_SCOPE_PROBE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
                         timeout=CLI_SCOPE_PROBE_TIMEOUT)
             except Exception as e:      # timeout, missing binary raced away, anything else
-                reason = "the probe (%s) failed: %s" % (" ".join(CLI_SCOPE_PROBE), e)
+                reason, problem = "the probe (%s) failed: %s" % (" ".join(CLI_SCOPE_PROBE), e), True
             else:
                 if r.returncode == 0:
                     ok = True
@@ -135,6 +143,7 @@ def cli_scope_supported(environ=None, which=shutil.which, run=subprocess.run, lo
                     err = err.decode("utf-8", "replace") if isinstance(err, bytes) else str(err)
                     reason = "the probe (%s) exited %s%s" % (" ".join(CLI_SCOPE_PROBE), r.returncode,
                                                              (": " + err.strip()) if err.strip() else "")
+                    problem = True
     elif want == "0":
         reason = "ROMP_CLI_SCOPE=0"
     else:
@@ -142,9 +151,12 @@ def cli_scope_supported(environ=None, which=shutil.which, run=subprocess.run, lo
     if log:
         if ok:
             log("cli scope: on — each session's CLI runs in its own transient systemd scope; a manager "
-                "restart leaves session-spawned tmux/setsid work alive")
+                "restart leaves session-spawned tmux/setsid work alive", problem=False)
+        elif problem:
+            log("cli scope: off — %s; sessions start with the CLI directly, inside the service cgroup, "
+                "and a service restart takes their background work down" % reason, problem=True)
         else:
-            log("cli scope: off — %s" % reason)
+            log("cli scope: off — %s" % reason, problem=False)
     return ok
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1326,16 +1326,20 @@ def task_death_notice(tasks: list, cause: str = "a restart or crash") -> str:
 
     It says "cut off", not "died" (2026-09-05): under the per-session scopes (cli_scope_supported) a
     task's tool shell can outlive the CLI — the process may well still be running, and the session
-    that relaunches it without checking runs two. So the ask is to check first. The voice is the person the
-    session works for; the only romp noun is the sanctioned [romp] prefix (test_injected_voice)."""
+    that relaunches it without checking runs two. So the ask is to check first. The voice is the person
+    the session works for, addressing it as "you" (so the sentence names the session once, not twice,
+    and "the claude process that started them" says whose process ended — review, 2026-09-06); the only
+    romp noun is the sanctioned [romp] prefix (test_injected_voice). `cause` is read after "ended" in
+    parentheses, so it must stand on its own there (_RECONNECT_CAUSE does)."""
     n = len(tasks)
     descs = "; ".join(d for d in ((t.get("desc") or "").strip() for t in tasks[:4]) if d)
     one = n == 1
-    return ("<!-- romp-injected --><!-- romp-system -->[romp] %d background task%s this session had "
-            "running %s cut off from the session when its claude process ended (%s)%s. "
+    return ("<!-- romp-injected --><!-- romp-system -->[romp] %d background task%s you had running %s "
+            "cut off when the claude process that started %s ended (%s)%s. "
             "%s completion notification%s will never arrive. Check whether %s still running before "
             "relaunching %s; if %s needed, carry on."
-            % (n, "" if one else "s", "was" if one else "were", cause, (": " + descs) if descs else "",
+            % (n, "" if one else "s", "was" if one else "were", "it" if one else "them", cause,
+               (": " + descs) if descs else "",
                "Its" if one else "Their", "" if one else "s", "it is" if one else "each is",
                "it", "it isn't" if one else "they aren't"))
 
@@ -4467,7 +4471,7 @@ class SdkSession:
                                                             len(died), "" if len(died) == 1 else "s", reason))
             self.backend._poke()
 
-    _RECONNECT_CAUSE = "its process was restarted by a settings switch or a rewind"   # the death notice's cause on
+    _RECONNECT_CAUSE = "a settings switch or a rewind restarted it"   # the death notice's cause on
     #   a reconnect: every trigger of the reconnect loop (effort/fast/auth/mode switches, edit-message rewinds and
     #   rollbacks) is named truthfully — the loop cannot tell them apart here, so the notice names the family
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,17 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
   was down, the real manager it starts ran `tmux start-server` on the
   default socket, and for the rest of the day the machine's tmux server was
   the test's, carrying the run's environment inside the service's cgroup.
+  The same helper call floors `ROMP_CLI_SCOPE=0`: under `ROMP_SUPERVISED`
+  (set by the service's unit, and inherited by a tool shell under a
+  self-hosted install) `bin/romp-manager` starts that server through
+  `systemd-run --scope` and the kernel spawns session CLIs the same way, so
+  a suite that starts the real manager would otherwise leave a transient
+  scope on the developer's user manager. Every suite that isolates tmux
+  inherits the floor; `romp-manager-tmux-scope.bats` turns the switch back
+  on only behind a fake `systemd-run` first on PATH. pytest's floor is
+  `conftest.py`; `test_cli_scope_floor.py` pins both halves of it on the
+  source, since a test that reads the value cannot tell the floor from
+  `test_cli_scope.py`'s own import-time set.
   Any test whose subject binds a loopback port picks it with `load
   free-port` + `free_port VAR...`, never a literal: a literal shared by two
   files collided within one run (`romp-manager-ensure.bats` once used

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,22 @@ def _no_model_catalog_fetch():
     yield
 
 
+# No test may reach the REAL `systemd-run` (2026-09-05): constructing the SDK backend decides once
+# whether to spawn CLIs inside per-session transient scopes (sdk_backend.cli_scope_supported), and
+# that verdict defaults to ON under the supervised service — ROMP_SUPERVISED=1 is inherited by every
+# tool shell of a session running on a self-hosted romp, so a suite run from one would probe the
+# live user manager at every backend construction and route every _options() through the wrapper.
+# Floored to the explicit off value; the truth-table tests pass their own environ and are unaffected.
+# Per-test re-assert below, on the same reasoning as the manager-port floor.
+os.environ["ROMP_CLI_SCOPE"] = "0"
+
+
+@pytest.fixture(autouse=True)
+def _no_cli_scope():
+    os.environ["ROMP_CLI_SCOPE"] = "0"
+    yield
+
+
 @pytest.fixture(autouse=True)
 def _stub_place_llm(monkeypatch):
     """Card-first placer floor (2026-07-08): every loaded romp-judge instance gets a no-op place_llm so

--- a/tests/manager-tmux-scope.test.js
+++ b/tests/manager-tmux-scope.test.js
@@ -1,0 +1,157 @@
+// romp-manager's default tmux server and the service cgroup (2026-09-05): the manager runs as a
+// systemd user service that relies on systemd's default KillMode=control-group, so a tmux server it
+// starts bare dies with `systemctl --user restart romp-manager`, and every session's tmux jobs die
+// with it. tmuxStartArgv is the pure argv choice, and it mirrors the kernel's cli_scope_supported
+// exactly: scoped when ROMP_CLI_SCOPE=1, or under ROMP_SUPERVISED unless ROMP_CLI_SCOPE=0 — and then
+// only on Linux with systemd-run on PATH. A terminal-run manager scopes nothing unless asked. No tmux
+// on PATH → null: nothing to start, nothing to log (the behaviour before the scopes). scopedStartFailure
+// turns the scoped call's execFileSync error into the log line's content: the tool that failed and its
+// first stderr line, bounded (startTmuxServer pipes stderr on that call for it).
+// Run: node --test tests/manager-*.test.js
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+process.env.ROMP_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'romp-mgr-tmux-scope-'));
+const { tmuxStartArgv, scopedStartFailure, commandOnPath, TMUX_START_ARGV } = require(path.join(__dirname, '..', 'bin', 'romp-manager'));
+
+const BARE = ['tmux', 'start-server', ';', 'set', '-g', 'exit-empty', 'off'];
+const both = (name) => name === 'systemd-run' || name === 'tmux';   // a Linux box with both installed
+const tmuxOnly = (name) => name === 'tmux';                         // no systemd-run
+const SUPERVISED = { ROMP_SUPERVISED: '1' };                         // what bin/romp-service's unit sets
+const pick = (env, opts = {}) => tmuxStartArgv({ platform: 'linux', env, onPath: both, now: () => 1725000000000, ...opts });
+
+test('the bare tmux argv is the one the manager always used', () => {
+  assert.deepEqual(TMUX_START_ARGV, BARE);
+});
+
+test('under the supervised service on linux with systemd-run: the server starts inside a transient scope', () => {
+  const p = pick(SUPERVISED);
+  assert.equal(p.scoped, true);
+  assert.equal(p.argv[0], 'systemd-run');
+  for (const flag of ['--user', '--scope', '--quiet', '--collect']) assert.ok(p.argv.includes(flag), flag);
+  const unit = p.argv.find((a) => a.startsWith('--unit='));
+  assert.equal(unit, '--unit=romp-tmux-1725000000000');
+  // the tmux argv follows `--`, verbatim
+  const dash = p.argv.indexOf('--');
+  assert.ok(dash > 0);
+  assert.deepEqual(p.argv.slice(dash + 1), BARE);
+});
+
+test('two picks get two unit names (systemd refuses a duplicate as "already loaded")', () => {
+  let t = 1;
+  const a = pick(SUPERVISED, { now: () => t++ });
+  const b = pick(SUPERVISED, { now: () => t++ });
+  assert.notEqual(a.argv.find((x) => x.startsWith('--unit=')), b.argv.find((x) => x.startsWith('--unit=')));
+});
+
+// The switch mirrors the kernel's (cli_scope_supported): the same environment gives the same answer.
+test('a terminal-run manager (ROMP_SUPERVISED unset) scopes nothing, systemd-run or not', () => {
+  assert.deepEqual(pick({}), { argv: BARE, scoped: false });
+  assert.deepEqual(pick({ ROMP_SUPERVISED: '' }), { argv: BARE, scoped: false }, 'an empty value is unset');
+});
+
+test('ROMP_CLI_SCOPE=1 turns the scope on for a manager run outside the service', () => {
+  assert.equal(pick({ ROMP_CLI_SCOPE: '1' }).scoped, true);
+});
+
+test('ROMP_CLI_SCOPE=0 turns the scope off under the service', () => {
+  assert.deepEqual(pick({ ...SUPERVISED, ROMP_CLI_SCOPE: '0' }), { argv: BARE, scoped: false });
+});
+
+test('an empty ROMP_CLI_SCOPE under the service is the default (on), as in the kernel', () => {
+  assert.equal(pick({ ...SUPERVISED, ROMP_CLI_SCOPE: '' }).scoped, true);
+});
+
+test('systemd-run absent: the bare call, even under the service', () => {
+  assert.deepEqual(pick(SUPERVISED, { onPath: tmuxOnly }), { argv: BARE, scoped: false });
+});
+
+test('darwin: the bare call, whatever is on PATH or in the environment (launchd owns the lineage there)', () => {
+  assert.deepEqual(pick(SUPERVISED, { platform: 'darwin' }), { argv: BARE, scoped: false });
+  assert.deepEqual(pick({ ROMP_CLI_SCOPE: '1' }, { platform: 'darwin' }), { argv: BARE, scoped: false });
+});
+
+// tmux is checked FIRST: a tmux-less box used to log "systemd-run could not start the tmux server in
+// a scope … " at every start, because the scoped call failed on the missing tmux inside the scope.
+test('tmux absent: null — nothing to start, nothing to log, whatever else is on PATH', () => {
+  const systemdRunOnly = (name) => name === 'systemd-run';
+  assert.equal(pick(SUPERVISED, { onPath: systemdRunOnly }), null);
+  assert.equal(pick({ ROMP_CLI_SCOPE: '1' }, { onPath: systemdRunOnly }), null);
+  assert.equal(pick({}, { onPath: () => false }), null);
+  assert.equal(pick({}, { platform: 'darwin', onPath: () => false }), null);
+});
+
+test('the returned bare argv is a copy — a caller cannot mutate the constant', () => {
+  const p = pick({});
+  p.argv.push('x');
+  assert.deepEqual(TMUX_START_ARGV, BARE);
+});
+
+test('commandOnPath finds an executable on the given PATH and nothing else', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'romp-onpath-'));
+  fs.writeFileSync(path.join(dir, 'systemd-run'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(dir, 'not-exec'), 'x', { mode: 0o644 });
+  const env = { PATH: ['', dir, '/nonexistent-dir'].join(path.delimiter) };
+  assert.equal(commandOnPath('systemd-run', env), true);
+  assert.equal(commandOnPath('not-exec', env), false);
+  assert.equal(commandOnPath('missing', env), false);
+  assert.equal(commandOnPath('systemd-run', { PATH: '' }), false);
+  assert.equal(commandOnPath('systemd-run', {}), false);
+});
+
+// startTmuxServer's failure line. execFileSync's error carries the piped stderr; with stdio 'ignore' its
+// message was "Command failed: <argv>", the argv and nothing about why, and the line named systemd-run
+// even when tmux had failed inside a scope that did start. systemd-run's logger prefixes every line
+// "Failed to …"; anything else on stderr is the command's own, so it is tmux that failed.
+const failed = (over) => Object.assign(new Error('Command failed: systemd-run --user --scope --quiet --collect --unit=romp-tmux-1 -- tmux start-server ; set -g exit-empty off'),
+                                       { status: 1, signal: null, stderr: null }, over);
+
+test("systemd-run's own failure: its first stderr line, and systemd-run named", () => {
+  const e = failed({ stderr: Buffer.from('Failed to start transient scope unit: Failed to connect to bus: No such file or directory\n') });
+  assert.deepEqual(scopedStartFailure(e),
+    { tool: 'systemd-run', detail: 'Failed to start transient scope unit: Failed to connect to bus: No such file or directory' });
+});
+
+test('tmux failing inside the scope: tmux named, and its line carried', () => {
+  const e = failed({ stderr: Buffer.from('error connecting to /nonexistent/tmux-0/default (No such file or directory)\n') });
+  assert.deepEqual(scopedStartFailure(e),
+    { tool: 'tmux', detail: 'error connecting to /nonexistent/tmux-0/default (No such file or directory)' });
+});
+
+test('the first non-blank stderr line only, trimmed; a string stderr reads the same as a Buffer', () => {
+  const two = '\n  Failed to create bus connection: Connection refused  \nsecond line, not for the log\n';
+  assert.equal(scopedStartFailure(failed({ stderr: Buffer.from(two) })).detail, 'Failed to create bus connection: Connection refused');
+  assert.equal(scopedStartFailure(failed({ stderr: two })).detail, 'Failed to create bus connection: Connection refused');
+});
+
+test('a long line is cut to 200 characters, the last an ellipsis', () => {
+  const { tool, detail } = scopedStartFailure(failed({ stderr: Buffer.from('Failed to ' + 'x'.repeat(500) + '\n') }));
+  assert.equal(tool, 'systemd-run');
+  assert.equal(detail.length, 200);
+  assert.ok(detail.startsWith('Failed to xxx'));
+  assert.ok(detail.endsWith('…'));
+  // at the bound exactly: untouched
+  assert.equal(scopedStartFailure(failed({ stderr: Buffer.from('Failed to ' + 'x'.repeat(190)) })).detail.length, 200);
+});
+
+test('nothing on stderr: the exit status, and systemd-run named (the command that ran)', () => {
+  assert.deepEqual(scopedStartFailure(failed({ stderr: Buffer.alloc(0), status: 1 })), { tool: 'systemd-run', detail: 'exit 1, nothing on stderr' });
+  assert.deepEqual(scopedStartFailure(failed({ stderr: null, status: 3 })), { tool: 'systemd-run', detail: 'exit 3, nothing on stderr' });
+  assert.deepEqual(scopedStartFailure(failed({ stderr: Buffer.from('\n  \n'), status: 2 })), { tool: 'systemd-run', detail: 'exit 2, nothing on stderr' });
+});
+
+test('a timeout or a signal with nothing on stderr says so; a stderr line wins over either', () => {
+  assert.equal(scopedStartFailure(failed({ code: 'ETIMEDOUT', status: null, signal: 'SIGTERM', stderr: Buffer.alloc(0) })).detail, 'timed out after 5 s');
+  assert.equal(scopedStartFailure(failed({ status: null, signal: 'SIGKILL', stderr: Buffer.alloc(0) })).detail, 'killed by SIGKILL');
+  assert.equal(scopedStartFailure(failed({ code: 'ETIMEDOUT', status: null, signal: 'SIGTERM', stderr: Buffer.from('Failed to connect to bus\n') })).detail, 'Failed to connect to bus');
+});
+
+test("a spawn error (no exit at all): the error's own first line, systemd-run named", () => {
+  const e = Object.assign(new Error('spawnSync systemd-run ENOENT'), { code: 'ENOENT', status: null, signal: null, stderr: null });
+  assert.deepEqual(scopedStartFailure(e), { tool: 'systemd-run', detail: 'spawnSync systemd-run ENOENT' });
+  assert.deepEqual(scopedStartFailure(null), { tool: 'systemd-run', detail: 'null' });
+});

--- a/tests/romp-cli-scope.bats
+++ b/tests/romp-cli-scope.bats
@@ -1,0 +1,350 @@
+#!/usr/bin/env bats
+
+# bin/romp-cli-scope — the exec-in-place wrapper the kernel spawns a session's `claude` CLI through
+# on Linux under systemd, so the CLI (and everything it later starts: tool shells, setsid children,
+# tmux servers) runs in a transient scope of its own instead of the manager service's cgroup, which
+# systemd's default KillMode=control-group empties on every service restart.
+#
+# A FAKE systemd-run first on PATH records its argv (FAKE_LOG holds the LAST call's argv, one element
+# per line; FAKE_CALLS appends one line per call) and then execs the command after `--`, so the tests
+# see exactly what the wrapper asked for and the fake "real CLI" still runs. The wrapper calls it
+# twice per launch: a pre-flight `-- true`, then the scoped CLI. Nothing here touches the real
+# systemd-run.
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    WRAPPER="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-cli-scope"
+    BIN="$TEST_DIR/bin"
+    mkdir -p "$BIN"
+    export FAKE_LOG="$TEST_DIR/systemd-run.argv"
+    export FAKE_CALLS="$TEST_DIR/systemd-run.calls"
+    cat > "$BIN/systemd-run" <<'SH'
+#!/bin/sh
+# one argv element per line, then exec the command after `--` (what --scope mode does for real)
+printf '%s\n' "$@" > "$FAKE_LOG"
+echo "$*" >> "$FAKE_CALLS"
+while [ "$#" -gt 0 ]; do a="$1"; shift; [ "$a" = "--" ] && break; done
+exec "$@"
+SH
+    chmod +x "$BIN/systemd-run"
+    # the fake "real CLI": its pid, its parent's pid, and its argv one element per line on stdout;
+    # its own pid to REAL_PIDFILE too, for the exec-in-place checks on a background launch
+    REAL="$TEST_DIR/claude"
+    export REAL_PIDFILE="$TEST_DIR/real.pid"
+    cat > "$REAL" <<'SH'
+#!/bin/sh
+echo "REAL pid=$$ ppid=$PPID"
+printf 'ARG:%s\n' "$@"
+echo "$$" > "$REAL_PIDFILE"
+SH
+    chmod +x "$REAL"
+    export PATH="$BIN:$PATH"
+    export ROMP_CLI_REAL="$REAL"
+    export ROMP_SID="11111111-2222-3333-4444-555555555555"
+    unset ROMP_CLI_SCOPE
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "runs the real CLI through systemd-run with the arguments passed verbatim" {
+    run "$WRAPPER" --input-format stream-json "two words" --resume "$ROMP_SID" ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REAL pid="* ]]
+    # every argument, in order, including the one with a space, the ones starting with --,
+    # and the empty one
+    expected="$(printf 'ARG:%s\n' --input-format stream-json "two words" --resume "$ROMP_SID" "")"
+    [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "$expected" ]
+    [ -s "$FAKE_LOG" ]
+}
+
+@test "asks systemd-run for a --user --scope --quiet --collect unit and hands it the real CLI after --" {
+    run "$WRAPPER" a b
+    [ "$status" -eq 0 ]
+    grep -qx -- '--user' "$FAKE_LOG"
+    grep -qx -- '--scope' "$FAKE_LOG"
+    grep -qx -- '--quiet' "$FAKE_LOG"
+    grep -qx -- '--collect' "$FAKE_LOG"
+    grep -qx -- "--description=romp session $ROMP_SID" "$FAKE_LOG"
+    # after `--`: the real CLI, then the args verbatim
+    tail_after_dash="$(sed -n '/^--$/,$p' "$FAKE_LOG" | sed 1d)"
+    [ "$tail_after_dash" = "$(printf '%s\n' "$REAL" a b)" ]
+}
+
+@test "the unit is romp-session-<first 8 of the sid>-<pid>-<start time>, and differs between two runs" {
+    run "$WRAPPER"
+    [ "$status" -eq 0 ]
+    unit1="$(grep '^--unit=' "$FAKE_LOG")"
+    # <pid> is the pid the CLI ran as (exec-in-place: wrapper pid == CLI pid); the time component is
+    # what keeps the name unique once pids wrap while an earlier CLI's scope is still loaded (a tmux
+    # server it started keeps the scope alive) — systemd refuses a duplicate name as "already loaded"
+    pid1="$(printf '%s\n' "$output" | sed -n 's/^REAL pid=\([0-9]*\) .*/\1/p')"
+    [ -n "$pid1" ]
+    [[ "$unit1" =~ ^--unit=romp-session-11111111-${pid1}-[0-9]+$ ]]
+    run "$WRAPPER"
+    [ "$status" -eq 0 ]
+    unit2="$(grep '^--unit=' "$FAKE_LOG")"
+    [[ "$unit2" =~ ^--unit=romp-session-11111111-[0-9]+-[0-9]+$ ]]
+    [ "$unit1" != "$unit2" ]
+}
+
+# No session identity, no scope (2026-09-05): the SDK's per-connect version check runs `<cli_path> -v`
+# with the KERNEL's environment — ROMP_CLI_REAL (the kernel exports it) but no ROMP_SID — and a probe
+# must run the CLI directly rather than mint a romp-session-unknown-* scope per connect.
+@test "an empty ROMP_SID runs the real CLI directly — a probe, not a session; systemd-run is not invoked" {
+    ROMP_SID= run "$WRAPPER" -v
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_LOG" ]
+    [ ! -e "$FAKE_CALLS" ]
+    [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "ARG:-v" ]
+}
+
+@test "an unset ROMP_SID runs the real CLI directly the same way" {
+    unset ROMP_SID
+    run "$WRAPPER" -v
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_CALLS" ]
+    [[ "$output" == *"REAL pid="* ]]
+}
+
+@test "a pre-flight scope (-- true) runs before the CLI's own scope" {
+    run "$WRAPPER" a
+    [ "$status" -eq 0 ]
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 2 ]
+    first="$(sed -n 1p "$FAKE_CALLS")"
+    [[ "$first" == *"--user --scope --quiet --collect -- true" ]]
+    [[ "$first" != *"--unit="* ]]
+    second="$(sed -n 2p "$FAKE_CALLS")"
+    [[ "$second" == *"--unit=romp-session-11111111-"* ]]
+    [[ "$second" == *"-- $REAL a" ]]
+}
+
+@test "a failing pre-flight falls back to the real CLI directly, with one stderr line naming the reason" {
+    # systemd-run that cannot start a scope (the user bus gone): the CLI must still launch, in
+    # the caller's cgroup, and the reason must reach stderr as ONE line starting
+    # `romp-cli-scope: fallback:` — the kernel logs a line of that form as a problem the moment it
+    # arrives (tests/test_cli_scope.py FallbackNotice); every other stderr line, the wrapper's
+    # `refused:` line included, it only buffers
+    cat > "$BIN/systemd-run" <<'SH'
+#!/bin/sh
+echo "$*" >> "$FAKE_CALLS"
+echo "Failed to connect to bus: No such file or directory" >&2
+echo "a second stderr line that must not be quoted" >&2
+exit 1
+SH
+    chmod +x "$BIN/systemd-run"
+    ERR="$TEST_DIR/stderr"
+    run sh -c '"$0" --input-format stream-json "two words" 2>"$1"' "$WRAPPER" "$ERR"
+    [ "$status" -eq 0 ]
+    # the real CLI ran, directly, with its arguments intact
+    [[ "$output" == *"REAL pid="* ]]
+    [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "$(printf 'ARG:%s\n' --input-format stream-json "two words")" ]
+    # systemd-run was tried exactly once (the pre-flight), never for the CLI itself
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 1 ]
+    [[ "$(cat "$FAKE_CALLS")" == *"-- true" ]]
+    # one stderr line: the fallback form, the reason's first line, and the direct run
+    [ "$(wc -l < "$ERR")" -eq 1 ]
+    grep -q '^romp-cli-scope: fallback: ' "$ERR"
+    grep -q 'Failed to connect to bus' "$ERR"
+    grep -q 'directly' "$ERR"
+    # armed absence check (a bare mid-test `! grep` is exempt from bats' errexit and asserts nothing)
+    run grep -q 'second stderr line' "$ERR"
+    [ "$status" -ne 0 ]
+}
+
+# The pre-flight is bounded (2026-09-05): `timeout 10 systemd-run … -- true` when coreutils' timeout is
+# on PATH. A user bus that accepts the connection and never answers would otherwise hold systemd-run
+# for its own 90 s default, past the SDK's 60 s initialize timeout, so the fallback never engaged in the
+# case it was added for. The fake systemd-run below sleeps on the pre-flight only; the wrapper must fall
+# back well inside that sleep, and the CLI's own launch must not run through timeout.
+_preflight_sleeps() {   # $1: seconds the fake systemd-run sleeps on a `-- true` pre-flight, then exits 0
+    cat > "$BIN/systemd-run" <<SH
+#!/bin/sh
+printf '%s\n' "\$@" > "\$FAKE_LOG"
+echo "\$*" >> "\$FAKE_CALLS"
+case "\$*" in *"-- true") sleep $1; exit 0 ;; esac
+while [ "\$#" -gt 0 ]; do a="\$1"; shift; [ "\$a" = "--" ] && break; done
+exec "\$@"
+SH
+    chmod +x "$BIN/systemd-run"
+}
+
+# A fake `timeout` first on PATH that records its argv (TIMEOUT_LOG, one call per line) and then hands
+# over to the real one, so the bound is real and its argv is visible. Skips the test without a real one.
+_fake_timeout() {
+    REAL_TIMEOUT="$(PATH="${PATH#"$BIN:"}" command -v timeout || true)"
+    [ -n "$REAL_TIMEOUT" ] || skip "no timeout(1) on this box"
+    export TIMEOUT_LOG="$TEST_DIR/timeout.calls"
+    cat > "$BIN/timeout" <<SH
+#!/bin/sh
+echo "\$*" >> "\$TIMEOUT_LOG"
+exec "$REAL_TIMEOUT" "\$@"
+SH
+    chmod +x "$BIN/timeout"
+}
+
+@test "a pre-flight that hangs is cut off at 10 s and the CLI falls back to a direct run" {
+    # without coreutils' timeout(1) (macOS) the wrapper runs the pre-flight unbounded, by design (the
+    # test after the next one), so the 10 s bound is not there to check
+    command -v timeout >/dev/null 2>&1 || skip "no timeout(1) on this box"
+    _preflight_sleeps 20
+    ERR="$TEST_DIR/stderr"
+    t0="$(date +%s)"
+    run sh -c '"$0" --input-format stream-json 2>"$1"' "$WRAPPER" "$ERR"
+    t1="$(date +%s)"
+    [ "$status" -eq 0 ]
+    [ $((t1 - t0)) -ge 9 ]
+    [ $((t1 - t0)) -lt 16 ]
+    # the CLI ran, directly: systemd-run was tried once (the pre-flight), never for the CLI itself
+    [[ "$output" == *"REAL pid="* ]]
+    [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "$(printf 'ARG:%s\n' --input-format stream-json)" ]
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 1 ]
+    [[ "$(cat "$FAKE_CALLS")" == *"-- true" ]]
+    # one stderr line, the fallback form, naming the bound as the reason
+    [ "$(wc -l < "$ERR")" -eq 1 ]
+    grep -q '^romp-cli-scope: fallback: ' "$ERR"
+    grep -q 'did not finish within 10 s' "$ERR"
+    grep -q 'directly' "$ERR"
+}
+
+@test "the pre-flight runs as \`timeout 10 systemd-run …\`; the CLI's own scope does not go through timeout" {
+    _fake_timeout
+    run "$WRAPPER" a
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REAL pid="* ]]
+    [ "$(wc -l < "$TIMEOUT_LOG")" -eq 1 ]
+    [ "$(cat "$TIMEOUT_LOG")" = "10 systemd-run --user --scope --quiet --collect -- true" ]
+    # both systemd-run calls still happened: the pre-flight (through timeout) and the scoped CLI
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 2 ]
+    [[ "$(sed -n 2p "$FAKE_CALLS")" == *"--unit=romp-session-11111111-"* ]]
+}
+
+@test "without timeout on PATH the pre-flight runs unbounded and a slow one still leads to a scoped CLI" {
+    # a PATH with the fake systemd-run, `date` (the unit name needs it) and `sleep` (the fake's
+    # pre-flight delay needs it), but no timeout at all
+    mkdir -p "$TEST_DIR/tools"
+    ln -s "$(command -v date)" "$TEST_DIR/tools/date"
+    ln -s "$(command -v sleep)" "$TEST_DIR/tools/sleep"
+    _preflight_sleeps 2
+    t0="$(date +%s)"
+    PATH="$BIN:$TEST_DIR/tools" run "$WRAPPER" a
+    t1="$(date +%s)"
+    [ "$status" -eq 0 ]
+    [ $((t1 - t0)) -ge 1 ]
+    # not cut off: the pre-flight completed and the CLI ran in its scope
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 2 ]
+    [[ "$(sed -n 2p "$FAKE_CALLS")" == *"--unit=romp-session-11111111-"* ]]
+    [[ "$output" == *"REAL pid="* ]]
+}
+
+@test "exec in place: the CLI keeps the wrapper's pid and its parent is the launching shell" {
+    # Launch from a shell whose pid we know; the wrapper execs systemd-run, which execs the CLI —
+    # so the CLI's pid must be that shell's pid and its ppid the shell's parent (this bats
+    # process), with no extra parent between them.
+    run sh -c 'echo "SH pid=$$ ppid=$PPID"; exec "$0"' "$WRAPPER"
+    [ "$status" -eq 0 ]
+    sh_pid="$(printf '%s\n' "$output" | sed -n 's/^SH pid=\([0-9]*\) .*/\1/p')"
+    sh_ppid="$(printf '%s\n' "$output" | sed -n 's/^SH pid=[0-9]* ppid=\([0-9]*\)$/\1/p')"
+    real_pid="$(printf '%s\n' "$output" | sed -n 's/^REAL pid=\([0-9]*\) .*/\1/p')"
+    real_ppid="$(printf '%s\n' "$output" | sed -n 's/^REAL pid=[0-9]* ppid=\([0-9]*\)$/\1/p')"
+    [ -n "$sh_pid" ] && [ -n "$real_pid" ]
+    [ "$real_pid" = "$sh_pid" ]
+    [ "$real_ppid" = "$sh_ppid" ]
+}
+
+# Exec-in-place and a clean stdout on the DIRECT paths (2026-09-05). The scoped path's pid test above
+# says nothing about the four direct paths, and a wrapper that forked the CLI (or printed anything of
+# its own) passed every test here. Both matter: the kernel finds the CLI by the pid the SDK spawned,
+# and one stray byte on stdout corrupts the SDK's stream-json protocol. So: launch the wrapper as a
+# background job (its pid is known before it runs), wait, and check that the fake CLI's own $$ IS that
+# pid, its parent is this shell, and stdout is EXACTLY the fake CLI's output.
+# $1..: `VAR=value` settings for the launch (none is fine), then `--`, then the wrapper's arguments.
+assert_direct_exec_in_place() {
+    local envs=()
+    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do envs+=("$1"); shift; done
+    shift
+    OUT="$TEST_DIR/stdout"; ERR="$TEST_DIR/stderr"; EXP="$TEST_DIR/expected"
+    env "${envs[@]}" "$WRAPPER" "$@" >"$OUT" 2>"$ERR" 3>&- &
+    local wpid=$!
+    wait "$wpid"
+    [ -s "$REAL_PIDFILE" ]
+    [ "$(cat "$REAL_PIDFILE")" = "$wpid" ]
+    printf 'REAL pid=%s ppid=%s\n' "$wpid" "$BASHPID" > "$EXP"
+    printf 'ARG:%s\n' "$@" >> "$EXP"
+    cmp -s "$OUT" "$EXP"
+    [ ! -e "$FAKE_LOG" ]   # never a scoped launch on a direct path
+}
+
+@test "direct path, ROMP_CLI_SCOPE=0: exec in place, stdout exactly the CLI's, stderr empty" {
+    assert_direct_exec_in_place ROMP_CLI_SCOPE=0 -- --input-format stream-json "two words" ""
+    [ ! -s "$ERR" ]
+    [ ! -e "$FAKE_CALLS" ]
+}
+
+@test "direct path, no systemd-run on PATH: exec in place, stdout exactly the CLI's, stderr empty" {
+    mkdir -p "$TEST_DIR/tools"   # a PATH with nothing on it the wrapper could mistake for systemd-run
+    assert_direct_exec_in_place "PATH=$TEST_DIR/tools" -- --input-format stream-json
+    [ ! -s "$ERR" ]
+    [ ! -e "$FAKE_CALLS" ]
+}
+
+@test "direct path, empty ROMP_SID (a probe): exec in place, stdout exactly the CLI's, stderr empty" {
+    assert_direct_exec_in_place ROMP_SID= -- -v
+    [ ! -s "$ERR" ]
+    [ ! -e "$FAKE_CALLS" ]
+}
+
+@test "direct path, a failed pre-flight: exec in place, stdout exactly the CLI's, ONE stderr line" {
+    cat > "$BIN/systemd-run" <<'SH'
+#!/bin/sh
+echo "$*" >> "$FAKE_CALLS"
+echo "Failed to connect to bus: No such file or directory" >&2
+exit 1
+SH
+    chmod +x "$BIN/systemd-run"
+    assert_direct_exec_in_place -- --input-format stream-json "two words"
+    # the notice went to stderr, never stdout, in the fallback form
+    [ "$(wc -l < "$ERR")" -eq 1 ]
+    grep -q '^romp-cli-scope: fallback: ' "$ERR"
+    [ "$(wc -l < "$FAKE_CALLS")" -eq 1 ]
+}
+
+@test "ROMP_CLI_SCOPE=0 runs the real CLI directly — systemd-run is not invoked" {
+    ROMP_CLI_SCOPE=0 run "$WRAPPER" x "y z"
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_LOG" ]
+    [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "$(printf 'ARG:%s\n' x "y z")" ]
+}
+
+@test "no systemd-run on PATH: the real CLI runs directly" {
+    rm "$BIN/systemd-run"
+    PATH="$BIN" run "$WRAPPER" --input-format stream-json
+    [ "$status" -eq 0 ]
+    [ ! -e "$FAKE_LOG" ]
+    [[ "$output" == *"ARG:--input-format"* ]]
+}
+
+# The refusal tests run the wrapper under an inner sh that reports the exit code on stdout: bats's
+# `run` warns on a bare 127 (it reads it as command-not-found), and 127 is exactly the code wanted.
+# The line is the `refused:` form, not `fallback:`: no CLI ran, so the kernel logs no fallback for
+# it and leaves it to the launch-error card (tests/test_cli_scope.py FallbackNotice).
+@test "an empty ROMP_CLI_REAL is refused: exit 127 and one \`refused:\` stderr line naming the variable" {
+    ERR="$TEST_DIR/stderr"
+    ROMP_CLI_REAL= run sh -c '"$0" a 2>"$1"; echo "exit=$?"' "$WRAPPER" "$ERR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "exit=127" ]
+    [ "$(wc -l < "$ERR")" -eq 1 ]
+    grep -q '^romp-cli-scope: refused: ' "$ERR"
+    grep -q 'ROMP_CLI_REAL' "$ERR"
+    [ ! -e "$FAKE_LOG" ]
+}
+
+@test "an unset ROMP_CLI_REAL is refused the same way" {
+    unset ROMP_CLI_REAL
+    ERR="$TEST_DIR/stderr"
+    run sh -c '"$0" 2>"$1"; echo "exit=$?"' "$WRAPPER" "$ERR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "exit=127" ]
+    [ "$(wc -l < "$ERR")" -eq 1 ]
+    grep -q '^romp-cli-scope: refused: ' "$ERR"
+    grep -q 'ROMP_CLI_REAL' "$ERR"
+}

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -29,11 +29,7 @@ exit 0
 FAKE
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
-    tmux_private_socket_dir "$TEST_DIR"
-    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
-    # romp session's tool shell inherits from the live service) — a test must never start a real scope
-    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
-    export ROMP_CLI_SCOPE=0
+    tmux_private_socket_dir "$TEST_DIR"   # also floors ROMP_CLI_SCOPE=0: no real scope on the user manager
     # Fake kernel launcher: stay alive without binding a real port (we assert on the
     # manager's control endpoint, not a live kernel).
     FAKE="$TEST_DIR/fake-serve"

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -30,6 +30,10 @@ FAKE
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
     tmux_private_socket_dir "$TEST_DIR"
+    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
+    # romp session's tool shell inherits from the live service) — a test must never start a real scope
+    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
+    export ROMP_CLI_SCOPE=0
     # Fake kernel launcher: stay alive without binding a real port (we assert on the
     # manager's control endpoint, not a live kernel).
     FAKE="$TEST_DIR/fake-serve"

--- a/tests/romp-manager-origin.bats
+++ b/tests/romp-manager-origin.bats
@@ -21,6 +21,10 @@ setup() {
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
     tmux_private_socket_dir "$TEST_DIR"
+    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
+    # romp session's tool shell inherits from the live service) — a test must never start a real scope
+    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
+    export ROMP_CLI_SCOPE=0
     # Fake kernel launcher: stays alive without binding a real port.
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"

--- a/tests/romp-manager-origin.bats
+++ b/tests/romp-manager-origin.bats
@@ -20,11 +20,7 @@ setup() {
     printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/tmux"
     chmod +x "$BIN/tmux"
     export PATH="$BIN:$PATH"
-    tmux_private_socket_dir "$TEST_DIR"
-    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
-    # romp session's tool shell inherits from the live service) — a test must never start a real scope
-    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
-    export ROMP_CLI_SCOPE=0
+    tmux_private_socket_dir "$TEST_DIR"   # also floors ROMP_CLI_SCOPE=0: no real scope on the user manager
     # Fake kernel launcher: stays alive without binding a real port.
     FAKE="$TEST_DIR/fake-serve"
     printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"

--- a/tests/romp-manager-tmux-scope.bats
+++ b/tests/romp-manager-tmux-scope.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+# bin/romp-manager's startTmuxServer, through a REAL manager start. On Linux with the switch on it runs
+# `tmux start-server` through `systemd-run --scope` in a romp-tmux-<ms> unit, so the server sits outside
+# the service cgroup and outlives a service restart; when systemd-run fails it says so and starts the
+# server bare, saying that too. tmuxStartArgv, the pure argv choice, has its node suite
+# (tests/manager-tmux-scope.test.js); this file covers the call itself, the fallback, and the log lines,
+# which nothing else did — the other manager-driving suites run with the switch floored off.
+#
+# A FAKE systemd-run first on PATH records its argv, then either execs the command after `--` (what
+# --scope mode does for real) or, with FAKE_SYSTEMD_RUN_FAIL set, exits 1 with a bus error on stderr. A
+# recording fake tmux answers the command either way; with FAKE_TMUX_FAIL set it exits 1 with tmux's
+# connect error on stderr, which is what tmux failing INSIDE a scope that did start looks like to the
+# manager. Nothing here reaches the real systemd-run or the user manager: the switch is turned on only
+# behind the fake, and the floor tmux_private_socket_dir sets (ROMP_CLI_SCOPE=0) stays for the case
+# that pins it.
+
+load free-port
+load tmux-private
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
+    BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
+    export FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" FAKE_SYSTEMD_RUN_CALLS="$TEST_DIR/systemd-run-calls"
+    cat > "$BIN/tmux" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_TMUX_CALLS"
+if [ -n "${FAKE_TMUX_FAIL:-}" ]; then
+    echo 'error connecting to /nonexistent/tmux-0/default (No such file or directory)' >&2
+    exit 1
+fi
+exit 0
+FAKE
+    # On failure, two stderr lines: the log must carry the first and only the first.
+    cat > "$BIN/systemd-run" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_SYSTEMD_RUN_CALLS"
+if [ -n "${FAKE_SYSTEMD_RUN_FAIL:-}" ]; then
+    echo 'Failed to start transient scope unit: Failed to connect to bus: No such file or directory' >&2
+    echo 'second stderr line, not for the log' >&2
+    exit 1
+fi
+while [ "$#" -gt 0 ]; do a="$1"; shift; [ "$a" = "--" ] && break; done
+exec "$@"
+FAKE
+    chmod +x "$BIN/tmux" "$BIN/systemd-run"
+    export PATH="$BIN:$PATH"
+    tmux_private_socket_dir "$TEST_DIR"   # private socket dir, and the ROMP_CLI_SCOPE=0 floor
+    # The manager's registry root is private too: a real `up` writes there.
+    export ROMP_STATE_DIR="$TEST_DIR/state"; mkdir -p "$ROMP_STATE_DIR"
+    # Fake kernel launcher: stays alive without binding a real port.
+    FAKE="$TEST_DIR/fake-serve"
+    printf '#!/usr/bin/env bash\nexec sleep 30\n' > "$FAKE"
+    chmod +x "$FAKE"
+    LOG="$TEST_DIR/manager.log"
+    free_port CPORT MPORT   # fresh per test, never a literal (tests/free-port.bash)
+}
+
+teardown() {
+    curl -fsS -X POST "http://127.0.0.1:${CPORT:-0}/stop" >/dev/null 2>&1 || true
+    [[ -n "${MGR_PID:-}" ]] && kill "$MGR_PID" 2>/dev/null || true
+    # The kill before the rm (a server the real tmux started must not outlive the test), and last, so
+    # its failure is teardown's status: bats swallows a failing command mid-teardown.
+    tmux_private_kill && rm -rf "$TEST_DIR"
+}
+
+need_tools() {
+    command -v node >/dev/null 2>&1 || skip "node not available"
+    command -v curl >/dev/null 2>&1 || skip "curl not available"
+}
+
+# The real manager, its stderr (where log() writes) in $LOG, up to the control port answering. The tmux
+# start runs before the port binds, so once /status answers the calls and the lines are on disk.
+start_manager() {
+    env ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKE" \
+        node "$MGR" up >"$LOG" 2>&1 &
+    MGR_PID=$!
+    local i
+    for i in $(seq 1 50); do
+        curl -fsS "http://127.0.0.1:$CPORT/status" >/dev/null 2>&1 && return 0
+        sleep 0.1
+    done
+    echo "the manager did not come up; its log:"; cat "$LOG"
+    return 1
+}
+
+BARE='start-server ; set -g exit-empty off'
+
+# Absence, armed: `run` then a status test, the form tests/romp-cli-scope.bats uses. A bare `! grep -q`
+# that is not a test's last command is exempt from bats' errexit and asserts nothing — a manager that
+# logged every forbidden line passed the first version of this file.
+log_lacks() {   # $1: a grep pattern that must match no line of the manager's log
+    run grep -q "$1" "$LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "switch on: the server starts through systemd-run --scope in a romp-tmux unit, and the log says so" {
+    need_tools
+    [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
+    export ROMP_CLI_SCOPE=1
+    start_manager
+    # one systemd-run call: a --user --scope --quiet --collect unit named romp-tmux-<ms>, the tmux argv after --
+    [ "$(wc -l < "$FAKE_SYSTEMD_RUN_CALLS")" -eq 1 ]
+    re='^--user --scope --quiet --collect --unit=romp-tmux-[0-9]+ -- tmux start-server ; set -g exit-empty off$'
+    [[ "$(cat "$FAKE_SYSTEMD_RUN_CALLS")" =~ $re ]]
+    # the fake exec'd the command after --, so tmux ran once, from inside the "scope", with the bare argv
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$BARE" ]
+    grep -q 'tmux server ensured in its own transient scope (romp-tmux-\*)' "$LOG"
+    log_lacks 'could not start the tmux server in a scope'
+    log_lacks 'failed inside the scope'
+    log_lacks 'ensured without a scope'
+    log_lacks 'launchd-rooted'
+}
+
+@test "switch on, systemd-run failing: the log names systemd-run and carries its first stderr line, the server starts bare, and the log says it is unscoped" {
+    need_tools
+    [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
+    export ROMP_CLI_SCOPE=1 FAKE_SYSTEMD_RUN_FAIL=1
+    start_manager
+    [ "$(wc -l < "$FAKE_SYSTEMD_RUN_CALLS")" -eq 1 ]   # tried once...
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$BARE" ]          # ...then the bare call, once
+    # the failure line: systemd-run named, its first stderr line in the parenthesis, the second line not
+    grep -q 'systemd-run could not start the tmux server in a scope (Failed to start transient scope unit: Failed to connect to bus: No such file or directory)' "$LOG"
+    log_lacks 'second stderr line'
+    log_lacks 'Command failed'
+    grep -q 'starting it the plain way instead' "$LOG"
+    grep -q 'tmux server ensured without a scope' "$LOG"
+    grep -q 'a service restart will take it down' "$LOG"
+    log_lacks 'failed inside the scope'
+    log_lacks 'in its own transient scope'
+    log_lacks 'launchd-rooted'
+}
+
+@test "switch on, tmux failing inside the scope: the log names tmux and carries its line, then the bare call is tried" {
+    # systemd-run execs tmux in place, so a tmux failure surfaces as the scoped call's own; the log must
+    # not blame systemd-run for it. The bare retry fails the same way here and, as before, says nothing.
+    need_tools
+    [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
+    export ROMP_CLI_SCOPE=1 FAKE_TMUX_FAIL=1
+    start_manager
+    [ "$(wc -l < "$FAKE_SYSTEMD_RUN_CALLS")" -eq 1 ]                        # the scope was started once...
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$(printf '%s\n%s' "$BARE" "$BARE")" ]   # ...tmux ran inside it, then bare
+    grep -q 'tmux failed inside the scope systemd-run started for it (error connecting to /nonexistent/tmux-0/default (No such file or directory))' "$LOG"
+    grep -q 'starting it the plain way instead' "$LOG"
+    log_lacks 'systemd-run could not start'
+    log_lacks 'Command failed'
+    log_lacks 'ensured'
+}
+
+@test "the helper's floor holds under an inherited ROMP_SUPERVISED: no systemd-run call, the bare start, the plain line" {
+    # What a tool shell under a self-hosted install carries. Every manager-driving suite relies on the
+    # floor tmux_private_socket_dir set in setup() — this case sets nothing itself — and with the fake in
+    # front of the real systemd-run a floor that failed would show as a recorded call, not as a scope.
+    need_tools
+    export ROMP_SUPERVISED=1
+    [ "$ROMP_CLI_SCOPE" = 0 ]
+    start_manager
+    [ ! -e "$FAKE_SYSTEMD_RUN_CALLS" ]
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$BARE" ]
+    grep -q 'tmux server ensured (launchd-rooted)' "$LOG"
+    log_lacks 'transient scope'
+    log_lacks 'without a scope'
+    log_lacks 'failed inside the scope'
+}

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -87,6 +87,10 @@ MOCK
     # (tests/tmux-private.bash has the 2026-09-06 incident).
     tmux_private_socket_dir "$TEST_DIR"
     unset TMUX            # default: outside tmux → attach-session branch
+    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
+    # romp session's tool shell inherits from the live service) — a test must never start a real scope
+    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
+    export ROMP_CLI_SCOPE=0
     # Hermetic HOME: bin/romp probes $HOME/.claude/romp-postal.mcp.json (would
     # nondeterministically append --mcp-config on a dev machine) and writes the
     # names map under XDG_STATE_HOME (was polluting the REAL state dir).

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -87,10 +87,6 @@ MOCK
     # (tests/tmux-private.bash has the 2026-09-06 incident).
     tmux_private_socket_dir "$TEST_DIR"
     unset TMUX            # default: outside tmux → attach-session branch
-    # bin/romp-manager starts its tmux server in a transient systemd scope under ROMP_SUPERVISED (which a
-    # romp session's tool shell inherits from the live service) — a test must never start a real scope
-    # on the live user manager, so the switch is floored off (the kernel and manager both honour it).
-    export ROMP_CLI_SCOPE=0
     # Hermetic HOME: bin/romp probes $HOME/.claude/romp-postal.mcp.json (would
     # nondeterministically append --mcp-config on a dev machine) and writes the
     # names map under XDG_STATE_HOME (was polluting the REAL state dir).

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -7,7 +7,9 @@ ONCE per backend by cli_scope_supported and applied in _options.
 
 Under test here, with NO real systemd-run ever invoked (which/run are injected; conftest floors
 ROMP_CLI_SCOPE=0 for every backend construction):
-  * the cli_scope_supported truth table and the exact probe argv;
+  * the cli_scope_supported truth table and the exact probe argv, and which off verdicts are filed
+    as problems (wanted on Linux and unavailable: the error center must show that sessions run inside
+    the service cgroup) rather than plain log lines (off by request, or no systemd on the platform);
   * the backend caches one verdict at construction, and _options honours it: cli_path becomes the
     wrapper and ROMP_CLI_REAL carries the real CLI when on; both untouched when off;
   * a missing or non-executable wrapper degrades loudly (a problem line, once) to the direct path;
@@ -42,6 +44,25 @@ def _which(found=True):
     return lambda name: ("/usr/bin/" + name) if found else None
 
 
+class _Log:
+    """A recording stand-in for SdkBackend._log, the callback cli_scope_supported is handed: every call
+    as (line, problem). `lines` is the text alone; `problems` the text of the calls flagged problem=True."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, m, problem=None):
+        self.calls.append((m, problem))
+
+    @property
+    def lines(self):
+        return [m for m, _ in self.calls]
+
+    @property
+    def problems(self):
+        return [m for m, p in self.calls if p]
+
+
 class _Run:
     """A recording stand-in for subprocess.run: returns a fixed result, or raises."""
 
@@ -66,44 +87,64 @@ class Supported(unittest.TestCase):
 
     def test_explicit_off_under_supervision(self):
         run = _Run()
+        logged = _Log()
         self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1", "ROMP_CLI_SCOPE": "0"},
-                                                which=_which(), platform="linux", run=run))
+                                                which=_which(), platform="linux", run=run, log=logged))
         self.assertEqual(run.calls, [])
+        self.assertEqual(logged.problems, [], "off by request is not a problem")
+        self.assertIn("ROMP_CLI_SCOPE=0", logged.lines[0])
 
+    # The three ways a WANTED switch fails on Linux — no systemd-run, a probe that exits non-zero, a
+    # probe that raises — are each filed as a problem (the error center shows them), and the line says
+    # what follows: sessions run inside the service cgroup. Before 2026-09-06 these were plain log lines,
+    # and a box whose user manager could not start scopes showed nothing anywhere the user looks.
     def test_supervised_without_systemd_run_is_off(self):
         run = _Run()
-        logged = []
+        logged = _Log()
         self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(False), platform="linux", run=run,
-                                                log=logged.append))
+                                                log=logged))
         self.assertEqual(run.calls, [], "nothing to probe with")
-        self.assertEqual(len(logged), 1)
-        self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
-        self.assertIn("systemd-run", logged[0])
+        self.assertEqual(len(logged.calls), 1)
+        self.assertTrue(logged.lines[0].startswith("cli scope: off — "), logged.lines)
+        self.assertIn("systemd-run", logged.lines[0])
+        self.assertEqual(logged.problems, logged.lines, "wanted and unavailable: a problem entry")
+        self.assertIn("inside the service cgroup", logged.lines[0], "the line says where sessions land")
 
     def test_supervised_with_a_failing_probe_is_off(self):
         run = _Run(returncode=1, stderr=b"Failed to start transient scope unit: Access denied\n")
-        logged = []
+        logged = _Log()
         self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
-                                                log=logged.append))
+                                                log=logged))
         self.assertEqual(len(run.calls), 1)
-        self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
-        self.assertIn("Access denied", logged[0], "the probe's stderr is the reason the user reads")
+        self.assertTrue(logged.lines[0].startswith("cli scope: off — "), logged.lines)
+        self.assertIn("Access denied", logged.lines[0], "the probe's stderr is the reason the user reads")
+        self.assertEqual(logged.problems, logged.lines, "a probe the user manager refused: a problem entry")
 
     def test_a_probe_that_raises_is_off(self):
         for exc in (subprocess.TimeoutExpired(PROBE, 10), OSError("boom")):
             run = _Run(raise_=exc)
-            logged = []
+            logged = _Log()
             self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
-                                                    log=logged.append))
-            self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
+                                                    log=logged))
+            self.assertTrue(logged.lines[0].startswith("cli scope: off — "), logged.lines)
+            self.assertEqual(logged.problems, logged.lines, "%r: a problem entry" % (exc,))
+
+    def test_explicit_on_that_cannot_be_honoured_is_a_problem_too(self):
+        # ROMP_CLI_SCOPE=1 outside the service is the user asking by hand; a box that cannot oblige
+        # reports it the same way
+        logged = _Log()
+        self.assertFalse(sb.cli_scope_supported({"ROMP_CLI_SCOPE": "1"}, which=_which(False), platform="linux",
+                                                run=_Run(), log=logged))
+        self.assertEqual(len(logged.problems), 1, logged.calls)
 
     def test_supervised_with_a_passing_probe_is_on(self):
         run = _Run()
-        logged = []
+        logged = _Log()
         self.assertTrue(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
-                                               log=logged.append))
-        self.assertEqual(len(logged), 1)
-        self.assertTrue(logged[0].startswith("cli scope: on — "), logged)
+                                               log=logged))
+        self.assertEqual(len(logged.calls), 1)
+        self.assertTrue(logged.lines[0].startswith("cli scope: on — "), logged.lines)
+        self.assertEqual(logged.problems, [], "on is not a problem")
 
     def test_explicit_on_outside_supervision_probes_and_turns_on(self):
         run = _Run()
@@ -134,15 +175,18 @@ class Supported(unittest.TestCase):
         for plat in ("darwin", "freebsd13", "win32"):
             run = _Run()
             which_calls = []
-            logged = []
+            logged = _Log()
             ok = sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=lambda n: which_calls.append(n),
-                                        run=run, log=logged.append, platform=plat)
+                                        run=run, log=logged, platform=plat)
             self.assertFalse(ok, plat)
             self.assertEqual(which_calls, [], "no PATH lookup off Linux")
             self.assertEqual(run.calls, [], "no probe off Linux")
-            self.assertEqual(len(logged), 1)
-            self.assertTrue(logged[0].startswith("cli scope: off — not Linux"), logged)
-            self.assertNotIn("PATH", logged[0])
+            self.assertEqual(len(logged.calls), 1)
+            self.assertTrue(logged.lines[0].startswith("cli scope: off — not Linux"), logged.lines)
+            self.assertNotIn("PATH", logged.lines[0])
+            # ...and not a problem: every macOS kernel start would otherwise open with an error-center
+            # entry for a feature the platform does not have
+            self.assertEqual(logged.problems, [], plat)
 
     def test_linux_variants_pass_the_platform_check(self):
         for plat in ("linux", "linux2"):
@@ -151,10 +195,10 @@ class Supported(unittest.TestCase):
 
     def test_the_switch_off_reasons_win_over_the_platform(self):
         # off Linux, an explicit 0 or an unsupervised run still reports ITS reason, not the platform's
-        logged = []
+        logged = _Log()
         sb.cli_scope_supported({"ROMP_SUPERVISED": "1", "ROMP_CLI_SCOPE": "0"}, which=_which(), run=_Run(),
-                               log=logged.append, platform="darwin")
-        self.assertIn("ROMP_CLI_SCOPE=0", logged[0])
+                               log=logged, platform="darwin")
+        self.assertIn("ROMP_CLI_SCOPE=0", logged.lines[0])
 
     def test_the_platform_defaults_to_this_process(self):
         # no injected platform → sys.platform; on Linux that is the on path, elsewhere the off one
@@ -207,6 +251,24 @@ class ConstructionVerdict(_Backend):
     def test_the_test_floor_leaves_the_scope_off(self):
         self.assertFalse(self.be.cli_scope)
         self.assertTrue(any(m.startswith("cli scope: off — ") for m in self.logged), self.logged)
+        self.assertEqual([r for r in self.be.problems() if r["text"].startswith("cli scope:")], [],
+                         "off by request (the floor) files nothing in the error center")
+
+    def test_a_wanted_but_unavailable_verdict_is_filed_as_a_problem(self):
+        # the boot verdict reaches the error center through the backend's own _log, the way the launch-time
+        # fallbacks do: the real cli_scope_supported, on a supervised Linux box with no systemd-run
+        real = sb.cli_scope_supported
+        sb.cli_scope_supported = lambda **kw: real({"ROMP_SUPERVISED": "1"}, which=_which(False),
+                                                   platform="linux", run=_Run(), **kw)
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        finally:
+            sb.cli_scope_supported = real
+        self.assertFalse(be.cli_scope)
+        rows = [r for r in be.problems() if r["text"].startswith("cli scope: off — ")]
+        self.assertEqual(len(rows), 1, be.problems())
+        self.assertIn("systemd-run is not on PATH", rows[0]["text"])
+        self.assertIn("inside the service cgroup", rows[0]["text"])
 
     def test_the_verdict_is_taken_once_and_cached(self):
         calls = []

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Per-session transient systemd scopes (2026-09-05). Under the systemd user service every process
+the service tree starts shares the service's cgroup, and KillMode=control-group (deliberately kept)
+empties it on `systemctl --user restart romp-manager` — sessions' tmux jobs died with it. The fix
+spawns each session's CLI through bin/romp-cli-scope (exec-in-place `systemd-run --scope`), decided
+ONCE per backend by cli_scope_supported and applied in _options.
+
+Under test here, with NO real systemd-run ever invoked (which/run are injected; conftest floors
+ROMP_CLI_SCOPE=0 for every backend construction):
+  * the cli_scope_supported truth table and the exact probe argv;
+  * the backend caches one verdict at construction, and _options honours it: cli_path becomes the
+    wrapper and ROMP_CLI_REAL carries the real CLI when on; both untouched when off;
+  * a missing or non-executable wrapper degrades loudly (a problem line, once) to the direct path;
+  * the wrapper's fallback notice (a failed pre-flight, the CLI run directly; its `fallback:` form)
+    is logged the moment it arrives, as a problem naming the session, since on that path the CLI
+    starts and nothing else would ever read it; its `refused:` line (ROMP_CLI_REAL unset, exit 127)
+    is only buffered — no CLI started, and the launch-error path reports it.
+Synthetic fixtures only: placeholder sid, /bin/true as the CLI.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_CLI_SCOPE"] = "0"   # the conftest floor, re-asserted for a bare unittest run
+sb = SourceFileLoader("romp_sdk_backend_cli_scope", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+PROBE = ["systemd-run", "--user", "--scope", "--quiet", "--collect", "--", "true"]
+
+
+def _which(found=True):
+    return lambda name: ("/usr/bin/" + name) if found else None
+
+
+class _Run:
+    """A recording stand-in for subprocess.run: returns a fixed result, or raises."""
+
+    def __init__(self, returncode=0, stderr=b"", raise_=None):
+        self.calls = []
+        self.rc, self.stderr, self.raise_ = returncode, stderr, raise_
+
+    def __call__(self, argv, **kw):
+        self.calls.append((list(argv), kw))
+        if self.raise_:
+            raise self.raise_
+        return subprocess.CompletedProcess(argv, self.rc, stdout=b"", stderr=self.stderr)
+
+
+class Supported(unittest.TestCase):
+    """cli_scope_supported's truth table, on injected inputs."""
+
+    def test_unsupervised_is_off_without_probing(self):
+        run = _Run()
+        self.assertFalse(sb.cli_scope_supported({}, which=_which(), platform="linux", run=run))
+        self.assertEqual(run.calls, [], "no probe when the switch is off")
+
+    def test_explicit_off_under_supervision(self):
+        run = _Run()
+        self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1", "ROMP_CLI_SCOPE": "0"},
+                                                which=_which(), platform="linux", run=run))
+        self.assertEqual(run.calls, [])
+
+    def test_supervised_without_systemd_run_is_off(self):
+        run = _Run()
+        logged = []
+        self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(False), platform="linux", run=run,
+                                                log=logged.append))
+        self.assertEqual(run.calls, [], "nothing to probe with")
+        self.assertEqual(len(logged), 1)
+        self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
+        self.assertIn("systemd-run", logged[0])
+
+    def test_supervised_with_a_failing_probe_is_off(self):
+        run = _Run(returncode=1, stderr=b"Failed to start transient scope unit: Access denied\n")
+        logged = []
+        self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
+                                                log=logged.append))
+        self.assertEqual(len(run.calls), 1)
+        self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
+        self.assertIn("Access denied", logged[0], "the probe's stderr is the reason the user reads")
+
+    def test_a_probe_that_raises_is_off(self):
+        for exc in (subprocess.TimeoutExpired(PROBE, 10), OSError("boom")):
+            run = _Run(raise_=exc)
+            logged = []
+            self.assertFalse(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
+                                                    log=logged.append))
+            self.assertTrue(logged[0].startswith("cli scope: off — "), logged)
+
+    def test_supervised_with_a_passing_probe_is_on(self):
+        run = _Run()
+        logged = []
+        self.assertTrue(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run,
+                                               log=logged.append))
+        self.assertEqual(len(logged), 1)
+        self.assertTrue(logged[0].startswith("cli scope: on — "), logged)
+
+    def test_explicit_on_outside_supervision_probes_and_turns_on(self):
+        run = _Run()
+        self.assertTrue(sb.cli_scope_supported({"ROMP_CLI_SCOPE": "1"}, which=_which(), platform="linux", run=run))
+        self.assertEqual(len(run.calls), 1)
+
+    def test_the_probe_argv_is_exact_and_bounded(self):
+        run = _Run()
+        sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), platform="linux", run=run)
+        argv, kw = run.calls[0]
+        self.assertEqual(argv, PROBE)
+        self.assertEqual(sb.CLI_SCOPE_PROBE, PROBE)
+        self.assertEqual(kw.get("timeout"), sb.CLI_SCOPE_PROBE_TIMEOUT)
+        self.assertGreater(sb.CLI_SCOPE_PROBE_TIMEOUT, 0)
+        self.assertLessEqual(sb.CLI_SCOPE_PROBE_TIMEOUT, 10)
+
+    def test_an_empty_switch_value_is_not_on(self):
+        run = _Run()
+        self.assertFalse(sb.cli_scope_supported({"ROMP_CLI_SCOPE": ""}, which=_which(), platform="linux", run=run))
+        self.assertEqual(run.calls, [])
+
+    def test_no_log_callback_is_fine(self):
+        self.assertTrue(sb.cli_scope_supported({"ROMP_CLI_SCOPE": "1"}, which=_which(), platform="linux", run=_Run()))
+
+    def test_not_linux_is_off_before_which_or_probe(self):
+        # the macOS launchd plist sets ROMP_SUPERVISED=1 too; scopes are a systemd feature, so the
+        # verdict there is off with a reason that says so — not "systemd-run is not on PATH"
+        for plat in ("darwin", "freebsd13", "win32"):
+            run = _Run()
+            which_calls = []
+            logged = []
+            ok = sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=lambda n: which_calls.append(n),
+                                        run=run, log=logged.append, platform=plat)
+            self.assertFalse(ok, plat)
+            self.assertEqual(which_calls, [], "no PATH lookup off Linux")
+            self.assertEqual(run.calls, [], "no probe off Linux")
+            self.assertEqual(len(logged), 1)
+            self.assertTrue(logged[0].startswith("cli scope: off — not Linux"), logged)
+            self.assertNotIn("PATH", logged[0])
+
+    def test_linux_variants_pass_the_platform_check(self):
+        for plat in ("linux", "linux2"):
+            self.assertTrue(sb.cli_scope_supported({"ROMP_SUPERVISED": "1"}, which=_which(), run=_Run(),
+                                                   platform=plat), plat)
+
+    def test_the_switch_off_reasons_win_over_the_platform(self):
+        # off Linux, an explicit 0 or an unsupervised run still reports ITS reason, not the platform's
+        logged = []
+        sb.cli_scope_supported({"ROMP_SUPERVISED": "1", "ROMP_CLI_SCOPE": "0"}, which=_which(), run=_Run(),
+                               log=logged.append, platform="darwin")
+        self.assertIn("ROMP_CLI_SCOPE=0", logged[0])
+
+    def test_the_platform_defaults_to_this_process(self):
+        # no injected platform → sys.platform; on Linux that is the on path, elsewhere the off one
+        run = _Run()
+        ok = sb.cli_scope_supported({"ROMP_CLI_SCOPE": "1"}, which=_which(), run=run)
+        self.assertEqual(ok, sys.platform.startswith("linux"))
+
+
+class _Backend(unittest.TestCase):
+    """A backend on a temp state dir, no real CLI, no real key claim, no SDK dependency."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self._stash_before = sb._WORK_KEY
+        sb._WORK_KEY = ""
+        self._fetch_before = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None
+        self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
+        if self._fake_sdk:
+            fake = types.ModuleType("claude_agent_sdk")
+            fake.HookMatcher = lambda **kw: kw
+            sys.modules["claude_agent_sdk"] = fake
+        self.logged = []
+        # A backend whose verdict is ON exports ROMP_CLI_REAL into os.environ (the SDK's version probe
+        # needs it there). Tests that turn the verdict on restore the variable themselves; this snapshot
+        # is the backstop, so no test in these classes can leak it into the rest of the pytest process.
+        self._real_before = os.environ.get("ROMP_CLI_REAL")
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logged.append)
+
+    def tearDown(self):
+        sb._WORK_KEY = self._stash_before
+        sb._fetch_key_fast_org = self._fetch_before
+        if self._fake_sdk:
+            sys.modules.pop("claude_agent_sdk", None)
+        if self._real_before is None:
+            os.environ.pop("ROMP_CLI_REAL", None)
+        else:
+            os.environ["ROMP_CLI_REAL"] = self._real_before
+
+    def _sess(self):
+        return sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": self.d, "mode": "acceptEdits"})
+
+    def _kw(self):
+        return self.be._options(self._sess(), dict)
+
+
+class ConstructionVerdict(_Backend):
+    """One verdict per backend, at construction."""
+
+    def test_the_test_floor_leaves_the_scope_off(self):
+        self.assertFalse(self.be.cli_scope)
+        self.assertTrue(any(m.startswith("cli scope: off — ") for m in self.logged), self.logged)
+
+    def test_the_verdict_is_taken_once_and_cached(self):
+        calls = []
+        before = sb.cli_scope_supported
+        real_before = os.environ.pop("ROMP_CLI_REAL", None)   # an ON verdict exports it — restore below
+        sb.cli_scope_supported = lambda **kw: calls.append(kw) or True
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        finally:
+            sb.cli_scope_supported = before
+            os.environ.pop("ROMP_CLI_REAL", None)
+            if real_before is not None:
+                os.environ["ROMP_CLI_REAL"] = real_before
+        self.assertEqual(len(calls), 1)
+        self.assertIn("log", calls[0])
+        self.assertTrue(be.cli_scope)
+
+    # The SDK's per-connect version check runs `[cli_path, "-v"]` with the KERNEL's os.environ, not
+    # options.env (claude_agent_sdk 0.2.132), so with the verdict on the wrapper must find ROMP_CLI_REAL
+    # in the process environment too — or the probe exits 127 and the version warning is silently off.
+    def test_on_exports_the_real_cli_into_the_kernels_environment(self):
+        before = os.environ.pop("ROMP_CLI_REAL", None)
+        saved = sb.cli_scope_supported
+        sb.cli_scope_supported = lambda **kw: True
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+            self.assertTrue(be.cli_scope)
+            self.assertEqual(os.environ.get("ROMP_CLI_REAL"), "/bin/true")
+        finally:
+            sb.cli_scope_supported = saved
+            os.environ.pop("ROMP_CLI_REAL", None)
+            if before is not None:
+                os.environ["ROMP_CLI_REAL"] = before
+
+    def test_off_leaves_the_kernels_environment_alone(self):
+        before = os.environ.pop("ROMP_CLI_REAL", None)
+        try:
+            be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)   # the test floor: off
+            self.assertFalse(be.cli_scope)
+            self.assertNotIn("ROMP_CLI_REAL", os.environ)
+        finally:
+            if before is not None:
+                os.environ["ROMP_CLI_REAL"] = before
+
+
+class OptionsWiring(_Backend):
+    """_options routes the spawn through the wrapper exactly when the verdict is on."""
+
+    def test_off_leaves_cli_path_and_env_untouched(self):
+        self.be.cli_scope = False
+        kw = self._kw()
+        self.assertEqual(kw["cli_path"], "/bin/true")
+        self.assertNotIn("ROMP_CLI_REAL", kw["env"])
+
+    def test_on_spawns_the_wrapper_with_the_real_cli_in_the_env(self):
+        self.be.cli_scope = True
+        kw = self._kw()
+        self.assertEqual(kw["cli_path"], sb.cli_scope_wrapper())
+        self.assertEqual(kw["env"]["ROMP_CLI_REAL"], "/bin/true")
+        # the identity vars the CLI relied on are still there — the overlay is additive
+        self.assertEqual(kw["env"]["ROMP_SID"], SID)
+        self.assertEqual(kw["env"]["ROMP_SESSION_NAME"], "web")
+
+    def test_the_wrapper_is_the_repos_executable(self):
+        w = sb.cli_scope_wrapper()
+        self.assertTrue(os.path.isabs(w))
+        self.assertEqual(os.path.realpath(w), os.path.realpath(os.path.join(BIN, "romp-cli-scope")))
+        self.assertTrue(os.access(w, os.X_OK), "bin/romp-cli-scope must be executable in the checkout")
+
+    def test_a_missing_wrapper_falls_back_loudly_once(self):
+        self.be.cli_scope = True
+        before = sb.cli_scope_wrapper
+        sb.cli_scope_wrapper = lambda: os.path.join(self.d, "no-such-wrapper")
+        problems = []
+        self.be._log = lambda m, problem=None: problems.append((m, problem))
+        try:
+            kw1 = self._kw()
+            kw2 = self._kw()
+        finally:
+            sb.cli_scope_wrapper = before
+        for kw in (kw1, kw2):
+            self.assertEqual(kw["cli_path"], "/bin/true", "the session still starts, on the direct path")
+            self.assertNotIn("ROMP_CLI_REAL", kw["env"])
+        loud = [(m, p) for m, p in problems if "no-such-wrapper" in m]
+        self.assertEqual(len(loud), 1, "reported once per backend, as a problem: %r" % (problems,))
+        self.assertTrue(loud[0][1])
+
+    def test_a_non_executable_wrapper_falls_back_too(self):
+        self.be.cli_scope = True
+        p = os.path.join(self.d, "romp-cli-scope")
+        with open(p, "w") as f:
+            f.write("#!/bin/sh\n")
+        os.chmod(p, 0o644)
+        before = sb.cli_scope_wrapper
+        sb.cli_scope_wrapper = lambda: p
+        try:
+            kw = self._kw()
+        finally:
+            sb.cli_scope_wrapper = before
+        self.assertEqual(kw["cli_path"], "/bin/true")
+
+
+class FallbackNotice(_Backend):
+    """bin/romp-cli-scope writes one stderr line, starting `romp-cli-scope: fallback:`, when it runs
+    the CLI directly after a failed pre-flight. The CLI then STARTS, so _record_launch_error never
+    drains the stderr tail and the line was never read (2026-09-05): the boot verdict kept saying
+    scopes were on while the session's work sat in the service cgroup. _on_cli_stderr now logs that
+    line at once, as a problem naming the session; every other line is still only buffered — the
+    wrapper's `romp-cli-scope: refused:` line included, since on that path no CLI started and the
+    launch-error card reports it from the tail."""
+
+    NOTICE = ("romp-cli-scope: fallback: systemd-run cannot start a transient scope (Failed to connect to bus: "
+              "No such file or directory) — running the CLI directly, outside a scope; a service restart will "
+              "take its background work down")
+    REFUSAL = ("romp-cli-scope: refused: ROMP_CLI_REAL is unset or empty; it must name the real claude CLI, "
+               "and this wrapper does not guess one")
+
+    def _capture(self):
+        problems = []
+        self.be._log = lambda m, problem=None: problems.append((m, problem))
+        return problems
+
+    def test_the_notice_is_logged_once_as_a_problem_naming_the_session(self):
+        problems = self._capture()
+        sess = self._sess()
+        sess._on_cli_stderr(self.NOTICE + "\n")
+        self.assertEqual(len(problems), 1, problems)
+        m, p = problems[0]
+        self.assertTrue(p, "a problem line — the error center shows it, not only the log file")
+        self.assertIn("web", m, "the session's name")
+        self.assertIn(SID[:8], m, "and its sid")
+        self.assertIn(self.NOTICE, m, "the wrapper's own reason, verbatim")
+        self.assertEqual(sess.stderr_tail(), self.NOTICE, "buffered too, like any other line")
+
+    def test_an_ordinary_line_is_only_buffered(self):
+        problems = self._capture()
+        sess = self._sess()
+        sess._on_cli_stderr("some CLI chatter\n")
+        # the prefix mid-line is not the wrapper speaking (a shell naming the wrapper's path, say)
+        sess._on_cli_stderr("sh: /x/bin/romp-cli-scope: Permission denied\n")
+        self.assertEqual(problems, [], "nothing logged per line — a chatty CLI must not drown the log")
+        self.assertEqual(sess.stderr_tail().splitlines(),
+                         ["some CLI chatter", "sh: /x/bin/romp-cli-scope: Permission denied"])
+
+    def test_the_refusal_line_is_not_logged_as_a_fallback(self):
+        # the wrapper's other line (ROMP_CLI_REAL unset, exit 127): no CLI started, so nothing ran
+        # outside a scope, and the launch fails — _record_launch_error reports the line from the
+        # stderr tail. Logging it here too reported the one event twice, the first time as a CLI
+        # "started outside a scope" when none had started.
+        problems = self._capture()
+        sess = self._sess()
+        sess._on_cli_stderr(self.REFUSAL + "\n")
+        self.assertEqual(problems, [], "left to the launch-error path")
+        self.assertEqual(sess.stderr_tail(), self.REFUSAL, "buffered: the launch-error card reads it from here")
+
+    def test_the_generic_prefix_alone_is_not_a_fallback(self):
+        # only the fallback FORM is logged: a line with the wrapper's prefix and neither second word
+        # (a future third message, say) is buffered and nothing more, rather than misreported
+        problems = self._capture()
+        self._sess()._on_cli_stderr(sb.CLI_SCOPE_NOTICE_PREFIX + " something else entirely\n")
+        self.assertEqual(problems, [])
+
+    def test_the_prefixes_are_what_the_wrapper_writes(self):
+        # the constants and the script agree: every stderr line the wrapper writes starts with the
+        # generic prefix, exactly one in the fallback form and exactly one in the refusal form
+        with open(os.path.join(BIN, "romp-cli-scope")) as f:
+            src = f.read()
+        lines = [ln for ln in src.splitlines() if ">&2" in ln and "echo" in ln]
+        self.assertEqual(len(lines), 2, "the refusal and the fallback: %r" % (lines,))
+        for ln in lines:
+            self.assertIn('"%s ' % sb.CLI_SCOPE_NOTICE_PREFIX, ln, ln)
+        self.assertEqual(sum('"%s ' % sb.CLI_SCOPE_FALLBACK_PREFIX in ln for ln in lines), 1, lines)
+        self.assertEqual(sum('"%s ' % sb.CLI_SCOPE_REFUSAL_PREFIX in ln for ln in lines), 1, lines)
+        # both forms are instances of the generic prefix, so "every line starts with it" still holds,
+        # and neither is a prefix of the other
+        for p in (sb.CLI_SCOPE_FALLBACK_PREFIX, sb.CLI_SCOPE_REFUSAL_PREFIX):
+            self.assertTrue(p.startswith(sb.CLI_SCOPE_NOTICE_PREFIX + " "), p)
+        self.assertFalse(sb.CLI_SCOPE_FALLBACK_PREFIX.startswith(sb.CLI_SCOPE_REFUSAL_PREFIX))
+        self.assertFalse(sb.CLI_SCOPE_REFUSAL_PREFIX.startswith(sb.CLI_SCOPE_FALLBACK_PREFIX))
+        # and the fixtures above are what the script writes, word for word up to the reason
+        self.assertTrue(self.NOTICE.startswith(sb.CLI_SCOPE_FALLBACK_PREFIX + " systemd-run cannot start"))
+        self.assertIn(self.REFUSAL.split(";")[0], src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_scope_floor.py
+++ b/tests/test_cli_scope_floor.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""The suite-wide cli-scope floor (tests/conftest.py, 2026-09-05): no test may start a REAL transient
+scope. Constructing the SDK backend decides once whether to spawn session CLIs through `systemd-run
+--scope` (sdk_backend.cli_scope_supported), and that verdict defaults to ON under ROMP_SUPERVISED, which
+every tool shell of a session on a self-hosted install inherits from the service — so a suite run from
+one would probe the live user manager at every backend construction and leave a scope behind for every
+launch. conftest.py floors ROMP_CLI_SCOPE=0 at import, so collection-time constructions are covered, and
+re-asserts it per test through an autouse fixture, because a module-level write in a test file also
+executes at collection and would otherwise hold for the rest of the run.
+
+Pinned on conftest's SOURCE, not on the value at run time. tests/test_cli_scope.py sets ROMP_CLI_SCOPE=0
+itself at import (for a bare unittest run of that module), and pytest collects every module on every
+worker before any test runs, so under a full run the value reads "0" whether or not conftest set it:
+dropping the floor failed nothing. Each half of the floor has its own pin here; nothing here sets the
+value. Synthetic throughout: the only input is conftest.py's text.
+"""
+import ast
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+CONFTEST = os.path.join(HERE, "conftest.py")
+
+
+def _sets_cli_scope_off(stmt):
+    """Is `stmt` the statement os.environ["ROMP_CLI_SCOPE"] = "0"? (Set, not setdefault: "0" is the
+    one value the switch reads as off, so no outer intent is being overridden.)"""
+    if not isinstance(stmt, ast.Assign):
+        return False
+    if not (isinstance(stmt.value, ast.Constant) and stmt.value.value == "0"):
+        return False
+    for t in stmt.targets:
+        if (isinstance(t, ast.Subscript) and isinstance(t.value, ast.Attribute) and t.value.attr == "environ"
+                and isinstance(t.slice, ast.Constant) and t.slice.value == "ROMP_CLI_SCOPE"):
+            return True
+    return False
+
+
+def _is_autouse_fixture(fn):
+    """Is `fn` decorated @pytest.fixture(autouse=True)?"""
+    for d in fn.decorator_list:
+        if not (isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute) and d.func.attr == "fixture"):
+            continue
+        for kw in d.keywords:
+            if kw.arg == "autouse" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                return True
+    return False
+
+
+class CliScopeFloor(unittest.TestCase):
+    def setUp(self):
+        with open(CONFTEST) as f:
+            self.body = ast.parse(f.read(), filename=CONFTEST).body
+
+    def test_the_import_time_floor_is_a_module_level_statement(self):
+        # Top level only: a set inside a function does not run at collection, and collection is when a
+        # test module's import-time backend construction would reach the real systemd-run.
+        self.assertTrue(any(_sets_cli_scope_off(stmt) for stmt in self.body),
+                        'tests/conftest.py must set os.environ["ROMP_CLI_SCOPE"] = "0" at module level — '
+                        "without it a test module that builds an SDK backend at import, under an inherited "
+                        "ROMP_SUPERVISED, probes the real user manager and scopes every launch")
+
+    def test_an_autouse_fixture_re_asserts_the_floor_per_test(self):
+        fixtures = [fn for fn in self.body if isinstance(fn, ast.FunctionDef) and _is_autouse_fixture(fn)]
+        self.assertTrue(fixtures, "tests/conftest.py has no autouse fixtures at all")
+        self.assertTrue(any(any(_sets_cli_scope_off(stmt) for stmt in fn.body) for fn in fixtures),
+                        'no autouse fixture in tests/conftest.py sets os.environ["ROMP_CLI_SCOPE"] = "0" — '
+                        "one test module's import-time write or pop would otherwise hold for every test after it")
+
+    def test_the_value_holds_while_this_test_runs(self):
+        # The run-time half, read only. Under a full run this cannot tell conftest's floor from
+        # test_cli_scope.py's own preamble (module docstring). Alone — `pytest tests/test_cli_scope_floor.py`
+        # — nothing but conftest's floor sets the value, so this fails only once the floor is gone (and the
+        # shell does not export "0" itself); while the floor stands it overrides whatever the shell exports.
+        self.assertEqual(os.environ.get("ROMP_CLI_SCOPE"), "0", "conftest's floor is not in effect")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -196,6 +196,35 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
         self.assertIn("renamed", body)
         self.assertIn("'tests'", body, "…and it names the new name itself")
 
+    def test_the_lost_tasks_notice_asks_for_a_check_in_the_persons_voice(self):
+        # the lost-background-tasks notice (task_death_notice) is the same [romp]-prefixed mechanics
+        # family; past the prefix it speaks plainly. Since 2026-09-05 it says the tasks were CUT OFF
+        # from the session, never that they died: under the per-session scopes a task's shell can
+        # outlive the CLI, so the ask is to check whether each still runs before relaunching it.
+        import os as _os
+        from importlib.machinery import SourceFileLoader as _L
+        sb = _L("romp_sdk_backend_voice", _os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        for tasks in ([{"desc": "watching the CI run"}],
+                      [{"desc": "watching the CI run"}, {"desc": "tailing the deploy log"}, {}]):
+            text = sb.task_death_notice(tasks)
+            prose = text[text.index("[romp]"):]
+            self.assertNotIn("<!--", prose, "markers lead, prose follows")
+            self.assertNotIn("\n", prose, "one line")
+            body = prose.split("]", 1)[1].lower()
+            for word, why in ROMP_WORDS:
+                self.assertNotIn(word, body, "the notice speaks plainly past its prefix (%r: %s)" % (word, why))
+            self.assertIn("%d background task" % len(tasks), body)
+            self.assertIn("cut off from the session when its claude process ended", body)
+            self.assertIn("will never arrive", body)
+            self.assertIn("still running before relaunching", body)
+            self.assertNotIn("died", body)
+            self.assertIn("watching the ci run", body, "the descriptions name what was lost")
+        # singular and plural agree throughout; an empty description is skipped, not printed
+        self.assertIn("1 background task this session had running was cut off", sb.task_death_notice([{}]))
+        three = sb.task_death_notice([{"desc": "a"}, {"desc": "b"}, {}])
+        self.assertIn("3 background tasks this session had running were cut off", three)
+        self.assertIn("(a restart or crash): a; b. Their completion notifications", three)
+
     def test_the_untitled_fallback_names_no_romp_object(self):
         # a node with no text still renders SOMETHING; that placeholder must not smuggle in "goal"
         nodes = _nodes()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -198,9 +198,11 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
 
     def test_the_lost_tasks_notice_asks_for_a_check_in_the_persons_voice(self):
         # the lost-background-tasks notice (task_death_notice) is the same [romp]-prefixed mechanics
-        # family; past the prefix it speaks plainly. Since 2026-09-05 it says the tasks were CUT OFF
-        # from the session, never that they died: under the per-session scopes a task's shell can
-        # outlive the CLI, so the ask is to check whether each still runs before relaunching it.
+        # family; past the prefix it speaks plainly, to "you". Since 2026-09-05 it says the tasks were
+        # CUT OFF, never that they died: under the per-session scopes a task's shell can outlive the
+        # CLI, so the ask is to check whether each still runs before relaunching it. Since 2026-09-06
+        # it names the session once (as "you") and says whose process ended (the one that started the
+        # tasks) — the earlier wording said "session" twice in one clause and left "its" dangling.
         import os as _os
         from importlib.machinery import SourceFileLoader as _L
         sb = _L("romp_sdk_backend_voice", _os.path.join(BIN, "romp_sdk_backend.py")).load_module()
@@ -214,16 +216,25 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             for word, why in ROMP_WORDS:
                 self.assertNotIn(word, body, "the notice speaks plainly past its prefix (%r: %s)" % (word, why))
             self.assertIn("%d background task" % len(tasks), body)
-            self.assertIn("cut off from the session when its claude process ended", body)
+            self.assertIn("cut off when the claude process that started", body)
+            self.assertNotIn("session", body, "the recipient is \"you\"; the noun appears in neither clause")
+            self.assertNotIn(" its claude process", body, "the antecedent-free wording is gone")
             self.assertIn("will never arrive", body)
             self.assertIn("still running before relaunching", body)
             self.assertNotIn("died", body)
             self.assertIn("watching the ci run", body, "the descriptions name what was lost")
         # singular and plural agree throughout; an empty description is skipped, not printed
-        self.assertIn("1 background task this session had running was cut off", sb.task_death_notice([{}]))
+        self.assertIn("1 background task you had running was cut off when the claude process that started it "
+                      "ended (a restart or crash). Its completion notification will never arrive. Check whether it "
+                      "is still running before relaunching it; if it isn't needed, carry on.",
+                      sb.task_death_notice([{}]))
         three = sb.task_death_notice([{"desc": "a"}, {"desc": "b"}, {}])
-        self.assertIn("3 background tasks this session had running were cut off", three)
-        self.assertIn("(a restart or crash): a; b. Their completion notifications", three)
+        self.assertIn("3 background tasks you had running were cut off when the claude process that started them "
+                      "ended (a restart or crash): a; b. Their completion notifications will never arrive. Check "
+                      "whether each is still running before relaunching it; if they aren't needed, carry on.", three)
+        # the reconnect cause reads as the parenthesis after "ended", with "it" the process that ended
+        self.assertIn("ended (a settings switch or a rewind restarted it): a",
+                      sb.task_death_notice([{"desc": "a"}], cause=sb.SdkSession._RECONNECT_CAUSE))
 
     def test_the_untitled_fallback_names_no_romp_object(self):
         # a node with no text still renders SOMETHING; that placeholder must not smuggle in "goal"

--- a/tests/test_kernel_bundled_echo_prune.py
+++ b/tests/test_kernel_bundled_echo_prune.py
@@ -30,7 +30,8 @@ km = SourceFileLoader("romp_kernel_bundled_echo", os.path.join(BIN, "romp-kernel
 SID = "11111111-2222-3333-4444-555555555555"
 
 RESTART = "<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this session's turn."
-DEATH = "<!-- romp-injected --><!-- romp-system -->[romp] 1 background task died with its claude process."
+DEATH = ("<!-- romp-injected --><!-- romp-system -->[romp] 1 background task this session had running "
+         "was cut off from the session when its claude process ended.")
 NUDGE = ("> Earlier note about the capture run.\n\nWhere does this stand?\n\n"
          "<!-- romp-injected --><!-- romp-auto --><!-- romp-goal-id: %s:g360 -->" % SID)
 

--- a/tests/test_kernel_bundled_echo_prune.py
+++ b/tests/test_kernel_bundled_echo_prune.py
@@ -30,8 +30,8 @@ km = SourceFileLoader("romp_kernel_bundled_echo", os.path.join(BIN, "romp-kernel
 SID = "11111111-2222-3333-4444-555555555555"
 
 RESTART = "<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this session's turn."
-DEATH = ("<!-- romp-injected --><!-- romp-system -->[romp] 1 background task this session had running "
-         "was cut off from the session when its claude process ended.")
+DEATH = ("<!-- romp-injected --><!-- romp-system -->[romp] 1 background task you had running was cut off "
+         "when the claude process that started it ended.")
 NUDGE = ("> Earlier note about the capture run.\n\nWhere does this stand?\n\n"
          "<!-- romp-injected --><!-- romp-auto --><!-- romp-goal-id: %s:g360 -->" % SID)
 

--- a/tests/test_sdk_launch_error.py
+++ b/tests/test_sdk_launch_error.py
@@ -126,6 +126,16 @@ class RecordedLaunchFailures(unittest.TestCase):
         self.assertIn("claude exited with code 1", rec["text"])
         self.assertFalse(rec["limit"], "a plain crash is not a usage limit")
 
+    def test_a_fallback_launch_that_then_fails_records_the_clis_reason(self):
+        # the scope wrapper's fallback notice is the first stderr line of such a launch, and it was
+        # logged when it arrived (tests/test_cli_scope.py FallbackNotice); the card keeps the CLI's line
+        sess = _FakeSess(stderr=[LaunchFailureText.NOTICE,
+                                 "Error: No conversation found with session ID: " + SID])
+        self.be._record_launch_error(sess, RuntimeError("Command failed with exit code 1"))
+        text = self._reg()["launchError"]["text"]
+        self.assertTrue(text.startswith("Error: No conversation found"), text)
+        self.assertNotIn("romp-cli-scope", text)
+
     def test_the_connect_that_disproves_it_clears_it(self):
         self.be._record_launch_error(_FakeSess(), RuntimeError("transport closed"))
         self.assertIsNotNone(self.be.launch_error(SID))
@@ -175,6 +185,47 @@ class LaunchFailureText(unittest.TestCase):
         exc = RuntimeError("Command failed")
         exc.stderr = "claude: command not found"
         self.assertIn("command not found", sb.launch_failure_text(exc, "some older noise"))
+
+    # bin/romp-cli-scope's fallback notice (2026-09-05): on a launch whose pre-flight scope failed it is
+    # the FIRST line of the CLI's stderr, about 230 characters, and the kernel logs it the moment it
+    # arrives (_note_cli_scope_fallback). Left in the tail, it led the card text of a CLI that then
+    # failed at start and pushed the CLI's own reason past the 600-character cut.
+    NOTICE = (sb.CLI_SCOPE_FALLBACK_PREFIX + " systemd-run cannot start a transient scope (Failed to connect to "
+              "bus: No such file or directory) — running the CLI directly, outside a scope; a service restart "
+              "will take its background work down")
+
+    def test_the_scope_wrappers_fallback_notice_is_dropped_from_the_tail(self):
+        exc = RuntimeError("Command failed with exit code 1")
+        exc.stderr = sb.SDK_STDERR_PLACEHOLDER
+        tail = self.NOTICE + "\n" + "y" * 500 + "\nNo conversation found with session ID: " + SID
+        text = sb.launch_failure_text(exc, tail)
+        self.assertNotIn("romp-cli-scope", text)
+        self.assertTrue(text.startswith("y" * 500), "the CLI's own stderr leads the card: %r" % text[:60])
+        self.assertIn("No conversation found", text, "and its reason fits inside the cut")
+
+    def test_the_notice_is_dropped_from_the_exceptions_own_stderr_too(self):
+        exc = RuntimeError("Command failed with exit code 1")
+        exc.stderr = self.NOTICE + "\nclaude: the CLI's own reason"
+        text = sb.launch_failure_text(exc)
+        self.assertNotIn("romp-cli-scope", text)
+        self.assertTrue(text.startswith("claude: the CLI's own reason"), text)
+
+    def test_a_tail_that_was_only_the_notice_falls_through_to_the_exception(self):
+        exc = RuntimeError("Command failed with exit code 1")
+        exc.stderr = sb.SDK_STDERR_PLACEHOLDER
+        text = sb.launch_failure_text(exc, self.NOTICE)
+        self.assertNotIn("romp-cli-scope", text)
+        self.assertIn("exit code 1", text)
+
+    def test_the_wrappers_refusal_stays_on_the_card(self):
+        # ROMP_CLI_REAL unset: the wrapper exits 127 before any CLI runs, so its line IS the reason and
+        # nothing else reports it (the kernel logs no fallback for it: tests/test_cli_scope.py)
+        exc = RuntimeError("Command failed with exit code 127")
+        exc.stderr = sb.SDK_STDERR_PLACEHOLDER
+        refusal = sb.CLI_SCOPE_REFUSAL_PREFIX + " ROMP_CLI_REAL is unset or empty; it must name the real claude CLI"
+        text = sb.launch_failure_text(exc, refusal)
+        self.assertIn("ROMP_CLI_REAL", text)
+        self.assertTrue(text.startswith(sb.CLI_SCOPE_REFUSAL_PREFIX), text)
 
     def test_usage_limits_are_classified_apart_from_breakage(self):
         self.assertTrue(sb.is_launch_limit("You've hit your session limit · resets 4:00pm"))

--- a/tests/tmux-private.bash
+++ b/tests/tmux-private.bash
@@ -18,12 +18,22 @@
 # silently when TMUX_TMPDIR names a missing one (verified: with TMUX_TMPDIR set to a missing path,
 # `#{socket_path}` reads /tmp/tmux-<uid>/default), so an export without the mkdir isolates nothing.
 # tmux puts its socket at $TMUX_TMPDIR/tmux-<uid>/default, creating the tmux-<uid> level itself.
+#
+# The same call floors ROMP_CLI_SCOPE=0 (2026-09-06). Under ROMP_SUPERVISED — what bin/romp-service's
+# unit sets, and what a tool shell under a self-hosted install inherits from it — bin/romp-manager
+# starts its tmux server through `systemd-run --scope`, and the kernel spawns each session's CLI the
+# same way (cli_scope_supported), so a suite that starts the real manager would leave a transient
+# scope on the developer's user manager. Every suite that isolates tmux inherits the floor here rather
+# than repeating it in setup(); pytest's is tests/conftest.py. A suite that means to exercise the scoped
+# path exports ROMP_CLI_SCOPE=1 AFTER this call, with a fake systemd-run first on PATH
+# (tests/romp-manager-tmux-scope.bats).
 
 tmux_private_socket_dir() {   # $1 = the test's temp dir, removed in teardown
     TMUX_PRIVATE_TEST_DIR="$1"
     TMUX_PRIVATE_DIR="$1/tmux"
     mkdir -p "$TMUX_PRIVATE_DIR"
     export TMUX_TMPDIR="$TMUX_PRIVATE_DIR"
+    export ROMP_CLI_SCOPE=0
 }
 
 # The machine's tmux: the first `tmux` on PATH that is NOT under the test directory, where every suite

--- a/tests/tmux-private.bats
+++ b/tests/tmux-private.bats
@@ -22,6 +22,17 @@ teardown() {
     [ "$TMUX_PRIVATE_TEST_DIR" = "$TEST_DIR" ]
 }
 
+@test "tmux_private_socket_dir floors ROMP_CLI_SCOPE=0, over an inherited supervised environment" {
+    # A tool shell under a self-hosted install carries ROMP_SUPERVISED, under which the real manager the
+    # suites start would put its tmux server in a transient scope on the developer's user manager (and a
+    # kernel its sessions' CLIs). The floor rides the one call every such suite already makes.
+    export ROMP_SUPERVISED=1 ROMP_CLI_SCOPE=1
+    tmux_private_socket_dir "$TEST_DIR"
+    [ "$ROMP_CLI_SCOPE" = 0 ]
+    # exported, not merely set: the manager is a child process
+    [ "$(env | grep '^ROMP_CLI_SCOPE=')" = "ROMP_CLI_SCOPE=0" ]
+}
+
 @test "tmux_private_kill fails loudly when the private directory is already gone" {
     # The teardown ordering bug: an `rm -rf "$TEST_DIR"` before the kill takes the sockets with it, so a
     # server started under the directory can no longer be reached by -S. Exit 0 there would hide a leak.


### PR DESCRIPTION
#941 and #951 have merged, so this PR sits on `main` as its own commits, rebased onto the current tip: the three that make the change (b570ef49, 4975d38d, 5e48c1b5) and three from review (947e2720, ad1cac11, 590ba7dc; see "From review" below). #941 is a prerequisite: the scopes remove the cgroup kill that had been terminating the orphans the ppid-1 reaper missed on Linux.

## What breaks

On Linux a service restart kills every session's detached work along with the kernel. The manager runs as a systemd user service with systemd's default `KillMode=control-group` (the unit sets no KillMode line, on purpose: a wedged kernel or postal bus still holding its port must die on a service restart). Every process the service tree starts lands in the service's cgroup: each session's `claude` CLI, its tool shells, their `setsid` children and any tmux server a session started. `systemctl --user restart romp-manager` empties that cgroup. Kernel-only restarts (`romp refresh`) never touch the service, so they leave the detached work running.

To reproduce on a Linux box with the service installed: from any SDK session's shell, run `tmux new-session -d -s sweep 'sleep 600'`, then `systemctl --user restart romp-manager`. `tmux ls` no longer lists `sweep`.

## The fix

1. `bin/romp-cli-scope`: an exec-in-place POSIX sh wrapper around `systemd-run --user --scope --quiet --collect --unit=romp-session-<sid8>-<pid>-<start-ns>`. The SDK spawns the wrapper as `cli_path`, the wrapper execs systemd-run, and systemd-run in `--scope` mode execs the CLI in place, so the CLI keeps the pid, parent and argv the SDK spawned; `find_session_cli` and `find_orphan_clis` are unchanged. A pre-flight `systemd-run … -- true` (bounded to 10 s when coreutils' `timeout` is on PATH; the SDK's initialize timeout is 60 s) that fails falls back to a direct launch with one `romp-cli-scope: fallback: …` stderr line, which the kernel logs at once as a problem naming the session (a launch that succeeds never drains the stderr tail, so nothing else would read it). `ROMP_CLI_REAL` unset is refused with exit 127 and a `romp-cli-scope: refused: …` line, which the launch-error card reports. With no `ROMP_SID` (the SDK's per-connect `claude -v` probe) the wrapper runs the CLI directly.
2. `cli_scope_supported` (kernel/sdk_backend.py) decides once per backend, at construction: on with `ROMP_CLI_SCOPE=1`, or under `ROMP_SUPERVISED` unless `ROMP_CLI_SCOPE=0`; then only on Linux, only with `systemd-run` on PATH, and only if a probe scope starts. The verdict is logged as `cli scope: on` or `cli scope: off` with the reason. When the switch was wanted on Linux and the box cannot honour it (no `systemd-run`, or the probe failing), the off verdict is also filed as a problem, so the error center shows that sessions are running inside the service cgroup; off by request, or off because the platform has no systemd, stays a plain log line. When on, the kernel also exports `ROMP_CLI_REAL` into its own environment: the SDK's minimum-version check spawns `[cli_path, "-v"]` with the kernel's environment rather than `options.env` (claude_agent_sdk 0.2.132), so the wrapper has to find the real CLI there too.
3. `bin/romp-manager` starts its default tmux server through the same switch (`tmuxStartArgv`, a pure function with its own node suite) in a `romp-tmux-<ms>` scope, and falls back to the bare call with a distinct log line. That line carries the first stderr line of the tool that failed, bounded to 200 characters: systemd-run's own (its logger prefixes every line `Failed to …`), or tmux's when tmux failed inside a scope that did start. With nothing on stderr it names systemd-run and says how the call ended (exit status, timeout, signal). A box without tmux logs nothing, as before.
4. The lost-background-tasks notice (`task_death_notice`) says the tasks were cut off when the claude process that started them ended, and asks the session to check whether each is still running before relaunching it: under scopes a task's shell can outlive the CLI.
5. `launch_failure_text` drops the wrapper's fallback notice from a failed launch's stderr tail so the CLI's own reason fits on the card.
6. `tests/conftest.py` floors `ROMP_CLI_SCOPE=0` so no test can start a real scope on a developer's user manager: the verdict defaults to on under `ROMP_SUPERVISED`, which a tool shell under a self-hosted install inherits. For bats, `tmux_private_socket_dir` (the helper every suite that starts the real manager already calls) exports the same floor.

Docs: a "What survives a restart" section in docs/reference.md (with the error-center entry) and a row for the wrapper in bin/README.md.

## macOS

macOS is unchanged by construction. The kernel answers "not Linux" before it looks for `systemd-run` (the launchd plist sets `ROMP_SUPERVISED` too; with the checks the other way round, every macOS start would log "systemd-run is not on PATH"), and that verdict is a plain line, not a problem entry (otherwise every macOS kernel start would open with an error-center entry for a feature the platform does not have). The manager picks the bare tmux argv on darwin. Both paths are covered on Linux CI by platform-injected tests, since the macOS matrix runs only on a manual dispatch: `Supported.test_not_linux_is_off_before_which_or_probe` over darwin, freebsd13 and win32 asserts no PATH lookup, no probe, no problem entry and an off verdict that names the platform; the node suite's darwin case asserts the bare argv whatever the environment. The bats wrapper suite skips its 10 s hang-bound check where `timeout(1)` is absent, and the manager suite skips its two scoped cases off Linux.

## Tests

- `tests/test_cli_scope.py`: the truth table with injected platform, `which` and `run`, with the problem flag asserted on every branch; the exact probe argv; one cached verdict per backend, and the wanted-but-unavailable verdict landing in the backend's `problems()`; the `ROMP_CLI_REAL` export; `_options` wiring; a missing or non-executable wrapper degrading loudly once; the fallback notice logged as a problem naming the session; the refusal line not logged as a fallback.
- `tests/romp-cli-scope.bats`: a fake `systemd-run` first on PATH records argv; verbatim argument pass-through; unit naming; pre-flight ordering, fallback and the 10 s bound; exec-in-place pid checks on the scoped path and every direct path; a clean stdout; the two refusals.
- `tests/romp-manager-tmux-scope.bats`: the real manager started with a fake `systemd-run` first on PATH and `ROMP_CLI_SCOPE=1`. The fake records its argv and either execs the command after `--`, as `--scope` mode does, or exits 1 with a bus error on stderr; the fake tmux can fail the same way with a connect error. Four cases: the scoped call (one `systemd-run` call with the `--user --scope --quiet --collect --unit=romp-tmux-<ms>` argv, tmux run once from inside it, the "in its own transient scope" line); `systemd-run` failing (tried once, then the bare call; the failure line names systemd-run and carries its first stderr line and not its second; the "without a scope" line); tmux failing inside the scope (`systemd-run` called once, tmux twice, inside the scope and then bare; the log names tmux and carries its line); and the floor under an inherited `ROMP_SUPERVISED` (no `systemd-run` call, the bare start, the plain line). Every absence check runs grep and tests its status, the form `romp-cli-scope.bats` uses. Nothing reaches the real `systemd-run` or the user manager.
- `tests/manager-tmux-scope.test.js`: 19 cases, collected by the existing `node --test tests/manager-*.test.js` step; seven cover `scopedStartFailure` (systemd-run's line, tmux's line, the first non-blank line only, the 200-character bound, nothing on stderr, a timeout and a signal, a spawn error).
- `tests/test_cli_scope_floor.py`: pins both halves of conftest's `ROMP_CLI_SCOPE=0` floor on its source, the module-level statement and the autouse fixture that re-asserts it. A test that reads the value cannot pin the floor: `test_cli_scope.py` sets `ROMP_CLI_SCOPE=0` itself at import, and pytest collects every module on every worker before any test runs, so with both floor lines removed the value still read "0" under a full run while the two source pins failed.
- Updated: `tests/test_sdk_launch_error.py` (the notice is dropped from the tail, the refusal stays), `tests/test_injected_voice.py` (the reworded notice, pinned in full in its singular, plural and reconnect forms), `tests/test_kernel_bundled_echo_prune.py` (its fixture literal), `tests/tmux-private.bats` (the helper's floor).

Against the base without the code: `test_cli_scope.py` collects and 27 of its 30 tests fail (the three that pass exercise behaviour the base already has: an ordinary stderr line is only buffered, the refusal line is not logged as a fallback, and `_options` with the switch off leaves `cli_path` alone); `test_sdk_launch_error.py` fails at collection (it reads `CLI_SCOPE_FALLBACK_PREFIX` in a class body); `romp-cli-scope.bats` fails on the missing wrapper; `romp-manager-tmux-scope.bats` fails its three scoped cases (the floor case pins behaviour the base has); `manager-tmux-scope.test.js` fails 19 of 19 on the missing exports; the injected-voice test fails on the old wording; `test_cli_scope_floor.py` fails 2 of 3 against a conftest without the floor under a full run (`test_cli_scope.py`'s import-time set satisfies the value check), and 3 of 3 run alone. With it, on Linux: pytest 7417 passed and 50 skipped; the six bats suites this PR touches or that start the real manager 135 of 135 (the previous revision's full bats run was 425 of 425, and this revision adds one case); `node --test tests/manager-*.test.js` 59 of 59. The extension is unchanged since the previous revision, where `npm test` was 2830 of 2830 and `tsc --noEmit` clean.

## From review

The review comment on this PR named three follow-ups and two nits. All are folded in, as three commits on top of the original three.

- The boot verdict is a problem entry when it should be (947e2720). `cli_scope_supported` hands its log callback `problem=<bool>`: true when the switch was wanted on Linux and `systemd-run` is missing or the probe fails, so the error center shows that sessions are running inside the service cgroup, as the launch-time fallbacks already did. The not-Linux and off-by-request verdicts stay plain lines. `test_cli_scope.py` asserts the flag on each branch of the truth table and, through a backend built on a supervised Linux box without `systemd-run`, the entry in `problems()`. docs/reference.md notes the entry.
- `startTmuxServer` has a bats suite (590ba7dc): `tests/romp-manager-tmux-scope.bats`, described under Tests.
- The `ROMP_CLI_SCOPE=0` floor for bats moved from three `setup()` blocks into `tmux_private_socket_dir` (same commit), so any suite that isolates tmux inherits it. `tests/tmux-private.bats` pins the export and `tests/README.md` records it beside the tmux and port floors. The new suite turns the switch back on after that call, behind the fake.
- The lost-tasks notice reads "N background tasks you had running were cut off when the claude process that started them ended (cause)" (ad1cac11): the session is named once, as "you", and the clause says whose process ended. The reconnect cause is reworded to read as that parenthesis ("a settings switch or a rewind restarted it"). The voice test pins the singular, plural and reconnect forms in full.
- The earlier body said `test_cli_scope.py` fails at import at the base. It collects; the per-test counts are above.

Second round. The review of 9fa583ac named three test follow-ups. All are folded by file into the commits where they belong, and the branch is rebased onto the current `main`.

- `tests/romp-manager-tmux-scope.bats` (590ba7dc): every absence check runs grep and tests its status (`log_lacks`), the form `romp-cli-scope.bats` uses. A bare `! grep -q` that was not a test's last command was exempt from bats' errexit and asserted nothing. Verified by mutation: a manager that logged the forbidden fragments on every path passed the old suite 3 of 3 and fails the new one on each of those three cases.
- `bin/romp-manager` (4975d38d): `startTmuxServer` pipes stderr on the scoped call and logs its first line, bounded, naming the tool that wrote it (`scopedStartFailure`, exported). With stdio `'ignore'` the line could carry only the "Command failed" argv, and it named systemd-run for a tmux failure inside the scope. Seven node cases cover the helper; the bats suite asserts the first stderr line in the log and not the second, and gains the case where tmux fails inside the scope. Against the previous revision's manager the bats suite fails 2 of 4 and the node suite 7 of 19.
- `tests/test_cli_scope_floor.py` (590ba7dc): pins both halves of conftest's floor on its source, described under Tests. With either half removed the matching pin fails; `tests/README.md` points to it.

## Points to weigh

- `ROMP_CLI_REAL` in the kernel's own environment: every session and its tool shells inherit it. It does no harm today; a later SDK that passes `options.env` to the version probe would make the export unnecessary, and a session's shell that sets `ROMP_SID` and runs the wrapper by hand gets a scope.
- The exec-in-place property relies on `systemd-run --scope` executing the command in the calling process, which every systemd since scopes existed (v205) does. Were systemd-run to fork instead, the CLI's pid would differ from the SDK's, `find_session_cli` would miss it, and the interrupt escalation would fall back to its existing behaviour. The bats exec-in-place test uses a fake systemd-run, so it proves the wrapper's `exec`, not systemd's.
- The bats hang-bound test needs coreutils' `timeout(1)`. It skips where that is absent, and the macOS matrix runs only on manual dispatch, so a regression there would surface late. `assert_direct_exec_in_place` also uses `$BASHPID` (bash 4 or newer; brew's bats-core brings bash 5).
- The lost-tasks notice is a user-visible injected string. `test_kernel_bundled_echo_prune.py` held it as a literal and is updated; `test_injected_voice.py` pins the sentences in full; `test_sdk_backend.py` and `test_sdk_boot_stagger.py` compare against the function's output and needed no change.
- The manager bats suite starts a real manager per case (four, on free ports, with a fake kernel launcher), like the two existing manager-driving suites. The scoped call pipes stderr for the failure line; the pipe closes when tmux's client exits (its server daemonizes onto /dev/null), so it holds nothing open, and the bare call keeps stdio `'ignore'`. The line attributes the failure by systemd-run's `Failed to …` log prefix, in both directions: a tmux error that began the same way would be attributed to systemd-run, and a systemd-run line without that prefix to tmux; the line itself is carried either way.

## Known and stated

The first service restart after this lands still empties the current cgroup, tmux servers included: the running manager and its tmux server predate the change. The guarantee holds from the following restart on. A scoped CLI the kernel's drain could not reach (kernel SIGKILLed at the stop timeout) outlives the restart and is terminated by the boot reaper from #941. Not in this PR: a postal bus autostarted from a session's MCP server starts inside that session's scope and keeps the `romp-session-*` unit loaded until the bus exits.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)


