### PR TITLE
Analytics cost view: count each API response once, read every subagent transcript, and price Fable 5.1's cache reads at its own rate

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26386,6 +26386,11 @@ DEFAULT_MODEL_PRICES = {   # $/token: input, output, cache write (5m), cache rea
                            # the LiteLLM refresh overwrites these with the live feed (which carries the
                            # exact ids), so they just need to be sane when offline / before the first fetch.
     "claude-fable-5":            {"in": 10e-6, "out": 50e-6, "cache_w": 12.5e-6, "cache_r": 1e-6},
+    "claude-fable-5-1":          {"in": 10e-6, "out": 50e-6, "cache_w": 12.5e-6, "cache_r": 0.25e-6},   # its
+    #   own row: without one the family fallback priced Fable 5.1's cache reads at Fable 5's $1/Mtok — 4x
+    #   the list rate. Rates read from Claude Code's baked-in model catalog (2.1.261, checked on 2.1.263),
+    #   where claude-fable-5-1 carries the tier `tier_10_50_cache_read_0_25` (10 / 50 / 12.5 / 0.25 $/Mtok;
+    #   1h cache writes are 20 and are folded into cache_w here at the 5m rate, a known simplification)
     "claude-opus-4-8":           {"in": 5e-6, "out": 25e-6, "cache_w": 6.25e-6, "cache_r": 0.5e-6},
     "claude-sonnet-5":           {"in": 3e-6, "out": 15e-6, "cache_w": 3.75e-6, "cache_r": 0.3e-6},
     "claude-sonnet-4-6":         {"in": 3e-6, "out": 15e-6, "cache_w": 3.75e-6, "cache_r": 0.3e-6},
@@ -26461,11 +26466,17 @@ def _model_prices(now=None):
 
 
 def _price_for(model, prices):
-    """The price row for a model: exact id, else any priced model of the same family
-    (fable/opus/sonnet/haiku) so a differently-dated id still gets a sane rate, else None
-    (uncounted — defensive)."""
+    """The price row for a model: exact id, else the priced model with the same (family, major, minor)
+    signature (a dated `claude-fable-5-1-2026…` lands on the fable-5-1 row, not on whichever fable row
+    the table lists first — the two differ 4x on cache reads), else any priced model of the same family
+    (fable/opus/sonnet/haiku) so an unknown id still gets a sane rate, else None (uncounted — defensive)."""
     if model in prices:
         return prices[model]
+    sig = _price_sig(model)
+    if sig:
+        for k, v in prices.items():
+            if _price_sig(k) == sig:
+                return v
     m = (model or "").lower()
     for fam in ("fable", "opus", "sonnet", "haiku"):
         if fam in m:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26140,7 +26140,34 @@ def _derive_judging(sid, caps, goals, t0, out, seg_ends=None):
         pass
 
 
-_session_tok_cache = {}   # path -> (mtime, [(t, in, out, cache_w, cache_r, model), ...]): per-message token rows
+_session_tok_cache = {}   # transcript path -> ((mtime, size), [(t, in, out, cache_w, cache_r, model), ...]): one
+#                           token row per API RESPONSE (message.id) in THAT file. The main transcript and each
+#                           subagent transcript cache separately, so a file that moved re-parses itself alone
+
+
+def _subagent_transcripts(path):
+    """The subagent transcripts beside a session's main one, sorted; [] when none. The CLI writes each
+    spawned agent's conversation under `<sid>/subagents/` next to `<sid>.jsonl`: Task agents as
+    `agent-<id>.jsonl` at the top, and (Claude Code 2.1.261) Workflow agents one level down at
+    `workflows/wf_<id>/agent-<id>.jsonl` — its path parser takes any extra segments — so the walk is
+    RECURSIVE (a flat listing misses every nested file; measured on one installation, those held a
+    quarter of the sessions' tokens and 62% of their output tokens). Bounded to the session's own
+    subagents tree: no symlink is followed — not a directory (os.walk's followlinks=False), not a FILE
+    (os.walk lists a symlinked file like any other and the reader would open it wherever it points; the
+    CLI writes none, so one is a user's, and it is skipped), and not the subagents directory itself.
+    Cost: one directory read per directory under it plus one lstat per file."""
+    base, ext = os.path.splitext(str(path))
+    if ext != ".jsonl":
+        return []
+    d = os.path.join(base, "subagents")
+    if os.path.islink(d):
+        return []
+    out = []
+    for root, dirs, files in os.walk(d):            # followlinks=False — never leaves the session's own tree
+        dirs.sort()
+        out.extend(p for p in (os.path.join(root, n) for n in files if n.endswith(".jsonl"))
+                   if not os.path.islink(p))
+    return sorted(out)
 
 
 def _msg_epoch(o):
@@ -26154,44 +26181,109 @@ def _msg_epoch(o):
         return None
 
 
-def _session_tokens(path, t0):
-    """Sum a session's token usage over assistant messages timestamped >= t0 — the SESSIONS half of the
-    token split, windowed to match the PIPELINE half (_judge_usage) so the footer compares like-for-like.
-    Each assistant record carries a `usage` block. The per-message rows are mtime-cached (now-independent);
-    the windowed sum is computed per call. Undated rows are counted (defensive). Zeros on error."""
-    z = {"in": 0, "out": 0, "cache_w": 0, "cache_r": 0}
+def _transcript_tok_rows(p):
+    """ONE transcript file's per-response token rows, cached in _session_tok_cache on the file's
+    (mtime, size) stamp — the parse runs only when the stamp moved — or None when the file is unreadable.
+
+    ONE row per API response, not per transcript record: the CLI writes a response with several content
+    blocks as several assistant records that share one `message.id`, so summing records counted each
+    response 2.3-3.0x (the analytics read 1.55x the spend ledger over a day). The row kept is the one
+    with the LARGEST output count, and that rule is load-bearing, not defensive: a MAIN transcript's
+    same-id records repeat one usage block, but a SUBAGENT transcript's carry the stream-start snapshot
+    (a few output tokens) on every record but the last, which holds the final tally — measured on one
+    installation's subagent files, about nine in ten multi-record groups differ (88% and 94% on two
+    samples) and the last record holds the maximum in every one; a first-record fold would keep about a
+    tenth of the subagents' output tokens. That is an observed regularity of the CLI's writer, not a
+    documented contract: a writer that logged per-block usage DELTAS under one id would be under-counted
+    by it. A record with no id counts on its own. The fold is per FILE: each API response is logged in
+    exactly one transcript, the conversation that made it (no id shared between a main transcript and
+    its subagents' in 130k measured), so the session's rows are the files' rows concatenated."""
     try:
-        mt = os.path.getmtime(path)
+        st = os.stat(p)
     except OSError:
-        return dict(z)
-    hit = _session_tok_cache.get(path)
-    if not hit or hit[0] != mt:
-        rows = []
-        try:
-            with open(path, errors="replace") as f:
-                for line in f:
-                    try:
-                        o = json.loads(line)
-                    except Exception:
+        return None
+    stamp = (st.st_mtime, st.st_size)
+    hit = _session_tok_cache.get(p)
+    if hit and hit[0] == stamp:
+        return hit[1]
+    rows, by_id = [], {}
+    try:
+        with open(p, errors="replace") as f:
+            for line in f:
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(o, dict) or o.get("type") != "assistant":
+                    continue
+                m = o.get("message") or {}
+                u = m.get("usage") or {}
+                row = (_msg_epoch(o),
+                       int(u.get("input_tokens") or 0), int(u.get("output_tokens") or 0),
+                       int(u.get("cache_creation_input_tokens") or 0),
+                       int(u.get("cache_read_input_tokens") or 0),
+                       m.get("model") or "")   # for cost weighting (price is per-model)
+                mid = m.get("id")
+                if mid:
+                    j = by_id.get(mid)
+                    if j is not None:            # the same response again (another content block)
+                        if row[2] > rows[j][2]:
+                            rows[j] = (rows[j][0],) + row[1:]
                         continue
-                    if o.get("type") != "assistant":
-                        continue
-                    m = o.get("message") or {}
-                    u = m.get("usage") or {}
-                    rows.append((_msg_epoch(o),
-                                 int(u.get("input_tokens") or 0), int(u.get("output_tokens") or 0),
-                                 int(u.get("cache_creation_input_tokens") or 0),
-                                 int(u.get("cache_read_input_tokens") or 0),
-                                 m.get("model") or ""))   # for cost weighting (price is per-model)
-        except OSError:
-            return dict(z)
-        _session_tok_cache[path] = (mt, rows)
-        hit = _session_tok_cache[path]
-    acc = dict(z)
-    for (t, i, o, cw, cr, _m) in hit[1]:
-        if t is None or t >= t0:
-            acc["in"] += i; acc["out"] += o; acc["cache_w"] += cw; acc["cache_r"] += cr
-    return acc
+                    by_id[mid] = len(rows)
+                rows.append(row)
+    except OSError:
+        return None
+    _session_tok_cache[p] = (stamp, rows)
+    return rows
+
+
+def _session_tok_rows(path):
+    """A session's per-response token rows — the main transcript's and every subagent transcript's
+    under it (_transcript_tok_rows each) — or None when the main transcript is unreadable. Each file
+    caches on its OWN stamp, so a subagent that lands or grows parses that one file while the main
+    transcript's rows (the largest file by far) stay cached, and the main file moving leaves every
+    subagent's rows in place; a per-session fingerprint would re-parse the whole tree whenever any one
+    file moved, which on a session with Workflow agents running is every build. A subagent file gone
+    between the listing and the read drops out and the rest still count. Cost per call: the subagents
+    walk (one directory read per directory), one stat per file, and the concatenation; parsing only for
+    the files whose stamp moved. The analytics build calls this ONCE per session (_session_usage)."""
+    rows = _transcript_tok_rows(str(path))
+    if rows is None:
+        return None
+    rows = list(rows)
+    for p in _subagent_transcripts(path):
+        sub = _transcript_tok_rows(p)
+        if sub is not None:                      # None: gone since the listing
+            rows.extend(sub)
+    return rows
+
+
+def _session_usage(path, t0, prices):
+    """The analytics build's ONE pass over a session's rows: token totals over responses timestamped
+    >= t0 (the SESSIONS half of the split, cut at the same t0 as the PIPELINE half, _judge_usage, so
+    the modal compares like-for-like) and the token-price estimate over the same span (`cost`: each
+    response's tokens x its model's _model_prices row — an ESTIMATE; sessions log no cost of their own,
+    unlike judges — with cache reads priced too, cheap per token but huge in volume). `prices` None
+    skips the pricing. Undated rows count (defensive). Zeros when the transcript is unreadable."""
+    out = {"in": 0, "out": 0, "cache_w": 0, "cache_r": 0, "cost": 0.0}
+    rows = _session_tok_rows(path)
+    if rows is None:
+        return out
+    for (t, i, o, cw, cr, model) in rows:
+        if t is not None and t < t0:
+            continue
+        out["in"] += i; out["out"] += o; out["cache_w"] += cw; out["cache_r"] += cr
+        pr = _price_for(model, prices) if prices else None
+        if pr:
+            out["cost"] += i * pr["in"] + o * pr["out"] + cw * pr["cache_w"] + cr * pr["cache_r"]
+    return out
+
+
+def _session_tokens(path, t0):
+    """A session's token totals over responses timestamped >= t0 — _session_usage's token half."""
+    u = _session_usage(path, t0, None)
+    return {k: u[k] for k in ("in", "out", "cache_w", "cache_r")}
 
 
 # judge-usage.jsonl is append-only, time-ordered, and never rotated (38.7 MB / 148k lines measured
@@ -26384,21 +26476,9 @@ def _price_for(model, prices):
 
 
 def _session_cost(path, t0, prices):
-    """$ cost of a session's token usage over [t0, now], priced per-message by its model — sessions carry
-    no logged cost (unlike judges). Reuses _session_tokens' per-message row cache (which now carries the
-    model). Cache reads are cheap per token but huge in volume, so all four token classes are priced."""
-    _session_tokens(path, t0)                        # populate/refresh the row cache
-    hit = _session_tok_cache.get(path)
-    if not hit:
-        return 0.0
-    c = 0.0
-    for (t, i, o, cw, cr, model) in hit[1]:
-        if t is not None and t < t0:
-            continue
-        pr = _price_for(model, prices)
-        if pr:
-            c += i * pr["in"] + o * pr["out"] + cw * pr["cache_w"] + cr * pr["cache_r"]
-    return c
+    """The token-price ESTIMATE of a session's usage over responses timestamped >= t0 — _session_usage's
+    cost half (priced per response by its model; sessions carry no logged cost, unlike judges)."""
+    return _session_usage(path, t0, prices)["cost"]
 
 
 _ANALYTICS_MEMO = {}   # window -> {"t": epoch, "jkey": judge-usage cache size, "resp": the payload}
@@ -26409,8 +26489,9 @@ def _token_analytics(now, window):
     the coding SESSIONS total (summed transcript usage of the discovered fleet) vs the judge PIPELINE
     broken out per judge AND per tier (_judge_usage). One ARBITRARY window — the modal's period picker.
     Each side also carries $ cost so the modal can toggle tokens↔cost without a refetch: judges = exact
-    logged cost, sessions = tokens × _model_prices. Cheap: _session_tokens caches per-path rows and
-    _judge_usage reads the shared incremental row cache, so this re-sums memory."""
+    logged cost, sessions = tokens × _model_prices. Cheap: _session_usage makes ONE pass per session over
+    _session_tok_rows' cached rows and _judge_usage reads the shared incremental row cache, so this
+    re-sums memory."""
     # a tiny TTL memo: the modal refetches on every period click and every reopen, and the recompute is
     # honest-but-pointless within seconds of itself (the user 2026-08-13's fast-and-visible rule); a new
     # judge row (cache size moved) invalidates early so the numbers never sit stale behind live judging
@@ -26425,9 +26506,9 @@ def _token_analytics(now, window):
     # the full window but sessions over only the last 48h of activity — the "judges = N% of session
     # cost" note was wrong there by construction (the user 2026-08-13's map)
     for fsid, path, anchor, name in jd.discover(now, window=max(window, 48 * 3600)):
-        d = _session_tokens(str(path), t0)
+        d = _session_usage(str(path), t0, prices)
         s["in"] += d["in"]; s["out"] += d["out"]
-        s["cost"] += _session_cost(str(path), t0, prices)
+        s["cost"] += d["cost"]
     resp = {"window": window, "now": now, "sessions": s, "judges": _judge_usage(t0)}
     _ANALYTICS_MEMO[window] = {"t": now, "jkey": _JUDGE_USAGE_CACHE["size"], "resp": resp}
     return resp

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -456,6 +456,18 @@ class CostWeighting(unittest.TestCase):
         self.assertEqual(km._price_for("claude-fable-5", prices)["in"], 10e-6, "fable input is 2x opus")
         self.assertEqual(km._price_for("claude-opus-4-8", prices)["in"], 5e-6, "opus rate unchanged")
 
+    def test_fable_5_1_has_its_own_row_with_the_quarter_rate_cache_read(self):
+        # Before the row existed the family fallback handed Fable 5.1 Fable 5's $1/Mtok cache read — 4x
+        # its list rate (Claude Code 2.1.261's catalog: tier_10_50_cache_read_0_25), and the remote feed
+        # could never correct it because only exact (family, major, minor) signatures match.
+        prices = km._model_prices(NOW)
+        row = km._price_for("claude-fable-5-1", prices)
+        self.assertEqual((row["in"], row["out"], row["cache_w"], row["cache_r"]), (10e-6, 50e-6, 12.5e-6, 0.25e-6))
+        self.assertEqual(km._price_for("claude-fable-5", prices)["cache_r"], 1e-6, "Fable 5 keeps its own rate")
+        self.assertEqual(km._price_sig("claude-fable-5-1"), ("fable", "5", "1"), "signs distinctly, so the feed can reach it")
+        self.assertEqual(km._price_for("claude-fable-5-1-20261201", prices)["cache_r"], 0.25e-6,
+                         "…and a dated id of the same model lands on the fable-5-1 row by signature, not on the first fable row")
+
     def test_price_sig_signs_single_number_ids_and_ignores_date_suffixes(self):
         self.assertEqual(km._price_sig("claude-opus-4-8"), ("opus", "4", "8"), "X-Y pair still signs")
         self.assertEqual(km._price_sig("claude-haiku-4-5-20251001"), ("haiku", "4", "5"), "date after a minor")

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for build_timeline's token-usage split:
-  _session_tokens  — per-session transcript token sums (the SESSIONS half)
+  _session_tokens  — per-session transcript token sums (the SESSIONS half), one row per API
+                     response across the main transcript and its subagents' (_session_tok_rows)
   _judge_usage     — the judge PIPELINE rollup from judge-usage.jsonl (per-judge / per-tier)
 Synthetic data only (placeholder usage numbers, a temp state dir)."""
 import json
@@ -26,10 +27,12 @@ def iso(epoch):
     return datetime.fromtimestamp(epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
-def _asst(usage, ts=None, model=None):
+def _asst(usage, ts=None, model=None, mid=None):
     msg = {"role": "assistant", "content": [], "usage": usage}
     if model is not None:
         msg["model"] = model
+    if mid is not None:
+        msg["id"] = mid
     o = {"type": "assistant", "message": msg}
     if ts is not None:
         o["timestamp"] = ts
@@ -55,6 +58,149 @@ class SessionTokens(unittest.TestCase):
     def test_missing_file_returns_zeros(self):
         self.assertEqual(km._session_tokens("/no/such/transcript.jsonl", NOW - 3600),
                          {"in": 0, "out": 0, "cache_w": 0, "cache_r": 0})
+
+    def test_records_sharing_a_message_id_count_once(self):
+        """The CLI writes a multi-block response as several assistant records sharing one message.id;
+        summing records counted each response 2.3-3.0x. In a MAIN transcript the records repeat one usage
+        block (2,515 groups measured, none differing); subagent transcripts differ — see the next test.
+        One row per id, the largest output count kept; an id-less record stands alone."""
+        u = {"input_tokens": 10, "output_tokens": 5, "cache_creation_input_tokens": 100, "cache_read_input_tokens": 200}
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "s.jsonl")
+            with open(p, "w") as f:
+                for _ in range(3):
+                    f.write(_asst(u, iso(NOW - 100), mid="msg_aaaa") + "\n")         # a 3-block response
+                f.write(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 90)) + "\n")   # no id
+                f.write(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 80)) + "\n")   # no id
+                f.write(_asst({"input_tokens": 7, "output_tokens": 2}, iso(NOW - 70), mid="msg_bbbb") + "\n")
+                # a split response whose LAST record carries a larger output count (a final tally): the
+                # larger figure is the one kept, never both
+                f.write(_asst({"input_tokens": 4, "output_tokens": 1}, iso(NOW - 60), mid="msg_cccc") + "\n")
+                f.write(_asst({"input_tokens": 4, "output_tokens": 9}, iso(NOW - 59), mid="msg_cccc") + "\n")
+            self.assertEqual(km._session_tokens(p, NOW - 3600),
+                             {"in": 10 + 2 + 7 + 4, "out": 5 + 2 + 2 + 9, "cache_w": 100, "cache_r": 200})
+
+    def test_subagent_same_id_records_keep_the_final_tally_whatever_their_order(self):
+        """A SUBAGENT transcript's same-id records DIFFER: every record but the last carries the
+        stream-start snapshot (a few output tokens) and the last the final tally — measured on one
+        installation's subagent files, about nine in ten multi-record groups (88% and 94% on two
+        samples), the last record the maximum in every one. The fold keeps the LARGEST output count, in either order, so a first-record fold (about
+        a tenth of the subagents' output) or a last-record fold cannot quietly replace it."""
+        first = {"input_tokens": 4000, "output_tokens": 3, "cache_read_input_tokens": 50000}    # stream start
+        last = {"input_tokens": 4000, "output_tokens": 1950, "cache_read_input_tokens": 50000}  # final tally
+        with tempfile.TemporaryDirectory() as d:
+            for name, order in (("a.jsonl", (first, first, last)), ("b.jsonl", (last, first, first))):
+                pth = os.path.join(d, name)
+                with open(pth, "w") as f:
+                    for k, u in enumerate(order):
+                        f.write(_asst(u, iso(NOW - 100 + k), mid="msg_sub") + "\n")
+                self.assertEqual(km._session_tokens(pth, NOW - 3600),
+                                 {"in": 4000, "out": 1950, "cache_w": 0, "cache_r": 50000},
+                                 name + ": one row, the final tally's output count")
+
+    def test_subagent_transcripts_beside_the_main_one_count_and_refresh_the_cache(self):
+        """`<sid>/subagents/agent-<id>.jsonl` holds each spawned agent's conversation; its tokens are the
+        session's spend too. Each contributing file caches on its own stamp, so a subagent landing
+        later refreshes the sum while the main file rests."""
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "11111111-2222-3333-4444-555555555555.jsonl")
+            with open(p, "w") as f:
+                f.write(_asst({"input_tokens": 10, "output_tokens": 5}, iso(NOW - 100), mid="m1") + "\n")
+            sub = pathlib.Path(d) / "11111111-2222-3333-4444-555555555555" / "subagents"
+            sub.mkdir(parents=True)
+            (sub / "agent-a1.jsonl").write_text(
+                _asst({"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 1000},
+                      iso(NOW - 90), mid="m2") + "\n"
+                + _asst({"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 1000},
+                        iso(NOW - 89), mid="m2") + "\n"                       # a split block, deduped too
+                + _asst({"input_tokens": 999, "output_tokens": 999}, iso(NOW - 99999), mid="m3") + "\n")  # out of window
+            (sub / "notes.txt").write_text("not a transcript\n")
+            # a Workflow agent's transcript one level down (Claude Code 2.1.261 writes
+            # subagents/workflows/wf_<id>/agent-<id>.jsonl): the walk is recursive, so it counts too
+            wf = sub / "workflows" / "wf_1111-2222"
+            wf.mkdir(parents=True)
+            (wf / "agent-c3.jsonl").write_text(_asst({"input_tokens": 1000, "output_tokens": 500}, iso(NOW - 80), mid="m5") + "\n")
+            # …but the walk never leaves the session's own tree: a symlinked directory is not followed
+            other = pathlib.Path(d) / "elsewhere"
+            other.mkdir()
+            (other / "agent-zz.jsonl").write_text(_asst({"input_tokens": 7777, "output_tokens": 7777}, iso(NOW - 70), mid="m6") + "\n")
+            os.symlink(other, sub / "linked")
+            # …nor is a symlinked FILE: os.walk lists one like any other file (only DIRECTORY links go
+            # unfollowed), so a reader that trusted the listing would open it wherever it points
+            os.symlink(other / "agent-zz.jsonl", sub / "agent-link.jsonl")
+            self.assertEqual(km._session_tokens(p, NOW - 3600), {"in": 1110, "out": 555, "cache_w": 0, "cache_r": 1000})
+            # a second subagent lands; the main transcript's mtime has not moved
+            mt = os.path.getmtime(p)
+            (sub / "agent-b2.jsonl").write_text(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 10), mid="m4") + "\n")
+            os.utime(p, (mt, mt))
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 1111, "the new subagent file refreshes the rows")
+            # a NESTED file growing refreshes them too (its mtime is in the fingerprint like any other)
+            with (wf / "agent-c3.jsonl").open("a") as f:
+                f.write(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 5), mid="m7") + "\n")
+            os.utime(p, (mt, mt))
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 1112, "a nested file's growth refreshes the rows")
+            self.assertEqual(km._subagent_transcripts(p),
+                             [str(sub / "agent-a1.jsonl"), str(sub / "agent-b2.jsonl"), str(wf / "agent-c3.jsonl")],
+                             "sorted, nested files included, the symlinked directory not walked, the symlinked file skipped")
+            self.assertEqual(km._subagent_transcripts(os.path.join(d, "no-such.jsonl")), [])
+            self.assertEqual(km._subagent_transcripts(os.path.join(d, "x.txt")), [])
+
+    def test_each_transcript_caches_on_its_own_stamp_so_one_file_moving_parses_only_itself(self):
+        """The row cache is per FILE (path -> (stamp, rows)), not per session: a subagent file landing or
+        growing parses that file alone while the main transcript's rows stay cached, and the main file
+        moving leaves every subagent's rows in place. A per-session fingerprint re-parsed the whole tree
+        (main transcript plus every subagent file) whenever any one of them moved — on a live session
+        with Workflow agents running, that is every build, on the GIL, in the /analytics handler."""
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "11111111-2222-3333-4444-555555555555.jsonl")
+            with open(p, "w") as f:
+                f.write(_asst({"input_tokens": 10, "output_tokens": 5}, iso(NOW - 100), mid="m1") + "\n")
+            sub = pathlib.Path(d) / "11111111-2222-3333-4444-555555555555" / "subagents"
+            sub.mkdir(parents=True)
+            a1 = sub / "agent-a1.jsonl"
+            a1.write_text(_asst({"input_tokens": 100, "output_tokens": 50}, iso(NOW - 90), mid="m2") + "\n")
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 110)
+            main_rows, a1_rows = km._session_tok_cache[p][1], km._session_tok_cache[str(a1)][1]
+            self.assertEqual([r[1] for r in main_rows], [10], "the main transcript's own rows, cached under its path")
+            self.assertEqual([r[1] for r in a1_rows], [100], "the subagent's own rows, cached under its path")
+            # a second subagent lands: it parses, the two cached files do not
+            mt = os.path.getmtime(p)
+            (sub / "agent-b2.jsonl").write_text(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 10), mid="m4") + "\n")
+            os.utime(p, (mt, mt))
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 111)
+            self.assertIs(km._session_tok_cache[p][1], main_rows, "the main transcript was not re-parsed")
+            self.assertIs(km._session_tok_cache[str(a1)][1], a1_rows, "the untouched subagent was not re-parsed")
+            # the main transcript grows: it parses, the subagents' rows stay
+            with open(p, "a") as f:
+                f.write(_asst({"input_tokens": 1000, "output_tokens": 1}, iso(NOW - 5), mid="m8") + "\n")
+            os.utime(p, (mt + 5, mt + 5))
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 1111)
+            self.assertIsNot(km._session_tok_cache[p][1], main_rows, "the grown main transcript was re-parsed")
+            self.assertIs(km._session_tok_cache[str(a1)][1], a1_rows, "…and the subagent's rows were not")
+            # a same-mtime rewrite that changes the size still refreshes (the stamp is mtime AND size)
+            b2_rows = km._session_tok_cache[str(sub / "agent-b2.jsonl")][1]
+            bmt = os.path.getmtime(sub / "agent-b2.jsonl")
+            with (sub / "agent-b2.jsonl").open("a") as f:
+                f.write(_asst({"input_tokens": 1, "output_tokens": 1}, iso(NOW - 4), mid="m9") + "\n")
+            os.utime(sub / "agent-b2.jsonl", (bmt, bmt))
+            self.assertEqual(km._session_tokens(p, NOW - 3600)["in"], 1112)
+            self.assertIsNot(km._session_tok_cache[str(sub / "agent-b2.jsonl")][1], b2_rows)
+
+    def test_a_symlinked_subagents_directory_is_not_walked_either(self):
+        """os.walk follows its TOP argument even when it is a symlink (followlinks governs the descent, not
+        the root), so `<sid>/subagents` itself pointing elsewhere would read another tree wholesale."""
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "11111111-2222-3333-4444-555555555555.jsonl")
+            with open(p, "w") as f:
+                f.write(_asst({"input_tokens": 10, "output_tokens": 5}, iso(NOW - 100), mid="m1") + "\n")
+            other = pathlib.Path(d) / "elsewhere"
+            other.mkdir()
+            (other / "agent-zz.jsonl").write_text(_asst({"input_tokens": 7777, "output_tokens": 7777}, iso(NOW - 70), mid="m6") + "\n")
+            sid_dir = pathlib.Path(d) / "11111111-2222-3333-4444-555555555555"
+            sid_dir.mkdir()
+            os.symlink(other, sid_dir / "subagents")
+            self.assertEqual(km._subagent_transcripts(p), [])
+            self.assertEqual(km._session_tokens(p, NOW - 3600), {"in": 10, "out": 5, "cache_w": 0, "cache_r": 0})
 
 
 class JudgeUsageIncrementalCache(unittest.TestCase):


### PR DESCRIPTION
The analytics modal's Sessions figure over-counts the main transcript, misses every subagent transcript, and prices Fable 5.1 cache reads at four times the catalog rate. This PR makes `_session_tokens` count each API response once across the main transcript and its subagents', adds a `claude-fable-5-1` price row, and has `_price_for` match a model's own version before falling back to its family. Two commits, two files (`kernel/kernel.py`, `tests/test_token_usage.py`); independent of #956, see below.

## What breaks

On one installation the Sessions figure (`/analytics`, `_token_analytics`) read about 1.5x the spend ledger over a day. Three causes, all in `kernel/kernel.py`:

1. **Every transcript record was summed.** The CLI writes a response with several content blocks as several `assistant` records sharing one `message.id`, each carrying the response's `usage` block. `_session_tokens` appended a row per record, so one response counted 2.3 to 3.0 times (measured on that installation).
2. **Only the main transcript was read.** The CLI writes each spawned agent's conversation under `<projects>/<slug>/<sid>/subagents/`: Task agents at the top as `agent-<id>.jsonl`, and since Claude Code 2.1.261 (checked on 2.1.263) Workflow agents one level down at `workflows/wf_<id>/agent-<id>.jsonl`. None of those tokens reached the view. On that installation they were a quarter of the sessions' tokens and 62% of the output tokens.
3. **Fable 5.1 cache reads were priced 4x.** `DEFAULT_MODEL_PRICES` has no `claude-fable-5-1` row, so `_price_for`'s family fallback returned the `claude-fable-5` row, whose cache read is 1 $/Mtok. Claude Code's baked-in catalog prices Fable 5.1 at `tier_10_50_cache_read_0_25` (10 / 50 / 12.5 / 0.25 $/Mtok). The remote feed could not correct it: `_refresh_remote_prices` matches only exact (family, major, minor) signatures, and the table had no fable-5-1 signature to look for.

## Reproduction

- Write a transcript with three `assistant` records sharing one `message.id`: `_session_tokens` returns three times the usage.
- Put a transcript under `<sid>/subagents/` beside the main one: it does not count at all.
- `_price_for("claude-fable-5-1", _model_prices(now))["cache_r"]` is 1e-6 (Fable 5's rate); the catalog says 0.25e-6.

Each is one of the new tests below, and each fails against the base commit.

## The fix

**Commit 1: `_subagent_transcripts`, `_session_tok_rows`, `_session_usage`**

- One row per `message.id`, keeping the record with the largest output count. The largest-output rule handles a difference between the two transcript kinds: a main transcript's same-id records repeat one usage block, while a subagent transcript's carry the stream-start snapshot (a few output tokens) on every record but the last, which holds the final tally. Measured over 30 days of one installation's subagent files, 94% of multi-record groups differ and the last record holds the maximum in every one; a first-seen fold keeps about a tenth of the subagents' output. An id-less record stands alone. This is an observed regularity of the CLI's writer, not a documented contract; the docstring says so, and a writer that logged per-block usage deltas under one id would be under-counted.
- `_subagent_transcripts` walks the session's `subagents/` tree recursively with `os.walk` (`followlinks=False`) and skips a symlinked `subagents` directory and symlinked files, so the reader never opens anything outside the session's own tree. The CLI writes no symlinks there.
- The row cache is per file, not per session: `_session_tok_cache` maps each transcript path (the main one and every subagent's) to `((mtime, size), rows)`, so a subagent file landing or growing re-parses that file alone while the main transcript's rows stay cached, and the main file moving leaves every subagent's rows in place. Commit bb0c40b8's message describes a per-session fingerprint over every file's `(path, mtime)` instead; that was the design rejected on the way, since it re-parses the whole tree whenever any one file moves, which on a session with Workflow agents running is every build. The per-file cache is what shipped (`_transcript_tok_rows`, and `_session_tok_rows`' docstring names the alternative as rejected). `_session_tokens` and `_session_cost` were the cache's only readers; both now go through `_session_usage`, which makes one pass per session for the tokens and the priced estimate, and `_token_analytics` calls it once per session instead of twice. Payload shape unchanged.

**Commit 2: prices**

- A `claude-fable-5-1` row: 10 / 50 / 12.5 / 0.25 $/Mtok. The catalog's 1h cache-write rate (20) folds into `cache_w` at the 5m rate; the table has one cache-write column for every model, so this is the simplification it already makes.
- `_price_for` tries an exact id, then a priced model with the same `_price_sig` signature, then the family. One behaviour change to name: a dated or minor-versioned id now lands on its own version's row rather than on whichever same-family row the dict lists first (`claude-sonnet-4-6-2099...` lands on `claude-sonnet-4-6`). The existing `test_price_for_exact_then_family_then_none` still passes, since `claude-opus-4-8-20990101` signs as the opus-4-8 row either way.

Cost: one directory walk per session per `/analytics` build (behind the existing 15 s memo) plus one stat per contributing file.

## Relation to #956 and #935

#956 (`romp spend-rebuild`) recounts the ledger's token columns from the transcripts under the same two rules, once per `message.id` with subagents included. It edits `cli/spend_rebuild.py`, `_spend_windows` and the chat-body hover; it does not touch `_session_tokens`, `_token_analytics`, `_price_for` or `DEFAULT_MODEL_PRICES`, so with #956 merged the analytics view still over-counts. The two PRs are complementary and share no hunks; whichever lands second rebases. Two things I would raise on #956 rather than fold in here: its `subagents/*.jsonl` glob is flat and misses the `workflows/wf_<id>/` nesting, and its first-seen dedupe keeps the stream-start snapshot in subagent transcripts.

#935 adds `_subagents_dir(path)`, which computes the same directory `_subagent_transcripts` derives. If #935 lands first, this PR should call it instead.

## Tests

`tests/test_token_usage.py`, synthetic data only (a placeholder sid, invented counts):

- `test_records_sharing_a_message_id_count_once`: three same-id records count once; id-less records stand alone; a split whose last record carries the larger output keeps the larger figure.
- `test_subagent_same_id_records_keep_the_final_tally_whatever_their_order`: the largest-output rule in both record orders, so neither a first-record nor a last-record fold can quietly replace it.
- `test_subagent_transcripts_beside_the_main_one_count_and_refresh_the_cache`: top-level and `workflows/wf_*/` files count; a non-`.jsonl` file, a symlinked directory and a symlinked file do not; a later subagent file and a nested file's growth refresh the cache while the main file's mtime stands.
- `test_each_transcript_caches_on_its_own_stamp_so_one_file_moving_parses_only_itself`: the cache is per file (`path -> ((mtime, size), rows)`): a second subagent landing parses that file alone while the main transcript's and the first subagent's cached rows stay; the main transcript growing re-parses it while the subagents' rows stay; a same-mtime rewrite that changes a file's size still refreshes it.
- `test_a_symlinked_subagents_directory_is_not_walked_either`: `os.walk` follows its top argument even when it is a symlink, so that case is closed separately.
- `test_fable_5_1_has_its_own_row_with_the_quarter_rate_cache_read`: the row, Fable 5's own rate kept, and a dated id landing on the fable-5-1 row by signature.

All six fail on the base commit (the two id tests sum three times, the subagent and cache tests hit the missing walk, the price test gets 1e-6). The full pytest suite, `npm test` and `npm run typecheck` pass locally. The change is file and JSON logic plus `os.walk(followlinks=False)` and `os.path.islink`, whose semantics are the same on macOS; no shell surface changed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)