### PR TITLE
The canonical remote is upstream when the clone has one: the updater, the release script and the recipe stop naming origin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ broad `git add` will sweep up your work). Conventions:
 - **Never commit on the shared `main` checkout** (user rule, 2026-07-24). Branches and
   worktrees are how work happens here, with no "quick one in main" exception. A commit
   that lands on the local `main` branch and is not pushed immediately makes local `main`
-  diverge from `origin/main`, and then every peer session is stuck: they cannot push,
+  diverge from `upstream/main`, and then every peer session is stuck: they cannot push,
   cannot fast-forward, and cannot reset the shared tree without destroying whatever
   uncommitted edits other sessions are holding in it. This happened on 2026-07-24 (six
   docs commits stranded on local `main`, already duplicated on a PR branch, blocking two
@@ -89,13 +89,19 @@ broad `git add` will sweep up your work). Conventions:
   without asking — through the fork (user rule, 2026-07-27): rulesets on the upstream
   block EVERY direct branch push (`main` and feature branches alike, no bypass), so
   publishing is always push-then-PR:
-  1. `git push -u fork <branch>` — the clone's `fork` remote is the maintainer's fork;
-     `remote.pushDefault` already points there, so a bare `git push` does the same.
-     Never push to `origin`: the server rejects it, and naming it in scripts bakes in
-     a failure.
+  1. `git push -u origin <branch>`: `origin` is the maintainer's **fork** and `upstream`
+     is romp-on/romp (remote convention, the user 2026-09-06; a plain install has only
+     `origin`, which is then romp-on itself). `remote.pushDefault` points at `origin`,
+     so a bare `git push` does the same. Never push to `upstream`: the server rejects
+     it, and naming it in scripts bakes in a failure.
   2. `gh pr create --repo romp-on/romp --label <tier>` (gh detects the fork head), then
      `gh pr merge --auto --merge`: it lands itself when the required Linux checks
      pass. There is no way to move `main` except a green PR.
+  Anything that reads the canonical repo (the release script's post-merge
+  fast-forward and tag push, the kernel's update and drift probes) resolves the remote
+  as `upstream` when the clone has one, else `origin` (`_release_remote` in
+  `kernel/kernel.py`, `canonical_remote` in `scripts/release.sh`); never a literal
+  `origin`, which in a fork layout is a stale mirror nobody advances.
 - **Every PR carries exactly one tier label** (maintainers' rule, 2026-09-06). A
   required check holds a PR with no tier label, or two, red, so an unlabeled PR never
   auto-merges. The author picks the tier at filing time:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3766,11 +3766,30 @@ def _semver(tag):
     return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
 
 
+def _release_remote():
+    """The git remote that carries romp's releases and its main: `upstream` when the clone has one,
+    else `origin`. A bootstrap install clones the canonical repo directly, so `origin` IS it; a
+    maintainer's clone follows the fork convention (the user 2026-09-06: `origin` = their fork,
+    `upstream` = the canonical repo), where `origin/main` is a stale mirror nobody advances. Every
+    updater probe and walk below goes through this, so the rename could not point the release
+    check, the drift notice, or auto-converge's checkout at the fork. Unreadable remotes (not a
+    git checkout, git missing) resolve to `origin`, the plain-install answer."""
+    try:
+        out = subprocess.run(["git", "-C", str(ROOT), "remote"],
+                             capture_output=True, text=True, timeout=10)
+        if out.returncode == 0 and "upstream" in out.stdout.split():
+            return "upstream"
+    except Exception:
+        pass
+    return "origin"
+
+
 def _latest_release_tag():
-    """The newest release tag on the clone's `origin`, read from the REMOTE's refs (ls-remote) — never
-    from the local tag list, which says only what this clone last fetched (refs do not travel with
-    commits; _kernel_ver's lesson). Raises on any git/network failure so the caller can say so."""
-    r = subprocess.run(["git", "-C", str(ROOT), "ls-remote", "--tags", "origin"],
+    """The newest release tag on the clone's release remote (_release_remote), read from the REMOTE's
+    refs (ls-remote), never from the local tag list, which says only what this clone last fetched
+    (refs do not travel with commits; _kernel_ver's lesson). Raises on any git/network failure so
+    the caller can say so."""
+    r = subprocess.run(["git", "-C", str(ROOT), "ls-remote", "--tags", _release_remote()],
                        capture_output=True, text=True, timeout=20)
     if r.returncode != 0:
         raise RuntimeError((r.stderr or "git ls-remote failed").strip()[:200])
@@ -3839,8 +3858,8 @@ def _run_update(tag):
         "cd %s || exit 1\n" % q(str(ROOT))
         + "{ echo; echo \"== romp self-update to %s ==\"; date; } >> %s 2>&1\n" % (tag, log)
         + advance
-        + "if git fetch origin refs/tags/%s:refs/tags/%s >> %s 2>&1 && advance "
-          "&& ./install.sh >> %s 2>&1; then\n" % (tag, tag, log, log)
+        + "if git fetch %s refs/tags/%s:refs/tags/%s >> %s 2>&1 && advance "
+          "&& ./install.sh >> %s 2>&1; then\n" % (_release_remote(), tag, tag, log, log)
         + "  printf '%%s' %s > %s\n" % (q(json.dumps(ok_rep)), rep)
         + restart
         + "else\n"
@@ -3895,7 +3914,7 @@ def _update_check():
     try:
         latest = _latest_release_tag()
     except Exception as e:
-        sys.stderr.write("romp-kernel: update check could not read origin's tags: %s\n" % e)
+        sys.stderr.write("romp-kernel: update check could not read the release remote's tags: %s\n" % e)
         return
     lv = _semver(latest)
     if not lv or lv <= cur:
@@ -3963,9 +3982,10 @@ _MAIN_DRIFT = ["", ""]                 # [origin sha a notice fired for, checkou
 
 
 def _origin_main_sha():
-    """origin/main's commit (short), '' when unreachable — offline is a normal state, never a crash."""
+    """The release remote's main commit (short; `upstream/main` in a fork layout, else `origin/main`),
+    '' when unreachable: offline is a normal state, never a crash."""
     try:
-        out = subprocess.run(["git", "ls-remote", "origin", "refs/heads/main"],
+        out = subprocess.run(["git", "ls-remote", _release_remote(), "refs/heads/main"],
                              cwd=str(ROOT), capture_output=True, text=True, timeout=15)
         return (out.stdout.split() or [""])[0][:8]
     except Exception:
@@ -4347,22 +4367,23 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
         try:
             dirty = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
                                    capture_output=True, text=True, timeout=10).stdout.strip()
+            remote = _release_remote()
             if dirty:
-                _sync_notice("main moved at origin, but the romp checkout has uncommitted work — "
-                             "not touching it. Commit or stash it, then Update again.", ok=False)
+                _sync_notice("main moved at %s, but the romp checkout has uncommitted work, so it "
+                             "was left alone. Commit or stash it, then Update again." % remote, ok=False)
                 _MAIN_DRIFT[0] = ""                   # let the notice re-fire once the tree is clean
                 return
-            subprocess.run(["git", "fetch", "origin", "main"], cwd=str(ROOT),
+            subprocess.run(["git", "fetch", remote, "main"], cwd=str(ROOT),
                            capture_output=True, text=True, timeout=60)
-            r = subprocess.run(["git", "checkout", "--detach", "origin/main"], cwd=str(ROOT),
+            r = subprocess.run(["git", "checkout", "--detach", "%s/main" % remote], cwd=str(ROOT),
                                capture_output=True, text=True, timeout=30)
             if r.returncode != 0:
-                _sync_notice("main moved at origin, but advancing the checkout failed: %s"
-                             % (r.stderr or r.stdout or "").strip()[-200:], ok=False)
+                _sync_notice("main moved at %s, but advancing the checkout failed: %s"
+                             % (remote, (r.stderr or r.stdout or "").strip()[-200:]), ok=False)
                 _MAIN_DRIFT[0] = ""
                 return
         except Exception as e:
-            _sync_notice("main moved at origin, but the pull step failed: %s" % e, ok=False)
+            _sync_notice("main moved at %s, but the pull step failed: %s" % (_release_remote(), e), ok=False)
             _MAIN_DRIFT[0] = ""
             return
     if kind == "pull":

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,6 +44,20 @@ PYTEST="${ROMP_RELEASE_PYTEST:-}"         # overridable suite runner (tests); em
 POLL="${ROMP_RELEASE_POLL:-5}"            # seconds between checks while the run starts
 REF="${ROMP_RELEASE_REF:-main}"
 UPSTREAM="${ROMP_RELEASE_UPSTREAM:-romp-on/romp}"
+
+# Which git remote is the canonical repo, and which one takes the branch push. The convention
+# (the user 2026-09-06): in a clone with a fork, `origin` is the fork and `upstream` is the
+# canonical repo; a plain clone has only `origin`, which is then both. So the canonical remote
+# is `upstream` when the clone has one, else `origin`; the branch push goes to
+# `remote.pushDefault` when set, else `origin`.
+canonical_remote() {
+    if git remote get-url upstream >/dev/null 2>&1; then echo upstream; else echo origin; fi
+}
+publish_remote() {
+    local p
+    p="$(git config --get remote.pushDefault || true)"
+    printf '%s\n' "${p:-origin}"
+}
 skip_macos=0
 skip_tests=0
 dry_run=0
@@ -134,10 +148,7 @@ say "releasing $tag (VERSION currently reads $current)."
 if [ "$current" != "$target" ]; then
     # Branch pushes to the upstream are blocked by rulesets, so publishing is always
     # push-to-a-fork then PR. remote.pushDefault is the configured answer when there is one.
-    publish="$(git config --get remote.pushDefault || true)"
-    if [ -z "$publish" ]; then
-        if git remote get-url fork >/dev/null 2>&1; then publish=fork; else publish=origin; fi
-    fi
+    publish="$(publish_remote)"
     branch="release-$target"
     say "VERSION $current → $target, via a PR on $branch (pushing to '$publish')."
     if [ "$dry_run" -eq 1 ]; then
@@ -180,8 +191,12 @@ if [ "$current" != "$target" ]; then
         done
         [ "$state" = "MERGED" ] || die "the version PR did not merge — check $UPSTREAM."
         git switch "$REF" >/dev/null 2>&1 || die "could not switch back to $REF."
-        git fetch -q origin
-        git merge --ff-only "origin/$REF" >/dev/null || die "could not fast-forward $REF after the merge."
+        # The merge landed on the CANONICAL repo. With a fork layout that is `upstream`, not
+        # `origin`: reading `origin/main` there would fast-forward onto the fork's stale main
+        # (a no-op) and then tag a commit that never got the bump.
+        canonical="$(canonical_remote)"
+        git fetch -q "$canonical"
+        git merge --ff-only "$canonical/$REF" >/dev/null || die "could not fast-forward $REF after the merge."
         say "version PR merged; $REF now carries $target."
     fi
 else
@@ -282,9 +297,11 @@ prev="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
 step git tag -a "$tag" -m "romp $tag"
 say "created tag $tag."
 
-# The tag goes to the UPSTREAM: rulesets block branch pushes there, but a tag is how a
-# release is published, and a tag that exists only locally installs for nobody.
-step git push -q origin "$tag" || die "could not push $tag to origin."
+# The tag goes to the CANONICAL repo (`upstream` in a fork layout, else `origin`): rulesets
+# block branch pushes there, but a tag is how a release is published, and a tag that lands
+# only on the fork, or only locally, installs for nobody.
+canonical="$(canonical_remote)"
+step git push -q "$canonical" "$tag" || die "could not push $tag to $canonical."
 say "pushed $tag."
 
 if [ -n "$prev" ]; then

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -41,6 +41,8 @@ teardown() { rm -rf "$TEST_DIR"; }
 # STUB_FLAKY_VIEWS = report nothing for the first N `run view` calls, as a transient API
 # error looks to the poll loop, then the real conclusion.
 # STUB_PR_STATE = what `gh pr view` reports (default MERGED).
+# STUB_MERGE_REMOTE = the remote the simulated merge lands on (default origin; a fork layout
+# names its canonical remote `upstream`).
 _stub_gh() {
     cat > "$TEST_DIR/gh" <<STUB
 #!/usr/bin/env bash
@@ -61,7 +63,7 @@ case "\$1 \$2" in
   # every later call by that number (a fork-headed branch is unresolvable by name — see below).
   "pr create")  echo "https://github.com/romp-on/romp/pull/4242" ;;
   "pr merge")   if [ "\${STUB_PR_STATE:-MERGED}" = "MERGED" ]; then
-                    git -C "$REPO" push -q origin HEAD:main
+                    git -C "$REPO" push -q "\${STUB_MERGE_REMOTE:-origin}" HEAD:main
                 fi ;;
   "pr view")    echo "\${STUB_PR_STATE:-MERGED}" ;;
 esac
@@ -232,6 +234,28 @@ STUB
     # the tag really reached the remote — a local-only tag installs for nobody
     run git -C "$TEST_DIR/origin.git" tag -l
     [ "$output" = "v0.1.0" ]
+}
+
+@test "release: a fork layout pushes the branch to origin, and reads main + pushes the tag at upstream" {
+    # The remote convention (the user 2026-09-06): `origin` is the fork, `upstream` the canonical
+    # repo. The version PR merges on the canonical repo, so the post-merge fast-forward must read
+    # upstream/main: origin/main is the fork's stale main, and fast-forwarding onto it silently
+    # tags a commit that never got the bump. And the tag must land where installs look for it.
+    _stub_gh
+    git init -q --bare "$TEST_DIR/upstream.git"
+    git -C "$REPO" remote add upstream "$TEST_DIR/upstream.git"
+    git -C "$REPO" push -q upstream main
+    export STUB_MERGE_REMOTE=upstream
+    run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -eq 0 ]
+    # the version branch went to the fork (origin: no pushDefault set here)
+    run git -C "$TEST_DIR/origin.git" branch --list release-0.2.0
+    [[ "$output" == *"release-0.2.0"* ]]
+    # local main was fast-forwarded from the canonical repo, so the tagged tree carries the bump
+    [ "$(cat "$REPO/VERSION")" = "0.2.0" ]
+    # the tag reached the canonical repo, and never the fork
+    [ "$(git -C "$TEST_DIR/upstream.git" tag -l)" = "v0.2.0" ]
+    [ -z "$(git -C "$TEST_DIR/origin.git" tag -l)" ]
 }
 
 @test "release: notes start at the PREVIOUS tag, never at the one being cut" {

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -355,7 +355,12 @@ class CheckLoop(Fresh):
 class RunUpdate(Fresh):
     def test_detached_child_lands_on_the_tag_installs_reports_and_restarts_only_on_success(self):
         calls = []
+        # The release remote is pinned: this test's Popen seam swallows every subprocess, the
+        # resolver's `git remote` included, and the real checkout's layout (a maintainer's clone
+        # has `upstream`) must not decide what a plain-install script says. The resolver has its
+        # own tests (test_main_drift_notice.ReleaseRemote).
         with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append((a, kw))), \
+             mock.patch.object(km, "_release_remote", return_value="origin"), \
              mock.patch.dict(km.os.environ, {"ROMP_MANAGER_PORT": "7777"}):
             self.assertTrue(km._run_update("v0.7.0"))
         (a, kw), = calls
@@ -615,8 +620,11 @@ class ReleaseChannelMigration(unittest.TestCase):
                 pass
         calls = []
         env = {**os.environ, "ROMP_MANAGER_PORT": ""}            # no manager → no restart leg
+        # The install clones its bare `origin` directly, the plain layout; the resolver would say
+        # so, but the Popen seam below swallows its `git remote` too, so it is pinned here.
         with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append(a)), \
              mock.patch.object(km, "ROOT", Path(inst)), \
+             mock.patch.object(km, "_release_remote", return_value="origin"), \
              mock.patch.dict(km.os.environ, env, clear=True):
             km._UPDATE_STATE[0] = ""
             self.assertTrue(km._run_update(tag))

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -24,6 +24,45 @@ SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_drift", os.path.join(BIN, "romp-kernel")).load_module()
 
 
+class ReleaseRemote(unittest.TestCase):
+    """_release_remote picks the remote the updater reads. The remote convention (the user
+    2026-09-06) makes a maintainer's `origin` their FORK, whose main nobody advances: an updater
+    still reading a literal `origin` would report the fork's stale main as the truth and, in auto
+    mode, walk the checkout backwards onto it. A plain bootstrap install has only `origin`, which
+    IS the canonical repo. Throwaway repos; no network."""
+
+    def _repo_with_remotes(self, *names):
+        import subprocess
+        d = tempfile.mkdtemp()
+        subprocess.run(["git", "init", "-q", d], check=True)
+        for n in names:
+            subprocess.run(["git", "-C", d, "remote", "add", n, "https://example.invalid/%s.git" % n], check=True)
+        return d
+
+    def _resolve_in(self, root):
+        from pathlib import Path
+        saved = km.ROOT
+        km.ROOT = Path(root)
+        try:
+            return km._release_remote()
+        finally:
+            km.ROOT = saved
+
+    def test_a_fork_layout_reads_upstream(self):
+        self.assertEqual(self._resolve_in(self._repo_with_remotes("origin", "upstream")), "upstream")
+
+    def test_a_plain_install_reads_origin(self):
+        self.assertEqual(self._resolve_in(self._repo_with_remotes("origin")), "origin")
+
+    def test_no_git_checkout_falls_back_to_origin(self):
+        self.assertEqual(self._resolve_in(tempfile.mkdtemp()), "origin")
+
+    def test_every_updater_probe_and_walk_goes_through_it(self):
+        for fn in (km._latest_release_tag, km._origin_main_sha, km._run_main_update, km._run_update):
+            self.assertIn("_release_remote()", inspect.getsource(fn), fn.__name__)
+            self.assertNotIn('"origin"', inspect.getsource(fn), "%s still names a literal origin" % fn.__name__)
+
+
 class DriftVerdict(unittest.TestCase):
     def test_origin_ahead_of_the_checkout_wants_a_pull(self):
         self.assertEqual(km._main_drift_verdict("aaaa1111", "bbbb2222", "bbbb2222"), ("pull", "aaaa1111"))
@@ -59,7 +98,9 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('"status", "--porcelain"', src)
         self.assertIn("uncommitted work", src, "the refusal names the real problem")
         self.assertIn('_MAIN_DRIFT[0] = ""', src, "the notice re-fires once the tree is clean")
-        self.assertIn('"checkout", "--detach", "origin/main"', src, "advance is the repo's own convention")
+        self.assertIn('"checkout", "--detach", "%s/main" % remote', src, "advance is the repo's own convention")
+        self.assertIn("remote = _release_remote()", src,
+                      "the walk targets the RELEASE remote, never a literal origin (a fork layout's stale mirror)")
 
     def test_every_converge_is_immediate_by_default_and_quiet_stays_expressible(self):
         # T160 (the user 2026-08-28): deploys cut in-flight turns NOW — auto converge included.


### PR DESCRIPTION
The remote convention (2026-09-06): in a clone with a fork, `origin` is the fork and `upstream` is romp-on/romp; a plain install has only `origin`. Three consumers still read a literal `origin` as the canonical repo, and on a renamed clone each pointed at the fork's main, a mirror nobody advances.

- **kernel**: the release-tag probe, the main-drift probe, the detached update script's tag fetch, and auto-converge's fetch + checkout. In auto mode the converge would have walked the checkout backwards onto the fork's stale main. A `_release_remote()` helper (`upstream` if present, else `origin`) feeds all of them; the drift notices name the remote they read.
- **scripts/release.sh**: the post-merge fast-forward read `origin/main`, a no-op against the fork, and then tagged a commit that never got the bump; the tag was pushed to `origin`, so it never reached the repo installs read. Both resolve `canonical_remote()`; the branch push resolves `publish_remote()` (`remote.pushDefault`, else `origin`) and the old `fork` probe is gone.
- **CLAUDE.md**: the publish recipe says `origin`/`upstream` and states the rule.

Tests: a fork-layout bats case (bare origin + bare upstream, the merge lands upstream) is red on the previous script. `ReleaseRemote` unit tests cover the resolver and pin every updater site to it. The two seam-based update tests pin the plain layout explicitly, so a maintainer's checkout cannot decide what a plain-install script says.

Tier: fix (a bug fix with tests that fail before it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)