### PR TITLE
The meta-command route reports the setter's own locked park verdict, and the drain's in-flight clear is pinned

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11013,7 +11013,7 @@ def _drive(msg, client):
         # the chat's fast badge — /fast on|off delivered like any slash command; mid-compaction → parked.
         # LOUD on refusal (fail loudly, never degrade silently): a dormant SDK session has no live CLI to
         # apply it, and silently swallowing the click would leave a toggle that "did nothing".
-        if not _set_fast_or_park(be, sid, str(msg["value"])):
+        if not _set_fast_or_park(be, sid, str(msg["value"]))[0]:
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't toggle fast mode — the session isn't connected right now."}))
         _push_soon()
@@ -21665,16 +21665,20 @@ def _set_model_or_park(be, sid, value, floating=False):
         _forget_model_pick(value)
     _mark_model_pending(sid, value)
     _note_model_pick(value)          # a version pick becomes its family's remembered default (2026-08-25)
-    if not _gate_or_park(sid, ("model", value)):
+    parked = _gate_or_park(sid, ("model", value))
+    if not parked:
         be.set_model(sid, value)
+    return parked
 
 
 def _set_effort_or_park(be, sid, value):
     """Apply an effort change now — or park it while the session compacts (the user 2026-07-02: /effort
     is a slash command like /model, so it must queue the same way — it used to slip straight through,
     with no queued chip and the same derail risk the /model park was built for)."""
-    if not _gate_or_park(sid, ("effort", value)):
+    parked = _gate_or_park(sid, ("effort", value))
+    if not parked:
         be.set_effort(sid, value)
+    return parked
 
 
 def _set_env_or_park(be, sid, value):
@@ -21699,13 +21703,16 @@ def _set_auth_or_park(be, sid, value):
 
 def _set_fast_or_park(be, sid, value):
     """Apply a fast-mode toggle now — or park it while the session compacts, exactly like /model and
-    /effort (it is a slash command and must keep press order in the same FIFO). Returns the backend's
-    verdict so the caller can be loud when a live apply refuses (dormant SDK session)."""
+    /effort (it is a slash command and must keep press order in the same FIFO). Returns (took, parked):
+    `took` is False on a bad value or a dormant SDK session's refused live apply (the caller is loud);
+    `parked` is True when the toggle queued (mid-compaction or behind a queue), so POST /send answers
+    queued truthfully from the setter's own locked decision rather than a second advisory gate read
+    (review find on #954, 2026-09-07)."""
     if value not in ("on", "off"):
-        return False
+        return (False, False)
     if _gate_or_park(sid, ("fast", value)):
-        return True
-    return be.set_fast(sid, value)
+        return (True, True)
+    return (be.set_fast(sid, value), False)
 
 
 def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
@@ -21735,16 +21742,16 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     # ours to swallow: it stays the CLI's, verbatim, and the user sees the CLI's own error.
     if not value or len(value.split()) != 1:
         return False
-    gate = _ops_gate(sid)                  # the setters park under exactly this gate; read here so `state` can say so
+    # each setter now DECIDES its park under the queue lock (#954) and returns it; read that verdict rather
+    # than a second, unlocked _ops_gate read that could disagree with the locked decision (review find on
+    # #954, 2026-09-07: a parked /model answered queued:false on POST /send). Also spares a redundant tmux
+    # fork + discover sweep + usage read per meta command.
     if head == "/model" and _vouched_model(value):
-        _set_model_or_park(be, sid, value, floating=floating)     # mid-compaction → parked as a queued command
-        parked = gate
+        parked = _set_model_or_park(be, sid, value, floating=floating)     # mid-compaction → parked as a queued command
     elif head == "/effort" and value in _EFFORT_VALUES:
-        _set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command
-        parked = gate
+        parked = _set_effort_or_park(be, sid, value)    # mid-compaction → parked as a queued command
     elif head == "/fast" and value in ("on", "off"):
-        took = _set_fast_or_park(be, sid, value)                  # mid-compaction → parked
-        parked = bool(took) and gate
+        took, parked = _set_fast_or_park(be, sid, value)          # took: applied or parked; parked: queued
         if not took and client:
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't toggle fast mode — the session isn't connected right now."}))

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -177,6 +177,24 @@ class HeadlessRoutes(unittest.TestCase):
         finally:
             km._pending_ops.clear()
 
+    def test_send_route_reads_the_setters_locked_verdict_not_a_second_gate(self):
+        # #954 moved the deciding park under the queue lock (_gate_or_park); the route must report the
+        # setter's OWN verdict, not a separate unlocked _ops_gate read that can disagree (review find on
+        # #954, 2026-09-07: a parked /model answered queued:false). Force the two apart: _gate_or_park
+        # parks (True) while _ops_gate reads False.
+        fake = mock.Mock(); fake.busy.return_value = None
+        km._pending_ops.clear()
+        try:
+            with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)), \
+                 mock.patch.object(km, "_ops_gate", lambda sid: False), \
+                 mock.patch.object(km, "_gate_or_park", lambda sid, op: (km._pending_ops.setdefault(str(sid), []).append(op) or True)):
+                code, resp = self._post("/send", {"id": "sid-x", "text": "/model sonnet"})
+            self.assertEqual((code, resp), (200, {"ok": True, "queued": True}),
+                             "the route reports the setter's locked park, not the unlocked gate")
+            fake.set_model.assert_not_called()
+        finally:
+            km._pending_ops.clear()
+
     def test_send_route_passes_a_remote_kernels_queued_through(self):
         # a session living on another kernel: its answer's `queued` rides back to the caller; an older
         # remote without the field reads as not queued (today's behaviour)

--- a/tests/test_kernel_parked_ops_lock.py
+++ b/tests/test_kernel_parked_ops_lock.py
@@ -25,6 +25,7 @@ SYNTHETIC fixtures only: placeholder uuids, invented texts.
 """
 import io
 import os
+import contextlib
 import tempfile
 import threading
 import time
@@ -633,3 +634,35 @@ class TheMirrorIsWrittenPerWriter(_Drain):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DrainRaiseClearsTheInFlightRecord(_Drain):
+    """The except path in _apply_pending_ops clears _inflight_ops for the sid — without it a drain that
+    raised mid-delivery leaves a stale in-flight record, and every later ✕ on that sid's head is refused
+    as 'too late' forever (review find on #954, 2026-09-07)."""
+
+    def test_a_raise_mid_delivery_does_not_leave_a_stale_in_flight_record(self):
+        # /compact is a turn-opening op: the drain records it in _inflight_ops, then calls the backend.
+        # Make that call raise; the sid's in-flight record must be cleared so a re-press is cancellable.
+        km._compact_or_park(self.be, SID)
+        self.assertEqual(km._pending_ops.get(SID), [("compact",)])
+        boom = mock.patch.object(self.be, "send", side_effect=RuntimeError("app-server died"))
+        with boom, contextlib.redirect_stderr(io.StringIO()):
+            km._apply_pending_ops()
+        self.assertNotIn(SID, km._inflight_ops, "the except path cleared the in-flight record")
+        # a second /compact press parks, and its ✕ is honoured — not refused as an in-flight head
+        km._compact_or_park(self.be, SID)
+        self.assertEqual(km._cancel_parked(SID, 0, km._parked_md(("compact",))), None,
+                         "the re-pressed compact is cancellable, not stuck behind a phantom in-flight op")
+
+    def test_the_park_wake_runs_after_the_lock_is_released(self):
+        # the drain's non-blocking top-of-walk acquire relies on a handler's park waking the pusher AFTER
+        # it drops the lock; a wake fired while still holding it could find the lock busy and skip a cycle
+        # with nothing to re-fire it (review find on #954, 2026-09-07).
+        held = []
+        with mock.patch.object(km, "_mark_views_dirty", lambda: held.append(km._pending_ops_lock._is_owned())):
+            km._park_op(SID, ("model", "opus"))
+            km._park_behind_queue(SID, ("send", "next", "human"))
+            km._cancel_parked(SID, 0, km._parked_md(("model", "opus")))
+        self.assertTrue(held, "the wake ran")
+        self.assertTrue(all(owned is False for owned in held), "every wake fired with the lock released")

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -108,20 +108,20 @@ class OpQueueParkOrDeliver(unittest.TestCase):
         # gate holds (compaction/open turn), a re-pick replaces the earlier parked toggle in place, and
         # _apply_pending_ops hands it to the backend once the session is quiet.
         km._compacting_now = lambda sid: True
-        self.assertTrue(km._set_fast_or_park(self.be, SID, "on"))
+        self.assertTrue(km._set_fast_or_park(self.be, SID, "on")[0])   # (took, parked): took
         km._send_or_park(self.be, SID, "then this", echo=None)
-        self.assertTrue(km._set_fast_or_park(self.be, SID, "off"))   # re-pick → in-place replace
+        self.assertTrue(km._set_fast_or_park(self.be, SID, "off")[0])   # re-pick → in-place replace
         self.assertEqual(self.be.calls, [], "mid-compaction the backend is NOT touched")
         self.assertEqual(km._pending_ops.get(SID),
                          [("fast", "off"), ("send", "then this", None)])
-        self.assertFalse(km._set_fast_or_park(self.be, SID, "sideways"), "only on|off are /fast arguments")
+        self.assertEqual(km._set_fast_or_park(self.be, SID, "sideways"), (False, False), "only on|off are /fast arguments")
         km.Sessions.backend_for = lambda sid: self.be
         km._compacting_now = lambda sid: False
         km._apply_pending_ops()
         self.assertEqual(self.be.calls, [("fast", "off"), ("send", "then this")],
                          "the toggle applies and delivery continues; the send ends the pass")
         km._compacting_now = lambda sid: False
-        self.assertTrue(km._set_fast_or_park(self.be, SID, "on"), "quiet session → applies immediately")
+        self.assertEqual(km._set_fast_or_park(self.be, SID, "on"), (True, False), "quiet session → applies immediately, not parked")
         self.assertEqual(self.be.calls[-1], ("fast", "on"))
 
     def test_apply_delivers_sequentially_when_quiet_and_not_before(self):


### PR DESCRIPTION
# PR 954 by lczh head 655549f9 labels=
## The parked-op queue is mutated under one lock that no backend call ever holds

Since the drain moved onto the pusher cycle (#904) it runs every 0.5 s and on every wake, on the pusher thread, while the WS and HTTP handler threads park and cancel ops in the same dict and the move thread re-inserts a head. Nothing serialized them. Adversarial review confirmed two races:

- A cancel, or the move thread's re-insert, could change a sid's list between the drain's head read and its pop. The drain then popped a list the cancel had just emptied (an `IndexError` its blanket `except` turned into a dropped queue), or the cancel's own check-then-pop landed on a list the drain had shifted and removed the op *behind* the one clicked.
- The disk mirror was written through one fixed temp path from any thread, so two writers could tear it and the next boot restored a wrong queue.

## What changes

**One RLock around every mutation** of the queue: the park, the cancel, the move thread's head re-insert, the drain's reads and pops, and the mirror write (now through `_atomic_write`'s per-writer temp name, so every snapshot is whole).

**The lock never spans a backend call.** `CodexBackend.send` can synchronously spawn and initialize the app server with no request timeout, and the SDK's `busy` and `turn_seq` take the backend's own lock, so a lock held across any of them would hold every handler's park behind it and could nest inside a backend lock. The drain takes the lock only to read a sid's head and to pop what a step delivered, releasing before the send, the setter or the `turn_seq` read. A raise still drops that sid's queue once, logged, exactly as before.

**The head stays the visible head while the backend has it.** Every handler gate keys on queue presence and otherwise on `busy`, which flips only once the backend has registered the op (the SDK backend runs `_ensure` under its own lock before it enqueues; the Codex backend may spawn the app server first). Popping before the call would leave the queue empty for that window, and a pane send landing in it would hand over *ahead* of a parked slash command. So a command, compact or settings op is read under the lock and recorded in flight, the call runs with the lock released and the op still at the head, and afterwards the head is popped only if it is still that very op. A cancel on the in-flight head is refused as too late rather than reported as a cancellation of something the backend already has; the refusal keys on the head slot, not identity alone, because a compact parks one interned tuple per code object. A move op is not recorded in flight (its only mid-call action is the `turn_seq` read), so a cancel on a waiting move still succeeds. The send run alone is popped before delivery, as the parent already did.

**Handler side:** the expensive gates (tmux fork, discover sweep, usage read, `busy`) run outside the lock as they always did; only the cheap queue-presence check and the park run under it, as one step (`_gate_or_park` / `_park_behind_queue`), so an op never slips past a queue another handler filled between the two reads. The top-of-walk acquire is non-blocking, so a cycle never stalls every session's push behind a handler.

Unchanged: the failure contract, park order and the sequential delivery rule, every gate and hold and where the hold is armed relative to the pops, and the rule that only a real mutation saves the mirror and wakes the pusher.

## Tests

`tests/test_kernel_parked_ops_lock.py` (17 tests) drives each race and each invariant: a cancel arriving while the backend has the head (in-flight one too late, the one behind cancelled, nothing dropped); a cancel paused between its body check and its pop while a drain cycle lands (event-keyed, no sleeps); a pane send issued from *inside* the backend's own call that must park behind the in-flight command (passes on `main`, fails when the head is popped before the call); a same-kind pick replacing the in-flight head; a second compact press cancelled while the first is with the backend; a waiting move cancelled from inside the `turn_seq` read; the locked re-check parking behind a queue the expensive gates missed; a backend that asserts from inside every call the drain makes that the drain does not own the lock and another thread can take it; and eight threads hammering the mirror. Source mutants that drop the locked re-check, the identity pop, the in-flight record or the head-slot refusal each fail exactly one test. Two setter source pins follow the setters' new call. The four test modules an earlier cut had rewritten are byte-identical to `main`.

Full suite 7346 passed / 44 skipped / 0 failed with nothing deselected; `bats tests/*.bats` 389/389.

## Notes for review

- **#923** (a model pick applies live mid-turn) edits the same lines of `_set_model_or_park`: it widens the gate but still reads the queue unlocked and hands over directly, which is the handler race this closes. Whichever lands second rebases; the shape here (gate function outside the lock, queue check + park inside) takes #923's wider gate unchanged.
- **#955** stacks on this one: it moves the drain's per-sid transcript-parse refresh out from under the lock to sit among the other gates that already run outside it, and reads the usage file once per drain instead of once per op. Its diff shows both commits until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

