### PR TITLE
Every PR carries one tier label: the publish recipe and the release script file with it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,21 @@ broad `git add` will sweep up your work). Conventions:
      `remote.pushDefault` already points there, so a bare `git push` does the same.
      Never push to `origin`: the server rejects it, and naming it in scripts bakes in
      a failure.
-  2. `gh pr create --repo romp-on/romp` (gh detects the fork head), then
-     `gh pr merge --auto --merge` — it lands itself when the six required Linux
-     checks pass. There is no way to move `main` except a green PR.
+  2. `gh pr create --repo romp-on/romp --label <tier>` (gh detects the fork head), then
+     `gh pr merge --auto --merge`: it lands itself when the required Linux checks
+     pass. There is no way to move `main` except a green PR.
+- **Every PR carries exactly one tier label** (maintainers' rule, 2026-09-06). A
+  required check holds a PR with no tier label, or two, red, so an unlabeled PR never
+  auto-merges. The author picks the tier at filing time:
+  - `tests-only` (tier 0): tests, docs, repo plumbing; no behavior change. Merges on green.
+  - `fix` (tier 1): a bug fix with a test that fails before it.
+  - `feature` (tier 2): a self-contained new capability inside romp's existing model;
+    put the design points in the body.
+  - `major-feature` (tier 3): new functionality that changes what romp does or its
+    contracts. Discussed first (an issue, or the PR as the RFC) and merged only on
+    agreement, so file it **without** `--auto` and leave the merge to the user.
+  The line that matters is 2 vs 3: adds a capability inside the existing model, `feature`;
+  changes what romp is, `major-feature`, talk first.
 - **Clean up when finished.** After publishing, remove the worktree
   (`git worktree remove ../romp-<session>`) and delete its branch — don't leave stale
   worktrees lying around.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,7 +154,12 @@ if [ "$current" != "$target" ]; then
         # "no pull requests found for branch release-0.3.0" and the release died one step after
         # opening the PR, leaving VERSION merged-but-untagged, exactly the half-finished state this
         # script exists to prevent. A number is unambiguous in any repo.
+        # Every PR on the upstream carries exactly one tier label (tests-only / fix / feature /
+        # major-feature), and a required check holds an unlabeled PR red, so auto-merge would
+        # never fire and the release would stall one step after opening it. A version bump is
+        # repo plumbing with no behavior change: tier 0, `tests-only`.
         pr_url="$("$GH" pr create --repo "$UPSTREAM" --title "VERSION $target" \
+            --label tests-only \
             --body "Version bump for \`$tag\`, opened by scripts/release.sh.")" \
             || die "could not open the version PR."
         pr="${pr_url##*/}"

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -108,6 +108,9 @@ STUB
     [[ "$output" == *"0.1.0 → 0.2.0"* ]]
     grep -q "pr create" "$GH_LOG"
     grep -q "pr merge" "$GH_LOG"
+    # The version PR carries its tier label at creation: a required upstream check holds an
+    # unlabeled PR red, so without it auto-merge never fires and the release stalls.
+    grep -q "pr create .*--label tests-only" "$GH_LOG"
     # BY NUMBER, never by branch name (the user 2026-08-01): every PR here is fork-headed, because
     # rulesets block branch pushes upstream — and `gh pr merge <branch> --repo <upstream>` cannot
     # resolve a branch that lives on the fork. It failed with "no pull requests found for branch


### PR DESCRIPTION
The maintainers agreed (2026-09-06) that every PR on the upstream carries exactly one tier label, enforced by a required check that holds an unlabeled PR red. Two of romp's own PR writers would then stall on auto-merge: the publish recipe in CLAUDE.md that every session follows, and the version-bump PR opened by scripts/release.sh.

- CLAUDE.md's publish step passes `--label <tier>` and states the four tiers; `major-feature` is filed without `--auto` so the merge stays the user's call.
- `scripts/release.sh` labels its version PR `tests-only` (repo plumbing, no behavior change).
- `tests/release-sh.bats` asserts the label rides the `pr create` call. Red on the previous script, green now.

Tier: tests-only (docs and repo plumbing; no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)