### PR TITLE
The converge stands down for a quiet deploy already parked for the code on disk

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1714,13 +1714,21 @@ case "${1:-}" in
                    RA_PPID="$PPID" \
                    RA_PARENT="$(ps -o command= -p "$PPID" 2>/dev/null | head -1)" \
                    RA_TTY="$(tty 2>/dev/null || true)" \
-                   RA_SID="$_ra_sid" RA_NAME="$_ra_name" \
+                   RA_SID="$_ra_sid" RA_NAME="$_ra_name" RA_WHEN="${2:-}" \
+                   RA_SHA="$(git -C "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)" rev-parse --short=8 HEAD 2>/dev/null || true)" \
                    python3 - >> "$_ra_dir/restart-audit.jsonl" <<'PYEOF'
 import json, os, time
-print(json.dumps({"t": int(time.time()), "ppid": int(os.environ.get("RA_PPID") or 0),
-                  "parent": os.environ.get("RA_PARENT") or "", "sid": os.environ.get("RA_SID") or "",
-                  "name": os.environ.get("RA_NAME") or "", "tty": os.environ.get("RA_TTY") or "",
-                  "tmux": os.environ.get("TMUX_PANE") or ""}))
+row = {"t": int(time.time()), "ppid": int(os.environ.get("RA_PPID") or 0),
+       "parent": os.environ.get("RA_PARENT") or "", "sid": os.environ.get("RA_SID") or "",
+       "name": os.environ.get("RA_NAME") or "", "tty": os.environ.get("RA_TTY") or "",
+       "tmux": os.environ.get("TMUX_PANE") or ""}
+if os.environ.get("RA_WHEN") == "--quiet":
+    # a PARKED restart: the kernel's drift check reads when + sha to stand down for it (T240d) —
+    # without them an immediate converge pre-empted the quiet window this flag asked for
+    row["when"] = "quiet"
+    if os.environ.get("RA_SHA"):
+        row["sha"] = os.environ["RA_SHA"]
+print(json.dumps(row))
 PYEOF
                } 2>/dev/null || true
                "${ROMP_POSTAL_BIN:-romp-postal-service}" restart >/dev/null 2>&1 || true

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4444,11 +4444,14 @@ def _parked_quiet_deploy(checkout, now=None):
     already gives such a row for cut attribution. So a park lost with its manager self-heals at that
     bound, and the cut row that lands the deploy consumes the row: events, not a timer of this
     function's own. The p2p row's sha rides its reason ("from <host> to <sha>"); the converge row
-    carries `sha` outright; a quiet row naming no sha matches nothing (never guess)."""
+    carries `sha` outright, and so does the CLI's `romp refresh --quiet` row, which names no action
+    (bin/romp's caller-attribution row, review find: that door parked a quiet restart the check
+    pre-empted just the same); a quiet row naming no sha matches nothing (never guess)."""
     rec = _recent_restart_audit(now=now)
     if not isinstance(rec, dict) or rec.get("when") != "quiet" or not checkout:
         return 0
-    if str(rec.get("action") or "") not in ("p2p-update", "main-converge"):
+    act = str(rec.get("action") or "")
+    if act and act not in ("p2p-update", "main-converge"):
         return 0
     sha = str(rec.get("sha") or "")
     if not sha:
@@ -4470,11 +4473,12 @@ def _main_drift_check():
         # one notice per new TAG, from _update_check — and must never hear about dev commits.
         # The maintainer's mesh keeps this watcher through its own signals (_main_channel_verdict).
         return
-    checkout = _checkout_sha()      # ONE read: the verdict's input and the parked-deploy match below
-    kind, target = _main_drift_verdict(_origin_main_sha(), checkout, _kernel_sha())
+    checkout = _checkout_sha()      # ONE read each: the verdict's inputs and the parked-deploy
+    running = _kernel_sha()         # match below read the same shas the verdict examined
+    kind, target = _main_drift_verdict(_origin_main_sha(), checkout, running)
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
-    if kind == "restart" and not _kernel_code_changed(_kernel_sha(), target):
+    if kind == "restart" and not _kernel_code_changed(running, target):
         # NO-KERNEL-CODE drift (the user 2026-08-23, widened T216): the checkout moved but nothing
         # the running process executes changed — converge in place, in EVERY mode and with no
         # cool-down (in-place converges cut no turns, which is the only thing the gates protect).
@@ -4485,6 +4489,7 @@ def _main_drift_check():
             return
     if not kind:
         _MAIN_DRIFT[0] = _MAIN_DRIFT[1] = ""          # in sync: a future drift is new information again
+        _QUIET_PARKED_LOGGED[0] = ""                  # whatever was parked has landed
         return
     slot = 0 if kind == "pull" else 1
     if _MAIN_DRIFT[slot] == target:
@@ -4511,14 +4516,22 @@ def _main_drift_check():
         # leave it to the window — one restart, and any pull follows on the pass after it lands. Not
         # marked acted on: the pass after the row is consumed (or expires) re-evaluates. Said once per
         # sha, not once per pass. The immediate policy for a genuinely new pull (T160) and the
-        # cool-down are unchanged.
-        if _parked_quiet_deploy(checkout):
+        # cool-down are unchanged. Only while the restart is still OWED (the kernel does not yet run
+        # the checkout): a quiet deploy that landed but lost its cut row leaves its row unconsumed
+        # for the rest of the window, and a pull must not wait on a park that already delivered
+        # (review find). When a stand-down ends without that landing — the row expired, the park
+        # died with its manager — say so once and let the converge proceed on its own terms.
+        if running != checkout and _parked_quiet_deploy(checkout):
             if _QUIET_PARKED_LOGGED[0] != checkout:
                 _QUIET_PARKED_LOGGED[0] = checkout
                 sys.stderr.write("romp-kernel: converge: %s already parked as a quiet deploy — leaving it "
                                  "to the quiet window\n" % checkout[:8])
             _MAIN_DRIFT[slot] = ""
             return
+        if _QUIET_PARKED_LOGGED[0] == checkout:
+            _QUIET_PARKED_LOGGED[0] = ""
+            sys.stderr.write("romp-kernel: converge: the quiet deploy parked for %s is no longer pending — "
+                             "the converge proceeds on its own terms\n" % checkout[:8])
         last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
         if time.time() - last < _CONVERGE_COOLDOWN_S:
             _MAIN_DRIFT[slot] = ""
@@ -4529,7 +4542,7 @@ def _main_drift_check():
         if target in _dismissed_updates():
             return                    # Not-now'd THIS sha, durably — a NEW sha offers again
         _send_to_app("shell", {"type": "updateAvail", "kind": "main", "drift": kind,
-                               "cur": _kernel_sha() or "", "tag": target, "boot": _BOOT_ID})
+                               "cur": running or "", "tag": target, "boot": _BOOT_ID})
 
 
 # HTTP-triggered restarts resolve ROMP_MANAGER_PORT BEFORE their ack goes out (2026-08-27): the
@@ -15771,10 +15784,12 @@ def _recent_restart_audit(window=90, now=None):
             return None
         consumed = _consumed_audit_t()
         rec = None
-        for line in reversed(tail[-50:]):
+        for line in reversed(tail[-200:]):
             # walk PAST rows that requested no restart — an in-place converge (main-converge-skip) or
             # a bus bounce writes an audit row but cuts no kernel, and reading only the last row named
-            # a real cut after it as the skip (T240 nit)
+            # a real cut after it as the skip (T240 nit). A deep tail: every session self-close writes
+            # an end-on-idle row, and fifty of them inside a parked quiet window pushed the live park's
+            # row out of a 50-row tail and un-parked it (T240d review find)
             try:
                 cand = json.loads(line)
             except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4432,6 +4432,33 @@ def _last_deploy_restart_t():
     return best
 
 
+_QUIET_PARKED_LOGGED = [""]   # the checkout sha whose parked quiet deploy the drift check last said it was leaving alone
+
+
+def _parked_quiet_deploy(checkout, now=None):
+    """The `t` of a QUIET deploy request still pending for the code the checkout holds, else 0
+    (T240d): the newest restart-requesting audit row is a p2p-update (a peer's apply, which advanced
+    the checkout and asked the manager for a quiet restart) or a main-converge with when=quiet, its
+    sha is the checkout's, no cut row has consumed it (auditT), and it is inside the window a quiet
+    request stays pending — the far manager's backstop bound, exactly what _recent_restart_audit
+    already gives such a row for cut attribution. So a park lost with its manager self-heals at that
+    bound, and the cut row that lands the deploy consumes the row: events, not a timer of this
+    function's own. The p2p row's sha rides its reason ("from <host> to <sha>"); the converge row
+    carries `sha` outright; a quiet row naming no sha matches nothing (never guess)."""
+    rec = _recent_restart_audit(now=now)
+    if not isinstance(rec, dict) or rec.get("when") != "quiet" or not checkout:
+        return 0
+    if str(rec.get("action") or "") not in ("p2p-update", "main-converge"):
+        return 0
+    sha = str(rec.get("sha") or "")
+    if not sha:
+        m = re.search(r"\bto ([0-9a-f]{7,40})\b", str(rec.get("reason") or ""))
+        sha = m.group(1) if m else ""
+    if not sha or not (checkout.startswith(sha) or sha.startswith(checkout)):
+        return 0
+    return int(rec["t"]) if isinstance(rec.get("t"), (int, float)) else 0
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -4443,7 +4470,8 @@ def _main_drift_check():
         # one notice per new TAG, from _update_check — and must never hear about dev commits.
         # The maintainer's mesh keeps this watcher through its own signals (_main_channel_verdict).
         return
-    kind, target = _main_drift_verdict(_origin_main_sha(), _checkout_sha(), _kernel_sha())
+    checkout = _checkout_sha()      # ONE read: the verdict's input and the parked-deploy match below
+    kind, target = _main_drift_verdict(_origin_main_sha(), checkout, _kernel_sha())
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
     if kind == "restart" and not _kernel_code_changed(_kernel_sha(), target):
@@ -4473,6 +4501,24 @@ def _main_drift_check():
         # this process's memory: the converge's own restart forgets module state, and a p2p-update
         # restart from a peer resets it the same way (T240). Module memory still covers the seconds
         # before the ledger row exists.
+        #
+        # A QUIET deploy already parked for the code on disk STANDS THIS CHECK DOWN (T240d): a peer's
+        # p2p apply advanced the checkout and asked the manager for a quiet restart, then this check
+        # saw the checkout ahead of the kernel and posted an IMMEDIATE restart-all — 16:23Z quiet
+        # park, 16:27Z converge/now, ten sessions cut, the quiet window the peer asked for never ran
+        # (and 08:42Z the same, two seconds apart, on the pull side: origin read ahead of the just-reset
+        # checkout, and the pull's restart pre-empted the park). The restart is already on its way;
+        # leave it to the window — one restart, and any pull follows on the pass after it lands. Not
+        # marked acted on: the pass after the row is consumed (or expires) re-evaluates. Said once per
+        # sha, not once per pass. The immediate policy for a genuinely new pull (T160) and the
+        # cool-down are unchanged.
+        if _parked_quiet_deploy(checkout):
+            if _QUIET_PARKED_LOGGED[0] != checkout:
+                _QUIET_PARKED_LOGGED[0] = checkout
+                sys.stderr.write("romp-kernel: converge: %s already parked as a quiet deploy — leaving it "
+                                 "to the quiet window\n" % checkout[:8])
+            _MAIN_DRIFT[slot] = ""
+            return
         last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
         if time.time() - last < _CONVERGE_COOLDOWN_S:
             _MAIN_DRIFT[slot] = ""
@@ -4550,7 +4596,8 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
         import urllib.request
         # the reason joins the dying kernel's restart-cuts.jsonl row to WHO restarted it (see
         # _recent_restart_reason) — the auto converge used to leave the row anonymous
-        _audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"))
+        _audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"),
+                               sha=_checkout_sha())      # what a quiet row deploys (T240d: _parked_quiet_deploy)
         req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"
                                      % (int(manager_port or 7432),
                                         "" if immediate else "?when=quiet"), method="POST")
@@ -15142,8 +15189,13 @@ def _update_remote(host):
         'if [ ! -x "$R/bin/romp-serve" ]; then echo "NOLAUNCH:$NEW"; exit 0; fi; '
         # NEVER AN ANONYMOUS SIGTERM (T238, the T121 rule): a restart-audit row lands BEFORE whichever
         # restart happens, so the far kernel's cut row carries WHO and WHY (the p2p update, from this
-        # machine, to this sha) — nine restarts in three hours had no reason on record. The restart
-        # goes THROUGH THE FAR MANAGER'S QUIET WINDOW (restart-all --quiet: no in-flight turn is cut,
+        # machine, to this sha) — nine restarts in three hours had no reason on record. The QUIET row
+        # lands HERE, right after the reset and before the owner check (T240d): the far kernel's drift
+        # check stands down for a quiet deploy of the code its checkout holds by reading this row, and
+        # the owner check's manager status call was a window in which the checkout was already ahead
+        # with no row on disk. When no owning manager answers, the fallback below writes its own
+        # IMMEDIATE row, which is then the newest and supersedes this one for every reader. The
+        # restart goes THROUGH THE FAR MANAGER'S QUIET WINDOW (restart-all --quiet: no in-flight turn is cut,
         # the 15-minute backstop still lands the deploy, a second apply arriving while one is pending
         # coalesces into the same bounce) — but ONLY when that manager actually OWNS the kernel on the
         # polled port (its /status lists it): a manager owning nothing, or a bare kernel beside a
@@ -15152,12 +15204,12 @@ def _update_remote(host):
         # = the immediate path below ran (no owning manager reachable — node absent, no manager, or
         # the polled kernel is bare). The quiet audit row says when=quiet; the fallback writes its own
         # row without it, so the cut row joins the right request with the right window.
+        'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
+        '\'reason\':\'from %s to %s\',\'when\':\'quiet\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
         'OWNED=0; if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then '
         'OWNED="$("$R/bin/romp-manager" status 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); '
         'print(1 if any(int(k.get(\'port\') or 0)==%d for k in (d.get(\'kernels\') or [])) else 0)" 2>/dev/null || echo 0)"; fi; '
         'if [ "$OWNED" = 1 ]; then '
-        'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
-        '\'reason\':\'from %s to %s\',\'when\':\'quiet\'}))" >>"$LOGDIR/restart-audit.jsonl" 2>/dev/null || true; '
         'if "$R/bin/romp-manager" restart-all --quiet >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:QUIET"; exit 0; fi; fi; '
         # LAST RESORT (no owning manager answering on this host): the immediate path below — audit row,
         # kill, then `ensure` upgrades the host to a supervised kernel.
@@ -15177,7 +15229,7 @@ def _update_remote(host):
         'if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve" >>"$LOGDIR/kernel.log" 2>&1 </dev/null &  sleep 1; fi; '
         'echo "SYNCED:$NEW:FALLBACK"'
     ) % (shlex.quote(rdir), _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF,
-         kport, _local_machine_label(), (_local_head(short=True) or lfull[:8]),
+         _local_machine_label(), (_local_head(short=True) or lfull[:8]), kport,
          _local_machine_label(), (_local_head(short=True) or lfull[:8]), kport)
     # The apply KILLS the running kernel before booting its replacement, so it must be immune to the
     # ssh dying between the two halves — exactly what a flaky link does (the user 2026-07-11:

--- a/tests/romp-refresh-audit.bats
+++ b/tests/romp-refresh-audit.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# `romp refresh --quiet` writes an audit row the kernel's drift check can read (T240d): when=quiet and
+# the checkout sha. Without them the check saw the checkout ahead of the kernel, read a row that
+# named no parked deploy, and posted an IMMEDIATE restart that pre-empted the quiet window this very
+# flag asked for. The immediate refresh keeps its row as it was. Fake manager + postal stand-ins.
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    mkdir -p "$TEST_DIR/bin"
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/manager-calls"\n' "$TEST_DIR" > "$TEST_DIR/bin/romp-manager"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$TEST_DIR/bin/romp-postal-service"
+    chmod +x "$TEST_DIR/bin/romp-manager" "$TEST_DIR/bin/romp-postal-service"
+    export ROMP_MANAGER_BIN="$TEST_DIR/bin/romp-manager"
+    export ROMP_POSTAL_BIN="$TEST_DIR/bin/romp-postal-service"
+    ROMP="$BATS_TEST_DIRNAME/../bin/romp"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp refresh --quiet: the audit row says when=quiet and names the checkout sha" {
+    run "$ROMP" refresh --quiet
+    [ "$status" -eq 0 ]
+    grep -qx 'restart-all --quiet' "$TEST_DIR/manager-calls"
+    python3 - "$ROMP_STATE_DIR/restart-audit.jsonl" <<'EOF'
+import json, re, sys
+row = [json.loads(l) for l in open(sys.argv[1]) if l.strip()][-1]
+assert row.get("when") == "quiet", row
+assert re.fullmatch(r"[0-9a-f]{8}", row.get("sha") or ""), row
+assert "action" not in row, row          # still the caller-attribution row, not a kernel action row
+EOF
+}
+
+@test "romp refresh (immediate): the audit row carries neither when nor sha" {
+    run "$ROMP" refresh
+    [ "$status" -eq 0 ]
+    grep -q '^restart-all' "$TEST_DIR/manager-calls"
+    python3 - "$ROMP_STATE_DIR/restart-audit.jsonl" <<'EOF'
+import json, sys
+row = [json.loads(l) for l in open(sys.argv[1]) if l.strip()][-1]
+assert "when" not in row and "sha" not in row, row
+EOF
+}

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -234,6 +234,119 @@ class DriftWiring(unittest.TestCase):
             km._STARTED = started
             audit.unlink()
 
+    def test_a_parked_quiet_deploy_for_the_checkouts_sha_stands_the_converge_down(self):
+        # T240d: a peer's p2p apply advanced the checkout and parked a QUIET restart at the manager;
+        # the drift check then saw the checkout ahead of the kernel and posted an IMMEDIATE
+        # restart-all — 16:23Z quiet park, 16:27Z converge/now, ten sessions cut — so the quiet
+        # window the peer asked for never ran. The restart is already on its way: stand down, once,
+        # keyed on the ledger row and its consumption (the row expires with the far manager's
+        # backstop, the same bound a pending quiet request already has for cut attribution).
+        import contextlib, io, json, time
+        now = time.time()
+        audit = km.jd.STATE / "restart-audit.jsonl"
+        ran = []
+        saved = (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+                 km._run_main_update, km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1],
+                 km._kernel_code_changed, km._QUIET_PARKED_LOGGED[0], km._CONVERGE_COOLDOWN_S)
+        km._update_mode = lambda: "auto"
+        km._kernel_code_changed = lambda a, b: True
+        km._CONVERGE_COOLDOWN_S = 0.0      # isolate the stand-down: the cool-down is T240's own gate
+        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        km._checkout_sha = lambda: "f3dc387a" + "0" * 32
+        km._origin_main_sha = km._checkout_sha
+        km._kernel_sha = lambda: "aaaaaaaa" + "0" * 32
+
+        def check():
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+            km._LAST_AUTO_CONVERGE[0] = 0.0
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                km._main_drift_check()
+            return err.getvalue()
+
+        try:
+            km._QUIET_PARKED_LOGGED[0] = ""
+            if km.RESTART_CUTS_FILE.exists():
+                km.RESTART_CUTS_FILE.unlink()
+            # the 16:23Z shape: checkout ahead of the kernel, a quiet p2p row for the checkout's sha
+            audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
+            out = check()
+            self.assertEqual(ran, [], "a quiet deploy for this very code is parked: the converge stands down")
+            self.assertIn("already parked as a quiet deploy", out, "one line says why nothing happened")
+            self.assertEqual(km._MAIN_DRIFT[1], "", "the sha is not marked acted on — the next pass re-evaluates")
+            self.assertNotIn("already parked", check(), "…but says it once per sha, not once per pass")
+            self.assertEqual(ran, [])
+            # the 08:42Z shape: origin reads ahead of the checkout too (a stale fetch, or a merge
+            # that landed meanwhile) — the parked restart still delivers the code on disk first;
+            # one restart, not two, and the pull follows on the next pass after it lands
+            km._origin_main_sha = lambda: "bbbbbbbb" + "0" * 32
+            check()
+            self.assertEqual(ran, [], "a pull does not pre-empt the parked quiet deploy either")
+            km._origin_main_sha = km._checkout_sha
+            # CONSUMED: the cut row that landed the quiet deploy joined the row — nothing is parked
+            km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(now - 30), "reason": "p2p-update: from TESTHOST to f3dc387a",
+                                                        "cutTurns": [], "auditT": int(now - 240)}) + "\n")
+            check()
+            self.assertEqual(ran, ["restart"], "a consumed row parks nothing: the converge proceeds as today")
+            km.RESTART_CUTS_FILE.unlink()
+            # a quiet row for a DIFFERENT sha: not this code — proceeds
+            ran.clear()
+            audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
+                                         "reason": "from TESTHOST to 99999999", "when": "quiet"}) + "\n")
+            check()
+            self.assertEqual(ran, ["restart"], "a quiet deploy of other code is not this converge")
+            # an IMMEDIATE p2p row (the no-owning-manager fallback): nothing is parked — proceeds
+            ran.clear()
+            audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a (immediate: no owning manager)"}) + "\n")
+            check()
+            self.assertEqual(ran, ["restart"], "an immediate request parks nothing")
+            # a quiet row older than the far manager's backstop bound: the park is gone (its manager
+            # died with it) — the converge proceeds rather than waiting forever
+            ran.clear()
+            audit.write_text(json.dumps({"t": int(now - km.RESTART_EXPECT_MAX_S - 30), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
+            check()
+            self.assertEqual(ran, ["restart"], "past the backstop bound nothing can still be parked")
+            # a local QUIET converge row (romp refresh --quiet) carries the sha it deployed: parked too
+            ran.clear()
+            km._QUIET_PARKED_LOGGED[0] = ""
+            audit.write_text(json.dumps({"t": int(now - 60), "action": "main-converge", "tag": "restart",
+                                         "when": "quiet", "sha": "f3dc387a" + "0" * 32}) + "\n")
+            check()
+            self.assertEqual(ran, [], "a quiet local converge for this sha is parked the same way")
+            # …a legacy quiet converge row without a sha cannot be matched: proceeds (never guesses)
+            audit.write_text(json.dumps({"t": int(now - 60), "action": "main-converge", "tag": "restart",
+                                         "when": "quiet"}) + "\n")
+            check()
+            self.assertEqual(ran, ["restart"], "no sha on the row, no stand-down")
+        finally:
+            (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+             km._run_main_update) = saved[:5]
+            km._LAST_AUTO_CONVERGE[0] = saved[5]
+            km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = saved[6], saved[7]
+            km._kernel_code_changed, km._QUIET_PARKED_LOGGED[0] = saved[8], saved[9]
+            km._CONVERGE_COOLDOWN_S = saved[10]
+            audit.unlink()
+            if km.RESTART_CUTS_FILE.exists():
+                km.RESTART_CUTS_FILE.unlink()
+
+    def test_the_quiet_deploy_rows_carry_what_the_stand_down_reads(self):
+        # T240d pins on the writers: the p2p apply's quiet audit row lands right after the reset that
+        # advances the checkout — BEFORE the owner check, whose manager status call is the window a
+        # drift pass could hit between "checkout ahead" and "row on disk" — and the local converge's
+        # row carries the sha it deploys, so a quiet `romp refresh` is matched, not guessed at
+        ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        reset = ksrc.index("reset --hard %s >/dev/null 2>&1 || {")
+        row = ksrc.index("\\'action\\':\\'p2p-update\\',")     # the shell script's escaped spelling
+        owned = ksrc.index("'OWNED=0; if command -v node")
+        self.assertLess(reset, row, "the row says the checkout IS at the sha: it follows the reset")
+        self.assertLess(row, owned, "and precedes the owner check, so the drift check sees it at once")
+        self.assertIn('_audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"),\n'
+                      '                               sha=', ksrc,
+                      "the converge row names the sha it deploys")
+
     def test_the_parent_watch_stands_down_under_a_graceful_term(self):
         # behavioral (review find: the source-order pin executed nothing): the manager is gone —
         # with the graceful term running the watchdog returns; without it, it exits the kernel

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -309,7 +309,8 @@ class DriftWiring(unittest.TestCase):
                                          "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
             check()
             self.assertEqual(ran, ["restart"], "past the backstop bound nothing can still be parked")
-            # a local QUIET converge row (romp refresh --quiet) carries the sha it deployed: parked too
+            # a QUIET converge row from the explicit immediate=False door carries the sha it deploys:
+            # parked too (no production caller passes immediate=False today; the CLI door is below)
             ran.clear()
             km._QUIET_PARKED_LOGGED[0] = ""
             audit.write_text(json.dumps({"t": int(now - 60), "action": "main-converge", "tag": "restart",
@@ -321,6 +322,48 @@ class DriftWiring(unittest.TestCase):
                                          "when": "quiet"}) + "\n")
             check()
             self.assertEqual(ran, ["restart"], "no sha on the row, no stand-down")
+            # the CLI door (review find): `romp refresh --quiet` writes bin/romp's caller-attribution
+            # row — no action — now with when=quiet and the checkout sha; it parks the same way
+            ran.clear()
+            km._QUIET_PARKED_LOGGED[0] = ""
+            audit.write_text(json.dumps({"t": int(now - 60), "ppid": 4242, "parent": "bash", "sid": "", "name": "",
+                                         "tty": "/dev/pts/0", "tmux": "", "when": "quiet", "sha": "f3dc387a"}) + "\n")
+            check()
+            self.assertEqual(ran, [], "a quiet CLI refresh for this sha is a parked deploy too")
+            # a busy box (review find): fifty session self-closes write fifty end-on-idle rows after
+            # the quiet row — the reader walks past them; the park is still live
+            ran.clear()
+            audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n"
+                             + "".join(json.dumps({"t": int(now - 200 + i), "action": "end-on-idle", "sid": "s%d" % i}) + "\n"
+                                       for i in range(50)))
+            check()
+            self.assertEqual(ran, [], "fifty no-restart rows do not hide a live park")
+            # LANDED, cut row lost (review find): the kernel already runs the checkout, the row is still
+            # unconsumed — nothing is owed, so a pull must not wait on it (and says nothing about a park)
+            ran.clear()
+            km._QUIET_PARKED_LOGGED[0] = ""
+            audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
+            km._kernel_sha = km._checkout_sha
+            km._origin_main_sha = lambda: "bbbbbbbb" + "0" * 32
+            out = check()
+            self.assertEqual(ran, ["pull"], "the parked restart already delivered: the pull proceeds")
+            self.assertNotIn("already parked", out)
+            km._kernel_sha = lambda: "aaaaaaaa" + "0" * 32
+            km._origin_main_sha = km._checkout_sha
+            # a stand-down that ENDS without landing (the row expired: the park died with its manager)
+            # says so once, then the converge proceeds on its own terms (review find: silent expiry)
+            ran.clear()
+            km._QUIET_PARKED_LOGGED[0] = ""
+            check()
+            self.assertEqual(ran, [], "parked again")
+            audit.write_text(json.dumps({"t": int(now - km.RESTART_EXPECT_MAX_S - 30), "action": "p2p-update",
+                                         "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
+            out = check()
+            self.assertEqual(ran, ["restart"])
+            self.assertIn("no longer pending", out, "the end of a stand-down is said, not silent")
+            self.assertNotIn("no longer pending", check(), "…once")
         finally:
             (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
              km._run_main_update) = saved[:5]
@@ -346,6 +389,12 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('_audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"),\n'
                       '                               sha=', ksrc,
                       "the converge row names the sha it deploys")
+        # the CLI door: bin/romp's own caller-attribution row says when=quiet and names the checkout
+        # sha under --quiet (behavior pinned in tests/romp-refresh-audit.bats; the spelling here)
+        rsrc = open(os.path.join(os.path.dirname(HERE), "bin", "romp")).read()
+        self.assertIn('RA_WHEN="${2:-}"', rsrc)
+        self.assertIn('if os.environ.get("RA_WHEN") == "--quiet":\n    # a PARKED restart', rsrc)
+        self.assertIn('row["when"] = "quiet"', rsrc)
 
     def test_the_parent_watch_stands_down_under_a_graceful_term(self):
         # behavioral (review find: the source-order pin executed nothing): the manager is gone —


### PR DESCRIPTION
**Bug (T240d).** A peer's p2p apply advanced this box's checkout and asked the manager for a **quiet** restart. The kernel's drift check then saw the checkout ahead of the running kernel and posted an **immediate** restart-all, so the quiet window the peer asked for never ran. Ledger evidence from 2026-09-07: a p2p-update quiet row at 09:23:39 PT, then a main-converge/now row at 09:27:27 PT whose cut stopped ten sessions, a running review workflow among them. The same shape at 01:42 PT two seconds apart on the pull side, where origin read ahead of the just-reset checkout.

**Fix, event-based.** Before converging in auto mode, the drift check reads the pending request row. When the newest restart-requesting audit row is a quiet p2p-update (or a quiet main-converge) for the sha the checkout holds, no cut row has consumed it (`auditT`), and it is inside the window a quiet request stays pending, the check **stands down**: one log line per sha ("already parked as a quiet deploy — leaving it to the quiet window"), the sha left unmarked so the pass after the row is consumed or expires re-evaluates. The pending window is the far manager's backstop bound, exactly what `_recent_restart_audit` already gives such a row for cut attribution, so a park lost with its manager self-heals there rather than holding forever. The pull side stands down too: the parked restart delivers the code on disk first, and any pull follows on the pass after it lands. One checkout read feeds both the verdict and the match.

**Unchanged.** The cool-down, the immediate policy for a genuinely new pull, and the manual-mode banner (a click is the user's explicit choice to restart now).

**Writers.** The converge's audit row now carries the sha it deploys, so a quiet `romp refresh` is matched rather than guessed at; a legacy quiet row without a sha matches nothing. The p2p apply script writes its quiet row right after the reset and before the owner check, whose manager status call was a window in which the checkout was already ahead with no row on disk. When no owning manager answers, the fallback's immediate row is newer and supersedes it for every reader.

**Review folds (second commit).** Adversarial review, two lenses, twelve findings each verified hermetically; five confirmed and folded:
- The pull-side stand-down applies only while the kernel does not yet run the checkout. A quiet deploy that landed but lost its cut row leaves its row unconsumed for the rest of the window, and a pull must not wait on a park that already delivered.
- The once-per-sha latch clears, and the end of a stand-down is said once ("no longer pending") instead of silently proceeding.
- The pending-row reader walks a 200-row tail. Fifty session self-closes inside a parked window had pushed the live park's row out of a 50-row tail.
- `romp refresh --quiet` wrote a row with no `when` and no `sha`, so the CLI's own quiet park was pre-empted just the same. The CLI row now carries both under `--quiet` (pinned by a new bats file against fake manager and postal stand-ins), and the reader accepts that action-less row. The main-converge quiet branch has no production writer today; the test comments now say so.

Stated, not folded: the pending window is the 20-minute bound the cut-attribution reader ties to the manager's default 15-minute backstop. A box that raises the manager's backstop past it by environment override converges over the tail of its own park. Refuted: short-sha matching hazards, the test's unconditional unlink, a future-stamped row, and the landed-with-lost-cut-row delay (masked by the default cool-down and removed by the first fold).

**Tests, red first.** The 09:23 PT ledger shape posts the restart on main and stands down here, with one line and no second line on the next pass; the pull shape stands down; consumed, other-sha, immediate and expired rows proceed; a quiet converge row with a sha stands down and a legacy one proceeds. Source pins hold the apply script's reset → row → owner-check order and the sha on the converge row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
