### PR TITLE
A PDF opens in its own browser tab, in the browser's viewer, with the in-app view kept as the fallback

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -55,10 +55,12 @@ on other sites open in a new tab, as before — and a ctrl- or ⌘-click still o
 a tab.
 
 **Opening a PDF.** A PDF the session mentions, or one you click in the file browser, opens
-in a new browser tab in the browser's own viewer, the way a paper opens from OpenReview:
-full size, and it stays open beside the dashboard while you keep working. If the browser
-blocks the new tab, the PDF opens in the in-app viewer instead; a PDF too large to show
-offers a download in its place.
+inside the dashboard like an image: the chat's PDF card opens it full-view, a path or a
+file-browser row opens it in the file viewer. Cmd-click it instead (Ctrl on Windows and
+Linux), or middle-click, and it opens in a new browser tab in the browser's own viewer, the
+way a paper opens from OpenReview: full size, and it stays open beside the dashboard while
+you keep working. If the browser blocks that new tab, the PDF opens inside the dashboard
+instead; a PDF too large to show offers a download in its place.
 
 ### The feed
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -54,6 +54,12 @@ beside it shows, and a link to a sibling document opens in the same viewer. Link
 on other sites open in a new tab, as before — and a ctrl- or ⌘-click still opens the file in
 a tab.
 
+**Opening a PDF.** A PDF the session mentions, or one you click in the file browser, opens
+in a new browser tab in the browser's own viewer, the way a paper opens from OpenReview:
+full size, and it stays open beside the dashboard while you keep working. If the browser
+blocks the new tab, the PDF opens in the in-app viewer instead; a PDF too large to show
+offers a download in its place.
+
 ### The feed
 
 The feed is Romp's task-management layer: a card for each task. Romp's

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36632,8 +36632,9 @@ class Handler(BaseHTTPRequestHandler):
                 # inside the click — so an oversize one lands its whole tab on this refusal, with no viewer
                 # around it to offer the Download button the in-pane path used to (review find). A refusal
                 # to RENDER is never a dead end: the tab itself gets the sentence and the way out — a link to
-                # the download half of this very route. Only a top-level navigation (Sec-Fetch-Dest:
-                # document) gets the page; the viewer's fetch and the card's HEAD probe keep the plain text
+                # the download half of this very route. Only a request that will be SHOWN (a navigation,
+                # or the lightbox's <iframe> fallback — _is_navigation) gets the page; the viewer's fetch
+                # and the card's HEAD probe keep the plain text
                 # they parse. Static markup, every value escaped, no script — nosniff rides as always.
                 return self._send(413, _too_large_page(msg, os.path.basename(fp), q), "text/html; charset=utf-8",
                                   cache="no-cache")
@@ -36718,10 +36719,20 @@ class Handler(BaseHTTPRequestHandler):
         return self._send(200, raw, mime, cache="no-cache", headers=extra)
 
     def _is_navigation(self):
-        """Is this request a browser NAVIGATING a tab to the URL (Sec-Fetch-Dest: document), as opposed to
-        a fetch, an <img>/<iframe> load or a HEAD probe? Every current browser sends the header on
-        same-origin requests; its absence reads as "not a navigation", the conservative answer."""
-        return ((getattr(self, "headers", None) or {}).get("Sec-Fetch-Dest") or "").strip().lower() == "document"
+        """Is this request going to be SHOWN as a page — a browser navigating a tab to the URL
+        (Sec-Fetch-Dest: document) or loading it into an <iframe> (the PDF card's lightbox fallback when
+        the popup is blocked) — as opposed to a fetch, an <img> load or a HEAD probe that parses the plain
+        text? Browsers attach the Sec-Fetch-* headers only to potentially trustworthy origins (https,
+        localhost); a dashboard reached over plain http on a LAN or through an http proxy sends none, and
+        reading that as "not a navigation" left the oversize-PDF tab on the bare text with no way out
+        (review find on #959, 2026-09-07). Without the header the Accept header decides: a navigation or
+        an iframe asks for text/html first, a fetch() sends */*. Absent both, "not a navigation" — the
+        conservative answer, the plain text the viewer's catch parses."""
+        h = getattr(self, "headers", None) or {}
+        dest = (h.get("Sec-Fetch-Dest") or "").strip().lower()
+        if dest:
+            return dest in ("document", "iframe")
+        return "text/html" in (h.get("Accept") or "").lower()
 
     def _file_download(self, fp, head=False):
         """GET/HEAD /file?download=1 — the SAVE half of the route (the user 2026-08-09): any file that

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8387,8 +8387,12 @@ def _list_dir(raw, sid=None, hidden=False, limit=DIR_LIST_MAX):
                 row = {"name": e.name, "isDir": is_dir, "isLink": is_link,
                        "size": 0 if is_dir else size, "mtime": mtime}
                 if not is_dir:
-                    row["viewable"] = bool(_PREVIEW_MIME.get(os.path.splitext(e.name)[1].lower())) \
-                        or _is_text_path(e.name)
+                    # SIZE-AWARE (2026-09-06): the same caps /file applies, so a row the view route would 413
+                    # is download-only up front — a PDF opens in its own tab now, and an oversize one would
+                    # otherwise land that tab on the refusal instead of the viewer that offered the save
+                    _m = _PREVIEW_MIME.get(os.path.splitext(e.name)[1].lower())
+                    row["viewable"] = (bool(_m) and size <= _PREVIEW_MAX_BYTES) \
+                        or (not _m and _is_text_path(e.name) and size <= _TEXT_MAX_BYTES)
                 (dirs if is_dir else files).append(row)
     except OSError as ex:
         return dict(err_ctx,
@@ -30141,16 +30145,43 @@ _TEXT_MAX_BYTES = 2 * 1024 * 1024                # 2 MB of source is already pas
 _DOWNLOAD_CHUNK = 256 * 1024                     # fixed stream chunk: bounded memory whatever the file size
 
 
-def _attachment_disposition(name):
-    """Content-Disposition for the download path. The basename lands inside a quoted-string, so anything
-    that could terminate or extend the HEADER is replaced: CR/LF (header injection), the quote and the
-    backslash (quoted-string escapes), other control bytes. A name the ASCII form had to mangle also
-    rides the RFC 6266/5987 `filename*` form, so a browser that speaks it saves the real name."""
+def _attachment_disposition(name, kind="attachment"):
+    """Content-Disposition for the download path — and, with kind="inline", for a PDF served to its own
+    browser tab (the tab's title and a Save's name come from it; 2026-09-06). The basename lands inside a
+    quoted-string, so anything that could terminate or extend the HEADER is replaced: CR/LF (header
+    injection), the quote and the backslash (quoted-string escapes), other control bytes. A name the
+    ASCII form had to mangle also rides the RFC 6266/5987 `filename*` form, so a browser that speaks it
+    saves the real name."""
     safe = "".join(c if " " <= c < "\x7f" and c not in '"\\' else "_" for c in name) or "download"
-    disp = 'attachment; filename="%s"' % safe
+    disp = '%s; filename="%s"' % (kind, safe)
     if safe != name:
         disp += "; filename*=UTF-8''" + quote(name, safe="")
     return disp
+
+
+def _html_esc(s):
+    """The five characters HTML gives meaning to, escaped — for the one static page /file renders."""
+    return (str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            .replace('"', "&quot;").replace("'", "&#39;"))
+
+
+def _too_large_page(msg, name, q, route="/file"):
+    """The 413 a PDF's OWN TAB shows (2026-09-06): the same sentence the text form carries, plus the way
+    out — a link to the download half of the SAME route (`route`: /file, or a federated session's
+    /remote/<host>/file relay) for the same path and sid. Same-origin, so the cookie rides the download
+    exactly as it rode the view. Built from the parsed query, never the raw request line, and every value
+    is escaped; the page has no script and inherits _send's nosniff."""
+    dq = {"path": (q.get("path") or [""])[0], "download": "1"}
+    sid = (q.get("sid") or [""])[0]
+    if sid:
+        dq["sid"] = sid
+    href = route + "?" + urlencode(dq)
+    return ("<!doctype html><html><head><meta charset=\"utf-8\"><title>%s</title>"
+            "<style>body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;"
+            "background:#1e1e1e;color:#cccccc;font:15px/1.5 system-ui,sans-serif}main{max-width:40em;padding:2em}"
+            "a{color:#9cd2ff}</style></head><body><main><p>%s</p>"
+            "<p><a href=\"%s\" download=\"%s\">Download %s</a> instead.</p></main></body></html>"
+            % (_html_esc(name), _html_esc(msg), _html_esc(href), _html_esc(name), _html_esc(name)))
 
 
 def _is_text_path(fp):
@@ -36595,10 +36626,18 @@ class Handler(BaseHTTPRequestHandler):
         size = os.path.getsize(fp)
         cap = _TEXT_MAX_BYTES if text else _PREVIEW_MAX_BYTES
         if size > cap:
-            return self._send(413, b"" if head else
-                              "too large to show: %s (%s, limit %s)"
-                              % (_tilde(fp), _human_bytes(size), _human_bytes(cap)),
-                              "text/plain")
+            msg = "too large to show: %s (%s, limit %s)" % (_tilde(fp), _human_bytes(size), _human_bytes(cap))
+            if not head and mime == "application/pdf" and self._is_navigation():
+                # A PDF opens in its OWN TAB now (preview.ts openPdfTab, 2026-09-06), decided by extension
+                # inside the click — so an oversize one lands its whole tab on this refusal, with no viewer
+                # around it to offer the Download button the in-pane path used to (review find). A refusal
+                # to RENDER is never a dead end: the tab itself gets the sentence and the way out — a link to
+                # the download half of this very route. Only a top-level navigation (Sec-Fetch-Dest:
+                # document) gets the page; the viewer's fetch and the card's HEAD probe keep the plain text
+                # they parse. Static markup, every value escaped, no script — nosniff rides as always.
+                return self._send(413, _too_large_page(msg, os.path.basename(fp), q), "text/html; charset=utf-8",
+                                  cache="no-cache")
+            return self._send(413, b"" if head else msg, "text/plain")
         # The file's mtime rides every success twice: Last-Modified (the standard form) and
         # X-Romp-Mtime-Ns — NANOSECONDS, the anchor saveFile's conflict floor actually compares,
         # because the HTTP date's whole seconds let an agent write landing in the same second slip
@@ -36612,6 +36651,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(size))   # the real length, no body (HEAD semantics)
             self.send_header("Last-Modified", lastmod)
             self.send_header("X-Romp-Mtime-Ns", mtime_ns)
+            if mime == "application/pdf":                     # the probe agrees with the GET (below) on the tab's name
+                self.send_header("Content-Disposition", _attachment_disposition(os.path.basename(fp), kind="inline"))
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):         # the chat's fetch-HEAD probe rides CORS too
@@ -36667,8 +36708,20 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(200, body, mime, cache="no-cache",
                               headers={"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns,
                                        "X-Romp-Text-Utf8": u8})
-        return self._send(200, raw, mime, cache="no-cache",
-                          headers={"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns})
+        extra = {"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns}
+        if mime == "application/pdf":
+            # INLINE, with the file's name (2026-09-06): a PDF opens in its own browser tab now (preview.ts
+            # openPdfTab), and the browser titles that tab and names a Save from this header — without it
+            # the tab reads as the route's name and a save lands as file.pdf. inline, never attachment: the
+            # tab must RENDER it, not download it. Images get none: an <img> reads no disposition.
+            extra["Content-Disposition"] = _attachment_disposition(os.path.basename(fp), kind="inline")
+        return self._send(200, raw, mime, cache="no-cache", headers=extra)
+
+    def _is_navigation(self):
+        """Is this request a browser NAVIGATING a tab to the URL (Sec-Fetch-Dest: document), as opposed to
+        a fetch, an <img>/<iframe> load or a HEAD probe? Every current browser sends the header on
+        same-origin requests; its absence reads as "not a navigation", the conservative answer."""
+        return ((getattr(self, "headers", None) or {}).get("Sec-Fetch-Dest") or "").strip().lower() == "document"
 
     def _file_download(self, fp, head=False):
         """GET/HEAD /file?download=1 — the SAVE half of the route (the user 2026-08-09): any file that
@@ -39485,6 +39538,22 @@ class Handler(BaseHTTPRequestHandler):
                 pass
         if len(body) > _PREVIEW_MAX_BYTES:       # backstop only — the remote's own cap 413s long before this
             return self._send(413, b"" if head else "too large to preview", "text/plain")
+        if status not in (200, 206):
+            # The remote's non-success verdict (404 / 413 / 415 / 502…) is PROSE from its own _file_preview,
+            # never file bytes — label it as such. It used to ride out under OUR media mime, which an <img>
+            # or the lightbox iframe merely failed on; a PDF opens in its own TAB now (2026-09-06), and a
+            # tab handed prose labelled application/pdf shows a corrupt-PDF error instead of the sentence
+            # (skeptic find). An oversize PDF navigated to gets the same way-out page the local route
+            # serves, linking THIS relay's download half — the remote never sees Sec-Fetch-Dest, so the
+            # decision is made here. Body only; the remote's own headers are not mirrored on this arm.
+            if head:
+                return self._send(status, b"", "text/plain")
+            if status == 413 and mime == "application/pdf" and self._is_navigation():
+                return self._send(413, _too_large_page(_decode_text(body) or "too large to show",
+                                                       os.path.basename(rp), q,
+                                                       route="/remote/%s/file" % quote(host, safe="")),
+                                  "text/html; charset=utf-8", cache="no-cache")
+            return self._send(status, body, "text/plain", cache="no-cache")
         if head:
             # mirror _file_preview's HEAD: the remote's verdict + real length, no body
             self.send_response(status)
@@ -39495,6 +39564,8 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header("Last-Modified", lastmod)
             if r_ns:
                 self.send_header("X-Romp-Mtime-Ns", r_ns)
+            if status == 200 and mime == "application/pdf":   # the tab's name — OURS, from the requested path
+                self.send_header("Content-Disposition", _attachment_disposition(os.path.basename(rp), kind="inline"))
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
@@ -39524,6 +39595,11 @@ class Handler(BaseHTTPRequestHandler):
         # and the Edit gate ride on them, and deriving them locally would lie about a remote disk.
         mirrored = {k: v for k, v in (("Last-Modified", lastmod), ("X-Romp-Mtime-Ns", r_ns),
                                       ("X-Romp-Text-Utf8", r_u8)) if v}
+        if status == 200 and mime == "application/pdf":
+            # A remote session's PDF opens in its own tab too (2026-09-06): the tab's title and a Save's name
+            # come from this header — derived HERE from the requested basename, like the Content-Type, never
+            # mirrored: a remote's disposition is an instruction to this browser, not a fact about its disk.
+            mirrored["Content-Disposition"] = _attachment_disposition(os.path.basename(rp), kind="inline")
         return self._send(status, body, ctype, cache="no-cache", headers=mirrored or None)
 
     def _relay_download(self, host, port, rtok, q, head=False):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8388,7 +8388,7 @@ def _list_dir(raw, sid=None, hidden=False, limit=DIR_LIST_MAX):
                        "size": 0 if is_dir else size, "mtime": mtime}
                 if not is_dir:
                     # SIZE-AWARE (2026-09-06): the same caps /file applies, so a row the view route would 413
-                    # is download-only up front — a PDF opens in its own tab now, and an oversize one would
+                    # is download-only up front — a PDF can open in its own tab (a modified click), and an oversize one would
                     # otherwise land that tab on the refusal instead of the viewer that offered the save
                     _m = _PREVIEW_MIME.get(os.path.splitext(e.name)[1].lower())
                     row["viewable"] = (bool(_m) and size <= _PREVIEW_MAX_BYTES) \

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -70,9 +70,9 @@ class FilePreviewEndpoint(unittest.TestCase):
         cls.srv.shutdown()
         cls.tmp.cleanup()
 
-    def _req(self, path, method="GET"):
+    def _req(self, path, method="GET", headers=None):
         url = "http://127.0.0.1:%d%s%stoken=%s" % (self.port, path, "&" if "?" in path else "?", TOKEN)
-        req = urllib.request.Request(url, method=method)
+        req = urllib.request.Request(url, method=method, headers=headers or {})
         try:
             with urllib.request.urlopen(req, timeout=3) as r:
                 return r.status, dict(r.headers), r.read()
@@ -84,6 +84,64 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual(hdrs.get("Content-Type"), "image/png")
         self.assertEqual(body, PNG)
+
+    def test_a_pdf_is_served_inline_with_its_name_so_its_own_tab_is_titled_and_a_save_names_it(self):
+        # a PDF opens in its OWN browser tab now (ui/webview/preview.ts openPdfTab, the user 2026-09-06);
+        # the browser titles that tab and names a Save from Content-Disposition — inline, never
+        # attachment, so the tab renders it instead of downloading. Images carry none: an <img> reads
+        # no disposition, and the header set they always had stays byte-for-byte.
+        code, hdrs, _ = self._req("/file?path=" + urllib.parse.quote(self.pdf))
+        self.assertEqual(code, 200)
+        self.assertEqual(hdrs.get("Content-Type"), "application/pdf")
+        self.assertEqual(hdrs.get("Content-Disposition"), 'inline; filename="report.pdf"')
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(self.pdf), method="HEAD")
+        self.assertEqual(code, 200)
+        self.assertEqual(hdrs.get("Content-Disposition"), 'inline; filename="report.pdf"', "the probe agrees")
+        self.assertEqual(body, b"")
+        for p in (self.png, self.svg):
+            code, hdrs, _ = self._req("/file?path=" + urllib.parse.quote(p))
+            self.assertEqual(code, 200)
+            self.assertIsNone(hdrs.get("Content-Disposition"), p)
+
+    def test_an_oversize_pdf_navigated_to_in_its_own_tab_gets_a_page_with_the_download_as_the_way_out(self):
+        # a PDF opens in its own tab now, decided by extension inside the click — so a PDF over the cap lands
+        # its whole tab on the 413, with no viewer around it to offer the Download button the in-pane path
+        # used to (review find 2026-09-06). A refusal to render is never a dead end: a NAVIGATION
+        # (Sec-Fetch-Dest: document) gets a page with the sentence and a link to the download half; a fetch,
+        # an <iframe>/<img> load or a HEAD probe keeps the plain text they parse.
+        big = os.path.join(self.tmp.name, "thesis <draft> & \"final\".pdf")
+        with open(big, "wb") as f:
+            f.truncate(km._PREVIEW_MAX_BYTES + 1)           # sparse: no bytes written, the cap is on st_size
+        try:
+            sid = "11111111-2222-3333-4444-555555555555"
+            qp = "/file?path=" + urllib.parse.quote(big) + "&sid=" + sid
+            code, hdrs, body = self._req(qp, headers={"Sec-Fetch-Dest": "document"})
+            self.assertEqual(code, 413)
+            self.assertTrue(hdrs.get("Content-Type", "").startswith("text/html"), hdrs.get("Content-Type"))
+            self.assertEqual(hdrs.get("X-Content-Type-Options"), "nosniff")
+            page = body.decode("utf-8")
+            self.assertIn("too large to show:", page)
+            self.assertNotIn("<draft>", page, "the path is escaped — it names a file, never markup")
+            self.assertIn("&lt;draft&gt; &amp; &quot;final&quot;.pdf", page)
+            dq = urllib.parse.urlencode({"path": big, "download": "1", "sid": sid})
+            self.assertIn('href="' + km._html_esc("/file?" + dq) + '"', page, "the way out: this route's download half, same path and sid")
+            self.assertNotIn("<script", page.lower())
+            # the same request without the navigation marker: the plain text the viewer's catch parses, unchanged
+            code, hdrs, body = self._req(qp)
+            self.assertEqual(code, 413)
+            self.assertEqual(hdrs.get("Content-Type"), "text/plain")
+            self.assertTrue(body.startswith(b"too large to show:"), body[:40])
+            code, hdrs, body = self._req(qp, method="HEAD", headers={"Sec-Fetch-Dest": "document"})
+            self.assertEqual((code, body), (413, b""), "a HEAD carries the verdict, never a page")
+            # an oversize IMAGE navigated to keeps the text — only a PDF opens in its own tab
+            bigpng = os.path.join(self.tmp.name, "huge.png")
+            with open(bigpng, "wb") as f:
+                f.truncate(km._PREVIEW_MAX_BYTES + 1)
+            code, hdrs, _ = self._req("/file?path=" + urllib.parse.quote(bigpng), headers={"Sec-Fetch-Dest": "document"})
+            self.assertEqual((code, hdrs.get("Content-Type")), (413, "text/plain"))
+            os.unlink(bigpng)
+        finally:
+            os.unlink(big)
 
     def test_a_media_200_carries_its_mime_and_no_text_utf8_marker(self):
         # The viewer's media branches (ui/webview/file-view.ts) key on exactly this contract: a media
@@ -207,9 +265,9 @@ class FileDownloadEndpoint(unittest.TestCase):
         cls.srv.shutdown()
         cls.tmp.cleanup()
 
-    def _req(self, path, method="GET"):
+    def _req(self, path, method="GET", headers=None):
         url = "http://127.0.0.1:%d%s%stoken=%s" % (self.port, path, "&" if "?" in path else "?", TOKEN)
-        req = urllib.request.Request(url, method=method)
+        req = urllib.request.Request(url, method=method, headers=headers or {})
         try:
             with urllib.request.urlopen(req, timeout=5) as r:
                 return r.status, dict(r.headers), r.read()

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -86,7 +86,7 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(body, PNG)
 
     def test_a_pdf_is_served_inline_with_its_name_so_its_own_tab_is_titled_and_a_save_names_it(self):
-        # a PDF opens in its OWN browser tab now (ui/webview/preview.ts openPdfTab, the user 2026-09-06);
+        # a PDF opens in its OWN browser tab on a Cmd/Ctrl- or middle-click (ui/webview/preview.ts openPdfTab, the user 2026-09-06/07);
         # the browser titles that tab and names a Save from Content-Disposition — inline, never
         # attachment, so the tab renders it instead of downloading. Images carry none: an <img> reads
         # no disposition, and the header set they always had stays byte-for-byte.
@@ -104,7 +104,7 @@ class FilePreviewEndpoint(unittest.TestCase):
             self.assertIsNone(hdrs.get("Content-Disposition"), p)
 
     def test_an_oversize_pdf_navigated_to_in_its_own_tab_gets_a_page_with_the_download_as_the_way_out(self):
-        # a PDF opens in its own tab now, decided by extension inside the click — so a PDF over the cap lands
+        # a modified click opens a PDF in its own tab, decided by extension inside the click — so a PDF over the cap lands
         # its whole tab on the 413, with no viewer around it to offer the Download button the in-pane path
         # used to (review find 2026-09-06). A refusal to render is never a dead end: a NAVIGATION
         # (Sec-Fetch-Dest: document) gets a page with the sentence and a link to the download half; a fetch,
@@ -148,7 +148,7 @@ class FilePreviewEndpoint(unittest.TestCase):
             self.assertEqual((code, hdrs.get("Content-Type")), (413, "text/plain"), "a fetch() keeps the text")
             code, hdrs, body = self._req(qp, headers={"Sec-Fetch-Dest": "empty", "Accept": "text/html"})
             self.assertEqual((code, hdrs.get("Content-Type")), (413, "text/plain"), "a present non-shown dest wins over Accept")
-            # an oversize IMAGE navigated to keeps the text — only a PDF opens in its own tab
+            # an oversize IMAGE navigated to keeps the text — only a PDF can open in its own tab
             bigpng = os.path.join(self.tmp.name, "huge.png")
             with open(bigpng, "wb") as f:
                 f.truncate(km._PREVIEW_MAX_BYTES + 1)

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -133,6 +133,21 @@ class FilePreviewEndpoint(unittest.TestCase):
             self.assertTrue(body.startswith(b"too large to show:"), body[:40])
             code, hdrs, body = self._req(qp, method="HEAD", headers={"Sec-Fetch-Dest": "document"})
             self.assertEqual((code, body), (413, b""), "a HEAD carries the verdict, never a page")
+            # the lightbox's <iframe> fallback (popup blocked) is shown too, so it gets the page as well
+            code, hdrs, body = self._req(qp, headers={"Sec-Fetch-Dest": "iframe"})
+            self.assertEqual(code, 413)
+            self.assertTrue(hdrs.get("Content-Type", "").startswith("text/html"), "an iframe load is shown, not parsed")
+            self.assertIn('href="' + km._html_esc("/file?" + dq) + '"', body.decode("utf-8"))
+            # Fetch Metadata rides only to trustworthy origins (https, localhost): a dashboard on plain http
+            # sends no Sec-Fetch-Dest, so the Accept header decides — a navigation asks for text/html first
+            # (review find on #959, 2026-09-07), a fetch() sends */* and keeps the text
+            code, hdrs, body = self._req(qp, headers={"Accept": "text/html,application/xhtml+xml,*/*;q=0.8"})
+            self.assertEqual(code, 413)
+            self.assertTrue(hdrs.get("Content-Type", "").startswith("text/html"), "no Sec-Fetch-Dest, Accept text/html → the page")
+            code, hdrs, body = self._req(qp, headers={"Accept": "*/*"})
+            self.assertEqual((code, hdrs.get("Content-Type")), (413, "text/plain"), "a fetch() keeps the text")
+            code, hdrs, body = self._req(qp, headers={"Sec-Fetch-Dest": "empty", "Accept": "text/html"})
+            self.assertEqual((code, hdrs.get("Content-Type")), (413, "text/plain"), "a present non-shown dest wins over Accept")
             # an oversize IMAGE navigated to keeps the text — only a PDF opens in its own tab
             bigpng = os.path.join(self.tmp.name, "huge.png")
             with open(bigpng, "wb") as f:

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -40,6 +40,7 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 REMOTE_TOKEN = "remote-token-DO-NOT-USE"
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+PDF_BYTES = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"   # a minimal synthetic PDF
 PY_BYTES = b"print('hello from the remote box')\n"
 # the download fixture: NUL-ridden, off every view allowlist, and BIGGER than one relay stream chunk,
 # so the pass-through provably crosses a chunk boundary intact
@@ -79,6 +80,27 @@ class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
             self.end_headers()
             if not head:
                 self.wfile.write(PY_BYTES)
+            return
+        if "big.pdf" in self.path:
+            # the remote's own size cap: its _file_preview's prose verdict, text/plain, no disposition
+            body = b"too large to show: /tmp/big.pdf (95.4 MB, limit 47.7 MB)"
+            self.send_response(413)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if not head:
+                self.wfile.write(body)
+            return
+        if "paper.pdf" in self.path:
+            # a (hostile) remote's own disposition — an instruction to this browser, which the relay must
+            # never echo: ours is derived from the requested name
+            self.send_response(200)
+            self.send_header("Content-Type", "application/pdf")
+            self.send_header("Content-Disposition", 'attachment; filename="evil.pdf"')
+            self.send_header("Content-Length", str(len(PDF_BYTES)))
+            self.end_headers()
+            if not head:
+                self.wfile.write(PDF_BYTES)
             return
         if "plot.png" not in self.path:
             body = b"not found: /tmp/gone" if "download=1" in self.path else b""
@@ -190,6 +212,60 @@ class RemoteFileRelay(unittest.TestCase):
         self.assertNotIn(km.TOKEN, req)
         self.assertIn("path=%2Ftmp%2Fplot.png", req)
         self.assertIn("sid=11111111-2222-3333-4444-555555555555", req)
+
+    def test_a_remote_pdf_is_served_inline_with_its_own_name_derived_here_never_the_remotes(self):
+        # a remote session's PDF opens in its own browser tab too (2026-09-06): the tab's title and a Save's
+        # name ride Content-Disposition, which the local route sends — so the relay must as well, from the
+        # REQUESTED basename, on GET and on the HEAD probe. The remote's header is discarded like its
+        # Content-Type: an instruction to this browser, not a fact about its disk.
+        self._register("gpu1", self.fake.server_address[1])
+        for method in ("GET", "HEAD"):
+            status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fpaper.pdf", method=method)
+            self.assertEqual(status, 200, method)
+            self.assertEqual(headers.get("Content-Type"), "application/pdf")
+            self.assertEqual(headers.get("Content-Disposition"), 'inline; filename="paper.pdf"', method)
+            self.assertNotIn("evil", headers.get("Content-Disposition") or "")
+            self.assertEqual(body, PDF_BYTES if method == "GET" else b"")
+        # a remote 404 for a .pdf name carries no disposition — there is no file to name
+        status, _, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fgone.pdf")
+        self.assertEqual(status, 404)
+        self.assertIsNone(headers.get("Content-Disposition"))
+        # …and an image never gets one, exactly as locally
+        status, _, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fplot.png")
+        self.assertEqual(status, 200)
+        self.assertIsNone(headers.get("Content-Disposition"))
+
+    def test_a_remote_error_verdict_is_prose_and_an_oversize_pdf_tab_gets_the_relays_own_way_out(self):
+        # a PDF opens in its own TAB now (2026-09-06): the remote's 413/404 prose used to come back labelled
+        # with OUR media mime, which an <img> merely failed on but a tab shows as a corrupt-PDF error
+        # (skeptic find). Every non-success verdict is text/plain; a navigation to an oversize PDF gets the
+        # same way-out page the local route serves, linking THIS relay's download half.
+        self._register("gpu1", self.fake.server_address[1])
+        sid = "11111111-2222-3333-4444-555555555555"
+        qp = "/remote/gpu1/file?path=%2Ftmp%2Fbig.pdf&sid=" + sid
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, qp),
+                                     headers={"X-Romp-Token": km.TOKEN, "Sec-Fetch-Dest": "document"})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                status, body, headers = r.status, r.read(), dict(r.headers)
+        except urllib.error.HTTPError as e:
+            status, body, headers = e.code, e.read(), dict(e.headers)
+        self.assertEqual(status, 413)
+        self.assertTrue(headers.get("Content-Type", "").startswith("text/html"), headers.get("Content-Type"))
+        page = body.decode("utf-8")
+        self.assertIn("too large to show: /tmp/big.pdf", page)
+        dq = urllib.parse.urlencode({"path": "/tmp/big.pdf", "download": "1", "sid": sid})
+        self.assertIn('href="' + km._html_esc("/remote/gpu1/file?" + dq) + '"', page, "the relay's download half")
+        # the same without the navigation marker: the remote's prose, labelled as prose
+        status, body, headers = self._get(qp)
+        self.assertEqual(status, 413)
+        self.assertEqual(headers.get("Content-Type"), "text/plain")
+        self.assertTrue(body.startswith(b"too large to show:"), body[:40])
+        status, body, headers = self._get(qp, method="HEAD")
+        self.assertEqual((status, body, headers.get("Content-Type")), (413, b"", "text/plain"))
+        # a remote 404 for a .pdf name: prose too, never application/pdf
+        status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fgone.pdf")
+        self.assertEqual((status, headers.get("Content-Type")), (404, "text/plain"))
 
     def test_head_relays_the_verdict_without_a_body(self):
         # the PDF chip's existence probe: headers only, the remote's real length

--- a/tests/test_listdir.py
+++ b/tests/test_listdir.py
@@ -68,6 +68,21 @@ class ListDirShape(_Tree):
         self.assertNotIn("viewable", [k for e in r["entries"] if e["isDir"] for k in e if k == "viewable"],
                          "directories carry no viewable verdict — they are navigated, not viewed")
 
+    def test_viewable_is_size_aware_so_an_oversize_file_is_download_only_up_front(self):
+        # a PDF opens in its own browser tab (2026-09-06), decided before any request — a row the view route
+        # would 413 must therefore be marked download-only here, or the tab lands on the refusal. Sparse
+        # files: the caps are on st_size, no bytes are written.
+        for name, over in (("big.pdf", km._PREVIEW_MAX_BYTES + 1), ("huge.log", km._TEXT_MAX_BYTES + 1),
+                           ("paper.pdf", 4096), ("notes.log", 4096)):
+            with open(os.path.join(self.tmp, name), "wb") as f:
+                f.truncate(over)
+        v = {e["name"]: e.get("viewable") for e in km._list_dir(self.tmp)["entries"]}
+        self.assertFalse(v["big.pdf"], "over the media cap -> download only, like /file's 413")
+        self.assertFalse(v["huge.log"], "over the text cap -> download only")
+        self.assertTrue(v["paper.pdf"])
+        self.assertTrue(v["notes.log"])
+        self.assertTrue(v["app.py"])
+
     def test_hidden_entries_only_when_asked(self):
         self.assertNotIn(".env", self.names(km._list_dir(self.tmp)))
         self.assertIn(".env", self.names(km._list_dir(self.tmp, hidden=True)))

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -26,7 +26,9 @@ test("previewFull renders the image itself; a PDF is a click-to-view CARD, never
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.doesNotMatch(pf, /createElement\("iframe"\)/, "no auto-loading PDF frame in the chat strip");
   assert.match(pf, /box\.classList\.add\("path-full-pdfcard"\);/);
-  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openLightbox\(path, sid\); \};/);
+  // the click opens the PDF in its OWN browser tab (openPdf → openPdfTab, 2026-09-06); the lightbox is
+  // only the fallback for a blocked popup — pdf-new-tab.test.ts runs the opener
+  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid\); \};/);
   // the HEAD probe (headers only — never a download) HIDES a failed UNVERIFIED card and keeps it
   // registered for the heal events (2026-08-24 — self-removal erased the spot until a send); a
   // kernel-verified card skips the probe — the kernel already stat'd the file

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -26,9 +26,9 @@ test("previewFull renders the image itself; a PDF is a click-to-view CARD, never
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.doesNotMatch(pf, /createElement\("iframe"\)/, "no auto-loading PDF frame in the chat strip");
   assert.match(pf, /box\.classList\.add\("path-full-pdfcard"\);/);
-  // the click opens the PDF in its OWN browser tab (openPdf → openPdfTab, 2026-09-06); the lightbox is
-  // only the fallback for a blocked popup — pdf-new-tab.test.ts runs the opener
-  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid\); \};/);
+  // a plain click opens the PDF in the lightbox, like an image; a Cmd/Ctrl- or middle-click opens it in
+  // its OWN browser tab (openPdf → openPdfTab, the user 2026-09-07) — pdf-new-tab.test.ts runs the opener
+  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid, ev\); \};/);   // the gesture rides along: a modified click → its own tab (pdf-new-tab.test.ts)
   // the HEAD probe (headers only — never a download) HIDES a failed UNVERIFIED card and keeps it
   // registered for the heal events (2026-08-24 — self-removal erased the spot until a send); a
   // kernel-verified card skips the probe — the kernel already stat'd the file

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -27,7 +27,7 @@ test("a relative path click carries the active session id so whoever resolves it
   assert.match(RENDER, /function openPathLink\(raw: string, open: string, relative = false\)/);
   // relative → send the session id; absolute/file:// → none needed. Both go through openPath, which
   // picks the host (VS Code editor vs the feed pane's viewer) — see the openPath test below.
-  assert.match(RENDER, /openPath\(open, relative \? activeId : null\);/);
+  assert.match(RENDER, /openPath\(open, relative \? activeId : null, e\);/);   // + the click itself: a modified click on a PDF takes a browser tab (pdf-new-tab.test.ts)
 });
 
 test("the cheap pre-filter keys on a slash — or, inside inline code, a dot", () => {

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -62,7 +62,7 @@ test("an image thumbnail renders per surface; other files wear an ext + name chi
   assert.match(RENDER, /nm\.textContent = p\.split\("\/"\)\.pop\(\) \|\| p;/);
   // click opens the file — routed by openPath (VS Code editor / the feed pane's viewer on the web);
   // the ✕ removes exactly that attachment
-  assert.match(fn, /openPath\(p, id \|\| null\);/);
+  assert.match(fn, /openPath\(p, id \|\| null, e\);/);   // with its click: a modified click on a PDF takes a browser tab
   assert.match(fn, /if \(id\) removeComposerFile\(id, i\);/);
   // the same file dropped twice attaches once
   assert.match(RENDER, /if \(!list\.includes\(path\)\) list\.push\(path\);/);

--- a/ui/webview/file-browse.ts
+++ b/ui/webview/file-browse.ts
@@ -362,7 +362,7 @@ function onListing(m: DirListing): void {
       if (dlOnly) row.classList.add("fb-dlonly");
       row.title = p + (en.isLink ? "  ·  symlink" : "")
         + "  ·  " + new Date(en.mtime * 1000).toLocaleString()
-        + (dlOnly ? "  ·  not viewable in the browser — click downloads it" : "");
+        + (dlOnly ? "  ·  opens as a download (not viewable in the browser, or too large to show)" : "");
       const sz = el("span", "fb-size");
       sz.textContent = (dlOnly ? "⤓ " : "") + human(en.size);
       row.appendChild(nm); row.appendChild(sz);

--- a/ui/webview/file-browse.ts
+++ b/ui/webview/file-browse.ts
@@ -18,7 +18,7 @@
 // disk needs zero relay code. Staleness is the dirComplete protocol — a client-minted reqId echoed
 // back, replies dropped on mismatch, one in-flight ask with newest-value coalescing (the pacing is the
 // round-trip itself — an event, not a timer). File BYTES stay on HTTP /file via the existing viewer.
-import { openFileView, closeFileView } from "./file-view";
+import { closeFileView, openFileClick } from "./file-view";
 import { fileUrl } from "./preview";
 
 type DirEntry = {
@@ -159,7 +159,20 @@ export function openFileBrowse(path: string, sid?: string | null): void {
     list.addEventListener("click", (ev) => {
       const row = (ev.target as HTMLElement).closest("[data-act]") as HTMLElement | null;
       if (!row || !list.contains(row)) return;
-      onAct(row);
+      onAct(row, ev);
+    });
+    const fileRowOf = (ev: MouseEvent) => {
+      const row = (ev.target as HTMLElement).closest("[data-act]") as HTMLElement | null;
+      return row && list.contains(row) && row.dataset.act === "file" ? row : null;   // a FILE row only: a middle-click
+    };                                                                                // never navigates or downloads
+    list.addEventListener("mousedown", (ev) => {         // the middle PRESS on a file row: no autoscroll, which
+      if (ev.button === 1 && fileRowOf(ev)) ev.preventDefault();   // starts on the press and would swallow the auxclick
+    });
+    list.addEventListener("auxclick", (ev) => {          // a middle-click: a PDF row in a browser tab of its own
+      if (ev.button !== 1) return;                        // (`click` never fires for the middle button)
+      const row = fileRowOf(ev);
+      if (!row) return;
+      onAct(row, ev);
     });
     crumbs.addEventListener("click", (ev) => {
       const c = (ev.target as HTMLElement).closest("[data-path]") as HTMLElement | null;
@@ -208,7 +221,7 @@ export function openFileBrowse(path: string, sid?: string | null): void {
       }
       if (e.key === "Enter") {
         const active = box2.querySelector<HTMLElement>(".fb-row.active");
-        if (active) { e.preventDefault(); onAct(active); }
+        if (active) { e.preventDefault(); onAct(active, e); }   // Cmd/Ctrl+Enter on a PDF row: its own tab, like the click
       }
     };
     document.addEventListener("keydown", onKey);
@@ -222,10 +235,10 @@ export function openFileBrowse(path: string, sid?: string | null): void {
   ask(path);
 }
 
-function onAct(row: HTMLElement): void {
+function onAct(row: HTMLElement, ev?: MouseEvent | KeyboardEvent): void {
   const p = row.dataset.path || "";
   if (row.dataset.act === "dir") { ask(p); return; }
-  if (row.dataset.act === "file") { openFileView(p, curSid); return; }
+  if (row.dataset.act === "file") { openFileClick(ev, p, curSid); return; }   // a modified click on a PDF → its own tab
   if (row.dataset.act === "dl") startDownload(p);       // download-only rows download directly —
 }                                                       // a viewer that could only apologize helps nobody
 

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -17,7 +17,7 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
   // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
   // so it takes the shared openPathLink's no-session-id branch
   assert.match(RENDER, /function fileUriLink\(uri: string\): HTMLElement \{ return openPathLink\(uri, fileUriToPath\(uri\)\); \}/);
-  assert.match(RENDER, /openPath\(open, relative \? activeId : null\);/);
+  assert.match(RENDER, /openPath\(open, relative \? activeId : null, e\);/);
   // the URL is turned into a real filesystem path: scheme stripped, percent-decoded
   assert.match(RENDER, /\.replace\(\/\^file:/);
   assert.match(RENDER, /decodeURIComponent\(p\)/);

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -166,7 +166,7 @@ test("it waits with the romp loader and fails with the kernel's own words, never
 });
 
 test("it reuses fileUrl, so a REMOTE session's file is relayed from the host that owns it", () => {
-  assert.match(VIEW, /import \{ fileUrl \} from "\.\/preview";/);
+  assert.match(VIEW, /import \{ fileUrl, openPdfTab \} from "\.\/preview";/);   // + the PDF tab opener (2026-09-06)
   assert.match(VIEW, /fetch\(fileUrl\(path, sid\), \{ cache: "no-store" \}\)/);
 });
 

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -21,18 +21,18 @@ const FEED_CSS = web("feed.css");
 const CHAT_CSS = web("styles.css");
 
 test("openPath routes by HOST: the in-pane viewer modal on the web, the editor in VS Code", () => {
-  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null\): void/);
+  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void/);   // ev: the click, for a PDF's modified-click tab
   // web → the viewer opens in THIS document, framed or standalone alike — no shell relay, no fallback
-  assert.match(RENDER, /openFileView\(path, sid \|\| activeId \|\| null\);/);
-  assert.match(RENDER, /import \{ openFileView \} from "\.\/file-view";/);
+  assert.match(RENDER, /openFileClick\(ev, path, sid \|\| activeId \|\| null\);/);   // via the gesture reader: a plain click is openFileView (pdf-new-tab.test.ts)
+  assert.match(RENDER, /import \{ openFileClick \} from "\.\/file-view";/);   // the gesture reader is the chat's only way in; openFileView is not imported
   assert.doesNotMatch(RENDER, /romp: "viewFile"/, "the chat→shell→feed relay is gone");
   // VS Code keeps the host editor
   assert.match(RENDER, /vscodeApi\.postMessage\(sid \? \{ type: "openFile", path, id: sid \} : \{ type: "openFile", path \}\);/);
 });
 
 test("every file-link surface in the chat goes through openPath — no direct openFile posts left", () => {
-  for (const call of [/openPath\(path\);/, /openPath\(open, relative \? activeId : null\);/,
-                      /openPath\(p, id \|\| null\);/]) assert.match(RENDER, call);
+  for (const call of [/openPath\(path, null, e\);/, /openPath\(open, relative \? activeId : null, e\);/,
+                      /openPath\(p, id \|\| null, e\);/]) assert.match(RENDER, call);   // each with its click (a PDF's modified-click tab)
   // the ONLY openFile postMessage left in render.ts is openPath's own fallback branch
   assert.equal((RENDER.match(/type: "openFile"/g) || []).length, 2,
                "both remaining mentions are the two arms of openPath's fallback");
@@ -166,7 +166,8 @@ test("it waits with the romp loader and fails with the kernel's own words, never
 });
 
 test("it reuses fileUrl, so a REMOTE session's file is relayed from the host that owns it", () => {
-  assert.match(VIEW, /import \{ fileUrl, openPdfTab \} from "\.\/preview";/);   // + the PDF tab opener (2026-09-06)
+  assert.match(VIEW, /import \{ fileUrl \} from "\.\/preview";/);
+  assert.match(VIEW, /import \{ openPdfTab, wantsOwnTab \} from "\.\/preview";/);   // + the PDF tab opener and its gesture test (2026-09-06/07)
   assert.match(VIEW, /fetch\(fileUrl\(path, sid\), \{ cache: "no-store" \}\)/);
 });
 

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -18,8 +18,8 @@
 import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
-import { fileUrl } from "./preview";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
+import { fileUrl, openPdfTab } from "./preview";
 import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -319,6 +319,13 @@ export function closeFileView(): void {
 
 /** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks. */
 export function openFileView(path: string, sid?: string | null, frag?: string | null): void {
+  // A PDF belongs in its own browser tab (preview.ts openPdfTab — the user 2026-09-06); the in-pane
+  // viewer below is only the fallback for a blocked popup. Decided by EXTENSION, synchronously, inside
+  // the click gesture: deciding on the fetched Content-Type would lose the gesture, and every browser
+  // would then block the tab. Every caller lands here — a path link, a file-browser row, a relayed
+  // viewFile — so this is the one place the choice lives. Nothing up is touched: the tab opens beside.
+  // (openPdfTab answers false for a non-PDF path: the kind check is its own, by extension.)
+  if (openPdfTab(path, sid ?? null)) return;
   // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
   // edited-but-unsaved file A must not silently eat A's buffer.
   if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -19,7 +19,8 @@ import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
-import { fileUrl, openPdfTab } from "./preview";
+import { fileUrl } from "./preview";
+import { openPdfTab, wantsOwnTab } from "./preview";   // a PDF's own tab, and the gesture that asks for it
 import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -317,15 +318,21 @@ export function closeFileView(): void {
   document.body.classList.remove("fileview-open");
 }
 
+/** A click on a file — a path in the chat, a file-browser row — WITH its gesture. A Cmd/Ctrl- or
+ *  middle-click on a PDF (or Cmd/Ctrl+Enter on a file-browser row) opens the browser's own tab (preview.ts
+ *  openPdfTab); a plain click opens the
+ *  viewer below, like an image (the user 2026-09-07). Decided by EXTENSION, synchronously, inside the
+ *  gesture: deciding on the fetched Content-Type would lose the gesture, and every browser would then
+ *  block the tab. Every clicked file lands here, so this is the one place the choice lives; a relayed
+ *  viewFile or a Reload has no gesture and opens the viewer directly. A BLOCKED popup falls through to
+ *  the viewer, so the PDF is never unreachable, and a non-PDF is simply not the opener's business. */
+export function openFileClick(ev: MouseEvent | KeyboardEvent | null | undefined, path: string, sid?: string | null): void {
+  if (wantsOwnTab(ev) && openPdfTab(path, sid ?? null)) return;
+  openFileView(path, sid);
+}
+
 /** Show `path` in a modal over this pane. Re-opening replaces whatever is up — never stacks. */
 export function openFileView(path: string, sid?: string | null, frag?: string | null): void {
-  // A PDF belongs in its own browser tab (preview.ts openPdfTab — the user 2026-09-06); the in-pane
-  // viewer below is only the fallback for a blocked popup. Decided by EXTENSION, synchronously, inside
-  // the click gesture: deciding on the fetched Content-Type would lose the gesture, and every browser
-  // would then block the tab. Every caller lands here — a path link, a file-browser row, a relayed
-  // viewFile — so this is the one place the choice lives. Nothing up is touched: the tab opens beside.
-  // (openPdfTab answers false for a non-PDF path: the kind check is its own, by extension.)
-  if (openPdfTab(path, sid ?? null)) return;
   // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
   // edited-but-unsaved file A must not silently eat A's buffer.
   if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -79,7 +79,7 @@ test("rows carry an honest verdict: download-only files are dimmed and download 
   assert.match(BROWSE, /if \(row\.dataset\.act === "dl"\) startDownload\(p\);/);
   assert.match(FEED_CSS, /\.fb-dlonly \.fb-name \{ color: var\(--dim\); \}/);
   // viewable files open through the EXISTING viewer — one leaf open action for the whole dashboard
-  assert.match(BROWSE, /if \(row\.dataset\.act === "file"\) \{ openFileView\(p, curSid\); return; \}/);
+  assert.match(BROWSE, /if \(row\.dataset\.act === "file"\) \{ openFileClick\(ev, p, curSid\); return; \}/);   // with the row's click: a modified click on a PDF takes a browser tab
 });
 
 test("clicks are delegated to stable roots and the cap is stated in-band", () => {
@@ -138,7 +138,7 @@ test("the feed boots both overlays side by side", () => {
 test("opening the browser CLOSES an open viewer — the stack is one-directional", () => {
   // a browser painted under the opaque viewer was a dead click, and viewer-first registration made
   // one Escape close both overlays; closing the viewer at browse-open kills both failure modes
-  assert.match(BROWSE, /import \{ openFileView, closeFileView \} from "\.\/file-view";/);
+  assert.match(BROWSE, /import \{ closeFileView, openFileClick \} from "\.\/file-view";/);   // the row opens through the gesture reader only
   assert.match(BROWSE, /if \(document\.getElementById\("romp-fileview"\)\) closeFileView\(\);/);
 });
 

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -52,7 +52,7 @@ test("the anchor delegate routes a same-origin .md href to the viewer BEFORE the
   const vsArm = HANDLER.slice(HANDLER.indexOf("} else if (vscodeApi) {"));
   assert.doesNotMatch(vsArm, /openUrlView/, "the webview cannot reach the kernel origin — no viewer there");
   // the helpers arrive on their own import lines (the openFileView import is pinned verbatim elsewhere)
-  assert.match(RENDER, /import \{ openFileView \} from "\.\/file-view";/);
+  assert.match(RENDER, /import \{ openFileClick \} from "\.\/file-view";/);   // the chat opens files through the gesture reader (pdf-new-tab.test.ts)
   assert.match(RENDER, /import \{ openUrlView \} from "\.\/file-view";/);
   assert.match(RENDER, /import \{ isMarkdownUrl \} from "\.\/md-links";/);
 });
@@ -62,8 +62,12 @@ test("a ctrl-, meta- or shift-click on a same-origin .md keeps the tab: the modi
   for (const mod of ["!e.ctrlKey", "!e.metaKey", "!e.shiftKey"]) assert.ok(branch.includes(mod), mod + " gates the viewer");
   // the fall-through is the SAME window.open the cross-origin path takes — one new-tab call, no second one
   assert.equal((HANDLER.match(/window\.open\(/g) || []).length, 1, "exactly one window.open in the delegate");
-  // middle-click is auxclick and was never intercepted — no auxclick listener was added anywhere
-  assert.doesNotMatch(RENDER, /addEventListener\("auxclick"/);
+  // middle-click on a LINK is auxclick and is never intercepted: the anchor delegate has no auxclick
+  // listener. The ONE auxclick listener in render.ts is onMiddleClick, on the path PILLS (spans, not
+  // anchors), where a middle-click opens a PDF in a tab of its own — pdf-new-tab.test.ts pins it
+  assert.doesNotMatch(HANDLER, /addEventListener\("auxclick"/);
+  assert.equal((RENDER.match(/addEventListener\("auxclick"/g) || []).length, 2,
+    "only onMiddleClick (path pills) and the composer ✕'s stopper — both on spans/buttons, never on an anchor");
   assert.match(GUIDE, /ctrl- or ⌘-click still opens the file in\s+a tab/, "the guide says so");
 });
 

--- a/ui/webview/pdf-new-tab.test.ts
+++ b/ui/webview/pdf-new-tab.test.ts
@@ -1,18 +1,22 @@
-// A PDF opens in its OWN browser tab (the user 2026-09-06, who wanted what OpenReview and HotCRP do:
-// the paper full size in a tab of its own, not a small window inside the dashboard). The opener is
-// ONE window.open inside the click gesture aimed at the kernel's /file URL — the browser's own viewer
-// renders the inline application/pdf response from its cache, nothing lands on disk — and a null
-// handle (the browser blocked the popup) falls back to the in-app view so the PDF is never
-// unreachable. Executed here with a stubbed window/location; the wiring is pinned in source.
+// A PDF opens inside the dashboard on a plain click, like an image, and in its OWN browser tab on a
+// Cmd/Ctrl- or middle-click (the user 2026-09-07, who wanted one opening rule for images and PDFs with
+// the modifier as the way out; 2026-09-06, who wanted what OpenReview and HotCRP do: the paper full
+// size in a tab of its own). The opener is ONE window.open inside the click gesture aimed at the
+// kernel's /file URL — the browser's own viewer renders the inline application/pdf response from its
+// cache, nothing lands on disk — and a null handle (the browser blocked the popup) falls back to the
+// in-app view so the PDF is never unreachable. Executed here with a stubbed window/location; the
+// wiring is pinned in source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { openPdfTab, fileUrl } from "./preview";
+import { openPdfTab, fileUrl, wantsOwnTab } from "./preview";
 
 const UI = path.resolve(process.cwd(), "..", "ui", "webview");
 const PREVIEW = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
 const VIEW = fs.readFileSync(path.join(UI, "file-view.ts"), "utf8");
+const BROWSE = fs.readFileSync(path.join(UI, "file-browse.ts"), "utf8");
+const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 const GUIDE = fs.readFileSync(path.resolve(process.cwd(), "..", "docs", "guide.md"), "utf8");
 
@@ -67,11 +71,27 @@ test("not the web dashboard (a webview origin): no attempt at all, false", () =>
   assert.equal(calls.length, 0, "the webview sandbox cannot window.open — callers keep their own path");
 });
 
-test("wiring: the card and the viewer open the tab first and fall back to the in-app view", () => {
-  // the card's click → openPdf → the tab, else the lightbox
-  assert.match(PREVIEW, /export function openPdf\(path: string, sid\?: string \| null\): void \{\n  if \(!openPdfTab\(path, sid\)\) openLightbox\(path, sid\);\n\}/);
+test("the gesture decides: a plain click is in-app, a Cmd/Ctrl-click or a middle button is the tab", () => {
+  assert.equal(wantsOwnTab(undefined), false);
+  assert.equal(wantsOwnTab(null), false);
+  assert.equal(wantsOwnTab({}), false, "a plain click stays inside the dashboard, like an image");
+  assert.equal(wantsOwnTab({ button: 0 }), false);
+  assert.equal(wantsOwnTab({ metaKey: true }), true, "Cmd-click (macOS)");
+  assert.equal(wantsOwnTab({ ctrlKey: true }), true, "Ctrl-click (Windows, Linux)");
+  assert.equal(wantsOwnTab({ button: 1 }), true, "the middle button, as auxclick reports it");
+  assert.equal(wantsOwnTab({ shiftKey: true } as any), false, "shift alone is selection, not a new tab");
+  assert.equal(wantsOwnTab({ metaKey: true, key: "Enter" } as any), true, "a keyboard gesture carries the same modifier: Cmd/Ctrl+Enter on a file-browser row");
+});
+
+test("wiring: every click on a PDF carries its gesture; modified → the tab, plain or blocked → the in-app view", () => {
+  // the card's click → openPdf(path, sid, ev) → the tab on a modified click, else (or when blocked) the lightbox
+  assert.match(PREVIEW, /export function openPdf\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void \{\n  if \(wantsOwnTab\(ev\) && openPdfTab\(path, sid\)\) return;\n  openLightbox\(path, sid\);\n\}/);
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
-  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid\); \};/);
+  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid, ev\); \};/);
+  assert.match(pf, /box\.onmousedown = \(ev\) => \{ if \(ev\.button === 1\) ev\.preventDefault\(\); \};/,
+    "the middle PRESS is cancelled: autoscroll (Firefox, Edge) starts on mousedown and would swallow the auxclick");
+  assert.match(pf, /box\.onauxclick = \(ev\) => \{ if \(ev\.button !== 1\) return; ev\.stopPropagation\(\); openPdf\(path, sid, ev\); \};/,
+    "a middle-click reaches the card as auxclick, never as click");
   // the opener itself: synchronous, two-argument window.open — the gesture and the handle both matter
   const opener = PREVIEW.slice(PREVIEW.indexOf("export function openPdfTab"), PREVIEW.indexOf("export function openPdf("));
   assert.match(opener, /if \(previewKind\(path\) !== "pdf" \|\| !canPreview\(\)\) return false;/, "the kind check is the opener's own");
@@ -79,13 +99,29 @@ test("wiring: the card and the viewer open the tab first and fall back to the in
   assert.doesNotMatch(opener, /"noopener/, "the noopener FEATURE makes window.open return null on success — the block signal would be lost");
   assert.match(opener, /if \(!w\) return false;[^\n]*\n\s+try \{ w\.opener = null; \}/, "…so the link is severed on the handle instead, before anything else");
   assert.doesNotMatch(opener, /await|\.then\(/, "the open happens inside the click gesture, never after a fetch");
-  // the viewer: a .pdf path takes the tab BEFORE anything on screen is touched, by extension, synchronously
+  // the viewer: the ONE place a clicked file's gesture is read — openFileClick — and the plain open below it
+  // never opens a tab (a relayed viewFile, a Reload: no gesture, the viewer)
+  assert.match(VIEW, /export function openFileClick\(ev: MouseEvent \| KeyboardEvent \| null \| undefined, path: string, sid\?: string \| null\): void \{\n  if \(wantsOwnTab\(ev\) && openPdfTab\(path, sid \?\? null\)\) return;\n  openFileView\(path, sid\);\n\}/);
+  // no click site bypasses the gesture reader: the chat and the browser never call openFileView themselves
+  assert.equal((RENDER.match(/openFileView\(/g) || []).length, 0, "render.ts opens files through openFileClick only");
+  assert.equal((BROWSE.match(/openFileView\(/g) || []).length, 0, "file-browse.ts opens files through openFileClick only");
   const view = VIEW.slice(VIEW.indexOf("export function openFileView("));
-  const branch = view.indexOf("if (openPdfTab(path, sid ?? null)) return;");
-  assert.ok(branch > 0, "the viewer's PDF branch exists");
-  assert.ok(branch < view.indexOf('document.getElementById("romp-fileview")?.remove();'),
-    "…and runs before the current viewer (if any) is replaced");
-  assert.ok(branch < view.indexOf("closeGuard && !closeGuard()"), "…and before the unsaved-edits ask: the tab disturbs nothing");
+  const body = view.slice(0, view.indexOf("\n}\n"));
+  assert.doesNotMatch(body, /openPdfTab|wantsOwnTab/, "openFileView itself opens in-app, whatever the path");
+  // the file browser's rows and the chat's path pills hand their gesture over, middle button included
+  assert.match(BROWSE, /list\.addEventListener\("click", \(ev\) => \{[\s\S]*?onAct\(row, ev\);/);
+  assert.match(BROWSE, /const fileRowOf = \(ev: MouseEvent\) => \{[\s\S]*?row\.dataset\.act === "file" \? row : null;/,
+    "a middle-click acts on a FILE row only — never a folder's navigation or a download-only row's download");
+  assert.match(BROWSE, /list\.addEventListener\("mousedown", \(ev\) => \{[\s\S]*?if \(ev\.button === 1 && fileRowOf\(ev\)\) ev\.preventDefault\(\);/,
+    "the middle PRESS on a file row is cancelled so autoscroll cannot swallow the auxclick");
+  assert.match(BROWSE, /list\.addEventListener\("auxclick", \(ev\) => \{[\s\S]*?if \(ev\.button !== 1\) return;[\s\S]*?const row = fileRowOf\(ev\);[\s\S]*?onAct\(row, ev\);/);
+  assert.match(BROWSE, /if \(active\) \{ e\.preventDefault\(\); onAct\(active, e\); \}/, "Enter on a row carries its modifiers: Cmd/Ctrl+Enter on a PDF → its own tab");
+  assert.match(BROWSE, /if \(row\.dataset\.act === "file"\) \{ openFileClick\(ev, p, curSid\); return; \}/);
+  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void \{[\s\S]*?openFileClick\(ev, path, sid \|\| activeId \|\| null\);/);
+  assert.match(RENDER, /function onMiddleClick\(a: HTMLElement, fn: \(e: MouseEvent\) => void\): void \{\n  a\.addEventListener\("mousedown", \(e\) => \{ if \(e\.button === 1\) e\.preventDefault\(\); \}\);\n  a\.addEventListener\("auxclick", \(e\) => \{ if \(e\.button !== 1\) return; e\.stopPropagation\(\); fn\(e\); \}\);/);
+  assert.match(RENDER, /x\.addEventListener\("auxclick", \(e\) => e\.stopPropagation\(\)\);/, "a middle-click on the composer attachment's ✕ is inert, never the box's open");
+  assert.equal((RENDER.match(/onMiddleClick\(/g) || []).length, 5, "the declaration and the four path pills: tool file, image path, path link, composer attachment");
+  assert.equal((RENDER.match(/openPath\([^)]*, e\)/g) || []).length, 8, "each pill passes its click AND its middle-click");
 });
 
 test("the kernel serves a PDF inline WITH its name, so the tab is titled and a Save names the file", () => {
@@ -119,6 +155,8 @@ test("an oversize PDF's tab is not a dead end, and the listing marks such a file
 });
 
 test("the guide says so, in the user's terms", () => {
-  assert.match(GUIDE, /\*\*Opening a PDF\.\*\* .*opens\nin a new browser tab/);
-  assert.match(GUIDE, /If the browser\nblocks the new tab, the PDF opens in the in-app viewer instead; a PDF too large to show\noffers a download in its place\./);
+  const flat = GUIDE.replace(/\s+/g, " ");
+  assert.match(flat, /\*\*Opening a PDF\.\*\* [^*]{0,160}opens inside the dashboard like an image/);
+  assert.match(flat, /Cmd-click it instead \(Ctrl on Windows and Linux\), or middle-click, and it opens in a new browser tab in the browser's own viewer/);
+  assert.match(flat, /If the browser blocks that new tab, the PDF opens inside the dashboard instead; a PDF too large to show offers a download in its place\./);
 });

--- a/ui/webview/pdf-new-tab.test.ts
+++ b/ui/webview/pdf-new-tab.test.ts
@@ -102,7 +102,10 @@ test("an oversize PDF's tab is not a dead end, and the listing marks such a file
   assert.match(KERNEL, /if not head and mime == "application\/pdf" and self\._is_navigation\(\):/);
   assert.match(KERNEL, /return self\._send\(413, _too_large_page\(msg, os\.path\.basename\(fp\), q\), "text\/html; charset=utf-8",/);
   assert.match(KERNEL, /def _is_navigation\(self\):/);
-  assert.match(KERNEL, /\.get\("Sec-Fetch-Dest"\) or ""\)\.strip\(\)\.lower\(\) == "document"/);
+  assert.match(KERNEL, /dest = \(h\.get\("Sec-Fetch-Dest"\) or ""\)\.strip\(\)\.lower\(\)/);
+  assert.match(KERNEL, /return dest in \("document", "iframe"\)/, "a navigation OR the lightbox iframe gets the page");
+  // Fetch Metadata is sent only to trustworthy origins: on plain http the Accept header decides
+  assert.match(KERNEL, /return "text\/html" in \(h\.get\("Accept"\) or ""\)\.lower\(\)/);
   assert.match(KERNEL, /def _too_large_page\(msg, name, q, route="\/file"\):/);
   // the relay: an error verdict is prose (text/plain), and an oversize remote PDF's tab gets the page too
   assert.match(KERNEL, /route="\/remote\/%s\/file" % quote\(host, safe=""\)/);

--- a/ui/webview/pdf-new-tab.test.ts
+++ b/ui/webview/pdf-new-tab.test.ts
@@ -1,0 +1,121 @@
+// A PDF opens in its OWN browser tab (the user 2026-09-06, who wanted what OpenReview and HotCRP do:
+// the paper full size in a tab of its own, not a small window inside the dashboard). The opener is
+// ONE window.open inside the click gesture aimed at the kernel's /file URL — the browser's own viewer
+// renders the inline application/pdf response from its cache, nothing lands on disk — and a null
+// handle (the browser blocked the popup) falls back to the in-app view so the PDF is never
+// unreachable. Executed here with a stubbed window/location; the wiring is pinned in source.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { openPdfTab, fileUrl } from "./preview";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const PREVIEW = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
+const VIEW = fs.readFileSync(path.join(UI, "file-view.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+const GUIDE = fs.readFileSync(path.resolve(process.cwd(), "..", "docs", "guide.md"), "utf8");
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const g = globalThis as any;
+
+function withBrowser(protocol: string, open: ((...a: unknown[]) => unknown) | null, run: () => void): unknown[][] {
+  const calls: unknown[][] = [];
+  const savedLoc = g.location, savedWin = g.window;
+  g.location = { protocol };
+  g.window = { open: (...a: unknown[]) => { calls.push(a); return open ? open(...a) : null; } };
+  try { run(); } finally { g.location = savedLoc; g.window = savedWin; }
+  return calls;
+}
+
+test("web dashboard, popup allowed: ONE window.open on the kernel's /file URL, in a new tab, opener severed by hand", () => {
+  let ok = false;
+  const handle: { opener: unknown } = { opener: { theDashboard: true } };   // what a fresh tab holds until disowned
+  const calls = withBrowser("https:", () => handle, () => { ok = openPdfTab("/tmp/paper.pdf", SID); });
+  assert.equal(ok, true);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], [fileUrl("/tmp/paper.pdf", SID), "_blank"],
+    "the same-origin file URL, a new tab, and NO noopener feature: it would return null even on success");
+  assert.equal(calls[0][0], "/file?path=%2Ftmp%2Fpaper.pdf&sid=" + SID);
+  assert.equal(handle.opener, null,
+    "the tab's opener is severed on the handle (a link inside the PDF navigates the tab to a foreign site — it must not hold the dashboard)");
+});
+
+test("a federated session's PDF goes through the relay URL, still same-origin", () => {
+  const calls = withBrowser("http:", () => ({}), () => { openPdfTab("out/report.pdf", "gpu1:" + SID); });
+  assert.equal(calls[0][0], "/remote/gpu1/file?path=out%2Freport.pdf&sid=" + SID);
+});
+
+test("popup BLOCKED (null handle): reports false so the caller falls back to the in-app view", () => {
+  let ok = true;
+  const calls = withBrowser("https:", null, () => { ok = openPdfTab("/tmp/paper.pdf", SID); });
+  assert.equal(ok, false);
+  assert.equal(calls.length, 1, "it did try — the block is the browser's verdict, read from the handle");
+});
+
+test("a non-PDF path is not the opener's business: false, no attempt — the viewer's media branch decides by Content-Type", () => {
+  let ok = true;
+  const calls = withBrowser("https:", () => ({}), () => { ok = openPdfTab("/tmp/notes.md", SID); });
+  assert.equal(ok, false);
+  assert.equal(calls.length, 0);
+});
+
+test("not the web dashboard (a webview origin): no attempt at all, false", () => {
+  let ok = true;
+  const calls = withBrowser("vscode-webview:", () => ({}), () => { ok = openPdfTab("/tmp/paper.pdf", SID); });
+  assert.equal(ok, false);
+  assert.equal(calls.length, 0, "the webview sandbox cannot window.open — callers keep their own path");
+});
+
+test("wiring: the card and the viewer open the tab first and fall back to the in-app view", () => {
+  // the card's click → openPdf → the tab, else the lightbox
+  assert.match(PREVIEW, /export function openPdf\(path: string, sid\?: string \| null\): void \{\n  if \(!openPdfTab\(path, sid\)\) openLightbox\(path, sid\);\n\}/);
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openPdf\(path, sid\); \};/);
+  // the opener itself: synchronous, two-argument window.open — the gesture and the handle both matter
+  const opener = PREVIEW.slice(PREVIEW.indexOf("export function openPdfTab"), PREVIEW.indexOf("export function openPdf("));
+  assert.match(opener, /if \(previewKind\(path\) !== "pdf" \|\| !canPreview\(\)\) return false;/, "the kind check is the opener's own");
+  assert.match(opener, /const w = window\.open\(fileUrl\(path, sid\), "_blank"\);/);
+  assert.doesNotMatch(opener, /"noopener/, "the noopener FEATURE makes window.open return null on success — the block signal would be lost");
+  assert.match(opener, /if \(!w\) return false;[^\n]*\n\s+try \{ w\.opener = null; \}/, "…so the link is severed on the handle instead, before anything else");
+  assert.doesNotMatch(opener, /await|\.then\(/, "the open happens inside the click gesture, never after a fetch");
+  // the viewer: a .pdf path takes the tab BEFORE anything on screen is touched, by extension, synchronously
+  const view = VIEW.slice(VIEW.indexOf("export function openFileView("));
+  const branch = view.indexOf("if (openPdfTab(path, sid ?? null)) return;");
+  assert.ok(branch > 0, "the viewer's PDF branch exists");
+  assert.ok(branch < view.indexOf('document.getElementById("romp-fileview")?.remove();'),
+    "…and runs before the current viewer (if any) is replaced");
+  assert.ok(branch < view.indexOf("closeGuard && !closeGuard()"), "…and before the unsaved-edits ask: the tab disturbs nothing");
+});
+
+test("the kernel serves a PDF inline WITH its name, so the tab is titled and a Save names the file", () => {
+  assert.match(KERNEL, /if mime == "application\/pdf":\n\s+#[^\n]*\n(\s+#[^\n]*\n)*\s+extra\["Content-Disposition"\] = _attachment_disposition\(os\.path\.basename\(fp\), kind="inline"\)/);
+  assert.match(KERNEL, /def _attachment_disposition\(name, kind="attachment"\):/);
+  assert.match(KERNEL, /disp = '%s; filename="%s"' % \(kind, safe\)/);
+  assert.doesNotMatch(KERNEL.slice(KERNEL.indexOf("def _file_preview"), KERNEL.indexOf("def _file_download")),
+    /kind="attachment"/, "the view route never serves a PDF as an attachment — the tab must render it");
+});
+
+test("an oversize PDF's tab is not a dead end, and the listing marks such a file download-only up front", () => {
+  // a navigation (Sec-Fetch-Dest: document) to a PDF over the cap gets a page whose one link is the download
+  // half of the route; a fetch / iframe / HEAD keeps the plain text the viewer parses (review find 2026-09-06)
+  assert.match(KERNEL, /if not head and mime == "application\/pdf" and self\._is_navigation\(\):/);
+  assert.match(KERNEL, /return self\._send\(413, _too_large_page\(msg, os\.path\.basename\(fp\), q\), "text\/html; charset=utf-8",/);
+  assert.match(KERNEL, /def _is_navigation\(self\):/);
+  assert.match(KERNEL, /\.get\("Sec-Fetch-Dest"\) or ""\)\.strip\(\)\.lower\(\) == "document"/);
+  assert.match(KERNEL, /def _too_large_page\(msg, name, q, route="\/file"\):/);
+  // the relay: an error verdict is prose (text/plain), and an oversize remote PDF's tab gets the page too
+  assert.match(KERNEL, /route="\/remote\/%s\/file" % quote\(host, safe=""\)/);
+  assert.match(KERNEL, /if status not in \(200, 206\):/);
+  assert.match(KERNEL, /dq = \{"path": \(q\.get\("path"\) or \[""\]\)\[0\], "download": "1"\}/);
+  // the listing's verdict follows /file's caps, so the browser routes an oversize row to the download
+  assert.match(KERNEL, /row\["viewable"\] = \(bool\(_m\) and size <= _PREVIEW_MAX_BYTES\) \\\n\s+or \(not _m and _is_text_path\(e\.name\) and size <= _TEXT_MAX_BYTES\)/);
+  // the relay names a remote PDF from the REQUESTED path, never the remote's header, on HEAD and GET
+  const relay = KERNEL.slice(KERNEL.indexOf("def _remote_file("), KERNEL.indexOf("def _relay_download("));
+  assert.equal((relay.match(/_attachment_disposition\(os\.path\.basename\(rp\), kind="inline"\)/g) || []).length, 2, "HEAD and GET");
+});
+
+test("the guide says so, in the user's terms", () => {
+  assert.match(GUIDE, /\*\*Opening a PDF\.\*\* .*opens\nin a new browser tab/);
+  assert.match(GUIDE, /If the browser\nblocks the new tab, the PDF opens in the in-app viewer instead; a PDF too large to show\noffers a download in its place\./);
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -111,8 +111,43 @@ export function fileUrl(path: string, sid?: string | null): string {
   return base + "?path=" + encodeURIComponent(path) + (bare ? "&sid=" + encodeURIComponent(bare) : "");
 }
 
+// A PDF opens in a NEW BROWSER TAB, in the browser's own viewer (the user 2026-09-06, who wanted what
+// OpenReview and HotCRP do: the paper in its own tab, full size, kept open beside the dashboard — not a
+// small window inside it). Those sites do nothing more than link the PDF's URL with target=_blank and
+// serve it inline as application/pdf; the browser renders it from its own cache, and nothing lands on
+// disk unless the browser is set to download PDFs — no download-then-delete dance is needed. /file
+// already serves exactly that (same-origin, cookie-authed, federation-aware through fileUrl), so the
+// tab is ONE window.open inside the click gesture — synchronous, so a popup blocker reads it as
+// user-initiated; a fetch-then-open would lose the gesture and be blocked everywhere. The opener
+// link is severed by hand (w.opener = null) rather than with the noopener feature: with noopener
+// window.open returns null even on success, which would hide the one signal needed — a null handle
+// means the browser BLOCKED the tab, and the caller falls back to the in-app view (lightbox /
+// viewer) so the PDF is never unreachable. Severed it must be (review find 2026-09-06, reproduced in
+// a real browser): the tab starts on our origin, but a link inside the PDF navigates that SAME tab
+// to a foreign site, and a document holding a live opener may replace the dashboard with a
+// look-alike (reverse tabnabbing) — every other new tab this UI opens is disowned the same way.
+// The flag is set while the tab is still its same-origin initial page and rides every later
+// navigation. Web dashboard only: the VS Code webview cannot window.open, and previews are gated off
+// there anyway (canPreview). The KIND check lives here, by
+// extension — the only fact available inside the gesture — so a caller passes any path and a non-PDF
+// is simply "not mine" (false): the viewer's own media branch keeps keying on the kernel's
+// Content-Type verdict, never on an extension re-test (file-view.test.ts pins that).
+export function openPdfTab(path: string, sid?: string | null): boolean {
+  if (previewKind(path) !== "pdf" || !canPreview()) return false;
+  const w = window.open(fileUrl(path, sid), "_blank");
+  if (!w) return false;                                   // blocked: the caller's in-app view takes over
+  try { w.opener = null; } catch { /* unreachable while the tab is our own initial page */ }
+  return true;
+}
+
+// The PDF card's click: its own tab, else the in-app lightbox when the popup was blocked.
+export function openPdf(path: string, sid?: string | null): void {
+  if (!openPdfTab(path, sid)) openLightbox(path, sid);
+}
+
 // Full-view lightbox: dark backdrop, the image at natural-but-capped size or the PDF in the browser's
-// native viewer, filename caption. One singleton element; backdrop click / Esc / ✕ closes. Styles live
+// native viewer (the FALLBACK for a blocked popup — a PDF opens in its own tab first, openPdf),
+// filename caption. One singleton element; backdrop click / Esc / ✕ closes. Styles live
 // in BOTH styles.css and feed.css (each page loads only its own sheet — the .romp-acted precedent).
 // Pinch-zoom on the lightbox image (T162, the user 2026-08-28 on Android). Pointer events only —
 // no gesture library: two pointers pinch around the gesture midpoint (the content point under it
@@ -218,6 +253,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   let cue: HTMLElement | null = null;                    // the compact position mark ("3/17") in the bar
   let curImg: (() => HTMLImageElement) | null = null;    // the img on screen NOW (step rebinds it) — the copy source
   if (kind === "pdf") {
+    // the in-app FALLBACK only (openPdf): a PDF opens in its own browser tab unless the popup was blocked
     const frame = document.createElement("iframe");
     frame.className = "romp-lightbox-frame";
     frame.src = fileUrl(path, sid);
@@ -358,7 +394,8 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
 // thumbnail but a rendered image, like the user messages). Self-verifying —
 // a path the kernel can't serve removes itself — and an image click still opens the lightbox. Images
 // render at the user-image scale (.path-full-img mirrors .user-img's 320px cap, one size per
-// information type). A PDF is a labeled CARD, not an auto-loading inline viewer (click → lightbox):
+// information type). A PDF is a labeled CARD, not an auto-loading inline viewer (click → its own
+// browser tab, openPdf; the lightbox only when the popup is blocked):
 // the first cut embedded an <iframe> per mentioned PDF, and a browser set to "Download PDFs" (or one
 // that declines to render inline) saved a FRESH COPY on every chat re-render — the user's Downloads
 // folder silently filled with datasheet copies (2026-07-20). A fetch must be user-initiated, once.
@@ -386,8 +423,8 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     nm.textContent = path.slice(path.lastIndexOf("/") + 1);
     box.append(tag, nm);
     box.style.cursor = "pointer";
-    box.title = "click to view " + path;
-    box.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
+    box.title = "open " + path + " in a new tab";
+    box.onclick = (ev) => { ev.stopPropagation(); openPdf(path, sid); };   // its own tab, else the lightbox
     // a chip can't self-verify like an <img> — HEAD-probe (headers only, no body — never a download)
     // so a missing PDF never shows a dead card. A kernel-VERIFIED card skips the probe: the kernel
     // said the file exists, and a transient probe failure must not erase the card.

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -29,6 +29,15 @@ export function canPreview(): boolean {
   return location.protocol === "http:" || location.protocol === "https:";
 }
 
+// Which click means "in a browser tab of its own"? The browser-wide idiom, so there is nothing new to
+// learn and no setting to find: a Cmd/Ctrl-click (the `click` event carries the modifier) or a
+// middle-button press (which arrives as `auxclick`, button 1). A plain click keeps a PDF inside the
+// dashboard exactly as an image opens (the user 2026-09-07, who wanted one opening rule for both); the
+// modifier is the one signal that the browser's own viewer, beside the dashboard, is what is wanted.
+export function wantsOwnTab(ev?: { metaKey?: boolean; ctrlKey?: boolean; button?: number } | null): boolean {
+  return !!ev && (!!ev.metaKey || !!ev.ctrlKey || ev.button === 1);
+}
+
 // LOADING CUE (the user 2026-07-31): a remote image's bytes arrive over the ssh tunnel, so for a
 // beat the message showed only the path text and the picture "popped in" with nothing saying it was
 // on the way. Per the loading-state rule the first thing up is the romp swirl: a mini spinning glyph
@@ -111,11 +120,13 @@ export function fileUrl(path: string, sid?: string | null): string {
   return base + "?path=" + encodeURIComponent(path) + (bare ? "&sid=" + encodeURIComponent(bare) : "");
 }
 
-// A PDF opens in a NEW BROWSER TAB, in the browser's own viewer (the user 2026-09-06, who wanted what
-// OpenReview and HotCRP do: the paper in its own tab, full size, kept open beside the dashboard — not a
-// small window inside it). Those sites do nothing more than link the PDF's URL with target=_blank and
-// serve it inline as application/pdf; the browser renders it from its own cache, and nothing lands on
-// disk unless the browser is set to download PDFs — no download-then-delete dance is needed. /file
+// A PDF's OWN browser tab — on a Cmd/Ctrl- or middle-click (wantsOwnTab). A plain click keeps the PDF
+// inside the dashboard like an image: the lightbox from the chat card, the in-pane viewer from a path or a
+// file-browser row (the user 2026-09-07). The modified click opens the paper full size in the browser's own
+// viewer, the way one opens from OpenReview or HotCRP (the user 2026-09-06), and it stays open beside the
+// dashboard while the work goes on. Those sites do nothing more than link the PDF's URL with a new-tab
+// target and serve it inline as application/pdf; the browser renders it from its own cache and nothing lands
+// on disk unless the browser is set to download PDFs — no download-then-delete dance is needed. /file
 // already serves exactly that (same-origin, cookie-authed, federation-aware through fileUrl), so the
 // tab is ONE window.open inside the click gesture — synchronous, so a popup blocker reads it as
 // user-initiated; a fetch-then-open would lose the gesture and be blocked everywhere. The opener
@@ -128,10 +139,10 @@ export function fileUrl(path: string, sid?: string | null): string {
 // look-alike (reverse tabnabbing) — every other new tab this UI opens is disowned the same way.
 // The flag is set while the tab is still its same-origin initial page and rides every later
 // navigation. Web dashboard only: the VS Code webview cannot window.open, and previews are gated off
-// there anyway (canPreview). The KIND check lives here, by
-// extension — the only fact available inside the gesture — so a caller passes any path and a non-PDF
-// is simply "not mine" (false): the viewer's own media branch keeps keying on the kernel's
-// Content-Type verdict, never on an extension re-test (file-view.test.ts pins that).
+// there anyway (canPreview). The KIND check lives here, by extension — the only fact available inside
+// the gesture — so a caller passes any path and a non-PDF is simply "not mine" (false): the viewer's own
+// media branch keeps keying on the kernel's Content-Type verdict, never on an extension re-test
+// (file-view.test.ts pins that).
 export function openPdfTab(path: string, sid?: string | null): boolean {
   if (previewKind(path) !== "pdf" || !canPreview()) return false;
   const w = window.open(fileUrl(path, sid), "_blank");
@@ -140,13 +151,16 @@ export function openPdfTab(path: string, sid?: string | null): boolean {
   return true;
 }
 
-// The PDF card's click: its own tab, else the in-app lightbox when the popup was blocked.
-export function openPdf(path: string, sid?: string | null): void {
-  if (!openPdfTab(path, sid)) openLightbox(path, sid);
+// The PDF card's click, with its gesture: a plain click opens the in-app lightbox, like an image; a
+// Cmd/Ctrl- or middle-click opens the PDF in its own browser tab (openPdfTab), and a BLOCKED popup falls
+// back to the lightbox so the PDF is never unreachable.
+export function openPdf(path: string, sid?: string | null, ev?: MouseEvent | null): void {
+  if (wantsOwnTab(ev) && openPdfTab(path, sid)) return;
+  openLightbox(path, sid);
 }
 
 // Full-view lightbox: dark backdrop, the image at natural-but-capped size or the PDF in the browser's
-// native viewer (the FALLBACK for a blocked popup — a PDF opens in its own tab first, openPdf),
+// native viewer (a plain click's PDF view, and the fallback when a modified click's tab was popup-blocked — openPdf),
 // filename caption. One singleton element; backdrop click / Esc / ✕ closes. Styles live
 // in BOTH styles.css and feed.css (each page loads only its own sheet — the .romp-acted precedent).
 // Pinch-zoom on the lightbox image (T162, the user 2026-08-28 on Android). Pointer events only —
@@ -253,7 +267,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   let cue: HTMLElement | null = null;                    // the compact position mark ("3/17") in the bar
   let curImg: (() => HTMLImageElement) | null = null;    // the img on screen NOW (step rebinds it) — the copy source
   if (kind === "pdf") {
-    // the in-app FALLBACK only (openPdf): a PDF opens in its own browser tab unless the popup was blocked
+    // a plain click's view (openPdf), and the fallback when a modified click's tab was popup-blocked
     const frame = document.createElement("iframe");
     frame.className = "romp-lightbox-frame";
     frame.src = fileUrl(path, sid);
@@ -394,8 +408,8 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
 // thumbnail but a rendered image, like the user messages). Self-verifying —
 // a path the kernel can't serve removes itself — and an image click still opens the lightbox. Images
 // render at the user-image scale (.path-full-img mirrors .user-img's 320px cap, one size per
-// information type). A PDF is a labeled CARD, not an auto-loading inline viewer (click → its own
-// browser tab, openPdf; the lightbox only when the popup is blocked):
+// information type). A PDF is a labeled CARD, not an auto-loading inline viewer (click → the
+// lightbox; Cmd/Ctrl- or middle-click → its own browser tab, openPdf):
 // the first cut embedded an <iframe> per mentioned PDF, and a browser set to "Download PDFs" (or one
 // that declines to render inline) saved a FRESH COPY on every chat re-render — the user's Downloads
 // folder silently filled with datasheet copies (2026-07-20). A fetch must be user-initiated, once.
@@ -423,8 +437,10 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     nm.textContent = path.slice(path.lastIndexOf("/") + 1);
     box.append(tag, nm);
     box.style.cursor = "pointer";
-    box.title = "open " + path + " in a new tab";
-    box.onclick = (ev) => { ev.stopPropagation(); openPdf(path, sid); };   // its own tab, else the lightbox
+    box.title = "Open " + path + " (Cmd/Ctrl-click or middle-click: a browser tab of its own)";
+    box.onclick = (ev) => { ev.stopPropagation(); openPdf(path, sid, ev); };   // plain: the lightbox; modified: its own tab
+    box.onmousedown = (ev) => { if (ev.button === 1) ev.preventDefault(); };   // the middle press: no autoscroll (it would swallow the auxclick)
+    box.onauxclick = (ev) => { if (ev.button !== 1) return; ev.stopPropagation(); openPdf(path, sid, ev); };
     // a chip can't self-verify like an <img> — HEAD-probe (headers only, no body — never a download)
     // so a missing PDF never shows a dead card. A kernel-VERIFIED card skips the probe: the kernel
     // said the file exists, and a transient probe failure must not erase the card.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -40,7 +40,7 @@ import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
-import { openFileView } from "./file-view";
+import { openFileClick } from "./file-view";                  // a clicked file WITH its gesture (pdf-new-tab.test.ts)
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
@@ -944,13 +944,22 @@ document.addEventListener("click", (e) => {
 //
 // Same document as the click, so there is no shell relay and no fallback ladder: standalone /chat
 // and the framed pane behave identically.
-function openPath(path: string, sid?: string | null): void {
+function openPath(path: string, sid?: string | null, ev?: MouseEvent | null): void {
   if (!vscodeApi) return;
   if (location.protocol === "http:" || location.protocol === "https:") {
-    openFileView(path, sid || activeId || null);
+    openFileClick(ev, path, sid || activeId || null);   // with its gesture: a Cmd/Ctrl- or middle-click on a PDF → the browser's own tab
     return;
   }
   vscodeApi.postMessage(sid ? { type: "openFile", path, id: sid } : { type: "openFile", path });
+}
+
+// A middle-click on a path pill is the same open with its gesture (a PDF then takes a browser tab of its
+// own, openFileClick). `click` never fires for the middle button; `auxclick` does. The middle PRESS is
+// cancelled on mousedown: its default, autoscroll (Firefox on Windows/macOS, Edge), starts on the press and
+// would swallow the release's auxclick — a pill is a span, not a link, so the browser does not exempt it.
+function onMiddleClick(a: HTMLElement, fn: (e: MouseEvent) => void): void {
+  a.addEventListener("mousedown", (e) => { if (e.button === 1) e.preventDefault(); });
+  a.addEventListener("auxclick", (e) => { if (e.button !== 1) return; e.stopPropagation(); fn(e); });
 }
 
 // Surface the FILE BROWSER at `path` for the session: the shell brings the feed pane forward and the
@@ -980,8 +989,9 @@ function fileLink(path: string): HTMLElement {
   a.title = "Open " + path;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    openPath(path);
+    openPath(path, null, e);
   });
+  onMiddleClick(a, (e) => openPath(path, null, e));
   return a;
 }
 
@@ -1272,8 +1282,9 @@ function imgPathLink(path: string): HTMLElement {
   a.title = "Open " + path;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    openPath(path);
+    openPath(path, null, e);
   });
+  onMiddleClick(a, (e) => openPath(path, null, e));
   return a;
 }
 // Make literal occurrences of the images' paths inside the rendered message text
@@ -1315,8 +1326,9 @@ function openPathLink(raw: string, open: string, relative = false): HTMLElement 
   a.title = "Open " + open;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    openPath(open, relative ? activeId : null);
+    openPath(open, relative ? activeId : null, e);
   });
+  onMiddleClick(a, (e) => openPath(open, relative ? activeId : null, e));
   return a;
 }
 function fileUriLink(uri: string): HTMLElement { return openPathLink(uri, fileUriToPath(uri)); }
@@ -11904,11 +11916,13 @@ function renderComposerFiles(id: string | null): void {
     } else {
       box.appendChild(composerFileDoc(p));
     }
-    box.addEventListener("click", () => { openPath(p, id || null); });
+    box.addEventListener("click", (e) => { openPath(p, id || null, e); });
+    onMiddleClick(box, (e) => openPath(p, id || null, e));
     const x = el("button", "composer-file-x");
     x.setAttribute("aria-label", "Remove attachment");
     x.textContent = "\u2715";
     x.addEventListener("click", (e) => { e.stopPropagation(); if (id) removeComposerFile(id, i); });
+    x.addEventListener("auxclick", (e) => e.stopPropagation());   // a middle-click on ✕ is inert, never the box's open
     box.appendChild(x);
     strip.appendChild(box);
   });


### PR DESCRIPTION
## What

When a session produced a PDF, the dashboard showed it in a small window inside itself: the chat's PDF card opened a lightbox with an iframe, and a `.pdf` link or file-browser row opened the in-pane viewer. This makes a PDF open **in its own browser tab, in the browser's viewer**, the way a paper opens from OpenReview or HotCRP: full size, kept open beside the dashboard while the work goes on.

Those sites do nothing more than link the PDF's URL with a new-tab target and serve it inline as `application/pdf`; the browser renders it from its own cache and nothing lands on disk unless the browser is set to download PDFs. The kernel's `/file` route already serves exactly that, same-origin and cookie-authed, with a federated session's file relayed through the same URL builder.

- **`ui/webview/preview.ts`** — `openPdfTab(path, sid)`: one synchronous `window.open(fileUrl(path, sid), "_blank")` inside the click gesture, so a popup blocker reads it as user-initiated (a fetch-then-open would lose the gesture). The kind check is the opener's own, by extension, the only fact available inside the gesture; the viewer's media branch keeps keying on the kernel's `Content-Type` verdict. The opener is severed on the handle (`w.opener = null`) rather than with the `noopener` feature, because that feature returns `null` even on success and the null handle is the one signal that the popup was **blocked**; on that signal the card falls back to the lightbox and the viewer to its in-pane frame, so the PDF is never unreachable. `openPdf()` = tab, else lightbox; the PDF card's click uses it.
- **`ui/webview/file-view.ts`** — `openFileView` starts with `if (openPdfTab(path, sid ?? null)) return;`, so every path into the viewer (a path link, a file-browser row, a relayed open) takes the tab first.
- **`kernel/kernel.py`** — a PDF is served with `Content-Disposition: inline; filename="<basename>"` on GET and HEAD, locally and through the `/remote/<host>/file` relay (derived from the requested name, never mirrored from the remote), so the tab is titled after the file and a save names it. Images are unchanged.
- **Not a dead end when the file is too large.** A PDF over `_PREVIEW_MAX_BYTES` used to reach the viewer, whose 413 handling offered a Download button; in a tab of its own it would have shown only the refusal. A *navigation* (`Sec-Fetch-Dest: document`) to such a PDF now gets a small page with the same sentence and a link to the download half of the same route (local or relay); fetches, iframes and HEAD probes keep the plain-text 413 they parse. The directory listing's `viewable` verdict is now size-aware (media cap / text cap), so the file browser routes an oversize row to the download up front, and its tooltip says "opens as a download" rather than "not viewable".
- **Relayed error verdicts are prose.** `_remote_file` used to hand a remote's 404/413/415 text back under the local media mime; an `<img>` merely failed on that, a tab shows a corrupt-PDF error. Every non-success relayed verdict is `text/plain` now.
- **`docs/guide.md`** — an "Opening a PDF" paragraph.

Web dashboard only: the VS Code webview cannot open a window and never rendered previews (routing a PDF to the OS browser from there would put the serve token in an OS-level URL, so it is deliberately left out).

## Review

Two adversarial passes with a refuter per finding, then a skeptic pass over the fixes. Five real problems in the first cut, all fixed here and each pinned by a test that fails on the old code: the live opener (reproduced in a real Chromium: a link inside the PDF navigates the same tab to a foreign site, which could then replace the dashboard with a look-alike); the oversize-PDF dead end; the relay's missing inline header; the relay's mislabelled error prose; the browser tooltip's wrong reason.

## Tests

`ui/webview/pdf-new-tab.test.ts` runs the opener against a stubbed window (permitted popup, blocked popup, webview origin, non-PDF path, federated relay URL, severed opener) and pins the wiring of the card, the viewer, the kernel header, the oversize page, the listing's verdict, the relay and the guide. `tests/test_kernel_preview.py` pins the inline disposition on GET and HEAD, its absence on images, and the oversize page with its escaping against a navigation only. `tests/test_listdir.py` pins the size-aware verdict. `tests/test_kernel_remote_file_relay.py` pins the relay's locally derived header against a remote that lies, its error verdicts as prose, and the oversize page on the relay route. The inline-preview and file-view pins follow the new click and import.

Full suites on this tree: Python 7393 passed / 40 skipped; node 2842; bats 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
