### PR TITLE
Every PR carries one tier label: a required check and a template that asks for it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- One line: what this changes and why. -->
+
+## Tier
+
+Apply exactly one of these labels to the PR. The "PR tier" check fails until it carries one, and fails again if it carries two.
+
+- [ ] `tests-only`: tests, docs or repo plumbing; no behavior change.
+- [ ] `fix`: a bug fix, with a test that fails before it.
+- [ ] `feature`: a self-contained new capability.
+- [ ] `major-feature`: new functionality that changes what romp does or its contracts; discuss first.
+
+## Tests
+
+<!-- What you ran, and which test covers the change. -->

--- a/.github/workflows/pr-tier.yml
+++ b/.github/workflows/pr-tier.yml
@@ -1,0 +1,37 @@
+name: PR tier
+
+# Every PR carries exactly one tier label: tests-only, fix, feature or
+# major-feature. The tier says who merges it and after what review, so a PR
+# with no label has not been sorted yet and a PR with two has been sorted two
+# ways; this check fails in both cases and passes otherwise.
+#
+# It reads the labels from the event payload and nothing else: no checkout,
+# no token use, no third-party action, so a PR from a fork can run it safely.
+# It re-runs when the labels change, and on every push to the PR, so the
+# status on the PR is always about the labels it carries now. Making it a
+# REQUIRED check on main is a branch-ruleset setting in the repository
+# settings, which is the maintainers' call, not something this file can do.
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  tier:
+    name: Exactly one tier label
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Count the tier labels on this PR
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          count=$(jq '[.[] | select(. == "tests-only" or . == "fix" or . == "feature" or . == "major-feature")] | length' <<<"$LABELS")
+          if [ "$count" -eq 1 ]; then
+            exit 0
+          fi
+          echo "::error::This PR carries $count tier labels; exactly one is required: tests-only, fix, feature or major-feature."
+          exit 1


### PR DESCRIPTION
Lands the PR-tier check the maintainers agreed on, as staged by @ksarma in their fork draft (ksarma/romp#198), cherry-picked with authorship intact so it can become a required check now.

- `.github/workflows/pr-tier.yml` — workflow "PR tier", job **Exactly one tier label**: fails a PR carrying none or more than one of `tests-only` / `fix` / `feature` / `major-feature`, passes otherwise. Reads only the labels in the `pull_request` event payload: no checkout, no token use, no third-party action, `contents: read`. Re-runs on `labeled` / `unlabeled` / `synchronize` / `edited` / `opened` / `reopened`, so the status always reflects the labels the PR carries now.
- `.github/PULL_REQUEST_TEMPLATE.md` — asks for the tier up front, with a one-clause definition of each.

Follow-up once this is on main (a repository-settings change, not something the file can do): add the `Exactly one tier label` context to the required status checks of the "protect main" ruleset. Doing it before the workflow is on main would block every open PR behind a check that never reports.

Tier: `tests-only` (repo plumbing; no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)