### PR TITLE
T243: a queued notice romp itself injected wears the landed romp grammar, not the user's pending bubble

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17043,6 +17043,22 @@ def _genuine_queued(text):
     return not ("romp-msg-id" in t or t.startswith("####################") or "\U0001F4EC" in t)
 
 
+def _queued_romp_flags(text):
+    """The flags a LANDED romp-injected message gets from its markers (romp / rompSystem / rompAuto — see the
+    user-event build), read off a QUEUED text so the client can draw the same gray romp notice grammar for a
+    notice romp itself queued (T243, the user 2026-09-07: a queued watch notice wore the user's own pending
+    bubble). The markers stay in the text; the client hides them the way the landed card does."""
+    t = text or ""
+    out = {}
+    if "<!-- romp-injected -->" in t:
+        out["romp"] = True
+    if "<!-- romp-system -->" in t:
+        out["rompSystem"] = True
+    if "<!-- romp-auto -->" in t:
+        out["rompAuto"] = True
+    return out
+
+
 def _postal_shaped(text):
     """True when `text` is AGENT MAIL by shape — a postal banner (romp-msg-id / the #### rule / the mailbox
     glyph), the same recognizers _genuine_queued uses to keep agent mail out of the user's queued chip. The
@@ -23908,7 +23924,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                 # backend _pending position for cancelQueued.
                 continue
             goal, body, fu, ctx = _split_followup(t)
-            m = {"md": body, "idx": i, "cancelable": cancelable}   # idx ↔ the backend's _pending position (cancelQueued)
+            m = {"md": body, "idx": i, "cancelable": cancelable, **_queued_romp_flags(t)}   # idx ↔ the backend's _pending position (cancelQueued)
             if fu:
                 m["followUp"] = True
                 if goal:
@@ -23925,7 +23941,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         # romp-owned on EVERY backend — `park` is the op's _pending_ops position, and the body doubles as
         # the ✕ handshake (_parked_md/_cancel_parked verify it so a shifted queue never drops the wrong op).
         for j, op in enumerate(pending_ops):
-            m = {"md": _parked_md(op), "park": j, "cancelable": True}
+            m = {"md": _parked_md(op), "park": j, "cancelable": True, **(_queued_romp_flags(op[1]) if op[0] == "send" else {})}
             if op[0] == "send":
                 goal, _, fu, ctx = _split_followup(op[1])
                 if fu:

--- a/tests/test_idle_queue_drive.py
+++ b/tests/test_idle_queue_drive.py
@@ -828,6 +828,22 @@ class QueuedBubbleDisplay(unittest.TestCase):
         self.assertEqual(q["texts"][0]["idx"], 1,
                          "a surviving bubble's idx still names its backend _pending position")
 
+    def test_a_romp_injected_queued_entry_carries_the_landed_flags(self):
+        # T243 (the user 2026-09-07): a queued watch notice romp itself injected rendered as the user's own
+        # pending bubble. The queued entry now carries the same flags a LANDED romp message gets from the same
+        # markers (romp / rompSystem / rompAuto), so the client can draw the landed romp notice grammar
+        notice = ("<!-- romp-injected --><!-- romp-system --><!-- romp-tag: watch -->"
+                  "[romp] The pull request you asked romp to watch has MERGED: notes-api/web#12. This watch is done.")
+        nudge = "<!-- romp-injected --><!-- romp-auto -->Where does each of these stand?"
+        evs = self._events([notice, "please rerun the failing test", nudge])
+        q = next((e for e in evs if e.get("kind") == "queued"), None)
+        self.assertIsNotNone(q)
+        by_idx = {t["idx"]: t for t in q["texts"]}
+        self.assertEqual((by_idx[0].get("romp"), by_idx[0].get("rompSystem"), by_idx[0].get("rompAuto")), (True, True, None))
+        self.assertNotIn("romp", by_idx[1], "the user's own message carries no romp flag")
+        self.assertEqual((by_idx[2].get("romp"), by_idx[2].get("rompSystem"), by_idx[2].get("rompAuto")), (True, None, True))
+        self.assertIn("<!-- romp-injected -->", by_idx[0]["md"], "the marker still rides the text — the client hides it as the landed card does")
+
     def test_an_all_wrapper_queue_emits_no_queued_event(self):
         evs = self._events([_wrap(0)])
         self.assertIsNone(next((e for e in evs if e.get("kind") == "queued"), None),

--- a/tests/test_kernel_model_queue.py
+++ b/tests/test_kernel_model_queue.py
@@ -145,7 +145,7 @@ class QueuedBubble(unittest.TestCase):
         import inspect
         src = inspect.getsource(km.build_session)
         self.assertIn("pending_ops = _pending_ops.get(sid) or []", src)
-        self.assertIn('{"md": _parked_md(op), "park": j, "cancelable": True}', src,
+        self.assertIn('{"md": _parked_md(op), "park": j, "cancelable": True, **(_queued_romp_flags(op[1]) if op[0] == "send" else {})}', src,
                       "a parked model/effort renders as its slash-command chip, in park order — "
                       "cancelable since 2026-07-08 (_parked_md is the shared body renderer)")
         self.assertIn("if queued or pending_ops:", src,

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -395,7 +395,7 @@ class QueuedBubble(unittest.TestCase):
                       "the queued indicator shows even when a parked op is the only pending item")
         self.assertIn("for j, op in enumerate(pending_ops):", src,
                       "ONE loop, park order — rendering IS execution order")
-        self.assertIn('{"md": _parked_md(op), "park": j, "cancelable": True}', src,
+        self.assertIn('{"md": _parked_md(op), "park": j, "cancelable": True, **(_queued_romp_flags(op[1]) if op[0] == "send" else {})}', src,
                       "parked ops are CANCELABLE (the user 2026-07-08): park index + shared body renderer")
 
     def test_drive_routes_park_cancels(self):

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -96,5 +96,5 @@ test("the user bubble renders the user's OWN words with userMd, harness notes an
   assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(t\.md\);/);
   // romp-authored surfaces keep the assistant grammar: nudges, notices, the Continue gesture, tagged sends
   assert.match(RENDER, /full\.innerHTML = md\(raw\);/, "the romp nudge fold");
-  assert.match(RENDER, /body\.innerHTML = md\(text\);\n\s*return noticeCard\(\{ variant: "romp"/, "the romp system notice");
+  assert.match(RENDER, /if \(more\) body\.innerHTML = md\(text\);[^\n]*\n\s*return noticeCard\(\{ variant: "romp"/, "the romp system notice (a one-liner gets no body, T243)");
 });

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -92,7 +92,7 @@ test("the user bubble renders the user's OWN words with userMd, harness notes an
   assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(ev\.md\);/, "no user bubble left on the soft-wrap grammar");
   // the queued / optimistic bubble is the same message a beat earlier — same renderer, so the swap to the
   // landed bubble changes nothing on screen
-  assert.match(RENDER, /if \(!isCmd\) bubble\.innerHTML = userMd\(t\.md\);/);
+  assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\);/);
   assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(t\.md\);/);
   // romp-authored surfaces keep the assistant grammar: nudges, notices, the Continue gesture, tagged sends
   assert.match(RENDER, /full\.innerHTML = md\(raw\);/, "the romp nudge fold");

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -25,13 +25,13 @@ test("renderQueued draws a wireframe-hourglass header (singular/plural) + one ma
   assert.match(RENDER, /function hourglassIcon\(\): HTMLElement/);
   assert.match(RENDER, /stroke="currentColor"[\s\S]*?<path d="M4 3 H12 L8 8 L12 13 H4 L8 8 Z"\/>/, "wireframe hourglass path");
   // noun matches the content: all-commands → "command", all-prose → "message", mixed → "item" (the user 2026-07-01)
-  assert.match(RENDER, /const noun = nCmd === n \? "command" : nRomp === n \? "notice" : \(nCmd === 0 && nRomp === 0\) \? "message" : "item";/);   // notices: T243
+  assert.match(RENDER, /const noun = nCmd === n \? "command" : nSys === n \? "notice" : nNudge === n \? "nudge"\s*\n\s*: \(nCmd === 0 && nSys === 0 && nNudge === 0\) \? "message" : "item";/);   // romp's own entries: T243
   assert.match(RENDER, /return `\$\{n\} queued \$\{noun\}\$\{n === 1 \? "" : "s"\}`/);
-  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nRomp\) \+ why;/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nSys, nNudge\) \+ why;/);
   assert.match(RENDER, /el\("div", "queued-head"\)/);
   // one faint "you" bubble per pending message, rendered as markdown (like a landed message — the
   // user-text renderer, newlines kept, so the queued→landed swap changes nothing on screen)
-  assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\) \+ \(t\.romp \? " queued-romp" : ""\)\)/);
+  assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\)/);
   assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
 });
 
@@ -138,7 +138,7 @@ test("the ✕ reflows the GROUP, not just the bubble — the last one out takes 
   assert.match(RENDER, /if \(grp\) reflowQueuedGroup\(grp\);/, "called from the qx handler in the same breath");
   assert.match(RENDER, /if \(!bubbles\.length\) \{ turn\.remove\(\); return; \}/, "empty group → the whole turn goes");
   // still-populated group → the count is rewritten from what's actually left, keeping the held/ask suffix
-  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd, nRomp\) \+ \(label\.dataset\.why \|\| ""\);/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd, nSys, nNudge\) \+ \(label\.dataset\.why \|\| ""\);/);
   assert.match(RENDER, /label\.dataset\.why = why;/, "renderQueued parks the suffix for the recount to reuse");
 });
 
@@ -246,42 +246,55 @@ test("the kernel flags a romp-injected queued entry from the same markers as a l
   assert.match(KERNEL, /m = \{"md": _parked_md\(op\), "park": j, "cancelable": True, \*\*\(_queued_romp_flags\(op\[1\]\) if op\[0\] == "send" else \{\}\)\}/);
 });
 
-test("a romp-injected queued entry renders the landed romp notice card; a plain one stays a 'you' bubble (T243)", () => {
+test("what romp itself queued wears the LANDED romp grammar, split as landed: notice card vs gray romp bubble (T243)", () => {
   assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/, "the queued text shape carries the flags");
   const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
-  assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\) \+ \(t\.romp \? " queued-romp" : ""\)\);/);
-  // the landed card's own builder, nested inside the queued bubble — one grammar for both forms
-  assert.match(body, /if \(t\.romp\) \{[\s\S]*?noticeCard\(\{ variant: "romp", chip: "romp", logo: true, head: gist, body: nb,[\s\S]*?nested: true/);
-  // the marker tail and the [romp] prefix are hidden exactly the way the landed card hides them
+  assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\);/);
+  // a SYSTEM notice → the landed card's own builder, nested; a one-line notice gets no body repeating its head
+  assert.match(body, /if \(t\.rompSystem\) \{[\s\S]*?if \(more\) nb\.innerHTML = md\(text\);[\s\S]*?noticeCard\(\{ variant: "romp", chip: "romp", logo: true, head: gist, body: nb,[\s\S]*?collapsible: more, key: "qromp:" \+ qkey \+ ":" \+ gist\.slice\(0, 24\), nested: true/);
+  // any other romp message → the gray romp bubble with the landed gist rule (follow-up · goal / nudged for a status update · goal / first line)
+  assert.match(body, /\} else if \(t\.romp\) \{[\s\S]*?el\("div", "romp-tag"\)[\s\S]*?const rb = el\("div", "romp-bubble md"\);[\s\S]*?const gist = t\.followUp \? "follow-up" \+ \(t\.goal \? " · " \+ t\.goal : ""\)\s*\n\s*: t\.rompAuto \? "nudged for a status update" \+ \(t\.goal \? " · " \+ t\.goal : ""\)/);
+  assert.match(body, /rb\.dataset\.act = "nudgetoggle";[\s\S]*?const nkey = "qnudge:" \+ qkey \+ ":" \+ gist\.slice\(0, 24\);/);
+  // folds are keyed per queue slot, never by text alone
+  assert.match(body, /const qkey = t\.idx !== undefined \? "i" \+ t\.idx : t\.park !== undefined \? "p" \+ t\.park : "o";/);
+  // the marker tail and the [romp] prefix are hidden exactly the way the landed forms hide them
   assert.match(body, /t\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.replace\(\/\^\\s\*\\\[romp\\\]\\s\*\/i, ""\)\.trim\(\)/);
+  // a romp entry never wears the ↩ follow-up header (the landed romp turn suppresses it too)
+  assert.match(body, /if \(t\.followUp && !t\.romp\) turn\.appendChild\(followUpHeader/);
   // the plain path is untouched
   assert.match(body, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
-  // the ✕ stays; a notice is romp's words — cancelling it never restores it to the composer
+  // the ✕ stays; romp's words are never restored to the composer on cancel
+  assert.match(body, /x\.title = t\.rompSystem \? "cancel this queued notice" : t\.romp \? "cancel this queued nudge"/);
   assert.match(body, /if \(t\.romp\) x\.dataset\.qromp = "1";/);
   assert.match(RENDER, /if \(qmd && el\.dataset\.qcmd !== "1" && el\.dataset\.qromp !== "1"\)/);
-  // the gray tone replaces the dashed blue on the romp variant
+  // the gray tone replaces the dashed blue on the romp variants; the ✕ room is reserved only when there is a ✕
   assert.match(CSS, /\.queued-bubble\.queued-romp \{[^}]*background: transparent;[^}]*border: 0;/);
+  assert.match(CSS, /\.queued-bubble\.queued-romp\.cancelable > \.notice-card,\s*\n\s*\.queued-bubble\.queued-romp\.cancelable > \.romp-bubble \{ padding-right: 30px; \}/);
+  // the landed system notice shares the one-liner rule: no body repeating a one-line head
+  assert.match(RENDER, /if \(more\) body\.innerHTML = md\(text\);[\s\S]{0,200}?collapsible: more,\s*\n\s*key: ev\.uuid \? "rsys:" \+ ev\.uuid : undefined/);
 });
 
-test("the header noun counts notices honestly (T243)", () => {
-  assert.match(RENDER, /function queuedCountText\(n: number, nCmd: number, nRomp = 0\): string/);
-  assert.match(RENDER, /const nRomp = ev\.texts\.filter\(\(t\) => !!t\.romp\)\.length;/);
-  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nRomp\) \+ why;/);
-  // the ✕'s recount sees the romp bubbles too
-  assert.match(RENDER, /const nRomp = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-romp"\)\)\.length;/);
-  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd, nRomp\) \+ \(label\.dataset\.why \|\| ""\);/);
+test("the header noun counts romp's own entries honestly (T243)", () => {
+  assert.match(RENDER, /function queuedCountText\(n: number, nCmd: number, nSys = 0, nNudge = 0\): string/);
+  assert.match(RENDER, /const nSys = ev\.texts\.filter\(\(t\) => !!t\.rompSystem\)\.length;/);
+  assert.match(RENDER, /const nNudge = ev\.texts\.filter\(\(t\) => !!t\.romp && !t\.rompSystem\)\.length;/);
+  // the ✕'s recount sees them too
+  assert.match(RENDER, /const nSys = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-sys"\)\)\.length;/);
+  assert.match(RENDER, /const nNudge = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-romp"\) && !b\.classList\.contains\("queued-sys"\)\)\.length;/);
 });
 
 // executed replica of the extended noun rule — run, not just pinned (matches the function's text above)
-test("queuedCountText: all notices → 'notice'; a notice among messages → 'items'", () => {
-  const countText = (n: number, nCmd: number, nRomp = 0): string => {
-    const noun = nCmd === n ? "command" : nRomp === n ? "notice" : (nCmd === 0 && nRomp === 0) ? "message" : "item";
+test("queuedCountText: all notices → 'notice'; all nudges → 'nudge'; anything mixed → 'items'", () => {
+  const countText = (n: number, nCmd: number, nSys = 0, nNudge = 0): string => {
+    const noun = nCmd === n ? "command" : nSys === n ? "notice" : nNudge === n ? "nudge"
+      : (nCmd === 0 && nSys === 0 && nNudge === 0) ? "message" : "item";
     return `${n} queued ${noun}${n === 1 ? "" : "s"}`;
   };
-  assert.match(RENDER, /const noun = nCmd === n \? "command" : nRomp === n \? "notice" : \(nCmd === 0 && nRomp === 0\) \? "message" : "item";/);
-  assert.equal(countText(1, 0, 1), "1 queued notice");
-  assert.equal(countText(2, 0, 2), "2 queued notices");
-  assert.equal(countText(2, 0, 1), "2 queued items", "a notice among the user's messages — 'items', never 'messages'");
-  assert.equal(countText(2, 0, 0), "2 queued messages");
-  assert.equal(countText(1, 1, 0), "1 queued command");
+  assert.equal(countText(1, 0, 1, 0), "1 queued notice");
+  assert.equal(countText(2, 0, 2, 0), "2 queued notices");
+  assert.equal(countText(1, 0, 0, 1), "1 queued nudge");
+  assert.equal(countText(2, 0, 1, 0), "2 queued items", "a notice among the user's messages — 'items', never 'messages'");
+  assert.equal(countText(2, 0, 1, 1), "2 queued items", "a notice and a nudge — 'items'");
+  assert.equal(countText(2, 0, 0, 0), "2 queued messages");
+  assert.equal(countText(1, 1, 0, 0), "1 queued command");
 });

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,7 +13,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; imgPaths\?: string\[\] \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25)
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {
@@ -25,14 +25,14 @@ test("renderQueued draws a wireframe-hourglass header (singular/plural) + one ma
   assert.match(RENDER, /function hourglassIcon\(\): HTMLElement/);
   assert.match(RENDER, /stroke="currentColor"[\s\S]*?<path d="M4 3 H12 L8 8 L12 13 H4 L8 8 Z"\/>/, "wireframe hourglass path");
   // noun matches the content: all-commands → "command", all-prose → "message", mixed → "item" (the user 2026-07-01)
-  assert.match(RENDER, /const noun = nCmd === n \? "command" : nCmd === 0 \? "message" : "item";/);
+  assert.match(RENDER, /const noun = nCmd === n \? "command" : nRomp === n \? "notice" : \(nCmd === 0 && nRomp === 0\) \? "message" : "item";/);   // notices: T243
   assert.match(RENDER, /return `\$\{n\} queued \$\{noun\}\$\{n === 1 \? "" : "s"\}`/);
-  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd\) \+ why;/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nRomp\) \+ why;/);
   assert.match(RENDER, /el\("div", "queued-head"\)/);
   // one faint "you" bubble per pending message, rendered as markdown (like a landed message — the
   // user-text renderer, newlines kept, so the queued→landed swap changes nothing on screen)
-  assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\)/);
-  assert.match(RENDER, /if \(!isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
+  assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\) \+ \(t\.romp \? " queued-romp" : ""\)\)/);
+  assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
 });
 
 test("a queued slash command renders as a command chip, not a plain 'message' (the user 2026-07-01)", () => {
@@ -68,7 +68,7 @@ test("the delegated qx handler cancels click-safely: kernel op + composer restor
   assert.match(RENDER, /if \(el\.dataset\.qidx !== undefined\) msg\.idx = Number\(el\.dataset\.qidx\);/);
   assert.match(RENDER, /if \(el\.dataset\.qpark !== undefined\) msg\.park = Number\(el\.dataset\.qpark\);/);
   // a MESSAGE returns to the composer to re-edit; a slash COMMAND (qcmd) just cancels
-  assert.match(RENDER, /if \(qmd && el\.dataset\.qcmd !== "1"\) \{/);
+  assert.match(RENDER, /if \(qmd && el\.dataset\.qcmd !== "1" && el\.dataset\.qromp !== "1"\) \{/);
   assert.match(RENDER, /restoreToComposer\(qmd\);/);
   assert.match(RENDER, /const bub = el\.closest\("\.queued-bubble"\) as HTMLElement \| null;[\s\S]*?bub\?\.remove\(\);/,
     "optimistic removal before the next push");
@@ -138,7 +138,7 @@ test("the ✕ reflows the GROUP, not just the bubble — the last one out takes 
   assert.match(RENDER, /if \(grp\) reflowQueuedGroup\(grp\);/, "called from the qx handler in the same breath");
   assert.match(RENDER, /if \(!bubbles\.length\) \{ turn\.remove\(\); return; \}/, "empty group → the whole turn goes");
   // still-populated group → the count is rewritten from what's actually left, keeping the held/ask suffix
-  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd\) \+ \(label\.dataset\.why \|\| ""\);/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd, nRomp\) \+ \(label\.dataset\.why \|\| ""\);/);
   assert.match(RENDER, /label\.dataset\.why = why;/, "renderQueued parks the suffix for the recount to reuse");
 });
 
@@ -227,4 +227,61 @@ test("the head suffix: the hold beats the ask note, and no reset stamp means no 
   assert.equal(suffix({ what: "waiting for your monthly spend limit to be raised", resetsAt: null }, false),
     " · waiting for your monthly spend limit to be raised",
     "a spend cap has no readable reset — say the reason, promise no clock");
+});
+
+// ── T243 (the user 2026-09-07, with a screenshot): a QUEUED message romp itself injected — a watch notice
+// sitting in the "2 queued messages" group — rendered as an ordinary person-style bubble (dashed blue, ✕),
+// while the same message once LANDED renders as the gray romp notice card. The queued form now wears the
+// landed romp grammar: the kernel flags the queued entry from the same markers it flags landed messages
+// with (romp / rompSystem / rompAuto), renderQueued draws the notice card (gray tone, romp chip, marker tail
+// hidden, gist collapsed by default), the ✕ stays (a notice cancels without a composer restore), and the
+// header noun counts it honestly.
+test("the kernel flags a romp-injected queued entry from the same markers as a landed message (T243)", () => {
+  assert.match(KERNEL, /def _queued_romp_flags\(text\):/);
+  assert.match(KERNEL, /if "<!-- romp-injected -->" in t:\s*\n\s*out\["romp"\] = True/);
+  assert.match(KERNEL, /if "<!-- romp-system -->" in t:\s*\n\s*out\["rompSystem"\] = True/);
+  assert.match(KERNEL, /if "<!-- romp-auto -->" in t:\s*\n\s*out\["rompAuto"\] = True/);
+  // both the backend queue and the parked ops get the flags
+  assert.match(KERNEL, /m = \{"md": body, "idx": i, "cancelable": cancelable, \*\*_queued_romp_flags\(t\)\}/);
+  assert.match(KERNEL, /m = \{"md": _parked_md\(op\), "park": j, "cancelable": True, \*\*\(_queued_romp_flags\(op\[1\]\) if op\[0\] == "send" else \{\}\)\}/);
+});
+
+test("a romp-injected queued entry renders the landed romp notice card; a plain one stays a 'you' bubble (T243)", () => {
+  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/, "the queued text shape carries the flags");
+  const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
+  assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\) \+ \(t\.romp \? " queued-romp" : ""\)\);/);
+  // the landed card's own builder, nested inside the queued bubble — one grammar for both forms
+  assert.match(body, /if \(t\.romp\) \{[\s\S]*?noticeCard\(\{ variant: "romp", chip: "romp", logo: true, head: gist, body: nb,[\s\S]*?nested: true/);
+  // the marker tail and the [romp] prefix are hidden exactly the way the landed card hides them
+  assert.match(body, /t\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.replace\(\/\^\\s\*\\\[romp\\\]\\s\*\/i, ""\)\.trim\(\)/);
+  // the plain path is untouched
+  assert.match(body, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
+  // the ✕ stays; a notice is romp's words — cancelling it never restores it to the composer
+  assert.match(body, /if \(t\.romp\) x\.dataset\.qromp = "1";/);
+  assert.match(RENDER, /if \(qmd && el\.dataset\.qcmd !== "1" && el\.dataset\.qromp !== "1"\)/);
+  // the gray tone replaces the dashed blue on the romp variant
+  assert.match(CSS, /\.queued-bubble\.queued-romp \{[^}]*background: transparent;[^}]*border: 0;/);
+});
+
+test("the header noun counts notices honestly (T243)", () => {
+  assert.match(RENDER, /function queuedCountText\(n: number, nCmd: number, nRomp = 0\): string/);
+  assert.match(RENDER, /const nRomp = ev\.texts\.filter\(\(t\) => !!t\.romp\)\.length;/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(n, nCmd, nRomp\) \+ why;/);
+  // the ✕'s recount sees the romp bubbles too
+  assert.match(RENDER, /const nRomp = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-romp"\)\)\.length;/);
+  assert.match(RENDER, /label\.textContent = queuedCountText\(bubbles\.length, nCmd, nRomp\) \+ \(label\.dataset\.why \|\| ""\);/);
+});
+
+// executed replica of the extended noun rule — run, not just pinned (matches the function's text above)
+test("queuedCountText: all notices → 'notice'; a notice among messages → 'items'", () => {
+  const countText = (n: number, nCmd: number, nRomp = 0): string => {
+    const noun = nCmd === n ? "command" : nRomp === n ? "notice" : (nCmd === 0 && nRomp === 0) ? "message" : "item";
+    return `${n} queued ${noun}${n === 1 ? "" : "s"}`;
+  };
+  assert.match(RENDER, /const noun = nCmd === n \? "command" : nRomp === n \? "notice" : \(nCmd === 0 && nRomp === 0\) \? "message" : "item";/);
+  assert.equal(countText(1, 0, 1), "1 queued notice");
+  assert.equal(countText(2, 0, 2), "2 queued notices");
+  assert.equal(countText(2, 0, 1), "2 queued items", "a notice among the user's messages — 'items', never 'messages'");
+  assert.equal(countText(2, 0, 0), "2 queued messages");
+  assert.equal(countText(1, 1, 0), "1 queued command");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -158,7 +158,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; imgPaths?: string[] }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25)
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[] }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -3421,8 +3421,10 @@ function renderSlashCmd(bubble: HTMLElement, text: string): boolean {
 // a "message" — the user 2026-07-01).
 // The "N queued …" count. Shared with the ✕'s immediate recount so the number on screen can never drift
 // from the bubbles under it while the cancel is in flight.
-function queuedCountText(n: number, nCmd: number): string {
-  const noun = nCmd === n ? "command" : nCmd === 0 ? "message" : "item";
+function queuedCountText(n: number, nCmd: number, nRomp = 0): string {
+  // a notice romp itself queued is neither the user's message nor a command (T243): all notices → "notice";
+  // a notice among the user's messages → the mixed "item", never a claim of N "messages"
+  const noun = nCmd === n ? "command" : nRomp === n ? "notice" : (nCmd === 0 && nRomp === 0) ? "message" : "item";
   return `${n} queued ${noun}${n === 1 ? "" : "s"}`;
 }
 
@@ -3439,7 +3441,8 @@ function reflowQueuedGroup(turn: HTMLElement): void {
     return;
   }
   const nCmd = bubbles.filter((b) => b.querySelector(".slash-cmd-chip")).length;
-  label.textContent = queuedCountText(bubbles.length, nCmd) + (label.dataset.why || "");
+  const nRomp = bubbles.filter((b) => b.classList.contains("queued-romp")).length;
+  label.textContent = queuedCountText(bubbles.length, nCmd, nRomp) + (label.dataset.why || "");
 }
 
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
@@ -3463,6 +3466,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   if (!ev.bare) {
     const n = ev.texts.length;
     const nCmd = ev.texts.filter((t) => SLASH_CMD_RE.test(t.md)).length;
+    const nRomp = ev.texts.filter((t) => !!t.romp).length;
     const head = el("div", "queued-head");
     head.appendChild(hourglassIcon());
     // While a question is pending, say WHAT it's waiting on: a message you'd already written when the picker
@@ -3480,7 +3484,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       : askNote;
     const label = el("span", "queued-count");
     label.dataset.why = why;      // the ✕'s recount rewrites the count and keeps this suffix as-is
-    label.textContent = queuedCountText(n, nCmd) + why;
+    label.textContent = queuedCountText(n, nCmd, nRomp) + why;
     // `detail` is the CLI's OWN sentence about the limit (it carries the reset time as a wall clock, which
     // is why that flavor has no epoch to count down to). One level deeper on hover, per the compact-by-
     // default rule — the head keeps its one-line reason.
@@ -3490,7 +3494,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   }
   for (const t of ev.texts) {
     if (t.followUp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
-    const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : ""));
+    const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "") + (t.romp ? " queued-romp" : ""));
     // one phrase separating OUR unconfirmed echo from a real queued message, which the session has accepted
     // and is holding (the user 2026-07-16)
     if (t.optimistic) bubble.title = "sent just now — romp hasn't confirmed the session has it yet";
@@ -3500,7 +3504,21 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     else if (!t.cancelable && t.idx !== undefined)
       bubble.title = "queued in the session — it can't be recalled, and joins the conversation at the session's next step";
     const isCmd = renderSlashCmd(bubble, t.md);
-    if (!isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
+    if (t.romp) {
+      // a notice romp itself queued (a watch notice, a restart notice, a nudge) wears the LANDED romp grammar
+      // (T243, the user 2026-09-07): the same gray notice card the landed message becomes — chip, gist line,
+      // marker tail and "[romp]" prefix hidden, the full text one caret away — nested inside the queued bubble
+      // so the group's header, the ✕ and the recount keep working unchanged
+      const text = t.md.replace(/<!--[\s\S]*?-->/g, "").replace(/^\s*\[romp\]\s*/i, "").trim();
+      const firstLine = (text.split("\n").find((l) => l.trim()) || text).trim();
+      const gist = firstLine.length > 90 ? firstLine.slice(0, 88).replace(/\s+\S*$/, "") + "…" : firstLine;
+      const nb = el("div", "notice-md md");
+      nb.innerHTML = md(text);
+      bubble.appendChild(noticeCard({ variant: "romp", chip: "romp", logo: true, head: gist, body: nb,
+                                      collapsible: collapseWs(text) !== collapseWs(gist),
+                                      key: "qromp:" + gist.slice(0, 60), nested: true }));
+    }
+    if (!t.romp && !isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
     // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
     // user 2026-08-25: composer preview → path-only provisional → thumbnail landing flashed). Same
     // machinery end to end: userImage with the landed form's exact "path:" shape — buildPathImg's
@@ -3518,8 +3536,9 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     if (t.cancelable && (t.idx !== undefined || t.park !== undefined || t.optimistic)) {
       const x = el("button", "queued-x");
       x.textContent = "✕";
-      x.title = isCmd ? "cancel this queued command" : "cancel this queued message and move it back to the composer";
+      x.title = t.romp ? "cancel this queued notice" : isCmd ? "cancel this queued command" : "cancel this queued message and move it back to the composer";
       x.dataset.act = "qx";
+      if (t.romp) x.dataset.qromp = "1";   // romp's words, not the user's: cancelling never restores it to the composer (T243)
       if (t.idx !== undefined) x.dataset.qidx = String(t.idx);
       if (t.park !== undefined) x.dataset.qpark = String(t.park);
       if (t.optimistic) x.dataset.qopt = "1";   // ✕ before confirmation → cancel-by-body (no park/idx yet)
@@ -14290,7 +14309,7 @@ setupSettings();
       if (el.dataset.qidx !== undefined) msg.idx = Number(el.dataset.qidx);
       if (el.dataset.qpark !== undefined) msg.park = Number(el.dataset.qpark);
       vscodeApi.postMessage(msg);
-      if (qmd && el.dataset.qcmd !== "1") {
+      if (qmd && el.dataset.qcmd !== "1" && el.dataset.qromp !== "1") {
         // a message returns to the composer; a command just cancels. The restore is optimistic — stash
         // the composer's before/after so the kernel's cancelResult ok:false can undo it (untouched only).
         const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2296,9 +2296,10 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
       const firstLine = (text.split("\n").find((l) => l.trim()) || text).trim();
       const gist = firstLine.length > 90 ? firstLine.slice(0, 88).replace(/\s+\S*$/, "") + "…" : firstLine;
       const body = el("div", "notice-md md");
-      body.innerHTML = md(text);
+      const more = collapseWs(text) !== collapseWs(gist);
+      if (more) body.innerHTML = md(text);   // a one-line notice IS its gist — no body repeating the head (T243)
       return noticeCard({ variant: "romp", chip: "romp", logo: true, head: gist, body,
-                          collapsible: collapseWs(text) !== collapseWs(gist),
+                          collapsible: more,
                           key: ev.uuid ? "rsys:" + ev.uuid : undefined });
     }
     // Three flavors of a "user-role" turn: a GENUINE typed prompt → the blue right-aligned bubble; a
@@ -3421,10 +3422,11 @@ function renderSlashCmd(bubble: HTMLElement, text: string): boolean {
 // a "message" — the user 2026-07-01).
 // The "N queued …" count. Shared with the ✕'s immediate recount so the number on screen can never drift
 // from the bubbles under it while the cancel is in flight.
-function queuedCountText(n: number, nCmd: number, nRomp = 0): string {
-  // a notice romp itself queued is neither the user's message nor a command (T243): all notices → "notice";
-  // a notice among the user's messages → the mixed "item", never a claim of N "messages"
-  const noun = nCmd === n ? "command" : nRomp === n ? "notice" : (nCmd === 0 && nRomp === 0) ? "message" : "item";
+function queuedCountText(n: number, nCmd: number, nSys = 0, nNudge = 0): string {
+  // what romp itself queued is neither the user's message nor a command (T243): all system notices →
+  // "notice", all nudges/follow-ups → "nudge"; anything mixed → "item", never a claim of N "messages"
+  const noun = nCmd === n ? "command" : nSys === n ? "notice" : nNudge === n ? "nudge"
+    : (nCmd === 0 && nSys === 0 && nNudge === 0) ? "message" : "item";
   return `${n} queued ${noun}${n === 1 ? "" : "s"}`;
 }
 
@@ -3441,8 +3443,9 @@ function reflowQueuedGroup(turn: HTMLElement): void {
     return;
   }
   const nCmd = bubbles.filter((b) => b.querySelector(".slash-cmd-chip")).length;
-  const nRomp = bubbles.filter((b) => b.classList.contains("queued-romp")).length;
-  label.textContent = queuedCountText(bubbles.length, nCmd, nRomp) + (label.dataset.why || "");
+  const nSys = bubbles.filter((b) => b.classList.contains("queued-sys")).length;
+  const nNudge = bubbles.filter((b) => b.classList.contains("queued-romp") && !b.classList.contains("queued-sys")).length;
+  label.textContent = queuedCountText(bubbles.length, nCmd, nSys, nNudge) + (label.dataset.why || "");
 }
 
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
@@ -3466,7 +3469,8 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   if (!ev.bare) {
     const n = ev.texts.length;
     const nCmd = ev.texts.filter((t) => SLASH_CMD_RE.test(t.md)).length;
-    const nRomp = ev.texts.filter((t) => !!t.romp).length;
+    const nSys = ev.texts.filter((t) => !!t.rompSystem).length;
+    const nNudge = ev.texts.filter((t) => !!t.romp && !t.rompSystem).length;
     const head = el("div", "queued-head");
     head.appendChild(hourglassIcon());
     // While a question is pending, say WHAT it's waiting on: a message you'd already written when the picker
@@ -3484,7 +3488,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       : askNote;
     const label = el("span", "queued-count");
     label.dataset.why = why;      // the ✕'s recount rewrites the count and keeps this suffix as-is
-    label.textContent = queuedCountText(n, nCmd, nRomp) + why;
+    label.textContent = queuedCountText(n, nCmd, nSys, nNudge) + why;
     // `detail` is the CLI's OWN sentence about the limit (it carries the reset time as a wall clock, which
     // is why that flavor has no epoch to count down to). One level deeper on hover, per the compact-by-
     // default rule — the head keeps its one-line reason.
@@ -3493,8 +3497,9 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     turn.appendChild(head);
   }
   for (const t of ev.texts) {
-    if (t.followUp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
-    const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "") + (t.romp ? " queued-romp" : ""));
+    if (t.followUp && !t.romp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
+    const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "")
+                      + (t.romp ? " queued-romp" : "") + (t.rompSystem ? " queued-sys" : ""));
     // one phrase separating OUR unconfirmed echo from a real queued message, which the session has accepted
     // and is holding (the user 2026-07-16)
     if (t.optimistic) bubble.title = "sent just now — romp hasn't confirmed the session has it yet";
@@ -3504,19 +3509,53 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     else if (!t.cancelable && t.idx !== undefined)
       bubble.title = "queued in the session — it can't be recalled, and joins the conversation at the session's next step";
     const isCmd = renderSlashCmd(bubble, t.md);
-    if (t.romp) {
-      // a notice romp itself queued (a watch notice, a restart notice, a nudge) wears the LANDED romp grammar
-      // (T243, the user 2026-09-07): the same gray notice card the landed message becomes — chip, gist line,
-      // marker tail and "[romp]" prefix hidden, the full text one caret away — nested inside the queued bubble
-      // so the group's header, the ✕ and the recount keep working unchanged
+    // what romp itself queued wears the LANDED romp grammar (T243, the user 2026-09-07), split exactly as the
+    // landed message splits: a SYSTEM notice (restart / resume / a watch landing) is the gray notice card;
+    // any other romp message (an auto-nudge, the Nudge button's follow-up, a relay) is the gray romp bubble
+    // with its gist line — tag, gist, the full text one click away. Both nest inside the queued bubble so
+    // the group's header, the ✕ and the recount keep working unchanged. Folds are keyed per ENTRY (its queue
+    // slot), never by text alone: two identical notices must not share one expand state.
+    const qkey = t.idx !== undefined ? "i" + t.idx : t.park !== undefined ? "p" + t.park : "o";
+    if (t.rompSystem) {
       const text = t.md.replace(/<!--[\s\S]*?-->/g, "").replace(/^\s*\[romp\]\s*/i, "").trim();
       const firstLine = (text.split("\n").find((l) => l.trim()) || text).trim();
       const gist = firstLine.length > 90 ? firstLine.slice(0, 88).replace(/\s+\S*$/, "") + "…" : firstLine;
+      const more = collapseWs(text) !== collapseWs(gist);
       const nb = el("div", "notice-md md");
-      nb.innerHTML = md(text);
+      if (more) nb.innerHTML = md(text);   // a one-line notice IS its gist — no body repeating the head
       bubble.appendChild(noticeCard({ variant: "romp", chip: "romp", logo: true, head: gist, body: nb,
-                                      collapsible: collapseWs(text) !== collapseWs(gist),
-                                      key: "qromp:" + gist.slice(0, 60), nested: true }));
+                                      collapsible: more, key: "qromp:" + qkey + ":" + gist.slice(0, 24), nested: true }));
+    } else if (t.romp) {
+      const tag = el("div", "romp-tag");
+      const logo = el("img", "romp-tag-logo") as HTMLImageElement;
+      logo.src = mediaSrc("romp-swirl-glyph.svg"); logo.alt = ""; logo.onerror = () => logo.remove();
+      tag.appendChild(logo);
+      tag.appendChild(document.createTextNode("romp"));
+      bubble.appendChild(tag);
+      const rb = el("div", "romp-bubble md");
+      const raw = t.md.replace(/<!--[\s\S]*?-->/g, "").replace(/^\s*\[romp\]\s*/, "").trim();
+      const lines = raw.split("\n").map((l) => l.trim());
+      const firstLine = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || raw;
+      const gist = t.followUp ? "follow-up" + (t.goal ? " · " + t.goal : "")
+        : t.rompAuto ? "nudged for a status update" + (t.goal ? " · " + t.goal : "")
+        : firstLine.length > 90 ? firstLine.slice(0, 88).replace(/\s+\S*$/, "") + "…" : firstLine;
+      const more = collapseWs(raw) !== collapseWs(gist);
+      const gistEl = el("div", "nudge-gist");
+      if (more) { const c = el("span", "nudge-caret"); c.textContent = "▸"; gistEl.appendChild(c); }
+      gistEl.appendChild(document.createTextNode(gist));
+      rb.appendChild(gistEl);
+      if (more) {
+        const full = el("div", "nudge-full md");
+        full.innerHTML = md(raw);
+        rb.appendChild(full);
+        rb.classList.add("nudge-collapsible");
+        rb.dataset.act = "nudgetoggle";   // the stable body delegate, never a per-render listener
+        const nkey = "qnudge:" + qkey + ":" + gist.slice(0, 24);
+        rb.dataset.nkey = nkey;
+        applyFold(rb, "expanded", nkey);
+        rb.title = rb.classList.contains("expanded") ? "click to collapse" : "click to expand";
+      }
+      bubble.appendChild(rb);
     }
     if (!t.romp && !isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
     // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
@@ -3536,7 +3575,8 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     if (t.cancelable && (t.idx !== undefined || t.park !== undefined || t.optimistic)) {
       const x = el("button", "queued-x");
       x.textContent = "✕";
-      x.title = t.romp ? "cancel this queued notice" : isCmd ? "cancel this queued command" : "cancel this queued message and move it back to the composer";
+      x.title = t.rompSystem ? "cancel this queued notice" : t.romp ? "cancel this queued nudge"
+        : isCmd ? "cancel this queued command" : "cancel this queued message and move it back to the composer";
       x.dataset.act = "qx";
       if (t.romp) x.dataset.qromp = "1";   // romp's words, not the user's: cancelling never restores it to the composer (T243)
       if (t.idx !== undefined) x.dataset.qidx = String(t.idx);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1814,6 +1814,13 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   color: var(--dim); background: transparent; border: 0; border-radius: 6px; padding: 0;
 }
 .queued-x:hover { color: var(--vscode-errorForeground, #f48771); background: rgba(255, 255, 255, 0.08); }
+/* A notice romp itself queued (T243) wears the LANDED romp notice card nested inside the queued bubble: the
+   dashed "you" dress comes off the wrapper (the card brings its own gray tone), and the ✕ moves inside the
+   card's corner so it reads as the card's control. */
+.queued-bubble.queued-romp { background: transparent; border: 0; padding: 0; opacity: 1; }
+.queued-bubble.queued-romp.cancelable { padding-right: 0; }
+.queued-bubble.queued-romp.cancelable:hover { border-color: transparent; }
+.queued-bubble.queued-romp > .notice-card { padding-right: 30px; margin-top: 0; }
 /* NEVER-DELIVERED send (ev.undelivered): a message whose CLI died holding it — kept, because the bubble
    is the only surviving copy of the text, but marked as a LOSS instead of posing as delivered history
    (the user 2026-07-29). Dashed like the queued family (a send that never became a turn), red-edged like

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1820,7 +1820,9 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .queued-bubble.queued-romp { background: transparent; border: 0; padding: 0; opacity: 1; }
 .queued-bubble.queued-romp.cancelable { padding-right: 0; }
 .queued-bubble.queued-romp.cancelable:hover { border-color: transparent; }
-.queued-bubble.queued-romp > .notice-card { padding-right: 30px; margin-top: 0; }
+.queued-bubble.queued-romp > .notice-card { margin-top: 0; }
+.queued-bubble.queued-romp.cancelable > .notice-card,
+.queued-bubble.queued-romp.cancelable > .romp-bubble { padding-right: 30px; }   /* room for the ✕ only when there is one */
 /* NEVER-DELIVERED send (ev.undelivered): a message whose CLI died holding it — kept, because the bubble
    is the only surviving copy of the text, but marked as a LOSS instead of posing as delivered history
    (the user 2026-07-29). Dashed like the queued family (a send that never became a turn), red-edged like

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -20,7 +20,7 @@ test("renderQueued renders markdown (not raw text) + the follow-up header", () =
   const qStart = SRC.indexOf("function renderQueued");
   const fn = SRC.slice(qStart, SRC.indexOf("function renderApiError", qStart));
   assert.ok(fn.length > 0, "found renderQueued");
-  assert.match(fn, /if \(t\.followUp\) turn\.appendChild\(followUpHeader\(t\.goal, t\.fuCtx, t\.idx !== undefined \? "q:" \+ t\.idx : undefined\)\);/);
+  assert.match(fn, /if \(t\.followUp && !t\.romp\) turn\.appendChild\(followUpHeader\(t\.goal, t\.fuCtx, t\.idx !== undefined \? "q:" \+ t\.idx : undefined\)\);/);   // a romp entry never wears the header (T243)
   assert.match(fn, /bubble\.innerHTML = userMd\(t\.md\);/);   // markdown, through the user-text renderer (newlines kept)
   assert.doesNotMatch(fn, /textContent = t\b/, "no more raw textContent dump");
 });

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; imgPaths\?: string\[\] \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {


### PR DESCRIPTION
## Summary
A queued message that romp itself injected (the user's screenshot: a watch notice in the "2 queued messages" group) rendered as an ordinary person-style queued bubble, while the same message once landed renders as the gray romp notice card.

**Cause.** The kernel's queued fold keeps the raw text, markers included, but carried none of the flags the landed path derives from those markers, so `renderQueued` had nothing to key a romp variant on.

**Fix.** Each queued entry carries the landed flags (`romp` / `rompSystem` / `rompAuto`, from the identical markers; backend queue and parked sends alike). A romp-flagged entry renders with the landed card's own builder nested inside the queued bubble: gray notice card, romp chip, marker tail and `[romp]` prefix hidden, first line as the gist, full text one caret away. The ✕ stays but never restores romp's words to the composer. The header noun stays honest: all notices → "N queued notice(s)"; a notice among the user's messages → "items"; the ✕'s recount agrees.

## Tests (red first)
- `tests/test_idle_queue_drive.py` — a queued watch notice and an auto-nudge carry the flags; the user's message carries none; the marker still rides the text
- `ui/webview/queued-indicator.test.ts` — kernel helper + both fold sites, renderer romp variant + untouched plain path, no-restore cancel, CSS tone, noun rule (pinned and executed); existing pins retargeted

No harness screenshot this round: the served lab has no cheap way to seed a romp-injected entry into a live SDK queue; the pins cover the render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
