### PR TITLE
The file browser's backdrop close needs both ends of the gesture on the dim, and a failed context refresh is logged

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2948,8 +2948,12 @@ class SdkSession:
         self._ctx_refreshing = True
         try:
             cu = await self.client.get_context_usage()
-        except Exception:
+        except Exception as e:
             cu = None
+            # say so: a control channel that keeps refusing otherwise shows only as a stale battery number
+            # (review find on #924, 2026-09-07); one line, not the problems ring, since a lone hiccup heals
+            # on the rerun below
+            self.backend._log("context refresh (%s) failed: %s: %s" % (self.name, type(e).__name__, e))
         finally:
             self._ctx_refreshing = False
         if not isinstance(cu, dict):

--- a/ui/webview/file-browse.ts
+++ b/ui/webview/file-browse.ts
@@ -116,7 +116,13 @@ export function openFileBrowse(path: string, sid?: string | null): void {
     // the dim, backdrop click closes (the lightbox contract — content clicks never do).
     const wrap = el("div", "");
     wrap.id = "romp-filebrowse";
-    wrap.onclick = (ev) => { if (ev.target === wrap) closeFileBrowse(); };
+    // Arm on pointerdown: a `click` is dispatched on the nearest common ancestor when the press and the
+    // release land on different elements, so a drag that STARTED inside the card and ended over the dim
+    // read as a backdrop click and closed the browser mid-gesture (review find on #924, 2026-09-07).
+    // Close only when both ends were on the dim.
+    let downOnDim = false;
+    wrap.addEventListener("pointerdown", (e) => { downOnDim = e.target === wrap; });
+    wrap.onclick = (ev) => { const close = downOnDim && ev.target === wrap; downOnDim = false; if (close) closeFileBrowse(); };
     const box = el("div", "filebrowse");
     document.body.classList.add("filebrowse-open");
 

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -23,8 +23,12 @@ test("the browser is the viewer's sibling MODAL, one z layer BENEATH it", () => 
   assert.match(FEED_CSS, /\.filebrowse \{ width: min\(720px, 95%\); height: min\(760px, 95%\);/);
   assert.match(FEED_CSS, /#romp-fileview \{ position: fixed; inset: 0; z-index: 1200;/);
   assert.match(BROWSE, /wrap\.id = "romp-filebrowse";/);
-  assert.match(BROWSE, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) closeFileBrowse\(\); \};/,
-    "backdrop clicks close; content clicks never do (the lightbox contract)");
+  // backdrop clicks close; content clicks never do (the lightbox contract) — and a drag that STARTED inside
+  // the card and ended over the dim is not a backdrop click: the close is armed on pointerdown and fires only
+  // when both ends were on the dim (review fold on #924, 2026-09-07)
+  assert.match(BROWSE, /wrap\.addEventListener\("pointerdown", \(e\) => \{ downOnDim = e\.target === wrap; \}\);/);
+  assert.match(BROWSE, /wrap\.onclick = \(ev\) => \{ const close = downOnDim && ev\.target === wrap; downOnDim = false; if \(close\) closeFileBrowse\(\); \};/,
+    "backdrop clicks close; content clicks and card-to-dim drags never do");
   assert.match(BROWSE, /document\.body\.classList\.add\("filebrowse-open"\);/);
 });
 


### PR DESCRIPTION
Review fold on #924 (merged as dd3979ae).

Review fold on #924:
- The browser's backdrop closed on `click` with target === wrap; browsers dispatch click on the nearest
  common ancestor when the press and the release land on different elements, so a drag that started inside
  the card (selecting a row's text) and ended over the dim closed the browser mid-gesture, losing the
  listing. The close is now armed on pointerdown and fires only when both ends were on the dim.
- A failed get_context_usage was swallowed with no trace; the PR made the queued rerun survive that failure
  (right) but a control channel that keeps refusing showed only as a stale battery number. The except branch
  now logs one line naming the session and the error.

Not folded, reported: the new white-ink rules for bold and headings in user bubbles also reach the unfilled
cont-row and cmd-row variants in the light theme (dormant today: the canned Continue text carries no emphasis).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
