### PR TITLE
The converge cool-down survives its own restart, and the quiet gate sees background work

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -317,10 +317,14 @@ function restartAllOrSelf() {
 // Pure decision (time injected → unit-testable). `st` = {since}; `busy` = the kernel's in-flight
 // SDK turn count, or null when the kernel is unreachable — a kernel that isn't answering has no
 // turns a restart could cut, so unreachable counts as quiet.
-function quietGate(st, busy, now, opts) {
+function quietGate(st, busy, now, opts, bd) {
   if (busy === null || busy === 0) return { action: 'apply', reason: busy === null ? 'kernel unreachable' : 'quiet' };
   if (now - st.since >= opts.maxDeferMs) return { action: 'apply', reason: 'backstop cap' };
-  return { action: 'wait', reason: `${busy} turn(s) in flight` };
+  // T240: `busy` counts sessions with a turn in flight OR live background work (a Workflow run, a
+  // background agent) — either kind defers the restart; the breakdown says which
+  const why = bd ? `${bd.inflight} turn(s) in flight, ${bd.background} session(s) with background work`
+                 : `${busy} turn(s) in flight`;
+  return { action: 'wait', reason: why };
 }
 
 let pendingQuiet = null;   // {since, count, mode:'all'|<kernel id>, timer, drainRefusedCount, drainArmedCount, drainRefusedAfterArm}
@@ -382,11 +386,14 @@ function fetchBusy(port, cb, path) {
   const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 2000, headers }, (res) => {
     let b = ''; res.on('data', (d) => (b += d));
     res.on('end', () => {
-      let n = null, draining = null;
+      let n = null, draining = null, bd = null;
       try {
         const j = JSON.parse(b);
         n = Number.isFinite(j.busy) ? j.busy : null;
         draining = typeof j.draining === 'boolean' ? j.draining : null;
+        // the breakdown (T240); an older kernel reports only `busy`, which then all counts as in flight
+        if (n !== null) bd = { inflight: Number.isFinite(j.inflight) ? j.inflight : n,
+                               background: Number.isFinite(j.background) ? j.background : 0 };
       } catch { n = null; }
       if (wantDrain && n !== null && draining === false && !drainNoticed) {
         drainNoticed = true;
@@ -398,11 +405,11 @@ function fetchBusy(port, cb, path) {
         drainNoticed = false;
         log('kernel armed the drain hold after the refusal above — new turn starts are held from here');
       }
-      cb(n, draining);
+      cb(n, draining, bd);
     });
   });
-  req.on('timeout', () => { req.destroy(); cb(null, null); });
-  req.on('error', () => cb(null, null));
+  req.on('timeout', () => { req.destroy(); cb(null, null, null); });
+  req.on('error', () => cb(null, null, null));
 }
 
 function clearPendingQuiet() {
@@ -434,7 +441,7 @@ function quietTick(deps) {
   if (!park) return;                      // an immediate restart satisfied it meanwhile
   schedule();                             // schedule-first: the chain outlives any probe failure
   let acted = false;
-  fetchBusy((busy) => {
+  fetchBusy((busy, bd) => {
     if (acted) return;
     acted = true;
     const cur = pending();
@@ -444,7 +451,7 @@ function quietTick(deps) {
       return;
     }
     try {
-      const g = quietGate(park, busy, now(), opts);
+      const g = quietGate(park, busy, now(), opts, bd);
       if (g.action === 'apply') apply(g);
     } catch (e) {
       log(`quiet-window evaluation failed (${e && e.message}) — the pending refresh stays queued`);
@@ -473,9 +480,15 @@ function queueQuietRestart(mode) {
       // reads fresh per poll, so a refusal can be transient (a token restored mid-park arms every
       // later poll), and the apply line below renders what this park's counts actually show.
       const park = pendingQuiet;
-      const cb = (busy, draining) => {
+      const cb = (busy, draining, bd) => {
         if (park && busy !== null) {
-          if (draining === false) {
+          // T240: remember whether any TURN is in flight — the drain hold (new turn starts held
+          // box-wide) is asked for only while one is; background-only busyness defers the restart
+          // without freezing other sessions' queued prompts for up to the backstop
+          park.lastInflight = bd ? bd.inflight : busy;
+          // a plain /busy poll (no hold asked) answers draining:false by construction — that is not
+          // a REFUSAL, and counting it as one made the backstop line blame a lost hold (review find)
+          if (draining === false && park.lastAsked) {
             park.drainRefusedCount++;
             // ORDER matters for the apply line (T227): two bare counters cannot tell "refused, then
             // armed" from "armed, then LOST" — a refusal that lands AFTER any arm is the loss, and
@@ -484,9 +497,13 @@ function queueQuietRestart(mode) {
             if (park.drainArmedCount > 0) park.drainRefusedAfterArm++;
           } else if (draining === true) park.drainArmedCount++;
         }
-        done(busy);
+        done(busy, bd);
       };
-      fetchBusy(KERNEL_PORT, cb, '/busy?drain=1');   // parked → hold new turn starts (T121)
+      // parked → hold new turn starts (T121) — but only while a turn is actually in flight (T240);
+      // the first poll, knowing nothing yet, asks for the hold as before
+      const holdTurns = park.lastInflight === undefined || park.lastInflight > 0;
+      park.lastAsked = holdTurns;            // what THIS poll asked for — the answer's refusal test reads it
+      fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy');
     },
     now: Date.now,
     opts: { maxDeferMs: QUIET_MAX_DEFER_MS },

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3958,7 +3958,12 @@ _MAIN_CHECK_EVERY_S = 300
 # no-op sleep with pytest printing nothing until the 15-minute cap.
 _CHECK_LOOP_STOP = threading.Event()
 _CONVERGE_COOLDOWN_S = float(os.environ.get("ROMP_CONVERGE_COOLDOWN", "1500"))   # min gap between AUTO converges (25 min → ≤2-3 restarts/hour on a hot main)
-_LAST_AUTO_CONVERGE = [0.0]   # when the last auto converge fired (module state; a restart resets it, which is fine — the restart WAS the converge)              # one ls-remote — cheap enough to notice a merge within minutes
+_LAST_AUTO_CONVERGE = [0.0]   # when THIS process last fired an auto converge — module memory that covers only
+#                               the seconds before the restart's own ledger row lands. It is NOT the cool-down's
+#                               source of truth: the converge's restart boots a fresh process with this at zero,
+#                               so the next merge converged again at once (05:19Z then 05:24Z against a 1500 s
+#                               window, T240). _last_deploy_restart_t reads the LANDED deploy restarts from the
+#                               restart-cuts ledger, which survives the restart it spaces.
 _MAIN_DRIFT = ["", ""]                 # [origin sha a notice fired for, checkout sha one fired for]
 
 
@@ -4276,6 +4281,69 @@ def _in_place_converge(target):
     return False
 
 
+_DEPLOY_RESTART_REASONS = ("main-converge", "p2p-update", "self-update",   # ledger reasons that ARE a
+                           "kernel-asks-manager-restart-all: self-update")   # deploy restart of this kernel
+_NO_RESTART_ACTIONS = {"main-converge-skip", "bus-converge", "end-on-idle"}   # audit rows that restart no
+#                                                                              kernel (in-place converges; a
+#                                                                              session's own self-close ask)
+
+
+def _last_deploy_restart_t():
+    """When the last DEPLOY restart actually LANDED on this box, from the restart-cuts ledger — the
+    row a restarting kernel writes as it dies, with `reason` joined from the audit row that asked
+    (main-converge, or a p2p-update from a peer; a main-converge-skip never restarts, a rail-button or
+    self-close restart is not a converge; a clicked Update IS one — the user just restarted, and
+    spacing the next AUTO converge after it is exactly the rate the cool-down exists for). Durable
+    across the restart it spaces, which module memory is not (T240). 0.0 when the ledger has no such
+    row or cannot be read — the cool-down then rests on module memory alone, exactly today's
+    behavior. A row stamped in the FUTURE (a clock stepped back) is ignored rather than holding every
+    converge until the clock catches up (review find)."""
+    try:
+        lines = RESTART_CUTS_FILE.read_text().strip().splitlines()[-200:]
+    except Exception:
+        lines = []                      # no ledger yet (or unreadable): the audit file below still counts
+    horizon = time.time() + 60.0
+    best = 0.0
+    for line in reversed(lines):
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        reason = str((r or {}).get("reason") or "")
+        if reason.startswith("main-converge-skip"):
+            continue
+        t = r.get("t")
+        if any(reason.startswith(p) for p in _DEPLOY_RESTART_REASONS) and isinstance(t, (int, float)) \
+                and t <= horizon:
+            best = float(t)
+            break
+    # The audit row is the SECOND source, and the one that survives the row-loss race (review find,
+    # reproduced by simulation): a converge that finds its manager stale takes the shutdownAll path,
+    # the manager exits ~0.8 s after the SIGTERM, and the kernel's parent-watch could os._exit before
+    # the graceful term finished its drain and wrote the cut row — the very path THIS change's own
+    # deploy takes. The old kernel writes its main-converge / self-update audit row BEFORE it posts
+    # the restart, and a peer's p2p-update row lands before its apply restarts us, so the request
+    # time anchors the window when the landing row is missing. The newer of the two wins.
+    try:
+        alines = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()[-200:]
+    except Exception:
+        alines = []
+    for line in reversed(alines):
+        try:
+            a = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(a, dict) or not isinstance(a.get("t"), (int, float)) or a["t"] > horizon:
+            continue
+        act, reason = str(a.get("action") or ""), str(a.get("reason") or "")
+        deploy = (act == "main-converge" and a.get("when") == "now") or act in ("p2p-update", "self-update") \
+            or (act == "kernel-asks-manager-restart-all" and reason.startswith("self-update"))
+        if deploy:
+            best = max(best, float(a["t"]))
+            break
+    return best
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -4313,7 +4381,12 @@ def _main_drift_check():
         # further auto converges HOLD for a cool-down; the slot is left unoffered so the first pass
         # past the window converges to the LATEST sha — N merges, one restart. A deliberate rate
         # policy on restart disruption, not a proxy for an event; a clicked Update never waits.
-        if time.time() - _LAST_AUTO_CONVERGE[0] < _CONVERGE_COOLDOWN_S:
+        # The window is measured from the last deploy restart that LANDED (the ledger), not from
+        # this process's memory: the converge's own restart forgets module state, and a p2p-update
+        # restart from a peer resets it the same way (T240). Module memory still covers the seconds
+        # before the ledger row exists.
+        last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
+        if time.time() - last < _CONVERGE_COOLDOWN_S:
             _MAIN_DRIFT[slot] = ""
             return
         _LAST_AUTO_CONVERGE[0] = time.time()
@@ -15245,25 +15318,72 @@ def _mark_boot(kind):
         pass
 
 
+def _audit_reason_text(rec):
+    """The cut row's `reason` for an audit row (or "" for none): action, plus its reason when it has one."""
+    if not isinstance(rec, dict):
+        return ""
+    return str(rec.get("action") or "") + (": " + str(rec["reason"]) if rec.get("reason") else "")
+
+
+def _consumed_audit_t():
+    """The `t` of the audit row the NEWEST cut row already joined (auditT) — a row consumed by the
+    restart it asked for must not name a later, anonymous cut too: a quiet p2p row stays inside its
+    20-minute window long after its restart landed, so an unaudited SIGTERM 15 minutes later
+    inherited its reason and even counted as a deploy for the cool-down (T240 review)."""
+    try:
+        lines = RESTART_CUTS_FILE.read_text().strip().splitlines()
+        for line in reversed(lines[-20:]):
+            r = json.loads(line)
+            if isinstance(r, dict) and "cutTurns" in r:          # a cut row (boot rows carry no cuts)
+                return int(r.get("auditT") or 0)
+    except Exception:
+        pass
+    return 0
+
+
 def _recent_restart_reason(window=90, now=None):
     """The most recent restart-audit action within `window` seconds — joins the cut row to WHO asked
     (deploy refresh, self-update, the rail button…). Best-effort: an anonymous SIGTERM has no row
     and reads as ""."""
+    return _audit_reason_text(_recent_restart_audit(window=window, now=now))
+
+
+def _recent_restart_audit(window=90, now=None):
+    """The restart-audit ROW (dict) that explains a cut happening now, or None: the newest row that
+    requested a kernel restart, not yet consumed by an earlier cut, inside its window (90 s; a
+    quiet-window request stays pending up to the far manager's 15-minute backstop)."""
     try:
         tail = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()
         if not tail:
-            return ""
-        rec = json.loads(tail[-1])
+            return None
+        consumed = _consumed_audit_t()
+        rec = None
+        for line in reversed(tail[-50:]):
+            # walk PAST rows that requested no restart — an in-place converge (main-converge-skip) or
+            # a bus bounce writes an audit row but cuts no kernel, and reading only the last row named
+            # a real cut after it as the skip (T240 nit)
+            try:
+                cand = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(cand, dict) and str(cand.get("action") or "") in _NO_RESTART_ACTIONS:
+                continue
+            if isinstance(cand, dict) and consumed and cand.get("t") == consumed:
+                return None                          # spent on the cut it asked for — this cut is anonymous
+            rec = cand
+            break
+        if rec is None:
+            return None
         t0 = int(now if now is not None else time.time())
         if isinstance(rec, dict) and rec.get("when") == "quiet":
             # a QUIET-WINDOW request is pending until the restart it asked for lands — up to the far
             # manager's 15-minute backstop — so it names the cut well past the immediate window (T238)
             window = max(window, RESTART_EXPECT_MAX_S)
         if isinstance(rec, dict) and isinstance(rec.get("t"), int) and t0 - rec["t"] <= window:
-            return str(rec.get("action") or "") + (": " + str(rec["reason"]) if rec.get("reason") else "")
+            return rec
     except Exception:
         pass
-    return ""
+    return None
 
 
 def _local_machine_label():
@@ -34448,6 +34568,10 @@ class Handler(BaseHTTPRequestHandler):
                 # but arms nothing; the manager reads the serve-token file and sends X-Romp-Token.
                 be = _sdk()
                 n = be.busy_count() if be and hasattr(be, "busy_count") else 0
+                # the breakdown rides beside the total (T240): the manager defers on EITHER kind of
+                # busyness but asks for the drain hold only while turns are actually in flight —
+                # background work must never freeze other sessions' queued prompts
+                inflight, background = (be.busy_breakdown() if be and hasattr(be, "busy_breakdown") else (n, 0))
                 draining = False
                 if be is not None and hasattr(be, "refresh_drain_hold"):
                     if q.get("drain", [""])[0] == "1":
@@ -34458,7 +34582,8 @@ class Handler(BaseHTTPRequestHandler):
                             _note_drain_refused()    # T224: the one event the gate exists for —
                             #                          read LOUDLY, once per episode (see the helper)
                     draining = be.drain_holding()
-                return self._send(200, json.dumps({"busy": n, "draining": draining}),
+                return self._send(200, json.dumps({"busy": n, "inflight": inflight, "background": background,
+                                                   "draining": draining}),
                                   "application/json", cache="no-cache")
             if p == "/manifest.webmanifest":
                 # the install manifest — auth-exempt like /healthz, and for a hard reason: the
@@ -37202,15 +37327,24 @@ def _pid_alive(pid):
         return True
 
 
+_TERMINATING = [False]   # set the moment _graceful_term starts: the watchdog below must not exit under it
+
+
 def _parent_watch():
     """Exit if the manager that spawned us (ROMP_MANAGER_PID) dies, so a supervisor crash doesn't
-    orphan the kernel. No-op when launched standalone (no ROMP_MANAGER_PID)."""
+    orphan the kernel. No-op when launched standalone (no ROMP_MANAGER_PID). STANDS DOWN while a
+    graceful term is already running (T240 review): a stale manager's shutdownAll SIGTERMs us and
+    exits ~0.8 s later, and this watchdog used to os._exit the kernel mid-drain — before the cut
+    row was written — losing the ledger row the deploy cool-down and the T121 metrics depend on.
+    The graceful term owns the exit then; it is bounded (~2 s) and ends in os._exit itself."""
     pid = os.environ.get("ROMP_MANAGER_PID")
     if not (pid and pid.isdigit()):
         return
     pid = int(pid)
     while _pid_alive(pid):
         time.sleep(2)
+    if _TERMINATING[0]:
+        return                                       # the graceful term is finishing the job
     os._exit(0)
 
 
@@ -37222,6 +37356,7 @@ def _graceful_term(signum, frame):
     mutation, and a cut turn keeps its 'working' state tail — the NEXT kernel's boot reconcile
     resumes exactly those. Bounded (~2s) so `romp refresh` stays snappy. Never construct the
     backend here — no SDK sessions were running if it doesn't exist."""
+    _TERMINATING[0] = True                          # the parent-watch stands down (see _parent_watch)
     _broadcast_restarting()                        # T217: announce the death FIRST — the frame is
     #                                                the shims' eager-reconnect event, and its
     #                                                sub-second budget cannot widen the shutdown
@@ -37240,8 +37375,11 @@ def _graceful_term(signum, frame):
         # the restart-cut ledger (T121): one row per restart, ALWAYS — an empty cutTurns row is the
         # clean-drain metric, and a drain that errored writes what it knew plus the error (T143).
         try:
+            rec = _recent_restart_audit()
             row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),
-                                   audit_reason=_recent_restart_reason())
+                                   audit_reason=_audit_reason_text(rec))
+            if rec:
+                row["auditT"] = int(rec["t"])       # the audit row this cut CONSUMED (see _recent_restart_audit)
             if err:
                 row["drainError"] = err.strip().splitlines()[-1][:200]
             _append_restart_cut(row)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5609,15 +5609,32 @@ class SdkBackend:
         run (the user 2026-07-28)."""
         return not self._sdk_missing
 
-    def busy_count(self) -> int:
-        """How many SDK sessions have a turn IN FLIGHT right now — the manager's quiet-window gate
-        for deferred deploy restarts (the kernel's /busy route). Authoritative: the same per-session
-        inflight counter the drain uses to count the turns a restart would cut. Queued-but-unstarted
-        turns don't count — the persisted queue survives a bounce losslessly; only an in-flight turn
-        gets interrupted."""
+    def busy_breakdown(self):
+        """(in-flight, background): how many SDK sessions have a turn IN FLIGHT, and how many OTHERS
+        have live BACKGROUND WORK — a Workflow run, a background agent or shell (_bg_tasks / _subagents)
+        — with no turn in flight between their own turns. Each session is counted once, in-flight
+        first. Background work counted nowhere was how a quiet deploy applied instantly over live
+        Workflow runs and killed them (T240: eight review runs lost in one night). Queued-but-
+        unstarted turns still don't count — the persisted queue survives a bounce losslessly."""
         with self._lock:
             sessions = list(self.sessions.values())
-        return sum(1 for s in sessions if s.inflight and not s.ended)
+        inflight = background = 0
+        for s in sessions:
+            if s.ended:
+                continue
+            if s.inflight:
+                inflight += 1
+            elif s._bg_tasks or s._subagents:
+                background += 1
+        return inflight, background
+
+    def busy_count(self) -> int:
+        """How many SDK sessions a restart would DISRUPT right now — a turn in flight OR live
+        background work (see busy_breakdown) — the manager's quiet-window gate for deferred deploy
+        restarts (the kernel's /busy route). Authoritative: the same per-session counters the drain
+        and the task stream keep."""
+        inflight, background = self.busy_breakdown()
+        return inflight + background
 
     # ── deploy-drain hold (T121 part 1) ─────────────────────────────────────
     # While a quiet deploy restart is PARKED at the manager, this kernel holds NEW turn starts so
@@ -5638,8 +5655,13 @@ class SdkBackend:
         now = time.time()
         with self._lock:
             first = self._drain_hold_until <= now
+            # a NEW episode, not a flap: the manager now drops the hold during background-only
+            # stretches and re-arms it when a turn starts (T240), so a lease that lapsed moments ago
+            # is the same park — its 5-minute ring and its "parked" line must not restart per flap
+            new_episode = first and (self._drain_hold_since == 0.0
+                                     or now - self._drain_hold_until > 2 * self.DRAIN_HOLD_TTL)
             self._drain_hold_until = now + self.DRAIN_HOLD_TTL
-            if first:
+            if new_episode:
                 self._drain_hold_since = now
                 self._drain_hold_rang = False
             t = self._drain_wake_timer
@@ -5649,17 +5671,17 @@ class SdkBackend:
         if t is not None:
             t.cancel()
         nt.start()
-        if first:
-            self._log("deploy restart parked: draining — %d in-flight turn(s); new turn starts held "
-                      "until this box quiets (queued prompts persist and start after the bounce)"
-                      % self.busy_count())
+        if new_episode:
+            self._log("deploy restart parked: draining — %d in-flight turn(s), %d session(s) with background "
+                      "work; new turn starts held until this box quiets (queued prompts persist and "
+                      "start after the bounce)" % self.busy_breakdown())
         elif now - self._drain_hold_since > self.DRAIN_LOUD_S and not self._drain_hold_rang:
             with self._lock:
                 self._drain_hold_rang = True
-            self._log("deploy restart still parked after %d min — %d in-flight turn(s) have not "
-                      "finished; new turn starts remain held (the manager's backstop will apply "
-                      "the restart regardless)" % (int((now - self._drain_hold_since) / 60),
-                                                   self.busy_count()), problem=True)
+            self._log("deploy restart still parked after %d min — %d in-flight turn(s), %d session(s) with "
+                      "background work have not finished; new turn starts remain held (the manager's "
+                      "backstop will apply the restart regardless)"
+                      % ((int((now - self._drain_hold_since) / 60),) + self.busy_breakdown()), problem=True)
 
     def drain_holding(self) -> bool:
         """Whether new turn starts are currently held for a parked deploy restart."""

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -319,8 +319,10 @@ test('the park records drain evidence and the backstop line names it (source pin
   const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
   assert.match(src, /drainRefusedCount/, 'the park counts refusals, never latching one bit');
   assert.match(src, /drainArmedCount/, 'the park counts arms, so a transient refusal reads true');
-  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')"),
-    'the parked poll still binds the drain-refresh spelling of the probe');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')"),
+    'the parked poll still binds the drain-refresh spelling of the probe — while a turn is in flight (T240)');
   assert.match(src, /never armed/, 'the backstop apply line can still say the hold never armed');
   assert.match(src, /resetDrainNotices\(\)/, 'a fresh park re-arms the once-per-episode notices');
+  assert.ok(src.includes('if (draining === false && park.lastAsked) {'),
+    'only a poll that ASKED for the hold can record a refusal — a plain /busy answers draining:false by construction (T240)');
 });

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -148,8 +148,10 @@ test('quietTick: the answer to the CURRENT park still applies exactly as before'
 test('the parked quiet poll refreshes the kernel drain lease in the same probe', () => {
   const fs = require('node:fs');
   const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
-  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')"),
-    'the quiet tick binds the drain-refresh spelling of the probe');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')"),
+    'the quiet tick binds the drain-refresh spelling of the probe — while a turn is in flight (T240)');
+  assert.ok(src.includes('const holdTurns = park.lastInflight === undefined || park.lastInflight > 0;'),
+    'the hold is asked for only while a turn is actually in flight (or on the first, uninformed poll) — background-only busyness defers without freezing other sessions');
   assert.ok(src.includes('path: path || \'/busy\''),
     'a plain /busy stays side-effect free — only the parked poll holds');
 });

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -259,3 +259,63 @@ PYEOF
     [ "$(grep -c spawn "$SPAWNS")" -eq 2 ]
     curl -fsS -X POST "http://127.0.0.1:$CPORT/stop" >/dev/null 2>&1 || true
 }
+
+@test "quiet-mode refresh defers on background work too, and asks for the drain hold only while turns are in flight" {
+    # T240: a session running a Workflow has no turn in flight between its own turns, so a quiet
+    # deploy applied instantly over it. The kernel now reports {busy, inflight, background}; the
+    # manager defers on either kind of busyness, but asks for the box-wide hold on NEW turn starts
+    # (/busy?drain=1) only while a turn is actually in flight — background work must never freeze
+    # other sessions' queued prompts.
+    command -v node >/dev/null 2>&1 || skip "node not available"
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+
+    local INF="$TEST_DIR/inflight" BG="$TEST_DIR/background" SPAWNS="$TEST_DIR/spawns" REQS="$TEST_DIR/reqs" FAKEK="$TEST_DIR/fake-kernel"
+    echo 0 > "$INF"; echo 1 > "$BG"; : > "$REQS"
+    cat > "$FAKEK" <<'PYEOF'
+#!/usr/bin/env python3
+import http.server, json, os
+with open(os.environ["SPAWN_LOG"], "a") as f:
+    f.write("spawn\n")
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        with open(os.environ["REQ_LOG"], "a") as f:
+            f.write(self.path + "\n")
+        def rd(k):
+            try: return int(open(os.environ[k]).read().strip())
+            except Exception: return 0
+        i, g = rd("INF_FILE"), rd("BG_FILE")
+        b = json.dumps({"busy": i + g, "inflight": i, "background": g, "draining": False}).encode()
+        self.send_response(200); self.send_header("Content-Length", str(len(b))); self.end_headers()
+        self.wfile.write(b)
+    def log_message(self, *a): pass
+http.server.HTTPServer(("127.0.0.1", int(os.environ["ROMP_SERVE_PORT"])), H).serve_forever()
+PYEOF
+    chmod +x "$FAKEK"
+
+    # 500 ms polls: a local answer always lands before the NEXT poll is issued, so "the first poll
+    # asks, no later poll does" cannot race on a slow CI box (review find)
+    env INF_FILE="$INF" BG_FILE="$BG" REQ_LOG="$REQS" SPAWN_LOG="$SPAWNS" ROMP_QUIET_POLL_MS=500 \
+        ROMP_MANAGER_PORT=$CPORT ROMP_SERVE_PORT=$MPORT ROMP_SERVE_BIN="$FAKEK" \
+        node "$MGR" up >/dev/null 2>&1 &
+    MGR_PID=$!
+    local i
+    for i in $(seq 1 50); do
+        curl -fsS "http://127.0.0.1:$CPORT/status" >/dev/null 2>&1 && [ -s "$SPAWNS" ] && break
+        sleep 0.1
+    done
+    [ "$(grep -c spawn "$SPAWNS")" -eq 1 ]
+
+    run curl -fsS -X POST "http://127.0.0.1:$CPORT/restart-all?when=quiet"
+    [[ "$output" == *'"deferred":true'* ]]
+    sleep 2.2
+    [ "$(grep -c spawn "$SPAWNS")" -eq 1 ]                    # background work alone DEFERS the restart
+    # the first poll asks for the hold (it knows nothing yet); every later poll, seeing 0 in flight,
+    # must not — the hold would freeze other sessions' queued prompts for nothing
+    [ "$(grep -c 'drain=1' "$REQS")" -le 1 ]
+    [ "$(grep -c '^/busy' "$REQS")" -ge 3 ]
+
+    echo 0 > "$BG"
+    for i in $(seq 1 60); do [ "$(grep -c spawn "$SPAWNS")" -ge 2 ] && break; sleep 0.1; done
+    [ "$(grep -c spawn "$SPAWNS")" -eq 2 ]                    # the work ended → the quiet event applies
+    curl -fsS -X POST "http://127.0.0.1:$CPORT/stop" >/dev/null 2>&1 || true
+}

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -49,6 +49,21 @@ class DrainLease(unittest.TestCase):
         self.assertTrue(woken, "the lease-end timer nudges every input generator — a held fresh "
                                "turn starts without waiting for another event")
 
+    def test_a_lapsed_lease_re_armed_moments_later_is_the_same_episode(self):
+        # T240: the manager drops the hold during background-only stretches and re-arms it when a
+        # turn starts — a flap, not a new park: the episode clock (the 5-minute ring) and the
+        # "parked" line must not restart per flap
+        be = _backend()
+        be.DRAIN_HOLD_TTL = 0.2
+        be.refresh_drain_hold()
+        since0 = be._drain_hold_since
+        time.sleep(0.3)                                    # lapsed
+        be.refresh_drain_hold()                            # re-armed within 2×TTL of the lapse
+        self.assertEqual(be._drain_hold_since, since0, "same episode")
+        time.sleep(0.7)                                    # lapsed for > 2×TTL: genuinely a new park
+        be.refresh_drain_hold()
+        self.assertGreater(be._drain_hold_since, since0, "a new episode starts its own clock")
+
     def test_arming_is_visible_and_a_long_hold_rings(self):
         logs = []
         be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=logs.append)
@@ -75,7 +90,7 @@ class DrainLease(unittest.TestCase):
                       "/busy?drain=1 refreshes the lease in the same round-trip that reads the count — "
                       "but the arm is a WRITE, gated on an explicit token (the behavioral pins live "
                       "in tests/test_kernel_auth_hardening.py::BusyDrainWriteGate); the READ stays exempt")
-        self.assertIn('json.dumps({"busy": n, "draining": draining})', ksrc,
+        self.assertIn('json.dumps({"busy": n, "inflight": inflight, "background": background,', ksrc,
                       "the payload says when the box is draining — glanceable, never mysterious")
         self.assertIn("'http://127.0.0.1:%d/restart-all'", ksrc,
                       "the self-update deploy cuts IMMEDIATELY (T160, reversing the T121 quiet "
@@ -84,7 +99,7 @@ class DrainLease(unittest.TestCase):
         self.assertNotIn("/restart-all?when=quiet'", ksrc,
                          "no kernel-side deploy path defaults to the quiet window any more")
         msrc = open(os.path.join(BIN, "romp-manager")).read()
-        self.assertIn("fetchBusy(KERNEL_PORT, cb, '/busy?drain=1')", msrc,
+        self.assertIn("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')", msrc,
                       "the manager's PARKED poll is the lease's refresher")
 
 

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -107,6 +107,92 @@ class DriftWiring(unittest.TestCase):
             km._LAST_AUTO_CONVERGE[0] = saved[5]
             km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = saved[6], saved[7]
 
+    def test_the_cool_down_holds_across_the_restart_it_spaces(self):
+        # T240: the cool-down lived in module memory ("a restart resets it, which is fine — the
+        # restart WAS the converge"). It was not fine: the converge's own restart boots a fresh
+        # process with the cool-down at zero, so the next merge converged again at once — 05:19Z then
+        # 05:24Z against a 1500 s window. The last DEPLOY restart is read from durable state (the
+        # restart-cuts ledger's newest deploy row), so a fresh process still honours the window.
+        import json, time
+        ran = []
+        saved = (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+                 km._run_main_update, km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1])
+        km._update_mode = lambda: "auto"
+        km._checkout_sha = lambda: "aaa"
+        km._kernel_sha = lambda: "aaa"
+        km._origin_main_sha = lambda: "bbb"
+        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        try:
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+            km._LAST_AUTO_CONVERGE[0] = 0.0                       # a FRESH process: module memory is empty
+            now = time.time()
+            with open(km.RESTART_CUTS_FILE, "a") as f:            # …but the ledger says a deploy restart
+                f.write(json.dumps({"t": int(now - 300), "reason": "main-converge", "cutTurns": []}) + "\n")
+            km._main_drift_check()
+            self.assertEqual(ran, [], "5 min after a landed deploy restart, the cool-down still holds")
+            self.assertEqual(km._MAIN_DRIFT[0], "", "the deferred sha stays unoffered — the first pass past the window takes the LATEST")
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 2000), "reason": "p2p-update: from X to Y",
+                                                        "cutTurns": []}) + "\n")
+            km._main_drift_check()
+            self.assertEqual(ran, ["pull"], "past the window, the converge fires")
+        finally:
+            (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+             km._run_main_update) = saved[:5]
+            km._LAST_AUTO_CONVERGE[0] = saved[5]
+            km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = saved[6], saved[7]
+            if km.RESTART_CUTS_FILE.exists():
+                km.RESTART_CUTS_FILE.unlink()
+
+    def test_the_audit_row_anchors_the_window_when_the_cut_row_was_lost(self):
+        # review find, reproduced by simulation: a stale-manager converge can lose its cut row (the
+        # parent-watch exited the kernel mid-drain). The deploy's AUDIT row is written before the
+        # restart and survives — it anchors the window on its own.
+        import json, time
+        now = time.time()
+        audit = km.jd.STATE / "restart-audit.jsonl"
+        audit.write_text(json.dumps({"t": int(now - 300), "action": "main-converge", "when": "now", "tag": "pull"}) + "\n")
+        try:
+            if km.RESTART_CUTS_FILE.exists():
+                km.RESTART_CUTS_FILE.unlink()
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 300, delta=2, msg="no cut row needed")
+            audit.write_text(json.dumps({"t": int(now - 200), "action": "main-converge", "tag": "abc"}) + "\n")
+            self.assertEqual(km._last_deploy_restart_t(), 0.0, "a clicked-Update request row without when=now "
+                             "is not a landed deploy on its own")
+            audit.write_text(json.dumps({"t": int(now - 100), "action": "p2p-update", "reason": "from X to Y",
+                                         "when": "quiet"}) + "\n")
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 100, delta=2, msg="a peer's apply anchors too")
+        finally:
+            audit.unlink()
+
+    def test_the_parent_watch_stands_down_under_a_graceful_term(self):
+        import inspect
+        pw = inspect.getsource(km._parent_watch)
+        self.assertLess(pw.index("if _TERMINATING[0]:"), pw.index("os._exit(0)"),
+                        "the watchdog never exits the kernel out from under its own drain")
+        gt = inspect.getsource(km._graceful_term)
+        self.assertLess(gt.index("_TERMINATING[0] = True"), gt.index("_broadcast_restarting()"),
+                        "the flag is the FIRST thing the graceful term does")
+
+    def test_only_deploy_restarts_count_toward_the_cool_down(self):
+        # a rail-button restart, a self-close, an in-place skip: none of them is a converge, so none
+        # of them spaces the next one
+        import json, time
+        now = time.time()
+        km.RESTART_CUTS_FILE.write_text("".join(json.dumps(r) + "\n" for r in [
+            {"t": int(now - 3000), "reason": "main-converge", "cutTurns": []},
+            {"t": int(now - 100), "reason": "kernel-asks-manager-restart-all: rail button", "cutTurns": []},
+            {"t": int(now - 50), "reason": "main-converge-skip", "cutTurns": []},
+            {"t": int(now + 7200), "reason": "p2p-update: from X to Y", "cutTurns": []},   # a clock stepped back
+        ]))
+        try:
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 3000, delta=2)
+            km.RESTART_CUTS_FILE.write_text(json.dumps(
+                {"t": int(now - 200), "reason": "self-update: v0.15 -> v0.16", "cutTurns": []}) + "\n")
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 200, delta=2,
+                                   msg="a release self-update is a deploy restart too")
+        finally:
+            km.RESTART_CUTS_FILE.unlink()
+
     def test_the_shell_banner_carries_the_drift_variants(self):
         src = inspect.getsource(km)
         self.assertIn("m.drift||''", src, "the shell relay forwards the drift kind")

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -56,6 +56,40 @@ class CutRow(unittest.TestCase):
         self.assertEqual(rows[1]["cutTurns"][0]["sid"], SID)
         km.RESTART_CUTS_FILE.unlink()
 
+    def test_reason_skips_rows_that_requested_no_restart(self):
+        # T240 nit: an in-place converge (main-converge-skip) writes an audit row but restarts nothing;
+        # reading only the LAST row labeled a real cut (the parked p2p deploy from 3 min earlier) as
+        # the skip. Rows that request no restart are walked past.
+        audit = jd.STATE / "restart-audit.jsonl"
+        audit.write_text("".join(json.dumps(r) + "\n" for r in [
+            {"t": 1000, "action": "p2p-update", "reason": "from X to abc1234", "when": "quiet"},
+            {"t": 1150, "action": "main-converge-skip", "tag": "def5678"},
+            {"t": 1160, "action": "bus-converge", "tag": "def5678"},
+            {"t": 1170, "action": "end-on-idle", "tag": "11111111-2222-3333-4444-555555555555"},
+        ]))
+        try:
+            self.assertIn("p2p-update", km._recent_restart_reason(window=90, now=1200))
+            audit.write_text(json.dumps({"t": 1150, "action": "main-converge-skip"}) + "\n")
+            self.assertEqual(km._recent_restart_reason(window=90, now=1200), "",
+                             "a skip alone names nothing — the cut was anonymous")
+        finally:
+            audit.unlink()
+
+    def test_a_consumed_audit_row_never_names_a_later_anonymous_cut(self):
+        # a quiet p2p row stays inside its 20-minute window long after its restart landed; the cut
+        # that consumed it records auditT, and an unaudited SIGTERM 15 min later reads anonymous
+        audit = jd.STATE / "restart-audit.jsonl"
+        audit.write_text(json.dumps({"t": 1000, "action": "p2p-update", "reason": "from X to abc1234",
+                                     "when": "quiet"}) + "\n")
+        try:
+            self.assertIn("p2p-update", km._recent_restart_reason(now=1240), "the restart it asked for")
+            km._append_restart_cut({"t": 1240, "reason": "p2p-update: from X to abc1234", "cutTurns": [],
+                                    "auditT": 1000})
+            self.assertEqual(km._recent_restart_reason(now=1900), "", "spent — the later cut is anonymous")
+        finally:
+            audit.unlink()
+            km.RESTART_CUTS_FILE.unlink()
+
     def test_reason_joins_the_recent_audit_tail_only(self):
         audit = jd.STATE / "restart-audit.jsonl"
         audit.write_text(json.dumps({"t": 1000, "action": "kernel-asks-manager-restart-all",
@@ -89,7 +123,8 @@ class CutRow(unittest.TestCase):
                       "…FINALLY block, so a raising drain still writes what it knew (T143: 2 of 18 "
                       "restarts died recordless)")
         self.assertIn('row["drainError"]', block, "an errored drain's row names the error")
-        self.assertIn("audit_reason=_recent_restart_reason()", block)
+        self.assertIn("audit_reason=_audit_reason_text(rec)", block)
+        self.assertIn("rec = _recent_restart_audit()", block, "the cut row joins — and CONSUMES — the audit row (auditT)")
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -4282,6 +4282,28 @@ class LiveSubagentsRetire(unittest.TestCase):
             e["startedAt"] = 2
         return e
 
+    def test_background_work_counts_as_busy_for_the_quiet_gate(self):
+        # T240: busy_count counted only in-flight turns, so a quiet deploy applied INSTANTLY over a
+        # session running a Workflow (no turn in flight between its own turns) and killed it — eight
+        # review runs lost in one night. Background work makes the session busy; the breakdown is
+        # separate so the manager can hold new turn starts only for turns that are actually in flight.
+        s = self._sess()
+        be = s.backend
+        be.sessions[s.sid] = s
+        self.assertEqual(be.busy_breakdown(), (0, 0))
+        self.assertEqual(be.busy_count(), 0)
+        s._on_task_event("task_started", {"task_id": "w1", "task_type": "local_workflow"})
+        self.assertEqual(be.busy_breakdown(), (0, 1), "a live workflow with no turn in flight is background work")
+        self.assertEqual(be.busy_count(), 1)
+        s._on_task_event("task_notification", {"task_id": "w1", "status": "completed"})
+        self.assertEqual(be.busy_breakdown(), (0, 0), "ended → not busy")
+        self.assertEqual(be.busy_count(), 0)
+        self._start(s, "a1")
+        self.assertEqual(be.busy_breakdown(), (0, 1), "a live background agent counts the same way")
+        s.inflight = 1
+        self.assertEqual(be.busy_breakdown(), (1, 0), "a session is counted ONCE — in flight wins")
+        self.assertEqual(be.busy_count(), 1)
+
     def test_a_failed_workflow_agent_retires_on_the_runs_progress_list(self):
         """The shape the probe recorded: the run's task_progress re-ships the whole per-agent list on every
         state change; the failed agent's slot flips to "error" with no SubagentStop ever following."""

--- a/tests/test_sdk_busy_count.py
+++ b/tests/test_sdk_busy_count.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """busy_count — the quiet-window gate for deferred deploy refreshes (the user 2026-07-20). Peers'
 `romp --refresh` deploys bounced the kernel 11x in one day, each cutting in-flight SDK turns; the
-manager now defers a deploy until the kernel's /busy reports zero turns in flight. busy_count must
-mirror exactly what the drain would cut: sessions with inflight > 0 and not ended — never queued
-turns (the persisted queue survives a bounce losslessly). Synthetic; no SDK import."""
+manager now defers a deploy until the kernel's /busy reports zero. busy_count must mirror exactly what
+a restart would DISRUPT: sessions with inflight > 0, plus (T240) sessions with live background work —
+a Workflow run or a background agent, which has no turn in flight between its own turns — and never
+ended sessions or queued turns (the persisted queue survives a bounce losslessly). Synthetic; no
+SDK import."""
 import os
 import tempfile
 import unittest
@@ -19,10 +21,12 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 sb = SourceFileLoader("romp_sdk_backend_busy", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 
-def _sess(inflight, ended=False):
+def _sess(inflight, ended=False, bg=False):
     s = mock.Mock()
     s.inflight = inflight
     s.ended = ended
+    s._bg_tasks = {"w1": {"type": "local_workflow"}} if bg else {}   # a Mock attribute would read truthy
+    s._subagents = {}
     return s
 
 
@@ -30,11 +34,16 @@ class BusyCount(unittest.TestCase):
     def _backend(self):
         return sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
 
-    def test_counts_only_inflight_unended_sessions(self):
+    def test_counts_inflight_and_background_unended_sessions(self):
         be = self._backend()
         be.sessions = {"a": _sess(1), "b": _sess(0), "c": _sess(2), "d": _sess(1, ended=True)}
         self.assertEqual(be.busy_count(), 2,
                          "idle and ended sessions are not turns a restart would cut")
+        be.sessions["e"] = _sess(0, bg=True)            # a Workflow between its own turns (T240)
+        self.assertEqual(be.busy_count(), 3, "background work is disrupted by a restart too")
+        self.assertEqual(be.busy_breakdown(), (2, 1), "counted once each, in flight first")
+        be.sessions["f"] = _sess(0, ended=True, bg=True)
+        self.assertEqual(be.busy_count(), 3, "an ended session's leftovers are nobody's work")
 
     def test_empty_backend_is_quiet(self):
         self.assertEqual(self._backend().busy_count(), 0)


### PR DESCRIPTION
## What (T240)

Five kernel restarts in 63 minutes on a merge night (05:14Z, 05:19Z, 05:24Z, 06:10Z, 06:17Z), each killing every session's background Workflow runs. Two kernel-side defects, both verified in the ledgers.

1. **The converge cool-down never held across the restart it spaces.** `_LAST_AUTO_CONVERGE` was module memory; the converge's own restart boots a fresh process with it at zero, so the next merge converged again at once (05:19Z then 05:24Z against a 1500 s window), and a p2p-update restart from a peer reset it the same way. The window is now measured from the last deploy restart on **durable record**, the newer of two sources: the restart-cuts ledger row a restart writes as it lands, and the deploy's own **restart-audit row**, written by the old kernel *before* it posts the restart. The audit row matters (review find, reproduced by simulation): a converge whose manager is stale takes the `shutdownAll` path, the manager exits ~0.8 s after the SIGTERM, and the kernel's parent-watch could `os._exit` mid-drain before the cut row existed — the path this PR's own deploy takes. The **parent-watch now stands down while the graceful term runs**, so the cut row lands too. A clicked Update is a restart and spaces the next *auto* converge (intended). The immediate=True converge (T160) is untouched.

2. **The quiet gate ignored background work.** `busy_breakdown()` counts sessions with live `_bg_tasks`/`_subagents` as background work (each once, in flight first); `busy_count` is the sum; `/busy` carries `busy`, `inflight`, `background`; the drain log lines say both. **Design point:** the manager asks for the drain hold (`/busy?drain=1`, new turn starts held box-wide) **only while a turn is actually in flight** — background-only busyness defers the restart (bounded as today by the 15-minute backstop) without freezing other sessions' queued prompts; a poll that did not ask for the hold cannot record a refusal; a lease that lapses during a background stretch and re-arms when a turn starts is the same park (no per-flap "parked" line, no reset ring). An older kernel reporting only `busy` reads as all-in-flight.

3. **Nit:** `_recent_restart_reason` walks past rows that request no kernel restart (`main-converge-skip`, `bus-converge`, `end-on-idle`), and a row the restart it asked for already **consumed** (the cut row records `auditT`) never names a later anonymous cut.

**Known limits, stated:** a long-lived background shell defers deploys to the backstop for as long as it lives (the protection asked for); an aux kernel profile with its own state dir keeps its own ledger, so only the requesting kernel's cool-down learns of a box-wide restart; a new kernel under an old, *unsupervised* manager over-holds on background work until that manager is restarted once.

## Pins, red-first, synthetic

Cool-down holds across a fresh process from a landed cut row (red on main) and from the audit row alone; only deploy rows count, self-update included, future-stamped ignored; parent-watch stand-down by source; busy breakdown (0, 1) for a live `local_workflow` with no turn, ended → 0, in flight once (red on main); the reason walker skips no-restart rows, treats a consumed row as spent (red on main); a lapsed lease re-armed moments later keeps its episode; bats: defers on background work, asks for the hold at most on its first poll, applies on the quiet event (500 ms polls); node: poll spelling and refusal gate.

## Review

3 lenses, 20 findings, 19 real: folded — the stale-manager row-loss race (dual-source anchor + parent-watch stand-down), the refusal miscount, the future-timestamp hold, self-update counting, the `end-on-idle` row, consumed audit rows, flap dampening, the bats timing; documented — the known limits above.

Out of scope, as dispatched: the immediate-converge policy (T160) stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)