### PR TITLE
File viewer: a session chip in the title bar, and a selection quote seeds the composer from the feed-hosted viewer too

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -28,8 +28,11 @@ passage, and repeat — each staged note remembers its quote and its place. **�
 everything you staged along with whatever is in the box, so the session applies the lot
 in one pass, and you never copy a line out of the document by hand. The line in each
 label is checked against the file at the moment you select, so numbers that moved under
-you are caught rather than quietly carried. The title bar's **GitHub ↗** button opens the
-file on GitHub. While the check runs, the button waits dimmed with pulsing dots beside it.
+you are caught rather than quietly carried. When several sessions work in the same
+repository, or in worktrees of it, the viewer's title bar says which one you opened the
+file from: a chip with the session's name, in the same color as its tab. The title bar's
+**GitHub ↗** button opens the file on GitHub. While the check runs, the button waits dimmed
+with pulsing dots beside it.
 When there is nothing to open, the button stays in place, dimmed, and a caption beside it
 says why (the file is not in a git repository or not committed — untracked, staged but in no
 commit, or on a branch with no commits yet — the repository has no origin remote, its origin

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31984,6 +31984,13 @@ if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');
     try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',true);}catch(e){}}
   try{window.__rompMobileTab&&window.__rompMobileTab('feed');}catch(e){}   // phone: one pane at a time
   try{bf&&bf.contentWindow&&bf.contentWindow.postMessage({romp:'browseFiles',path:m.path,sid:m.sid},'*');}catch(e){}}
+// A passage selected in a viewer hosted by a pane with NO composer (the feed) posts up in the
+// editorSelection shape the chat already handles (file-view.ts composerWindow); the shell forwards it
+// whole into the chat pane, whose composer seeds the labeled quote chip for the session the file was
+// opened for (m.sid beats the active tab there). The chat-hosted viewer posts to its own window and
+// never gets here.
+if(m.type==='editorSelection'&&typeof m.text==='string'){var fc=document.getElementById('f-chat');
+  try{fc&&fc.contentWindow&&fc.contentWindow.postMessage(m,'*');}catch(e){}}
 // the browser owns the restore: browseClosed alone puts a brought-forward feed back the way it was
 if(m.romp==='browseClosed'&&window.__rompFeedWasOff){window.__rompFeedWasOff=false;
   try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',false);}catch(e){}}});

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -260,6 +260,17 @@ class LandingShell(unittest.TestCase):
         self.assertIn("html.ios-standalone #mtabs{padding-bottom:env(safe-area-inset-bottom,0px)}", html)
         self.assertIn("#mtabs{display:flex;position:fixed;left:0;right:0;bottom:0", html)
 
+    def test_the_shell_forwards_a_quote_seed_from_a_composerless_pane_into_the_chat(self):
+        # A passage selected in the file viewer hosted by the FEED pane (the file browser's document)
+        # has no composer in its own document; file-view.ts posts the editorSelection message up to the
+        # shell, which forwards it whole into the chat iframe, whose existing handler seeds the labeled
+        # quote chip for m.sid. The arm sits in the same listener as the browseFiles relay, and the chat
+        # iframe carries the id it keys on.
+        js = km._LANDING_SETTINGS_JS
+        self.assertIn("if(m.type==='editorSelection'&&typeof m.text==='string'){var fc=document.getElementById('f-chat');", js)
+        self.assertIn("try{fc&&fc.contentWindow&&fc.contentWindow.postMessage(m,'*');}catch(e){}}", js)
+        self.assertIn("<iframe id=f-chat class=m-on src=/chat>", km._landing())
+
 
 class TimelineTouchSurface(unittest.TestCase):
     def test_timeline_fits_svg_and_drops_overflow_scroller_on_touch(self):

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1387,6 +1387,22 @@ body.fileview-open { overflow: hidden; }
 .fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
   overflow: hidden; text-overflow: ellipsis; }
 .fileview-base { flex: 0 0 auto; }
+/* the SESSION the file was opened from (the user 2026-09-03): a pill in the session's identity colour
+   (inline, from the resolved row — the colour its tab wears), a remote session's "host:" quiet inside.
+   Fixed width: the chip never yields to the path — only .fileview-dir above gives up room. Uncolored
+   when the session has no colour (a stub for a sid the document cannot name); absent when there is no
+   sid. The host: token takes the pill's OWN foreground (color: inherit): the global .host-prefix rule's
+   var(--dim) would otherwise beat the inline colour and sit near-invisible on a saturated pill.
+   Sized at the bar's button size — 0.82em of --fs, not a px value — so the chip scales with its
+   neighbours. A BLOCK container, not inline-flex: text-overflow acts on block containers only — on a flex
+   container the text sits in an anonymous flex item the property cannot reach, and an over-long name
+   hard-clipped at max-width (the review of #970). The bar's align-items centres the pill; its one nowrap
+   line centres within it. */
+.fileview-sess { flex: 0 0 auto; display: block; max-width: 38%; padding: 1px 8px;
+  border-radius: var(--radius-pill, 999px); font-size: 0.82em; font-weight: 600; line-height: 1.5;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); }
+.fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
   padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -24,7 +24,7 @@ import { initStrip } from "./strip";
 import { installSettingsSync, loadSettings, onExternalSettingsChange } from "./settings";
 import { applyTheme } from "./theme";
 import { canPreview } from "./preview";
-import { initFileView } from "./file-view";
+import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 import { wireTip, setTip, pruneTip } from "./tip";
@@ -5406,6 +5406,14 @@ setInterval(() => {
 }, 15000);
 
 initFileView((m) => vscodeApi?.postMessage(m));   // the file browser opens the viewer in this pane (and saves ride the poster)
+// …and how the viewer names the session a file was opened from: this pane's session list (the same tab
+// set the chat has, relayed per frame, dormant sessions included), else a card carrying the session's
+// name and colour — never sessionColors, which is keyed by NAME; a sid neither knows falls to the
+// kernel's 8-character stub.
+setFileViewIdentity((id) => {
+  const s = sessionsMeta.find((x) => x.sid === id) ?? asks.find((a) => a.sid === id);
+  return s && s.name ? { name: s.name, color: s.color ?? null } : hostStub(id);
+});
 initFileBrowse((m) => vscodeApi?.postMessage(m));   // …and a Browse files ask lands its sibling overlay
 
 vscodeApi?.postMessage({ type: "ready" });

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -78,10 +78,11 @@ test("the viewer is a singleton MODAL over its pane: ~95% card, dimmed backdrop,
 // chat already has. "Comment" means only the transcript's live threads now. ──
 
 test("selecting in the viewer seeds the composer's editor chip — the editorSelection shape, path:line label", () => {
-  // mouseup posts to our OWN window (the browseFiles precedent — no import cycle with render.ts),
+  // mouseup posts to the composer's window — this document's when it holds one (the browseFiles
+  // precedent — no import cycle with render.ts), else the shell's chat pane (composerWindow, below) —
   // and render.ts's existing editorSelection handler owns the chip end to end
   assert.match(VIEW, /box\.addEventListener\("mouseup", \(\) => \{/);
-  assert.match(VIEW, /window\.postMessage\(\{ type: "editorSelection", text: picked, sid: sid \|\| undefined, src: quoteSrcLabel\(path, doc, picked\) \}, "\*"\);/);
+  assert.match(VIEW, /seedTarget\.postMessage\(\{ type: "editorSelection", text: picked, sid: sid \|\| undefined, src: quoteSrcLabel\(path, doc, picked\) \}, "\*"\);/);
   // a collapsed or out-of-viewer selection seeds nothing, and CodeMirror selections are edits
   assert.match(VIEW, /if \(!sel \|\| sel\.isCollapsed \|\| !sel\.anchorNode \|\| !box\.contains\(sel\.anchorNode\)\) return;/);
   assert.match(VIEW, /if \(editing\) return;/);
@@ -107,14 +108,47 @@ test("the label's line is minted against a FRESH read, and a failed re-read fall
   assert.match(VIEW, /if \(seq !== seedSeq\) return;/, "two racing reads: the last gesture wins");
 });
 
-test("the FEED-hosted viewer stays inert: no editorSelection listener there, and no review layer anywhere", () => {
-  // the feed document has no composer — the posted message just lands unheard, by design
+test("a viewer whose document has no composer seeds THROUGH the shell: the feed reaches the chat's chip", () => {
+  // The feed document has no composer, so a post to its own window landed unheard — the guide's
+  // promise that any passage selected in the viewer lands in the composer was false for a file opened
+  // from the feed's file browser, and each selection still paid the fresh read. So the TARGET is
+  // resolved: this window when it holds the composer, else the same-origin shell, which forwards the
+  // unchanged message into the chat pane. No composer and no shell (VS Code's cross-origin parent, a
+  // standalone pane) still stands the gesture down before the fresh read (the no-sink gating).
+  assert.match(VIEW, /function composerWindow\(\): Window \| null \{\n\s*if \(document\.getElementById\("composer-input"\)\) return window;\n\s*try \{ if \(window\.parent !== window && window\.parent\.document\.getElementById\("chat-pane"\)\) return window\.parent; \}\n\s*catch \{[^}]*\}\n\s*return null;\n\}/);
+  assert.match(VIEW, /const seedTarget = composerWindow\(\);\n\s*if \(!seedTarget\) return;/);
+  // the shell's arm: the SAME message, forwarded whole into the chat frame — sid intact, so the chip
+  // lands in the session the file was opened for (the 2026-08-19 routing rule holds across documents)
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /if\(m\.type==='editorSelection'&&typeof m\.text==='string'\)\{var fc=document\.getElementById\('f-chat'\);\n\s*try\{fc&&fc\.contentWindow&&fc\.contentWindow\.postMessage\(m,'\*'\);\}catch\(e\)\{\}\}/);
+  // …and the chat's existing window-message handler is the receiver: nothing new listens in feed.ts
+  assert.match(RENDER, /else if \(m\.type === "editorSelection" && typeof m\.text === "string" && m\.text\.trim\(\)\) \{/);
   assert.doesNotMatch(FEED, /editorSelection/);
   // the review layer is gone from every module and both sheets, and the orphaned store is swept
   for (const source of [VIEW, RENDER, FEED, CHAT_CSS, FEED_CSS]) {
     assert.doesNotMatch(source, /setCommentSink|buildReviewMessage|fv-hl|fileview-submit/);
   }
   assert.match(VIEW, /localStorage\.removeItem\("romp:fileviewComments"\)/);
+});
+
+// executed: composerWindow's ladder, lifted from the source (a hand copy would drift), run against
+// shimmed window/document pairs for each hosting situation
+test("composerWindow, executed: own composer → the same-origin shell's chat pane → nothing", () => {
+  const m = VIEW.match(/function composerWindow\(\): Window \| null \{[\s\S]*?\n\}/);
+  assert.ok(m, "composerWindow found");
+  const body = m![0].replace(/^function composerWindow\(\): Window \| null /, "");
+  const run = new Function("window", "document", "return (function()" + body + ")();") as (w: unknown, d: unknown) => unknown;
+  const doc = (ids: string[]) => ({ getElementById: (id: string) => (ids.includes(id) ? {} : null) });
+  const self: any = {}; self.parent = self;
+  assert.equal(run(self, doc(["composer-input"])), self, "the chat document: its own window");
+  const shell = { document: doc(["chat-pane"]) };
+  const framed = { parent: shell };
+  assert.equal(run(framed, doc([])), shell, "a pane inside the shell: the shell, which forwards into the chat");
+  assert.equal(run(framed, doc(["composer-input"])), framed, "a composer at hand always wins over the relay");
+  assert.equal(run({ parent: { get document() { throw new Error("cross-origin"); } } }, doc([])), null,
+    "VS Code's cross-origin parent is not the shell — the gesture stands down");
+  assert.equal(run({ parent: { document: doc([]) } }, doc([])), null, "a same-origin parent that is not the shell");
+  assert.equal(run(self, doc([])), null, "unframed and composer-less: nowhere to seed");
 });
 
 test("it waits with the romp loader and fails with the kernel's own words, never a blank pane", () => {
@@ -434,16 +468,18 @@ test("a 200 image renders ONE <img> at an object URL; the quote gesture stays of
 // a selection there seeds a labeled quote chip exactly as in any text view; a blanket media gate
 // would make an .svg's XML unquotable. ──
 test("the quote seed gates off RENDERED media only — the SVG Source view is a text view like any other", () => {
-  // executed: the seed offer across the view states
-  const seedable = (isImage: boolean, isPdf: boolean, srcView: boolean): boolean =>
-    !((isImage || isPdf) && !srcView);
-  assert.equal(seedable(true, false, true), true, "SVG Source view: the selection seeds a chip");
-  assert.equal(seedable(true, false, false), false, "the img view has no honest text to quote");
-  assert.equal(seedable(false, true, false), false, "the PDF iframe owns its own surface");
-  assert.equal(seedable(false, false, false), true, "plain text views are untouched");
-  // source: the media arm of the mouseup gate carves out the Source view, sitting right after the
-  // edit-mode gate (CodeMirror selections are edit gestures, not quotes)
-  assert.match(VIEW, /if \(editing\) return;[^\n]*\n(\s*\/\/[^\n]*\n)*\s*if \(\(isImage \|\| isPdf\) && !\(svgSource && svgText !== null\)\) return;/);
+  // executed: the seed offer across the view states (the no-target gate holds throughout — a
+  // reachable composer, own document or the chat's through the shell, is what makes a gesture)
+  const seedable = (target: boolean, isImage: boolean, isPdf: boolean, srcView: boolean): boolean =>
+    target && !((isImage || isPdf) && !srcView);
+  assert.equal(seedable(true, true, false, true), true, "SVG Source view: the selection seeds a chip");
+  assert.equal(seedable(true, true, false, false), false, "the img view has no honest text to quote");
+  assert.equal(seedable(true, false, true, false), false, "the PDF iframe owns its own surface");
+  assert.equal(seedable(false, true, false, true), false, "no composer reachable still gates everything off");
+  assert.equal(seedable(true, false, false, false), true, "plain text views are untouched");
+  // source: the media arm of the mouseup gate carves out the Source view, sitting AFTER the
+  // no-target gate (whose pin lives in the through-the-shell test above)
+  assert.match(VIEW, /if \(!seedTarget\) return;\n(\s*\/\/[^\n]*\n)*\s*if \(\(isImage \|\| isPdf\) && !\(svgSource && svgText !== null\)\) return;/);
   // anchoring reads the text THE VIEW SHOWS — the Source view's decoded XML, never the text
   // pipeline's null — so a quote on the XML earns its path:line label (viewText, pinned with the
   // fresh-read test above); renderBody's Source arm builds those text nodes through codeBlock

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -622,3 +622,99 @@ test("the line gutter numbers every line and drops a trailing newline's phantom 
   assert.match(FEED_CSS, /\.fileview-gutter \{[\s\S]*?user-select: none;/);
   assert.match(CHAT_CSS, /\.fileview-gutter \{[\s\S]*?user-select: none;/);
 });
+
+// ── the session chip (the user 2026-09-03): the title bar names the session the file was opened
+// from. The viewer knows only a sid — and its openers mostly know no more (the relay branch and the
+// conflict Reload live inside this module, the file browser hands over a bare sid) — so the identity
+// is RESOLVED from the sid through a lookup each hosting document registers once at boot. The DOM
+// build itself runs for real in fileview-chip.test.ts; these are the source pins. ──
+
+test("the title bar carries a session chip resolved from the sid — never invented, absent when unknown", () => {
+  assert.match(VIEW, /import \{ hostOf, bareId, hostNameNodes \} from "\.\/host-prefix";/);
+  assert.match(VIEW, /export interface FileViewIdentity \{ name: string; color: \{ bg: string; fg: string \} \| null \}/);
+  assert.match(VIEW, /let identityOf: \(sid: string\) => FileViewIdentity \| null = \(\) => null;/,
+    "unregistered → nothing to show, not a guess");
+  assert.match(VIEW, /export function setFileViewIdentity\(fn: typeof identityOf\): void \{ identityOf = fn; \}/);
+  const openFn = VIEW.split("export function openFileView")[1].split("function offersDownload")[0];
+  assert.match(openFn, /const owner = sid \? identityOf\(sid\) : null;/, "no sid → the resolver is not even asked");
+  assert.match(openFn, /if \(owner\) \{\n\s*sess = el\("span", "fileview-sess"\);/, "no identity → no chip element at all");
+  assert.match(openFn, /sess\.replaceChildren\(\.\.\.hostNameNodes\(owner\.name, sid\)\);/, "host: quiet for a remote session");
+  assert.match(openFn, /if \(owner\.color\) \{ sess\.style\.background = owner\.color\.bg; sess\.style\.color = owner\.color\.fg; \}/,
+    "the session's identity colour, inline — an uncolored stub keeps the sheet's neutral pill");
+  assert.match(openFn, /sess\.title = "Opened from the " \+ owner\.name \+ " session";/,
+    "capitalized like this bar's other tooltips; 'session' so a name like web is not read as a place");
+  assert.match(openFn, /bar\.appendChild\(name\); if \(sess\) bar\.appendChild\(sess\); bar\.appendChild\(acts\);/,
+    "between the path and the actions");
+  // the signatures every opener and the relay pin depend on are exactly as they were
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null\): void \{/);
+  assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void\): void \{/);
+});
+
+test("both hosting documents register a resolver beside their initFileView boot", () => {
+  // the chat document: the tab set, the way renderTabs names a tab (the session first, then the
+  // kernel's tab meta, which keeps a dormant session's name and colour)
+  assert.match(RENDER, /import \{ initFileView, setFileViewIdentity, hostStub \} from "\.\/file-view";/);
+  assert.match(RENDER, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);\n(\/\/.*\n)*setFileViewIdentity\(\(id\) => \{\n\s*const s = sessions\.get\(id\) \?\? tabMeta\.get\(id\);\n\s*return s && s\.name \? \{ name: s\.name, color: s\.color \?\? null \} : hostStub\(id\);\n\}\);/);
+  // the feed document: its session list (the same tab set, relayed per frame), else a card carrying
+  // the session's name and colour — never sessionColors, which is keyed by NAME, not sid
+  assert.match(FEED, /import \{ initFileView, setFileViewIdentity, hostStub \} from "\.\/file-view";/);
+  assert.match(FEED, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);.*\n(\/\/.*\n)*setFileViewIdentity\(\(id\) => \{\n\s*const s = sessionsMeta\.find\(\(x\) => x\.sid === id\) \?\? asks\.find\(\(a\) => a\.sid === id\);\n\s*return s && s\.name \? \{ name: s\.name, color: s\.color \?\? null \} : hostStub\(id\);\n\}\);/);
+  const feedReg = FEED.split("setFileViewIdentity(")[1].split("});")[0];
+  assert.doesNotMatch(feedReg, /sessionColors/, "a name-keyed index cannot answer a sid");
+});
+
+// executed: the ladder each document's resolver runs — its own lists, then the kernel's
+// _peer_identity fallback (a remote sid's host + the sid's first 8 characters, uncolored), then no
+// chip at all. Synthetic rows: the notes-api world, TESTHOST for the remote kernel.
+test("resolver ladder: a named session, then a host-prefixed 8-char stub, then no chip", () => {
+  type Id = { name: string; color: { bg: string; fg: string } | null };
+  const hostOf = (id: string) => { const i = id.indexOf(":"); return i > 0 ? id.slice(0, i) : ""; };
+  const bareId = (id: string) => { const i = id.indexOf(":"); return i > 0 ? id.slice(i + 1) : id; };
+  const hostStub = (sid: string): Id | null => {
+    const bare = bareId(sid);
+    if (!bare) return null;
+    const host = hostOf(sid);
+    return { name: (host ? host + ":" : "") + bare.slice(0, 8), color: null };
+  };
+  const WEB = "11111111-2222-3333-4444-555555555555";
+  const API = "22222222-3333-4444-5555-666666666666";
+  const TESTS = "33333333-4444-5555-6666-777777777777";
+  const rows = new Map<string, Id>([
+    [WEB, { name: "web", color: { bg: "#3a7bd5", fg: "#ffffff" } }],
+    ["TESTHOST:" + API, { name: "TESTHOST:api", color: { bg: "#d53a7b", fg: "#ffffff" } }],   // federation prefixes sid AND name
+    [TESTS, { name: "", color: null }],                                                        // a placeholder tab, name not yet known
+  ]);
+  const resolve = (id: string): Id | null => {
+    const s = rows.get(id);
+    return s && s.name ? { name: s.name, color: s.color ?? null } : hostStub(id);
+  };
+  assert.deepEqual(resolve(WEB), { name: "web", color: { bg: "#3a7bd5", fg: "#ffffff" } });
+  assert.deepEqual(resolve("TESTHOST:" + API), { name: "TESTHOST:api", color: { bg: "#d53a7b", fg: "#ffffff" } },
+    "a remote row keeps its host: prefix — hostNameNodes renders it as quiet metadata");
+  assert.deepEqual(resolve("44444444-5555-6666-7777-888888888888"), { name: "44444444", color: null },
+    "an unknown local sid → the kernel's 8-character stub, uncolored");
+  assert.deepEqual(resolve("TESTHOST:44444444-5555-6666-7777-888888888888"), { name: "TESTHOST:44444444", color: null },
+    "an unknown remote sid → host: + stub, so the host still reads as metadata");
+  assert.deepEqual(resolve(TESTS), { name: "33333333", color: null },
+    "a row with no name yet is not a name — the stub, never an empty chip");
+  assert.equal(resolve(""), null, "no sid → no chip");
+  assert.equal(resolve("TESTHOST:"), null, "a host with no sid names nothing");
+  // replica ↔ source
+  assert.match(VIEW, /export function hostStub\(sid: string\): FileViewIdentity \| null \{\n\s*const bare = bareId\(sid\);\n\s*if \(!bare\) return null;\n\s*const host = hostOf\(sid\);\n\s*return \{ name: \(host \? host \+ ":" : ""\) \+ bare\.slice\(0, 8\), color: null \};\n\}/);
+});
+
+test("the chip's dress is in BOTH sheets: a fixed-width pill that never yields to the path", () => {
+  for (const css of [CHAT_CSS, FEED_CSS]) {
+    // A BLOCK container, not inline-flex: text-overflow acts on block containers only — on a flex container
+    // the text sits in an anonymous flex item the property cannot reach, and an over-long name hard-clipped
+    // at max-width (the review of #970). 0.82em of --fs, the size the bar's buttons wear, so the chip scales
+    // with its neighbours; a px value did not.
+    assert.match(css, /\.fileview-sess \{ flex: 0 0 auto; display: block; max-width: 38%;[^}]*font-size: 0\.82em;[^}]*overflow: hidden; white-space: nowrap; text-overflow: ellipsis;/);
+    const sess = css.slice(css.indexOf(".fileview-sess {"), css.indexOf("}", css.indexOf(".fileview-sess {")));
+    assert.doesNotMatch(sess, /inline-flex|align-items|font-size: [\d.]+px/, "no flex container around the text, no px size");
+    // color:inherit so the host: token takes the pill's own fg — the global .host-prefix{color:var(--dim)}
+    // otherwise wins over the inline foreground and the token is near-invisible on a coloured pill
+    // (~1:1 contrast for a remote session's chip). opacity keeps it quiet without dimming to gray.
+    assert.match(css, /\.fileview-sess \.host-prefix \{ color: inherit; opacity: 0\.75; \}/, "the host: token uses the pill's fg, quiet");
+  }
+});

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -245,17 +245,33 @@ registerFileViewAction(githubLinkAction);
 
 // ── quote a passage into the composer (the user 2026-08-23, the three-verbs consolidation) ────────
 // Selecting text in the viewer seeds the SAME labeled quote chip a VS Code editor highlight does:
-// the selection posts to our own window in the editorSelection shape, so render.ts's existing
-// handler owns the chip end to end (no import cycle — the browseFiles precedent), labeled path:line
-// via quoteSrcLabel. From there the flow is the chat's own: type a note (or none), Stage, keep
-// going, send once. This REPLACED the viewer's separate review layer — the per-file comment store
-// (romp:fileviewComments), the painted marks, and the one-shot Submit that assembled a message —
-// because batching notes for one hand-off is exactly what quote chips + ⌘⏎ staging already do,
-// and "comment" now means only the transcript's live threads.
+// the selection posts in the editorSelection shape to the composer's window — this document's, or
+// the shell's chat pane (composerWindow below) — so render.ts's existing handler owns the chip end
+// to end (no import cycle — the browseFiles precedent), labeled path:line via quoteSrcLabel. From
+// there the flow is the chat's own: type a note (or none), Stage, keep going, send once. This
+// REPLACED the viewer's separate review layer — the per-file comment store (romp:fileviewComments),
+// the painted marks, and the one-shot Submit that assembled a message — because batching notes for
+// one hand-off is exactly what quote chips + ⌘⏎ staging already do, and "comment" now means only
+// the transcript's live threads.
 
 // The retired store's data would otherwise sit in localStorage forever on every browser that
 // ever commented — sweep it on load.
 try { localStorage.removeItem("romp:fileviewComments"); } catch { /* storage may be denied */ }
+
+// Where a quote seed lands (2026-09-03): the composer in THIS document when there is one (the
+// chat-hosted viewer posts to its own window, and render.ts's editorSelection handler owns the chip
+// end to end); otherwise the SHELL, when this document is framed by one. The feed (the file browser's
+// document) hosts the viewer without a composer, and the shell forwards the seed into the chat pane
+// (the editorSelection arm in kernel.py's landing shell). Before this, a selection in the feed-hosted
+// viewer was dead air. No composer and no shell (a VS Code webview's cross-origin parent throws; a
+// standalone pane has none) → null, and the gesture stands down without a fresh read. Presence is the
+// DOM id, the Back button's import-free idiom (render.ts's inRompShell keys on the same node).
+function composerWindow(): Window | null {
+  if (document.getElementById("composer-input")) return window;
+  try { if (window.parent !== window && window.parent.document.getElementById("chat-pane")) return window.parent; }
+  catch { /* a cross-origin parent (VS Code) is not the romp shell */ }
+  return null;
+}
 
 export function closeFileView(): void {
   const wrap = document.getElementById("romp-fileview");
@@ -560,6 +576,12 @@ export function openFileView(path: string, sid?: string | null): void {
   let seedSeq = 0;                                 // last gesture wins if two fresh reads race
   box.addEventListener("mouseup", () => {
     if (editing) return;   // CodeMirror selections are edit gestures, not quotes
+    // No chip target reachable → no seed (the no-sink gating): the post would be dead air and the
+    // label's fresh read dead work. The target is this document's composer (the chat-hosted viewer)
+    // or, from a pane without one — the feed — the shell, which forwards the seed into the chat pane
+    // (composerWindow above).
+    const seedTarget = composerWindow();
+    if (!seedTarget) return;
     // RENDERED media has no honest text to quote — an <img>/iframe body owns its own selection
     // surface; the SVG SOURCE view is a real text view and quotes like any other (renderBody's
     // media gate, same rule).
@@ -580,8 +602,8 @@ export function openFileView(path: string, sid?: string | null): void {
       .catch(() => viewText())
       .then((doc) => {
         if (seq !== seedSeq) return;
-        try { window.postMessage({ type: "editorSelection", text: picked, sid: sid || undefined, src: quoteSrcLabel(path, doc, picked) }, "*"); }
-        catch { /* messaging our own window cannot really fail */ }
+        try { seedTarget.postMessage({ type: "editorSelection", text: picked, sid: sid || undefined, src: quoteSrcLabel(path, doc, picked) }, "*"); }
+        catch { /* messaging our own window or the same-origin shell cannot really fail */ }
       });
   });
 

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -19,6 +19,7 @@ import hljs from "highlight.js/lib/core";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { fileUrl } from "./preview";
+import { hostOf, bareId, hostNameNodes } from "./host-prefix";
 import { kernelUrl } from "./media";
 import { quoteSrcLabel } from "./docreview";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -117,6 +118,26 @@ function el(tag: string, cls?: string): HTMLElement {
 // The save op rides the WS poster the pane's boot hands initFileView; replies route back to the OPEN
 // viewer through these module-level hooks (the viewer itself is a per-open closure).
 let post: (m: Record<string, unknown>) => void = () => { /* bound by initFileView */ };
+
+// ── the session the file was opened from (the user 2026-09-03) ────────────────────────────────────
+// The viewer knows only a sid, and its openers mostly know no more: the relay branch initFileView
+// keeps and the conflict Reload live in this module, the file browser hands over a bare sid. So the
+// session's name and colour are RESOLVED from the sid here, through a lookup each hosting document
+// registers once at boot beside initFileView (render.ts reads its tab set, feed.ts its session list).
+// Unregistered, or a sid the document cannot name, the title bar carries no chip: an identity is
+// looked up, never invented.
+export interface FileViewIdentity { name: string; color: { bg: string; fg: string } | null }
+let identityOf: (sid: string) => FileViewIdentity | null = () => null;
+export function setFileViewIdentity(fn: typeof identityOf): void { identityOf = fn; }
+/** The tail of a resolver's ladder when its lists hold no row for the sid — the kernel's own
+ *  _peer_identity fallback: the sid's first 8 characters as an uncolored stub, a remote sid's `host:`
+ *  kept in front so hostNameNodes still renders the host quiet. An empty sid names nothing. */
+export function hostStub(sid: string): FileViewIdentity | null {
+  const bare = bareId(sid);
+  if (!bare) return null;
+  const host = hostOf(sid);
+  return { name: (host ? host + ":" : "") + bare.slice(0, 8), color: null };
+}
 let saveSeq = 0;
 let editHooks: { reqId: number; saved: (mtimeNs: string) => void; failed: (err: string) => void } | null = null;
 // Set by the open viewer: returns false to VETO a close (an editor holding unsaved changes asks
@@ -301,6 +322,18 @@ export function openFileView(path: string, sid?: string | null): void {
     });
   }
   name.appendChild(dir); name.appendChild(base);
+  // The SESSION this file was opened from: a pill in the session's identity colour (the colour its
+  // tab wears), "host:" quiet for a remote session (and marked while its link is down). Resolved
+  // through the hosting document's registered lookup — no sid, or a sid it cannot name, and there is
+  // no chip.
+  const owner = sid ? identityOf(sid) : null;
+  let sess: HTMLElement | null = null;
+  if (owner) {
+    sess = el("span", "fileview-sess");
+    sess.replaceChildren(...hostNameNodes(owner.name, sid));
+    if (owner.color) { sess.style.background = owner.color.bg; sess.style.color = owner.color.fg; }
+    sess.title = "Opened from the " + owner.name + " session";
+  }
   const acts = el("div", "fileview-acts");
 
   // ── format toggles (the user 2026-08-09) ── A markdown file opens RENDERED, its Raw form one click
@@ -445,7 +478,7 @@ export function openFileView(path: string, sid?: string | null): void {
   close.setAttribute("aria-label", "Close the file viewer");
   close.addEventListener("click", closeFileView);
   acts.appendChild(copy); acts.appendChild(close);
-  bar.appendChild(name); bar.appendChild(acts);
+  bar.appendChild(name); if (sess) bar.appendChild(sess); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
   // Per the loading-state rule the first thing up is the romp loader, not a blank pane — a file coming

--- a/ui/webview/fileview-chip.test.ts
+++ b/ui/webview/fileview-chip.test.ts
@@ -1,0 +1,123 @@
+// The viewer's session chip (the user 2026-09-03), run FOR REAL: openFileView mounts through
+// document.createElement against the same small DOM stand-in github-link.test.ts uses, so the chip's
+// three outcomes — a registered identity, a sid the document cannot name, no sid at all — are read
+// off the built title bar rather than pinned at source (file-view.test.ts keeps the pins). The fetch
+// the viewer starts for the file's bytes never settles here: the chip is built before it, and a
+// pending promise is exactly the wait a real open shows.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+
+// ── a DOM stand-in: the members openFileView touches while it builds the bar ──────────────────────
+class El {
+  id = ""; title = ""; hidden = false; type = ""; disabled = false; tabIndex = -1; innerHTML = "";
+  href = ""; target = ""; rel = ""; spellcheck = true; isConnected = true;
+  style: Record<string, string> = {};
+  childNodes: Array<El | string> = [];
+  private attrs = new Map<string, string>();
+  private classes = new Set<string>();
+  classList = {
+    add: (...c: string[]) => { for (const x of c) this.classes.add(x); },
+    remove: (...c: string[]) => { for (const x of c) this.classes.delete(x); },
+    toggle: (c: string, on?: boolean) => { if (on ?? !this.classes.has(c)) this.classes.add(c); else this.classes.delete(c); },
+    contains: (c: string) => this.classes.has(c),
+  };
+  constructor(public tagName: string) {}
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  get textContent(): string { return this.childNodes.map((c) => (typeof c === "string" ? c : c.textContent)).join(""); }
+  set textContent(v: string) { this.childNodes = v === "" ? [] : [v]; }
+  appendChild<T extends El>(c: T): T { this.childNodes.push(c); return c; }
+  replaceChildren(...cs: Array<El | string>): void { this.childNodes = [...cs]; }
+  remove(): void { this.isConnected = false; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+const win: any = new EventTarget();
+win.parent = win;
+(globalThis as any).window = win;
+const body = new El("body");
+(globalThis as any).document = {
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => s,
+  getElementById: () => null,               // no viewer up, no listing beneath, no composer
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  body,
+};
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+(globalThis as any).fetch = () => new Promise(() => { /* the bytes never land — the bar is built before them */ });
+
+const WEB = "11111111-2222-3333-4444-555555555555";
+const API = "22222222-3333-4444-5555-666666666666";
+
+/** Open `path` for `sid` and return the title bar's children by class (null where a part is absent). */
+async function openBar(path: string, sid: string | null): Promise<{ bar: El; name: El; sess: El | null; acts: El }> {
+  const fv = await import("./file-view");
+  fv.initFileView(() => {});
+  fv.openFileView(path, sid);
+  const wrap = body.childNodes[body.childNodes.length - 1] as El;
+  assert.equal(wrap.id, "romp-fileview");
+  const box = wrap.childNodes[0] as El;
+  const bar = box.childNodes[0] as El;
+  assert.equal(bar.className, "fileview-bar");
+  const byClass = (c: string) => bar.childNodes.find((n) => n instanceof El && n.classList.contains(c)) as El | undefined;
+  const name = byClass("fileview-name"), sess = byClass("fileview-sess"), acts = byClass("fileview-acts");
+  assert.ok(name && acts, "the path and the actions are always there");
+  return { bar, name: name!, sess: sess ?? null, acts: acts! };
+}
+
+test("a registered identity puts the session's chip between the path and the actions, in its colour", async () => {
+  const fv = await import("./file-view");
+  fv.setFileViewIdentity((sid) => sid === API ? { name: "api", color: { bg: "#123456", fg: "#ffffff" } } : null);
+  const { bar, name, sess, acts } = await openBar("/tmp/notes-api/app.py", API);
+  assert.ok(sess, "the chip is built");
+  assert.equal(sess!.tagName, "span");
+  assert.equal(sess!.textContent, "api");
+  assert.equal(sess!.title, "Opened from the api session");
+  assert.equal(sess!.style.background, "#123456", "the identity colour rides inline, from the resolved row");
+  assert.equal(sess!.style.color, "#ffffff");
+  assert.ok(bar.childNodes.indexOf(name) < bar.childNodes.indexOf(sess!) && bar.childNodes.indexOf(sess!) < bar.childNodes.indexOf(acts),
+    "path, then the chip, then the actions");
+});
+
+test("a remote session's chip renders its host: as a quiet token inside the pill", async () => {
+  const fv = await import("./file-view");
+  fv.setFileViewIdentity((sid) => sid === "TESTHOST:" + WEB ? { name: "TESTHOST:web", color: { bg: "#3a7bd5", fg: "#ffffff" } } : null);
+  const { sess } = await openBar("/tmp/notes-api/app.py", "TESTHOST:" + WEB);
+  assert.ok(sess);
+  assert.equal(sess!.textContent, "TESTHOST:web");
+  const host = sess!.childNodes[0] as El;
+  assert.ok(host instanceof El && host.classList.contains("host-prefix"), "hostNameNodes marks the host: token");
+  assert.equal(host.textContent, "TESTHOST:");
+  assert.equal(sess!.childNodes[1], "web", "…and the name follows as plain text");
+});
+
+test("a sid the resolver cannot name falls to the resolver's own stub, uncoloured", async () => {
+  const fv = await import("./file-view");
+  // a resolver ends its ladder in hostStub — the same tail render.ts and feed.ts register
+  fv.setFileViewIdentity((sid) => fv.hostStub(sid));
+  const { sess } = await openBar("/tmp/notes-api/app.py", "44444444-5555-6666-7777-888888888888");
+  assert.ok(sess);
+  assert.equal(sess!.textContent, "44444444", "the kernel's 8-character stub");
+  assert.equal(sess!.style.background, undefined, "no colour to wear — the sheet's neutral pill shows");
+  assert.equal(sess!.style.color, undefined);
+  assert.equal(sess!.title, "Opened from the 44444444 session");
+});
+
+test("no sid, or a resolver that names nothing, means no chip element at all", async () => {
+  const fv = await import("./file-view");
+  fv.setFileViewIdentity((sid) => sid === API ? { name: "api", color: null } : null);
+  assert.equal((await openBar("/tmp/notes-api/app.py", null)).sess, null, "no sid → the resolver is not even asked");
+  assert.equal((await openBar("/tmp/notes-api/app.py", "")).sess, null, "an empty sid is no sid");
+  fv.setFileViewIdentity(() => null);
+  assert.equal((await openBar("/tmp/notes-api/app.py", API)).sess, null, "a resolver with no answer → no chip, never a guess");
+});

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -15,7 +15,7 @@ const FEED = read("feed.css");
 
 const RULES = [
   "#romp-fileview {", ".fileview {", "body.fileview-open {", ".fileview-bar {", ".fileview-name {",
-  ".fileview-dir {", ".fileview-base {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
+  ".fileview-dir {", ".fileview-base {", ".fileview-sess {", ".fileview-sess .host-prefix {", ".fileview-acts {", ".fileview-btn {", ".fileview-btn:hover {",
   "a.fileview-btn {", ".fileview-gh {", ".fileview-gh-why {", ".fileview-gh-dots {",
   ".fileview-gh .fileview-btn:disabled {", ".fileview-gh .fileview-btn:disabled:hover {",
   ".fileview-gh .fileview-btn:disabled:active {", "a.fileview-gh-note {", ".fileview-body {",

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -40,7 +40,7 @@ import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileView } from "./file-view";
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
-import { initFileView } from "./file-view";
+import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
@@ -14000,4 +14000,11 @@ document.getElementById("content")?.addEventListener("contextmenu", showSelectio
 // the kernel's replies come back as window MessageEvents via the pane shim — either document, one
 // mechanism (file-view.ts initFileView).
 initFileView((m) => vscodeApi?.postMessage(m));
+// …and how the viewer names the session a file was opened from: the tab set, the way renderTabs names
+// a tab (nameOf's ladder — the session first, then the kernel's tab meta, which keeps a dormant
+// session's name and colour); a sid neither knows falls to the kernel's 8-character stub.
+setFileViewIdentity((id) => {
+  const s = sessions.get(id) ?? tabMeta.get(id);
+  return s && s.name ? { name: s.name, color: s.color ?? null } : hostStub(id);
+});
 if (vscodeApi) vscodeApi.postMessage({ type: "ready" });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3279,6 +3279,22 @@ body.fileview-open { overflow: hidden; }
 .fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
   overflow: hidden; text-overflow: ellipsis; }
 .fileview-base { flex: 0 0 auto; }
+/* the SESSION the file was opened from (the user 2026-09-03): a pill in the session's identity colour
+   (inline, from the resolved row — the colour its tab wears), a remote session's "host:" quiet inside.
+   Fixed width: the chip never yields to the path — only .fileview-dir above gives up room. Uncolored
+   when the session has no colour (a stub for a sid the document cannot name); absent when there is no
+   sid. The host: token takes the pill's OWN foreground (color: inherit): the global .host-prefix rule's
+   var(--dim) would otherwise beat the inline colour and sit near-invisible on a saturated pill.
+   Sized at the bar's button size — 0.82em of --fs, not a px value — so the chip scales with its
+   neighbours. A BLOCK container, not inline-flex: text-overflow acts on block containers only — on a flex
+   container the text sits in an anonymous flex item the property cannot reach, and an over-long name
+   hard-clipped at max-width (the review of #970). The bar's align-items centres the pill; its one nowrap
+   line centres within it. */
+.fileview-sess { flex: 0 0 auto; display: block; max-width: 38%; padding: 1px 8px;
+  border-radius: var(--radius-pill, 999px); font-size: 0.82em; font-weight: 600; line-height: 1.5;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); }
+.fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
   padding: 3px 9px; border-radius: 6px; background: transparent; color: var(--fg);   /* T151: the one button rest */


### PR DESCRIPTION
Two changes to the shared file viewer (`ui/webview/file-view.ts`), one commit each. Both are browser-dashboard only; the VS Code extension's behavior is unchanged.

## 1. The title bar names the session the file was opened from

**What is wrong at tip.** The viewer carries a sid (for the GitHub link, the file browser and `fileUrl`'s federation routing) but never shows it. With several sessions on one repository, or on worktrees of it, a file opened over one chat looks the same as the same file opened over another.

**Reproduction.** Two sessions, `web` and `api`, on a `notes-api` checkout. Click `app.py` in `web`'s transcript, then the same path in `api`'s. The two viewers are indistinguishable; the tab color behind the dimmed backdrop is the only cue, and the modal covers it.

**The change.** A session chip sits in the title bar between the path and the actions: a pill in the session's identity color (the color its tab wears), with the `host:` token quiet inside for a remote (federated) session and marked while that host's link is down (`hostNameNodes`), tooltip "Opened from the api session". The chip is fixed width; only the directory half of the path yields room.

The identity is resolved from the sid inside `file-view.ts` rather than threaded through arguments, because the openers mostly know only a sid (the relay branch `initFileView` keeps and the conflict Reload live in the module; the file browser hands over a bare sid). Each hosting document registers a lookup once beside its `initFileView` boot:

- `render.ts`: `sessions`, then `tabMeta` (the ladder `renderTabs` uses, so a dormant session keeps its name and color).
- `feed.ts`: `sessionsMeta`, then the asks list. Never `sessionColors`, which is keyed by name.

A sid neither list can name falls to the same 8-character stub the kernel's `_peer_identity` uses, uncolored. No sid, or no registered lookup, means no chip: an identity is looked up, never invented. `openFileView` and `initFileView` keep their signatures.

CSS lands in both mirrored sheets. `.fileview-sess .host-prefix` sets `color: inherit`: the global `.host-prefix { color: var(--dim) }` would otherwise beat the pill's inline foreground, and a remote session's `host:` token sat at about 1:1 contrast on a saturated pill.

One sentence in the guide's "Reviewing a document" paragraph.

## 2. A passage selected in the feed-hosted viewer reaches the chat composer

**What is wrong at tip.** The guide says any passage selected in the file viewer lands in the composer as a quote chip. The viewer opened from the feed pane's file browser posts its `editorSelection` message to its own window, where nothing listens (`feed.ts` has no composer and no handler). The gesture is dead, and each selection still pays a fresh read of the file. `file-view.test.ts` recorded this as by design.

**Reproduction.** In the feed pane, Browse files for `api`, open a file, select a line. Nothing appears in any composer.

**The change.** `composerWindow()` resolves where the seed goes: this window when it holds `#composer-input` (the chat-hosted viewer, unchanged); else the same-origin shell when it frames this document (detected by the shell's `#chat-pane` node, the idiom `inRompShell` in `render.ts` already uses); else `null`, and the gesture stands down before the fresh read (a cross-origin parent such as the VS Code webview host, or a standalone pane). The shell's message listener in `_LANDING_SETTINGS_JS` gains one arm that forwards an `editorSelection` message whole into the chat iframe. The chat's existing handler seeds the chip for `m.sid`, so the quote lands in the browsed session even if the active tab changed. The feed gains no listener; `render.ts` and the sheets are untouched.

Design points to rule on:

- The new arm checks the message shape only, not `e.origin`, matching every other arm in that listener. An origin check is a one-token change; say so if you want it and the TS pin follows.
- On the phone layout the chip lands in the chat tab without switching tabs, since reviewing a document is a select-several-passages loop.
- A standalone `/feed` page or a cross-origin-framed page now skips the fetch on selection instead of fetching into dead air.

## Tests

- `file-view.test.ts`: source pins for the resolver export, the chip build and both registrations; an executed replica of the resolver ladder (named session, host-prefixed 8-character stub, no chip) on synthetic rows; pins for `composerWindow`'s body, the gate order and the shell arm (kernel.py read from the TS suite, as the relay test already does); `composerWindow` lifted from the source and run against shimmed window/document pairs for six hosting cases; the media-gate order pin moved behind the target gate.
- `fileview-chip.test.ts` (new): `openFileView` runs against the DOM stand-in `github-link.test.ts` uses; asserts the chip's text, title, inline colors and position for a registered identity, the `host:` token for a remote one, the uncolored stub for an unknown sid, and no element for no sid or no resolver.
- `fileview-parity.test.ts`: the two new rules are byte-equal in both sheets, `color: inherit` included.
- `tests/test_kernel_mobile.py`: the shell arm and the `f-chat` iframe id, from pytest.

Red first: with the source hunks reverted, 9 UI tests fail for the chip (4 pins, 4 executed, 1 parity) and 4 UI plus 1 Python fail for the seed; dropping `color: inherit` alone fails the CSS pin. Typecheck, the file-viewer test files and the two Python modules that read the shell constant are green locally; CI runs the full suites.

## Notes

Both changes have run on a self-hosted instance since 2026-09-03. The build machine is headless, so the phone layout deserves a real-browser glance. #958 and #959 touch `file-view.ts`'s import block, `closeFileView`'s neighborhood, both sheets and the same guide paragraph; the overlap is adjacent lines only (#958's URL viewer intentionally carries no chip: a URL has no sid), and this rebases after them. The file browser's own bar stays unlabeled; a possible follow-up on the same resolver.

## From review

Two nits from the review of #970, folded into the first commit (both sheets and the CSS pin in `file-view.test.ts`):

- The chip is `font-size: 0.82em`, the size of the bar's buttons, instead of `11px`. The px value was a third size on a bar whose text is `0.86em` and `0.82em` of `--fs`, and it did not scale with its neighbors.
- The chip is `display: block` instead of `inline-flex`, which makes `text-overflow: ellipsis` take effect: the property acts on block containers only (a flex container's text sits in an anonymous flex item the property cannot reach), so an over-long name hard-clipped at `max-width`. `align-items: center` goes too; the bar's own `align-items` centers the pill, and its single nowrap line centers within it. Truncation is made real rather than the declaration dropped because an ellipsis tells the reader there is more (the tooltip carries the full name); a clip through a glyph reads as a rendering fault.

The pin asserts `display: block`, `font-size: 0.82em` and the overflow triple and rejects `inline-flex`, `align-items` and a px size; the parity test keeps the rule byte-equal in both sheets. Red first: with the fold reverted the pin fails for both sheets; with one sheet reverted the parity test fails too.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
