### PR TITLE
Codex judge child: strip every ANTHROPIC_* name, not only the API key

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -48,7 +48,9 @@ one-shot `codex exec` call — ephemeral (no session files), using romp's custom
 `romp_judge` permission profile, and billing the machine's Codex login. The
 profile grants only Codex's minimal runtime files plus read access to the fresh
 empty scratch workspace supplied by `-C`; it denies writes, network access, and
-host-wide reads. Verified live: the real caption and gist
+host-wide reads. Every `ANTHROPIC_*` variable is removed from the child's
+environment, so a key, proxy URL or custom header configured for Claude never
+reaches Codex. Verified live: the real caption and gist
 judges answer correctly in ~5–6s per call.
 
 Honest caveats while this is new:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1528,9 +1528,14 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             outp = os.path.join(JUDGE_SCRATCH, "codex-%d-%d.out" % (os.getpid(), rid))
             try:
                 try:
-                    # another vendor's process has no use for the Anthropic key (_judge_env re-injects
-                    # it for key-billed sessions); strip it from the child's environment (PR #885 review)
-                    cenv = {k: v for k, v in env.items() if k != "ANTHROPIC_API_KEY"}
+                    # another vendor's process has no use for anything in the Anthropic namespace.
+                    # _judge_env already withholds the billing names for a codex call (auth "codex":
+                    # nothing is injected back), but the kernel's environment can carry more under the
+                    # same prefix — ANTHROPIC_BASE_URL and ANTHROPIC_CUSTOM_HEADERS for a proxy (the
+                    # header usually carries its credential), ANTHROPIC_MODEL, debug knobs — and a list
+                    # would need maintaining as the CLI grows names. Strip the prefix; the harmless
+                    # names go too, on purpose (PR #885 review, widened from the one key)
+                    cenv = {k: v for k, v in env.items() if not k.startswith("ANTHROPIC_")}
                     p = subprocess.run(_judge_cmd_codex(model, _codex_effort(effort, tier), outp),
                                        input=(sys_prompt or "") + "\n\n" + (user or ""),
                                        capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=cenv,

--- a/tests/test_judge_engine.py
+++ b/tests/test_judge_engine.py
@@ -154,13 +154,17 @@ class JudgeEngine(unittest.TestCase):
         self.assertIn("--output-format", cmd)
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 class CodexChildEnvIsVendorScoped(unittest.TestCase):
-    """The Anthropic key never reaches the codex judge child (PR #885 review): _judge_env re-injects it
-    for key-billed sessions, and another vendor's process has no use for it."""
+    """No ANTHROPIC_* name reaches the codex judge child (PR #885 review, widened to the prefix):
+    _judge_env withholds the billing names for a codex call, and the branch strips whatever else rides
+    under the vendor's prefix — a proxy URL, custom headers, a model pin — because another vendor's
+    process has no use for any of it."""
+
+    # not credential-shaped (the repo is scanned for secrets), and a failure prints names only
+    FIXTURES = {"ANTHROPIC_API_KEY": "sk-test-not-real",
+                "ANTHROPIC_AUTH_TOKEN": "romp-test-fixture-token",
+                "ANTHROPIC_BASE_URL": "https://proxy.example.invalid",
+                "ANTHROPIC_CUSTOM_HEADERS": "X-Test: fixture"}
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
@@ -168,7 +172,8 @@ class CodexChildEnvIsVendorScoped(unittest.TestCase):
         jd._state_cache.clear()
         (jd.STATE / "judge-engine").write_text("codex")
 
-    def test_the_codex_subprocess_env_lacks_the_anthropic_key(self):
+    def _codex_child_env(self, *patches):
+        """One codex judge call with subprocess.run replaced; returns the env the child was given."""
         from unittest import mock
         seen = {}
 
@@ -182,14 +187,42 @@ class CodexChildEnvIsVendorScoped(unittest.TestCase):
                 Path(outp[-1]).write_text("ok")
             return _P()
 
-        fake_env = dict(os.environ, ANTHROPIC_API_KEY="sk-test-not-real", ROMP_SUMMARIZING="1")
-        with mock.patch.object(jd, "_judge_env", return_value=fake_env), \
-             mock.patch.object(jd.subprocess, "run", side_effect=fake_run), \
-             contextlib.redirect_stderr(io.StringIO()):
+        with contextlib.ExitStack() as stack:
+            for patch in patches:
+                stack.enter_context(patch)
+            stack.enter_context(mock.patch.object(jd.subprocess, "run", side_effect=fake_run))
+            stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
             try:
                 jd._judge_run("gpt-5", "SYS", "payload", judge="captioner", tier="index")
             except Exception:
                 pass                                  # the reply shape is not under test here
         self.assertIsNotNone(seen.get("env"), "the codex branch ran through subprocess.run")
-        self.assertNotIn("ANTHROPIC_API_KEY", seen["env"], "the Anthropic key is stripped from the codex child")
-        self.assertEqual(seen["env"].get("ROMP_SUMMARIZING"), "1", "…and the rest of the judge env rides as before")
+        return seen["env"]
+
+    def _assert_no_anthropic_name(self, env):
+        # names only, in every message: assertNotIn on a mapping prints the whole mapping on failure,
+        # i.e. a developer's real environment
+        for name in self.FIXTURES:
+            self.assertFalse(name in env, "%s reached the codex child" % name)
+        leaked = sorted(k for k in env if k.startswith("ANTHROPIC_"))
+        self.assertEqual(leaked, [], "ANTHROPIC_* names reached the codex child: %s" % leaked)
+        self.assertEqual(env.get("ROMP_SUMMARIZING"), "1", "…and the rest of the judge env rides as before")
+
+    def test_the_codex_subprocess_env_lacks_every_anthropic_name(self):
+        # whatever _judge_env hands over, the branch strips the prefix — its own rule, not _judge_env's list
+        from unittest import mock
+        fake_env = dict(os.environ, ROMP_SUMMARIZING="1", **self.FIXTURES)
+        env = self._codex_child_env(mock.patch.object(jd, "_judge_env", return_value=fake_env))
+        self._assert_no_anthropic_name(env)
+
+    def test_the_real_judge_env_and_the_strip_compose(self):
+        # the unmocked path: a codex call resolves auth "codex", so _judge_env withholds the billing names
+        # and injects none back; the proxy URL and headers are what the prefix strip is for
+        from unittest import mock
+        env = self._codex_child_env(mock.patch.dict(os.environ, self.FIXTURES))
+        self._assert_no_anthropic_name(env)
+        self.assertEqual(env.get("DISABLE_PROMPT_CACHING"), "1", "the real _judge_env built this env")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What breaks

`_judge_run`'s codex branch launches `codex exec` with the judge environment minus `ANTHROPIC_API_KEY` (the #885 fold). Every other variable in the Anthropic namespace that the kernel's environment carries still reaches another vendor's process. Since #962 the billing names are no longer among them: a codex call resolves `auth = "codex"`, so `_judge_env` withholds `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` and injects none back. What still rides:

- `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS`: a proxy or gateway URL and the header that usually carries the gateway's own credential. The kernel reads `ANTHROPIC_BASE_URL` itself (`sdk_backend._fetch_key_fast_org`), so an installation that sets it is an ordinary one.
- `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `ANTHROPIC_LOG` and any deployment-specific `ANTHROPIC_*` name.

## Reproduction

With the judge engine set to codex and `ANTHROPIC_BASE_URL=https://proxy.example.invalid` exported to the kernel, the codex child's environment contains that variable. The new test `test_the_real_judge_env_and_the_strip_compose` does this in-process: it runs the real `_judge_env` and fails on main with `ANTHROPIC_BASE_URL reached the codex child`.

## The fix

The filter in the codex branch becomes a prefix test:

```python
cenv = {k: v for k, v in env.items() if not k.startswith("ANTHROPIC_")}
```

A prefix rather than a longer list, because the namespace is the vendor's: a list has to be maintained as the CLI grows names, and a new one would land in the child silently. The prefix also drops harmless names (`ANTHROPIC_LOG` and other debug knobs) from the codex child, on purpose; that child has no use for them either. The claude-engine path is untouched: that child is the vendor's own CLI, and `_judge_env` still injects the key for a key-billed call.

Composition with #962: its codex bypass lives in `_judge_env` (the `auth = "codex"` short-circuit in `_judge_run` and the pops of the three billing names), and this change is on the branch's own `cenv` line, about 220 lines below. Neither replaces the other. `_judge_env` decides billing and withholds credentials for every engine; the codex branch removes whatever else the vendor's namespace carries. The unmocked test runs both.

## Tests

`tests/test_judge_engine.py`, `CodexChildEnvIsVendorScoped` (the home of the #885 pin):

- `test_the_codex_subprocess_env_lacks_every_anthropic_name`: `_judge_env` mocked to hand over `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS`; asserts that none of them, and no other `ANTHROPIC_`-prefixed name, reaches the child, and that `ROMP_SUMMARIZING` still rides. Fails on main: `ANTHROPIC_AUTH_TOKEN reached the codex child`.
- `test_the_real_judge_env_and_the_strip_compose`: the same fixtures placed in `os.environ`, `_judge_env` real. Fails on main: `ANTHROPIC_BASE_URL reached the codex child` (the two billing names were already gone, which is #962 doing its part).

Assertions name the variable and never print the mapping; a failed `assertNotIn` on a dict prints the developer's whole environment, so the existing assertion is rewritten the same way. Fixture values are not credential-shaped. The module's `if __name__ == "__main__"` guard sat above this class and moves to the end, so a direct run collects it too.

`docs/codex.md` gains one sentence in "Running the judges on Codex".

Full `pytest` run locally: 7584 passed, 50 skipped, 0 failed. The change is a dict comprehension with no platform branch, and the tests replace `subprocess.run`, so the Linux CI cell covers every changed line. The widened filter has been in a Linux installation's kernel since 2026-09-05; that installation runs the Claude judge engine, so the codex path is exercised by the tests, not by live traffic.

## Design point

`CLAUDE_CODE_OAUTH_TOKEN` is Claude Code's login token and sits outside the prefix. `_judge_env` withholds it for a codex call since #962, so the codex child does not see it today; it is left out of this filter to keep the rule one vendor namespace. If you would rather the branch's own filter cover it too, it is one more exact name in the same comprehension.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)