### PR TITLE
An unknown Codex server request is answered, never raised, and the Auto choice says what it lets out of the sandbox

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -90,11 +90,16 @@ when the kernel restarts. Existing and new sessions default to Sandboxed.
 
 - **Sandboxed:** commands stay within the workspace permission profile;
   requests to execute outside it are denied.
-- **Auto:** the same sandbox stays enabled. Codex's own automatic reviewer
-  evaluates escalation requests (`on-request` with `auto_review`); ROMP does not
-  approve them itself. A reviewer refusal remains a refusal. Requests routed
-  back to ROMP for manual approval are declined with a warning because the
-  current SDK cannot wait for a UI answer without blocking its shared reader.
+- **Auto:** the sandbox applies only to commands the reviewer does not let
+  out. Codex's own automatic reviewer evaluates escalation requests
+  (`on-request` with `auto_review`); ROMP does not approve them itself. A
+  command the reviewer approves runs OUTSIDE the sandbox, as the kernel's user,
+  with that user's full access; the reviewer approves low- and medium-risk
+  actions on its own judgement, so the read-confidentiality the Sandboxed mode
+  gives is not promised here. A reviewer refusal remains a refusal. Requests
+  routed back to ROMP for manual approval are declined with a warning because
+  the current SDK cannot wait for a UI answer without blocking its shared
+  reader.
 
 Change modes between turns; an in-flight turn retains the mode it started with.
 Auto may allow a reviewed command to run outside the sandbox, so it has a wider

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -601,8 +601,15 @@ class CodexBackend:
             return {"permissions": {}, "scope": "turn"}
         if method == "item/tool/requestUserInput":
             return {"answers": {}}
-        # Unknown reply schemas must fail the transport rather than accidentally grant access.
-        raise RuntimeError("Unsupported Codex server request: %s" % method)
+        # An UNKNOWN server request must not raise: the pinned SDK invokes this handler inline on its single
+        # stdout reader thread, whose loop has no per-request error handling — a raise ends the reader
+        # (`except BaseException: router.fail_all`), no JSON-RPC reply is ever written, and every in-flight
+        # request and turn of EVERY Codex session fails at once (review find on #930, 2026-09-07). Answer the
+        # SDK's own default for an unrecognised method, `{}`: the app-server's parse fallbacks read an empty
+        # or malformed approval answer as a denial (deny / decline / empty at 0.153.3), scoped to that one
+        # request, so nothing is granted and the transport stays up. Loud on the log and the session.
+        self.log("unknown Codex server request %s declined with an empty answer; no permission granted" % method)
+        return {}
 
     def _check_auth(self, client):
         """A missing `codex login` must surface as text on the session, not as a hung turn."""

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -301,8 +301,11 @@ class ApprovalModes(unittest.TestCase):
             self.assertEqual(be._handle_approval(method, {}), {"decision": "decline"})
         self.assertEqual(be._handle_approval("item/permissions/requestApproval", {}),
                          {"permissions": {}, "scope": "turn"})
-        with self.assertRaises(RuntimeError):
-            be._handle_approval("unknown/requestApproval", {})
+        # an UNKNOWN request answers the SDK's own default, `{}` — never a raise: the handler runs inline on
+        # the SDK's single reader thread, and a raise there ends the reader and fails every Codex session's
+        # in-flight turn at once (review find on #930, 2026-09-07); the app-server reads an empty approval
+        # answer as a denial, scoped to that one request
+        self.assertEqual(be._handle_approval("unknown/requestApproval", {}), {})
         self.assertTrue(notices)
         self.assertTrue(all(msg["type"] == "warn" for msg in notices))
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10683,7 +10683,7 @@ function prettyMode(m: string | undefined): string {
 }
 const CODEX_MODE_CHOICES: MetaChoice[] = [
   { label: "Sandboxed", value: "sandboxed", sub: "commands stay sandboxed; escalation is denied" },
-  { label: "Auto", value: "auto", sub: "Codex reviews escalations; manual requests are denied" },
+  { label: "Auto", value: "auto", sub: "approved commands run unsandboxed as you; the rest denied" },
 ];
 const META_CHOICES: Record<MetaKind, MetaChoice[]> = {
   mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,


### PR DESCRIPTION
Review fold on #930 (merged as 94e228dc).

Review fold on #930:
- _handle_approval raised RuntimeError for any server request outside its four named methods. The
  pinned SDK invokes the handler inline on its single stdout reader thread, whose loop has no
  per-request error handling: a raise ended the reader (router.fail_all), no JSON-RPC reply was ever
  written, and every in-flight request and turn of EVERY Codex session failed at once. The handler
  now answers the SDK's own default for an unrecognised method, {}, which the app-server reads as a
  denial scoped to that one request, and logs it loudly. Nothing is granted; the transport stays up.
- The Auto choice's sub-line and the guide said the same sandbox stayed enabled. A command the
  reviewer approves runs outside the sandbox as the kernel's user with that user's full access; the
  copy now says so, within the picker's accepted width.

Not folded, reported: Auto-approved escalations leave no trace in the transcript (autoApprovalReview
notifications are dropped), a mid-turn mode pick is refused rather than parked like model/effort,
and the SDK venv is still installed by version pin only.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
