### PR TITLE
A message typed with Shift+Enter keeps its line breaks in the chat

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18177,7 +18177,20 @@ def _split_reminders(text):
             reminders.append(text[j + len(OPEN):].strip()); break
         reminders.append(text[j + len(OPEN):k].strip())
         i = k + len(CLOSE)
-    return " ".join("".join(out).split()), [r for r in reminders if r]
+    # Rejoin the fragments around the peeled blocks. Each SEAM collapses to one separator — a paragraph
+    # break if the whitespace the block sat in held a blank line, a newline if it held one, else a space —
+    # and the prompt's OWN whitespace is kept. This used to be " ".join(prompt.split()), which flattened
+    # every newline in a message that happened to arrive with a reminder attached (the first prompt of a
+    # session rides with the CLAUDE.md block; a prompt after a background task rides with its notification),
+    # so a message typed with Shift+Enter line breaks rendered as one run-together line (the user 2026-09-06).
+    prompt = out[0]
+    for seg in out[1:]:
+        left, right = prompt.rstrip(), seg.lstrip()
+        lws, rws = prompt[len(left):], seg[:len(seg) - len(right)]     # the whitespace on each side of the block
+        nl = max(lws.count("\n"), rws.count("\n"))                     # per side: a blank line on either side is a paragraph break
+        sep = "\n\n" if nl >= 2 else "\n" if nl else " " if (lws or rws) else ""
+        prompt = left + sep + right
+    return prompt.strip(), [r for r in reminders if r]
 
 
 _IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp|bmp|svg))\b", re.I)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5448,6 +5448,24 @@ class ViewBuilder(unittest.TestCase):
         self.assertIn("real ask", p3); self.assertIn("mid", p3); self.assertIn("end", p3)
         self.assertEqual(r3, ["x", "y"])
 
+    def test_split_reminders_keeps_the_prompts_newlines(self):
+        # A message typed with Shift+Enter line breaks must keep them when a harness block rides along
+        # (the user 2026-09-06: the old " ".join(split()) flattened the whole prompt to one line). The
+        # CLI appends the block as its own text block; build_session joins blocks with a space.
+        p, r = km._split_reminders("line one\nline two <system-reminder>ctx</system-reminder>")
+        self.assertEqual(p, "line one\nline two"); self.assertEqual(r, ["ctx"])
+        # …and leads with it on a session's first prompt
+        p, r = km._split_reminders("<system-reminder>ctx</system-reminder> line one\n\nline three")
+        self.assertEqual(p, "line one\n\nline three"); self.assertEqual(r, ["ctx"])
+        # indentation inside the prompt (a pasted snippet) survives too
+        p, _ = km._split_reminders("see:\n    x = 1\n    y = 2 <task-notification>t</task-notification>")
+        self.assertEqual(p, "see:\n    x = 1\n    y = 2")
+        # the SEAM a block sat in collapses to what it held: a space, a newline, or a paragraph break
+        self.assertEqual(km._split_reminders("a <system-reminder>x</system-reminder> b")[0], "a b")
+        self.assertEqual(km._split_reminders("a\n<system-reminder>x</system-reminder>\nb")[0], "a\nb")
+        self.assertEqual(km._split_reminders("a\n\n<system-reminder>x</system-reminder>\n\nb")[0], "a\n\nb")
+        self.assertEqual(km._split_reminders("a<system-reminder>x</system-reminder>b")[0], "ab")
+
     def test_img_hydration_and_dropped_file_host_handlers(self):
         # ported host handlers (the user 2026-06-16): a path-image hydrates to a data: URL, and a
         # dropped file's bytes are saved under the state dir's drops/ for the prompt to reference.

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -1,0 +1,100 @@
+// The user's own words keep their line breaks in the chat (the user 2026-09-06): Shift+Enter in the
+// composer inserts a newline, the text reaches the kernel and the transcript with it intact, and then the
+// blue bubble rendered it through the shared `marked` singleton — `breaks: false`, right for assistant
+// markdown where a lone newline is a soft wrap — so the lines ran together into one paragraph. The fix is
+// a SECOND marked instance for user text (chat-md.ts `userMarked`, `breaks: true`) built from the same
+// extensions the singleton gets, so only the newlines change. Executed here for real (marked + katex are
+// plain JS); the render.ts wiring is source-pinned, since the webview has no jsdom harness.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Marked } from "marked";
+import { chatMdExtensions, userMdHtml } from "./chat-md";
+
+// the singleton's configuration, rebuilt on a private instance: gfm, breaks OFF, the same extensions
+const assistant = new Marked({ gfm: true, breaks: false }, ...chatMdExtensions);
+const assistantHtml = (src: string) => assistant.parse(src) as string;
+
+// --- executed: the user renderer keeps newlines, the assistant grammar does not ---
+
+test("a single newline in user text becomes a hard line break; the assistant grammar keeps it a soft wrap", () => {
+  const user = userMdHtml("line one\nline two");
+  assert.match(user, /line one<br>\s*line two/, "the user's newline renders as <br>");
+  const asst = assistantHtml("line one\nline two");
+  assert.doesNotMatch(asst, /<br>/, "assistant markdown: a lone newline stays a soft wrap");
+  assert.match(asst, /line one\nline two/);
+});
+
+test("a blank line is still a paragraph break, not a run of <br>", () => {
+  const out = userMdHtml("para one\n\npara two");
+  assert.equal((out.match(/<p>/g) || []).length, 2);
+  assert.doesNotMatch(out, /<br>/);
+});
+
+test("a fenced code block keeps its literal newlines and gains no <br>", () => {
+  const out = userMdHtml("```\nfirst\nsecond\n```");
+  assert.match(out, /<pre><code>first\nsecond\n<\/code><\/pre>/);
+  assert.doesNotMatch(out, /<br>/);
+});
+
+test("a list stays a list; an indented pasted snippet stays code", () => {
+  const list = userMdHtml("- a\n- b");
+  assert.equal((list.match(/<li>/g) || []).length, 2);
+  assert.doesNotMatch(list, /<br>/);
+  const snippet = userMdHtml("see:\n\n    x = 1\n    y = 2");
+  assert.match(snippet, /<pre><code>x = 1\ny = 2\n<\/code><\/pre>/);
+});
+
+test("the chat grammar rides along: ~~double~~ strikes, a lone ~ stays literal", () => {
+  assert.match(userMdHtml("this is ~~struck~~ out"), /<del>struck<\/del>/);
+  const lone = userMdHtml("near the ~21 Wh budget, ~1.5 days");
+  assert.doesNotMatch(lone, /<del>/);
+  assert.match(lone, /~21/);
+});
+
+test("the chat grammar rides along: $x$ still renders KaTeX, and a price stays a price", () => {
+  const out = userMdHtml("Euler: $e^{i\\pi}+1=0$\nnext line");
+  assert.ok(out.includes('class="katex"'), "inline math renders");
+  assert.match(out, /<br>\s*next line/, "…and the newline after it is still kept");
+  const price = userMdHtml("costs $5 and $10 today");
+  assert.ok(!price.includes('class="katex"'));
+  assert.match(price, /\$5/);
+});
+
+test("the user renderer and the assistant grammar produce identical HTML when there is no newline", () => {
+  for (const src of ["plain words", "**bold** and `code`", "a [link](https://example.test) here", "~~gone~~ $x$"]) {
+    assert.equal(userMdHtml(src), assistantHtml(src), src);
+  }
+});
+
+// --- source pins: the wiring in render.ts ---
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the singleton stays breaks:false — assistant rendering is unchanged", () => {
+  assert.match(RENDER, /marked\.setOptions\(\{ gfm: true, breaks: false \}\);/);
+  assert.match(RENDER, /marked\.use\(\.\.\.chatMdExtensions\);/, "…and takes the same grammar the user instance does");
+});
+
+test("userMd() renders through the breaks:true instance and the SAME DOMPurify profile as md()", () => {
+  const fn = RENDER.match(/function userMd\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.ok(fn, "userMd() must exist");
+  assert.match(fn, /DOMPurify\.sanitize\(userMdHtml\(src\), MD_PURIFY\)/);
+  const mdFn = RENDER.match(/function md\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(mdFn, /DOMPurify\.sanitize\(dirty, MD_PURIFY\)/, "md() sanitizes with the same shared profile");
+  assert.match(RENDER, /const MD_PURIFY: Config = \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\] \};/);
+});
+
+test("the user bubble renders the user's OWN words with userMd, harness notes and everything else with md", () => {
+  // the landed bubble: kind "user" → userMd; the harness-injected note sharing the branch → md
+  assert.match(RENDER, /bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);
+  assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(ev\.md\);/, "no user bubble left on the soft-wrap grammar");
+  // the queued / optimistic bubble is the same message a beat earlier — same renderer, so the swap to the
+  // landed bubble changes nothing on screen
+  assert.match(RENDER, /if \(!isCmd\) bubble\.innerHTML = userMd\(t\.md\);/);
+  assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(t\.md\);/);
+  // romp-authored surfaces keep the assistant grammar: nudges, notices, the Continue gesture, tagged sends
+  assert.match(RENDER, /full\.innerHTML = md\(raw\);/, "the romp nudge fold");
+  assert.match(RENDER, /body\.innerHTML = md\(text\);\n\s*return noticeCard\(\{ variant: "romp"/, "the romp system notice");
+});

--- a/ui/webview/chat-md.ts
+++ b/ui/webview/chat-md.ts
@@ -1,0 +1,45 @@
+// The chat's markdown grammar, in ONE place, and the renderer for the user's OWN words.
+//
+// Two marked configurations render the chat, and they must agree on everything except line breaks:
+//   - the shared `marked` singleton (render.ts, file-view.ts) — `breaks: false`: assistant output is real
+//     markdown, where a single newline is a soft wrap and a paragraph break takes a blank line;
+//   - `userMarked` below — `breaks: true`: what the user typed is not authored markdown. Shift+Enter in the
+//     composer means "new line", and the bubble must show the line the person made (the user 2026-09-06:
+//     a multi-line message ran together into one paragraph once it reached the chat). marked's `breaks`
+//     option turns each newline inside a paragraph into <br> and touches nothing else — fenced code keeps
+//     its literal newlines, lists stay lists, a blank line is still a paragraph break.
+// Both take the SAME extensions from `chatMdExtensions`, so a user message with math or strikethrough
+// renders exactly as it did before — only its newlines are kept. Pure (no DOM): the executed tests import
+// it directly, the way render-math.test.ts exercises math.ts. Sanitizing is the caller's job: render.ts's
+// userMd() runs the output through the same DOMPurify profile md() uses before it ever reaches innerHTML.
+import { Marked, type MarkedExtension } from "marked";
+import { mathBlock, mathInline } from "./math";
+
+// Strikethrough requires DOUBLE tildes (the user 2026-06-26). marked's built-in GFM `del` tokenizer also
+// fires on a SINGLE tilde, so prose like "near the ~21 Wh/day budget … gives ~1.5–2 days" renders as one big
+// <del> struck through from the first ~ to the second. GitHub itself only strikes ~~double~~, so match that:
+// a lone ~ (commonly "approximately") stays literal. Returning undefined lets marked treat the ~ as text.
+export const delDoubleTilde = {
+  tokenizer: {
+    del(src: string) {
+      const m = /^~~(?=\S)([\s\S]*?\S)~~/.exec(src);
+      if (!m) return undefined;
+      return { type: "del", raw: m[0], text: m[1], tokens: (this as { lexer: { inlineTokens(s: string): unknown[] } }).lexer.inlineTokens(m[1]) };
+    },
+  },
+} as MarkedExtension;
+
+// TeX math ($..$, $$..$$, \(..\), \[..\]) rendered via KaTeX. All delimiter heuristics (the
+// $-vs-shell/price disambiguation) live in math.ts; the output is plain spans + inline styles
+// (output: "html"), which DOMPurify's html profile in md() passes through unchanged.
+export const chatMdExtensions: MarkedExtension[] = [delDoubleTilde, { extensions: [mathBlock, mathInline] }];
+
+// The user-text instance: the chat grammar with hard line breaks. Its own `Marked` so the singleton's
+// `breaks: false` — every assistant message — is untouched.
+export const userMarked = new Marked({ gfm: true, breaks: true }, ...chatMdExtensions);
+
+/** marked's HTML for the user's own typed text: newlines kept as <br>, otherwise the chat grammar.
+ *  UNSANITIZED — render.ts's userMd() is the only caller that reaches innerHTML, and it purifies first. */
+export function userMdHtml(src: string): string {
+  return userMarked.parse(src) as string;
+}

--- a/ui/webview/injected-render.test.ts
+++ b/ui/webview/injected-render.test.ts
@@ -54,9 +54,10 @@ test("the visible source prefix strips for DISPLAY only, in the romp render bran
     "comments AND the literal source prefix strip from the displayed text");
   assert.ok(!branch.includes("ev.md =") && !RENDER.includes("ev.md = ev.md.replace"),
     "the transcript record is never mutated — the prefix still tells the AGENT where the message came from");
-  // the plain user branch renders md untouched — the strip is romp-only
+  // the plain user branch renders ev.md untouched (no strip — that is romp-only); the user's own
+  // words go through userMd (newlines kept), a harness note through md
   const userBranch = RENDER.slice(RENDER.indexOf("} else if (ev.md) {", at));
-  assert.match(userBranch.slice(0, 200), /bubble\.innerHTML = md\(ev\.md\);/);
+  assert.match(userBranch.slice(0, 400), /bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);/);
 });
 
 test("the watch notices carry the marker at the injection site — no prose pattern-matching anywhere", () => {

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -29,9 +29,10 @@ test("renderQueued draws a wireframe-hourglass header (singular/plural) + one ma
   assert.match(RENDER, /return `\$\{n\} queued \$\{noun\}\$\{n === 1 \? "" : "s"\}`/);
   assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd\) \+ why;/);
   assert.match(RENDER, /el\("div", "queued-head"\)/);
-  // one faint "you" bubble per pending message, rendered as markdown (like a landed message)
+  // one faint "you" bubble per pending message, rendered as markdown (like a landed message — the
+  // user-text renderer, newlines kept, so the queued→landed swap changes nothing on screen)
   assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\)/);
-  assert.match(RENDER, /if \(!isCmd\) bubble\.innerHTML = md\(t\.md\)/);
+  assert.match(RENDER, /if \(!isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
 });
 
 test("a queued slash command renders as a command chip, not a plain 'message' (the user 2026-07-01)", () => {

--- a/ui/webview/render-math.test.ts
+++ b/ui/webview/render-math.test.ts
@@ -91,10 +91,15 @@ test("escaped \\$ never opens math", () => {
 
 const UI = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 
-test("render.ts wires the math extensions into marked", () => {
+test("render.ts wires the math extensions into marked, through the shared chat grammar", () => {
+  // chat-md.ts owns the extension list (shared with the breaks:true user-text instance, so a user
+  // message with math renders exactly as before); render.ts applies it to the singleton.
+  const grammar = UI("chat-md.ts");
+  assert.match(grammar, /import \{ mathBlock, mathInline \} from "\.\/math";/);
+  assert.match(grammar, /export const chatMdExtensions: MarkedExtension\[\] = \[delDoubleTilde, \{ extensions: \[mathBlock, mathInline\] \}\];/);
   const src = UI("render.ts");
-  assert.match(src, /import \{ mathBlock, mathInline \} from "\.\/math";/);
-  assert.match(src, /marked\.use\(\{ extensions: \[mathBlock, mathInline\] \}\)/);
+  assert.match(src, /import \{ chatMdExtensions, userMdHtml \} from "\.\/chat-md";/);
+  assert.match(src, /marked\.use\(\.\.\.chatMdExtensions\);/);
 });
 
 test("math.ts renders html-only output so md()'s DOMPurify profile passes it", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1,5 +1,6 @@
 import { marked } from "marked";
 import DOMPurify from "dompurify";
+import type { Config } from "dompurify";   // the one sanitizer profile both md() and userMd() share
 import hljs from "highlight.js/lib/core";
 import bash from "highlight.js/lib/languages/bash";
 import python from "highlight.js/lib/languages/python";
@@ -48,7 +49,7 @@ import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from ".
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
-import { mathBlock, mathInline } from "./math";
+import { chatMdExtensions, userMdHtml } from "./chat-md";
 import { setTip, pruneTip } from "./tip";
 import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 import { dragSlotIndex } from "./dragslot";
@@ -62,24 +63,10 @@ for (const [name, lang] of Object.entries({
 }
 
 marked.setOptions({ gfm: true, breaks: false });
-// Strikethrough requires DOUBLE tildes (the user 2026-06-26). marked's built-in GFM `del` tokenizer also
-// fires on a SINGLE tilde, so prose like "near the ~21 Wh/day budget … gives ~1.5–2 days" renders as one big
-// <del> struck through from the first ~ to the second. GitHub itself only strikes ~~double~~, so match that:
-// a lone ~ (commonly "approximately") stays literal. Returning undefined lets marked treat the ~ as text.
-marked.use({
-  tokenizer: {
-    del(src: string) {
-      const m = /^~~(?=\S)([\s\S]*?\S)~~/.exec(src);
-      if (!m) return undefined;
-      return { type: "del", raw: m[0], text: m[1], tokens: (this as { lexer: { inlineTokens(s: string): unknown[] } }).lexer.inlineTokens(m[1]) };
-    },
-  },
-} as Parameters<typeof marked.use>[0]);
-
-// TeX math ($..$, $$..$$, \(..\), \[..\]) rendered via KaTeX. All delimiter heuristics (the
-// $-vs-shell/price disambiguation) live in math.ts; the output is plain spans + inline styles
-// (output: "html"), which DOMPurify's html profile in md() passes through unchanged.
-marked.use({ extensions: [mathBlock, mathInline] });
+// The chat grammar — the ~~-only `del` tokenizer and the KaTeX math extensions — is defined ONCE in
+// chat-md.ts and shared with `userMarked`, the breaks:true instance that renders the user's own words
+// (userMd below). Everything assistant-authored stays on this singleton, breaks:false.
+marked.use(...chatMdExtensions);
 
 // One answered (or pending) question on an AskUserQuestion turn: the prompt + its options, plus the
 // user's answer TEXT per question (`chosen`). Answer text may name an option label OR be free-text
@@ -725,21 +712,34 @@ function el(tag: string, cls?: string): HTMLElement {
   return e;
 }
 
+// ONE sanitizer profile for both renderers. svg profile too (the user 2026-08-19): KaTeX's html output
+// still draws STRETCHY glyphs — \sqrt radicals, wide accents, extensible arrows — as inline <svg><path>,
+// and the html-only profile silently ate them: $\sqrt{d}$ rendered as a bare serif "d", the radical gone.
+// DOMPurify's svg profile is still sanitized (no scripts, handlers, or foreignObject). Keep data: URIs on
+// <img> (the CSP allows them and inline transcript images rely on them).
+const MD_PURIFY: Config = { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] };
+
 function md(src: string): string {
   // Transcript text (user prompts, assistant output, subagent reports, postal
   // bodies) is UNTRUSTED and `marked` emits raw HTML verbatim, so its output
   // must be sanitized before it ever reaches .innerHTML — otherwise a payload
   // like `<img src=x onerror=...>` or `[x](javascript:...)` runs in the webview
   // (which can postMessage the host to open files / drive sessions). DOMPurify
-  // strips event-handler attributes and dangerous URL schemes. Keep data: URIs
-  // on <img> (the CSP allows them and inline transcript images rely on them).
+  // strips event-handler attributes and dangerous URL schemes (profile: MD_PURIFY).
   try {
     const dirty = marked.parse(src) as string;
-    // svg profile too (the user 2026-08-19): KaTeX's html output still draws STRETCHY glyphs —
-    // \sqrt radicals, wide accents, extensible arrows — as inline <svg><path>, and the html-only
-    // profile silently ate them: $\sqrt{d}$ rendered as a bare serif "d", the radical gone.
-    // DOMPurify's svg profile is still sanitized (no scripts, handlers, or foreignObject).
-    return DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"] });
+    return DOMPurify.sanitize(dirty, MD_PURIFY);
+  } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
+}
+
+// The user's OWN typed words (the blue bubble, its queued/optimistic twin): same grammar, same sanitizer,
+// but newlines KEPT — Shift+Enter in the composer means a new line, and the singleton's breaks:false
+// (right for assistant markdown, where a lone newline is a soft wrap) ran a multi-line message together
+// into one paragraph once it landed in the chat (the user 2026-09-06). userMarked is the breaks:true
+// instance in chat-md.ts; the singleton and every assistant surface are untouched.
+function userMd(src: string): string {
+  try {
+    return DOMPurify.sanitize(userMdHtml(src), MD_PURIFY);
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
 }
 
@@ -2410,7 +2410,9 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
           bubble.title = bubble.classList.contains("expanded") ? "click to collapse" : "click to expand";
         }
       } else if (ev.md) {
-        bubble.innerHTML = md(ev.md);
+        // the user's OWN words keep their line breaks (userMd); a harness-injected note — compact
+        // summary, command stdout — shares this branch and stays on the assistant grammar
+        bubble.innerHTML = kind === "user" ? userMd(ev.md) : md(ev.md);
         linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs in a message → clickable (open in the host's default app)
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
@@ -3455,7 +3457,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     else if (!t.cancelable && t.idx !== undefined)
       bubble.title = "queued in the session — it can't be recalled, and joins the conversation at the session's next step";
     const isCmd = renderSlashCmd(bubble, t.md);
-    if (!isCmd) bubble.innerHTML = md(t.md);
+    if (!isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
     // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
     // user 2026-08-25: composer preview → path-only provisional → thumbnail landing flashed). Same
     // machinery end to end: userImage with the landed form's exact "path:" shape — buildPathImg's

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -15,8 +15,9 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /if \(!romp && !injected && !tagged && ev\.md && renderSlashCmd\(bubble, ev\.md\)\) \{/);
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
-  // the non-command path still renders markdown as before (now also linkifies bare file:// URLs)
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*\}/);
+  // the non-command path still renders markdown as before (now also linkifies bare file:// URLs);
+  // the user's own words through userMd (newlines kept), a harness note through md
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -21,7 +21,7 @@ test("renderQueued renders markdown (not raw text) + the follow-up header", () =
   const fn = SRC.slice(qStart, SRC.indexOf("function renderApiError", qStart));
   assert.ok(fn.length > 0, "found renderQueued");
   assert.match(fn, /if \(t\.followUp\) turn\.appendChild\(followUpHeader\(t\.goal, t\.fuCtx, t\.idx !== undefined \? "q:" \+ t\.idx : undefined\)\);/);
-  assert.match(fn, /bubble\.innerHTML = md\(t\.md\);/);
+  assert.match(fn, /bubble\.innerHTML = userMd\(t\.md\);/);   // markdown, through the user-text renderer (newlines kept)
   assert.doesNotMatch(fn, /textContent = t\b/, "no more raw textContent dump");
 });
 

--- a/vscode-extension/src/md-strikethrough.test.ts
+++ b/vscode-extension/src/md-strikethrough.test.ts
@@ -1,38 +1,36 @@
 // Strikethrough must require DOUBLE tildes (the user 2026-06-26): marked's built-in GFM `del` fires on a
 // SINGLE tilde, so prose with two "approximately" tildes ("~21 Wh … ~1.5 days") rendered as one big struck-
-// through run. render.ts overrides the `del` tokenizer to require ~~ (matching GitHub). This test mirrors
-// that config and checks behavior, then source-pins render.ts so the two can't drift.
+// through run. The chat overrides the `del` tokenizer to require ~~ (matching GitHub). The override lives in
+// ui/webview/chat-md.ts (shared by the assistant singleton and the user-text instance), so this test runs the
+// REAL definition — no mirrored copy to drift — and source-pins that render.ts wires it into its marked.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { marked } from "marked";
+import { Marked } from "marked";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { delDoubleTilde } from "../../ui/webview/chat-md";
 
-marked.setOptions({ gfm: true, breaks: false });
-marked.use({
-  tokenizer: {
-    del(src: string) {
-      const m = /^~~(?=\S)([\s\S]*?\S)~~/.exec(src);
-      if (!m) return undefined;
-      return { type: "del", raw: m[0], text: m[1], tokens: (this as { lexer: { inlineTokens(s: string): unknown[] } }).lexer.inlineTokens(m[1]) };
-    },
-  },
-} as Parameters<typeof marked.use>[0]);
+const m = new Marked({ gfm: true, breaks: false }, delDoubleTilde);
 
 test("a single ~ (approximately) does NOT strike through", () => {
-  const html = marked.parse("near the ~21 Wh/day budget and it gives ~1.5 days of buffer") as string;
+  const html = m.parse("near the ~21 Wh/day budget and it gives ~1.5 days of buffer") as string;
   assert.doesNotMatch(html, /<del>/, "lone tildes stay literal — no strikethrough");
   assert.match(html, /~21/);
   assert.match(html, /~1\.5/);
 });
 
 test("double ~~ still strikes through", () => {
-  const html = marked.parse("this is ~~struck~~ out") as string;
+  const html = m.parse("this is ~~struck~~ out") as string;
   assert.match(html, /<del>struck<\/del>/);
 });
 
-test("render.ts ships the same del-requires-double-tilde override", () => {
-  const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
-  assert.match(RENDER, /del\(src: string\)/);
-  assert.match(RENDER, /\/\^~~\(\?=\\S\)\(\[\\s\\S\]\*\?\\S\)~~\//, "the ~~-only del regex");
+test("chat-md.ts holds the del-requires-double-tilde override and render.ts's marked takes it", () => {
+  const ui = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+  const grammar = ui("chat-md.ts");
+  assert.match(grammar, /del\(src: string\)/);
+  assert.match(grammar, /\/\^~~\(\?=\\S\)\(\[\\s\\S\]\*\?\\S\)~~\//, "the ~~-only del regex");
+  assert.match(grammar, /export const chatMdExtensions: MarkedExtension\[\] = \[delDoubleTilde, /);
+  const render = ui("render.ts");
+  assert.match(render, /marked\.use\(\.\.\.chatMdExtensions\);/, "the singleton takes the shared grammar");
+  assert.doesNotMatch(render, /del\(src: string\)/, "no second copy of the tokenizer in render.ts");
 });


### PR DESCRIPTION
## What

A chat message typed with Shift+Enter line breaks rendered in the chat with the newlines gone — the lines ran together into one paragraph. The user's bubble now keeps its line breaks.

Two loss points, both fixed:

- **Render.** The user's bubble went through the shared `marked` singleton, whose `breaks: false` is right for assistant output (real markdown, where a lone newline is a soft wrap) and wrong for a person's typed message. The user's own words now render through a second `Marked` instance (`ui/webview/chat-md.ts`, `breaks: true`) built from the same extensions the singleton gets — the `~~`-only strikethrough tokenizer and the KaTeX math extensions, now defined once and applied to both — and pass through the same DOMPurify profile (`MD_PURIFY`, one const so the two cannot drift). Only newlines change: fenced code keeps its literal newlines, lists stay lists, a blank line is still a paragraph break, a message with no newline renders byte-identically. Two surfaces switch: the landed blue bubble (the user's words only; a harness-injected note sharing that branch stays on `md`) and the queued/optimistic bubble, so the sent-just-now → landed swap changes nothing on screen. Assistant and romp-authored surfaces are untouched; the singleton stays `breaks: false`.
- **Kernel.** `_split_reminders` rejoined a prompt with `" ".join(split())` whenever a `<system-reminder>`/`<task-notification>` block rode along — every session's first prompt does — flattening every newline before the client ever saw the text. It now rejoins the fragments around the peeled blocks with one separator per seam (paragraph break / newline / space, by the whitespace the block sat in) and leaves the prompt's own whitespace alone. Reminder-free prompts were never touched and still aren't.

## Verification

- `npm run typecheck`, `npm test` (2843 pass), `npm run build`; targeted pytest over the reminder / session-build / event-model / golden suites (996 pass).
- Executed tests for the user renderer (newline kept vs. the assistant grammar, fences, lists, `~~`, `$x$`, no-newline parity) and the kernel seam join (leading, trailing, adjacent, inline, unclosed reminders; CRLF). Source pins hold the singleton's `breaks: false`, the `userMd` wiring at both surfaces, and that romp-authored surfaces still use `md`. The strikethrough test now executes the real shared tokenizer instead of a mirrored copy.
- Adversarial review: no material findings; 675 parent-vs-current assistant-HTML comparisons byte-identical; the new module appears only in the chat bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
