### PR TITLE
Docs: the postal hook and skill teach send_message's kind parameter; the set_model/set_effort contract says which backend can refuse a change

### DIFF
--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -10,7 +10,7 @@ Only applies inside a romp session (a tmux session tagged `@romp`, or an SDK-bac
 
 ## Tools
 
-Message sibling sessions with the postal MCP tools (each tool's own description carries the specifics): `send_message(to, body)`, `check_inbox()`, `list_agents()`, `set_working(text)`, `check_sent()`, `recall_message(to, id?)`. Inbox is also delivered automatically at each turn's end, so you rarely call `check_inbox` yourself.
+Message sibling sessions with the postal MCP tools (each tool's own description carries the specifics): `send_message(to, body, kind)`, `check_inbox()`, `list_agents()`, `set_working(text)`, `check_sent()`, `recall_message(to, id?)`. Inbox is also delivered automatically at each turn's end, so you rarely call `check_inbox` yourself.
 
 Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving. A session's stable id (the uuid `list_agents` shows) also works as the recipient — rename-proof, unique by construction, so it never hits the shared-name ambiguity refusal.
 
@@ -18,7 +18,7 @@ Role-named recipients go stale: a role handed to a new session keeps the OLD nam
 
 Names are not guaranteed unique. If more than one live session answers to the one you used, the send is refused and the candidates are listed as `host:name`: pick one and resend. Your own name is refused outright, since a message there arrives in your own inbox looking exactly like a reply from someone else. Your row in `list_agents` is the one marked `(you)`.
 
-From the shell (also how the human drives it): `romp mail send <name> "<text>"`, `romp mail inbox|agents|sent`, `romp mail working "<note>"`, `romp mail recall <name> [id]`.
+From the shell (also how the human drives it): `romp mail send --kind delegate|coordinate|question <name> "<text>"`, `romp mail inbox|agents|sent`, `romp mail working "<note>"`, `romp mail recall <name> [id]`.
 
 ## On a remote machine
 
@@ -29,7 +29,7 @@ If you SSH'd into another machine and are running romp there, run `romp mail rem
 **Keep it tight.** Message a peer only for something substantive: a question you need answered, information they need, or a result worth sharing. A message wakes the recipient and costs it a turn, so never send just to acknowledge, and stop once the exchange is done.
 
 **Write so the recipient can act from your first line** (they share none of your context):
-- Lead with `DELEGATE:` (you own this now, reply only to clarify), `COORDINATE:` (aligning or heads-up, reply optional), or `QUESTION:` (reply required).
+- Set `kind` to `delegate` (the recipient owns this now; reply only to clarify), `coordinate` (aligning or a heads-up; reply optional), or `question` (reply required).
 - First sentence is the whole point: the ask or conclusion, not how you got there. Context after, only what they need to act.
 - Name things exactly: files by path, sessions by name, the same term each time. Mark verified vs. suspected, and whose ask it is.
 - End with the reply you need, or that none is. One point per message; when brevity and clarity conflict, clarity wins.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -182,11 +182,13 @@ code {dir}                          # VS Code instead
 
 ### Model and effort, from the statusline or a typed command
 
-Typing `/model X`, `/effort X`, or `/fast on|off` into the chat composer, or
-sending one with `romp send`, is the same setting change as a pick from the
-statusline's model and effort dropdowns: the kernel takes it through its own
-setters, so what it remembers (the value a reconnect relaunches with, the
-defaults new sessions start from) follows the switch. A bare `/model` (the
+Typing `/model X` or `/effort X` into the chat composer, or sending one with
+`romp send`, is the same setting change as a pick from the statusline's model
+and effort dropdowns: the kernel takes it through its own setters, so what it
+remembers (the value a reconnect relaunches with, the defaults new sessions
+start from) follows the switch. A typed `/fast on|off` goes through the same
+setters and matches a pick from the fast badge the next section describes, a
+separate toggle rather than one of the two dropdowns. A bare `/model` (the
 CLI's own picker), a value the kernel cannot vouch for (a typo), or a longer
 message that merely opens with the command goes to the CLI verbatim, and the
 chat shows the CLI's own reply.

--- a/hooks/romp-postal-context.sh
+++ b/hooks/romp-postal-context.sh
@@ -10,7 +10,7 @@
 [ "$(tmux show -v @romp 2>/dev/null)" = "1" ] || exit 0
 read -r -d '' CTX <<'TXT'
 You're in a romp session with sibling sessions you can message: use the postal MCP tools (send_message, list_agents, set_working, check_inbox, check_sent, recall_message) or `romp mail`. Each tool's description carries its norms. Two to know up front:
-- Message a peer only for something substantive (it wakes them and costs a turn), leading with DELEGATE:/COORDINATE:/QUESTION: and the whole point in the first sentence.
+- Message a peer only for something substantive (it wakes them and costs a turn); set `kind` to delegate, coordinate, or question, and put the whole point in the first sentence.
 - BEFORE editing shared files, run list_agents and check peers' branches + working-notes to avoid collisions (overlap only collides on the same branch); publish yours with set_working.
 For the full guide (shell CLI, remote-machine tunnel setup, coordination detail), invoke the romp-postal skill.
 TXT

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -125,8 +125,16 @@ class SessionBackend(ABC):
         into the pane and presses Enter once more to accept the confirmation the CLI asks for
         (TmuxBackend.set_model, `_tmux_send(model_cmd=True)`): the dashboard cannot press it in the pane,
         and the next send's clear-guard would refuse to paste over the open dialog.
-        False when it can't be applied (unknown sid, bad value) so the kernel can be loud instead of
-        pretending."""
+        False when the backend can tell the change did not land, so the kernel can be loud instead of
+        pretending. The SDK and Codex refuse an unknown sid (no registry row, no session); Codex refuses a
+        model outside its engine; the SDK's own writes are optimistic (True at once, every layer reverted
+        when the CLI refuses the value live — SdkSession._do_set_model). The tmux side cannot tell: the
+        command is pasted into the pane from a daemon thread whose delivery failures land on stderr
+        (`_tmux_send`), and a bad value is answered by the CLI in the pane, so TmuxBackend.set_model
+        returns True unconditionally and the caller vouches for the value first — _route_meta_command
+        checks it against the kernel's catalog (_vouched_model) and the pickers offer only catalog rows;
+        POST /new passes its model through verbatim by design, so a typo there reaches the pane and the
+        CLI answers it there."""
 
     @abstractmethod
     def set_mode(self, sid: str, mode: str) -> bool:
@@ -140,8 +148,13 @@ class SessionBackend(ABC):
         at once if the session is idle, at the end of the turn if it's busy — with `effortPending` driving
         the badge's switching-dots and the chat's "Reloading session…" notice (SdkBackend.set_effort). tmux
         types '/effort X' into the pane, which the TUI applies in place: no reconnect, no confirmation, so
-        no second Enter (TmuxBackend.set_effort). False when it can't be applied (unknown sid, bad value)
-        so the kernel can be loud instead of pretending."""
+        no second Enter (TmuxBackend.set_effort). False when the backend can tell the change did not land,
+        so the kernel can be loud instead of pretending: the SDK refuses an unknown sid or a value outside
+        EFFORT_LEVELS, Codex a level its engine lacks. tmux cannot tell (it types the command; the TUI
+        answers a bad value in the pane), so TmuxBackend.set_effort returns True unconditionally and the
+        caller vouches for the value first — _route_meta_command checks _EFFORT_VALUES and the picker
+        offers only those; POST /new passes its effort through verbatim by design, so a typo there reaches
+        the pane and the CLI answers it there."""
 
     @abstractmethod
     def set_fast(self, sid: str, value: str) -> bool:

--- a/tests/romp-postal-context.bats
+++ b/tests/romp-postal-context.bats
@@ -29,7 +29,11 @@ teardown() { rm -rf "$TEST_DIR"; }
     [[ "$output" == *'"additionalContext"'* ]]
     [[ "$output" == *'"hookEventName": "SessionStart"'* ]]
     [[ "$output" == *'postal MCP tools'* ]]
-    [[ "$output" == *'DELEGATE'* ]]        # the lead-with-intent norm is present up front
+    # the declare-your-intent norm is present up front — as send_message's REQUIRED `kind` parameter, never
+    # the retired DELEGATE:/COORDINATE:/QUESTION: body prefix the hook used to teach beside it (two
+    # instructions for one fact). The negative pin is deliberate: the prefix must not come back.
+    [[ "$output" == *'set `kind` to delegate, coordinate, or question'* ]]
+    [[ "$output" != *'DELEGATE'* ]]
     [[ "$output" == *'list_agents'* ]]     # the coordinate-before-editing norm is present up front
     [[ "$output" == *'romp-postal skill'* ]]   # points to the full guide, not inlined
 }


### PR DESCRIPTION
Two prose-only corrections, one commit each. No behavior change: a hook's heredoc text, a skill, two abstract docstrings, one paragraph of the reference, and a bats pin.

## 1. The postal hook and skill teach `send_message`'s `kind` parameter, not the retired body prefix

**What is wrong.** `send_message`'s `kind` parameter is required (`postal/postal_service.py`: the tool schema has `"required": ["to", "body", "kind"]` with enum `delegate|coordinate|question`), and the MCP server's own instructions say to declare the message kind via that parameter. But the SessionStart hook (`hooks/romp-postal-context.sh`) told a session to lead the body with `DELEGATE:/COORDINATE:/QUESTION:`, and the romp-postal skill (`claude/skills/romp-postal/SKILL.md`) did the same, listed the tool as `send_message(to, body)`, and showed the shell form without `--kind`. The kernel's intent reader documents the leading body token as the old scheme, kept working as a fallback (`kernel/kernel.py`, `_postal_intent`), so a session following the hook wrote a prefix nothing reads as the kind and still had to supply `kind` for the call to be accepted: two instructions for one fact, one of them retired.

**Reproduction.** In a romp tmux session (`@romp` set), the hook's `additionalContext` contains "leading with DELEGATE:/COORDINATE:/QUESTION:". At this PR's base, `bats tests/romp-postal-context.bats` with the new assertions fails test 1 on the `set \`kind\`` check, and with that check removed fails it on `!= *'DELEGATE'*`.

**The change** (three files, text only):
- The hook's bullet now reads: set `kind` to delegate, coordinate, or question, and put the whole point in the first sentence.
- The skill's Norms bullet says the same with the three meanings; its tool signature is `send_message(to, body, kind)`; its shell form is `romp mail send --kind delegate|coordinate|question <name> "<text>"`, the form the delivered reply hint already uses.
- `tests/romp-postal-context.bats` asserts the new wording and that `DELEGATE` is absent from the emitted `additionalContext`.

Two design points. The shell CLI accepts `--kind` as optional (its usage line brackets it); the skill teaches it as the norm on purpose, matching the reply hint and the MCP tool's requirement, so an agent gets one rule whichever door it uses. The negative pin is deliberate: a future hook edit that mentions `DELEGATE` (a compatibility note, say) fails the test, and the test comment says so.

Deliberately unchanged: the courier judge prompt (`kernel/judge.py`) still treats a `DELEGATE:/COORDINATE:/QUESTION:` lead word as a hint for mail that arrives without a declared kind, and the test fixtures that put the prefix in message bodies exercise that compatibility path. This PR only stops teaching the prefix.

## 2. The setter contract says which backend can refuse a change; the reference puts a typed `/fast` under the fast badge

Follow-up to the two wording notes on #950's merge comment.

**`kernel/session_backend.py`.** `SessionBackend.set_model` and `set_effort` promised False for an unknown sid or a bad value, but only some implementers can say so. The docstrings now state the split, checked against each implementer:
- `SdkBackend.set_model` returns False for an unknown sid only; a bad value is written optimistically (True at once) and every layer is reverted when the CLI refuses it live (`_do_set_model`). `SdkBackend.set_effort` refuses an unknown sid and a value outside `EFFORT_LEVELS`.
- `CodexBackend` refuses an unknown sid, a model outside its engine, and a Claude-only effort level.
- `TmuxBackend.set_model` and `set_effort` return True unconditionally. They paste the CLI's own command into the pane from a daemon thread (`_tmux_send`) whose delivery failures land on stderr, and the TUI answers a bad value in the pane, so the setter cannot tell. The caller vouches for the value first: `_route_meta_command` checks `_vouched_model` and `_EFFORT_VALUES`, the pickers offer only catalog rows, and POST /new passes model and effort through verbatim by design (its docstring says so), so a typo there is answered by the CLI in the pane.

The True return of the tmux setters is pinned by `tests/test_kernel_pane_clear.py` and is unchanged: this documents the split, as #950 chose, rather than aligning it. Making the tmux setters report a failed paste would need a synchronous probe of the pane, a behavior change for its own PR. `set_fast`'s clause is left as it was (tmux does refuse a bad value there), and `kernel/kernel.py` is not touched.

**`docs/reference.md`**, "Model and effort, from the statusline or a typed command": a typed `/fast on|off` was listed as equal to a pick from the model and effort dropdowns; the fast toggle is the separate badge the next section describes. The sentence now names `/model` and `/effort` for the dropdowns and says a typed `/fast` goes through the same setters and matches a pick from that badge. The second paragraph (tmux `/effort` and `/fast` apply in place) was accurate and is unchanged.

## Verification

- `bats --print-output-on-failure tests/romp-postal-context.bats`: with the new assertions against the unfixed hook, test 1 fails at the `set \`kind\`` line; with that line removed, at `!= *'DELEGATE'*`; with the hook change, 3/3 pass.
- `bats --print-output-on-failure tests/*.bats` (CI's Shell job command): 429/429.
- `pytest -n 8 tests`: 7583 passed, 50 skipped.
- The three tests that read `SKILL.md` text (`tests/test_postal_native_steering.py`, `tests/test_postal_live_only.py`, `tests/test_kernel_postal_isolation_routes.py`): 33 passed.
- `tests/test_session_api.py` (docstring word pins control/reconnect/connect), `tests/test_kernel_pane_clear.py` (tmux call shape, True return) and `tests/test_sdk_kernel.py::KernelWiring`: pass.
- `kernel/session_backend.py` compiles to the same 34 code objects at base and head with docstrings stripped (bytecode, names, varnames and non-docstring constants identical).
- `mkdocs build --strict`: exit 0 (PR CI does not build docs; docs.yml runs on push to main).
- `git diff --check` clean; `grep -E 'DELEGATE:|COORDINATE:|QUESTION:' hooks/romp-postal-context.sh claude/skills/romp-postal/SKILL.md` returns nothing.
- macOS: CI runs bats on Linux by default. The hook's runtime constructs (the `read -r -d ''` heredoc, the `tmux show -v @romp` gate, the python3 JSON emitter) are unchanged; the change is heredoc text and bash `[[ == *pattern* ]]` / `!=` comparisons the same test already uses on both OSes. No UI or Node surface is touched.

Tier: tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)