### PR TITLE
The idle prebuild keeps chunking on a timed-out callback and re-collapses an overgrown hidden view off the click path

### DIFF
--- a/ui/webview/prebuild-wiring.test.ts
+++ b/ui/webview/prebuild-wiring.test.ts
@@ -24,13 +24,18 @@ test("a pass YIELDS to the active tab's build and is chunked to the idle deadlin
   // never compete with the active (foreground) heavy build — defer and retry next idle
   assert.match(RENDER, /if \(pendingBuildRaf != null\) \{ schedulePrebuild\(\); return; \}/);
   // stop when the idle budget is spent and resume next idle (chunked → never janks the main thread); checked
-  // BEFORE each tab since 2026-09-04 (see tab-switch-lag.test.ts), and a timed-out callback runs regardless
-  assert.match(RENDER, /if \(deadline\.timeRemaining\(\) < \d+ && !deadline\.didTimeout\) \{ schedulePrebuild\(\); break; \}/);
+  // BEFORE each tab since 2026-09-04 (see tab-switch-lag.test.ts). A timed-out callback (didTimeout true,
+  // timeRemaining 0) still chunks — one tab per pass — rather than building every planned tab at once
+  // (review fold on #934, 2026-09-07): the break fires unless nothing has been built yet this pass.
+  assert.match(RENDER, /if \(deadline\.timeRemaining\(\) < \d+ && \(!deadline\.didTimeout \|\| built > 0\)\) \{ schedulePrebuild\(\); break; \}/);
 });
 
 test("a pass builds each off-screen tab's hidden DOM via ensureView + syncView", () => {
   assert.match(RENDER, /function runPrebuild\(deadline: IdleDeadline\): void/);
-  assert.match(RENDER, /ensureView\(id\);\s*\n\s*syncView\(id\);/);
+  // ensureView, then (a re-collapse of an overgrown hidden view — #934 fold), then syncView
+  assert.match(RENDER, /ensureView\(id\);[\s\S]*?syncView\(id\);/);
+  assert.match(RENDER, /v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{\s*\n\s*v\.rendered = 0; v\.winStart = 0;/,
+    "an overgrown hidden view is re-collapsed to the tail window in idle, off the click path");
   // one malformed tab must not abort pre-building the rest
   assert.match(RENDER, /try \{[\s\S]*ensureView\(id\);[\s\S]*syncView\(id\);[\s\S]*\} catch/);
   // restore the render-key so nothing keys off a pre-built tab after the pass

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9052,12 +9052,29 @@ function runPrebuild(deadline: IdleDeadline): void {
   };
   const savedRenderingSid = renderingSid; // syncView sets this; restore it so nothing keys off a pre-built tab
   const savedOwnerSid = renderingOwnerSid;
+  let built = 0;
   for (const id of prebuildPlan(activeId, mru, order, viewState)) {
     if (!sessions.has(id)) continue;
-    if (deadline.timeRemaining() < 3 && !deadline.didTimeout) { schedulePrebuild(); break; } // budget gone → resume next idle
+    // Budget gone → resume next idle. A TIMED-OUT idle callback reports didTimeout true and
+    // timeRemaining() 0, so `!didTimeout` alone never broke and the loop then built EVERY planned
+    // tab in one synchronous task — the click-time cost this prebuild exists to remove (review find
+    // on #934, 2026-09-07). Keep chunking on a timed-out deadline too, but guarantee forward progress:
+    // build at least one tab per pass before yielding.
+    if (deadline.timeRemaining() < 3 && (!deadline.didTimeout || built > 0)) { schedulePrebuild(); break; }
     try {
       ensureView(id);
+      const v = views.get(id);
+      // Re-collapse an overgrown hidden view HERE, in idle, not on the click: the background chatTail
+      // branch lowers v.rendered and takes syncViewInner's incremental append path, which grows winEnd
+      // to total and never re-collapses, so a long-backgrounded tab's DOM grew without bound and
+      // showActive's WINDOW_CAP guard paid the full-window rebuild ON the switch (review find on #934,
+      // 2026-09-07). Same collapse showActive does, moved off the critical path.
+      if (v && !pendingAnchor && pendingAnchorT == null
+          && v.el.querySelectorAll(".turn").length > WINDOW_CAP) {
+        v.rendered = 0; v.winStart = 0; v.avgTurnH = undefined; v.stick = true;
+      }
       syncView(id); // build the hidden view now, off the critical path
+      built++;
     } catch { /* one malformed tab must not break idle pre-building of the rest */ }
   }
   renderingSid = savedRenderingSid;

--- a/ui/webview/tab-switch-lag.test.ts
+++ b/ui/webview/tab-switch-lag.test.ts
@@ -32,7 +32,7 @@ test("inbound tails repaint the tab strip once per animation frame; gestures sti
 
 test("the idle pre-build checks its budget before each tab, on a deadline that counts down", () => {
   const run = /^function runPrebuild\([\s\S]*?\n\}/m.exec(RENDER)![0];
-  const check = run.indexOf("if (deadline.timeRemaining() < 3 && !deadline.didTimeout) { schedulePrebuild(); break; }");
+  const check = run.indexOf("if (deadline.timeRemaining() < 3 && (!deadline.didTimeout || built > 0)) { schedulePrebuild(); break; }");
   const work = run.indexOf("syncView(id); // build the hidden view now");
   assert.ok(check > 0 && work > 0 && check < work, "the budget check precedes the work");
   assert.match(RENDER, /cb\(\{ timeRemaining: \(\) => Math\.max\(0, 12 - \(performance\.now\(\) - t0\)\) \}\)/);


### PR DESCRIPTION
Review fold on #934 (merged as 249e0a72).

Review fold on #934, two click-time regressions the PR's own goal is to remove:
- A timed-out requestIdleCallback reports didTimeout true and timeRemaining() 0, so the budget check
  `< 3 && !didTimeout` never broke and the loop built EVERY planned tab in one synchronous task. It now
  breaks unless nothing has been built this pass, so a timed-out pass still builds one tab and yields.
- A background chatTail lowers v.rendered and takes syncViewInner's incremental append path, which grows
  winEnd to total and never re-collapses, so a long-backgrounded tab's DOM grew without bound and
  showActive's WINDOW_CAP guard paid the full-window rebuild ON the switch. runPrebuild now re-collapses
  an over-cap hidden view to the tail window in idle, the same reset showActive does, off the click path.
Tests: the two prebuild pins follow the new budget-check text and assert the idle re-collapse.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
