### PR TITLE
A same-origin markdown link opens in the file viewer, rendered, with its figures resolved against the document

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -46,6 +46,13 @@ clone writes its tracking ref; where nothing local could refresh the answer (a
 `--single-branch` clone, or a branch on origin this clone has not fetched) origin is asked on
 each open.
 
+**Opening a markdown document.** A markdown link in the chat opens in the file viewer,
+rendered, with **Raw** one click away — a path on the session's machine, or a link to a
+file served from the dashboard's own address (a published report, an evidence doc). Figures
+and links inside the document resolve relative to the document, so a `![fig](fig.png)`
+beside it shows, and a link to a sibling document opens in the same viewer. Links to files
+on other sites open in a new tab, as before.
+
 ### The feed
 
 The feed is Romp's task-management layer: a card for each task. Romp's

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -51,7 +51,8 @@ rendered, with **Raw** one click away — a path on the session's machine, or a 
 file served from the dashboard's own address (a published report, an evidence doc). Figures
 and links inside the document resolve relative to the document, so a `![fig](fig.png)`
 beside it shows, and a link to a sibling document opens in the same viewer. Links to files
-on other sites open in a new tab, as before.
+on other sites open in a new tab, as before — and a ctrl- or ⌘-click still opens the file in
+a tab.
 
 ### The feed
 

--- a/ui/webview/capped-read.test.ts
+++ b/ui/webview/capped-read.test.ts
@@ -4,7 +4,7 @@
 // these run the real reader. Fixtures are invented bytes; nothing here is recorded data.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { readTextCapped, humanSize, overCapWords } from "./capped-read";
+import { readTextCapped, humanSize, overCapWords, settleUrlResponse } from "./capped-read";
 
 const enc = new TextEncoder();
 
@@ -120,4 +120,67 @@ test("overCapWords: a KNOWN size names it against the limit; a size that would r
 
 test("overCapWords: the streaming refusal names no measured size — the true size was never read", () => {
   assert.equal(overCapWords(null, CAP), "this document is over 2 MB — too large to show here");
+});
+
+// ── settleUrlResponse: the pre-read decision, and the transfer STOPS on every refusal ──
+// A refused response used to paint its words and return while the body kept downloading for a modal
+// already closed (measured live: received bytes kept climbing after the close). The verdict helper
+// fires `stop` — the open's AbortController.abort — on every verdict that will not read the body.
+
+function resp(over: { ok?: boolean; status?: number; headers?: Record<string, string>; body?: ReadableStream<Uint8Array> | null | "stream" }) {
+  const h = new Map(Object.entries(over.headers || {}).map(([k, v]) => [k.toLowerCase(), v]));
+  const body = over.body === "stream" || over.body === undefined ? source([enc.encode("# doc\n")]).stream : over.body;
+  return { ok: over.ok ?? true, status: over.status ?? 200, headers: { get: (n: string) => h.get(n.toLowerCase()) ?? null }, body };
+}
+// a `stop` that behaves like the real one: aborting the controller also cancels the response body
+function stopper(body: ReadableStream<Uint8Array> | null) {
+  const ac = new AbortController();
+  const calls = { n: 0 };
+  return { ac, calls, stop: () => { calls.n++; ac.abort(); if (body) void body.cancel().catch(() => {}); } };
+}
+
+test("settleUrlResponse: a non-OK status → http verdict, and the transfer is stopped", () => {
+  const { stream, state } = source([enc.encode("nope")]);
+  const r = resp({ ok: false, status: 404, body: stream });
+  const s = stopper(r.body);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "http", status: 404 });
+  assert.equal(s.calls.n, 1, "stop fired exactly once");
+  assert.equal(s.ac.signal.aborted, true, "the controller is aborted");
+  return new Promise<void>((done) => setTimeout(() => { assert.equal(state.cancelled, true, "…and the body's source was cancelled"); done(); }, 5));
+});
+
+test("settleUrlResponse: a declared Content-Length past the cap → declared-too-large with the number, transfer stopped", () => {
+  const { stream, state } = source([enc.encode("x")]);
+  const r = resp({ headers: { "Content-Length": String(CAP + 1) }, body: stream });
+  const s = stopper(r.body);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "declared-too-large", bytes: CAP + 1 });
+  assert.equal(s.calls.n, 1);
+  assert.equal(s.ac.signal.aborted, true);
+  return new Promise<void>((done) => setTimeout(() => { assert.equal(state.cancelled, true); done(); }, 5));
+});
+
+test("settleUrlResponse: no body stream → no-body, stop still fires (symmetry: every non-read verdict aborts)", () => {
+  const r = resp({ body: null });
+  const s = stopper(null);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "no-body" });
+  assert.equal(s.calls.n, 1);
+  assert.equal(s.ac.signal.aborted, true);
+});
+
+test("settleUrlResponse: an OK response with a body under (or without) a declared length → read, and stop NEVER fires", () => {
+  const cases: Record<string, string>[] = [{}, { "Content-Length": String(CAP) }, { "Content-Length": "12" }, { "Content-Length": "not-a-number" }, { "content-length": "0" }];
+  for (const headers of cases) {
+    const r = resp({ headers });
+    const s = stopper(r.body);
+    assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "read" }, JSON.stringify(headers));
+    assert.equal(s.calls.n, 0, "the body is about to be read — nothing is stopped: " + JSON.stringify(headers));
+    assert.equal(s.ac.signal.aborted, false);
+  }
+});
+
+test("settleUrlResponse: the order is status, then declared length, then body — a 404 with a huge Content-Length is an http verdict", () => {
+  const r = resp({ ok: false, status: 500, headers: { "Content-Length": String(10 * CAP) }, body: null });
+  const s = stopper(null);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "http", status: 500 });
+  assert.equal(s.calls.n, 1, "stopped once, not once per reason");
 });

--- a/ui/webview/capped-read.test.ts
+++ b/ui/webview/capped-read.test.ts
@@ -184,3 +184,32 @@ test("settleUrlResponse: the order is status, then declared length, then body �
   assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "http", status: 500 });
   assert.equal(s.calls.n, 1, "stopped once, not once per reason");
 });
+
+// ── a 200 that is a WEB PAGE, not the document (review find on #958, 2026-09-07) ──
+// A proxy's SPA fallback or an auth page answers a missing/gated .md with 200 text/html; rendering that
+// as the document showed a scrambled page under the document's name with no error.
+
+test("settleUrlResponse: a 200 labelled text/html → not-document with the bare type, transfer stopped", () => {
+  const { stream, state } = source([enc.encode("<!doctype html><html>app shell</html>")]);
+  const r = resp({ headers: { "Content-Type": "text/html; charset=utf-8" }, body: stream });
+  const s = stopper(r.body);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "not-document", type: "text/html" });
+  assert.equal(s.calls.n, 1, "stop fired exactly once");
+  assert.equal(s.ac.signal.aborted, true);
+  return new Promise<void>((done) => setTimeout(() => { assert.equal(state.cancelled, true, "the page's bytes are not downloaded"); done(); }, 5));
+});
+
+test("settleUrlResponse: only text/html is refused — markdown, plain text, octet-stream and an ABSENT type all read", () => {
+  for (const type of ["text/markdown", "text/plain; charset=utf-8", "application/octet-stream", "text/x-markdown", null]) {
+    const r = resp({ headers: type === null ? {} : { "Content-Type": type }, body: source([enc.encode("# doc")]).stream });
+    const s = stopper(r.body);
+    assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "read" }, String(type));
+    assert.equal(s.calls.n, 0, "read never stops the transfer: " + String(type));
+  }
+});
+
+test("settleUrlResponse: a non-OK text/html answer is still the http verdict (the status is the news)", () => {
+  const r = resp({ ok: false, status: 404, headers: { "Content-Type": "text/html" }, body: source([enc.encode("<h1>404</h1>")]).stream });
+  const s = stopper(r.body);
+  assert.deepEqual(settleUrlResponse(r, CAP, s.stop), { kind: "http", status: 404 });
+});

--- a/ui/webview/capped-read.test.ts
+++ b/ui/webview/capped-read.test.ts
@@ -1,0 +1,123 @@
+// The URL viewer's capped body read, EXECUTED against synthetic streams (the review of 2026-09-06:
+// r.text() buffered the whole body, a closed modal did not cancel the read, and .length counted UTF-16
+// code units instead of bytes). ReadableStream / TextDecoder / AbortController are Node globals, so
+// these run the real reader. Fixtures are invented bytes; nothing here is recorded data.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { readTextCapped, humanSize, overCapWords } from "./capped-read";
+
+const enc = new TextEncoder();
+
+// A source that hands out `chunks` one per pull, recording how many were pulled and whether the
+// consumer cancelled it. `gate` (optional) holds the pull AFTER `holdAt` chunks until released — the
+// shape of a body still arriving from the network.
+function source(chunks: Uint8Array[], opts: { holdAt?: number } = {}) {
+  // pullsStarted: how many times the stream asked the source for a chunk; pulled: chunks handed out
+  const state = { pullsStarted: 0, pulled: 0, cancelled: false, release: () => { /* set below when a gate exists */ } };
+  const gate = opts.holdAt === undefined ? null : new Promise<void>((res) => { state.release = res; });
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      state.pullsStarted++;
+      if (gate && state.pulled === opts.holdAt) await gate;
+      if (state.cancelled) return;                       // a well-behaved source stops once cancelled
+      if (state.pulled >= chunks.length) { controller.close(); return; }
+      controller.enqueue(chunks[state.pulled++]);
+    },
+    cancel() { state.cancelled = true; },
+  }, { highWaterMark: 0 });        // no read-ahead: a pull happens only when the reader asks
+  return { stream, state };
+}
+
+test("a body of exactly the cap is accepted, in full, with its byte count", async () => {
+  const { stream, state } = source([enc.encode("12345"), enc.encode("67890")]);
+  const got = await readTextCapped(stream, 10);
+  assert.deepEqual(got, { text: "1234567890", bytes: 10 });
+  assert.equal(state.cancelled, false, "a body within the cap is never cancelled");
+  assert.equal(state.pulled, 2);
+});
+
+test("a body over the cap is refused after at most ONE chunk past it, and the source is cancelled", async () => {
+  const six = enc.encode("abcdef");
+  const { stream, state } = source([six, six, six, six, six]);
+  const got = await readTextCapped(stream, 10);
+  assert.ok("tooLarge" in got, "refused");
+  assert.equal(got.bytesSeen, 12, "the running total the moment it passed the cap — one chunk past, not the whole body");
+  assert.equal(state.cancelled, true, "the source was cancelled");
+  assert.ok(state.pulled < 5, "the rest of the body was never pulled (" + state.pulled + " of 5 chunks)");
+});
+
+test("a multi-byte UTF-8 body split mid-codepoint across chunks decodes correctly under the cap", async () => {
+  const whole = enc.encode("héllo — €uro ✓");            // 2-, 3- and 3-byte sequences
+  // split INSIDE the euro sign (E2 82 AC): find it and cut after its first byte
+  const at = whole.indexOf(0xe2) + 1;
+  const { stream } = source([whole.slice(0, at), whole.slice(at, at + 1), whole.slice(at + 1)]);
+  const got = await readTextCapped(stream, 1024);
+  assert.deepEqual(got, { text: "héllo — €uro ✓", bytes: whole.byteLength });
+});
+
+test("the cap is BYTES, not code units: a body of few characters but many bytes is refused", async () => {
+  // 8 code units of 3 bytes each = 24 bytes; a code-unit count would have accepted it under a cap of 20
+  const { stream, state } = source([enc.encode("€€€€"), enc.encode("€€€€")]);
+  const got = await readTextCapped(stream, 20);
+  assert.ok("tooLarge" in got && got.bytesSeen === 24);
+  assert.equal(state.cancelled, true);
+});
+
+test("an already-aborted signal rejects with an AbortError and cancels the source without reading", async () => {
+  const ac = new AbortController();
+  ac.abort();
+  const { stream, state } = source([enc.encode("never"), enc.encode("read")]);
+  await assert.rejects(readTextCapped(stream, 100, ac.signal), (e: Error) => e.name === "AbortError");
+  assert.equal(state.cancelled, true);
+  assert.equal(state.pulled, 0, "not one chunk consumed");
+});
+
+test("an abort MID-BODY rejects with an AbortError, cancels the source, and pulls nothing further", async () => {
+  const ac = new AbortController();
+  const { stream, state } = source([enc.encode("first"), enc.encode("second"), enc.encode("third")], { holdAt: 1 });
+  const pending = readTextCapped(stream, 100, ac.signal);
+  await new Promise((r) => setTimeout(r, 10));            // the reader has taken "first" and is waiting on the gate
+  assert.equal(state.pulled, 1);
+  assert.equal(state.pullsStarted, 2, "the second pull is in flight, held by the gate");
+  ac.abort();                                              // the viewer was closed
+  await assert.rejects(pending, (e: Error) => e.name === "AbortError", "never resolves with a torso");
+  assert.equal(state.cancelled, true, "the source was cancelled — the network read stops");
+  state.release();                                         // let the held pull settle; it must deliver nothing
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(state.pulled, 1, "the held pull handed out nothing after the cancel");
+  assert.equal(state.pullsStarted, 2, "and the stream never asked the source for another chunk");
+});
+
+test("an empty body is accepted as empty text", async () => {
+  const { stream } = source([]);
+  assert.deepEqual(await readTextCapped(stream, 10), { text: "", bytes: 0 });
+});
+
+// ── the refusal's words: base-1024 like the cap itself, and never an equal-looking pair ──
+
+const CAP = 2 * 1024 * 1024;
+
+test("humanSize is base-1024 with a trailing .0 dropped, so the 2 MiB cap reads '2 MB'", () => {
+  assert.equal(humanSize(CAP), "2 MB");
+  assert.equal(humanSize(1024 * 1024), "1 MB");
+  assert.equal(humanSize(2.5 * 1024 * 1024), "2.5 MB");
+  assert.equal(humanSize(3_000_000), "2.9 MB", "3,000,000 bytes is 2.86 MiB");
+  assert.equal(humanSize(1536), "2 KB", "whole kilobytes below a megabyte");
+  assert.equal(humanSize(12), "1 KB", "never '0 KB'");
+});
+
+test("overCapWords: a KNOWN size names it against the limit; a size that would read equal is spelled in bytes", () => {
+  assert.equal(overCapWords(3_000_000, CAP), "this document is 2.9 MB, over the 2 MB limit");
+  assert.equal(overCapWords(10 * 1024 * 1024, CAP), "this document is 10 MB, over the 2 MB limit");
+  // the cosmetic bug: 2,097,252 bytes rounds to the same words as the cap
+  assert.equal(overCapWords(2_097_252, CAP), "this document is 2,097,252 bytes, over the 2 MB limit");
+  // sweep the whole collision band: no pair of equal-looking words anywhere past the cap
+  for (let n = CAP + 1; n < CAP + 60_000; n += 997) {
+    const words = overCapWords(n, CAP);
+    assert.doesNotMatch(words, /is 2 MB, over the 2 MB/, words);
+  }
+});
+
+test("overCapWords: the streaming refusal names no measured size — the true size was never read", () => {
+  assert.equal(overCapWords(null, CAP), "this document is over 2 MB — too large to show here");
+});

--- a/ui/webview/capped-read.ts
+++ b/ui/webview/capped-read.ts
@@ -51,6 +51,42 @@ export async function readTextCapped(stream: ReadableStream<Uint8Array>, cap: nu
   }
 }
 
+// ── the decision a URL response gets BEFORE its body is read ──────────────────────────────────────
+// Pure apart from one callback, so it executes under node --test: `stop` is the open's
+// AbortController.abort, and it fires on EVERY verdict that will not read the body. The review found
+// the hole this closes: a refused response (a 404, an oversized Content-Length) painted its words and
+// returned, but the TRANSFER kept running — Chromium went on receiving the body for a modal that had
+// already been closed, because nothing had aborted the signal and the teardown had by then let go of
+// the controller. Aborting after the response resolved tears the body stream down, and nothing
+// reaches the fetch's .catch, since that promise has already settled.
+export type ResponseLike = {
+  ok: boolean;
+  status: number;
+  headers: { get(name: string): string | null };
+  body: ReadableStream<Uint8Array> | null;
+};
+export type UrlVerdict =
+  | { kind: "read" }
+  | { kind: "http"; status: number }
+  | { kind: "declared-too-large"; bytes: number }
+  | { kind: "no-body" };
+
+/** http (a non-OK status) → declared-too-large (a Content-Length past `cap`; absent or unparseable is
+ *  not a refusal — the streamed read decides) → no-body (nothing to read) → read. `stop` fires on the
+ *  first three, never on read. */
+export function settleUrlResponse(r: ResponseLike, cap: number, stop: () => void): UrlVerdict {
+  let v: UrlVerdict;
+  if (!r.ok) v = { kind: "http", status: r.status };
+  else {
+    const declared = Number(r.headers.get("Content-Length") || "");
+    if (declared > cap) v = { kind: "declared-too-large", bytes: declared };
+    else if (!r.body) v = { kind: "no-body" };
+    else v = { kind: "read" };
+  }
+  if (v.kind !== "read") stop();
+  return v;
+}
+
 /** Base-1024, the unit the cap is set in (2 * 1024 * 1024 IS 2 MB here): a trailing ".0" is dropped
  *  so the cap reads "2 MB", and anything under a megabyte is whole kilobytes. */
 export function humanSize(n: number): string {

--- a/ui/webview/capped-read.ts
+++ b/ui/webview/capped-read.ts
@@ -1,0 +1,75 @@
+// Reading a URL document's body under a byte cap, INCREMENTALLY (the URL viewer's review, 2026-09-06).
+// The first cut called r.text() and measured afterwards, which was wrong three ways: the whole body was
+// buffered before any check whenever Content-Length was absent (or described compressed bytes), a
+// closed modal did not stop the read, and `.length` counts UTF-16 code units rather than bytes — a
+// 2.4 MB UTF-8 document of 0.8 M code units slipped under a 2 MB cap. This reader pulls the stream
+// chunk by chunk, counts the BYTES as they arrive, cancels the source the moment the running total
+// passes the cap (so at most one chunk past it is ever pulled), decodes with a streaming TextDecoder so
+// a multi-byte codepoint split across two chunks decodes correctly, and stops on an AbortSignal. Pure:
+// ReadableStream, TextDecoder and DOMException are globals in the browser and in Node ≥ 18 alike, so
+// it executes under `node --test` (capped-read.test.ts) instead of being pinned.
+
+export type CappedRead = { text: string; bytes: number } | { tooLarge: true; bytesSeen: number };
+
+function abortError(): Error {
+  return typeof DOMException !== "undefined"
+    ? new DOMException("the read was aborted", "AbortError")
+    : Object.assign(new Error("the read was aborted"), { name: "AbortError" });
+}
+
+/** Read `stream` as UTF-8 text while its byte count stays ≤ `cap`. Resolves `{ text, bytes }` for a body
+ *  within the cap, `{ tooLarge, bytesSeen }` once the bytes read exceed it (the source is cancelled at
+ *  that moment — the rest is never pulled), and REJECTS with an AbortError when `signal` fires (the
+ *  source is cancelled then too, so a torn-down viewer keeps pulling nothing). */
+export async function readTextCapped(stream: ReadableStream<Uint8Array>, cap: number, signal?: AbortSignal): Promise<CappedRead> {
+  const reader = stream.getReader();
+  const cancel = () => reader.cancel().catch(() => { /* already settled */ });
+  if (signal?.aborted) { await cancel(); throw abortError(); }
+  // The abort cancels the SOURCE, not just this loop: a pending read() settles as done and no further
+  // chunk is pulled — the loop then notices the signal and rejects rather than returning a torso.
+  const onAbort = () => { void cancel(); };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  const decoder = new TextDecoder("utf-8");
+  let seen = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (signal?.aborted) throw abortError();
+      if (done) break;
+      seen += value.byteLength;
+      if (seen > cap) {
+        await cancel();
+        return { tooLarge: true, bytesSeen: seen };
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();                          // flush a trailing partial sequence (as U+FFFD)
+    return { text, bytes: seen };
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+/** Base-1024, the unit the cap is set in (2 * 1024 * 1024 IS 2 MB here): a trailing ".0" is dropped
+ *  so the cap reads "2 MB", and anything under a megabyte is whole kilobytes. */
+export function humanSize(n: number): string {
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1).replace(/\.0$/, "") + " MB";
+  return Math.max(1, Math.round(n / 1024)) + " KB";
+}
+
+function withCommas(n: number): string {
+  return String(n).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/** The refusal's words. `bytes` is the size when it is KNOWN (a Content-Length the server declared);
+ *  null when the streaming reader tripped the cap mid-body — the true size was never measured, and
+ *  naming one would claim it. A known size that rounds to the same words as the cap ("2.1 MB … 2.1 MB",
+ *  the cosmetic bug) is spelled out in bytes instead, so the pair never reads as equal. */
+export function overCapWords(bytes: number | null, cap: number): string {
+  const limit = humanSize(cap);
+  if (bytes === null) return "this document is over " + limit + " — too large to show here";
+  const size = humanSize(bytes);
+  const shown = size === limit ? withCommas(bytes) + " bytes" : size;
+  return "this document is " + shown + ", over the " + limit + " limit";
+}

--- a/ui/webview/capped-read.ts
+++ b/ui/webview/capped-read.ts
@@ -68,15 +68,22 @@ export type ResponseLike = {
 export type UrlVerdict =
   | { kind: "read" }
   | { kind: "http"; status: number }
+  | { kind: "not-document"; type: string }
   | { kind: "declared-too-large"; bytes: number }
   | { kind: "no-body" };
 
-/** http (a non-OK status) → declared-too-large (a Content-Length past `cap`; absent or unparseable is
- *  not a refusal — the streamed read decides) → no-body (nothing to read) → read. `stop` fires on the
- *  first three, never on read. */
+/** http (a non-OK status) → not-document (a 200 labelled text/html: a proxy's SPA fallback or an
+ *  auth page standing in for a missing .md — rendering that as the document would show a scrambled
+ *  page under the document's name with no error, against the fail-loudly rule; review find on #958,
+ *  2026-09-07. Only text/html is refused: text/markdown, text/plain, application/octet-stream and an
+ *  ABSENT header all read, so a static server with an odd MIME map still works) → declared-too-large
+ *  (a Content-Length past `cap`; absent or unparseable is not a refusal — the streamed read decides)
+ *  → no-body (nothing to read) → read. `stop` fires on every verdict but read. */
 export function settleUrlResponse(r: ResponseLike, cap: number, stop: () => void): UrlVerdict {
   let v: UrlVerdict;
+  const type = (r.headers.get("Content-Type") || "").trim().toLowerCase();
   if (!r.ok) v = { kind: "http", status: r.status };
+  else if (type.startsWith("text/html")) v = { kind: "not-document", type: type.split(";")[0] };
   else {
     const declared = Number(r.headers.get("Content-Length") || "");
     if (declared > cap) v = { kind: "declared-too-large", bytes: declared };

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -83,7 +83,7 @@ test("userMd() renders through the breaks:true instance and the SAME DOMPurify p
   assert.match(fn, /DOMPurify\.sanitize\(userMdHtml\(src\), MD_PURIFY\)/);
   const mdFn = RENDER.match(/function md\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
   assert.match(mdFn, /DOMPurify\.sanitize\(dirty, MD_PURIFY\)/, "md() sanitizes with the same shared profile");
-  assert.match(RENDER, /const MD_PURIFY: Config = \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\] \};/);
+  assert.match(RENDER, /const MD_PURIFY: Config = \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\], ALLOW_DATA_ATTR: false \};/);
 });
 
 test("the user bubble renders the user's OWN words with userMd, harness notes and everything else with md", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1498,6 +1498,9 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
   font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
 .fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+/* a heading an in-document link lands on (scrollIntoView) sits a breath below the title bar's hairline
+   rather than flush against it — the bar's own 10px spacing */
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 { scroll-margin-top: 10px; }
 .fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
 .fileview-md li { margin: 0.2em 0; }
 .fileview-md strong { color: var(--fg); font-weight: 600; }

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -264,7 +264,8 @@ test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML u
   assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
   assert.match(VIEW, /import DOMPurify from "dompurify";/);
   // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs as inline <svg>
-  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\] \}\);/);
+  // …and data-* never rides in from a document's raw HTML: the page's delegates key actions off data-act
+  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\], ALLOW_DATA_ATTR: false \}\);/);
   // a README's links open a NEW tab rather than navigating the hosting pane's document away
   assert.match(VIEW, /target = "_blank"/);
   assert.match(VIEW, /rel = "noopener"/);
@@ -685,7 +686,7 @@ test("the title bar carries a session chip resolved from the sid — never inven
   assert.match(openFn, /bar\.appendChild\(name\); if \(sess\) bar\.appendChild\(sess\); bar\.appendChild\(acts\);/,
     "between the path and the actions");
   // the signatures every opener and the relay pin depend on are exactly as they were
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null\): void \{/);
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, frag\?: string \| null\): void \{/);   // frag: a sibling link's fragment lands after the render
   assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void\): void \{/);
 });
 

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -318,7 +318,7 @@ export function closeFileView(): void {
 }
 
 /** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks. */
-export function openFileView(path: string, sid?: string | null): void {
+export function openFileView(path: string, sid?: string | null, frag?: string | null): void {
   // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
   // edited-but-unsaved file A must not silently eat A's buffer.
   if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
@@ -335,6 +335,10 @@ export function openFileView(path: string, sid?: string | null): void {
   wrap.id = "romp-fileview";
   wrap.onclick = (ev) => { if (ev.target === wrap) closeFileView(); };
   const box = el("div", "fileview");
+  // A sibling link's `#fragment` (`[see](report.md#results)`, stamped data-frag by mdBlock) lands on
+  // its heading after the FIRST rendered paint — once; a Raw view has no ids to land on, so the
+  // landing waits for the Rendered toggle rather than being spent (review find on #958, 2026-09-07).
+  let pendingFrag: string | null = frag || null;
   document.body.classList.add("fileview-open");
 
   const bar = el("div", "fileview-bar");
@@ -541,7 +545,7 @@ export function openFileView(path: string, sid?: string | null): void {
     "fv-open": (a, ev) => {
       ev.preventDefault();
       const target = a.dataset.path;
-      if (target) openFileView(target, sid);
+      if (target) openFileView(target, sid, a.dataset.frag || null);
     },
     // an in-document `[top](#evidence)` lands on its heading (mdBlock minted the ids) — never a tab
     "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
@@ -613,7 +617,11 @@ export function openFileView(path: string, sid?: string | null): void {
       return;
     }
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
-    body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));   // long lines always soft-wrap (the user 2026-08-24)
+    body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));
+    if (rendered && pendingFrag) {
+      const h = pendingFrag; pendingFrag = null;
+      requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, h); });
+    }   // long lines always soft-wrap (the user 2026-08-24)
   };
 
   // Selection → labeled quote chip (the user 2026-08-23): mouseup is the gesture's settle point.
@@ -962,6 +970,19 @@ export function openUrlView(href: string): void {
   wrap.appendChild(box);
   document.body.appendChild(wrap);
 
+  // The URL's own #fragment (`evidence.md#results`) lands after the FIRST RENDERED paint — once. A
+  // Raw view has no heading ids, so a saved Raw preference does not SPEND the landing: it waits for
+  // the Rendered toggle (review find on #958, 2026-09-07: landed was set before the mode check).
+  let landed = false;
+  const landFragment = () => {
+    if (landed) return;
+    let hash = "";
+    try { hash = new URL(href).hash; } catch { /* not a URL — nothing to land on */ }
+    if (!hash) { landed = true; return; }
+    if (fmt.md !== "rendered") return;                 // nothing to land on yet; the next rendered paint tries again
+    landed = true;
+    requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, hash); });
+  };
   const renderBody = () => {
     for (const [mode, b] of segBtns) {
       const on = fmt.md === mode;
@@ -972,6 +993,7 @@ export function openUrlView(href: string): void {
     body.replaceChildren(fmt.md === "rendered"
       ? mdBlock(text, { kind: "url", href: loc })      // relative refs resolve against where it LIVES
       : codeBlock(text, parts.base, true));            // basename → langFor → markdown highlighting
+    landFragment();                                    // after the paint, and only a rendered one lands
   };
   renderBody();
 
@@ -1004,21 +1026,15 @@ export function openUrlView(href: string): void {
     parts = urlTitleParts(loc);
     dir.textContent = parts.dir; base.textContent = parts.base; name.title = loc;
   };
-  // The URL's own #fragment (`evidence.md#results`) lands after the FIRST rendered paint — once, and
-  // only when there is a rendered body with heading ids to land on.
-  let landed = false;
-  const landFragment = () => {
-    if (landed) return;
-    landed = true;
-    let hash = "";
-    try { hash = new URL(href).hash; } catch { /* not a URL — nothing to land on */ }
-    if (hash && fmt.md === "rendered") requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, hash); });
-  };
-
   // Same-origin, cookie-authed, cache: no-store like every viewer fetch, on this open's abort signal.
-  // No Content-Type sniffing: the URL was intercepted because its PATH is markdown, so the body is
-  // read as text and rendered as markdown, whatever the server labelled it.
-  fetch(href, { cache: "no-store", signal: ctrl.signal }).then(async (r) => {
+  // mode: "same-origin" holds the rule through REDIRECTS too: the clicked URL passed isMarkdownUrl, but
+  // a same-origin alias that 302s to a foreign host answering with a permissive CORS header would
+  // otherwise be fetched and rendered with that host as the base for every relative figure (review
+  // find on #958, 2026-09-07); the browser now rejects such a redirect and the .catch below says so.
+  // No Content-Type sniffing beyond one refusal: the URL was intercepted because its PATH is markdown,
+  // so the body is read as text and rendered as markdown whatever the server labelled it — except a
+  // 200 labelled text/html, which is a web page standing in for the document (settleUrlResponse).
+  fetch(href, { cache: "no-store", mode: "same-origin", signal: ctrl.signal }).then(async (r) => {
     // EVERY exit that stops short of consuming the body aborts this open's controller — once the
     // response has resolved that is what tears the transfer down (the review: a refused response's
     // bytes kept arriving for a modal already closed, because .finally had let go of the controller
@@ -1027,6 +1043,7 @@ export function openUrlView(href: string): void {
     relocate(r);
     const v = settleUrlResponse(r, URL_TEXT_MAX_BYTES, () => ctrl.abort());
     if (v.kind === "http") { fail("HTTP " + v.status + " from " + hostWord(loc)); return; }
+    if (v.kind === "not-document") { fail("the server answered with a web page, not a document (" + v.type + ")"); return; }
     if (v.kind === "declared-too-large") { fail(overCapWords(v.bytes, URL_TEXT_MAX_BYTES)); return; }
     if (v.kind === "no-body") { fail("this document could not be loaded from this page — the response carried no body"); return; }
     // Streamed under the cap: bytes counted as they arrive, the source cancelled the moment they pass
@@ -1036,8 +1053,7 @@ export function openUrlView(href: string): void {
     if (!wrap.isConnected) { ctrl.abort(); return; }
     if ("tooLarge" in got) { ctrl.abort(); fail(overCapWords(null, URL_TEXT_MAX_BYTES)); return; }
     text = got.text;
-    renderBody();
-    landFragment();
+    renderBody();                                      // paints, and lands the fragment if this paint is rendered
   }).catch((err) => {
     // Only the TEARDOWN's abort is silent (the modal is gone, or a refusal already painted its words);
     // an independently errored stream that merely wears the AbortError name still paints its failure.
@@ -1155,7 +1171,12 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
     const dirty = marked.parse(text) as string;
     // html + svg, in lockstep with the chat's md(): KaTeX draws stretchy glyphs (\sqrt radicals,
     // wide accents) as inline <svg> even in html output, and the html-only profile ate them.
-    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] });
+    // ALLOW_DATA_ATTR: false — a document's raw HTML must not carry data-* into the page: the viewer's
+    // body delegate lets an act it does not own bubble to render.ts's document-level delegate, so a
+    // `<span data-act="stopRetrying">` in a published report would interrupt the active session on a
+    // click (review find on #958, 2026-09-07). The viewer's own fv-open / fv-anchor stamps are set
+    // AFTER this sanitize, so they are unaffected.
+    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"], ALLOW_DATA_ATTR: false });
   } catch {
     box.textContent = text;                            // a marked bug must never cost the content
   }
@@ -1199,6 +1220,8 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
         const joined = joinDocPath(doc.path, href);
         a.dataset.act = "fv-open";
         a.dataset.path = joined;
+        const hash = href.indexOf("#") >= 0 ? href.slice(href.indexOf("#")) : "";
+        if (hash.length > 1) a.dataset.frag = hash;          // `report.md#results`: the heading to land on, once open
         a.title = joined;
       }
     });

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -26,7 +26,7 @@ import { quoteSrcLabel } from "./docreview";
 const gclock = require("./gesture-clock.js");   // the gesture clock every settings post stamps through
 import { delegate } from "./actions";
 import { resolveDocRelative, joinDocPath, urlTitleParts, headingSlug, uniqueSlugs } from "./md-links";
-import { readTextCapped, overCapWords } from "./capped-read";
+import { readTextCapped, overCapWords, settleUrlResponse } from "./capped-read";
 
 // hljs is registered per-bundle. Same language set (and grammar registrations) the chat's fence
 // highlighting uses, dup-guarded, so importing this module alongside render.ts costs nothing.
@@ -1019,23 +1019,29 @@ export function openUrlView(href: string): void {
   // No Content-Type sniffing: the URL was intercepted because its PATH is markdown, so the body is
   // read as text and rendered as markdown, whatever the server labelled it.
   fetch(href, { cache: "no-store", signal: ctrl.signal }).then(async (r) => {
-    if (!wrap.isConnected) return;
+    // EVERY exit that stops short of consuming the body aborts this open's controller — once the
+    // response has resolved that is what tears the transfer down (the review: a refused response's
+    // bytes kept arriving for a modal already closed, because .finally had let go of the controller
+    // and nothing had aborted it). settleUrlResponse fires the abort itself on each refusal verdict.
+    if (!wrap.isConnected) { ctrl.abort(); return; }
     relocate(r);
-    if (!r.ok) { fail("HTTP " + r.status + " from " + hostWord(loc)); return; }
-    const declared = Number(r.headers.get("Content-Length") || "");
-    if (declared > URL_TEXT_MAX_BYTES) { fail(overCapWords(declared, URL_TEXT_MAX_BYTES)); return; }
-    if (!r.body) { fail("this document could not be loaded from this page — the response carried no body"); return; }
+    const v = settleUrlResponse(r, URL_TEXT_MAX_BYTES, () => ctrl.abort());
+    if (v.kind === "http") { fail("HTTP " + v.status + " from " + hostWord(loc)); return; }
+    if (v.kind === "declared-too-large") { fail(overCapWords(v.bytes, URL_TEXT_MAX_BYTES)); return; }
+    if (v.kind === "no-body") { fail("this document could not be loaded from this page — the response carried no body"); return; }
     // Streamed under the cap: bytes counted as they arrive, the source cancelled the moment they pass
     // it (never the whole body buffered first), decoded as a stream so a codepoint split across two
     // chunks survives, and aborted with the viewer (ctrl.signal).
-    const got = await readTextCapped(r.body, URL_TEXT_MAX_BYTES, ctrl.signal);
-    if (!wrap.isConnected) return;
-    if ("tooLarge" in got) { fail(overCapWords(null, URL_TEXT_MAX_BYTES)); return; }
+    const got = await readTextCapped(r.body!, URL_TEXT_MAX_BYTES, ctrl.signal);   // read verdict: the body is there
+    if (!wrap.isConnected) { ctrl.abort(); return; }
+    if ("tooLarge" in got) { ctrl.abort(); fail(overCapWords(null, URL_TEXT_MAX_BYTES)); return; }
     text = got.text;
     renderBody();
     landFragment();
   }).catch((err) => {
-    if ((err as { name?: string } | null)?.name === "AbortError") return;   // the teardown cancelled it — the modal is gone
+    // Only the TEARDOWN's abort is silent (the modal is gone, or a refusal already painted its words);
+    // an independently errored stream that merely wears the AbortError name still paints its failure.
+    if (ctrl.signal.aborted) return;
     fail("this document could not be loaded from this page — " + String(err && (err as Error).message || err));
   }).finally(() => {
     if (urlAbort === ctrl) urlAbort = null;              // this read is over; a later open's registration stands

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -25,7 +25,8 @@ import { quoteSrcLabel } from "./docreview";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const gclock = require("./gesture-clock.js");   // the gesture clock every settings post stamps through
 import { delegate } from "./actions";
-import { resolveDocRelative, joinDocPath, urlTitleParts } from "./md-links";
+import { resolveDocRelative, joinDocPath, urlTitleParts, headingSlug, uniqueSlugs } from "./md-links";
+import { readTextCapped, overCapWords } from "./capped-read";
 
 // hljs is registered per-bundle. Same language set (and grammar registrations) the chat's fence
 // highlighting uses, dup-guarded, so importing this module alongside render.ts costs nothing.
@@ -128,13 +129,10 @@ function loaderEl(): HTMLElement {
 
 // The 2 MB body cap for a URL document — a MIRROR of the kernel's _TEXT_MAX_BYTES (kernel.py), which
 // is what a local .md is already held to on the /file route. The URL viewer fetches from the browser,
-// so no kernel ever sees the body; the cap is applied here, from Content-Length when the server
-// sends one and from the decoded length otherwise. md-url-view.test.ts pins the two numbers equal.
+// so no kernel ever sees the body; the cap is applied here — a declared Content-Length refuses before
+// the body is read, and otherwise the streaming reader (capped-read.ts) counts the bytes as they
+// arrive and cancels the source the moment they pass it. md-url-view.test.ts pins the two numbers equal.
 const URL_TEXT_MAX_BYTES = 2 * 1024 * 1024;
-
-function humanSize(n: number): string {
-  return n >= 1e6 ? (n / 1e6).toFixed(1) + " MB" : Math.max(1, Math.round(n / 1e3)) + " KB";
-}
 
 // ── raw-mode editing (the file browser's slice 2, the user 2026-08-14) ─────────────────────────────
 // The save op rides the WS poster the pane's boot hands initFileView; replies route back to the OPEN
@@ -176,6 +174,17 @@ function dropMediaUrl(): void {
   if (mediaUrlLive) {
     try { URL.revokeObjectURL(mediaUrlLive); } catch { /* already gone */ }
     mediaUrlLive = null;
+  }
+}
+// ONE in-flight URL read at a time, the same shape as mediaUrlLive: the URL viewer registers its
+// AbortController here and BOTH exits (closeFileView and either replace path) abort it, so a modal
+// torn down mid-body cancels its fetch and its stream — a stale read must never keep pulling bytes
+// for a viewer that is gone.
+let urlAbort: AbortController | null = null;
+function dropUrlRead(): void {
+  if (urlAbort) {
+    try { urlAbort.abort(); } catch { /* already settled */ }
+    urlAbort = null;
   }
 }
 
@@ -303,6 +312,7 @@ export function closeFileView(): void {
   editHooks = null;
   gitHooks = null;                                     // a reply landing after the close decorates nothing
   dropMediaUrl();                                      // an image/PDF view's bytes leave with the viewer
+  dropUrlRead();                                       // …and a URL view's in-flight read is cancelled
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
@@ -316,6 +326,7 @@ export function openFileView(path: string, sid?: string | null): void {
   editHooks = null;
   gitHooks = null;                                     // the replace path skips closeFileView — same drop
   dropMediaUrl();                                      // …and the old viewer's image bytes (the Reload path)
+  dropUrlRead();                                       // …and a URL viewer's in-flight read, if that is what was up
   document.getElementById("romp-fileview")?.remove();
   // backdrop (the whole overlay carries the id every open/closed check targets) + the ~95% card.
   // The backdrop treatment matches the lightbox: dimmed, click outside the card closes, content
@@ -532,6 +543,8 @@ export function openFileView(path: string, sid?: string | null): void {
       const target = a.dataset.path;
       if (target) openFileView(target, sid);
     },
+    // an in-document `[top](#evidence)` lands on its heading (mdBlock minted the ids) — never a tab
+    "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
   });
   // Per the loading-state rule the first thing up is the romp loader, not a blank pane — a file coming
   // over an ssh tunnel to a phone is a real wait.
@@ -872,7 +885,12 @@ export function openUrlView(href: string): void {
   editHooks = null;
   gitHooks = null;
   dropMediaUrl();
+  dropUrlRead();                                       // a previous URL viewer's read stops pulling bytes
   document.getElementById("romp-fileview")?.remove();
+  // THIS open's read, registered for the teardowns above (the mediaUrlLive pattern): the fetch and the
+  // streaming body read both ride ctrl.signal, so a close or a replace mid-body cancels them.
+  const ctrl = new AbortController();
+  urlAbort = ctrl;
   const wrap = el("div");
   wrap.id = "romp-fileview";
   wrap.onclick = (ev) => { if (ev.target === wrap) closeFileView(); };
@@ -880,11 +898,13 @@ export function openUrlView(href: string): void {
   document.body.classList.add("fileview-open");
 
   // Title: host/dir/ dimmed then the basename, the local viewer's two-element treatment — but the
-  // directory half is NOT a browse link here: there is no listing to open for a URL.
+  // directory half is NOT a browse link here: there is no listing to open for a URL. Drawn from the
+  // clicked href now and RE-DRAWN from the response's URL once it lands (a redirect moves the document).
   const bar = el("div", "fileview-bar");
   const name = el("div", "fileview-name");
   name.title = href;                                   // the full URL, one hover away
-  const parts = urlTitleParts(href);
+  let parts = urlTitleParts(href);
+  let loc = href;                                      // where the document LIVES: the response URL once it lands
   const dir = el("span", "fileview-dir");
   dir.textContent = parts.dir;
   const base = el("span", "fileview-base");
@@ -931,6 +951,12 @@ export function openUrlView(href: string): void {
   bar.appendChild(name); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  // In-document links land on their heading (mdBlock's fv-anchor stamp): one delegated listener, the
+  // local viewer's pattern. No fv-open here — a URL document's sibling links are made absolute and
+  // the chat's own anchor delegate routes them.
+  delegate(body, {
+    "fv-anchor": (a, ev) => { ev.preventDefault(); scrollToFragment(body, a.getAttribute("href") || ""); },
+  });
   body.appendChild(loaderEl());                        // loader first; the fetch below replaces it
   box.appendChild(bar); box.appendChild(body);
   wrap.appendChild(box);
@@ -944,7 +970,7 @@ export function openUrlView(href: string): void {
     }
     if (text === null) return;                         // the loader holds the body until the bytes land
     body.replaceChildren(fmt.md === "rendered"
-      ? mdBlock(text, { kind: "url", href })
+      ? mdBlock(text, { kind: "url", href: loc })      // relative refs resolve against where it LIVES
       : codeBlock(text, parts.base, true));            // basename → langFor → markdown highlighting
   };
   renderBody();
@@ -969,26 +995,50 @@ export function openUrlView(href: string): void {
     why.appendChild(linkOut());
     body.replaceChildren(why);
   };
-  const host = parts.dir.split("/")[0] || href;
-  const tooLarge = (n: number) =>
-    fail("this document is " + humanSize(n) + " — too large to show here (the cap is " + humanSize(URL_TEXT_MAX_BYTES) + ")");
+  const hostWord = (u: string) => urlTitleParts(u).dir.split("/")[0] || u;
+  // Redraw the title from where the response actually CAME from: `/latest.md` → 302 →
+  // `/reports/run-1/evidence.md` names the second, and relative figures resolve against it (loc feeds
+  // mdBlock). The clicked href stays what Open ↗ and Copy URL hand back — the link the user was given.
+  const relocate = (r: Response) => {
+    loc = r.url || href;
+    parts = urlTitleParts(loc);
+    dir.textContent = parts.dir; base.textContent = parts.base; name.title = loc;
+  };
+  // The URL's own #fragment (`evidence.md#results`) lands after the FIRST rendered paint — once, and
+  // only when there is a rendered body with heading ids to land on.
+  let landed = false;
+  const landFragment = () => {
+    if (landed) return;
+    landed = true;
+    let hash = "";
+    try { hash = new URL(href).hash; } catch { /* not a URL — nothing to land on */ }
+    if (hash && fmt.md === "rendered") requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, hash); });
+  };
 
-  // Same-origin, cookie-authed, cache: no-store like every viewer fetch. No Content-Type sniffing:
-  // the URL was intercepted because its PATH is markdown, so the body is read as text and rendered as
-  // markdown, whatever the server labelled it.
-  fetch(href, { cache: "no-store" }).then((r) => {
+  // Same-origin, cookie-authed, cache: no-store like every viewer fetch, on this open's abort signal.
+  // No Content-Type sniffing: the URL was intercepted because its PATH is markdown, so the body is
+  // read as text and rendered as markdown, whatever the server labelled it.
+  fetch(href, { cache: "no-store", signal: ctrl.signal }).then(async (r) => {
     if (!wrap.isConnected) return;
-    if (!r.ok) { fail("HTTP " + r.status + " from " + host); return; }
+    relocate(r);
+    if (!r.ok) { fail("HTTP " + r.status + " from " + hostWord(loc)); return; }
     const declared = Number(r.headers.get("Content-Length") || "");
-    if (declared > URL_TEXT_MAX_BYTES) { tooLarge(declared); return; }
-    return r.text().then((t) => {
-      if (!wrap.isConnected) return;
-      if (t.length > URL_TEXT_MAX_BYTES) { tooLarge(t.length); return; }
-      text = t;
-      renderBody();
-    });
+    if (declared > URL_TEXT_MAX_BYTES) { fail(overCapWords(declared, URL_TEXT_MAX_BYTES)); return; }
+    if (!r.body) { fail("this document could not be loaded from this page — the response carried no body"); return; }
+    // Streamed under the cap: bytes counted as they arrive, the source cancelled the moment they pass
+    // it (never the whole body buffered first), decoded as a stream so a codepoint split across two
+    // chunks survives, and aborted with the viewer (ctrl.signal).
+    const got = await readTextCapped(r.body, URL_TEXT_MAX_BYTES, ctrl.signal);
+    if (!wrap.isConnected) return;
+    if ("tooLarge" in got) { fail(overCapWords(null, URL_TEXT_MAX_BYTES)); return; }
+    text = got.text;
+    renderBody();
+    landFragment();
   }).catch((err) => {
+    if ((err as { name?: string } | null)?.name === "AbortError") return;   // the teardown cancelled it — the modal is gone
     fail("this document could not be loaded from this page — " + String(err && (err as Error).message || err));
+  }).finally(() => {
+    if (urlAbort === ctrl) urlAbort = null;              // this read is over; a later open's registration stands
   });
 }
 
@@ -1065,6 +1115,20 @@ function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement 
   return wrap;
 }
 
+// Land an in-document fragment on its heading. The fragment — as typed, percent-encoded or not —
+// slugs the same way the heading ids were minted, so `#Evidence%20Results`, `#evidence-results` and
+// `#Evidence Results` all find md-evidence-results inside THIS rendered box (never the page's own ids).
+// Nothing found → nothing happens: inert, never a scroll to the top and never a navigation.
+function scrollToFragment(box: HTMLElement, fragment: string): boolean {
+  let frag = fragment.replace(/^#/, "");
+  try { frag = decodeURIComponent(frag); } catch { /* a stray % — match the bytes as written */ }
+  if (!frag) return false;
+  const target = box.querySelector('[id="md-' + headingSlug(frag) + '"]');   // the slug's alphabet needs no escaping
+  if (!target) return false;
+  target.scrollIntoView({ block: "start" });
+  return true;
+}
+
 // Where the rendered document LIVES, so its relative references can be resolved against it (the user
 // 2026-09-06: a `![fig](fig.png)` in a viewed document pointed at the dashboard's root). Two homes:
 //   • url  — the document was fetched from `href` by the browser (openUrlView); a relative src/href
@@ -1093,6 +1157,14 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   // dropped every dangerous scheme; what is left is either absolute — untouched — or relative to a
   // document the browser knows nothing about). getAttribute, never the .src/.href property: the
   // property is already resolved against the PAGE, which is the wrong base.
+  //
+  // Every heading gets an id first — marked 12 emits none, so a document's own `[top](#evidence)`
+  // had nothing to land on. GitHub's slug (headingSlug, made unique in order by uniqueSlugs), and
+  // PREFIXED `md-` on purpose: an unprefixed id="tabs" would dress a heading in the chat page's
+  // #tabs CSS and shadow getElementById("tabs") for the page's own controls.
+  const heads = Array.from(box.querySelectorAll("h1, h2, h3, h4, h5, h6")) as HTMLElement[];
+  const slugs = uniqueSlugs(heads.map((h) => headingSlug(h.textContent || "")));
+  heads.forEach((h, i) => { h.id = "md-" + slugs[i]; });
   if (doc) {
     box.querySelectorAll("img[src]").forEach((node) => {
       const img = node as HTMLImageElement;
@@ -1126,12 +1198,16 @@ function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
     });
   }
   // Links open a NEW tab: the viewer lives inside the chat pane's document, and letting a README link
-  // navigate it away would silently eat the chat until a reload. (A local document's sibling links,
-  // stamped fv-open above, open in the viewer instead.)
-  box.querySelectorAll("a[href]").forEach((a) => {
-    if ((a as HTMLElement).dataset.act === "fv-open") return;
-    (a as HTMLAnchorElement).target = "_blank";
-    (a as HTMLAnchorElement).rel = "noopener";
+  // navigate it away would silently eat the chat until a reload. Two kinds stay in the viewer: a local
+  // document's sibling links (stamped fv-open above), and IN-DOCUMENT `#fragment` links, which land on
+  // their heading through the body's delegated fv-anchor handler — a forced _blank on those opened a
+  // REAL tab at the chat page's own URL plus the fragment (found live, 2026-09-06).
+  box.querySelectorAll("a[href]").forEach((node) => {
+    const a = node as HTMLAnchorElement;
+    if (a.dataset.act === "fv-open") return;
+    if ((a.getAttribute("href") || "").startsWith("#")) { a.dataset.act = "fv-anchor"; return; }
+    a.target = "_blank";
+    a.rel = "noopener";
   });
   // Fenced blocks: highlight only a language the fence NAMES and this bundle registers — the same
   // no-guessing rule as langFor; an unnamed block stays plain rather than being painted at random.

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -24,6 +24,8 @@ import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const gclock = require("./gesture-clock.js");   // the gesture clock every settings post stamps through
+import { delegate } from "./actions";
+import { resolveDocRelative, joinDocPath, urlTitleParts } from "./md-links";
 
 // hljs is registered per-bundle. Same language set (and grammar registrations) the chat's fence
 // highlighting uses, dup-guarded, so importing this module alongside render.ts costs nothing.
@@ -112,6 +114,26 @@ function el(tag: string, cls?: string): HTMLElement {
   const e = document.createElement(tag);
   if (cls) e.className = cls;
   return e;
+}
+
+// The romp loader (swirl + wordmark + three pulsing accent dots), per the loading-state rule: the
+// FIRST thing up on any wait, fading the instant real content lands. The viewer's earlier waits
+// build this markup inline; the URL viewer reaches for it here.
+function loaderEl(): HTMLElement {
+  const load = el("div", "fileview-load");
+  load.innerHTML = '<img src="/media/romp-swirl-glyph.svg" alt=""><span>romp</span>'
+    + '<i class="fileview-dot"></i><i class="fileview-dot"></i><i class="fileview-dot"></i>';
+  return load;
+}
+
+// The 2 MB body cap for a URL document — a MIRROR of the kernel's _TEXT_MAX_BYTES (kernel.py), which
+// is what a local .md is already held to on the /file route. The URL viewer fetches from the browser,
+// so no kernel ever sees the body; the cap is applied here, from Content-Length when the server
+// sends one and from the decoded length otherwise. md-url-view.test.ts pins the two numbers equal.
+const URL_TEXT_MAX_BYTES = 2 * 1024 * 1024;
+
+function humanSize(n: number): string {
+  return n >= 1e6 ? (n / 1e6).toFixed(1) + " MB" : Math.max(1, Math.round(n / 1e3)) + " KB";
 }
 
 // ── raw-mode editing (the file browser's slice 2, the user 2026-08-14) ─────────────────────────────
@@ -497,6 +519,20 @@ export function openFileView(path: string, sid?: string | null): void {
   bar.appendChild(name); if (sess) bar.appendChild(sess); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
+  // A rendered document's RELATIVE links (`[notes](./notes.md)`, `[fig](plots/a.png)`) open the
+  // sibling file in this same viewer — mdBlock stamps each one `data-act="fv-open"` with the joined
+  // path (joinDocPath) instead of a target the page would navigate to. One delegated listener on
+  // the body, installed once per open and keyed off data-act (actions.ts: click-safe across the
+  // Rendered ⇄ Raw swaps that rebuild the body's children, and the press flash acknowledges the
+  // click). The chat's document-level anchor delegate (render.ts) leaves scheme-less hrefs alone,
+  // so the click reaches here in the chat document and in the feed document alike.
+  delegate(body, {
+    "fv-open": (a, ev) => {
+      ev.preventDefault();
+      const target = a.dataset.path;
+      if (target) openFileView(target, sid);
+    },
+  });
   // Per the loading-state rule the first thing up is the romp loader, not a blank pane — a file coming
   // over an ssh tunnel to a phone is a real wait.
   const load = el("div", "fileview-load");
@@ -564,7 +600,7 @@ export function openFileView(path: string, sid?: string | null): void {
       return;
     }
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
-    body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, true));   // long lines always soft-wrap (the user 2026-08-24)
+    body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));   // long lines always soft-wrap (the user 2026-08-24)
   };
 
   // Selection → labeled quote chip (the user 2026-08-23): mouseup is the gesture's settle point.
@@ -814,6 +850,148 @@ function offersDownload(status: number | undefined): boolean {
   return status === 413 || status === 415;
 }
 
+// ── URL mode (the user 2026-09-06) ─────────────────────────────────────────────────────────────────
+// A chat message linking a markdown file on the dashboard's OWN origin (`https://<this host>/figs/
+// run-1/evidence.md` — a published report, an evidence doc) used to open the raw text in a new tab.
+// It presents here instead: same modal, same Rendered ⇄ Raw preference (FMT_KEY), same loader-first
+// wait, same mdBlock — fetched by the BROWSER from the URL itself, with no kernel in the loop. Zero new
+// kernel surface is the point: the kernel's /file relay is a preview relay and has stayed one on
+// purpose (_remote_file's docstring), and a same-origin URL needs no relay — the browser already has
+// the cookie. Cross-origin .md links are never routed here (render.ts checks isMarkdownUrl first).
+//
+// The shell is built here rather than threaded through openFileView because almost everything in that
+// row is keyed on the KERNEL's reply — Edit on the text/plain + mtime verdicts, Download on the
+// ?download=1 route, the GitHub link on a fileGitLink ask, ‹ Files on the browser overlay — and none
+// of it exists for a URL. What both modes share is shared by construction: el/loaderEl, the format
+// pref, mdBlock/codeBlock, closeFileView and the module-level teardown registrations.
+export function openUrlView(href: string): void {
+  // The same replace path as openFileView: an editor holding unsaved changes is asked first, and
+  // every module-level registration the old viewer made is dropped before it is torn down.
+  if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
+  closeGuard = null;
+  editHooks = null;
+  gitHooks = null;
+  dropMediaUrl();
+  document.getElementById("romp-fileview")?.remove();
+  const wrap = el("div");
+  wrap.id = "romp-fileview";
+  wrap.onclick = (ev) => { if (ev.target === wrap) closeFileView(); };
+  const box = el("div", "fileview");
+  document.body.classList.add("fileview-open");
+
+  // Title: host/dir/ dimmed then the basename, the local viewer's two-element treatment — but the
+  // directory half is NOT a browse link here: there is no listing to open for a URL.
+  const bar = el("div", "fileview-bar");
+  const name = el("div", "fileview-name");
+  name.title = href;                                   // the full URL, one hover away
+  const parts = urlTitleParts(href);
+  const dir = el("span", "fileview-dir");
+  dir.textContent = parts.dir;
+  const base = el("span", "fileview-base");
+  base.textContent = parts.base;
+  name.appendChild(dir); name.appendChild(base);
+  const acts = el("div", "fileview-acts");
+
+  const fmt = loadFmt();
+  let text: string | null = null;
+  const segBtns: Array<["rendered" | "raw", HTMLButtonElement]> = [];
+  for (const mode of ["rendered", "raw"] as const) {
+    const b = el("button", "fileview-btn") as HTMLButtonElement;
+    b.type = "button";
+    b.textContent = mode === "rendered" ? "Rendered" : "Raw";
+    b.title = mode === "rendered" ? "The prose the markdown means" : "The document's actual bytes";
+    b.addEventListener("click", () => { fmt.md = mode; saveFmt(fmt); renderBody(); });
+    segBtns.push([mode, b]);
+    acts.appendChild(b);
+  }
+  // The way OUT to the URL itself, in a new tab — an anchor wearing the button treatment, the
+  // GitHub link's dress: the browser owns the tab. It is also every failure pane's exit below.
+  // data-new-tab: this href IS a same-origin .md, exactly what the chat's anchor delegate routes
+  // back into this viewer — the marker tells it this one click means the tab.
+  const linkOut = (): HTMLAnchorElement => {
+    const a = el("a", "fileview-btn fileview-gh") as HTMLAnchorElement;
+    a.href = href; a.target = "_blank"; a.rel = "noopener";
+    a.dataset.newTab = "1";
+    a.textContent = "Open ↗"; a.title = "Open the URL in a new tab";
+    return a;
+  };
+  acts.appendChild(linkOut());
+  const copy = el("button", "fileview-btn") as HTMLButtonElement;
+  copy.type = "button"; copy.textContent = "Copy URL"; copy.title = href;
+  copy.addEventListener("click", () => {
+    navigator.clipboard?.writeText(href).then(
+      () => { copy.textContent = "Copied"; setTimeout(() => { copy.textContent = "Copy URL"; }, 1200); },
+      () => { copy.textContent = "Copy failed"; });
+  });
+  const close = el("button", "fileview-btn fileview-close") as HTMLButtonElement;
+  close.type = "button"; close.textContent = "✕"; close.title = "Close (Esc)";
+  close.setAttribute("aria-label", "Close the file viewer");
+  close.addEventListener("click", closeFileView);
+  acts.appendChild(copy); acts.appendChild(close);
+  bar.appendChild(name); bar.appendChild(acts);
+
+  const body = el("div", "fileview-body");
+  body.appendChild(loaderEl());                        // loader first; the fetch below replaces it
+  box.appendChild(bar); box.appendChild(body);
+  wrap.appendChild(box);
+  document.body.appendChild(wrap);
+
+  const renderBody = () => {
+    for (const [mode, b] of segBtns) {
+      const on = fmt.md === mode;
+      b.classList.toggle("on", on);
+      b.setAttribute("aria-pressed", String(on));
+    }
+    if (text === null) return;                         // the loader holds the body until the bytes land
+    body.replaceChildren(fmt.md === "rendered"
+      ? mdBlock(text, { kind: "url", href })
+      : codeBlock(text, parts.base, true));            // basename → langFor → markdown highlighting
+  };
+  renderBody();
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key !== "Escape" || !document.getElementById("romp-fileview")) return;
+    e.preventDefault();
+    closeFileView();
+    document.removeEventListener("keydown", onKey);
+  };
+  document.addEventListener("keydown", onKey);
+
+  // Every failure says WHY, in the pane, with the way out: never a console-only failure, never a
+  // blank pane. The lines name the host and the URL rather than the viewer's mechanics.
+  const fail = (words: string) => {
+    if (!wrap.isConnected) return;                     // closed or replaced while in flight — paint nothing
+    const why = el("div", "fileview-err");
+    why.textContent = words;
+    const hint = el("div", "fileview-err-hint");
+    hint.textContent = href;
+    why.appendChild(hint);
+    why.appendChild(linkOut());
+    body.replaceChildren(why);
+  };
+  const host = parts.dir.split("/")[0] || href;
+  const tooLarge = (n: number) =>
+    fail("this document is " + humanSize(n) + " — too large to show here (the cap is " + humanSize(URL_TEXT_MAX_BYTES) + ")");
+
+  // Same-origin, cookie-authed, cache: no-store like every viewer fetch. No Content-Type sniffing:
+  // the URL was intercepted because its PATH is markdown, so the body is read as text and rendered as
+  // markdown, whatever the server labelled it.
+  fetch(href, { cache: "no-store" }).then((r) => {
+    if (!wrap.isConnected) return;
+    if (!r.ok) { fail("HTTP " + r.status + " from " + host); return; }
+    const declared = Number(r.headers.get("Content-Length") || "");
+    if (declared > URL_TEXT_MAX_BYTES) { tooLarge(declared); return; }
+    return r.text().then((t) => {
+      if (!wrap.isConnected) return;
+      if (t.length > URL_TEXT_MAX_BYTES) { tooLarge(t.length); return; }
+      text = t;
+      renderBody();
+    });
+  }).catch((err) => {
+    fail("this document could not be loaded from this page — " + String(err && (err as Error).message || err));
+  });
+}
+
 // Kick the browser's downloader at `url` without touching the pane: a clicked <a download> starts a
 // same-origin, cookie-authed request the BROWSER owns (its progress UI, its save location), and since
 // the kernel answers with Content-Disposition: attachment the page never navigates — the viewer, the
@@ -887,11 +1065,21 @@ function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement 
   return wrap;
 }
 
+// Where the rendered document LIVES, so its relative references can be resolved against it (the user
+// 2026-09-06: a `![fig](fig.png)` in a viewed document pointed at the dashboard's root). Two homes:
+//   • url  — the document was fetched from `href` by the browser (openUrlView); a relative src/href
+//            resolves against that URL, exactly as it would have on the page itself.
+//   • file — the document is `path` on the session's disk (openFileView); a relative image is the
+//            sibling file over the kernel's /file route (fileUrl — federation-aware, never hand-built),
+//            and a relative link opens the sibling in this same viewer.
+// No location at all (a caller with nothing to say) leaves the markup as marked emitted it.
+type MdDocLoc = { kind: "url"; href: string } | { kind: "file"; path: string; sid: string | null };
+
 // Markdown rendered as the prose it means (the user 2026-08-09: Rendered is the default, Raw one click
 // away). The file is arbitrary bytes off a disk and marked emits raw HTML verbatim, so — exactly like the
 // chat's md() in render.ts — the output goes through DOMPurify before it ever reaches .innerHTML: an
 // <img onerror> or a javascript: href in a README must never run in the dashboard.
-function mdBlock(text: string): HTMLElement {
+function mdBlock(text: string, doc?: MdDocLoc): HTMLElement {
   const box = el("div", "fileview-md");
   try {
     const dirty = marked.parse(text) as string;
@@ -901,9 +1089,47 @@ function mdBlock(text: string): HTMLElement {
   } catch {
     box.textContent = text;                            // a marked bug must never cost the content
   }
+  // Relative references resolve against the DOCUMENT, after sanitisation (DOMPurify has already
+  // dropped every dangerous scheme; what is left is either absolute — untouched — or relative to a
+  // document the browser knows nothing about). getAttribute, never the .src/.href property: the
+  // property is already resolved against the PAGE, which is the wrong base.
+  if (doc) {
+    box.querySelectorAll("img[src]").forEach((node) => {
+      const img = node as HTMLImageElement;
+      const src = img.getAttribute("src") || "";
+      if (doc.kind === "url") {
+        const abs = resolveDocRelative(src, doc.href);
+        if (abs !== src) img.setAttribute("src", abs);
+      } else if (src && !/^[a-z][a-z0-9+.-]*:/i.test(src) && !src.startsWith("//")) {
+        // Every path-shaped src — relative, absolute, ~-anchored — is a file on the session's disk;
+        // only a scheme (http:, data:) or a protocol-relative URL names something the browser fetches.
+        img.setAttribute("src", fileUrl(joinDocPath(doc.path, src), doc.sid));
+      }
+    });
+    box.querySelectorAll("a[href]").forEach((node) => {
+      const a = node as HTMLAnchorElement;
+      const href = a.getAttribute("href") || "";
+      if (!href || href.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(href)) return;   // in-document, or already absolute
+      if (doc.kind === "url") {
+        // Absolute now, so the chat's document-level anchor delegate sees a scheme: a same-origin
+        // .md target opens in this viewer (isMarkdownUrl), everything else in a new tab.
+        a.setAttribute("href", resolveDocRelative(href, doc.href));
+      } else if (!href.startsWith("//")) {
+        // The sibling path rides data-act/data-path for openFileView's delegated body listener;
+        // the href stays as written (hover still shows where it goes) and no _blank is forced —
+        // the page would only 404 on it.
+        const joined = joinDocPath(doc.path, href);
+        a.dataset.act = "fv-open";
+        a.dataset.path = joined;
+        a.title = joined;
+      }
+    });
+  }
   // Links open a NEW tab: the viewer lives inside the chat pane's document, and letting a README link
-  // navigate it away would silently eat the chat until a reload.
+  // navigate it away would silently eat the chat until a reload. (A local document's sibling links,
+  // stamped fv-open above, open in the viewer instead.)
   box.querySelectorAll("a[href]").forEach((a) => {
+    if ((a as HTMLElement).dataset.act === "fv-open") return;
     (a as HTMLAnchorElement).target = "_blank";
     (a as HTMLAnchorElement).rel = "noopener";
   });

--- a/ui/webview/md-links.test.ts
+++ b/ui/webview/md-links.test.ts
@@ -1,0 +1,148 @@
+// The pure helpers behind "a markdown link opens in the file viewer" (the user 2026-09-06), EXECUTED:
+// md-links.ts is string → string with no DOM, so these run the real functions rather than pinning
+// them. Synthetic hosts and paths throughout (TESTHOST, the notes-api demo tree).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { isMarkdownUrl, resolveDocRelative, joinDocPath, urlTitleParts } from "./md-links";
+
+const ORIGIN = "https://TESTHOST";
+const DOC = "https://TESTHOST/figs/run-1/evidence.md";
+
+// ── isMarkdownUrl: the ONE interception condition — http(s), same origin, path ends .md/.markdown ──
+
+test("isMarkdownUrl: a same-origin .md / .markdown URL, case-insensitive, query and fragment tolerated", () => {
+  assert.equal(isMarkdownUrl(DOC, ORIGIN), true);
+  assert.equal(isMarkdownUrl(DOC, "https://testhost"), true, "location.origin's normalised (lower-case) form");
+  assert.equal(isMarkdownUrl(DOC, "https://TESTHOST:443"), true, "a hand-written origin normalises the same way");
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/README.MD", ORIGIN), true, "case-insensitive extension");
+  assert.equal(isMarkdownUrl("https://TESTHOST/notes/design.markdown", ORIGIN), true);
+  assert.equal(isMarkdownUrl(DOC + "?v=3", ORIGIN), true, "a query string is allowed");
+  assert.equal(isMarkdownUrl(DOC + "#results", ORIGIN), true, "a fragment is allowed");
+  assert.equal(isMarkdownUrl(DOC + "?v=3#results", ORIGIN), true);
+  assert.equal(isMarkdownUrl("http://TESTHOST:8765/x.md", "http://TESTHOST:8765"), true, "plain http with a port");
+  assert.equal(isMarkdownUrl("https://TESTHOST:443/x.md", ORIGIN), true, "the default port normalises away");
+  assert.equal(isMarkdownUrl("https://TESTHOST/a%20b/my%20doc.md", ORIGIN), true, "percent-encoded paths");
+});
+
+test("isMarkdownUrl: cross-origin is false — another host, scheme or port keeps the new tab", () => {
+  assert.equal(isMarkdownUrl("https://OTHERHOST/figs/run-1/evidence.md", ORIGIN), false, "another host");
+  assert.equal(isMarkdownUrl("http://TESTHOST/x.md", ORIGIN), false, "http vs https is a different origin");
+  assert.equal(isMarkdownUrl("https://TESTHOST:8443/x.md", ORIGIN), false, "another port");
+  assert.equal(isMarkdownUrl("https://github.com/notes-api/notes-api/blob/main/README.md", ORIGIN), false,
+    "a GitHub blob page merely ends in .md");
+});
+
+test("isMarkdownUrl: not a markdown path, not http(s), not absolute, or not a URL at all → false, never a throw", () => {
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/evidence.md.png", ORIGIN), false, ".md.png is an image");
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/evidence.md/", ORIGIN), false, "a directory named like a file");
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/evidence.md.bak", ORIGIN), false);
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/plot.png", ORIGIN), false);
+  assert.equal(isMarkdownUrl("https://TESTHOST/figs/run-1/", ORIGIN), false);
+  assert.equal(isMarkdownUrl("mailto:someone@TESTHOST", ORIGIN), false);
+  assert.equal(isMarkdownUrl("vscode://romp.romp-chat-view/open?path=x.md", ORIGIN), false);
+  assert.equal(isMarkdownUrl("file:///srv/notes-api/docs/README.md", ORIGIN), false);
+  assert.equal(isMarkdownUrl("javascript:alert(1)//x.md", ORIGIN), false);
+  assert.equal(isMarkdownUrl("figs/run-1/evidence.md", ORIGIN), false, "relative — not an absolute URL");
+  assert.equal(isMarkdownUrl("/figs/run-1/evidence.md", ORIGIN), false, "root-relative — same");
+  assert.equal(isMarkdownUrl("//TESTHOST/x.md", ORIGIN), false, "protocol-relative has no scheme to parse");
+  assert.equal(isMarkdownUrl("", ORIGIN), false);
+  assert.equal(isMarkdownUrl("not a url at all.md", ORIGIN), false);
+  assert.equal(isMarkdownUrl("https://", ORIGIN), false);
+  assert.equal(isMarkdownUrl(DOC, ""), false, "no page origin → nothing can match");
+  assert.equal(isMarkdownUrl(DOC, "null"), false, "an opaque origin (a sandboxed webview) never matches");
+  assert.equal(isMarkdownUrl(undefined as unknown as string, ORIGIN), false, "non-string input");
+  assert.equal(isMarkdownUrl(DOC, null as unknown as string), false);
+});
+
+// ── resolveDocRelative: a reference INSIDE a URL document resolves against the document ──
+
+// (the URL parser lower-cases hosts — the resolved forms below read `testhost`)
+test("resolveDocRelative: relative, ./, ../, root-relative and nested refs resolve against the document URL", () => {
+  assert.equal(resolveDocRelative("fig.png", DOC), "https://testhost/figs/run-1/fig.png");
+  assert.equal(resolveDocRelative("./fig.png", DOC), "https://testhost/figs/run-1/fig.png");
+  assert.equal(resolveDocRelative("../fig.png", DOC), "https://testhost/figs/fig.png");
+  assert.equal(resolveDocRelative("../../fig.png", DOC), "https://testhost/fig.png");
+  assert.equal(resolveDocRelative("plots/a/b.svg", DOC), "https://testhost/figs/run-1/plots/a/b.svg");
+  assert.equal(resolveDocRelative("/shared/logo.png", DOC), "https://testhost/shared/logo.png", "root-relative → the base origin");
+  assert.equal(resolveDocRelative("other.md", DOC), "https://testhost/figs/run-1/other.md", "a sibling document, absolute now");
+  assert.equal(resolveDocRelative("other.md#sec", DOC), "https://testhost/figs/run-1/other.md#sec", "its fragment rides along");
+  assert.equal(resolveDocRelative("?v=2", DOC), "https://testhost/figs/run-1/evidence.md?v=2");
+  assert.equal(resolveDocRelative("fig.png", DOC + "?v=3#top"), "https://testhost/figs/run-1/fig.png",
+    "the base's own query/fragment do not leak into a sibling");
+  assert.equal(resolveDocRelative("my fig.png", DOC), "https://testhost/figs/run-1/my%20fig.png", "a space is encoded");
+  assert.equal(resolveDocRelative("my%20fig.png", DOC), "https://testhost/figs/run-1/my%20fig.png", "already-encoded stays");
+  assert.equal(resolveDocRelative("//TESTHOST/x.png", DOC), "https://testhost/x.png", "protocol-relative takes the base scheme");
+  // the resolved sibling is exactly what the anchor delegate then intercepts
+  assert.equal(isMarkdownUrl(resolveDocRelative("other.md", DOC), ORIGIN), true);
+  assert.equal(isMarkdownUrl(resolveDocRelative("fig.png", DOC), ORIGIN), false);
+});
+
+test("resolveDocRelative: refs with a scheme, bare fragments and empty refs come back untouched", () => {
+  for (const ref of [
+    "https://OTHERHOST/fig.png", "http://TESTHOST/fig.png", "data:image/png;base64,AAAA",
+    "blob:https://TESTHOST/11111111-2222-3333-4444-555555555555", "mailto:someone@TESTHOST",
+    "javascript:alert(1)", "vscode://romp.romp-chat-view/x", "#results", "#", "",
+  ]) assert.equal(resolveDocRelative(ref, DOC), ref, ref + " is left alone");
+});
+
+test("resolveDocRelative: a base that is not a URL leaves the ref alone rather than throwing", () => {
+  assert.equal(resolveDocRelative("fig.png", "/srv/notes-api/docs/README.md"), "fig.png", "a disk path is not a URL base");
+  assert.equal(resolveDocRelative("fig.png", ""), "fig.png");
+  assert.equal(resolveDocRelative("fig.png", "not a url"), "fig.png");
+  assert.equal(resolveDocRelative("fig.png", undefined as unknown as string), "fig.png");
+  assert.equal(resolveDocRelative(undefined as unknown as string, DOC), undefined, "a non-string ref is echoed");
+});
+
+// ── joinDocPath: a reference INSIDE a LOCAL document joins onto the document's directory ──
+
+const LOCAL = "/srv/notes-api/docs/README.md";
+
+test("joinDocPath: relative, ./ and ../ refs join onto the document's directory", () => {
+  assert.equal(joinDocPath(LOCAL, "fig.png"), "/srv/notes-api/docs/fig.png");
+  assert.equal(joinDocPath(LOCAL, "./fig.png"), "/srv/notes-api/docs/fig.png");
+  assert.equal(joinDocPath(LOCAL, "../CHANGELOG.md"), "/srv/notes-api/CHANGELOG.md");
+  assert.equal(joinDocPath(LOCAL, "../../other/x.md"), "/srv/other/x.md");
+  assert.equal(joinDocPath(LOCAL, "plots/../a/b.png"), "/srv/notes-api/docs/a/b.png", "an interior .. collapses");
+  assert.equal(joinDocPath(LOCAL, "a//b.png"), "/srv/notes-api/docs/a/b.png", "a doubled slash collapses");
+  assert.equal(joinDocPath(LOCAL, "sub/"), "/srv/notes-api/docs/sub", "a trailing slash drops");
+  assert.equal(joinDocPath("/a/b.md", "../../../x.png"), "/x.png", "climbing past the root stays at the root");
+});
+
+test("joinDocPath: absolute and ~-anchored refs, and refs with a scheme, are not joined", () => {
+  assert.equal(joinDocPath(LOCAL, "/srv/shared/logo.png"), "/srv/shared/logo.png");
+  assert.equal(joinDocPath(LOCAL, "~/notes/x.md"), "~/notes/x.md");
+  assert.equal(joinDocPath(LOCAL, "~/a/../x.md"), "~/a/../x.md", "left alone as written — the kernel expands ~ and the filesystem resolves ..");
+  assert.equal(joinDocPath(LOCAL, "/srv/a/../x.md"), "/srv/a/../x.md", "same for an absolute path");
+  assert.equal(joinDocPath(LOCAL, "https://TESTHOST/x.md"), "https://TESTHOST/x.md");
+  assert.equal(joinDocPath(LOCAL, "data:image/png;base64,AAAA"), "data:image/png;base64,AAAA");
+  assert.equal(joinDocPath(LOCAL, "mailto:someone@TESTHOST"), "mailto:someone@TESTHOST");
+});
+
+test("joinDocPath: the link is a URL by convention but the kernel wants a path — fragment off, percent-decoded", () => {
+  assert.equal(joinDocPath(LOCAL, "other.md#install"), "/srv/notes-api/docs/other.md", "no in-document anchors to land on");
+  assert.equal(joinDocPath(LOCAL, "my%20notes.md"), "/srv/notes-api/docs/my notes.md");
+  assert.equal(joinDocPath(LOCAL, "%ZZ.md"), "/srv/notes-api/docs/%ZZ.md", "a stray % keeps the bytes as written, never throws");
+  assert.equal(joinDocPath(LOCAL, "#install"), "#install", "a bare fragment has no path to join (callers skip it anyway)");
+  assert.equal(joinDocPath(LOCAL, ""), "", "empty in, empty out");
+  assert.equal(joinDocPath(LOCAL, undefined as unknown as string), undefined);
+});
+
+test("joinDocPath: a RELATIVE document (the kernel resolves it against the session's cwd) keeps its relativity", () => {
+  assert.equal(joinDocPath("docs/README.md", "fig.png"), "docs/fig.png");
+  assert.equal(joinDocPath("docs/README.md", "../x.md"), "x.md");
+  assert.equal(joinDocPath("docs/README.md", "../../x.md"), "../x.md", "above the start: keeps climbing, for the kernel to resolve");
+  assert.equal(joinDocPath("README.md", "fig.png"), "fig.png", "a bare filename has no directory");
+  assert.equal(joinDocPath("README.md", "../fig.png"), "../fig.png");
+  assert.equal(joinDocPath("README.md", "."), ".", "the document's own directory");
+});
+
+// ── urlTitleParts: the title bar's two halves for a URL document ──
+
+test("urlTitleParts: host/dir/ then the basename, decoded for reading, port kept, query and fragment dropped", () => {
+  assert.deepEqual(urlTitleParts("https://TESTHOST/figs/run-1/evidence.md?v=3#results"),
+    { dir: "testhost/figs/run-1/", base: "evidence.md" });
+  assert.deepEqual(urlTitleParts("https://TESTHOST:8443/x.md"), { dir: "testhost:8443/", base: "x.md" });
+  assert.deepEqual(urlTitleParts("https://TESTHOST/x.md"), { dir: "testhost/", base: "x.md" }, "a root file: host and slash");
+  assert.deepEqual(urlTitleParts("https://TESTHOST/a%20b/my%20doc.md"), { dir: "testhost/a b/", base: "my doc.md" });
+  assert.deepEqual(urlTitleParts("not a url"), { dir: "", base: "not a url" }, "a non-URL still draws a bar");
+});

--- a/ui/webview/md-links.test.ts
+++ b/ui/webview/md-links.test.ts
@@ -119,7 +119,7 @@ test("joinDocPath: absolute and ~-anchored refs, and refs with a scheme, are not
 });
 
 test("joinDocPath: the link is a URL by convention but the kernel wants a path — fragment off, percent-decoded", () => {
-  assert.equal(joinDocPath(LOCAL, "other.md#install"), "/srv/notes-api/docs/other.md", "no in-document anchors to land on");
+  assert.equal(joinDocPath(LOCAL, "other.md#install"), "/srv/notes-api/docs/other.md", "the path is what the kernel wants; the fragment rides separately");
   assert.equal(joinDocPath(LOCAL, "my%20notes.md"), "/srv/notes-api/docs/my notes.md");
   assert.equal(joinDocPath(LOCAL, "%ZZ.md"), "/srv/notes-api/docs/%ZZ.md", "a stray % keeps the bytes as written, never throws");
   assert.equal(joinDocPath(LOCAL, "#install"), "#install", "a bare fragment has no path to join (callers skip it anyway)");

--- a/ui/webview/md-links.test.ts
+++ b/ui/webview/md-links.test.ts
@@ -3,7 +3,7 @@
 // them. Synthetic hosts and paths throughout (TESTHOST, the notes-api demo tree).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { isMarkdownUrl, resolveDocRelative, joinDocPath, urlTitleParts } from "./md-links";
+import { isMarkdownUrl, resolveDocRelative, joinDocPath, urlTitleParts, headingSlug, uniqueSlugs } from "./md-links";
 
 const ORIGIN = "https://TESTHOST";
 const DOC = "https://TESTHOST/figs/run-1/evidence.md";
@@ -145,4 +145,44 @@ test("urlTitleParts: host/dir/ then the basename, decoded for reading, port kept
   assert.deepEqual(urlTitleParts("https://TESTHOST/x.md"), { dir: "testhost/", base: "x.md" }, "a root file: host and slash");
   assert.deepEqual(urlTitleParts("https://TESTHOST/a%20b/my%20doc.md"), { dir: "testhost/a b/", base: "my doc.md" });
   assert.deepEqual(urlTitleParts("not a url"), { dir: "", base: "not a url" }, "a non-URL still draws a bar");
+});
+
+// ── headingSlug / uniqueSlugs: the ids a rendered document's own `#fragment` links land on ──
+
+test("headingSlug: GitHub's shape — lower-case, letters/digits/spaces/hyphens kept, the rest dropped, spaces → hyphens", () => {
+  assert.equal(headingSlug("Evidence"), "evidence");
+  assert.equal(headingSlug("Hello World"), "hello-world");
+  assert.equal(headingSlug("Hello  World"), "hello-world", "a whitespace run is ONE hyphen");
+  assert.equal(headingSlug("  Hello World  "), "hello-world", "outer whitespace trimmed");
+  assert.equal(headingSlug("Results: arm A vs. arm B!"), "results-arm-a-vs-arm-b", "punctuation dropped");
+  assert.equal(headingSlug("Run 1 — pooled estimate"), "run-1-pooled-estimate", "an em dash is not a hyphen; it drops");
+  assert.equal(headingSlug("keep-the-hyphens"), "keep-the-hyphens");
+  assert.equal(headingSlug("Ünïcödé Ωmega 日本語"), "ünïcödé-ωmega-日本語", "letters of any script are kept");
+  assert.equal(headingSlug("v2.0 (final)"), "v20-final");
+  assert.equal(headingSlug("`code` & <b>tags</b>"), "code-btagsb", "only the text — angle brackets and ampersands go");
+});
+
+test("headingSlug: idempotent (a slug slugs to itself), and empty → the stable fallback 'section'", () => {
+  for (const s of ["evidence", "hello-world", "results-arm-a-vs-arm-b", "run-1-pooled-estimate"]) assert.equal(headingSlug(s), s);
+  assert.equal(headingSlug(""), "section");
+  assert.equal(headingSlug("   "), "section");
+  assert.equal(headingSlug("!!! ??? ..."), "section", "nothing survives → the fallback, never an empty id");
+  assert.equal(headingSlug(undefined as unknown as string), "section");
+});
+
+test("uniqueSlugs: duplicates are numbered -1, -2… in document order, skipping a suffix a heading already owns", () => {
+  assert.deepEqual(uniqueSlugs(["x", "x", "x"]), ["x", "x-1", "x-2"]);
+  assert.deepEqual(uniqueSlugs(["a", "b", "a", "c", "b"]), ["a", "b", "a-1", "c", "b-1"]);
+  assert.deepEqual(uniqueSlugs(["x", "x-1", "x"]), ["x", "x-1", "x-2"], "the literal heading 'x-1' keeps its slug; the duplicate moves on");
+  assert.deepEqual(uniqueSlugs(["section", "section"]), ["section", "section-1"], "two empty headings still get distinct ids");
+  assert.deepEqual(uniqueSlugs([]), []);
+});
+
+test("the round trip a fragment link takes: heading text → id, fragment → the same id", () => {
+  const ids = uniqueSlugs(["Evidence", "Results", "Results"].map(headingSlug));
+  assert.deepEqual(ids, ["evidence", "results", "results-1"]);
+  // the author wrote [top](#Evidence), [r](#results), [r2](#Results%20) — decoded, slugged, found
+  assert.equal(headingSlug(decodeURIComponent("Evidence")), "evidence");
+  assert.equal(headingSlug(decodeURIComponent("Results%20")), "results");
+  assert.equal(headingSlug("results-1"), "results-1", "the numbered id is reachable as written");
 });

--- a/ui/webview/md-links.test.ts
+++ b/ui/webview/md-links.test.ts
@@ -186,3 +186,22 @@ test("the round trip a fragment link takes: heading text → id, fragment → th
   assert.equal(headingSlug(decodeURIComponent("Results%20")), "results");
   assert.equal(headingSlug("results-1"), "results-1", "the numbered id is reachable as written");
 });
+
+test("uniqueSlugs is amortised linear: 20,000 identical headings dedupe in well under a second, all distinct, last = setup-19999", () => {
+  // the regression: a per-duplicate restart at suffix 1 was quadratic — 12,000 repeated `## Setup`
+  // headings in an 84 KB document (well under the cap) took 11 s to render and froze the page
+  const slugs = new Array(20_000).fill("setup");
+  const t0 = process.hrtime.bigint();
+  const out = uniqueSlugs(slugs);
+  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+  assert.ok(ms < 500, "took " + ms.toFixed(1) + " ms");
+  assert.equal(out.length, 20_000);
+  assert.equal(new Set(out).size, 20_000, "all distinct");
+  assert.equal(out[0], "setup");
+  assert.equal(out[1], "setup-1");
+  assert.equal(out[19_999], "setup-19999");
+  // explicit numbered headings interleaved with duplicates still never collide, and the counter never restarts
+  const mixed = uniqueSlugs(["setup", "setup-2", "setup", "setup", "setup", "setup-5", "setup"]);
+  assert.deepEqual(mixed, ["setup", "setup-2", "setup-1", "setup-3", "setup-4", "setup-5", "setup-6"]);
+  assert.equal(new Set(mixed).size, mixed.length);
+});

--- a/ui/webview/md-links.ts
+++ b/ui/webview/md-links.ts
@@ -1,0 +1,91 @@
+// Pure helpers behind "a markdown link opens in the file viewer" (the user 2026-09-06): a chat message
+// linking `https://<this dashboard>/figs/run-1/evidence.md` used to open the RAW text in a new tab; it
+// presents in the in-pane viewer now, rendered, with its figures resolved against the document. This
+// module is string → string only — no DOM, no fetch — so it executes under `node --test` (the DOM
+// wiring in render.ts / file-view.ts is pinned at the source, as every viewer test is).
+//
+// Two rules the helpers encode, both deliberate:
+//   • SAME ORIGIN ONLY. The viewer fetches the URL from the browser, and a cross-origin fetch is a
+//     CORS guess — sometimes it works, mostly it does not, and a try-then-fall-back would flash the
+//     loader before opening the tab anyway. A `.md` on another origin (a GitHub blob page whose path
+//     merely ends in .md) keeps today's new-tab behaviour exactly. No kernel proxy either: the repo
+//     has kept the kernel's /file relay a preview relay, never a general URL fetch (_remote_file's
+//     docstring), and this feature adds no kernel surface at all.
+//   • A RENDERED DOCUMENT'S RELATIVE REFERENCES RESOLVE AGAINST THE DOCUMENT, not the page. marked
+//     leaves `![fig](fig.png)` as `<img src="fig.png">`, which the browser would fetch from the
+//     dashboard's root — wrong for a URL document (its own directory) and wrong for a local file
+//     (the kernel's /file route for the sibling on disk). Each mode has its own resolver below.
+
+/** Does `href` name a markdown file on THIS page's origin — the one case the viewer intercepts?
+ *  http/https only, same origin as `pageOrigin`, pathname ending .md/.markdown (case-insensitive,
+ *  ?query and #fragment tolerated). Anything else — another origin, a relative href, mailto:,
+ *  vscode://, file://, `.md.png`, malformed input — is false, and nothing here ever throws. */
+export function isMarkdownUrl(href: string, pageOrigin: string): boolean {
+  if (typeof href !== "string" || typeof pageOrigin !== "string" || !href || !pageOrigin) return false;
+  let u: URL, origin: string;
+  try { u = new URL(href); } catch { return false; }        // relative or malformed — not an absolute URL
+  // location.origin is already normalised (lower-case host, default port dropped); parsing the page
+  // origin the same way keeps a hand-written or upper-cased caller value comparable. "null" (an
+  // opaque origin — a sandboxed webview) is not a URL and can match nothing.
+  try { origin = new URL(pageOrigin).origin; } catch { return false; }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+  if (u.origin !== origin) return false;
+  return /\.(md|markdown)$/i.test(u.pathname);
+}
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;                    // the same shape the chat's anchor delegate keys on
+
+/** Resolve a relative `src`/`href` found INSIDE a rendered document against the document's URL
+ *  (`new URL(ref, base).href`). Returned unchanged: a ref that already carries a scheme (http:,
+ *  data:, blob:, mailto:, javascript: — DOMPurify has already dropped the dangerous ones), a bare
+ *  `#fragment` (in-document), an empty ref, or any ref when `base` is not itself a URL. Root-relative
+ *  (`/x.png`) resolves against the base's origin, `../x.png` walks the base's directory. */
+export function resolveDocRelative(ref: string, base: string): string {
+  if (typeof ref !== "string" || !ref) return ref;
+  if (ref.startsWith("#")) return ref;
+  if (SCHEME_RE.test(ref)) return ref;
+  if (typeof base !== "string" || !base) return ref;
+  try { return new URL(ref, base).href; } catch { return ref; }
+}
+
+/** Join a relative reference found in a LOCAL document (`docPath` on the session's disk) into the
+ *  sibling's path: `./`, `../`, doubled slashes and a trailing `#fragment` are normalised away and a
+ *  percent-encoded name (`my%20notes.md`) is decoded, because the link is a URL by convention but the
+ *  kernel wants a path. An absolute (`/…`) or home-anchored (`~…`) ref, a ref with a scheme, or an
+ *  empty ref comes back untouched — there is nothing to join. */
+export function joinDocPath(docPath: string, rel: string): string {
+  if (typeof rel !== "string" || !rel) return rel;
+  if (SCHEME_RE.test(rel)) return rel;
+  let r = rel.replace(/#.*$/, "");                           // the viewer has no in-document anchors to land on
+  try { r = decodeURIComponent(r); } catch { /* a stray % — keep the bytes as written */ }
+  if (!r) return rel;
+  if (r.startsWith("/") || r.startsWith("~")) return r;
+  const dir = typeof docPath === "string" ? docPath.slice(0, docPath.lastIndexOf("/") + 1) : "";
+  const out: string[] = [];
+  const segs = (dir + r).split("/");
+  for (let i = 0; i < segs.length; i++) {
+    const s = segs[i];
+    if (s === "" && i > 0) continue;                        // `a//b`, or a trailing slash
+    if (s === ".") continue;
+    if (s === "..") {
+      const last = out.length ? out[out.length - 1] : undefined;
+      if (last === undefined || last === "..") out.push(".."); // above a relative doc's start: keep climbing
+      else if (last !== "") out.pop();                         // root's parent is root
+      continue;
+    }
+    out.push(s);
+  }
+  const joined = out.join("/");
+  return joined || (dir.startsWith("/") ? "/" : ".");
+}
+
+/** The title-bar halves for a URL document: `host/dir/` (dimmed in the bar, like a local path's
+ *  directory) and the basename, percent-decoded for reading. A non-URL yields the whole string as
+ *  the basename and no directory, so a bar can always be drawn. */
+export function urlTitleParts(href: string): { dir: string; base: string } {
+  let u: URL;
+  try { u = new URL(href); } catch { return { dir: "", base: href }; }
+  const cut = u.pathname.lastIndexOf("/");
+  const dec = (s: string): string => { try { return decodeURIComponent(s); } catch { return s; } };
+  return { dir: u.host + dec(u.pathname.slice(0, cut + 1)), base: dec(u.pathname.slice(cut + 1)) };
+}

--- a/ui/webview/md-links.ts
+++ b/ui/webview/md-links.ts
@@ -79,6 +79,28 @@ export function joinDocPath(docPath: string, rel: string): string {
   return joined || (dir.startsWith("/") ? "/" : ".");
 }
 
+/** A GitHub-style slug for a heading's text, so a document's own `[top](#evidence)` has an id to land
+ *  on (marked 12 emits none): lower-case; letters of any script, digits, spaces and hyphens kept,
+ *  everything else dropped; whitespace runs become one hyphen. Empty → "section", a stable fallback so
+ *  every heading gets an id. Idempotent — a slug slugs to itself — which is what lets a hand-written
+ *  `#my-section` fragment find the same id the heading "My Section" was given. */
+export function headingSlug(text: string): string {
+  const s = String(text ?? "").toLowerCase().replace(/[^\p{L}\p{N}\s-]/gu, "").trim().replace(/\s+/g, "-");
+  return s || "section";
+}
+
+/** Make heading slugs unique in document order, GitHub's way: the first `x` stays `x`, later ones
+ *  become `x-1`, `x-2`, … — skipping a suffix an earlier heading already holds as its own slug. */
+export function uniqueSlugs(slugs: string[]): string[] {
+  const used = new Set<string>();
+  return slugs.map((s) => {
+    let out = s;
+    for (let i = 1; used.has(out); i++) out = s + "-" + i;
+    used.add(out);
+    return out;
+  });
+}
+
 /** The title-bar halves for a URL document: `host/dir/` (dimmed in the bar, like a local path's
  *  directory) and the basename, percent-decoded for reading. A non-URL yields the whole string as
  *  the basename and no directory, so a bar can always be drawn. */

--- a/ui/webview/md-links.ts
+++ b/ui/webview/md-links.ts
@@ -90,12 +90,21 @@ export function headingSlug(text: string): string {
 }
 
 /** Make heading slugs unique in document order, GitHub's way: the first `x` stays `x`, later ones
- *  become `x-1`, `x-2`, … — skipping a suffix an earlier heading already holds as its own slug. */
+ *  become `x-1`, `x-2`, … — skipping a suffix an earlier heading already holds as its own slug.
+ *  Amortised linear: each base keeps the NEXT suffix to try, so a duplicate never rescans the
+ *  suffixes already handed out (restarting at 1 per duplicate was quadratic — 12,000 repeated
+ *  headings in an 84 KB document took 11 s to render and froze the page, ✕ included). An explicitly
+ *  numbered heading that already holds `base-N` just advances that base's counter past it. */
 export function uniqueSlugs(slugs: string[]): string[] {
   const used = new Set<string>();
+  const next = new Map<string, number>();
   return slugs.map((s) => {
     let out = s;
-    for (let i = 1; used.has(out); i++) out = s + "-" + i;
+    if (used.has(out)) {
+      let n = next.get(s) ?? 1;
+      for (out = s + "-" + n; used.has(out); out = s + "-" + ++n) { /* held by an explicit heading — keep advancing */ }
+      next.set(s, n + 1);
+    }
     used.add(out);
     return out;
   });

--- a/ui/webview/md-links.ts
+++ b/ui/webview/md-links.ts
@@ -56,7 +56,7 @@ export function resolveDocRelative(ref: string, base: string): string {
 export function joinDocPath(docPath: string, rel: string): string {
   if (typeof rel !== "string" || !rel) return rel;
   if (SCHEME_RE.test(rel)) return rel;
-  let r = rel.replace(/#.*$/, "");                           // the viewer has no in-document anchors to land on
+  let r = rel.replace(/#.*$/, "");                           // the kernel wants a path; the fragment rides separately (data-frag)
   try { r = decodeURIComponent(r); } catch { /* a stray % — keep the bytes as written */ }
   if (!r) return rel;
   if (r.startsWith("/") || r.startsWith("~")) return r;

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -82,7 +82,8 @@ test("openUrlView exists, fetches the given href from the browser (never fileUrl
   assert.ok(VIEW.indexOf("export function openUrlView") > VIEW.indexOf("function offersDownload"),
     "sits after offersDownload — outside the slice file-view.test.ts takes as openFileView's body");
   assert.doesNotMatch(OPEN_FN, /openUrlView|kind: "url"/, "the local viewer's body is untouched by URL mode");
-  assert.match(URL_FN, /fetch\(href, \{ cache: "no-store", signal: ctrl\.signal \}\)/);
+  assert.match(URL_FN, /fetch\(href, \{ cache: "no-store", mode: "same-origin", signal: ctrl\.signal \}\)/,
+    "same-origin MODE, so a redirect off the origin is refused rather than followed and rendered");
   assert.doesNotMatch(URL_FN, /fileUrl\(|kernelUrl\(|\/file\?|\/remote\//, "the URL is fetched as given — no kernel route, no relay");
   assert.doesNotMatch(URL_FN, /\bpost\(/, "nothing is asked of the kernel over the socket either");
   // …and the kernel gained no route for it
@@ -290,12 +291,14 @@ test("local file mode: a relative image is the sibling over the kernel's /file r
 
 test("local file mode: a relative link opens the sibling in the viewer via ONE delegated data-act listener on the body", () => {
   // the anchor carries the joined path as data, keeps its href for hover, and is not forced to _blank
-  assert.match(MD_FN, /const joined = joinDocPath\(doc\.path, href\);\s*\n\s*a\.dataset\.act = "fv-open";\s*\n\s*a\.dataset\.path = joined;\s*\n\s*a\.title = joined;/);
+  assert.match(MD_FN, /const joined = joinDocPath\(doc\.path, href\);\s*\n\s*a\.dataset\.act = "fv-open";\s*\n\s*a\.dataset\.path = joined;\s*\n\s*const hash = href\.indexOf\("#"\) >= 0 \? href\.slice\(href\.indexOf\("#"\)\) : "";\s*\n\s*if \(hash\.length > 1\) a\.dataset\.frag = hash;[^\n]*\n\s*a\.title = joined;/,
+    "the joined path rides data-path and the link's own #fragment rides data-frag (review fold 2026-09-07)");
   assert.match(MD_FN, /if \(a\.dataset\.act === "fv-open"\) return;/);
   // …the delegate: actions.ts's delegate, installed once per open on the body (stable across the
   // Rendered ⇄ Raw swaps that rebuild its children), preventDefault, then openFileView with this sid
   assert.match(VIEW, /import \{ delegate \} from "\.\/actions";/);
-  assert.match(OPEN_FN, /delegate\(body, \{\s*\n\s*"fv-open": \(a, ev\) => \{\s*\n\s*ev\.preventDefault\(\);\s*\n\s*const target = a\.dataset\.path;\s*\n\s*if \(target\) openFileView\(target, sid\);/);
+  assert.match(OPEN_FN, /delegate\(body, \{\s*\n\s*"fv-open": \(a, ev\) => \{\s*\n\s*ev\.preventDefault\(\);\s*\n\s*const target = a\.dataset\.path;\s*\n\s*if \(target\) openFileView\(target, sid, a\.dataset\.frag \|\| null\);/,
+    "the sibling opens in this viewer, for this sid, landing on its fragment");
   assert.equal((OPEN_FN.match(/delegate\(body/g) || []).length, 1, "one listener per open, never in a render path");
   assert.ok(OPEN_FN.indexOf("delegate(body") < OPEN_FN.indexOf("const renderBody ="), "installed before any render can run");
   // the chat's document-level delegate ignores scheme-less hrefs, so the click reaches the body listener
@@ -342,10 +345,13 @@ test("both viewers handle fv-anchor in their body delegate: preventDefault, then
 });
 
 test("the opened URL's own #fragment lands after the FIRST rendered paint — once, and only with a rendered body", () => {
-  assert.match(URL_FN, /let landed = false;\s*\n\s*const landFragment = \(\) => \{\s*\n\s*if \(landed\) return;\s*\n\s*landed = true;/);
+  assert.match(URL_FN, /let landed = false;\s*\n\s*const landFragment = \(\) => \{\s*\n\s*if \(landed\) return;\s*\n\s*let hash = "";/,
+    "the landing is one-shot, but only SPENT by a rendered paint (a Raw view waits for the toggle)");
+  assert.match(URL_FN, /if \(!hash\) \{ landed = true; return; \}\s*\n\s*if \(fmt\.md !== "rendered"\) return;[^\n]*\n\s*landed = true;/);
   assert.match(URL_FN, /try \{ hash = new URL\(href\)\.hash; \} catch \{/);
-  assert.match(URL_FN, /if \(hash && fmt\.md === "rendered"\) requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, hash\); \}\);/);
-  assert.match(URL_FN, /text = got\.text;\s*\n\s*renderBody\(\);\s*\n\s*landFragment\(\);/, "after the paint, not before it");
+  assert.match(URL_FN, /landed = true;\s*\n\s*requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, hash\); \}\);/);
+  assert.match(URL_FN, /codeBlock\(text, parts\.base, true\)\);[^\n]*\n\s*landFragment\(\);/, "after the paint, inside renderBody — so a later Rendered toggle lands too");
+  assert.doesNotMatch(URL_FN, /renderBody\(\);\s*\n\s*landFragment\(\);/, "no second, mode-blind landing after the bytes");
 });
 
 // ── 7. styling: no new rules — the URL viewer wears the viewer's existing chrome in BOTH sheets ──
@@ -368,4 +374,30 @@ test("a landed heading sits a breath below the title bar: scroll-margin-top on h
   assert.match(CHAT_CSS, /\.fileview-bar \{[^}]*padding: 7px 10px;/);
   assert.match(CHAT_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
   assert.doesNotMatch(RULE, /font-size|--/, "no font size, no token");
+});
+
+// ── review fold on #958 (2026-09-07): a web page is not a document, redirects stay home, data-* never rides ──
+
+test("URL mode: a 200 labelled text/html is refused as a web page, with the way out; the read is same-origin through redirects", () => {
+  assert.match(URL_FN, /if \(v\.kind === "not-document"\) \{ fail\("the server answered with a web page, not a document \(" \+ v\.type \+ "\)"\); return; \}/);
+  assert.match(URL_FN, /mode: "same-origin"/, "a same-origin alias that 302s off the origin is refused, not rendered with the foreign base");
+});
+
+test("rendered markdown never carries data-* attributes into the page, in the viewer and in the chat alike", () => {
+  // a document's or a message's raw HTML with data-act=\"stopRetrying\" would otherwise bubble to the
+  // document-level delegate and interrupt the active session on a click
+  const sanitizes = (MD_FN.match(/DOMPurify\.sanitize\([^)]*\)/g) || []);
+  assert.equal(sanitizes.length, 1);
+  assert.match(sanitizes[0], /ALLOW_DATA_ATTR: false/);
+  const chatMd = (RENDER.split("function md(src: string): string {")[1] || "").split("\nfunction ")[0];
+  assert.match(chatMd, /DOMPurify\.sanitize\(dirty, MD_PURIFY\)/);
+  assert.match(RENDER, /const MD_PURIFY: Config = \{.*ALLOW_DATA_ATTR: false \};/, "the chat's shared sanitizer config forbids data-*");
+  // the viewer's own stamps are set AFTER the sanitize, so they are unaffected
+  assert.ok(MD_FN.indexOf("DOMPurify.sanitize(") < MD_FN.indexOf('a.dataset.act = "fv-open"'));
+});
+
+test("local file mode: a sibling link's #fragment lands after the first RENDERED paint, once", () => {
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, frag\?: string \| null\): void \{/);
+  assert.match(OPEN_FN, /let pendingFrag: string \| null = frag \|\| null;/);
+  assert.match(OPEN_FN, /if \(rendered && pendingFrag\) \{\s*\n\s*const h = pendingFrag; pendingFrag = null;\s*\n\s*requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, h\); \}\);/);
 });

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -3,8 +3,11 @@
 // fetches the URL itself (no kernel route, no proxy — the kernel's /file relay is a preview relay and
 // stays one), mdBlock renders it with the shared Rendered ⇄ Raw preference, and relative figures and
 // links inside the document resolve against the document rather than the page. Cross-origin .md links
-// keep the new tab exactly. No jsdom harness for these modules → source pins, plus the executed
-// helpers in md-links.test.ts. Synthetic hosts/paths only (TESTHOST, /figs/run-1/evidence.md).
+// keep the new tab exactly. The review round added: a streamed, byte-counted body read cancelled with
+// the viewer (capped-read.ts), redirect-aware document location, modifier clicks keeping the tab,
+// heading ids + in-document fragment links that land instead of spawning a tab, and cap words that
+// never read as an equal pair. No jsdom harness for these modules → source pins, plus the executed
+// helpers in md-links.test.ts and capped-read.test.ts. Synthetic hosts/paths only.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -16,6 +19,7 @@ const VIEW = web("file-view.ts");
 const CHAT_CSS = web("styles.css");
 const FEED_CSS = web("feed.css");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const GUIDE = fs.readFileSync(path.resolve(process.cwd(), "..", "docs", "guide.md"), "utf8");
 
 // the chat's global anchor-click delegate (the same isolation chat-link-open.test.ts uses)
 const HANDLER = (RENDER.match(/closest\?\.\("a\[href\]"\)[\s\S]*?\}, true\);/) || [""])[0];
@@ -26,12 +30,15 @@ const MD_FN = (VIEW.split("function mdBlock(")[1] || "").split("// The image bod
 // the local viewer (the split file-view.test.ts uses — openUrlView sits AFTER offersDownload so it
 // never leaks into this slice)
 const OPEN_FN = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+const CLOSE_FN = VIEW.split("export function closeFileView")[1].split("/** Show `path`")[0];
 
-// ── 1. the interception: same-origin .md, BEFORE window.open, web only ──
+// ── 1. the interception: same-origin .md, unmodified primary click, BEFORE window.open, web only ──
+
+const COND = 'if (!a.dataset.newTab && !e.ctrlKey && !e.metaKey && !e.shiftKey && isMarkdownUrl(href, location.origin)) { openUrlView(href); return; }';
 
 test("the anchor delegate routes a same-origin .md href to the viewer BEFORE the new-tab window.open", () => {
   assert.ok(HANDLER, "found the anchor-click handler");
-  assert.match(HANDLER, /if \(!a\.dataset\.newTab && isMarkdownUrl\(href, location\.origin\)\) \{ openUrlView\(href\); return; \}/);
+  assert.ok(HANDLER.includes(COND), "the exact interception condition");
   const viewer = HANDLER.indexOf("openUrlView(href)");
   const tab = HANDLER.indexOf('window.open(href, "_blank", "noopener,noreferrer")');
   assert.ok(viewer > -1 && tab > -1 && viewer < tab, "the viewer branch precedes window.open");
@@ -50,6 +57,16 @@ test("the anchor delegate routes a same-origin .md href to the viewer BEFORE the
   assert.match(RENDER, /import \{ isMarkdownUrl \} from "\.\/md-links";/);
 });
 
+test("a ctrl-, meta- or shift-click on a same-origin .md keeps the tab: the modifier test sits IN the .md branch", () => {
+  const branch = HANDLER.slice(HANDLER.indexOf("if (!a.dataset.newTab"), HANDLER.indexOf("openUrlView(href)"));
+  for (const mod of ["!e.ctrlKey", "!e.metaKey", "!e.shiftKey"]) assert.ok(branch.includes(mod), mod + " gates the viewer");
+  // the fall-through is the SAME window.open the cross-origin path takes — one new-tab call, no second one
+  assert.equal((HANDLER.match(/window\.open\(/g) || []).length, 1, "exactly one window.open in the delegate");
+  // middle-click is auxclick and was never intercepted — no auxclick listener was added anywhere
+  assert.doesNotMatch(RENDER, /addEventListener\("auxclick"/);
+  assert.match(GUIDE, /ctrl- or ⌘-click still opens the file in\s+a tab/, "the guide says so");
+});
+
 test("the whole-backtick URL anchors (url-code-link) flow through the same delegate — no handler of their own", () => {
   const linkify = RENDER.split("function linkifyFileUris(")[1].split("const previewable")[0];
   assert.match(linkify, /a\.href = t;/, "an absolute http(s) href — the delegate sees a scheme");
@@ -65,7 +82,7 @@ test("openUrlView exists, fetches the given href from the browser (never fileUrl
   assert.ok(VIEW.indexOf("export function openUrlView") > VIEW.indexOf("function offersDownload"),
     "sits after offersDownload — outside the slice file-view.test.ts takes as openFileView's body");
   assert.doesNotMatch(OPEN_FN, /openUrlView|kind: "url"/, "the local viewer's body is untouched by URL mode");
-  assert.match(URL_FN, /fetch\(href, \{ cache: "no-store" \}\)/);
+  assert.match(URL_FN, /fetch\(href, \{ cache: "no-store", signal: ctrl\.signal \}\)/);
   assert.doesNotMatch(URL_FN, /fileUrl\(|kernelUrl\(|\/file\?|\/remote\//, "the URL is fetched as given — no kernel route, no relay");
   assert.doesNotMatch(URL_FN, /\bpost\(/, "nothing is asked of the kernel over the socket either");
   // …and the kernel gained no route for it
@@ -78,9 +95,23 @@ test("URL mode: the loader is up before the fetch, the body renders through mdBl
   const loader = URL_FN.indexOf("body.appendChild(loaderEl());");
   const fetchAt = URL_FN.indexOf("fetch(href, { cache");
   assert.ok(loader > -1 && fetchAt > -1 && loader < fetchAt, "loader first, then the fetch replaces it");
-  assert.match(URL_FN, /mdBlock\(text, \{ kind: "url", href \}\)/);
+  assert.match(URL_FN, /mdBlock\(text, \{ kind: "url", href: loc \}\)/, "the EFFECTIVE location, not the clicked href");
   assert.match(URL_FN, /codeBlock\(text, parts\.base, true\)/, "Raw is the same soft-wrapped code view, highlighted as markdown");
   assert.match(URL_FN, /if \(text === null\) return;/, "the loader holds the body until the bytes land");
+});
+
+test("redirects: the document LIVES at the response URL — mdBlock's base and the title follow it; Open ↗ and Copy URL keep the clicked link", () => {
+  assert.match(URL_FN, /let loc = href;/);
+  assert.match(URL_FN, /const relocate = \(r: Response\) => \{\s*\n\s*loc = r\.url \|\| href;\s*\n\s*parts = urlTitleParts\(loc\);\s*\n\s*dir\.textContent = parts\.dir; base\.textContent = parts\.base; name\.title = loc;/);
+  // relocate runs on the response BEFORE any status branch — a 404's title names where it was looked for
+  const rel = URL_FN.indexOf("relocate(r);");
+  assert.ok(rel > -1 && rel < URL_FN.indexOf("if (!r.ok)"), "relocate precedes the status check");
+  assert.match(URL_FN, /fail\("HTTP " \+ r\.status \+ " from " \+ hostWord\(loc\)\)/, "the status line names the effective host");
+  // the clicked href is what the user was given: the link-out, the copy, and the failure hint keep it
+  assert.match(URL_FN, /a\.href = href; a\.target = "_blank"; a\.rel = "noopener";/);
+  assert.match(URL_FN, /navigator\.clipboard\?\.writeText\(href\)/);
+  assert.match(URL_FN, /hint\.textContent = href;/);
+  assert.doesNotMatch(URL_FN, /writeText\(loc\)|a\.href = loc/);
 });
 
 test("URL mode shares the Rendered ⇄ Raw preference (the same localStorage key) and acknowledges the toggle synchronously", () => {
@@ -92,13 +123,12 @@ test("URL mode shares the Rendered ⇄ Raw preference (the same localStorage key
 });
 
 test("URL mode chrome: host/dir/ dimmed (not a browse link) + basename; Open ↗ link-out; Copy URL; ✕; Esc closes", () => {
-  assert.match(URL_FN, /const parts = urlTitleParts\(href\);/);
+  assert.match(URL_FN, /let parts = urlTitleParts\(href\);/);
   assert.match(URL_FN, /el\("span", "fileview-dir"\)[\s\S]*?dir\.textContent = parts\.dir;/);
   assert.match(URL_FN, /el\("span", "fileview-base"\)[\s\S]*?base\.textContent = parts\.base;/);
   assert.doesNotMatch(URL_FN, /fileview-dir-link|browseFiles/, "no file browser for a URL — the directory half is plain");
   // the link-out: an anchor in the button dress, new tab, noopener — the GitHub link's treatment
   assert.match(URL_FN, /el\("a", "fileview-btn fileview-gh"\)/);
-  assert.match(URL_FN, /a\.href = href; a\.target = "_blank"; a\.rel = "noopener";/);
   assert.match(URL_FN, /a\.textContent = "Open ↗";/);
   // …and it marks itself data-new-tab: its href IS the same-origin .md the delegate would otherwise
   // route straight back into this viewer — the marker is what makes the tab open
@@ -109,7 +139,6 @@ test("URL mode chrome: host/dir/ dimmed (not a browse link) + basename; Open ↗
   assert.doesNotMatch(MD_FN, /newTab|new-tab/);
   // Copy copies the URL (the local mode's Copy path equivalent), with the same feedback words
   assert.match(URL_FN, /copy\.textContent = "Copy URL";/);
-  assert.match(URL_FN, /navigator\.clipboard\?\.writeText\(href\)/);
   assert.match(URL_FN, /copy\.textContent = "Copied";/);
   assert.match(URL_FN, /copy\.textContent = "Copy failed";/);
   // ✕ and Esc close through the shared closeFileView
@@ -130,15 +159,39 @@ test("URL mode has NO Edit / Save / Download / GitHub / ‹ Files — every one 
 
 test("URL mode replaces an open viewer through the same guarded path (unsaved edits ask first; registrations drop)", () => {
   assert.match(URL_FN, /if \(document\.getElementById\("romp-fileview"\) && closeGuard && !closeGuard\(\)\) return;/);
-  for (const drop of ["closeGuard = null;", "editHooks = null;", "gitHooks = null;", "dropMediaUrl();"])
+  for (const drop of ["closeGuard = null;", "editHooks = null;", "gitHooks = null;", "dropMediaUrl();", "dropUrlRead();"])
     assert.ok(URL_FN.includes(drop), drop + " before the old viewer is torn down");
-  assert.ok(URL_FN.indexOf("dropMediaUrl();") < URL_FN.indexOf('document.getElementById("romp-fileview")?.remove();'));
+  assert.ok(URL_FN.indexOf("dropUrlRead();") < URL_FN.indexOf('document.getElementById("romp-fileview")?.remove();'));
 });
 
-// ── 3. loud failures, and the 2 MB cap mirrored from the kernel ──
+// ── 3. the in-flight read is cancelled by EVERY teardown ──
+
+test("the fetch and the body read ride one AbortController, registered module-level like mediaUrlLive", () => {
+  assert.match(VIEW, /let urlAbort: AbortController \| null = null;\s*\nfunction dropUrlRead\(\): void \{\s*\n\s*if \(urlAbort\) \{\s*\n\s*try \{ urlAbort\.abort\(\); \} catch \{[^}]*\}\s*\n\s*urlAbort = null;/);
+  // registered right after the old viewer is dropped, BEFORE any element is built
+  assert.match(URL_FN, /const ctrl = new AbortController\(\);\s*\n\s*urlAbort = ctrl;/);
+  assert.ok(URL_FN.indexOf("urlAbort = ctrl;") < URL_FN.indexOf('const wrap = el("div");'));
+  assert.match(URL_FN, /signal: ctrl\.signal \}\)/, "the fetch is on the signal");
+  assert.match(URL_FN, /readTextCapped\(r\.body, URL_TEXT_MAX_BYTES, ctrl\.signal\)/, "…and so is the streaming read");
+  // an abort is the teardown's doing, not a failure to paint
+  assert.match(URL_FN, /if \(\(err as \{ name\?: string \} \| null\)\?\.name === "AbortError"\) return;/);
+  // this read's registration is released when it is over — never a LATER open's
+  assert.match(URL_FN, /\.finally\(\(\) => \{\s*\n\s*if \(urlAbort === ctrl\) urlAbort = null;/);
+});
+
+test("closeFileView and BOTH replace paths call dropUrlRead — a stale read never keeps pulling for a gone modal", () => {
+  assert.match(CLOSE_FN, /dropMediaUrl\(\);[^\n]*\n\s*dropUrlRead\(\);/, "close: right beside the media-URL revoke");
+  assert.match(OPEN_FN, /dropMediaUrl\(\);[^\n]*\n\s*dropUrlRead\(\);[^\n]*\n\s*document\.getElementById\("romp-fileview"\)\?\.remove\(\);/,
+    "the local viewer's replace path: before the old viewer is torn down");
+  assert.match(URL_FN, /dropMediaUrl\(\);\s*\n\s*dropUrlRead\(\);[^\n]*\n\s*document\.getElementById\("romp-fileview"\)\?\.remove\(\);/,
+    "the URL viewer's own replace path too");
+  assert.equal((VIEW.match(/dropUrlRead\(\);/g) || []).length, 3, "exactly the three exits");
+});
+
+// ── 4. loud failures, and the 2 MB cap mirrored from the kernel — streamed, not buffered ──
 
 test("a non-OK status shows `HTTP <status> from <host>` in the pane, plus the link-out — never console-only", () => {
-  assert.match(URL_FN, /if \(!r\.ok\) \{ fail\("HTTP " \+ r\.status \+ " from " \+ host\); return; \}/);
+  assert.match(URL_FN, /if \(!r\.ok\) \{ fail\("HTTP " \+ r\.status \+ " from " \+ hostWord\(loc\)\); return; \}/);
   const failFn = (URL_FN.split("const fail = ")[1] || "").split("\n  };")[0];
   assert.ok(failFn, "the failure pane builder exists");
   assert.match(failFn, /el\("div", "fileview-err"\)/);
@@ -151,43 +204,35 @@ test("a non-OK status shows `HTTP <status> from <host>` in the pane, plus the li
 });
 
 test("a thrown fetch (network) says the document could not be loaded from this page, with the link-out", () => {
-  assert.match(URL_FN, /\.catch\(\(err\) => \{\s*\n\s*fail\("this document could not be loaded from this page — " \+ String\(err && \(err as Error\)\.message \|\| err\)\);/);
+  assert.match(URL_FN, /fail\("this document could not be loaded from this page — " \+ String\(err && \(err as Error\)\.message \|\| err\)\);/);
 });
 
-test("the body cap is the kernel's 2 MB text cap: Content-Length when declared, the decoded length otherwise", () => {
+test("the cap is the kernel's 2 MB: a declared Content-Length refuses first, then the body is STREAMED and counted in bytes", () => {
   assert.match(VIEW, /const URL_TEXT_MAX_BYTES = 2 \* 1024 \* 1024;/);
   assert.match(KERNEL, /^_TEXT_MAX_BYTES = 2 \* 1024 \* 1024/m, "the kernel's cap the viewer mirrors");
+  assert.match(VIEW, /import \{ readTextCapped, overCapWords \} from "\.\/capped-read";/);
   assert.match(URL_FN, /const declared = Number\(r\.headers\.get\("Content-Length"\) \|\| ""\);/);
-  assert.match(URL_FN, /if \(declared > URL_TEXT_MAX_BYTES\) \{ tooLarge\(declared\); return; \}/);
-  assert.match(URL_FN, /if \(t\.length > URL_TEXT_MAX_BYTES\) \{ tooLarge\(t\.length\); return; \}/);
-  assert.match(URL_FN, /too large to show here \(the cap is " \+ humanSize\(URL_TEXT_MAX_BYTES\) \+ "\)"/);
-  // ordering: status → declared length → body → decoded length; the body is never read past a refusal
+  assert.match(URL_FN, /if \(declared > URL_TEXT_MAX_BYTES\) \{ fail\(overCapWords\(declared, URL_TEXT_MAX_BYTES\)\); return; \}/,
+    "a known size is named against the limit");
+  assert.match(URL_FN, /const got = await readTextCapped\(r\.body, URL_TEXT_MAX_BYTES, ctrl\.signal\);/);
+  assert.match(URL_FN, /if \("tooLarge" in got\) \{ fail\(overCapWords\(null, URL_TEXT_MAX_BYTES\)\); return; \}/,
+    "the streaming refusal names no measured size");
+  assert.match(URL_FN, /text = got\.text;/);
+  // the buffering read is GONE: no r.text(), no code-unit .length check
+  assert.doesNotMatch(URL_FN, /r\.text\(\)|t\.length|\.length > URL_TEXT_MAX_BYTES/);
+  // ordering: status → declared length → streamed read → refusal; the body is never pulled past a refusal
   const status = URL_FN.indexOf("if (!r.ok)");
   const declared = URL_FN.indexOf("if (declared > URL_TEXT_MAX_BYTES)");
-  const readBody = URL_FN.indexOf("return r.text()");
-  const decoded = URL_FN.indexOf("if (t.length > URL_TEXT_MAX_BYTES)");
-  assert.ok(status < declared && declared < readBody && readBody < decoded, "status, header cap, read, decoded cap");
+  const readBody = URL_FN.indexOf("await readTextCapped(");
+  const tripped = URL_FN.indexOf('if ("tooLarge" in got)');
+  assert.ok(status < declared && declared < readBody && readBody < tripped, "status, header cap, streamed read, streamed cap");
   // no Content-Type sniffing: the path decided it is markdown, the body is text and renders as markdown
   assert.doesNotMatch(URL_FN, /headers\.get\("Content-Type"\)/);
-  assert.match(URL_FN, /return r\.text\(\)\.then/, "read as text, whatever the server labelled it");
-  // executed: the pipeline model — an absent/unparseable Content-Length falls through to the decoded length
-  const CAP = 2 * 1024 * 1024;
-  const route = (ok: boolean, status: number, lengthHeader: string | null, textLen: number) => {
-    if (!ok) return "HTTP " + status;
-    const declared = Number(lengthHeader || "");
-    if (declared > CAP) return "large";
-    if (textLen > CAP) return "large";
-    return "ok";
-  };
-  assert.equal(route(false, 404, null, 0), "HTTP 404");
-  assert.equal(route(true, 200, String(CAP + 1), 10), "large", "the header alone refuses — the body is never read");
-  assert.equal(route(true, 200, String(CAP), CAP), "ok", "exactly the cap is fine");
-  assert.equal(route(true, 200, null, CAP + 1), "large", "no header: the decoded length decides");
-  assert.equal(route(true, 200, "not-a-number", 10), "ok", "an unparseable header is not a refusal");
-  assert.equal(route(true, 200, "", 10), "ok");
+  // a response without a body stream fails loudly rather than pretending
+  assert.match(URL_FN, /if \(!r\.body\) \{ fail\("this document could not be loaded from this page — the response carried no body"\); return; \}/);
 });
 
-// ── 4. relative references inside the rendered document ──
+// ── 5. relative references inside the rendered document ──
 
 test("mdBlock takes the document's location and rewrites relative img/src and a/href AFTER DOMPurify", () => {
   assert.match(VIEW, /type MdDocLoc = \{ kind: "url"; href: string \} \| \{ kind: "file"; path: string; sid: string \| null \};/);
@@ -202,10 +247,10 @@ test("mdBlock takes the document's location and rewrites relative img/src and a/
   // URL mode: both resolve against the document URL through the executed helper
   assert.match(MD_FN, /const abs = resolveDocRelative\(src, doc\.href\);\s*\n\s*if \(abs !== src\) img\.setAttribute\("src", abs\);/);
   assert.match(MD_FN, /a\.setAttribute\("href", resolveDocRelative\(href, doc\.href\)\);/);
-  // in-document and already-absolute anchors are left alone
+  // in-document and already-absolute anchors are left alone by the resolver
   assert.match(MD_FN, /if \(!href \|\| href\.startsWith\("#"\) \|\| \/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(href\)\) return;/);
-  // the two helpers arrive from the pure module
-  assert.match(VIEW, /import \{ resolveDocRelative, joinDocPath, urlTitleParts \} from "\.\/md-links";/);
+  // the helpers arrive from the pure module
+  assert.match(VIEW, /import \{ resolveDocRelative, joinDocPath, urlTitleParts, headingSlug, uniqueSlugs \} from "\.\/md-links";/);
 });
 
 test("local file mode: a relative image is the sibling over the kernel's /file route (fileUrl, never hand-built)", () => {
@@ -221,7 +266,7 @@ test("local file mode: a relative image is the sibling over the kernel's /file r
 test("local file mode: a relative link opens the sibling in the viewer via ONE delegated data-act listener on the body", () => {
   // the anchor carries the joined path as data, keeps its href for hover, and is not forced to _blank
   assert.match(MD_FN, /const joined = joinDocPath\(doc\.path, href\);\s*\n\s*a\.dataset\.act = "fv-open";\s*\n\s*a\.dataset\.path = joined;\s*\n\s*a\.title = joined;/);
-  assert.match(MD_FN, /if \(\(a as HTMLElement\)\.dataset\.act === "fv-open"\) return;\s*\n\s*\(a as HTMLAnchorElement\)\.target = "_blank";/);
+  assert.match(MD_FN, /if \(a\.dataset\.act === "fv-open"\) return;/);
   // …the delegate: actions.ts's delegate, installed once per open on the body (stable across the
   // Rendered ⇄ Raw swaps that rebuild its children), preventDefault, then openFileView with this sid
   assert.match(VIEW, /import \{ delegate \} from "\.\/actions";/);
@@ -232,7 +277,53 @@ test("local file mode: a relative link opens the sibling in the viewer via ONE d
   assert.match(HANDLER, /if \(!\/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(href\)\) return;/);
 });
 
-// ── 5. styling: no new rules — the URL viewer wears the viewer's existing chrome in BOTH sheets ──
+// ── 6. in-document fragments: heading ids, and `#links` that land instead of spawning a tab ──
+
+test("every heading gets id=md-<slug> after sanitisation, in both modes (the md- prefix keeps the page's own ids and CSS out of it)", () => {
+  assert.match(MD_FN, /const heads = Array\.from\(box\.querySelectorAll\("h1, h2, h3, h4, h5, h6"\)\) as HTMLElement\[\];\s*\n\s*const slugs = uniqueSlugs\(heads\.map\(\(h\) => headingSlug\(h\.textContent \|\| ""\)\)\);\s*\n\s*heads\.forEach\(\(h, i\) => \{ h\.id = "md-" \+ slugs\[i\]; \}\);/);
+  const sanitize = MD_FN.indexOf("DOMPurify.sanitize(");
+  const ids = MD_FN.indexOf('h.id = "md-"');
+  const docGate = MD_FN.indexOf("if (doc) {");
+  assert.ok(sanitize < ids && ids < docGate, "after DOMPurify, and OUTSIDE the doc gate — every mode, every caller");
+  assert.match(MD_FN, /an unprefixed id="tabs" would dress a heading in the chat page's[\s\S]*?#tabs CSS and shadow getElementById\("tabs"\)/, "the prefix's reason is written down");
+});
+
+test("a `#fragment` anchor is stamped fv-anchor and gets NO _blank; every other anchor still does", () => {
+  assert.match(MD_FN, /if \(\(a\.getAttribute\("href"\) \|\| ""\)\.startsWith\("#"\)\) \{ a\.dataset\.act = "fv-anchor"; return; \}\s*\n\s*a\.target = "_blank";\s*\n\s*a\.rel = "noopener";/);
+  // the fragment branch is in the UNCONDITIONAL loop — a document with no location still lands its own links
+  const finalLoop = MD_FN.slice(MD_FN.lastIndexOf('box.querySelectorAll("a[href]")'));
+  assert.ok(finalLoop.includes('a.dataset.act = "fv-anchor"'), "stamped in the final, doc-independent pass");
+  assert.ok(finalLoop.includes('if (a.dataset.act === "fv-open") return;'), "…which also leaves the sibling links alone");
+});
+
+test("scrollToFragment: decode, slug, find md-<slug> inside THIS box, scrollIntoView; nothing found → inert", () => {
+  const fn = VIEW.split("function scrollToFragment(")[1].split("\n}")[0];
+  assert.match(fn, /let frag = fragment\.replace\(\/\^#\/, ""\);/);
+  assert.match(fn, /try \{ frag = decodeURIComponent\(frag\); \} catch \{/);
+  assert.match(fn, /if \(!frag\) return false;/);
+  assert.match(fn, /const target = box\.querySelector\('\[id="md-' \+ headingSlug\(frag\) \+ '"\]'\);/, "the box, never document.getElementById");
+  assert.match(fn, /if \(!target\) return false;/);
+  assert.match(fn, /target\.scrollIntoView\(\{ block: "start" \}\);/);
+  assert.doesNotMatch(fn, /location\.|document\.getElementById|window\.open/);
+});
+
+test("both viewers handle fv-anchor in their body delegate: preventDefault, then scrollToFragment on the body", () => {
+  const H = /"fv-anchor": \(a, ev\) => \{ ev\.preventDefault\(\); scrollToFragment\(body, a\.getAttribute\("href"\) \|\| ""\); \},/;
+  assert.match(OPEN_FN, H, "the local viewer's existing delegate gained the handler");
+  assert.match(URL_FN, H, "the URL viewer installs its own delegate for it");
+  assert.equal((URL_FN.match(/delegate\(body/g) || []).length, 1, "one listener per open");
+  assert.ok(URL_FN.indexOf("delegate(body") < URL_FN.indexOf("const renderBody ="), "installed before any render can run");
+  assert.doesNotMatch(URL_FN, /"fv-open"/, "no sibling-path links in URL mode — those are absolute and the chat's delegate routes them");
+});
+
+test("the opened URL's own #fragment lands after the FIRST rendered paint — once, and only with a rendered body", () => {
+  assert.match(URL_FN, /let landed = false;\s*\n\s*const landFragment = \(\) => \{\s*\n\s*if \(landed\) return;\s*\n\s*landed = true;/);
+  assert.match(URL_FN, /try \{ hash = new URL\(href\)\.hash; \} catch \{/);
+  assert.match(URL_FN, /if \(hash && fmt\.md === "rendered"\) requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, hash\); \}\);/);
+  assert.match(URL_FN, /text = got\.text;\s*\n\s*renderBody\(\);\s*\n\s*landFragment\(\);/, "after the paint, not before it");
+});
+
+// ── 7. styling: no new rules — the URL viewer wears the viewer's existing chrome in BOTH sheets ──
 
 test("every class the URL viewer uses is already declared in both sheets (nothing new to mirror)", () => {
   for (const head of ["#romp-fileview {", ".fileview {", ".fileview-bar {", ".fileview-name {", ".fileview-dir {",

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -103,10 +103,10 @@ test("URL mode: the loader is up before the fetch, the body renders through mdBl
 test("redirects: the document LIVES at the response URL — mdBlock's base and the title follow it; Open ↗ and Copy URL keep the clicked link", () => {
   assert.match(URL_FN, /let loc = href;/);
   assert.match(URL_FN, /const relocate = \(r: Response\) => \{\s*\n\s*loc = r\.url \|\| href;\s*\n\s*parts = urlTitleParts\(loc\);\s*\n\s*dir\.textContent = parts\.dir; base\.textContent = parts\.base; name\.title = loc;/);
-  // relocate runs on the response BEFORE any status branch — a 404's title names where it was looked for
+  // relocate runs on the response BEFORE any verdict branch — a 404's title names where it was looked for
   const rel = URL_FN.indexOf("relocate(r);");
-  assert.ok(rel > -1 && rel < URL_FN.indexOf("if (!r.ok)"), "relocate precedes the status check");
-  assert.match(URL_FN, /fail\("HTTP " \+ r\.status \+ " from " \+ hostWord\(loc\)\)/, "the status line names the effective host");
+  assert.ok(rel > -1 && rel < URL_FN.indexOf("settleUrlResponse(r,"), "relocate precedes the verdict");
+  assert.match(URL_FN, /fail\("HTTP " \+ v\.status \+ " from " \+ hostWord\(loc\)\)/, "the status line names the effective host");
   // the clicked href is what the user was given: the link-out, the copy, and the failure hint keep it
   assert.match(URL_FN, /a\.href = href; a\.target = "_blank"; a\.rel = "noopener";/);
   assert.match(URL_FN, /navigator\.clipboard\?\.writeText\(href\)/);
@@ -172,9 +172,11 @@ test("the fetch and the body read ride one AbortController, registered module-le
   assert.match(URL_FN, /const ctrl = new AbortController\(\);\s*\n\s*urlAbort = ctrl;/);
   assert.ok(URL_FN.indexOf("urlAbort = ctrl;") < URL_FN.indexOf('const wrap = el("div");'));
   assert.match(URL_FN, /signal: ctrl\.signal \}\)/, "the fetch is on the signal");
-  assert.match(URL_FN, /readTextCapped\(r\.body, URL_TEXT_MAX_BYTES, ctrl\.signal\)/, "…and so is the streaming read");
-  // an abort is the teardown's doing, not a failure to paint
-  assert.match(URL_FN, /if \(\(err as \{ name\?: string \} \| null\)\?\.name === "AbortError"\) return;/);
+  assert.match(URL_FN, /readTextCapped\(r\.body!, URL_TEXT_MAX_BYTES, ctrl\.signal\)/, "…and so is the streaming read");
+  // only the TEARDOWN's abort is silent — keyed on this open's signal, never on an error's name: an
+  // independently errored stream that merely wears the AbortError name still paints its failure
+  assert.match(URL_FN, /\.catch\(\(err\) => \{[\s\S]*?if \(ctrl\.signal\.aborted\) return;\s*\n\s*fail\("this document could not be loaded from this page — "/);
+  assert.doesNotMatch(URL_FN, /name === "AbortError"/);
   // this read's registration is released when it is over — never a LATER open's
   assert.match(URL_FN, /\.finally\(\(\) => \{\s*\n\s*if \(urlAbort === ctrl\) urlAbort = null;/);
 });
@@ -191,7 +193,7 @@ test("closeFileView and BOTH replace paths call dropUrlRead — a stale read nev
 // ── 4. loud failures, and the 2 MB cap mirrored from the kernel — streamed, not buffered ──
 
 test("a non-OK status shows `HTTP <status> from <host>` in the pane, plus the link-out — never console-only", () => {
-  assert.match(URL_FN, /if \(!r\.ok\) \{ fail\("HTTP " \+ r\.status \+ " from " \+ hostWord\(loc\)\); return; \}/);
+  assert.match(URL_FN, /if \(v\.kind === "http"\) \{ fail\("HTTP " \+ v\.status \+ " from " \+ hostWord\(loc\)\); return; \}/);
   const failFn = (URL_FN.split("const fail = ")[1] || "").split("\n  };")[0];
   assert.ok(failFn, "the failure pane builder exists");
   assert.match(failFn, /el\("div", "fileview-err"\)/);
@@ -210,26 +212,49 @@ test("a thrown fetch (network) says the document could not be loaded from this p
 test("the cap is the kernel's 2 MB: a declared Content-Length refuses first, then the body is STREAMED and counted in bytes", () => {
   assert.match(VIEW, /const URL_TEXT_MAX_BYTES = 2 \* 1024 \* 1024;/);
   assert.match(KERNEL, /^_TEXT_MAX_BYTES = 2 \* 1024 \* 1024/m, "the kernel's cap the viewer mirrors");
-  assert.match(VIEW, /import \{ readTextCapped, overCapWords \} from "\.\/capped-read";/);
-  assert.match(URL_FN, /const declared = Number\(r\.headers\.get\("Content-Length"\) \|\| ""\);/);
-  assert.match(URL_FN, /if \(declared > URL_TEXT_MAX_BYTES\) \{ fail\(overCapWords\(declared, URL_TEXT_MAX_BYTES\)\); return; \}/,
+  assert.match(VIEW, /import \{ readTextCapped, overCapWords, settleUrlResponse \} from "\.\/capped-read";/);
+  // the pre-read decision is the executed helper's (capped-read.test.ts), fed this open's abort as `stop`
+  assert.match(URL_FN, /const v = settleUrlResponse\(r, URL_TEXT_MAX_BYTES, \(\) => ctrl\.abort\(\)\);/);
+  assert.match(URL_FN, /if \(v\.kind === "declared-too-large"\) \{ fail\(overCapWords\(v\.bytes, URL_TEXT_MAX_BYTES\)\); return; \}/,
     "a known size is named against the limit");
-  assert.match(URL_FN, /const got = await readTextCapped\(r\.body, URL_TEXT_MAX_BYTES, ctrl\.signal\);/);
-  assert.match(URL_FN, /if \("tooLarge" in got\) \{ fail\(overCapWords\(null, URL_TEXT_MAX_BYTES\)\); return; \}/,
+  assert.match(URL_FN, /const got = await readTextCapped\(r\.body!, URL_TEXT_MAX_BYTES, ctrl\.signal\);/);
+  assert.match(URL_FN, /if \("tooLarge" in got\) \{ ctrl\.abort\(\); fail\(overCapWords\(null, URL_TEXT_MAX_BYTES\)\); return; \}/,
     "the streaming refusal names no measured size");
   assert.match(URL_FN, /text = got\.text;/);
-  // the buffering read is GONE: no r.text(), no code-unit .length check
+  // the buffering read is GONE: no r.text(), no code-unit .length check — and no header is read here
+  // at all (the helper owns Content-Length; Content-Type is never sniffed)
   assert.doesNotMatch(URL_FN, /r\.text\(\)|t\.length|\.length > URL_TEXT_MAX_BYTES/);
-  // ordering: status → declared length → streamed read → refusal; the body is never pulled past a refusal
-  const status = URL_FN.indexOf("if (!r.ok)");
-  const declared = URL_FN.indexOf("if (declared > URL_TEXT_MAX_BYTES)");
+  assert.doesNotMatch(URL_FN, /headers\.get\(/);
+  // ordering: status → declared length → no-body → streamed read → refusal; the body is never pulled
+  // past a refusal
+  const status = URL_FN.indexOf('if (v.kind === "http")');
+  const declared = URL_FN.indexOf('if (v.kind === "declared-too-large")');
+  const noBody = URL_FN.indexOf('if (v.kind === "no-body")');
   const readBody = URL_FN.indexOf("await readTextCapped(");
   const tripped = URL_FN.indexOf('if ("tooLarge" in got)');
-  assert.ok(status < declared && declared < readBody && readBody < tripped, "status, header cap, streamed read, streamed cap");
-  // no Content-Type sniffing: the path decided it is markdown, the body is text and renders as markdown
-  assert.doesNotMatch(URL_FN, /headers\.get\("Content-Type"\)/);
+  assert.ok(status > -1 && status < declared && declared < noBody && noBody < readBody && readBody < tripped,
+    "status, header cap, no-body, streamed read, streamed cap");
   // a response without a body stream fails loudly rather than pretending
-  assert.match(URL_FN, /if \(!r\.body\) \{ fail\("this document could not be loaded from this page — the response carried no body"\); return; \}/);
+  assert.match(URL_FN, /if \(v\.kind === "no-body"\) \{ fail\("this document could not be loaded from this page — the response carried no body"\); return; \}/);
+});
+
+test("EVERY exit that stops short of consuming the body aborts this open's controller — a refused response's transfer stops", () => {
+  // the hole (measured live): a 404 / oversized-length refusal painted its words and returned, .finally
+  // let go of the controller, and the body kept downloading for a modal already closed
+  const thenBody = URL_FN.split(".then(async (r) => {")[1].split(".catch(")[0];
+  assert.match(thenBody, /^\s*(\/\/[^\n]*\n\s*)*if \(!wrap\.isConnected\) \{ ctrl\.abort\(\); return; \}/, "closed before the response landed: abort");
+  assert.match(thenBody, /settleUrlResponse\(r, URL_TEXT_MAX_BYTES, \(\) => ctrl\.abort\(\)\)/, "http / declared-too-large / no-body: the helper fires the abort");
+  assert.match(thenBody, /await readTextCapped\(r\.body!, URL_TEXT_MAX_BYTES, ctrl\.signal\);[^\n]*\n\s*if \(!wrap\.isConnected\) \{ ctrl\.abort\(\); return; \}/, "closed while the body streamed: abort");
+  assert.match(thenBody, /if \("tooLarge" in got\) \{ ctrl\.abort\(\);/, "the streaming trip: abort (the reader already cancelled its source; the signal makes it symmetric)");
+  // three literal aborts in the closure + the one the helper fires = every early return; the success path has none
+  assert.equal((thenBody.match(/ctrl\.abort\(\)/g) || []).length, 4);
+  const success = thenBody.slice(thenBody.indexOf("text = got.text;"));
+  assert.doesNotMatch(success, /ctrl\.abort/, "a consumed body has nothing left to stop");
+  // every early `return` in the closure is preceded on its line by an abort or by a verdict branch
+  // (whose abort the helper already fired)
+  for (const line of thenBody.split("\n").filter((l) => /return;/.test(l))) {
+    assert.ok(/ctrl\.abort\(\)|v\.kind ===/.test(line), "an early exit without an abort: " + line.trim());
+  }
 });
 
 // ── 5. relative references inside the rendered document ──
@@ -333,4 +358,14 @@ test("every class the URL viewer uses is already declared in both sheets (nothin
     assert.ok(FEED_CSS.includes(head), head + " in feed.css");
   }
   assert.doesNotMatch(URL_FN, /style\.|cssText|innerHTML = '<style/, "no inline styling");
+});
+
+test("a landed heading sits a breath below the title bar: scroll-margin-top on h1–h6, byte-equal in both sheets, the bar's own 10px", () => {
+  const RULE = ".fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 { scroll-margin-top: 10px; }";
+  assert.ok(CHAT_CSS.includes(RULE), "styles.css");
+  assert.ok(FEED_CSS.includes(RULE), "feed.css");
+  // 10px is a spacing the viewer already wears (the bar's padding, the refusal's Download offset) — no new value
+  assert.match(CHAT_CSS, /\.fileview-bar \{[^}]*padding: 7px 10px;/);
+  assert.match(CHAT_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
+  assert.doesNotMatch(RULE, /font-size|--/, "no font size, no token");
 });

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -1,0 +1,245 @@
+// A markdown link on the dashboard's OWN origin opens in the file viewer, rendered (the user
+// 2026-09-06) — it used to open the raw text in a new tab. The viewer grew a URL mode: the browser
+// fetches the URL itself (no kernel route, no proxy — the kernel's /file relay is a preview relay and
+// stays one), mdBlock renders it with the shared Rendered ⇄ Raw preference, and relative figures and
+// links inside the document resolve against the document rather than the page. Cross-origin .md links
+// keep the new tab exactly. No jsdom harness for these modules → source pins, plus the executed
+// helpers in md-links.test.ts. Synthetic hosts/paths only (TESTHOST, /figs/run-1/evidence.md).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = web("render.ts");
+const VIEW = web("file-view.ts");
+const CHAT_CSS = web("styles.css");
+const FEED_CSS = web("feed.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+// the chat's global anchor-click delegate (the same isolation chat-link-open.test.ts uses)
+const HANDLER = (RENDER.match(/closest\?\.\("a\[href\]"\)[\s\S]*?\}, true\);/) || [""])[0];
+// the URL viewer, from its export to the next top-level function
+const URL_FN = (VIEW.split("export function openUrlView")[1] || "").split("// Kick the browser's downloader")[0];
+// the markdown renderer
+const MD_FN = (VIEW.split("function mdBlock(")[1] || "").split("// The image body:")[0];
+// the local viewer (the split file-view.test.ts uses — openUrlView sits AFTER offersDownload so it
+// never leaks into this slice)
+const OPEN_FN = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+
+// ── 1. the interception: same-origin .md, BEFORE window.open, web only ──
+
+test("the anchor delegate routes a same-origin .md href to the viewer BEFORE the new-tab window.open", () => {
+  assert.ok(HANDLER, "found the anchor-click handler");
+  assert.match(HANDLER, /if \(!a\.dataset\.newTab && isMarkdownUrl\(href, location\.origin\)\) \{ openUrlView\(href\); return; \}/);
+  const viewer = HANDLER.indexOf("openUrlView(href)");
+  const tab = HANDLER.indexOf('window.open(href, "_blank", "noopener,noreferrer")');
+  assert.ok(viewer > -1 && tab > -1 && viewer < tab, "the viewer branch precedes window.open");
+  // …inside the web arm: the check sits after the http/https protocol test
+  const webArm = HANDLER.indexOf('location.protocol === "http:" || location.protocol === "https:"');
+  assert.ok(webArm > -1 && webArm < viewer, "the .md branch lives in the web (http/https) arm");
+  // the cross-origin path still reaches the exact new-tab call it always did
+  assert.match(HANDLER, /window\.open\(href, "_blank", "noopener,noreferrer"\);/);
+  // the VS Code branch is untouched — openLink still posts to the host, and never opens the viewer
+  assert.match(HANDLER, /\} else if \(vscodeApi\) \{\s*\n\s*vscodeApi\.postMessage\(\{ type: "openLink", href \}\);/);
+  const vsArm = HANDLER.slice(HANDLER.indexOf("} else if (vscodeApi) {"));
+  assert.doesNotMatch(vsArm, /openUrlView/, "the webview cannot reach the kernel origin — no viewer there");
+  // the helpers arrive on their own import lines (the openFileView import is pinned verbatim elsewhere)
+  assert.match(RENDER, /import \{ openFileView \} from "\.\/file-view";/);
+  assert.match(RENDER, /import \{ openUrlView \} from "\.\/file-view";/);
+  assert.match(RENDER, /import \{ isMarkdownUrl \} from "\.\/md-links";/);
+});
+
+test("the whole-backtick URL anchors (url-code-link) flow through the same delegate — no handler of their own", () => {
+  const linkify = RENDER.split("function linkifyFileUris(")[1].split("const previewable")[0];
+  assert.match(linkify, /a\.href = t;/, "an absolute http(s) href — the delegate sees a scheme");
+  assert.match(linkify, /a\.className = "url-code-link";/);
+  assert.doesNotMatch(linkify, /addEventListener\("click"|onclick|window\.open|openUrlView/,
+    "the anchor carries no click logic; the document-level delegate decides viewer vs tab");
+});
+
+// ── 2. the URL viewer itself ──
+
+test("openUrlView exists, fetches the given href from the browser (never fileUrl), and adds no kernel surface", () => {
+  assert.match(VIEW, /export function openUrlView\(href: string\): void \{/);
+  assert.ok(VIEW.indexOf("export function openUrlView") > VIEW.indexOf("function offersDownload"),
+    "sits after offersDownload — outside the slice file-view.test.ts takes as openFileView's body");
+  assert.doesNotMatch(OPEN_FN, /openUrlView|kind: "url"/, "the local viewer's body is untouched by URL mode");
+  assert.match(URL_FN, /fetch\(href, \{ cache: "no-store" \}\)/);
+  assert.doesNotMatch(URL_FN, /fileUrl\(|kernelUrl\(|\/file\?|\/remote\//, "the URL is fetched as given — no kernel route, no relay");
+  assert.doesNotMatch(URL_FN, /\bpost\(/, "nothing is asked of the kernel over the socket either");
+  // …and the kernel gained no route for it
+  assert.doesNotMatch(KERNEL, /\/(fetch-url|url-proxy|proxy-url|remote-url)\b/, "no URL relay route was added");
+});
+
+test("URL mode: the loader is up before the fetch, the body renders through mdBlock with the document's URL as base", () => {
+  assert.match(VIEW, /function loaderEl\(\): HTMLElement \{/);
+  assert.match(VIEW, /const load = el\("div", "fileview-load"\);\s*\n\s*load\.innerHTML = '<img src="\/media\/romp-swirl-glyph\.svg" alt=""><span>romp<\/span>'/);
+  const loader = URL_FN.indexOf("body.appendChild(loaderEl());");
+  const fetchAt = URL_FN.indexOf("fetch(href, { cache");
+  assert.ok(loader > -1 && fetchAt > -1 && loader < fetchAt, "loader first, then the fetch replaces it");
+  assert.match(URL_FN, /mdBlock\(text, \{ kind: "url", href \}\)/);
+  assert.match(URL_FN, /codeBlock\(text, parts\.base, true\)/, "Raw is the same soft-wrapped code view, highlighted as markdown");
+  assert.match(URL_FN, /if \(text === null\) return;/, "the loader holds the body until the bytes land");
+});
+
+test("URL mode shares the Rendered ⇄ Raw preference (the same localStorage key) and acknowledges the toggle synchronously", () => {
+  assert.match(URL_FN, /const fmt = loadFmt\(\);/);
+  assert.match(URL_FN, /b\.addEventListener\("click", \(\) => \{ fmt\.md = mode; saveFmt\(fmt\); renderBody\(\); \}\);/);
+  assert.match(URL_FN, /b\.classList\.toggle\("on", on\);/);
+  assert.match(VIEW, /const FMT_KEY = "romp:fileviewFmt";/);
+  assert.equal((VIEW.match(/localStorage\.(get|set)Item\(FMT_KEY/g) || []).length, 2, "one key, read and written in one place");
+});
+
+test("URL mode chrome: host/dir/ dimmed (not a browse link) + basename; Open ↗ link-out; Copy URL; ✕; Esc closes", () => {
+  assert.match(URL_FN, /const parts = urlTitleParts\(href\);/);
+  assert.match(URL_FN, /el\("span", "fileview-dir"\)[\s\S]*?dir\.textContent = parts\.dir;/);
+  assert.match(URL_FN, /el\("span", "fileview-base"\)[\s\S]*?base\.textContent = parts\.base;/);
+  assert.doesNotMatch(URL_FN, /fileview-dir-link|browseFiles/, "no file browser for a URL — the directory half is plain");
+  // the link-out: an anchor in the button dress, new tab, noopener — the GitHub link's treatment
+  assert.match(URL_FN, /el\("a", "fileview-btn fileview-gh"\)/);
+  assert.match(URL_FN, /a\.href = href; a\.target = "_blank"; a\.rel = "noopener";/);
+  assert.match(URL_FN, /a\.textContent = "Open ↗";/);
+  // …and it marks itself data-new-tab: its href IS the same-origin .md the delegate would otherwise
+  // route straight back into this viewer — the marker is what makes the tab open
+  assert.match(URL_FN, /a\.dataset\.newTab = "1";/);
+  assert.ok(HANDLER.includes("!a.dataset.newTab &&"), "the delegate honours the marker before the .md check");
+  // the marker rides ONLY the link-out: a rendered document's own anchors never carry it, so a
+  // sibling .md link keeps navigating in place
+  assert.doesNotMatch(MD_FN, /newTab|new-tab/);
+  // Copy copies the URL (the local mode's Copy path equivalent), with the same feedback words
+  assert.match(URL_FN, /copy\.textContent = "Copy URL";/);
+  assert.match(URL_FN, /navigator\.clipboard\?\.writeText\(href\)/);
+  assert.match(URL_FN, /copy\.textContent = "Copied";/);
+  assert.match(URL_FN, /copy\.textContent = "Copy failed";/);
+  // ✕ and Esc close through the shared closeFileView
+  assert.match(URL_FN, /el\("button", "fileview-btn fileview-close"\)/);
+  assert.match(URL_FN, /close\.addEventListener\("click", closeFileView\);/);
+  assert.match(URL_FN, /if \(e\.key !== "Escape" \|\| !document\.getElementById\("romp-fileview"\)\) return;/);
+  // the same modal shell: the id every open/closed check targets, backdrop click closes, body class
+  assert.match(URL_FN, /wrap\.id = "romp-fileview";/);
+  assert.match(URL_FN, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) closeFileView\(\); \};/);
+  assert.match(URL_FN, /document\.body\.classList\.add\("fileview-open"\);/);
+});
+
+test("URL mode has NO Edit / Save / Download / GitHub / ‹ Files — every one of those is keyed on a kernel reply", () => {
+  assert.doesNotMatch(URL_FN, /textContent = "(Edit|Save|Cancel|Download|‹ Files|GitHub ↗)"/);
+  assert.doesNotMatch(URL_FN, /fileViewActions|registerFileViewAction|fileGitLink|editingAllowed|enterEdit|startDownload/);
+  assert.doesNotMatch(URL_FN, /headers\.get\("(X-Romp-[A-Za-z-]+|Content-Type)"\)/, "no kernel verdict headers are read — there is no kernel reply");
+});
+
+test("URL mode replaces an open viewer through the same guarded path (unsaved edits ask first; registrations drop)", () => {
+  assert.match(URL_FN, /if \(document\.getElementById\("romp-fileview"\) && closeGuard && !closeGuard\(\)\) return;/);
+  for (const drop of ["closeGuard = null;", "editHooks = null;", "gitHooks = null;", "dropMediaUrl();"])
+    assert.ok(URL_FN.includes(drop), drop + " before the old viewer is torn down");
+  assert.ok(URL_FN.indexOf("dropMediaUrl();") < URL_FN.indexOf('document.getElementById("romp-fileview")?.remove();'));
+});
+
+// ── 3. loud failures, and the 2 MB cap mirrored from the kernel ──
+
+test("a non-OK status shows `HTTP <status> from <host>` in the pane, plus the link-out — never console-only", () => {
+  assert.match(URL_FN, /if \(!r\.ok\) \{ fail\("HTTP " \+ r\.status \+ " from " \+ host\); return; \}/);
+  const failFn = (URL_FN.split("const fail = ")[1] || "").split("\n  };")[0];
+  assert.ok(failFn, "the failure pane builder exists");
+  assert.match(failFn, /el\("div", "fileview-err"\)/);
+  assert.match(failFn, /why\.textContent = words;/);
+  assert.match(failFn, /el\("div", "fileview-err-hint"\)[\s\S]*?hint\.textContent = href;/, "the URL under the words");
+  assert.match(failFn, /why\.appendChild\(linkOut\(\)\);/, "the way out: the URL in a new tab");
+  assert.match(failFn, /body\.replaceChildren\(why\);/);
+  assert.match(failFn, /if \(!wrap\.isConnected\) return;/, "a failure landing after a close paints nothing");
+  assert.doesNotMatch(URL_FN, /console\.(log|warn|error)/);
+});
+
+test("a thrown fetch (network) says the document could not be loaded from this page, with the link-out", () => {
+  assert.match(URL_FN, /\.catch\(\(err\) => \{\s*\n\s*fail\("this document could not be loaded from this page — " \+ String\(err && \(err as Error\)\.message \|\| err\)\);/);
+});
+
+test("the body cap is the kernel's 2 MB text cap: Content-Length when declared, the decoded length otherwise", () => {
+  assert.match(VIEW, /const URL_TEXT_MAX_BYTES = 2 \* 1024 \* 1024;/);
+  assert.match(KERNEL, /^_TEXT_MAX_BYTES = 2 \* 1024 \* 1024/m, "the kernel's cap the viewer mirrors");
+  assert.match(URL_FN, /const declared = Number\(r\.headers\.get\("Content-Length"\) \|\| ""\);/);
+  assert.match(URL_FN, /if \(declared > URL_TEXT_MAX_BYTES\) \{ tooLarge\(declared\); return; \}/);
+  assert.match(URL_FN, /if \(t\.length > URL_TEXT_MAX_BYTES\) \{ tooLarge\(t\.length\); return; \}/);
+  assert.match(URL_FN, /too large to show here \(the cap is " \+ humanSize\(URL_TEXT_MAX_BYTES\) \+ "\)"/);
+  // ordering: status → declared length → body → decoded length; the body is never read past a refusal
+  const status = URL_FN.indexOf("if (!r.ok)");
+  const declared = URL_FN.indexOf("if (declared > URL_TEXT_MAX_BYTES)");
+  const readBody = URL_FN.indexOf("return r.text()");
+  const decoded = URL_FN.indexOf("if (t.length > URL_TEXT_MAX_BYTES)");
+  assert.ok(status < declared && declared < readBody && readBody < decoded, "status, header cap, read, decoded cap");
+  // no Content-Type sniffing: the path decided it is markdown, the body is text and renders as markdown
+  assert.doesNotMatch(URL_FN, /headers\.get\("Content-Type"\)/);
+  assert.match(URL_FN, /return r\.text\(\)\.then/, "read as text, whatever the server labelled it");
+  // executed: the pipeline model — an absent/unparseable Content-Length falls through to the decoded length
+  const CAP = 2 * 1024 * 1024;
+  const route = (ok: boolean, status: number, lengthHeader: string | null, textLen: number) => {
+    if (!ok) return "HTTP " + status;
+    const declared = Number(lengthHeader || "");
+    if (declared > CAP) return "large";
+    if (textLen > CAP) return "large";
+    return "ok";
+  };
+  assert.equal(route(false, 404, null, 0), "HTTP 404");
+  assert.equal(route(true, 200, String(CAP + 1), 10), "large", "the header alone refuses — the body is never read");
+  assert.equal(route(true, 200, String(CAP), CAP), "ok", "exactly the cap is fine");
+  assert.equal(route(true, 200, null, CAP + 1), "large", "no header: the decoded length decides");
+  assert.equal(route(true, 200, "not-a-number", 10), "ok", "an unparseable header is not a refusal");
+  assert.equal(route(true, 200, "", 10), "ok");
+});
+
+// ── 4. relative references inside the rendered document ──
+
+test("mdBlock takes the document's location and rewrites relative img/src and a/href AFTER DOMPurify", () => {
+  assert.match(VIEW, /type MdDocLoc = \{ kind: "url"; href: string \} \| \{ kind: "file"; path: string; sid: string \| null \};/);
+  assert.match(VIEW, /function mdBlock\(text: string, doc\?: MdDocLoc\): HTMLElement \{/);
+  const sanitize = MD_FN.indexOf("DOMPurify.sanitize(");
+  const rewrite = MD_FN.indexOf("resolveDocRelative(");
+  assert.ok(sanitize > -1 && rewrite > sanitize, "sanitise first; the rewrite only ever sees what DOMPurify kept");
+  // the ATTRIBUTE, never the property — .src/.href are already resolved against the page (the wrong base)
+  assert.match(MD_FN, /const src = img\.getAttribute\("src"\) \|\| "";/);
+  assert.match(MD_FN, /const href = a\.getAttribute\("href"\) \|\| "";/);
+  assert.doesNotMatch(MD_FN, /img\.src\b|a\.href\b/, "no property reads");
+  // URL mode: both resolve against the document URL through the executed helper
+  assert.match(MD_FN, /const abs = resolveDocRelative\(src, doc\.href\);\s*\n\s*if \(abs !== src\) img\.setAttribute\("src", abs\);/);
+  assert.match(MD_FN, /a\.setAttribute\("href", resolveDocRelative\(href, doc\.href\)\);/);
+  // in-document and already-absolute anchors are left alone
+  assert.match(MD_FN, /if \(!href \|\| href\.startsWith\("#"\) \|\| \/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(href\)\) return;/);
+  // the two helpers arrive from the pure module
+  assert.match(VIEW, /import \{ resolveDocRelative, joinDocPath, urlTitleParts \} from "\.\/md-links";/);
+});
+
+test("local file mode: a relative image is the sibling over the kernel's /file route (fileUrl, never hand-built)", () => {
+  assert.match(MD_FN, /img\.setAttribute\("src", fileUrl\(joinDocPath\(doc\.path, src\), doc\.sid\)\);/);
+  // gated to path-shaped refs: a scheme (http:, data:) or a protocol-relative URL is the browser's
+  assert.match(MD_FN, /else if \(src && !\/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(src\) && !src\.startsWith\("\/\/"\)\) \{/);
+  assert.doesNotMatch(MD_FN, /"\/file\?path="|\/remote\//, "the route is fileUrl's to build (federation-aware)");
+  assert.match(VIEW, /import \{ fileUrl \} from "\.\/preview";/);
+  // openFileView hands mdBlock its location
+  assert.match(OPEN_FN, /mdBlock\(text, \{ kind: "file", path, sid: sid \|\| null \}\)/);
+});
+
+test("local file mode: a relative link opens the sibling in the viewer via ONE delegated data-act listener on the body", () => {
+  // the anchor carries the joined path as data, keeps its href for hover, and is not forced to _blank
+  assert.match(MD_FN, /const joined = joinDocPath\(doc\.path, href\);\s*\n\s*a\.dataset\.act = "fv-open";\s*\n\s*a\.dataset\.path = joined;\s*\n\s*a\.title = joined;/);
+  assert.match(MD_FN, /if \(\(a as HTMLElement\)\.dataset\.act === "fv-open"\) return;\s*\n\s*\(a as HTMLAnchorElement\)\.target = "_blank";/);
+  // …the delegate: actions.ts's delegate, installed once per open on the body (stable across the
+  // Rendered ⇄ Raw swaps that rebuild its children), preventDefault, then openFileView with this sid
+  assert.match(VIEW, /import \{ delegate \} from "\.\/actions";/);
+  assert.match(OPEN_FN, /delegate\(body, \{\s*\n\s*"fv-open": \(a, ev\) => \{\s*\n\s*ev\.preventDefault\(\);\s*\n\s*const target = a\.dataset\.path;\s*\n\s*if \(target\) openFileView\(target, sid\);/);
+  assert.equal((OPEN_FN.match(/delegate\(body/g) || []).length, 1, "one listener per open, never in a render path");
+  assert.ok(OPEN_FN.indexOf("delegate(body") < OPEN_FN.indexOf("const renderBody ="), "installed before any render can run");
+  // the chat's document-level delegate ignores scheme-less hrefs, so the click reaches the body listener
+  assert.match(HANDLER, /if \(!\/\^\[a-z\]\[a-z0-9\+\.-\]\*:\/i\.test\(href\)\) return;/);
+});
+
+// ── 5. styling: no new rules — the URL viewer wears the viewer's existing chrome in BOTH sheets ──
+
+test("every class the URL viewer uses is already declared in both sheets (nothing new to mirror)", () => {
+  for (const head of ["#romp-fileview {", ".fileview {", ".fileview-bar {", ".fileview-name {", ".fileview-dir {",
+    ".fileview-base {", ".fileview-acts {", ".fileview-btn {", "a.fileview-btn {", ".fileview-body {",
+    ".fileview-err {", ".fileview-err-hint {", ".fileview-load {", ".fileview-md {"]) {
+    assert.ok(CHAT_CSS.includes(head), head + " in styles.css");
+    assert.ok(FEED_CSS.includes(head), head + " in feed.css");
+  }
+  assert.doesNotMatch(URL_FN, /style\.|cssText|innerHTML = '<style/, "no inline styling");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -43,6 +43,8 @@ import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, ref
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
+import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
+import { isMarkdownUrl } from "./md-links";
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
@@ -913,6 +915,14 @@ document.addEventListener("click", (e) => {
   e.preventDefault();
   e.stopPropagation();
   if (location.protocol === "http:" || location.protocol === "https:") {
+    // A markdown file on THIS origin (a published report, an evidence doc under the dashboard's own
+    // host) presents in the file viewer, rendered, instead of as raw text in a tab (the user
+    // 2026-09-06). Same origin ONLY — the viewer fetches from the browser, and a cross-origin fetch
+    // is a CORS guess; a .md on any other origin keeps the new tab exactly as before. Anchors inside
+    // the open viewer bubble through this same delegate, so a document's own same-origin .md links
+    // navigate in place too — except the viewer's own link-out, which marks itself data-new-tab
+    // because its href is that very document and the click means "in a tab, please".
+    if (!a.dataset.newTab && isMarkdownUrl(href, location.origin)) { openUrlView(href); return; }
     window.open(href, "_blank", "noopener,noreferrer"); // web dashboard → open in the viewer's browser
   } else if (vscodeApi) {
     vscodeApi.postMessage({ type: "openLink", href });  // VS Code webview → host openExternal

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -747,7 +747,10 @@ function el(tag: string, cls?: string): HTMLElement {
 // and the html-only profile silently ate them: $\sqrt{d}$ rendered as a bare serif "d", the radical gone.
 // DOMPurify's svg profile is still sanitized (no scripts, handlers, or foreignObject). Keep data: URIs on
 // <img> (the CSP allows them and inline transcript images rely on them).
-const MD_PURIFY: Config = { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] };
+// ALLOW_DATA_ATTR: false (2026-09-07): transcript HTML must not mint data-* attributes — the chat's
+// document-level delegate keys every action off data-act, so a `<span data-act="stopRetrying">` in a
+// message would post an interrupt on a click. Nothing the renderer needs rides data-* through md().
+const MD_PURIFY: Config = { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"], ALLOW_DATA_ATTR: false };
 
 function md(src: string): string {
   // Transcript text (user prompts, assistant output, subagent reports, postal

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -921,8 +921,10 @@ document.addEventListener("click", (e) => {
     // is a CORS guess; a .md on any other origin keeps the new tab exactly as before. Anchors inside
     // the open viewer bubble through this same delegate, so a document's own same-origin .md links
     // navigate in place too — except the viewer's own link-out, which marks itself data-new-tab
-    // because its href is that very document and the click means "in a tab, please".
-    if (!a.dataset.newTab && isMarkdownUrl(href, location.origin)) { openUrlView(href); return; }
+    // because its href is that very document and the click means "in a tab, please". Only an
+    // UNMODIFIED primary click takes the viewer: a ctrl-, ⌘- or shift-click asked for a tab and gets
+    // the one it always got (middle-click is auxclick and was never intercepted).
+    if (!a.dataset.newTab && !e.ctrlKey && !e.metaKey && !e.shiftKey && isMarkdownUrl(href, location.origin)) { openUrlView(href); return; }
     window.open(href, "_blank", "noopener,noreferrer"); // web dashboard → open in the viewer's browser
   } else if (vscodeApi) {
     vscodeApi.postMessage({ type: "openLink", href });  // VS Code webview → host openExternal

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3488,6 +3488,9 @@ body.filebrowse-open { overflow: hidden; }
 .fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
   font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
 .fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+/* a heading an in-document link lands on (scrollIntoView) sits a breath below the title bar's hairline
+   rather than flush against it — the bar's own 10px spacing */
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4, .fileview-md h5, .fileview-md h6 { scroll-margin-top: 10px; }
 .fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
 .fileview-md li { margin: 0.2em 0; }
 .fileview-md strong { color: var(--fg); font-weight: 600; }


### PR DESCRIPTION
## What

A chat message linking a markdown file on the dashboard's **own origin** — a published report or evidence doc served beside romp, e.g. `https://<host>/figs/<run>/evidence.md` — used to open as raw text in a new tab. It now opens in the pane's existing file viewer, rendered, exactly like a local `.md` path already did: same modal, same Rendered ⇄ Raw preference, same loader-first wait, same `mdBlock` (marked + DOMPurify + hljs).

- **One viewer for all markdown.** `openUrlView(href)` is a URL mode of the file viewer; the chat's anchor delegate routes an unmodified click on a same-origin `.md`/`.markdown` link there. Bar: dimmed `host/dir/` + basename, Rendered / Raw, `Open ↗` (the raw URL, new tab), `Copy URL`, ✕; Esc closes.
- **Same origin only — cross-origin links are unchanged.** The browser fetches the URL itself, so a cross-origin fetch would be a CORS guess; a `.md` on any other origin keeps today's new tab exactly (no try-then-fall-back, no regression for `github.com/…/blob/…/README.md` pages that merely end in `.md`). Ctrl/⌘/Shift-click still opens the tab.
- **Zero new kernel surface.** No route, no relay, no server-side fetch: the kernel's `/file` relay stays a preview relay (`_remote_file`'s docstring).
- **Relative references resolve against the document**, in both modes: `![fig](fig.png)` beside a URL document fetches from the document's directory (and the *response* URL, so a redirected alias resolves correctly); beside a local file it rides `fileUrl()` to the sibling on disk. A sibling `.md` link opens in the same viewer; in-document `#fragment` links land on `md-`-prefixed heading ids inside the modal instead of spawning a tab.
- **Loud failures, bounded reads.** `HTTP <status> from <host>`, could-not-load, and the kernel's 2 MB text cap mirrored — refused from `Content-Length` when declared, else by streaming the body and counting bytes as they arrive (cancelled one chunk past the cap). Closing or replacing the modal, or refusing a response, aborts the transfer.

## Why

Sessions publish their results as `.md` reports next to their figures; reading them meant a raw-text tab. Since the local-path case already rendered in the viewer, extending that one surface (rather than a new tab page or a kernel-side renderer) keeps one code path, one set of styles, and the user in the dashboard.

## Verification

- `npm run typecheck`, `npm test` (2838 pass), `npm run build`; `tests/test_file_view.py` + `tests/test_kernel_preview.py` (42 pass; no kernel change).
- Executed unit tests for every pure helper (`isMarkdownUrl`, `resolveDocRelative`, `joinDocPath`, `urlTitleParts`, `headingSlug`/`uniqueSlugs`, `readTextCapped`, `settleUrlResponse`, `overCapWords`); source pins for the DOM wiring in `md-url-view.test.ts`.
- Two rounds of adversarial review, each finding fixed in its own commit (streamed byte-counted cap with abort on teardown; `Response.url` as the document base; modifier clicks; refused responses abort the transfer; linear slug dedupe).
- Headless Chromium smoke against a throwaway kernel serving the built bundle: same-origin `.md` renders with figures resolved, sibling and fragment links navigate in place, cross-origin and modified clicks reach `window.open`, redirect resolves from the response URL, and a real chunked no-`Content-Length` server showed the reader disconnecting one 64 KiB chunk past the cap and refused responses disconnecting after 131 KB.

## Not in this PR

- Cross-origin `.md` links (a peer kernel's host, raw.githubusercontent.com) still open raw in a tab. Rendering them needs either CORS on the file server or a kernel relay — the latter is an SSRF trade-off the repo has so far declined, so it is left as a separate decision.
- The VS Code webview path is untouched (`openLink` → `openExternal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
