### PR TITLE
Review follow-ups from #968, #967, #964 and #965: one commit per merge comment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -44,26 +44,28 @@ while IFS= read -r line; do
 done < "$strings_file"
 [ ${#grep_args[@]} -gt 0 ] || exit 0
 
-# $1 is the remote being pushed to: a name, or a bare URL when pushing by URL.
-remote="${1:-}"
 zero=0000000000000000000000000000000000000000
 
-# The commits THIS push publishes for one ref: what the remote does not already
-# have. "Already has" means reachable from ANY of the remote's refs as this clone
-# last fetched them (refs/remotes/<remote>/*), not only from the ref being pushed.
-# The difference is a branch that merged main: its range holds main's commits,
-# every one of them on the remote already through main. Scanning those refuses
-# the push over a string that main itself published, and a string already on the
-# remote is fixed FORWARD, on main (redact, push main) — not by blocking every
-# branch that merged main before the redaction. The exclusion is scoped to the
-# remote being pushed to: a commit only another remote has is still new to this
-# one. With no remote-tracking refs for the remote (never fetched, or a push to a
-# bare URL) the exclusion matches nothing and the range falls back to everything
-# the remote ref lacks — for a new ref, the whole history.
+# The commits THIS push publishes for one ref: what no remote already has.
+# "Already has" means reachable from the remote ref's current value or from ANY
+# remote-tracking ref this clone holds (refs/remotes/*, as last fetched) — every
+# remote's, not only the pushed-to remote's or the ref being pushed. The
+# difference from the ref's plain update range is a branch that merged main: its
+# range holds main's commits, every one of them published already through main.
+# Scanning those refuses the push over a string that main itself published, and a
+# string already on a remote is fixed FORWARD, on main (redact, push main) — not
+# by blocking every branch that merged main before the redaction. Every remote
+# counts because that remedy exists only for a commit no remote has yet: in a
+# clone with a fork and the project it forked from, a clean branch cut from the
+# project's main is pushed to the fork as a new ref, and an exclusion scoped to
+# the fork left the project's own commits in the range — one named as adding a
+# string the project had since redacted, which no rewrite of the branch could
+# fix (the #968 review). With no remote-tracking refs at all (never fetched) the
+# exclusion matches nothing and the range falls back to everything the remote
+# ref lacks — for a new ref, the whole history.
 rev_range() {   # <local_sha> <remote_sha> → a rev-list argument list
-    local args="$1 --not"
+    local args="$1 --not --remotes"
     [ "$2" = "$zero" ] || args="$args $2"
-    [ -z "$remote" ] || args="$args --remotes=$remote"
     printf '%s' "$args"
 }
 
@@ -118,7 +120,8 @@ if [ "$blocked" -ne 0 ]; then
     echo "romp pre-push: BLOCKED — a banned string from $strings_file is in a pushed commit." >&2
     echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
     echo "  If the string is only in an INTERMEDIATE commit, squash or rewrite the branch." >&2
-    echo "  If the tip only INHERITS a string an older commit added and main has since redacted, merge main." >&2
+    echo "  If the tip only INHERITS a string an older commit added, merge the main that has since redacted it." >&2
+    echo "  If the named commit is already on some remote, this clone has not fetched it: fetch, then push again." >&2
     echo "  To bypass for one push (you are sure it is fine): git push --no-verify" >&2
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,15 +12,17 @@
 #
 #   the tip's tree    the content the push exposes. A banned string anywhere in
 #                     it refuses the push.
-#   each new commit   the lines it ADDS against its first parent. A string
-#                     introduced in an intermediate commit and removed by a
-#                     later one is still caught, and the commit named; a commit
-#                     whose tree merely INHERITS a string an older commit put
-#                     there is not. Every commit on every branch cut from main
-#                     between a string landing there and its redaction inherits
-#                     it that way, and a per-commit TREE scan refuses them all,
-#                     over files the branch never touched, when the only
-#                     exposure any of them could add is its tip.
+#   each new commit   the lines it ADDS: against its parent, or for a merge the
+#                     lines in none of its parents. A string introduced in an
+#                     intermediate commit and removed by a later one is still
+#                     caught, and the commit named; a commit whose tree merely
+#                     INHERITS a string an older commit put there is not, and
+#                     neither is a merge that brought one in from a parent the
+#                     remote already has. Every commit on every branch cut from
+#                     main between a string landing there and its redaction
+#                     inherits it that way, and a per-commit TREE scan refuses
+#                     them all, over files the branch never touched, when the
+#                     only exposure any of them could add is its tip.
 #
 # Why pushed commits rather than a working-tree scan: the hook is symlinked into
 # the SHARED git hooks dir (by install.sh), so it fires from every worktree —
@@ -69,25 +71,30 @@ rev_range() {   # <local_sha> <remote_sha> → a rev-list argument list
     printf '%s' "$args"
 }
 
-# The lines a commit adds, one per line as "<path>\t<text>": its diff against
-# its first parent (for a root commit, against the empty tree). A merge is read
-# the same way, so content in neither parent — a conflict resolution — counts as
-# the merge's own addition. -M keeps a rename from re-adding every line of the
-# file. The path comes from the `+++ b/<path>` header, read only between a
-# `diff --git` line and the first hunk: inside a hunk, a line that begins with
-# `+++ ` is added content (`++ b/x` as written) and belongs to the current file.
+# The lines a commit adds, one per line as "<path>\t<text>". A commit with one
+# parent: its diff against that parent (a root commit, against the empty tree).
+# A merge: the combined diff against ALL its parents (-c), keeping only the lines
+# in NONE of them — a conflict resolution, a line typed into the merge — which is
+# what the merge itself adds. A diff against the first parent alone named a merge
+# of main, taken while main carried a string, as adding it: the content came in
+# through the second parent, which the remote already had, and the branch's tip
+# was clean (the #968 review). In a combined diff every content line carries one
+# column per parent, and a line in no parent has a `+` in each; -c also omits a
+# file that matches any parent outright, which holds no such line. -M keeps a
+# rename from re-adding every line of the file. The path comes from the
+# `+++ b/<path>` header, read only between a `diff --git` or `diff --combined`
+# line and the first hunk: inside a hunk, a line that begins with `+++ ` is added
+# content (`++ b/x` as written) and belongs to the current file.
 added_lines() {   # <rev>
-    local parent
-    { if parent=$(git rev-parse -q --verify "$1^" 2>/dev/null); then
-          git diff-tree -p -r -M --no-color "$parent" "$1"
-      else
-          git diff-tree -p -r -M --no-color --root "$1"
-      fi; } | awk '
-        /^diff --git /       { hdr = 1; next }
-        hdr && /^\+\+\+ b\// { f = substr($0, 7); next }
-        hdr && /^\+\+\+ /    { f = $0; next }
-        /^@@/                { hdr = 0; next }
-        !hdr && /^\+/        { print f "\t" substr($0, 2) }'
+    local n
+    n=$(git rev-list --parents -n 1 "$1" | awk '{ print NF - 1 }')
+    git diff-tree -p -r -M -c --root --no-commit-id --no-color "$1" | awk -v n="$n" '
+        BEGIN { if (n < 1) n = 1; for (i = 0; i < n; i++) plus = plus "+" }
+        /^diff --(git|combined) /        { hdr = 1; next }
+        hdr && /^\+\+\+ b\//             { f = substr($0, 7); next }
+        hdr && /^\+\+\+ /                { f = $0; next }
+        /^@@/                            { hdr = 0; next }
+        !hdr && substr($0, 1, n) == plus { print f "\t" substr($0, n + 1) }'
 }
 
 blocked=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,16 @@ This repo may go public; assume every commit is permanent and world-readable.
   worlds.
 - Two machine-local backstops enforce this, neither a substitute for the rule:
   the `.githooks/pre-push` hook greps each pushed ref's TIP tree, plus the lines
-  every commit new to the remote ADDS, for the strings in
+  every commit new to every fetched remote ADDS, for the strings in
   `~/.config/romp/private-strings.txt` (absent file → no-op, so contributors
   are unaffected; it reads pushed shas, not the working tree, so it arms every
   worktree — a working-tree scan missed a leak pushed from a peer worktree on
-  2026-07-25; and added lines rather than every commit's tree, so a branch that
-  only INHERITED a string main has since redacted pushes once it merges main —
-  2026-09-06); and the maintainer's clone carries an UNTRACKED
+  2026-07-25; added lines rather than every commit's tree, so a branch that
+  only INHERITED a string main has since redacted pushes once it merges the
+  main that carries the redaction — 2026-09-06; and "new" to EVERY fetched
+  remote, so a clone with a fork and the project as two remotes is not refused
+  over the project's own history when it pushes a branch cut from the project's
+  main to the fork — 2026-09-07); and the maintainer's clone carries an UNTRACKED
   `tests/test_no_personal_identifiers.py` that scans the working tree for the
   same strings plus that machine's hostname and home path. The pytest file is
   deliberately not in the repo: one machine's identifiers mean nothing on anyone

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -653,17 +653,39 @@ function scopedStartFailure(e) {
 // display-message does not start a server (exit 1, "no server running on …", when there is none — tmux 3.4).
 const TMUX_SERVER_PID_ARGV = ['tmux', 'display-message', '-p', '#{pid}'];
 
-// PURE: where a /proc/<pid>/cgroup text places the server. cgroup v2 is one `0::/…/<unit>` line; v1 is one
-// line per controller, each ending in the unit — so every line is tried. Only the manager's own romp-tmux-*
-// scopes count: a romp-session-* scope is a session CLI's, not this feature's claim.
-function placementFromCgroup(text) {
+// PURE: the path of the hierarchy systemd manages, from a /proc/<pid>/cgroup text — the `0::<path>` line on
+// cgroup v2; on v1 (one `<id>:<controllers>:<path>` line per controller) the `name=systemd` controller's,
+// else the first path present. '' when the text carries none.
+function systemdCgroupPath(text) {
+  const rows = String(text || '').split('\n').map((l) => l.trim()).filter(Boolean).map((l) => {
+    const parts = l.split(':');
+    return parts.length >= 3 ? { id: parts[0], controllers: parts[1], path: parts.slice(2).join(':') } : null;
+  }).filter(Boolean);
+  const v2 = rows.find((r) => r.id === '0' && r.controllers === '');
+  const v1 = rows.find((r) => r.controllers.split(',').includes('name=systemd'));
+  return ((v2 || v1 || rows[0]) || { path: '' }).path;
+}
+
+// PURE: where a /proc/<pid>/cgroup text places the server, against the manager's own (/proc/self/cgroup).
+// Every line is tried for a romp-tmux-* scope (cgroup v1 has one per controller, each ending in the unit);
+// only the manager's own scopes count — a romp-session-* scope is a session CLI's, not this feature's claim.
+// Otherwise the server's cgroup is COMPARED with the manager's, not classified from the shape of its path
+// (the #967 review): the same cgroup, or one under it, is the service's own, which KillMode=control-group
+// takes down with the service — 'unscoped', the line as it always was. Any other cgroup is outside the
+// service's reach — a server the user started from a terminal sits in the login session's scope — and a
+// service restart leaves it alive, so 'outside' names the cgroup instead of predicting a loss.
+function placementFromCgroup(text, own) {
   const lines = String(text || '').split('\n');
   for (const line of lines) {
     const m = /\/(romp-tmux-\d+\.scope)\s*$/.exec(line);
     if (m) return { placement: 'scoped', unit: m[1] };
   }
-  if (lines.some((l) => l.trim())) return { placement: 'unscoped' };
-  return { placement: 'unknown', why: 'empty cgroup file' };
+  const server = systemdCgroupPath(text);
+  if (!server) return { placement: 'unknown', why: lines.some((l) => l.trim()) ? 'no cgroup path in the file' : 'empty cgroup file' };
+  const mine = systemdCgroupPath(own);
+  if (!mine) return { placement: 'unknown', why: "the manager's own cgroup file is empty" };
+  if (server === mine || server.startsWith(mine.replace(/\/$/, '') + '/')) return { placement: 'unscoped' };
+  return { placement: 'outside', cgroup: server };
 }
 
 function defaultServerPid() {
@@ -676,7 +698,8 @@ function defaultReadCgroup(pid) { return fs.readFileSync('/proc/' + pid + '/cgro
 // Never throws — a throw here would abort startManager before the control port binds — so every failure
 // of the probe is an 'unknown' placement carrying the failure's first line, bounded like the failure
 // line's detail. `serverPid` and `readCgroup` are injectable for the node suite; the defaults ask tmux
-// (bounded by the same timeout as the start) and read /proc.
+// (bounded by the same timeout as the start) and read /proc — the server's file, then the manager's own
+// (`self`), which the placement compares it with.
 function tmuxServerPlacement({ serverPid = defaultServerPid, readCgroup = defaultReadCgroup } = {}) {
   const why = (e) => {
     const first = String((e && e.stderr) || '').split('\n').map((s) => s.trim()).find(Boolean)
@@ -686,19 +709,22 @@ function tmuxServerPlacement({ serverPid = defaultServerPid, readCgroup = defaul
   let pid;
   try { pid = String(serverPid()).trim(); } catch (e) { return { placement: 'unknown', why: why(e) }; }
   if (!/^\d+$/.test(pid)) return { placement: 'unknown', why: 'tmux reported no server pid' };
-  let text;
-  try { text = readCgroup(pid); } catch (e) { return { placement: 'unknown', why: why(e) }; }
-  return placementFromCgroup(text);
+  let text, own;
+  try { text = readCgroup(pid); own = readCgroup('self'); } catch (e) { return { placement: 'unknown', why: why(e) }; }
+  return placementFromCgroup(text, own);
 }
 
 // PURE: the line the bare call's success logs, worded from where the server sits. The unscoped wording is
-// the line as it always was (its pins stay); the other two predict no loss.
-function bareEnsuredLine({ placement, unit, why }) {
+// the line as it always was (its pins stay); the other three predict no loss.
+function bareEnsuredLine({ placement, unit, cgroup, why }) {
   if (placement === 'scoped') {
     return `tmux server ensured — already running inside ${unit} (the scoped start had begun it, or an earlier one still holds it); a service restart leaves it and its sessions' jobs alive`;
   }
   if (placement === 'unscoped') {
     return 'tmux server ensured without a scope — under the service, a service restart will take it down';
+  }
+  if (placement === 'outside') {
+    return `tmux server ensured — already running outside the service's cgroup, in ${cgroup} (a server begun from a terminal sits in the login session's scope); a service restart leaves it and its sessions' jobs alive`;
   }
   return `tmux server ensured — whether it sits in a scope could not be read (${why}); under the service, a restart takes it down only if it is not in one`;
 }

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -149,9 +149,10 @@ class SessionBackend(ABC):
         the badge's switching-dots and the chat's "Reloading session…" notice (SdkBackend.set_effort). tmux
         types '/effort X' into the pane, which the TUI applies in place: no reconnect, no confirmation, so
         no second Enter (TmuxBackend.set_effort). False when the backend can tell the change did not land,
-        so the kernel can be loud instead of pretending: the SDK refuses an unknown sid or a value outside
-        EFFORT_LEVELS, Codex a level its engine lacks. tmux cannot tell (it types the command; the TUI
-        answers a bad value in the pane), so TmuxBackend.set_effort returns True unconditionally and the
+        so the kernel can be loud instead of pretending: the SDK and Codex refuse an unknown sid (no
+        registry row, no session); the SDK also refuses a value outside EFFORT_LEVELS, Codex a level its
+        engine lacks. tmux cannot tell (it types the command; the TUI answers a bad value in the pane), so
+        TmuxBackend.set_effort returns True unconditionally and the
         caller vouches for the value first — _route_meta_command checks _EFFORT_VALUES and the picker
         offers only those; POST /new passes its effort through verbatim by design, so a typo there reaches
         the pane and the CLI answers it there."""

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -290,8 +290,8 @@ PY
 # reads the banned strings from ~/.config/romp/private-strings.txt (so it arms
 # EVERY worktree, not just the one holding an untracked scanner) and reads the
 # PUSHED commits, not the working tree, which is not what gets published: each
-# pushed ref's TIP tree must be clean, and each commit new to the remote must
-# ADD no banned line — so a leak in an intermediate commit is caught even when
+# pushed ref's TIP tree must be clean, and each commit new to every fetched remote
+# must ADD no banned line — so a leak in an intermediate commit is caught even when
 # the tip is clean, while a tree that only inherits an older one is not refused.
 # No strings file → a no-op, so a contributor's clone is unaffected.
 # (ROMP_GITHOOK_DIR redirects install.sh's symlink target below; the behaviour

--- a/tests/manager-tmux-scope.test.js
+++ b/tests/manager-tmux-scope.test.js
@@ -9,9 +9,11 @@
 // first stderr line, bounded (startTmuxServer pipes stderr on that call for it). After a failed scoped
 // start the bare call runs and the log then READS where the server sits (the #953 review: a timed-out
 // scoped call kills only tmux's client, the daemon it forked stays inside the scope, so the old fixed
-// line predicted a loss that would not happen): placementFromCgroup places a /proc/<pid>/cgroup text,
-// tmuxServerPlacement asks tmux for the server pid and reads that file (never throws), bareEnsuredLine
-// words the line from the answer.
+// line predicted a loss that would not happen): placementFromCgroup places a /proc/<pid>/cgroup text
+// against the manager's own (the #967 review: a path that is no romp-tmux scope is not thereby the
+// service's cgroup — a terminal's server sits in the login session's scope, which a restart leaves alone),
+// tmuxServerPlacement asks tmux for the server pid and reads that file and /proc/self/cgroup (never
+// throws), bareEnsuredLine words the line from the answer.
 // Run: node --test tests/manager-*.test.js
 'use strict';
 const { test } = require('node:test');
@@ -167,36 +169,67 @@ test("a spawn error (no exit at all): the error's own first line, systemd-run na
 // that timed out the server was already up inside the scope (systemd-run exec'd the client in place; the
 // timeout killed the client, not the daemon it forked), and after a service restart an earlier manager's
 // scope may still hold the server while systemd-run fails this time. Both predicted a loss that would not
-// happen.
+// happen. And a path that names no romp-tmux scope is not thereby the service's cgroup (the #967 review):
+// a server the user started from a terminal sits in their login session's scope, which a service restart
+// leaves alone, and the old classification read it as unscoped and predicted the loss. The placement now
+// COMPARES the server's cgroup with the manager's own (/proc/self/cgroup): the same cgroup, or one under
+// it, dies with the service; any other is outside its reach.
 const UNSCOPED_LINE = 'tmux server ensured without a scope — under the service, a service restart will take it down';
+const SERVICE = '0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-manager.service\n';   // the manager's own, under the service
+const LOGIN = '0::/user.slice/user-1000.slice/session-3.scope\n';                                       // a terminal's server: the login session
 
-test('placementFromCgroup: a romp-tmux scope on the path is scoped, named; anything else is unscoped', () => {
-  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-tmux-1725000000000.scope\n'),
+test('placementFromCgroup: a romp-tmux scope on the path is scoped, named, wherever the manager sits', () => {
+  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-tmux-1725000000000.scope\n', SERVICE),
     { placement: 'scoped', unit: 'romp-tmux-1725000000000.scope' });
-  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-manager.service\n'),
+  assert.deepEqual(placementFromCgroup('0::/app.slice/romp-tmux-9.scope\n', LOGIN), { placement: 'scoped', unit: 'romp-tmux-9.scope' });
+});
+
+test("placementFromCgroup: the manager's own cgroup is unscoped — that server dies with the service", () => {
+  assert.deepEqual(placementFromCgroup(SERVICE, SERVICE), { placement: 'unscoped' });
+  // a cgroup under the service's is the service's too: KillMode=control-group takes the whole subtree
+  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-manager.service/sub\n', SERVICE),
     { placement: 'unscoped' });
-  assert.deepEqual(placementFromCgroup('0::/init.scope\n'), { placement: 'unscoped' }, "pid 1's cgroup: the bats fake's answer");
+  assert.deepEqual(placementFromCgroup(LOGIN, LOGIN), { placement: 'unscoped' }, 'a terminal-run manager and the bare server it started share the login session');
 });
 
-test('placementFromCgroup: cgroup v1 is one line per controller, each ending in the unit — every line is tried', () => {
-  const v1 = '12:pids:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n'
-    + '3:cpu,cpuacct:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n'
-    + '1:name=systemd:/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope\n';
-  assert.deepEqual(placementFromCgroup(v1), { placement: 'scoped', unit: 'romp-tmux-7.scope' });
+test("placementFromCgroup: any other cgroup is outside the service — a login session's server (the #967 review)", () => {
+  assert.deepEqual(placementFromCgroup(LOGIN, SERVICE), { placement: 'outside', cgroup: '/user.slice/user-1000.slice/session-3.scope' });
+  assert.deepEqual(placementFromCgroup('0::/init.scope\n', SERVICE), { placement: 'outside', cgroup: '/init.scope' }, "pid 1's cgroup: the bats fake's answer");
+  // a name that merely begins with the service's is a different unit
+  assert.equal(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-manager.service-old\n', SERVICE).placement, 'outside');
+  const sessionScope = '/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-2222-3333-4444-555555555555.scope';
+  assert.deepEqual(placementFromCgroup('0::' + sessionScope + '\n', SERVICE), { placement: 'outside', cgroup: sessionScope },
+    "a session CLI's scope is not the manager's claim, and not the service's cgroup either");
 });
 
-test("placementFromCgroup: a session's romp-session scope is not the manager's claim; an empty file is unknown", () => {
-  assert.deepEqual(placementFromCgroup('0::/user.slice/user-1000.slice/user@1000.service/app.slice/romp-session-11111111-2222-3333-4444-555555555555.scope\n'),
-    { placement: 'unscoped' });
-  assert.deepEqual(placementFromCgroup(''), { placement: 'unknown', why: 'empty cgroup file' });
-  assert.deepEqual(placementFromCgroup('\n  \n'), { placement: 'unknown', why: 'empty cgroup file' });
+test('placementFromCgroup: cgroup v1 is one line per controller — every line is tried for the scope; the name=systemd hierarchy is the one compared', () => {
+  const v1 = (p) => '12:pids:' + p + '\n3:cpu,cpuacct:' + p + '\n1:name=systemd:' + p + '\n';
+  const service = '/user.slice/user-1000.slice/user@1000.service/romp-manager.service';
+  assert.deepEqual(placementFromCgroup(v1('/user.slice/user-1000.slice/user@1000.service/romp-tmux-7.scope'), v1(service)),
+    { placement: 'scoped', unit: 'romp-tmux-7.scope' });
+  assert.deepEqual(placementFromCgroup(v1(service), v1(service)), { placement: 'unscoped' });
+  assert.deepEqual(placementFromCgroup(v1('/user.slice/user-1000.slice/session-3.scope'), v1(service)),
+    { placement: 'outside', cgroup: '/user.slice/user-1000.slice/session-3.scope' });
+  // v1 controllers may sit in different paths from the systemd hierarchy: the comparison reads name=systemd
+  const split = '12:pids:/elsewhere\n1:name=systemd:' + service + '\n';
+  assert.deepEqual(placementFromCgroup(split, v1(service)), { placement: 'unscoped' });
 });
 
-test("tmuxServerPlacement asks for the server pid, then reads THAT pid's cgroup", () => {
+test("placementFromCgroup: an empty file — the server's or the manager's — is unknown, saying which", () => {
+  assert.deepEqual(placementFromCgroup('', SERVICE), { placement: 'unknown', why: 'empty cgroup file' });
+  assert.deepEqual(placementFromCgroup('\n  \n', SERVICE), { placement: 'unknown', why: 'empty cgroup file' });
+  assert.deepEqual(placementFromCgroup(LOGIN, ''), { placement: 'unknown', why: "the manager's own cgroup file is empty" });
+});
+
+test("tmuxServerPlacement asks for the server pid, then reads THAT pid's cgroup and the manager's own", () => {
   const read = [];
-  const r = tmuxServerPlacement({ serverPid: () => '4242\n', readCgroup: (pid) => { read.push(pid); return '0::/app.slice/romp-tmux-9.scope\n'; } });
-  assert.deepEqual(r, { placement: 'scoped', unit: 'romp-tmux-9.scope' });
-  assert.deepEqual(read, ['4242'], 'the pid as tmux printed it, trimmed');
+  const files = { 4242: LOGIN, self: SERVICE };
+  const r = tmuxServerPlacement({ serverPid: () => '4242\n', readCgroup: (pid) => { read.push(pid); return files[pid]; } });
+  assert.deepEqual(r, { placement: 'outside', cgroup: '/user.slice/user-1000.slice/session-3.scope' });
+  assert.deepEqual(read, ['4242', 'self'], 'the pid as tmux printed it, trimmed; then /proc/self');
+  // the manager's own file unreadable: unknown, like any other failure of the probe
+  const r2 = tmuxServerPlacement({ serverPid: () => '4242', readCgroup: (pid) => { if (pid === 'self') throw new Error('EACCES: permission denied'); return LOGIN; } });
+  assert.deepEqual(r2, { placement: 'unknown', why: 'EACCES: permission denied' });
 });
 
 test('tmuxServerPlacement never throws: every failure of the probe is unknown, with its first line as the why', () => {
@@ -226,6 +259,15 @@ test('bareEnsuredLine: a scoped server names its unit and predicts no loss', () 
   const line = bareEnsuredLine({ placement: 'scoped', unit: 'romp-tmux-1725000000000.scope' });
   assert.ok(line.startsWith('tmux server ensured'), line);
   assert.ok(line.includes('romp-tmux-1725000000000.scope'), 'the unit that holds it');
+  assert.ok(line.includes('leaves it'), 'a restart leaves it alive');
+  assert.ok(!line.includes('will take it down') && !line.includes('without a scope'), 'no prediction of a loss');
+});
+
+test("bareEnsuredLine: a server outside the service's cgroup names where it sits and predicts no loss", () => {
+  const line = bareEnsuredLine({ placement: 'outside', cgroup: '/user.slice/user-1000.slice/session-3.scope' });
+  assert.ok(line.startsWith('tmux server ensured'), line);
+  assert.ok(line.includes("outside the service's cgroup"), line);
+  assert.ok(line.includes('/user.slice/user-1000.slice/session-3.scope'), 'the cgroup that holds it');
   assert.ok(line.includes('leaves it'), 'a restart leaves it alive');
   assert.ok(!line.includes('will take it down') && !line.includes('without a scope'), 'no prediction of a loss');
 });

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -245,6 +245,64 @@ project_leaked_and_redacted_fork_behind() {
     [[ "$output" != *"${LEAK_SHA:0:10}"* ]]       # the project's own commit is not re-flagged
 }
 
+# ── merges ────────────────────────────────────────────────────────────────
+# A merge's own additions are the lines in NONE of its parents: a conflict
+# resolution, a line typed into the merge. A merge of main taken while main
+# carried a string brings it in through the second parent, which the remote
+# already has, and a diff against the first parent alone named the merge as
+# adding it although the branch's tip was clean (the #968 review).
+
+# A branch cut BEFORE main publishes an identifier merges main while the string
+# is live (the merge's first-parent diff adds it; its second parent has it),
+# then merges the redaction: the tip is clean. Leaves HEAD on the branch.
+branch_merged_main_while_leak_was_live() {
+    add_remote
+    commit_file base.txt "notes-api" "base"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q -b feature
+    commit_file web.txt "the web session's work" "branch work"
+    git -C "$REPO" checkout -q main
+    commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q feature
+    git -C "$REPO" merge -q -m "merge main while the leak is live" main
+    LIVE_MERGE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+    git -C "$REPO" checkout -q main
+    remove_file leak.txt "redact"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q feature
+    git -C "$REPO" merge -q -m "merge the redaction" main
+}
+
+@test "a merge of main taken while the leak was live is not the merge's own addition" {
+    branch_merged_main_while_leak_was_live
+    run_hook                # new ref: the branch commit and both merges are in the range, main's commits are not
+    [ "$status" -eq 0 ]
+}
+
+@test "a string typed into a merge's conflict resolution is the merge's own addition, naming the merge" {
+    add_remote
+    commit_file notes.txt "notes-api" "base"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q -b feature
+    commit_file notes.txt "the web session's line" "branch side"
+    git -C "$REPO" checkout -q main
+    commit_file notes.txt "the api session's line" "main side"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" checkout -q feature
+    run git -C "$REPO" merge -q -m "merge main" main
+    [ "$status" -ne 0 ]                           # both sides changed notes.txt: a conflict to resolve
+    printf '%s\n' "resolved at /home/zzsynthuser/notes" > "$REPO/notes.txt"   # in neither parent
+    git -C "$REPO" add notes.txt
+    git -C "$REPO" commit -qm "merge main, resolved"
+    merge_sha="$(git -C "$REPO" rev-parse HEAD)"
+    commit_file notes.txt "settled" "settle"      # tip is clean, so the added-lines pass decides
+    run_hook
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"commit ${merge_sha:0:10} ADDS a personal identifier"* ]]
+    [[ "$output" == *"  notes.txt"* ]]
+}
+
 @test "with no remote-tracking refs, the same rule covers everything the remote ref lacks (the fallback)" {
     commit_file base.txt "notes-api" "base"
     remote_sha="$(git -C "$REPO" rev-parse HEAD)"

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -8,8 +8,8 @@
 # stop): the denylist, the paths and the hostnames are all invented per test.
 #
 # Two rules, both about what a push changes on the remote: the TIP tree of each
-# pushed ref must be clean (that is what a push exposes), and each commit the
-# remote does not already have must ADD no banned line — a commit that only
+# pushed ref must be clean (that is what a push exposes), and each commit no
+# fetched remote already has must ADD no banned line — a commit that only
 # inherits an older leak in its tree is not refused, a commit that introduced
 # one is, even if a later commit removed it again. install-sh.bats exercises the
 # hook through a real `git push`; this file feeds it ref lines directly, so it
@@ -20,6 +20,12 @@ HOOK="$ROMP_DIR/.githooks/pre-push"
 
 setup() {
     TEST_DIR="$(mktemp -d)"
+    # Hermetic git: the fixtures commit and merge with plain defaults, and a developer's global
+    # config (merge.ff=only, commit.gpgsign, a hooks path) must not reach them (the #968 review).
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME"
+    export GIT_CONFIG_GLOBAL="$TEST_DIR/gitconfig" GIT_CONFIG_NOSYSTEM=1
+    : > "$GIT_CONFIG_GLOBAL"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO"
     git -C "$REPO" init -q
@@ -162,7 +168,7 @@ main_redacts_and_branch_merges() {
     [[ "$output" == *"the tip of refs/heads/main"* ]]   # named as the tip, not as an introduction
     [[ "$output" == *"leak.txt"* ]]
     [[ "$output" != *"ADDS"* ]]
-    [[ "$output" == *"merge main"* ]]                   # the remedy is spelled out
+    [[ "$output" == *"merge the main that has since redacted it"* ]]   # the remedy is spelled out
 }
 
 @test "a leak ADDED by a branch commit and removed by a later one is refused, naming the commit" {
@@ -187,15 +193,56 @@ main_redacts_and_branch_merges() {
     [[ "$output" != *"leak.txt"* ]]       # main's commits were skipped, not re-flagged
 }
 
-@test "a commit only ANOTHER remote has is still new to this one" {
-    # --not --remotes (every remote) would have excused this; the exclusion is per remote
+# ── two remotes: a fork and the project it forked from ────────────────────
+# "New" means new to EVERY fetched remote, not only the one being pushed to. With
+# the exclusion scoped to the pushed-to remote, a clean branch cut from the
+# project's main was refused on its way to the fork as a new ref, over a commit
+# only the project's main reaches — named as ADDING a string the project had
+# since redacted, which no rewrite of the branch could fix — and syncing the
+# fork's main to the project's was refused the same way (the #968 review). A
+# string a remote already holds is fixed forward on that remote, whichever one.
+
+# The project (upstream) publishes an identifier and redacts it; the fork
+# (origin) still holds only the base. Leaves HEAD on main, at the project's tip.
+project_leaked_and_redacted_fork_behind() {
+    add_remote
+    git init -q --bare "$TEST_DIR/upstream.git"
+    git -C "$REPO" remote add upstream "$TEST_DIR/upstream.git"
+    commit_file base.txt "notes-api" "base"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" push -q upstream main
     commit_file leak.txt "home is /home/zzsynthuser/code" "leak"
+    LEAK_SHA="$(git -C "$REPO" rev-parse HEAD)"
+    remove_file leak.txt "redact"
+    git -C "$REPO" push -q upstream main          # the fork's main is still at the base
+}
+
+@test "a clean branch cut from the project's main passes to the fork as a NEW ref" {
+    project_leaked_and_redacted_fork_behind
+    git -C "$REPO" checkout -q -b feature
+    commit_file web.txt "the web session's work" "branch work"
+    run_hook                                      # to origin, which reaches none of the project's commits
+    [ "$status" -eq 0 ]
+}
+
+@test "syncing the fork's main to the project's passes" {
+    project_leaked_and_redacted_fork_behind
+    run_hook "$(git -C "$REPO" rev-parse origin/main)"   # updating origin's main from the base
+    [ "$status" -eq 0 ]
+}
+
+@test "a commit no remote has is still scanned on the way to either remote" {
+    # the exclusion excuses what a remote already published, never a leak still local to this clone
+    project_leaked_and_redacted_fork_behind
+    git -C "$REPO" checkout -q -b feature
+    commit_file api.txt "home is /home/zzsynthuser/api" "branch leak"
     leak_sha="$(git -C "$REPO" rev-parse HEAD)"
-    remove_file leak.txt "redact"                # tip is clean
-    git -C "$REPO" update-ref refs/remotes/elsewhere/main HEAD
+    remove_file api.txt "remove it"               # tip is clean; the branch's own history is not
     run_hook
     [ "$status" -ne 0 ]
-    [[ "$output" == *"commit ${leak_sha:0:10} ADDS"* ]]
+    [[ "$output" == *"commit ${leak_sha:0:10} ADDS a personal identifier"* ]]
+    [[ "$output" == *"  api.txt"* ]]
+    [[ "$output" != *"${LEAK_SHA:0:10}"* ]]       # the project's own commit is not re-flagged
 }
 
 @test "with no remote-tracking refs, the same rule covers everything the remote ref lacks (the fallback)" {

--- a/tests/romp-manager-tmux-scope.bats
+++ b/tests/romp-manager-tmux-scope.bats
@@ -12,9 +12,10 @@
 # recording fake tmux answers the command either way; with FAKE_TMUX_FAIL set it exits 1 with tmux's
 # connect error on stderr, which is what tmux failing INSIDE a scope that did start looks like to the
 # manager. After a failed scoped start the manager also asks tmux for the server's pid and reads that
-# pid's cgroup to word the line that follows the bare call (the #953 review); the fake answers pid 1
-# (whose cgroup is never a romp-tmux scope) unless FAKE_TMUX_PID=none, tmux's answer when no server
-# runs. Nothing here reaches the real systemd-run or the user manager: the switch is turned on only
+# pid's cgroup to word the line that follows the bare call (the #953 review), compared with its own
+# (the #967 review); the fake answers pid 1 (whose cgroup is never a romp-tmux scope, and not the
+# manager's own outside a container) unless FAKE_TMUX_PID=none, tmux's answer when no server runs.
+# Nothing here reaches the real systemd-run or the user manager: the switch is turned on only
 # behind the fake, and the floor tmux_private_socket_dir sets (ROMP_CLI_SCOPE=0) stays for the case
 # that pins it.
 
@@ -26,11 +27,13 @@ setup() {
     MGR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
     BIN="$TEST_DIR/bin"; mkdir -p "$BIN"
     export FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" FAKE_SYSTEMD_RUN_CALLS="$TEST_DIR/systemd-run-calls"
-    # The pid probe: pid 1 by default — its cgroup is never a romp-tmux scope, so the manager reads
-    # the server as unscoped; FAKE_TMUX_PID=none is tmux with no server (exit 1, its line on stderr).
-    # A fake cannot put a process in a scope, so the scoped answer is the node suite's. Never answer
-    # with $PPID: a suite run from a window on the manager's own default server has the manager
-    # sitting in a romp-tmux scope, and the case would read "scoped" on that box while passing in CI.
+    # The pid probe: pid 1 by default — its cgroup is never a romp-tmux scope and, outside a container,
+    # not the manager's own, so the manager reads the server as outside the service's cgroup (the
+    # login-session case of the #967 review); FAKE_TMUX_PID=none is tmux with no server (exit 1, its
+    # line on stderr). A fake cannot put a process in a scope or in the manager's cgroup, so the scoped
+    # and unscoped answers are the node suite's. Never answer with $PPID: a suite run from a window on
+    # the manager's own default server has the manager sitting in a romp-tmux scope, and the case
+    # would read "scoped" on that box while passing in CI.
     cat > "$BIN/tmux" <<'FAKE'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$FAKE_TMUX_CALLS"
@@ -131,23 +134,30 @@ log_lacks() {   # $1: a grep pattern that must match no line of the manager's lo
     log_lacks 'launchd-rooted'
 }
 
-@test "switch on, systemd-run failing: the log names systemd-run and carries its first stderr line, the server starts bare, and the log reads it as unscoped" {
+@test "switch on, systemd-run failing: the log names systemd-run and carries its first stderr line, the server starts bare, and the log reads it as outside the service's cgroup" {
     need_tools
     [ "$(uname -s)" = Linux ] || skip "the scoped path is Linux-only by construction (tmuxStartArgv)"
     [ -r /proc/1/cgroup ] || skip "the placement is read from /proc/<pid>/cgroup (pid 1's here)"
+    # the manager started below inherits this process's cgroup; pid 1's must differ for the case to model a
+    # server outside the service (a container without systemd puts both at the root)
+    [ "$(cat /proc/1/cgroup)" != "$(cat /proc/self/cgroup)" ] || skip "pid 1 shares this process's cgroup"
     export ROMP_CLI_SCOPE=1 FAKE_SYSTEMD_RUN_FAIL=1
     start_manager
     [ "$(wc -l < "$FAKE_SYSTEMD_RUN_CALLS")" -eq 1 ]   # tried once...
     # ...then the bare call, once, then the pid probe: the fake answers pid 1, whose cgroup names no
-    # romp-tmux scope, so the line reads the server as unscoped — the line as it always was
+    # romp-tmux scope and is not the manager's own, so the line reads the server as outside the
+    # service's cgroup and predicts no loss — the login-session server of the #967 review, which the
+    # old classification called unscoped
     [ "$(cat "$FAKE_TMUX_CALLS")" = "$(printf '%s\n%s' "$BARE" "$PROBE")" ]
     # the failure line: systemd-run named, its first stderr line in the parenthesis, the second line not
     grep -q 'systemd-run could not start the tmux server in a scope (Failed to start transient scope unit: Failed to connect to bus: No such file or directory)' "$LOG"
     log_lacks 'second stderr line'
     log_lacks 'Command failed'
     grep -q 'starting it the plain way instead' "$LOG"
-    grep -q 'tmux server ensured without a scope' "$LOG"
-    grep -q 'a service restart will take it down' "$LOG"
+    grep -q "tmux server ensured — already running outside the service's cgroup, in /" "$LOG"
+    grep -q 'a service restart leaves it and its sessions' "$LOG"
+    log_lacks 'without a scope'
+    log_lacks 'will take it down'
     log_lacks 'could not be read'
     log_lacks 'failed inside the scope'
     log_lacks 'in its own transient scope'

--- a/tests/test_kernel_postal_isolation_routes.py
+++ b/tests/test_kernel_postal_isolation_routes.py
@@ -82,7 +82,10 @@ class RouteGates(unittest.TestCase):
 
 
 class PolicyPins(unittest.TestCase):
-    """The norms declare an isolation refusal final — the residual a route gate can't close."""
+    """The norms declare an isolation refusal final — the residual a route gate can't close — and teach
+    send_message's `kind` parameter."""
+
+    SKILL = os.path.join(os.path.dirname(BIN), "claude", "skills", "romp-postal", "SKILL.md")
 
     def test_mcp_instructions_declare_refusal_final(self):
         src = open(os.path.join(BIN, "romp-postal-service")).read()
@@ -90,9 +93,18 @@ class PolicyPins(unittest.TestCase):
         self.assertIn("do NOT reroute", src)
 
     def test_skill_declares_refusal_final(self):
-        p = os.path.join(os.path.dirname(BIN), "claude", "skills", "romp-postal", "SKILL.md")
-        src = open(p).read()
+        src = open(self.SKILL).read()
         self.assertIn("An isolation refusal is final", src)
+
+    def test_skill_teaches_the_kind_parameter(self):
+        # the SessionStart hook's kind bullet is pinned in tests/romp-postal-context.bats; this pins the
+        # skill's (the #964 review): the REQUIRED `kind` parameter with its three values, never the retired
+        # DELEGATE:/COORDINATE:/QUESTION: body prefix beside it
+        src = open(self.SKILL).read()
+        self.assertIn("Set `kind` to `delegate`", src)
+        for kind in ("`delegate`", "`coordinate`", "`question`"):
+            self.assertIn(kind, src)
+        self.assertNotIn("DELEGATE:", src)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_move_live.py
+++ b/tests/test_session_move_live.py
@@ -191,13 +191,13 @@ class ApiKeyHelperPrecedence(unittest.TestCase):
 
     def test_explicit_env_var_wins_over_the_borrowed_command(self):
         cfg = self._settings("cfg", "/opt/example/borrowed --print")
-        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": cfg,
+        with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "home"), "CLAUDE_CONFIG_DIR": cfg,
                                           "ROMP_MOVE_LIVE_API_KEY_HELPER": "/opt/example/explicit"}):
             self.assertEqual(_api_key_helper(), "/opt/example/explicit")
 
     def test_without_the_env_var_the_borrowed_command_is_used(self):
         cfg = self._settings("cfg", "/opt/example/borrowed --print")
-        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": cfg}):
+        with mock.patch.dict(os.environ, {"HOME": os.path.join(self.td, "home"), "CLAUDE_CONFIG_DIR": cfg}):
             os.environ.pop("ROMP_MOVE_LIVE_API_KEY_HELPER", None)
             self.assertEqual(_api_key_helper(), "/opt/example/borrowed --print")
             self.assertEqual(_user_api_key_helper(), "/opt/example/borrowed --print", "no argument: $CLAUDE_CONFIG_DIR")

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -788,6 +788,14 @@ function initGear(post) {
     'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
     'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast' };
+  // store name → the words its select shows for the sentinel options whose value is not the word. The
+  // effort selects' Default is the EMPTY value (no effort flag), which read as no value at all, so a
+  // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
+  // one pick the user most needs to see named (#967 review). Kept in step with paintChoices' option
+  // lists: setting-stale.test.ts pins every literal sentinel there against this map.
+  var STALE_WORDS = { 'judge-effort': { '': 'Default' }, 'index-effort': { '': 'Default' },
+    'distill-model': { 'triage': 'Follow triage' }, 'distill-effort': { 'triage': 'Follow triage', 'none': 'Default' },
+    'comment-model': { 'session': 'Same as the session', 'default': 'Default' }, 'comment-effort': { 'session': 'Same as the session' } };
   // Dismissal is the warn-toast FAMILY treatment (the user 2026-08-25: a notice with no visible
   // way out gets in the way — worst on touch, and this toast's mint site is a frozen phone tab
   // flushing on recovery): a visible ✕ in the chip-✕ dress, the whole toast still click-dismisses,
@@ -844,8 +852,13 @@ function initGear(post) {
     return label + ': ' + (refused ? refused + ' was not applied on ' : 'not applied on ') + hosts.join(', ') + '.'
       + (kept ? ' Keeping ' + kept + '.' : '');
   }
-  // Values read as words: a boolean toggle's on/off, a string as itself, anything else as absent.
-  function staleWord(v) { return v === true ? 'on' : v === false ? 'off' : (typeof v === 'string' && v ? v : ''); }
+  // Values read as words: a boolean toggle's on/off, a select's sentinel by the name the select shows for
+  // it (STALE_WORDS, per setting), any other string as itself, anything else as absent.
+  function staleWord(v, setting) {
+    var words = STALE_WORDS[setting];
+    if (words && typeof v === 'string' && Object.prototype.hasOwnProperty.call(words, v)) return words[v];
+    return v === true ? 'on' : v === false ? 'off' : (typeof v === 'string' && v ? v : '');
+  }
   // The value the refused gesture carried. Every emitter posts {type, <one value field>, gt} and the
   // kernel echoes it without gt, so the value is the echo's one key beside type — read generically
   // rather than through a third type→field map kept in step with STALE_TYPE. Trusted only for the
@@ -855,7 +868,7 @@ function initGear(post) {
   function staleRefused(m) {
     if (!m.gesture || typeof m.gesture !== 'object' || STALE_TYPE[m.setting] !== m.gesture.type) return '';
     var keys = Object.keys(m.gesture).filter(function (k) { return k !== 'type'; });
-    return keys.length === 1 ? staleWord(m.gesture[keys[0]]) : '';
+    return keys.length === 1 ? staleWord(m.gesture[keys[0]], m.setting) : '';
   }
   // One toast per refused GESTURE, not per refusing kernel: a dashboard's broadcast reaches every
   // linked kernel, so one stale flush used to draw N identical toasts naming no host. The fold key
@@ -888,7 +901,7 @@ function initGear(post) {
     if (!m || m.type !== 'settingStale') return;
     gclock.learn(m.setting, m.storedGt);   // the frame IS new information about that store's clock
     var label = STALE_LABELS[m.setting] || String(m.setting || 'A setting');
-    var kept = staleWord(m.kept);
+    var kept = staleWord(m.kept, m.setting);
     var refused = staleRefused(m);
     var key = typeof m.gt === 'number' ? m.setting + ':' + m.gt : '';
     var live = key && staleOpen[key] && staleLive(staleOpen[key].t) ? staleOpen[key] : null;

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -281,8 +281,8 @@ test("the foreground path abandoning an ARMED quiet socket raises too; its redia
 
 test("a redial armed as FOREGROUND that then stays silent raises when the watchdog abandons it: the why is foreground-quiet", () => {
   // the arm names the path that forced the reconnect, and a silent socket's raise keeps that name with the
-  // -quiet suffix — the shim comment, docs/read-side.md and the body name both spellings; only reconnect-quiet
-  // was pinned before this
+  // -quiet suffix — the shim comment and docs/read-side.md name both spellings; only reconnect-quiet was
+  // pinned before this
   const h = FEED();
   h.ws.open(); h.ws.msg({ type: "feed", asks: [] });   // connected, then the socket goes quiet while the tab sleeps
   h.now += 31_000;

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -167,6 +167,31 @@ test("no action when the echo's type is not the setting's, or when there is no e
   assert.deepEqual(g.texts(), ["Triage model: not applied on web. Keeping fable.", "Triage model: not applied on web. Keeping fable."]);
 });
 
+test("a refused Default effort pick reads by the name its select shows, not as no value (the #967 review)", () => {
+  // the effort selects' Default option is the EMPTY value (no effort flag); staleWord('') read it as no
+  // value, so a refused Default drew the value-less copy and a plain Apply anyway — the frozen-tab case
+  // the refused value exists for. Every sentinel option a select renders under another name reads by
+  // that name, the kept value included; the re-issue still sends the value, not the word.
+  const g = lift();
+  g.frame({ type: "settingStale", setting: "judge-effort", storedGt: 2000, gt: 1000, kept: "high",
+            gesture: { type: "setJudgeEffort", effort: "" }, host: "web" });
+  assert.deepEqual(g.texts(), ["Triage effort: Default was not applied on web. Keeping high."]);
+  const btn = g.box().children[0].children.find((c) => c.className === "rs-stale-toast-act")!;
+  assert.equal(btn.textContent, "Apply Default anyway", "the label names the pick");
+  assert.ok(btn.title.includes("Default"), "…and so does the tooltip: " + btn.title);
+  btn.clicks.forEach((fn) => fn({}));
+  assert.deepEqual(g.posts, [{ type: "setJudgeEffort", effort: "", gt: 7777 }], "the echo re-issued as sent: the empty value, never the word");
+  g.frame({ type: "settingStale", setting: "distill-effort", storedGt: 2000, gt: 1001, kept: "triage",
+            gesture: { type: "setDistillEffort", effort: "none" }, host: "web" });
+  assert.equal(g.texts()[1], "Distilling effort: Default was not applied on web. Keeping Follow triage.", "the distilling pair's two sentinels");
+  g.frame({ type: "settingStale", setting: "comment-model", storedGt: 2000, gt: 1002, kept: "default",
+            gesture: { type: "setCommentModel", model: "session" }, host: "web" });
+  assert.equal(g.texts()[2], "Comment model: Same as the session was not applied on web. Keeping Default.", "the comment pair's");
+  g.frame({ type: "settingStale", setting: "index-effort", storedGt: 2000, gt: 1003, kept: "",
+            gesture: { type: "setIndexEffort", effort: "low" }, host: "web" });
+  assert.equal(g.texts()[3], "Indexing effort: low was not applied on web. Keeping Default.", "a plain level reads as itself; the kept Default by name");
+});
+
 test("an echo of an unexpected shape shows no refused value: plain Apply anyway, value-less copy", () => {
   // every emitter posts {type, <one value field>, gt}; a future two-field gesture reads as no value
   // rather than guessing which field is the pick

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -166,8 +166,21 @@ test("one toast per refused gesture, naming the refusing hosts: the fold key is 
     "the fold keys on the gesture, never on a clock or a window");
 });
 
-test("the kept value rides when cheap, and reads as words (booleans become on/off)", () => {
+test("the kept value rides when cheap, and reads as words (booleans become on/off; a select's sentinel by the name it shows)", () => {
   assert.match(KERNEL, /def _setting_kept_value\(name\)/, "one cheap store read at reply time, never on the apply path");
-  assert.ok(GEAR.includes("function staleWord(v) { return v === true ? 'on' : v === false ? 'off'"), "a boolean value reads as on/off in the toast");
-  assert.ok(GEAR.includes("var kept = staleWord(m.kept);"), "…the kept value through the one helper");
+  assert.ok(GEAR.includes("function staleWord(v, setting) {"), "the one helper takes the setting, for the sentinel names");
+  assert.ok(GEAR.includes("return v === true ? 'on' : v === false ? 'off'"), "a boolean value reads as on/off in the toast");
+  assert.ok(GEAR.includes("var kept = staleWord(m.kept, m.setting);"), "…the kept value through the one helper");
+  assert.ok(GEAR.includes("staleWord(m.gesture[keys[0]], m.setting)"), "…and the refused value");
+  // every sentinel option paintChoices renders under a name other than its value has that name in
+  // STALE_WORDS, so the toast says what the select shows — the effort selects' Default is the EMPTY
+  // value, which staleWord read as no value at all (the #967 review); setting-stale-fold.test.ts drives it
+  const wordsSrc = GEAR.match(/var STALE_WORDS = \{([\s\S]*?)\};/);
+  assert.ok(wordsSrc, "gear.js's STALE_WORDS map located");
+  const paint = GEAR.slice(GEAR.indexOf("function paintChoices() {"), GEAR.indexOf("var choicesP = null;"));
+  assert.ok(paint.length > 0 && paint.length < 4000, "paintChoices located");
+  const sentinels = Array.from(paint.matchAll(/<option value="([a-z]*)">([^<]+)<\/option>/g)).filter((m) => m[1] !== m[2]);
+  assert.ok(sentinels.length >= 5, `the selects' literal sentinel options located (${sentinels.length})`);
+  for (const [, value, label] of sentinels)
+    assert.ok(wordsSrc![1].includes(`'${value}': '${label}'`), `STALE_WORDS words ${JSON.stringify(value)} as ${label}`);
 });


### PR DESCRIPTION
Five commits, one per follow-up the merge reviews of #968, #967, #964 and #965 filed. Each fix landed with its test failing first against the merged code.

## `.githooks/pre-push`: the exclusion covers every fetched remote (the review of #968)

The added-lines pass scanned every commit the pushed-to remote lacked (`--not --remotes=<remote>`). In a clone with a fork and the project it forked from, a clean branch cut from the project's main is pushed to the fork as a new ref; no fork ref reaches the project's newer commits, so the range held them all, and one that added a string the project had since redacted was named as the branch's own addition. Nothing on the branch could clear that: the footer's merge-main remedy addresses a tip that inherits a string, not a range that holds the project's history. Syncing the fork's main was refused the same way.

The exclusion is now every remote-tracking ref (`--not --remotes`). A commit any fetched remote already holds was published there, and the fix for a string it carries is forward on that remote. A commit no remote has is still scanned on the way to either remote. The footer names the main that carries the redaction and adds a fetch step for a refusal that names a commit already on some remote; `CLAUDE.md` and the `install-sh.bats` header say "new to every fetched remote". The suite's `setup()` also exports a temp `HOME` and `GIT_CONFIG_GLOBAL` (the review's nit), so a developer's global `merge.ff` or `commit.gpgsign` cannot reach the fixtures.

Tests: the per-remote case in `tests/pre-push-hook.bats` is replaced by three two-remote cases (origin as the fork, upstream as the project): a clean branch cut from the project's main passes to the fork as a new ref; syncing the fork's main passes; a leak local to the clone is still refused without re-flagging the project's commit. The tip case pins the qualified remedy. Against the merged hook 4 of 13 fail (cases 7, 10, 11, 12); 13/13 after.

## `.githooks/pre-push`: a merge's additions are the lines in none of its parents (the review of #968)

Every commit was diffed against its first parent, a merge included, although the body of #968 said only a conflict resolution would count as a merge's own addition. A branch that merged main while main carried a string, then merged the redaction, was refused over the first merge: its first-parent diff added the string, but the content came in through the second parent, which the remote already had, and the branch's tip was clean.

A merge is now read through the combined diff against all its parents (`git diff-tree -c`), keeping the lines that carry a `+` in every parent's column: content in no parent, a conflict resolution or a line typed into the merge. `-c` omits outright a file that matches any parent, which holds no such line. One `diff-tree` form serves every commit: on a single-parent commit `-c` is the ordinary diff, `--root` covers a root commit, and the awk sizes the column prefix from `rev-list --parents`. The path header is read on `diff --combined` as well as `diff --git`; rename detection stays.

Tests: a merge of main taken while the leak was live passes once the tip merged the redaction (refused by the first-parent diff, naming the merge); a string typed into a merge's conflict resolution is refused naming the merge. Against the hook after the first commit 1 of 15 fails; 15/15 after. `install-sh.bats` 29/29 throughout; shellcheck clean at warning level.

## `bin/romp-manager`: the server's cgroup is compared with the manager's own (the review of #967)

`placementFromCgroup` returned `unscoped` for every cgroup that was not a `romp-tmux-N` scope, and the line then said a service restart would take the server down. A default-socket server the user started from a terminal sits in the login session's scope, which is neither a romp scope nor the service's cgroup; a restart leaves it alone, so the line predicted a loss that would not happen, the fault the #953 follow-up had just removed for the scoped cases.

The placement now reads the answer: the server's `/proc/<pid>/cgroup` is compared with the manager's own `/proc/self/cgroup`. The same cgroup, or one under it, is the service's (`KillMode=control-group` takes the subtree) and stays `unscoped`, the line as it always was; a romp-tmux scope stays `scoped`; any other cgroup is `outside`, and the line names it and predicts no loss. `systemdCgroupPath` picks the hierarchy systemd manages from either cgroup version (the `0::` line, or v1's `name=systemd` controller). `tmuxServerPlacement` reads the server's file, then `self`; a failure of either read is `unknown` with its first line, as before.

Tests: `tests/manager-tmux-scope.test.js` drives the classification with synthetic `/proc/<pid>/cgroup` texts: a login-session server against a service-run manager is outside and named; the manager's own cgroup and a child of it are unscoped; a romp-tmux scope is scoped wherever the manager sits; v1's `name=systemd` hierarchy is the one compared; an empty file on either side is unknown, saying which; the outside line names the cgroup. Against the merged manager 5 of 31 fail; 31/31 after, 75/75 across the manager suites. `tests/romp-manager-tmux-scope.bats`: the pid-1 case now reads as outside the service's cgroup (pid 1's cgroup is never the manager's own outside a container, which the case skips on); it fails against the merged manager at the outside-line grep; 5/5 after.

## `ui/webview/gear.js`: a refused Default effort pick reads as Default (the review of #967)

The effort selects' Default option is the empty value (no effort flag), and `staleWord('')` read it as no value: a refused Default pick drew the value-less copy and a plain Apply anyway, in the frozen-tab case the copy exists for.

`STALE_WORDS` maps, per setting, the sentinel options whose value is not the word the select shows: the effort selects' `''` and the distilling pair's `none` read as Default, `triage` as Follow triage, the comment pair's `session` as Same as the session and `default` as Default. `staleWord` takes the setting and words the refused and the kept value through it; any other string still reads as itself, booleans as on/off. Apply anyway re-issues the echoed gesture as sent: the value, never the word.

Tests: `setting-stale-fold.test.ts` drives a refused Default triage effort ("Triage effort: Default was not applied on web. Keeping high.", an "Apply Default anyway" button whose click posts the empty value), the distilling and comment sentinels by name, and a plain level as itself with a kept Default named. `setting-stale.test.ts` pins the helper's shape and, generically, that every literal sentinel option `paintChoices` renders under another name has that name in `STALE_WORDS`. Against the merged gear 2 of 2842 fail; 2842/2842 after, typecheck clean; the pytest modules that read `gear.js`: 717 passed.

## Wording follow-ups (the reviews of #964 and #965)

- `kernel/session_backend.py`: the `set_effort` docstring names Codex beside the SDK as refusing an unknown sid, as the `set_model` paragraph already does.
- `tests/test_kernel_postal_isolation_routes.py`: `PolicyPins` pins the skill's `kind` bullet (the hook's was pinned in `romp-postal-context.bats`, the skill's nowhere): the required parameter, its three values, no retired body prefix. Against a `SKILL.md` without the bullet it fails at the first assertion.
- `tests/test_session_move_live.py`: the first two `ApiKeyHelperPrecedence` tests patch `HOME` as well as `CLAUDE_CONFIG_DIR`, so the class docstring holds.
- `ui/webview/pane-shim-stale.test.ts`: the foreground-quiet comment no longer cites "the body".

## Verification at head

`bats tests/pre-push-hook.bats` 15/15; `tests/install-sh.bats` 29/29; `tests/romp-manager-tmux-scope.bats` 5/5; `tests/romp-postal-context.bats` 3/3; `node --test tests/manager-*.test.js` 75/75; `npm test` 2842/2842 and `npm run typecheck` clean; `shellcheck -S warning .githooks/pre-push` clean. Full pytest: 7616 passed, 46 skipped (a first run had three xdist-ordering failures in `tests/test_postal_read_receipts.py`, a module this branch does not touch, which passes 16/16 alone and in the rerun).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)