### PR TITLE
Tests: the relay-honesty disk-twin test seeds its own state directory, and six follow-ups the #941–#957 reviews named

### DIFF
--- a/tests/romp-cli-scope.bats
+++ b/tests/romp-cli-scope.bats
@@ -154,8 +154,9 @@ SH
 # The pre-flight is bounded (2026-09-05): `timeout 10 systemd-run … -- true` when coreutils' timeout is
 # on PATH. A user bus that accepts the connection and never answers would otherwise hold systemd-run
 # for its own 90 s default, past the SDK's 60 s initialize timeout, so the fallback never engaged in the
-# case it was added for. The fake systemd-run below sleeps on the pre-flight only; the wrapper must fall
-# back well inside that sleep, and the CLI's own launch must not run through timeout.
+# case it was added for. The fake systemd-run below sleeps on the pre-flight only, so the no-timeout test
+# can show an unbounded pre-flight that completes; the bound itself is proven with a fake timeout that
+# exits 124.
 _preflight_sleeps() {   # $1: seconds the fake systemd-run sleeps on a `-- true` pre-flight, then exits 0
     cat > "$BIN/systemd-run" <<SH
 #!/bin/sh
@@ -182,23 +183,27 @@ SH
     chmod +x "$BIN/timeout"
 }
 
-@test "a pre-flight that hangs is cut off at 10 s and the CLI falls back to a direct run" {
-    # without coreutils' timeout(1) (macOS) the wrapper runs the pre-flight unbounded, by design (the
-    # test after the next one), so the 10 s bound is not there to check
-    command -v timeout >/dev/null 2>&1 || skip "no timeout(1) on this box"
-    _preflight_sleeps 20
+@test "a pre-flight that hits the 10 s bound (timeout exits 124) falls back to a direct run" {
+    # coreutils' timeout exits 124 when the bound is hit; a fake that says so at once covers the wrapper's
+    # branch in milliseconds, where a real 20 s sleeper and a 9-16 s wall-clock window could miss on a
+    # loaded runner. The fake IS the timeout(1) the wrapper finds, so this runs on a box without one too.
+    export TIMEOUT_LOG="$TEST_DIR/timeout.calls"
+    cat > "$BIN/timeout" <<'SH'
+#!/bin/sh
+echo "$*" >> "$TIMEOUT_LOG"
+exit 124
+SH
+    chmod +x "$BIN/timeout"
     ERR="$TEST_DIR/stderr"
-    t0="$(date +%s)"
     run sh -c '"$0" --input-format stream-json 2>"$1"' "$WRAPPER" "$ERR"
-    t1="$(date +%s)"
     [ "$status" -eq 0 ]
-    [ $((t1 - t0)) -ge 9 ]
-    [ $((t1 - t0)) -lt 16 ]
-    # the CLI ran, directly: systemd-run was tried once (the pre-flight), never for the CLI itself
+    # the bound was asked for once, with the pre-flight behind it; systemd-run itself never ran — not for
+    # the pre-flight (the fake cut it) and not for the CLI (it ran directly)
+    [ "$(wc -l < "$TIMEOUT_LOG")" -eq 1 ]
+    [ "$(cat "$TIMEOUT_LOG")" = "10 systemd-run --user --scope --quiet --collect -- true" ]
+    [ ! -e "$FAKE_CALLS" ]
     [[ "$output" == *"REAL pid="* ]]
     [ "$(printf '%s\n' "$output" | grep '^ARG:')" = "$(printf 'ARG:%s\n' --input-format stream-json)" ]
-    [ "$(wc -l < "$FAKE_CALLS")" -eq 1 ]
-    [[ "$(cat "$FAKE_CALLS")" == *"-- true" ]]
     # one stderr line, the fallback form, naming the bound as the reason
     [ "$(wc -l < "$ERR")" -eq 1 ]
     grep -q '^romp-cli-scope: fallback: ' "$ERR"

--- a/tests/test_model_versions.py
+++ b/tests/test_model_versions.py
@@ -459,7 +459,10 @@ class LearnedVersions(_ModelsServer):
         self._reg("11111111-2222-3333-4444-555555555501", liveModelId="claude-opus-5-1")
         self._reg("11111111-2222-3333-4444-555555555502", liveModelId="claude-sonnet-5-1")
         self._reg("11111111-2222-3333-4444-555555555503", liveModelId="claude-haiku-5")
-        first = km._learned_versions()
+        with self._counting_reg_reads() as cold:
+            first = km._learned_versions()
+        self.assertEqual(sorted(cold), ["11111111-2222-3333-4444-5555555555%02d.json" % n for n in (1, 2, 3)],
+                         "the cold scan reads each reg once — so the counter below is proven to see reads")
         self.assertEqual(sorted(first), ["haiku", "opus", "sonnet"])
         with self._counting_reg_reads() as reads:
             second = km._learned_versions()

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -277,6 +277,12 @@ class PresenceBlinkHonesty(_RelayBase):
         super().setUp()
         pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False
         pm._PRESENCE_SERVE_WARNED[0] = False
+        # serve() creates the postal state directory before any listing is read; these tests drive
+        # _local_presence without it, and the twin's write failure is swallowed by design, so without
+        # this the first answered read leaves no twin and the disk-twin test depends on whether an
+        # earlier test in the same process made the directory (the relay ack tests do, through
+        # peer_seen_add) — red when selected alone or on an xdist worker that had not run one of them
+        pm._PRESENCE_GOOD_FILE.parent.mkdir(parents=True, exist_ok=True)
         pm._PRESENCE_GOOD_FILE.unlink(missing_ok=True)
 
     def test_unanswered_serves_the_last_answered_rows(self):
@@ -306,6 +312,7 @@ class PresenceBlinkHonesty(_RelayBase):
         # authoritative emptiness — the disk twin primes it
         _set_live([{"id": ALPHA, "name": "web"}])
         pm._local_presence()                                     # answered → disk twin written
+        self.assertTrue(pm._PRESENCE_GOOD_FILE.exists(), "an answered read writes the disk twin")
         pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False   # a fresh bus process
         os.environ.pop("ROMP_SESSIONS_FILE", None)
         pm.KERNEL_BASE = "http://127.0.0.1:9"

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -16,7 +16,8 @@ Covers the backend half:
   * drain — the SIGTERM path stops every running session, counts in-flight turns, and writes NO
     idle/waiting state (the trailing 'working' IS the next boot's resume marker).
 
-All deterministic: no SDK import, no real claude processes (ps/os.kill are patched).
+All deterministic: no SDK import, no real claude processes (ps/os.kill are patched) — except PsArgv's
+two real-ps tests, Linux-only, which run the machine's ps against a sleeper child they spawn and kill.
 """
 import json
 import os

--- a/tests/test_session_move_live.py
+++ b/tests/test_session_move_live.py
@@ -31,6 +31,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 SID = "aaaaaaaa-1111-4222-8333-444444444444"
 CODEWORD = "PLUM-FORTY-TWO"
@@ -171,6 +172,52 @@ class UserApiKeyHelper(unittest.TestCase):
             shutil.rmtree(td, ignore_errors=True)
 
 
+class ApiKeyHelperPrecedence(unittest.TestCase):
+    """The helper the hermetic settings get (always-run; the live class stays opt-in): the explicit
+    $ROMP_MOVE_LIVE_API_KEY_HELPER wins; else the command borrowed from $CLAUDE_CONFIG_DIR/settings.json;
+    else from ~/.claude/settings.json; "" when none names one. HOME and CLAUDE_CONFIG_DIR point at temp
+    dirs throughout, so nothing here reads the operator's own settings."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp(prefix="romp-move-live-prec-")
+        self.addCleanup(shutil.rmtree, self.td, ignore_errors=True)
+
+    def _settings(self, sub, helper):
+        d = os.path.join(self.td, sub)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "settings.json"), "w") as f:
+            json.dump({"apiKeyHelper": helper}, f)
+        return d
+
+    def test_explicit_env_var_wins_over_the_borrowed_command(self):
+        cfg = self._settings("cfg", "/opt/example/borrowed --print")
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": cfg,
+                                          "ROMP_MOVE_LIVE_API_KEY_HELPER": "/opt/example/explicit"}):
+            self.assertEqual(_api_key_helper(), "/opt/example/explicit")
+
+    def test_without_the_env_var_the_borrowed_command_is_used(self):
+        cfg = self._settings("cfg", "/opt/example/borrowed --print")
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": cfg}):
+            os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            self.assertEqual(_api_key_helper(), "/opt/example/borrowed --print")
+            self.assertEqual(_user_api_key_helper(), "/opt/example/borrowed --print", "no argument: $CLAUDE_CONFIG_DIR")
+
+    def test_the_default_dir_is_dot_claude_under_home(self):
+        home = os.path.join(self.td, "home")
+        self._settings("home/.claude", "/opt/example/home-helper")
+        with mock.patch.dict(os.environ, {"HOME": home}):
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            self.assertEqual(_user_api_key_helper(), "/opt/example/home-helper")
+            self.assertEqual(_api_key_helper(), "/opt/example/home-helper")
+
+    def test_empty_when_nothing_names_a_helper(self):
+        with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "empty"),
+                                          "CLAUDE_CONFIG_DIR": os.path.join(self.td, "absent")}):
+            os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
+            self.assertEqual(_api_key_helper(), "")
+
+
 @unittest.skipIf(_skip_reason(), _skip_reason())
 class LiveSetCwd(unittest.TestCase):
     def test_set_cwd_relocates_and_the_conversation_survives(self):
@@ -193,6 +240,9 @@ class LiveSetCwd(unittest.TestCase):
                 f.write(CHILD)
             r = subprocess.run([_sdk_python(), child, cfg, a, b, cli, SID, CODEWORD, spath],
                                capture_output=True, text=True, timeout=300, env=env, cwd=td)
+            # a failure embeds the child's stderr, which can carry the apiKeyHelper's own diagnostics (never
+            # a key: the helper's output is not read here) — read a failing run's message with that in mind
+            # before pasting it anywhere
             self.assertEqual(r.returncode, 0, "child failed:\n%s\n%s" % (r.stdout[-2000:], r.stderr[-4000:]))
             res = json.loads(r.stdout.strip().splitlines()[-1])
             self.assertTrue(res["has_sender"], "the SDK still exposes _send_control_request")

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -85,9 +85,16 @@ function assertPending(unit: El): void {
   assert.ok(dots!.childNodes.every((c) => c instanceof El && c.tagName === "i" && c.className === "fileview-dot"));
   assert.ok(unit.childNodes.indexOf(dots!) < unit.childNodes.indexOf(ctl), "dots before the button, as the caption will be");
 }
+// The module with its poster bound ONCE for this file: every initFileView call adds another romp:wsup
+// (and message) listener on the shared window, so binding per test would make the re-ask count below
+// equal the number of tests run so far — which is why it could only be asserted as "at least one".
+let bound: Promise<typeof import("./file-view")> | null = null;
+function view(): Promise<typeof import("./file-view")> {
+  if (!bound) bound = import("./file-view").then((fv) => { fv.initFileView((m) => posted.push(m)); return fv; });
+  return bound;
+}
 async function mountAndAnswer(url: string, reason: string): Promise<El> {
-  const fv = await import("./file-view");
-  fv.initFileView((m) => posted.push(m));
+  const fv = await view();
   const unit = fv.githubLinkAction.mount({ path: "/tmp/notes-api/src/app.py", sid: null }) as unknown as El;
   assertPending(unit);
   const ask = posted[posted.length - 1];
@@ -150,8 +157,7 @@ test("state 3 — a URL whose branch is not on origin: a dashed anchor with the 
 });
 
 test("a reply for an older open lands nowhere — the newer open keeps waiting for its own", async () => {
-  const fv = await import("./file-view");
-  fv.initFileView((m) => posted.push(m));
+  const fv = await view();
   const ctx = { path: "/tmp/notes-api/src/app.py", sid: null };
   const first = fv.githubLinkAction.mount(ctx) as unknown as El;
   const firstReq = posted[posted.length - 1].reqId;
@@ -170,8 +176,7 @@ test("a socket drop while the ask is out: the reconnect re-asks with the same re
   // the frame went and nothing re-sends it, so the reply is lost and the placeholder would pulse for
   // the rest of the open. The shim's romp:wsup (its RECONNECT event; the first connect fires none) is
   // the re-ask's trigger — an event, not a timer, as the browse overlay does.
-  const fv = await import("./file-view");
-  fv.initFileView((m) => posted.push(m));
+  const fv = await view();
   const unit = fv.githubLinkAction.mount({ path: "/tmp/notes-api/src/app.py", sid: null }) as unknown as El;
   const reqId = posted[posted.length - 1].reqId;
   const before = posted.length;
@@ -179,7 +184,7 @@ test("a socket drop while the ask is out: the reconnect re-asks with the same re
   assertPending(unit);     // the drop alone changes nothing: the answer may still come
   win.dispatchEvent(new Event("romp:wsup"));
   const again = posted.slice(before);
-  assert.ok(again.length >= 1, "the return re-asks");
+  assert.equal(again.length, 1, "exactly one re-ask per reconnect: one listener, one pending ask");
   assert.ok(again.every((m) => m.type === "fileGitLink" && m.reqId === reqId && m.path === "/tmp/notes-api/src/app.py"),
     "the same question, same reqId: a late first reply and the second are one answer");
   win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId, url: "", reason: "not committed (staged only)" } }));

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -6,7 +6,8 @@
 // on this socket with no resync between them — a single keepalive can be a beat that was already queued
 // when the socket was accepted), by the reconnected socket CLOSING before it, or by the shim ABANDONING it
 // as quiet before it (the watchdog's tick or the foreground path: a socket the kernel accepted and never
-// spoke on — abandon() disowns its onclose, so it runs the close rule itself), and by nothing else — no
+// spoke on — abandon() disowns its onclose, so it runs the close rule itself; the why names the path that
+// ARMED, reconnect-quiet or foreground-quiet), and by nothing else — no
 // timer (every scenario runs the pending timers afterwards and asserts nothing fired, and asserts no timer
 // is armed on open; the watchdog's interval is captured and ticked by hand); the first non-keepalive frame
 // retires it; a keepalive never reaches the bundle. Also run here: the close breadcrumbs (one `wsclose` per
@@ -276,6 +277,30 @@ test("the foreground path abandoning an ARMED quiet socket raises too; its redia
   assert.equal(h.stale(), 2, "the foreground redial armed on its own account, and its two beats raise as usual");
   assert.equal(h.diags("stale-raise")[1].data.why, "foreground");
   h.settles(2);
+});
+
+test("a redial armed as FOREGROUND that then stays silent raises when the watchdog abandons it: the why is foreground-quiet", () => {
+  // the arm names the path that forced the reconnect, and a silent socket's raise keeps that name with the
+  // -quiet suffix — the shim comment, docs/read-side.md and the body name both spellings; only reconnect-quiet
+  // was pinned before this
+  const h = FEED();
+  h.ws.open(); h.ws.msg({ type: "feed", asks: [] });   // connected, then the socket goes quiet while the tab sleeps
+  h.now += 31_000;
+  for (const f of h.visibility) f();                    // foregrounded: the quiet socket is abandoned (it never armed: no raise) and redialed now
+  assert.equal(h.stale(), 0, "abandoning a socket that never armed is not a raise");
+  assert.equal(h.sockets.length, 2, "abandoned and redialed at once");
+  h.ws.open();                                          // the forced reconnect opens and arms as foreground
+  assert.equal(h.timers.length, 0, "no timer is armed on open");
+  h.now += 31_000;
+  h.tick();                                             // the foreground redial said nothing either: the watchdog abandons it
+  assert.equal(h.stale(), 1, "abandoning the armed foreground redial is the event");
+  assert.equal(h.sockets.length, 3, "…and the same tick redialed");
+  h.ws.open();
+  assert.deepEqual(h.diags("stale-raise").map((m) => m.data.why), ["foreground-quiet"], "named for the path that armed, with the quiet suffix");
+  assert.equal(h.diags("watchdog-close").length, 1);
+  h.ws.msg({ type: "feed", asks: [] });
+  assert.equal(h.fresh(), 1, "the redial's resync retires it");
+  h.settles(1);
 });
 
 test("every close the browser reports for a socket that OPENED leaves a wsclose breadcrumb with the code, the socket's age and the quiet gap", () => {


### PR DESCRIPTION
Seven tests-only commits, one per item, under `tests/` and `ui/webview/*.test.ts`; no product code changes. The first fixes a test whose result depended on which tests ran before it. The other six answer follow-ups named in the merge reviews of #941, #946, #947, #949, #953 and #957.

## The ordering-dependent test

`tests/test_postal_relay_honesty.py::PresenceBlinkHonesty::test_disk_twin_carries_the_cache_across_a_bus_restart` fails whenever it runs without an earlier test in the same process having created the postal state directory: selected alone by node id or `-k`, as its class alone (1 failed, 4 passed), or on a pytest-xdist worker that did not first run one of the relay ack tests (4 of 5 `-n 8` runs of the module at the base commit). The module in file order passes (30 passed). This is the pre-existing ordering failure the verification notes of #887, #944 and #950 mention.

Why: the presence twin lives at `STATE/local-presence-good.json`. `_local_presence` writes it inside a `try/except` that swallows every failure (deliberately: the twin is best-effort), and the directory is created only by `serve()` and `ensure()`, which these tests never call. Every explicit mkdir in the module (the session-flags parent, `names/`, `sdk/`, the timeline log) lands beside `postal/`, not inside it. In file order the directory appears as a side effect of three `IdShapedAddressingRoutes` tests whose `_relay_in` reaches the ack branch and calls `peer_seen_add`, which mkdirs `PEER_SEEN`'s parent, the same directory. So the disk-twin test's first answered read silently wrote nothing, and the second read found no twin.

Fix: `PresenceBlinkHonesty.setUp`, which already resets the in-memory cache and unlinks the twin, now also creates the twin's directory, the one thing `serve()` would have done. The test additionally asserts the twin exists after the answered read, so a future regression of the write is reported at the write with its own message rather than at the second read. Removing the seed while keeping that assertion fails at "an answered read writes the disk twin" (checked, then restored). The swallowed write in `_local_presence` is correct for a running bus, where the directory exists before the first listing, so no product code changes.

## The six follow-ups

- **#941**: the lifecycle-hardening header no longer claims ps is patched in every test; `PsArgv`'s two real-ps tests (Linux-only, against a sleeper child they spawn and kill) are named as the exception. Comment-only.
- **#946**: a comment at the child-returncode assertion in `test_session_move_live.py` says the failure message embeds the child's stderr, which can carry the helper's own diagnostics. An always-run `ApiKeyHelperPrecedence` class covers the explicit `$ROMP_MOVE_LIVE_API_KEY_HELPER` winning, the command borrowed from `$CLAUDE_CONFIG_DIR/settings.json`, the `~/.claude` default, and `""` when nothing names one, with `HOME` and `CLAUDE_CONFIG_DIR` under a temp dir throughout, so nothing reads the operator's own settings. The live class stays opt-in.
- **#949**: the cold `_learned_versions()` call in `test_a_warm_scan_re_reads_no_reg_whose_file_is_unchanged` now runs inside `_counting_reg_reads` and asserts the three reg names, so the warm scan's zero is proven against a counter that sees reads. A counter that never matches fails the new assertion (checked, then restored).
- **#957**: `pane-shim-stale.test.ts` gains a scenario that forces a reconnect from the visibility path (a quiet socket abandoned on foreground, no raise since it never armed), lets the redial arm as `foreground`, and ticks it silent: the watchdog's abandon raises `foreground-quiet`, the spelling `docs/read-side.md` and the shim comment name alongside `reconnect-quiet`. Changing the shim's `raiseStale(qw+"-quiet")` to `raiseStale(qw)` fails this test and the three `reconnect-quiet` pins (checked, then restored).
- **#947**: `github-link.test.ts` binds the viewer's poster once per file, so the reconnect re-ask is asserted as exactly one. Every `initFileView` call adds another `romp:wsup` listener on the shared window, which is why the count could only be asserted as "at least one" before. A duplicated `romp:wsup` listener inside `initFileView` now fails the test with 2 != 1 (checked, then restored). `tsc --noEmit` accepts the `typeof import("./file-view")` type.
- **#953**: the 10 s pre-flight test in `romp-cli-scope.bats` is replaced by a fake `timeout` on PATH that exits 124: same wrapper branch, same single stderr line, in milliseconds instead of a 20 s sleeper with a 9 to 16 s wall-clock window. The fake is the `timeout(1)` the wrapper finds, so the test also runs on a box without coreutils timeout (macOS), where the old one skipped. The file runs in 3.5 s instead of 13.5 s. What goes away: the only executable check that a real coreutils timeout cuts a hanging pre-flight tree. The argv pin that runs the real timeout on a fast pre-flight stays, and `_preflight_sleeps` stays for the no-timeout test. Changing the wrapper's `-eq 124` to `-eq 125` fails the new test at the "did not finish within 10 s" pin (checked, then restored).

## Not in this PR

The other follow-ups from the same reviews come separately: the `__main__` import in `test_tempdir_hygiene.py` (#944), the `_ALIAS_SERVED.clear()` setUps in `test_judge.py` (#948), and the dead-wait mid-pass comment (#943). Also out: the `_set_live` NamedTemporaryFile leftovers noted in #944, and any change to the twin's write path.

## Tests

Targeted, at head: `test_postal_relay_honesty.py` 30 passed in order, the single test and its class green alone, `-n 8` on the module 5 of 5 green (base: 4 of 5 red); `test_session_move_live.py` 6 passed, 1 skipped (was 2 and 1); `test_model_versions.py` 41 passed; `test_sdk_lifecycle_hardening.py` 39 passed; `test_state_isolation_order.py` 2 passed; `romp-cli-scope.bats` 19/19 (the replaced test runs, not skipped); `pane-shim-stale.test.ts` 14/14 (was 13); `github-link.test.ts` 12/12; `npm run typecheck` clean.

Full: `bats tests/*.bats` 429/429; `npm test` 2839/2839; `pytest -n 8` 7583 passed, 46 skipped, 8 failed in two untouched modules (`test_kernel_deferral_sweep.py`, `test_kernel_nudge_last_resort.py`) that pass alone (11 and 34 passed): xdist ordering, not this change. CI runs pytest serially, so it never saw the relay-honesty failure and will not see those. CI proves Linux only (the macOS jobs are dispatch-only); the bats fake is POSIX sh and the two webview tests are platform-independent node tests.

Tier: tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)