### PR TITLE
A feed-hosted quote seed brings the chat pane forward first, and the session chip's text is not selectable

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -33299,6 +33299,10 @@ if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');
 // opened for (m.sid beats the active tab there). The chat-hosted viewer posts to its own window and
 // never gets here.
 if(m.type==='editorSelection'&&typeof m.text==='string'){var fc=document.getElementById('f-chat');
+  // the chat pane may be toggled OFF (hidden by CSS, iframe still loaded): the chip would seed a composer
+  // nobody can see, a silent gesture (review find on #970, 2026-09-07). Bring the pane forward first, the
+  // way the browseFiles arm does for the feed — desktop only; the phone's one-pane tab swap is untouched.
+  if(!document.body.classList.contains('po-chat')){try{window.__rompPaneToggle&&window.__rompPaneToggle('chat',true);}catch(e){}}
   try{fc&&fc.contentWindow&&fc.contentWindow.postMessage(m,'*');}catch(e){}}
 // the browser owns the restore: browseClosed alone puts a brought-forward feed back the way it was
 if(m.romp==='browseClosed'&&window.__rompFeedWasOff){window.__rompFeedWasOff=false;

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1401,7 +1401,7 @@ body.fileview-open { overflow: hidden; }
 .fileview-sess { flex: 0 0 auto; display: block; max-width: 38%; padding: 1px 8px;
   border-radius: var(--radius-pill, 999px); font-size: 0.82em; font-weight: 600; line-height: 1.5;
   overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
-  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); }
+  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); user-select: none; }
 .fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -120,7 +120,10 @@ test("a viewer whose document has no composer seeds THROUGH the shell: the feed 
   // the shell's arm: the SAME message, forwarded whole into the chat frame — sid intact, so the chip
   // lands in the session the file was opened for (the 2026-08-19 routing rule holds across documents)
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.match(KERNEL, /if\(m\.type==='editorSelection'&&typeof m\.text==='string'\)\{var fc=document\.getElementById\('f-chat'\);\n\s*try\{fc&&fc\.contentWindow&&fc\.contentWindow\.postMessage\(m,'\*'\);\}catch\(e\)\{\}\}/);
+  assert.match(KERNEL, /if\(m\.type==='editorSelection'&&typeof m\.text==='string'\)\{var fc=document\.getElementById\('f-chat'\);[\s\S]{0,700}?try\{fc&&fc\.contentWindow&&fc\.contentWindow\.postMessage\(m,'\*'\);\}catch\(e\)\{\}\}/);
+  // …and a chat pane toggled OFF is brought forward first, the browseFiles arm's rule for the feed: a chip
+  // seeded into a hidden composer is a silent gesture (review fold on #970, 2026-09-07)
+  assert.match(KERNEL, /if\(!document\.body\.classList\.contains\('po-chat'\)\)\{try\{window\.__rompPaneToggle&&window\.__rompPaneToggle\('chat',true\);\}catch\(e\)\{\}\}\n\s*try\{fc&&fc\.contentWindow&&fc\.contentWindow\.postMessage\(m,'\*'\);/);
   // …and the chat's existing window-message handler is the receiver: nothing new listens in feed.ts
   assert.match(RENDER, /else if \(m\.type === "editorSelection" && typeof m\.text === "string" && m\.text\.trim\(\)\) \{/);
   assert.doesNotMatch(FEED, /editorSelection/);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3332,7 +3332,7 @@ body.fileview-open { overflow: hidden; }
 .fileview-sess { flex: 0 0 auto; display: block; max-width: 38%; padding: 1px 8px;
   border-radius: var(--radius-pill, 999px); font-size: 0.82em; font-weight: 600; line-height: 1.5;
   overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
-  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); }
+  background: var(--overlay-10, rgba(255, 255, 255, 0.12)); color: var(--fg); user-select: none; }
 .fileview-sess .host-prefix { color: inherit; opacity: 0.75; }
 .fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
 .fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;


### PR DESCRIPTION
Review fold on #970 (merged as 26219f4c).

Review fold on #970:
- The shell's new editorSelection arm forwarded the seed into the chat iframe unconditionally, but the shell
  hides the chat pane with CSS while keeping the iframe loaded, so with the pane toggled off the chip was
  seeded into a composer nobody could see: a silent gesture. The arm now brings the chat pane forward first
  when it is off, the same rule the browseFiles arm applies to the feed pane (desktop only; the phone's
  one-pane tab swap is untouched).
- The chip lives inside the box the mouseup quote gate watches, so double-clicking the session name selected
  it and seeded a quote chip whose text was the session name, with a fresh file read. The chip is
  user-select: none in both sheets.

Not folded, reported: the chip's text-overflow ellipsis is inert on an inline-flex box and 11px is a new
absolute size; the chip is a dead-end compact view (no way to the session); no acknowledgement reaches the
feed viewer when the seed lands or is dropped.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
