### PR TITLE
The quiet gate treats a missed busy poll as a miss, and six T240 residuals

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -199,6 +199,13 @@ const STORM_COOLDOWN_MS = 30000;      // during a storm, hold to 1 restart per t
 // loudly. Immediate restarts (the dashboard ↻, `--now`) behave exactly as before and satisfy any
 // pending quiet request in passing.
 const QUIET_POLL_MS = Number(process.env.ROMP_QUIET_POLL_MS) || 3000;
+// T240b: a busy poll that gets NO answer is a MISS, not quiet. Under load — exactly when a review
+// workflow's agents are running — the kernel answers /busy late, and one timed-out poll applied a
+// parked deploy over live background work ten minutes before the backstop (07:57Z 2026-09-07).
+// The tunnel supervisor's STALE_MISSES precedent: unreachable applies only after this many
+// CONSECUTIVE misses (~9 s of 3 s polls); any answer resets the streak. A wedged kernel still
+// restarts within ~10 s; the backstop stays the ultimate bound.
+const BUSY_MISS_LIMIT = Number(process.env.ROMP_BUSY_MISS_LIMIT) || 3;
 const QUIET_MAX_DEFER_MS = Number(process.env.ROMP_QUIET_MAX_DEFER_MS) || 15 * 60 * 1000;
 
 function spawnKernel(spec) {
@@ -317,8 +324,15 @@ function restartAllOrSelf() {
 // Pure decision (time injected → unit-testable). `st` = {since}; `busy` = the kernel's in-flight
 // SDK turn count, or null when the kernel is unreachable — a kernel that isn't answering has no
 // turns a restart could cut, so unreachable counts as quiet.
-function quietGate(st, busy, now, opts, bd) {
-  if (busy === null || busy === 0) return { action: 'apply', reason: busy === null ? 'kernel unreachable' : 'quiet' };
+function quietGate(st, busy, now, opts, bd, misses) {
+  if (busy === null) {
+    // no answer: a MISS (T240b) — injected like `now`, counted by quietTick on the park
+    const n = misses || 0, lim = opts.missLimit || BUSY_MISS_LIMIT;
+    if (n >= lim) return { action: 'apply', reason: `kernel unreachable — ${n} consecutive busy polls missed` };
+    if (now - st.since >= opts.maxDeferMs) return { action: 'apply', reason: 'backstop cap' };
+    return { action: 'wait', reason: `busy poll missed (${n}/${lim}) — a slow or unreachable kernel is not yet quiet` };
+  }
+  if (busy === 0) return { action: 'apply', reason: 'quiet' };
   if (now - st.since >= opts.maxDeferMs) return { action: 'apply', reason: 'backstop cap' };
   // T240: `busy` counts sessions with a turn in flight OR live background work (a Workflow run, a
   // background agent) — either kind defers the restart; the breakdown says which
@@ -383,7 +397,9 @@ function fetchBusy(port, cb, path) {
   const tok = kernelToken();
   const headers = tok ? { 'X-Romp-Token': tok } : {};
   const wantDrain = /[?&]drain=1(?:&|$)/.test(path || '');
-  const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 2000, headers }, (res) => {
+  // 5 s, not 2 (T240b): the kernel answers /busy on a thread that competes with its pushers under
+  // load, and a 2 s cap turned ordinary slowness into "unreachable"
+  const req = http.get({ host: HOST, port, path: path || '/busy', timeout: 5000, headers }, (res) => {
     let b = ''; res.on('data', (d) => (b += d));
     res.on('end', () => {
       let n = null, draining = null, bd = null;
@@ -451,7 +467,17 @@ function quietTick(deps) {
       return;
     }
     try {
-      const g = quietGate(park, busy, now(), opts, bd);
+      // the miss streak lives on the park (one per generation, like its drain evidence): a null
+      // answer extends it and logs once per miss; ANY answer ends it, loudly if it ran (T240b)
+      const lim = opts.missLimit || BUSY_MISS_LIMIT;
+      if (busy === null) {
+        park.misses = (park.misses || 0) + 1;
+        log(`busy poll missed (${park.misses}/${lim}): timeout or no answer — ${park.misses >= lim ? 'treating the kernel as unreachable' : 'not yet quiet'}`);
+      } else if (park.misses) {
+        log(`busy poll answered again after ${park.misses} miss(es) — the kernel was slow, not gone`);
+        park.misses = 0;
+      }
+      const g = quietGate(park, busy, now(), opts, bd, park.misses || 0);
       if (g.action === 'apply') apply(g);
     } catch (e) {
       log(`quiet-window evaluation failed (${e && e.message}) — the pending refresh stays queued`);

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -203,8 +203,12 @@ const QUIET_POLL_MS = Number(process.env.ROMP_QUIET_POLL_MS) || 3000;
 // workflow's agents are running — the kernel answers /busy late, and one timed-out poll applied a
 // parked deploy over live background work ten minutes before the backstop (07:57Z 2026-09-07).
 // The tunnel supervisor's STALE_MISSES precedent: unreachable applies only after this many
-// CONSECUTIVE misses (~9 s of 3 s polls); any answer resets the streak. A wedged kernel still
-// restarts within ~10 s; the backstop stays the ultimate bound.
+// CONSECUTIVE unanswered probes; any answer resets the streak. Probes go out on the 3 s grid and
+// each carries its own 5 s timeout, so a DEAD kernel (connection refused, instant) applies at
+// ~6 s and one that accepts but never answers at ~11 s (timeouts at 5, 8, 11) — measured, not
+// "3 poll intervals". The stated trade-off: a live kernel whose /busy latency stays above 5 s for
+// three probes in a row (a stall of ~10 s) is indistinguishable from a wedged one and is cut; the
+// backstop stays the ultimate bound.
 const BUSY_MISS_LIMIT = Number(process.env.ROMP_BUSY_MISS_LIMIT) || 3;
 const QUIET_MAX_DEFER_MS = Number(process.env.ROMP_QUIET_MAX_DEFER_MS) || 15 * 60 * 1000;
 
@@ -529,7 +533,11 @@ function queueQuietRestart(mode) {
       // the first poll, knowing nothing yet, asks for the hold as before
       const holdTurns = park.lastInflight === undefined || park.lastInflight > 0;
       park.lastAsked = holdTurns;            // what THIS poll asked for — the answer's refusal test reads it
-      fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy');
+      // the park's identity rides every parked poll (T240c): the kernel keys its drain EPISODE — one
+      // "parked" line, one 5-minute ring — on it instead of a time window, and can ring from a plain
+      // poll while only background work holds the park
+      const pk = 'park=' + Math.round(park.since);
+      fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1&' + pk : '/busy?' + pk);
     },
     now: Date.now,
     opts: { maxDeferMs: QUIET_MAX_DEFER_MS },

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4384,18 +4384,27 @@ def _last_deploy_restart_t():
     # deploy takes. The old kernel writes its main-converge / self-update audit row BEFORE it posts
     # the restart, and a peer's p2p-update row lands before its apply restarts us, so the request
     # time anchors the window when the landing row is missing. A request counts only once the
-    # restart it asked for LANDED — a boot row newer than it exists (event, not time): a self-update
-    # click whose detached script failed, or a p2p apply that never restarted anything, anchors
-    # nothing (review find). The newer of the two sources wins.
-    boot_t = 0.0
-    for line in reversed(lines):
+    # restart it asked for LANDED (event, not time): a boot at or after it exists — a boot row, or
+    # THIS process, since a running kernel has by construction booted after every request older than
+    # its start (its own boot row lands only after the first serve and the reconcile, and the drift
+    # loop's first pass runs before that, so a lost-row deploy anchored nothing on exactly the pass
+    # that matters — review find) — and NO cut row lies between the request and that boot unless the
+    # ledger joined it to this very request: a cut row in between means the ledger DID record that
+    # restart and attributed it elsewhere (an anonymous manual restart after a self-update click
+    # whose script failed), so this request restarted nothing (review find). The lost-row race is
+    # specifically "a boot, and no cut row between", and still counts. The newer source wins.
+    boots, cuts = [float(_STARTED)], []
+    for line in lines:
         try:
             r = json.loads(line)
         except Exception:
             continue
-        if isinstance(r, dict) and r.get("bootSettled") and isinstance(r.get("t"), (int, float)):
-            boot_t = float(r["t"])
-            break
+        if not isinstance(r, dict) or not isinstance(r.get("t"), (int, float)):
+            continue
+        if r.get("bootSettled"):
+            boots.append(float(r["t"]))
+        elif "cutTurns" in r:
+            cuts.append((float(r["t"]), float(r.get("auditT") or 0)))
     try:
         alines = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()[-200:]
     except Exception:
@@ -4407,14 +4416,19 @@ def _last_deploy_restart_t():
             continue
         if not isinstance(a, dict) or not isinstance(a.get("t"), (int, float)) or a["t"] > horizon:
             continue
-        if a["t"] > boot_t:
-            continue                                  # requested, but nothing has booted since: not landed
         act, reason = str(a.get("action") or ""), str(a.get("reason") or "")
         deploy = (act == "main-converge" and a.get("when") == "now") or act in ("p2p-update", "self-update") \
             or (act == "kernel-asks-manager-restart-all" and reason.startswith("self-update"))
-        if deploy:
-            best = max(best, float(a["t"]))
-            break
+        if not deploy:
+            continue
+        at = float(a["t"])
+        landed = min((b for b in boots if b >= at), default=None)
+        if landed is None:
+            continue                                  # requested, but nothing has booted since: not landed
+        if any(at < ct <= landed and aud != at for ct, aud in cuts):
+            continue                                  # the ledger recorded that restart and joined it elsewhere
+        best = max(best, at)
+        break
     return best
 
 
@@ -36152,10 +36166,13 @@ class Handler(BaseHTTPRequestHandler):
                 inflight, background = (be.busy_breakdown() if be and hasattr(be, "busy_breakdown") else (n, 0))
                 # ?park=<since> (T240c): the manager's park identity, on EVERY parked poll — the drain
                 # episode (its "parked" line, its 5-minute ring) keys on it, not on a time window, and a
-                # park held only by background work (plain polls, no hold) still rings. Bookkeeping and
-                # logging only — never a hold — so it rides the exempt read; an older manager sends none.
+                # park held only by background work (plain polls, no hold) still rings. Never a hold —
+                # but the episode clock and the 5-minute problem ring ARE writable state (a drive-by
+                # loopback GET could reset a live park's ring, or fabricate one — review find), so it
+                # rides the same explicit token as the arm: the manager sends X-Romp-Token on every
+                # poll, and an older manager sends no park at all.
                 park = (q.get("park", [""])[0] or "")[:32]
-                if park and be is not None and hasattr(be, "note_parked_poll"):
+                if park and be is not None and hasattr(be, "note_parked_poll") and self._write_token_ok(q):
                     be.note_parked_poll(park)
                 draining = False
                 if be is not None and hasattr(be, "refresh_drain_hold"):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4383,7 +4383,19 @@ def _last_deploy_restart_t():
     # the graceful term finished its drain and wrote the cut row — the very path THIS change's own
     # deploy takes. The old kernel writes its main-converge / self-update audit row BEFORE it posts
     # the restart, and a peer's p2p-update row lands before its apply restarts us, so the request
-    # time anchors the window when the landing row is missing. The newer of the two wins.
+    # time anchors the window when the landing row is missing. A request counts only once the
+    # restart it asked for LANDED — a boot row newer than it exists (event, not time): a self-update
+    # click whose detached script failed, or a p2p apply that never restarted anything, anchors
+    # nothing (review find). The newer of the two sources wins.
+    boot_t = 0.0
+    for line in reversed(lines):
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(r, dict) and r.get("bootSettled") and isinstance(r.get("t"), (int, float)):
+            boot_t = float(r["t"])
+            break
     try:
         alines = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()[-200:]
     except Exception:
@@ -4395,6 +4407,8 @@ def _last_deploy_restart_t():
             continue
         if not isinstance(a, dict) or not isinstance(a.get("t"), (int, float)) or a["t"] > horizon:
             continue
+        if a["t"] > boot_t:
+            continue                                  # requested, but nothing has booted since: not landed
         act, reason = str(a.get("action") or ""), str(a.get("reason") or "")
         deploy = (act == "main-converge" and a.get("when") == "now") or act in ("p2p-update", "self-update") \
             or (act == "kernel-asks-manager-restart-all" and reason.startswith("self-update"))
@@ -15533,12 +15547,18 @@ def _consumed_audit_t():
     inherited its reason and even counted as a deploy for the cool-down (T240 review)."""
     try:
         lines = RESTART_CUTS_FILE.read_text().strip().splitlines()
-        for line in reversed(lines[-20:]):
-            r = json.loads(line)
-            if isinstance(r, dict) and "cutTurns" in r:          # a cut row (boot rows carry no cuts)
-                return int(r.get("auditT") or 0)
     except Exception:
-        pass
+        return 0
+    for line in reversed(lines[-50:]):
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue                                  # a torn or glued line never disables the guard
+        if isinstance(r, dict) and "cutTurns" in r and r.get("auditT"):
+            # the newest cut that CONSUMED a row — walked back past anonymous cuts (a service stop, a
+            # Ctrl+C, a bare kill), which used to reset consumption to 0 and let the next anonymous cut
+            # re-inherit the still-in-window row (review find: rows alternated consumed/anonymous/consumed)
+            return int(r["auditT"])
     return 0
 
 
@@ -36130,11 +36150,18 @@ class Handler(BaseHTTPRequestHandler):
                 # busyness but asks for the drain hold only while turns are actually in flight —
                 # background work must never freeze other sessions' queued prompts
                 inflight, background = (be.busy_breakdown() if be and hasattr(be, "busy_breakdown") else (n, 0))
+                # ?park=<since> (T240c): the manager's park identity, on EVERY parked poll — the drain
+                # episode (its "parked" line, its 5-minute ring) keys on it, not on a time window, and a
+                # park held only by background work (plain polls, no hold) still rings. Bookkeeping and
+                # logging only — never a hold — so it rides the exempt read; an older manager sends none.
+                park = (q.get("park", [""])[0] or "")[:32]
+                if park and be is not None and hasattr(be, "note_parked_poll"):
+                    be.note_parked_poll(park)
                 draining = False
                 if be is not None and hasattr(be, "refresh_drain_hold"):
                     if q.get("drain", [""])[0] == "1":
                         if self._write_token_ok(q):
-                            be.refresh_drain_hold()
+                            be.refresh_drain_hold(park=park or None)
                             _note_drain_armed()
                         else:
                             _note_drain_refused()    # T224: the one event the gate exists for —

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36161,7 +36161,12 @@ class Handler(BaseHTTPRequestHandler):
                 if be is not None and hasattr(be, "refresh_drain_hold"):
                     if q.get("drain", [""])[0] == "1":
                         if self._write_token_ok(q):
-                            be.refresh_drain_hold(park=park or None)
+                            # The keyword only when a park arrived: a backend without it (an older
+                            # build, a test stand-in) keeps arming the hold the old way.
+                            if park:
+                                be.refresh_drain_hold(park=park)
+                            else:
+                                be.refresh_drain_hold()
                             _note_drain_armed()
                         else:
                             _note_drain_refused()    # T224: the one event the gate exists for —

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5685,18 +5685,33 @@ class SdkBackend:
         on a time window: the manager drops the hold for minutes at a time during background-only
         stretches (T240), so the 2×TTL window mis-read the next in-flight re-arm as a new park, and a
         park held ONLY by background work never reached refresh_drain_hold at all and stayed silent
-        after its first line. A plain parked poll now starts, continues and rings the episode too."""
+        after its first line. A plain parked poll now starts, continues and rings the episode too.
+        An empty identity is a no-op (nothing to key on), and one BELOW the current identity is a
+        stale probe from a park the manager has since replaced — ignored rather than flipping the
+        episode back and forth (review find: handler threads take the lock in no fixed order)."""
         self._park_seen(str(park or ""), time.time())
 
+    @staticmethod
+    def _park_ord(park):
+        try:
+            return int(park)
+        except (TypeError, ValueError):
+            return None
+
     def _park_seen(self, park: str, now: float) -> None:
+        if not park:
+            return
         with self._lock:
             new_episode = park != self._drain_park
             if new_episode:
+                a, b = self._park_ord(park), self._park_ord(self._drain_park)
+                if a is not None and b is not None and a < b:
+                    return                            # a stale probe from a replaced park
                 self._drain_park = park
                 self._drain_hold_since = now
                 self._drain_hold_rang = False
-            ring = (not new_episode and now - self._drain_hold_since > self.DRAIN_LOUD_S
-                    and not self._drain_hold_rang)
+            ring = (not new_episode and self._drain_hold_since > 0.0
+                    and now - self._drain_hold_since > self.DRAIN_LOUD_S and not self._drain_hold_rang)
             if ring:
                 self._drain_hold_rang = True
         if new_episode:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4980,6 +4980,7 @@ class SdkBackend:
         self._drain_hold_until = 0.0              # deploy-drain lease (T121): RUNTIME-ONLY — a fresh boot starts clear by construction
         self._drain_hold_since = 0.0
         self._drain_hold_rang = False
+        self._drain_park = ""                     # the manager's park identity (?park=<since>) the episode is keyed on (T240c)
         self._drain_wake_timer = None
         self.login_ok = lambda: True              # the kernel wires its credential-store probe (T124); permissive unwired
         self._usage_all_keyed = False             # refresh_usage's one-shot: the last refresh found only
@@ -5678,16 +5679,50 @@ class SdkBackend:
     DRAIN_HOLD_TTL = 12.0     # seconds; ~4 manager polls — the lease outlives a missed poll, not a dead manager
     DRAIN_LOUD_S = 300.0      # a drain still holding after 5 min rings — visible, never mysterious
 
-    def refresh_drain_hold(self) -> None:
-        """Arm/extend the drain lease (the manager's parked quiet poll calls this each tick)."""
+    def note_parked_poll(self, park: str) -> None:
+        """A parked quiet poll carrying the manager's park identity (T240c). The EPISODE — the one
+        "deploy restart parked" line and the 5-minute "still parked" ring — keys on that identity, never
+        on a time window: the manager drops the hold for minutes at a time during background-only
+        stretches (T240), so the 2×TTL window mis-read the next in-flight re-arm as a new park, and a
+        park held ONLY by background work never reached refresh_drain_hold at all and stayed silent
+        after its first line. A plain parked poll now starts, continues and rings the episode too."""
+        self._park_seen(str(park or ""), time.time())
+
+    def _park_seen(self, park: str, now: float) -> None:
+        with self._lock:
+            new_episode = park != self._drain_park
+            if new_episode:
+                self._drain_park = park
+                self._drain_hold_since = now
+                self._drain_hold_rang = False
+            ring = (not new_episode and now - self._drain_hold_since > self.DRAIN_LOUD_S
+                    and not self._drain_hold_rang)
+            if ring:
+                self._drain_hold_rang = True
+        if new_episode:
+            self._log("deploy restart parked: draining — %d in-flight turn(s), %d session(s) with background "
+                      "work; new turn starts hold while a turn is in flight (queued prompts persist and "
+                      "start after the bounce)" % self.busy_breakdown())
+        elif ring:
+            self._log("deploy restart still parked after %d min — %d in-flight turn(s), %d session(s) with "
+                      "background work have not finished (the manager's backstop will apply the restart "
+                      "regardless)" % ((int((now - self._drain_hold_since) / 60),) + self.busy_breakdown()),
+                      problem=True)
+
+    def refresh_drain_hold(self, park: str | None = None) -> None:
+        """Arm/extend the drain lease (the manager's parked quiet poll calls this each tick). With a
+        park identity the episode bookkeeping is _park_seen's (no time window); without one — an
+        older manager — the 2×TTL flap window below stands in for it."""
         now = time.time()
+        if park:
+            self._park_seen(str(park), now)
         with self._lock:
             first = self._drain_hold_until <= now
-            # a NEW episode, not a flap: the manager now drops the hold during background-only
-            # stretches and re-arms it when a turn starts (T240), so a lease that lapsed moments ago
-            # is the same park — its 5-minute ring and its "parked" line must not restart per flap
-            new_episode = first and (self._drain_hold_since == 0.0
-                                     or now - self._drain_hold_until > 2 * self.DRAIN_HOLD_TTL)
+            # a NEW episode, not a flap (the legacy, no-park path): the manager drops the hold during
+            # background-only stretches and re-arms it when a turn starts (T240), so a lease that
+            # lapsed moments ago is the same park — its ring and its "parked" line must not restart
+            new_episode = (not park) and first and (self._drain_hold_since == 0.0
+                                                   or now - self._drain_hold_until > 2 * self.DRAIN_HOLD_TTL)
             self._drain_hold_until = now + self.DRAIN_HOLD_TTL
             if new_episode:
                 self._drain_hold_since = now
@@ -5703,7 +5738,7 @@ class SdkBackend:
             self._log("deploy restart parked: draining — %d in-flight turn(s), %d session(s) with background "
                       "work; new turn starts held until this box quiets (queued prompts persist and "
                       "start after the bounce)" % self.busy_breakdown())
-        elif now - self._drain_hold_since > self.DRAIN_LOUD_S and not self._drain_hold_rang:
+        elif not park and now - self._drain_hold_since > self.DRAIN_LOUD_S and not self._drain_hold_rang:
             with self._lock:
                 self._drain_hold_rang = True
             self._log("deploy restart still parked after %d min — %d in-flight turn(s), %d session(s) with "

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -232,6 +232,42 @@ test('kernelToken prefers the env, then the token file', () => {
 // baked above): evidence is counted per park, stamped only on the park that issued the poll, and
 // the apply line renders what the counts actually show.
 
+test('a park held only by background work polls plainly, carries its identity, and counts no refusal (T240c behavioral)', async () => {
+  // mutation check (review): forcing park.lastAsked = true left every source pin green while the
+  // backstop line blamed a lost hold — this drives the REAL park through the stub instead
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.seen.length = 0;
+  // the first, uninformed poll ASKS for the hold and the kernel arms it; every later poll is plain
+  // (0 in flight) and answers draining:false by construction — none of those may count as a refusal
+  kstub.answers = [JSON.stringify({ busy: 1, inflight: 0, background: 1, draining: true })];
+  kstub.fallback = JSON.stringify({ busy: 1, inflight: 0, background: 1, draining: false });
+  let logged;
+  try {
+    logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
+  } finally { clearPendingQuiet(); }
+  const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
+  assert.match(applyLine, /backstop cap/, 'background work never quiets here, so the backstop applies');
+  assert.doesNotMatch(applyLine, /refused|never armed|LOST/, 'plain polls answer draining:false by construction — no refusal');
+  const drainPolls = kstub.seen.filter((u) => /drain=1/.test(u));
+  assert.ok(drainPolls.length <= 1, 'only the first, uninformed poll asks for the hold: ' + kstub.seen.join(' '));
+  assert.ok(kstub.seen.length >= 2 && kstub.seen.every((u) => /[?&]park=\d+/.test(u)),
+    'every parked poll carries the park identity: ' + kstub.seen.join(' '));
+});
+
+test('a real refusal on a poll that ASKED for the hold is still counted (T240c behavioral)', async () => {
+  fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
+  kstub.seen.length = 0;
+  kstub.answers = [];
+  kstub.fallback = JSON.stringify({ busy: 1, inflight: 1, background: 0, draining: false });   // a turn in flight, hold refused
+  let logged;
+  try {
+    logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
+  } finally { clearPendingQuiet(); }
+  const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
+  assert.match(applyLine, /never armed/, 'every asked poll was refused: the hold never armed');
+  assert.ok(kstub.seen.every((u) => /drain=1/.test(u)), 'a turn in flight: every poll asks for the hold');
+});
+
 test('a transient refusal (the hold arms later) renders the armed-after-refusal cause, never "never armed"', async () => {
   fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
   kstub.answers = [JSON.stringify({ busy: 1, draining: false })];   // first poll: hold refused once…
@@ -319,8 +355,8 @@ test('the park records drain evidence and the backstop line names it (source pin
   const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
   assert.match(src, /drainRefusedCount/, 'the park counts refusals, never latching one bit');
   assert.match(src, /drainArmedCount/, 'the park counts arms, so a transient refusal reads true');
-  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')"),
-    'the parked poll still binds the drain-refresh spelling of the probe — while a turn is in flight (T240)');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1&' + pk : '/busy?' + pk)"),
+    'the parked poll still binds the drain-refresh spelling of the probe — while a turn is in flight (T240), carrying the park identity (T240c)');
   assert.match(src, /never armed/, 'the backstop apply line can still say the hold never armed');
   assert.match(src, /resetDrainNotices\(\)/, 'a fresh park re-arms the once-per-episode notices');
   assert.ok(src.includes('if (draining === false && park.lastAsked) {'),

--- a/tests/manager-drain.test.js
+++ b/tests/manager-drain.test.js
@@ -55,7 +55,8 @@ function scriptedStub() {
     const srv = http.createServer((req, res) => {
       stub.seen.push(req.url);
       res.setHeader('Content-Type', 'application/json');
-      const next = stub.answers.length ? stub.answers.shift() : stub.fallback;
+      const fb = typeof stub.fallback === 'function' ? stub.fallback(req.url) : stub.fallback;
+      const next = stub.answers.length ? stub.answers.shift() : fb;
       if (next === HOLD) { stub.held.push(res); return; }
       res.end(next);
     });
@@ -237,10 +238,12 @@ test('a park held only by background work polls plainly, carries its identity, a
   // backstop line blamed a lost hold — this drives the REAL park through the stub instead
   fs.writeFileSync(TOKEN_FILE, 'drain-probe-credential\n');
   kstub.seen.length = 0;
-  // the first, uninformed poll ASKS for the hold and the kernel arms it; every later poll is plain
-  // (0 in flight) and answers draining:false by construction — none of those may count as a refusal
-  kstub.answers = [JSON.stringify({ busy: 1, inflight: 0, background: 1, draining: true })];
-  kstub.fallback = JSON.stringify({ busy: 1, inflight: 0, background: 1, draining: false });
+  // the kernel answers what a real one does, BY PATH: a poll that asks (drain=1) arms the hold and
+  // reads draining:true, a plain poll reads draining:false. Path-aware rather than scripted, so a
+  // slow first round trip that lets the 25 ms tick issue a second uninformed probe never
+  // manufactures a refusal (review find: the scripted single arm made the test cadence-dependent)
+  kstub.answers = [];
+  kstub.fallback = (url) => JSON.stringify({ busy: 1, inflight: 0, background: 1, draining: /drain=1/.test(url) });
   let logged;
   try {
     logged = await capturedUntil(/applying deferred refresh/, () => { queueQuietRestart('ghost'); });
@@ -248,8 +251,12 @@ test('a park held only by background work polls plainly, carries its identity, a
   const applyLine = logged.split('\n').find((l) => /applying deferred refresh/.test(l));
   assert.match(applyLine, /backstop cap/, 'background work never quiets here, so the backstop applies');
   assert.doesNotMatch(applyLine, /refused|never armed|LOST/, 'plain polls answer draining:false by construction — no refusal');
-  const drainPolls = kstub.seen.filter((u) => /drain=1/.test(u));
-  assert.ok(drainPolls.length <= 1, 'only the first, uninformed poll asks for the hold: ' + kstub.seen.join(' '));
+  // the uninformed probe(s) ask for the hold; once the kernel has said 0 in flight, every later
+  // poll is plain — a prefix, never a return to asking (stall-tolerant: a tick that fires before
+  // the first answer lands issues one more uninformed probe)
+  const firstPlain = kstub.seen.findIndex((u) => !/drain=1/.test(u));
+  assert.ok(firstPlain >= 0 && firstPlain <= 2 && kstub.seen.slice(firstPlain).every((u) => !/drain=1/.test(u)),
+    'only the uninformed first probe(s) ask for the hold, then the polls stay plain: ' + kstub.seen.join(' '));
   assert.ok(kstub.seen.length >= 2 && kstub.seen.every((u) => /[?&]park=\d+/.test(u)),
     'every parked poll carries the park identity: ' + kstub.seen.join(' '));
 });

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -69,7 +69,7 @@ test('an unreachable kernel applies only after three consecutive missed polls (T
   assert.equal(quietGate({ since: 1000 }, null, 2000, QOPTS, null, 1).action, 'wait', 'first miss waits');
   assert.match(quietGate({ since: 1000 }, null, 2000, QOPTS, null, 2).reason, /missed \(2\/3\)/);
   const gone = quietGate({ since: 1000 }, null, 2000, QOPTS, null, 3);
-  assert.equal(gone.action, 'apply', 'a genuinely wedged kernel still restarts within ~10 s');
+  assert.equal(gone.action, 'apply', 'a genuinely wedged kernel still restarts in ~6 s (dead) to ~11 s (accepts, never answers)');
   assert.match(gone.reason, /unreachable.*3.*miss/, 'the apply line names the misses');
   assert.equal(quietGate({ since: 1000 }, null, 1000 + QOPTS.maxDeferMs, QOPTS, null, 1).action, 'apply',
     'the backstop is the ultimate bound whatever the poll did');
@@ -183,8 +183,10 @@ test('quietTick: the answer to the CURRENT park still applies exactly as before'
 test('the parked quiet poll refreshes the kernel drain lease in the same probe', () => {
   const fs = require('node:fs');
   const src = fs.readFileSync(path.join(__dirname, '..', 'bin', 'romp-manager'), 'utf8');
-  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')"),
-    'the quiet tick binds the drain-refresh spelling of the probe — while a turn is in flight (T240)');
+  assert.ok(src.includes("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1&' + pk : '/busy?' + pk)"),
+    'the quiet tick binds the drain-refresh spelling of the probe — while a turn is in flight (T240), carrying the park identity (T240c)');
+  assert.ok(src.includes("const pk = 'park=' + Math.round(park.since);"),
+    'the park identity keys the kernel\'s drain episode (T240c)');
   assert.ok(src.includes('const holdTurns = park.lastInflight === undefined || park.lastInflight > 0;'),
     'the hold is asked for only while a turn is actually in flight (or on the first, uninformed poll) — background-only busyness defers without freezing other sessions');
   assert.ok(src.includes('path: path || \'/busy\''),

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -62,8 +62,17 @@ test('in-flight turns defer the bounce', () => {
   assert.match(g.reason, /2 turn/);
 });
 
-test('an unreachable kernel applies — nothing a restart could cut', () => {
-  assert.equal(quietGate({ since: 1000 }, null, 2000, QOPTS).action, 'apply');
+test('an unreachable kernel applies only after three consecutive missed polls (T240b)', () => {
+  // T240b: ONE failed busy poll is a MISS, not quiet — under load (a review workflow's agents) the
+  // kernel answers /busy late, and a single null applied a parked deploy over live background work
+  // 10 minutes before the backstop (07:57Z 2026-09-07). Unreachable applies only after 3 misses.
+  assert.equal(quietGate({ since: 1000 }, null, 2000, QOPTS, null, 1).action, 'wait', 'first miss waits');
+  assert.match(quietGate({ since: 1000 }, null, 2000, QOPTS, null, 2).reason, /missed \(2\/3\)/);
+  const gone = quietGate({ since: 1000 }, null, 2000, QOPTS, null, 3);
+  assert.equal(gone.action, 'apply', 'a genuinely wedged kernel still restarts within ~10 s');
+  assert.match(gone.reason, /unreachable.*3.*miss/, 'the apply line names the misses');
+  assert.equal(quietGate({ since: 1000 }, null, 1000 + QOPTS.maxDeferMs, QOPTS, null, 1).action, 'apply',
+    'the backstop is the ultimate bound whatever the poll did');
 });
 
 test('the backstop cap applies even while busy — a deploy can never starve', () => {
@@ -103,6 +112,32 @@ test('quietTick: a throwing evaluation is LOUD and leaves the refresh queued', (
               opts: QOPTS, log: (m) => { logged = m; }, schedule: () => {}, apply: () => { applied++; } });
   assert.match(logged, /stays queued/);
   assert.equal(applied, 0);
+});
+
+test('quietTick: one timed-out busy poll then an answer waits — misses reset on any answer', () => {
+  // the 07:57Z shape: the poll times out once under load while background work runs; today the
+  // gate applied on that single null and cut every session's workflows
+  let applied = 0; const logs = []; const park = { since: 0 };
+  const answers = [[null, null], [1, { inflight: 0, background: 1 }]];
+  const deps = { pending: () => park, fetchBusy: (c) => c(...answers.shift()), now: () => 1000,
+                 opts: QOPTS, log: (m) => logs.push(m), schedule: () => {}, apply: () => { applied++; } };
+  quietTick(deps);                                  // miss 1
+  assert.equal(applied, 0, 'a single miss must not apply');
+  assert.equal(park.misses, 1);
+  assert.ok(logs.some((m) => /busy poll missed \(1\/3\)/.test(m)), 'each miss is logged with its streak: ' + logs);
+  quietTick(deps);                                  // an answer: busy, background work
+  assert.equal(applied, 0);
+  assert.equal(park.misses, 0, 'any answer resets the streak');
+});
+
+test('quietTick: three consecutive misses apply, naming them', () => {
+  let reason = ''; const park = { since: 0 };
+  const deps = { pending: () => park, fetchBusy: (c) => c(null, null), now: () => 1000,
+                 opts: QOPTS, log: () => {}, schedule: () => {}, apply: (g) => { reason = g.reason; } };
+  quietTick(deps); quietTick(deps);
+  assert.equal(reason, '', 'two misses still wait');
+  quietTick(deps);
+  assert.match(reason, /unreachable.*3.*miss/);
 });
 
 test('quietTick: a satisfied pending (an immediate restart won) neither probes nor re-arms', () => {

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -64,6 +64,30 @@ class DrainLease(unittest.TestCase):
         be.refresh_drain_hold()
         self.assertGreater(be._drain_hold_since, since0, "a new episode starts its own clock")
 
+    def test_the_episode_keys_on_the_managers_park_identity_not_a_window(self):
+        # T240c: the manager drops the hold for MINUTES during background-only stretches, so a time
+        # window mis-read the next in-flight re-arm as a new park; and a park held only by background
+        # work never reached refresh_drain_hold, so it never rang. The park identity on every parked
+        # poll fixes both: one "parked" line per park, the ring from a plain poll, a new park = new line.
+        logs = []
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=logs.append)
+        be.note_parked_poll("1700000000")                 # a plain parked poll (background-only park)
+        self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 1)
+        since0 = be._drain_hold_since
+        be.DRAIN_HOLD_TTL = 0.2
+        be.refresh_drain_hold(park="1700000000")          # a turn started: the hold arms — same park
+        time.sleep(0.3)                                    # …and lapses for far longer than any window
+        be.note_parked_poll("1700000000")
+        be.refresh_drain_hold(park="1700000000")
+        self.assertEqual(be._drain_hold_since, since0, "the same park is the same episode, whatever the gaps")
+        self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 1, "one line per park")
+        be._drain_hold_since = time.time() - be.DRAIN_LOUD_S - 1
+        be.note_parked_poll("1700000000")                 # a PLAIN poll rings — background-only parks are not silent
+        self.assertTrue(any("still parked" in str(l) for l in logs))
+        be.note_parked_poll("1700000900")                 # a new park identity: a new episode, its own line
+        self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 2)
+        self.assertGreater(be._drain_hold_since, since0)
+
     def test_arming_is_visible_and_a_long_hold_rings(self):
         logs = []
         be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=logs.append)
@@ -86,7 +110,7 @@ class DrainLease(unittest.TestCase):
         # T224 split the gate into branches so a REFUSED drain can be counted and said loudly; the
         # arm still sits under the explicit-token check and nowhere else
         self.assertIn('if q.get("drain", [""])[0] == "1":\n                        if self._write_token_ok(q):\n'
-                      '                            be.refresh_drain_hold()', ksrc,
+                      '                            be.refresh_drain_hold(park=park or None)', ksrc,
                       "/busy?drain=1 refreshes the lease in the same round-trip that reads the count — "
                       "but the arm is a WRITE, gated on an explicit token (the behavioral pins live "
                       "in tests/test_kernel_auth_hardening.py::BusyDrainWriteGate); the READ stays exempt")
@@ -99,7 +123,7 @@ class DrainLease(unittest.TestCase):
         self.assertNotIn("/restart-all?when=quiet'", ksrc,
                          "no kernel-side deploy path defaults to the quiet window any more")
         msrc = open(os.path.join(BIN, "romp-manager")).read()
-        self.assertIn("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1' : '/busy')", msrc,
+        self.assertIn("fetchBusy(KERNEL_PORT, cb, holdTurns ? '/busy?drain=1&' + pk : '/busy?' + pk)", msrc,
                       "the manager's PARKED poll is the lease's refresher")
 
 

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -76,7 +76,7 @@ class DrainLease(unittest.TestCase):
         since0 = be._drain_hold_since
         be.DRAIN_HOLD_TTL = 0.2
         be.refresh_drain_hold(park="1700000000")          # a turn started: the hold arms — same park
-        time.sleep(0.3)                                    # …and lapses for far longer than any window
+        be._drain_hold_until = time.time() - 10 * be.DRAIN_HOLD_TTL   # …and the lease lapsed far longer ago than any window
         be.note_parked_poll("1700000000")
         be.refresh_drain_hold(park="1700000000")
         self.assertEqual(be._drain_hold_since, since0, "the same park is the same episode, whatever the gaps")
@@ -87,6 +87,27 @@ class DrainLease(unittest.TestCase):
         be.note_parked_poll("1700000900")                 # a new park identity: a new episode, its own line
         self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 2)
         self.assertGreater(be._drain_hold_since, since0)
+
+    def test_an_empty_or_stale_park_identity_is_ignored(self):
+        # review finds: an empty identity on a fresh backend compared equal to the initial "" and
+        # rang a bogus "still parked after 29 million minutes" problem; and a stale probe from a park
+        # the manager had since replaced could flip the episode back and reset the newer park's clock
+        logs = []
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=logs.append)
+        be.note_parked_poll("")
+        be.note_parked_poll(None)
+        self.assertFalse(any("parked" in str(l) for l in logs), "nothing to key on: no episode, no ring")
+        self.assertFalse(be._drain_hold_rang)
+        self.assertFalse(any("still parked" in str(p) for p in be.problems()), "no fabricated ring")
+        be.note_parked_poll("1700000900")
+        since0 = be._drain_hold_since
+        be.note_parked_poll("1700000000")                 # a probe issued for the park this one replaced
+        self.assertEqual(be._drain_park, "1700000900", "a lower identity is a stale probe, not a new park")
+        self.assertEqual(be._drain_hold_since, since0)
+        self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 1)
+        be.note_parked_poll("not-a-number")                # a non-numeric identity is simply a different park
+        self.assertEqual(be._drain_park, "not-a-number")
+        self.assertEqual(sum("deploy restart parked" in str(l) for l in logs), 2)
 
     def test_arming_is_visible_and_a_long_hold_rings(self):
         logs = []

--- a/tests/test_deploy_drain.py
+++ b/tests/test_deploy_drain.py
@@ -109,11 +109,18 @@ class DrainLease(unittest.TestCase):
         ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         # T224 split the gate into branches so a REFUSED drain can be counted and said loudly; the
         # arm still sits under the explicit-token check and nowhere else
-        self.assertIn('if q.get("drain", [""])[0] == "1":\n                        if self._write_token_ok(q):\n'
-                      '                            be.refresh_drain_hold(park=park or None)', ksrc,
+        gate = 'if q.get("drain", [""])[0] == "1":\n                        if self._write_token_ok(q):\n'
+        self.assertIn(gate, ksrc,
                       "/busy?drain=1 refreshes the lease in the same round-trip that reads the count — "
                       "but the arm is a WRITE, gated on an explicit token (the behavioral pins live "
                       "in tests/test_kernel_auth_hardening.py::BusyDrainWriteGate); the READ stays exempt")
+        armed = ksrc[ksrc.index(gate):].split("_note_drain_armed()", 1)[0]
+        self.assertIn("be.refresh_drain_hold(park=park)", armed,
+                      "the arm carries the manager's park identity when the poll brought one (T240c)")
+        self.assertIn("be.refresh_drain_hold()", armed,
+                      "and keeps the old spelling for a poll without one: a backend that never learned "
+                      "the keyword still arms")
+        self.assertNotIn("_note_drain_refused()", armed, "both arms sit under the token check")
         self.assertIn('json.dumps({"busy": n, "inflight": inflight, "background": background,', ksrc,
                       "the payload says when the box is draining — glanceable, never mysterious")
         self.assertIn("'http://127.0.0.1:%d/restart-all'", ksrc,

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -230,8 +230,9 @@ class _DrainSpy:
     def busy_count(self):
         return 3
 
-    def refresh_drain_hold(self):
+    def refresh_drain_hold(self, park=None):
         self.refreshed += 1
+        self.park = park
         self.holding = True
 
     def drain_holding(self):

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -235,6 +235,9 @@ class _DrainSpy:
         self.park = park
         self.holding = True
 
+    def note_parked_poll(self, park):
+        self.parks = getattr(self, "parks", []) + [park]
+
     def drain_holding(self):
         return self.holding
 
@@ -295,6 +298,20 @@ class BusyDrainWriteGate(unittest.TestCase):
         status, _ = _serve_get("/busy?drain=1&token=" + TOK)
         self.assertEqual(status, 200)
         self.assertEqual(self.spy.refreshed, 1, "an explicit ?token= arms it too")
+
+    def test_the_park_identity_rides_the_same_token_as_the_arm(self):
+        # T240c review find: the park identity drives the drain EPISODE — its clock and its 5-minute
+        # problem ring — which is writable state a tokenless drive-by GET must not reach
+        status, _ = _serve_get("/busy?park=1700000000")
+        self.assertEqual(status, 200, "the read still answers")
+        self.assertEqual(getattr(self.spy, "parks", []), [], "a tokenless park is bookkeeping nobody asked for")
+        status, _ = _serve_get("/busy?park=1700000000", headers={"X-Romp-Token": TOK})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.spy.parks, ["1700000000"], "the manager's X-Romp-Token carries it")
+        status, _ = _serve_get("/busy?drain=1&park=1700000000", headers={"X-Romp-Token": TOK})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.spy.refreshed, 1)
+        self.assertEqual(self.spy.park, "1700000000", "…and the arm carries it too")
 
     # ── T224: a REFUSED drain is the one event the gate exists for — it must read LOUDLY ──
     def _refusals(self):

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -192,6 +192,8 @@ class DriftWiring(unittest.TestCase):
         now = time.time()
         audit = km.jd.STATE / "restart-audit.jsonl"
         audit.write_text(json.dumps({"t": int(now - 300), "action": "main-converge", "when": "now", "tag": "pull"}) + "\n")
+        started = km._STARTED
+        km._STARTED = now - 3600      # this process booted long before every row below
         try:
             # the request LANDED: a boot row newer than it (the cut row itself was lost)
             km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 296), "bootSettled": True, "pid": 1}) + "\n")
@@ -200,6 +202,25 @@ class DriftWiring(unittest.TestCase):
             # apply that restarted nothing — anchors NOTHING (event, not time)
             km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 900), "bootSettled": True, "pid": 1}) + "\n")
             self.assertEqual(km._last_deploy_restart_t(), 0.0, "requested, never landed")
+            # the RUNNING kernel is a boot too (review find): the new kernel's own boot row lands only
+            # after its first serve and reconcile, and the drift loop's first pass runs before that —
+            # a lost-row deploy must anchor on that very pass, not one boot row later
+            km._STARTED = now - 10
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 300, delta=2,
+                                   msg="a request older than this process has, by construction, been followed by a boot")
+            km._STARTED = now - 3600
+            # a cut row BETWEEN the request and the boot that the ledger did not join to it (review
+            # find): the restart that booted was recorded and attributed elsewhere — an anonymous
+            # manual restart ten minutes after a self-update click whose script failed — so the
+            # click restarted nothing and anchors nothing, however many boots follow it
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 94), "reason": "", "cutTurns": []}) + "\n"
+                                            + json.dumps({"t": int(now - 90), "bootSettled": True, "pid": 1}) + "\n")
+            self.assertEqual(km._last_deploy_restart_t(), 0.0, "a later unrelated restart does not land an earlier request")
+            # …but a cut row the ledger DID join to the request (auditT) is the request landing
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 294), "reason": "", "cutTurns": [],
+                                                        "auditT": int(now - 300)}) + "\n"
+                                            + json.dumps({"t": int(now - 290), "bootSettled": True, "pid": 1}) + "\n")
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 300, delta=2, msg="its own cut row is not a stranger's")
             km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 296), "bootSettled": True, "pid": 1}) + "\n")
             audit.write_text(json.dumps({"t": int(now - 200), "action": "main-converge", "tag": "abc"}) + "\n")
             self.assertEqual(km._last_deploy_restart_t(), 0.0, "a clicked-Update request row without when=now "
@@ -210,6 +231,7 @@ class DriftWiring(unittest.TestCase):
             km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 90), "bootSettled": True, "pid": 1}) + "\n")
             self.assertAlmostEqual(km._last_deploy_restart_t(), now - 100, delta=2, msg="a peer's apply anchors once it landed")
         finally:
+            km._STARTED = started
             audit.unlink()
 
     def test_the_parent_watch_stands_down_under_a_graceful_term(self):

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -193,23 +193,50 @@ class DriftWiring(unittest.TestCase):
         audit = km.jd.STATE / "restart-audit.jsonl"
         audit.write_text(json.dumps({"t": int(now - 300), "action": "main-converge", "when": "now", "tag": "pull"}) + "\n")
         try:
-            if km.RESTART_CUTS_FILE.exists():
-                km.RESTART_CUTS_FILE.unlink()
+            # the request LANDED: a boot row newer than it (the cut row itself was lost)
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 296), "bootSettled": True, "pid": 1}) + "\n")
             self.assertAlmostEqual(km._last_deploy_restart_t(), now - 300, delta=2, msg="no cut row needed")
+            # a request nothing has booted since — a self-update click whose script failed, a p2p
+            # apply that restarted nothing — anchors NOTHING (event, not time)
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 900), "bootSettled": True, "pid": 1}) + "\n")
+            self.assertEqual(km._last_deploy_restart_t(), 0.0, "requested, never landed")
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 296), "bootSettled": True, "pid": 1}) + "\n")
             audit.write_text(json.dumps({"t": int(now - 200), "action": "main-converge", "tag": "abc"}) + "\n")
             self.assertEqual(km._last_deploy_restart_t(), 0.0, "a clicked-Update request row without when=now "
                              "is not a landed deploy on its own")
             audit.write_text(json.dumps({"t": int(now - 100), "action": "p2p-update", "reason": "from X to Y",
                                          "when": "quiet"}) + "\n")
-            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 100, delta=2, msg="a peer's apply anchors too")
+            self.assertEqual(km._last_deploy_restart_t(), 0.0, "a peer's apply that has not restarted us yet anchors nothing")
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 90), "bootSettled": True, "pid": 1}) + "\n")
+            self.assertAlmostEqual(km._last_deploy_restart_t(), now - 100, delta=2, msg="a peer's apply anchors once it landed")
         finally:
             audit.unlink()
 
     def test_the_parent_watch_stands_down_under_a_graceful_term(self):
+        # behavioral (review find: the source-order pin executed nothing): the manager is gone —
+        # with the graceful term running the watchdog returns; without it, it exits the kernel
+        from unittest import mock
+        exits = []
+        saved = (km._pid_alive, os.environ.get("ROMP_MANAGER_PID"), km._TERMINATING[0])
+        km._pid_alive = lambda pid: False
+        os.environ["ROMP_MANAGER_PID"] = "424242"
+        try:
+            km._TERMINATING[0] = True
+            with mock.patch.object(km.os, "_exit", lambda code: exits.append(code)):
+                km._parent_watch()
+            self.assertEqual(exits, [], "the graceful term owns the exit")
+            km._TERMINATING[0] = False
+            with mock.patch.object(km.os, "_exit", lambda code: exits.append(code)):
+                km._parent_watch()
+            self.assertEqual(exits, [0], "a dead manager with no drain running still exits the kernel")
+        finally:
+            km._pid_alive = saved[0]
+            if saved[1] is None:
+                os.environ.pop("ROMP_MANAGER_PID", None)
+            else:
+                os.environ["ROMP_MANAGER_PID"] = saved[1]
+            km._TERMINATING[0] = saved[2]
         import inspect
-        pw = inspect.getsource(km._parent_watch)
-        self.assertLess(pw.index("if _TERMINATING[0]:"), pw.index("os._exit(0)"),
-                        "the watchdog never exits the kernel out from under its own drain")
         gt = inspect.getsource(km._graceful_term)
         self.assertLess(gt.index("_TERMINATING[0] = True"), gt.index("_broadcast_restarting()"),
                         "the flag is the FIRST thing the graceful term does")

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -85,7 +85,18 @@ class CutRow(unittest.TestCase):
             self.assertIn("p2p-update", km._recent_restart_reason(now=1240), "the restart it asked for")
             km._append_restart_cut({"t": 1240, "reason": "p2p-update: from X to abc1234", "cutTurns": [],
                                     "auditT": 1000})
-            self.assertEqual(km._recent_restart_reason(now=1900), "", "spent — the later cut is anonymous")
+            self.assertEqual(km._recent_restart_reason(now=1500), "", "spent — the later cut is anonymous")
+            # …and that anonymous cut's own row (no auditT) must not reset consumption: the NEXT
+            # anonymous cut inside the window used to re-inherit the row (rows alternated
+            # consumed / anonymous / consumed — review find)
+            km._append_restart_cut({"t": 1500, "reason": "", "cutTurns": []})
+            self.assertEqual(km._recent_restart_reason(now=1900), "", "still spent after an anonymous cut")
+            km._append_restart_cut({"t": 1900, "reason": "", "cutTurns": []})
+            self.assertEqual(km._recent_restart_reason(now=2100), "")
+            # a torn line NEWER than the consuming cut never disables the guard
+            with open(km.RESTART_CUTS_FILE, "a") as f:
+                f.write('{"t": 2100, "reason": "", "cutTur\n')
+            self.assertEqual(km._recent_restart_reason(now=2150), "", "a malformed line is skipped, not fatal")
         finally:
             audit.unlink()
             km.RESTART_CUTS_FILE.unlink()


### PR DESCRIPTION
Two commits, both follow-ups to T240 (the durable converge cool-down + background-aware quiet gate).

## Commit 1 — T240b: a missed busy poll is a miss, not quiet

The gate applied a parked deploy on **one** failed busy poll — under load (a review workflow's agents), exactly when the kernel answers `/busy` late. Verified in the manager journal (07:57Z 2026-09-07): a p2p-update parked at 07:52Z deferred correctly on "1 session(s) with background work", then "applying deferred refresh — kernel unreachable … waited 305s" cut every session's background work ten minutes before the backstop; `fetchBusy` carried a 2 s timeout, one slow answer became `busy === null`, and the gate's "unreachable counts as quiet" arm fired.

**Fix** (the tunnel supervisor's `STALE_MISSES` precedent): a null answer is a **miss**. `quietTick` counts the streak on the park, logs each miss with its count, and ends the streak loudly on any answer; `quietGate` stays pure and takes the count as an injected argument — unreachable applies only at `BUSY_MISS_LIMIT` (3) consecutive unanswered probes, waits below it ("busy poll missed (N/3)"), and the 15-minute backstop remains the ultimate bound. Poll timeout 2 s → 5 s. Measured bounds (review): a dead kernel applies at ~6 s, one that accepts but never answers at ~11 s; the stated trade-off is that a live kernel whose `/busy` latency stays above 5 s for three probes in a row is indistinguishable from a wedged one.

Pins, red-first (`node --test`): one timed-out poll then an answer with background work → waits, streak reset (red on main: applied); two misses wait; three apply with a reason naming them; the backstop applies regardless.

## Commit 2 — T240c: six residuals from the post-merge review of T240

- `_consumed_audit_t` read only the newest cut row, so an anonymous cut reset consumption and the next anonymous cut inside a quiet row's 20-minute window re-inherited its reason (rows alternated consumed / anonymous / consumed; a manual restart then anchored the cool-down). It returns the newest **non-zero** `auditT` past anonymous rows and parses per line.
- `_last_deploy_restart_t` counted a self-update click or a p2p request as a landed deploy with no outcome check. A request counts only once a **boot row newer than it** exists (event, not time); the lost-cut-row race stays covered by the surviving kernel's boot row.
- The drain episode keyed on a 2×TTL window, which the manager's minutes-long background-only stretches defeated, and a park held only by background work never rang. The manager now carries the **park identity on every parked poll** (`?park=<since>`); the kernel keys the episode on it — one "parked" line per park, the 5-minute ring from a plain poll — and an older manager keeps the window behavior.
- Behavioral node tests through the scripted stub replace source-string pins for the `lastAsked` refusal guard (a mutation had left every pin green); a behavioral parent-watch test replaces the source-order pin.
- Timing comment corrected to the measured bounds.

## Commits 3 and 4 — the stand-in fix and the review folds

- The route passes the park keyword only when a park arrived, so a backend or test stand-in with the old `refresh_drain_hold()` signature keeps arming (four write-gate tests were red on the second commit).
- Adversarial review of the T240c commit (two lenses, hermetic verification), five findings folded:
  - **Landing gate over-anchored.** A request counted once *any* later boot row existed, so a failed self-update click anchored the cool-down as soon as an unrelated manual restart booted. A request lands only if a boot at or after it exists **and** no cut row lies between the request and that boot unless the ledger joined it to this request via `auditT`. The lost-row race ("a boot, and no cut row between") still counts.
  - **First-drift-pass race.** The new kernel's own boot row lands after its first serve and reconcile, and the drift loop's first pass runs before that, so a lost-row deploy anchored nothing on exactly that pass. The running process is a boot too: `_STARTED` joins the boot set.
  - **Park identity under the write token.** It was read in the token-exempt block, so any loopback GET could reset a live park's ring clock or fabricate a "still parked" problem row. The manager already sends `X-Romp-Token` on every poll.
  - **Empty and stale identities.** Empty is a no-op (was a latent bogus ring), the ring needs a started clock, and an identity below the current one is a stale probe from a replaced park and is ignored.
  - **Test hygiene.** The behavioral node test's stub now answers by path like a real kernel, with a stall-tolerant prefix assertion; the drain test's dead sleep is a lease pushed into the past.
- Refuted by verification: the claim that the park-keyed test's headline assertion does not discriminate (the initial arm discriminates; only the comment was inaccurate, fixed with the sleep).

**Design point, unchanged and stated:** `busy_breakdown` counts every live `_bg_tasks` entry, including a never-ending background shell, so one such session defers every quiet deploy to the backstop for as long as it lives — the protection asked for; raised with the user as a policy item.

**Deploy note:** the manager is long-lived — this box picks both commits' manager half up at its next `romp-manager` restart.

Suites: python targeted 73, `node --test` 79, manager bats 7; full pytest on the branch pending at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
