### PR TITLE
The parked-op queue is mutated under one lock that no backend call ever holds

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19858,6 +19858,26 @@ def _session_chip(sid, path, session, tm, now):
 # the moment compaction ends. A repeated model/effort pick REPLACES its earlier parked op in place (last
 # pick wins — one queued chip, not a pile), since only the final setting can matter.
 _PENDING_OPS_FILE = Path(jd.STATE) / "pending-ops.json"
+# ONE lock around every MUTATION of _pending_ops (2026-09-05): the WS/HTTP handler threads park and cancel,
+# the move thread re-inserts a head, and the pusher thread drains — all on this dict, and since the drain
+# moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake. Unlocked, two races were
+# confirmed by review: (1) a ✕ — or the move thread's head re-insert — changed a sid's list between the
+# drain's head read and its pop, so the drain popped a list the ✕ had just emptied (an IndexError the
+# blanket except turned into a dropped queue) or the ✕, re-locating by index+body and then popping,
+# removed the op BEHIND the one clicked once the drain's pop had shifted the list; (2) two writers tore the
+# disk mirror through one shared temp path (a kernel death then restored a wrong queue). The lock guards the
+# mutations ONLY: no backend call ever runs under it (CodexBackend.send can synchronously spawn and
+# initialize `codex app-server` with no request timeout; SdkBackend.busy/turn_seq take the backend's own
+# lock), and a handler evaluates only the queue-presence check under it (_park_behind_queue) — its
+# expensive gates (_compacting_now / _working_now / _limit_hold: a tmux fork, a discover sweep, the usage
+# file) run outside. So a holder owns it for a dict read, a list append or pop, and the mirror write —
+# microseconds. Re-entrant, because _park_op and _save_pending_ops take it and are called from under it.
+# The drain takes it NON-BLOCKING at the top of its walk (_apply_pending_ops). No backend thread ever takes
+# it (the poke, push and push_session callbacks the backends hold touch no queue). Reads stay unlocked
+# (build_session's chip list, the nudge guard, the parse refresh, _ops_gate's advisory queue read): a dict
+# get or list iteration under the GIL never raises, and a chip one cycle early or late is corrected by the
+# next push.
+_pending_ops_lock = threading.RLock()
 
 
 def _load_pending_ops():
@@ -19878,13 +19898,18 @@ def _load_pending_ops():
 
 def _save_pending_ops():
     """Mirror _pending_ops to disk on every mutation, atomically, so parked ops survive a kernel
-    death. Tiny file, mutation-rate writes (a park or a delivery), not a hot path."""
-    try:
-        tmp = _PENDING_OPS_FILE.with_suffix(".tmp")
-        tmp.write_text(json.dumps({k: [list(o) for o in v] for k, v in _pending_ops.items() if v}))
-        os.replace(tmp, _PENDING_OPS_FILE)
-    except Exception:
-        sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
+    death. Tiny file, mutation-rate writes (a park or a delivery), not a hot path. Under the queue lock,
+    so the snapshot is whole (an unlocked writer iterating the dict while a handler parked raised
+    "dictionary changed size during iteration" and skipped the save), and through _atomic_write's
+    per-writer temp: the old fixed `pending-ops.tmp` was shared by every thread, so the loser renamed a
+    temp the winner had already moved, or wrote into one mid-rename — a torn mirror that the next boot
+    restored as the queue (review find on #904, 2026-09-05)."""
+    with _pending_ops_lock:
+        try:
+            _atomic_write(_PENDING_OPS_FILE,
+                          json.dumps({k: [list(o) for o in v] for k, v in _pending_ops.items() if v}))
+        except Exception:
+            sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
 
 
 _pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("env", {…}) | ("cwd", path, busy_retries) | ("compact",), …] in park order
@@ -20021,13 +20046,61 @@ def _ops_gate(sid):
     sid = str(sid)
     return (_compacting_now(sid) or _working_now(sid) or bool(_pending_ops.get(sid))
             or sid in _moving or _limit_hold(sid) is not None)   # a move in flight holds the queue too
+    # ^ EXPENSIVE (a tmux fork, a discover sweep, the usage file, the backend's busy()) — the handlers call
+    #   it OUTSIDE _pending_ops_lock; its queue read is advisory, and the one that decides is the locked
+    #   re-check in _park_behind_queue (_gate_or_park). A backend must never be called under that lock.
+
+
+def _gate_or_park(sid, op):
+    """The park-or-hand-over decision every drive op except a send takes (a send composes its own gates in
+    _send_or_park, same shape). Returns True when PARKED — the caller answers "queued" — and False when the
+    caller should hand the op to the backend now. Two steps, in this order (2026-09-05): the EXPENSIVE gates
+    (_ops_gate) run outside the queue lock, since they fork tmux, sweep discover, read the usage file and
+    call the backend's busy() — none of which a lock that the pusher's drain also takes may wait on; then
+    the CHEAP queue-presence check and the park run as ONE locked step (_park_behind_queue), so an op never
+    slips past a queue that another handler filled between the two reads."""
+    sid = str(sid)
+    if _ops_gate(sid):
+        _park_op(sid, op)
+        return True
+    return _park_behind_queue(sid, op)
+
+
+def _park_behind_queue(sid, op):
+    """A handler's cheap gate — does a queue exist for this sid right now? — and its park, as ONE step under
+    _pending_ops_lock (2026-09-05). True when parked behind the existing queue; False when there is none
+    (the caller hands over). The only gate a handler evaluates under the lock: a queue-presence read is a
+    dict get and the park is an append plus the tiny mirror write, so a handler owns the lock for
+    microseconds, and the drain — which takes it non-blocking at the top of its walk and blocks on it per
+    pop — is never held behind a backend call. Why this pair is all press order needs: a park that completed
+    before this read is seen here, and this op lines up behind it; two handlers that both find no queue both
+    hand over, and reach the backend in call order — the same order a lock held across the handover would
+    have imposed, as lock-acquisition order. Nothing is lost by releasing before the backend call, and a
+    slow backend (a Codex client connect can take seconds) stalls no other handler and no push."""
+    sid = str(sid)
+    with _pending_ops_lock:
+        if not _pending_ops.get(sid):
+            return False
+        _park_op_locked(sid, op)
+    _mark_views_dirty()               # the wake AFTER the release, so the cycle it brings finds the lock free
+    return True
 
 
 def _park_op(sid, op):
     """Park one mid-compaction drive op in the sid's FIFO queue and push at once (the queued bubble
     appears immediately, never waiting out the backstop poll). A repeat model/effort pick REPLACES the
     earlier parked op of the same kind IN PLACE — its queue position stands, its value updates — so the
-    chat shows one "/model …" chip carrying the latest pick. Messages always append."""
+    chat shows one "/model …" chip carrying the latest pick. Messages always append. The mutation runs
+    under the queue lock (_park_op_locked: the drain's pops, a ✕, the move thread's re-park all touch this
+    list); the pusher wake comes AFTER the release, so the cycle it brings finds the lock free."""
+    with _pending_ops_lock:
+        _park_op_locked(sid, op)
+    _mark_views_dirty()               # the queue lives in memory — no sig sees it; the woken push renders the chip
+
+
+def _park_op_locked(sid, op):
+    """_park_op's mutation + mirror write, for a caller that already holds _pending_ops_lock and will wake
+    the pusher itself after releasing (_park_behind_queue)."""
     q = _pending_ops.setdefault(str(sid), [])
     if op[0] in ("model", "effort", "fast", "env", "cwd"):
         for i, o in enumerate(q):
@@ -20039,7 +20112,6 @@ def _park_op(sid, op):
     else:
         q.append(op)
     _save_pending_ops()               # mirror the park to disk (survives a kernel death)
-    _mark_views_dirty()               # the queue lives in memory — no sig sees it; the woken push renders the chip
 
 
 def _parked_md(op):
@@ -20084,6 +20156,15 @@ _TMUX_PROMPT_HOLD_S = 3.0        # the prompt hold's clock FALLBACK: after the d
 _drain_hold: dict = {}           # sid -> (time.monotonic() deadline, until_busy); _apply_pending_ops skips the sid
                                  # while the hold is open (_drain_hold_open)
 _refresh_parse_failures: dict = {}   # sid -> consecutive cycles its parked-parse refresh raised (_refresh_parked_parses)
+_inflight_ops: dict = {}         # sid -> the HEAD op the drain has handed to the backend, lock released, and not yet
+                                 # popped (2026-09-05; never a cwd op — a move hands nothing over while its turn_seq
+                                 # is read, so a ✕ on a waiting move must still succeed). It stays the visible head
+                                 # for the whole call, so every handler's gate still sees the queue and parks BEHIND
+                                 # it (SdkBackend.send runs _ensure before it enqueues, CodexBackend.send may spawn
+                                 # the app server first — busy() flips only once the backend has the op, so an empty
+                                 # queue in that window let a pane send hand over AHEAD of a parked /clear), and a ✕
+                                 # on it is refused as too late (_cancel_parked). Popped only if still the head when
+                                 # the call returns (_apply_pending_ops). Read and written under _pending_ops_lock.
 
 
 def _hold_drain(sid, seconds, until_busy=False):
@@ -20168,8 +20249,7 @@ def _move_or_park(be, sid, path, client=None):
     fires at the turn's end (_apply_pending_ops); quiet, it fires now."""
     sid = str(sid)
     wid = (client or {}).get("wid") or ""
-    if _ops_gate(sid):
-        _park_op(sid, ("cwd", path, 0))
+    if _gate_or_park(sid, ("cwd", path, 0)):
         _move_askers[sid] = wid
         return None
     return _fire_move(be, sid, path, 0, wid)
@@ -20211,11 +20291,14 @@ def _move_now(be, sid, path, tries, wid):
             res = "%s: %s" % (type(e).__name__, str(e)[:200])
         if res == "busy":
             # re-park and hold BEFORE `_moving` releases the queue (review find, #904): a drain cycle landing
-            # between the release and the re-park would fire the op behind the move, or burn a retry
+            # between the release and the re-park would fire the op behind the move, or burn a retry. The
+            # backend's turn_seq is read OUTSIDE the queue lock (it takes the backend's own); the re-insert
+            # and its hold are one locked step against a handler's park and the drain's pops (2026-09-05)
             seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None  # the turn end this retry waits on
-            _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
-            _move_askers[sid] = wid
-            _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (_hold_drain)
+            with _pending_ops_lock:
+                _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
+                _move_askers[sid] = wid
+                _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (_hold_drain)
     finally:
         _moving.discard(sid)
     if res == "busy":
@@ -20257,19 +20340,39 @@ def _cancel_parked(sid, park, md):
     read as a successful cancel while the message got answered anyway (the user 2026-07-20). Persists +
     wakes the pusher like every queue mutation. LOGGED — sid and op kind, never the body, which is user
     text — so an emptied queue can be told apart from one that was never delivered: the 2026-09-03
-    diagnosis of a parked /clear that vanished had to infer this ✕ by elimination."""
+    diagnosis of a parked /clear that vanished had to infer this ✕ by elimination. The locate and the
+    pop are ONE step under the queue lock: unlocked, the drain could pop its head between the body check
+    and the pop, and the ✕ removed whatever had shifted into the clicked slot (2026-09-05). An op the
+    drain has already popped for delivery is simply gone from here — the honest 'too late' below — and
+    the op the drain is handing to the backend RIGHT NOW (_inflight_ops: still the head, so the chip
+    still shows) is the same miss: the backend has it, and a ✕ must never report a delivered op as
+    cancelled. That refusal keys on the HEAD SLOT, not on identity alone: the in-flight op is always
+    ops[0] while it is listed (read as the head, its own ✕ refused, a replace-in-place swaps in a new
+    object; a handler-fired move can only start on an empty queue (_park_behind_queue), and the
+    drain-fired one holds _moving until it has re-inserted) — and identity alone would be wrong, because
+    _compact_or_park parks the literal ("compact",), one interned tuple per code object, so a second
+    compact press appends an op that `is` the first; a ✕ on that SECOND chip while the first is with the
+    backend is a cancel, and the redundant compaction must not run. The body re-locate skips that head
+    slot too, so a STALE index for the second chip (a send ahead delivered between the push and the
+    click) lands on the chip and not on the head it cannot take; with only the in-flight op listed it
+    finds nothing, the same miss as today."""
     sid = str(sid)
-    ops = _pending_ops.get(sid) or []
-    if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
-        park = next((j for j, op in enumerate(ops) if _parked_md(op) == md), -1) if md else -1
-        if park < 0:
-            return _cancel_miss_text(md)
-    sys.stderr.write("parked-op cancel: %s %s\n" % (sid, ops[park][0]))
-    ops.pop(park)
-    if not ops:
-        _pending_ops.pop(sid, None)
-        _drain_hold.pop(sid, None)        # an emptied queue leaves no hold behind (nothing left for it to protect)
-    _save_pending_ops()
+    with _pending_ops_lock:
+        ops = _pending_ops.get(sid) or []
+        inflight_head = bool(ops) and ops[0] is _inflight_ops.get(sid)   # the head is with the backend this instant
+        if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
+            park = next((j for j, op in enumerate(ops)
+                         if _parked_md(op) == md and not (j == 0 and inflight_head)), -1) if md else -1
+            if park < 0:
+                return _cancel_miss_text(md)
+        if park == 0 and inflight_head:
+            return _cancel_miss_text(md)          # too late, not a wrong-op removal
+        sys.stderr.write("parked-op cancel: %s %s\n" % (sid, ops[park][0]))
+        ops.pop(park)
+        if not ops:
+            _pending_ops.pop(sid, None)
+            _drain_hold.pop(sid, None)    # an emptied queue leaves no hold behind (nothing left for it to protect)
+        _save_pending_ops()
     _mark_views_dirty()
     return None
 
@@ -20356,7 +20459,18 @@ def _send_or_park(be, sid, text, echo=None):
     Returns True when PARKED, False when handed over now, so a route can tell its caller which: POST
     /send answers `queued` and `romp send` prints it. An agent sending ITSELF a slash command from inside
     its own turn otherwise read 'ok' and had no way to know the command was waiting for that turn to end
-    (2026-09-03, a /clear that then never fired)."""
+    (2026-09-03, a /clear that then never fired).
+
+    THE LOCK (2026-09-05): the gates above are EXPENSIVE — _compacting_now and _working_now fork tmux or
+    sweep discover and call the backend's busy(), _limit_hold reads the usage file — so they run OUTSIDE
+    _pending_ops_lock, on this handler thread, as they always did (the queue read among them is advisory).
+    What runs under the lock is the cheap queue-presence re-check and the park, as ONE step
+    (_park_behind_queue), so a queue another handler filled between the two reads is never slipped past.
+    The handover (`be.send`) runs outside the lock too: it is not a queue mutation, and a backend call can
+    be slow (a Codex client connect takes seconds), during which no other handler's park and no drain pop
+    may wait. Press order loses nothing: two handovers reach the backend in call order — a lock held across
+    them would only have substituted lock-acquisition order — and a park behind an existing queue is atomic
+    with the check that found the queue."""
     cmd = _is_slash_command(text)
     op = ("command", text, echo) if cmd else ("send", text, echo)
     if _compacting_now(sid) or _pending_ops.get(sid) or _limit_hold(sid):
@@ -20364,6 +20478,8 @@ def _send_or_park(be, sid, text, echo=None):
         return True
     if _working_now(sid) and (cmd or not _forwards_sends(be)):
         _park_op(sid, op)
+        return True
+    if _park_behind_queue(sid, op):
         return True
     be.send(sid, text)
     if echo:
@@ -20377,8 +20493,7 @@ def _compact_or_park(be, sid):
     account hold) → park as a ("compact",) op, which fires ALONE at turn end; quiet → /compact NOW with
     the instant 'compacting' cue. Returns True when parked (queued), False when fired now — the route
     tells its caller which ("compacting now" vs "queued")."""
-    if _ops_gate(sid):
-        _park_op(sid, ("compact",))
+    if _gate_or_park(sid, ("compact",)):
         return True
     be.send(sid, "/compact")
     _mark_compacting(sid)
@@ -20431,9 +20546,7 @@ def _set_model_or_park(be, sid, value, floating=False):
         _forget_model_pick(value)
     _mark_model_pending(sid, value)
     _note_model_pick(value)          # a version pick becomes its family's remembered default (2026-08-25)
-    if _ops_gate(sid):
-        _park_op(sid, ("model", value))
-    else:
+    if not _gate_or_park(sid, ("model", value)):
         be.set_model(sid, value)
 
 
@@ -20441,9 +20554,7 @@ def _set_effort_or_park(be, sid, value):
     """Apply an effort change now — or park it while the session compacts (the user 2026-07-02: /effort
     is a slash command like /model, so it must queue the same way — it used to slip straight through,
     with no queued chip and the same derail risk the /model park was built for)."""
-    if _ops_gate(sid):
-        _park_op(sid, ("effort", value))
-    else:
+    if not _gate_or_park(sid, ("effort", value)):
         be.set_effort(sid, value)
 
 
@@ -20452,9 +20563,7 @@ def _set_env_or_park(be, sid, value):
     the session compacts, in the same FIFO as /model and /effort: a CHANGE applies by reconnecting
     (env is connect-time, like effort), which mid-compaction would derail the compaction exactly the
     way an effort switch would. An unchanged re-assert is a no-op inside set_env either way."""
-    if _ops_gate(sid):
-        _park_op(sid, ("env", value))
-    else:
+    if not _gate_or_park(sid, ("env", value)):
         be.set_env(sid, value)
 
 
@@ -20464,8 +20573,7 @@ def _set_auth_or_park(be, sid, value):
     exactly the way a model switch would). Returns the backend's verdict so the caller can be loud."""
     if value not in ("login", "key"):
         return False
-    if _ops_gate(sid):
-        _park_op(sid, ("auth", value))
+    if _gate_or_park(sid, ("auth", value)):
         return True
     return be.set_auth(sid, value)
 
@@ -20476,8 +20584,7 @@ def _set_fast_or_park(be, sid, value):
     verdict so the caller can be loud when a live apply refuses (dormant SDK session)."""
     if value not in ("on", "off"):
         return False
-    if _ops_gate(sid):
-        _park_op(sid, ("fast", value))
+    if _gate_or_park(sid, ("fast", value)):
         return True
     return be.set_fast(sid, value)
 
@@ -20616,6 +20723,43 @@ def _apply_pending_ops():
     reset stamp passes, so the whole sequence goes in at the reset in the order it was typed); a dead
     session's queue is dropped (fails once, logged), never retried.
 
+    ONE LOCK, HELD FOR THE MUTATIONS ONLY (2026-09-05): every writer of _pending_ops — a handler's park or
+    cancel, the move thread's head re-insert, this walk — takes _pending_ops_lock, and this walk takes it
+    for exactly two things: reading a sid's head, and popping what a step has delivered. Every backend
+    call — send, set_*, turn_seq, busy() inside the gates and the hold check — runs with the lock
+    RELEASED, because a backend call can be slow (CodexBackend.send may synchronously spawn and initialize
+    `codex app-server`, with no request timeout) and every handler's queue check + park would otherwise
+    wait behind it. The lock closes the two races review confirmed: (1) a ✕, or the move thread's head
+    re-insert, changing the list between this walk's head read and its pop — the pop landed on a list the
+    ✕ had emptied (an IndexError the except below turned into a dropped queue), or the ✕'s own check-then-
+    pop landed on a list this walk had shifted (the op BEHIND the clicked one vanished); (2) two writers
+    tearing the mirror through one shared temp (_save_pending_ops). Only this one thread ever walks the
+    queue (the pusher); the handlers and the move thread are the other writers.
+
+    THE HEAD STAYS VISIBLE WHILE THE BACKEND HAS IT (2026-09-05, second review): every gate a handler
+    decides on keys on queue presence (_ops_gate, _send_or_park's first gate, _park_behind_queue) and
+    otherwise on busy() — which flips only once the backend has REGISTERED the op (SdkBackend.send runs
+    _ensure under the backend lock before it enqueues; CodexBackend.send may spawn the app server first).
+    So a command / compact / settings op is NOT popped before its call: it is read under the lock and
+    recorded in _inflight_ops, the call runs with the lock released and the op still at the head, and
+    afterwards the head is popped only if it `is` still that op — a same-kind pick that replaced it in
+    place meanwhile is a new tuple, so the identity fails and the replacement delivers on the next
+    iteration; a ✕ on the in-flight head is refused as too late (_cancel_parked). A cwd op takes the same
+    read-then-identity-pop shape but is NOT recorded: its only mid-call action is the turn_seq read,
+    nothing is handed over, and a ✕ on a move still waiting for its turn end must succeed — recorded, it
+    was refused with a message-shaped 'already reached the session' every cycle the move waited (delta
+    review, 2026-09-05). A pane send landing during the call therefore sees the queue and parks BEHIND
+    the parked /clear, as it did before the drain moved (the parent called first and popped after for
+    these kinds), and the chip retires only once the backend accepted the op. The SEND run alone is
+    popped before delivery — pre-existing on the parent, and kept as is: the batch is handed over as one
+    unit, and a ✕ on it after the pop is the same honest 'too late' it always was. The top-of-walk
+    acquire is NON-BLOCKING: a handler that owns the lock skips the drain for this cycle rather than
+    stalling every session's push, and its own park wakes the pusher after it releases; the per-step
+    acquires inside the walk block, since every holder owns the lock for a dict read, a list mutation and
+    the tiny mirror write. No backend thread takes this lock (the poke, push and push_session callbacks
+    touch no queue), so it never nests inside a backend's. The failure contract is UNCHANGED: a raise
+    anywhere in a sid's pass drops that sid's queue once, logged.
+
     WHO runs this (2026-09-03): the pusher cycle (_pusher_cycle_jobs), woken by the backends' turn-end poke
     (_wake_kernel), by /tick, by every park / cancel / move, and by its own 0.5 s backstop — NOT the tail
     of the judge producer's pass, where it lived before. A judge pass can run for hours (one session's
@@ -20631,11 +20775,18 @@ def _apply_pending_ops():
     emits no event), and a session just handed a turn-opening op whose busy gate has not yet been SEEN
     closed (until its backend reads busy — tmux's UserPromptSubmit flip — or the fallback clock passes) —
     see _hold_drain."""
-    for sid, ops in list(_pending_ops.items()):
-        if not ops:
-            _pending_ops.pop(sid, None)
-            _drain_hold.pop(sid, None)                # no queue, no hold
-            continue
+    if not _pending_ops_lock.acquire(blocking=False):
+        return                                        # a handler owns the queue mid-park: its wake brings the next cycle
+    try:
+        sids = list(_pending_ops)
+    finally:
+        _pending_ops_lock.release()
+    for sid in sids:
+        with _pending_ops_lock:
+            if not _pending_ops.get(sid):
+                _pending_ops.pop(sid, None)
+                _drain_hold.pop(sid, None)            # no queue, no hold
+                continue
         if sid in _moving:
             continue                                  # a move is mid-flight: its relocation must finish first
         hold = _drain_hold.get(sid)
@@ -20648,8 +20799,24 @@ def _apply_pending_ops():
         changed = False                               # a real mutation below → save the mirror + wake the pusher
         try:
             be = Sessions.backend_for(sid)
-            while ops:
-                op = ops[0]
+            while True:
+                with _pending_ops_lock:               # READ the head. A send run is popped here (pre-existing on the
+                    ops = _pending_ops.get(sid) or [] # parent); every other kind stays the visible head, recorded
+                    if not ops:                       # in flight, until the backend has it
+                        break
+                    op = ops[0]
+                    if op[0] == "send":
+                        run = []                      # coalesce the leading run of sends → deliver them AT ONCE
+                        while ops and ops[0][0] == "send":
+                            run.append(ops.pop(0))
+                    elif op[0] != "cwd":
+                        _inflight_ops[sid] = op       # (a move hands nothing over below: not recorded)
+                if op[0] == "send":
+                    changed = True
+                    _deliver_send_batch(be, sid, run)
+                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                    break                             # the delivered turn must END before any op behind it fires
+                # every other kind: the backend call runs with the lock RELEASED and the op still at the head
                 if op[0] == "cwd":
                     # a parked move: fires on its own thread and CLAIMS _moving before this cycle ends, so
                     # the ops behind it wait for the relocation to finish (the next cycle skips the sid
@@ -20659,61 +20826,59 @@ def _apply_pending_ops():
                     if (seq is not None and tries >= _MOVE_BUSY_RETRIES and hasattr(be, "turn_seq")
                             and be.turn_seq(sid) == seq):
                         break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
-                    ops.pop(0)
-                    changed = True
-                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
-                    break
-                changed = True                        # every arm below pops at least one op
-                if op[0] == "send":
-                    run = []                          # coalesce the leading run of sends → deliver them AT ONCE
-                    while ops and ops[0][0] == "send":
-                        run.append(ops.pop(0))
-                    _deliver_send_batch(be, sid, run)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # the delivered turn must END before any op behind it fires
                 elif op[0] == "command":
                     # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
                     # send batch (or forwarded mid-turn) it reaches the model as text instead of executing
                     # (the user 2026-08-13: /autocompact absorbed mid-turn got a polite reply and no
                     # setting change). Echo stamped at fire time, like a delivered send.
                     be.send(sid, op[1])
-                    if len(op) > 2 and op[2]:
-                        _optimistic_echo(sid, op[1], author=op[2])
-                    if op[1].strip().split()[0] == "/compact":
-                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
-                    ops.pop(0)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # its turn must end before anything behind it fires
                 elif op[0] == "compact":
                     be.send(sid, "/compact")
-                    _mark_compacting(sid)
-                    ops.pop(0)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # the compaction must finish first
                 elif op[0] == "model":
                     be.set_model(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "effort":
                     be.set_effort(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "fast":
                     be.set_fast(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "auth":
                     be.set_auth(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "env":
                     be.set_env(sid, op[1])
-                    ops.pop(0)
-                else:
-                    ops.pop(0)                        # unknown op kind → drop, never wedge the queue
+                # (an unknown op kind gets no call: it is popped below and dropped — never wedge the queue)
+                with _pending_ops_lock:               # POP the head — only if it is still the op the backend got
+                    _inflight_ops.pop(sid, None)      # (a no-op for a cwd op, which was never recorded)
+                    ops = _pending_ops.get(sid) or []
+                    took = bool(ops) and ops[0] is op
+                    if took:
+                        ops.pop(0)
+                        changed = True
+                if op[0] == "cwd":
+                    if not took:
+                        continue                      # a repeat pick replaced the head while turn_seq was read: read it
+                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
+                    break
+                if op[0] in ("command", "compact"):
+                    # the backend HAS a turn-opening op: its cue, the hold and the end of this pass follow
+                    # regardless of `took` (which is always True here — a ✕ on an in-flight op is refused and
+                    # these kinds are never replaced in place)
+                    if op[0] == "command" and len(op) > 2 and op[2]:
+                        _optimistic_echo(sid, op[1], author=op[2])
+                    if op[0] == "compact" or op[1].strip().split()[0] == "/compact":
+                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
+                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                    break                             # its turn / compaction must end before anything behind it fires
+                # a settings op (or an unknown kind): delivery continues. `took` False means a same-kind pick
+                # replaced the head in place while it was with the backend — the replacement delivers next
         except Exception:
             sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
-            _pending_ops.pop(sid, None)               # a dead session's queue is dropped, never retried
-            _drain_hold.pop(sid, None)                # …and its hold with it
+            with _pending_ops_lock:
+                _inflight_ops.pop(sid, None)
+                _pending_ops.pop(sid, None)           # a dead session's queue is dropped, never retried
+                _drain_hold.pop(sid, None)            # …and its hold with it
             changed = True
-        if not _pending_ops.get(sid):
-            _pending_ops.pop(sid, None)
+        with _pending_ops_lock:
+            if not _pending_ops.get(sid):
+                _pending_ops.pop(sid, None)
         if changed:
             _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
             _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
@@ -34959,8 +35124,7 @@ class Handler(BaseHTTPRequestHandler):
                         'no live session named "%s" (a dormant one can be moved by sid)' % target}),
                                       "application/json")
                 be = Sessions.backend_for(tsid)
-                if _ops_gate(tsid):
-                    _park_op(tsid, ("cwd", path, 0))
+                if _gate_or_park(tsid, ("cwd", path, 0)):
                     return self._send(200, json.dumps({"ok": True, "id": tsid, "queued": True, "dir": path}),
                                       "application/json")
                 _moving.add(tsid)

--- a/tests/test_kernel_parked_ops_lock.py
+++ b/tests/test_kernel_parked_ops_lock.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""The parked-op queue is mutated under ONE lock that no backend call ever holds (2026-09-05).
+
+Since the drain moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake, on the pusher
+thread, while WS/HTTP handler threads park and cancel ops in the same dict and the move thread re-inserts
+a head — with no lock between them. Two races followed, each confirmed by review: (1) a ✕ (or the move
+thread's re-insert) changed a sid's list between the drain's head read and its pop — the drain popped a
+list the ✕ had emptied (an IndexError the blanket except turned into a dropped queue), or the ✕'s own
+check-then-pop landed on a list the drain had shifted and removed the op BEHIND the one clicked; (2) the
+disk mirror was written through ONE fixed temp path from any thread, so two writers could tear it (a
+kernel death then restores a wrong queue).
+
+Now every mutation of _pending_ops runs under _pending_ops_lock, and the lock guards the mutations ONLY:
+the drain reads a head under it, releases before every backend call (CodexBackend.send can synchronously
+spawn `codex app-server`; the SDK's busy()/turn_seq take the backend's own lock), and pops afterwards. A
+send run alone is popped before its delivery, as the parent already did; every other kind is popped only
+if the head is still the op the backend got, and stays the visible head meanwhile (_inflight_ops — a move
+waiting on its turn_seq is not recorded, since nothing is handed over while that is read), so a handler's
+gate still sees the queue and parks BEHIND it, and a ✕ on the in-flight head is refused as too late. A
+handler runs its expensive gates outside the lock and holds it only for the queue-presence check + park,
+one step; the mirror is published through the kernel's per-writer atomic write. The failure contract is
+unchanged: a raise during a sid's pass drops that sid's queue once, logged.
+
+SYNTHETIC fixtures only: placeholder uuids, invented texts.
+"""
+import io
+import os
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_parkedlock", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The ACCOUNT gate is a separate axis (tests/test_kernel_limit_queue.py); pinned off so the real
+# machine's usage.json can never make these tests park for a reason none of them is about.
+km._limit_hold = lambda sid: None
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+# Every pusher-cycle job except the drain, quieted so a cycle run here does exactly one thing.
+_OTHER_JOBS = ("_push_all", "_lift_spent_awaiting", "_death_sweep_tick", "_end_on_idle_sweep",
+               "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick", "_auto_pause_on_limit",
+               "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+               "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+               "_clear_done_working_notes")
+
+
+def _lock_free_for_another_thread():
+    """Can a thread other than the caller take the queue lock right now? (RLock ownership is per thread.)"""
+    got = []
+
+    def probe():
+        ok = km._pending_ops_lock.acquire(blocking=False)
+        if ok:
+            km._pending_ops_lock.release()
+        got.append(ok)
+    th = threading.Thread(target=probe, daemon=True)
+    th.start()
+    th.join(5)
+    return bool(got and got[0])
+
+
+class _FakeBackend:
+    """A tmux-shaped backend: it cannot forward its own sends, so a send parks while the turn is open."""
+
+    def __init__(self):
+        self.calls = []
+        self.open = True
+
+    def busy(self, sid):
+        return self.open
+
+    def forwards_sends(self):
+        return False
+
+    def send(self, sid, text):
+        self.calls.append(("send", text))
+        self.open = True                  # as SdkBackend.send: the turn is pending under the lock before send() returns
+        return True
+
+    def set_model(self, sid, value):
+        self.calls.append(("model", value))
+        return True
+
+    def set_effort(self, sid, value):
+        self.calls.append(("effort", value))
+        return True
+
+    def set_fast(self, sid, value):
+        self.calls.append(("fast", value))
+        return True
+
+    def set_auth(self, sid, value):
+        self.calls.append(("auth", value))
+        return True
+
+    def set_env(self, sid, value):
+        self.calls.append(("env", value))
+        return True
+
+    def turn_seq(self, sid):
+        return 0
+
+
+def _tmux_row(state):
+    return {"state": state, "since": int(time.time()) - 5, "model": "", "effort": "", "context": None,
+            "compactPct": None, "color": None, "mode": "", "backend": "tmux"}
+
+
+class _Drain(unittest.TestCase):
+    def setUp(self):
+        self.be = _FakeBackend()
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
+            mock.patch.object(km, "_compacting_now", lambda sid, **k: False),
+            mock.patch.object(km, "_optimistic_echo", lambda *a, **k: None),
+            mock.patch.object(km, "_mark_compacting", lambda sid: None),
+            mock.patch.object(km, "_names_snapshot", lambda: {}),
+            mock.patch.object(km, "_tmux_sessions", lambda: {SID: _tmux_row("waiting")}),
+        ] + [mock.patch.object(km, name, lambda *a, **k: None) for name in _OTHER_JOBS]
+        for p in self._patches:
+            p.start()
+        self._reset()
+        km._pusher_wake.clear()
+        km._producer_wake.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._reset()
+
+    def _reset(self):
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._move_askers.clear()
+        km._drain_hold.clear()
+        km._refresh_parse_failures.clear()
+        km._inflight_ops.clear()
+        try:
+            os.unlink(km._PENDING_OPS_FILE)
+        except OSError:
+            pass
+
+
+class OneLockAroundEveryMutation(_Drain):
+    """WS/HTTP handlers park and cancel, the move thread re-inserts a head, and the pusher (the ONE thread
+    that ever walks the queue) drains — all on the same dict. One RLock serializes the mutations; no backend
+    call runs under it; the head an op is being delivered from stays visible until the backend has it."""
+
+    def test_a_cancel_mid_call_cannot_shift_the_list_under_the_drains_pop(self):
+        # race (1): the drain read its head and called the backend; a ✕ arrived before the pop. Unlocked,
+        # the ✕ on the head "succeeded" (it popped the op the backend was already delivering), and the
+        # drain's pop then took the op behind — or, with nothing behind, an IndexError that dropped the
+        # queue. Now the in-flight head is refused as too late, a ✕ on the op behind succeeds, and the
+        # drain pops exactly what it delivered.
+        self.be.open = False
+        entered, release = threading.Event(), threading.Event()
+
+        def set_model(sid, value):
+            self.be.calls.append(("model", value))
+            entered.set()
+            release.wait(5)
+            return True
+        self.be.set_model = set_model
+        head, behind = ("model", "opus"), ("effort", "high")
+        km._pending_ops[SID] = [head, behind]
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+            walker.start()
+            self.assertTrue(entered.wait(5))               # the backend has the head; the lock is free
+            err_head = km._cancel_parked(SID, 0, km._parked_md(head))
+            err_behind = km._cancel_parked(SID, 1, km._parked_md(behind))
+            release.set()
+            walker.join(5)
+        self.assertEqual(err_head, km._cancel_miss_text(km._parked_md(head)), "the in-flight head is too late")
+        self.assertIsNone(err_behind, "the op behind it is cancellable")
+        self.assertEqual(self.be.calls, [("model", "opus")], "the head was delivered exactly once, the effort pick never")
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertNotIn("pending ops apply", buf.getvalue(), "nothing raised, so nothing was dropped")
+
+    def test_a_parked_op_stays_the_visible_head_while_the_backend_has_it(self):
+        # the ordering regression the second review caught: popping the head BEFORE the backend call left
+        # the queue empty for the whole call, and every handler's park decision keys on queue presence —
+        # busy() flips only once the backend has registered the op (SdkBackend.send runs _ensure first,
+        # CodexBackend.send may spawn the app server first). A pane send landing in that window saw no
+        # queue and busy False and handed over AHEAD of the parked /clear. The head now stays until the
+        # backend has it, so the send parks behind.
+        self.be.open = False
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            if text == "/clear":                           # a pane send lands while the backend still has the /clear…
+                self.assertTrue(km._send_or_park(self.be, SID, "hello", echo="human"), "…and PARKS")
+            self.be.open = True                            # only now does busy() flip
+            return True
+        self.be.send = send
+        km._pending_ops[SID] = [("command", "/clear", None)]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "/clear")], "nothing overtook the in-flight command")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "hello", "human")], "the send waits behind it")
+        self.be.open = False                               # the /clear's turn ends
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "/clear"), ("send", "hello")], "…and delivers next, in order")
+
+    def test_a_head_replaced_in_place_while_with_the_backend_is_not_popped(self):
+        # the identity check: a same-kind pick replaces the in-flight head in place (a new tuple); the drain
+        # must not pop the replacement as if it had delivered it, and delivers it on the next iteration
+        self.be.open = False
+
+        def set_model(sid, value):
+            self.be.calls.append(("model", value))
+            if value == "opus":
+                km._park_op(SID, ("model", "other"))       # lock free: the user re-picks mid-call
+            return True
+        self.be.set_model = set_model
+        km._pending_ops[SID] = [("model", "opus"), ("effort", "high")]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("model", "opus"), ("model", "other"), ("effort", "high")],
+                         "the replacement delivered, not silently popped; the op behind after it")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_second_compact_press_is_cancellable_while_the_first_is_in_flight(self):
+        # _compact_or_park parks the literal ("compact",); CPython interns one constant tuple per code object,
+        # so every compact parked in a kernel life is the SAME object, and compact is not in the replace set:
+        # a second press appends [C, C] with ops[0] is ops[1]. The in-flight refusal must therefore key on
+        # the HEAD slot, not on identity alone — a ✕ on the second chip while the first is with the backend
+        # is a cancel, and the redundant compaction never runs
+        self.be.open = True                                # a turn is open: the press parks
+        self.assertTrue(km._compact_or_park(self.be, SID))
+        results = []
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            self.assertTrue(km._compact_or_park(self.be, SID), "a second press parks behind the in-flight one")
+            ops = km._pending_ops[SID]
+            self.assertEqual([op[0] for op in ops], ["compact", "compact"])
+            self.assertIs(ops[0], ops[1], "the same interned tuple, twice")
+            results.append(km._cancel_parked(SID, 1, "/compact"))       # ✕ on the SECOND chip
+            self.be.open = True
+            return True
+        self.be.send = send
+        self.be.open = False
+        with redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertEqual(results, [None], "the second chip is cancelled, not refused as too late")
+        self.assertEqual(self.be.calls, [("send", "/compact")], "one compaction")
+        self.assertNotIn(SID, km._pending_ops, "…and no redundant one stays queued")
+
+    def test_a_stale_index_re_locates_past_the_in_flight_head_to_the_identical_chip_behind_it(self):
+        # the ✕ carries the chip's index from the last push; a send ahead delivered since makes it stale, and
+        # the body re-locate then walks the list for the first op with that body. With [C(in-flight), C] that
+        # is slot 0 — the head no ✕ can take — so the re-locate skips it and lands on the second chip; with
+        # only the in-flight op listed it finds nothing, the same miss as today
+        self.be.open = True                                # a turn is open: the press parks
+        self.assertTrue(km._compact_or_park(self.be, SID))
+        results, seen = [], []
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            results.append(km._cancel_parked(SID, 3, "/compact"))       # stale index, one chip: the in-flight head
+            self.assertTrue(km._compact_or_park(self.be, SID), "a second press parks behind the in-flight one")
+            results.append(km._cancel_parked(SID, 2, "/compact"))       # stale index, two chips: the second
+            seen.append(list(km._pending_ops.get(SID) or []))
+            self.be.open = True
+            return True
+        self.be.send = send
+        self.be.open = False
+        with redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertEqual(results, [km._cancel_miss_text("/compact"), None],
+                         "alone in flight → too late; behind an in-flight twin → cancelled")
+        self.assertEqual(seen, [[("compact",)]], "the in-flight head alone remains after the ✕, until the backend has it")
+        self.assertEqual(self.be.calls, [("send", "/compact")], "one compaction")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_move_waiting_on_its_turn_end_is_cancellable_during_the_turn_seq_read(self):
+        # a waiting cwd head's only action in a cycle is the turn_seq read — nothing is handed over — so it is
+        # not recorded in flight, and a ✕ landing inside that read is a cancel, not a false "already reached
+        # the session" that would recur every cycle while the move waited
+        self.be.open = False
+        d = tempfile.mkdtemp()
+        op = ("cwd", d, km._MOVE_BUSY_RETRIES, 0)
+        results, fired = [], []
+
+        def turn_seq(sid):
+            results.append(km._cancel_parked(SID, 0, km._parked_md(op)))
+            return 0                                       # unchanged: the move would keep waiting
+        self.be.turn_seq = turn_seq
+        km._pending_ops[SID] = [op]
+        buf = io.StringIO()
+        with mock.patch.object(km, "_fire_move", lambda be, sid, path, tries, wid: fired.append(path)), \
+             redirect_stderr(buf):
+            km._apply_pending_ops()
+        self.assertEqual(results, [None], "cancelled")
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertEqual(fired, [], "no move fires")
+        self.assertNotIn("pending ops apply", buf.getvalue(), "nothing raised, so the empty queue is the ✕'s doing")
+
+    def test_a_move_replaced_in_place_while_its_turn_seq_is_read_fires_the_replacement_once(self):
+        # the cwd twin of the replaced-head test: the user re-picks the folder while the drain reads turn_seq
+        # (lock free); the superseded folder must never fire, the replacement fires exactly once
+        self.be.open = False
+        d1, d2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        fired = []
+
+        def turn_seq(sid):
+            km._park_op(SID, ("cwd", d2, 0))               # replace-in-place: a new tuple at the head
+            return 1                                       # the turn ended: the move may proceed
+        self.be.turn_seq = turn_seq
+        km._pending_ops[SID] = [("cwd", d1, km._MOVE_BUSY_RETRIES, 0)]
+        with mock.patch.object(km, "_fire_move", lambda be, sid, path, tries, wid: fired.append(path)):
+            km._apply_pending_ops()
+        self.assertEqual(fired, [d2], "the replacement fires, exactly once; the superseded folder never")
+        self.assertNotIn(SID, km._pending_ops, "nothing dropped, nothing left")
+
+    def test_the_locked_re_check_parks_behind_a_queue_the_expensive_gates_missed(self):
+        # _park_behind_queue's locked re-check is the gate that decides: with every expensive gate saying
+        # quiet, an op that finds a queue there parks BEHIND it and never reaches the backend
+        self.be.open = False
+        km._pending_ops[SID] = [("compact",)]
+        with mock.patch.object(km, "_ops_gate", lambda sid: False):
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertTrue(km._send_or_park(self.be, SID, "hello"))   # (its own first gate reads the queue too)
+        self.assertEqual(self.be.calls, [], "nothing handed over past an existing queue")
+        self.assertEqual(km._pending_ops[SID], [("compact",), ("model", "opus"), ("send", "hello", None)])
+
+    def test_a_cancel_racing_the_drains_pop_never_removes_the_wrong_op(self):
+        # _cancel_parked verifies the clicked index by body, THEN pops. Unlocked, the drain could pop its
+        # head between the two, and the ✕ removed whatever had shifted into the clicked slot: the user
+        # cancelled the queued message, the message was delivered, and the effort pick vanished. Now the
+        # check and the pop are one locked step, so a drain landing mid-cancel yields the cycle instead.
+        # Event-keyed: the cancel pauses INSIDE its body check (holding the lock), the drain is run then.
+        self.be.open = False
+        checked, go_cancel = threading.Event(), threading.Event()
+        real_md = km._parked_md
+
+        def md_probe(op):
+            if threading.current_thread().name == "cancel-under-test" and not checked.is_set():
+                checked.set()                              # paused between the check and the pop…
+                go_cancel.wait(5)
+            return real_md(op)
+        msg = ("send", "two", None)
+        km._pending_ops[SID] = [("model", "opus"), msg, ("fast", "on"), ("effort", "high")]
+        result = []
+        with mock.patch.object(km, "_parked_md", md_probe), redirect_stderr(io.StringIO()):
+            canceller = threading.Thread(target=lambda: result.append(km._cancel_parked(SID, 1, real_md(msg))),
+                                         name="cancel-under-test", daemon=True)
+            canceller.start()
+            self.assertTrue(checked.wait(5))
+            km._apply_pending_ops()                        # …a drain cycle lands exactly there
+            go_cancel.set()
+            canceller.join(5)
+            self.assertIsNone(result[0], "the ✕ reports success")
+            km._apply_pending_ops()                        # the next cycle
+        self.assertNotIn(("send", "two"), self.be.calls, "…so the cancelled message was never delivered")
+        self.assertEqual(self.be.calls, [("model", "opus"), ("fast", "on"), ("effort", "high")],
+                         "every other op delivered, in order, none lost")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_cancel_during_an_in_flight_send_hits_only_what_is_still_queued(self):
+        # the lock is released while the backend takes a send: a ✕ arriving in that window can still remove
+        # an op BEHIND the one in flight, and a ✕ on the in-flight one itself finds it gone — the honest
+        # 'too late', not a wrong-op removal
+        self.be.open = False
+        in_send, release = threading.Event(), threading.Event()
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            in_send.set()
+            release.wait(5)
+            self.be.open = True
+            return True
+        self.be.send = send
+        first, behind = ("send", "first", None), ("model", "opus")
+        km._pending_ops[SID] = [first, behind]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        with redirect_stderr(io.StringIO()):
+            walker.start()
+            self.assertTrue(in_send.wait(5))               # the head is popped and with the backend; the lock is free
+            err_behind = km._cancel_parked(SID, 1, km._parked_md(behind))
+            err_inflight = km._cancel_parked(SID, 0, km._parked_md(first))
+            release.set()
+            walker.join(5)
+        self.assertIsNone(err_behind, "the op behind the in-flight one is cancellable")
+        self.assertEqual(err_inflight, km._cancel_miss_text(km._parked_md(first)), "the in-flight one is too late")
+        self.assertEqual(self.be.calls, [("send", "first")])
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_drain_yields_to_a_handler_holding_the_lock_and_the_push_still_runs(self):
+        # the drain is the first job of every cycle; its top-of-walk acquire is non-blocking, so a cycle
+        # that finds a handler holding the lock skips the drain rather than stalling every session's push;
+        # the handler's own park wakes the pusher, so the skipped delivery costs nothing
+        self.be.open = False
+        km._pending_ops[SID] = [("model", "opus")]
+        held, release = threading.Event(), threading.Event()
+
+        def handler():
+            with km._pending_ops_lock:
+                held.set()
+                release.wait(5)
+        th = threading.Thread(target=handler, name="handler-under-test", daemon=True)
+        th.start()
+        self.assertTrue(held.wait(5))
+        pushes = []
+        try:
+            with mock.patch.object(km, "_push_all", lambda **k: pushes.append(1)), \
+                 mock.patch.object(km, "_clients", [object()]):                      # a browser is connected
+                km._pusher_cycle()
+            self.assertEqual(self.be.calls, [], "the drain skipped: a handler owns the queue")
+            self.assertEqual(km._pending_ops[SID], [("model", "opus")], "nothing lost")
+            self.assertEqual(pushes, [1], "…and the push still ran, not stalled behind the handler")
+        finally:
+            release.set()
+            th.join(5)
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("model", "opus")], "the next cycle drains")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_lock_is_never_held_across_a_backend_call(self):
+        # CodexBackend.send can synchronously spawn `codex app-server` with no request timeout; a lock held
+        # across it would hold every handler's queue check + park behind it. Pinned from inside the backend,
+        # for EVERY call the drain makes — the setters, the send, busy() (the working gate and the hold
+        # check behind a delivered send) and turn_seq (a waiting move): the drain thread does not own the
+        # lock, and another thread can take it
+        probes = []
+
+        def probe(name):
+            probes.append((name, km._pending_ops_lock._is_owned(), _lock_free_for_another_thread()))
+
+        class _Probed(_FakeBackend):
+            def busy(self, sid):
+                probe("busy")
+                return self.open
+
+            def send(self, sid, text):
+                probe("send")
+                return _FakeBackend.send(self, sid, text)
+
+            def set_model(self, sid, value):
+                probe("set_model")
+                return _FakeBackend.set_model(self, sid, value)
+
+            def set_effort(self, sid, value):
+                probe("set_effort")
+                return _FakeBackend.set_effort(self, sid, value)
+
+            def set_fast(self, sid, value):
+                probe("set_fast")
+                return _FakeBackend.set_fast(self, sid, value)
+
+            def set_auth(self, sid, value):
+                probe("set_auth")
+                return _FakeBackend.set_auth(self, sid, value)
+
+            def set_env(self, sid, value):
+                probe("set_env")
+                return _FakeBackend.set_env(self, sid, value)
+
+            def turn_seq(self, sid):
+                probe("turn_seq")
+                return 0
+        self.be = _Probed()
+        self.be.open = False
+        d = tempfile.mkdtemp()
+        env = {"A": "1"}
+        km._pending_ops[SID] = [("model", "opus"), ("effort", "high"), ("fast", "on"), ("auth", "key"), ("env", env),
+                                ("send", "hello", None),
+                                ("cwd", d, km._MOVE_BUSY_RETRIES, 0)]         # behind the send: waits on turn_seq
+        km._apply_pending_ops()                            # busy (gate) → 5 setters → send → busy (the hold check)
+        self.assertEqual(self.be.calls, [("model", "opus"), ("effort", "high"), ("fast", "on"), ("auth", "key"),
+                                         ("env", env), ("send", "hello")])
+        self.be.open = False                               # the send's turn ends
+        km._apply_pending_ops()                            # busy (gate) → turn_seq: the move waits on its turn end
+        self.assertEqual(km._pending_ops[SID], [("cwd", d, km._MOVE_BUSY_RETRIES, 0)], "still parked, waiting")
+        names = [n for n, _, _ in probes]
+        self.assertEqual(names, ["busy", "set_model", "set_effort", "set_fast", "set_auth", "set_env", "send",
+                                 "busy", "busy", "turn_seq"])
+        self.assertEqual([o for _, o, _ in probes], [False] * len(probes), "the drain never owns the lock in a backend call")
+        self.assertEqual([f for _, _, f in probes], [True] * len(probes), "…and another thread can take it every time")
+
+    def test_a_handlers_park_completes_while_the_drain_is_inside_a_slow_send(self):
+        # the release around the backend call is what lets a user's press land during a slow delivery
+        self.be.open = False
+        in_send, release = threading.Event(), threading.Event()
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            self.be.open = True                            # the turn is pending before send() returns
+            in_send.set()
+            release.wait(5)
+            return True
+        self.be.send = send
+        km._pending_ops[SID] = [("send", "first", "human")]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        walker.start()
+        self.assertTrue(in_send.wait(5))                   # the backend has the send; the lock is released
+        parker = threading.Thread(target=lambda: km._send_or_park(self.be, SID, "second", echo="human"),
+                                  name="handler-under-test", daemon=True)
+        parker.start()
+        parker.join(5)
+        self.assertFalse(parker.is_alive(), "the handler's park did not wait for the backend")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "second", "human")], "…and landed behind the in-flight send")
+        release.set()
+        walker.join(5)
+        self.assertEqual(self.be.calls, [("send", "first")], "the parked second waits for the delivered turn to end")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "second", "human")])
+
+    def test_a_handlers_queue_check_and_park_share_the_lock_but_its_gates_and_handover_do_not(self):
+        # the expensive gates (they fork tmux / call the backend's busy()) run outside the lock; the
+        # queue-presence check and the park are one locked step; the handover runs outside it again
+        owned = {"gate": [], "park": [], "handover": []}
+        real_wn, real_park_locked = km._working_now, km._park_op_locked
+
+        def gate_probe(sid):
+            owned["gate"].append(km._pending_ops_lock._is_owned())
+            return real_wn(sid)
+
+        def park_probe(sid, op):
+            owned["park"].append(km._pending_ops_lock._is_owned())
+            return real_park_locked(sid, op)
+
+        def send(sid, text):
+            owned["handover"].append(km._pending_ops_lock._is_owned())
+            self.be.calls.append(("send", text))
+            return True
+
+        def set_model(sid, value):
+            owned["handover"].append(km._pending_ops_lock._is_owned())
+            self.be.calls.append(("model", value))
+            return True
+        self.be.send, self.be.set_model = send, set_model
+        self.be.open = False                               # quiet…
+        with mock.patch.object(km, "_working_now", gate_probe), \
+             mock.patch.object(km, "_park_op_locked", park_probe):
+            km._pending_ops[SID] = [("compact",)]          # …but a queue exists: everything parks BEHIND it
+            self.assertTrue(km._send_or_park(self.be, SID, "hello"))
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertTrue(km._compact_or_park(self.be, SID))
+            self.assertEqual([op[0] for op in km._pending_ops[SID]], ["compact", "send", "model", "compact"],
+                             "every op parked BEHIND the queue, in press order (a compact appends, it never replaces)")
+            self.assertEqual(owned["park"], [True] * 3, "the queue check + park is one locked step")
+            self.assertEqual(self.be.calls, [])
+            km._pending_ops.clear()                        # no queue: everything hands over
+            self.assertFalse(km._send_or_park(self.be, SID, "hello"))
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertEqual(owned["handover"], [False, False], "the handover to the backend is outside the lock")
+            self.assertEqual(self.be.calls, [("send", "hello"), ("model", "opus")])
+        # (_send_or_park short-circuits on the queue read, so not every call reaches _working_now — every one
+        # that did ran outside the lock)
+        self.assertTrue(owned["gate"], "the expensive gate was consulted")
+        self.assertEqual(set(owned["gate"]), {False}, "…and every time outside the lock")
+
+    def test_the_move_threads_head_repark_runs_under_the_lock(self):
+        # _move_now re-inserts a `busy` move at the head from its own thread; the insert and its hold are one
+        # locked step, so a handler's park or the drain's pops cannot interleave with them
+        owned = []
+        real_hold = km._hold_drain
+
+        def hold_probe(sid, seconds, until_busy=False):
+            owned.append(km._pending_ops_lock._is_owned())
+            return real_hold(sid, seconds, until_busy)
+        self.be.move = lambda sid, path: "busy"
+        d = tempfile.mkdtemp()
+        km._moving.add(SID)
+        with mock.patch.object(km, "_hold_drain", hold_probe):
+            self.assertEqual(km._move_now(self.be, SID, d, 0, ""), "busy")
+        self.assertEqual(km._pending_ops[SID], [("cwd", d, 1, 0)], "back at the head, carrying the try")
+        self.assertEqual(owned, [True], "the re-insert and its hold are one locked step")
+        self.assertNotIn(SID, km._moving)
+
+
+class TheMirrorIsWrittenPerWriter(_Drain):
+    """pending-ops.json used to be published through ONE fixed temp path from any thread: the loser renamed
+    a temp the winner had already moved, or wrote into a temp mid-rename — a torn mirror that a kernel
+    death then restored as the queue."""
+
+    def test_concurrent_parks_never_tear_the_mirror_or_log_a_failed_save(self):
+        errors, buf = [], io.StringIO()
+
+        def hammer(t):
+            sid = "11111111-2222-3333-4444-%012d" % t
+            for i in range(120):
+                try:
+                    km._park_op(sid, ("model", "pick-%d-%d" % (t, i)))    # replace-in-place: one op per sid
+                except Exception as e:
+                    errors.append(repr(e))
+        with redirect_stderr(buf):
+            threads = [threading.Thread(target=hammer, args=(t,)) for t in range(8)]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join(30)
+        self.assertEqual(errors, [])
+        self.assertNotIn("pending-ops save", buf.getvalue(), "no writer lost its temp to another")
+        leftovers = [p.name for p in km._PENDING_OPS_FILE.parent.iterdir()
+                     if p.name.startswith(km._PENDING_OPS_FILE.stem) and p.name != km._PENDING_OPS_FILE.name]
+        self.assertEqual(leftovers, [], "no temp left behind")
+        self.assertEqual(km._load_pending_ops(), dict(km._pending_ops), "the mirror is the final state, whole")
+        self.assertEqual(len(km._pending_ops), 8)
+
+    def test_the_mirrors_temp_name_is_per_writer_not_a_shared_sibling(self):
+        srcs = []
+        real_replace = os.replace
+
+        def replace_probe(src, dst, *a, **k):
+            if str(dst) == str(km._PENDING_OPS_FILE):
+                srcs.append(str(src))
+            return real_replace(src, dst, *a, **k)
+        km._pending_ops[SID] = [("model", "opus")]
+        with mock.patch.object(km.os, "replace", replace_probe):
+            km._save_pending_ops()
+            km._save_pending_ops()
+        self.assertEqual(len(srcs), 2)
+        self.assertNotEqual(srcs[0], srcs[1], "two writes, two temps")
+        self.assertNotIn(str(km._PENDING_OPS_FILE.with_suffix(".tmp")), srcs, "the shared sibling temp is gone")
+        for s in srcs:
+            self.assertEqual(os.path.dirname(s), str(km._PENDING_OPS_FILE.parent),
+                             "published from the file's own directory (a same-filesystem rename)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -559,7 +559,7 @@ class DrivePlumbing(unittest.TestCase):
         self.assertIn('"setAuth", "endSession"', src.replace("\n", " "), "an ID_OPS member")
         self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
         self.assertIn("def _set_auth_or_park(be, sid, value):", src)
-        self.assertIn('_park_op(sid, ("auth", value))', src)
+        self.assertIn('_gate_or_park(sid, ("auth", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "auth":', src)
         self.assertIn("be.set_auth(sid, op[1])", src)
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -464,7 +464,7 @@ class DrivePlumbing(unittest.TestCase):
     def test_the_op_is_routed_parked_and_replayed(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("def _set_env_or_park(be, sid, value):", src)
-        self.assertIn('_park_op(sid, ("env", value))', src)
+        self.assertIn('_gate_or_park(sid, ("env", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "env":', src)
         self.assertIn("be.set_env(sid, op[1])", src)
         self.assertIn('("model", "effort", "fast", "env", "cwd")', src,


### PR DESCRIPTION
Since the drain moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake, on the pusher thread, while the WS and HTTP handler threads park and cancel ops in the same dict and the move thread re-inserts a head. Nothing serialized them. Adversarial review confirmed two races:

- A cancel, or the move thread's re-insert, could change a sid's list between the drain's head read and its pop. The drain then popped a list the cancel had just emptied (an `IndexError` its blanket `except` turned into a dropped queue), or the cancel's own check-then-pop landed on a list the drain had shifted and removed the op *behind* the one clicked.
- The disk mirror was written through one fixed temp path from any thread, so two writers could tear it and the next boot restored a wrong queue.

## What changes

**One RLock around every mutation** of the queue: the park, the cancel, the move thread's head re-insert, the drain's reads and pops, and the mirror write (now through `_atomic_write`'s per-writer temp name, so every snapshot is whole).

**The lock never spans a backend call.** `CodexBackend.send` can synchronously spawn and initialize the app server with no request timeout, and the SDK's `busy` and `turn_seq` take the backend's own lock, so a lock held across any of them would hold every handler's park behind it and could nest inside a backend lock. The drain takes the lock only to read a sid's head and to pop what a step delivered, releasing before the send, the setter or the `turn_seq` read. A raise still drops that sid's queue once, logged, exactly as before.

**The head stays the visible head while the backend has it.** Every handler gate keys on queue presence and otherwise on `busy`, which flips only once the backend has registered the op (the SDK backend runs `_ensure` under its own lock before it enqueues; the Codex backend may spawn the app server first). Popping before the call would leave the queue empty for that window, and a pane send landing in it would hand over *ahead* of a parked slash command. So a command, compact or settings op is read under the lock and recorded in flight, the call runs with the lock released and the op still at the head, and afterwards the head is popped only if it is still that very op. A cancel on the in-flight head is refused as too late rather than reported as a cancellation of something the backend already has; the refusal keys on the head slot, not identity alone, because a compact parks one interned tuple per code object. A move op is not recorded in flight (its only mid-call action is the `turn_seq` read), so a cancel on a waiting move still succeeds. The send run alone is popped before delivery, as the parent already did.

**Handler side:** the expensive gates (tmux fork, discover sweep, usage read, `busy`) run outside the lock as they always did; only the cheap queue-presence check and the park run under it, as one step (`_gate_or_park` / `_park_behind_queue`), so an op never slips past a queue another handler filled between the two reads. The top-of-walk acquire is non-blocking, so a cycle never stalls every session's push behind a handler.

Unchanged: the failure contract, park order and the sequential delivery rule, every gate and hold and where the hold is armed relative to the pops, and the rule that only a real mutation saves the mirror and wakes the pusher.

## Tests

`tests/test_kernel_parked_ops_lock.py` (17 tests) drives each race and each invariant: a cancel arriving while the backend has the head (in-flight one too late, the one behind cancelled, nothing dropped); a cancel paused between its body check and its pop while a drain cycle lands (event-keyed, no sleeps); a pane send issued from *inside* the backend's own call that must park behind the in-flight command (passes on `main`, fails when the head is popped before the call); a same-kind pick replacing the in-flight head; a second compact press cancelled while the first is with the backend; a waiting move cancelled from inside the `turn_seq` read; the locked re-check parking behind a queue the expensive gates missed; a backend that asserts from inside every call the drain makes that the drain does not own the lock and another thread can take it; and eight threads hammering the mirror. Source mutants that drop the locked re-check, the identity pop, the in-flight record or the head-slot refusal each fail exactly one test. Two setter source pins follow the setters' new call. The four test modules an earlier cut had rewritten are byte-identical to `main`.

Full suite 7346 passed / 44 skipped / 0 failed with nothing deselected; `bats tests/*.bats` 389/389.

## Notes for review

- **#923** (a model pick applies live mid-turn) edits the same lines of `_set_model_or_park`: it widens the gate but still reads the queue unlocked and hands over directly, which is the handler race this closes. Whichever lands second rebases; the shape here (gate function outside the lock, queue check + park inside) takes #923's wider gate unchanged.
- **#955** stacks on this one: it moves the drain's per-sid transcript-parse refresh out from under the lock to sit among the other gates that already run outside it, and reads the usage file once per drain instead of once per op. Its diff shows both commits until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
