### PR TITLE
The bare-area paste is an undo step: the focused box takes the browser's editing command

### DIFF
--- a/ui/webview/composer-insert.ts
+++ b/ui/webview/composer-insert.ts
@@ -15,6 +15,17 @@ export interface CaretBox {
 }
 
 export function insertAtCaret(box: CaretBox, text: string): void {
+  // Prefer the browser's own EDITING command when the box is the focused element: setRangeText is a
+  // programmatic value change, which Chromium records as no undo step and which discards the box's
+  // existing undo history — so a dictated utterance that landed through the bare-area paste could not
+  // be Cmd+Z'd, unlike the same paste into the focused box (review find on #939, 2026-09-07).
+  // execCommand("insertText") replaces the selection at the caret, fires `input` itself, and IS an undo
+  // step. Fallback to setRangeText where there is no document (node tests), the box is not focused,
+  // or the command is refused, so the helper's contract holds everywhere.
+  try {
+    if (typeof document !== "undefined" && (box as unknown) === document.activeElement
+        && typeof document.execCommand === "function" && document.execCommand("insertText", false, text)) return;
+  } catch { /* fall through to the programmatic path */ }
   box.setRangeText(text, box.selectionStart, box.selectionEnd, "end");
   box.dispatchEvent(new Event("input", { bubbles: true }));
 }

--- a/ui/webview/composer-paste-focus.test.ts
+++ b/ui/webview/composer-paste-focus.test.ts
@@ -129,6 +129,16 @@ class FakeBox implements CaretBox {
   dispatchEvent(event: Event): boolean { this.events.push(event); return true; }
 }
 
+test("insertAtCaret prefers the browser's editing command on the focused box, so the paste is an undo step", () => {
+  // Chromium records setRangeText as a programmatic change (no undo step; the box's undo history dies);
+  // execCommand("insertText") is an editing command (review fold on #939, 2026-09-07). Source pin: the
+  // renderer has no DOM harness, and node has no document, so the fallback path is what the fake box tests.
+  const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "composer-insert.ts"), "utf8");
+  assert.match(SRC, /\(box as unknown\) === document\.activeElement/, "only the FOCUSED box takes the editing command");
+  assert.match(SRC, /document\.execCommand\("insertText", false, text\)\) return;/, "…and it returns: the command fires input itself");
+  assert.ok(SRC.indexOf('document.execCommand("insertText"') < SRC.indexOf("box.setRangeText("), "the programmatic path is the fallback");
+});
+
 test("insertAtCaret puts the text at the caret and leaves the caret after it", () => {
   const box = new FakeBox("hello world", 5);
   insertAtCaret(box, ", dictated");


### PR DESCRIPTION
Review fold on #939 (merged as 0f9b7114).

Review fold on #939: insertAtCaret inserted through setRangeText, which Chromium records as a programmatic
value change, so a dictated utterance that landed through the bare-area paste could not be undone with
Cmd+Z and the box's existing undo history stopped working, unlike the same paste into the focused box.
When the box is the focused element, the helper now uses execCommand("insertText") (an editing command
that replaces the selection, fires input itself and is an undo step) and falls back to setRangeText
where there is no document, the box is not focused, or the command is refused, so the node tests' fake
box and every other caller keep the same contract.

Not folded, reported: a path-shaped clipboard pasted from the bare area lands as literal text instead of
taking the composer's path-to-attachment rule; the fix hoists the composer paste handler's text branch
into one shared function both routes call.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
