### PR TITLE
A crafted push-card value cannot break the feed's card reveal

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -34246,6 +34246,10 @@ if('serviceWorker' in navigator&&navigator.serviceWorker&&navigator.serviceWorke
 navigator.serviceWorker.addEventListener('message',function(ev){var m=ev&&ev.data;
 if(m&&m.romp==='notificationClick')land(String(m.sid||''),String(m.kind||''),String(m.cardId||''),false);});}
 var u=new URL(location.href),pr=u.searchParams.get('push-reveal'),pc=u.searchParams.get('push-card');
+// push-card is a goal id; a crafted link with a quote or bracket would reach the feed's
+// [data-key="a:..."] lookup as a selector and throw a SyntaxError that skips the openSession fallback
+// too (review find on #940, 2026-09-07). Drop a non-id value before it lands.
+if(pc&&!/^[A-Za-z0-9_.:-]{1,128}$/.test(pc))pc='';
 if(pr||pc){land(pr||'',pc?'card':'',pc||'',true);
 u.searchParams['delete']('push-reveal');u.searchParams['delete']('push-card');
 try{history.replaceState(null,'',u.pathname+(u.searchParams.toString()?'?'+u.searchParams.toString():'')+u.hash);}catch(e){}}

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -125,7 +125,10 @@ test("the feed answers revealCard: scroll to the card, pulse it accent, session 
   // the return path of the bell's jump (the user 2026-07-28): the shell posts {romp:'revealCard'};
   // the feed finds the card by its data-key, scrolls + pulses; a gone card opens the session instead.
   assert.match(FEED, /if \(m\.romp === "revealCard"\) \{/);
-  assert.match(FEED, /\[data-key="a:\$\{String\(m\.itemId \|\| ""\)\}"\]/);
+  // the card is found by dataset.key EQUALITY over [data-key] nodes, never an interpolated selector (a
+  // crafted push-card value with a quote threw inside querySelector; review fold on #940, 2026-09-07)
+  assert.match(FEED, /const key = "a:" \+ String\(m\.itemId \|\| ""\);/);
+  assert.match(FEED, /\.find\(\(c\) => c\.dataset\.key === key\) \|\| null;/);
   assert.match(FEED, /target\.scrollIntoView\(\{ block: "center", behavior: "smooth" \}\);/);
   assert.match(FEED, /target\.classList\.add\("reveal-pulse"\);/);
   assert.match(FEED, /animationend.*reveal-pulse.*once: true/, "the pulse is one-shot");

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -5192,8 +5192,13 @@ window.addEventListener("message", (e: MessageEvent) => {
     // FOLDED thread has no element yet — unfold first (the same rule revealCards follows: the navigation wins
     // over the disclosure). A card that no longer exists under its own key (cleared, or folded into a group)
     // falls back to opening the session.
-    unfoldThreadsFor(new Set(["a:" + String(m.itemId || "")]));
-    const target = document.querySelector(`[data-key="a:${String(m.itemId || "")}"]`) as HTMLElement | null;
+    const key = "a:" + String(m.itemId || "");
+    unfoldThreadsFor(new Set([key]));
+    // Match the key STRUCTURALLY, never an interpolated attribute selector: a crafted push-card value
+    // with a quote or bracket would throw a SyntaxError inside querySelector and abort this handler,
+    // dropping the openSession fallback too (review find on #940, 2026-09-07).
+    const target = (Array.from(document.querySelectorAll("[data-key]")) as HTMLElement[])
+      .find((c) => c.dataset.key === key) || null;
     if (target) {
       target.scrollIntoView({ block: "center", behavior: "smooth" });
       target.classList.remove("reveal-pulse"); void target.offsetWidth;   // restart the animation on a repeat jump

--- a/ui/webview/notify-click-reveal.test.ts
+++ b/ui/webview/notify-click-reveal.test.ts
@@ -30,7 +30,13 @@ test("the shell's reveal script waits for exactly that message, never another pa
 test("revealCard unfolds a collapsed thread before looking for the card (no silent miss on a fold)", () => {
   assert.match(SRC, /function unfoldThreadsFor\(keys: Set<string>\): void \{/);
   // both "take me to this card" entries share it: the bell-entry/notification jump and the chat-dot jump
-  assert.match(SRC, /unfoldThreadsFor\(new Set\(\["a:" \+ String\(m\.itemId \|\| ""\)\]\)\);\n    const target = document\.querySelector/);
+  // the card id is matched STRUCTURALLY (dataset.key equality), never interpolated into a selector: a
+  // crafted push-card value with a quote or bracket used to throw inside querySelector and skip the
+  // openSession fallback (review fold on #940, 2026-09-07); the landing script also drops a non-id value
+  assert.match(SRC, /const key = "a:" \+ String\(m\.itemId \|\| ""\);\n    unfoldThreadsFor\(new Set\(\[key\]\)\);/);
+  assert.match(SRC, /\.find\(\(c\) => c\.dataset\.key === key\) \|\| null;/);
+  assert.doesNotMatch(SRC, /querySelector\(`\[data-key="a:\$\{/, "no interpolated selector");
+  assert.match(KERNEL, /if\(pc&&!\/\^\[A-Za-z0-9_\.:-\]\{1,128\}\$\/\.test\(pc\)\)pc='';/, "a non-id push-card is dropped before it lands");
   assert.match(SRC, /function revealCards\(keys: Set<string>\) \{\n  unfoldThreadsFor\(keys\);/);
   // and the existing fallback stands: a card gone from the feed still opens its session
   assert.match(SRC, /\} else if \(m\.sid\) \{\n      vscodeApi\?\.postMessage\(\{ type: "openSession", id: String\(m\.sid\) \}\);/);


### PR DESCRIPTION
Review fold on #940 (merged as 3908f2ff).

Review fold on #940 (merged as 3908f2ff; rebuilt on main after the merge, where #937 already routes the
notification tap to the top-level dashboard, so only the second find remains):
- push-card from the deep link reached the feed's revealCard, which interpolated the id into a
  [data-key="a:..."] selector; a crafted value with a quote or bracket threw a SyntaxError inside
  querySelector and aborted the handler, dropping the openSession fallback too. The landing script now
  drops a non-id push-card before it lands, and the feed matches the key structurally (dataset.key
  equality over the [data-key] nodes) instead of building a selector from it.
Pins in notify-click-reveal.test.ts and badge-mirror.test.ts follow the new shape.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
