### PR TITLE
The pane shim raises the stale prompt when it abandons a silent reconnected socket, and the drop bell names the pane by its label

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -55,22 +55,29 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   consistent by construction. Keeping the WS protocol stable is the compatibility
   contract.
 - **Liveness is a keepalive, and staleness is event-keyed.** The kernel sends a
-  `ka` frame to every socket every 10 s; the pane shim force-closes a socket that
-  has gone 30 s without any frame. After a reconnect the shim raises the "what you
-  see may be stale" prompt only on the SECOND `ka` arriving before the resync
-  frame — one full heartbeat period, bracketed by two kernel heartbeats on that
-  socket with no resync between them (a single `ka` can be a beat that was already
-  queued when the socket was accepted) — or on the reconnected socket closing
-  again before its resync; the first non-keepalive frame retires the prompt, never
-  a timer. A client that falls 16 MB behind is dropped by the kernel, loudly: one
-  `ws: dropping` line in the kernel log, written where the drop is decided so every
-  send path is covered, naming the pane, the dashboard, the backlog and the push
-  slot whose frame tipped the budget when a push did; and a row in the dashboard's
-  bell (at most five drop rows, none older than an hour, so they never crowd out a
-  backend problem). Every close of a socket that opened leaves a `wsclose`
-  breadcrumb (code, reason, socket age) in `client-diag.jsonl`; the redials an
-  outage refuses are counted and reported as one `wsconnfail` row on the next
-  open, and at most 20 breadcrumbs wait in the shim's queue for it.
+  `ka` frame to every socket every 10 s; the pane shim abandons a socket that has
+  gone 30 s without any frame and redials at once. After a reconnect the shim
+  raises the "what you see may be stale" prompt only on the SECOND `ka` arriving
+  before the resync frame — one full heartbeat period, bracketed by two kernel
+  heartbeats on that socket with no resync between them (a single `ka` can be a
+  beat that was already queued when the socket was accepted) — on the reconnected
+  socket closing again before its resync, or on the shim abandoning it as quiet
+  before its resync (a kernel that accepts the reconnect and never speaks on it
+  sends nothing to count and nothing to close); the first non-keepalive frame
+  retires the prompt, never a timer. A client that falls 16 MB behind is dropped
+  by the kernel, loudly: one `ws: dropping` line in the kernel log, written where
+  the drop is decided so every send path is covered, naming the pane, the
+  dashboard, the backlog and the push slot whose frame tipped the budget when a
+  push did; and a row in the dashboard's bell (at most five drop rows, none older
+  than an hour, so they never crowd out a backend problem). Every close the
+  browser reports for a socket that opened leaves a `wsclose` breadcrumb (code,
+  reason, socket age) in `client-diag.jsonl`; a socket the shim abandons leaves
+  none — the watchdog's own `watchdog-close` row went down the quiet socket
+  before the abandon (the foreground path's abandon sends none), so an armed
+  socket's raise, `reconnect-quiet` or `foreground-quiet`, queued for the redial,
+  is the record that survives; the redials an outage refuses are counted and
+  reported as one `wsconnfail` row on the next open, and at most 20 breadcrumbs
+  wait in the shim's queue for it.
 - **The Outline pane's ages run on the kernel's clock.** Its timestamps are the
   kernel's, so the pane never reads the browser's clock against them: it anchors
   on the frame's `now` paired with the moment that frame arrived from the wire

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27500,10 +27500,14 @@ def _note_ws_drop(c, why, frame_len, key=None):
                             int(c.get("qbytes") or 0), int(frame_len)))
         if "bytes behind" in str(why):
             _WS_DROP_SEQ[0] += 1
+            # the row names the pane as the rail does — _PANE_ORDER's label, so the Outline pane is not its
+            # internal app id to the person reading it; an app with no rail label keeps its id. The stderr
+            # line above keeps the id: it is the log's word for the pane, shared with _drop_dead_ws_client.
+            app = c.get("app") or "?"
             _WS_DROPS.append({"seq": _WS_DROP_SEQ[0], "t": time.time(),
                               "text": "The %s pane's live connection was dropped: it had %.1f MB of "
                                       "updates waiting and had stopped reading them. It reconnects on "
-                                      "its own." % (c.get("app") or "?", int(c.get("qbytes") or 0) / 1e6)})
+                                      "its own." % (dict(_PANE_ORDER).get(app, app), int(c.get("qbytes") or 0) / 1e6)})
             del _WS_DROPS[:-20]
     except Exception:
         pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30384,7 +30384,11 @@ if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}
 // while the resync is still pending — one full heartbeat period, bracketed by two kernel heartbeats on
 // this very socket with no resync between them: the kernel is alive and talking to it and has not
 // resynced it, exactly the state the prompt warns about — and the reconnected socket CLOSING again before
-// its resync — no frame is coming on it. Both fire in onmessage/onclose below. ONE keepalive is not the
+// its resync — no frame is coming on it. Both fire in onmessage/onclose below; abandon() runs the close
+// rule itself for a socket the shim gives up on as quiet (the watchdog's tick or the foreground path), since
+// it disowns that socket's onclose — a kernel that accepts the reconnect and then never speaks on it
+// sends no keepalive to count and no close to rule on, and without this the next open re-armed from zero
+// on every 30 s cycle: the loader flapped and the prompt never came. ONE keepalive is not the
 // event: the heartbeat thread can enqueue a beat the instant a socket is accepted, ahead of the connect
 // push, and raising on it flashed the banner exactly as the timer did. The timer was approximating all
 // this, and on a board of several hundred cards the connect push is a multi-megabyte frame that takes
@@ -30442,13 +30446,16 @@ else if(msg&&DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
-// Every close of a socket that OPENED leaves a breadcrumb with the CLOSE CODE and reason: a kernel-side drop
-// (the client fell WS_QUEUE_BYTES behind — shutdown, no close frame → 1006), a clean kernel restart, a proxy
-// timeout and the watchdog's own close all looked identical from here, and a day of drops read as a flaky
-// network. send() queues while the socket is down, so the row rides the reconnect. A handshake that never
-// opened fires onclose too (every 1.5 s redial of an outage — an 8 h outage is ~19k of them, and their timings
-// would be the PREVIOUS socket's): those are counted and reported as one wsconnfail row on the next open,
-// never queued one by one.
+// Every close the BROWSER reports for a socket that OPENED leaves a breadcrumb with the CLOSE CODE and
+// reason: a kernel-side drop (the client fell WS_QUEUE_BYTES behind — shutdown, no close frame → 1006), a
+// clean kernel restart and a proxy timeout all looked identical from here, and a day of drops read as a
+// flaky network. A socket the shim ABANDONS leaves no wsclose row (abandon() disowns its onclose). Its
+// watchdog-close row, when there is one, went down the quiet socket before the abandon (the foreground
+// path sends none), so it lands only if that socket still carried writes; for an armed socket the "-quiet"
+// raise abandon() queues for the redial is the record that survives. send() queues while the socket is
+// down, so the row rides the reconnect. A handshake that never opened fires onclose too (every 1.5 s redial
+// of an outage — an 8 h outage is ~19k of them, and their timings would be the PREVIOUS socket's): those
+// are counted and reported as one wsconnfail row on the next open, never queued one by one.
 ws.onclose=function(ev){netState("down");
 if(openSock===this){try{send({type:"clientDiag",surface:"pane-shim",what:"wsclose",data:{app:APP,code:ev?ev.code:-1,reason:(ev&&ev.reason)||"",wasClean:!!(ev&&ev.wasClean),sinceOpenMs:openT?Date.now()-openT:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,everConnected:everConnected}});}catch(e){}}
 else{if(!failedConnects)firstFailT=Date.now();failedConnects++;}
@@ -30495,8 +30502,12 @@ setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}
 // the audited phone panes came back 64s after their own watchdog-close for exactly this reason (a pane's
 // quiet socket → close() → nothing → the reconnect only when the browser gave up). Detach its handlers
 // (its eventual onclose is nobody's event — it must not fire wsdown or a second redial), close it for
-// hygiene, do what onclose did (flag the shell, re-show the loader), and let the caller dial NOW.
+// hygiene, do what onclose did (flag the shell, run the close rule, re-show the loader), and let the caller
+// dial NOW. The close rule runs AFTER ws is nulled so its breadcrumb queues and rides the reconnect. (The
+// watchdog's own watchdog-close row goes down the quiet socket before this call and lands only if that
+// socket still carries writes; the raise's row does not depend on that.)
 function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;
+if(stalePending&&openSock===d){var qw=stalePending;stalePending="";raiseStale(qw+"-quiet");}   // the reconnected socket armed and then said nothing before its resync: nothing is coming on it, and the view IS stale — the disowned onclose cannot rule on it, and the redial's open would otherwise re-arm from zero
 netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}
 // progress watchdog (state-keyed, one per socket state): OPEN but silent past STALE_MS = half-open, no
 // onclose will ever fire — force-close (the user 2026-06-29). CONNECTING past its deadline = the browser is

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -87,8 +87,11 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('staleDiag("watchdog-close","quiet");', js)
         self.assertIn('armStale(pendingWhy||"reconnect");', js)
         self.assertIn('pendingWhy="foreground";', js)
-        # …and every CLOSE leaves one too, with the close code/reason and the socket's age: a kernel-side
-        # drop (1006, no reason), a clean restart and a proxy timeout were indistinguishable
+        # …and every close the BROWSER reports leaves one too, with the close code/reason and the socket's
+        # age: a kernel-side drop (1006, no reason), a clean restart and a proxy timeout were
+        # indistinguishable. (A socket the shim ABANDONS leaves none — abandon() disowns its onclose; the
+        # watchdog-close row above went down the quiet socket before the abandon, and an armed socket's
+        # "-quiet" raise rides the redial.)
         self.assertIn('if(openSock===this){try{send({type:"clientDiag",surface:"pane-shim",what:"wsclose",data:{app:APP,code:ev?ev.code:-1,'
                       'reason:(ev&&ev.reason)||"",wasClean:!!(ev&&ev.wasClean),'
                       'sinceOpenMs:openT?Date.now()-openT:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,everConnected:everConnected}', js)
@@ -115,7 +118,7 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");abandon();connect();}return;}', js)
         self.assertIn("function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;", js)
         self.assertIn('netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}', js,
-                      "the abandoned socket's onclose is disowned, so abandon() itself does what onclose did (banner + loader)")
+                      "the abandoned socket's onclose is disowned, so abandon() itself does what onclose did (banner + close rule + loader)")
         self.assertIn("if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}", js)
         self.assertIn("if(ws.readyState===3&&Date.now()-connT>8000){connect();}", js)
         # the foregrounding fast-path abandons an OPEN-but-quiet socket and redials it NOW (same 60s
@@ -163,8 +166,11 @@ class DisconnectBanner(unittest.TestCase):
         # reconnect once frames grew): it raises on the SECOND KEEPALIVE arriving while the resync is still
         # pending — one full heartbeat period on this socket with the kernel alive, talking to it, and not
         # resyncing it; a single keepalive can be a beat queued at accept, ahead of the resync frame — or on
-        # the reconnected socket CLOSING again before its resync. Nothing else. pane-shim-stale.test.ts RUNS
-        # the rule; these pins hold its text.
+        # the reconnected socket CLOSING again before its resync — or being ABANDONED by the shim before it (the
+        # watchdog's tick or the foreground path, on a socket the kernel accepted and never spoke on: abandon()
+        # disowns the socket's onclose, so it runs the close rule itself; without that, every silent cycle
+        # re-armed from zero and the prompt never came). Nothing else. pane-shim-stale.test.ts RUNS the rule;
+        # these pins hold its text.
         self.assertIn("function armStale(why){stalePending=why;staleKa=0;}", js, "arming records the path, shows nothing")
         self.assertNotIn("setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js, "the timer is gone")
         self.assertNotIn("staleTimer", js)
@@ -172,6 +178,8 @@ class DisconnectBanner(unittest.TestCase):
                       "the second keepalive on the reconnected socket, resync still pending → raise")
         self.assertIn('if(stalePending&&openSock===this){var cw=stalePending;stalePending="";raiseStale(cw+"-closed");}', js,
                       "the reconnected socket closing before its resync → raise")
+        self.assertIn('if(stalePending&&openSock===d){var qw=stalePending;stalePending="";raiseStale(qw+"-quiet");}', js,
+                      "the reconnected socket abandoned as quiet before its resync → raise (the disowned onclose cannot)")
         self.assertIn('if(!ann)armStale(pendingWhy||"reconnect");', js,
                       "the reconnect ARMS it — except the one an ANNOUNCED restart already explained (T217)")
         self.assertNotIn("if(wasReconn){raiseStale();", js, "…and never raises it outright")

--- a/tests/test_ws_drop_loud.py
+++ b/tests/test_ws_drop_loud.py
@@ -88,7 +88,7 @@ class DroppedClientsAreLoud(unittest.TestCase):
             sys.stderr = old
         self.assertEqual(len(km._WS_DROPS), n0 + 1)
         row = km._WS_DROPS[-1]
-        self.assertIn("feed pane", row["text"]); self.assertIn("17.0 MB", row["text"])
+        self.assertIn("The Feed pane's live connection was dropped", row["text"]); self.assertIn("17.0 MB", row["text"])
         self.assertTrue(any(r["text"] == row["text"] and r["sig"].startswith("sdk|") and "|ws|" in r["sig"]
                             for r in km._sdk_problem_rows()), "rides the feed's sdkNotices → the bell")
 
@@ -115,7 +115,7 @@ class DroppedClientsAreLoud(unittest.TestCase):
         self.assertIn("dropping chat client", lines[0]); self.assertIn("wid=w3", lines[0]); self.assertIn("bytes behind", lines[0])
         self.assertFalse(client["alive"])
         self.assertEqual(len(km._WS_DROPS), n0 + 1)
-        self.assertIn("chat pane", km._WS_DROPS[-1]["text"])
+        self.assertIn("The Chat pane's", km._WS_DROPS[-1]["text"])
 
     def test_a_push_path_drop_names_the_slot_whose_frame_tipped_the_budget(self):
         # the raise site has no key of its own; _client_send leaves the slot in flight on the client for
@@ -174,7 +174,29 @@ class DroppedClientsAreLoud(unittest.TestCase):
         self.assertIn("dropping feed client", lines[0]); self.assertIn("slot=feed ", lines[0])
         self.assertNotIn("view-delta feed:", err.getvalue(), "the drop is a drop, not an encoder failure")
         self.assertFalse(client["alive"])
-        self.assertIn("feed pane", km._WS_DROPS[-1]["text"])
+        self.assertIn("The Feed pane's", km._WS_DROPS[-1]["text"])
+
+    def test_the_bell_row_names_the_pane_as_the_rail_does(self):
+        # the row is read by the person at the dashboard, who knows the panes by the rail's labels; the
+        # Outline pane's internal app id (the key probed below) is not one of them, and the row used to name
+        # it by that id. The stderr line keeps the id — it is the log's word for the pane, and the line
+        # beside it (_drop_dead_ws_client) uses it.
+        old = sys.stderr; sys.stderr = io.StringIO()
+        try:
+            texts = {}
+            for app, label in km._PANE_ORDER:
+                c = self._dropping(); c["app"] = app
+                km._send_client(c, ("feed",), {"type": "feed"})
+                texts[app] = km._WS_DROPS[-1]["text"]
+                self.assertIn("The %s pane's live connection was dropped" % label, texts[app], app)
+            self.assertNotIn("fleet", texts["fleet"], "the internal id never reaches the row")
+            self.assertIn("The Outline pane's", texts["fleet"])
+            self.assertIn("dropping fleet client", sys.stderr.getvalue(), "…while the log line keeps it")
+            c = self._dropping(); c["app"] = "shell"   # a client with no rail label: the id itself, never a blank
+            km._send_client(c, ("feed",), {"type": "feed"})
+            self.assertIn("The shell pane's", km._WS_DROPS[-1]["text"])
+        finally:
+            sys.stderr = old
 
     def test_drop_rows_never_crowd_a_backend_problem_out_of_the_bell(self):
         class _Be:

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -4,11 +4,16 @@
 // rule under test: after a reconnect, the "what you see may be stale" prompt is raised by the SECOND
 // KEEPALIVE arriving before the resync frame (one full heartbeat period, bracketed by two kernel heartbeats
 // on this socket with no resync between them — a single keepalive can be a beat that was already queued
-// when the socket was accepted), or by the reconnected socket CLOSING before it, and by nothing else — no
+// when the socket was accepted), by the reconnected socket CLOSING before it, or by the shim ABANDONING it
+// as quiet before it (the watchdog's tick or the foreground path: a socket the kernel accepted and never
+// spoke on — abandon() disowns its onclose, so it runs the close rule itself), and by nothing else — no
 // timer (every scenario runs the pending timers afterwards and asserts nothing fired, and asserts no timer
-// is armed on open); the first non-keepalive frame retires it; a keepalive never reaches the bundle. Also
-// run here: the close breadcrumbs (one `wsclose` per socket that OPENED; the redials an outage refused
-// coalesced into one `wsconnfail` row on the next open) and the cap on queued breadcrumbs.
+// is armed on open; the watchdog's interval is captured and ticked by hand); the first non-keepalive frame
+// retires it; a keepalive never reaches the bundle. Also run here: the close breadcrumbs (one `wsclose` per
+// socket that OPENED and was closed by the browser — an abandoned socket leaves none: the watchdog's own
+// `watchdog-close` row went down the quiet socket before the abandon, and an armed socket's `-quiet` raise
+// rides the redial; the redials an outage refused coalesced into one `wsconnfail` row on the next open)
+// and the cap on queued breadcrumbs.
 // Synthetic only (TESTHOST, no session data).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -35,6 +40,7 @@ class Harness {
   toBundle: any[] = [];        // frames the shim handed to the bundle
   sockets: any[] = [];
   timers: Array<() => void> = [];
+  interval: (() => void) | null = null;   // the progress watchdog's 5 s tick, run by hand (tick)
   visibility: Array<() => void> = [];
   now = 1_000_000;
   win: any;                    // the sandbox window (the shim hangs __rompLocalSend on it)
@@ -68,7 +74,7 @@ class Harness {
       Event: class { type: string; constructor(t: string) { this.type = t; } },
       MessageEvent: class { type: string; data: any; constructor(t: string, o: any) { this.type = t; this.data = o.data; } },
       setTimeout: (f: () => void) => { h.timers.push(f); return h.timers.length; },
-      clearTimeout: () => {}, setInterval: () => 0,
+      clearTimeout: () => {}, setInterval: (f: () => void) => { h.interval = f; return 1; },
     };
     sandbox.window.window = sandbox.window;
     this.win = sandbox.window;
@@ -76,6 +82,8 @@ class Harness {
   }
   get ws() { return this.sockets[this.sockets.length - 1]; }
   runTimers() { const t = this.timers.splice(0); for (const f of t) f(); }
+  /** one tick of the progress watchdog (the shim's setInterval body) */
+  tick() { assert.ok(this.interval, "the watchdog is armed"); this.interval!(); }
   stale() { return this.posted.filter((m) => m.romp === "wsStale" && !m.build).length; }
   fresh() { return this.posted.filter((m) => m.romp === "wsFresh").length; }
   diags(what: string) { return this.sent.filter((m) => m.type === "clientDiag" && m.what === what); }
@@ -210,7 +218,67 @@ test("an announced restart's reconnect skips the arm once (T217); a second recon
   h.settles(1);
 });
 
-test("every close of a socket that OPENED leaves a wsclose breadcrumb with the code, the socket's age and the quiet gap", () => {
+test("a reconnected socket that stays SILENT — no keepalive, no resync — raises when the watchdog abandons it; the redial resyncs as usual", () => {
+  // the kernel accepted the reconnect and never spoke on it (a wedged kernel; a proxy that accepted and
+  // forwards nothing): no keepalive arrives to count, and abandon() disowns the socket's onclose, so the
+  // close rule never sees it either. Until abandon() ran that rule itself, every silent cycle re-armed from
+  // zero — the loader flapped every 30 s and the prompt never came, where the old timer raised on the first.
+  const h = FEED();
+  const ws = h.reconnected();
+  h.now += 31_000;
+  h.tick();
+  assert.equal(h.stale(), 1, "abandoning an armed socket is the event: nothing is coming on it");
+  assert.equal(h.sockets.length, 3, "…and the same tick redialed");
+  assert.equal(ws.onclose, null, "the abandoned socket is disowned: its eventual close is nobody's event");
+  assert.equal(h.sent.filter((m) => m.type === "clientDiag" && m.what === "stale-raise").length, 0,
+    "the breadcrumb queued rather than going down the quiet socket, which would have swallowed it");
+  h.ws.open();
+  assert.equal(h.timers.length, 0, "no timer is armed on open");
+  const raised = h.diags("stale-raise");
+  assert.equal(raised.length, 1, "…and it rode the reconnect");
+  assert.equal(raised[0].data.why, "reconnect-quiet");
+  assert.equal(h.diags("wsclose").length, 1, "the abandoned socket leaves no wsclose row: only the browser-reported drop did");
+  assert.equal(h.diags("watchdog-close").length, 1, "the watchdog's own row, sent down the quiet socket before the abandon");
+  h.ws.msg({ type: "feed", asks: [] });
+  assert.equal(h.fresh(), 1, "the redial's resync retires the prompt as always");
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 1, "…after which its keepalives are just keepalives");
+  h.settles(1);
+});
+
+test("three silent cycles: one raise per cycle, one watchdog row each, and no wsclose for any abandoned socket", () => {
+  const h = FEED();
+  h.reconnected();
+  for (let i = 1; i <= 3; i++) {
+    h.now += 31_000;
+    h.tick();
+    assert.equal(h.stale(), i, "cycle " + i + " raised: the watchdog never eats an armed cycle");
+    h.ws.open();
+    assert.equal(h.timers.length, 0, "no timer is armed on open");
+  }
+  assert.equal(h.sockets.length, 5);
+  assert.deepEqual(h.diags("stale-raise").map((m) => m.data.why), ["reconnect-quiet", "reconnect-quiet", "reconnect-quiet"]);
+  assert.equal(h.diags("watchdog-close").length, 3);
+  assert.equal(h.diags("wsclose").length, 1, "the first, browser-reported drop — and nothing for the three abandonments");
+  h.settles(3);
+});
+
+test("the foreground path abandoning an ARMED quiet socket raises too; its redial arms as foreground", () => {
+  const h = FEED();
+  h.reconnected();                          // armed on the reconnect; the tab then slept on a socket that said nothing
+  h.now += 31_000;
+  for (const f of h.visibility) f();
+  assert.equal(h.stale(), 1, "the tab came back to a socket that armed and then heard nothing");
+  assert.equal(h.sockets.length, 3, "abandoned and redialed at once");
+  h.ws.open();
+  assert.equal(h.diags("stale-raise")[0].data.why, "reconnect-quiet", "named for the path that armed, not the one that abandoned");
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 2, "the foreground redial armed on its own account, and its two beats raise as usual");
+  assert.equal(h.diags("stale-raise")[1].data.why, "foreground");
+  h.settles(2);
+});
+
+test("every close the browser reports for a socket that OPENED leaves a wsclose breadcrumb with the code, the socket's age and the quiet gap", () => {
   const h = FEED();
   h.ws.open(); h.now += 4_000; h.ws.msg({ type: "feed", asks: [] }); h.now += 2_500;
   h.ws.close();


### PR DESCRIPTION
## What breaks

Follow-up from the review of #952, which found this gap and the bell-row nit below (that PR shipped as reviewed; both are folded here).

The stale prompt has two raising events: the second keepalive landing on the reconnected socket before its resync, and that socket closing before its resync. `abandon()`, which the watchdog and the foreground path call on a socket quiet past 30 s, nulls `onclose` before closing it, so the close rule never runs for an abandoned socket, and the redial's open re-arms from zero. A kernel that accepts the reconnect and then never speaks on it (no keepalive to count, no close to rule on) flaps the loader every 30 s and never raises the prompt. The 1 s timer this rule replaced raised on the first cycle.

Reproduction: `ui/webview/pane-shim-stale.test.ts` now captures the shim's `setInterval` and ticks the watchdog by hand. Against the shim before this change, three silent cycles produce three `watchdog-close` rows, three redials and zero raises.

## The fix

`abandon()` runs the close rule itself: an armed socket it gives up on retires the arm and raises with the arming path plus `-quiet` (`reconnect-quiet`, `foreground-quiet`). The review suggested running the rule before `abandon()` at its two call sites; it lives inside `abandon()` instead, a deliberate departure: abandon's contract is to do what the disowned `onclose` would have done, so every caller is covered by construction (the call-site pins in `test_kernel_disconnect_banner.py` are unchanged), and running the raise after `ws` is nulled lets its breadcrumb queue and ride the reconnect instead of going down the quiet socket.

The `onclose` comment and `docs/read-side.md` said every close of an opened socket leaves a `wsclose` row. An abandoned socket leaves none: the watchdog's own `watchdog-close` row goes down the quiet socket before the abandon (the foreground path's abandon sends no row of its own), and for an armed socket the `-quiet` raise, queued for the redial, is the record that survives. Both now say so.

Second commit: `_note_ws_drop` formatted the raw app id into the bell text, so a dropped Outline pane was named by its internal id. The row now maps the id through `_PANE_ORDER`; an app with no rail label keeps its id. The stderr line keeps the id on purpose: it is the log's word for the pane, shared with `_drop_dead_ws_client`.

## Tests

Red first: every new or changed assertion was run against the unchanged code before the fix.

- `ui/webview/pane-shim-stale.test.ts`: one silent cycle raises once (`reconnect-quiet`), the breadcrumb rides the redial instead of going down the quiet socket, the abandoned socket leaves no `wsclose` row, and the redial's resync retires the prompt; three silent cycles raise once each, with one `watchdog-close` row each and no `wsclose`; the foreground path abandoning an armed socket raises too, and its redial arms as `foreground`. Against the unchanged shim all three fail at the first raise count (expected 1, got 0).
- `tests/test_kernel_disconnect_banner.py`: pins the rule's text in `abandon()`; fails against the unchanged shim.
- `tests/test_ws_drop_loud.py`: drops a client of every `_PANE_ORDER` app and checks each bell row carries the label, the Outline row never carries the id while its log line still does, and an unlabeled app keeps its id. Three existing assertions follow the labels. Four failures against the unchanged code.
- Runs at head: `npm test` 2833 passed and `npm run typecheck` clean; `pytest tests/test_ws_drop_loud.py tests/test_kernel_disconnect_banner.py tests/test_kernel_ws_heartbeat.py tests/test_restart_seam.py tests/test_injected_voice.py` 52 passed; the full `pytest tests` 7372 passed, 46 skipped.

Tier: fix
🤖 Generated with [Claude Code](https://claude.com/claude-code)