### PR TITLE
pre-push hook: scan each ref's tip and each new commit's added lines, not every inherited tree

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
 # romp pre-push hook: refuse to publish a commit that carries a personal identifier.
 #
-# The repo may go public and history is permanent, so this scans the COMMITS
-# BEING PUSHED (every new commit's full tree, not the working tree) for the
-# strings in ~/.config/romp/private-strings.txt — one banned string per line,
-# `#` comments and blank lines ignored, matched case-insensitively. With no such
-# file it exits 0 and stays out of your way, so on a clone that never set one up
-# (any contributor's machine) it is a no-op.
+# The repo may go public and history is permanent, so this reads the COMMITS
+# BEING PUSHED (not the working tree) for the strings in
+# ~/.config/romp/private-strings.txt — one banned string per line, `#` comments
+# and blank lines ignored, matched case-insensitively. With no such file it
+# exits 0 and stays out of your way, so on a clone that never set one up (any
+# contributor's machine) it is a no-op.
 #
-# Why pushed trees rather than a working-tree scan: the hook is symlinked into
+# Two checks per pushed ref, both about what THIS push changes on the remote:
+#
+#   the tip's tree    the content the push exposes. A banned string anywhere in
+#                     it refuses the push.
+#   each new commit   the lines it ADDS against its first parent. A string
+#                     introduced in an intermediate commit and removed by a
+#                     later one is still caught, and the commit named; a commit
+#                     whose tree merely INHERITS a string an older commit put
+#                     there is not. Every commit on every branch cut from main
+#                     between a string landing there and its redaction inherits
+#                     it that way, and a per-commit TREE scan refuses them all,
+#                     over files the branch never touched, when the only
+#                     exposure any of them could add is its tip.
+#
+# Why pushed commits rather than a working-tree scan: the hook is symlinked into
 # the SHARED git hooks dir (by install.sh), so it fires from every worktree —
 # but a working-tree scan is only as good as the tree you happen to push from,
 # and an untracked scanner script exists in only one worktree. Reading the
-# denylist from $HOME and grepping the pushed shas arms every worktree equally,
-# and catches a string buried in an intermediate commit whose tip is clean.
+# denylist from $HOME and reading the pushed shas arms every worktree equally.
 #
 # Bypass a false positive with `git push --no-verify`.
 set -euo pipefail
@@ -31,23 +44,70 @@ while IFS= read -r line; do
 done < "$strings_file"
 [ ${#grep_args[@]} -gt 0 ] || exit 0
 
+# $1 is the remote being pushed to: a name, or a bare URL when pushing by URL.
+remote="${1:-}"
 zero=0000000000000000000000000000000000000000
+
+# The commits THIS push publishes for one ref: what the remote does not already
+# have. "Already has" means reachable from ANY of the remote's refs as this clone
+# last fetched them (refs/remotes/<remote>/*), not only from the ref being pushed.
+# The difference is a branch that merged main: its range holds main's commits,
+# every one of them on the remote already through main. Scanning those refuses
+# the push over a string that main itself published, and a string already on the
+# remote is fixed FORWARD, on main (redact, push main) — not by blocking every
+# branch that merged main before the redaction. The exclusion is scoped to the
+# remote being pushed to: a commit only another remote has is still new to this
+# one. With no remote-tracking refs for the remote (never fetched, or a push to a
+# bare URL) the exclusion matches nothing and the range falls back to everything
+# the remote ref lacks — for a new ref, the whole history.
+rev_range() {   # <local_sha> <remote_sha> → a rev-list argument list
+    local args="$1 --not"
+    [ "$2" = "$zero" ] || args="$args $2"
+    [ -z "$remote" ] || args="$args --remotes=$remote"
+    printf '%s' "$args"
+}
+
+# The lines a commit adds, one per line as "<path>\t<text>": its diff against
+# its first parent (for a root commit, against the empty tree). A merge is read
+# the same way, so content in neither parent — a conflict resolution — counts as
+# the merge's own addition. -M keeps a rename from re-adding every line of the
+# file. The path comes from the `+++ b/<path>` header, read only between a
+# `diff --git` line and the first hunk: inside a hunk, a line that begins with
+# `+++ ` is added content (`++ b/x` as written) and belongs to the current file.
+added_lines() {   # <rev>
+    local parent
+    { if parent=$(git rev-parse -q --verify "$1^" 2>/dev/null); then
+          git diff-tree -p -r -M --no-color "$parent" "$1"
+      else
+          git diff-tree -p -r -M --no-color --root "$1"
+      fi; } | awk '
+        /^diff --git /       { hdr = 1; next }
+        hdr && /^\+\+\+ b\// { f = substr($0, 7); next }
+        hdr && /^\+\+\+ /    { f = $0; next }
+        /^@@/                { hdr = 0; next }
+        !hdr && /^\+/        { print f "\t" substr($0, 2) }'
+}
+
 blocked=0
-while read -r _local_ref local_sha _remote_ref remote_sha; do
+while read -r local_ref local_sha _remote_ref remote_sha; do
     [ -n "${local_sha:-}" ] || continue
     [ "$local_sha" = "$zero" ] && continue          # deleting a remote ref pushes nothing
-    # Only the commits this push actually publishes: what the remote ref lacks,
-    # or (for a new ref) what no remote-tracking ref already has.
-    if [ "$remote_sha" = "$zero" ]; then
-        revs=$(git rev-list "$local_sha" --not --remotes 2>/dev/null || git rev-list "$local_sha")
-    else
-        revs=$(git rev-list "$remote_sha..$local_sha")
+
+    # The tip's tree. -I skips binaries; -l lists files.
+    if hits=$(git grep -i -I -l -F "${grep_args[@]}" "$local_sha" -- 2>/dev/null) && [ -n "$hits" ]; then
+        echo "romp pre-push: the tip of $local_ref (${local_sha:0:10}) would publish a personal identifier in:" >&2
+        echo "$hits" | sed "s/^$local_sha:/  /" >&2
+        blocked=1
     fi
+
+    # The lines each commit new to the remote adds.
+    # shellcheck disable=SC2046  # the range is deliberately word-split
+    revs=$(git rev-list $(rev_range "$local_sha" "$remote_sha") 2>/dev/null \
+           || git rev-list "$local_sha")
     for rev in $revs; do
-        # -I skips binaries; -l lists files; the tree at $rev is what ships.
-        if hits=$(git grep -i -I -l -F "${grep_args[@]}" "$rev" -- 2>/dev/null) && [ -n "$hits" ]; then
-            echo "romp pre-push: commit ${rev:0:10} would publish a personal identifier in:" >&2
-            echo "$hits" | sed "s/^$rev:/  /" >&2
+        if hits=$(added_lines "$rev" | grep -i -F "${grep_args[@]}" | cut -f1 | sort -u) && [ -n "$hits" ]; then
+            echo "romp pre-push: commit ${rev:0:10} ADDS a personal identifier in:" >&2
+            echo "$hits" | sed 's/^/  /' >&2
             blocked=1
         fi
     done
@@ -58,6 +118,7 @@ if [ "$blocked" -ne 0 ]; then
     echo "romp pre-push: BLOCKED — a banned string from $strings_file is in a pushed commit." >&2
     echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
     echo "  If the string is only in an INTERMEDIATE commit, squash or rewrite the branch." >&2
+    echo "  If the tip only INHERITS a string an older commit added and main has since redacted, merge main." >&2
     echo "  To bypass for one push (you are sure it is fine): git push --no-verify" >&2
     exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,14 @@ This repo may go public; assume every commit is permanent and world-readable.
   `notes-api` with `web`/`api`/`tests` sessions) rather than inventing per-test
   worlds.
 - Two machine-local backstops enforce this, neither a substitute for the rule:
-  the `.githooks/pre-push` hook greps every PUSHED commit's tree for the strings
-  in `~/.config/romp/private-strings.txt` (absent file → no-op, so contributors
-  are unaffected; it scans pushed shas, not the working tree, so it arms every
+  the `.githooks/pre-push` hook greps each pushed ref's TIP tree, plus the lines
+  every commit new to the remote ADDS, for the strings in
+  `~/.config/romp/private-strings.txt` (absent file → no-op, so contributors
+  are unaffected; it reads pushed shas, not the working tree, so it arms every
   worktree — a working-tree scan missed a leak pushed from a peer worktree on
-  2026-07-25); and the maintainer's clone carries an UNTRACKED
+  2026-07-25; and added lines rather than every commit's tree, so a branch that
+  only INHERITED a string main has since redacted pushes once it merges main —
+  2026-09-06); and the maintainer's clone carries an UNTRACKED
   `tests/test_no_personal_identifiers.py` that scans the working tree for the
   same strings plus that machine's hostname and home path. The pytest file is
   deliberately not in the repo: one machine's identifiers mean nothing on anyone

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -288,11 +288,14 @@ PY
 # ── git pre-push identifier hook ──────────────────────────────────────
 # install.sh symlinks .githooks/pre-push into the shared git hooks dir. The hook
 # reads the banned strings from ~/.config/romp/private-strings.txt (so it arms
-# EVERY worktree, not just the one holding an untracked scanner) and greps each
-# PUSHED commit's tree — the working tree is not what gets published, and a leak
-# in an intermediate commit ships even when the tip is clean. No strings file →
-# a no-op, so a contributor's clone is unaffected. (ROMP_GITHOOK_DIR redirects
-# install.sh's symlink target below; the behaviour tests copy the hook directly.)
+# EVERY worktree, not just the one holding an untracked scanner) and reads the
+# PUSHED commits, not the working tree, which is not what gets published: each
+# pushed ref's TIP tree must be clean, and each commit new to the remote must
+# ADD no banned line — so a leak in an intermediate commit is caught even when
+# the tip is clean, while a tree that only inherits an older one is not refused.
+# No strings file → a no-op, so a contributor's clone is unaffected.
+# (ROMP_GITHOOK_DIR redirects install.sh's symlink target below; the behaviour
+# tests copy the hook directly.)
 
 @test "install.sh: symlinks the pre-push hook into the git hooks dir" {
     run "$ROMP_DIR/install.sh"

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+
+# .githooks/pre-push — the identifier scan, driven by hand against real commits.
+#
+# The hook refuses to publish a commit carrying a string from the machine's
+# private-strings denylist. Every identifier below is SYNTHETIC (the repo may go
+# public, and a real one written here would be the very leak the hook exists to
+# stop): the denylist, the paths and the hostnames are all invented per test.
+#
+# Two rules, both about what a push changes on the remote: the TIP tree of each
+# pushed ref must be clean (that is what a push exposes), and each commit the
+# remote does not already have must ADD no banned line — a commit that only
+# inherits an older leak in its tree is not refused, a commit that introduced
+# one is, even if a later commit removed it again. install-sh.bats exercises the
+# hook through a real `git push`; this file feeds it ref lines directly, so it
+# can model a remote and its remote-tracking refs the way a clone has them.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+HOOK="$ROMP_DIR/.githooks/pre-push"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    REPO="$TEST_DIR/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -q
+    git -C "$REPO" symbolic-ref HEAD refs/heads/main     # whatever init.defaultBranch says
+    git -C "$REPO" config user.email t@example.invalid
+    git -C "$REPO" config user.name  Tester
+    # The hook under test is run BY HAND below; the fixture's own git operations
+    # (commits, pushes to the bare remote) must not run this machine's hooks.
+    mkdir -p "$TEST_DIR/no-hooks"
+    git -C "$REPO" config core.hooksPath "$TEST_DIR/no-hooks"
+
+    # the denylist: invented identifiers, nothing that exists on any real box
+    STRINGS="$TEST_DIR/private-strings.txt"
+    printf '# synthetic\nzzsynthuser\nTESTHOST\n' > "$STRINGS"
+
+    export ROMP_PRIVATE_STRINGS="$STRINGS"
+}
+
+teardown() { rm -rf "${TEST_DIR:-}"; }
+
+ZERO=0000000000000000000000000000000000000000
+
+# Run the hook from inside the repo, the way git does. bats' `run` executes the
+# command in a subshell, so the cd here does not leak into the test. (A cd
+# helper rather than `env -C`, which BSD env lacks.)
+_hook_in() { cd "$1" && shift && bash "$@"; }
+
+# Feed the hook a ref line the way git does: <local_ref> <sha> <remote_ref> <remote_sha>.
+# The default remote sha of zero means a new branch, i.e. every commit here is
+# being published; pass the sha the remote holds to model updating a branch it has.
+run_hook() {
+    local sha remote_sha="${1:-$ZERO}"
+    sha="$(git -C "$REPO" rev-parse HEAD)"
+    run _hook_in "$REPO" "$HOOK" origin git@example.invalid:x/y.git <<< \
+        "refs/heads/main $sha refs/heads/main $remote_sha"
+}
+
+commit_file() {   # <path> <content> <message>
+    printf '%s\n' "$2" > "$REPO/$1"
+    git -C "$REPO" add "$1"
+    git -C "$REPO" commit -qm "$3"
+}
+
+# A bare remote named origin, so refs/remotes/origin/* exist the way they do in a
+# real clone: the hook decides what is "already on the remote" from those refs.
+add_remote() {
+    git init -q --bare "$TEST_DIR/remote.git"
+    git -C "$REPO" remote add origin "$TEST_DIR/remote.git"
+}
+
+remove_file() {   # <path> <message>
+    git -C "$REPO" rm -q "$1"
+    git -C "$REPO" commit -qm "$2"
+}
+
+# main publishes an identifier (LEAK_SHA, pushed, so the remote has it); a branch
+# is cut from there and commits work of its own, whose tree INHERITS the leak
+# although its diff is clean. Leaves HEAD on the branch; main has not yet redacted.
+branch_inheriting_mains_leak() {
+    add_remote
+    commit_file base.txt "notes-api" "base"
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    LEAK_SHA="$(git -C "$REPO" rev-parse HEAD)"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q -b feature
+    commit_file web.txt "the web session's work" "branch work"
+}
+
+# ...and main redacts the leak (pushed), and the branch merges main: its own
+# earlier commit still has the leaky tree, but its tip is clean.
+main_redacts_and_branch_merges() {
+    git -C "$REPO" checkout -q main
+    remove_file leak.txt "redact"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q feature
+    git -C "$REPO" merge -q -m "merge main" main
+}
+
+@test "a clean commit passes" {
+    commit_file file.txt "nothing to see" "clean"
+    run_hook
+    [ "$status" -eq 0 ]
+}
+
+@test "an identifier in a regular file is blocked" {
+    commit_file file.txt "home is /home/zzsynthuser/code" "leak"
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"personal identifier"* ]]
+}
+
+@test "an identifier in an INTERMEDIATE commit is caught, not just the tip" {
+    commit_file bad.txt "home is /home/zzsynthuser/x" "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file bad.txt "remove it"               # tip is clean; history is not
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]
+    [[ "$output" == *"  bad.txt"* ]]
+}
+
+@test "an added line shaped like a diff header is content, not a new path" {
+    # In a patch, content `++ b/decoy.txt` renders as `+++ b/decoy.txt`, the same
+    # text as a file header. Only a header names the path the next hit belongs to.
+    printf '%s\n' '++ b/decoy.txt' 'home is /home/zzsynthuser/x' > "$REPO/real.txt"
+    git -C "$REPO" add real.txt
+    git -C "$REPO" commit -qm "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file real.txt "remove it"              # tip is clean, so the added-lines pass decides
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]
+    [[ "$output" == *"  real.txt"* ]]
+    [[ "$output" != *"decoy.txt"* ]]
+}
+
+@test "no denylist file means no identifier scan (a fresh clone is unaffected)" {
+    export ROMP_PRIVATE_STRINGS="$TEST_DIR/does-not-exist.txt"
+    commit_file bad.txt "home is /home/zzsynthuser/x" "leak"
+    run_hook
+    [ "$status" -eq 0 ]
+}
+
+# ── which commits a push publishes ────────────────────────────────────────
+# A leak already on the remote is fixed forward on main, not by refusing every
+# branch cut since: the tip tree must be clean, and only commits the remote lacks
+# are read, for the lines they ADD.
+
+@test "a branch that only INHERITED main's leak in its tree passes once its tip merged the redaction" {
+    branch_inheriting_mains_leak
+    main_redacts_and_branch_merges
+    run_hook                                    # new ref: range = the branch commit + the merge
+    [ "$status" -eq 0 ]
+}
+
+@test "the same branch is refused while its TIP still carries the inherited leak" {
+    branch_inheriting_mains_leak
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"the tip of refs/heads/main"* ]]   # named as the tip, not as an introduction
+    [[ "$output" == *"leak.txt"* ]]
+    [[ "$output" != *"ADDS"* ]]
+    [[ "$output" == *"merge main"* ]]                   # the remedy is spelled out
+}
+
+@test "a leak ADDED by a branch commit and removed by a later one is refused, naming the commit" {
+    commit_file base.txt "notes-api" "base"
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file leak.txt "redact"
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]
+    [[ "$output" == *"leak.txt"* ]]
+}
+
+@test "an identifier in the branch's OWN new commit is still refused after merging main" {
+    branch_inheriting_mains_leak
+    main_redacts_and_branch_merges
+    commit_file api.txt "home is /home/zzsynthuser/api" "branch leak"
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ADDS a personal identifier"* ]]
+    [[ "$output" == *"api.txt"* ]]
+    [[ "$output" != *"leak.txt"* ]]       # main's commits were skipped, not re-flagged
+}
+
+@test "a commit only ANOTHER remote has is still new to this one" {
+    # --not --remotes (every remote) would have excused this; the exclusion is per remote
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file leak.txt "redact"                # tip is clean
+    git -C "$REPO" update-ref refs/remotes/elsewhere/main HEAD
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS"* ]]
+}
+
+@test "with no remote-tracking refs, the same rule covers everything the remote ref lacks (the fallback)" {
+    commit_file base.txt "notes-api" "base"
+    remote_sha="$(git -C "$REPO" rev-parse HEAD)"
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    leak_sha="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file leak.txt "redact"
+    commit_file web.txt "the web session's work" "more work"   # tip is clean; the range is not
+    run_hook "$remote_sha"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS"* ]]
+}


### PR DESCRIPTION
## What breaks

`.githooks/pre-push` greps the full tree of every commit in a ref's update range (`remote_sha..local_sha`; for a new ref, everything no remote-tracking ref has). That is the wrong unit once a denylisted string has landed on `main` and been redacted forward: every branch cut from `main` in between inherits the string in the trees of its own commits although none of its diffs adds it, and a branch that merged `main` also carries `main`'s own commits in its range. The hook then refuses those pushes, naming the branch's own commit over a file the branch never touched, and the only way through is `--no-verify` on every such branch — the habit the hook exists to prevent.

## Reproduction

With a synthetic denylist (`zzsynthuser`) and a bare remote:

1. On `main`, commit `leak.txt` containing `/home/zzsynthuser/code`; push (the string escaped before the denylist knew it).
2. Cut `feature` from that commit and commit `web.txt` (clean).
3. On `main`, remove `leak.txt`; push.
4. On `feature`, merge `main`. Its tip is clean; its earlier commit's tree still holds `leak.txt`.
5. `git push -u origin feature` — refused: `commit <branch-work sha> would publish a personal identifier in: leak.txt`.

`tests/pre-push-hook.bats` (new) scripts this against the hook; the case "a branch that only INHERITED main's leak in its tree passes once its tip merged the redaction" fails on the current hook with status 1.

## The fix

Two rules replace the per-commit tree scan, both about what THIS push changes on the remote:

1. **The tip tree of each pushed ref must be clean.** That is the exposure a push creates; a string anywhere in it refuses the push, named as the tip (`the tip of refs/heads/<branch> (<sha>) would publish a personal identifier in: <path>`).
2. **Each commit new to the remote must add no banned line** in its diff against its first parent. A string introduced in an intermediate commit and removed by a later one is still caught, and the commit named (`commit <sha> ADDS a personal identifier in: <path>`) — the property #23 established. A commit whose tree only inherits an older string is not refused.

"New to the remote" is `<tip> --not <remote_sha> --remotes=<remote>`: anything reachable from the pushed-to remote's refs as last fetched is excluded, scoped to that remote — a commit only another remote has is still scanned, where the old new-ref form (`--not --remotes`) excused it. With no remote-tracking refs for the remote (never fetched, or a push by URL, where git passes the URL as `$1`) the exclusion matches nothing and the range is what the remote ref lacks, as before.

The added-lines pass is `git diff-tree -p -r -M` against the first parent (`--root` for a root commit) through a short awk that takes the path from the `+++ b/<path>` header only between a `diff --git` line and the first `@@` hunk, so an added content line that itself begins with `++ b/` (rendered `+++ b/...` in the patch) is content, attributed to the file it is in. `-M` keeps a rename from re-adding every line of the moved file. A merge is diffed against its first parent, so a string that exists in neither parent (a conflict resolution) counts as the merge's own addition.

A string already on the remote is fixed forward on `main` (redact, push `main`), not by refusing every branch cut since; the refusal footer now says so: `If the tip only INHERITS a string an older commit added and main has since redacted, merge main.`

One semantics change to accept explicitly: a branch whose intermediate commits inherit a string already on the remote is no longer refused — only its tip and its own added lines are checked. The tip rule still refuses re-exposing that string in any pushed tip.

## Tests

`tests/pre-push-hook.bats` (new, 11 cases) drives the hook by hand — ref lines on stdin, remote name as `$1` — with a synthetic denylist and a bare remote, so it can model remote-tracking refs the way a clone has them:

- basic: a clean commit passes; a string in a regular file is refused; a string in an intermediate commit is refused naming the commit; no denylist file means no scan;
- a branch that inherited `main`'s string passes once its tip merged the redaction; the same branch is refused while its tip still carries it, named as the tip, with the `merge main` remedy and no `ADDS`;
- a string added by one commit and removed by the next is refused naming the commit; a fresh string after merging `main` is refused naming `api.txt` without re-flagging `leak.txt`;
- a commit only another remote has is still scanned (per-remote scoping); with a real `remote_sha` and no remote-tracking refs, the fallback range still catches an intermediate addition;
- an added line shaped like a diff header (`++ b/decoy.txt`) is content: the hit is attributed to the real file, not to `decoy.txt`.

Eight of the eleven fail against the current hook (five on behavior — the inherited-leak pass, tip naming, per-remote scoping, and two whose refusal changes — and three more that pin the `ADDS` wording). The header-shaped case fails against a header parser that reads `+++ ` anywhere in the patch.

The eight existing `tests/install-sh.bats` hook tests (through a real `git push`) are unchanged and stay green: the intermediate-commit case is caught by the added-lines pass, and the only-new-commits case passes because the tip is clean and the range excludes what `origin/main` holds. `CLAUDE.md`'s backstop sentence and the `install-sh.bats` header comment describe the new rule.

Verified: `bats tests/pre-push-hook.bats` 11/11; `bats tests/install-sh.bats` 29/29; `bats tests/*.bats` 440/440; `shellcheck .githooks/pre-push` clean at warning level (the pre-existing SC2001 style notes on `sed` remain); full pytest unaffected (no Python changed). The reproduction above was also run through a real `git push` with the old and the new hook: refused before, accepted after; a new banned line on the branch is then refused naming that commit; a push by URL still catches it through the fallback range.

## Portability and limits

bash 3.2-safe (arrays are expanded only after the non-empty check, so `set -u` holds; `${var:0:10}`, `local`, here-strings) and POSIX awk/grep/sed/cut/sort. The test runs the hook through a `cd` helper rather than GNU `env -C`, so the suite stays GNU/BSD-portable per `tests/README.md`. Neither pass scans binaries (`git grep -I`; `diff-tree` prints `Binary files differ`), as before. `git grep` reads regular-file blobs only, so a symlink whose target holds a string is caught by the added-lines pass when the link is new to the remote, not by the tip scan when it is older. The exclusion is only as fresh as `refs/remotes/<remote>/*`: a clone that never fetched excludes nothing, which is stricter, never looser.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)