### PR TITLE
T243 follow-up: the queued nudge is the landed nudge's width and side, with the ✕ in its corner; folds keyed by text, not slot

### DIFF
--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -257,7 +257,8 @@ test("what romp itself queued wears the LANDED romp grammar, split as landed: no
   assert.match(body, /rb\.dataset\.act = "nudgetoggle";[\s\S]*?const nkey = "qnudge:" \+ qkey \+ ":" \+ gist\.slice\(0, 24\);/);
   // folds are keyed by the text's hash plus its occurrence — never the queue slot (it renumbers), never text alone
   assert.match(RENDER, /function strHash32\(str: string\): string/);
-  assert.match(body, /const sig = strHash32\(t\.md\);\s*\n\s*const nth = seenSig\.get\(sig\) \|\| 0;\s*\n\s*seenSig\.set\(sig, nth \+ 1\);\s*\n\s*const qkey = sig \+ ":" \+ nth;/);
+  assert.match(body, /const sig = strHash32\(t\.md\);\s*\n\s*const before = seenSig\.get\(sig\) \|\| 0;\s*\n\s*seenSig\.set\(sig, before \+ 1\);\s*\n\s*const nth = \(totalSig\.get\(sig\) \|\| 1\) - before - 1;/,
+    "the fold identity counts the identical texts AFTER the entry — the queue drains from the front");
   // the nudge's ✕ lives in its bubble's corner; the wrapper is the landed right-aligned column and the nested
   // bubble sheds its own 72% cap (T243 follow-up — measured in queued-romp-layout.test.ts)
   assert.match(body, /xHost = rb;/); assert.match(body, /xHost\.appendChild\(x\);/);

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -255,8 +255,14 @@ test("what romp itself queued wears the LANDED romp grammar, split as landed: no
   // any other romp message → the gray romp bubble with the landed gist rule (follow-up · goal / nudged for a status update · goal / first line)
   assert.match(body, /\} else if \(t\.romp\) \{[\s\S]*?el\("div", "romp-tag"\)[\s\S]*?const rb = el\("div", "romp-bubble md"\);[\s\S]*?const gist = t\.followUp \? "follow-up" \+ \(t\.goal \? " · " \+ t\.goal : ""\)\s*\n\s*: t\.rompAuto \? "nudged for a status update" \+ \(t\.goal \? " · " \+ t\.goal : ""\)/);
   assert.match(body, /rb\.dataset\.act = "nudgetoggle";[\s\S]*?const nkey = "qnudge:" \+ qkey \+ ":" \+ gist\.slice\(0, 24\);/);
-  // folds are keyed per queue slot, never by text alone
-  assert.match(body, /const qkey = t\.idx !== undefined \? "i" \+ t\.idx : t\.park !== undefined \? "p" \+ t\.park : "o";/);
+  // folds are keyed by the text's hash plus its occurrence — never the queue slot (it renumbers), never text alone
+  assert.match(RENDER, /function strHash32\(str: string\): string/);
+  assert.match(body, /const sig = strHash32\(t\.md\);\s*\n\s*const nth = seenSig\.get\(sig\) \|\| 0;\s*\n\s*seenSig\.set\(sig, nth \+ 1\);\s*\n\s*const qkey = sig \+ ":" \+ nth;/);
+  // the nudge's ✕ lives in its bubble's corner; the wrapper is the landed right-aligned column and the nested
+  // bubble sheds its own 72% cap (T243 follow-up — measured in queued-romp-layout.test.ts)
+  assert.match(body, /xHost = rb;/); assert.match(body, /xHost\.appendChild\(x\);/);
+  assert.match(CSS, /\.queued-bubble\.queued-romp:not\(\.queued-sys\) \{ display: flex; flex-direction: column; align-items: flex-end; \}/);
+  assert.match(CSS, /\.queued-bubble\.queued-romp > \.romp-bubble \{ max-width: none; position: relative; \}/);
   // the marker tail and the [romp] prefix are hidden exactly the way the landed forms hide them
   assert.match(body, /t\.md\.replace\(\/<!--\[\\s\\S\]\*\?-->\/g, ""\)\.replace\(\/\^\\s\*\\\[romp\\\]\\s\*\/i, ""\)\.trim\(\)/);
   // a romp entry never wears the ↩ follow-up header (the landed romp turn suppresses it too)

--- a/ui/webview/queued-romp-layout.test.ts
+++ b/ui/webview/queued-romp-layout.test.ts
@@ -71,11 +71,11 @@ function measure(): Measured | null {
   const driver = path.join(dir, "driver.mjs"); fs.writeFileSync(driver, DRIVER);
   const htmlPath = path.join(dir, "page.html"); fs.writeFileSync(htmlPath, html);
   try {
-    const p = cp.spawnSync("node", [driver], { encoding: "utf8", timeout: 120000,
+    const p = cp.spawnSync(process.execPath, [driver], { encoding: "utf8", timeout: 120000,   // the running node, never PATH
       env: { ...process.env, EXT_PKG: path.resolve(process.cwd(), "package.json"), HTML_PATH: htmlPath, CSS_PATH: CSS_PATH,
              SHOT: process.env.QROMP_LAYOUT_SHOT || "" } });
     if (p.status === 3) return null;                                  // no playwright / no browser here
-    if (p.status !== 0) throw new Error("layout driver failed: " + (p.stderr || p.stdout).slice(-800));
+    if (p.status !== 0) throw new Error("layout driver failed: " + String(p.stderr || p.stdout || p.error || "").slice(-800));
     const line = (p.stdout || "").split("\n").find((l: string) => l.startsWith("RESULT:"));
     if (!line) throw new Error("layout driver printed no result: " + (p.stdout || "").slice(-400));
     return JSON.parse(line.slice("RESULT:".length));

--- a/ui/webview/queued-romp-layout.test.ts
+++ b/ui/webview/queued-romp-layout.test.ts
@@ -1,0 +1,117 @@
+// T243 follow-up (my review's round-2 finding, 2026-09-07): the queued NUDGE form nests the landed .romp-tag +
+// .romp-bubble inside the .queued-bubble wrapper — but .romp-bubble kept its landed max-width: 72% inside a
+// wrapper already capped at 72%, the wrapper's block flow put the tag on the LEFT, and the wrapper-anchored ✕
+// floated 100px+ off the bubble on the tag's row. Measured with a real browser against the real stylesheet:
+// the queued nudge must be the landed nudge's width, right-aligned like it, with the ✕ in the bubble's corner
+// and a one-line gist staying one line. Runs only where a Playwright browser exists (CI installs none) — it
+// SKIPS LOUDLY there; the CI-safe source pins live in queued-indicator.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS_PATH = path.resolve(process.cwd(), "..", "ui", "webview", "styles.css");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const LONG = "Where does each of these stand? Tell me what shipped, what is next, or exactly what you need from me if you are stuck on any of it.";
+const GIST_LONG = LONG.slice(0, 88).replace(/\s+\S*$/, "") + "…";
+const tag = `<div class="romp-tag"><img class="romp-tag-logo" alt=""> romp</div>`;
+// the ✕ sits where render.ts puts it: inside the nested romp bubble for a nudge (T243b), on the wrapper for a notice
+const rb = (gist: string, cls = "", withX = false) =>
+  `<div class="romp-bubble md nudge-collapsible${cls}" data-act="nudgetoggle"><div class="nudge-gist"><span class="nudge-caret">▸</span>${gist}</div>` +
+  `<div class="nudge-full md"><p>${LONG}</p><p>${LONG}</p></div>${withX ? '<button class="queued-x">✕</button>' : ""}</div>`;
+const html = `<body style="margin:0;width:700px">
+<div id="landed-short" class="turn turn-user romp">${tag}${rb("follow-up · notes-api tests")}</div>
+<div id="landed-long" class="turn turn-user romp">${tag}${rb(GIST_LONG)}</div>
+<div id="q-short" class="turn turn-queued"><div class="queued-head"><span class="queued-count">1 queued nudge</span></div>
+  <div class="queued-bubble md cancelable queued-romp">${tag}${rb("follow-up · notes-api tests", "", true)}</div></div>
+<div id="q-long" class="turn turn-queued"><div class="queued-head"><span class="queued-count">1 queued nudge</span></div>
+  <div class="queued-bubble md cancelable queued-romp">${tag}${rb(GIST_LONG, "", true)}</div></div>
+<div id="q-sys" class="turn turn-queued"><div class="queued-head"><span class="queued-count">1 queued notice</span></div>
+  <div class="queued-bubble md cancelable queued-romp queued-sys"><div class="notice-card notice-card-romp notice-nested"><div class="notice-head"><span class="notice-chip notice-chip-romp">romp</span><span class="notice-head-text">${GIST_LONG}</span></div></div><button class="queued-x">✕</button></div></div>
+</body>`;
+
+type Box = { l: number; r: number; t: number; b: number; w: number; h: number } | null;
+type Measured = Record<string, { wrap: Box; tag: Box; bubble: Box; x: Box; gist: Box }>;
+
+// The measurement runs in a standalone driver process (the T225 served-test pattern): the test bundle is
+// CommonJS without top-level await, and esbuild must never try to bundle playwright itself.
+const DRIVER = `
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+let chromium;
+try { chromium = require("playwright").chromium; } catch (e) { process.exit(3); }
+let browser;
+try { browser = await chromium.launch(); } catch (e) { process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 900, height: 1100 } });
+await page.setContent(fs.readFileSync(process.env.HTML_PATH, "utf8"));
+await page.addStyleTag({ path: process.env.CSS_PATH });
+const out = await page.evaluate(() => {
+  const r = (el) => { if (!el) return null; const b = el.getBoundingClientRect(); return { l: Math.round(b.left), r: Math.round(b.right), t: Math.round(b.top), b: Math.round(b.bottom), w: Math.round(b.width), h: Math.round(b.height) }; };
+  const res = {};
+  for (const id of ["landed-short", "landed-long", "q-short", "q-long", "q-sys"]) {
+    const turn = document.getElementById(id);
+    res[id] = { wrap: r(turn.querySelector(".queued-bubble")), tag: r(turn.querySelector(".romp-tag")),
+                bubble: r(turn.querySelector(".romp-bubble") || turn.querySelector(".notice-card")),
+                x: r(turn.querySelector(".queued-x")), gist: r(turn.querySelector(".nudge-gist")) };
+  }
+  return res;
+});
+if (process.env.SHOT) await page.screenshot({ path: process.env.SHOT, fullPage: true });
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\\n");
+await browser.close();
+process.exit(0);
+`;
+
+function measure(): Measured | null {
+  const os = require("node:os");
+  const cp = require("node:child_process");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "qromp-layout-"));
+  const driver = path.join(dir, "driver.mjs"); fs.writeFileSync(driver, DRIVER);
+  const htmlPath = path.join(dir, "page.html"); fs.writeFileSync(htmlPath, html);
+  try {
+    const p = cp.spawnSync("node", [driver], { encoding: "utf8", timeout: 120000,
+      env: { ...process.env, EXT_PKG: path.resolve(process.cwd(), "package.json"), HTML_PATH: htmlPath, CSS_PATH: CSS_PATH,
+             SHOT: process.env.QROMP_LAYOUT_SHOT || "" } });
+    if (p.status === 3) return null;                                  // no playwright / no browser here
+    if (p.status !== 0) throw new Error("layout driver failed: " + (p.stderr || p.stdout).slice(-800));
+    const line = (p.stdout || "").split("\n").find((l: string) => l.startsWith("RESULT:"));
+    if (!line) throw new Error("layout driver printed no result: " + (p.stdout || "").slice(-400));
+    return JSON.parse(line.slice("RESULT:".length));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+}
+
+const m = measure();
+const skip = m ? false : "no Playwright browser here — the layout pin needs one (CI installs none); the CI-safe source pins live in queued-indicator.test.ts";
+
+test("a queued nudge is the landed nudge's width and stands on the landed side (T243b)", { skip }, () => {
+  const L = m!["landed-long"], Q = m!["q-long"];
+  assert.ok(Q.bubble!.w >= L.bubble!.w * 0.95, `queued bubble ${Q.bubble!.w}px vs landed ${L.bubble!.w}px — no 72%-of-72% double shrink`);
+  assert.ok(Math.abs(Q.bubble!.r - Q.wrap!.r) <= 2, "the bubble hugs the wrapper's right edge like the landed bubble hugs the turn's");
+  assert.ok(Math.abs(Q.tag!.r - Q.wrap!.r) <= 4, `the romp tag stands on the right (tag right ${Q.tag!.r}, wrapper right ${Q.wrap!.r})`);
+});
+
+test("the ✕ sits in the queued nudge bubble's corner, not off in the wrapper's gap (T243b)", { skip }, () => {
+  const Q = m!["q-long"];
+  const inside = Q.x!.l >= Q.bubble!.l && Q.x!.r <= Q.bubble!.r + 1 && Q.x!.t >= Q.bubble!.t && Q.x!.b <= Q.bubble!.b;
+  assert.ok(inside, `✕ ${JSON.stringify(Q.x)} must lie inside the bubble ${JSON.stringify(Q.bubble)}`);
+});
+
+test("a one-line queued gist stays one line, as landed (T243b)", { skip }, () => {
+  const L = m!["landed-short"], Q = m!["q-short"];
+  assert.ok(Q.gist!.h <= L.gist!.h + 2, `queued gist height ${Q.gist!.h} vs landed ${L.gist!.h} — the 72%-of-itself cap wrapped it`);
+});
+
+test("the queued SYSTEM notice card spans its wrapper with the ✕ inside its corner (unchanged, round 1)", { skip }, () => {
+  const S = m!["q-sys"];
+  assert.ok(Math.abs(S.bubble!.w - S.wrap!.w) <= 2, "the card spans the wrapper");
+  assert.ok(S.x!.l >= S.bubble!.l && S.x!.r <= S.bubble!.r + 1, "the ✕ is inside the card's corner");
+});
+
+test("render.ts hosts the nudge's ✕ inside the nested romp bubble (CI-safe pin, T243b)", () => {
+  const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
+  assert.match(body, /let xHost: HTMLElement = bubble;/);
+  assert.match(body, /xHost = rb;/, "a nudge's ✕ lives in its bubble's corner");
+  assert.match(body, /xHost\.appendChild\(x\);/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3517,7 +3517,12 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     head.appendChild(label);
     turn.appendChild(head);
   }
-  const seenSig = new Map<string, number>();   // text hash → how many identical texts precede this one
+  // text hash → how many identical texts the queue holds; each entry's fold identity is "hash : how many
+  // identical texts FOLLOW it" — the queue drains from the FRONT, so a duplicate landing ahead leaves every
+  // later duplicate's count untouched (counting the ones BEFORE renumbered them, review 2026-09-07)
+  const totalSig = new Map<string, number>();
+  for (const t of ev.texts) { const k = strHash32(t.md); totalSig.set(k, (totalSig.get(k) || 0) + 1); }
+  const seenSig = new Map<string, number>();
   for (const t of ev.texts) {
     if (t.followUp && !t.romp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
     const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "")
@@ -3539,8 +3544,9 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // text plus its occurrence among identical texts), never by the queue slot (which renumbers as entries
     // ahead land) and never by text alone (two identical notices must not share one expand state).
     const sig = strHash32(t.md);
-    const nth = seenSig.get(sig) || 0;
-    seenSig.set(sig, nth + 1);
+    const before = seenSig.get(sig) || 0;
+    seenSig.set(sig, before + 1);
+    const nth = (totalSig.get(sig) || 1) - before - 1;   // identical texts AFTER this one — stable across a front drain
     const qkey = sig + ":" + nth;
     let xHost: HTMLElement = bubble;   // where the ✕ lives: the nudge's own bubble corner, else the wrapper
     if (t.rompSystem) {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3460,6 +3460,15 @@ function reflowQueuedGroup(turn: HTMLElement): void {
   label.textContent = queuedCountText(bubbles.length, nCmd, nSys, nNudge) + (label.dataset.why || "");
 }
 
+// A stable per-text identity for the queued romp folds (T243 follow-up): the queue SLOT renumbers as entries
+// ahead land or are cancelled, which snapped an expanded fold shut with no user action; the text hash plus
+// its occurrence among identical texts survives the shift and still tells two identical notices apart.
+function strHash32(str: string): string {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) h = ((h << 5) + h + str.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   const turn = el("div", "turn turn-queued");
   // A BARE group is romp's own optimistic echo with nothing else known-queued: "N queued messages" is a
@@ -3508,6 +3517,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     head.appendChild(label);
     turn.appendChild(head);
   }
+  const seenSig = new Map<string, number>();   // text hash → how many identical texts precede this one
   for (const t of ev.texts) {
     if (t.followUp && !t.romp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
     const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "")
@@ -3526,8 +3536,13 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // any other romp message (an auto-nudge, the Nudge button's follow-up, a relay) is the gray romp bubble
     // with its gist line — tag, gist, the full text one click away. Both nest inside the queued bubble so
     // the group's header, the ✕ and the recount keep working unchanged. Folds are keyed per ENTRY (its queue
-    // slot), never by text alone: two identical notices must not share one expand state.
-    const qkey = t.idx !== undefined ? "i" + t.idx : t.park !== undefined ? "p" + t.park : "o";
+    // text plus its occurrence among identical texts), never by the queue slot (which renumbers as entries
+    // ahead land) and never by text alone (two identical notices must not share one expand state).
+    const sig = strHash32(t.md);
+    const nth = seenSig.get(sig) || 0;
+    seenSig.set(sig, nth + 1);
+    const qkey = sig + ":" + nth;
+    let xHost: HTMLElement = bubble;   // where the ✕ lives: the nudge's own bubble corner, else the wrapper
     if (t.rompSystem) {
       const text = t.md.replace(/<!--[\s\S]*?-->/g, "").replace(/^\s*\[romp\]\s*/i, "").trim();
       const firstLine = (text.split("\n").find((l) => l.trim()) || text).trim();
@@ -3568,6 +3583,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
         rb.title = rb.classList.contains("expanded") ? "click to collapse" : "click to expand";
       }
       bubble.appendChild(rb);
+      xHost = rb;   // the ✕ in the bubble's corner, as a landed bubble would wear it — never floating in the wrapper's gap
     }
     if (!t.romp && !isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
     // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
@@ -3596,7 +3612,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       if (t.optimistic) x.dataset.qopt = "1";   // ✕ before confirmation → cancel-by-body (no park/idx yet)
       if (isCmd) x.dataset.qcmd = "1";
       (x as any)._qmd = t.md;   // the bubble's body — the kernel's drift guard + the composer restore read it
-      bubble.appendChild(x);
+      xHost.appendChild(x);
     }
     turn.appendChild(bubble);
   }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1821,6 +1821,12 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .queued-bubble.queued-romp.cancelable { padding-right: 0; }
 .queued-bubble.queued-romp.cancelable:hover { border-color: transparent; }
 .queued-bubble.queued-romp > .notice-card { margin-top: 0; }
+/* The queued NUDGE nests the landed .romp-tag + .romp-bubble: the wrapper is the landed romp turn's own
+   right-aligned column (tag above, bubble flush right), the nested bubble sheds its own 72% cap (the
+   wrapper already carries it — nested, it shrank to 72% of 72% and wrapped one-line gists) and anchors the
+   ✕ in ITS corner, not the wrapper's (T243 follow-up, measured in queued-romp-layout.test.ts). */
+.queued-bubble.queued-romp:not(.queued-sys) { display: flex; flex-direction: column; align-items: flex-end; }
+.queued-bubble.queued-romp > .romp-bubble { max-width: none; position: relative; }
 .queued-bubble.queued-romp.cancelable > .notice-card,
 .queued-bubble.queued-romp.cancelable > .romp-bubble { padding-right: 30px; }   /* room for the ✕ only when there is one */
 /* NEVER-DELIVERED send (ev.undelivered): a message whose CLI died holding it — kept, because the bubble


### PR DESCRIPTION
## Summary
Follow-up to #990, from my own review of the merged change, measured in a browser: the queued **nudge** form nested the landed romp tag and bubble inside the queued wrapper, but the bubble kept its own `max-width: 72%` inside a wrapper already capped at 72% (363 px where the landed bubble is 487 px; a one-line gist wrapped), the wrapper's block flow put the romp tag on the left, and the wrapper-anchored ✕ floated 117 px off the bubble.

**Fix.** The wrapper becomes the landed romp turn's own right-aligned column; the nested bubble sheds its cap and anchors the ✕ in its own corner (the renderer appends a nudge's ✕ to the bubble). The system-notice card path is unchanged. The romp folds are keyed by the text's hash plus its occurrence instead of the queue slot, which renumbers as entries ahead land.

## Test (red first)
`ui/webview/queued-romp-layout.test.ts` drives the emitted structure and the real stylesheet through a standalone Playwright driver and measures: queued bubble ≥ 95% of the landed width, bubble and tag flush right, ✕ inside the bubble, one-line gist one line, notice card unchanged. Skips loudly without a browser (CI installs none); CI-safe source pins ride `queued-indicator.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
