### PR TITLE
The session Codex runtime honours ROMP_CODEX_BIN and logs which binary launched

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -25,7 +25,10 @@ Codex sessions need, once per machine:
     with its sandbox and code-mode helpers. Linux and macOS, x86-64 and ARM64,
     are supported. Neither system Python nor the SDK's own dependency is replaced.
     Sessions explicitly use this managed runtime even if another `codex` is on
-    PATH. Your existing CLI remains available for `codex login`.
+    PATH. To point both the sessions and the judges at a specific binary, set
+    `ROMP_CODEX_BIN`; unset, sessions take the managed runtime and the judges
+    resolve `ROMP_CODEX_BIN`, then PATH, then the bundled binary. Your existing
+    CLI remains available for `codex login`.
 
     Rerun setup to install the runtime when upgrading from an older ROMP version.
     Restart the ROMP kernel after setup if its Codex backend is already running.

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -526,6 +526,7 @@ class CodexBackend:
                     candidate = CodexClient(config=cfg, approval_handler=self._handle_approval)
                     candidate.start()
                     candidate.initialize()
+                    self.log("app-server runtime: %s" % (self.codex_bin or "ROMP-managed %s" % getattr(_runtime, "VERSION", "")))
                 self._check_auth(candidate)
                 self._client = candidate
                 self._client_err = None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9958,6 +9958,11 @@ def _codex():
                     push_session=_push_session_now,
                     # Let the backend choose ROMP's managed runtime and helpers.
                     # A separately installed CLI on PATH may use a different protocol.
+                    # …but honour the one EXPLICIT knob romp already has — ROMP_CODEX_BIN, which the judges read
+                    # (judge.py _judge_codex_bin) — so an operator who sets it governs both surfaces with one
+                    # switch: an opt-in override of the managed runtime, not the ambient PATH accident #929 closed
+                    # (review find, 2026-09-07). Unset → None → the backend picks the managed runtime.
+                    codex_bin=os.environ.get("ROMP_CODEX_BIN") or None,
                     log=lambda m: sys.stderr.write("codex-backend: %s\n" % m))
             except Exception:
                 sys.stderr.write("codex-backend unavailable: %s\n" % traceback.format_exc())

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -216,6 +216,19 @@ class CodexRuntimeSelection(unittest.TestCase):
         self.assertIsNone(fake_mod.CodexBackend.call_args.kwargs.get("codex_bin"),
                           "the backend must resolve its managed runtime even when codex is on PATH")
 
+    def test_romp_codex_bin_overrides_the_session_runtime(self):
+        # PATH is ignored, but the one explicit knob the judges already read (ROMP_CODEX_BIN) governs
+        # sessions too — an opt-in, not the ambient PATH accident #929 closed (review fold, 2026-09-07)
+        fake_mod = mock.Mock()
+        fake_loader = mock.Mock(); fake_loader.load_module.return_value = fake_mod
+        with mock.patch.object(km, "_codex_backend", None), \
+             mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+             mock.patch.dict(km.os.environ, {"ROMP_CODEX_BIN": "/opt/codex/bin/codex"}), \
+             mock.patch.object(km.shutil, "which", return_value="/TESTBIN/codex"):
+            km._codex()
+        self.assertEqual(fake_mod.CodexBackend.call_args.kwargs.get("codex_bin"), "/opt/codex/bin/codex",
+                         "the explicit knob is forwarded; PATH is still not")
+
 
 class SdkSingleFlight(unittest.TestCase):
     """Concurrent _sdk() calls must construct exactly ONE backend. The 2026-07-06 storm: the eager


### PR DESCRIPTION
Review fold on #929 (merged as 1fb32022; #930 landed since and selects the managed runtime, so the override is an explicit opt-in over that).

Review fold on #929: dropping the PATH `codex` left sessions with no runtime override at all, while
the judges keep honouring ROMP_CODEX_BIN, and nothing logged which runtime the app-server launched.
_codex() now passes codex_bin from ROMP_CODEX_BIN (unset = None = the SDK-bundled runtime), so one
explicit knob governs both surfaces rather than the ambient PATH accident the PR closed; CodexClient
start logs "app-server runtime: <bin or SDK-bundled>" once. A test asserts the env value is forwarded
while PATH still is not, and the doc states the judges' resolution order.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
