### PR TITLE
The receiver's switches gate a relayed push, the turn tick reads once per file version, a Stop is not a finished turn, and a yielding bell keeps its badge

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5434,6 +5434,20 @@ def _last_state(sid):
     return (val, vt)
 
 
+def _last_natural_state(sid):
+    """(value, t) of the most-recent state transition the SESSION itself produced — the rows romp
+    appended for a Stop press (`by` set: _record_idle and the SDK interrupt) skipped. A finished-turn
+    signal reads this one: a Stop press is the user's own act, not a turn the session finished (review
+    find on #937, 2026-09-07). Served from _states_rows, the append-incremental cache every other states
+    reader uses, so the turn tick's per-cycle ask is a stat while the log is quiet."""
+    val, vt = "", 0
+    for rec in _states_rows(sid):
+        if isinstance(rec, dict) and isinstance(rec.get("state"), str) and not rec.get("by"):
+            val = rec["state"]
+            vt = rec.get("t", vt)
+    return (val, vt)
+
+
 def _last_state_value(sid):
     """Just the value of _last_state — the most-recent STATE transition; '' when none."""
     return _last_state(sid)[0]
@@ -11573,7 +11587,7 @@ class TmuxBackend(sb.SessionBackend):
 
     def interrupt(self, sid):
         _interrupt(_name_of(sid) or sid)                  # Esc to stop + clear the restored prompt
-        _record_idle(str(sid), int(time.time()))          # Esc writes no end_turn → settle idle (was done in the
+        _record_idle(str(sid), int(time.time()), by="interrupt")   # Esc writes no end_turn → settle idle (was done in the
         return True                                       #   dispatch; here so tmux+SDK interrupt both settle idle)
 
     def dismiss_dialog(self, sid):
@@ -16392,19 +16406,28 @@ def _record_death(sid, now, by):
     return True
 
 
-def _record_idle(sid, now):
+def _record_idle(sid, now, by=""):
     """Append a state:"idle" transition to states/<sid>.jsonl so the session reads as DONE on the next build.
     The chat status chip is driven by the event-model open-turn signal (open turn + no idle atom): a normal
     turn flips it via the transcript's end_turn, but an Esc INTERRUPT writes no end_turn and the Stop hook
     doesn't fire — so without this the chip stays 'working' after Stop (the user 2026-06-20). Backdated 1s so
-    synthesize_idle's [start,end] span is non-empty on the very next build (end=now > start=now-1)."""
+    synthesize_idle's [start,end] span is non-empty on the very next build (end=now > start=now-1).
+
+    `by` tags who wrote it, for the ONE reader that must tell a romp-written settle from a turn the
+    session finished — the turn-finished push (_last_natural_state, #937 fold). Default "" writes the
+    plain row every other reader keys on by "state"; an Esc interrupt passes "interrupt". The death
+    path leaves it "" on purpose: a dead session is not in _alive_sessions, so it never reaches the
+    turn push, and the row stays byte-identical to a Stop-hook idle (one state vocabulary)."""
     if not sid:
         return
     try:
         sdir = jd.STATE / "states"
         sdir.mkdir(parents=True, exist_ok=True)
+        rec = {"t": int(now) - 1, "state": "idle"}
+        if by:
+            rec["by"] = by
         with open(sdir / (sid + ".jsonl"), "a") as f:
-            f.write(json.dumps({"t": int(now) - 1, "state": "idle"}) + "\n")
+            f.write(json.dumps(rec) + "\n")
     except Exception:
         pass
 
@@ -30924,6 +30947,12 @@ def _cached_feed(now, tmux, sig, connect=False):
         # whichever of the two files first buzzes, the other yields. The desktop notice above and
         # the badge below are not the buzz and never yield.
         if not _buzz_claim(_sid, _turn_end_key(_sid), "bell"):
+            # the turn push already buzzed for this turn end, but carried no badge — and a CLOSED
+            # installed app learns the needs-you count only from a push (review find on #937,
+            # 2026-09-07). Send the card push QUIET: no sound, no re-alert; the per-session tag
+            # replaces the turn notification with the more informative card one, and the icon count
+            # stays current. Local only — the count is this kernel's.
+            _push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid, quiet=True)
             continue
         # same events to subscribed phones (plans/ios-app.md); kind + card id are what the tap acts on
         _push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)
@@ -31250,7 +31279,7 @@ def _push_test(endpoint, sid="", host="", label=""):
     return res
 
 
-def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host=""):
+def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host="", quiet=False):
     """The JSON one web push carries — the ONE builder every push kind goes through, so a tap on
     any of them lands the same way (the user 2026-09-06, who wants a tap to focus the romp
     window they already have open and put them on the session — and card — that buzzed).
@@ -31288,10 +31317,15 @@ def _push_payload(title, body, sid="", badge=None, kind="card", card_id="", host
          "data": {"sid": sid, "host": host, "kind": kind, "cardId": card_id, "url": url}}
     if badge is not None:
         d["badge"] = int(badge or 0)
+    if quiet:
+        # a card push that yields the BUZZ to an already-fired turn push, but still carries the badge
+        # (#937 fold): the worker shows it silent, without re-alerting, so the per-session tag replaces
+        # the turn notification and the icon count stays current
+        d["quiet"] = True
     return d
 
 
-def _push_notify(title, body, sid="", badge=None, kind="card", card_id="", host=""):
+def _push_notify(title, body, sid="", badge=None, kind="card", card_id="", host="", quiet=False):
     """_system_notify's sibling sink: the same (title, body) — the card's gist and nothing more —
     to every subscribed device, plus the ROUTING metadata _push_payload documents: sid, so
     tapping the notification lands on the session that fired (the user 2026-08-08); badge, the
@@ -31309,7 +31343,7 @@ def _push_notify(title, body, sid="", badge=None, kind="card", card_id="", host=
         print("romp: web push: %d subscription(s) on file but the python 'cryptography' package "
               "is missing — notification not delivered" % len(subs), file=sys.stderr)
         return
-    payload = json.dumps(_push_payload(title, body, sid, badge, kind, card_id, host)).encode()
+    payload = json.dumps(_push_payload(title, body, sid, badge, kind, card_id, host, quiet=quiet)).encode()
 
     def run():
         dead = []
@@ -31390,8 +31424,10 @@ def _turn_end_key(sid):
         t = 0
     if t:
         return t
-    val, vt = _last_state(sid)
+    val, vt = _last_natural_state(sid)          # the session's own settle — never the idle romp wrote for a Stop press
     return (vt or 0) if val in ("waiting", "idle") else 0
+
+
 
 
 def _buzz_claim(sid, key, kind):
@@ -31466,7 +31502,8 @@ var d={};try{d=e.data?e.data.json():{};}catch(err){}
 // lock screen instead of stacking (renotify keeps it audible); the kernel picks the tag.
 var opts={body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',
 data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}};
-if(d.tag){opts.tag=d.tag;opts.renotify=true;}
+if(d.tag){opts.tag=d.tag;opts.renotify=!d.quiet;}   // a quiet push replaces without re-alerting
+if(d.quiet)opts.silent=true;
 var work=[self.registration.showNotification(d.title||'romp',opts)];
 // the app-icon count, kept current while the app is CLOSED (the open shell re-paints it live over
 // its own WS). setAppBadge exists in the SW only where badging works at all (iOS installed apps).
@@ -35333,7 +35370,7 @@ def _landing():
             # phone can be set up before anything is switched on.
             "<div id=rbell-back hidden><div id=rbell-pop role=dialog aria-label='Notification settings'>"
             "<div class=rbp-row data-act=all role=switch aria-checked=false><div class=rbp-head>Notifications<span class=rbp-sw></span></div>"
-            "<div class=rbp-sub>The main switch: off silences every device, and the desktop of every machine you've attached. "
+            "<div class=rbp-sub>The main switch: off silences every device subscribed to this romp, and this desktop. "
             "The bells on sessions and cards are mutes under it.</div></div>"
             "<div class=rbp-nest>"
             "<div class=rbp-row data-act=dev role=switch aria-checked=false><div class=rbp-head>This device<span class=rbp-sw></span></div>"
@@ -36510,6 +36547,7 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "mirrored": 0,
                                                        "tier": tier or "unknown"}), "application/json")
                 n = 0
+                held = {"all": 0, "turn": 0}
                 for ev in events[:16]:            # a bell mirror, not a bulk pipe — cap the fan-in
                     if not isinstance(ev, dict):
                         continue
@@ -36517,6 +36555,18 @@ class Handler(BaseHTTPRequestHandler):
                     b = str(ev.get("body") or "")
                     sid = str(ev.get("sid") or "")
                     if not (t or b):
+                        continue
+                    # THIS kernel's switches gate what reaches the devices subscribed HERE (review find on
+                    # #937, 2026-09-07): the origin gated on ITS switches, so a peer whose turn switch was
+                    # on buzzed a phone whose own kernel had the switch off — and the popover copy said the
+                    # main switch silenced every device. The subscriber's kernel is authoritative for its
+                    # own devices: the master drops everything, the turn switch drops the turn events.
+                    kind = str(ev.get("kind") or "card")
+                    if not _notify_all_on():
+                        held["all"] += 1
+                        continue
+                    if kind == "turn" and not _notify_turns_on():
+                        held["turn"] += 1
                         continue
                     # Wear the origin the way every federated surface wears it (host-prefix.ts):
                     # the sid gains "origin:" so a tap routes through the merged dashboard's own
@@ -36531,9 +36581,13 @@ class Handler(BaseHTTPRequestHandler):
                     # (an older peer sends neither → the card default, which is all it had);
                     # the card id is a goal id, globally unique and never host-prefixed
                     # (federation.ts), so the merged feed finds it as-is.
-                    _push_notify(t, b, sid, kind=str(ev.get("kind") or "card"),
-                                 card_id=str(ev.get("cardId") or ""), host=origin)
+                    _push_notify(t, b, sid, kind=kind, card_id=str(ev.get("cardId") or ""), host=origin)
                     n += 1
+                if held["all"] or held["turn"]:
+                    print("romp: web push: held %d event(s) relayed from '%s' — %d under this kernel's "
+                          "main notification switch (off), %d turn-finished event(s) under its turn switch "
+                          "(off); the switches here decide what reaches the devices subscribed here"
+                          % (held["all"] + held["turn"], origin, held["all"], held["turn"]), file=sys.stderr)
                 return self._send(200, json.dumps({"ok": True, "mirrored": n}), "application/json")
             if u.path == "/reveal":
                 # The cold-start half of a push tap (see _PENDING_REVEAL): the freshly opened

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -763,10 +763,12 @@ def permission_to_live(tool_name: str, tool_input: dict, context=None) -> dict:
 _STATES = ("working", "waiting", "idle", "permission", "compacting", "picker")
 
 
-def append_state(state_dir: Path, sid: str, state: str, t: int | None = None) -> None:
+def append_state(state_dir: Path, sid: str, state: str, t: int | None = None, by: str = "") -> None:
     p = Path(state_dir) / "states" / (sid + ".jsonl")
     p.parent.mkdir(parents=True, exist_ok=True)
     rec = {"t": int(time.time()) if t is None else int(t), "state": state}
+    if by:
+        rec["by"] = by          # a romp-written settle (an interrupt), skipped by the turn-finished push (#937 fold)
     with open(p, "a") as f:
         f.write(json.dumps(rec) + "\n")
 
@@ -7144,7 +7146,7 @@ class SdkBackend:
         if not s:
             return False
         s.interrupt()
-        append_state(self.state_dir, sid, "idle", int(time.time()) - 1)
+        append_state(self.state_dir, sid, "idle", int(time.time()) - 1, by="interrupt")
         self._poke()
         return True
 

--- a/tests/test_kernel_notify_popover.py
+++ b/tests/test_kernel_notify_popover.py
@@ -544,6 +544,42 @@ class TurnFinishedPush(unittest.TestCase):
         _stamp_stop(SID_WEB, 1010)
         self.assertEqual(len(self._tick()[0]), 1, "…and with both on the next end fires")
 
+    def test_a_tmux_interrupt_settle_is_not_a_finished_turn(self):
+        # a Stop press writes an idle row (romp's _record_idle, tagged by:interrupt) — the user's own
+        # act, not a turn the session finished, so the fallback key must skip it (#937 fold). A tmux
+        # session has no lastStopAt, so the fallback is what decides.
+        km._set_notify_all(True)
+        km._set_notify_turns(True)
+        _append_state(SID_WEB, "working", 1000)
+        self._tick()                                       # baseline
+        d = jd.STATE / "states"
+        with open(d / (SID_WEB + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": 1001, "state": "idle", "by": "interrupt"}) + "\n")
+        self.assertEqual(self._tick()[0], [], "the interrupt's settle is not a turn end")
+        # a genuine stop the SESSION wrote (no `by`) does fire
+        with open(d / (SID_WEB + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": 1002, "state": "waiting"}) + "\n")
+        self.assertEqual(len(self._tick()[0]), 1, "a real stopped transition still fires")
+
+    def test_a_states_log_that_has_not_moved_is_not_reread(self):
+        # the tick asks _turn_end_key for every alive session every pusher cycle; a states log whose
+        # (mtime, size) is unchanged is answered from the memo, not re-scanned (#937 fold)
+        km._set_notify_all(True); km._set_notify_turns(True)
+        _append_state(SID_WEB, "waiting", 1000)
+        self._tick()
+        opens = {"n": 0}
+        import builtins
+        real_open = builtins.open
+        target = str(jd.STATE / "states" / (SID_WEB + ".jsonl"))
+        def counting_open(f, *a, **k):
+            if str(f) == target:
+                opens["n"] += 1
+            return real_open(f, *a, **k)
+        with mock.patch.object(builtins, "open", counting_open):
+            for _ in range(5):
+                self._tick()
+        self.assertEqual(opens["n"], 0, "the unchanged states log is served from the memo, never re-opened")
+
     def test_switching_on_later_never_replays_old_ends(self):
         _stamp_stop(SID_WEB, 1000)
         self._tick()
@@ -650,6 +686,16 @@ class OneBuzzPerTurnEnd(unittest.TestCase):
             pn.assert_not_called()
             pf.assert_not_called()
 
+    def test_the_yielding_bell_push_still_carries_the_badge_quietly(self):
+        # a card push that yields the BUZZ to an already-fired turn push must still deliver the badge,
+        # QUIET: a closed installed app learns the needs-you count only from a push (#937 fold)
+        import inspect
+        src = inspect.getsource(km._cached_feed)
+        self.assertIn('_push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid, quiet=True)', src,
+                      "the yielding branch still pushes, with the badge, quiet")
+        self.assertLess(src.index('quiet=True'), src.index('_push_notify(_t, _b, _sid, _badge, kind="card", card_id=_iid)'),
+                        "the quiet yield sits in the claim-failed branch, above the normal push")
+
     def test_the_feed_path_claims_before_it_pushes(self):
         import inspect
         src = inspect.getsource(km._cached_feed)
@@ -660,6 +706,14 @@ class OneBuzzPerTurnEnd(unittest.TestCase):
 
 
 class RelayOfTurnEvents(unittest.TestCase):
+    def setUp(self):
+        km._set_notify_all(True)                 # the receiver's switches must be on for a relay to land (#937 fold)
+        km._set_notify_turns(True)
+
+    def tearDown(self):
+        km._set_notify_all(False)
+        km._set_notify_turns(False)
+
     def test_a_turn_shaped_event_mirrors_with_the_origin_on_its_sid(self):
         # the relay's tolerant surgery (the federation test's contract): a session-named title
         # passes as composed, the sid gains the origin so a tap routes through the merged dashboard
@@ -713,7 +767,7 @@ class ShellPopover(unittest.TestCase):
         self.assertIn(">Also when a turn finishes<", h)
         self.assertIn("id=rbp-test data-act=test>Send a test notification<", h)
         # the "why" under each switch — the master's in two sentences: what off does, what the bells are
-        self.assertIn("The main switch: off silences every device, and the desktop of every machine you've attached. "
+        self.assertIn("The main switch: off silences every device subscribed to this romp, and this desktop. "
                       "The bells on sessions and cards are mutes under it.", h)
         self.assertIn("Buzzes every time any session finishes a turn. With many sessions running, that is a lot of buzzing.", h)
         self.assertIn("id=rbp-test-out", h)

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -131,7 +131,8 @@ class ServiceWorkerRoute(unittest.TestCase):
         js = body.decode()
         self.assertIn("data:(d.data&&typeof d.data==='object')?d.data:{sid:d.sid||''}", js,
                       "the routing block verbatim; an older kernel's flat sid still lands")
-        self.assertIn("opts.tag=d.tag;opts.renotify=true", js, "one notification per session, still audible")
+        self.assertIn("opts.tag=d.tag;opts.renotify=!d.quiet", js, "one notification per session, still audible unless it is the quiet card push that yields the buzz")
+        self.assertIn("if(d.quiet)opts.silent=true", js, "a quiet push carries the badge without re-alerting")
         self.assertIn("romp:'notificationClick'", js)
         self.assertIn("clients.openWindow(url)", js)
         self.assertIn("/?push-reveal=", js)              # the fallback deep link for a data block without one

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -130,9 +130,13 @@ class PushForward(unittest.TestCase):
 class RelayRoute(unittest.TestCase):
     def setUp(self):
         _clear_remotes()
+        km._set_notify_all(True)                # THIS kernel is authoritative for its devices (#937 fold):
+        km._set_notify_turns(True)              # a relayed event reaches them only while its switches are on
 
     def tearDown(self):
         _clear_remotes()
+        km._set_notify_all(False)
+        km._set_notify_turns(False)
 
     def _relay(self, body, token=True):
         headers = {"X-Romp-Token": km.TOKEN} if token else {}
@@ -160,6 +164,23 @@ class RelayRoute(unittest.TestCase):
             status, _, pn, _, _ = self._relay(bad)
             self.assertEqual(status, 400)
             pn.assert_not_called()
+
+    def test_the_receivers_switches_gate_a_relayed_event(self):
+        # the subscriber's own kernel decides what reaches its devices, not the origin's switches
+        # (#937 fold): master off drops everything, turn switch off drops the turn-kind events
+        _seed_remote("boxa", "trusted")
+        card = {"title": "romp: web", "body": "Needs you", "sid": "s", "kind": "card"}
+        turn = {"title": "web", "body": "Done", "sid": "s", "kind": "turn"}
+        km._set_notify_all(False)
+        status, parsed, pn, _, err = self._relay({"origin": "boxa", "events": [card, turn]})
+        self.assertEqual((status, parsed["mirrored"]), (200, 0), "master off holds both")
+        pn.assert_not_called()
+        self.assertIn("held 2 event(s) relayed from 'boxa'", err)
+        km._set_notify_all(True)
+        km._set_notify_turns(False)
+        status, parsed, pn, _, err = self._relay({"origin": "boxa", "events": [card, turn]})
+        self.assertEqual((status, parsed["mirrored"]), (200, 1), "turn switch off holds only the turn event")
+        pn.assert_called_once_with("romp: boxa:web", "Needs you", "boxa:s", kind="card", card_id="", host="boxa")
 
     def test_a_trusted_origin_mirrors_wearing_its_host_prefix(self):
         _seed_remote("boxa", "trusted")


### PR DESCRIPTION
Review fold on #937 (merged as a4860500). Rebased onto main after the merge: the states-log memo now rides main's own _states_rows cache and the registry read its memoized _thread_reg.

Review fold on #937, four confirmed finds:
- A relayed turn/card event is gated on the RECEIVING kernel's switches, not the origin's: the master
  drops everything and the turn switch drops turn events, so a peer whose turn switch was on can no
  longer buzz a phone whose own kernel has it off. The popover copy stops promising it silences other
  machines and says it silences every device subscribed to this romp plus this desktop.
- _turn_notify_tick asked _turn_end_key for every alive session every pusher cycle, which for a tmux
  session scanned the whole states log and for an SDK session re-read the registry, both uncached, for
  a feature off by default. _last_states and _thread_reg_cached memoize per file version (mtime, size),
  so an unchanged log is a stat, not a scan.
- A Stop press is the user's own act, not a turn the session finished, so the settle idle romp writes
  for an interrupt is tagged `by` and the turn-end fallback reads only the session's own settle
  (_last_natural_state). Tmux Esc, the SDK interrupt and _record_idle carry the tag; the death path
  leaves the row plain (a dead session never reaches the turn push) so it stays byte-identical.
- When a card's bell event yields the buzz to an already-fired turn push, the card push still goes,
  quiet (no sound, no re-alert): a closed installed app learns the needs-you count only from a push,
  and the per-session tag replaces the turn notification while the icon count stays current.

Tests: the relay gate both ways, the interrupt-not-a-turn fallback, the states memo not re-reading an
unchanged log, and the quiet yielding push; the relay tests enable the receiver's switches.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
