### PR TITLE
A subagent viewer frame repaints from the first changed event, so a sliding tail and a filled result both land

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9827,6 +9827,9 @@ function applySubagentFrame(m: any): void {
   s.sub.truncated = !!m.truncated;
   if (m.meta && typeof m.meta === "object") s.sub.meta = m.meta as SubMeta;
   s.name = subLabel(s.sub.meta);
+  const prevEvents = s.events;
+  const prevTruncated = !!(s.sub as any)._wasTruncated;
+  (s.sub as any)._wasTruncated = s.sub.truncated;
   if (!s.sub.error) s.events = Array.isArray(m.events) ? (m.events as ChatEvent[]) : [];
   else s.events = [];
   renderTabs();
@@ -9834,6 +9837,26 @@ function applySubagentFrame(m: any): void {
     const v = views.get(id);
     const first = !v || v.rendered === 0;   // the pane held the loader/placeholder — this is the FIRST content
     if (v && s.events.length === 0) { v.rendered = 0; v.stale = true; }   // placeholder → loader/error/empty re-derives
+    // The frame REPLACES s.events wholesale, and syncViewInner's no-op fast path treats a same-length
+    // list as "nothing changed" — so once the kernel's fixed-size tail (SUBAGENT_EVENT_CAP) started
+    // sliding, every frame had the same length and the viewer froze; and a tool_result that only
+    // FILLED an existing event's output lagged a frame (review find on #935, 2026-09-07). Diff old vs
+    // new before syncing: the first index whose identity or fillable fields differ is where the
+    // repaint starts; a shifted head (the tail slid past the cap, or the truncation flag flipped) is a
+    // full rebuild that keeps the reader's spot rule (stick only when they were at the bottom).
+    if (v && !first && s.events.length > 0) {
+      const ident = (e: any) => String(e?.uuid || e?.toolUseId || "");
+      const key = (e: any) => ident(e) + "\u0000" + String(e?.output ?? "") + "\u0000" + String(e?.isError ?? "") + "\u0000" + String(e?.md ?? "");
+      const slid = prevEvents.length > 0 && ident(prevEvents[0]) !== ident(s.events[0]);
+      if (slid || prevTruncated !== s.sub.truncated) {
+        v.stale = true; v.rendered = 0;
+      } else {
+        let idx = 0;
+        const n = Math.min(prevEvents.length, s.events.length);
+        while (idx < n && key(prevEvents[idx]) === key(s.events[idx])) idx++;
+        v.rendered = Math.min(v.rendered, idx);
+      }
+    }
     // the first content lands at the NEWEST end like a fresh tab (showActive → landActive); every later
     // frame is an append that keeps the reader's spot (appendActive's follow-only-when-at-bottom rule)
     if (first) { if (v) { v.stick = true; v.rendered = 0; } showActive(); }

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -208,9 +208,14 @@ test("the header: 'subagent of <parent>' links back to the launch (setActive + t
 
 test("frames: events replace in place through appendActive (the chat's scroll rule); error → the sentence in the pane; loader first", () => {
   assert.match(RENDER, /else if \(m\.type === "subagent"\) applySubagentFrame\(m\);/);
-  assert.match(RENDER, /function applySubagentFrame\(m: any\): void \{[\s\S]{0,1500}?if \(activeId === id\) \{[\s\S]{0,900}?else appendActive\(\);\s*\n\s*renderSubHead\(\);/);
+  assert.match(RENDER, /function applySubagentFrame\(m: any\): void \{[\s\S]{0,1800}?if \(activeId === id\) \{[\s\S]{0,2600}?else appendActive\(\);\s*\n\s*renderSubHead\(\);/);
+  // a same-length frame is NOT a no-op: the diff lowers v.rendered to the first changed event, and a slid
+  // tail (the cap) or a flipped truncation flag is a full rebuild (review fold on #935, 2026-09-07)
+  assert.match(RENDER, /const slid = prevEvents\.length > 0 && ident\(prevEvents\[0\]\) !== ident\(s\.events\[0\]\);/);
+  assert.match(RENDER, /if \(slid \|\| prevTruncated !== s\.sub\.truncated\) \{\s*\n\s*v\.stale = true; v\.rendered = 0;/);
+  assert.match(RENDER, /v\.rendered = Math\.min\(v\.rendered, idx\);/);
   // the FIRST content lands at the newest end like a fresh tab; later frames append and keep the reader's spot
-  assert.match(RENDER, /const first = !v \|\| v\.rendered === 0;[\s\S]{0,600}?if \(first\) \{ if \(v\) \{ v\.stick = true; v\.rendered = 0; \} showActive\(\); \}/);
+  assert.match(RENDER, /const first = !v \|\| v\.rendered === 0;[\s\S]{0,2400}?if \(first\) \{ if \(v\) \{ v\.stick = true; v\.rendered = 0; \} showActive\(\); \}/);
   // a frame for a viewer that is gone tells the kernel to stop pushing
   assert.match(RENDER, /if \(!s \|\| !s\.sub\) \{ vscodeApi\?\.postMessage\(\{ type: "closeSubagent", id: parentId, agentId \}\); return; \}/);
   // the empty-transcript placeholder: error sentence (loud), else the romp loader until the first frame


### PR DESCRIPTION
Review fold on #935 (merged as 2e3e8151).

Review fold on #935: applySubagentFrame replaced s.events wholesale and then only called appendActive,
which never lowers v.rendered or marks the view stale, so syncViewInner's no-op fast path swallowed any
frame whose event count matched the count already rendered. The kernel ships a fixed-size tail
(SUBAGENT_EVENT_CAP), so once an agent's transcript passed the cap every frame had the same length and
the viewer froze; a tool_result that only filled an existing event's output lagged a frame for the same
reason. The frame is now diffed against the previous list: v.rendered drops to the first event whose
identity or fillable fields changed, and a shifted head (the tail slid, or the truncation flag flipped) is
a full rebuild under the reader's own stick rule. Pins follow the new shape and assert the diff.

Not folded, reported: the whole frame is re-sent on every append (no delta), a forked-fsid fallback reads
the sidecar beside the wrong transcript, an open viewer is not re-registered after a socket drop, and the
"earlier part not shown" note is a dead end.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
