### PR TITLE
Review follow-ups from #941, #942/#943/#957, #945, #947, #948 and #953: one fix per merge comment

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -586,8 +586,10 @@ function withoutOpCredentials(env) {
 // starts the daemon outside the service cgroup; a session's later `tmux new-session` joins that server
 // and survives a service restart. The tmux CLIENT still exits at once (it only starts the daemon), so
 // execFileSync's semantics are unchanged, and when a server already runs the call is the same no-op and
-// the scope collects itself. Any failure of the scoped path falls back to the bare call. The macOS path
-// is as it was: launchd owns the lineage there and the TCC rationale above still applies.
+// the scope collects itself. Any failure of the scoped path falls back to the bare call, and the line after
+// it READS where the server actually sits (its cgroup) rather than assuming the bare call placed it: a
+// timed-out scoped call kills only tmux's client, the daemon it forked stays inside the scope. The macOS
+// path is as it was: launchd owns the lineage there and the TCC rationale above still applies.
 const TMUX_START_ARGV = ['tmux', 'start-server', ';', 'set', '-g', 'exit-empty', 'off'];
 
 // Is `name` an executable on the env's PATH? (Node has no `which`.)
@@ -641,6 +643,66 @@ function scopedStartFailure(e) {
   return { tool, detail };
 }
 
+// After a failed scoped start the bare call runs, and where the server then sits is READ, not predicted
+// (the #953 review): the old fixed line said the server was unscoped and a service restart would take it
+// down, which is wrong in two cases. A scoped call that times out — execFileSync SIGTERMs the tmux CLIENT
+// (systemd-run exec'd it in place) while the server daemon that client forked stays alive inside the
+// romp-tmux scope, so the bare retry is a no-op onto a scoped server. And after a service restart the
+// previous manager's server is still up in its old scope, so if systemd-run fails on THIS start (bus not
+// up yet, a refused unit) the bare call no-ops onto a scoped server again. `#{pid}` is the server's pid;
+// display-message does not start a server (exit 1, "no server running on …", when there is none — tmux 3.4).
+const TMUX_SERVER_PID_ARGV = ['tmux', 'display-message', '-p', '#{pid}'];
+
+// PURE: where a /proc/<pid>/cgroup text places the server. cgroup v2 is one `0::/…/<unit>` line; v1 is one
+// line per controller, each ending in the unit — so every line is tried. Only the manager's own romp-tmux-*
+// scopes count: a romp-session-* scope is a session CLI's, not this feature's claim.
+function placementFromCgroup(text) {
+  const lines = String(text || '').split('\n');
+  for (const line of lines) {
+    const m = /\/(romp-tmux-\d+\.scope)\s*$/.exec(line);
+    if (m) return { placement: 'scoped', unit: m[1] };
+  }
+  if (lines.some((l) => l.trim())) return { placement: 'unscoped' };
+  return { placement: 'unknown', why: 'empty cgroup file' };
+}
+
+function defaultServerPid() {
+  return execFileSync(TMUX_SERVER_PID_ARGV[0], TMUX_SERVER_PID_ARGV.slice(1),
+                      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: TMUX_START_TIMEOUT_MS,
+                        env: withoutOpCredentials(process.env) });
+}
+function defaultReadCgroup(pid) { return fs.readFileSync('/proc/' + pid + '/cgroup', 'utf8'); }
+
+// Never throws — a throw here would abort startManager before the control port binds — so every failure
+// of the probe is an 'unknown' placement carrying the failure's first line, bounded like the failure
+// line's detail. `serverPid` and `readCgroup` are injectable for the node suite; the defaults ask tmux
+// (bounded by the same timeout as the start) and read /proc.
+function tmuxServerPlacement({ serverPid = defaultServerPid, readCgroup = defaultReadCgroup } = {}) {
+  const why = (e) => {
+    const first = String((e && e.stderr) || '').split('\n').map((s) => s.trim()).find(Boolean)
+      || String(e && e.message || e).split('\n')[0];
+    return first.length > FAILURE_LINE_MAX ? first.slice(0, FAILURE_LINE_MAX - 1) + '…' : first;
+  };
+  let pid;
+  try { pid = String(serverPid()).trim(); } catch (e) { return { placement: 'unknown', why: why(e) }; }
+  if (!/^\d+$/.test(pid)) return { placement: 'unknown', why: 'tmux reported no server pid' };
+  let text;
+  try { text = readCgroup(pid); } catch (e) { return { placement: 'unknown', why: why(e) }; }
+  return placementFromCgroup(text);
+}
+
+// PURE: the line the bare call's success logs, worded from where the server sits. The unscoped wording is
+// the line as it always was (its pins stay); the other two predict no loss.
+function bareEnsuredLine({ placement, unit, why }) {
+  if (placement === 'scoped') {
+    return `tmux server ensured — already running inside ${unit} (the scoped start had begun it, or an earlier one still holds it); a service restart leaves it and its sessions' jobs alive`;
+  }
+  if (placement === 'unscoped') {
+    return 'tmux server ensured without a scope — under the service, a service restart will take it down';
+  }
+  return `tmux server ensured — whether it sits in a scope could not be read (${why}); under the service, a restart takes it down only if it is not in one`;
+}
+
 function startTmuxServer() {
   const pick = tmuxStartArgv();
   if (!pick) return;   // no tmux on PATH: nothing to start, and nothing to log (as before the scopes)
@@ -656,7 +718,8 @@ function startTmuxServer() {
     return;
   } catch (e) {
     if (!pick.scoped) return;   // a server is already up, or tmux itself failed — nothing more to do
-    // Say what failed and where the server will land: this may be a terminal run with no service cgroup.
+    // Say what failed; where the server sits is read from its cgroup after the bare call (bareEnsuredLine),
+    // not predicted here.
     const { tool, detail } = scopedStartFailure(e);
     log(tool === 'tmux'
       ? `tmux failed inside the scope systemd-run started for it (${detail}) — starting it the plain way instead`
@@ -664,7 +727,7 @@ function startTmuxServer() {
   }
   try {
     execFileSync(TMUX_START_ARGV[0], TMUX_START_ARGV.slice(1), { stdio: 'ignore', timeout: TMUX_START_TIMEOUT_MS, env: withoutOpCredentials(process.env) });
-    log('tmux server ensured without a scope — under the service, a service restart will take it down');
+    log(bareEnsuredLine(tmuxServerPlacement()));
   } catch (e) { /* a server is already up, or tmux itself failed — nothing to do */ }
 }
 
@@ -777,6 +840,7 @@ function ensureUp() {
 module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp,
                    kernelToken, fetchBusy, resetDrainNotices, queueQuietRestart, clearPendingQuiet,
                    tmuxStartArgv, scopedStartFailure, commandOnPath, TMUX_START_ARGV,
+                   placementFromCgroup, tmuxServerPlacement, bareEnsuredLine, TMUX_SERVER_PID_ARGV,
                    withoutOpCredentials, serviceEnvHasRef };
 if (require.main === module) {
   const cmd = process.argv[2];

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2769,7 +2769,8 @@ def declared_plan(session):
     live task store, so downstream (the judge's plan-sync) sees a generic 'declared plan' shape
     instead of raw tool calls. Mirrors the kernel's _fold_tasks, with the same blind spots: only the
     MAIN agent's TaskCreate/TaskUpdate calls, and only those on the transcript's live chain — and the
-    same skip: a TaskCreate the CLI rejected (its paired tool_result carries is_error) is not a step.
+    same skips: a TaskCreate the CLI rejected (its paired tool_result carries is_error) is not a step,
+    and a rejected TaskUpdate moves none.
     `key` is the stable `Task #N` id lifted from TaskCreate's
     result text (a creation-order `cN` fallback if the result is unreadable); `status` rides each
     TaskUpdate. Only TaskCreate/TaskUpdate are folded — plain TodoWrite (no durable ids) is not
@@ -2810,6 +2811,8 @@ def declared_plan(session):
                                   "activeForm": str(af) if af else None, "status": "pending"}
                     order += 1
                 elif b.get("name") == "TaskUpdate":
+                    if b.get("id") in rejected:            # the same rejection-keyed skip as the kernel's
+                        continue                           # _fold_tasks: a refused update moved nothing
                     t = tasks.get(str(inp.get("taskId", "")))
                     if t:
                         t["status"] = str(inp.get("status") or t["status"])

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -204,6 +204,8 @@ _UNKNOWN_MODEL_LOGGED = set()   # ids already announced as unplaceable (one stde
 _ALIAS_SERVED = {}              # family -> (major, minor) the CLI served for the BARE alias this process, read off
                                 #   result envelopes (_note_served_model); _adaptive_thinking asks it before the table
 _ALIAS_DRIFT_LOGGED = set()     # (family, served id) pairs already announced as off the table (one stderr line each)
+_NO_MODEL_USAGE_LOGGED = set()  # a result envelope carried no modelUsage map: said once per PROCESS (the field is a
+                                #   property of the CLI, not of the call), so a stale table is never trusted silently
 
 
 def _model_family_version(model):
@@ -275,15 +277,27 @@ def _note_served_model(model, wrap):
     The same-family entry with the most output tokens is the model that wrote the reply (a side call's
     entry cannot move the alias). Quiet when they agree, when `model` is a versioned id (a pin is a
     pin, never remapped), and when the envelope names no same-family model — that carries no evidence
-    either way, so the table's answer stands exactly as it did before this check. Every tier feeds the
-    record; only the index tier's lever reads it. Best-effort, never raises (mirrors _log_judge_usage —
-    bookkeeping must not cost the reply)."""
+    either way, so the table's answer stands exactly as it did before this check. An envelope with no
+    modelUsage map at all is a different case (the #948 review): the check cannot run for ANY alias, so
+    a stale table would be trusted with nothing in the log — said once per process
+    (_NO_MODEL_USAGE_LOGGED), the loud-failure rule's minimum; a map that names no same-family model
+    stays quiet. Every tier feeds the record; only the index tier's lever reads it. Best-effort, never
+    raises (mirrors _log_judge_usage — bookkeeping must not cost the reply)."""
     try:
         fam, ver = _model_family_version(model)
         if fam is None or ver is not None:
             return
         mu = wrap.get("modelUsage") if isinstance(wrap, dict) else None
         if not isinstance(mu, dict):
+            # no map (a CLI older than the field, a shape change) or a malformed non-dict value — the same
+            # failed precondition either way; the bare-alias gate above keeps a versioned pin silent, so
+            # only a call the check WOULD have served says this, and only the first one does
+            if not _NO_MODEL_USAGE_LOGGED:
+                _NO_MODEL_USAGE_LOGGED.add(True)
+                sys.stderr.write("romp-judge: the result envelope for the bare %s alias carries no modelUsage map, "
+                                 "so the version the CLI served cannot be checked — the index tier's lever answers "
+                                 "from the alias table until a CLI that reports the field (said once per process)\n"
+                                 % fam)
             return
         best = None                               # (output tokens, served id, served version)
         for mid, u in mu.items():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18668,7 +18668,7 @@ def _fold_tasks(session):
     """Fold a session's TaskCreate/TaskUpdate tool calls into ONE checklist — the FALLBACK for _read_task_store
     when a session has no live task store (mirrors the old TS transcript.foldTasks the Python rewrite dropped).
     Task id = the number in TaskCreate's RESULT text ('Task #N created…'); status rides each TaskUpdate
-    {taskId,status}. NOTE this is lossy — it can't see a completion a subagent wrote only to the store (see
+    {taskId,status} the CLI accepted. NOTE this is lossy — it can't see a completion a subagent wrote only to the store (see
     _read_task_store). Returns the tasks in creation
     order, or None if there were none. The webview renders this as a todo card (kind:'todo') and hides the
     raw Task* calls (ACK_TOOLS) — so the kernel emits the folded card and skips the raw tool events."""
@@ -18713,6 +18713,13 @@ def _fold_tasks(session):
                                   "activeForm": str(af) if af else None, "status": "pending"}
                     order += 1
                 elif b.get("name") == "TaskUpdate":
+                    # A TaskUpdate the CLI REJECTED — its paired tool_result carries is_error (a status value
+                    # outside its set, a transition it refused) — wrote nothing to the store, so it moves no
+                    # checklist item; applied, the refused status stood in for the store's. Keyed on the
+                    # result's is_error like the TaskCreate skip above, so this fold and event_model's
+                    # declared_plan stay identical. An update whose result has not landed still applies.
+                    if b.get("id") in rejected:
+                        continue
                     t = tasks.get(str(inp.get("taskId", "")))
                     if t:
                         t["status"] = str(inp.get("status") or t["status"])

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31424,6 +31424,19 @@ setTimeout(hide,5000);})();
 # posts {romp:'wsState',app,state}; the timeline/feed/etc. are pushed from the kernel, so a drop silently
 # freezes them), the usage-limit + judge-degraded signatures (see _LANDING_USAGE_JS), and any
 # {romp:'notify',kind,text} a pane posts. window.__rompNotify(kind,text) is the one write path.
+#
+# THE pane presentation order (the user 2026-08-30: mobile must list the panes in the desktop
+# order — "mobile is a re-layout of the desktop, never a re-ordering"). This list is the desktop
+# rail strip's left-to-right order, which is the user's own choice (2026-07-05) and the desktop's
+# actual visible LIST of the named panes (the column layout cannot express it: Sessions/timeline
+# is a band, not a column). The desktop rail buttons (_rail_buttons_html), the mobile #mtabs buttons
+# (_mtab_buttons_html), the WS drop row (_note_ws_drop) and the bell's pane-label map (PN, in the
+# script below) all render from this one constant — reorder or rename here and every surface moves
+# together; a second hardcoded list is the bug this replaces (the bell's PN was the last one, the
+# #957 review). Defined above _LANDING_ERRS_JS because that string is built from it at import.
+# Keys stay internal (timeline/fleet); labels are the user-facing names.
+_PANE_ORDER = (("chat", "Chat"), ("timeline", "Sessions"), ("fleet", "Outline"), ("feed", "Feed"))
+
 _LANDING_ERRS_JS = """
 (function(){var icon=document.getElementById('rail-errs'),micon=document.getElementById('merr'),
 back=document.getElementById('rerr-back'),list=document.getElementById('rerr-list'),
@@ -31531,7 +31544,7 @@ if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text,
 var st={};
 function shown(k){return document.body.classList.contains('po-'+k);}
 function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}return false;}
-var PN={chat:'Chat',feed:'Feed',timeline:'Sessions',fleet:'Outline'};   // timeline key stays internal; the pane outgrew the name (filter, tags, lane controls — the user 2026-08-24)
+var PN=""" + json.dumps(dict(_PANE_ORDER)) + """;   // key → rail label, from _PANE_ORDER (one list with the rail, the tabs and the drop row); timeline key stays internal — the pane outgrew the name (filter, tags, lane controls — the user 2026-08-24)
 window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;
 var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;
 if(s==='down'&&prev!=='down'&&shown(m.app))
@@ -33209,16 +33222,6 @@ _REFRESH_SVG = (
     # the arrowhead must READ at 18px (the user 2026-07-27: the first cut's ~3px triangle was invisible) —
     # a 4.4-wide, 3.4-deep triangle straddling the arc's end point, pointing along its clockwise tangent
     "<path d='M9.5 5.4 L11.7 1.6 L13.5 5.2 Z' fill='currentColor'/></svg>")
-
-
-# THE pane presentation order (the user 2026-08-30: mobile must list the panes in the desktop
-# order — "mobile is a re-layout of the desktop, never a re-ordering"). This list is the desktop
-# rail strip's left-to-right order, which is the user's own choice (2026-07-05) and the desktop's
-# actual visible LIST of the named panes (the column layout cannot express it: Sessions/timeline
-# is a band, not a column). BOTH the desktop rail buttons and the mobile #mtabs buttons render
-# from this one constant — reorder here and both surfaces move together; a second hardcoded list
-# is the bug this replaces. Keys stay internal (timeline/fleet); labels are the user-facing names.
-_PANE_ORDER = (("chat", "Chat"), ("timeline", "Sessions"), ("fleet", "Outline"), ("feed", "Feed"))
 
 
 def _rail_buttons_html():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5632,6 +5632,24 @@ def _auto_nudge_tick(now, tmux, run_dead_wait=True):
         _AUTO_NUDGE_TICK_LOCK.release()
 
 
+def _ws_act_now_tick():
+    """The setAutoNudge / setCompactSuggest arms' act-now pass on the WS handler thread — ONE wrap for
+    both (PR #943 review). The reader loop (Handler._ws) re-raises OSError as a socket failure and its
+    outer handler tears the connection down silently, so an OSError out of the pass head (the
+    session-listing fork, a store read) closed the dashboard's socket with no log line — since #846 for
+    setCompactSuggest, for setAutoNudge once #943 restored its tick. Catches Exception as the pusher's
+    wrap does, and that is safe HERE because the tick never writes to the delivering socket: its only
+    push is _push_soon(), a wake flag, so nothing caught is that socket's own failure (a tick that wrote
+    to the client would have to let its socket errors through). Skips the dead-wait sweep: the death
+    transition has ONE observer, the pusher's tick (see _auto_nudge_tick), and this thread racing its
+    prev-swap could spend a transition uncorroborated. Single-flight against the pusher's pass through
+    _AUTO_NUDGE_TICK_LOCK, inside the call."""
+    try:
+        _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+    except Exception:
+        sys.stderr.write("auto-nudge (ws act-now): %s\n" % traceback.format_exc())
+
+
 def _auto_nudge_pass(now, tmux, run_dead_wait):
     """The body of one pass — the walk, the sweeps, the push. Only _auto_nudge_tick calls it, under
     the single-flight guard (split out the way _pusher_cycle_jobs is from _pusher_cycle)."""
@@ -36226,23 +36244,20 @@ class Handler(BaseHTTPRequestHandler):
             if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
                 # turn-ON acts at once instead of waiting out the pusher's 0.5 s backstop; turning off
                 # has nothing to act on (the tick is a no-op when off, so this also spares the WS
-                # thread the listing fork). The tick is single-flight against the pusher's pass
-                # (_AUTO_NUDGE_TICK_LOCK) and skips the dead-wait sweep: the death transition has ONE
-                # observer (the pusher's tick; see _auto_nudge_tick), and this WS thread racing its
-                # prev-swap could spend a transition uncorroborated
+                # thread the listing fork). The single-flight rule, the dead-wait sweep skip and the
+                # try/except that keeps a failing tick from reading as a socket failure are all
+                # _ws_act_now_tick's; the stale reply below stays outside it (a real client write)
                 if msg["enabled"]:
-                    _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+                    _ws_act_now_tick()
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
             # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a
-            # real apply acts at once on turn-on (instead of waiting out the pusher's 0.5 s backstop;
-            # single-flight against its pass, _AUTO_NUDGE_TICK_LOCK) — a stood-down toggle is not
-            # new information — and the tick skips the dead-wait sweep: the death transition has
-            # ONE observer (the pusher's tick; see _auto_nudge_tick), and this WS thread racing
-            # its prev-swap could spend a transition uncorroborated
+            # real apply acts at once on turn-on (instead of waiting out the pusher's 0.5 s backstop)
+            # — a stood-down toggle is not new information — through the same wrap as setAutoNudge
+            # (_ws_act_now_tick: single-flight, no dead-wait sweep, a failure logged not raised)
             if _set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
-                _auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)
+                _ws_act_now_tick()
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28653,8 +28653,13 @@ def _git_net_out(args, cwd, timeout, env):
     """_git_out for the one query that leaves the machine (ls-remote): git runs in its OWN session, and
     the deadline kills the whole process group. subprocess.run's timeout kill reaches its direct child
     alone, and the ssh git had spawned sat in its TCP connect for minutes after the viewer had already
-    been told "could not check" (reproduced 2026-09-05). A fresh session also has no controlling
-    terminal, so an ssh that wants a passphrase fails instead of waiting for one."""
+    been told "could not check" (reproduced 2026-09-05). No prompt of any kind reaches the user: the
+    caller's env closes every route (GIT_TERMINAL_PROMPT=0 for the terminal; GIT_ASKPASS="" for git's
+    askpass, which also overrides core.askPass and git's SSH_ASKPASS fallback; SSH_ASKPASS_REQUIRE=never
+    for ssh's own), so a query that would need a credential fails at once and the viewer reads "could not
+    check". That is the choice made (the #947 review): an editor's askpass helper that would have
+    answered silently for a signed-in user is refused too, and such an origin reads "could not check"
+    rather than a verdict. A configured credential.helper is not disabled and may still answer silently."""
     try:
         p = subprocess.Popen(["git", "-C", cwd] + args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
                              stderr=subprocess.DEVNULL, text=True, start_new_session=True, env=env)
@@ -28784,7 +28789,8 @@ def _origin_has_branch(top, ref):
     locally), and any answer in a clone whose refspec leaves the branch untracked (`--single-branch`).
     The verdict is as fresh as this clone's refs, then: a branch deleted on GitHub reads as present
     until `fetch --prune`, one pushed from elsewhere as absent until a fetch. The query gets a short
-    timeout and no terminal prompt: the viewer must never hang on it. The pattern is the full ref and
+    timeout and no prompt of any kind (terminal, git's askpass, ssh's askpass): the viewer must never
+    hang on it. The pattern is the full ref and
     the answer is matched on it exactly, because ls-remote patterns match a ref's TAIL (`main` would
     also match `refs/heads/x/main`)."""
     key = (top, ref)
@@ -28805,8 +28811,14 @@ def _origin_has_branch(top, ref):
     on = None
     try:
         full = "refs/heads/" + ref
+        # GIT_TERMINAL_PROMPT=0 closes the terminal route only. git reads GIT_ASKPASS before core.askPass
+        # and before its SSH_ASKPASS fallback, and tests the variable's PRESENCE, so a set-EMPTY
+        # GIT_ASKPASS overrides all three (unsetting it would not); SSH_ASKPASS_REQUIRE=never closes
+        # ssh's own askpass (OpenSSH 8.4+, ignored by older ssh). Without these a kernel started from a
+        # shell exporting an askpass program showed a GUI prompt on every viewer open of a file under a
+        # credential-wanting private origin, and the deadline then killed it (the #947 review).
         out = _git_net_out(["ls-remote", "--heads", "origin", full], top, timeout=GH_LS_REMOTE_S,
-                           env=dict(os.environ, GIT_TERMINAL_PROMPT="0"))
+                           env=dict(os.environ, GIT_TERMINAL_PROMPT="0", GIT_ASKPASS="", SSH_ASKPASS_REQUIRE="never"))
         if out is not None:
             on = any(line.split("\t")[-1] == full for line in out.splitlines())
     finally:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1391,7 +1391,7 @@ def _is_kernel_cmd(cmd: str) -> bool:
     return False
 
 
-def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
+def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int) -> list[int]:
     """PIDs of ORPHANED SDK-driven `claude` CLIs holding one of OUR sessions (--resume/--session-id
     in either flag spelling, + the stream-json mark — see _cli_carries_sid). Orphaned = its PARENT
     is not a live romp kernel (absent from the listing, or a process that is not a kernel): a live
@@ -1399,7 +1399,13 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
     zombie writer that would fight the resume for the transcript — has any other parent. The parent
     check is load-bearing: matching on the command line alone let a duplicate backend's reconcile
     reap freshly-resumed LIVE sessions mid-turn (2026-07-06); and a CLI parented to a DIFFERENT live
-    kernel is that kernel's, never reaped here.
+    kernel is that kernel's, never reaped here. `own_pid` is the calling kernel's pid: a CLI whose
+    ppid is own_pid is this kernel's live child whatever `ps` calls the kernel. _is_kernel_cmd knows
+    the spellings romp-serve and a hand run produce (`…/bin/romp-kernel`, `kernel/kernel.py`); the pid
+    check keeps this kernel's own children out of the reap under any other (`python3 ./kernel.py`, a
+    `-c` runner, a renamed launcher) — the unconditional protection the old `ppid != 1` test gave them
+    (the 2026-09-06 review of the parent-is-a-kernel definition). The reconcile runs on a thread after
+    the backend is up, so a session started before its `ps` is exactly such a child.
 
     Until 2026-09-05 "orphaned" meant ppid 1 (macOS: an orphan re-parents to launchd). Under
     `systemd --user` that never happens: the user manager sets PR_SET_CHILD_SUBREAPER, so a CLI left
@@ -1419,6 +1425,8 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
     for pid, (ppid, cmd) in procs.items():
         if _SDK_CLI_MARK not in cmd or not _cli_carries_sid(cmd, lastsids):
             continue
+        if ppid == own_pid:
+            continue    # this kernel's own child, whatever ps calls this kernel (or with our line missing)
         parent = procs.get(ppid)
         if parent is not None and _is_kernel_cmd(parent[1]):
             continue    # a live kernel's child — ours or another kernel's, either way not an orphan
@@ -5224,7 +5232,7 @@ class SdkBackend:
             if lastsids:
                 try:
                     ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10).stdout
-                    for pid in find_orphan_clis(ps.splitlines(), lastsids):
+                    for pid in find_orphan_clis(ps.splitlines(), lastsids, os.getpid()):
                         if pid == os.getpid():
                             continue
                         try:

--- a/tests/manager-tmux-scope.test.js
+++ b/tests/manager-tmux-scope.test.js
@@ -6,7 +6,12 @@
 // only on Linux with systemd-run on PATH. A terminal-run manager scopes nothing unless asked. No tmux
 // on PATH → null: nothing to start, nothing to log (the behaviour before the scopes). scopedStartFailure
 // turns the scoped call's execFileSync error into the log line's content: the tool that failed and its
-// first stderr line, bounded (startTmuxServer pipes stderr on that call for it).
+// first stderr line, bounded (startTmuxServer pipes stderr on that call for it). After a failed scoped
+// start the bare call runs and the log then READS where the server sits (the #953 review: a timed-out
+// scoped call kills only tmux's client, the daemon it forked stays inside the scope, so the old fixed
+// line predicted a loss that would not happen): placementFromCgroup places a /proc/<pid>/cgroup text,
+// tmuxServerPlacement asks tmux for the server pid and reads that file (never throws), bareEnsuredLine
+// words the line from the answer.
 // Run: node --test tests/manager-*.test.js
 'use strict';
 const { test } = require('node:test');
@@ -16,7 +21,8 @@ const os = require('node:os');
 const path = require('node:path');
 
 process.env.ROMP_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'romp-mgr-tmux-scope-'));
-const { tmuxStartArgv, scopedStartFailure, commandOnPath, TMUX_START_ARGV } = require(path.join(__dirname, '..', 'bin', 'romp-manager'));
+const { tmuxStartArgv, scopedStartFailure, commandOnPath, TMUX_START_ARGV,
+        placementFromCgroup, tmuxServerPlacement, bareEnsuredLine, TMUX_SERVER_PID_ARGV } = require(path.join(__dirname, '..', 'bin', 'romp-manager'));
 
 const BARE = ['tmux', 'start-server', ';', 'set', '-g', 'exit-empty', 'off'];
 const both = (name) => name === 'systemd-run' || name === 'tmux';   // a Linux box with both installed
@@ -154,4 +160,83 @@ test("a spawn error (no exit at all): the error's own first line, systemd-run na
   const e = Object.assign(new Error('spawnSync systemd-run ENOENT'), { code: 'ENOENT', status: null, signal: null, stderr: null });
   assert.deepEqual(scopedStartFailure(e), { tool: 'systemd-run', detail: 'spawnSync systemd-run ENOENT' });
   assert.deepEqual(scopedStartFailure(null), { tool: 'systemd-run', detail: 'null' });
+});
+
+// Where the server sits after the bare call, read from its cgroup — never predicted. The old line after a
+// scoped failure always said "without a scope … a service restart will take it down"; on a scoped call
+// that timed out the server was already up inside the scope (systemd-run exec'd the client in place; the
+// timeout killed the client, not the daemon it forked), and after a service restart an earlier manager's
+// scope may still hold the server while systemd-run fails this time. Both predicted a loss that would not
+// happen.
+const UNSCOPED_LINE = 'tmux server ensured without a scope — under the service, a service restart will take it down';
+
+test('placementFromCgroup: a romp-tmux scope on the path is scoped, named; anything else is unscoped', () => {
+  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-tmux-1725000000000.scope\n'),
+    { placement: 'scoped', unit: 'romp-tmux-1725000000000.scope' });
+  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-manager.service\n'),
+    { placement: 'unscoped' });
+  assert.deepEqual(placementFromCgroup('0::/init.scope\n'), { placement: 'unscoped' }, "pid 1's cgroup: the bats fake's answer");
+});
+
+test('placementFromCgroup: cgroup v1 is one line per controller, each ending in the unit — every line is tried', () => {
+  const v1 = '12:pids:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n'
+    + '3:cpu,cpuacct:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n'
+    + '1:name=systemd:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n';
+  assert.deepEqual(placementFromCgroup(v1), { placement: 'scoped', unit: 'romp-tmux-7.scope' });
+});
+
+test("placementFromCgroup: a session's romp-session scope is not the manager's claim; an empty file is unknown", () => {
+  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-2222-3333-4444-555555555555.scope\n'),
+    { placement: 'unscoped' });
+  assert.deepEqual(placementFromCgroup(''), { placement: 'unknown', why: 'empty cgroup file' });
+  assert.deepEqual(placementFromCgroup('\n  \n'), { placement: 'unknown', why: 'empty cgroup file' });
+});
+
+test("tmuxServerPlacement asks for the server pid, then reads THAT pid's cgroup", () => {
+  const read = [];
+  const r = tmuxServerPlacement({ serverPid: () => '4242\n', readCgroup: (pid) => { read.push(pid); return '0::/app.slice/romp-tmux-9.scope\n'; } });
+  assert.deepEqual(r, { placement: 'scoped', unit: 'romp-tmux-9.scope' });
+  assert.deepEqual(read, ['4242'], 'the pid as tmux printed it, trimmed');
+});
+
+test('tmuxServerPlacement never throws: every failure of the probe is unknown, with its first line as the why', () => {
+  const noServer = Object.assign(new Error('Command failed: tmux display-message -p #{pid}'),
+                                 { status: 1, stderr: Buffer.from('no server running on /nonexistent/tmux-0/default\n') });
+  assert.deepEqual(tmuxServerPlacement({ serverPid: () => { throw noServer; } }),
+    { placement: 'unknown', why: 'no server running on /nonexistent/tmux-0/default' });
+  const timedOut = Object.assign(new Error('spawnSync tmux ETIMEDOUT'), { code: 'ETIMEDOUT', stderr: Buffer.alloc(0) });
+  assert.deepEqual(tmuxServerPlacement({ serverPid: () => { throw timedOut; } }),
+    { placement: 'unknown', why: 'spawnSync tmux ETIMEDOUT' }, "nothing on stderr: the error's own first line");
+  assert.deepEqual(tmuxServerPlacement({ serverPid: () => '' }), { placement: 'unknown', why: 'tmux reported no server pid' });
+  assert.deepEqual(tmuxServerPlacement({ serverPid: () => 'abc' }), { placement: 'unknown', why: 'tmux reported no server pid' });
+  const gone = Object.assign(new Error("ENOENT: no such file or directory, open '/proc/4242/cgroup'"), { code: 'ENOENT' });
+  assert.deepEqual(tmuxServerPlacement({ serverPid: () => '4242', readCgroup: () => { throw gone; } }),
+    { placement: 'unknown', why: "ENOENT: no such file or directory, open '/proc/4242/cgroup'" });
+  const long = Object.assign(new Error('x'), { stderr: Buffer.from('no server ' + 'y'.repeat(500)) });
+  const { why } = tmuxServerPlacement({ serverPid: () => { throw long; } });
+  assert.equal(why.length, 200);
+  assert.ok(why.endsWith('…'), 'bounded like the failure line');
+});
+
+test('bareEnsuredLine: unscoped is the line as it always was, byte for byte', () => {
+  assert.equal(bareEnsuredLine({ placement: 'unscoped' }), UNSCOPED_LINE);
+});
+
+test('bareEnsuredLine: a scoped server names its unit and predicts no loss', () => {
+  const line = bareEnsuredLine({ placement: 'scoped', unit: 'romp-tmux-1725000000000.scope' });
+  assert.ok(line.startsWith('tmux server ensured'), line);
+  assert.ok(line.includes('romp-tmux-1725000000000.scope'), 'the unit that holds it');
+  assert.ok(line.includes('leaves it'), 'a restart leaves it alive');
+  assert.ok(!line.includes('will take it down') && !line.includes('without a scope'), 'no prediction of a loss');
+});
+
+test('bareEnsuredLine: an unreadable placement says so, carries the why, and predicts no loss', () => {
+  const line = bareEnsuredLine({ placement: 'unknown', why: 'no server running on /nonexistent/tmux-0/default' });
+  assert.ok(line.startsWith('tmux server ensured'), line);
+  assert.ok(line.includes('could not be read (no server running on /nonexistent/tmux-0/default)'), line);
+  assert.ok(!line.includes('will take it down') && !line.includes('without a scope'), 'no prediction of a loss');
+});
+
+test('the probe is tmux display-message -p #{pid}: the server pid, and no server started when there is none', () => {
+  assert.deepEqual(TMUX_SERVER_PID_ARGV, ['tmux', 'display-message', '-p', '#{pid}']);
 });

--- a/tests/romp-manager-tmux-scope.bats
+++ b/tests/romp-manager-tmux-scope.bats
@@ -11,7 +11,10 @@
 # --scope mode does for real) or, with FAKE_SYSTEMD_RUN_FAIL set, exits 1 with a bus error on stderr. A
 # recording fake tmux answers the command either way; with FAKE_TMUX_FAIL set it exits 1 with tmux's
 # connect error on stderr, which is what tmux failing INSIDE a scope that did start looks like to the
-# manager. Nothing here reaches the real systemd-run or the user manager: the switch is turned on only
+# manager. After a failed scoped start the manager also asks tmux for the server's pid and reads that
+# pid's cgroup to word the line that follows the bare call (the #953 review); the fake answers pid 1
+# (whose cgroup is never a romp-tmux scope) unless FAKE_TMUX_PID=none, tmux's answer when no server
+# runs. Nothing here reaches the real systemd-run or the user manager: the switch is turned on only
 # behind the fake, and the floor tmux_private_socket_dir sets (ROMP_CLI_SCOPE=0) stays for the case
 # that pins it.
 
@@ -23,9 +26,22 @@ setup() {
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
     BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
     export FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" FAKE_SYSTEMD_RUN_CALLS="$TEST_DIR/systemd-run-calls"
+    # The pid probe: pid 1 by default — its cgroup is never a romp-tmux scope, so the manager reads
+    # the server as unscoped; FAKE_TMUX_PID=none is tmux with no server (exit 1, its line on stderr).
+    # A fake cannot put a process in a scope, so the scoped answer is the node suite's. Never answer
+    # with $PPID: a suite run from a window on the manager's own default server has the manager
+    # sitting in a romp-tmux scope, and the case would read "scoped" on that box while passing in CI.
     cat > "$BIN/tmux" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FAKE_TMUX_CALLS"
+if [ "$1" = display-message ]; then
+    if [ "${FAKE_TMUX_PID:-}" = none ]; then
+        echo 'no server running on /nonexistent/tmux-0/default' >&2
+        exit 1
+    fi
+    printf '%s\n' "${FAKE_TMUX_PID:-1}"
+    exit 0
+fi
 if [ -n "${FAKE_TMUX_FAIL:-}" ]; then
     echo 'error connecting to /nonexistent/tmux-0/default (No such file or directory)' >&2
     exit 1
@@ -86,6 +102,7 @@ start_manager() {
 }
 
 BARE='start-server ; set -g exit-empty off'
+PROBE='display-message -p #{pid}'
 
 # Absence, armed: `run` then a status test, the form tests/romp-cli-scope.bats uses. A bare `! grep -q`
 # that is not a test's last command is exempt from bats' errexit and asserts nothing — a manager that
@@ -110,16 +127,20 @@ log_lacks() {   # $1: a grep pattern that must match no line of the manager's lo
     log_lacks 'could not start the tmux server in a scope'
     log_lacks 'failed inside the scope'
     log_lacks 'ensured without a scope'
+    log_lacks 'could not be read'
     log_lacks 'launchd-rooted'
 }
 
-@test "switch on, systemd-run failing: the log names systemd-run and carries its first stderr line, the server starts bare, and the log says it is unscoped" {
+@test "switch on, systemd-run failing: the log names systemd-run and carries its first stderr line, the server starts bare, and the log reads it as unscoped" {
     need_tools
     [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
+    [ -r /proc/1/cgroup ] || skip "the placement is read from /proc/<pid>/cgroup (pid 1's here)"
     export ROMP_CLI_SCOPE=1 FAKE_SYSTEMD_RUN_FAIL=1
     start_manager
     [ "$(wc -l < "$FAKE_SYSTEMD_RUN_CALLS")" -eq 1 ]   # tried once...
-    [ "$(cat "$FAKE_TMUX_CALLS")" = "$BARE" ]          # ...then the bare call, once
+    # ...then the bare call, once, then the pid probe: the fake answers pid 1, whose cgroup names no
+    # romp-tmux scope, so the line reads the server as unscoped — the line as it always was
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$(printf '%s\n%s' "$BARE" "$PROBE")" ]
     # the failure line: systemd-run named, its first stderr line in the parenthesis, the second line not
     grep -q 'systemd-run could not start the tmux server in a scope (Failed to start transient scope unit: Failed to connect to bus: No such file or directory)' "$LOG"
     log_lacks 'second stderr line'
@@ -127,9 +148,26 @@ log_lacks() {   # $1: a grep pattern that must match no line of the manager's lo
     grep -q 'starting it the plain way instead' "$LOG"
     grep -q 'tmux server ensured without a scope' "$LOG"
     grep -q 'a service restart will take it down' "$LOG"
+    log_lacks 'could not be read'
     log_lacks 'failed inside the scope'
     log_lacks 'in its own transient scope'
     log_lacks 'launchd-rooted'
+}
+
+@test "switch on, systemd-run failing, the server's place unreadable: the line says so and predicts no loss" {
+    # tmux answers "no server running" to the probe (the bare call's server is a fake here): the manager
+    # cannot tell where the server sits, and says that instead of asserting it is unscoped — the wrong
+    # prediction the #953 review named after a scoped call that timed out with the server alive inside
+    # its scope
+    need_tools
+    [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
+    export ROMP_CLI_SCOPE=1 FAKE_SYSTEMD_RUN_FAIL=1 FAKE_TMUX_PID=none
+    start_manager
+    [ "$(cat "$FAKE_TMUX_CALLS")" = "$(printf '%s\n%s' "$BARE" "$PROBE")" ]
+    grep -q 'tmux server ensured — whether it sits in a scope could not be read (no server running on /nonexistent/tmux-0/default)' "$LOG"
+    log_lacks 'ensured without a scope'
+    log_lacks 'will take it down'
+    log_lacks 'in its own transient scope'
 }
 
 @test "switch on, tmux failing inside the scope: the log names tmux and carries its line, then the bare call is tried" {
@@ -161,5 +199,6 @@ log_lacks() {   # $1: a grep pattern that must match no line of the manager's lo
     grep -q 'tmux server ensured (launchd-rooted)' "$LOG"
     log_lacks 'transient scope'
     log_lacks 'without a scope'
+    log_lacks 'could not be read'
     log_lacks 'failed inside the scope'
 }

--- a/tests/test_dead_wait_block.py
+++ b/tests/test_dead_wait_block.py
@@ -433,7 +433,10 @@ class DeadWaitOneObserver(_HermeticDeadWait):
     def test_a_mid_pass_ws_tick_leaves_the_transition_alone(self):
         # the racing interleave, deterministically: the pusher is MID-PASS (inside a candidate's
         # corroboration) when the WS handler's tick fires. The transition set must be exactly
-        # what the pusher's pass installed — untouched by the nested tick.
+        # what the pusher's pass installed — untouched by the nested tick. What holds it today is
+        # the single-flight guard: the pusher's pass holds _AUTO_NUDGE_TICK_LOCK (a plain Lock), so
+        # the nested tick returns at its try-acquire before run_dead_wait is even read. The
+        # run_dead_wait=False sweep skip is pinned by the sequential sibling above, not by this test.
         _seed_store()
         _write_state("idle", STAMP_T + 50)
         km._PREV_ALIVE = {SID}
@@ -444,7 +447,7 @@ class DeadWaitOneObserver(_HermeticDeadWait):
             if "ran" not in seen:
                 seen["ran"] = True
                 before = set(km._PREV_ALIVE)
-                km._auto_nudge_tick(STAMP_T + 901, {}, run_dead_wait=False)   # WS fires mid-pass
+                km._auto_nudge_tick(STAMP_T + 901, {}, run_dead_wait=False)   # WS fires mid-pass: returns at the lock
                 seen["moved"] = set(km._PREV_ALIVE) != before
             return real(sid, scan=scan, stats=stats)
 
@@ -460,19 +463,22 @@ class DeadWaitOneObserver(_HermeticDeadWait):
 
     def test_the_setautonudge_call_site_skips_the_sweep(self):
         # the ownership rule holds at every WS call site (setAutoNudge and setCompactSuggest),
-        # pinned the way test_wake_goal_routes_its_dormant_branch_here pins its wiring. The
-        # setAutoNudge arm is sliced out and checked on its own: a whole-source substring match
-        # stayed green while that arm's tick was missing, satisfied by setCompactSuggest's line
-        # (#846 inserted the new arm between the setter and its tick, re-parenting the tick).
+        # pinned the way test_wake_goal_routes_its_dormant_branch_here pins its wiring. Each arm is
+        # sliced out and checked on its own: a whole-source substring match stayed green while the
+        # setAutoNudge arm's tick was missing, satisfied by setCompactSuggest's line (#846 inserted
+        # the new arm between the setter and its tick, re-parenting the tick). Both arms tick
+        # through the one wrap, _ws_act_now_tick (the #943 review), which holds the one WS-shaped
+        # call — so the sweep skip is pinned there, and no arm may call the tick around the wrap.
         src = inspect.getsource(km.Handler._dispatch_ws)
-        arm = src[src.index('"setAutoNudge"'):src.index('"setCompactSuggest"')]
-        self.assertIn("_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)", arm,
-                      "setAutoNudge's own arm re-ticks, and skips the sweep")
-        calls = src.count("_auto_nudge_tick(int(time.time())")
-        self.assertGreaterEqual(calls, 2, "both WS arms re-tick")
-        self.assertEqual(calls, src.count("_auto_nudge_tick(int(time.time()), _tmux_sessions(), "
-                                          "run_dead_wait=False)"),
-                         "no WS call site runs the one-observer sweep")
+        arm_a = src[src.index('"setAutoNudge"'):src.index('"setCompactSuggest"')]
+        arm_c = src[src.index('"setCompactSuggest"'):src.index('"setUpdateMode"')]
+        self.assertIn("_ws_act_now_tick()", arm_a, "setAutoNudge's own arm re-ticks, through the wrap")
+        self.assertIn("_ws_act_now_tick()", arm_c, "setCompactSuggest's arm re-ticks, through the wrap")
+        self.assertNotIn("_auto_nudge_tick(", src, "no WS call site ticks around the wrap")
+        wrap = inspect.getsource(km._ws_act_now_tick)
+        self.assertIn("_auto_nudge_tick(int(time.time()), _tmux_sessions(), run_dead_wait=False)", wrap,
+                      "the WS-shaped tick skips the one-observer sweep")
+        self.assertIn("except Exception", wrap, "…and a failure in it is logged, not a socket failure")
 
 
 if __name__ == "__main__":

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -9,6 +9,7 @@ expects to read), or the sha when HEAD is detached. Real temp git repos, synthet
 (TESTORG / notes-api — the demo world); the one network query (ls-remote) is served by a LOCAL bare
 repo through a stand-in ssh, so no test reaches GitHub.
 """
+import http.server
 import json
 import os
 import shutil
@@ -580,6 +581,76 @@ class BranchOnOrigin(_WithOrigin):
         os.environ["GIT_SSH_COMMAND"] = _script(self.root, "probe-ssh", "touch '%s'\nexit 255\n" % marker)
         self.assertEqual(km._file_github_url(self.fp, None), self.URL % "wip")
         self.assertFalse(os.path.exists(marker), "_file_github_url pays no network query")
+
+
+class NoPromptOnOrigin(_WithOrigin):
+    """The origin check's git must never pop a prompt of any kind (the #947 review). GIT_TERMINAL_PROMPT=0
+    closes the terminal route only: the child inherited GIT_ASKPASS, core.askPass and SSH_ASKPASS, so an
+    https origin answering 401 asked for a username and a password through the first of those it found —
+    with a GUI askpass exported in the kernel's shell, a prompt on every viewer open of a file under such
+    an origin, then killed at the deadline. ssh's own SSH_ASKPASS use (DISPLAY set, no tty) was open too.
+    The chosen behaviour: such an origin reads "could not check" rather than a verdict, and an askpass
+    that would have answered silently for a signed-in user is refused with the rest."""
+
+    def test_the_transport_child_sees_every_prompt_route_closed(self):
+        # the environment git hands its transport child is the one its own askpass lookup read; the
+        # stand-in ssh dumps it. Set-EMPTY GIT_ASKPASS is what overrides core.askPass and SSH_ASKPASS: git
+        # tests the variable's presence before falling to either, so unset would not do — pinned as
+        # `${GIT_ASKPASS+set}:` so a later cleanup to a pop() reads as the regression it is.
+        _restore_env_after(self, "GIT_ASKPASS", "SSH_ASKPASS", "DISPLAY")
+        gui = os.path.join(self.root, "gui-askpass")          # a path only; nothing runs it on the ssh path
+        os.environ["GIT_ASKPASS"] = os.environ["SSH_ASKPASS"] = gui
+        os.environ["DISPLAY"] = ":0"
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        dump = os.path.join(self.root, "child-env")
+        os.environ["GIT_SSH_COMMAND"] = _script(
+            self.root, "env-ssh",
+            'printf "%%s\\n" "${GIT_ASKPASS+set}:$GIT_ASKPASS" "$SSH_ASKPASS_REQUIRE" "$GIT_TERMINAL_PROMPT" > "%s"\n'
+            'exit 255\n' % dump)
+        self.assertEqual(km._file_github_link(self.fp, None),
+                         (self.URL % "wip", "could not check whether branch wip is on origin"),
+                         "the stand-in refused, so the verdict is unchecked: the dump came from the kernel's query")
+        with open(dump) as f:
+            self.assertEqual(f.read().splitlines(), ["set:", "never", "0"],
+                             "GIT_ASKPASS set-empty (never unset), SSH_ASKPASS_REQUIRE=never, GIT_TERMINAL_PROMPT=0")
+
+    def test_a_credential_wanting_origin_pops_no_askpass_and_reads_unchecked(self):
+        # A loopback origin answering 401 with a Basic challenge is the credential-wanting private origin;
+        # a marker-writing askpass stands in for the GUI one. The control comes first: under
+        # GIT_TERMINAL_PROMPT=0 alone git DOES run the askpass, so the stand-in elicits the prompt this
+        # test is about. Then the kernel's query: no askpass run, and the verdict is unchecked.
+        # _origin_has_branch is called directly because _file_github_link's URL check reads a loopback
+        # origin as not GitHub before any ls-remote (and _local_origin's note says why an insteadOf
+        # rewrite cannot stand in for the URL).
+        exec_path = subprocess.run(["git", "--exec-path"], capture_output=True, text=True).stdout.strip()
+        if not os.path.exists(os.path.join(exec_path, "git-remote-https")):
+            self.skipTest("this git has no https transport")
+
+        class Challenge(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", 'Basic realm="notes-api"')
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *a):
+                pass
+        srv = http.server.HTTPServer(("127.0.0.1", 0), Challenge)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)                        # cleanups run last-added first: shutdown, then close
+        marker = os.path.join(self.root, "asked")
+        _restore_env_after(self, "GIT_ASKPASS")
+        os.environ["GIT_ASKPASS"] = _script(self.root, "askpass", 'echo asked >> "%s"\necho user\n' % marker)
+        _git("remote", "set-url", "origin", "http://127.0.0.1:%d/TESTORG/notes-api.git" % srv.server_address[1],
+             cwd=self.tmp)
+        _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
+        subprocess.run(["git", "-C", self.tmp, "ls-remote", "--heads", "origin", "refs/heads/wip"],
+                       env=dict(os.environ, GIT_TERMINAL_PROMPT="0"), capture_output=True, timeout=30)
+        self.assertTrue(os.path.exists(marker), "control: under GIT_TERMINAL_PROMPT=0 alone git runs the askpass")
+        os.remove(marker)
+        self.assertIsNone(km._origin_has_branch(self.tmp, "wip"), "a credential-wanting origin reads as unchecked")
+        self.assertFalse(os.path.exists(marker), "the kernel's query ran no askpass program")
 
 
 class GitLinkWire(_WithOrigin):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6677,8 +6677,10 @@ class AliasHeadDrift(unittest.TestCase):
     (_ALIAS_SERVED), and _adaptive_thinking consults that ahead of the table from then on; a served
     version the table disagrees with is announced once per (alias, served id). Quiet when they agree, on
     a versioned pin (never remapped), and when the envelope names no same-family model — no evidence
-    either way, so the table's answer stands exactly as before. The subprocess is stubbed and its argv +
-    env captured — nothing runs."""
+    either way, so the table's answer stands exactly as before. An envelope with no modelUsage map at
+    all is the other case (the #948 review): the check cannot run for any alias, so a stale table would
+    be trusted with nothing logged — said once per process, latched in _NO_MODEL_USAGE_LOGGED. The
+    subprocess is stubbed and its argv + env captured — nothing runs."""
 
     def setUp(self):
         self.calls = []
@@ -6709,10 +6711,12 @@ class AliasHeadDrift(unittest.TestCase):
         jd._LEVER_LOGGED.clear()
         jd._ALIAS_SERVED.clear()
         jd._ALIAS_DRIFT_LOGGED.clear()
+        jd._NO_MODEL_USAGE_LOGGED.clear()
 
     def _run(self, model, model_usage=None, tier="index", judge="captioner"):
         """One stubbed call; the envelope carries `model_usage` under modelUsage when given (None: the
-        envelope names no model, the IndexTierLever stub's shape). Returns (argv, env, stderr text)."""
+        envelope carries no modelUsage map at all, the IndexTierLever stub's shape). Returns (argv, env,
+        stderr text)."""
         self.calls.clear()
         wrap = {"result": "a caption", "usage": {}}
         if model_usage is not None:
@@ -6732,6 +6736,10 @@ class AliasHeadDrift(unittest.TestCase):
     @staticmethod
     def _drift_lines(err):
         return [ln for ln in err.splitlines() if "_ALIAS_HEAD" in ln]
+
+    @staticmethod
+    def _missing_map_lines(err):
+        return [ln for ln in err.splitlines() if "modelUsage" in ln]
 
     def test_a_served_version_that_matches_the_table_is_quiet(self):
         cmd, env, err = self._run("haiku", {"claude-haiku-4-5-20251001": {"inputTokens": 100, "outputTokens": 15}})
@@ -6799,15 +6807,41 @@ class AliasHeadDrift(unittest.TestCase):
         self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
 
     def test_an_envelope_naming_no_model_is_quiet(self):
-        # absence carries no evidence of drift: the table's answer stands exactly as before this check
-        # existed (and IndexTierLever's stub, which names no model, keeps its empty-stderr assertion)
-        for mu in (None, {}):
+        # a PRESENT map that names no same-family model carries no evidence of drift: the table's answer
+        # stands exactly as before this check existed, and nothing is said — the absence of a
+        # same-family entry is not the absence of the map (the next test)
+        for mu in ({}, {"claude-sonnet-5-20260201": {"outputTokens": 30}}):
             self._reset()
             cmd, env, err = self._run("haiku", mu)
             self.assertEqual(self._drift_lines(err), [], "modelUsage=%r" % (mu,))
-            self.assertEqual(jd._ALIAS_SERVED, {})
+            self.assertEqual(self._missing_map_lines(err), [], "modelUsage=%r" % (mu,))
+            self.assertNotIn("haiku", jd._ALIAS_SERVED)
             self.assertNotIn("--effort", cmd)
             self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+
+    def test_a_missing_model_usage_map_is_announced_once_per_process(self):
+        # No map at all — a CLI older than the field, or a shape change: the check's own precondition
+        # fails, so the index tier keeps choosing its lever from a table nothing has verified. Silent, that
+        # is the degradation the loud-failure rule forbids; one line per PROCESS is the whole signal (the
+        # field is a property of the CLI, not of the call), so IndexTierLever's stub, which carries no
+        # map, still keeps its second-call empty-stderr pin.
+        cmd, env, err = self._run("haiku", None)
+        lines = self._missing_map_lines(err)
+        self.assertEqual(len(lines), 1, "one line, got: %r" % err)
+        self.assertIn("haiku", lines[0], "the line names the alias whose call revealed it")
+        self.assertIn("alias table", lines[0], "…and says what the lever answers from meanwhile")
+        self.assertEqual(self._drift_lines(err), [], "not a drift line: the table was not contradicted")
+        self.assertEqual(jd._ALIAS_SERVED, {})
+        self.assertNotIn("--effort", cmd)
+        self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+        _cmd, _env, err = self._run("sonnet", None)
+        self.assertEqual(self._missing_map_lines(err), [], "once per process, not per alias")
+        self._reset()
+        _cmd, _env, err = self._run("claude-haiku-4-5", None)
+        self.assertEqual(self._missing_map_lines(err), [], "a versioned pin is never checked: nothing to announce")
+        self._reset()
+        _cmd, _env, err = self._run("haiku", None)
+        self.assertEqual(len(self._missing_map_lines(err)), 1, "the latch is the state the tests clear")
 
     def test_a_malformed_entry_cannot_cost_the_reply(self):
         # best-effort like _log_judge_usage: the reply is the call's product, the check is bookkeeping

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6470,6 +6470,11 @@ class EffortCapability(unittest.TestCase):
            "claude-opus-4-0", "claude-sonnet-4-0", "claude-sonnet-4-5[1m]", "claude-sonnet-4-5-20250929",
            "claude-opus-4-20250514", "claude-3-7-sonnet-20250219", "claude-3-5-haiku-20241022")
 
+    def setUp(self):
+        # `haiku -> False` below reads the table only while the alias record is empty: cleared here so
+        # the pin does not depend on AliasHeadDrift's tearDown having run in the same xdist worker
+        jd._ALIAS_SERVED.clear()
+
     def test_the_catalog_rule_in_both_directions(self):
         with contextlib.redirect_stderr(io.StringIO()) as err:
             for m in self.ADAPTIVE:
@@ -6541,6 +6546,10 @@ class IndexTierLever(unittest.TestCase):
         (jd.STATE / "index-effort").unlink(missing_ok=True)
         jd._state_cache.clear()
         jd._LEVER_LOGGED.clear()
+        # the alias record and the no-modelUsage latch are per process: cleared here so this class's
+        # `haiku` pins do not depend on AliasHeadDrift's tearDown having run in the same xdist worker
+        jd._ALIAS_SERVED.clear()
+        jd._NO_MODEL_USAGE_LOGGED.clear()
         os.environ.pop("MAX_THINKING_TOKENS", None)
 
         class _P:
@@ -6655,6 +6664,8 @@ class IndexTierLever(unittest.TestCase):
         self.assertIn("--effort low", err, "the line names the lever that applied")
         self.calls.clear()
         _cmd, _env, err2 = self._run("fable")
+        # the stub carries no modelUsage, so the once-per-process line about that lands on the FIRST
+        # call of this test (setUp cleared the latch) and the second is quiet by the latch — in any order
         self.assertEqual(err2, "", "same model again → no second line (one line per lever change)")
         self.calls.clear()
         _cmd, _env, err3 = self._run("haiku")

--- a/tests/test_judge_authoritative_plan_sync.py
+++ b/tests/test_judge_authoritative_plan_sync.py
@@ -152,6 +152,28 @@ def rejected_plan_session(accepted=True):
     return build_session(recs)
 
 
+REJECTED_UPDATE = ("InputValidationError: TaskUpdate failed due to the following issue:\n"
+                   "The value of `status` must be one of pending, in_progress, completed")
+
+
+def rejected_update_session(status="done", then=None):
+    """One accepted create (Task #1) followed by a TaskUpdate the CLI REJECTED — a status outside its set,
+    answered by an is_error tool_result — so the store still holds the item open; `then`, when given, is
+    the status of an ACCEPTED update after it (the skip is per call, not per item)."""
+    recs = [uline(T0, "run the migration", "u1"),
+            tcreate(T0 + 5, "ac1", "u1", "Design v3", "Designing v3", "tc1"),
+            tres(T0 + 6, "rc1", "ac1", "tc1", "Task #1 created successfully. Use TaskUpdate to update it."),
+            tupdate(T0 + 7, "ax1", "rc1", "1", status, "tx1"),
+            tres(T0 + 8, "rx1", "ax1", "tx1", REJECTED_UPDATE, is_error=True)]
+    parent, t = "rx1", T0 + 9
+    if then is not None:
+        recs.append(tupdate(t, "au1", parent, "1", then, "tu1")); t += 1
+        recs.append(tres(t, "ru1", "au1", "tu1", "Task #1 updated.")); t += 1
+        parent = "ru1"
+    recs.append(aline(t, "On it.", "aend", parent, stop="end_turn"))
+    return build_session(recs)
+
+
 def fresh_store():
     return {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
 
@@ -189,6 +211,14 @@ class DeclaredPlanAdapter(unittest.TestCase):
         items = em.declared_plan(rejected_plan_session())
         self.assertEqual([(it["key"], it["text"]) for it in items], [("1", "Design v3")],
                          "the accepted create (its result carries Task #N) still folds")
+
+    def test_a_rejected_taskupdate_moves_no_step(self):
+        """The TaskCreate skip's twin (the #942 review): a TaskUpdate the CLI rejected — its paired
+        tool_result carries is_error — wrote nothing to the store, so the step keeps the status the store
+        holds. Without the skip the refused value folded as the item's status. The skip is per call: an
+        accepted update after the rejected one still applies (mirroring the kernel's _fold_tasks)."""
+        self.assertEqual(em.declared_plan(rejected_update_session())[0]["status"], "pending")
+        self.assertEqual(em.declared_plan(rejected_update_session(then="in_progress"))[0]["status"], "in_progress")
 
 
 class SyncFindOrCreate(unittest.TestCase):
@@ -288,6 +318,19 @@ class SyncFindOrCreate(unittest.TestCase):
         self.assertEqual({k: nd["text"] for k, nd in agent_nodes(store).items()}, {"1": "Design v3"},
                          "only the accepted create is mirrored")
         self.assertNotIn("(declared step)", [nd["text"] for nd in store["nodes"].values()])
+
+    def test_a_rejected_taskupdate_leaves_the_mirrored_node_open(self):
+        """What the fold-path leak costs on the sync side: a rejected completing update read as the agent
+        crossing the item off, so the mirror flipped to authoritative-done for a task the store still holds
+        open. The node must stay open — the fold gave the sync no new status."""
+        store = fresh_store()
+        jd._sync_declared_plan(store, plan_session([("Design v3", "Designing v3", [])]), "seg1", T0 + 50)
+        nd = agent_nodes(store)["1"]
+        self.assertEqual(nd["agentTask"]["status"], "open")
+        self.assertFalse(jd._sync_declared_plan(store, rejected_update_session(status="completed"), "seg2", T0 + 100),
+                         "a rejected update is not new information: nothing to mutate")
+        self.assertEqual(nd["agentTask"]["status"], "open", "the store still holds the item open")
+        self.assertFalse(nd["nodeComplete"])
 
     def test_open_backlog_node_is_adopted_not_deleted(self):
         """A pre-fix OPEN agentTask node (marker absent) is ADOPTED (marker added), never deleted — so it

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -450,6 +450,40 @@ class ViewBuilder(unittest.TestCase):
         self.assertNotIn("todo", kinds_batch, "rejected {tasks} batch → no phantom to-do card, no error")
         self.assertTrue(todo and todo[0].get("error"), "control: an accepted create still surfaces the error")
 
+    def test_fold_ignores_a_rejected_taskupdate(self):
+        # The TaskCreate skip's twin (the #942 review): a TaskUpdate the CLI REJECTED — a status value
+        # outside its set, a transition it refused — answers with an is_error tool_result and writes nothing
+        # to the store, so it moves no checklist item. Before the skip the fold applied the refused status as
+        # if the store held it. Keyed on the result's is_error, exactly as the TaskCreate branch is, so this
+        # fold and event_model.declared_plan stay identical; an accepted update still applies, and so does
+        # one whose result has not landed yet (unchanged, pinned beside the skip).
+        def _tu(name, inp, rid):
+            return {"type": "tool_use", "id": rid, "name": name, "input": inp}
+        def _tr(rid, text, is_error=False):
+            b = {"type": "tool_result", "tool_use_id": rid, "content": text}
+            if is_error:
+                b["is_error"] = True
+            return {"type": "user", "message": {"content": [b]}}
+        def _asst(*blocks):
+            return {"type": "assistant", "message": {"content": list(blocks)}}
+        refused = ("InputValidationError: TaskUpdate failed due to the following issue:\n"
+                   "The value of `status` must be one of pending, in_progress, completed")
+        created = [_asst(_tu("TaskCreate", {"subject": "vet the pairs"}, "toolu_TEST0011")),
+                   _tr("toolu_TEST0011", "Task #1 created successfully. Use TaskUpdate to update it.")]
+        rejected = [_asst(_tu("TaskUpdate", {"taskId": "1", "status": "done"}, "toolu_TEST0012")),
+                    _tr("toolu_TEST0012", refused, is_error=True)]
+        s = {"turns": [{"atoms": created + rejected}]}
+        self.assertEqual(km._fold_tasks(s)[0]["status"], "pending", "a rejected update moves nothing")
+        # the skip is per call: an accepted update after the rejected one still applies
+        accepted = [_asst(_tu("TaskUpdate", {"taskId": "1", "status": "in_progress"}, "toolu_TEST0013")),
+                    _tr("toolu_TEST0013", "Task #1 updated.")]
+        s = {"turns": [{"atoms": created + rejected + accepted}]}
+        self.assertEqual(km._fold_tasks(s)[0]["status"], "in_progress")
+        # an update whose result has not landed (the turn is still open) applies as before
+        pending = [_asst(_tu("TaskUpdate", {"taskId": "1", "status": "completed"}, "toolu_TEST0014"))]
+        s = {"turns": [{"atoms": created + pending}]}
+        self.assertEqual(km._fold_tasks(s)[0]["status"], "completed", "no result yet is not a rejection")
+
     def test_fully_completed_store_drops_the_todo_card(self):
         # a done list is not a live to-do (the user 2026-06-10). At `track`'s screenshot time the store was
         # already all-completed, so the store-based card is correctly ABSENT — not a stale "3/5".

--- a/tests/test_op_credential_boundary.py
+++ b/tests/test_op_credential_boundary.py
@@ -58,7 +58,9 @@ class ManagerAndLauncher(unittest.TestCase):
         self.assertIn("if (!out.ROMP_API_KEY_REF && !serviceEnvHasRef(env)) return out;", src,
                       "a helper box keeps its environment; the env file's own line counts as configured")
         self.assertRegex(src, r"k === 'OP_SERVICE_ACCOUNT_TOKEN' \|\| k === 'OP_CONNECT_HOST' \|\| k === 'OP_CONNECT_TOKEN' \|\| k === 'OP_ACCOUNT' \|\| k\.startsWith\('OP_SESSION_'\)\s*\|\| k === 'ANTHROPIC_API_KEY'")
-        self.assertEqual(src.count("env: withoutOpCredentials(process.env) });"), 2, "the scoped and the bare start")
+        self.assertEqual(src.count("env: withoutOpCredentials(process.env) });"), 3,
+                         "the scoped start, the bare start, and the pid probe after a failed scoped start (a tmux "
+                         "client that starts no server, scrubbed all the same: every tmux exec here is)")
 
     def test_the_launcher_scrubs_the_servers_globals_before_the_pane_exists(self):
         src = _read("bin/romp")

--- a/tests/test_pane_order_parity.py
+++ b/tests/test_pane_order_parity.py
@@ -5,6 +5,7 @@ re-ordering". The desktop's presentation order is the rail strip's left-to-right
 own choice, 2026-07-05); both the rail buttons and the mobile #mtabs now render from the one
 _PANE_ORDER constant, so the pin below survives any future reorder of that constant: it asserts
 the two BUILT surfaces agree, not any particular sequence."""
+import json
 import os
 import re
 import tempfile
@@ -64,11 +65,22 @@ class PaneOrderParity(unittest.TestCase):
 
     def test_labels_match_the_pn_map(self):
         # the JS-side PN map (key → user-facing label) and the constant must agree, or a pane
-        # wears one name in the shell chrome and another in the tabs
+        # wears one name in the shell chrome and another in the tabs. The map is JSON spliced into
+        # the bell's script from the constant at import (the #957 review: a hand-written PN was a
+        # second list, and drifted), so it parses as JSON here.
         html = km._landing()
         pn = re.search(r"var PN=\{([^}]*)\}", html).group(1)
-        js = dict(re.findall(r"(\w+):'([^']*)'", pn))
-        self.assertEqual(dict(km._PANE_ORDER), js)
+        self.assertEqual(dict(km._PANE_ORDER), json.loads("{" + pn + "}"))
+
+    def test_the_pn_map_is_built_from_the_constant(self):
+        # the mechanism, as test_both_surfaces_render_from_the_one_constant pins it for the HTML: the
+        # bell's map is derived, not typed, and the constant is defined before the string built from it
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        # assertTrue(needle in src), not assertIn: a failure must not print the kernel's source
+        self.assertTrue('var PN=""" + json.dumps(dict(_PANE_ORDER)) + """' in src, "PN is json.dumps of the constant")
+        self.assertFalse("var PN={chat:" in src, "no hand-written pane-label map remains")
+        self.assertLess(src.index("_PANE_ORDER = ("), src.index('_LANDING_ERRS_JS = """'),
+                        "the constant is defined before the script constant that is built from it")
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -72,6 +72,7 @@ class LastStateValue(unittest.TestCase):
 
 class FindOrphanClis(unittest.TestCase):
     SID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    OWN = 31337   # this kernel's pid in the fixtures; no fixture below uses it as a parent
 
     def test_matches_only_sdk_clis_resuming_ours(self):
         lines = [
@@ -84,7 +85,7 @@ class FindOrphanClis(unittest.TestCase):
             # junk / short lines are skipped, not crashed on
             "garbage", " 99", " 99 100", "",
         ]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [4242])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [4242])
 
     def test_live_children_are_never_orphans(self):
         # Same command line as a true orphan, but still parented to a running kernel (the kernel's
@@ -95,7 +96,7 @@ class FindOrphanClis(unittest.TestCase):
             " 4242 38438 /x/claude --output-format stream-json --resume %s --input-format stream-json" % self.SID,
             " 4245 1 /x/claude --output-format stream-json --resume %s --input-format stream-json" % self.SID,
         ]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [4245])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [4245])
 
     # Orphaned = the parent is not a live romp kernel (2026-09-05). Until then the check was ppid 1,
     # which is what an orphan gets under launchd — and never under `systemd --user`, whose
@@ -107,17 +108,17 @@ class FindOrphanClis(unittest.TestCase):
     def test_orphan_reparented_to_launchd(self):
         # macOS: pid 1 is launchd, present in the listing and not a kernel
         lines = [" 1 0 /sbin/launchd", self._cli(700, 1)]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [700])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [700])
 
     def test_orphan_reparented_to_the_systemd_user_manager(self):
         # Linux under the service: the orphan's ppid is the `systemd --user` pid, never 1
         lines = [" 1 0 /sbin/init", " 901 1 /usr/lib/systemd/systemd --user", self._cli(701, 901)]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [701])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [701])
 
     def test_orphan_whose_parent_is_absent_from_the_listing(self):
         # the parent died between the CLI's line and its own (ps is not atomic) — an orphan
         lines = [self._cli(702, 65000)]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [702])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [702])
 
     def test_a_live_cli_parented_to_a_romp_kernel_is_never_reaped(self):
         for kernel in (" 500 901 /usr/bin/python3.12 /x/romp/bin/romp-kernel",
@@ -125,7 +126,7 @@ class FindOrphanClis(unittest.TestCase):
                        " 500 901 python3 kernel/kernel.py",
                        " 500 901 /usr/bin/python3 /x/romp/kernel/kernel.py"):
             lines = [" 901 1 /usr/lib/systemd/systemd --user", kernel, self._cli(703, 500)]
-            self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [], kernel)
+            self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [], kernel)
 
     def test_a_cli_parented_to_a_different_live_kernel_is_that_kernels(self):
         # another kernel (an aux port, a second install) owns this CLI — not ours to reap, whatever
@@ -133,7 +134,32 @@ class FindOrphanClis(unittest.TestCase):
         lines = [" 901 1 /usr/lib/systemd/systemd --user",
                  " 600 901 /usr/bin/python3.12 /elsewhere/romp/bin/romp-kernel",
                  self._cli(704, 600), self._cli(705, 901)]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [705])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [705])
+
+    # This kernel's own children are live by PID, not by how `ps` spells the kernel (the #941 review).
+    # _is_kernel_cmd knows the spellings romp-serve and a hand run produce; under any other (a `-c`
+    # runner, a renamed launcher, `python3 ./kernel.py`) it read the caller's own children as orphans —
+    # the unconditional protection the old `ppid != 1` test gave them, lost. A foreign kernel is still
+    # judged by its text: the pid shortcut is for the caller only.
+    def test_this_kernels_own_children_are_live_whatever_ps_calls_it(self):
+        for kernel in ("python3 ./kernel.py",
+                       "/usr/bin/python3 -c import runpy; runpy.run_path('kernel/kernel.py')",
+                       "/x/venv/bin/python /x/romp/bin/romp-kernel-dev"):
+            self.assertFalse(sb._is_kernel_cmd(kernel), kernel)     # so the pid path is what protects them
+            lines = [" 901 1 /usr/lib/systemd/systemd --user", " %d 901 %s" % (self.OWN, kernel),
+                     self._cli(707, self.OWN), self._cli(708, 901)]
+            self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [708], kernel)
+
+    def test_own_children_stay_live_when_the_kernels_own_line_is_absent(self):
+        # unlike test_orphan_whose_parent_is_absent_from_the_listing (ppid 65000 is not us, so that one
+        # IS an orphan): a listing that missed our own line still protects our children, by pid
+        self.assertEqual(sb.find_orphan_clis([self._cli(709, self.OWN)], [self.SID], self.OWN), [])
+
+    def test_another_kernels_children_are_still_judged_by_its_text(self):
+        # the boundary #941 drew, unchanged: a kernel spelled in a way _is_kernel_cmd does not know
+        # shields nothing unless it is THIS kernel
+        lines = [" 901 1 /usr/lib/systemd/systemd --user", " 600 901 python3 ./kernel.py", self._cli(710, 600)]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [710])
 
     def test_kernel_match_is_on_argv_tokens_not_substrings(self):
         self.assertTrue(sb._is_kernel_cmd("/usr/bin/python3.12 /x/romp/bin/romp-kernel"))
@@ -145,11 +171,11 @@ class FindOrphanClis(unittest.TestCase):
         self.assertFalse(sb._is_kernel_cmd("/usr/lib/systemd/systemd --user"))
         self.assertFalse(sb._is_kernel_cmd("python3 other/kernel.py"))
         lines = [" 800 1 tail -f /x/state/romp/romp-kernel.log", self._cli(706, 800)]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [706])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [706])
 
     def test_empty_sids_match_nothing(self):
         lines = [" 1 1 claude --resume  --input-format stream-json"]
-        self.assertEqual(sb.find_orphan_clis(lines, [""]), [])
+        self.assertEqual(sb.find_orphan_clis(lines, [""], self.OWN), [])
 
     def test_equals_flag_spelling_matches(self):
         # The Agent SDK moved to `--resume=<sid>` (equals form); the space-only match was blind to
@@ -163,7 +189,7 @@ class FindOrphanClis(unittest.TestCase):
             # equals form but a foreign sid → still not ours
             " 5004 1 /x/claude --resume=ffffffff-0000-1111-2222-333333333333 --input-format stream-json",
         ]
-        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [5001, 5002, 5003])
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [5001, 5002, 5003])
 
 
 class QueuePersistence(unittest.TestCase):
@@ -387,6 +413,29 @@ class BootReconcile(unittest.TestCase):
                          "the SDK orphan is reaped; the tmux CLI and the live (parented) CLI "
                          "on the same sid are untouched")
         self.assertEqual(run.call_args_list[0][0][0], sb.PS_ARGV, "the listing is read with PS_ARGV")
+
+    def test_the_reaper_shields_this_kernels_own_children_by_pid(self):
+        # The reconcile runs on a thread after the backend is up, concurrent with the kernel serving
+        # requests, so a session started before the thread's `ps` is THIS kernel's child carrying one
+        # of the lastsids. With the kernel spelled in a way _is_kernel_cmd does not know it was reaped
+        # as an orphan (the #941 review); the caller hands its own pid down, and the child is live by it.
+        d, be = self._setup()
+        sid = "11111111-aaaa-0000-0000-00000000000d"
+        _reg(d, sid)
+        sb.append_state(Path(d), sid, "working")
+        me = os.getpid()
+        ps = ("  901 1 /usr/lib/systemd/systemd --user\n"
+              "  %d 901 python3 ./kernel.py\n"
+              "  558 %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  559 901 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              ) % (me, me, sid, sid)
+        killed = []
+        with mock.patch.object(sb.subprocess, "run", return_value=mock.Mock(stdout=ps)), \
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))):
+            be._boot_reconcile([sb.read_reg(Path(d), sid)])
+        self.assertEqual(killed, [(559, sb.signal.SIGTERM)],
+                         "a child this kernel already spawned is left alone whatever ps calls the kernel; "
+                         "the orphan under the user manager is still reaped")
 
     def test_reconcile_is_opt_in(self):
         # Constructing the backend plain (tests, ad-hoc) must NOT spawn a reconcile thread; the

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -898,6 +898,56 @@ class AutoNudgeTurnOnActsNow(_Base):
         self.assertEqual(len(self.ticks), 1, "only the turn-on ticked")
 
 
+class WsActNowTickIsWrapped(_Base):
+    """The act-now tick runs on the WS handler thread, and the reader loop (Handler._ws) re-raises
+    OSError as a socket failure whose outer handler tears the connection down silently — so an
+    OSError out of the pass head (the session-listing fork, a store read) closed the dashboard's
+    socket with no log line: since #846 for setCompactSuggest, for setAutoNudge once #943 restored
+    its tick. Both arms now tick through one wrap (_ws_act_now_tick) that logs the traceback the way
+    the pusher's own wrap does. The tick never writes to the delivering socket (its only push is
+    _push_soon(), a wake flag), which is what makes catching everything there safe: nothing caught
+    is that socket's own failure. Driven through the real dispatch, the incident's shape."""
+
+    ARMS = ({"type": "setAutoNudge", "enabled": True, "gt": T_NEW},
+            {"type": "setCompactSuggest", "enabled": True, "gt": T_NEW})
+
+    def _dispatch_with_failing_tick(self, exc):
+        def boom(*a, **k):
+            raise exc
+        km._auto_nudge_tick = boom                                # restored by _Base.tearDown
+        out = []
+        for msg in self.ARMS:
+            client = {"send": lambda s: None, "alive": True}
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                try:
+                    km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+                except OSError:
+                    self.fail("an OSError escaped _dispatch_ws (%s) — the reader loop re-raises it as a "
+                              "socket failure and silently tears the WebSocket down" % msg["type"])
+            self.assertTrue(client["alive"], "%s: the delivering client survives the failed tick" % msg["type"])
+            out.append(err.getvalue())
+        return out
+
+    def test_a_failing_act_now_tick_is_logged_not_a_socket_failure(self):
+        errs = self._dispatch_with_failing_tick(OSError(28, "No space left on device"))
+        for msg, err in zip(self.ARMS, errs):
+            self.assertIn("auto-nudge", err, "%s: the failure is loud and names the tick" % msg["type"])
+            self.assertIn("OSError", err, "%s: the traceback is logged, as the pusher's wrap logs it" % msg["type"])
+            self.assertIn("No space left on device", err)
+        km._autonudge_cache.clear()
+        self.assertTrue(km._auto_nudge_on(), "the flag write preceded the tick and stands")
+        self.assertTrue(km._compact_suggest_on(), "…for both arms")
+
+    def test_any_failure_of_the_tick_is_caught_the_same_way(self):
+        # the pusher's wrap catches Exception; so does this one — a TypeError in the pass head is no
+        # more a socket failure than an OSError is
+        errs = self._dispatch_with_failing_tick(RuntimeError("a bad store record"))
+        for err in errs:
+            self.assertIn("auto-nudge", err)
+            self.assertIn("RuntimeError: a bad store record", err)
+
+
 SF_SID = "11111111-2222-4333-8444-555555555555"   # the single-flight tests' one fake alive session
 
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -842,12 +842,15 @@ function initGear(post) {
   // linked kernel, so one stale flush used to draw N identical toasts naming no host. The fold key
   // is the gesture's identity — setting + its own gt, which the frame carries — an event key, never
   // a time window: N kernels refusing one flush share it, two different gestures never do. A frame
-  // without gt (an older kernel) keeps one toast per frame. Liveness is the node's parentNode at
-  // lookup, so a dismissed or expired toast never absorbs a later frame and no cleanup rides the
-  // timers. A remote kernel's frame arrives host-stamped (federation.ts prefixInbound); the local
-  // kernel's has no host and reads as this machine, the name the gear already uses for it.
+  // without gt (an older kernel) keeps one toast per frame. Liveness is read at lookup — the node's
+  // parentNode, and not yet fading: a toast in its fade→remove second sits at opacity 0, so a frame
+  // written into it would never be seen (#945 review) — so a dismissed, expired or fading toast never
+  // absorbs a later frame, and still no cleanup rides the timers. A remote kernel's frame arrives
+  // host-stamped (federation.ts prefixInbound); the local kernel's has no host and reads as this
+  // machine, the name the gear already uses for it.
   var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...] } while the toast is up
   function staleHost(m) { return (typeof m.host === 'string' && m.host) ? m.host : 'this machine'; }
+  function staleLive(t) { return !!t.parentNode && !(t.classList && t.classList.contains('fade')); }
   // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
   // page has seen (the frame's storedGt included, learned just before): a fresh click is legitimate
   // new information, the event the ordering rule wants — never a clock heuristic. Offered only when
@@ -865,7 +868,7 @@ function initGear(post) {
     var kept = m.kept === true ? 'on' : m.kept === false ? 'off'
       : (typeof m.kept === 'string' && m.kept ? m.kept : '');
     var key = typeof m.gt === 'number' ? m.setting + ':' + m.gt : '';
-    var live = key && staleOpen[key] && staleOpen[key].t.parentNode ? staleOpen[key] : null;
+    var live = key && staleOpen[key] && staleLive(staleOpen[key].t) ? staleOpen[key] : null;
     var where = staleHost(m);
     if (live) {   // the same gesture, refused by one more kernel: add the host to the toast on screen
       if (live.hosts.indexOf(where) < 0) live.hosts.push(where);

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -818,6 +818,7 @@ function initGear(post) {
     if (act) {   // the toast's one action: a real button whose click also bubbles to the container's
       var b = document.createElement('button');   // delegated dismiss, so acting clears the toast too
       b.type = 'button'; b.className = 'rs-stale-toast-act'; b.textContent = act.label;
+      b.title = act.title;   // its own tooltip: the toast's reads "click to dismiss", which the button is not
       b.addEventListener('click', act.run);
       t.appendChild(b);
     }
@@ -830,13 +831,31 @@ function initGear(post) {
     setTimeout(function () { t.remove(); }, 12000);   // …then the self-clearing backstop; a click/Esc dismisses sooner
     return t;
   }
-  // The copy names the setting, the kernels that refused, and the value in force, and says the pick
-  // was not applied. It does NOT say who or where changed it: the kernel knows only that it holds a
-  // larger stamp, and with device clocks in the mix that is not the same as "someone changed it
-  // after you" (#879 review). The hosts ARE known: each refusal came from one of them.
-  function staleText(label, kept, hosts) {
-    return label + ': not applied on ' + hosts.join(', ') + '. A later pick'
-      + (kept ? ' (' + kept + ')' : '') + ' is already in place.';
+  // The copy names the setting, the value that was refused, the kernels that refused it and the value
+  // they kept, and says the pick was not applied. The refused value matters in the frozen-tab case: the
+  // pick is hours old and one click on Apply anyway sends it to every linked kernel, so the user must
+  // see what they would be applying (#945 review). It does NOT say who changed the setting, nor that
+  // the kept pick came after this one: the kernel knows only that it holds a larger stamp, and with
+  // device clocks in the mix that is not the same as "someone changed it after you" (#879 review; the
+  // #945 review retired the copy's recency claim on the same ground). The hosts ARE known: each
+  // refusal came from one of them. Either value may be absent (an older kernel echoes no gesture and
+  // sends no kept value); the copy drops that clause.
+  function staleText(label, refused, kept, hosts) {
+    return label + ': ' + (refused ? refused + ' was not applied on ' : 'not applied on ') + hosts.join(', ') + '.'
+      + (kept ? ' Keeping ' + kept + '.' : '');
+  }
+  // Values read as words: a boolean toggle's on/off, a string as itself, anything else as absent.
+  function staleWord(v) { return v === true ? 'on' : v === false ? 'off' : (typeof v === 'string' && v ? v : ''); }
+  // The value the refused gesture carried. Every emitter posts {type, <one value field>, gt} and the
+  // kernel echoes it without gt, so the value is the echo's one key beside type — read generically
+  // rather than through a third type→field map kept in step with STALE_TYPE. Trusted only for the
+  // setting the frame names (the whitelist Apply anyway uses: an echo for another setting is not this
+  // setting's value); an echo of any other shape (two value fields, none, or no echo from an older
+  // kernel) reads as no value, and the copy and the label take their value-less form.
+  function staleRefused(m) {
+    if (!m.gesture || typeof m.gesture !== 'object' || STALE_TYPE[m.setting] !== m.gesture.type) return '';
+    var keys = Object.keys(m.gesture).filter(function (k) { return k !== 'type'; });
+    return keys.length === 1 ? staleWord(m.gesture[keys[0]]) : '';
   }
   // One toast per refused GESTURE, not per refusing kernel: a dashboard's broadcast reaches every
   // linked kernel, so one stale flush used to draw N identical toasts naming no host. The fold key
@@ -848,7 +867,7 @@ function initGear(post) {
   // absorbs a later frame, and still no cleanup rides the timers. A remote kernel's frame arrives
   // host-stamped (federation.ts prefixInbound); the local kernel's has no host and reads as this
   // machine, the name the gear already uses for it.
-  var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...] } while the toast is up
+  var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...], refused: the value in words } while the toast is up
   function staleHost(m) { return (typeof m.host === 'string' && m.host) ? m.host : 'this machine'; }
   function staleLive(t) { return !!t.parentNode && !(t.classList && t.classList.contains('fade')); }
   // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
@@ -856,26 +875,30 @@ function initGear(post) {
   // new information, the event the ordering rule wants — never a clock heuristic. Offered only when
   // the echo's type is the setting the frame names, so a frame from any linked kernel may re-issue
   // that one setting and nothing else; an older kernel sends no echo and the toast shows without it.
-  function staleAction(m) {
+  // The label names the value one click would apply everywhere (the frozen-tab case again), and the
+  // button carries its own title: without one it inherited the toast's click-to-dismiss tooltip.
+  function staleAction(m, refused) {
     if (!m.gesture || typeof m.gesture !== 'object' || STALE_TYPE[m.setting] !== m.gesture.type) return null;
-    return { label: 'Apply anyway', run: function () { post(Object.assign({}, m.gesture, { gt: gclock.stamp(m.setting) })); } };
+    return { label: refused ? 'Apply ' + refused + ' anyway' : 'Apply anyway',
+             title: 'apply ' + (refused || 'this pick') + ' on every linked kernel, replacing the value they kept',
+             run: function () { post(Object.assign({}, m.gesture, { gt: gclock.stamp(m.setting) })); } };
   }
   window.addEventListener('message', function (e) {
     var m = e.data;
     if (!m || m.type !== 'settingStale') return;
     gclock.learn(m.setting, m.storedGt);   // the frame IS new information about that store's clock
     var label = STALE_LABELS[m.setting] || String(m.setting || 'A setting');
-    var kept = m.kept === true ? 'on' : m.kept === false ? 'off'
-      : (typeof m.kept === 'string' && m.kept ? m.kept : '');
+    var kept = staleWord(m.kept);
+    var refused = staleRefused(m);
     var key = typeof m.gt === 'number' ? m.setting + ':' + m.gt : '';
     var live = key && staleOpen[key] && staleLive(staleOpen[key].t) ? staleOpen[key] : null;
     var where = staleHost(m);
     if (live) {   // the same gesture, refused by one more kernel: add the host to the toast on screen
       if (live.hosts.indexOf(where) < 0) live.hosts.push(where);
-      live.t.querySelector('.rs-stale-toast-msg').textContent = staleText(label, kept, live.hosts);
+      live.t.querySelector('.rs-stale-toast-msg').textContent = staleText(label, live.refused || refused, kept, live.hosts);
     } else {
-      var t = staleToast(staleText(label, kept, [where]), staleAction(m));
-      if (key) staleOpen[key] = { t: t, hosts: [where] };
+      var t = staleToast(staleText(label, refused, kept, [where]), staleAction(m, refused));
+      if (key) staleOpen[key] = { t: t, hosts: [where], refused: refused };
     }
     if (!p.hidden) fill();   // the open modal re-reads the kernel's values so it stops showing the refused pick
   });

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -78,7 +78,7 @@ test("three kernels refusing one gesture draw ONE toast that names all three", (
   g.frame({ ...REFUSED, host: "api" });
   g.frame({ ...REFUSED });                         // the local kernel: no host key
   assert.equal(g.box().children.length, 1, "one toast for one refused gesture");
-  assert.deepEqual(g.texts(), ["Triage model: not applied on web, api, this machine. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on web, api, this machine. Keeping fable."]);
   assert.deepEqual(g.learned.filter(([, gt]) => gt > 0), [["judge-model", 2000], ["judge-model", 2000], ["judge-model", 2000]],
     "every frame teaches the clock the stamp it lost to");
 });
@@ -87,12 +87,12 @@ test("the same host refusing twice is named once; a different gesture gets its o
   const g = lift();
   g.frame({ ...REFUSED, host: "web" });
   g.frame({ ...REFUSED, host: "web" });            // a duplicate delivery
-  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on web. Keeping fable."]);
   g.frame({ ...REFUSED, gt: 999, host: "web" });   // an older click of the same setting — its own identity
   assert.equal(g.box().children.length, 2);
   g.frame({ ...REFUSED, setting: "auto-nudge", kept: false, gesture: { type: "setAutoNudge", enabled: true }, host: "web" });
   assert.equal(g.box().children.length, 3);
-  assert.equal(g.texts()[2], "Auto Nudge: not applied on web. A later pick (off) is already in place.", "booleans read as on/off");
+  assert.equal(g.texts()[2], "Auto Nudge: on was not applied on web. Keeping off.", "booleans read as on/off, the refused one too");
 });
 
 test("a frame without gt (an older kernel) keeps one toast per frame — no key, no fold", () => {
@@ -101,8 +101,8 @@ test("a frame without gt (an older kernel) keeps one toast per frame — no key,
   g.frame({ ...old, host: "web" });
   g.frame({ ...old, host: "api" });
   assert.equal(g.box().children.length, 2);
-  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place.",
-                               "Triage model: not applied on api. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on web. Keeping fable.",
+                               "Triage model: opus was not applied on api. Keeping fable."]);
 });
 
 test("a dismissed or expired toast never absorbs a later frame: liveness is the node's presence, not a window", () => {
@@ -112,12 +112,12 @@ test("a dismissed or expired toast never absorbs a later frame: liveness is the 
   first.remove();                                  // click-dismissed (the container's delegated handler)
   g.frame({ ...REFUSED, host: "api" });
   assert.equal(g.box().children.length, 1, "a fresh toast, not a resurrection");
-  assert.deepEqual(g.texts(), ["Triage model: not applied on api. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on api. Keeping fable."]);
   // the self-clearing backstop: run the 12000ms callbacks, then the same key again
   g.timers.filter((t) => t.ms === 12000).forEach((t) => t.fn());
   assert.equal(g.box().children.length, 0, "expired");
   g.frame({ ...REFUSED, host: "web" });
-  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on web. Keeping fable."]);
 });
 
 test("a toast already fading does not absorb a later refusal of the same gesture: it gets its own toast", () => {
@@ -131,8 +131,8 @@ test("a toast already fading does not absorb a later refusal of the same gesture
   assert.equal(g.box().children.length, 2, "a fresh toast, not a write into the fading one");
   assert.ok(g.box().children[0].classList.contains("fade"));
   assert.ok(!g.box().children[1].classList.contains("fade"));
-  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place.",
-                               "Triage model: not applied on api. A later pick (fable) is already in place."]);
+  assert.deepEqual(g.texts(), ["Triage model: opus was not applied on web. Keeping fable.",
+                               "Triage model: opus was not applied on api. Keeping fable."]);
 });
 
 test("the folded toast keeps its Apply anyway: one click re-issues the echo with a fresh stamp", () => {
@@ -142,8 +142,10 @@ test("the folded toast keeps its Apply anyway: one click re-issues the echo with
   const t = g.box().children[0];
   const btn = t.children.find((c) => c.className === "rs-stale-toast-act")!;
   assert.ok(btn, "the action button rides the folded toast");
-  assert.equal(btn.textContent, "Apply anyway");
+  assert.equal(btn.textContent, "Apply opus anyway", "the label names the value one click would apply everywhere");
   assert.equal(btn.type, "button");
+  assert.ok(btn.title && btn.title !== "click to dismiss", "the button has its own tooltip, not the toast's dismiss one: " + btn.title);
+  assert.ok(btn.title.includes("opus"), "…and it names the value too");
   btn.clicks.forEach((fn) => fn({}));
   assert.deepEqual(g.posts, [{ type: "setJudgeModel", model: "opus", gt: 7777 }],
     "the echoed gesture, stamped through the clock (which has learned both refusals' storedGt)");
@@ -160,6 +162,19 @@ test("no action when the echo's type is not the setting's, or when there is no e
   assert.equal(g.box().children.length, 2);
   for (const t of g.box().children)
     assert.equal(t.children.find((c) => c.className === "rs-stale-toast-act"), undefined, "no Apply anyway");
+  // and neither shows a refused value: an echo for another setting is not this setting's value, and no
+  // echo carries none — the copy degrades to the value-less form
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. Keeping fable.", "Triage model: not applied on web. Keeping fable."]);
+});
+
+test("an echo of an unexpected shape shows no refused value: plain Apply anyway, value-less copy", () => {
+  // every emitter posts {type, <one value field>, gt}; a future two-field gesture reads as no value
+  // rather than guessing which field is the pick
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web", gesture: { type: "setJudgeModel", model: "opus", scope: "all" } });
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. Keeping fable."]);
+  const btn = g.box().children[0].children.find((c) => c.className === "rs-stale-toast-act")!;
+  assert.equal(btn.textContent, "Apply anyway", "the action still rides: the echo's type is the setting's");
 });
 
 test("the open modal re-fills once per frame; a closed one never does", () => {

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -120,6 +120,21 @@ test("a dismissed or expired toast never absorbs a later frame: liveness is the 
   assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place."]);
 });
 
+test("a toast already fading does not absorb a later refusal of the same gesture: it gets its own toast", () => {
+  // the 11 s fade precedes the 12 s removal; with liveness read as parentNode alone, a refusal arriving
+  // in that second was written into a toast at opacity 0 and never seen (the #945 review). Event-keyed
+  // still: the fade class is read at the frame, no cleanup rides the timers.
+  const g = lift();
+  g.frame({ ...REFUSED, host: "web" });
+  g.timers.filter((t) => t.ms === 11000).forEach((t) => t.fn());   // the fade arms; the node is still on screen
+  g.frame({ ...REFUSED, host: "api" });
+  assert.equal(g.box().children.length, 2, "a fresh toast, not a write into the fading one");
+  assert.ok(g.box().children[0].classList.contains("fade"));
+  assert.ok(!g.box().children[1].classList.contains("fade"));
+  assert.deepEqual(g.texts(), ["Triage model: not applied on web. A later pick (fable) is already in place.",
+                               "Triage model: not applied on api. A later pick (fable) is already in place."]);
+});
+
 test("the folded toast keeps its Apply anyway: one click re-issues the echo with a fresh stamp", () => {
   const g = lift();
   g.frame({ ...REFUSED, host: "web" });

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -70,7 +70,7 @@ test("the toast's copy names the setting and the kept value and never claims ano
   assert.match(GEAR, /return label \+ ': not applied on ' \+ hosts\.join\(', '\) \+ '\. A later pick'\s*\n\s*\+ \(kept \? ' \(' \+ kept \+ '\)' : ''\) \+ ' is already in place\.';/,
     "the copy: what was not applied, on which kernels, and what is in force");
   const copy = GEAR.slice(GEAR.indexOf("function staleText("), GEAR.indexOf("if (!p.hidden) fill();"));
-  assert.ok(copy.length > 0 && copy.length < 3000, "the copy helper and the listener located");
+  assert.ok(copy.length > 0 && copy.length < 6000, "the copy helper and the listener located (a sanity bound on the slice)");
   for (const claim of ["somewhere else", "another device", "elsewhere", "changed more recently"])
     assert.ok(!copy.includes(claim), `the toast no longer says "${claim}"`);
   assert.ok(!GEAR.includes("changed more recently"), "the old copy is gone from the file");
@@ -144,7 +144,11 @@ test("one toast per refused gesture, naming the refusing hosts: the fold key is 
   const FED = read("ui", "webview", "federation.ts");
   assert.ok(FED.includes('if (out.type === "settingStale") out.host = host;'), "a remote kernel's frame is host-stamped on the way in");
   assert.match(GEAR, /var key = typeof m\.gt === 'number' \? m\.setting \+ ':' \+ m\.gt : '';/, "the fold key; no gt (an older kernel) → no fold");
-  assert.match(GEAR, /staleOpen\[key\]\.t\.parentNode \? staleOpen\[key\] : null/, "liveness is the node's parentNode at lookup — no cleanup on the timers");
+  assert.match(GEAR, /staleLive\(staleOpen\[key\]\.t\) \? staleOpen\[key\] : null/, "liveness is read at lookup — no cleanup on the timers");
+  // live = on screen AND not yet fading: a toast in its fade→remove second sits at opacity 0, so a frame
+  // written into it would never be seen (the #945 review) — it gets a fresh toast instead
+  assert.match(GEAR, /function staleLive\(t\) \{ return !!t\.parentNode && !\(t\.classList && t\.classList\.contains\('fade'\)\); \}/,
+    "a fading toast is not live");
   assert.match(GEAR, /return \(typeof m\.host === 'string' && m\.host\) \? m\.host : 'this machine';/, "the local kernel's frame reads as this machine");
   assert.doesNotMatch(GEAR.slice(GEAR.indexOf("var staleOpen"), GEAR.indexOf("if (!p.hidden) fill();")), /Date\.now\(|setTimeout|setInterval/,
     "the fold keys on the gesture, never on a clock or a window");

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -64,16 +64,25 @@ test("the gear hears the frame: a plain-words toast, and a re-fill only while th
   assert.match(seg, /gclock\.learn\(m\.setting, m\.storedGt\);/, "the listener learns storedGt");
 });
 
-test("the toast's copy names the setting and the kept value and never claims another device acted", () => {
+test("the toast's copy names the setting, the refused value, the hosts and the kept value, and claims no ordering", () => {
   // the kernel knows only that it holds a larger stamp — with device clocks minting the stamps,
-  // "changed more recently somewhere else" asserted a fact it could not know (#879 review)
-  assert.match(GEAR, /return label \+ ': not applied on ' \+ hosts\.join\(', '\) \+ '\. A later pick'\s*\n\s*\+ \(kept \? ' \(' \+ kept \+ '\)' : ''\) \+ ' is already in place\.';/,
-    "the copy: what was not applied, on which kernels, and what is in force");
+  // "changed more recently somewhere else" asserted a fact it could not know (#879 review), and so
+  // did "a later pick is already in place" (#945 review: a larger stamp is not a later pick). The
+  // refused value rides too: in the frozen-tab case the pick is hours old and one click sends it to
+  // every linked kernel, so the user must see what they would be applying.
+  assert.match(GEAR, /function staleText\(label, refused, kept, hosts\)/, "the copy takes the refused value beside the kept one");
+  assert.ok(GEAR.includes("(refused ? refused + ' was not applied on ' : 'not applied on ')"), "the refused value, when the echo carries one");
+  assert.ok(GEAR.includes("(kept ? ' Keeping ' + kept + '.' : '')"), "the kept value, with no ordering word");
   const copy = GEAR.slice(GEAR.indexOf("function staleText("), GEAR.indexOf("if (!p.hidden) fill();"));
   assert.ok(copy.length > 0 && copy.length < 6000, "the copy helper and the listener located (a sanity bound on the slice)");
-  for (const claim of ["somewhere else", "another device", "elsewhere", "changed more recently"])
+  for (const claim of ["somewhere else", "another device", "elsewhere", "changed more recently", "later pick", "newer pick", "already in place"])
     assert.ok(!copy.includes(claim), `the toast no longer says "${claim}"`);
-  assert.ok(!GEAR.includes("changed more recently"), "the old copy is gone from the file");
+  assert.ok(!GEAR.includes("changed more recently") && !GEAR.includes("already in place"), "the old copy is gone from the file");
+  // the refused value is the echo's one field beside type (every emitter posts {type, <value>, gt} and
+  // the kernel echoes it without gt), read only for the setting the frame names — the whitelist Apply
+  // anyway uses — and any other shape reads as no value
+  assert.match(GEAR, /function staleRefused\(m\)/, "the refused value is read off the echo");
+  assert.ok(GEAR.includes("var keys = Object.keys(m.gesture).filter(function (k) { return k !== 'type'; });"), "…as the one key beside type");
 });
 
 test("Apply anyway re-issues the echoed gesture with a fresh stamp, and only for the setting the frame names", () => {
@@ -83,12 +92,15 @@ test("Apply anyway re-issues the echoed gesture with a fresh stamp, and only for
   // frame from any linked kernel can re-issue that one setting and nothing else
   assert.match(GEAR, /STALE_TYPE\[m\.setting\] !== m\.gesture\.type\) return null;/, "the whitelist");
   assert.match(GEAR, /post\(Object\.assign\(\{\}, m\.gesture, \{ gt: gclock\.stamp\(m\.setting\) \}\)\)/, "the re-issue: the echo plus a fresh stamp");
-  assert.ok(GEAR.includes("label: 'Apply anyway'"), "the action's label");
+  assert.ok(GEAR.includes("label: refused ? 'Apply ' + refused + ' anyway' : 'Apply anyway'"), "the action's label names the value it would apply");
   assert.match(GEAR, /if \(!m\.gesture \|\| typeof m\.gesture !== 'object'/, "an older kernel sends no echo: the toast shows without the action");
   // the button: a real <button type=button>, appended before the ✕; its click bubbles to the
   // container's delegated dismiss (no stopPropagation), so applying also clears the toast
   assert.match(GEAR, /b\.type = 'button'; b\.className = 'rs-stale-toast-act'; b\.textContent = act\.label;/);
   assert.match(GEAR, /b\.addEventListener\('click', act\.run\);/);
+  // the button's own tooltip: without one it inherited the toast's "click to dismiss" (#945 review)
+  assert.match(GEAR, /b\.title = act\.title;/, "the button carries the action's title");
+  assert.ok(GEAR.includes("title: 'apply ' + (refused || 'this pick') + ' on every linked kernel, replacing the value they kept'"), "…which says what the click does");
   const toast = GEAR.slice(GEAR.indexOf("function staleToast(text, act)"), GEAR.indexOf("function staleText("));
   assert.ok(toast.length > 0, "staleToast(text, act) located");
   assert.doesNotMatch(toast, /\.stopPropagation\(/, "the action's click still dismisses the toast");
@@ -156,5 +168,6 @@ test("one toast per refused gesture, naming the refusing hosts: the fold key is 
 
 test("the kept value rides when cheap, and reads as words (booleans become on/off)", () => {
   assert.match(KERNEL, /def _setting_kept_value\(name\)/, "one cheap store read at reply time, never on the apply path");
-  assert.ok(GEAR.includes("m.kept === true ? 'on'"), "a boolean setting's kept value reads as on/off in the toast");
+  assert.ok(GEAR.includes("function staleWord(v) { return v === true ? 'on' : v === false ? 'off'"), "a boolean value reads as on/off in the toast");
+  assert.ok(GEAR.includes("var kept = staleWord(m.kept);"), "…the kept value through the one helper");
 });


### PR DESCRIPTION
Eight follow-ups the merge comments on #941, #942, #943, #945, #947, #948, #953 and #957 named as out of scope for those PRs, one commit each, each with a test that fails on the code before it. Nothing here changes a frame, a store or a wire format; the commits are independent and separable.

## 1. A TaskUpdate the CLI rejected moves no item in either to-do fold (from the #942 comment)

What breaks: `_fold_tasks` (kernel) and `declared_plan` (event_model) record the tool_use ids whose tool_result came back `is_error` and skip a TaskCreate in that set, but a TaskUpdate in the same set was still applied. A status value the CLI refused (an `InputValidationError` on `status`) folded as the item's status, and on the sync side a refused completing update flipped the mirrored agentTask node to done for a task the store still holds open.

The fix: both TaskUpdate branches skip a rejected update before the lookup, keyed on the result's `is_error` exactly as the TaskCreate branch is, so the two folds stay identical. An update whose result has not landed still applies.

Tests: `test_fold_ignores_a_rejected_taskupdate` (tests/test_kernel.py); `test_a_rejected_taskupdate_moves_no_step` and `test_a_rejected_taskupdate_leaves_the_mirrored_node_open` (tests/test_judge_authoritative_plan_sync.py). All three fail before the change: the refused status lands, and the sync returns True and flips the node. Fixtures are synthetic, with invented `InputValidationError` text.

## 2. The WS-thread act-now tick logs a failure instead of closing the socket (from the #943 comment)

What breaks: the setAutoNudge and setCompactSuggest arms run the auto-nudge tick on the WS handler thread with no wrap. The reader loop re-raises OSError as a socket failure and its outer handler tears the connection down silently, so an OSError out of the pass head (the session-listing fork, a store read) closed the dashboard's socket with no log line: since #846 for setCompactSuggest, and for setAutoNudge once #943 restored its tick.

The fix: one module-level wrap, `_ws_act_now_tick()`, beside `_auto_nudge_tick`, holds the `run_dead_wait=False` call in a try/except that logs the traceback (`auto-nudge (ws act-now): ...`) the way the pusher's own wrap does; both arms call it. Catching Exception there is safe because the tick never writes to the delivering socket (its only push is `_push_soon()`, a wake flag), so nothing caught is that socket's own failure; the helper's docstring says so. `_tell_stale_gesture` stays outside the wrap. The single-flight lock and the one-observer sweep skip are unchanged (the same call text, inside the helper).

Tests: `WsActNowTickIsWrapped` (tests/test_setting_gesture_order.py) drives the real dispatch for both arms with a tick that raises OSError, then RuntimeError; before the change the exception escapes `_dispatch_ws`. After: the client stays alive, the flag write stands, stderr names auto-nudge and the traceback. The dead-wait call-site pin (tests/test_dead_wait_block.py) is re-pointed: both arm slices call the helper, `_dispatch_ws` has no direct `_auto_nudge_tick(` call, and the helper's source carries the exact sweep-skipping call. The mid-pass test's comment now names the single-flight lock as what holds its transition (the nested same-thread tick returns at the try-acquire before `run_dead_wait` is read), not the sweep skip. If you prefer two inline wraps over the helper, that pin needs no change; say so.

## 3. The bell names panes from `_PANE_ORDER` (from the #957 comment)

What breaks: `_LANDING_ERRS_JS` kept its own four-entry `PN` map beside `_PANE_ORDER`, a second hand-written list.

The fix: `PN` is `json.dumps(dict(_PANE_ORDER))` spliced into the script constant at import, so the rail, the mobile tabs, the drop row (#957) and the connection-lost row name panes from one list. `_PANE_ORDER` and its comment move above `_LANDING_ERRS_JS` because the string is built from it at import; no module-level reference precedes the new position, and `_rail_buttons_html` / `_mtab_buttons_html` stay where they are. The constant remains one complete string, so `test_error_center`, which runs it in node, keeps proving the script executes (its chat-drop entry still reads "Chat").

Tests (tests/test_pane_order_parity.py): `test_labels_match_the_pn_map` now parses the literal as JSON (the old parser read bare keys and single-quoted labels, so against JSON it read nothing); `test_the_pn_map_is_built_from_the_constant` pins the derivation and the definition order. Both fail before the change.

## 4. The boot orphan reaper treats this kernel's own children as live by pid (from the #941 comment)

What breaks: since #941 `find_orphan_clis` decides "live" from the parent's `ps` text alone, so the calling kernel's own children are shielded only when its launch spelling is one `_is_kernel_cmd` knows (`.../bin/romp-kernel`, `kernel/kernel.py`). The old `ppid != 1` test shielded them unconditionally. The exposure is not only a second kernel: the reconcile runs on a thread after the backend is constructed, concurrent with the kernel serving requests, so a session started before the thread's `ps` is this kernel's child carrying one of the lastsids, and a kernel run as `python3 ./kernel.py`, through a `-c` runner or from a renamed launcher would SIGTERM its own live session at boot.

Reproduction (synthetic, the pure function before the change): a listing with the user manager at 901, the kernel at 31337 spelled `python3 ./kernel.py`, its child 707 and an orphan 708 under 901 returns [707, 708]; a listing holding only the child, with the kernel's own line absent, returns the child.

The fix: `find_orphan_clis` takes the calling kernel's pid as a required third positional (`own_pid`, the shape `find_session_cli` already has with `parent_pid`) and treats `ppid == own_pid` as live before the parent lookup, so a listing missing the kernel's own line still protects its children; `_boot_reconcile` passes `os.getpid()`. A CLI parented to any other kernel is judged by that kernel's text as before; the caller's existing `pid == os.getpid()` skip stays. An `own_pid=None` default is a two-line change if you prefer the ten existing calls untouched.

Tests (tests/test_sdk_lifecycle_hardening.py): the ten FindOrphanClis calls gain the pid; three new pure tests (own children live under three spellings `_is_kernel_cmd` does not know, asserted False for each so the test rests on the pid path; own children live when our line is absent; another kernel's child under an unknown spelling is still an orphan); one BootReconcile test runs the reconcile with `ps` and `os.kill` patched and the kernel spelled `python3 ./kernel.py` under this process's pid, and asserts only the orphan under the user manager is signalled. Before the change: the amended and new pure tests fail on the signature (TypeError) and the BootReconcile test on the property (the child is killed too).

## 5. A judge envelope with no `modelUsage` map is announced once per process (from the #948 comment)

What breaks: since #948 `_note_served_model` checks the bare-alias table against the model id the CLI's result envelope reports under `modelUsage`. When the envelope carries no such map (a CLI older than the field, or a shape change) the check returned without a word, so the index tier kept choosing its lever from a table nothing had verified, with nothing in the log.

Reproduction: stub `subprocess.run` to return `{"result": "a caption", "usage": {}}` and call `_judge_run("haiku", ..., tier="index")`: stderr carries only the lever line and `_ALIAS_SERVED` stays empty.

The fix: at the existing `if not isinstance(mu, dict): return` site, after the bare-alias gate (a versioned pin is never checked, so it stays silent), one stderr line per process names the alias whose call revealed it, says the served version cannot be checked, and that the index tier's lever answers from the alias table until a CLI that reports the field. The latch is a module set beside `_UNKNOWN_MODEL_LOGGED` and `_ALIAS_DRIFT_LOGGED`, check-then-add without a lock like them. Design points: once per process, not per alias (the field's presence is a property of the CLI); the same line fires for a malformed non-dict value (same site; the malformed-entry test still proves the reply survives); a present map that names no same-family model stays quiet as before, and the tests pin the two cases apart; the text avoids the `_ALIAS_HEAD` token so the test class's drift-line filter keeps meaning drift lines. Default picks are bare aliases, so on such a CLI a default install logs one line at its first successful judge call; on a CLI that emits the field nothing changes. Per-alias instead of per-process, or excluding the malformed case, is a one-line change either way.

Tests (tests/test_judge.py, AliasHeadDrift): `test_a_missing_model_usage_map_is_announced_once_per_process` (one line on the first bare-alias call, none on a second alias, none for a versioned pin, one again after the latch is cleared), and the present-map case pinned quiet separately. Before the change, with the tests in place: every AliasHeadDrift test errors on the missing latch; with the latch alone, the new test fails on the missing line and the other eight pass.

A second, tests-only commit is the comment's other follow-up: `IndexTierLever.setUp` and a new `EffortCapability.setUp` clear `_ALIAS_SERVED` (and the new latch), so their `haiku -> False` pins no longer depend on `AliasHeadDrift`'s tearDown having run in the same xdist worker. Shown load-bearing by a scratch run with that tearDown reset disabled and the moved-alias test run first: four assertions across the two classes fail without the setUps and pass with them. The `IndexTierLever` stub is unchanged: its empty-stderr pin is on a second call within one test, which the per-process latch keeps quiet in any order (the #948 body assumed the stub would need `modelUsage`; it does not).

## 6. The GitHub button's origin check never pops an askpass prompt (from the #947 comment)

What breaks: the origin check's `ls-remote` ran with `GIT_TERMINAL_PROMPT=0` alone, so the child inherited `GIT_ASKPASS`, `core.askPass` and `SSH_ASKPASS`. For an https origin that answers 401, git asks for a username and a password through the first of those it finds; with a GUI askpass exported in the kernel's shell a prompt appeared on every viewer open of a file under such an origin, then died at the 3 s deadline (reproduced against a loopback 401 stand-in). ssh's own `SSH_ASKPASS` use (DISPLAY set, no tty) was open as well, and `_git_net_out`'s docstring claimed the sessionless ssh would fail rather than wait, which did not hold on this path.

The fix: `GIT_ASKPASS=""` and `SSH_ASKPASS_REQUIRE="never"` join `GIT_TERMINAL_PROMPT="0"` in the same env dict. The empty value is load-bearing: git tests the variable's presence before falling to `core.askPass` and then `SSH_ASKPASS`, so set-empty overrides both while unset would not (on git 2.43 each of the three sources ran the askpass twice under `GIT_TERMINAL_PROMPT=0` alone; zero runs with `GIT_ASKPASS=""`, failure in about 10 ms). `SSH_ASKPASS_REQUIRE=never` is honoured by OpenSSH 8.4 and later and ignored by older ssh. The chosen behaviour, now in the docstrings: no prompt of any kind; an origin that wants a credential reads "could not check whether branch X is on origin", including where an editor's askpass would have answered silently for a signed-in user. A configured `credential.helper` is not disabled and may still answer silently; out of scope here.

Tests (tests/test_file_github.py, `NoPromptOnOrigin`, both red before the change): the stand-in ssh dumps the transport child's environment and the test asserts set-empty `GIT_ASKPASS` (pinned as `${GIT_ASKPASS+set}:` so a later pop() reads as the regression it is), `SSH_ASKPASS_REQUIRE=never` and `GIT_TERMINAL_PROMPT=0`; a loopback 401 server plus a marker-writing askpass shows the kernel's query runs no askpass and returns unchecked, after a control run proves the stand-in does elicit the askpass under `GIT_TERMINAL_PROMPT=0` alone (skips on a git without the https helper). OS-neutral: POSIX sh, `http.server` on 127.0.0.1:0, env vars only.

## 7. romp-manager: after a failed scoped start, the log reads where the tmux server sits (from the #953 comment)

What breaks: `startTmuxServer`'s fallback logged "tmux server ensured without a scope — under the service, a service restart will take it down" whenever the bare `tmux start-server` succeeded after a scoped failure. That predicts a loss in two cases where none happens. A scoped call that times out: `execFileSync` SIGTERMs the tmux client (systemd-run exec'd it in place), the server daemon that client forked stays alive inside the romp-tmux scope, and the bare retry no-ops onto it (the shape the #953 review measured). And after a service restart the previous manager's server is still up in its old scope, so if systemd-run fails on this start (bus not up, a refused unit) the bare call again no-ops onto a scoped server.

The fix: after the bare call succeeds the manager reads the server's pid (`tmux display-message -p '#{pid}'`, which does not start a server and exits 1 with "no server running" when there is none; tmux 3.4) and its `/proc/<pid>/cgroup`, and words the line from that: a `romp-tmux-*.scope` on the path names the unit and says a restart leaves it alive; anything else is the previous line verbatim; an unreadable answer (probe failure, non-numeric pid, missing cgroup file) says it could not be read and predicts no loss. cgroup v1 (one line per controller) and v2 are matched per line. The probe is bounded by the start's timeout, runs only on the fallback path, never throws, and runs with the same scrubbed env as the two starts (so `test_op_credential_boundary`'s exec-count pin goes from two to three, with the reason). Wording the line as uncertain only on ETIMEDOUT would miss the second case; `systemctl is-active` on the unit probes the scope, not the server. Unchanged: the first failure line, the scoped-success line, and the darwin path (the edited branch is unreachable when `tmuxStartArgv` returns `scoped:false`).

Tests: tests/manager-tmux-scope.test.js covers `placementFromCgroup` (v1 and v2 samples, a romp-session scope not counted, an empty file), `tmuxServerPlacement` (the pid is what the cgroup read receives; every probe failure is unknown with its first line, bounded) and `bareEnsuredLine` (the unscoped string byte-identical to the old one); nine tests that fail before the change on the missing exports. tests/romp-manager-tmux-scope.bats gains the probe in the fake tmux (pid 1, whose cgroup is never a romp-tmux scope; `FAKE_TMUX_PID=none` for no server) and a case for the unreadable outcome; case 2 now pins the bare call followed by the probe. Both fail before the change.

## 8. Stale-setting toast: fade liveness, the refused value, no recency claim, the button's own title (from the #945 comment)

Two commits, gear.js and its two test files only; no kernel, frame or CSS change.

What breaks: (a) a stale flush refused by N kernels folds into one toast keyed by (setting, gt), and liveness read only the node's parentNode; the toast fades at 11 s and is removed at 12 s, so a refusal arriving in that second was written into a toast at opacity 0 and never shown. (b) Neither the copy nor the Apply anyway label showed the refused value, only the kept one; in the frozen-tab case the pick is hours old and one click sends it to every linked kernel, so the user could not see what they were about to apply. (c) The copy called the kept pick "a later pick ... already in place", a recency claim the kernel cannot make under the clock skew #945 fixed: it holds only a larger stamp. (d) The Apply anyway button set no title, so it inherited the toast's "click to dismiss" tooltip.

The fix: (a) `staleLive(t)` reads the fade class beside parentNode at lookup, so a dismissed, expired or fading toast is not live and the frame gets a fresh toast; still event-keyed, no cleanup rides the timers (the fold block holds no setTimeout, which the source test pins). (b, c) The frame's gesture echo already carries the value: every emitter posts `{type, <one value field>, gt}` and the kernel echoes it without gt, so `staleRefused` reads the echo's one key beside `type`, worded through `staleWord` (booleans as on/off), and only for the setting the frame names (the whitelist Apply anyway uses; an echo for another setting is not this setting's value). An echo of any other shape, or none from an older kernel, reads as no value and the copy and label take their value-less form. The copy becomes "Triage model: opus was not applied on web, api, this machine. Keeping fable." (value-less: "Triage model: not applied on web. Keeping fable."), with no ordering word; the label becomes "Apply opus anyway". A folded toast keeps the value its first frame carried. A boolean toggle reads "Auto Nudge: on was not applied on web. Keeping off." under the same uniform wording; a "Turn on anyway" special case is a reasonable alternative if you prefer it. (d) The button gets its own title: "apply opus on every linked kernel, replacing the value they kept". An older kernel's frame (no gesture, no gt) behaves as before.

Tests: setting-stale-fold.test.ts fires the 11000 ms timer between two frames of one gesture and expects two toasts (one before the change); its exact strings are rewritten to the new copy, and it gains the label, the button title, a mismatched echo (no value shown) and a two-field echo (value-less copy, plain label); setting-stale.test.ts pins the new lookup, the helpers, the title line and the retired claims (its fold-region sanity bound widens from 3000 to 6000 characters, since the helpers grew the region). Before the changes: 2 tests fail for (a), 11 for (b) to (d).

## Test runs

Per commit, red first as stated above, then green. Whole suites at the head, on Linux: `pytest -n 8` over tests/: 7599 passed, 46 skipped, and one failure, `test_op_credential_boundary`'s exec-count pin, raised to three with the reason and folded into commit 7 (that module re-run alone: 5 passed; no other file changed after the sweep). `bats tests/*.bats`: 430 ok. In vscode-extension: `npm test` 2840 pass, `npm run typecheck` and `npm run build` clean. None of the surfaces is platform-specific: the Python and node changes have no platform branch, the bats scoped-path cases are Linux-only by construction as before, and the manager edit sits in a branch unreachable on darwin.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)