### PR TITLE
The login reader owns its PTY fd, and a link the validator rejects fails at the paste prompt instead of ten minutes later

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25930,16 +25930,18 @@ def _login_state():
 
 
 def _login_abort_locked(err=""):
-    pid, fd = _login_flow["pid"], _login_flow["fd"]
+    """End the flow: clear the record and SIGTERM the CLI. The PTY master fd is NOT closed here — the
+    reader thread owns it and closes it when it exits (within one 0.5 s select timeout once the pid
+    check fails). Closing it from here while the reader was parked in select on that fd number let the
+    next _login_start reuse the same number for ITS master, and the old thread's os.read then swallowed
+    the new flow's first output — the trust prompt never seen, the new flow hung until its timeout
+    (review find on #931, 2026-09-07; the PR's own flow tests tripped it: tearDown cancels, the next
+    test starts)."""
+    pid = _login_flow["pid"]
     _login_flow.update(state=("error" if err else ""), url="", err=err, pid=0, fd=-1)
     if pid:
         try:
             os.kill(pid, signal.SIGTERM)
-        except Exception:
-            pass
-    if fd >= 0:
-        try:
-            os.close(fd)
         except Exception:
             pass
 
@@ -26050,6 +26052,16 @@ def _login_reader(fd, proc):
     nothing from this stream is ever logged verbatim (the paste prompt window can contain the code
     echo), and the buffer dies with the thread."""
     import select as _select
+    try:
+        _login_reader_loop(fd, proc, _select)
+    finally:
+        try:
+            os.close(fd)                         # the reader is the fd's sole owner (see _login_abort_locked)
+        except OSError:
+            pass
+
+
+def _login_reader_loop(fd, proc, _select):
     buf = ""
     sent_login = sent_pick = trust_answered = False
     t0 = time.time()
@@ -26101,6 +26113,17 @@ def _login_reader(fd, proc):
         low0all = low.replace(" ", "")
         pidx = low0all.rfind("pastecodehere")
         low0v = low0all[pidx:] if pidx >= 0 else ""
+        if pidx >= 0 and not url:
+            # The CLI is already asking for the code, so it HAS printed its sign-in link — and _login_url
+            # found none it will stand behind (the allowlist rejected it, or the shape moved). Waiting on
+            # would only report a timeout ten minutes later; the event is here, so say what happened now
+            # (review find on #931, 2026-09-07).
+            with _login_lock:
+                if _login_flow["pid"] == proc.pid and _login_flow["state"] == "starting":
+                    _login_abort_locked("the sign-in link the CLI printed could not be read — log in from a "
+                                        "terminal with `claude /login`, or update the CLI")
+                    _push_soon()
+                    return
         if "loggedinas" in low0v or "loginsuccessful" in low0v:
             with _login_lock:
                 if _login_flow["pid"] == proc.pid:

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -199,6 +199,43 @@ class LoginFlow(unittest.TestCase):
         self.assertEqual(km._login_start(), "", "…and a fresh start is allowed after")
         km._login_cancel()
 
+    def test_cancel_then_immediate_restart_reaches_the_url_again(self):
+        # the fd race (review find on #931, 2026-09-07): cancel used to close the PTY master while the old
+        # reader was parked in select on that fd number; the next start reused the number and the old
+        # thread's os.read swallowed the new flow's first output, so the new flow never saw the trust
+        # prompt and hung to its timeout. The reader owns the fd now; a restart right after a cancel lands.
+        for _ in range(3):
+            self.assertEqual(km._login_start(), "")
+            st = _wait_state("url")
+            self.assertEqual(st["state"], "url", "a fresh flow reaches its URL after a cancel: %r" % st)
+            km._login_cancel()
+
+    def test_a_paste_prompt_with_no_readable_link_fails_loudly_at_once(self):
+        # the CLI is already asking for the code, so it HAS printed its link — and _login_url found none it
+        # will stand behind (allowlist rejected it / the shape moved). Waiting on would only report a
+        # timeout ten minutes later; the event is the prompt, so the flow errors there (review find on
+        # #931, 2026-09-07). Driven on a private PTY pair with a fake child, no CLI involved.
+        import pty as _pty, select as _select, threading
+        m, sl = _pty.openpty()
+        class _Proc:
+            pid = 999999991
+            def poll(self): return None
+        proc = _Proc()
+        with km._login_lock:
+            km._login_flow.update(state="starting", url="", err="", t=time.time(), pid=proc.pid, fd=m)
+        th = threading.Thread(target=km._login_reader, args=(m, proc), daemon=True)
+        th.start()
+        os.write(sl, b"Browser did not open? Use this link instead:\r\nhttps://evil.example/oauth/authorize?x=1 \r\nPaste code here if prompted > ")
+        deadline = time.time() + 5
+        while time.time() < deadline and km._login_state()["state"] == "starting":
+            time.sleep(0.05)
+        st = km._login_state()
+        os.close(sl)
+        th.join(3)
+        self.assertEqual(st["state"], "error", "no waiting for the timeout: %r" % st)
+        self.assertIn("could not be read", st["err"])
+        self.assertFalse(th.is_alive(), "the reader exited and closed its fd")
+
     def test_code_without_a_flow_refuses(self):
         self.assertNotEqual(km._login_code("SYNTH-ORPHAN"), "")
 


### PR DESCRIPTION
Review fold on #931 (merged as 90334004).

Review fold on #931:
- _login_abort_locked closed the PTY master while the reader thread was still parked in select on that
  fd number; the next _login_start reused the number for its own master, and the old thread's os.read
  swallowed the new flow's first output, so the new flow never saw the trust prompt and hung to its
  timeout. The PR's own flow tests tripped this (tearDown cancels, the next test starts). Abort now only
  clears the record and signals the CLI; the reader closes the fd in a finally when it exits, within one
  select timeout of the pid check failing. A test cancels and restarts three times and reaches the URL
  each time.
- When the CLI is already asking for the code but _login_url found no link it will stand behind (the
  allowlist rejected it, or the shape moved), the flow errored only at the ten-minute timeout and called
  it a timeout. The paste prompt is the event: the flow now fails there with a message that names the
  way out. Driven on a private PTY pair with a fake child.

Not folded, reported: the plain-text fallback truncates at any OSC sequence (a terminal-title escape
before a plain URL hides it), and redirect_uri/client_id are checked for presence only.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
