### PR TITLE
The parked-op drain reads usage once per cycle, gates in cost order, and re-parses only a session about to be judged

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19858,6 +19858,26 @@ def _session_chip(sid, path, session, tm, now):
 # the moment compaction ends. A repeated model/effort pick REPLACES its earlier parked op in place (last
 # pick wins — one queued chip, not a pile), since only the final setting can matter.
 _PENDING_OPS_FILE = Path(jd.STATE) / "pending-ops.json"
+# ONE lock around every MUTATION of _pending_ops (2026-09-05): the WS/HTTP handler threads park and cancel,
+# the move thread re-inserts a head, and the pusher thread drains — all on this dict, and since the drain
+# moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake. Unlocked, two races were
+# confirmed by review: (1) a ✕ — or the move thread's head re-insert — changed a sid's list between the
+# drain's head read and its pop, so the drain popped a list the ✕ had just emptied (an IndexError the
+# blanket except turned into a dropped queue) or the ✕, re-locating by index+body and then popping,
+# removed the op BEHIND the one clicked once the drain's pop had shifted the list; (2) two writers tore the
+# disk mirror through one shared temp path (a kernel death then restored a wrong queue). The lock guards the
+# mutations ONLY: no backend call ever runs under it (CodexBackend.send can synchronously spawn and
+# initialize `codex app-server` with no request timeout; SdkBackend.busy/turn_seq take the backend's own
+# lock), and a handler evaluates only the queue-presence check under it (_park_behind_queue) — its
+# expensive gates (_compacting_now / _working_now / _limit_hold: a tmux fork, a discover sweep, the usage
+# file) run outside. So a holder owns it for a dict read, a list append or pop, and the mirror write —
+# microseconds. Re-entrant, because _park_op and _save_pending_ops take it and are called from under it.
+# The drain takes it NON-BLOCKING at the top of its walk (_apply_pending_ops). No backend thread ever takes
+# it (the poke, push and push_session callbacks the backends hold touch no queue). Reads stay unlocked
+# (build_session's chip list, the nudge guard, the parse refresh, _ops_gate's advisory queue read): a dict
+# get or list iteration under the GIL never raises, and a chip one cycle early or late is corrected by the
+# next push.
+_pending_ops_lock = threading.RLock()
 
 
 def _load_pending_ops():
@@ -19878,13 +19898,18 @@ def _load_pending_ops():
 
 def _save_pending_ops():
     """Mirror _pending_ops to disk on every mutation, atomically, so parked ops survive a kernel
-    death. Tiny file, mutation-rate writes (a park or a delivery), not a hot path."""
-    try:
-        tmp = _PENDING_OPS_FILE.with_suffix(".tmp")
-        tmp.write_text(json.dumps({k: [list(o) for o in v] for k, v in _pending_ops.items() if v}))
-        os.replace(tmp, _PENDING_OPS_FILE)
-    except Exception:
-        sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
+    death. Tiny file, mutation-rate writes (a park or a delivery), not a hot path. Under the queue lock,
+    so the snapshot is whole (an unlocked writer iterating the dict while a handler parked raised
+    "dictionary changed size during iteration" and skipped the save), and through _atomic_write's
+    per-writer temp: the old fixed `pending-ops.tmp` was shared by every thread, so the loser renamed a
+    temp the winner had already moved, or wrote into one mid-rename — a torn mirror that the next boot
+    restored as the queue (review find on #904, 2026-09-05)."""
+    with _pending_ops_lock:
+        try:
+            _atomic_write(_PENDING_OPS_FILE,
+                          json.dumps({k: [list(o) for o in v] for k, v in _pending_ops.items() if v}))
+        except Exception:
+            sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
 
 
 _pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("env", {…}) | ("cwd", path, busy_retries) | ("compact",), …] in park order
@@ -20021,13 +20046,61 @@ def _ops_gate(sid):
     sid = str(sid)
     return (_compacting_now(sid) or _working_now(sid) or bool(_pending_ops.get(sid))
             or sid in _moving or _limit_hold(sid) is not None)   # a move in flight holds the queue too
+    # ^ EXPENSIVE (a tmux fork, a discover sweep, the usage file, the backend's busy()) — the handlers call
+    #   it OUTSIDE _pending_ops_lock; its queue read is advisory, and the one that decides is the locked
+    #   re-check in _park_behind_queue (_gate_or_park). A backend must never be called under that lock.
+
+
+def _gate_or_park(sid, op):
+    """The park-or-hand-over decision every drive op except a send takes (a send composes its own gates in
+    _send_or_park, same shape). Returns True when PARKED — the caller answers "queued" — and False when the
+    caller should hand the op to the backend now. Two steps, in this order (2026-09-05): the EXPENSIVE gates
+    (_ops_gate) run outside the queue lock, since they fork tmux, sweep discover, read the usage file and
+    call the backend's busy() — none of which a lock that the pusher's drain also takes may wait on; then
+    the CHEAP queue-presence check and the park run as ONE locked step (_park_behind_queue), so an op never
+    slips past a queue that another handler filled between the two reads."""
+    sid = str(sid)
+    if _ops_gate(sid):
+        _park_op(sid, op)
+        return True
+    return _park_behind_queue(sid, op)
+
+
+def _park_behind_queue(sid, op):
+    """A handler's cheap gate — does a queue exist for this sid right now? — and its park, as ONE step under
+    _pending_ops_lock (2026-09-05). True when parked behind the existing queue; False when there is none
+    (the caller hands over). The only gate a handler evaluates under the lock: a queue-presence read is a
+    dict get and the park is an append plus the tiny mirror write, so a handler owns the lock for
+    microseconds, and the drain — which takes it non-blocking at the top of its walk and blocks on it per
+    pop — is never held behind a backend call. Why this pair is all press order needs: a park that completed
+    before this read is seen here, and this op lines up behind it; two handlers that both find no queue both
+    hand over, and reach the backend in call order — the same order a lock held across the handover would
+    have imposed, as lock-acquisition order. Nothing is lost by releasing before the backend call, and a
+    slow backend (a Codex client connect can take seconds) stalls no other handler and no push."""
+    sid = str(sid)
+    with _pending_ops_lock:
+        if not _pending_ops.get(sid):
+            return False
+        _park_op_locked(sid, op)
+    _mark_views_dirty()               # the wake AFTER the release, so the cycle it brings finds the lock free
+    return True
 
 
 def _park_op(sid, op):
     """Park one mid-compaction drive op in the sid's FIFO queue and push at once (the queued bubble
     appears immediately, never waiting out the backstop poll). A repeat model/effort pick REPLACES the
     earlier parked op of the same kind IN PLACE — its queue position stands, its value updates — so the
-    chat shows one "/model …" chip carrying the latest pick. Messages always append."""
+    chat shows one "/model …" chip carrying the latest pick. Messages always append. The mutation runs
+    under the queue lock (_park_op_locked: the drain's pops, a ✕, the move thread's re-park all touch this
+    list); the pusher wake comes AFTER the release, so the cycle it brings finds the lock free."""
+    with _pending_ops_lock:
+        _park_op_locked(sid, op)
+    _mark_views_dirty()               # the queue lives in memory — no sig sees it; the woken push renders the chip
+
+
+def _park_op_locked(sid, op):
+    """_park_op's mutation + mirror write, for a caller that already holds _pending_ops_lock and will wake
+    the pusher itself after releasing (_park_behind_queue)."""
     q = _pending_ops.setdefault(str(sid), [])
     if op[0] in ("model", "effort", "fast", "env", "cwd"):
         for i, o in enumerate(q):
@@ -20039,7 +20112,6 @@ def _park_op(sid, op):
     else:
         q.append(op)
     _save_pending_ops()               # mirror the park to disk (survives a kernel death)
-    _mark_views_dirty()               # the queue lives in memory — no sig sees it; the woken push renders the chip
 
 
 def _parked_md(op):
@@ -20084,6 +20156,15 @@ _TMUX_PROMPT_HOLD_S = 3.0        # the prompt hold's clock FALLBACK: after the d
 _drain_hold: dict = {}           # sid -> (time.monotonic() deadline, until_busy); _apply_pending_ops skips the sid
                                  # while the hold is open (_drain_hold_open)
 _refresh_parse_failures: dict = {}   # sid -> consecutive cycles its parked-parse refresh raised (_refresh_parked_parses)
+_inflight_ops: dict = {}         # sid -> the HEAD op the drain has handed to the backend, lock released, and not yet
+                                 # popped (2026-09-05; never a cwd op — a move hands nothing over while its turn_seq
+                                 # is read, so a ✕ on a waiting move must still succeed). It stays the visible head
+                                 # for the whole call, so every handler's gate still sees the queue and parks BEHIND
+                                 # it (SdkBackend.send runs _ensure before it enqueues, CodexBackend.send may spawn
+                                 # the app server first — busy() flips only once the backend has the op, so an empty
+                                 # queue in that window let a pane send hand over AHEAD of a parked /clear), and a ✕
+                                 # on it is refused as too late (_cancel_parked). Popped only if still the head when
+                                 # the call returns (_apply_pending_ops). Read and written under _pending_ops_lock.
 
 
 def _hold_drain(sid, seconds, until_busy=False):
@@ -20168,8 +20249,7 @@ def _move_or_park(be, sid, path, client=None):
     fires at the turn's end (_apply_pending_ops); quiet, it fires now."""
     sid = str(sid)
     wid = (client or {}).get("wid") or ""
-    if _ops_gate(sid):
-        _park_op(sid, ("cwd", path, 0))
+    if _gate_or_park(sid, ("cwd", path, 0)):
         _move_askers[sid] = wid
         return None
     return _fire_move(be, sid, path, 0, wid)
@@ -20211,11 +20291,14 @@ def _move_now(be, sid, path, tries, wid):
             res = "%s: %s" % (type(e).__name__, str(e)[:200])
         if res == "busy":
             # re-park and hold BEFORE `_moving` releases the queue (review find, #904): a drain cycle landing
-            # between the release and the re-park would fire the op behind the move, or burn a retry
+            # between the release and the re-park would fire the op behind the move, or burn a retry. The
+            # backend's turn_seq is read OUTSIDE the queue lock (it takes the backend's own); the re-insert
+            # and its hold are one locked step against a handler's park and the drain's pops (2026-09-05)
             seq = be.turn_seq(sid) if hasattr(be, "turn_seq") else None  # the turn end this retry waits on
-            _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
-            _move_askers[sid] = wid
-            _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (_hold_drain)
+            with _pending_ops_lock:
+                _pending_ops.setdefault(sid, []).insert(0, ("cwd", path, tries + 1, seq))   # head: it was already first
+                _move_askers[sid] = wid
+                _hold_drain(sid, _MOVE_BUSY_RETRY_S)   # the retry waits out the CLI's post-result window (_hold_drain)
     finally:
         _moving.discard(sid)
     if res == "busy":
@@ -20257,19 +20340,39 @@ def _cancel_parked(sid, park, md):
     read as a successful cancel while the message got answered anyway (the user 2026-07-20). Persists +
     wakes the pusher like every queue mutation. LOGGED — sid and op kind, never the body, which is user
     text — so an emptied queue can be told apart from one that was never delivered: the 2026-09-03
-    diagnosis of a parked /clear that vanished had to infer this ✕ by elimination."""
+    diagnosis of a parked /clear that vanished had to infer this ✕ by elimination. The locate and the
+    pop are ONE step under the queue lock: unlocked, the drain could pop its head between the body check
+    and the pop, and the ✕ removed whatever had shifted into the clicked slot (2026-09-05). An op the
+    drain has already popped for delivery is simply gone from here — the honest 'too late' below — and
+    the op the drain is handing to the backend RIGHT NOW (_inflight_ops: still the head, so the chip
+    still shows) is the same miss: the backend has it, and a ✕ must never report a delivered op as
+    cancelled. That refusal keys on the HEAD SLOT, not on identity alone: the in-flight op is always
+    ops[0] while it is listed (read as the head, its own ✕ refused, a replace-in-place swaps in a new
+    object; a handler-fired move can only start on an empty queue (_park_behind_queue), and the
+    drain-fired one holds _moving until it has re-inserted) — and identity alone would be wrong, because
+    _compact_or_park parks the literal ("compact",), one interned tuple per code object, so a second
+    compact press appends an op that `is` the first; a ✕ on that SECOND chip while the first is with the
+    backend is a cancel, and the redundant compaction must not run. The body re-locate skips that head
+    slot too, so a STALE index for the second chip (a send ahead delivered between the push and the
+    click) lands on the chip and not on the head it cannot take; with only the in-flight op listed it
+    finds nothing, the same miss as today."""
     sid = str(sid)
-    ops = _pending_ops.get(sid) or []
-    if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
-        park = next((j for j, op in enumerate(ops) if _parked_md(op) == md), -1) if md else -1
-        if park < 0:
-            return _cancel_miss_text(md)
-    sys.stderr.write("parked-op cancel: %s %s\n" % (sid, ops[park][0]))
-    ops.pop(park)
-    if not ops:
-        _pending_ops.pop(sid, None)
-        _drain_hold.pop(sid, None)        # an emptied queue leaves no hold behind (nothing left for it to protect)
-    _save_pending_ops()
+    with _pending_ops_lock:
+        ops = _pending_ops.get(sid) or []
+        inflight_head = bool(ops) and ops[0] is _inflight_ops.get(sid)   # the head is with the backend this instant
+        if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
+            park = next((j for j, op in enumerate(ops)
+                         if _parked_md(op) == md and not (j == 0 and inflight_head)), -1) if md else -1
+            if park < 0:
+                return _cancel_miss_text(md)
+        if park == 0 and inflight_head:
+            return _cancel_miss_text(md)          # too late, not a wrong-op removal
+        sys.stderr.write("parked-op cancel: %s %s\n" % (sid, ops[park][0]))
+        ops.pop(park)
+        if not ops:
+            _pending_ops.pop(sid, None)
+            _drain_hold.pop(sid, None)    # an emptied queue leaves no hold behind (nothing left for it to protect)
+        _save_pending_ops()
     _mark_views_dirty()
     return None
 
@@ -20356,7 +20459,18 @@ def _send_or_park(be, sid, text, echo=None):
     Returns True when PARKED, False when handed over now, so a route can tell its caller which: POST
     /send answers `queued` and `romp send` prints it. An agent sending ITSELF a slash command from inside
     its own turn otherwise read 'ok' and had no way to know the command was waiting for that turn to end
-    (2026-09-03, a /clear that then never fired)."""
+    (2026-09-03, a /clear that then never fired).
+
+    THE LOCK (2026-09-05): the gates above are EXPENSIVE — _compacting_now and _working_now fork tmux or
+    sweep discover and call the backend's busy(), _limit_hold reads the usage file — so they run OUTSIDE
+    _pending_ops_lock, on this handler thread, as they always did (the queue read among them is advisory).
+    What runs under the lock is the cheap queue-presence re-check and the park, as ONE step
+    (_park_behind_queue), so a queue another handler filled between the two reads is never slipped past.
+    The handover (`be.send`) runs outside the lock too: it is not a queue mutation, and a backend call can
+    be slow (a Codex client connect takes seconds), during which no other handler's park and no drain pop
+    may wait. Press order loses nothing: two handovers reach the backend in call order — a lock held across
+    them would only have substituted lock-acquisition order — and a park behind an existing queue is atomic
+    with the check that found the queue."""
     cmd = _is_slash_command(text)
     op = ("command", text, echo) if cmd else ("send", text, echo)
     if _compacting_now(sid) or _pending_ops.get(sid) or _limit_hold(sid):
@@ -20364,6 +20478,8 @@ def _send_or_park(be, sid, text, echo=None):
         return True
     if _working_now(sid) and (cmd or not _forwards_sends(be)):
         _park_op(sid, op)
+        return True
+    if _park_behind_queue(sid, op):
         return True
     be.send(sid, text)
     if echo:
@@ -20377,8 +20493,7 @@ def _compact_or_park(be, sid):
     account hold) → park as a ("compact",) op, which fires ALONE at turn end; quiet → /compact NOW with
     the instant 'compacting' cue. Returns True when parked (queued), False when fired now — the route
     tells its caller which ("compacting now" vs "queued")."""
-    if _ops_gate(sid):
-        _park_op(sid, ("compact",))
+    if _gate_or_park(sid, ("compact",)):
         return True
     be.send(sid, "/compact")
     _mark_compacting(sid)
@@ -20431,9 +20546,7 @@ def _set_model_or_park(be, sid, value, floating=False):
         _forget_model_pick(value)
     _mark_model_pending(sid, value)
     _note_model_pick(value)          # a version pick becomes its family's remembered default (2026-08-25)
-    if _ops_gate(sid):
-        _park_op(sid, ("model", value))
-    else:
+    if not _gate_or_park(sid, ("model", value)):
         be.set_model(sid, value)
 
 
@@ -20441,9 +20554,7 @@ def _set_effort_or_park(be, sid, value):
     """Apply an effort change now — or park it while the session compacts (the user 2026-07-02: /effort
     is a slash command like /model, so it must queue the same way — it used to slip straight through,
     with no queued chip and the same derail risk the /model park was built for)."""
-    if _ops_gate(sid):
-        _park_op(sid, ("effort", value))
-    else:
+    if not _gate_or_park(sid, ("effort", value)):
         be.set_effort(sid, value)
 
 
@@ -20452,9 +20563,7 @@ def _set_env_or_park(be, sid, value):
     the session compacts, in the same FIFO as /model and /effort: a CHANGE applies by reconnecting
     (env is connect-time, like effort), which mid-compaction would derail the compaction exactly the
     way an effort switch would. An unchanged re-assert is a no-op inside set_env either way."""
-    if _ops_gate(sid):
-        _park_op(sid, ("env", value))
-    else:
+    if not _gate_or_park(sid, ("env", value)):
         be.set_env(sid, value)
 
 
@@ -20464,8 +20573,7 @@ def _set_auth_or_park(be, sid, value):
     exactly the way a model switch would). Returns the backend's verdict so the caller can be loud."""
     if value not in ("login", "key"):
         return False
-    if _ops_gate(sid):
-        _park_op(sid, ("auth", value))
+    if _gate_or_park(sid, ("auth", value)):
         return True
     return be.set_auth(sid, value)
 
@@ -20476,8 +20584,7 @@ def _set_fast_or_park(be, sid, value):
     verdict so the caller can be loud when a live apply refuses (dormant SDK session)."""
     if value not in ("on", "off"):
         return False
-    if _ops_gate(sid):
-        _park_op(sid, ("fast", value))
+    if _gate_or_park(sid, ("fast", value)):
         return True
     return be.set_fast(sid, value)
 
@@ -20616,6 +20723,43 @@ def _apply_pending_ops():
     reset stamp passes, so the whole sequence goes in at the reset in the order it was typed); a dead
     session's queue is dropped (fails once, logged), never retried.
 
+    ONE LOCK, HELD FOR THE MUTATIONS ONLY (2026-09-05): every writer of _pending_ops — a handler's park or
+    cancel, the move thread's head re-insert, this walk — takes _pending_ops_lock, and this walk takes it
+    for exactly two things: reading a sid's head, and popping what a step has delivered. Every backend
+    call — send, set_*, turn_seq, busy() inside the gates and the hold check — runs with the lock
+    RELEASED, because a backend call can be slow (CodexBackend.send may synchronously spawn and initialize
+    `codex app-server`, with no request timeout) and every handler's queue check + park would otherwise
+    wait behind it. The lock closes the two races review confirmed: (1) a ✕, or the move thread's head
+    re-insert, changing the list between this walk's head read and its pop — the pop landed on a list the
+    ✕ had emptied (an IndexError the except below turned into a dropped queue), or the ✕'s own check-then-
+    pop landed on a list this walk had shifted (the op BEHIND the clicked one vanished); (2) two writers
+    tearing the mirror through one shared temp (_save_pending_ops). Only this one thread ever walks the
+    queue (the pusher); the handlers and the move thread are the other writers.
+
+    THE HEAD STAYS VISIBLE WHILE THE BACKEND HAS IT (2026-09-05, second review): every gate a handler
+    decides on keys on queue presence (_ops_gate, _send_or_park's first gate, _park_behind_queue) and
+    otherwise on busy() — which flips only once the backend has REGISTERED the op (SdkBackend.send runs
+    _ensure under the backend lock before it enqueues; CodexBackend.send may spawn the app server first).
+    So a command / compact / settings op is NOT popped before its call: it is read under the lock and
+    recorded in _inflight_ops, the call runs with the lock released and the op still at the head, and
+    afterwards the head is popped only if it `is` still that op — a same-kind pick that replaced it in
+    place meanwhile is a new tuple, so the identity fails and the replacement delivers on the next
+    iteration; a ✕ on the in-flight head is refused as too late (_cancel_parked). A cwd op takes the same
+    read-then-identity-pop shape but is NOT recorded: its only mid-call action is the turn_seq read,
+    nothing is handed over, and a ✕ on a move still waiting for its turn end must succeed — recorded, it
+    was refused with a message-shaped 'already reached the session' every cycle the move waited (delta
+    review, 2026-09-05). A pane send landing during the call therefore sees the queue and parks BEHIND
+    the parked /clear, as it did before the drain moved (the parent called first and popped after for
+    these kinds), and the chip retires only once the backend accepted the op. The SEND run alone is
+    popped before delivery — pre-existing on the parent, and kept as is: the batch is handed over as one
+    unit, and a ✕ on it after the pop is the same honest 'too late' it always was. The top-of-walk
+    acquire is NON-BLOCKING: a handler that owns the lock skips the drain for this cycle rather than
+    stalling every session's push, and its own park wakes the pusher after it releases; the per-step
+    acquires inside the walk block, since every holder owns the lock for a dict read, a list mutation and
+    the tiny mirror write. No backend thread takes this lock (the poke, push and push_session callbacks
+    touch no queue), so it never nests inside a backend's. The failure contract is UNCHANGED: a raise
+    anywhere in a sid's pass drops that sid's queue once, logged.
+
     WHO runs this (2026-09-03): the pusher cycle (_pusher_cycle_jobs), woken by the backends' turn-end poke
     (_wake_kernel), by /tick, by every park / cancel / move, and by its own 0.5 s backstop — NOT the tail
     of the judge producer's pass, where it lived before. A judge pass can run for hours (one session's
@@ -20631,11 +20775,18 @@ def _apply_pending_ops():
     emits no event), and a session just handed a turn-opening op whose busy gate has not yet been SEEN
     closed (until its backend reads busy — tmux's UserPromptSubmit flip — or the fallback clock passes) —
     see _hold_drain."""
-    for sid, ops in list(_pending_ops.items()):
-        if not ops:
-            _pending_ops.pop(sid, None)
-            _drain_hold.pop(sid, None)                # no queue, no hold
-            continue
+    if not _pending_ops_lock.acquire(blocking=False):
+        return                                        # a handler owns the queue mid-park: its wake brings the next cycle
+    try:
+        sids = list(_pending_ops)
+    finally:
+        _pending_ops_lock.release()
+    for sid in sids:
+        with _pending_ops_lock:
+            if not _pending_ops.get(sid):
+                _pending_ops.pop(sid, None)
+                _drain_hold.pop(sid, None)            # no queue, no hold
+                continue
         if sid in _moving:
             continue                                  # a move is mid-flight: its relocation must finish first
         hold = _drain_hold.get(sid)
@@ -20648,8 +20799,24 @@ def _apply_pending_ops():
         changed = False                               # a real mutation below → save the mirror + wake the pusher
         try:
             be = Sessions.backend_for(sid)
-            while ops:
-                op = ops[0]
+            while True:
+                with _pending_ops_lock:               # READ the head. A send run is popped here (pre-existing on the
+                    ops = _pending_ops.get(sid) or [] # parent); every other kind stays the visible head, recorded
+                    if not ops:                       # in flight, until the backend has it
+                        break
+                    op = ops[0]
+                    if op[0] == "send":
+                        run = []                      # coalesce the leading run of sends → deliver them AT ONCE
+                        while ops and ops[0][0] == "send":
+                            run.append(ops.pop(0))
+                    elif op[0] != "cwd":
+                        _inflight_ops[sid] = op       # (a move hands nothing over below: not recorded)
+                if op[0] == "send":
+                    changed = True
+                    _deliver_send_batch(be, sid, run)
+                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                    break                             # the delivered turn must END before any op behind it fires
+                # every other kind: the backend call runs with the lock RELEASED and the op still at the head
                 if op[0] == "cwd":
                     # a parked move: fires on its own thread and CLAIMS _moving before this cycle ends, so
                     # the ops behind it wait for the relocation to finish (the next cycle skips the sid
@@ -20659,61 +20826,59 @@ def _apply_pending_ops():
                     if (seq is not None and tries >= _MOVE_BUSY_RETRIES and hasattr(be, "turn_seq")
                             and be.turn_seq(sid) == seq):
                         break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
-                    ops.pop(0)
-                    changed = True
-                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
-                    break
-                changed = True                        # every arm below pops at least one op
-                if op[0] == "send":
-                    run = []                          # coalesce the leading run of sends → deliver them AT ONCE
-                    while ops and ops[0][0] == "send":
-                        run.append(ops.pop(0))
-                    _deliver_send_batch(be, sid, run)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # the delivered turn must END before any op behind it fires
                 elif op[0] == "command":
                     # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
                     # send batch (or forwarded mid-turn) it reaches the model as text instead of executing
                     # (the user 2026-08-13: /autocompact absorbed mid-turn got a polite reply and no
                     # setting change). Echo stamped at fire time, like a delivered send.
                     be.send(sid, op[1])
-                    if len(op) > 2 and op[2]:
-                        _optimistic_echo(sid, op[1], author=op[2])
-                    if op[1].strip().split()[0] == "/compact":
-                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
-                    ops.pop(0)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # its turn must end before anything behind it fires
                 elif op[0] == "compact":
                     be.send(sid, "/compact")
-                    _mark_compacting(sid)
-                    ops.pop(0)
-                    _after_turn_opening(be, sid, ops)
-                    break                             # the compaction must finish first
                 elif op[0] == "model":
                     be.set_model(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "effort":
                     be.set_effort(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "fast":
                     be.set_fast(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "auth":
                     be.set_auth(sid, op[1])
-                    ops.pop(0)
                 elif op[0] == "env":
                     be.set_env(sid, op[1])
-                    ops.pop(0)
-                else:
-                    ops.pop(0)                        # unknown op kind → drop, never wedge the queue
+                # (an unknown op kind gets no call: it is popped below and dropped — never wedge the queue)
+                with _pending_ops_lock:               # POP the head — only if it is still the op the backend got
+                    _inflight_ops.pop(sid, None)      # (a no-op for a cwd op, which was never recorded)
+                    ops = _pending_ops.get(sid) or []
+                    took = bool(ops) and ops[0] is op
+                    if took:
+                        ops.pop(0)
+                        changed = True
+                if op[0] == "cwd":
+                    if not took:
+                        continue                      # a repeat pick replaced the head while turn_seq was read: read it
+                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
+                    break
+                if op[0] in ("command", "compact"):
+                    # the backend HAS a turn-opening op: its cue, the hold and the end of this pass follow
+                    # regardless of `took` (which is always True here — a ✕ on an in-flight op is refused and
+                    # these kinds are never replaced in place)
+                    if op[0] == "command" and len(op) > 2 and op[2]:
+                        _optimistic_echo(sid, op[1], author=op[2])
+                    if op[0] == "compact" or op[1].strip().split()[0] == "/compact":
+                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
+                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                    break                             # its turn / compaction must end before anything behind it fires
+                # a settings op (or an unknown kind): delivery continues. `took` False means a same-kind pick
+                # replaced the head in place while it was with the backend — the replacement delivers next
         except Exception:
             sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
-            _pending_ops.pop(sid, None)               # a dead session's queue is dropped, never retried
-            _drain_hold.pop(sid, None)                # …and its hold with it
+            with _pending_ops_lock:
+                _inflight_ops.pop(sid, None)
+                _pending_ops.pop(sid, None)           # a dead session's queue is dropped, never retried
+                _drain_hold.pop(sid, None)            # …and its hold with it
             changed = True
-        if not _pending_ops.get(sid):
-            _pending_ops.pop(sid, None)
+        with _pending_ops_lock:
+            if not _pending_ops.get(sid):
+                _pending_ops.pop(sid, None)
         if changed:
             _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
             _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
@@ -34959,8 +35124,7 @@ class Handler(BaseHTTPRequestHandler):
                         'no live session named "%s" (a dormant one can be moved by sid)' % target}),
                                       "application/json")
                 be = Sessions.backend_for(tsid)
-                if _ops_gate(tsid):
-                    _park_op(tsid, ("cwd", path, 0))
+                if _gate_or_park(tsid, ("cwd", path, 0)):
                     return self._send(200, json.dumps({"ok": True, "id": tsid, "queued": True, "dir": path}),
                                       "application/json")
                 _moving.add(tsid)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11240,8 +11240,8 @@ class TmuxBackend(sb.SessionBackend):
     # "" before the first hook publish, an unknown spelling — is likewise no answer, never a hold.
     BUSY_STATES = ("working", "permission", "picker")
     QUIET_STATES = ("waiting", "idle")
-    corroborates_with_transcript = True   # busy() below may be overruled by the cached parse → the pusher keeps
-    #                                       it current for this backend's parked sids (_refresh_parked_parses)
+    corroborates_with_transcript = True   # busy() below may be overruled by the cached parse → the drain keeps
+    #                                       it current for a parked sid before reading busy() (_refresh_parked_parse)
 
     def busy(self, sid):
         """AUTHORITATIVE 'is a turn in flight' for a tmux session: the hook-maintained @claude-state,
@@ -11286,9 +11286,9 @@ class TmuxBackend(sb.SessionBackend):
 
         This never parses — it also serves the WS handler, which must stay cheap — so headless (no chat or
         timeline client, or every session after a kernel restart until one connects) nothing would fill
-        the cache and the row would stand verbatim; _refresh_parked_parses, at the head of every pusher
-        cycle, re-parses the moved transcripts of the sids that hold parked ops so the drain's gates read a
-        current transcript.
+        the cache and the row would stand verbatim; the drain (_apply_pending_ops) re-parses a parked sid's
+        moved transcript (_refresh_parked_parse) right before the gate that reads busy() — after the account
+        hold, so a session held by a usage limit is not re-parsed for a verdict nothing reads.
 
         None when there is no answer: no tmux row for the sid (the hook is not installed, or the pane is
         gone), a row another backend owns, a state no hook has published yet, an unknown word, or
@@ -19874,7 +19874,7 @@ _PENDING_OPS_FILE = Path(jd.STATE) / "pending-ops.json"
 # microseconds. Re-entrant, because _park_op and _save_pending_ops take it and are called from under it.
 # The drain takes it NON-BLOCKING at the top of its walk (_apply_pending_ops). No backend thread ever takes
 # it (the poke, push and push_session callbacks the backends hold touch no queue). Reads stay unlocked
-# (build_session's chip list, the nudge guard, the parse refresh, _ops_gate's advisory queue read): a dict
+# (build_session's chip list, the nudge guard, _ops_gate's advisory queue read; the parked-parse refresh reads no queue — the drain hands it each sid from a snapshot taken under the lock): a dict
 # get or list iteration under the GIL never raises, and a chip one cycle early or late is corrected by the
 # next push.
 _pending_ops_lock = threading.RLock()
@@ -19972,9 +19972,19 @@ def _working_now(sid):
     return _session_working(session["turns"])
 
 
+_UNSET = object()
+_UNREADABLE = object()   # _live_scope.usage when the drain's one usage.json read failed: 'no hold', never 'empty usage'
+
+
 def _limit_hold(sid):
     """Is this session's input HELD because the ACCOUNT cannot serve it yet — a 5h/7d rate window sitting
     at its cap, or the monthly spend cap? Returns the hold {reason, resetsAt, what} or None.
+
+    Inside the parked-op drain the readings of usage.json (with its colormap ramps) and of the retry-pause
+    file come from the drain's scope (_live_scope.usage / _live_scope.spend_pause — the same thread-confined
+    idiom as the cycle's liveness snapshot and path memo), read ONCE per drain instead of once per held
+    session: an account limit parks every session's input for hours, and the per-session re-read was most
+    of the drain's 46 ms on a seventeen-session board (measured 2026-09-05). Elsewhere it reads fresh.
 
     The gap this closes (the user 2026-07-24): hitting a usage limit turned every following gesture into
     its own failure. /compact came back refused ("this would take you over your limit"), the message typed
@@ -20009,10 +20019,15 @@ def _limit_hold(sid):
     if _le and _le.get("limit"):
         return {"reason": "limit", "resetsAt": None,
                 "what": "waiting for your usage limit to reset", "detail": _le.get("text") or ""}
-    try:
-        u = _usage() or {}
-    except Exception:
-        return None                                   # unreadable usage → never invent a hold
+    usage = getattr(_live_scope, "usage", _UNSET)
+    if usage is _UNSET:
+        try:
+            usage = _usage()
+        except Exception:
+            usage = _UNREADABLE
+    if usage is _UNREADABLE:
+        return None                                   # unreadable usage → never invent a hold (the drain's
+    u = usage or {}                                   # hoisted reading says so the same way: review find 2026-09-05)
     lim = u.get("limited") or {}
     resets = [(u.get(k) or {}).get("resetsAt") for k in ("fiveHour", "sevenDay") if lim.get(k)]
     if resets:
@@ -20023,7 +20038,8 @@ def _limit_hold(sid):
                 # epoch) → nothing to count down to, so promise no clock rather than a wrong one.
                 "resetsAt": max(known) if len(known) == len(resets) else None,
                 "what": "waiting for your usage limit to reset"}
-    spend = _retry_paused_on() and _retry_pause_reason() == "spend"
+    spend_pause = getattr(_live_scope, "spend_pause", None)
+    spend = (_retry_paused_on() and _retry_pause_reason() == "spend") if spend_pause is None else spend_pause
     if not spend:
         path = _path_of(sid)                          # the pause is account-wide, but the transcript is the
         e = _api_error(path) if path else None        # first place the cap shows — hold from that edge too
@@ -20155,7 +20171,7 @@ _TMUX_PROMPT_HOLD_S = 3.0        # the prompt hold's clock FALLBACK: after the d
                                  # (a paste tmux refused, a builtin that opens no prompt turn), until this many seconds
 _drain_hold: dict = {}           # sid -> (time.monotonic() deadline, until_busy); _apply_pending_ops skips the sid
                                  # while the hold is open (_drain_hold_open)
-_refresh_parse_failures: dict = {}   # sid -> consecutive cycles its parked-parse refresh raised (_refresh_parked_parses)
+_refresh_parse_failures: dict = {}   # sid -> consecutive cycles its parked-parse refresh raised (_refresh_parked_parse)
 _inflight_ops: dict = {}         # sid -> the HEAD op the drain has handed to the backend, lock released, and not yet
                                  # popped (2026-09-05; never a cwd op — a move hands nothing over while its turn_seq
                                  # is read, so a ✕ on a waiting move must still succeed). It stays the visible head
@@ -20664,9 +20680,9 @@ def _deliver_send_batch(be, sid, run):
         _optimistic_echo(sid, merged, author=author)
 
 
-def _refresh_parked_parses(now):
-    """Before the drain: re-parse the transcript of every sid that HOLDS PARKED OPS and whose cached parse
-    has gone stale (second review of the tmux busy change, 2026-09-03). TmuxBackend.busy corroborates the
+def _refresh_parked_parse(sid, now):
+    """For ONE sid the drain is about to gate: re-parse its transcript when it HOLDS PARKED OPS and its cached
+    parse has gone stale (second review of the tmux busy change, 2026-09-03). TmuxBackend.busy corroborates the
     hook row against the CACHED parse and can overrule a stranded row (an Esc fires no hook) only when
     _parse_cached returns a session — and _parse_cached never parses. The cache is filled by client builds
     (build_session, build_timeline), the client-gated warmer, and a few gesture paths; headless — no chat or
@@ -20685,31 +20701,30 @@ def _refresh_parked_parses(now):
     know: a headless `romp send` typed right after a pane Esc parks ONCE (at that instant the hook is all
     busy() has), and the next cycle's refresh lets the drain deliver it — within the 0.5 s backstop instead
     of ~2 minutes."""
-    for sid in list(_pending_ops):
-        try:
-            be = Sessions.backend_for(sid)
-        except Exception:
-            be = None
-        if be is None or not getattr(be, "corroborates_with_transcript", False):
-            continue                                  # its busy() is the whole truth: nothing here reads its cache
-        try:                                          # per sid: one sid whose parse raises must not starve the
-            path = _path_of(sid)                      # OTHER parked sids' refresh, cycle after cycle (review find,
-            if path and _parse_cached(path) is None:  # 2026-09-04) — that sid stays held on its hook row, and the
-                _parse(path, sid, now)                # failure is on the record
-            _refresh_parse_failures.pop(sid, None)    # a parse that came back clears its count
-        except Exception:
-            # the failing sid is retried every cycle (a parse that raises writes nothing to _parse_cache), so the
-            # line is count-gated like _chat_fold_warned: the first with its traceback, then at 10, 100, 1000
-            n = _refresh_parse_failures.get(sid, 0) + 1
-            if len(_refresh_parse_failures) > 256:
-                _refresh_parse_failures.clear()
-            _refresh_parse_failures[sid] = n
-            if n in (1, 10, 100, 1000):
-                sys.stderr.write("parked-parse refresh %s (failure %d): %s\n"
-                                 % (sid, n, traceback.format_exc() if n == 1 else repr(sys.exc_info()[1])))
+    try:
+        be = Sessions.backend_for(sid)
+    except Exception:
+        be = None
+    if be is None or not getattr(be, "corroborates_with_transcript", False):
+        return                                        # its busy() is the whole truth: nothing here reads its cache
+    try:                                              # per sid: one sid whose parse raises must not starve the
+        path = _path_of(sid)                          # OTHER parked sids' refresh, cycle after cycle (review find,
+        if path and _parse_cached(path) is None:      # 2026-09-04) — that sid stays held on its hook row, and the
+            _parse(path, sid, now)                    # failure is on the record
+        _refresh_parse_failures.pop(sid, None)        # a parse that came back clears its count
+    except Exception:
+        # the failing sid is retried every cycle (a parse that raises writes nothing to _parse_cache), so the
+        # line is count-gated like _chat_fold_warned: the first with its traceback, then at 10, 100, 1000
+        n = _refresh_parse_failures.get(sid, 0) + 1
+        if len(_refresh_parse_failures) > 256:
+            _refresh_parse_failures.clear()
+        _refresh_parse_failures[sid] = n
+        if n in (1, 10, 100, 1000):
+            sys.stderr.write("parked-parse refresh %s (failure %d): %s\n"
+                             % (sid, n, traceback.format_exc() if n == 1 else repr(sys.exc_info()[1])))
 
 
-def _apply_pending_ops():
+def _apply_pending_ops(now=None):
     """Pusher cycle: FIFO-deliver parked ops once the session is QUIET (neither compacting nor an open
     turn) — in exactly the order they were parked, which is exactly the order the chat rendered their
     queued bubbles (the user 2026-07-02: what you see is what runs). SEQUENTIAL by construction (the user
@@ -20774,114 +20789,149 @@ def _apply_pending_ops():
     Two sids are skipped even when they read quiet — a move the CLI answered busy (a clock: its window
     emits no event), and a session just handed a turn-opening op whose busy gate has not yet been SEEN
     closed (until its backend reads busy — tmux's UserPromptSubmit flip — or the fallback clock passes) —
-    see _hold_drain."""
+    see _hold_drain.
+
+    COST ORDER (2026-09-05): `now` is the drain's clock — the pusher calls it bare and it stamps its own
+    (a caller may hand one in); the liveness snapshot already reaches every gate through the cycle's
+    scope. usage.json and the retry-pause file are read ONCE per drain, not once per held session (an
+    account limit parks every session's input for hours — that re-read was most of a 46 ms drain on a
+    seventeen-session board); and each sid's gates run cheapest first: the move and hold windows, then the
+    account hold, and only for a sid that passes those the transcript refresh a tmux busy() needs and the
+    compacting/working reads — a held session's transcript is not re-parsed for a verdict nothing reads.
+    The one hold that READS busy() — an until-busy drain hold (_hold_drain) — gets the refresh first, so a
+    tmux row the transcript overrules can still release it (review find 2026-09-05). The gates, and so the
+    refresh — a full transcript parse when the cache is stale, seconds on a large file — run OUTSIDE
+    _pending_ops_lock, as this walk's gates always have: the lock guards the queue's reads and pops only
+    and is never held across anything slow. A cycle the lock yields to a handler reads nothing at all."""
+    now = int(time.time()) if now is None else now
+    if not _pending_ops:
+        return                                        # nothing parked: no lock, no reads
     if not _pending_ops_lock.acquire(blocking=False):
         return                                        # a handler owns the queue mid-park: its wake brings the next cycle
     try:
         sids = list(_pending_ops)
     finally:
         _pending_ops_lock.release()
-    for sid in sids:
-        with _pending_ops_lock:
-            if not _pending_ops.get(sid):
-                _pending_ops.pop(sid, None)
-                _drain_hold.pop(sid, None)            # no queue, no hold
-                continue
-        if sid in _moving:
-            continue                                  # a move is mid-flight: its relocation must finish first
-        hold = _drain_hold.get(sid)
-        if hold is not None:
-            if _drain_hold_open(sid, hold):
-                continue                              # this sid's window is still open (_hold_drain)
-            _drain_hold.pop(sid, None)
-        if _compacting_now(sid) or _working_now(sid) or _limit_hold(sid):
-            continue                                  # …or the account can't serve a request yet
-        changed = False                               # a real mutation below → save the mirror + wake the pusher
+    try:
+        # ONE reading each for the whole drain, on the cycle's thread-confined scope (see _limit_hold): an
+        # unreadable usage.json is stored as _UNREADABLE, which _limit_hold answers with "no hold" exactly as
+        # its own failed read does (None would read as an EMPTY usage and fall through to the spend arm —
+        # a verdict the WS thread's fresh _ops_gate would not share; review find 2026-09-05). Inside the
+        # try, so a raise from either read still clears the scope below.
         try:
-            be = Sessions.backend_for(sid)
-            while True:
-                with _pending_ops_lock:               # READ the head. A send run is popped here (pre-existing on the
-                    ops = _pending_ops.get(sid) or [] # parent); every other kind stays the visible head, recorded
-                    if not ops:                       # in flight, until the backend has it
-                        break
-                    op = ops[0]
-                    if op[0] == "send":
-                        run = []                      # coalesce the leading run of sends → deliver them AT ONCE
-                        while ops and ops[0][0] == "send":
-                            run.append(ops.pop(0))
-                    elif op[0] != "cwd":
-                        _inflight_ops[sid] = op       # (a move hands nothing over below: not recorded)
-                if op[0] == "send":
-                    changed = True
-                    _deliver_send_batch(be, sid, run)
-                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
-                    break                             # the delivered turn must END before any op behind it fires
-                # every other kind: the backend call runs with the lock RELEASED and the op still at the head
-                if op[0] == "cwd":
-                    # a parked move: fires on its own thread and CLAIMS _moving before this cycle ends, so
-                    # the ops behind it wait for the relocation to finish (the next cycle skips the sid
-                    # until then) — a send fed mid-move could make the CLI reject the move as busy
-                    tries = int(op[2]) if len(op) > 2 else 0
-                    seq = op[3] if len(op) > 3 else None
-                    if (seq is not None and tries >= _MOVE_BUSY_RETRIES and hasattr(be, "turn_seq")
-                            and be.turn_seq(sid) == seq):
-                        break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
-                elif op[0] == "command":
-                    # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
-                    # send batch (or forwarded mid-turn) it reaches the model as text instead of executing
-                    # (the user 2026-08-13: /autocompact absorbed mid-turn got a polite reply and no
-                    # setting change). Echo stamped at fire time, like a delivered send.
-                    be.send(sid, op[1])
-                elif op[0] == "compact":
-                    be.send(sid, "/compact")
-                elif op[0] == "model":
-                    be.set_model(sid, op[1])
-                elif op[0] == "effort":
-                    be.set_effort(sid, op[1])
-                elif op[0] == "fast":
-                    be.set_fast(sid, op[1])
-                elif op[0] == "auth":
-                    be.set_auth(sid, op[1])
-                elif op[0] == "env":
-                    be.set_env(sid, op[1])
-                # (an unknown op kind gets no call: it is popped below and dropped — never wedge the queue)
-                with _pending_ops_lock:               # POP the head — only if it is still the op the backend got
-                    _inflight_ops.pop(sid, None)      # (a no-op for a cwd op, which was never recorded)
-                    ops = _pending_ops.get(sid) or []
-                    took = bool(ops) and ops[0] is op
-                    if took:
-                        ops.pop(0)
-                        changed = True
-                if op[0] == "cwd":
-                    if not took:
-                        continue                      # a repeat pick replaced the head while turn_seq was read: read it
-                    _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
-                    break
-                if op[0] in ("command", "compact"):
-                    # the backend HAS a turn-opening op: its cue, the hold and the end of this pass follow
-                    # regardless of `took` (which is always True here — a ✕ on an in-flight op is refused and
-                    # these kinds are never replaced in place)
-                    if op[0] == "command" and len(op) > 2 and op[2]:
-                        _optimistic_echo(sid, op[1], author=op[2])
-                    if op[0] == "compact" or op[1].strip().split()[0] == "/compact":
-                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
-                    _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
-                    break                             # its turn / compaction must end before anything behind it fires
-                # a settings op (or an unknown kind): delivery continues. `took` False means a same-kind pick
-                # replaced the head in place while it was with the backend — the replacement delivers next
+            _live_scope.usage = _usage()
         except Exception:
-            sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
+            _live_scope.usage = _UNREADABLE
+        _live_scope.spend_pause = _retry_paused_on() and _retry_pause_reason() == "spend"
+        for sid in sids:
             with _pending_ops_lock:
-                _inflight_ops.pop(sid, None)
-                _pending_ops.pop(sid, None)           # a dead session's queue is dropped, never retried
-                _drain_hold.pop(sid, None)            # …and its hold with it
-            changed = True
-        with _pending_ops_lock:
-            if not _pending_ops.get(sid):
-                _pending_ops.pop(sid, None)
-        if changed:
-            _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
-            _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
+                if not _pending_ops.get(sid):
+                    _pending_ops.pop(sid, None)
+                    _drain_hold.pop(sid, None)        # no queue, no hold
+                    continue
+            if sid in _moving:
+                continue                              # a move is mid-flight: its relocation must finish first
+            hold = _drain_hold.get(sid)
+            if hold is not None:
+                if hold[1]:                           # an until-busy hold READS busy(), which a tmux backend
+                    _refresh_parked_parse(sid, now)   # corroborates against the cached parse: keep it current
+                if _drain_hold_open(sid, hold):       # for that read (only a held sid pays; the refresh below
+                    continue                          # finds the cache fresh). Window still open → next cycle.
+                _drain_hold.pop(sid, None)
+            if _limit_hold(sid):
+                continue                              # the account can't serve a request yet: no parse, no gates
+            _refresh_parked_parse(sid, now)           # a stranded hook row can be overruled by what the transcript says
+            if _compacting_now(sid) or _working_now(sid):
+                continue
+            changed = False                               # a real mutation below → save the mirror + wake the pusher
+            try:
+                be = Sessions.backend_for(sid)
+                while True:
+                    with _pending_ops_lock:               # READ the head. A send run is popped here (pre-existing on the
+                        ops = _pending_ops.get(sid) or [] # parent); every other kind stays the visible head, recorded
+                        if not ops:                       # in flight, until the backend has it
+                            break
+                        op = ops[0]
+                        if op[0] == "send":
+                            run = []                      # coalesce the leading run of sends → deliver them AT ONCE
+                            while ops and ops[0][0] == "send":
+                                run.append(ops.pop(0))
+                        elif op[0] != "cwd":
+                            _inflight_ops[sid] = op       # (a move hands nothing over below: not recorded)
+                    if op[0] == "send":
+                        changed = True
+                        _deliver_send_batch(be, sid, run)
+                        _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                        break                             # the delivered turn must END before any op behind it fires
+                    # every other kind: the backend call runs with the lock RELEASED and the op still at the head
+                    if op[0] == "cwd":
+                        # a parked move: fires on its own thread and CLAIMS _moving before this cycle ends, so
+                        # the ops behind it wait for the relocation to finish (the next cycle skips the sid
+                        # until then) — a send fed mid-move could make the CLI reject the move as busy
+                        tries = int(op[2]) if len(op) > 2 else 0
+                        seq = op[3] if len(op) > 3 else None
+                        if (seq is not None and tries >= _MOVE_BUSY_RETRIES and hasattr(be, "turn_seq")
+                                and be.turn_seq(sid) == seq):
+                            break      # the CLI still owns a turn romp cannot see: its ResultMessage is the cue (_move_now)
+                    elif op[0] == "command":
+                        # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
+                        # send batch (or forwarded mid-turn) it reaches the model as text instead of executing
+                        # (the user 2026-08-13: /autocompact absorbed mid-turn got a polite reply and no
+                        # setting change). Echo stamped at fire time, like a delivered send.
+                        be.send(sid, op[1])
+                    elif op[0] == "compact":
+                        be.send(sid, "/compact")
+                    elif op[0] == "model":
+                        be.set_model(sid, op[1])
+                    elif op[0] == "effort":
+                        be.set_effort(sid, op[1])
+                    elif op[0] == "fast":
+                        be.set_fast(sid, op[1])
+                    elif op[0] == "auth":
+                        be.set_auth(sid, op[1])
+                    elif op[0] == "env":
+                        be.set_env(sid, op[1])
+                    # (an unknown op kind gets no call: it is popped below and dropped — never wedge the queue)
+                    with _pending_ops_lock:               # POP the head — only if it is still the op the backend got
+                        _inflight_ops.pop(sid, None)      # (a no-op for a cwd op, which was never recorded)
+                        ops = _pending_ops.get(sid) or []
+                        took = bool(ops) and ops[0] is op
+                        if took:
+                            ops.pop(0)
+                            changed = True
+                    if op[0] == "cwd":
+                        if not took:
+                            continue                      # a repeat pick replaced the head while turn_seq was read: read it
+                        _fire_move(be, sid, op[1], tries, _move_askers.pop(sid, ""))
+                        break
+                    if op[0] in ("command", "compact"):
+                        # the backend HAS a turn-opening op: its cue, the hold and the end of this pass follow
+                        # regardless of `took` (which is always True here — a ✕ on an in-flight op is refused and
+                        # these kinds are never replaced in place)
+                        if op[0] == "command" and len(op) > 2 and op[2]:
+                            _optimistic_echo(sid, op[1], author=op[2])
+                        if op[0] == "compact" or op[1].strip().split()[0] == "/compact":
+                            _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
+                        _after_turn_opening(be, sid, _pending_ops.get(sid) or [])
+                        break                             # its turn / compaction must end before anything behind it fires
+                    # a settings op (or an unknown kind): delivery continues. `took` False means a same-kind pick
+                    # replaced the head in place while it was with the backend — the replacement delivers next
+            except Exception:
+                sys.stderr.write("pending ops apply: %s\n" % traceback.format_exc())
+                with _pending_ops_lock:
+                    _inflight_ops.pop(sid, None)
+                    _pending_ops.pop(sid, None)           # a dead session's queue is dropped, never retried
+                    _drain_hold.pop(sid, None)            # …and its hold with it
+                changed = True
+            with _pending_ops_lock:
+                if not _pending_ops.get(sid):
+                    _pending_ops.pop(sid, None)
+            if changed:
+                _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
+                _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
+    finally:
+        _live_scope.usage = _UNSET
+        _live_scope.spend_pause = None
 
 
 # ── the chat's pinned "system context" card (the user 2026-06-19) ──────────────────────────────────
@@ -20893,6 +20943,7 @@ def _apply_pending_ops():
 # rides each assistant message — it writes no system:init atom, so the event model never carries them.
 _GLOBAL_CLAUDE_MD = Path(os.path.expanduser("~/.claude/CLAUDE.md"))   # overridable in tests
 _session_meta_cache = {}   # path -> ((mtime,size), {...})
+
 
 
 def _tilde(p):
@@ -30205,12 +30256,10 @@ def _pusher_cycle():
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
-    try:                                  # the drain's gates read the CACHED parse: re-parse the parked sids'
-        _refresh_parked_parses(now)       # moved transcripts first, so a stranded hook row can be overruled by
-    except Exception:                     # what the transcript says (headless, nobody else fills the cache)
-        sys.stderr.write("parked-parse refresh: %s\n" % traceback.format_exc())
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
         _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
+        #                                   the parked-parse refresh runs inside, per sid, after the
+        #                                   holds (2026-09-05)
     except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
         sys.stderr.write("pending-ops: %s\n" % traceback.format_exc())   # never behind a judge pass (2026-09-03)
     if any_client:

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -30,8 +30,8 @@ from abc import ABC, abstractmethod
 
 
 class SessionBackend(ABC):
-    # True when busy() may be overruled by the cached transcript parse, so the pusher must keep that parse
-    # current for the sids it holds parked ops for (_refresh_parked_parses); a backend whose busy() is the
+    # True when busy() may be overruled by the cached transcript parse, so the parked-op drain must keep that
+    # parse current for a sid before it reads busy() (_refresh_parked_parse); a backend whose busy() is the
     # whole truth (SDK, Codex) leaves it False and its parked sids are never re-parsed on its account.
     corroborates_with_transcript = False
 

--- a/tests/test_drain_hoists.py
+++ b/tests/test_drain_hoists.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""The parked-op drain does its per-cycle work in cost order (2026-09-05).
+
+Since #904 the drain runs inside the pusher loop, every 0.5 s. An account limit parks every session's
+input for hours, and the drain then re-read usage.json (with its colormap ramps) and the retry-pause file
+once PER HELD SESSION per cycle, and re-parsed a held tmux session's moved transcript for a busy() verdict
+nothing read — 46 ms of a 0.5 s cycle on a seventeen-session board, measured on a replay. Now usage and
+the pause are read once per drain and ride the cycle's scope for _limit_hold; each sid's gates run cheapest
+first; and the parked-parse refresh runs only for a sid the holds let through — plus, first, for a sid whose
+until-busy hold is about to read busy(). Synthetic sids; a fake backend; the limit-queue test's fixture
+shape."""
+import inspect
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_drainhoists", os.path.join(BIN, "romp-kernel")).load_module()
+
+SIDS = ["11111111-2222-3333-4444-aaaaaaaaaa%02d" % i for i in range(1, 6)]
+
+
+class _FakeBackend:
+    corroborates_with_transcript = False
+    def __init__(self): self.sent = []
+    def send(self, sid, text, **kw): self.sent.append((sid, text)); return True
+    def owns(self, sid): return True
+    def busy(self, sid): return False
+    def turn_seq(self, sid): return 0
+
+
+class DrainHoists(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        self.be = _FakeBackend()
+        self._saved = {n: getattr(km, n) for n in
+                       ("_compacting_now", "_working_now", "_push_all", "_optimistic_echo", "_mark_views_dirty",
+                        "_mark_compacting", "_mark_model_pending", "_path_of", "_usage", "_retry_paused_on",
+                        "_retry_pause_reason", "_refresh_parked_parse", "_deliver_send_batch")}
+        self._saved_backend = km.Sessions.backend_for
+        km._compacting_now = lambda sid: False
+        km._working_now = lambda sid: False
+        km._push_all = lambda *a, **k: None
+        km._optimistic_echo = lambda sid, text, author="human": None
+        km._mark_views_dirty = lambda *a, **k: None
+        km._mark_compacting = lambda sid: None
+        km._mark_model_pending = lambda sid, v: None
+        km._path_of = lambda sid, now=None: None
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        self.usage_calls = []
+        self.capped = False
+        def usage():
+            self.usage_calls.append(1)
+            return {"limited": {"fiveHour": True}, "fiveHour": {"resetsAt": 4102444800}} if self.capped else {"limited": None}
+        km._usage = usage
+        self.pause_calls = []
+        km._retry_paused_on = lambda: (self.pause_calls.append(1), False)[1]
+        km._retry_pause_reason = lambda: ""
+        self.refreshed = []
+        km._refresh_parked_parse = lambda sid, now: self.refreshed.append(sid)
+        self.delivered = []                                       # what the (stubbed) send batch was handed
+        km._deliver_send_batch = lambda be, sid, ops: (self.delivered.append((sid, [o[1] for o in ops])), ops.clear(), True)[2]
+        km._pending_ops.clear(); km._drain_hold.clear(); km._moving.clear()
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(km, n, v)
+        km.Sessions.backend_for = self._saved_backend
+        km._pending_ops.clear(); km._drain_hold.clear(); km._moving.clear()
+        jd.STATE = self.saved_state
+
+    def test_a_usage_and_the_pause_are_read_once_per_drain_however_many_sessions_are_held(self):
+        self.capped = True
+        for s in SIDS:
+            km._pending_ops[s] = [("send", "queued while limited")]
+        km._apply_pending_ops(1000)
+        self.assertEqual(len(self.usage_calls), 1, "one usage.json reading for the whole drain")
+        self.assertEqual(len(self.pause_calls), 1, "one retry-pause reading for the whole drain")
+        self.assertEqual(sorted(km._pending_ops), sorted(SIDS), "every session stays held")
+        self.assertEqual(self.refreshed, [], "a held session's transcript is not re-parsed for a verdict nothing reads")
+        self.assertEqual(self.delivered, [])
+        self.assertIs(getattr(km._live_scope, "usage", km._UNSET), km._UNSET, "the drain clears its scope on the way out")
+        self.assertIsNone(getattr(km._live_scope, "spend_pause", None))
+
+    def test_b_a_hoisted_reading_gives_the_same_verdict_as_a_fresh_one(self):
+        for capped in (False, True):
+            self.capped = capped
+            fresh = km._limit_hold(SIDS[0])
+            km._live_scope.usage = km._usage(); km._live_scope.spend_pause = False
+            try:
+                hoisted = km._limit_hold(SIDS[0])
+            finally:
+                km._live_scope.usage = km._UNSET; km._live_scope.spend_pause = None
+            self.assertEqual(fresh, hoisted, "capped=%s" % capped)
+        km._live_scope.usage = {"limited": None}; km._live_scope.spend_pause = True
+        try:
+            self.assertEqual(km._limit_hold(SIDS[0])["reason"], "spend")
+        finally:
+            km._live_scope.usage = km._UNSET; km._live_scope.spend_pause = None
+        # an unreadable usage.json with the spend pause ON: the fresh read answers "no hold" (never invent one);
+        # the hoisted reading must say the same, not read as an EMPTY usage that falls through to the spend arm
+        # (review find 2026-09-05 — the WS thread's fresh _ops_gate and the drain would otherwise disagree)
+        def boom(): raise ValueError("usage.json is not an object")
+        km._usage = boom
+        km._retry_paused_on = lambda: True; km._retry_pause_reason = lambda: "spend"
+        self.assertIsNone(km._limit_hold(SIDS[0]), "fresh: unreadable usage is no hold, whatever the pause says")
+        km._live_scope.usage = km._UNREADABLE; km._live_scope.spend_pause = True
+        try:
+            self.assertIsNone(km._limit_hold(SIDS[0]), "hoisted: the same verdict")
+        finally:
+            km._live_scope.usage = km._UNSET; km._live_scope.spend_pause = None
+        km._pending_ops[SIDS[0]] = [("send", "go")]
+        km._apply_pending_ops(1000)
+        self.assertEqual(self.delivered, [(SIDS[0], ["go"])], "the drain fires it, as the per-sid read always did")
+
+    def test_c_the_parse_refresh_runs_only_for_a_session_the_holds_let_through(self):
+        self.capped = False
+        km._pending_ops[SIDS[0]] = [("send", "go")]
+        km._pending_ops[SIDS[1]] = [("send", "later")]
+        km._moving.add(SIDS[1])                                   # a move in flight: skipped before any read
+        km._apply_pending_ops(1000)
+        self.assertEqual(self.refreshed, [SIDS[0]], "the refresh ran for the deliverable sid only")
+        self.assertEqual(self.delivered, [(SIDS[0], ["go"])], "…and its send was delivered")
+        self.assertNotIn(SIDS[0], km._pending_ops)
+
+    def test_d_the_drain_still_answers_a_bare_call(self):
+        km._pending_ops[SIDS[0]] = [("send", "go")]
+        km._apply_pending_ops()                                   # tests and older callers pass nothing
+        self.assertNotIn(SIDS[0], km._pending_ops)
+
+    def test_e_the_pusher_runs_no_whole_set_refresh_ahead_of_the_drain(self):
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertIn("_apply_pending_ops()", src)
+        self.assertNotIn("_refresh_parked_parses", src)
+        self.assertFalse(hasattr(km, "_refresh_parked_parses"), "the whole-set pre-pass is gone, not parked")
+        drain = inspect.getsource(km._apply_pending_ops)
+        self.assertIn("_live_scope.usage = _usage()", drain)
+        self.assertIn("_live_scope.usage = _UNSET", drain, "the scope is cleared even when the loop raises")
+        held = drain.index("_limit_hold(sid)")
+        refresh = drain.index("_refresh_parked_parse(sid, now)", held)
+        self.assertLess(held, refresh, "the account hold is checked before the parse")
+        self.assertLess(refresh, drain.index("_compacting_now(sid) or _working_now(sid)"),
+                        "…and the parse before the gates that read it")
+        self.assertLess(drain.index("_refresh_parked_parse(sid, now)"), drain.index("_drain_hold_open(sid, hold)"),
+                        "an until-busy hold's busy() read sees a current parse")
+
+    def test_f_the_scope_is_cleared_when_the_loop_raises(self):
+        km._pending_ops[SIDS[0]] = [("send", "go")]
+        def boom(sid, now): raise RuntimeError("parse refresh blew up")
+        km._refresh_parked_parse = boom
+        with self.assertRaises(RuntimeError):
+            km._apply_pending_ops(1000)
+        self.assertIs(getattr(km._live_scope, "usage", km._UNSET), km._UNSET)
+        self.assertIsNone(getattr(km._live_scope, "spend_pause", None))
+        self.assertIsNone(km._limit_hold(SIDS[0]), "…so the next fresh caller reads usage.json, not a stale scope")
+
+    def test_g_an_until_busy_hold_reads_busy_against_a_current_parse(self):
+        # the hold keyed on the tmux row's flip reads busy(), which a tmux backend corroborates against the
+        # cached parse; before 2026-09-05 the whole-set pre-pass kept that cache current, so the drain must
+        # refresh such a sid BEFORE the hold's read — once, not again below (review find 2026-09-05)
+        km._pending_ops[SIDS[0]] = [("send", "behind the hold")]
+        km._drain_hold[SIDS[0]] = (time.monotonic() + 1000, True)   # until_busy, fallback far away
+        km._pending_ops[SIDS[1]] = [("send", "behind a clock")]
+        km._drain_hold[SIDS[1]] = (time.monotonic() + 1000, False)  # a clock hold reads nothing
+        km._apply_pending_ops(1000)
+        self.assertEqual(self.refreshed, [SIDS[0]], "refreshed once, for the busy-reading hold only")
+        self.assertEqual(sorted(km._pending_ops), sorted(SIDS[:2]), "both still held (busy() read False, deadlines far)")
+        self.assertEqual(self.delivered, [])
+        # the same sid with a hold whose window has closed on the clock: refreshed once for the read, once more
+        # below would be a second parse of an unmoved file — the refresh is idempotent by its cache check, and
+        # here the stub just counts: the drain calls it for the hold's read and again ahead of the gates
+        km._drain_hold[SIDS[0]] = (time.monotonic() - 1, True)
+        self.be.busy = lambda sid: False
+        self.refreshed.clear()
+        km._apply_pending_ops(1000)
+        self.assertNotIn(SIDS[0], km._pending_ops, "the fallback deadline passed: delivered")
+        self.assertEqual(self.refreshed, [SIDS[0], SIDS[0]])
+
+    def test_h_the_refresh_and_the_gates_run_outside_the_queue_lock_and_a_yielded_cycle_reads_nothing(self):
+        # the lock guards the queue's reads and pops only; a transcript parse (seconds on a large file) must
+        # never run under it — a first rebase of this change put the refresh inside a locked walk and every
+        # handler's park and cancel stalled behind it (rebase review find 2026-09-05)
+        owned = []
+        km._refresh_parked_parse = lambda sid, now: owned.append((sid, km._pending_ops_lock._is_owned()))
+        km._pending_ops[SIDS[0]] = [("send", "go")]                       # a deliverable sid
+        km._pending_ops[SIDS[1]] = [("send", "behind the hold")]
+        km._drain_hold[SIDS[1]] = (time.monotonic() + 1000, True)          # an until-busy hold: its busy() read
+        km._apply_pending_ops(1000)
+        self.assertEqual(sorted(owned), sorted([(SIDS[0], False), (SIDS[1], False)]),
+                         "both refreshes ran, neither with the lock held")
+        self.assertFalse(km._pending_ops_lock._is_owned(), "…and the lock is not held on the way out")
+        # a handler (another thread — the lock is re-entrant) holding the lock: the drain yields the cycle
+        # before it reads anything — no usage read, no parse, no scope left behind
+        owned.clear(); self.usage_calls.clear()
+        km._pending_ops.pop(SIDS[1], None); km._drain_hold.pop(SIDS[1], None)
+        km._pending_ops[SIDS[0]] = [("send", "again")]
+        held, release = threading.Event(), threading.Event()
+        def handler():
+            with km._pending_ops_lock:
+                held.set()
+                release.wait(5)
+        th = threading.Thread(target=handler, daemon=True); th.start()
+        self.assertTrue(held.wait(5))
+        try:
+            km._apply_pending_ops(1000)
+            self.assertIn(SIDS[0], km._pending_ops, "the walk yielded to the handler")
+        finally:
+            release.set(); th.join(5)
+        self.assertEqual(owned, [], "a yielded cycle parses nothing")
+        self.assertEqual(self.usage_calls, [], "…and reads no usage")
+        self.assertIs(getattr(km._live_scope, "usage", km._UNSET), km._UNSET)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_parked_ops_lock.py
+++ b/tests/test_kernel_parked_ops_lock.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""The parked-op queue is mutated under ONE lock that no backend call ever holds (2026-09-05).
+
+Since the drain moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake, on the pusher
+thread, while WS/HTTP handler threads park and cancel ops in the same dict and the move thread re-inserts
+a head — with no lock between them. Two races followed, each confirmed by review: (1) a ✕ (or the move
+thread's re-insert) changed a sid's list between the drain's head read and its pop — the drain popped a
+list the ✕ had emptied (an IndexError the blanket except turned into a dropped queue), or the ✕'s own
+check-then-pop landed on a list the drain had shifted and removed the op BEHIND the one clicked; (2) the
+disk mirror was written through ONE fixed temp path from any thread, so two writers could tear it (a
+kernel death then restores a wrong queue).
+
+Now every mutation of _pending_ops runs under _pending_ops_lock, and the lock guards the mutations ONLY:
+the drain reads a head under it, releases before every backend call (CodexBackend.send can synchronously
+spawn `codex app-server`; the SDK's busy()/turn_seq take the backend's own lock), and pops afterwards. A
+send run alone is popped before its delivery, as the parent already did; every other kind is popped only
+if the head is still the op the backend got, and stays the visible head meanwhile (_inflight_ops — a move
+waiting on its turn_seq is not recorded, since nothing is handed over while that is read), so a handler's
+gate still sees the queue and parks BEHIND it, and a ✕ on the in-flight head is refused as too late. A
+handler runs its expensive gates outside the lock and holds it only for the queue-presence check + park,
+one step; the mirror is published through the kernel's per-writer atomic write. The failure contract is
+unchanged: a raise during a sid's pass drops that sid's queue once, logged.
+
+SYNTHETIC fixtures only: placeholder uuids, invented texts.
+"""
+import io
+import os
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_parkedlock", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The ACCOUNT gate is a separate axis (tests/test_kernel_limit_queue.py); pinned off so the real
+# machine's usage.json can never make these tests park for a reason none of them is about.
+km._limit_hold = lambda sid: None
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+# Every pusher-cycle job except the drain, quieted so a cycle run here does exactly one thing.
+_OTHER_JOBS = ("_push_all", "_lift_spent_awaiting", "_death_sweep_tick", "_end_on_idle_sweep",
+               "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick", "_auto_pause_on_limit",
+               "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+               "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+               "_clear_done_working_notes")
+
+
+def _lock_free_for_another_thread():
+    """Can a thread other than the caller take the queue lock right now? (RLock ownership is per thread.)"""
+    got = []
+
+    def probe():
+        ok = km._pending_ops_lock.acquire(blocking=False)
+        if ok:
+            km._pending_ops_lock.release()
+        got.append(ok)
+    th = threading.Thread(target=probe, daemon=True)
+    th.start()
+    th.join(5)
+    return bool(got and got[0])
+
+
+class _FakeBackend:
+    """A tmux-shaped backend: it cannot forward its own sends, so a send parks while the turn is open."""
+
+    def __init__(self):
+        self.calls = []
+        self.open = True
+
+    def busy(self, sid):
+        return self.open
+
+    def forwards_sends(self):
+        return False
+
+    def send(self, sid, text):
+        self.calls.append(("send", text))
+        self.open = True                  # as SdkBackend.send: the turn is pending under the lock before send() returns
+        return True
+
+    def set_model(self, sid, value):
+        self.calls.append(("model", value))
+        return True
+
+    def set_effort(self, sid, value):
+        self.calls.append(("effort", value))
+        return True
+
+    def set_fast(self, sid, value):
+        self.calls.append(("fast", value))
+        return True
+
+    def set_auth(self, sid, value):
+        self.calls.append(("auth", value))
+        return True
+
+    def set_env(self, sid, value):
+        self.calls.append(("env", value))
+        return True
+
+    def turn_seq(self, sid):
+        return 0
+
+
+def _tmux_row(state):
+    return {"state": state, "since": int(time.time()) - 5, "model": "", "effort": "", "context": None,
+            "compactPct": None, "color": None, "mode": "", "backend": "tmux"}
+
+
+class _Drain(unittest.TestCase):
+    def setUp(self):
+        self.be = _FakeBackend()
+        self._patches = [
+            mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: self.be)),
+            mock.patch.object(km, "_compacting_now", lambda sid, **k: False),
+            mock.patch.object(km, "_optimistic_echo", lambda *a, **k: None),
+            mock.patch.object(km, "_mark_compacting", lambda sid: None),
+            mock.patch.object(km, "_names_snapshot", lambda: {}),
+            mock.patch.object(km, "_tmux_sessions", lambda: {SID: _tmux_row("waiting")}),
+        ] + [mock.patch.object(km, name, lambda *a, **k: None) for name in _OTHER_JOBS]
+        for p in self._patches:
+            p.start()
+        self._reset()
+        km._pusher_wake.clear()
+        km._producer_wake.clear()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._reset()
+
+    def _reset(self):
+        km._pending_ops.clear()
+        km._moving.clear()
+        km._move_askers.clear()
+        km._drain_hold.clear()
+        km._refresh_parse_failures.clear()
+        km._inflight_ops.clear()
+        try:
+            os.unlink(km._PENDING_OPS_FILE)
+        except OSError:
+            pass
+
+
+class OneLockAroundEveryMutation(_Drain):
+    """WS/HTTP handlers park and cancel, the move thread re-inserts a head, and the pusher (the ONE thread
+    that ever walks the queue) drains — all on the same dict. One RLock serializes the mutations; no backend
+    call runs under it; the head an op is being delivered from stays visible until the backend has it."""
+
+    def test_a_cancel_mid_call_cannot_shift_the_list_under_the_drains_pop(self):
+        # race (1): the drain read its head and called the backend; a ✕ arrived before the pop. Unlocked,
+        # the ✕ on the head "succeeded" (it popped the op the backend was already delivering), and the
+        # drain's pop then took the op behind — or, with nothing behind, an IndexError that dropped the
+        # queue. Now the in-flight head is refused as too late, a ✕ on the op behind succeeds, and the
+        # drain pops exactly what it delivered.
+        self.be.open = False
+        entered, release = threading.Event(), threading.Event()
+
+        def set_model(sid, value):
+            self.be.calls.append(("model", value))
+            entered.set()
+            release.wait(5)
+            return True
+        self.be.set_model = set_model
+        head, behind = ("model", "opus"), ("effort", "high")
+        km._pending_ops[SID] = [head, behind]
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+            walker.start()
+            self.assertTrue(entered.wait(5))               # the backend has the head; the lock is free
+            err_head = km._cancel_parked(SID, 0, km._parked_md(head))
+            err_behind = km._cancel_parked(SID, 1, km._parked_md(behind))
+            release.set()
+            walker.join(5)
+        self.assertEqual(err_head, km._cancel_miss_text(km._parked_md(head)), "the in-flight head is too late")
+        self.assertIsNone(err_behind, "the op behind it is cancellable")
+        self.assertEqual(self.be.calls, [("model", "opus")], "the head was delivered exactly once, the effort pick never")
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertNotIn("pending ops apply", buf.getvalue(), "nothing raised, so nothing was dropped")
+
+    def test_a_parked_op_stays_the_visible_head_while_the_backend_has_it(self):
+        # the ordering regression the second review caught: popping the head BEFORE the backend call left
+        # the queue empty for the whole call, and every handler's park decision keys on queue presence —
+        # busy() flips only once the backend has registered the op (SdkBackend.send runs _ensure first,
+        # CodexBackend.send may spawn the app server first). A pane send landing in that window saw no
+        # queue and busy False and handed over AHEAD of the parked /clear. The head now stays until the
+        # backend has it, so the send parks behind.
+        self.be.open = False
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            if text == "/clear":                           # a pane send lands while the backend still has the /clear…
+                self.assertTrue(km._send_or_park(self.be, SID, "hello", echo="human"), "…and PARKS")
+            self.be.open = True                            # only now does busy() flip
+            return True
+        self.be.send = send
+        km._pending_ops[SID] = [("command", "/clear", None)]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "/clear")], "nothing overtook the in-flight command")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "hello", "human")], "the send waits behind it")
+        self.be.open = False                               # the /clear's turn ends
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "/clear"), ("send", "hello")], "…and delivers next, in order")
+
+    def test_a_head_replaced_in_place_while_with_the_backend_is_not_popped(self):
+        # the identity check: a same-kind pick replaces the in-flight head in place (a new tuple); the drain
+        # must not pop the replacement as if it had delivered it, and delivers it on the next iteration
+        self.be.open = False
+
+        def set_model(sid, value):
+            self.be.calls.append(("model", value))
+            if value == "opus":
+                km._park_op(SID, ("model", "other"))       # lock free: the user re-picks mid-call
+            return True
+        self.be.set_model = set_model
+        km._pending_ops[SID] = [("model", "opus"), ("effort", "high")]
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("model", "opus"), ("model", "other"), ("effort", "high")],
+                         "the replacement delivered, not silently popped; the op behind after it")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_second_compact_press_is_cancellable_while_the_first_is_in_flight(self):
+        # _compact_or_park parks the literal ("compact",); CPython interns one constant tuple per code object,
+        # so every compact parked in a kernel life is the SAME object, and compact is not in the replace set:
+        # a second press appends [C, C] with ops[0] is ops[1]. The in-flight refusal must therefore key on
+        # the HEAD slot, not on identity alone — a ✕ on the second chip while the first is with the backend
+        # is a cancel, and the redundant compaction never runs
+        self.be.open = True                                # a turn is open: the press parks
+        self.assertTrue(km._compact_or_park(self.be, SID))
+        results = []
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            self.assertTrue(km._compact_or_park(self.be, SID), "a second press parks behind the in-flight one")
+            ops = km._pending_ops[SID]
+            self.assertEqual([op[0] for op in ops], ["compact", "compact"])
+            self.assertIs(ops[0], ops[1], "the same interned tuple, twice")
+            results.append(km._cancel_parked(SID, 1, "/compact"))       # ✕ on the SECOND chip
+            self.be.open = True
+            return True
+        self.be.send = send
+        self.be.open = False
+        with redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertEqual(results, [None], "the second chip is cancelled, not refused as too late")
+        self.assertEqual(self.be.calls, [("send", "/compact")], "one compaction")
+        self.assertNotIn(SID, km._pending_ops, "…and no redundant one stays queued")
+
+    def test_a_stale_index_re_locates_past_the_in_flight_head_to_the_identical_chip_behind_it(self):
+        # the ✕ carries the chip's index from the last push; a send ahead delivered since makes it stale, and
+        # the body re-locate then walks the list for the first op with that body. With [C(in-flight), C] that
+        # is slot 0 — the head no ✕ can take — so the re-locate skips it and lands on the second chip; with
+        # only the in-flight op listed it finds nothing, the same miss as today
+        self.be.open = True                                # a turn is open: the press parks
+        self.assertTrue(km._compact_or_park(self.be, SID))
+        results, seen = [], []
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            results.append(km._cancel_parked(SID, 3, "/compact"))       # stale index, one chip: the in-flight head
+            self.assertTrue(km._compact_or_park(self.be, SID), "a second press parks behind the in-flight one")
+            results.append(km._cancel_parked(SID, 2, "/compact"))       # stale index, two chips: the second
+            seen.append(list(km._pending_ops.get(SID) or []))
+            self.be.open = True
+            return True
+        self.be.send = send
+        self.be.open = False
+        with redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertEqual(results, [km._cancel_miss_text("/compact"), None],
+                         "alone in flight → too late; behind an in-flight twin → cancelled")
+        self.assertEqual(seen, [[("compact",)]], "the in-flight head alone remains after the ✕, until the backend has it")
+        self.assertEqual(self.be.calls, [("send", "/compact")], "one compaction")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_move_waiting_on_its_turn_end_is_cancellable_during_the_turn_seq_read(self):
+        # a waiting cwd head's only action in a cycle is the turn_seq read — nothing is handed over — so it is
+        # not recorded in flight, and a ✕ landing inside that read is a cancel, not a false "already reached
+        # the session" that would recur every cycle while the move waited
+        self.be.open = False
+        d = tempfile.mkdtemp()
+        op = ("cwd", d, km._MOVE_BUSY_RETRIES, 0)
+        results, fired = [], []
+
+        def turn_seq(sid):
+            results.append(km._cancel_parked(SID, 0, km._parked_md(op)))
+            return 0                                       # unchanged: the move would keep waiting
+        self.be.turn_seq = turn_seq
+        km._pending_ops[SID] = [op]
+        buf = io.StringIO()
+        with mock.patch.object(km, "_fire_move", lambda be, sid, path, tries, wid: fired.append(path)), \
+             redirect_stderr(buf):
+            km._apply_pending_ops()
+        self.assertEqual(results, [None], "cancelled")
+        self.assertNotIn(SID, km._pending_ops)
+        self.assertEqual(fired, [], "no move fires")
+        self.assertNotIn("pending ops apply", buf.getvalue(), "nothing raised, so the empty queue is the ✕'s doing")
+
+    def test_a_move_replaced_in_place_while_its_turn_seq_is_read_fires_the_replacement_once(self):
+        # the cwd twin of the replaced-head test: the user re-picks the folder while the drain reads turn_seq
+        # (lock free); the superseded folder must never fire, the replacement fires exactly once
+        self.be.open = False
+        d1, d2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        fired = []
+
+        def turn_seq(sid):
+            km._park_op(SID, ("cwd", d2, 0))               # replace-in-place: a new tuple at the head
+            return 1                                       # the turn ended: the move may proceed
+        self.be.turn_seq = turn_seq
+        km._pending_ops[SID] = [("cwd", d1, km._MOVE_BUSY_RETRIES, 0)]
+        with mock.patch.object(km, "_fire_move", lambda be, sid, path, tries, wid: fired.append(path)):
+            km._apply_pending_ops()
+        self.assertEqual(fired, [d2], "the replacement fires, exactly once; the superseded folder never")
+        self.assertNotIn(SID, km._pending_ops, "nothing dropped, nothing left")
+
+    def test_the_locked_re_check_parks_behind_a_queue_the_expensive_gates_missed(self):
+        # _park_behind_queue's locked re-check is the gate that decides: with every expensive gate saying
+        # quiet, an op that finds a queue there parks BEHIND it and never reaches the backend
+        self.be.open = False
+        km._pending_ops[SID] = [("compact",)]
+        with mock.patch.object(km, "_ops_gate", lambda sid: False):
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertTrue(km._send_or_park(self.be, SID, "hello"))   # (its own first gate reads the queue too)
+        self.assertEqual(self.be.calls, [], "nothing handed over past an existing queue")
+        self.assertEqual(km._pending_ops[SID], [("compact",), ("model", "opus"), ("send", "hello", None)])
+
+    def test_a_cancel_racing_the_drains_pop_never_removes_the_wrong_op(self):
+        # _cancel_parked verifies the clicked index by body, THEN pops. Unlocked, the drain could pop its
+        # head between the two, and the ✕ removed whatever had shifted into the clicked slot: the user
+        # cancelled the queued message, the message was delivered, and the effort pick vanished. Now the
+        # check and the pop are one locked step, so a drain landing mid-cancel yields the cycle instead.
+        # Event-keyed: the cancel pauses INSIDE its body check (holding the lock), the drain is run then.
+        self.be.open = False
+        checked, go_cancel = threading.Event(), threading.Event()
+        real_md = km._parked_md
+
+        def md_probe(op):
+            if threading.current_thread().name == "cancel-under-test" and not checked.is_set():
+                checked.set()                              # paused between the check and the pop…
+                go_cancel.wait(5)
+            return real_md(op)
+        msg = ("send", "two", None)
+        km._pending_ops[SID] = [("model", "opus"), msg, ("fast", "on"), ("effort", "high")]
+        result = []
+        with mock.patch.object(km, "_parked_md", md_probe), redirect_stderr(io.StringIO()):
+            canceller = threading.Thread(target=lambda: result.append(km._cancel_parked(SID, 1, real_md(msg))),
+                                         name="cancel-under-test", daemon=True)
+            canceller.start()
+            self.assertTrue(checked.wait(5))
+            km._apply_pending_ops()                        # …a drain cycle lands exactly there
+            go_cancel.set()
+            canceller.join(5)
+            self.assertIsNone(result[0], "the ✕ reports success")
+            km._apply_pending_ops()                        # the next cycle
+        self.assertNotIn(("send", "two"), self.be.calls, "…so the cancelled message was never delivered")
+        self.assertEqual(self.be.calls, [("model", "opus"), ("fast", "on"), ("effort", "high")],
+                         "every other op delivered, in order, none lost")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_a_cancel_during_an_in_flight_send_hits_only_what_is_still_queued(self):
+        # the lock is released while the backend takes a send: a ✕ arriving in that window can still remove
+        # an op BEHIND the one in flight, and a ✕ on the in-flight one itself finds it gone — the honest
+        # 'too late', not a wrong-op removal
+        self.be.open = False
+        in_send, release = threading.Event(), threading.Event()
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            in_send.set()
+            release.wait(5)
+            self.be.open = True
+            return True
+        self.be.send = send
+        first, behind = ("send", "first", None), ("model", "opus")
+        km._pending_ops[SID] = [first, behind]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        with redirect_stderr(io.StringIO()):
+            walker.start()
+            self.assertTrue(in_send.wait(5))               # the head is popped and with the backend; the lock is free
+            err_behind = km._cancel_parked(SID, 1, km._parked_md(behind))
+            err_inflight = km._cancel_parked(SID, 0, km._parked_md(first))
+            release.set()
+            walker.join(5)
+        self.assertIsNone(err_behind, "the op behind the in-flight one is cancellable")
+        self.assertEqual(err_inflight, km._cancel_miss_text(km._parked_md(first)), "the in-flight one is too late")
+        self.assertEqual(self.be.calls, [("send", "first")])
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_drain_yields_to_a_handler_holding_the_lock_and_the_push_still_runs(self):
+        # the drain is the first job of every cycle; its top-of-walk acquire is non-blocking, so a cycle
+        # that finds a handler holding the lock skips the drain rather than stalling every session's push;
+        # the handler's own park wakes the pusher, so the skipped delivery costs nothing
+        self.be.open = False
+        km._pending_ops[SID] = [("model", "opus")]
+        held, release = threading.Event(), threading.Event()
+
+        def handler():
+            with km._pending_ops_lock:
+                held.set()
+                release.wait(5)
+        th = threading.Thread(target=handler, name="handler-under-test", daemon=True)
+        th.start()
+        self.assertTrue(held.wait(5))
+        pushes = []
+        try:
+            with mock.patch.object(km, "_push_all", lambda **k: pushes.append(1)), \
+                 mock.patch.object(km, "_clients", [object()]):                      # a browser is connected
+                km._pusher_cycle()
+            self.assertEqual(self.be.calls, [], "the drain skipped: a handler owns the queue")
+            self.assertEqual(km._pending_ops[SID], [("model", "opus")], "nothing lost")
+            self.assertEqual(pushes, [1], "…and the push still ran, not stalled behind the handler")
+        finally:
+            release.set()
+            th.join(5)
+        km._pusher_cycle()
+        self.assertEqual(self.be.calls, [("model", "opus")], "the next cycle drains")
+        self.assertNotIn(SID, km._pending_ops)
+
+    def test_the_lock_is_never_held_across_a_backend_call(self):
+        # CodexBackend.send can synchronously spawn `codex app-server` with no request timeout; a lock held
+        # across it would hold every handler's queue check + park behind it. Pinned from inside the backend,
+        # for EVERY call the drain makes — the setters, the send, busy() (the working gate and the hold
+        # check behind a delivered send) and turn_seq (a waiting move): the drain thread does not own the
+        # lock, and another thread can take it
+        probes = []
+
+        def probe(name):
+            probes.append((name, km._pending_ops_lock._is_owned(), _lock_free_for_another_thread()))
+
+        class _Probed(_FakeBackend):
+            def busy(self, sid):
+                probe("busy")
+                return self.open
+
+            def send(self, sid, text):
+                probe("send")
+                return _FakeBackend.send(self, sid, text)
+
+            def set_model(self, sid, value):
+                probe("set_model")
+                return _FakeBackend.set_model(self, sid, value)
+
+            def set_effort(self, sid, value):
+                probe("set_effort")
+                return _FakeBackend.set_effort(self, sid, value)
+
+            def set_fast(self, sid, value):
+                probe("set_fast")
+                return _FakeBackend.set_fast(self, sid, value)
+
+            def set_auth(self, sid, value):
+                probe("set_auth")
+                return _FakeBackend.set_auth(self, sid, value)
+
+            def set_env(self, sid, value):
+                probe("set_env")
+                return _FakeBackend.set_env(self, sid, value)
+
+            def turn_seq(self, sid):
+                probe("turn_seq")
+                return 0
+        self.be = _Probed()
+        self.be.open = False
+        d = tempfile.mkdtemp()
+        env = {"A": "1"}
+        km._pending_ops[SID] = [("model", "opus"), ("effort", "high"), ("fast", "on"), ("auth", "key"), ("env", env),
+                                ("send", "hello", None),
+                                ("cwd", d, km._MOVE_BUSY_RETRIES, 0)]         # behind the send: waits on turn_seq
+        km._apply_pending_ops()                            # busy (gate) → 5 setters → send → busy (the hold check)
+        self.assertEqual(self.be.calls, [("model", "opus"), ("effort", "high"), ("fast", "on"), ("auth", "key"),
+                                         ("env", env), ("send", "hello")])
+        self.be.open = False                               # the send's turn ends
+        km._apply_pending_ops()                            # busy (gate) → turn_seq: the move waits on its turn end
+        self.assertEqual(km._pending_ops[SID], [("cwd", d, km._MOVE_BUSY_RETRIES, 0)], "still parked, waiting")
+        names = [n for n, _, _ in probes]
+        self.assertEqual(names, ["busy", "set_model", "set_effort", "set_fast", "set_auth", "set_env", "send",
+                                 "busy", "busy", "turn_seq"])
+        self.assertEqual([o for _, o, _ in probes], [False] * len(probes), "the drain never owns the lock in a backend call")
+        self.assertEqual([f for _, _, f in probes], [True] * len(probes), "…and another thread can take it every time")
+
+    def test_a_handlers_park_completes_while_the_drain_is_inside_a_slow_send(self):
+        # the release around the backend call is what lets a user's press land during a slow delivery
+        self.be.open = False
+        in_send, release = threading.Event(), threading.Event()
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            self.be.open = True                            # the turn is pending before send() returns
+            in_send.set()
+            release.wait(5)
+            return True
+        self.be.send = send
+        km._pending_ops[SID] = [("send", "first", "human")]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        walker.start()
+        self.assertTrue(in_send.wait(5))                   # the backend has the send; the lock is released
+        parker = threading.Thread(target=lambda: km._send_or_park(self.be, SID, "second", echo="human"),
+                                  name="handler-under-test", daemon=True)
+        parker.start()
+        parker.join(5)
+        self.assertFalse(parker.is_alive(), "the handler's park did not wait for the backend")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "second", "human")], "…and landed behind the in-flight send")
+        release.set()
+        walker.join(5)
+        self.assertEqual(self.be.calls, [("send", "first")], "the parked second waits for the delivered turn to end")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "second", "human")])
+
+    def test_a_handlers_queue_check_and_park_share_the_lock_but_its_gates_and_handover_do_not(self):
+        # the expensive gates (they fork tmux / call the backend's busy()) run outside the lock; the
+        # queue-presence check and the park are one locked step; the handover runs outside it again
+        owned = {"gate": [], "park": [], "handover": []}
+        real_wn, real_park_locked = km._working_now, km._park_op_locked
+
+        def gate_probe(sid):
+            owned["gate"].append(km._pending_ops_lock._is_owned())
+            return real_wn(sid)
+
+        def park_probe(sid, op):
+            owned["park"].append(km._pending_ops_lock._is_owned())
+            return real_park_locked(sid, op)
+
+        def send(sid, text):
+            owned["handover"].append(km._pending_ops_lock._is_owned())
+            self.be.calls.append(("send", text))
+            return True
+
+        def set_model(sid, value):
+            owned["handover"].append(km._pending_ops_lock._is_owned())
+            self.be.calls.append(("model", value))
+            return True
+        self.be.send, self.be.set_model = send, set_model
+        self.be.open = False                               # quiet…
+        with mock.patch.object(km, "_working_now", gate_probe), \
+             mock.patch.object(km, "_park_op_locked", park_probe):
+            km._pending_ops[SID] = [("compact",)]          # …but a queue exists: everything parks BEHIND it
+            self.assertTrue(km._send_or_park(self.be, SID, "hello"))
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertTrue(km._compact_or_park(self.be, SID))
+            self.assertEqual([op[0] for op in km._pending_ops[SID]], ["compact", "send", "model", "compact"],
+                             "every op parked BEHIND the queue, in press order (a compact appends, it never replaces)")
+            self.assertEqual(owned["park"], [True] * 3, "the queue check + park is one locked step")
+            self.assertEqual(self.be.calls, [])
+            km._pending_ops.clear()                        # no queue: everything hands over
+            self.assertFalse(km._send_or_park(self.be, SID, "hello"))
+            km._set_model_or_park(self.be, SID, "opus")
+            self.assertEqual(owned["handover"], [False, False], "the handover to the backend is outside the lock")
+            self.assertEqual(self.be.calls, [("send", "hello"), ("model", "opus")])
+        # (_send_or_park short-circuits on the queue read, so not every call reaches _working_now — every one
+        # that did ran outside the lock)
+        self.assertTrue(owned["gate"], "the expensive gate was consulted")
+        self.assertEqual(set(owned["gate"]), {False}, "…and every time outside the lock")
+
+    def test_the_move_threads_head_repark_runs_under_the_lock(self):
+        # _move_now re-inserts a `busy` move at the head from its own thread; the insert and its hold are one
+        # locked step, so a handler's park or the drain's pops cannot interleave with them
+        owned = []
+        real_hold = km._hold_drain
+
+        def hold_probe(sid, seconds, until_busy=False):
+            owned.append(km._pending_ops_lock._is_owned())
+            return real_hold(sid, seconds, until_busy)
+        self.be.move = lambda sid, path: "busy"
+        d = tempfile.mkdtemp()
+        km._moving.add(SID)
+        with mock.patch.object(km, "_hold_drain", hold_probe):
+            self.assertEqual(km._move_now(self.be, SID, d, 0, ""), "busy")
+        self.assertEqual(km._pending_ops[SID], [("cwd", d, 1, 0)], "back at the head, carrying the try")
+        self.assertEqual(owned, [True], "the re-insert and its hold are one locked step")
+        self.assertNotIn(SID, km._moving)
+
+
+class TheMirrorIsWrittenPerWriter(_Drain):
+    """pending-ops.json used to be published through ONE fixed temp path from any thread: the loser renamed
+    a temp the winner had already moved, or wrote into a temp mid-rename — a torn mirror that a kernel
+    death then restored as the queue."""
+
+    def test_concurrent_parks_never_tear_the_mirror_or_log_a_failed_save(self):
+        errors, buf = [], io.StringIO()
+
+        def hammer(t):
+            sid = "11111111-2222-3333-4444-%012d" % t
+            for i in range(120):
+                try:
+                    km._park_op(sid, ("model", "pick-%d-%d" % (t, i)))    # replace-in-place: one op per sid
+                except Exception as e:
+                    errors.append(repr(e))
+        with redirect_stderr(buf):
+            threads = [threading.Thread(target=hammer, args=(t,)) for t in range(8)]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join(30)
+        self.assertEqual(errors, [])
+        self.assertNotIn("pending-ops save", buf.getvalue(), "no writer lost its temp to another")
+        leftovers = [p.name for p in km._PENDING_OPS_FILE.parent.iterdir()
+                     if p.name.startswith(km._PENDING_OPS_FILE.stem) and p.name != km._PENDING_OPS_FILE.name]
+        self.assertEqual(leftovers, [], "no temp left behind")
+        self.assertEqual(km._load_pending_ops(), dict(km._pending_ops), "the mirror is the final state, whole")
+        self.assertEqual(len(km._pending_ops), 8)
+
+    def test_the_mirrors_temp_name_is_per_writer_not_a_shared_sibling(self):
+        srcs = []
+        real_replace = os.replace
+
+        def replace_probe(src, dst, *a, **k):
+            if str(dst) == str(km._PENDING_OPS_FILE):
+                srcs.append(str(src))
+            return real_replace(src, dst, *a, **k)
+        km._pending_ops[SID] = [("model", "opus")]
+        with mock.patch.object(km.os, "replace", replace_probe):
+            km._save_pending_ops()
+            km._save_pending_ops()
+        self.assertEqual(len(srcs), 2)
+        self.assertNotEqual(srcs[0], srcs[1], "two writes, two temps")
+        self.assertNotIn(str(km._PENDING_OPS_FILE.with_suffix(".tmp")), srcs, "the shared sibling temp is gone")
+        for s in srcs:
+            self.assertEqual(os.path.dirname(s), str(km._PENDING_OPS_FILE.parent),
+                             "published from the file's own directory (a same-filesystem rename)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -559,7 +559,7 @@ class DrivePlumbing(unittest.TestCase):
         self.assertIn('"setAuth", "endSession"', src.replace("\n", " "), "an ID_OPS member")
         self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
         self.assertIn("def _set_auth_or_park(be, sid, value):", src)
-        self.assertIn('_park_op(sid, ("auth", value))', src)
+        self.assertIn('_gate_or_park(sid, ("auth", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "auth":', src)
         self.assertIn("be.set_auth(sid, op[1])", src)
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -464,7 +464,7 @@ class DrivePlumbing(unittest.TestCase):
     def test_the_op_is_routed_parked_and_replayed(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("def _set_env_or_park(be, sid, value):", src)
-        self.assertIn('_park_op(sid, ("env", value))', src)
+        self.assertIn('_gate_or_park(sid, ("env", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "env":', src)
         self.assertIn("be.set_env(sid, op[1])", src)
         self.assertIn('("model", "effort", "fast", "env", "cwd")', src,

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -193,7 +193,10 @@ test("the kernel parks every drive op while the account can't serve one, and dra
   // the send path needs its OWN arm, ahead of the forwards_sends handoff: an SDK backend takes a send even
   // mid-turn, so without this the message goes straight out and comes back an API error
   assert.match(KERNEL, /if _compacting_now\(sid\) or _pending_ops\.get\(sid\) or _limit_hold\(sid\):/);
-  assert.match(KERNEL, /if _compacting_now\(sid\) or _working_now\(sid\) or _limit_hold\(sid\):/, "the drain gate");
+  // the drain's account gate is its own step, checked before the transcript refresh and the compacting/working
+  // reads (2026-09-05): a held session is not re-parsed for a verdict the hold already decided
+  assert.match(KERNEL, /if _limit_hold\(sid\):\n\s+continue\s+# the account can't serve a request yet/, "the drain gate");
+  assert.match(KERNEL, /if _compacting_now\(sid\) or _working_now\(sid\):\n\s+continue/, "the drain's quiet gate");
   // RELEASE rides the API's own stamp — no romp-invented timer, and no clock promised without one
   assert.match(KERNEL, /"resetsAt": max\(known\) if len\(known\) == len\(resets\) else None,/);
   assert.match(KERNEL, /known = \[r for r in resets if isinstance\(r, \(int, float\)\) and r > 0\]/);


### PR DESCRIPTION
**Stacks on #954** (the parked-op lock, `lczh:parked-ops-lock` @ 655549f9). This branch is one commit on top of that one; until #954 merges, the diff here shows both commits. Only the second is this PR.

## What

Since the drain moved into the pusher loop (#904) it runs every half second, and two of its per-session costs were sized for the judge pass it used to ride at the tail of. An account limit parks every session's input for hours, and for every held session on every cycle the drain re-read `usage.json`, re-ran the colormap ramps over its windows, and re-read the retry-pause file, then for a tmux session re-parsed a transcript that had moved, all to reach a verdict the hold had already decided. On a replay of a seventeen-session board with a capped window that was 46 ms of every 0.5 s cycle, most of it the usage re-read.

Now:

- `usage.json` and the retry-pause file are read **once per drain** and ride the cycle's thread-confined scope (`_live_scope`, the same idiom that already carries the liveness snapshot and the path memo). `_limit_hold` reads them from there inside the drain and reads fresh everywhere else, with its one-argument shape unchanged. A failed usage read is stored as its own sentinel, so the hold answers it exactly as it answers its own failed read (no hold), never as an empty usage that falls through to the spend arm.
- Each session's gates run **cheapest first**: the move and hold windows, then the account hold, and only for a session that passes those the transcript refresh a tmux `busy()` corroboration needs and the compacting and working reads. The one hold that itself reads `busy()`, the until-busy hold armed after a tmux send, gets the refresh first, so a row the transcript overrules can still release it. A held session's transcript is not re-parsed for a verdict nothing reads.
- The whole-set refresh the pusher ran ahead of the drain (`_refresh_parked_parses`) is gone; the comments that described it now name the per-session refresh.
- The gates, and so the refresh (a full transcript parse when the cache is stale, seconds on a large file), run **outside `_pending_ops_lock`**, as the walk's gates do in #954: the lock guards the queue's reads and pops only. A cycle the lock yields to a handler reads nothing at all.

Nothing about what fires or when changes: the same gates in the same order of authority, the same readings, one per cycle instead of one per session, and an unreadable `usage.json` still reads as no hold for every session.

## Review

Two adversarial review passes with one refuter per finding, each on the tree as it stood:

- On the main-based shape: two divergences confirmed and fixed. A failed usage read stored as `None` ran the spend arm the fresh path skipped, and the until-busy hold read `busy()` against a cache the retired pre-pass used to refresh.
- On an earlier rebase onto a draft of the lock: the refresh had landed inside a locked walk, so every handler's park and cancel stalled behind a transcript parse. The lock as it landed in #954 runs the gates outside the lock, so the refresh stays unlocked; a test pins that it never runs with the lock held.

## Tests

`tests/test_drain_hoists.py` pins one usage and one pause reading per drain however many sessions are held, the scoped reading agreeing with a fresh one on every arm including the failed read with the spend pause on, the scope cleared on the way out and when the loop raises, the parse refresh running only for a session the holds let through and first for an until-busy hold's read, never under the queue lock, a cycle yielded to a handler reading nothing, the bare call still working, and the pusher's wiring. Full Python suite on this tree: 7354 passed, 44 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
