### PR TITLE
A pending send ends on events rather than a 20 s timer; a message taken mid-turn says so and leaves a cue where its bubble sat

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -208,6 +208,40 @@ widget per block), with **no second transcript parser** — the event model alre
 produced the tree. Plus the live chip from the state read, and the TOC ledger below
 the tabs.
 
+**A send stays visible from the press until its record lands, and each layer
+retires on an event, never a timer.** The kernel keeps an input echo (a synthetic
+user atom in the backend's live store, mirrored to the registry so a restart cannot
+lose it) from `send()` until the transcript carries the same text. For a message fed
+into a running turn that record is the `queued_command` attachment the CLI writes
+when it splices the message in at its next tool boundary. On the SDK route no floor
+retires an echo: it retires when its text lands in a record stamped at or after the
+send (a user record or that attachment), or when the CLI dies holding it (`dropped`,
+which the chat shows as never delivered, with restore and dismiss). The CLI extracts
+no image paths on the stream-json route (its only image-path test belongs to the
+interactive composer's paste handler), so an image path in an SDK send lands as
+typed and the echo's text matches. `_path_bearing` and the extension set it tests
+(png, jpe?g, gif, webp, case-insensitive: the CLI bundle's single image-path test,
+pinned equal between kernel and backend) remain for the tmux settle path only, where
+the paste hook does run and rewrites the path to `[Image #N]`. The chat's own image
+previews (`_user_images`) use a separate set, built from the served MIME table
+(`_IMG_MIME`, svg and bmp included), so a preview is never proposed for a file the
+image route cannot serve.
+
+**A kernel restart does not re-run a mid-turn send.** The boot duplicate guard
+(`_text_landed`) reads the `queued_command` attachment too, and it scans from the
+transcript's byte size at the moment of the send (recorded on the echo as
+`_echo_off` with the file id `_echo_fsid`, mirrored in the registry as `off` and
+`fsid`) to the end of the file, so a landed send is neither re-queued nor flagged as
+undelivered however much the session wrote afterwards. A mark from another file (a
+/clear or a fork since), a mark past the end of the file, or an echo with no mark
+reads the whole file. The found verdict is recorded on the echo (`_landed`), and
+`prune_live` and the chat merge retire the echo on it without a text match, so a
+found echo always has an exit and a later boot never re-scans it. Every by-text
+comparison of an echo against a record (the guard's scan, `prune_live`'s retire, the
+kernel's `_atom_user_texts` and its folds, and the tmux echo's prune
+`_tmux_echo_prune`) uses one key, `echo_text_key` in `session_backend.py`: outer
+whitespace stripped, nothing else.
+
 **The ledger is a table of contents** (pure projection of captions + archive):
 - top: the archiver's one-sentence headline for the session,
 - then **turn captions** as top-level bullets, the whole session (not just recent),

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -216,7 +216,15 @@ into a running turn that record is the `queued_command` attachment the CLI write
 when it splices the message in at its next tool boundary. On the SDK route no floor
 retires an echo: it retires when its text lands in a record stamped at or after the
 send (a user record or that attachment), or when the CLI dies holding it (`dropped`,
-which the chat shows as never delivered, with restore and dismiss). The CLI extracts
+which the chat shows as never delivered, with restore and dismiss). The chat's own
+pending bubble, painted at the press, has no lifetime either: it ends on the same
+events, read from the events after the send (a landing of the text, the kernel's
+never-delivered verdict, or the user's ✕), and a record the CLI wrote from several
+back-to-back sends retires one bubble per text block (`blocks` on the user event).
+While the socket is down the bubble is labelled "not confirmed", until a kernel
+copy of the send clears the label. A send that landed mid-turn (`absorbed` and
+`landedAt` on the user chat event) wears a "joined mid-turn" header and, when its
+bubble sat at the tail, leaves a cue where the bubble was. The CLI extracts
 no image paths on the stream-json route (its only image-path test belongs to the
 interactive composer's paste handler), so an image path in an SDK send lands as
 typed and the echo's text matches. `_path_bearing` and the extension set it tests

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -595,6 +595,32 @@ check whether each is still running before relaunching it. A kernel restart has
 never touched work a session deliberately detached: tmux servers, `setsid`
 children and other processes that outlive their shell.
 
+A message the kernel cannot handle does not end the session's CLI. The kernel
+handles each streamed message on its own: when a handler raises, it logs the
+exception type, the message's type and subtype, the exception's own text
+(uuid-shaped ids shortened to eight characters, clipped to 160 characters; it
+carries whatever the raising code put in it, never the message's content), what
+that message lost (an assistant or user message is also a transcript record, so
+the chat rebuilds it from disk — a compaction boundary is one too, while a model
+or mode change's confirmation line is not; a turn result still settles its turn,
+and the line says so only when the settle ran; a stream-only frame's content is
+gone until the next such frame), and a compact frame chain (file, line and
+function for at most the innermost eight frames, no locals, at most 600
+characters, dropping outer frames first so the failing frame is always named) to
+the kernel log and the dashboard's error center, then goes on to the next
+message. A failure while filing a turn result — its spend, its live-tail
+sweep — still settles the turn: the session reads waiting, its queue moves,
+and a reconnect that waited for the turn's end runs. A handler that
+fails on every message is one error-center entry with a repeat count; every
+repeat is still a kernel log line, and an entry the ring has since dropped
+re-enters with its full detail.
+Before 2026-09-06 one such exception ended the receive loop, which closed the
+CLI in the middle of its work (the in-flight turn, its subagents, its background
+tasks) and resumed the session as after a crash. A fault of the stream itself,
+such as the CLI exiting or its transport closing, still ends the loop; the log
+names the failing task and its frame chain, and the session resumes with its
+history, told what was cut.
+
 A service restart (`systemctl --user restart romp-manager`, or the machine's
 own service management) kills everything in the service's cgroup, so on Linux
 under systemd Romp runs each session's CLI, and the default tmux server the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -597,23 +597,27 @@ children and other processes that outlive their shell.
 
 A message the kernel cannot handle does not end the session's CLI. The kernel
 handles each streamed message on its own: when a handler raises, it logs the
-exception type, the message's type and subtype, the exception's own text
-(uuid-shaped ids shortened to eight characters, clipped to 160 characters; it
-carries whatever the raising code put in it, never the message's content), what
-that message lost (an assistant or user message is also a transcript record, so
-the chat rebuilds it from disk — a compaction boundary is one too, while a model
-or mode change's confirmation line is not; a turn result still settles its turn,
-and the line says so only when the settle ran; a stream-only frame's content is
-gone until the next such frame), and a compact frame chain (file, line and
-function for at most the innermost eight frames, no locals, at most 600
-characters, dropping outer frames first so the failing frame is always named) to
-the kernel log and the dashboard's error center, then goes on to the next
-message. A failure while filing a turn result — its spend, its live-tail
-sweep — still settles the turn: the session reads waiting, its queue moves,
-and a reconnect that waited for the turn's end runs. A handler that
-fails on every message is one error-center entry with a repeat count; every
-repeat is still a kernel log line, and an entry the ring has since dropped
-re-enters with its full detail.
+exception type and the failing frame (file, line and function, first on the line
+so the error center's clipped row still shows it), the message's type and
+subtype, what that message lost (an assistant or user message is also a
+transcript record, so the chat rebuilds it from disk — a compaction boundary is
+one too, while a model or mode change's confirmation line is not; a turn result
+still settles its turn, and the line says so only when the settle ran; a
+stream-only frame's content is gone until the next such frame), the exception's
+own text (uuid-shaped ids shortened to eight characters, clipped to 160
+characters; it carries whatever the raising code put in it, never the message's
+content), and a compact frame chain (innermost first: file, line and function
+for at most the innermost eight frames, no locals, at most 600 characters,
+dropping outer frames first so the failing frame is always named) to the kernel
+log and the dashboard's error center, then goes on to the next message. A
+failure while filing a turn result — its spend, its live-tail sweep — still
+settles the turn: the session reads waiting, its queue moves, and a reconnect
+that waited for the turn's end runs; the spend accounting runs last among the
+result's bookkeeping, so its failure skips nothing else. A handler that fails on
+every message is one error-center entry, showing its first occurrence: the
+repeat count is kept on the kernel's problem ring (appended to the row's text,
+past what the error center displays), every repeat is a kernel log line, and an
+entry the ring has since dropped re-enters with its full detail.
 Before 2026-09-06 one such exception ended the receive loop, which closed the
 CLI in the middle of its work (the in-flight turn, its subagents, its background
 tasks) and resumed the session as after a crash. A fault of the stream itself,

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -26,7 +26,7 @@ Auxiliary inputs the file adapter may read (same category as the transcript):
                                transcript lost to an API-errored try; judge parse only)
   timeline/messages.jsonl   -> peer rompUuid for a postal atom (join on the msg id)
 """
-import copy, json, os, re, sys, time, hashlib, threading
+import bisect, copy, json, os, re, sys, time, hashlib, threading
 from datetime import datetime
 from pathlib import Path
 
@@ -906,6 +906,9 @@ class FileAdapter:
                                  #   text (full prompt, markers intact), seq}
         self.leaf_uuid = None
         self._seq = 0            # global read-order counter — continued by assembly folds
+        self._seq_ts = []        # (seq, repaired ts) per uuid-bearing record, in read order — sorted by
+        #                          construction, so _landing_t bisects it for a record's file-order
+        #                          predecessor without a per-lookup scan or a per-fold sort
         self.ts_of = {}          # uuid -> repaired epoch seconds — THE timestamp every consumer
         #                          reads (_chrono, the emit, the boundary splice). A record whose
         #                          stamp does not parse borrows the last good stamp seen in file
@@ -984,6 +987,11 @@ class FileAdapter:
                 else:
                     self._last_ts = ts
                 self.ts_of[u] = ts
+                if t != "attachment":
+                    # an attachment is never a landing WITNESS (a queued_command IS the spliced item,
+                    # stamped with its send time): several sends spliced at one boundary must all
+                    # read that boundary, not each other — see _landing_t
+                    self._seq_ts.append((seq, ts))
                 # parentUuid normally; compact_boundary carries parentUuid:null +
                 # logicalParentUuid:<pre-compaction leaf> — follow that so the active
                 # path survives compaction instead of orphaning every pre-compaction turn.
@@ -1549,9 +1557,43 @@ class FileAdapter:
             #                     PLACEMENTS_V bump).
             "_seq": seq,
         }
+        landed_t = self._landing_t(seq)
+        if landed_t is not None:
+            if landed_t < t:
+                # The witness (the attachment's file-order predecessor) is stamped BEFORE the
+                # attachment's own ENQUEUE stamp. Real transcripts do this only by clock granularity
+                # (the live corpus's worst case is -0.2 s, which whole-second stamps can turn into a
+                # 1 s inversion); anything larger is a shape the CLI does not write. No truthful
+                # landing precedes the send, and the chat's cue must never read "took it at" a time
+                # before the bubble's own send time — so clamp to the send, and COUNT it: parse stats
+                # (`landedT-clamp`, beside ts-repair, served on the version route) are where a run of
+                # these would show up, since a silent clamp would hide a CLI write-order change. (The
+                # 2026-09-06 review: two goldens had pinned a landedT 30-40 s before the send, from a
+                # synthetic shape with no tool_result before the attachment.)
+                _ASM_STATS["landedT-clamp"] = _ASM_STATS.get("landedT-clamp", 0) + 1
+                landed_t = t
+            atom["landedT"] = landed_t   # when the CLI TOOK it (metadata, like `absorbed`; see _landing_t)
         if ROMP_AUTO_RE.search(full):   # an AUTO-nudge → flag it, mirroring the native user-record path
             atom["rompAuto"] = True
         return atom
+
+    def _landing_t(self, seq):
+        """When the CLI TOOK a mid-turn prompt: the repaired stamp of the record written just BEFORE
+        the queued_command attachment in file order. The attachment's own stamp is the ENQUEUE time
+        (the moment the user sent it — where the atom is placed, above the steps that ran while it
+        waited), but the CLI writes the record at the splice, right after the tool boundary it waited
+        for, so that boundary's own record — the file-order predecessor — is the landing moment to
+        within the boundary's latency. The chat's mid-turn cue reads it (kernel `landedAt`): "the
+        session took this at HH:MM" is a different fact from "sent at HH:MM", and the rail already
+        shows the latter. The PREDECESSOR, not the successor, on purpose: it is always ingested when
+        the atom is emitted, so a fold that sees the attachment as the newest record still stamps
+        it — a successor read would find nothing there, and no later fold re-emits the atom (the
+        (ts, text) dedup). Attachment records are skipped as witnesses (a run of splices at one
+        boundary all read that boundary). None only when nothing precedes the attachment in the
+        read. The caller clamps the result to the atom's own send time (never earlier — see
+        _absorbed_atom). Metadata only: no atom-set or seg-id change, no PLACEMENTS_V bump."""
+        i = bisect.bisect_left(self._seq_ts, (seq,)) - 1
+        return self._seq_ts[i][1] if i >= 0 else None
 
     def _absorbed(self, qatts, kept, st, rompuuid, postal_index):
         """Mid-turn prompts spliced into a running turn. The witness is the queued_command

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19290,7 +19290,12 @@ def _split_reminders(text):
     return prompt.strip(), [r for r in reminders if r]
 
 
-_IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp|bmp|svg))\b", re.I)
+# The extension set is the CLI's, not romp's: the composer paste hook's one image-path test,
+# `/\.(png|jpe?g|gif|webp)$/i` (Claude Code 2.1.261 bundle) — the paths it reads and rewrites to
+# "[Image #N]" before the submit. No bmp, no svg: the wider set this carried until 2026-09-06 claimed
+# extractions the CLI never performs (a `.svg` send waited for a rewrite that never came). Twin of
+# sdk_backend._IMG_PATH_RE; tests/test_kernel_fed_echo_absorbed.py pins both to that set.
+_IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp))\b", re.I)
 def _user_images(blocks, text, human):
     """A user turn's images. Inline base64 → a data: URL; an image
     source path → "path:<abs>" (the webview hydrates it via imgRequest); and — the common case — a bare
@@ -22700,9 +22705,10 @@ def _atom_user_texts(a):
     the nudge body. _atom_user_text space-JOINS the blocks, so the echo's exact text was never a member of
     the transcript set and the landing check ("et in tx_user_texts") could not fire. The echo then never
     retired: it rode the bottom of the thread forever, still wearing its original SEND time, so a nudge
-    sent at 16:43 appeared BELOW a 17:00 answer (the user 2026-07-22). The FIFO floor can't save it either
-    — that was deliberately narrowed to PATH-BEARING echoes (2026-07-20) so a genuinely dropped send stays
-    visible. Per-block EXACT match, never a substring test: a bundled block is the very string that was
+    sent at 16:43 appeared BELOW a 17:00 answer (the user 2026-07-22). No floor can save it either —
+    sdk_backend.prune_live floors no echo (2026-09-06; before that the floor was narrowed to path-bearing
+    echoes, 2026-07-20), so a genuinely dropped send stays visible. Per-block EXACT match, never a
+    substring test: a bundled block is the very string that was
     echoed, so this retires the delivered nudge without ever guessing about containment."""
     if a.get("type") != "user":
         return ()
@@ -22754,8 +22760,9 @@ def _tmux_echo_prune(sid, tx_uuids, tx_texts):
 
 def _human_turn_floor(session):
     """The newest GENUINE-HUMAN user atom's timestamp in the parsed session, or 0. The one event that says
-    "the transcript has moved past anything typed before this": read by the SDK's echo floor
-    (sdk_backend.prune_live), by the tmux echo's settle below, and by the queued fold.
+    "the transcript has moved past anything typed before this": read by sdk_backend.prune_live (to retire
+    stale command-feedback atoms — since 2026-09-06 it floors no echo), by the tmux echo's settle below,
+    and by the queued fold.
 
     EXCLUDES the interrupt record (the user 2026-07-07): it authors 'human' but is a STOP event, not a
     message that landed and processed the echo. When a just-sent message hadn't hit disk yet, the
@@ -22785,11 +22792,14 @@ def _tmux_echo_settle(sid, human_floor, still_queued=()):
 
     Marking, NOT pruning: a tmux echo is the only record of a send the pane dropped, and that loss must
     stay on screen — the whole reason the echo outlives a later turn (see TmuxBackend.prune_live). The one
-    exception mirrors the SDK's own floor: a PATH-BEARING echo can fail the text match STRUCTURALLY,
-    because the transcript extracts image paths out of the user text, so that flavor is retired the way
-    sdk_backend.prune_live retires it rather than labelled a loss it may not be. With the SDK module
-    unavailable the predicate is simply unavailable too, and marking (the visible, reversible outcome)
-    covers every echo.
+    exception is an IMAGE-PATH echo: a tmux send is a paste into the composer, whose paste hook reads a
+    pasted image path and rewrites the token to "[Image #N]" (sdk_backend._IMG_PATH_RE names the hook's
+    extension set), so the echo's text can fail the match STRUCTURALLY and "overtaken" is not evidence of
+    loss — that flavor is retired rather than labelled a loss it may not be. The predicate is borrowed
+    from the SDK module (sdk_backend._path_bearing, kept for this reader: the SDK route itself floors no
+    echo since 2026-09-06, because stream-json input never reaches the hook). With that module
+    unavailable the predicate is unavailable too, and marking (the visible, reversible outcome) covers
+    every echo.
 
     STANDS DOWN for an echo whose text the queue ledger still lists as pending (`still_queued`,
     2026-08-27): the floor is a per-SESSION clock, so an OLDER queued sibling delivering raises it past

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9428,12 +9428,15 @@ def _comments_frame(sid, tmux=None):
                 # LOST — a reconnect with it in flight; the popover shows "never delivered") owes nothing.
                 user_atoms = [a for tr in turns for a in (tr.get("atoms") or []) if a.get("type") == "user"]
                 def _landed(e):
-                    et = (e.get("_echo_text") or "").strip()
+                    et = sb.echo_text_key(e.get("_echo_text"))
                     since = float(e.get("t") or 0)                     # the send's own stamp: the record the CLI writes for
                     return any(et in _atom_user_texts(a) for a in user_atoms if float(a.get("t") or 0) >= since)   # it is at or after it
                 floor = _human_turn_floor({"turns": turns}) if turns else 0
-                held = [a for a in live if (a.get("_echo_text") or "").strip() and not a.get("command")
-                        and not a.get("dropped") and not _landed(a) and not _echo_overtaken(a, floor)]
+                # `_landed` on the atom: the backend's boot/spawn scan read the landing off the transcript
+                # itself (sdk_backend._mark_dropped_echoes) — delivered, so nothing is held for it
+                held = [a for a in live if sb.echo_text_key(a.get("_echo_text")) and not a.get("command")
+                        and not a.get("dropped") and not a.get("_landed") and not _landed(a)
+                        and not _echo_overtaken(a, floor)]
                 queued = max(queued, len(held))
         # the newest record the projection shows (or the transcript holds): the client's "did the transcript
         # move?" datum, independent of the 80-event / 40-message caps on the shipped projections
@@ -22694,13 +22697,15 @@ def _claudemd_docs(cwd):
 
 
 def _atom_user_text(a):
-    """The plain text of a user atom (for deduping the optimistic input echo against the transcript)."""
+    """The plain text of a user atom (for deduping the optimistic input echo against the transcript), keyed
+    by sb.echo_text_key — the ONE rule the SDK backend's by-text prune and its landing scan share with the
+    keys built here (2026-09-06: the scan matched a collapsed text the prune's raw comparison never could)."""
     if a.get("type") != "user":
         return None
     c = (a.get("message") or {}).get("content")
     if isinstance(c, list):
-        return " ".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text").strip() or None
-    return (c.strip() if isinstance(c, str) else None) or None
+        return sb.echo_text_key(" ".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")) or None
+    return sb.echo_text_key(c) or None
 
 
 def _atom_user_texts(a):
@@ -22725,7 +22730,7 @@ def _atom_user_texts(a):
     if isinstance(c, list):
         for b in c:
             if isinstance(b, dict) and b.get("type") == "text":
-                t = (b.get("text") or "").strip()
+                t = sb.echo_text_key(b.get("text") or "")
                 if t and t != joined:
                     out.append(t)
     return tuple(out)
@@ -22752,12 +22757,20 @@ def _tmux_echo_atoms(sid):
     return list(_tmux_echo.get(sid, {}).values())
 
 def _tmux_echo_prune(sid, tx_uuids, tx_texts):
-    """Drop an echo once the transcript has its real user atom (by uuid or text); pop the sid when empty."""
+    """Drop an echo once the transcript has its real user atom (by uuid or text); pop the sid when empty.
+    The text side compares under sb.echo_text_key — `tx_texts` are the keys _atom_user_texts built (outer
+    whitespace stripped), and the echo stores the send's text verbatim, so a raw comparison never matched a
+    trailing-newline send (`romp send` passes its argument verbatim): the delivered echo stayed, hidden by
+    the display dedup, and the settle then marked it `dropped` once a later human turn landed — a "never
+    delivered" bubble for a message the transcript holds (2026-09-06)."""
     d = _tmux_echo.get(sid)
     if not d:
         return
-    for k in [k for k, a in d.items()
-              if a.get("uuid") in tx_uuids or (a.get("_echo_text") and a["_echo_text"] in tx_texts)]:
+
+    def _landed(a):
+        et = sb.echo_text_key(a.get("_echo_text"))
+        return a.get("uuid") in tx_uuids or (et and et in tx_texts)
+    for k in [k for k, a in d.items() if _landed(a)]:
         d.pop(k, None)
     if not d:
         _tmux_echo.pop(sid, None)
@@ -22917,9 +22930,13 @@ def _merge_live_atoms(session, sid, shown_texts=()):
                 tx_text_t[t] = max(tx_text_t.get(t, 0), float(a.get("t") or 0))
     human_floor = _human_turn_floor(session)
     be.prune_live(sid, tx_uuids, tx_text_t, human_floor)
-    hide = tx_texts | {t.strip() for t in shown_texts if t}    # transcript dups + already-shown queued msgs
+    hide = tx_texts | {sb.echo_text_key(t) for t in shown_texts if t}    # transcript dups + already-shown queued msgs
+    # `live` was snapshotted before the prune, so each of prune_live's three exits has its paint-side twin
+    # here: by uuid (tx_uuids), by text (hide), and the recorded landing (`_landed`: the backend's boot/spawn
+    # scan read the record off the transcript — the prune just retired it, and painting it once more would
+    # show a delivered message as a pending bubble for one build)
     fresh = [a for a in live if a.get("uuid") not in tx_uuids
-             and not (a.get("_echo_text") and a["_echo_text"].strip() in hide)]
+             and not (a.get("_echo_text") and (a.get("_landed") or sb.echo_text_key(a["_echo_text"]) in hide))]
     if not fresh:
         return session
     # Reopen the turn ONLY for genuine live ASSISTANT work (a streaming reply), never for a lone input echo.
@@ -23274,7 +23291,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         tx_user = {t for turn in parsed["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
         echo_floor = _human_turn_floor(parsed)
         for a in be.live_atoms(sid):
-            et = (a.get("_echo_text") or "").strip()
+            et = sb.echo_text_key(a.get("_echo_text"))
             if et and et not in already and et not in tx_user and not _echo_overtaken(a, echo_floor):
                 queued = queued + [et]; already.add(et)
     session = parsed if path_override else _merge_live_atoms(parsed, sid, shown_texts=queued)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23624,6 +23624,18 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                         if prompt or reminders or imgs:
                             ev = {"kind": "user", "md": prompt, "uuid": a.get("uuid"), "ts": ts,
                                   "human": author == "human" or bool(imgs), "reminders": reminders}
+                            if a.get("absorbed"):
+                                # A mid-turn splice (event_model._absorbed): the CLI queued this send
+                                # behind the running turn and took it at a later tool boundary, so the
+                                # atom sits at its SEND time, above the steps that ran while it waited.
+                                # The client marks it ("joined mid-turn") and, when the landing retires
+                                # a pending bubble that sat at the tail, leaves a cue where the bubble
+                                # was — the user 2026-09-05 watched a message vanish from the bottom
+                                # and reappear higher up with no explanation. `landedAt`: when the CLI
+                                # took it (the attachment's file-order predecessor; `ts` is the send).
+                                ev["absorbed"] = True
+                                if a.get("landedT"):
+                                    ev["landedAt"] = int(a["landedT"])
                             sp = _space_paths(prompt, sid, a.get("uuid"))
                             if sp:
                                 ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19294,13 +19294,18 @@ def _split_reminders(text):
 # `/\.(png|jpe?g|gif|webp)$/i` (Claude Code 2.1.261 bundle) — the paths it reads and rewrites to
 # "[Image #N]" before the submit. No bmp, no svg: the wider set this carried until 2026-09-06 claimed
 # extractions the CLI never performs (a `.svg` send waited for a rewrite that never came). Twin of
-# sdk_backend._IMG_PATH_RE; tests/test_kernel_fed_echo_absorbed.py pins both to that set.
+# sdk_backend._IMG_PATH_RE; tests/test_kernel_fed_echo_absorbed.py pins both to that set. Its reader is
+# the one that WAITS ON the CLI's rewrite: _injected_img_paths (the tmux pre-Enter wait). The bare-path
+# PREVIEW in _user_images is romp's own feature and reads _PREVIEW_IMG_RE (beside _IMG_MIME) instead —
+# it never claims a CLI extraction, so it is not bound to the CLI's set.
 _IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp))\b", re.I)
 def _user_images(blocks, text, human):
     """A user turn's images. Inline base64 → a data: URL; an image
     source path → "path:<abs>" (the webview hydrates it via imgRequest); and — the common case — a bare
     image PATH typed or dragged into the composer arrives as PLAIN TEXT, so scan a human turn's text for
-    absolute / ~ paths with a known image extension. Capped at 4."""
+    absolute / ~ paths with an extension the imgRequest route can serve (_PREVIEW_IMG_RE, built from
+    _IMG_MIME's keys — bmp and svg included; on an SDK session every image path lands as text, so this
+    scan is the only way a referenced picture gets shown). Capped at 4."""
     imgs = []
     for b in (blocks or []):
         if isinstance(b, dict) and b.get("type") == "image":
@@ -19310,7 +19315,7 @@ def _user_images(blocks, text, human):
             elif s.get("path"):
                 imgs.append({"src": "path:" + s["path"], "path": s["path"]})
     if human and not imgs:                            # a bare image path typed/dragged in → plain text
-        for m in _IMG_PATH_RE.finditer(text or ""):
+        for m in _PREVIEW_IMG_RE.finditer(text or ""):
             p = m.group(1)
             if not any(im.get("path") == p for im in imgs):
                 imgs.append({"src": "path:" + p, "path": p})
@@ -30162,6 +30167,16 @@ def _tell_stale_gesture(client, msg):
 #      hydrated and OS drops did nothing — the user 2026-06-16) ----
 _IMG_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
              ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp", ".svg": "image/svg+xml"}
+# The bare-path PREVIEW scan's extension set (_user_images): exactly the extensions this route can
+# serve, derived from _IMG_MIME so the two cannot drift — a path the scan proposed but _img_data_url
+# refused would leave a chip with no picture. Same path shape as _IMG_PATH_RE (absolute or ~-rooted,
+# delimited), but NOT that regex: _IMG_PATH_RE is the CLI paste hook's set, read by the code that waits
+# on the CLI's "[Image #N]" rewrite, and the preview claims no such extraction. Until 2026-09-06 both
+# readers shared one regex; narrowing it to the CLI's set for the extraction reader would have silently
+# dropped svg/bmp previews, so the preview got its own.
+_PREVIEW_IMG_RE = re.compile(
+    r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:%s))\b"
+    % "|".join(re.escape(k[1:]) for k in sorted(_IMG_MIME)), re.I)
 _IMG_MAX_BYTES = 8_000_000
 _img_cache = {}                                  # "path:mtime:size" → dataURL | None
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23636,6 +23636,19 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                                 ev["absorbed"] = True
                                 if a.get("landedT"):
                                     ev["landedAt"] = int(a["landedT"])
+                            # Several back-to-back sends the CLI took together land as ONE user record
+                            # with a text block each — the shape _atom_user_texts prunes the kernel's
+                            # echoes against. The chat's own pending bubbles end on an EXACT text match
+                            # with a landed event, and `md` is the blocks joined, which matches none of
+                            # them: without the blocks none of those bubbles ever ended (2026-09-07
+                            # review). Shipped only when there are two or more, each under the one text
+                            # key; the client counts one copy per matching block. (Not `texts`: the
+                            # queued event uses that name for another shape.)
+                            btexts = [sb.echo_text_key(b.get("text")) for b in blocks
+                                      if isinstance(b, dict) and b.get("type") == "text"]
+                            btexts = [t for t in btexts if t]
+                            if len(btexts) >= 2:
+                                ev["blocks"] = btexts
                             sp = _space_paths(prompt, sid, a.get("uuid"))
                             if sp:
                                 ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -50,6 +50,15 @@ _pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py"))
 # the reader can never disagree about which path holds the key or how its line is parsed.
 _keysrc = sys.modules.get("romp_keysource") or _SFL(
     "romp_keysource", str(Path(__file__).resolve().parent / "keysource.py")).load_module()
+# The by-text KEY RULE (session_backend.echo_text_key): the one normalization under which an input echo's
+# text is compared with a transcript record's, shared with the kernel's _atom_user_texts so the landing
+# scan below can never find what prune_live cannot retire. The kernel's own copy of that module when it
+# is loaded (the same idiom as _keysrc above); otherwise the file is loaded under its OWN module name:
+# the kernel loads it as romp_session_backend and TmuxBackend subclasses that copy's ABC, and
+# re-executing the source into that module object would rebind the class out from under the subclass.
+echo_text_key = (sys.modules.get("romp_session_backend") or _SFL(
+    "romp_session_backend_keys", str(Path(__file__).resolve().parent / "session_backend.py")).load_module()
+).echo_text_key
 
 
 def _bin_on_path_env(environ) -> dict:
@@ -2772,11 +2781,12 @@ class SdkSession:
         - A RESUMABLE conversation: the atom may genuinely have landed, so re-feeding risks a real
           duplicate. Surface the loss instead, FLAG-ONLY (refeed=False, 2026-08-26): the drop-mark flips
           the echo to "never delivered" NOW, rather than hours later at the next thread spawn.
-          _mark_dropped_echoes' redeliver arm must not run here: its _text_landed scan is a bounded
-          transcript-tail read whose miss would land the message TWICE in the resumed conversation, the
-          exact duplicate this branch is documented to refuse. The re-feed lives only where the
-          conversation is NOT resumable — the re-head above, and the boot/dead-spawn callers
-          (_reseed_echoes, _run), where no client survives to have landed it."""
+          _mark_dropped_echoes' redeliver arm must not run here: the abandoned client may still be
+          flushing the record its _text_landed scan looks for, so a miss is not proof of loss, and a
+          re-feed would land the message TWICE in the resumed conversation, the exact duplicate this
+          branch is documented to refuse. The re-feed lives only where the conversation is NOT
+          resumable — the re-head above, and the boot/dead-spawn callers (_reseed_echoes, _run), where
+          no client survives to have landed it."""
         if not self.inflight:
             return
         stranded = list(self._inflight_texts)      # fed to the abandoned client, never resulted
@@ -5134,6 +5144,51 @@ def _path_bearing(text: str) -> bool:
     return bool(_IMG_PATH_RE.search(text or ""))
 
 
+def _landed_texts(rec: dict) -> set:
+    """Every text a transcript record could have landed a send as — _text_landed's match set, keyed by
+    echo_text_key exactly as the kernel's _atom_user_texts keys the by-text prune (the joined text AND
+    each text block: romp bundles its injected messages as several blocks in one record). Two record
+    shapes carry user text: a native USER record, and the queued_command ATTACHMENT a mid-turn splice
+    leaves, whose prompt is a plain string or a content-block list (the SDK injection path; event_model
+    reads it the same way). Anything else → empty."""
+    out: set = set()
+    typ = rec.get("type")
+    if typ == "user":
+        c = (rec.get("message") or {}).get("content")
+    elif typ == "attachment":
+        a = rec.get("attachment") or {}
+        if a.get("type") != "queued_command":
+            return out
+        c = a.get("prompt")
+    else:
+        return out
+    if isinstance(c, str):
+        blocks = [c]
+    elif isinstance(c, list):
+        blocks = [str(b.get("text") or "") for b in c if isinstance(b, dict) and b.get("type") == "text"]
+    else:
+        return out
+    joined = echo_text_key(" ".join(blocks))
+    if joined:
+        out.add(joined)
+    for b in blocks:
+        cb = echo_text_key(b)
+        if cb:
+            out.add(cb)
+    return out
+
+
+def _record_epoch(ts) -> int | None:
+    """A transcript record's ISO-8601 'Z' stamp as an epoch second, or None when absent or unreadable."""
+    if not isinstance(ts, str) or not ts.strip():
+        return None
+    try:
+        from datetime import datetime
+        return int(datetime.fromisoformat(ts.strip().replace("Z", "+00:00")).timestamp())
+    except Exception:
+        return None
+
+
 _UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 
 
@@ -7208,8 +7263,12 @@ class SdkBackend:
             # from the instant of the send. Cleared event-based by the lastSid-flipping init (the fresh
             # conversation exists) / the turn's ResultMessage.
             s._clearing = True
-        sent_t = int(time.time())              # the echo's stamp, minted BEFORE the CLI can see the text: the
-        s.enqueue(text)                         # record it writes is then at or after it by construction (T237b)
+        # The echo's stamp AND the transcript's byte size, both taken BEFORE the CLI can see the text: the
+        # record it writes is then at or after both by construction (T237b for the stamp; the size,
+        # 2026-09-06, is where _text_landed starts the scan for this echo — see _transcript_mark).
+        sent_t = int(time.time())
+        sent_off, sent_fsid = self._transcript_mark(sid)
+        s.enqueue(text)
         # optimistic input echo: show the user's own message INSTANTLY (neither the transcript nor the
         # stream has it yet at send time — only we know the text). Synthetic uuid; pruned by text once the
         # transcript writes the real user atom.
@@ -7228,10 +7287,32 @@ class SdkBackend:
             "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
         if injected and "<!-- romp-auto -->" in text:
             echo["rompAuto"] = True                          # auto-nudge → romp-logo on the chat/timeline
+        if sent_off is not None:
+            echo["_echo_off"], echo["_echo_fsid"] = sent_off, sent_fsid   # the landing scan's start
         self._stash_live(sid, key, echo)
         self._persist_echoes(sid)                            # unlanded echoes survive a kernel restart (reg mirror)
         self._wake_push()
         return True
+
+    def _transcript_mark(self, sid: str):
+        """(byte size, fsid) of the sid's current transcript at this instant — the send-time mark an echo
+        carries as _echo_off / _echo_fsid (mirrored as off / fsid), so _text_landed can start its scan
+        where this send's landing can first appear. The transcript is append-only and the CLI has not
+        seen the text yet, so every record that can land it begins at or after this size; a file that
+        does not exist yet marks 0. The fsid names the file the mark was measured on: a /clear or a fork
+        lands later sends in a different file, where the mark means nothing and the scan reads from the
+        start. (None, None) when the registry cannot be read — the echo then carries no mark and the
+        scan reads the whole file, the side that never duplicates."""
+        try:
+            reg = read_reg(self.state_dir, sid) or {}
+            fsid = str(reg.get("lastSid") or sid)
+            try:
+                size = os.path.getsize(transcript_path(reg.get("cwd") or "", fsid))
+            except OSError:
+                size = 0
+            return size, fsid
+        except Exception:
+            return None, None
 
     def _persist_echoes(self, sid: str) -> None:
         """Mirror the sid's UNLANDED input echoes to the registry (reg['echoes']), the way _persist_queue
@@ -7247,11 +7328,20 @@ class SdkBackend:
         kernel thread while the session thread stashes and retires atoms, an unlocked walk raised
         `RuntimeError: dictionary changed size during iteration` out of the pusher's chat build —
         every client missed that cycle and nothing reached the error center (2026-09-06)."""
+        snap = []
         with self._live_lock:
             d = self._live.get(sid) or {}
-            snap = [{"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
+            for a in list(d.values()):
+                if not a.get("_echo_text") or a.get("command"):
+                    continue
+                e = {"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
                      "rompAuto": bool(a.get("rompAuto")), "dropped": bool(a.get("dropped"))}
-                    for a in list(d.values()) if a.get("_echo_text") and not a.get("command")]
+                if a.get("_echo_off") is not None:
+                    e["off"] = int(a["_echo_off"])                 # the send-time transcript mark (_transcript_mark)
+                    e["fsid"] = str(a.get("_echo_fsid") or "")
+                if a.get("_landed"):
+                    e["landed"] = True            # the boot/spawn scan found its record: prune_live retires it
+                snap.append(e)
         try:
             self._update_reg(sid, echoes=snap)
         except Exception as e:
@@ -7280,6 +7370,10 @@ class SdkBackend:
                     atom["rompAuto"] = True
                 if e.get("dropped"):
                     atom["dropped"] = True
+                if isinstance(e.get("off"), int) and not isinstance(e.get("off"), bool):
+                    atom["_echo_off"], atom["_echo_fsid"] = e["off"], str(e.get("fsid") or "")
+                if e.get("landed"):
+                    atom["_landed"] = True           # already adjudicated landed: never re-scanned, never flagged
                 self._stash_live(reg["sid"], key, atom)
             if self._live.get(reg["sid"]):
                 self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
@@ -7293,15 +7387,17 @@ class SdkBackend:
         a two-day-old lost send kept resurfacing mid-chat, hopping turns as new ones landed, posing as
         history). Event-based — keyed on the spawn/boot that orphaned the send, never on age — and
         self-correcting: an echo whose text actually LANDED still prunes by text on the next build, so a
-        premature flag can never stick to a delivered message. The flag rides the registry mirror
+        premature flag can never stick to a delivered message; and one the transcript scan below FINDS
+        is not flagged in the first place (2026-09-06). The flag rides the registry mirror
         (_persist_echoes), so it survives further restarts.
 
         `refeed=False` (2026-08-26, honoring _reconcile_stranded's documented policy): the RESUMABLE-
-        reconnect caller takes the flag path ONLY — the redeliver arm's _text_landed scan is a bounded
-        tail read whose miss would land the message a second time in a conversation that genuinely
-        kept the first, exactly the duplicate that branch refuses by design. The loss still surfaces in
-        full (the dropped flag); only the queue re-add is withheld. Boot and dead-spawn callers keep the
-        default: no client survived there to have landed anything."""
+        reconnect caller takes the flag path ONLY — the abandoned client may still be flushing the record
+        the redeliver arm's _text_landed scan looks for, so a miss there is not proof of loss, and a
+        re-feed would land the message a second time in a conversation that genuinely kept the first,
+        exactly the duplicate that branch refuses by design. The loss still surfaces in full (the dropped
+        flag); only the queue re-add is withheld. Boot and dead-spawn callers keep the default: no client
+        survived there to be writing anything."""
         qs = {q for q in queued_texts if isinstance(q, str)}
         # The selection is under the live-tail lock; everything after it (the transcript scan, the
         # queue re-add, the reg write) is not. This runs on the SESSION thread at spawn and at every
@@ -7314,26 +7410,40 @@ class SdkBackend:
                 return
             newly = [a for a in list(d.values())
                      if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
-                     and a["_echo_text"] not in qs]
+                     and not a.get("_landed") and a["_echo_text"] not in qs]
         if not newly:
             return
         # RE-DELIVER, don't just flag (the user 2026-08-23, their strongest point in the restart
-        # audit: "it would be very, very bad if we ever lost stuff because of restarts" — a typed
-        # prompt queued at 11:20 was silently discarded by the 11:25 restart). A HUMAN send whose
-        # loss is proven — and whose text a direct transcript scan confirms never landed as a user
-        # record (the flag path self-corrects on a wrong guess; a re-delivery would DUPLICATE, so it
-        # verifies first) — goes back into the queue in send order, exactly like the surviving
-        # queue, recreating the pre-restart state: the LIVE session's _pending when one is running
-        # (its mirror rewrites reg['queue'] on every mutation, so only _pending sticks), else the
-        # persisted reg queue the next spawn's seed reads.
+        # audit: a typed prompt queued at 11:20 was silently discarded by the 11:25 restart, and
+        # losing input to a restart is the one thing this must never do). A HUMAN send whose loss is
+        # proven — and whose text a direct transcript scan (_text_landed) confirms never landed, as a
+        # user record or as the queued_command attachment of a mid-turn splice — goes back into the
+        # queue in send order, exactly like the surviving queue, recreating the pre-restart state:
+        # the LIVE session's _pending when one is running (its mirror rewrites reg['queue'] on every
+        # mutation, so only _pending sticks), else the persisted reg queue the next spawn's seed reads.
+        # A send the scan FINDS is neither re-delivered (a duplicate) nor flagged: it landed and is
+        # merely un-pruned. The verdict is recorded on the echo (`_landed`, mirrored to the reg) and the
+        # next build's prune_live retires it — by text, or on the verdict alone should the two texts
+        # not meet — and a later boot never re-scans it. A `dropped` flag would call a delivered message
+        # "never delivered" for a push (the absorbed case, 2026-09-06: the scan knew only user records,
+        # so an absorbed send was re-queued and ran twice). A scan that cannot read the transcript
+        # answers None and the echo takes the flag path: never re-deliver on doubt, but never hide the
+        # possible loss either.
         # romp-authored echoes (nudges) keep the flag path: re-delivering one could double-nudge,
         # and its content is regenerable machinery, not the user's words. A refeed=False caller
         # (the resumable reconnect — docstring above) keeps EVERY echo on the flag path.
-        redeliver = []
+        redeliver, landed = [], set()
         if refeed:
             for a in sorted(newly, key=lambda x: x.get("t") or 0):
-                if a.get("author") == "human" and not self._text_landed(sid, a["_echo_text"]):
+                if a.get("author") != "human":
+                    continue
+                seen = self._text_landed(sid, a["_echo_text"], a.get("t"),
+                                         a.get("_echo_off"), a.get("_echo_fsid"))
+                if seen is False:
                     redeliver.append(a)
+                elif seen:
+                    a["_landed"] = True                    # the verdict, for prune_live and the next boot
+                    landed.add(a["_echo_text"])
         if redeliver:
             # The LIVE-session caller (a fresh spawn's _run) must deliver through the session's
             # own queue: there the in-memory _pending is authoritative and its very next
@@ -7374,6 +7484,8 @@ class SdkBackend:
         for a in newly:
             if a["_echo_text"] in rekeyed:
                 continue                                   # now in the queue → renders as queued, prunes on landing
+            if a["_echo_text"] in landed:
+                continue                                   # landed, un-pruned → the next build's prune_live
             a["dropped"] = True
             self._touch_live(sid)
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
@@ -7381,35 +7493,64 @@ class SdkBackend:
         self._persist_echoes(sid)
         self._wake_push()
 
-    def _text_landed(self, sid: str, text: str) -> bool:
-        """Did `text` land as a USER record in the sid's transcript? The re-delivery guard: the echo
-        prune is lazy (a landed echo may still be un-pruned at boot), so a queue re-add without this
-        scan would duplicate a delivered message. Reads the transcript TAIL (the loss window is recent
-        by construction — the send predates the death that orphaned it); unreadable → True, the safe
-        side: never re-deliver on doubt, the flag path still surfaces the loss for a human call."""
+    def _text_landed(self, sid: str, text: str, t: int | None = None, off=None, fsid=None):
+        """Did `text` land in the sid's transcript? The re-delivery guard: the echo prune is lazy (a landed
+        echo may still be un-pruned at boot), so a queue re-add without this scan would duplicate a
+        delivered message. Three answers, because the caller acts on each differently:
+          True  — a record carries the text: a native USER record, or the queued_command ATTACHMENT a
+                  mid-turn splice leaves. That attachment is the ONLY record an absorbed send ever gets
+                  (event_model._absorbed reads the atom's text off it; _landed_texts reads it the same
+                  way). Until 2026-09-06 this scan accepted user records alone, so after a kernel restart
+                  an absorbed send read as never landed, was re-queued, and the resumed CLI ran the same
+                  instruction twice — the chat showed it twice, the absorbed atom and a new native record.
+          False — the transcript is readable and no record carries it: the send is provably lost.
+          None  — the transcript cannot be read: never re-deliver on doubt; the caller flags the echo, so
+                  the loss still surfaces for a human call.
+        `t` is the echo's send time: a record stamped BEFORE it is not this send's landing — "ok", "go
+        ahead" and a deliberate re-send repeat earlier texts (prune_live's own rule, T237b) — while a
+        record with no readable stamp still counts, the side that never duplicates. The match is
+        echo_text_key's, the same rule the kernel's _atom_user_texts keys prune_live's by-text retire
+        with, so a found echo is always one the prune can retire: the joined text or any one text block
+        EQUAL to the send — never a substring, or a found-but-never-pruned echo would ride the tail
+        forever. `off` / `fsid` are the echo's send-time transcript mark (_transcript_mark): the file's
+        byte size when the send was made, and the fsid it was measured on. The scan starts THERE — every
+        record that can land this send is at or after it, however much the session wrote afterwards —
+        rather than at a fixed distance from EOF, which read a landed send whose record sat more than
+        2 MB before EOF as never landed and re-queued it (2026-09-06). A mark from another file (the
+        fsid changed: a /clear, a fork), one past the file's end, or no mark at all (an echo persisted
+        before marks existed) reads from the start. Lines are streamed, never read whole, and
+        pre-filtered on the two record types' literals only, never on the text: JSON escapes newlines
+        and quotes, so a raw-line prefix test skipped every multi-line send (a quote chip's reply, for
+        one) as never landed. A mark taken while the CLI was mid-write leaves a line fragment first; it
+        fails to parse and is skipped like any other non-record line."""
         try:
             reg = read_reg(self.state_dir, sid) or {}
-            path = transcript_path(reg.get("cwd") or "", reg.get("lastSid") or sid)
-            want = " ".join(text.split())
+            cur = str(reg.get("lastSid") or sid)
+            path = transcript_path(reg.get("cwd") or "", cur)
+            want = echo_text_key(text)
+            floor = int(t or 0)
+            start = 0
+            if (isinstance(off, int) and not isinstance(off, bool) and fsid is not None
+                    and str(fsid) == cur and 0 <= off <= os.path.getsize(path)):
+                start = off
             with open(path, "rb") as f:
-                f.seek(max(0, os.path.getsize(path) - 2_000_000))
-                for line in f.read().decode(errors="replace").splitlines():
-                    if '"user"' not in line or want[:60] not in " ".join(line.split()):
+                f.seek(start)
+                for raw in f:
+                    if b'"user"' not in raw and b'"queued_command"' not in raw:
                         continue
                     try:
-                        rec = json.loads(line)
+                        rec = json.loads(raw.decode(errors="replace"))
                     except ValueError:
                         continue
-                    if rec.get("type") != "user":
+                    if not isinstance(rec, dict) or want not in _landed_texts(rec):
                         continue
-                    c = ((rec.get("message") or {}).get("content"))
-                    txt = c if isinstance(c, str) else " ".join(
-                        b.get("text", "") for b in c if isinstance(b, dict)) if isinstance(c, list) else ""
-                    if want in " ".join(txt.split()):
-                        return True
+                    ts = _record_epoch(rec.get("timestamp"))
+                    if floor and ts is not None and ts < floor:
+                        continue                       # an earlier record wearing the same words
+                    return True
             return False
         except Exception:
-            return True
+            return None
 
     def dismiss_echo(self, sid: str, uuid: str | None = None, t: int | None = None) -> str | None:
         """✕ on a never-delivered bubble: retire a DROPPED echo the user has acknowledged. Matched by the
@@ -8914,6 +9055,14 @@ class SdkBackend:
         of every client but the sender's. The tmux route keeps its own floor in kernel._tmux_echo_settle,
         borrowing _path_bearing: there a send is a paste into the composer.
 
+        The by-text comparison is keyed by echo_text_key on BOTH sides (2026-09-06): the kernel builds
+        `tx_user_texts` from _atom_user_texts, and the echo's text is keyed the same way here — before,
+        the raw text was compared against stripped keys, so an echo whose text carried a trailing
+        newline never retired. An echo the boot/spawn scan already FOUND (`_landed`, recorded by
+        _mark_dropped_echoes from a direct read of the transcript and mirrored to the reg) retires
+        without the comparison at all: that is its exit when the two texts cannot meet, since a found
+        echo is neither flagged nor dismissable.
+
         `human_floor` still retires COMMAND atoms below. (Echo-only: real stream atoms have no
         _echo_text and prune by uuid as before.)
 
@@ -8927,11 +9076,12 @@ class SdkBackend:
         # held. A plain set (older callers) keeps the unfloored match.
         text_t = tx_user_texts if isinstance(tx_user_texts, dict) else None
         def _by_text(a, et):
-            if not et:
+            key = echo_text_key(et)
+            if not key:
                 return False
             if text_t is None:
-                return et in tx_user_texts
-            return et in text_t and float(text_t[et] or 0) >= float(a.get("t") or 0)
+                return key in tx_user_texts
+            return key in text_t and float(text_t[key] or 0) >= float(a.get("t") or 0)
         echo_removed = False
         vanished = 0
         with self._live_lock:
@@ -8940,7 +9090,7 @@ class SdkBackend:
                 return
             for k, a in list(d.items()):   # a SNAPSHOT (belt-and-braces under the lock — _note_live_tail_race)
                 et = a.get("_echo_text")
-                landed = a.get("uuid") in tx_uuids or _by_text(a, et)
+                landed = a.get("uuid") in tx_uuids or bool(a.get("_landed")) or _by_text(a, et)
                 # A COMMAND atom (the CLI's streamed /model, /compact feedback) from a TURN-LESS control
                 # request may never get a transcript record to land against — retire it once a genuine human
                 # turn postdates it, so the stale confirmation line doesn't ride pinned inside every later

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3698,12 +3698,16 @@ class SdkSession:
             return False
 
     def _note_message_failure(self, msg, e) -> None:
-        """One problem line per failure, with enough to fix by: the exception type, the message's type
-        and subtype (never its content), the exception's own text (uuid-shaped ids shortened, clipped —
-        _mask_ids), what that message losing its handling cost (_failure_consequence — for a
-        ResultMessage read from whether the settle's finally ran for it, never assumed), and the frame
-        chain (file:line function, no locals, bounded; _compact_tb). A bare `KeyError: '<uuid>'` with
-        none of this is what the last such failure left to diagnose from.
+        """One problem line per failure, with enough to fix by: the exception type and the FAILING SITE
+        (the innermost frame, file:line function — _failing_site), the message's type and subtype
+        (never its content), what that message losing its handling cost (_failure_consequence — for a
+        ResultMessage read from whether the settle's finally ran for it, never assumed), the exception's
+        own text (uuid-shaped ids shortened, clipped — _mask_ids), and the frame chain (innermost
+        first, no locals, bounded; _compact_tb). A bare `KeyError: '<uuid>'` with none of this is what
+        the last such failure left to diagnose from. The site LEADS the line, right after the type: the
+        error center shows a row's first 240 characters (the kernel feed caps the text at 400), and
+        with the chain at the end of ~335 characters of prose a user never saw where a handler failed
+        (2026-09-07 review). The full chain stays at the tail for the kernel log.
 
         Repeats: a signature is (session, exception type, the failing frame as file/line/function —
         _failing_frame, read from the traceback itself, so the chain's length cap cannot change it).
@@ -3727,9 +3731,10 @@ class SdkSession:
             return
         settled = getattr(self, "_settled_msg", None) is msg   # getattr: __new__-built test doubles
         again = "" if n == 1 else " (repeat %d this kernel life; its earlier error-center entry was evicted)" % n
-        self.backend._log("sdk session %s: %s while handling a %s message%s; that message's handling "
-                          "stopped there (%s) and the stream continues. %s: %s, at %s"
-                          % (self.name, type(e).__name__, kind, again, _failure_consequence(msg, settled=settled),
+        self.backend._log("sdk session %s: %s at %s while handling a %s message%s; that message's handling "
+                          "stopped there (%s) and the stream continues. %s: %s. Frames, innermost first: %s"
+                          % (self.name, type(e).__name__, _failing_site(e), kind, again,
+                             _failure_consequence(msg, settled=settled),
                              type(e).__name__, _mask_ids(e), _compact_tb(e)), problem=True, key=key)
 
     def _on_message(self, msg, AssistantMessage, ResultMessage, SystemMessage):
@@ -3952,24 +3957,10 @@ class SdkSession:
         elif isinstance(msg, ResultMessage):
             try:
                 # (This try is the whole branch: its body is the result's BOOKKEEPING, its finally is
-                # THE SETTLE — the finally's comment has the rule.)
-                # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
-                # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
-                # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
-                # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
-                total = getattr(msg, "total_cost_usd", None)
-                if isinstance(total, (int, float)) and total > 0:
-                    delta = total - self._last_cost_total if total >= self._last_cost_total else total
-                    self._last_cost_total = float(total)
-                    # the tokens: THIS turn's counts, from whichever result counter is a running total —
-                    # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
-                    turn_u = self._turn_usage(msg)
-                    self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
-                                               sid=self.thread_of or self.sid)   # the rail's spend —
-                    #   a comment THREAD bills its owning session (T144: whole-session truth for the
-                    #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
-                    #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
-                    #   honest on a mixed host (see _record_spend)
+                # THE SETTLE — the finally's comment has the rule. The spend accounting runs LAST in the
+                # body: it is the step most likely to raise on data (a NaN usage field, a failing spend
+                # write), and ahead of the others it skipped the rewind consumption and the live-tail
+                # sweep — 2026-09-07 review.)
                 if self._rewind_to and getattr(self, "_rewind_wait", False):
                     # delete-while-busy: THIS settle is the interrupted turn ending — the flag is being
                     # ARMED here, not consumed. Second observer of the turn-end fact (the Stop hook is
@@ -4005,10 +3996,28 @@ class SdkSession:
                 asyncio.ensure_future(self._do_refresh_context())   # refresh ctx % + model from the SDK and
                 #   persist them, so the bar reflects the turn that just landed and survives idle/restart.
                 asyncio.ensure_future(self._do_refresh_usage())     # + the exact /usage snapshot (rail bars)
+                # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
+                # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
+                # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
+                # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
+                # (The scheduled refreshes above cannot run before this synchronous step: nothing yields.)
+                total = getattr(msg, "total_cost_usd", None)
+                if isinstance(total, (int, float)) and total > 0:
+                    delta = total - self._last_cost_total if total >= self._last_cost_total else total
+                    self._last_cost_total = float(total)
+                    # the tokens: THIS turn's counts, from whichever result counter is a running total —
+                    # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
+                    turn_u = self._turn_usage(msg)
+                    self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
+                                               sid=self.thread_of or self.sid)   # the rail's spend —
+                    #   a comment THREAD bills its owning session (T144: whole-session truth for the
+                    #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
+                    #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
+                    #   honest on a mixed host (see _record_spend)
             finally:
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
-                # bookkeeping above did (the spend fold, the rewind flags, the live-tail
-                # sweep, the refreshes: any step may raise and stop the rest). The rule
+                # bookkeeping above did (the rewind flags, the live-tail sweep, the refreshes, the spend
+                # accounting last: any step may raise and stop the rest). The rule
                 # (2026-09-06): a ResultMessage is the CLI saying the turn ended, so a kernel-side failure
                 # while filing it must never leave the session reading 'working' with its queue parked.
                 # The first cut opened the try only ahead of the rewind steps, so a raise in the spend
@@ -5223,17 +5232,26 @@ def _failing_frame(exc):
     return (os.path.basename(f.filename), f.lineno or 0, f.name)
 
 
+def _failing_site(exc) -> str:
+    """The failing frame rendered as the chain renders a step (`file:line function`), or "?" when the
+    exception carries no traceback — what the problem line names right after the exception type."""
+    site = _failing_frame(exc)
+    return "%s:%d %s" % site if site else "?"
+
+
 def _compact_tb(exc, max_frames: int = COMPACT_TB_FRAMES, cap: int = COMPACT_TB_CHARS) -> str:
-    """The exception's frame chain as `file:line function` steps, outermost first — no locals, no
-    source lines: enough to name the site on the next occurrence, small enough for one log line.
-    BOUNDED FROM THE OUTER END: at most the innermost `max_frames` frames, then outer frames dropped
-    one at a time until the chain fits `cap` characters, with a prefix saying how many were dropped
-    in all. The innermost frame — the failing site — is always kept; if it alone overflows the cap,
-    its function name is clipped and its file:line stands. (A RecursionError's chain ran to 18 KB
-    before any bound, into the error-center ring and every feed payload that carries it; the first
-    bound then clipped the chain's TAIL, which is the innermost frame, so a chain through long-named
-    frames lost its failing site, and a dedupe key read off the rendering became the literal '…' —
-    every long-chained failure of one type folded into one ring entry. 2026-09-06.)"""
+    """The exception's frame chain as `file:line function` steps, INNERMOST FIRST — the failing site
+    leads, and each ` < ` step is the caller of the one before it — no locals, no source lines: enough
+    to name the site on the next occurrence, small enough for one log line. BOUNDED FROM THE OUTER
+    END: at most the innermost `max_frames` frames, then outer frames dropped one at a time until the
+    chain fits `cap` characters, with a suffix saying how many were dropped in all. The innermost
+    frame — the failing site — is always kept; if it alone overflows the cap, its function name is
+    clipped and its file:line stands. (A RecursionError's chain ran to 18 KB before any bound, into
+    the error-center ring and every feed payload that carries it; the first bound then clipped the
+    chain's TAIL, which was the innermost frame, so a chain through long-named frames lost its failing
+    site, and a dedupe key read off the rendering became the literal '…' — every long-chained failure
+    of one type folded into one ring entry. 2026-09-06. Innermost first since 2026-09-07: the chain
+    sits at the end of a line the error center clips, so what survives the clip must be the site.)"""
     frames = traceback.extract_tb(getattr(exc, "__traceback__", None))
     if not frames:
         return "?"
@@ -5241,21 +5259,21 @@ def _compact_tb(exc, max_frames: int = COMPACT_TB_FRAMES, cap: int = COMPACT_TB_
 
     def render(kept):
         dropped = total - len(kept)
-        s = " > ".join(kept)
-        return "…%d outer frame%s dropped… > %s" % (dropped, "" if dropped == 1 else "s", s) if dropped else s
+        s = " < ".join(kept)
+        return "%s < …%d outer frame%s dropped…" % (s, dropped, "" if dropped == 1 else "s") if dropped else s
 
-    steps = [_frame_step(f) for f in frames[-max(1, max_frames):]]
-    kept = steps[-1:]                        # the innermost frame, unconditionally
-    for step in reversed(steps[:-1]):        # then outward, one frame at a time, while the whole fits
-        if len(render([step] + kept)) > cap:
+    steps = [_frame_step(f) for f in reversed(frames[-max(1, max_frames):])]   # innermost first
+    kept = steps[:1]                         # the innermost frame, unconditionally
+    for step in steps[1:]:                   # then outward, one frame at a time, while the whole fits
+        if len(render(kept + [step])) > cap:
             break
-        kept = [step] + kept
+        kept = kept + [step]
     s = render(kept)
     if len(s) > cap:                         # the innermost frame alone overflows: clip its function name
         site, _, func = kept[0].partition(" ")
-        head = render([site + " "])          # the prefix and the file:line — never clipped
-        room = cap - len(head) - 1
-        s = (head + func[:room] + "…") if room >= 0 else s[:cap - 1] + "…"   # (a site wider than the cap: bound it anyway)
+        bare = render([site + " "])          # the file:line and the drop suffix — never clipped
+        room = cap - len(bare) - 1
+        s = render([site + " " + func[:room] + "…"]) if room >= 0 else s[:cap - 1] + "…"   # (a site wider than the cap: bound it anyway)
     return s
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3699,15 +3699,16 @@ class SdkSession:
 
     def _note_message_failure(self, msg, e) -> None:
         """One problem line per failure, with enough to fix by: the exception type and the FAILING SITE
-        (the innermost frame, file:line function — _failing_site), the message's type and subtype
-        (never its content), what that message losing its handling cost (_failure_consequence — for a
-        ResultMessage read from whether the settle's finally ran for it, never assumed), the exception's
-        own text (uuid-shaped ids shortened, clipped — _mask_ids), and the frame chain (innermost
-        first, no locals, bounded; _compact_tb). A bare `KeyError: '<uuid>'` with none of this is what
-        the last such failure left to diagnose from. The site LEADS the line, right after the type: the
-        error center shows a row's first 240 characters (the kernel feed caps the text at 400), and
-        with the chain at the end of ~335 characters of prose a user never saw where a handler failed
-        (2026-09-07 review). The full chain stays at the tail for the kernel log.
+        (the innermost frame of a real function, file:line function — _failing_site; a comprehension's
+        or lambda's own frame is skipped, so the site reads the same on every interpreter), the
+        message's type and subtype (never its content), what that message losing its handling cost
+        (_failure_consequence — for a ResultMessage read from whether the settle's finally ran for it,
+        never assumed), the exception's own text (uuid-shaped ids shortened, clipped — _mask_ids), and
+        the frame chain (innermost first, no locals, bounded; _compact_tb). A bare `KeyError: '<uuid>'`
+        with none of this is what the last such failure left to diagnose from. The site LEADS the line,
+        right after the type: the error center shows a row's first 240 characters (the kernel feed caps
+        the text at 400), and with the chain at the end of ~335 characters of prose a user never saw
+        where a handler failed (2026-09-07 review). The full chain stays at the tail for the kernel log.
 
         Repeats: a signature is (session, exception type, the failing frame as file/line/function —
         _failing_frame, read from the traceback itself, so the chain's length cap cannot change it).
@@ -5221,14 +5222,26 @@ def _frame_step(f) -> str:
 
 
 def _failing_frame(exc):
-    """The exception's innermost frame — where it was raised — as (file basename, line, function),
-    read from the traceback itself. This is the recurring-failure dedupe key (_note_message_failure):
-    taken from the frame and not from the rendered chain, so no rendering bound can change it. None
-    when the exception carries no traceback."""
+    """The exception's failing frame — the innermost frame of a REAL function — as (file basename,
+    line, function), read from the traceback itself. This is the recurring-failure dedupe key
+    (_note_message_failure) and the site the problem line names (_failing_site): taken from the frame
+    and not from the rendered chain, so no rendering bound can change it. None when the exception
+    carries no traceback.
+
+    Synthetic scopes are skipped: a frame whose code name is angle-bracketed (`<dictcomp>`,
+    `<listcomp>`, `<setcomp>`, `<genexpr>`, `<lambda>`, `<module>`) is not a function a reader can look
+    up by name, and whether one exists at all depends on the interpreter — before Python 3.12
+    (PEP 709) a comprehension runs in its own frame, so a raise inside one named `<dictcomp>` on 3.10
+    and 3.11 while 3.12 and 3.13 named the enclosing function, and the site (the dedupe key with it)
+    differed by interpreter (upstream CI on the 2026-09-07 review: the NaN-usage settle test). The
+    site is the innermost frame whose name is a function's, at the line that frame reports (for a
+    comprehension, the line the comprehension is on); when every frame is synthetic (a raise caught at
+    the top level of an exec'd string) the innermost one stands. The rendered chain (_compact_tb)
+    keeps every frame, synthetic ones included."""
     frames = traceback.extract_tb(getattr(exc, "__traceback__", None))
     if not frames:
         return None
-    f = frames[-1]
+    f = next((f for f in reversed(frames) if not f.name.startswith("<")), frames[-1])
     return (os.path.basename(f.filename), f.lineno or 0, f.name)
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2568,6 +2568,15 @@ class SdkSession:
         with self._lock:
             return list(self._pending)
 
+    def fed_texts(self) -> list[str]:
+        """The texts FED to the current client whose ResultMessage has not landed (`_inflight_texts`,
+        oldest first); thread-safe. A mid-turn send lives here from the inputs() pop until the turn
+        settles: the CLI holds it, queued behind the running turn, to splice at the next tool boundary.
+        The observable twin of `inflight`, for diagnostics and tests; nothing gates on it (prune_live
+        floors no echo, so there is nothing to shield a fed echo from — its docstring)."""
+        with self._lock:
+            return list(self._inflight_texts)
+
     def unqueue(self, idx: int, expect: str | None = None) -> str | None:
         """Remove the queued turn at position `idx` (the chat's queued list is this same _pending order)
         and return its raw text, or None if it's gone. Lets the user CANCEL a message they queued
@@ -5099,15 +5108,29 @@ class SdkSession:
 
 LIVE_TAIL_CAP = 100
 
-# A path-looking token (absolute or ~-rooted): the one case where an echo's text-match against the
-# transcript can structurally FAIL — the transcript extracts an attached file's path out of the user
-# text (the user 2026-06-25) — so only these echoes stay eligible for the genuine-human-turn floor
-# retire in prune_live. Everything else prunes by its own text landing, or persists (a visible loss).
-_PATHY_RE = re.compile(r"(?:^|[\s'\"`(])(?:~/|/)[^\s'\"`)]+")
+# An IMAGE path (absolute or ~-rooted) with one of the extensions the CLI's composer paste hook
+# recognises. SOURCE OF TRUTH: the installed Claude Code bundle (2.1.261) carries exactly one image-path
+# test, `/\.(png|jpe?g|gif|webp)$/i`, and its callers are the terminal composer's bracketed-paste
+# handler — which reads a pasted path wearing one of those extensions and rewrites the token in the
+# submitted text to "[Image #N]", so the picture lands as an image block and the path is gone from the
+# record's text (the user 2026-06-25, the screenshots-piling-up bug) — and two attachment uploaders'
+# isImage. No bmp, no svg: the wider set this carried until 2026-09-06 (any absolute or ~-rooted path,
+# then an image set with both) classed a `.svg` path echo, or a quote chip's `path:line` label, as an
+# extraction the CLI never performs.
+# WHO READS IT. The kernel's _tmux_echo_settle borrows _path_bearing for the TMUX route, where a send
+# IS a paste into the composer and the hook runs. The SDK route never reaches it: its input is
+# stream-json and the CLI takes the text as typed (a count over one installation's SDK transcripts,
+# 2026-09-06: 0 image blocks in 8,569 user records across 71 sessions; every image-path text landed
+# verbatim), which is why prune_live below floors NO echo — see its docstring. Twin of the kernel's
+# _IMG_PATH_RE (_injected_img_paths waits on the CLI's rewrite; _user_images reads the extraction back);
+# tests/test_kernel_fed_echo_absorbed.py pins both twins to the CLI's set.
+_IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp))\b", re.I)
 
 
 def _path_bearing(text: str) -> bool:
-    return bool(_PATHY_RE.search(text or ""))
+    """True when `text` carries an image path the CLI's composer paste hook would extract (_IMG_PATH_RE).
+    Read by kernel._tmux_echo_settle through sys.modules — the tmux route's floor; keep the name."""
+    return bool(_IMG_PATH_RE.search(text or ""))
 
 
 _UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
@@ -8868,16 +8891,30 @@ class SdkBackend:
         """Drop live atoms the transcript has now caught up on — by uuid (assistant/tool/user from the
         stream) or by text (the optimistic input echo, which has a synthetic uuid).
 
-        FIFO floor for echoes — PATH-BEARING ONLY (narrowed, the user 2026-07-20): an input echo whose text
-        can't match because the transcript EXTRACTED an image path out of the user text (`_atom_user_text`
-        no longer contains the echoed path — the screenshots-piling-up-at-the-bottom bug, the user
-        2026-06-25) is retired once the transcript's newest GENUINE-HUMAN turn is at/after the echo's send
-        time. The floor used to apply to EVERY echo, justified by "a still-queued send keeps showing via
-        the queued indicator" — but since queued sends FORWARD into the CLI mid-turn (2026-07-17) a message
-        can be neither queued nor landed, and the blanket floor hid exactly that in-flight message the
-        moment any other human record landed. A plain-text echo now prunes ONLY by its own text landing —
-        and a genuinely dropped send's echo PERSISTS, so the loss shows (the tmux echo's semantics).
-        (Echo-only: real stream atoms have no _echo_text and prune by uuid as before.)
+        NO FLOOR RETIRES AN ECHO ON THIS BACKEND (2026-09-06). An input echo retires on exactly two
+        events: its text LANDS — a native user record, or the queued_command attachment a mid-turn splice
+        leaves; the kernel's _atom_user_texts reads both, and `tx_user_texts` maps each text to the newest
+        record time carrying it, so the record must be stamped at or after the send — or the CLI DIES
+        holding it, when _mark_dropped_echoes / _reconcile_stranded flag it `dropped` and it stays as the
+        visible loss until the user dismisses it. A dropped echo that never lands persists on purpose
+        (the tmux echo's semantics): a genuinely lost send must show.
+
+        The floor this replaces: `human_floor` (the newest genuine-human atom's time) once retired every
+        echo it postdated, was narrowed to path-bearing echoes (the user 2026-07-20) — the image-
+        extraction case, where the CLI's composer paste hook rewrites a pasted image path to "[Image #N]"
+        and the echo's text can never match — and that predicate matched far more than image paths: it
+        retired a staged comment whose quote chip carried a `path:line` label while the CLI still held
+        the message, so nothing showed the message until the splice. Narrowing it to image paths left a
+        rule with no true positives here: the hook runs only in the terminal composer, and an SDK
+        session's input is stream-json, so the CLI takes the text as typed (0 image blocks in 8,569 user
+        records over 71 sessions of one installation; every image-path text landed verbatim). Its only
+        effect was the false kind — a `.png` echo retired while its text sat in the CLI's queue, or in
+        the gap between the turn's ResultMessage and the next turn's record, so the message blinked out
+        of every client but the sender's. The tmux route keeps its own floor in kernel._tmux_echo_settle,
+        borrowing _path_bearing: there a send is a paste into the composer.
+
+        `human_floor` still retires COMMAND atoms below. (Echo-only: real stream atoms have no
+        _echo_text and prune by uuid as before.)
 
         Pure dict work, so the whole sweep runs under the live-tail lock (the emptiness check and the
         sid-level pop included — one step, so a stash can never land in a dict this pops); the echo
@@ -8903,14 +8940,12 @@ class SdkBackend:
             for k, a in list(d.items()):   # a SNAPSHOT (belt-and-braces under the lock — _note_live_tail_race)
                 et = a.get("_echo_text")
                 landed = a.get("uuid") in tx_uuids or _by_text(a, et)
-                stale_echo = (bool(et) and human_floor and a.get("t", 0) <= human_floor
-                              and not a.get("command") and _path_bearing(et))
                 # A COMMAND atom (the CLI's streamed /model, /compact feedback) from a TURN-LESS control
                 # request may never get a transcript record to land against — retire it once a genuine human
                 # turn postdates it, so the stale confirmation line doesn't ride pinned inside every later
                 # turn forever (the user 2026-07-02, with the live_work command exemption).
                 stale_cmd = bool(a.get("command")) and human_floor and a.get("t", 0) <= human_floor
-                if landed or stale_echo or stale_cmd:
+                if landed or stale_cmd:
                     echo_removed = echo_removed or bool(et and not a.get("command"))
                     if d.pop(k, None) is None:
                         vanished += 1

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2238,6 +2238,12 @@ class SdkSession:
     # One diagnostic per process if an api_retry payload stops matching every spelling we know (see the
     # api_retry branch): the retry detail goes blank silently otherwise, which is how it stayed broken.
     _retry_shape_warned = False
+    # Per-message handler failures (_handle_stream_message): (sid, exception type, innermost frame as
+    # (file, line, function)) → count, per kernel life. The first of a signature logs its frame chain;
+    # a repeat logs one short counted line while the ring still holds the signature's entry, and the
+    # full line again once the ring has evicted it — so a handler failing on each message stays visible.
+    _stream_fail_seen: dict = {}
+    _stream_fail_lock = threading.Lock()
 
     def __init__(self, backend: "SdkBackend", reg: dict):
         self.backend = backend
@@ -2462,6 +2468,8 @@ class SdkSession:
         self._wake: asyncio.Event | None = None
         self._reconnect = False                 # the current break is a reconnect (not a shutdown)
         self._reconnect_when_idle = False        # a reconnect was requested mid-turn → apply at turn end
+        self._settled_msg = None                 # the ResultMessage whose settle ran last (its finally records
+        #   it) — what _note_message_failure reads to say whether a failed result's turn still settled
         # The handshake as a cross-thread EVENT: set the moment a ClaudeSDKClient is up, cleared when
         # it goes down — what a kernel-thread caller that needs the control channel (SdkBackend.move on
         # a just-revived session) waits on, instead of polling for self.client.
@@ -3287,15 +3295,10 @@ class SdkSession:
                 yield {"type": "user",
                        "message": {"role": "user", "content": [{"type": "text", "text": item}]}}
 
-        async def drain(client):
-            # Feed turns and receive messages CONCURRENTLY: query() with a streaming input iterable BLOCKS
-            # until the iterable ends (it writes each turn to stdin), and our input generator never ends —
-            # so awaiting it before receiving would starve the receive loop. The control channel
-            # (can_use_tool) has its own reader; the message stream does not, so it's drained here.
-            async for msg in client.receive_messages():
-                if self.ended:
-                    break
-                self._on_message(msg, AssistantMessage, ResultMessage, SystemMessage)
+        # Feed turns and receive messages CONCURRENTLY: query() with a streaming input iterable BLOCKS
+        # until the iterable ends (it writes each turn to stdin), and our input generator never ends —
+        # so awaiting it before receiving would starve the receive loop. The control channel
+        # (can_use_tool) has its own reader; the message stream does not, so _drain drains it.
 
         # Reconnect loop: one persistent client per iteration. A connect-time option change (effort, a CLI
         # flag with no runtime control) reconnects with fresh options — resume_sid continues the conversation
@@ -3386,20 +3389,25 @@ class SdkSession:
                     # this, nothing showed after a kernel restart until each session's next turn.
                     asyncio.ensure_future(self._do_adopt_server_info())
                     feeder = asyncio.ensure_future(client.query(inputs()))
-                    recv = asyncio.ensure_future(drain(client))
+                    recv = asyncio.ensure_future(self._drain(client, AssistantMessage, ResultMessage, SystemMessage))
                     waker = asyncio.ensure_future(self._wake.wait())
                     try:
                         await asyncio.wait({recv, waker}, return_when=asyncio.FIRST_COMPLETED)
                     finally:
                         for tk in (feeder, recv, waker):
                             tk.cancel()
-                        for tk in (feeder, recv, waker):
+                        for tk, role in ((feeder, "input feeder"), (recv, "message receiver"), (waker, "waker")):
                             try:
                                 await tk
                             except asyncio.CancelledError:
                                 pass
                             except Exception as e:                 # a genuine stream/transport error — surface it
-                                self.backend._log(f"sdk session {self.name}: {type(e).__name__}: {e}")
+                                # Per-message failures stop inside _handle_stream_message, so what reaches
+                                # here is the stream itself failing (the CLI exiting on an error, a
+                                # transport fault) or the feeder. Named with its task and frame chain: the
+                                # old bare `type: text` line left a session death with nothing to fix by.
+                                self.backend._log("sdk session %s: the %s ended on %s: %s, at %s"
+                                                  % (self.name, role, type(e).__name__, _mask_ids(e), _compact_tb(e)))
                         self.client = None
                         self._connected.clear()
             except Exception as e:
@@ -3626,6 +3634,85 @@ class SdkSession:
         u = u if isinstance(u, dict) else {}
         return {k: (int(u[k]) if isinstance(u.get(k), (int, float)) else 0) for k, _ in self._USAGE_KEYS}
 
+    async def _drain(self, client, AssistantMessage, ResultMessage, SystemMessage):
+        """The receive loop. Every streamed message goes through _handle_stream_message, which keeps
+        a handler's failure to that one message; what ends this loop is the STREAM ending — the CLI
+        exiting, a transport fault the SDK re-raises, our own `ended` — never a message the kernel
+        mishandled. (_amain drains this concurrently with the input feeder: query() with a streaming
+        input blocks until the iterable ends, and ours never does.)"""
+        async for msg in client.receive_messages():
+            if self.ended:
+                break
+            self._handle_stream_message(msg, AssistantMessage, ResultMessage, SystemMessage)
+
+    def _handle_stream_message(self, msg, AssistantMessage, ResultMessage, SystemMessage) -> bool:
+        """_on_message, with its failures contained to the message that caused them. Until 2026-09-06
+        any exception in a handler propagated out of the receive loop, and the client teardown that
+        followed treated it as the stream ending: the CLI process was closed — killing its in-flight
+        turn, every subagent and every background task — and the session came back as a crash resume,
+        all over ONE message the kernel could not file (a `KeyError` on a message uuid, from a
+        live-tail sweep racing the kernel thread; see SdkBackend._note_live_tail_race). A malformed or
+        unexpected message now costs its own handling and nothing else: the CLI keeps running (what
+        the kernel lost of that one message depends on its class — see _failure_consequence).
+        Returns whether the handler ran clean.
+
+        The REPORT is guarded too: an exception's `__str__` can raise (a third-party error type
+        wrapping partial data), and the kernel's log callback can (stderr closed under a service
+        restart). Unguarded, either ended the drain from inside the except — the outcome this method
+        exists to prevent. A reporter failure logs one plain line built from names only, and if even
+        that cannot be written the failure is swallowed: the stream comes first."""
+        try:
+            self._on_message(msg, AssistantMessage, ResultMessage, SystemMessage)
+            return True
+        except Exception as e:
+            try:
+                self._note_message_failure(msg, e)
+            except Exception as e2:
+                try:
+                    self.backend._log("sdk session %s: a %s in a handler on a %s message, and reporting it "
+                                      "failed too (%s); handling stopped, stream continues"
+                                      % (self.name, type(e).__name__, type(msg).__name__, type(e2).__name__),
+                                      problem=True,
+                                      key=("stream-fail-report", self.sid, type(e).__name__, type(e2).__name__))
+                except Exception:
+                    pass
+            return False
+
+    def _note_message_failure(self, msg, e) -> None:
+        """One problem line per failure, with enough to fix by: the exception type, the message's type
+        and subtype (never its content), the exception's own text (uuid-shaped ids shortened, clipped —
+        _mask_ids), what that message losing its handling cost (_failure_consequence — for a
+        ResultMessage read from whether the settle's finally ran for it, never assumed), and the frame
+        chain (file:line function, no locals, bounded; _compact_tb). A bare `KeyError: '<uuid>'` with
+        none of this is what the last such failure left to diagnose from.
+
+        Repeats: a signature is (session, exception type, the failing frame as file/line/function —
+        _failing_frame, read from the traceback itself, so the chain's length cap cannot change it).
+        The error-center RING keeps one entry per signature and counts the repeats on it (_log's
+        `key`), so a handler failing on every message neither evicts every other problem from the ring
+        nor busts the feed cache per message (2026-09-06); while that entry is in the ring the kernel
+        log gets one short counted line per repeat. Once the ring has evicted the entry, the next
+        repeat re-enters it with the FULL line — chain, consequence and the count — because the short
+        form's "logged with the first" points at a kernel log that may have rotated, and a ring row
+        built from it named no site to fix by (2026-09-06)."""
+        kind = _describe_msg(msg)
+        sig = (self.sid, type(e).__name__, _failing_frame(e))
+        with SdkSession._stream_fail_lock:
+            n = SdkSession._stream_fail_seen.get(sig, 0) + 1
+            SdkSession._stream_fail_seen[sig] = n
+        key = ("stream-fail",) + sig
+        if n > 1 and self.backend.problem_keyed(key):
+            self.backend._log("sdk session %s: %s while handling a %s message (repeat %d this kernel life; "
+                              "the frame chain was logged with the first); handling stopped, stream continues"
+                              % (self.name, type(e).__name__, kind, n), problem=True, key=key)
+            return
+        settled = getattr(self, "_settled_msg", None) is msg   # getattr: __new__-built test doubles
+        again = "" if n == 1 else " (repeat %d this kernel life; its earlier error-center entry was evicted)" % n
+        self.backend._log("sdk session %s: %s while handling a %s message%s; that message's handling "
+                          "stopped there (%s) and the stream continues. %s: %s, at %s"
+                          % (self.name, type(e).__name__, kind, again, _failure_consequence(msg, settled=settled),
+                             type(e).__name__, _mask_ids(e), _compact_tb(e)), problem=True, key=key)
+
     def _on_message(self, msg, AssistantMessage, ResultMessage, SystemMessage):
         if getattr(self, "_ping_feeding", False):   # getattr: __new__-built test doubles skip __init__
             # the ping's turn is streaming — the CLI demonstrably started it, so a message fed from
@@ -3844,89 +3931,134 @@ class SdkSession:
         elif isinstance(msg, ResultMessage) and self._consume_move_settle(msg):
             pass   # the accepted move's turn-less result — nothing ended, so nothing settles (see the def)
         elif isinstance(msg, ResultMessage):
-            # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
-            # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
-            # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
-            # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
-            total = getattr(msg, "total_cost_usd", None)
-            if isinstance(total, (int, float)) and total > 0:
-                delta = total - self._last_cost_total if total >= self._last_cost_total else total
-                self._last_cost_total = float(total)
-                # the tokens: THIS turn's counts, from whichever result counter is a running total —
-                # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
-                turn_u = self._turn_usage(msg)
-                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
-                                           sid=self.thread_of or self.sid)   # the rail's spend —
-                #   a comment THREAD bills its owning session (T144: whole-session truth for the
-                #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
-                #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
-                #   honest on a mixed host (see _record_spend)
-            self.retrying = False
-            self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
-            self.retry_info = None
-            self._interrupted = False              # this turn's result settled it (whether it finished or was interrupted)
-            self._intr_level = 0                   # settle ends the escalation episode — the next stop starts polite
-            # A ResultMessage is the AUTHORITATIVE turn-end: the CLI has processed everything we handed it
-            # — one message or a stream of mid-turn forwards that folded into this turn — and is now idle.
-            # So settle to idle in ONE step and UNCONDITIONALLY, never gated on a feed-vs-result count.
-            # (The old `inflight -= 1; if inflight == 0:` guard stranded the session 'working' forever
-            # whenever the two diverged: each mid-turn forward did inflight += 1 but the CLI emits ONE
-            # Result for the merged turn, so inflight never returned to 0 and the settle never ran — the
-            # phantom-working bug, the user 2026-07-09.) If a genuinely separate turn is still queued in
-            # the CLI, its next streamed atom re-asserts 'working' via _forward — the stream is the truth.
-            self.inflight = 0
-            self._inflight_texts.clear()           # the CLI processed everything fed — same settle semantics
-            # A /compact that found NOTHING to compact emits no boundary — the turn just settles here. Clear
-            # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
-            self._compacting = False
-            self._clearing = False   # /clear backstop: the turn settled, whatever the init did or didn't flip
-            if self._rewind_to and getattr(self, "_rewind_wait", False):
-                # delete-while-busy: THIS settle is the interrupted turn ending — the flag is being
-                # ARMED here, not consumed. Second observer of the turn-end fact (the Stop hook is
-                # the first; _complete_rewind_wait is idempotent, first one wins) — it exists for
-                # the turn shapes where Stop never fires (an interrupt that dies straight to the
-                # ResultMessage).
+            try:
+                # (This try is the whole branch: its body is the result's BOOKKEEPING, its finally is
+                # THE SETTLE — the finally's comment has the rule.)
+                # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
+                # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
+                # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
+                # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
+                total = getattr(msg, "total_cost_usd", None)
+                if isinstance(total, (int, float)) and total > 0:
+                    delta = total - self._last_cost_total if total >= self._last_cost_total else total
+                    self._last_cost_total = float(total)
+                    # the tokens: THIS turn's counts, from whichever result counter is a running total —
+                    # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
+                    turn_u = self._turn_usage(msg)
+                    self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
+                                               sid=self.thread_of or self.sid)   # the rail's spend —
+                    #   a comment THREAD bills its owning session (T144: whole-session truth for the
+                    #   rail and the optimizer; a deliberate fork has no threadOf and bills itself)
+                    #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
+                    #   honest on a mixed host (see _record_spend)
+                if self._rewind_to and getattr(self, "_rewind_wait", False):
+                    # delete-while-busy: THIS settle is the interrupted turn ending — the flag is being
+                    # ARMED here, not consumed. Second observer of the turn-end fact (the Stop hook is
+                    # the first; _complete_rewind_wait is idempotent, first one wins) — it exists for
+                    # the turn shapes where Stop never fires (an interrupt that dies straight to the
+                    # ResultMessage).
+                    try:
+                        self.backend._complete_rewind_wait(self)
+                    except Exception as e:
+                        self.backend._log("rewind (%s): delete-while-busy completion failed at the "
+                                          "settle: %s" % (self.name, e))
+                elif self._rewind_to and self._rewind_armed:
+                    # the rewind turn settled — the flag is CONSUMED (the leaf moved past the recorded one, so
+                    # rewind_disposition would drop it on the next connect anyway; this just tidies the reg now).
+                    # A bare rollback consumes here too: the settled turn IS the branch's first (leaf moved).
+                    # ARMED is part of the guard (delete-while-busy): the interrupted turn's own settle
+                    # lands moments after the Stop hook armed the flag, and an unguarded consume read
+                    # that fresh arm as the branch-take — flags could never accompany an UNARMED
+                    # running turn before, so armed-only is byte-identical for the idle paths.
+                    self._rewind_to = self._rewind_leaf = ""
+                    self._rewind_bare = False
+                    self._rewind_armed = False
+                    self._rewind_wait = False
+                    try:
+                        self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False,
+                                                 rewindWait=False)
+                    except Exception as e:
+                        self.backend._log("rewind (%s): registry clear failed after the turn landed: %s" % (self.name, e))
+                    # the BRANCH-TAKE event: the settled turn is the new branch's first landed record —
+                    # the kernel's held goal cleanup archives on exactly this (two-phase rewind timing)
+                    self.backend._rewind_resolved(self.sid, "taken")
+                self.backend.retire_live_work(self.sid)   # turn over → a work atom that never landed never will
+                asyncio.ensure_future(self._do_refresh_context())   # refresh ctx % + model from the SDK and
+                #   persist them, so the bar reflects the turn that just landed and survives idle/restart.
+                asyncio.ensure_future(self._do_refresh_usage())     # + the exact /usage snapshot (rail bars)
+            finally:
+                # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
+                # bookkeeping above did (the spend fold, the rewind flags, the live-tail
+                # sweep, the refreshes: any step may raise and stop the rest). The rule
+                # (2026-09-06): a ResultMessage is the CLI saying the turn ended, so a kernel-side failure
+                # while filing it must never leave the session reading 'working' with its queue parked.
+                # The first cut opened the try only ahead of the rewind steps, so a raise in the spend
+                # fold (a NaN usage field — json.loads accepts the token and int() refuses it — or a
+                # failing spend write) was contained by _handle_stream_message with inflight still 1,
+                # the feeder still parked, no poke and no 'waiting', while the failure line claimed the
+                # turn had closed. Ordered so that nothing that can raise comes before the flag writes:
+                # the state resets and the queue wake are plain assignments; the two steps that touch a
+                # file or a lock are guarded and reported LAST, and the report itself is guarded, so a
+                # failing log callback can neither skip the poke, the rename ping or the deferred
+                # reconnect nor replace the bookkeeping's exception. That exception, if any, is the
+                # only one that propagates out of this finally, to the containment's report.
+                self.retrying = False
+                self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
+                self.retry_info = None
+                self._interrupted = False              # this turn's result settled it (whether it finished or was interrupted)
+                self._intr_level = 0                   # settle ends the escalation episode — the next stop starts polite
+                # A ResultMessage is the AUTHORITATIVE turn-end: the CLI has processed everything we handed it
+                # — one message or a stream of mid-turn forwards that folded into this turn — and is now idle.
+                # So settle to idle in ONE step and UNCONDITIONALLY, never gated on a feed-vs-result count.
+                # (The old `inflight -= 1; if inflight == 0:` guard stranded the session 'working' forever
+                # whenever the two diverged: each mid-turn forward did inflight += 1 but the CLI emits ONE
+                # Result for the merged turn, so inflight never returned to 0 and the settle never ran — the
+                # phantom-working bug, the user 2026-07-09.) If a genuinely separate turn is still queued in
+                # the CLI, its next streamed atom re-asserts 'working' via _forward — the stream is the truth.
+                self.inflight = 0
+                self._inflight_texts.clear()           # the CLI processed everything fed — same settle semantics
+                # A /compact that found NOTHING to compact emits no boundary — the turn just settles here. Clear
+                # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
+                self._compacting = False
+                self._clearing = False   # /clear backstop: the turn settled, whatever the init did or didn't flip
+                self._settled_msg = msg  # the exact event the failure report reads: the settle ran for THIS result
+                if self._input_wake is not None:   # turn done → release the next queued turn, if any
+                    self._input_wake.set()
+                failed = []
+                for what, step in (("the turn-end count", lambda: self.backend._turn_completed(self.sid)),
+                                   #   ↑ a landed result re-arms the crash-resume budget + bumps turn_seq
+                                   ("the 'waiting' state write", lambda: self._mark("waiting"))):
+                    try:
+                        step()
+                    except Exception as e:
+                        failed.append((what, e))
+                self.backend._poke()   # (guards its own callback) — the kernel's parked-op drain wakes on this
+                # a pending rename ping delivers HERE, as its own turn (the user answered first; the
+                # empty-queue guard + the feed-hold make its record unfoldable — see _deliver_rename_ping)
                 try:
-                    self.backend._complete_rewind_wait(self)
+                    self.backend._deliver_rename_ping(self)
                 except Exception as e:
-                    self.backend._log("rewind (%s): delete-while-busy completion failed at the "
-                                      "settle: %s" % (self.name, e))
-            elif self._rewind_to and self._rewind_armed:
-                # the rewind turn settled — the flag is CONSUMED (the leaf moved past the recorded one, so
-                # rewind_disposition would drop it on the next connect anyway; this just tidies the reg now).
-                # A bare rollback consumes here too: the settled turn IS the branch's first (leaf moved).
-                # ARMED is part of the guard (delete-while-busy): the interrupted turn's own settle
-                # lands moments after the Stop hook armed the flag, and an unguarded consume read
-                # that fresh arm as the branch-take — flags could never accompany an UNARMED
-                # running turn before, so armed-only is byte-identical for the idle paths.
-                self._rewind_to = self._rewind_leaf = ""
-                self._rewind_bare = False
-                self._rewind_armed = False
-                self._rewind_wait = False
-                try:
-                    self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False,
-                                             rewindWait=False)
-                except Exception as e:
-                    self.backend._log("rewind (%s): registry clear failed after the turn landed: %s" % (self.name, e))
-                # the BRANCH-TAKE event: the settled turn is the new branch's first landed record —
-                # the kernel's held goal cleanup archives on exactly this (two-phase rewind timing)
-                self.backend._rewind_resolved(self.sid, "taken")
-            self.backend._turn_completed(self.sid)   # a landed result re-arms the crash-resume budget
-            self._mark("waiting")
-            self.backend.retire_live_work(self.sid)   # turn over → a work atom that never landed never will
-            asyncio.ensure_future(self._do_refresh_context())   # refresh ctx % + model from the SDK and
-            #   persist them, so the bar reflects the turn that just landed and survives idle/restart.
-            asyncio.ensure_future(self._do_refresh_usage())     # + the exact /usage snapshot (rail bars)
-            self.backend._poke()
-            if self._input_wake is not None:   # turn done → release the next queued turn, if any
-                self._input_wake.set()
-            # a pending rename ping delivers HERE, as its own turn (the user answered first; the
-            # empty-queue guard + the feed-hold make its record unfoldable — see _deliver_rename_ping)
-            self.backend._deliver_rename_ping(self)
-            if self._reconnect_when_idle and not self.ended:   # an effort change waited for this turn to end
-                self._reconnect_when_idle = False
-                self._reconnect = True
-                self._wake_set()
+                    failed.append(("the rename ping's delivery", e))
+                if self._reconnect_when_idle and not self.ended:   # an effort change waited for this turn to end
+                    self._reconnect_when_idle = False
+                    self._reconnect = True     # inputs() holds the queue from here: the wake above cannot feed
+                    self._wake_set()           #   the head to THIS client — the new one takes it (see inputs)
+                for what, err in failed:
+                    # The report is guarded too: _log runs the kernel's log callback
+                    # bare, and a callback raising here (a closed stderr under a service restart) would
+                    # propagate out of this finally and REPLACE the bookkeeping's exception, so the
+                    # containment reported the callback's fault and the bookkeeping's site never
+                    # reached the ring. One attempt: the line is built in its own try (an err whose
+                    # __str__ raises falls back to the type alone), the ring row lands before the
+                    # callback runs (see _log), and a callback failure costs the kernel log line only.
+                    try:
+                        line = "settle (%s): %s failed: %s: %s" % (self.name, what, type(err).__name__, _mask_ids(err))
+                    except Exception:
+                        line = "settle (%s): %s failed: %s" % (self.name, what, type(err).__name__)
+                    try:
+                        self.backend._log(line, problem=True)
+                    except Exception:
+                        pass
         elif getattr(msg, "rate_limit_info", None) is not None:
             # A RateLimitEvent: the account-wide /usage limits (5h + weekly) the CLI streams when the limit state
             # changes — the SDK's designed source for the rail usage bars. Duck-typed (no SDK-type import needed).
@@ -4976,6 +5108,139 @@ _PATHY_RE = re.compile(r"(?:^|[\s'\"`(])(?:~/|/)[^\s'\"`)]+")
 
 def _path_bearing(text: str) -> bool:
     return bool(_PATHY_RE.search(text or ""))
+
+
+_UUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+
+
+def _mask_ids(text, cap: int = 160) -> str:
+    """A log-safe rendering of an exception's text: every uuid-shaped token keeps its first 8
+    characters, and the whole thing is clipped. A KeyError's text IS the key, and a message uuid or
+    session id in the log is more than a diagnosis needs — the site and the key's KIND are what fix
+    it (the failure this was written for left a bare `KeyError: '<full uuid>'` and nothing else)."""
+    s = _UUID_RE.sub(lambda m: m.group(0)[:8] + "…", str(text))
+    return s if len(s) <= cap else s[:cap] + "…"
+
+
+COMPACT_TB_FRAMES = 8     # the innermost frames a compact chain keeps (the failing site is at that end)
+COMPACT_TB_CHARS = 600    # and its hard length cap
+
+
+def _frame_step(f) -> str:
+    """One traceback frame as the chain renders it: `file:line function` — basename only, no locals,
+    no source line."""
+    return "%s:%d %s" % (os.path.basename(f.filename), f.lineno or 0, f.name)
+
+
+def _failing_frame(exc):
+    """The exception's innermost frame — where it was raised — as (file basename, line, function),
+    read from the traceback itself. This is the recurring-failure dedupe key (_note_message_failure):
+    taken from the frame and not from the rendered chain, so no rendering bound can change it. None
+    when the exception carries no traceback."""
+    frames = traceback.extract_tb(getattr(exc, "__traceback__", None))
+    if not frames:
+        return None
+    f = frames[-1]
+    return (os.path.basename(f.filename), f.lineno or 0, f.name)
+
+
+def _compact_tb(exc, max_frames: int = COMPACT_TB_FRAMES, cap: int = COMPACT_TB_CHARS) -> str:
+    """The exception's frame chain as `file:line function` steps, outermost first — no locals, no
+    source lines: enough to name the site on the next occurrence, small enough for one log line.
+    BOUNDED FROM THE OUTER END: at most the innermost `max_frames` frames, then outer frames dropped
+    one at a time until the chain fits `cap` characters, with a prefix saying how many were dropped
+    in all. The innermost frame — the failing site — is always kept; if it alone overflows the cap,
+    its function name is clipped and its file:line stands. (A RecursionError's chain ran to 18 KB
+    before any bound, into the error-center ring and every feed payload that carries it; the first
+    bound then clipped the chain's TAIL, which is the innermost frame, so a chain through long-named
+    frames lost its failing site, and a dedupe key read off the rendering became the literal '…' —
+    every long-chained failure of one type folded into one ring entry. 2026-09-06.)"""
+    frames = traceback.extract_tb(getattr(exc, "__traceback__", None))
+    if not frames:
+        return "?"
+    total = len(frames)
+
+    def render(kept):
+        dropped = total - len(kept)
+        s = " > ".join(kept)
+        return "…%d outer frame%s dropped… > %s" % (dropped, "" if dropped == 1 else "s", s) if dropped else s
+
+    steps = [_frame_step(f) for f in frames[-max(1, max_frames):]]
+    kept = steps[-1:]                        # the innermost frame, unconditionally
+    for step in reversed(steps[:-1]):        # then outward, one frame at a time, while the whole fits
+        if len(render([step] + kept)) > cap:
+            break
+        kept = [step] + kept
+    s = render(kept)
+    if len(s) > cap:                         # the innermost frame alone overflows: clip its function name
+        site, _, func = kept[0].partition(" ")
+        head = render([site + " "])          # the prefix and the file:line — never clipped
+        room = cap - len(head) - 1
+        s = (head + func[:room] + "…") if room >= 0 else s[:cap - 1] + "…"   # (a site wider than the cap: bound it anyway)
+    return s
+
+
+def _describe_msg(msg) -> str:
+    """`SystemMessage/task_notification`, `AssistantMessage`, … — the message's type and, where the
+    type carries one, its subtype. Never its content."""
+    n = type(msg).__name__
+    st = getattr(msg, "subtype", None)
+    return "%s/%s" % (n, st) if isinstance(st, str) and st else n
+
+
+def _is_command_stdout(msg) -> bool:
+    """A UserMessage carrying a slash command's `<local-command-stdout>` output — the shape msg_to_atom
+    turns into the turn-closing command atom. Reads the text only to match the wrapper tag; nothing
+    of it is kept or returned."""
+    c = getattr(msg, "content", None)
+    if isinstance(c, str):
+        text = c
+    elif isinstance(c, list):
+        parts = []
+        for b in c:
+            t = b.get("text") if isinstance(b, dict) else getattr(b, "text", None)
+            if isinstance(t, str):
+                parts.append(t)
+        text = " ".join(parts)
+    else:
+        return False
+    return bool(_LOCAL_STDOUT_RE.match(text))
+
+
+def _failure_consequence(msg, settled: bool = True) -> str:
+    """What the kernel lost when this message's handler failed, by the message's SHAPE — the problem
+    line's reassurance has to be true for the message it is about, so the class name alone is not
+    enough (2026-09-06). An assistant message, and a user message that is a real
+    turn, are also transcript records, so the chat rebuilds them from disk — but a user message
+    carrying a command's `<local-command-stdout>` has a record only when the command was TYPED: a
+    control request (client.set_model, a permission-mode set) streams the same line and the CLI
+    persists nothing for it (msg_to_atom), so that confirmation line is lost to the chat. A
+    ResultMessage exists only on the stream; whether its turn still settled is a FACT the caller
+    passes (`settled`: the settle's finally records the result it ran for — see _on_message), not a
+    property of the class: when it did, the settle ran whole (idle, queue released, poked, any
+    deferred reconnect fired) and only this result's own bookkeeping stopped where it failed; when
+    the failure came before the branch was entered, the turn did not settle, and the line says so. A
+    stream event is a partial the full message supersedes. A compact boundary IS a transcript record
+    (the CLI writes it as a `system` row the event model reads from disk). Every other frame (a
+    SystemMessage subtype: task events, status, hooks) exists only on the stream: the kernel's copy
+    of what it carried is gone until the next such frame."""
+    n = type(msg).__name__
+    if n == "ResultMessage":
+        if not settled:
+            return ("the turn did NOT settle (the failure came before the settle ran): the session may read "
+                    "working, with its queue parked, until its next result")
+        return ("the turn still settled — idle, its queue released, the kernel poked, any deferred reconnect "
+                "fired; this result's own bookkeeping (spend, the live-tail sweep) stopped where it failed")
+    if n == "UserMessage" and _is_command_stdout(msg):
+        return ("a command's output line: the transcript keeps it after a typed command, but a control request "
+                "(a model or permission-mode set) leaves no record, and then the confirmation is lost to the chat")
+    if n in ("AssistantMessage", "UserMessage"):
+        return "the transcript keeps the message"
+    if n == "StreamEvent":
+        return "a partial-stream event; the full message follows"
+    if getattr(msg, "subtype", None) == "compact_boundary":
+        return "the transcript keeps the boundary record (the chat rebuilds the compaction from disk)"
+    return "a stream-only frame the transcript never holds: what it carried is lost to the kernel until the next one"
 
 
 def _evict_live_overflow(d: dict, cap: int = LIVE_TAIL_CAP) -> int:
@@ -6252,7 +6517,7 @@ class SdkBackend:
     # ---- logging / wakeups ----
     PROBLEM_RING = 100        # how many backend problems are kept for the dashboard (oldest dropped)
 
-    def _log(self, m, problem=None):
+    def _log(self, m, problem=None, key=None):
         """Every backend line goes to the kernel log; the ones that report a FAILURE also land in a ring
         the dashboard's error center reads, so an SDK problem shows up where the user is looking instead
         of only in a file nobody tails (the user 2026-07-28, who could tell exceptions were happening and
@@ -6261,15 +6526,38 @@ class SdkBackend:
         What counts as a problem is the exact event, not a keyword sniff on the message: a line logged
         while an exception is being handled IS that exception's report. sys.exc_info() is live for the
         whole dynamic extent of an `except` block — helpers called from inside one included — so the
-        classification follows the code path that produced the line. `problem=` overrides either way."""
+        classification follows the code path that produced the line. `problem=` overrides either way.
+
+        `key` (hashable) dedupes a RECURRING problem in the ring: a repeat of a key already in the ring
+        counts on that entry (its text gains the count) instead of appending — the kernel log still
+        gets every line, but the ring is 100 entries and its sequence number is the feed's cache key,
+        so a handler failing on every streamed message used to evict every other problem within a
+        minute and force a feed rebuild per message (2026-09-06). One cache bust per NEW problem; a
+        key whose entry the ring has since dropped enters again as new."""
         if problem is None:
             problem = sys.exc_info()[0] is not None
         if problem:
             with self._problem_lock:
-                self._problem_seq += 1
-                self._problems.append({"seq": self._problem_seq, "t": time.time(), "text": str(m)})
-                if len(self._problems) > self.PROBLEM_RING:
-                    del self._problems[:-self.PROBLEM_RING]
+                hit = None
+                if key is not None:
+                    for row in reversed(self._problems):
+                        if row.get("key") == key:
+                            hit = row
+                            break
+                if hit is not None:
+                    hit["count"] = int(hit.get("count") or 1) + 1
+                    hit["last"] = time.time()
+                    reps = hit["count"] - 1
+                    hit["text"] = "%s (%d repeat%s this kernel life; each is a kernel log line)" % (
+                        hit.get("first", hit["text"]), reps, "" if reps == 1 else "s")
+                else:
+                    self._problem_seq += 1
+                    row = {"seq": self._problem_seq, "t": time.time(), "text": str(m)}
+                    if key is not None:
+                        row.update(key=key, first=str(m), count=1)
+                    self._problems.append(row)
+                    if len(self._problems) > self.PROBLEM_RING:
+                        del self._problems[:-self.PROBLEM_RING]
         if self._log_cb:
             self._log_cb(m)
 
@@ -6284,6 +6572,15 @@ class SdkBackend:
         with self._problem_lock:
             rows = list(self._problems)
         return rows[-limit:] if limit else rows
+
+    def problem_keyed(self, key) -> bool:
+        """Whether a keyed problem's entry is in the ring NOW. The reporter of a recurring failure asks
+        before choosing its short repeat form: a repeat whose entry the ring has since evicted must
+        re-enter with the full report (SdkSession._note_message_failure), because the ring row is
+        built from whatever line creates it. A key added by another thread between this answer and
+        the caller's `_log` merely counts the full line on that row — harmless."""
+        with self._problem_lock:
+            return any(row.get("key") == key for row in self._problems)
 
     def _note_cli_scope_fallback(self, sess, text: str) -> None:
         """The scope wrapper wrote its fallback notice on `sess`'s stderr (SdkSession._on_cli_stderr,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5122,7 +5122,8 @@ LIVE_TAIL_CAP = 100
 # stream-json and the CLI takes the text as typed (a count over one installation's SDK transcripts,
 # 2026-09-06: 0 image blocks in 8,569 user records across 71 sessions; every image-path text landed
 # verbatim), which is why prune_live below floors NO echo — see its docstring. Twin of the kernel's
-# _IMG_PATH_RE (_injected_img_paths waits on the CLI's rewrite; _user_images reads the extraction back);
+# _IMG_PATH_RE (_injected_img_paths waits on the CLI's rewrite; the kernel's bare-path PREVIEW,
+# _user_images, is romp's own feature on its own set, _PREVIEW_IMG_RE — not bound to the CLI's);
 # tests/test_kernel_fed_echo_absorbed.py pins both twins to the CLI's set.
 _IMG_PATH_RE = re.compile(r"(?:^|[\s'\"`(])((?:~/|/)[^\s'\"`()]+\.(?:png|jpe?g|gif|webp))\b", re.I)
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2734,9 +2734,11 @@ class SdkSession:
         legitimately be in flight (the user 2026-07-01, who switched the model on a new session and it
         said working indefinitely). A reconnect abandons the previous client; a turn it left in flight
         can NEVER get its ResultMessage on the new connection — so inflight, and the "working" signal it
-        drives, would be stranded elevated FOREVER. request_reconnect defers while inflight>0, but a race
-        (it fired at inflight==0, then the input generator fed a turn before the teardown ran) can still
-        strand a turn here: settle the counters to idle. A not-yet-STARTED _pending turn survives as
+        drives, would be stranded elevated FOREVER. request_reconnect defers while inflight>0, and
+        inputs() holds the queue once a reconnect is armed (2026-09-06: that closed, at the feed, the
+        race this guarded — the arm at inflight==0, then the feeder fed a turn before the teardown
+        ran); this stays as the backstop for anything that still strands a turn here: settle the
+        counters to idle. A not-yet-STARTED _pending turn survives as
         before (never fed to the dead client; the new inputs() re-feeds it). No-op on the first connect
         and on a clean reconnect. Event-based on the reconnect itself, not a time/age heuristic.
 
@@ -3247,6 +3249,16 @@ class SdkSession:
                     # would land it on the un-rewound branch (the exact wrong-branch delivery this guards)
                     blocked = blocked or bool(self._rewind_to and not self._rewind_armed)
                     blocked = blocked or self._ping_feeding   # the ping's record must not share its window
+                    # a reconnect is ARMED (_reconnect: the waker is about to tear this client down) →
+                    # hold the head for the NEXT client. The settle wakes this feeder and arms a deferred
+                    # reconnect in the same finally, both wakeups queued FIFO on the loop, so without
+                    # this hold the feeder ran first and fed a message gate-held behind an interrupted
+                    # turn to the dying client; the teardown stranded it in flight and
+                    # _reconcile_stranded, on a resumable conversation, flagged it 'never delivered'
+                    # (2026-09-06). The same hold covers the idle arm in
+                    # _do_request_reconnect racing a send that lands before the waker runs. The loop's
+                    # top clears _reconnect before the new client's inputs() is created.
+                    blocked = blocked or self._reconnect
                     # a parked deploy restart is DRAINING (T121): hold NEW turn starts — the queued
                     # prompt persists (the checkpoint) and /busy falls to 0 on this box's own
                     # turn-end events. Mid-turn forwards keep flowing (inflight > 0), so the
@@ -4966,24 +4978,35 @@ def _path_bearing(text: str) -> bool:
     return bool(_PATHY_RE.search(text or ""))
 
 
-def _evict_live_overflow(d: dict, cap: int = LIVE_TAIL_CAP) -> None:
+def _evict_live_overflow(d: dict, cap: int = LIVE_TAIL_CAP) -> int:
     """Bound a session's in-memory live tail when no client ever drains/prunes it — but never at the
     cost of an INPUT ECHO or a command-feedback line. A stream WORK atom is disposable (the transcript
     supersedes it by uuid within a second), but an echo is the ONLY record of a send the transcript
     hasn't caught up on — evicting it makes an in-flight or dropped message silently invisible (the
     user 2026-07-20: a reply vanished from the chat with no trace). Oldest work atoms go first; only
     in the pathological all-echo case does the cap fall back to evicting oldest-regardless, because a
-    bounded store still beats an unbounded leak."""
+    bounded store still beats an unbounded leak.
+
+    Sweeps a SNAPSHOT of the items and pops with a default: the tail is shared with the kernel thread
+    (see SdkBackend._note_live_tail_race), which may retire a key between the snapshot and the pop.
+    Returns how many keys had vanished that way, for the caller to report."""
     if len(d) <= cap:
-        return
-    for k in list(d.keys()):
+        return 0
+    vanished = 0
+    for k, a in list(d.items()):
         if len(d) <= cap:
-            return
-        a = d[k]
+            return vanished
         if not a.get("_echo_text") and not a.get("command"):
-            del d[k]
+            if d.pop(k, None) is None:
+                vanished += 1
     while len(d) > cap:
-        del d[next(iter(d))]
+        try:
+            k = next(iter(d))
+        except StopIteration:        # emptied under us
+            break
+        if d.pop(k, None) is None:
+            vanished += 1
+    return vanished
 
 
 # ---------------------------------------------------------------------------
@@ -5028,6 +5051,21 @@ class SdkBackend:
         #                                           the exact "the live tail moved" event the kernel's active-tab
         #                                           cache keys on (2026-09-03); bumped by _touch_live at every
         #                                           mutation site, never read as a value beyond equality
+        # THE LIVE-TAIL LOCK (2026-09-06). `_live` and every per-sid dict inside it are shared by the
+        # kernel thread (send, recall, dismiss_echo, the pusher's live_atoms/prune_live) and each
+        # session's loop thread (_forward, the settle's retire_live_work, _mark_dropped_echoes at
+        # spawn/reconnect). Lock-free, the sweeps read `d[k]` off stale key lists (KeyError ended a
+        # session's CLI), _persist_echoes and _mark_dropped_echoes walked a dict the other thread was
+        # resizing (RuntimeError: out of the pusher's build; out of the session thread at reconnect),
+        # and `if not d: _live.pop(sid)` was two steps, so an atom stashed between them landed in a
+        # dict nothing could reach. The rule: every write to the tail (a stash, a pop, the sid-level
+        # pop) and every read that iterates it happens under this lock; iteration walks a snapshot
+        # taken under it; the emptiness check and the sid-level pop are one step under it; and the
+        # lock is never held across I/O (a reg write, a transcript read, the orphan-reply append) or
+        # a callback (the pusher wake, a state mark) — copy under the lock, act outside. Re-entrant
+        # so a locked site may call a helper that locks. The class attribute below is the default
+        # for __new__-built test doubles.
+        self._live_lock = threading.RLock()
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
         self._drain_hold_until = 0.0              # deploy-drain lease (T121): RUNTIME-ONLY — a fresh boot starts clear by construction
         self._drain_hold_since = 0.0
@@ -6803,11 +6841,14 @@ class SdkBackend:
             return None
         text = s.unqueue(idx, expect)
         if text is not None:
-            live = self._live.get(sid) or {}
-            for k, a in list(live.items()):                # snapshot: the live-tail thread may mutate concurrently
-                if a.get("_echo_text") == text:
-                    live.pop(k, None)                      # one echo per canceled message
-                    break
+            with self._live_lock:                          # find + pop + the sid-level pop, one step
+                live = self._live.get(sid) or {}
+                for k, a in list(live.items()):
+                    if a.get("_echo_text") == text:
+                        live.pop(k, None)                  # one echo per canceled message
+                        break
+                if not live and self._live.get(sid) is live:
+                    self._live.pop(sid, None)
             self._persist_echoes(sid)                      # the canceled echo leaves the restart mirror too
             self._wake_push()                              # repaint without the echo so it stops reading as sent
         return text
@@ -6866,8 +6907,7 @@ class SdkBackend:
             "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
         if injected and "<!-- romp-auto -->" in text:
             echo["rompAuto"] = True                          # auto-nudge → romp-logo on the chat/timeline
-        self._live.setdefault(sid, {})[key] = echo
-        self._touch_live(sid)
+        self._stash_live(sid, key, echo)
         self._persist_echoes(sid)                            # unlanded echoes survive a kernel restart (reg mirror)
         self._wake_push()
         return True
@@ -6880,11 +6920,17 @@ class SdkBackend:
         echo died with the kernel, and the message vanished with NO trace anywhere. With the mirror, the
         reseeded echo persists unanswered in the chat, so the LOSS is visible and the user can resend.
         Command-feedback lines (/model etc.) are deliberately not mirrored — replaying a stale confirmation
-        after a restart would assert something that may no longer be true."""
-        d = self._live.get(sid) or {}
-        snap = [{"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
-                 "rompAuto": bool(a.get("rompAuto")), "dropped": bool(a.get("dropped"))}
-                for a in d.values() if a.get("_echo_text") and not a.get("command")]
+        after a restart would assert something that may no longer be true.
+
+        The walk is under the live-tail lock (the reg write is not): reached from prune_live on the
+        kernel thread while the session thread stashes and retires atoms, an unlocked walk raised
+        `RuntimeError: dictionary changed size during iteration` out of the pusher's chat build —
+        every client missed that cycle and nothing reached the error center (2026-09-06)."""
+        with self._live_lock:
+            d = self._live.get(sid) or {}
+            snap = [{"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
+                     "rompAuto": bool(a.get("rompAuto")), "dropped": bool(a.get("dropped"))}
+                    for a in list(d.values()) if a.get("_echo_text") and not a.get("command")]
         try:
             self._update_reg(sid, echoes=snap)
         except Exception as e:
@@ -6913,8 +6959,7 @@ class SdkBackend:
                     atom["rompAuto"] = True
                 if e.get("dropped"):
                     atom["dropped"] = True
-                self._live.setdefault(reg["sid"], {})[key] = atom
-                self._touch_live(reg["sid"])
+                self._stash_live(reg["sid"], key, atom)
             if self._live.get(reg["sid"]):
                 self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
 
@@ -6936,13 +6981,19 @@ class SdkBackend:
         kept the first, exactly the duplicate that branch refuses by design. The loss still surfaces in
         full (the dropped flag); only the queue re-add is withheld. Boot and dead-spawn callers keep the
         default: no client survived there to have landed anything."""
-        d = self._live.get(sid)
-        if not d:
-            return
         qs = {q for q in queued_texts if isinstance(q, str)}
-        newly = [a for a in d.values()
-                 if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
-                 and a["_echo_text"] not in qs]
+        # The selection is under the live-tail lock; everything after it (the transcript scan, the
+        # queue re-add, the reg write) is not. This runs on the SESSION thread at spawn and at every
+        # reconnect, outside the connect's try — while the kernel thread's send() stashes an echo into
+        # the same dict. Unlocked, the comprehension raised RuntimeError there and the session thread
+        # died with no reconnect (2026-09-06).
+        with self._live_lock:
+            d = self._live.get(sid)
+            if not d:
+                return
+            newly = [a for a in list(d.values())
+                     if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
+                     and a["_echo_text"] not in qs]
         if not newly:
             return
         # RE-DELIVER, don't just flag (the user 2026-08-23, their strongest point in the restart
@@ -7046,19 +7097,24 @@ class SdkBackend:
         only: a live (pending) echo is the sole visible record of an in-flight send and must stay until
         it lands or its loss is proven. Returns the retired text, or None on a miss (already gone —
         idempotent; the next push simply paints without it)."""
-        live = self._live.get(sid) or {}
-        for k, a in list(live.items()):                    # snapshot: the live-tail thread may mutate concurrently
-            if not (a.get("_echo_text") and a.get("dropped")):
-                continue
-            if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
-                live.pop(k, None)
-                self._touch_live(sid)
-                if not live:
-                    self._live.pop(sid, None)
-                self._persist_echoes(sid)
-                self._wake_push()
-                return a.get("_echo_text")
-        return None
+        hit = None
+        with self._live_lock:                              # find + pop + the sid-level pop, one step
+            live = self._live.get(sid) or {}
+            for k, a in list(live.items()):
+                if not (a.get("_echo_text") and a.get("dropped")):
+                    continue
+                if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
+                    live.pop(k, None)
+                    self._touch_live(sid)
+                    if not live and self._live.get(sid) is live:
+                        self._live.pop(sid, None)
+                    hit = a
+                    break
+        if hit is None:
+            return None
+        self._persist_echoes(sid)                          # the reg write and the wake, outside the lock
+        self._wake_push()
+        return hit.get("_echo_text")
 
     def rewind(self, sid: str, target_uuid: str, text: str) -> "tuple[bool, str]":
         """Rewind the conversation to `target_uuid` (a transcript record uuid the KERNEL has validated:
@@ -7914,10 +7970,10 @@ class SdkBackend:
         a dormant session."""
         t = int(time.time())
         uid = "cmd:%d:%s" % (t, command.lstrip("/"))
-        self._live.setdefault(sid, {})[uid] = {
+        self._stash_live(sid, uid, {
             "type": "user", "uuid": uid, "session_id": sid, "fsid": fsid, "parentUuid": None,
             "t": t, "author": "human", "command": command, "_echo_text": disp,
-            "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+            "message": {"role": "user", "content": [{"type": "text", "text": disp}]}})
         append_cmd_gesture(self.state_dir, sid, disp, t=t)
         self._wake_push()
 
@@ -8406,6 +8462,44 @@ class SdkBackend:
         replays durably to chat clients — and so the poll never clobbers it with an askLiveClear."""
         return self._pending_ask.get(sid)
 
+    _live_tail_race_seen: set = set()          # sweep sites that saw a key vanish mid-sweep, per kernel life
+    _live_tail_race_lock = threading.Lock()
+    _live_lock = threading.RLock()             # the default for __new__-built test doubles; __init__ gives
+    #                                            each backend its own (the rule is documented there)
+
+    def _note_live_tail_race(self, site: str) -> None:
+        """A live-tail sweep, holding the live-tail lock, found a key gone between its snapshot and its
+        pop. Before the lock (2026-09-06) the tail (`self._live[sid]`) was a plain dict shared by two
+        threads: the session's loop thread added atoms (_forward) and retired them at the settle
+        (retire_live_work), the kernel thread pruned landed ones during a chat build (prune_live), and
+        each sweep walked a stale key list and read `d[k]` — so when the kernel thread pruned a
+        just-landed reply while the settle sweep still held its uuid, `KeyError: '<message uuid>'`
+        escaped _on_message and ended the receive loop, which tore the CLI down mid-work (the in-flight
+        turn, its subagents and its background tasks went with it). The lock (`_live_lock`,
+        see __init__) is the fix; the sweeps still walk a snapshot and pop with a default, so a key
+        that vanishes anyway costs nothing — and it is reported, ONCE per site per kernel life, because
+        under the lock it can only mean a mutator changed the tail without taking it: a fix that made
+        that invisible would hide the next thing that shares this dict. (retire_live_work does not
+        report: it releases the lock for the orphan salvage's transcript read, and a key gone at its
+        pop is a landing prune_live filed in that window — expected, not a fault.)"""
+        with SdkBackend._live_tail_race_lock:
+            if site in SdkBackend._live_tail_race_seen:
+                return
+            SdkBackend._live_tail_race_seen.add(site)
+        self._log("live tail (%s): a message-uuid key vanished between the sweep's snapshot and its pop "
+                  "with the live-tail lock held — something changed the tail without taking _live_lock. "
+                  "Harmless here: the sweep continued (before 2026-09-06 this KeyError ended the "
+                  "session's receive loop and its CLI). Reported once per site per kernel life." % site,
+                  problem=True)
+
+    def _stash_live(self, sid: str, key: str, atom: dict) -> None:
+        """Add one atom to the sid's live tail — the ONE way a key enters it from outside _forward
+        (send's echo, the boot reseed, the /model chip). Under the live-tail lock, so the stash can
+        never land in a dict a sweep is popping from `_live` in the same instant."""
+        with self._live_lock:
+            self._live.setdefault(sid, {})[key] = atom
+            self._touch_live(sid)
+
     def _forward(self, sess: SdkSession, msg):
         # LIVE TAIL: translate the streamed message to an atom and stash it in memory, AHEAD of the
         # transcript on disk (the SDK stream leads the disk write), then wake the kernel's pusher for an
@@ -8415,10 +8509,13 @@ class SdkBackend:
         if not (atom and atom.get("uuid")):
             return
         _note_skill_tool_ids(atom, sess._skill_tool_ids)   # a Skill tool_use arms its payload's classification
-        d = self._live.setdefault(sess.sid, {})
-        d[atom["uuid"]] = atom
-        _evict_live_overflow(d)                  # safety cap if no client ever drains/prunes — never an echo
-        self._touch_live(sess.sid)
+        with self._live_lock:
+            d = self._live.setdefault(sess.sid, {})
+            d[atom["uuid"]] = atom
+            vanished = _evict_live_overflow(d)   # safety cap if no client ever drains/prunes — never an echo
+            self._touch_live(sess.sid)
+        if vanished:
+            self._note_live_tail_race("_evict_live_overflow")
         # The stream is the AUTHORITATIVE busy signal: a genuine WORK atom (streamed assistant/tool
         # output — not an input echo, not a /model-style command line) means the CLI is producing RIGHT
         # NOW, so re-assert 'working' if a prior state write settled ahead of it (e.g. a separate turn
@@ -8465,8 +8562,10 @@ class SdkBackend:
 
     def live_atoms(self, sid: str) -> list:
         """The session's in-memory live-tail atoms (newest last), for build_session to merge ahead of disk."""
-        d = self._live.get(sid)
-        return sorted(d.values(), key=lambda a: a.get("t", 0)) if d else []
+        with self._live_lock:                      # the pusher's read: copy under the lock, sort outside
+            d = self._live.get(sid)
+            vals = list(d.values()) if d else []
+        return sorted(vals, key=lambda a: a.get("t", 0))
 
     def prune_live(self, sid: str, tx_uuids, tx_user_texts=(), human_floor: int = 0) -> None:
         """Drop live atoms the transcript has now caught up on — by uuid (assistant/tool/user from the
@@ -8481,10 +8580,11 @@ class SdkBackend:
         can be neither queued nor landed, and the blanket floor hid exactly that in-flight message the
         moment any other human record landed. A plain-text echo now prunes ONLY by its own text landing —
         and a genuinely dropped send's echo PERSISTS, so the loss shows (the tmux echo's semantics).
-        (Echo-only: real stream atoms have no _echo_text and prune by uuid as before.)"""
-        d = self._live.get(sid)
-        if not d:
-            return
+        (Echo-only: real stream atoms have no _echo_text and prune by uuid as before.)
+
+        Pure dict work, so the whole sweep runs under the live-tail lock (the emptiness check and the
+        sid-level pop included — one step, so a stash can never land in a dict this pops); the echo
+        mirror's reg write follows outside it."""
         # `tx_user_texts` may be a MAPPING text → the newest record time carrying it (the kernel's
         # _merge_live_atoms ships that since T237b): an echo then lands by text only through a record
         # written AT OR AFTER its own send — a fork copies the parent's history, and "ok" / "go ahead" /
@@ -8498,23 +8598,30 @@ class SdkBackend:
                 return et in tx_user_texts
             return et in text_t and float(text_t[et] or 0) >= float(a.get("t") or 0)
         echo_removed = False
-        for k in list(d.keys()):
-            a = d[k]
-            et = a.get("_echo_text")
-            landed = a.get("uuid") in tx_uuids or _by_text(a, et)
-            stale_echo = (bool(et) and human_floor and a.get("t", 0) <= human_floor
-                          and not a.get("command") and _path_bearing(et))
-            # A COMMAND atom (the CLI's streamed /model, /compact feedback) from a TURN-LESS control
-            # request may never get a transcript record to land against — retire it once a genuine human
-            # turn postdates it, so the stale confirmation line doesn't ride pinned inside every later
-            # turn forever (the user 2026-07-02, with the live_work command exemption).
-            stale_cmd = bool(a.get("command")) and human_floor and a.get("t", 0) <= human_floor
-            if landed or stale_echo or stale_cmd:
-                echo_removed = echo_removed or bool(et and not a.get("command"))
-                del d[k]
-                self._touch_live(sid)
-        if not d:
-            self._live.pop(sid, None)
+        vanished = 0
+        with self._live_lock:
+            d = self._live.get(sid)
+            if not d:
+                return
+            for k, a in list(d.items()):   # a SNAPSHOT (belt-and-braces under the lock — _note_live_tail_race)
+                et = a.get("_echo_text")
+                landed = a.get("uuid") in tx_uuids or _by_text(a, et)
+                stale_echo = (bool(et) and human_floor and a.get("t", 0) <= human_floor
+                              and not a.get("command") and _path_bearing(et))
+                # A COMMAND atom (the CLI's streamed /model, /compact feedback) from a TURN-LESS control
+                # request may never get a transcript record to land against — retire it once a genuine human
+                # turn postdates it, so the stale confirmation line doesn't ride pinned inside every later
+                # turn forever (the user 2026-07-02, with the live_work command exemption).
+                stale_cmd = bool(a.get("command")) and human_floor and a.get("t", 0) <= human_floor
+                if landed or stale_echo or stale_cmd:
+                    echo_removed = echo_removed or bool(et and not a.get("command"))
+                    if d.pop(k, None) is None:
+                        vanished += 1
+                    self._touch_live(sid)
+            if not d and self._live.get(sid) is d:
+                self._live.pop(sid, None)
+        if vanished:
+            self._note_live_tail_race("prune_live")
         if echo_removed:
             self._persist_echoes(sid)   # keep the restart mirror in step (empty once everything landed)
 
@@ -8526,44 +8633,52 @@ class SdkBackend:
         belongs to an attempt that produced NO transcript record (an API-errored/rate-limited try, a
         killed process). Left in place it is merged forever, and its live_work forces the turn open —
         the chat chip read WORKING with a 3h20m timer on a session whose turn died in a usage-limit
-        retry storm, while the timeline lane said READY (the user 2026-07-03)."""
-        d = self._live.get(sid)
-        if not d:
-            return
-        for k in list(d.keys()):
-            a = d[k]
-            if not a.get("_echo_text") and not a.get("command"):
-                # An assistant atom carrying real TEXT that never landed on disk is a reply the user WATCHED
-                # stream but the transcript dropped (an API-errored try — the CLI discards the partial and the
-                # retry writes a fresh record with a new uuid). Persist it durably BEFORE dropping the live
-                # atom, so build_session can interleave it back at its timestamp — dedup'd against the disk so a
-                # retry that DID re-reply never doubles. Without this the reply vanishes at settle and only the
-                # "Recovered after N retries" note remains where it was (the user 2026-07-21).
-                if a.get("type") == "assistant" and not a.get("isApiError"):
-                    txt = _atom_text(a)
-                    # "(no content)" is the CLI's placeholder for contentless command feedback (an SDK
-                    # /clear streams one) — nothing the user watched, nothing to salvage. Persisted, it
-                    # resurfaced as a worked reply on the bare command turn (the user 2026-07-27); the
-                    # parse-side guard in synthesize_orphans covers markers already written.
-                    # VERIFIED AT THE WRITE MOMENT (the user 2026-08-26): a marker claims "this reply
-                    # is on disk nowhere", and the claim's precondition — prune_live retired every
-                    # landed atom — holds only for sessions the chat BUILDS. A comment thread is never
-                    # built (hidden by design), so its landed replies were still live at settle and
-                    # EVERY thread reply minted a spurious marker: states/ litter, and the judge's
-                    # per-push marker scan grows with it. One tail read of the sid's own transcript
-                    # per would-be marker (settles are rare; healthy sessions already pruned) keeps
-                    # the salvage honest for every hidden-session shape, threads and future ones. A
-                    # genuinely-lost reply (the API-error discard) is on disk nowhere and still mints.
-                    if txt.strip() and txt.strip() != "(no content)" \
-                            and not self._reply_on_disk(sid, a.get("uuid") or ""):
-                        try:
-                            append_orphan_reply(self.state_dir, sid, a.get("uuid") or "", txt, t=a.get("t"))
-                        except Exception:
-                            self._log("orphan-reply persist failed: %s" % traceback.format_exc())
-                del d[k]
+        retry storm, while the timeline lane said READY (the user 2026-07-03).
+
+        Three phases around the live-tail lock: the work atoms are snapshotted under it, the orphan
+        salvage's I/O (a transcript tail read, the marker append) runs outside it, and the pops go
+        back under it — from the SAME dict object the snapshot came from, with the emptiness check
+        and the sid-level pop as one step. A key already gone at its pop is a landing prune_live
+        filed during the I/O window (legitimate, under the lock), so it is not reported as a race."""
+        with self._live_lock:
+            d = self._live.get(sid)
+            if not d:
+                return
+            work = [(k, a) for k, a in list(d.items()) if not a.get("_echo_text") and not a.get("command")]
+        for k, a in work:
+            # An assistant atom carrying real TEXT that never landed on disk is a reply the user WATCHED
+            # stream but the transcript dropped (an API-errored try — the CLI discards the partial and the
+            # retry writes a fresh record with a new uuid). Persist it durably BEFORE dropping the live
+            # atom, so build_session can interleave it back at its timestamp — dedup'd against the disk so a
+            # retry that DID re-reply never doubles. Without this the reply vanishes at settle and only the
+            # "Recovered after N retries" note remains where it was (the user 2026-07-21).
+            if a.get("type") == "assistant" and not a.get("isApiError"):
+                txt = _atom_text(a)
+                # "(no content)" is the CLI's placeholder for contentless command feedback (an SDK
+                # /clear streams one) — nothing the user watched, nothing to salvage. Persisted, it
+                # resurfaced as a worked reply on the bare command turn (the user 2026-07-27); the
+                # parse-side guard in synthesize_orphans covers markers already written.
+                # VERIFIED AT THE WRITE MOMENT (the user 2026-08-26): a marker claims "this reply
+                # is on disk nowhere", and the claim's precondition — prune_live retired every
+                # landed atom — holds only for sessions the chat BUILDS. A comment thread is never
+                # built (hidden by design), so its landed replies were still live at settle and
+                # EVERY thread reply minted a spurious marker: states/ litter, and the judge's
+                # per-push marker scan grows with it. One tail read of the sid's own transcript
+                # per would-be marker (settles are rare; healthy sessions already pruned) keeps
+                # the salvage honest for every hidden-session shape, threads and future ones. A
+                # genuinely-lost reply (the API-error discard) is on disk nowhere and still mints.
+                if txt.strip() and txt.strip() != "(no content)" \
+                        and not self._reply_on_disk(sid, a.get("uuid") or ""):
+                    try:
+                        append_orphan_reply(self.state_dir, sid, a.get("uuid") or "", txt, t=a.get("t"))
+                    except Exception:
+                        self._log("orphan-reply persist failed: %s" % traceback.format_exc())
+        with self._live_lock:
+            for k, _a in work:
+                d.pop(k, None)
                 self._touch_live(sid)
-        if not d:
-            self._live.pop(sid, None)
+            if not d and self._live.get(sid) is d:
+                self._live.pop(sid, None)
 
     def _reply_on_disk(self, sid: str, uuid: str) -> bool:
         """Does the sid's transcript already hold this uuid? The orphan salvage's own precondition,
@@ -8605,11 +8720,11 @@ class SdkBackend:
         fate at settle (echo, command, apiError, hasText). The kernel's chat-divergence tripwire logs it
         to pin WHICH atom held a chat turn open after the backend settled — the 2026-07-25 stale-"running"
         chat could not be diagnosed because a restart cleared exactly this state before anyone read it."""
-        d = self._live.get(sid)
-        if not d:
-            return []
+        with self._live_lock:
+            d = self._live.get(sid)
+            vals = list(d.values()) if d else []   # copy under the lock; the summary is built outside
         out = []
-        for a in list(d.values()):                 # copy: loop threads mutate the dict mid-iteration
+        for a in vals:
             if not isinstance(a, dict):
                 continue
             out.append({"uuid": a.get("uuid") or "", "type": a.get("type") or "",

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -29,6 +29,21 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 
+def echo_text_key(text) -> str:
+    """The one rule under which an input echo's text and a transcript record's user text are compared:
+    outer whitespace stripped, nothing else. Every reader shares it and must agree: the kernel's
+    _atom_user_text(s) (the keys of the `tx_user_texts` mapping prune_live receives, and the sets the
+    queued fold, _merge_live_atoms, _comments_frame and _tmux_echo_prune compare against),
+    SdkBackend.prune_live's by-text retire (the echo side of that comparison), and SdkBackend._text_landed
+    / _landed_texts (the transcript scan behind the boot and dead-spawn duplicate guard). Until 2026-09-06
+    the scan collapsed internal whitespace while the prune compared the raw echo text against stripped
+    keys, so a send whose text carried a trailing newline (`romp send` passes its argument verbatim) was
+    FOUND by the scan, neither re-fed nor flagged, and never pruned or dismissable. Strip is as wide as
+    the data needs: the CLI stores user text verbatim (checked against recorded SDK transcripts,
+    2026-09-06 — double spaces, bare CRs and line-trailing blanks all preserved). Not a str → ""."""
+    return text.strip() if isinstance(text, str) else ""
+
+
 class SessionBackend(ABC):
     # True when busy() may be overruled by the cached transcript parse, so the parked-op drain must keep that
     # parse current for a sid before it reads busy() (_refresh_parked_parse); a backend whose busy() is the

--- a/tests/fixtures/event-model-golden/multi_input_absorbed.json
+++ b/tests/fixtures/event-model-golden/multi_input_absorbed.json
@@ -58,6 +58,7 @@
      "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
+     "landedT": 1781096455,
      "message": {
       "content": [
        {
@@ -67,11 +68,29 @@
       ],
       "role": "user"
      },
-     "parentUuid": "a1",
+     "parentUuid": "tr1",
      "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096460,
+     "t": 1781096440,
      "type": "user",
      "uuid": "att1"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "content": "ok",
+        "tool_use_id": "tu_a1_0",
+        "type": "tool_result"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "a1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096455,
+     "type": "user",
+     "uuid": "tr1"
     },
     {
      "fsid": "11111111-2222-3333-4444-555555555555",

--- a/tests/fixtures/event-model-golden/popall.json
+++ b/tests/fixtures/event-model-golden/popall.json
@@ -58,6 +58,7 @@
      "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
+     "landedT": 1781096450,
      "message": {
       "content": [
        {
@@ -67,9 +68,9 @@
       ],
       "role": "user"
      },
-     "parentUuid": "a1",
+     "parentUuid": "tr1",
      "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096450,
+     "t": 1781096430,
      "type": "user",
      "uuid": "att1"
     },
@@ -77,6 +78,7 @@
      "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
+     "landedT": 1781096450,
      "message": {
       "content": [
        {
@@ -88,9 +90,27 @@
      },
      "parentUuid": "att1",
      "session_id": "11111111-2222-3333-4444-555555555555",
-     "t": 1781096451,
+     "t": 1781096440,
      "type": "user",
      "uuid": "att2"
+    },
+    {
+     "fsid": "11111111-2222-3333-4444-555555555555",
+     "message": {
+      "content": [
+       {
+        "content": "ok",
+        "tool_use_id": "tu_a1_0",
+        "type": "tool_result"
+       }
+      ],
+      "role": "user"
+     },
+     "parentUuid": "a1",
+     "session_id": "11111111-2222-3333-4444-555555555555",
+     "t": 1781096450,
+     "type": "user",
+     "uuid": "tr1"
     },
     {
      "fsid": "11111111-2222-3333-4444-555555555555",

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -716,6 +716,27 @@ class ThreadProjection(CommentBase):
         finally:
             self._State.live = []
 
+    def test_an_echo_the_backends_scan_found_is_not_held(self):
+        # 2026-09-06 (send durability): the backend's boot/spawn scan reads a landing off the transcript
+        # itself and records the verdict on the echo (`_landed`) — a delivered send, merely un-pruned. The
+        # held count excludes it like a landed one, even though no record in the thread's own projection
+        # carries the text yet (the scan read a queued_command attachment the projection takes in later)
+        t = self.now - 500
+        self._seed_thread(seen=self.now)
+        recs = self._thread_side(aline(t + 120, "Jitter prevents thundering herds.", "ca1", parent="cu1"))
+        echo = {"type": "user", "author": "human", "t": t + 130, "uuid": "echo:1", "_echo_text": "and the cap?"}
+        try:
+            self._State.live = [dict(echo, _landed=True)]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 0, "found by the scan: delivered, nothing is held for it")
+            self.assertFalse(th["replyOwed"], "…and no green promise rides on it")
+            self._State.live = [dict(echo)]
+            th = self._frame_thread(recs, state="")
+            self.assertEqual(th["queued"], 1, "the same echo without the verdict is a held send")
+            self.assertTrue(th["replyOwed"])
+        finally:
+            self._State.live = []
+
     def test_the_newest_record_uuid_moves_when_a_consumed_slash_command_lands(self):
         t = self.now - 500
         self._seed_thread(seen=self.now)

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -179,15 +179,20 @@ SENT_LOG = [{"t": T0 + 190, "ev": "sent", "id": MID, "from": "feeddesign",
 
 # ───────────────────────── scenarios ─────────────────────────
 def scenario_multi_input_absorbed():
-    """A typed opener, then a mid-turn prompt spliced in (enqueue -> remove, recorded
-    only as a queued_command attachment) while the assistant is mid-tool. One turn,
-    two inputs, two segments."""
+    """A typed opener, then a mid-turn prompt spliced in while the assistant is mid-tool, in the
+    shape the CLI writes: the enqueue op (no uuid — never a landing witness), the tool_result the
+    splice waited for, the remove op, then the queued_command ATTACHMENT — stamped with the ENQUEUE
+    time (where the atom is placed) but written at the splice, so its file-order predecessor, the
+    tool_result, is when the session took it (`landedT`). One turn, two inputs, two segments.
+    Until 2026-09-06 this scenario had no tool_result and stamped the attachment at the remove
+    time — a shape the CLI never writes — so the golden pinned a landedT 40 s BEFORE the send."""
     return [
         uline(T0, "refactor the ledger", "u1", ps="typed"),
         aline(T0 + 20, "Reading romp-ledger.", "a1", "u1", tools=("Read",), stop="tool_use"),
         qop(T0 + 40, "enqueue", "also rename the digest file"),
-        qop(T0 + 60, "remove"),
-        attline(T0 + 60, "also rename the digest file", "att1", "a1"),
+        trline(T0 + 55, "tu_a1_0", "tr1", "a1"),
+        qop(T0 + 55, "remove"),
+        attline(T0 + 40, "also rename the digest file", "att1", "tr1"),
         aline(T0 + 90, "Folded the rename in too.", "a2", "att1", stop="end_turn"),
     ]
 
@@ -286,15 +291,19 @@ IDLE_STATES = [
 
 def scenario_popall():
     """popAll clears the whole queue at once: every still-queued item is spliced into the
-    continuation as an absorbed mid-turn atom (the old code missed this op)."""
+    continuation as an absorbed mid-turn atom (the old code missed this op). The CLI's shape, as in
+    scenario_multi_input_absorbed: the tool_result the splice waited for precedes the attachments,
+    each stamped with its own ENQUEUE time, and both read that boundary as `landedT` (attachments
+    are never witnesses for each other)."""
     return [
         uline(T0, "start the big task", "u1", ps="typed"),
         aline(T0 + 20, "Working.", "a1", "u1", tools=("Read",), stop="tool_use"),
         qop(T0 + 30, "enqueue", "first queued note"),
         qop(T0 + 40, "enqueue", "second queued note"),
+        trline(T0 + 50, "tu_a1_0", "tr1", "a1"),
         qop(T0 + 50, "popAll"),
-        attline(T0 + 50, "first queued note", "att1", "a1"),
-        attline(T0 + 51, "second queued note", "att2", "att1"),
+        attline(T0 + 30, "first queued note", "att1", "tr1"),
+        attline(T0 + 40, "second queued note", "att2", "att1"),
         aline(T0 + 90, "Folded both notes in.", "a2", "att2", stop="end_turn"),
     ]
 
@@ -1806,6 +1815,61 @@ class PopAll(unittest.TestCase):
         absorbed = [a.get("uuid") for a in out["turns"][0]["atoms"]
                     if a.get("uuid") in ("att1", "att2")]
         self.assertEqual(absorbed, ["att1", "att2"])
+
+
+class AbsorbedLandingNeverPrecedesTheSend(unittest.TestCase):
+    """`landedT` — when the CLI took a mid-turn send — is read off the attachment's file-order
+    predecessor, whose stamp can precede the attachment's own (the ENQUEUE time) only by clock
+    granularity: the live corpus's worst case is -0.2 s, which whole-second stamps can turn into a 1 s
+    inversion. No truthful landing precedes the send, so the event model clamps landedT to the send
+    and counts the clamp in parse stats (`landedT-clamp`): the chat's cue can never read "delivered at"
+    a time before the bubble's own send. Pinned across every golden, because the two goldens that carry
+    absorbed atoms once pinned the inverted value (2026-09-06 review) from a scenario shape with no
+    tool_result before the attachment."""
+
+    def _absorbed(self, out):
+        return [a for t in out["turns"] for a in t["atoms"] if a.get("absorbed")]
+
+    def test_every_golden_absorbed_atom_lands_at_or_after_its_send(self):
+        seen = 0
+        for name in ALL_SCENARIOS:
+            for a in self._absorbed(run_scenario(name)):
+                seen += 1
+                self.assertGreaterEqual(a["landedT"], a["t"], (name, a["uuid"]))
+        self.assertGreaterEqual(seen, 3, "multi_input_absorbed and popall carry the absorbed atoms this pins")
+
+    def test_the_realistic_shape_lands_at_the_boundary_after_the_send(self):
+        a = self._absorbed(run_scenario("multi_input_absorbed"))
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 55)],
+                         "placed at the enqueue, taken at the tool_result that followed it in file order")
+        a = self._absorbed(run_scenario("popall"))
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 30, T0 + 50), (T0 + 40, T0 + 50)],
+                         "two splices at one boundary both read that boundary")
+
+    def test_an_inverted_witness_clamps_to_the_send_and_is_counted(self):
+        # the tool_result stamped before the attachment's enqueue stamp: clock granularity at worst, an
+        # impossible shape beyond it — either way the landing reads as the send, never earlier
+        recs = [uline(T0, "refactor the ledger", "u1", ps="typed"),
+                aline(T0 + 20, "Reading.", "a1", "u1", tools=("Read",), stop="tool_use"),
+                trline(T0 + 39, "tu_a1_0", "tr1", "a1"),
+                attline(T0 + 40, "also rename the digest file", "att1", "tr1"),
+                aline(T0 + 90, "Done.", "a2", "att1", stop="end_turn")]
+        before = em._ASM_STATS.get("landedT-clamp", 0)
+        a = self._absorbed(run_recs(recs))
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 40)])
+        self.assertEqual(em._ASM_STATS.get("landedT-clamp", 0), before + 1,
+                         "counted in parse stats, beside ts-repair — a run of these is a CLI write-order change")
+
+    def test_a_witness_at_the_send_second_is_not_a_clamp(self):
+        recs = [uline(T0, "refactor the ledger", "u1", ps="typed"),
+                aline(T0 + 20, "Reading.", "a1", "u1", tools=("Read",), stop="tool_use"),
+                trline(T0 + 40, "tu_a1_0", "tr1", "a1"),
+                attline(T0 + 40, "also rename the digest file", "att1", "tr1"),
+                aline(T0 + 90, "Done.", "a2", "att1", stop="end_turn")]
+        before = em._ASM_STATS.get("landedT-clamp", 0)
+        a = self._absorbed(run_recs(recs))
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 40, T0 + 40)])
+        self.assertEqual(em._ASM_STATS.get("landedT-clamp", 0), before, "equal stamps are a landing, not an inversion")
 
 
 class SafeDefault(unittest.TestCase):

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -9,8 +9,11 @@ absorbed atom's text lands: the kernel's _atom_user_texts reads the queued_comma
 absorbed atom, so the by-text prune fires on it and the message never renders twice.
 
 The sdk_backend twin of the image-path predicate is pinned against the kernel's, and both against the
-CLI paste hook's extension set (ImagePathPredicateTwins names the source). SYNTHETIC fixtures only (a
-private synthetic sid, the notes-api demo domain)."""
+CLI paste hook's extension set (ImagePathPredicateTwins names the source). The TEXT KEY the kernel's
+_atom_user_texts and the backend's scan + prune compare under is ONE function (session_backend.
+echo_text_key), pinned in OneTextRuleAcrossKernelAndBackend: the backend's landing scan can never find a
+text the kernel-fed prune cannot retire. SYNTHETIC fixtures only (a private synthetic sid, the notes-api
+demo domain)."""
 import json
 import os
 import re
@@ -177,6 +180,133 @@ class FedEchoSurvivesUntilTheSpliceLands(unittest.TestCase):
         merged = km._merge_live_atoms(self.w.parse(), SID)
         self.assertIn(key, self.w.be._live.get(SID, {}))
         self.assertEqual(self._texts(merged).count("compare with /tmp/notes-api/docs/before.png"), 1)
+
+
+
+class OneTextRuleAcrossKernelAndBackend(unittest.TestCase):
+    """The by-text prune has two sides in two modules: the kernel builds the keys (_atom_user_texts →
+    tx_user_texts) and the SDK backend compares an echo's text against them (prune_live), while its boot
+    scan (_text_landed via _landed_texts) decides which echoes are "landed, merely un-pruned". Until
+    2026-09-06 the scan collapsed whitespace, the kernel stripped, and the prune compared raw — three
+    rules, so a trailing-newline send was found yet never retired. One function now, imported by both
+    modules; the property tested here is that the scan's match set for a record IS the kernel's key set
+    for the same record, and that an echo the scan would find retires through the real merge."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def _texts(self, session):
+        return [t for turn in session["turns"] for a in turn["atoms"] for t in km._atom_user_texts(a)]
+
+    def test_the_kernel_and_the_backend_import_the_same_key_function(self):
+        k, b = km.sb.echo_text_key, sb.echo_text_key
+        self.assertEqual(os.path.realpath(k.__code__.co_filename), os.path.realpath(b.__code__.co_filename),
+                         "one definition, in session_backend.py")
+        self.assertEqual(k.__code__.co_code, b.__code__.co_code)
+        for probe in (" a\n", "a  b", "a\r\nb", "\n\t", "", None, 7):
+            self.assertEqual(k(probe), b(probe))
+        self.assertEqual(k(" fix the tests \n"), "fix the tests")
+        self.assertEqual(k("one  two\nthree"), "one  two\nthree", "outer whitespace only")
+
+    def test_the_scan_match_set_is_the_kernel_key_set_for_every_record_shape(self):
+        recs = [
+            uline(T0, " fix the tests \n", "u9"),                                       # edge whitespace, verbatim
+            uline(T0, [{"type": "text", "text": "one  two"}, {"type": "text", "text": " three "}], "u9"),
+            uline(T0, "a\r\nb", "u9"),                                                  # a bare CR, preserved
+            uline(T0, [{"type": "text", "text": "solo"}], "u9"),
+            uline(T0, [{"type": "tool_result", "tool_use_id": "t", "content": "ok"}], "u9"),
+        ]
+        for rec in recs:
+            self.assertEqual(sb._landed_texts(rec), set(km._atom_user_texts(rec)), json.dumps(rec)[:120])
+        # the absorbed shape: the scan reads the queued_command attachment, the kernel the parsed atom
+        self.w.write(running_turn() + spliced_tail())
+        absorbed = [a for t in self.w.parse()["turns"] for a in t["atoms"] if a.get("absorbed")]
+        self.assertEqual([a["uuid"] for a in absorbed], ["att1"])
+        self.assertEqual(sb._landed_texts(attline(T0 + 38, FED, "att1", "tr1")), set(km._atom_user_texts(absorbed[0])))
+
+    def test_an_edge_whitespace_echo_retires_when_its_text_lands(self):
+        # `romp send` passes its argument verbatim; the record stores the trailing newline verbatim; the
+        # kernel's key strips it. Pre-fix the raw echo text never matched the key and the echo stayed in
+        # the store forever (hidden by the display dedup, so the user saw nothing — and no exit).
+        text = FED + "\n"
+        self.w.write(running_turn() + [uline(T0 + 80, text, "u3", "tr1")])
+        key = self.w.echo(text, T0 + 38)
+        merged = km._merge_live_atoms(self.w.parse(), SID)
+        self.assertNotIn(SID, self.w.be._live, "the landed text retires the echo under the shared key")
+        self.assertEqual(self._texts(merged).count(km.sb.echo_text_key(text)), 1, "shown once: the record")
+
+    def test_a_recorded_landed_verdict_retires_through_the_merge_without_a_text_match(self):
+        # the backend's boot scan found the record and recorded `_landed` on the echo; the parse has no
+        # atom with that text (the two texts cannot meet) — the verdict alone is the exit
+        self.w.write(running_turn())
+        text = "a send the scan found but no key can match"
+        key = self.w.echo(text, T0 + 38)
+        self.w.be._live[SID][key]["_landed"] = True
+        merged = km._merge_live_atoms(self.w.parse(), SID)
+        self.assertNotIn(SID, self.w.be._live, "prune_live honours the recorded verdict")
+        self.assertNotIn(text, self._texts(merged), "…and nothing paints it as fresh")
+
+    def test_an_unlanded_echo_still_survives_the_merge(self):
+        # the control: no record, no verdict → the echo stays (guarantee 2: no floor retires it)
+        self.w.write(running_turn())
+        key = self.w.echo(FED + "\n", T0 + 38)
+        merged = km._merge_live_atoms(self.w.parse(), SID)
+        self.assertIn(key, self.w.be._live.get(SID, {}))
+        self.assertEqual(self._texts(merged).count(FED), 1, "the echo itself is shown, once")
+
+
+class TmuxEchoPrunesUnderTheOneKey(unittest.TestCase):
+    """The tmux route's by-text prune (_tmux_echo_prune) is another reader of the key, and until 2026-09-06
+    it compared the echo's RAW text against the kernel's stripped keys: a tmux send with a trailing newline
+    (`romp send` passes its argument verbatim; the CLI records it verbatim) was never pruned by text once
+    it landed. The display dedup hid the echo behind the record, so nothing showed — until a later human
+    turn landed and the settle marked the still-resident echo `dropped`: a "never delivered" bubble, with
+    restore and dismiss, for a message the transcript holds."""
+
+    def setUp(self):
+        self._saved = km._sdk
+        km._sdk = lambda: None                 # the tmux route: no SDK backend owns the sid
+        km._tmux_echo.clear()
+
+    def tearDown(self):
+        km._sdk = self._saved
+        km._tmux_echo.clear()
+
+    @staticmethod
+    def _session(atoms):
+        return {"turns": [{"id": "t", "trigger": None, "t": T0, "end": T0, "ended": True, "atoms": atoms}]}
+
+    @staticmethod
+    def _human(text, uid, t):
+        return {"type": "user", "uuid": uid, "author": "human", "t": t,
+                "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+    def _echo(self, text, sent_at):
+        km._tmux_echo_add(SID, text)
+        atom = next(a for a in km._tmux_echo[SID].values() if a.get("_echo_text") == text)
+        atom["t"] = sent_at
+        return atom
+
+    def test_a_trailing_newline_tmux_echo_is_pruned_when_its_text_lands(self):
+        text = "rename this to fetch_notes\n"
+        echo = self._echo(text, T0 + 10)
+        # the record holds the text verbatim; a later human turn has landed since
+        merged = km._merge_live_atoms(self._session([self._human(text, "u1", T0 + 12),
+                                                     self._human("and the tests", "u2", T0 + 500)]), SID)
+        self.assertNotIn(SID, km._tmux_echo, "the echo's key and the record's key agree: pruned by text")
+        self.assertFalse(echo.get("dropped"), "a delivered send is never marked never-delivered")
+        texts = [t for turn in merged["turns"] for a in turn["atoms"] for t in km._atom_user_texts(a)]
+        self.assertEqual(texts.count(km.sb.echo_text_key(text)), 1, "shown once: the record")
+
+    def test_an_unlanded_tmux_echo_still_survives(self):
+        # the control: the record carries a different text, so the echo stays (and is overtaken → dropped)
+        echo = self._echo("this Enter dropped at the prompt\n", T0 + 10)
+        km._merge_live_atoms(self._session([self._human("and the tests", "u2", T0 + 500)]), SID)
+        self.assertIn(SID, km._tmux_echo)
+        self.assertTrue(echo.get("dropped"))
 
 
 class ImagePathPredicateTwins(unittest.TestCase):

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""A send fed into a RUNNING turn is held by the CLI until its next tool boundary, then spliced in as a
+queued_command attachment stamped with the ENQUEUE time — so its atom lands ABOVE the tool calls that
+streamed while it waited. Until that splice the kernel's input echo is the message's only visible
+record, and that must hold end to end: the echo of a FED, unlanded text outlives its sibling's landing —
+no floor retires an SDK echo at all (sdk_backend.prune_live, 2026-09-06: the CLI's image-path extraction
+is a composer paste-hook behaviour that stream-json input never reaches) — and retires exactly when the
+absorbed atom's text lands: the kernel's _atom_user_texts reads the queued_command text off the parsed
+absorbed atom, so the by-text prune fires on it and the message never renders twice.
+
+The sdk_backend twin of the image-path predicate is pinned against the kernel's, and both against the
+CLI paste hook's extension set (ImagePathPredicateTwins names the source). SYNTHETIC fixtures only (a
+private synthetic sid, the notes-api demo domain)."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_fed_echo", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_fed_echo", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+em = km.em
+
+SID = "1f3e5d7c-9b1a-4c2d-8e6f-0a1b2c3d4e5f"   # private synthetic sid (goal-store fixtures rule)
+T0 = 1_800_000_000
+NOW = T0 + 3600
+FED = ("Replying to this highlighted code (/tmp/notes-api/notes/api.py:42):\n"
+       "> def list_notes():\n\nrename this to fetch_notes")
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="sdk"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, tools=(), stop="end_turn"):
+    content = [{"type": "text", "text": text}] if text else []
+    for i, n in enumerate(tools):
+        content.append({"type": "tool_use", "id": "tu_%s_%d" % (uuid, i), "name": n, "input": {"command": "true"}})
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": content, "stop_reason": stop}}
+
+
+def trline(t, tool_use_id, uuid, parent, content="ok"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_use_id,
+                                                     "content": content}]}}
+
+
+def attline(t, prompt, uuid, parent):
+    return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "isSidechain": False, "attachment": {"type": "queued_command", "prompt": prompt}}
+
+
+def running_turn():
+    """The first staged comment lands at T0+39 and opens a turn whose tool call is still running."""
+    return [
+        uline(T0, "tighten the notes-api search", "u1"),
+        aline(T0 + 10, "Done.", "a1", "u1"),
+        uline(T0 + 39, "the first comment: drop the unused import", "u2", "a1"),
+        aline(T0 + 41, "Removing it.", "a2", "u2", tools=("Bash",), stop="tool_use"),
+        trline(T0 + 50, "tu_a2_0", "tr1", "a2"),
+    ]
+
+
+def spliced_tail():
+    """The CLI took the second comment at the T0+50 boundary: the attachment carries the send time."""
+    return [
+        attline(T0 + 38, FED, "att1", "tr1"),
+        aline(T0 + 75, "Renamed it as well.", "a3", "att1"),
+    ]
+
+
+class _World:
+    """A real SdkBackend bound as the kernel's backend, owning SID, with a thread-less SdkSession."""
+
+    def __init__(self):
+        self.td = tempfile.TemporaryDirectory()
+        root = Path(self.td.name)
+        (root / "sdk").mkdir()
+        self.cwd = root / "proj"; self.cwd.mkdir()
+        os.environ["CLAUDE_CONFIG_DIR"] = str(root / "claude")
+        self.tpath = Path(sb.transcript_path(str(self.cwd), SID))
+        self.tpath.parent.mkdir(parents=True, exist_ok=True)
+        self.tpath.write_text("")
+        self.be = sb.SdkBackend(str(root), "/bin/true", lambda *a, **k: None)
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True,
+               "cwd": str(self.cwd), "lastSid": SID}
+        sb.write_reg(self.be.state_dir, SID, reg)
+        self.s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = self.s
+        self.saved = km._sdk
+        km._sdk = lambda: self.be
+
+    def close(self):
+        km._sdk = self.saved
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        self.td.cleanup()
+
+    def write(self, recs):
+        self.tpath.write_text("".join(json.dumps(r) + "\n" for r in recs))
+
+    def parse(self):
+        return em.parse_session(str(self.tpath), rompuuid=SID, candidate_files=[str(self.tpath)],
+                                postal_log=[], now=NOW, sdk_human=True)
+
+    def echo(self, text, t):
+        key = "echo:fed"
+        self.be._live[SID] = {key: {"type": "user", "uuid": key, "session_id": SID, "t": t,
+                                     "parentUuid": None, "author": "human", "_echo_text": text,
+                                     "message": {"role": "user", "content": [{"type": "text", "text": text}]}}}
+        return key
+
+
+class FedEchoSurvivesUntilTheSpliceLands(unittest.TestCase):
+    def setUp(self):
+        self.w = _World()
+        self.assertTrue(self.w.be.owns(SID))
+        self.assertIs(km.Sessions.backend_for(SID), self.w.be)
+
+    def tearDown(self):
+        self.w.close()
+
+    def _texts(self, session):
+        return [t for turn in session["turns"] for a in turn["atoms"] for t in km._atom_user_texts(a)]
+
+    def test_the_fed_echo_outlives_the_siblings_landing(self):
+        # the second comment was fed at second 38; the first landed at 39 and is the human floor.
+        # Pre-change: the quote chip's path made the echo "path-bearing" and the floor retired it —
+        # the store emptied with the message still in the CLI's queue.
+        self.w.write(running_turn())
+        key = self.w.echo(FED, T0 + 38)
+        self.w.s.inflight = 1
+        self.w.s._inflight_texts.append(FED)
+        parsed = self.w.parse()
+        self.assertEqual(km._human_turn_floor(parsed), T0 + 39, "the sibling's landing IS the floor")
+        merged = km._merge_live_atoms(parsed, SID)
+        self.assertIn(key, self.w.be._live.get(SID, {}), "the fed echo survives the floor")
+        self.assertIn(FED, self._texts(merged), "…and the chat still shows the message, once")
+        self.assertEqual(self._texts(merged).count(FED), 1)
+
+    def test_the_landing_retires_it_by_text_through_the_queued_command_atom(self):
+        self.w.write(running_turn() + spliced_tail())
+        key = self.w.echo(FED, T0 + 38)
+        self.w.s.inflight = 1
+        self.w.s._inflight_texts.append(FED)          # still fed: the turn has not settled
+        parsed = self.w.parse()
+        absorbed = [a for t in parsed["turns"] for a in t["atoms"] if a.get("absorbed")]
+        self.assertEqual([a["uuid"] for a in absorbed], ["att1"])
+        self.assertIn(FED, km._atom_user_texts(absorbed[0]),
+                      "the kernel's landing set covers the queued_command shape")
+        merged = km._merge_live_atoms(parsed, SID)
+        self.assertNotIn(SID, self.w.be._live, "the absorbed atom's text landed → the echo retires")
+        self.assertEqual(self._texts(merged).count(FED), 1, "never twice: the atom, not the echo")
+
+    def test_an_unfed_image_echo_survives_the_floor_too(self):
+        # nobody holds it, nothing landed it: until 2026-09-06 the image-extraction floor retired this
+        # echo the moment the sibling landed — but on this route the CLI never rewrites the path, so the
+        # text WILL land verbatim, and the echo waits for that (or for the dropped marking)
+        self.w.write(running_turn())
+        key = self.w.echo("compare with /tmp/notes-api/docs/before.png", T0 + 38)
+        merged = km._merge_live_atoms(self.w.parse(), SID)
+        self.assertIn(key, self.w.be._live.get(SID, {}))
+        self.assertEqual(self._texts(merged).count("compare with /tmp/notes-api/docs/before.png"), 1)
+
+
+class ImagePathPredicateTwins(unittest.TestCase):
+    """The extension set is the CLI's, not romp's. SOURCE OF TRUTH: the installed Claude Code bundle
+    (2.1.261) carries exactly one image-path test, `/\\.(png|jpe?g|gif|webp)$/i`; its callers are the
+    terminal composer's bracketed-paste handler — which reads a pasted path with one of those extensions
+    and rewrites the token to "[Image #N]" (the "Failed to read pasted image file" path) — and two
+    attachment uploaders' isImage. Nothing on the stream-json input path an SDK session uses reaches it,
+    which is why sdk_backend.prune_live floors no echo; the kernel's tmux settle borrows the predicate
+    for the route where the hook does run. When the CLI's set changes, change BOTH twins here: the kernel
+    waits on the rewrite (_injected_img_paths), the backend exports the predicate — a drift between them
+    or from the CLI makes an echo the CLI did rewrite persist forever, or one it did not rewrite get
+    retired as an extraction."""
+
+    CLI_SET = "png|jpe?g|gif|webp"
+
+    def test_the_backend_regex_is_the_kernels(self):
+        self.assertEqual(sb._IMG_PATH_RE.pattern, km._IMG_PATH_RE.pattern)
+        self.assertEqual(sb._IMG_PATH_RE.flags, km._IMG_PATH_RE.flags)
+
+    def test_the_set_is_the_cli_paste_hooks(self):
+        for rx in (sb._IMG_PATH_RE, km._IMG_PATH_RE):
+            m = re.search(r"\\\.\(\?:([a-z|?]+)\)", rx.pattern)
+            self.assertIsNotNone(m, rx.pattern)
+            self.assertEqual(m.group(1), self.CLI_SET, "the alternation is the CLI's, verbatim")
+            self.assertTrue(rx.flags & re.IGNORECASE, "the CLI's test is case-insensitive (/i)")
+        for ext in ("png", "PNG", "jpg", "JPEG", "jpeg", "gif", "webp", "WebP"):
+            self.assertTrue(sb._path_bearing("see /tmp/notes-api/docs/shot.%s now" % ext), ext)
+            self.assertEqual(km._injected_img_paths("see /tmp/notes-api/docs/shot.%s now" % ext),
+                             ["/tmp/notes-api/docs/shot.%s" % ext])
+        for ext in ("svg", "bmp", "ico", "avif", "heic", "tiff", "txt", "md"):
+            self.assertFalse(sb._path_bearing("see /tmp/notes-api/docs/shot.%s now" % ext),
+                             "%s: the CLI never rewrites it" % ext)
+            self.assertEqual(km._injected_img_paths("see /tmp/notes-api/docs/shot.%s now" % ext), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -2,11 +2,16 @@
 """A send fed into a RUNNING turn is held by the CLI until its next tool boundary, then spliced in as a
 queued_command attachment stamped with the ENQUEUE time — so its atom lands ABOVE the tool calls that
 streamed while it waited. Until that splice the kernel's input echo is the message's only visible
-record, and that must hold end to end: the echo of a FED, unlanded text outlives its sibling's landing —
-no floor retires an SDK echo at all (sdk_backend.prune_live, 2026-09-06: the CLI's image-path extraction
-is a composer paste-hook behaviour that stream-json input never reaches) — and retires exactly when the
-absorbed atom's text lands: the kernel's _atom_user_texts reads the queued_command text off the parsed
-absorbed atom, so the by-text prune fires on it and the message never renders twice.
+record, and two things must hold end to end:
+
+  1. the echo of a FED, unlanded text outlives its sibling's landing — no floor retires an SDK echo at
+     all (sdk_backend.prune_live, 2026-09-06: the CLI's image-path extraction is a composer paste-hook
+     behaviour that stream-json input never reaches) — and retires exactly when the absorbed atom's text
+     lands: the kernel's _atom_user_texts reads the queued_command text off the parsed absorbed atom, so
+     the by-text prune fires on it and the message never renders twice;
+  2. the chat event for that atom says so (`absorbed`, plus `landedAt`: when the CLI took it — the
+     file-order predecessor of the attachment record, since the attachment's own stamp is the send
+     time), so the client can mark it and leave a cue where the pending bubble was.
 
 The sdk_backend twin of the image-path predicate is pinned against the kernel's, and both against the
 CLI paste hook's extension set (ImagePathPredicateTwins names the source). The TEXT KEY the kernel's
@@ -181,6 +186,139 @@ class FedEchoSurvivesUntilTheSpliceLands(unittest.TestCase):
         self.assertIn(key, self.w.be._live.get(SID, {}))
         self.assertEqual(self._texts(merged).count("compare with /tmp/notes-api/docs/before.png"), 1)
 
+
+
+class AbsorbedAtomCarriesItsLandingTime(unittest.TestCase):
+    """The attachment record is stamped with the SEND time; the CLI wrote it at the splice, right
+    after the tool boundary it waited for — so the file-order predecessor (the tool result at T0+50)
+    is when the session took the message. Stamped at emit time from the ingest-order (seq, ts) list,
+    on the full parse and on the assembly fold alike."""
+
+    def setUp(self):
+        self.w = _World()
+
+    def tearDown(self):
+        self.w.close()
+
+    def _absorbed(self, session):
+        return [a for t in session["turns"] for a in t["atoms"] if a.get("absorbed")]
+
+    def test_full_parse_stamps_the_predecessors_time(self):
+        self.w.write(running_turn() + spliced_tail())
+        a = self._absorbed(self.w.parse())
+        self.assertEqual(len(a), 1)
+        self.assertEqual(a[0]["t"], T0 + 38, "placed at the SEND time, above the steps that ran meanwhile")
+        self.assertEqual(a[0]["landedT"], T0 + 50, "taken at the boundary before it in file order")
+        self.assertNotIn("_seq", a[0], "the parse still strips its private ordering key")
+
+    def test_the_fold_stamps_it_too(self):
+        # the live shape: the running turn is already parsed and cached when the splice records append
+        self.w.write(running_turn())
+        mode = []
+        em.parse_session(str(self.w.tpath), rompuuid=SID, candidate_files=[str(self.w.tpath)],
+                         postal_log=[], now=NOW, sdk_human=True, asm_mode_out=mode)
+        self.assertEqual(mode, ["full"])
+        with open(self.w.tpath, "a") as f:
+            for r in spliced_tail():
+                f.write(json.dumps(r) + "\n")
+        mode = []
+        out = em.parse_session(str(self.w.tpath), rompuuid=SID, candidate_files=[str(self.w.tpath)],
+                               postal_log=[], now=NOW, sdk_human=True, asm_mode_out=mode)
+        self.assertEqual(mode, ["fold"], "the appended splice folds onto the cached parse")
+        a = self._absorbed(out)
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 38, T0 + 50)])
+
+    def test_two_splices_at_one_boundary_read_that_boundary(self):
+        # the CLI drains its queue at a boundary: the second attachment's file-order neighbour is the
+        # FIRST attachment, whose stamp is its own send time — not a landing. Attachments are skipped
+        # as witnesses, so both read the tool result they waited for.
+        second = "and update the docstring"
+        recs = running_turn() + [attline(T0 + 38, FED, "att1", "tr1"),
+                                 attline(T0 + 44, second, "att2", "att1"),
+                                 aline(T0 + 75, "Both done.", "a3", "att2")]
+        self.w.write(recs)
+        a = self._absorbed(self.w.parse())
+        self.assertEqual([(x["uuid"], x["landedT"]) for x in a], [("att1", T0 + 50), ("att2", T0 + 50)])
+
+    def test_a_witness_stamped_before_the_send_clamps_to_the_send(self):
+        # whole-second stamps can invert a sub-second gap between the tool_result and the enqueue (the
+        # corpus's worst case is -0.2 s); the landing then reads as the send, never earlier, so the
+        # chat's `landedAt` can never precede the bubble's own `ts`
+        recs = running_turn()[:-1] + [trline(T0 + 37, "tu_a2_0", "tr1", "a2"),
+                                      attline(T0 + 38, FED, "att1", "tr1"),
+                                      aline(T0 + 75, "Renamed.", "a3", "att1")]
+        self.w.write(recs)
+        a = self._absorbed(self.w.parse())
+        self.assertEqual([(x["t"], x["landedT"]) for x in a], [(T0 + 38, T0 + 38)])
+
+    def test_an_attachment_with_no_predecessor_carries_no_stamp(self):
+        # nothing before it in the read → nothing truthful to stamp; the field is simply absent
+        self.w.write([attline(T0 + 38, FED, "att1", None), aline(T0 + 75, "ok", "a1", "att1")])
+        a = self._absorbed(self.w.parse())
+        self.assertEqual(len(a), 1)
+        self.assertNotIn("landedT", a[0])
+
+
+class ChatEventSaysAbsorbed(unittest.TestCase):
+    """build_session's kind:"user" event for the absorbed atom carries `absorbed` and `landedAt`, so
+    the client can mark the bubble and place the mid-turn cue. A synthetic session discovery can see
+    (names/ + projects/<cdir>/<SID>.jsonl under a hermetic state root), the test_chat_fold shape."""
+
+    def setUp(self):
+        self.w = _World()
+        root = Path(self.w.td.name)
+        proj = root / "projects"
+        self.tpath = proj / km.jd._proj_dir(str(self.w.cwd)).name / (SID + ".jsonl")
+        self.tpath.parent.mkdir(parents=True, exist_ok=True)
+        names = root / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(self.w.cwd))
+        self.saved = (km.jd.NAMES, km.jd.PROJECTS, km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR, km.jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        km.jd.NAMES, km.jd.PROJECTS = names, proj
+        km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR = root / "captions", root / "archive", root / "goals"
+        km.jd.STATE = root
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = root / "no-global-claude.md"
+        self.now = int(__import__("time").time())       # discovery keys on the real clock
+        self.tm = {SID: {"state": "working", "since": self.now - 100, "model": "", "effort": "",
+                         "context": None, "compactPct": None, "color": None}}
+        km._tmux_sessions = lambda: self.tm
+        km._chat_fold.clear(); km._parse_cache.clear()
+        km._PATH_LINK_CACHE.clear(); km._SPACE_PATH_CACHE.clear()
+        km._postal_index_memo[0] = None
+        if isinstance(km.jd._discover_cache, dict):
+            km.jd._discover_cache.clear()
+
+    def tearDown(self):
+        (km.jd.NAMES, km.jd.PROJECTS, km.jd.CAPDIR, km.jd.ARCHDIR, km.jd.GOALDIR, km.jd.STATE,
+         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved
+        km._chat_fold.clear(); km._parse_cache.clear()
+        self.w.close()
+
+    def _recs(self, base):
+        # discovery keys on the real clock: shift the fixture to "just now"
+        shift = (self.now - 600) - T0
+        out = []
+        for r in base:
+            r = dict(r)
+            r["timestamp"] = iso(datetime.strptime(r["timestamp"], "%Y-%m-%dT%H:%M:%S.000Z")
+                                 .replace(tzinfo=timezone.utc).timestamp() + shift)
+            out.append(r)
+        return out, shift
+
+    def test_the_user_event_carries_absorbed_and_landed_at(self):
+        recs, shift = self._recs(running_turn() + spliced_tail())
+        self.tpath.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        m = km.build_session(SID, self.now, self.tm)
+        self.assertIsNotNone(m)
+        users = [e for e in m["events"] if e.get("kind") == "user" and e.get("md")]
+        ab = [e for e in users if e.get("absorbed")]
+        self.assertEqual([e["uuid"] for e in ab], ["att1"])
+        self.assertEqual(ab[0]["md"], FED)
+        self.assertEqual(ab[0]["landedAt"], T0 + 50 + shift, "when the CLI took it, not when it was sent")
+        self.assertEqual(ab[0]["ts"][:19], iso(T0 + 38 + shift)[:19], "ts stays the send time — placement unchanged")
+        self.assertTrue(all("absorbed" not in e for e in users if e["uuid"] != "att1"),
+                        "a native user record never wears the flag")
 
 
 class OneTextRuleAcrossKernelAndBackend(unittest.TestCase):

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -320,6 +320,26 @@ class ChatEventSaysAbsorbed(unittest.TestCase):
         self.assertTrue(all("absorbed" not in e for e in users if e["uuid"] != "att1"),
                         "a native user record never wears the flag")
 
+    def test_a_record_of_several_sends_carries_its_blocks(self):
+        """Back-to-back sends the CLI takes together land as ONE user record with a text block each (the
+        shape _atom_user_texts prunes the kernel's echoes against). The chat's own pending bubbles end
+        on an exact match with a landed event's text, and `md` is the blocks joined, which matches
+        none of them — so the event ships `blocks`, each under the one text key, and only when there
+        are two or more (2026-09-07 review)."""
+        first, second = "rename this to fetch_notes", "and update the docstring  "
+        batched = {"type": "user", "timestamp": iso(T0 + 90), "uuid": "u9", "parentUuid": "a3", "promptSource": "sdk",
+                   "message": {"role": "user", "content": [{"type": "text", "text": first},
+                                                           {"type": "text", "text": second}]}}
+        recs, shift = self._recs(running_turn() + spliced_tail() + [batched, aline(T0 + 95, "Both done.", "a4", "u9")])
+        self.tpath.write_text("".join(json.dumps(r) + "\n" for r in recs))
+        m = km.build_session(SID, self.now, self.tm)
+        self.assertIsNotNone(m)
+        users = {e["uuid"]: e for e in m["events"] if e.get("kind") == "user" and e.get("md")}
+        self.assertEqual(users["u9"]["blocks"], [first, second.strip()], "one entry per block, under echo_text_key")
+        self.assertEqual(users["u9"]["md"], (first + " " + second).strip(), "md stays the joined text")
+        self.assertEqual([u for u, e in users.items() if "blocks" in e], ["u9"],
+                         "a single-block record and the absorbed attachment ship no blocks")
+
 
 class OneTextRuleAcrossKernelAndBackend(unittest.TestCase):
     """The by-text prune has two sides in two modules: the kernel builds the keys (_atom_user_texts →

--- a/tests/test_kernel_fed_echo_absorbed.py
+++ b/tests/test_kernel_fed_echo_absorbed.py
@@ -189,7 +189,8 @@ class ImagePathPredicateTwins(unittest.TestCase):
     for the route where the hook does run. When the CLI's set changes, change BOTH twins here: the kernel
     waits on the rewrite (_injected_img_paths), the backend exports the predicate — a drift between them
     or from the CLI makes an echo the CLI did rewrite persist forever, or one it did not rewrite get
-    retired as an extraction."""
+    retired as an extraction. The kernel's bare-path PREVIEW (_user_images) is deliberately NOT a
+    reader: it is romp's own feature on its own set (PreviewSetIsTheHydrationRoutes below)."""
 
     CLI_SET = "png|jpe?g|gif|webp"
 
@@ -211,6 +212,38 @@ class ImagePathPredicateTwins(unittest.TestCase):
             self.assertFalse(sb._path_bearing("see /tmp/notes-api/docs/shot.%s now" % ext),
                              "%s: the CLI never rewrites it" % ext)
             self.assertEqual(km._injected_img_paths("see /tmp/notes-api/docs/shot.%s now" % ext), [])
+
+
+class PreviewSetIsTheHydrationRoutes(unittest.TestCase):
+    """_user_images scans a human turn's text for a bare image path to preview — on an SDK session every
+    image path lands as text, so this scan is the only way a referenced picture gets shown. Its set is
+    NOT the CLI twin's: it is exactly what the imgRequest route can serve (_IMG_MIME's keys, bmp and svg
+    included), derived from that map so the scan can never propose a path _img_data_url would refuse.
+    Pinned because narrowing the shared regex to the CLI's set on 2026-09-06 would otherwise have dropped
+    svg/bmp previews without any test noticing."""
+
+    def test_the_preview_set_is_derived_from_the_mime_map(self):
+        m = re.search(r"\\\.\(\?:([a-z|]+)\)", km._PREVIEW_IMG_RE.pattern)
+        self.assertIsNotNone(m, km._PREVIEW_IMG_RE.pattern)
+        self.assertEqual(set(m.group(1).split("|")), {k[1:] for k in km._IMG_MIME})
+        self.assertTrue(km._PREVIEW_IMG_RE.flags & re.IGNORECASE, "_img_data_url lowercases the extension")
+        self.assertIn("svg", m.group(1)); self.assertIn("bmp", m.group(1))
+
+    def test_a_bare_svg_or_bmp_path_still_previews(self):
+        for ext in ("svg", "bmp", "BMP", "png", "jpeg", "JPG", "gif", "webp"):
+            p = "/tmp/notes-api/docs/diagram.%s" % ext
+            self.assertEqual(km._user_images([], "compare with %s please" % p, True),
+                             [{"src": "path:" + p, "path": p}], ext)
+        self.assertEqual(km._user_images([], "~/notes/todo.md is stale, see /tmp/x.ico", True), [],
+                         "an extension the route cannot serve is not proposed")
+
+    def test_the_preview_is_wider_than_the_cli_twin_and_the_twin_is_unchanged(self):
+        # the extraction reader still answers with the CLI's set: an svg path is previewed, yet the tmux
+        # pre-Enter wait does not wait for a rewrite the CLI never performs
+        text = "compare with /tmp/notes-api/docs/diagram.svg"
+        self.assertEqual(len(km._user_images([], text, True)), 1)
+        self.assertEqual(km._injected_img_paths(text), [])
+        self.assertFalse(sb._path_bearing(text))
 
 
 if __name__ == "__main__":

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -43,6 +43,7 @@ class Redelivery(unittest.TestCase):
             state_dir = None
             _live = {}
             _reg_lock = __import__("threading").RLock()
+            _live_lock = __import__("threading").RLock()   # the live tail's lock (_mark_dropped_echoes selects under it)
             _persisted = []
             _logs = []
 

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -4,7 +4,9 @@ a HUMAN send whose CLI died holding it — provably lost (not in the surviving q
 never-landed by a direct transcript scan — is RE-DELIVERED through the persisted queue in send
 order, recreating the pre-restart state, instead of parking as a never-delivered bubble waiting on
 a manual restore. romp-authored echoes keep the flag path (re-delivering a nudge double-nudges),
-and a landed-but-unpruned echo never re-delivers (the scan is the duplicate guard). SYNTHETIC."""
+and a landed-but-unpruned echo never re-delivers (the scan is the duplicate guard) — nor is it flagged
+lost: it landed, the next build's by-text prune retires it (2026-09-06; the scan also reads the
+queued_command attachment an absorbed send leaves — tests/test_sdk_echo_durability.py). SYNTHETIC."""
 import json
 import os
 import tempfile
@@ -95,8 +97,8 @@ class Redelivery(unittest.TestCase):
         self._echo("already landed words")
         self.be._mark_dropped_echoes(SID, [])
         self.assertEqual(self._reg_queue(), [], "the transcript scan is the duplicate guard")
-        self.assertTrue(any(a.get("dropped") for a in self.be._live[SID].values()),
-                        "…so it takes the flag path (self-correcting on the next build)")
+        self.assertFalse(any(a.get("dropped") for a in self.be._live[SID].values()),
+                         "…and a found text is not flagged either: it landed, the by-text prune retires it")
 
     def test_romp_authored_echoes_keep_the_flag_path(self):
         self._echo("a nudge body", author="romp")

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -392,23 +392,24 @@ class LiveTail(unittest.TestCase):
         self.assertIn("blocked = self.inflight > 0 and self._interrupted", src,
                       "inputs() holds queued turns while a turn is interrupted/wedged")
 
-    def test_image_echo_pruned_by_human_floor_when_text_cant_match(self):
-        # The screenshots-piling-up bug (the user 2026-06-25): an image send's echo text is the raw composer
-        # text (an image path), but the transcript extracts the path into an image block, so the echoed path
-        # is NOT in tx_user_texts and the text-prune can never retire it → every screenshot echo accumulates.
-        # The FIFO floor retires it once the transcript's newest genuine-human turn is at/after its send time.
+    def test_image_echo_is_never_floored_it_lands_by_text(self):
+        # The screenshots-piling-up bug (the user 2026-06-25) was the TMUX composer's: its paste hook
+        # rewrites a pasted image path to "[Image #N]", so the echoed path is never in tx_user_texts and a
+        # FIFO floor had to retire the echo once a later genuine-human turn landed. The SDK route never
+        # runs that hook — stream-json input lands the path as typed — so since 2026-09-06 no SDK echo is
+        # floored: an image echo retires when its own text lands (or when the CLI dies holding it, the
+        # dropped marking), exactly like a plain-text one. tests/test_sdk_echo_durability.py has the rest.
         be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
         be._live["s"] = {"echo:img": {"uuid": "echo:img", "t": 100, "_echo_text": "/abs/shot.png"}}
-        be.prune_live("s", set(), set())               # no text/uuid match, no floor → echo persists (the bug)
+        be.prune_live("s", set(), set())               # nothing landed → the echo is the send's only record
         self.assertEqual([a["uuid"] for a in be.live_atoms("s")], ["echo:img"])
-        be.prune_live("s", set(), set(), human_floor=120)   # a later genuine-human turn landed → FIFO-retire it
+        be.prune_live("s", set(), set(), human_floor=120)   # a later genuine-human turn: not a retire here
+        self.assertEqual([a["uuid"] for a in be.live_atoms("s")], ["echo:img"],
+                         "the message may still sit in the CLI's queue; its path will land as typed")
+        be.prune_live("s", set(), {"/abs/shot.png": 130}, human_floor=130)   # its own record lands → retire
         self.assertEqual(be.live_atoms("s"), [])
-        # a not-yet-landed echo (send time AFTER the floor) must survive
-        be._live["s"] = {"echo:new": {"uuid": "echo:new", "t": 200, "_echo_text": "/abs/new.png"}}
-        be.prune_live("s", set(), set(), human_floor=120)
-        self.assertEqual([a["uuid"] for a in be.live_atoms("s")], ["echo:new"])
         # the floor must NOT retire a real stream atom (no _echo_text) — those prune by uuid only
-        be._live["s"]["a9"] = {"uuid": "a9", "t": 50}
+        be._live["s"] = {"a9": {"uuid": "a9", "t": 50}}
         be.prune_live("s", set(), set(), human_floor=300)
         self.assertEqual([a["uuid"] for a in be.live_atoms("s")], ["a9"])
 

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -4696,7 +4696,8 @@ class SettleBeforePoke(unittest.TestCase):
         # busy() is inflight>0 or _pending; the input generator pops _pending and must count the turn in
         # flight under the SAME lock, or a drain re-running right after a delivery reads the gap as idle
         src = open(os.path.join(BIN, "romp_sdk_backend.py"), encoding="utf-8").read()
-        body = src[src.index("async def inputs():"):src.index("async def drain(client):")]
+        body = src[src.index("async def inputs():"):src.index("# Reconnect loop:")]   # the generator, up to the
+        #   connect loop that follows it (the receive side is SdkSession._drain since 2026-09-06)
         self.assertLess(body.index("self.inflight += 1"), body.index("if item is None:"),
                         "the increment sits inside the lock block that popped the item")
         self.assertLess(body.index("self.inflight += 1"), body.index("self._persist_queue()"),

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -5,9 +5,14 @@ queued nor landed, and the echo must own it (the user 2026-07-20: a reply sat in
 and one message was silently LOST across a kernel restart with no trace anywhere). Four durability
 guarantees, each pinned here:
   1. the live-tail overflow cap never evicts an echo (work atoms are disposable; echoes aren't),
-  2. the genuine-human-turn floor retires only PATH-BEARING echoes (the image-extraction case whose
-     text-match structurally fails) — a plain-text echo prunes only by its own text landing, and a
-     dropped send's echo PERSISTS so the loss shows (the tmux echo's semantics),
+  2. NO floor retires an SDK echo (2026-09-06): an echo prunes only by its own text landing, and a
+     dropped send's echo PERSISTS so the loss shows (the tmux echo's semantics). The genuine-human-turn
+     floor once retired path-bearing echoes for the image-extraction case — the CLI's composer paste
+     hook rewrites a pasted image path to "[Image #N]", so the text can never match — but that hook
+     runs only in the terminal composer; an SDK session's input is stream-json and the CLI takes the
+     text as typed, so on this backend the rule had only false positives (a `.png` echo retired with
+     its message still in the CLI's queue). `_path_bearing` stays, narrowed to the hook's set, for the
+     tmux settle that borrows it,
   3. unlanded echoes mirror to the registry (reg['echoes']) and reseed on backend construction, so a
      kernel restart cannot wipe the only evidence of an in-flight send,
   4. an echo that survives its holder is MARKED dropped at the event that orphaned it (boot reseed /
@@ -63,7 +68,17 @@ class OverflowCapSparesEchoes(unittest.TestCase):
         self.assertLessEqual(len(d), sb.LIVE_TAIL_CAP)
 
 
-class FloorOnlyRetiresPathBearingEchoes(unittest.TestCase):
+class NoFloorRetiresAnEcho(unittest.TestCase):
+    """Guarantee 2. The genuine-human-turn floor once retired path-bearing echoes — the image-extraction
+    case, where the CLI's composer paste hook rewrites a pasted image path to "[Image #N]" and the echo's
+    text can never match. That hook runs only in the terminal composer: an SDK session's input is
+    stream-json, and the CLI takes the text as typed (a count over one installation's SDK transcripts,
+    2026-09-06: 0 image blocks in 8,569 user records across 71 sessions; every image-path text landed
+    verbatim). So on this backend the rule had only false positives — a `.png` echo retired while its
+    message sat in the CLI's queue — and no echo is floored any more: an echo retires by its own text
+    landing or by the dropped marking. `_path_bearing` stays, narrowed to the hook's set, for the tmux
+    settle that borrows it (kernel._tmux_echo_settle): there a send IS a paste into the composer."""
+
     def _backend(self):
         return sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
 
@@ -75,14 +90,13 @@ class FloorOnlyRetiresPathBearingEchoes(unittest.TestCase):
         self.assertIn(k, be._live.get(SID, {}),
                       "a plain echo must not be floored away — its message may still be inside the CLI")
 
-    def test_path_bearing_echo_retires_on_the_floor(self):
-        # the image-extraction case: the landed record's text can never match, so the floor is the
-        # only retire — exactly the 2026-06-25 screenshots-piling-up semantics, now scoped to it
+    def test_an_image_path_echo_survives_a_later_human_turn_too(self):
+        # pre-change: retired here as the image-extraction case, with the message still inside the CLI
         be = self._backend()
         k, e = _echo("look at ~/Screenshots/shot.png please")
         be._live[SID] = dict([(k, e)])
         be.prune_live(SID, tx_uuids=set(), tx_user_texts=set(), human_floor=e["t"] + 100)
-        self.assertNotIn(SID, be._live, "path-bearing echo floors away once a human turn postdates it")
+        self.assertIn(k, be._live.get(SID, {}), "no SDK echo is floored: the CLI takes the path as typed")
 
     def test_text_landing_still_prunes_any_echo(self):
         be = self._backend()
@@ -91,11 +105,136 @@ class FloorOnlyRetiresPathBearingEchoes(unittest.TestCase):
         be.prune_live(SID, tx_uuids=set(), tx_user_texts={"please refactor the parser"}, human_floor=0)
         self.assertNotIn(SID, be._live)
 
+    def test_an_image_path_echo_retires_when_its_text_lands(self):
+        # the record carries the path verbatim (no rewrite on this route), so the by-text prune is the retire
+        be = self._backend()
+        text = "look at ~/Screenshots/shot.png please"
+        k, e = _echo(text)
+        be._live[SID] = dict([(k, e)])
+        be.prune_live(SID, tx_uuids=set(), tx_user_texts={text: e["t"] + 5}, human_floor=0)
+        self.assertNotIn(SID, be._live)
+
     def test_path_bearing_predicate(self):
+        # the tmux settle's predicate: exactly the CLI paste hook's set, `/\.(png|jpe?g|gif|webp)$/i`
+        # (absolute or ~-rooted paths; tests/test_kernel_fed_echo_absorbed.py pins the set itself)
         self.assertTrue(sb._path_bearing("see /tmp/x.png"))
-        self.assertTrue(sb._path_bearing("~/notes/todo.md is stale"))
+        self.assertTrue(sb._path_bearing("look at ~/Screenshots/shot-2.PNG please"))
+        self.assertTrue(sb._path_bearing("(/tmp/notes-api/docs/fig.jpeg)"))
+        self.assertTrue(sb._path_bearing("and ~/Downloads/anim.GIF, then /srv/pics/x.webp"))
+        self.assertFalse(sb._path_bearing("compare with /tmp/notes-api/docs/diagram.svg"),
+                         "svg is not in the hook's set — the CLI never rewrites it")
+        self.assertFalse(sb._path_bearing("see /tmp/old.bmp"), "nor bmp")
+        self.assertFalse(sb._path_bearing("~/notes/todo.md is stale"),
+                         "a non-image path is never rewritten out of the record — not extraction")
         self.assertFalse(sb._path_bearing("just a plain reply, and/or nothing else"))
         self.assertFalse(sb._path_bearing(""))
+
+    def test_a_quote_chip_source_label_is_not_path_bearing(self):
+        # the 2026-09-06 incident: a staged comment's quote chip leads with where the passage came from
+        # (`path:line`), which the old any-path predicate called path-bearing — so the floor retired the
+        # echo of a message the CLI still held. The text has no image in it; it must prune by text only.
+        body = ("Replying to this highlighted code (/tmp/notes-api/notes/api.py:42):\n"
+                "> def list_notes():\n\nrename this to fetch_notes")
+        self.assertFalse(sb._path_bearing(body), "the tmux settle must not retire this as an extraction")
+        be = self._backend()
+        k, e = _echo(body, t=39)
+        be._live[SID] = dict([(k, e)])
+        be.prune_live(SID, tx_uuids=set(), tx_user_texts={"an earlier comment": 39}, human_floor=39)
+        self.assertIn(k, be._live.get(SID, {}), "a quote-chip echo survives its sibling's landing")
+        be.prune_live(SID, tx_uuids=set(), tx_user_texts={body: 69}, human_floor=69)
+        self.assertNotIn(SID, be._live, "…and retires when its own text lands")
+
+
+class FedEchoesOutliveTheFloor(unittest.TestCase):
+    """An echo whose text the session has fed to the CLI (SdkSession._inflight_texts, the fed-turn twin
+    of `inflight`) is in flight by construction — the CLI queues a mid-turn send behind the running turn
+    and splices it at the next tool boundary — so no floor may retire it. It retires on its text landing
+    (the absorbed atom's queued_command text) or on the CLI dying with it (the dropped marking). A
+    fed-texts guard once shielded exactly these echoes from the floor; the floor itself is gone now
+    (NoFloorRetiresAnEcho), so fed or unfed, dropped or live, an echo is never floored — these pin that
+    the fed lifecycle and the CLI-death marking still behave. SYNTHETIC fixtures only; the session is
+    registered without a thread."""
+
+    IMG = "compare against /tmp/notes-api/docs/before.png please"
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.state, "sdk"))
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        open(tp, "w").close()
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True, "cwd": self.cwd, "lastSid": SID}
+        sb.write_reg(self.be.state_dir, SID, reg)
+        self.s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = self.s
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _fed_echo(self, text, t=38):
+        self.s.inflight = 1
+        self.s._inflight_texts.append(text)
+        k, e = _echo(text, t=t)
+        self.be._live[SID] = dict([(k, e)])
+        return k, e
+
+    def test_a_fed_image_echo_survives_the_floor(self):
+        # a human record at t=39 (the sibling's landing) postdates the fed echo at t=38; the old rule
+        # retired an image-bearing echo here — the CLI still has the message
+        k, e = self._fed_echo(self.IMG, t=38)
+        self.assertEqual(self.s.fed_texts(), [self.IMG])
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts={"the first comment": 39}, human_floor=39)
+        self.assertIn(k, self.be._live.get(SID, {}), "a fed echo outranks the floor")
+
+    def test_it_still_retires_when_its_text_lands(self):
+        # the queued_command attachment lands the text (the kernel's _atom_user_texts covers that shape)
+        k, e = self._fed_echo(self.IMG, t=38)
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts={self.IMG: 69}, human_floor=69)
+        self.assertNotIn(SID, self.be._live, "landing retires a fed echo as before")
+
+    def test_the_unfed_image_echo_survives_too(self):
+        # nothing fed, nothing landed: an image-path echo used to floor away here; with no floor at all
+        # it stays, like any echo of a message the transcript has not caught up on
+        k, e = _echo(self.IMG, t=38)
+        self.be._live[SID] = dict([(k, e)])
+        self.assertEqual(self.s.fed_texts(), [])
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts=set(), human_floor=39)
+        self.assertIn(k, self.be._live.get(SID, {}))
+
+    def test_the_cli_dying_marks_the_loss_and_the_loss_stays(self):
+        # the reconnect teardown (a resumable conversation): the fed list empties and the echo is flagged
+        # dropped — the loss is visible, and it STAYS visible: a dropped echo retires by its text landing
+        # or by the user's dismissal, never by a later sibling's turn (pre-change, a dropped image echo
+        # floored away here and the loss record vanished)
+        k, e = self._fed_echo(self.IMG, t=38)
+        self.assertEqual(self.s.resume_sid, SID)
+        self.s._reconcile_stranded()
+        self.assertEqual(self.s.fed_texts(), [])
+        self.assertTrue(e.get("dropped"), "the CLI died holding it → never delivered, shown as such")
+        self.assertIn(k, self.be._live.get(SID, {}), "the flag path keeps the echo as the loss record")
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts=set(), human_floor=39)
+        self.assertIn(k, self.be._live.get(SID, {}), "the loss record outlives the sibling's turn")
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts={self.IMG: 69}, human_floor=69)
+        self.assertNotIn(SID, self.be._live, "…and retires when its own text lands (a resend)")
+
+    def test_a_dropped_echo_is_dismissed_not_floored(self):
+        # the only other retire for a dropped echo is the user's ✕ (dismiss_echo)
+        k, e = self._fed_echo(self.IMG, t=38)
+        e["dropped"] = True
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts=set(), human_floor=39)
+        self.assertIn(k, self.be._live.get(SID, {}))
+        self.assertEqual(self.be.dismiss_echo(SID, uuid=k), self.IMG)
+        self.assertNotIn(SID, self.be._live)
+
+    def test_fed_texts_is_a_snapshot(self):
+        self.s._inflight_texts.append("one")
+        snap = self.s.fed_texts()
+        snap.append("two")
+        self.assertEqual(self.s.fed_texts(), ["one"])
 
 
 class EchoesSurviveARestart(unittest.TestCase):

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -2,7 +2,7 @@
 """An SDK input echo is the ONLY visible record of a send the transcript hasn't caught up on — since
 queued sends forward into the CLI mid-turn (2026-07-17) there is a window where a message is neither
 queued nor landed, and the echo must own it (the user 2026-07-20: a reply sat invisible in the chat,
-and one message was silently LOST across a kernel restart with no trace anywhere). Four durability
+and one message was silently LOST across a kernel restart with no trace anywhere). Five durability
 guarantees, each pinned here:
   1. the live-tail overflow cap never evicts an echo (work atoms are disposable; echoes aren't),
   2. NO floor retires an SDK echo (2026-09-06): an echo prunes only by its own text landing, and a
@@ -17,12 +17,22 @@ guarantees, each pinned here:
      kernel restart cannot wipe the only evidence of an in-flight send,
   4. an echo that survives its holder is MARKED dropped at the event that orphaned it (boot reseed /
      fresh CLI spawn), so persistence reads as "never delivered", not as delivered history (the user
-     2026-07-29: a two-day-old lost send kept resurfacing mid-chat, posing as an ordinary bubble).
+     2026-07-29: a two-day-old lost send kept resurfacing mid-chat, posing as an ordinary bubble) —
+     unless the transcript already carries the text, as a native user record OR as the queued_command
+     attachment a mid-turn splice leaves (the absorbed send's only record): that echo is neither
+     re-delivered nor flagged — the verdict is recorded on it and prune_live retires it, by the text key
+     the scan and the prune share (session_backend.echo_text_key) or on the verdict alone
+     (AbsorbedSendsCountAsLandedAtBoot, FoundImpliesPrunable),
+  5. that scan starts at the transcript's byte size at SEND time — the mark the echo carries — never at
+     a fixed distance from EOF, so a landed send buried under megabytes of later output is still found
+     and never re-run (LandingScanStartsAtTheSend).
 SYNTHETIC fixtures only."""
+import json
 import os
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -528,6 +538,395 @@ class ReconnectStrandIsFlagOnly(unittest.TestCase):
         s._reconcile_stranded()
         self.assertEqual(s.pending(), [self.TEXT],
                          "the not-yet-materialized conversation re-heads the queue, as documented")
+
+
+
+class _SpliceWorld(unittest.TestCase):
+    """A registry + transcript for one SDK session, with the CLI's record shapes for a running turn and a
+    mid-turn splice, and a backend constructor that runs the boot reseed. Shared by the scan classes
+    below; no tests of its own. A PRIVATE synthetic sid (the shared placeholder is reserved for fixtures
+    other modules journal against); the notes-api demo domain."""
+
+    SID = "5a5a5a5a-6b6b-4c7c-8d8d-9e9e9e9e9e9e"
+    SENT = ("Replying to this highlighted code (/tmp/notes-api/notes/api.py:42):\n"
+            "> def list_notes():\n\nrename this to fetch_notes")
+    T = 1_800_000_038          # the send (the echo's stamp)
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.state, "sdk"))
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        self.tpath = sb.transcript_path(self.cwd, self.SID)
+        os.makedirs(os.path.dirname(self.tpath), exist_ok=True)
+        open(self.tpath, "w").close()
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    @staticmethod
+    def _iso(t):
+        return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    def _user(self, t, text, uuid, parent):
+        return {"type": "user", "timestamp": self._iso(t), "uuid": uuid, "parentUuid": parent,
+                "promptSource": "sdk", "userType": "external", "isSidechain": False,
+                "message": {"role": "user", "content": text}}
+
+    def _att(self, t, prompt, uuid, parent):
+        # the real record's key shape (keys only — content invented): no '"user"' literal anywhere,
+        # `userType` is the near-miss; the prompt is a string or a content-block list
+        return {"type": "attachment", "timestamp": self._iso(t), "uuid": uuid, "parentUuid": parent,
+                "isSidechain": False, "userType": "external",
+                "attachment": {"type": "queued_command", "prompt": prompt, "commandMode": "prompt",
+                               "timestamp": int(t) * 1000}}
+
+    def _qop(self, t, op, content=None):
+        return {"type": "queue-operation", "timestamp": self._iso(t), "operation": op, "content": content}
+
+    def _write(self, recs):
+        with open(self.tpath, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def _append(self, recs):
+        with open(self.tpath, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def _size(self):
+        return os.path.getsize(self.tpath)
+
+    def _pad(self, mb, t0):
+        """`mb` megabytes of later output: tool_use / tool_result pairs of ~100 KB each, the shape a long
+        autonomous run writes after a splice. Every tool_result line carries the literal '"user"', so the
+        scan's prefilter lets each one through to the parser — the realistic cost, not a shortcut."""
+        out, i, n = [], 0, int(mb * 10)
+        for i in range(n):
+            u = "pad_%d" % i
+            out.append({"type": "assistant", "timestamp": self._iso(t0 + 2 * i), "uuid": "a_" + u, "parentUuid": None,
+                        "message": {"role": "assistant", "content": [
+                            {"type": "tool_use", "id": "tu_" + u, "name": "Bash", "input": {"command": "true"}}],
+                            "stop_reason": "tool_use"}})
+            out.append({"type": "user", "timestamp": self._iso(t0 + 2 * i + 1), "uuid": "tr_" + u, "parentUuid": "a_" + u,
+                        "message": {"role": "user", "content": [
+                            {"type": "tool_result", "tool_use_id": "tu_" + u, "content": "x" * 100_000}]}})
+        return out
+
+    def _running_turn(self):
+        return [self._user(self.T - 38, "tighten the notes-api search", "u1", None),
+                {"type": "assistant", "timestamp": self._iso(self.T - 28), "uuid": "a1", "parentUuid": "u1",
+                 "message": {"role": "assistant", "content": [
+                     {"type": "tool_use", "id": "tu_a1_0", "name": "Bash", "input": {"command": "true"}}],
+                     "stop_reason": "tool_use"}}]
+
+    def _splice(self, prompt=None, t=None):
+        # the CLI's shape for a mid-turn splice: enqueue op (no uuid), the tool_result it waited for,
+        # then the attachment stamped with the ENQUEUE time — and no user record for the text, ever
+        return [self._qop(self.T, "enqueue", None),
+                {"type": "user", "timestamp": self._iso(self.T + 12), "uuid": "tr1", "parentUuid": "a1",
+                 "message": {"role": "user", "content": [
+                     {"type": "tool_result", "tool_use_id": "tu_a1_0", "content": "ok"}]}},
+                self._qop(self.T + 12, "remove"),
+                self._att(t if t is not None else self.T, prompt if prompt is not None else self.SENT,
+                          "att1", "tr1")]
+
+    def _backend(self, echoes, queue=()):
+        sb.write_reg(self.state, self.SID, {"sid": self.SID, "name": "web", "mode": "acceptEdits",
+                                            "alive": True, "cwd": self.cwd, "lastSid": self.SID,
+                                            "queue": list(queue), "echoes": echoes})
+        return sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)   # __init__ runs the reseed
+
+    def _echo(self, text=None, t=None, **mark):
+        e = {"t": t if t is not None else self.T, "text": text if text is not None else self.SENT,
+             "author": "human", "rompAuto": False, "dropped": False}
+        e.update(mark)                # off / fsid: the send-time transcript mark; landed: a recorded verdict
+        return e
+
+    def _queue(self):
+        return (sb.read_reg(self.state, self.SID) or {}).get("queue") or []
+
+    def _mirror(self):
+        return (sb.read_reg(self.state, self.SID) or {}).get("echoes") or []
+
+    def _live(self, be):
+        return list((be._live.get(self.SID) or {}).values())
+
+
+class AbsorbedSendsCountAsLandedAtBoot(_SpliceWorld):
+    """The boot/dead-spawn duplicate guard (_text_landed) must know the shape an ABSORBED send leaves. A
+    message fed into a running turn is spliced in at the CLI's next tool boundary as a queued_command
+    ATTACHMENT record — no native user line is ever written for it — and until 2026-09-06 the scan
+    accepted user records alone (its raw-line prefilter even required the literal '"user"', which an
+    attachment line lacks; it carries `userType`). So a kernel restart in the window between the splice
+    and the next merged build reseeded the echo, read the send as never landed, re-queued the text, and
+    the resumed CLI ran the same instruction a second time — the chat showed it twice.
+
+    Now a found text is neither re-delivered nor flagged: it landed and is merely un-pruned, and the next
+    build's prune_live (the absorbed atom's text reaches _atom_user_texts) retires it. Two more scan
+    rules ride along, both mirrored from prune_live's by-text rule: a record stamped BEFORE the send is
+    not this send's landing ("ok" repeats), and the match is the whole text under the shared key
+    (echo_text_key), never a substring."""
+
+    def test_the_attachment_only_transcript_counts_as_landed(self):
+        self._write(self._running_turn() + self._splice())
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T), True,
+                      "the queued_command attachment IS the absorbed send's landing")
+
+    def test_a_content_block_prompt_counts_too(self):
+        # the SDK injection path writes the prompt as a content-block list, not a string
+        self._write(self._running_turn() + self._splice(prompt=[{"type": "text", "text": self.SENT}]))
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T), True)
+
+    def test_boot_reseed_neither_refeeds_nor_flags_an_absorbed_send(self):
+        # the incident's shape: the CLI spliced the message (attachment written), the kernel died before
+        # the next merged build pruned the echo. Pre-fix: the echo was re-queued and the CLI ran it twice.
+        self._write(self._running_turn() + self._splice())
+        be = self._backend([self._echo()])
+        self.assertEqual(self._queue(), [], "a landed send is never re-queued — the CLI would run it twice")
+        live = self._live(be)
+        self.assertEqual([a["_echo_text"] for a in live], [self.SENT], "the echo is reseeded, awaiting its prune")
+        self.assertFalse(live[0].get("dropped"), "…and not flagged: it landed, it is merely un-pruned")
+        self.assertFalse((sb.read_reg(self.state, self.SID).get("echoes") or [{}])[0].get("dropped"))
+        # the next merged build lands the absorbed atom's text at the attachment's (enqueue) stamp
+        be.prune_live(self.SID, tx_uuids=set(), tx_user_texts={self.SENT: self.T}, human_floor=self.T - 38)
+        self.assertNotIn(self.SID, be._live, "the by-text prune retires it, exactly once")
+
+    def test_a_multi_line_send_is_found_through_the_json_escaping(self):
+        # the old raw-line prefilter looked for the collapsed text's first 60 chars in the raw JSON line,
+        # where every newline is the two characters backslash-n — a quote chip's reply never matched
+        self._write(self._running_turn() + [self._user(self.T + 3, self.SENT, "u2", "a1")])
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T), True)
+
+    def test_an_earlier_twin_of_the_text_is_not_this_sends_landing(self):
+        # prune_live's T237b rule, mirrored: "ok" from an hour ago is not the landing of the "ok" the
+        # dead CLI was holding — that send IS lost, and it goes back into the queue
+        self._write([self._user(self.T - 3600, "ok", "u1", None)])
+        be = self._backend([self._echo(text="ok")])
+        self.assertIs(be._text_landed(self.SID, "ok", self.T), False)
+        self.assertEqual(self._queue(), ["ok"], "re-delivered: the only record of the text predates the send")
+        self.assertFalse(self._live(be)[0].get("dropped"))
+
+    def test_a_record_at_the_send_second_counts(self):
+        # the echo's stamp is minted before the CLI can see the text, so its record is at or after it —
+        # the same second included (both stamps are whole seconds)
+        self._write([self._user(self.T, "ok", "u1", None)])
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, "ok", self.T), True)
+
+    def test_a_superstring_record_is_not_a_match(self):
+        # the whole text, never a substring: a found echo is handed to the by-text prune, which matches
+        # exactly — a substring "find" would leave an echo nothing ever prunes
+        self._write([self._user(self.T + 2, "ok go ahead with the rename", "u1", None)])
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, "ok", self.T), False)
+
+    def test_a_lost_send_with_only_its_enqueue_op_is_still_re_delivered(self):
+        # the control: the CLI died holding the message — the enqueue op is on disk, no attachment, no
+        # user record. Provably lost → back into the queue, as before.
+        self._write(self._running_turn() + [self._qop(self.T, "enqueue", None)])
+        be = self._backend([self._echo()])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T), False)
+        self.assertEqual(self._queue(), [self.SENT])
+        self.assertFalse(self._live(be)[0].get("dropped"), "re-queued renders as queued, never as lost")
+
+    def test_an_unreadable_transcript_still_takes_the_flag_path(self):
+        os.remove(self.tpath)
+        be = self._backend([self._echo()])
+        self.assertIsNone(be._text_landed(self.SID, self.SENT, self.T), "cannot read → no verdict")
+        self.assertEqual(self._queue(), [], "never re-deliver on doubt")
+        self.assertTrue(self._live(be)[0].get("dropped"), "…but the possible loss is shown, for a human call")
+
+    def test_the_match_set_reads_both_record_shapes(self):
+        # the helper _text_landed matches against: user text (string or blocks, joined AND per block —
+        # romp bundles injected messages), and the queued_command prompt (string or blocks); nothing else.
+        # Keyed by echo_text_key — outer whitespace only, the kernel's rule — never collapsed: the CLI
+        # stores user text verbatim, and a wider match here is one the prune could never retire
+        self.assertEqual(sb._landed_texts({"type": "user", "message": {"content": " a  b "}}), {"a  b"})
+        self.assertEqual(sb._landed_texts({"type": "user", "message": {"content": [
+            {"type": "text", "text": "one"}, {"type": "text", "text": "two"}]}}), {"one two", "one", "two"})
+        self.assertEqual(sb._landed_texts({"type": "attachment", "attachment": {
+            "type": "queued_command", "prompt": "x\ny"}}), {"x\ny"})
+        self.assertEqual(sb._landed_texts({"type": "attachment", "attachment": {
+            "type": "queued_command", "prompt": [{"type": "text", "text": "p"}]}}), {"p"})
+        self.assertEqual(sb._landed_texts({"type": "attachment", "attachment": {"type": "total_tokens_reminder"}}), set())
+        self.assertEqual(sb._landed_texts({"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "t", "content": "ok"}]}}), set())
+        self.assertEqual(sb._landed_texts({"type": "assistant", "message": {"content": [{"type": "text", "text": "z"}]}}), set())
+
+
+class LandingScanStartsAtTheSend(_SpliceWorld):
+    """The scan's bound is the SEND EVENT, not a byte count. _text_landed once read the last 2 MB of the
+    transcript: fine for the LOST verdict (nothing to find anyway), wrong for the LANDED one — a send
+    spliced into a running turn, its echo left un-pruned because no client was connected to build, then
+    2 MB of tool output, then a kernel restart: the attachment sat above the window, the scan answered
+    False, and the resumed CLI ran the instruction a second time. Now send() records the transcript's
+    byte size (and the fsid it measured) on the echo, the mirror carries it across restarts, and the scan
+    reads from that mark to EOF: every record that can land the send is at or after it, however much
+    follows. An echo with no mark (persisted before marks existed), or whose mark belongs to another
+    file or lies past the end, reads the whole file — the side that never duplicates."""
+
+    def _spliced_then_padded(self, mb=3):
+        """running turn → the mark (the send happens here) → the splice → `mb` MB of later output."""
+        self._write(self._running_turn())
+        off = self._size()
+        self._append(self._splice() + self._pad(mb, self.T + 20))
+        return off
+
+    def test_an_attachment_three_megabytes_before_eof_is_found(self):
+        off = self._spliced_then_padded(3)
+        self.assertGreater(self._size() - off, 3_000_000, "the landing sits well outside any 2 MB tail")
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, off, self.SID), True)
+
+    def test_the_reseed_neither_refeeds_nor_flags_a_marked_send_buried_under_later_output(self):
+        off = self._spliced_then_padded(3)
+        be = self._backend([self._echo(off=off, fsid=self.SID)])
+        self.assertEqual(self._queue(), [], "found from the mark: never re-queued, the CLI would run it twice")
+        live = self._live(be)
+        self.assertEqual([a["_echo_text"] for a in live], [self.SENT])
+        self.assertFalse(live[0].get("dropped"))
+        self.assertTrue(live[0].get("_landed"), "the verdict is recorded for prune_live")
+        self.assertEqual((live[0].get("_echo_off"), live[0].get("_echo_fsid")), (off, self.SID),
+                         "the mark rides the reseeded atom")
+
+    def test_an_echo_without_a_mark_reads_the_whole_file(self):
+        # an echo persisted before marks existed: no tail window either — the whole file, and found
+        self._spliced_then_padded(3)
+        be = self._backend([self._echo()])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T), True)
+        self.assertEqual(self._queue(), [])
+        self.assertFalse(self._live(be)[0].get("dropped"))
+
+    def test_a_mark_from_another_file_or_past_the_end_reads_from_the_start(self):
+        off = self._spliced_then_padded(3)
+        be = self._backend([])
+        # the fsid changed since the send (a /clear, a fork): the mark means nothing in this file
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, off, "0f0f0f0f-1e1e-4d2d-8c3c-9b4b9b4b9b4b"), True)
+        # a mark past EOF (the file is not the one it was measured on) → from the start
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, self._size() + 4096, self.SID), True)
+        # a mark with no fsid, or a non-integer, is no mark
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, off, None), True)
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, "%d" % off, self.SID), True)
+
+    def test_the_scan_starts_at_the_mark(self):
+        # a twin of the text BEFORE the mark with no readable stamp — which the send-time floor cannot
+        # exclude ("a record with no readable stamp still counts") — is excluded by position: it was on
+        # disk before the send, so it cannot be this send's landing
+        self._write([{"type": "user", "uuid": "u0", "parentUuid": None, "message": {"role": "user", "content": "ok"}}])
+        off = self._size()
+        self._append(self._running_turn())
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, "ok", self.T), True, "unmarked: the stampless twin counts")
+        self.assertIs(be._text_landed(self.SID, "ok", self.T, off, self.SID), False, "marked: nothing after the send")
+
+    def test_a_mark_inside_a_record_skips_the_fragment(self):
+        # the mark was taken while the CLI was mid-write: the scan's first line is a fragment of that
+        # record — skipped like any non-record line, never an error (which would read as "cannot scan")
+        self._write(self._running_turn())
+        first_line_end = open(self.tpath, "rb").read().index(b"\n") + 1
+        off = first_line_end + 10
+        self._append(self._splice())
+        be = self._backend([])
+        self.assertIs(be._text_landed(self.SID, self.SENT, self.T, off, self.SID), True)
+
+    def test_send_marks_the_echo_and_the_mirror_and_the_mark_survives_the_restart(self):
+        self._write(self._running_turn())
+        be = self._backend([])
+        reg = sb.read_reg(self.state, self.SID)
+        s = sb.SdkSession(be, dict(reg))
+        be._ensure = lambda sid: s                     # no real session thread
+        size_at_send = self._size()
+        self.assertTrue(be.send(self.SID, self.SENT))
+        atom = self._live(be)[0]
+        self.assertEqual((atom.get("_echo_off"), atom.get("_echo_fsid")), (size_at_send, self.SID),
+                         "the echo carries the transcript's size at the send, on the file it measured")
+        m = self._mirror()
+        self.assertEqual((m[0].get("off"), m[0].get("fsid")), (size_at_send, self.SID), "…and so does the mirror")
+        # the CLI took the text (the queue empties), spliced it, then wrote 3 MB; the kernel restarts
+        reg = sb.read_reg(self.state, self.SID); reg["queue"] = []; sb.write_reg(self.state, self.SID, reg)
+        self._append(self._splice() + self._pad(3, self.T + 20))
+        be2 = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)
+        self.assertEqual(self._queue(), [], "the restart never re-runs a send the mark proves landed")
+        live = self._live(be2)
+        self.assertEqual(len(live), 1)
+        self.assertFalse(live[0].get("dropped"))
+        self.assertTrue(live[0].get("_landed"))
+
+    def test_a_send_before_the_transcript_exists_marks_zero(self):
+        os.remove(self.tpath)
+        be = self._backend([])
+        s = sb.SdkSession(be, dict(sb.read_reg(self.state, self.SID)))
+        be._ensure = lambda sid: s
+        self.assertTrue(be.send(self.SID, self.SENT))
+        self.assertEqual(self._live(be)[0].get("_echo_off"), 0, "everything the file will ever hold is after the send")
+
+    def test_an_unmarked_mirror_entry_reseeds_without_a_mark(self):
+        # byte-compat with entries persisted before marks existed: no off → no _echo_off, and the
+        # mirror written back carries none either
+        self._write(self._running_turn())
+        be = self._backend([self._echo()])
+        atom = self._live(be)[0]
+        self.assertNotIn("_echo_off", atom)
+        self.assertNotIn("off", self._mirror()[0])
+
+
+class FoundImpliesPrunable(_SpliceWorld):
+    """A text the scan reports landed must be one prune_live can retire — else the echo has no exit: a
+    found echo is neither re-fed nor flagged, and dismiss_echo refuses a non-dropped echo. Until
+    2026-09-06 the scan matched whitespace-COLLAPSED text while the prune compared the RAW echo text
+    against the kernel's stripped keys, so `romp send <sid> $'text\n'` (the route passes its argument
+    verbatim) left an echo the chat hid, the prune never retired, and every boot re-scanned. Two fixes,
+    both pinned: one key rule on every side (session_backend.echo_text_key), and the found verdict
+    recorded on the echo so prune_live retires it even when no key matches."""
+
+    TEXT = "hello from a script\n"          # a trailing newline: the record stores it verbatim
+
+    def test_the_scan_and_the_prune_share_one_key(self):
+        self.assertEqual(sb.echo_text_key(" q\n"), "q")
+        self.assertEqual(sb.echo_text_key("a  b\nc"), "a  b\nc", "outer whitespace only, never collapsed")
+        self.assertEqual(sb.echo_text_key(None), "")
+        self._write(self._running_turn() + [self._user(self.T + 3, self.TEXT, "u2", "a1")])
+        be = self._backend([self._echo(text=self.TEXT)])
+        self.assertIs(be._text_landed(self.SID, self.TEXT, self.T), True)
+        self.assertEqual(self._queue(), [])
+        live = self._live(be)
+        self.assertFalse(live[0].get("dropped"))
+        # the kernel's key for that record (_atom_user_texts strips) retires the echo whose raw text differs
+        be.prune_live(self.SID, tx_uuids=set(), tx_user_texts={sb.echo_text_key(self.TEXT): self.T + 3}, human_floor=0)
+        self.assertNotIn(self.SID, be._live, "found ⇒ prunable")
+        self.assertEqual(self._mirror(), [])
+
+    def test_the_recorded_verdict_is_the_exit_when_no_key_matches(self):
+        self._write(self._running_turn() + [self._user(self.T + 3, self.TEXT, "u2", "a1")])
+        be = self._backend([self._echo(text=self.TEXT)])
+        live = self._live(be)
+        self.assertTrue(live[0].get("_landed"), "the scan's verdict is recorded on the echo")
+        self.assertTrue(self._mirror()[0].get("landed"), "…and mirrored, so a restart keeps it")
+        be.prune_live(self.SID, tx_uuids=set(), tx_user_texts={}, human_floor=0)
+        self.assertNotIn(self.SID, be._live, "prune_live honours the verdict without a text match")
+        self.assertEqual(self._mirror(), [])
+
+    def test_a_landed_echo_is_never_rescanned_or_flagged(self):
+        # the transcript is unreadable at this boot — the path that flags an unadjudicated echo
+        # (AbsorbedSendsCountAsLandedAtBoot's unreadable case) — but this one was already found
+        os.remove(self.tpath)
+        be = self._backend([self._echo(text=self.TEXT, landed=True)])
+        live = self._live(be)
+        self.assertTrue(live[0].get("_landed"))
+        self.assertFalse(live[0].get("dropped"), "a recorded landing is final: never re-scanned, never flagged")
+        self.assertEqual(self._queue(), [])
+
+    def test_an_unlanded_echo_is_still_unaffected_by_the_verdict_path(self):
+        # the control: no record, no verdict → the redeliver arm as before
+        self._write(self._running_turn())
+        be = self._backend([self._echo(text=self.TEXT)])
+        self.assertEqual(self._queue(), [self.TEXT])
+        self.assertFalse(self._live(be)[0].get("_landed"))
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -1,0 +1,1270 @@
+#!/usr/bin/env python3
+"""A handler failure on ONE streamed message must not end a session's CLI, and the live tail the two
+threads share must be safe to sweep (2026-09-06).
+
+What happened live: a session's receive loop died on `KeyError: '<message uuid>'` — the only line
+the log had — and the client teardown that followed closed its CLI mid-work (the in-flight turn, its
+subagents and its background tasks), then the session came back as a crash resume. The KeyError came from a live-tail sweep at the ResultMessage settle (retire_live_work)
+racing the kernel thread's prune_live on the same unlocked dict: `for k in list(d.keys()): a = d[k]`
+with the kernel thread deleting the just-landed reply between the snapshot and the read. The review
+then found the same unlocked dict raising RuntimeError out of the pusher's build (_persist_echoes)
+and out of the session thread at reconnect (_mark_dropped_echoes), and the two-step
+`if not d: _live.pop(sid)` orphaning an atom stashed between the steps. Three fixes, all covered here,
+and a fourth the review of the settle turned up:
+
+  * the live tail has ONE lock (SdkBackend._live_lock): every stash, every pop, the sid-level pop and
+    every iterating read take it; sweeps walk a snapshot taken under it; the emptiness check and the
+    sid-level pop are one step; the lock is never held across I/O or a callback. Real-thread hammers
+    below drive the shapes review probes reproduced on the lock-free tail;
+  * the sweeps still walk a snapshot and pop with a default (belt-and-braces), and prune_live /
+    _evict_live_overflow report a key that vanishes anyway once per site per kernel life — under the
+    lock that means a mutator bypassed it;
+  * the receive loop (_drain) runs each message through _handle_stream_message, which keeps a
+    handler's exception to that message — logged with its type, the message kind, a frame chain
+    bounded from the OUTER end (the failing frame is always kept, and is the dedupe key) and what
+    that message losing its handling cost, by its shape (for a result: read from whether the settle
+    actually ran) — deduped in the error-center ring and re-entering with the full line once
+    evicted; the reporter itself is guarded; the ResultMessage branch is ONE try whose finally is
+    the whole settle (state resets, 'waiting', the queue wake, the poke, the rename ping, the
+    deferred reconnect), so a raise anywhere in the result's bookkeeping still closes the turn; a
+    fault of the stream itself still ends the loop as before;
+  * that settle woke the input feeder and THEN armed the deferred reconnect, both wakeups FIFO on
+    the loop, so the feeder fed a message gate-held behind an interrupted turn to the client about
+    to be torn down, and _reconcile_stranded flagged it 'never delivered' (pre-existing on main).
+    inputs() now holds the queue while a reconnect is armed; the new client's feeder takes the head.
+
+Every id here is synthetic (the placeholder uuid family); no message content is real.
+"""
+import asyncio
+import inspect
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import types
+import unittest
+from importlib.machinery import ModuleSpec, SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()       # hermetic state BEFORE the load (import-time root)
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_streamsurvive",
+                      os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-aaaaaaaaaaa1"           # this module's own synthetic sid
+UNKNOWN_SID = "11111111-2222-3333-4444-bbbbbbbbbbb2"   # a session id the kernel never registered
+MSG_UUID = "11111111-2222-3333-4444-ccccccccccc3"      # a message uuid (the live tail's key kind)
+
+
+# ---- message doubles: the SDK's shapes, by class name (msg_to_atom / _on_message key on them) ----
+class _TextBlock:
+    def __init__(self, text): self.text = text
+class _ToolUseBlock:
+    def __init__(self, id, name, inp): self.id, self.name, self.input = id, name, inp
+class _AssistantMessage:
+    def __init__(self, content, model="claude-x", uuid="a1", parent_tool_use_id=None):
+        self.content, self.model, self.uuid = content, model, uuid
+        self.parent_tool_use_id, self.stop_reason, self.error = parent_tool_use_id, "end_turn", None
+class _UserMessage:
+    def __init__(self, content, uuid="u1", parent_tool_use_id=None):
+        self.content, self.uuid, self.parent_tool_use_id, self.tool_use_result = content, uuid, parent_tool_use_id, None
+class _ResultMessage:
+    uuid = "r1"
+    num_turns = 1
+def _result(**fields):
+    """A ResultMessage double carrying result fields (total_cost_usd, usage, …). Built as a subclass so
+    the handler's isinstance and the reporter's class-name checks both see a ResultMessage."""
+    return type("ResultMessage", (_ResultMessage,), dict(fields))()
+class _SystemMessage:
+    def __init__(self, subtype, data=None, uuid=None):
+        self.subtype, self.data, self.uuid = subtype, (data or {}), uuid
+class _HookEventMessage(_SystemMessage):
+    """The SDK's HookEventMessage IS a SystemMessage subclass (types.py) — so hook_started /
+    hook_response reach the SystemMessage catch-all exactly as the new subtypes did live."""
+class _StreamEvent:
+    uuid = "se1"
+_TextBlock.__name__ = "TextBlock"; _ToolUseBlock.__name__ = "ToolUseBlock"
+_AssistantMessage.__name__ = "AssistantMessage"; _UserMessage.__name__ = "UserMessage"
+_ResultMessage.__name__ = "ResultMessage"; _SystemMessage.__name__ = "SystemMessage"
+_HookEventMessage.__name__ = "HookEventMessage"; _StreamEvent.__name__ = "StreamEvent"
+
+
+class _RacyTail(dict):
+    """A live tail whose snapshot goes stale by one key: right after a sweep takes its keys()/items()
+    snapshot, `victim` is removed — a mutator changing the dict without the lock, which is the shape
+    that killed the session live. The old `a = d[k]` raises KeyError(victim) on it; a snapshot-and-pop
+    sweep does not."""
+    def __init__(self, *a, victim=None, **k):
+        super().__init__(*a, **k)
+        self.victim = victim
+    def keys(self):
+        ks = list(super().keys()); self._other_thread_prunes(); return ks
+    def items(self):
+        it = list(super().items()); self._other_thread_prunes(); return it
+    def _other_thread_prunes(self):
+        if self.victim in self:
+            dict.__delitem__(self, self.victim)
+
+
+def _backend(lines=None, **kw):
+    d = tempfile.mkdtemp()
+    log = (lambda m: lines.append(str(m))) if lines is not None else (lambda *a, **k: None)
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=log, **kw)
+
+
+def _problems(be):
+    """The backend's problem ring, minus the construction-time line this venv always adds (no SDK
+    installed here → 'claude_agent_sdk is NOT importable'), which is not what these tests observe."""
+    return [p["text"] for p in be.problems() if "claude_agent_sdk" not in p["text"]]
+
+
+def _session(be):
+    s = sb.SdkSession(be, {"sid": SID, "name": "web", "cwd": "/tmp"})
+    async def _noop(): pass
+    s._do_refresh_context = _noop
+    s._do_refresh_usage = _noop
+    return s
+
+
+def _work(uuid, t):
+    return {"type": "assistant", "uuid": uuid, "t": t,
+            "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_" + uuid, "name": "Bash", "input": {}}]}}
+
+
+def _text_atom(uuid, t):
+    return {"type": "assistant", "uuid": uuid, "t": t,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "a reply the user watched"}]}}
+
+
+def _echo(key, text, t, **flags):
+    a = {"type": "user", "uuid": key, "session_id": SID, "t": t, "parentUuid": None, "author": "human",
+         "_echo_text": text, "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+    a.update(flags)
+    return a
+
+
+def _chain(e):
+    return " > ".join("%s:%d %s" % (os.path.basename(f.filename), f.lineno, f.name)
+                      for f in traceback.extract_tb(e.__traceback__))
+
+
+class LiveTailSweepsSurviveAConcurrentPrune(unittest.TestCase):
+    """The scripted race: a dict subclass drops a key between a sweep's snapshot and its pop. Under the
+    lock this can only be a mutator bypassing it, and the sweeps still tolerate it."""
+    def setUp(self):
+        sb.SdkBackend._live_tail_race_seen.clear()     # per-kernel-life set; a fresh life per test
+
+    def _problems(self, be, site):
+        return [t for t in _problems(be) if t.startswith("live tail (%s)" % site)]
+
+    def test_retire_live_work_survives_the_settle_race_and_does_not_report_it(self):
+        """THE reported failure: the settle sweep held a snapshot of keys while the kernel thread pruned
+        the just-landed reply — `a = d[k]` raised KeyError('<message uuid>') out of _on_message. The
+        sweep tolerates the vanished key. It does NOT report it: retire_live_work releases the lock for
+        the orphan salvage's transcript read, so a key gone at its pop is a landing prune_live filed in
+        that window — legitimate, and a problem line for it would be a false alarm on every such settle."""
+        be = _backend()
+        be._live[SID] = _RacyTail({MSG_UUID: _work(MSG_UUID, 5), "w2": _work("w2", 6)}, victim=MSG_UUID)
+        be.retire_live_work(SID)                        # raised KeyError before the fix
+        self.assertNotIn(SID, be._live, "every work atom retired, the vanished one included")
+        self.assertEqual(self._problems(be, "retire_live_work"), [], "not a fault at this site")
+        self.assertEqual(_problems(be), [])
+
+    def test_prune_live_survives_a_key_taken_from_under_it_and_reports_once(self):
+        """prune_live runs wholly under the lock, so a key that vanishes anyway means a mutator bypassed
+        it — reported once per site per kernel life, naming the key's KIND and never its value."""
+        be = _backend()
+        be._live[SID] = _RacyTail({MSG_UUID: _work(MSG_UUID, 5), "w2": _work("w2", 6)}, victim=MSG_UUID)
+        be.prune_live(SID, {MSG_UUID, "w2"})            # both landed; the victim vanished mid-sweep
+        self.assertNotIn(SID, be._live)
+        self.assertEqual(len(self._problems(be, "prune_live")), 1, "the bypass is reported")
+        be._live[SID] = _RacyTail({"w3": _work("w3", 7)}, victim="w3")
+        be.prune_live(SID, {"w3"})
+        self.assertEqual(len(self._problems(be, "prune_live")), 1, "…ONCE per site per kernel life")
+        txt = self._problems(be, "prune_live")[0]
+        self.assertIn("message-uuid key", txt, "the line names the key KIND")
+        self.assertIn("_live_lock", txt, "…and what a vanished key means now: the lock was bypassed")
+        self.assertNotIn(MSG_UUID, txt, "…never the key's value")
+
+    def test_evict_live_overflow_survives_a_prune_under_it(self):
+        d = _RacyTail({("w%03d" % i): _work("w%03d" % i, i) for i in range(sb.LIVE_TAIL_CAP + 5)}, victim="w000")
+        vanished = sb._evict_live_overflow(d)          # raised KeyError('w000') before the fix
+        self.assertLessEqual(len(d), sb.LIVE_TAIL_CAP, "still bounded")
+        self.assertEqual(vanished, 1, "the sweep counts the key another thread took, for the caller to report")
+        self.assertEqual(sb._evict_live_overflow(dict(d)), 0, "a quiet sweep reports nothing")
+
+    def test_forward_reports_an_evict_race_once(self):
+        be = _backend()
+        s = _session(be)
+        tail = _RacyTail({("w%03d" % i): _work("w%03d" % i, i) for i in range(sb.LIVE_TAIL_CAP + 2)}, victim="w000")
+        be._live[SID] = tail
+        be._forward(s, _AssistantMessage([_TextBlock("hi")], uuid="new1"))
+        self.assertIn("new1", tail, "the new atom landed")
+        self.assertLessEqual(len(tail), sb.LIVE_TAIL_CAP)
+        self.assertEqual(len(self._problems(be, "_evict_live_overflow")), 1)
+
+    def test_the_result_settle_survives_a_pruned_live_tail(self):
+        """The reproduction through the real handler: a ResultMessage settles the turn → retire_live_work
+        → the racy tail. Before the fix this raised out of _on_message; the receive loop ended on it."""
+        be = _backend()
+        s = _session(be)
+        be._live[SID] = _RacyTail({MSG_UUID: _work(MSG_UUID, 5)}, victim=MSG_UUID)
+        s.inflight = 1
+
+        async def run():
+            s._on_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+            await asyncio.sleep(0)
+        asyncio.run(run())                              # no KeyError
+        self.assertEqual(s.inflight, 0, "the turn settled")
+        self.assertNotIn(SID, be._live)
+
+
+class TheLiveTailLock(unittest.TestCase):
+    """REAL threads on plain dicts, with the interpreter's switch interval lowered so the interleavings
+    the GIL permits show up within a second: one thread plays the session's loop (stash work atoms,
+    retire them at the settle, mark dropped echoes at a reconnect), the other plays the kernel (stash
+    an echo at send, land it in prune_live, mirror it). On the lock-free tail, probes of this shape
+    raised RuntimeError out of prune_live on 1412 of 1500 calls, out of _mark_dropped_echoes on 8 of
+    3000, and orphaned 343 of 60000 stashes in the sid-level pop's window; under the lock nothing
+    raises and nothing is orphaned. Each hammer runs until BOTH sides have done their floor of
+    iterations (the kernel keeps hammering until the session thread has completed its turns), so the
+    overlap asserted on is guaranteed by construction rather than sampled — under a lock convoy the
+    session thread's count for a fixed 1500 kernel calls varied 10–447 run to run, and a `> 2` floor
+    on it was a margin by luck. A wall-clock cap is the only other stop, and hitting
+    it FAILS the test: the work takes about a second idle, so the cap means a wedge, not load."""
+    SEEDED = 60          # unlanded echoes sitting in the tail (the _persist_echoes walk's length)
+    CAP_S = 20.0         # ~20x the idle runtime of the longest hammer
+
+    def setUp(self):
+        self._interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        sb.SdkBackend._live_tail_race_seen.clear()
+
+    def tearDown(self):
+        sys.setswitchinterval(self._interval)          # process-global; the rest of the suite gets it back
+
+    def _backend(self):
+        be = _backend()
+        be._update_reg = lambda sid, **f: None          # the reg write is file I/O outside the lock — not under test
+        for i in range(self.SEEDED):
+            be._stash_live(SID, "echo:seed%03d" % i, _echo("echo:seed%03d" % i, "seed %d" % i, 5))
+        return be
+
+    def _hammer(self, session_body, kernel_body, n_kernel, n_session):
+        """Two threads off one barrier: kernel_body(i) runs on one until BOTH floors are met — n_kernel
+        calls of its own and n_session completed session_body(i) iterations on the other — then stops
+        the session thread. Returns (errors, session_iterations, kernel_iterations, timed_out)."""
+        barrier = threading.Barrier(2)
+        stop = threading.Event()
+        errors, iters, timed_out = [], [0, 0], [False]
+        deadline = time.monotonic() + self.CAP_S
+        def session():
+            barrier.wait()
+            i = 0
+            while not stop.is_set():
+                try:
+                    session_body(i)
+                except Exception as e:
+                    errors.append(("session", repr(e), _chain(e)))
+                i += 1
+                iters[0] = i
+        def kernel():
+            barrier.wait()
+            i = 0
+            while i < n_kernel or iters[0] < n_session:
+                if time.monotonic() > deadline:
+                    timed_out[0] = True
+                    break
+                try:
+                    kernel_body(i)
+                except Exception as e:
+                    errors.append(("kernel", repr(e), _chain(e)))
+                i += 1
+                iters[1] = i
+            stop.set()
+        ts = threading.Thread(target=session, name="session"), threading.Thread(target=kernel, name="kernel")
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(self.CAP_S + 5)
+        return errors, iters[0], iters[1], timed_out[0]
+
+    def _assert_overlap(self, res, n_session, n_kernel):
+        """No exception on either thread, and both floors met — the interleaving happened."""
+        errors, si, ki, timed_out = res
+        self.assertEqual(errors, [], "no exception on either thread: %r" % errors[:3])
+        self.assertFalse(timed_out, "the hammer hit its %.0fs cap at %d session / %d kernel iterations"
+                         % (self.CAP_S, si, ki))
+        self.assertGreaterEqual(si, n_session, "the session thread ran its floor (%d of %d, against %d kernel calls)"
+                                % (si, n_session, ki))
+        self.assertGreaterEqual(ki, n_kernel, "the kernel thread ran its floor (%d of %d)" % (ki, n_kernel))
+
+    def test_prune_live_and_the_echo_mirror_survive_the_session_threads_stash_and_retire(self):
+        """Refuter finding 1: prune_live (kernel thread) lands an echo → _persist_echoes walks the tail
+        while the session thread's _forward stashes and retire_live_work pops — RuntimeError('dictionary
+        changed size during iteration') escaped prune_live and aborted the pusher's whole build."""
+        be = self._backend()
+        s = _session(be)
+        s._mark = lambda state: None                   # the state write is I/O the hammer does not need
+        def session_body(i):
+            for j in range(3):                         # _forward: one stash per streamed message
+                be._forward(s, _AssistantMessage([_ToolUseBlock("toolu_%d_%d" % (i, j), "Bash", {})],
+                                                 uuid="s%d-%d" % (i, j)))
+            be.retire_live_work(SID)                   # the settle sweep, once per 'turn'
+        def kernel_body(i):
+            text = "probe send %d" % i
+            be._stash_live(SID, "echo:k%d" % i, _echo("echo:k%d" % i, text, 5))   # send(): the echo
+            be._persist_echoes(SID)                                                # …and its mirror
+            be.prune_live(SID, set(), {text: 6.0}, 0)  # the echo lands by text → echo_removed → the mirror walk
+        self._assert_overlap(self._hammer(session_body, kernel_body, 1500, 20), 20, 1500)
+        tail = be._live.get(SID) or {}
+        self.assertTrue(all(("echo:seed%03d" % i) in tail for i in range(self.SEEDED)), "no seeded echo was lost")
+        self.assertFalse([k for k in tail if k.startswith("echo:k")], "every landed echo was pruned")
+        self.assertEqual([p for p in _problems(be) if p.startswith("live tail (")], [],
+                         "under the lock no key vanishes mid-sweep, so no race line")
+
+    def test_mark_dropped_echoes_survives_a_concurrent_send_stash(self):
+        """Refuter finding 2: _mark_dropped_echoes runs on the SESSION thread at spawn and at every
+        reconnect, outside the connect's try; its comprehension over the tail raised RuntimeError when
+        the kernel thread's send() stashed an echo mid-walk, and the session thread died with no reconnect."""
+        be = self._backend()
+        def session_body(i):
+            be._mark_dropped_echoes(SID, [], refeed=False)   # the resumable-reconnect arm (flag path only)
+        def kernel_body(i):
+            text = "probe send %d" % i
+            be._stash_live(SID, "echo:k%d" % i, _echo("echo:k%d" % i, text, 5))
+            be._persist_echoes(SID)
+            be.prune_live(SID, set(), {text: 6.0}, 0)  # land it, so the tail stays bounded
+        self._assert_overlap(self._hammer(session_body, kernel_body, 3000, 20), 20, 3000)
+        tail = be._live.get(SID) or {}
+        self.assertTrue(all(tail["echo:seed%03d" % i].get("dropped") for i in range(self.SEEDED)),
+                        "the seeded echoes were marked (the marking still does its job)")
+
+    def test_no_stash_is_orphaned_by_the_sid_level_pop(self):
+        """Refuter finding 3: `if not d: _live.pop(sid)` was two steps; a stash between them landed in a
+        dict nothing could reach (an input echo gone from the chat and from reg['echoes']; a work atom
+        the settle's salvage never sees). Under the lock the check and the pop are one step, so an atom
+        just stashed is always reachable from _live — checked from OUTSIDE the lock after every stash,
+        which is exactly the invariant: the sid's dict is never unreachable while non-empty."""
+        for pair in ("retire_live_work vs an echo stash", "prune_live vs a work stash"):
+            with self.subTest(pair=pair):
+                be = _backend()
+                be._update_reg = lambda sid, **f: None
+                orphans = []
+                if pair.startswith("retire"):
+                    def session_body(i):
+                        be._stash_live(SID, "w%d" % i, _work("w%d" % i, 1))
+                        be.retire_live_work(SID)       # empties the tail → the sid-level pop
+                    def kernel_body(i):
+                        key = "echo:%08x" % i
+                        be._stash_live(SID, key, _echo(key, "message %d" % i, 2))
+                        if key not in (be._live.get(SID) or {}):
+                            orphans.append(key)
+                        with be._live_lock:
+                            (be._live.get(SID) or {}).pop(key, None)
+                else:
+                    def session_body(i):
+                        be.prune_live(SID, {"landed"}, (), 0)   # pops the landed atom → maybe the sid-level pop
+                    def kernel_body(i):
+                        be._stash_live(SID, "landed", _work("landed", 1))
+                        key = "x%08x" % i
+                        be._stash_live(SID, key, _work(key, 3))
+                        if key not in (be._live.get(SID) or {}):
+                            orphans.append(key)
+                        with be._live_lock:
+                            (be._live.get(SID) or {}).pop(key, None)
+                res = self._hammer(session_body, kernel_body, 20000, 50)
+                self._assert_overlap(res, 50, 20000)
+                self.assertEqual(orphans, [], "%d of %d stashes landed in an unreachable dict" % (len(orphans), res[2]))
+
+    def test_the_lock_is_never_held_across_io_or_a_callback(self):
+        """The rule's other half: copy under the lock, act outside. The reg write (the echo mirror), the
+        transcript read and the marker append (the orphan salvage) and the pusher wake all observe the
+        lock UNHELD — a lock held across a 4 MB tail read would stall the pusher's build on it."""
+        be = _backend()
+        seen = []
+        note = lambda what: seen.append((what, be._live_lock._is_owned()))
+        be._update_reg = lambda sid, **f: note("reg write")
+        be._push_cb = lambda: note("pusher wake")
+        be._reply_on_disk = lambda sid, u: (note("transcript read"), False)[1]
+        orig = sb.append_orphan_reply
+        sb.append_orphan_reply = lambda *a, **k: note("orphan append")
+        try:
+            be._stash_live(SID, "echo:a", _echo("echo:a", "hello", 5))
+            be._persist_echoes(SID)                                     # send()'s mirror write
+            be.prune_live(SID, set(), {"hello": 6.0}, 0)                # landing → the mirror write
+            be._live[SID] = {MSG_UUID: _text_atom(MSG_UUID, 5)}
+            be.retire_live_work(SID)                                    # the salvage's read + append
+            be._live[SID] = {"echo:d": _echo("echo:d", "lost", 5, dropped=True)}
+            self.assertEqual(be.dismiss_echo(SID, uuid="echo:d"), "lost")   # mirror write + wake
+        finally:
+            sb.append_orphan_reply = orig
+        kinds = {w for w, _ in seen}
+        self.assertEqual(kinds, {"reg write", "pusher wake", "transcript read", "orphan append"}, seen)
+        self.assertFalse([w for w, held in seen if held], "the lock was held across: %r" % [w for w, h in seen if h])
+        self.assertNotIn(SID, be._live, "the dismiss emptied the tail and popped the sid entry")
+
+    def test_every_sweep_and_stash_is_locked_by_source(self):
+        """A pin on the rule's coverage, so a new unlocked walk fails here before it fails live: every
+        method that touches `_live` takes the lock (or goes through _stash_live, which does)."""
+        for name in ("live_atoms", "prune_live", "retire_live_work", "live_atom_kinds", "_persist_echoes",
+                     "_mark_dropped_echoes", "dismiss_echo", "unqueue", "_forward", "_stash_live"):
+            src = inspect.getsource(getattr(sb.SdkBackend, name))
+            self.assertIn("with self._live_lock", src, "%s does not take the live-tail lock" % name)
+        for name in ("send", "_reseed_echoes"):
+            src = inspect.getsource(getattr(sb.SdkBackend, name))
+            self.assertIn("self._stash_live(", src, "%s stashes outside _stash_live" % name)
+            self.assertNotIn("self._live.setdefault", src)
+        whole = inspect.getsource(sb.SdkBackend)
+        self.assertEqual(whole.count("self._live.setdefault("), 2, "_stash_live and _forward are the only stashes")
+
+
+class HandlerFailuresStayWithTheirMessage(unittest.TestCase):
+    def setUp(self):
+        sb.SdkSession._stream_fail_seen.clear()
+
+    def test_a_raising_handler_is_logged_with_detail_and_does_not_propagate(self):
+        lines = []
+        be = _backend(lines)
+        s = _session(be)
+        def boom(msg, *a):
+            raise KeyError(MSG_UUID)                    # the live failure's shape: the key IS a uuid
+        s._on_message = boom
+        msg = _SystemMessage("background_tasks_changed", {"session_id": UNKNOWN_SID})
+        self.assertFalse(s._handle_stream_message(msg, _AssistantMessage, _ResultMessage, _SystemMessage))
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1, "one problem line, in the error center's ring")
+        txt = probs[0]
+        self.assertIn("KeyError", txt, "the exception type")
+        self.assertIn("SystemMessage/background_tasks_changed", txt, "the message type and subtype")
+        self.assertRegex(txt, r"at .*\.py:\d+ \w+", "a file:line frame chain")
+        self.assertIn(MSG_UUID[:8] + "…", txt, "the key's first 8 characters…")
+        self.assertNotIn(MSG_UUID, txt, "…and not its full value")
+        self.assertIn("stream continues", txt)
+        self.assertIn(txt, lines, "the same line reached the kernel log")
+
+    def test_the_line_says_what_that_message_lost_by_its_shape(self):
+        """'(the transcript keeps it)' was true for assistant/user records only; a SystemMessage frame
+        or a ResultMessage exists on the stream alone, and the line has to say so for the message it is
+        about. By SHAPE, not class: a compact_boundary IS a transcript record, a
+        `<local-command-stdout>` UserMessage from a control request is not, and a ResultMessage's turn
+        'still closed' only if the settle ran — here the whole handler is replaced, so it did not."""
+        lines = []
+        be = _backend(lines)
+        s = _session(be)
+        def boom(msg, *a):
+            raise ValueError("v")
+        s._on_message = boom
+        stdout = "<local-command-stdout>Set model to sonnet (claude-sonnet-x)</local-command-stdout>"
+        cases = ((_SystemMessage("task_notification", {"task_id": "t1"}), "stream-only frame"),
+                 (_ResultMessage(), "the turn did NOT settle"),
+                 (_AssistantMessage([_TextBlock("x")]), "the transcript keeps the message"),
+                 (_UserMessage([_TextBlock("a typed prompt")]), "the transcript keeps the message"),
+                 (_UserMessage([_TextBlock(stdout)]), "a command's output line"),
+                 (_SystemMessage("compact_boundary", {"compact_metadata": {"trigger": "manual"}}), "keeps the boundary record"),
+                 (_StreamEvent(), "partial-stream event"))
+        for msg, phrase in cases:
+            sb.SdkSession._stream_fail_seen.clear()        # each case is a first-of-signature line…
+            s._handle_stream_message(msg, _AssistantMessage, _ResultMessage, _SystemMessage)
+            self.assertIn(phrase, lines[-1], "%s: %s" % (sb._describe_msg(msg), lines[-1]))
+        self.assertNotIn("Set model", "".join(lines), "the command's output text is matched, never logged")
+        # …in the kernel log; the ring folds them (same session, exception type and site), and its one
+        # entry keeps the first line's phrase with the repeat count
+        self.assertEqual(len(_problems(be)), 1)
+        self.assertIn("stream-only frame", _problems(be)[0])
+        self.assertIn("(6 repeats this kernel life", _problems(be)[0])
+        self.assertEqual(sb._failure_consequence(_HookEventMessage("hook_started")),
+                         sb._failure_consequence(_SystemMessage("status")), "every other frame: stream-only")
+        # the result's phrase is a fact the caller passes, and the settled form names what did NOT run
+        settled = sb._failure_consequence(_ResultMessage(), settled=True)
+        self.assertIn("the turn still settled", settled)
+        for word in ("spend", "live-tail sweep"):
+            self.assertIn(word, settled, "the bookkeeping that stopped is named")
+        self.assertIn("did NOT settle", sb._failure_consequence(_ResultMessage(), settled=False))
+        # the stdout wrapper is matched on a plain-string content too, and a string that merely
+        # mentions the tag mid-text is a typed prompt
+        self.assertTrue(sb._is_command_stdout(_UserMessage(stdout)))
+        self.assertFalse(sb._is_command_stdout(_UserMessage([_TextBlock("about " + stdout)])))
+
+    def test_repeats_count_on_one_ring_entry_and_bust_the_feed_cache_once(self):
+        """Every repeat is a kernel-log line; the error-center RING keeps one entry per (session,
+        exception type, failing frame) and counts on it. Before: a handler failing on every streamed
+        message put every repeat in the 100-entry ring (evicting every unrelated problem within a
+        minute) and bumped problem_seq — the feed's cache key — per message."""
+        lines = []
+        be = _backend(lines)
+        s = _session(be)
+        def boom(msg, *a):
+            raise KeyError("k")
+        s._on_message = boom
+        seq0 = be.problem_seq()
+        for _ in range(5):
+            s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1, "ONE ring entry for the five failures: %r" % probs)
+        self.assertRegex(probs[0], r"at .*\.py:\d+", "it carries the frame chain from the first")
+        self.assertIn("(4 repeats this kernel life", probs[0], "…and the count of the repeats")
+        self.assertEqual(be.problem_seq(), seq0 + 1, "one cache bust for the new problem, none per repeat")
+        logged = [l for l in lines if "KeyError while handling" in l]
+        self.assertEqual(len(logged), 5, "every failure is a kernel-log line — nothing silent")
+        self.assertIn("repeat 5", logged[4])
+        self.assertNotRegex(logged[4], r"\.py:\d+", "repeats do not re-print the chain")
+        # a different exception TYPE at the same site is a new problem: a new entry, one more bust
+        def boom2(msg, *a):
+            raise ValueError("other")
+        s._on_message = boom2
+        s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+        self.assertEqual(len(_problems(be)), 2)
+        self.assertEqual(be.problem_seq(), seq0 + 2)
+        # …while the same failure on ANOTHER message kind folds into the first entry (same site, same type)
+        s._on_message = boom
+        s._handle_stream_message(_AssistantMessage([_TextBlock("x")]), _AssistantMessage, _ResultMessage, _SystemMessage)
+        self.assertEqual(len(_problems(be)), 2)
+        self.assertIn("(5 repeats this kernel life", _problems(be)[0])
+
+    def test_a_ring_entry_evicted_meanwhile_enters_again_as_new_with_the_full_line(self):
+        """The first-vs-repeat decision and the ring's dedupe were two independent counters: once
+        the ring had evicted the entry, the next repeat logged the short line and the
+        ring built its NEW row from it — no frame chain, no consequence, and a pointer at 'the first'
+        in a kernel log that may have rotated. A repeat whose key is not in the ring now re-enters with
+        the full line, counted; the repeats after it count on that row in the short form again."""
+        lines = []
+        be = _backend(lines)
+        s = _session(be)
+        def boom(msg, *a):
+            raise KeyError("k")
+        s._on_message = boom
+        s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+        for i in range(be.PROBLEM_RING):
+            be._log("unrelated problem %d" % i, problem=True)   # the ring turns over
+        self.assertFalse([p for p in _problems(be) if "KeyError" in p], "the entry was evicted")
+        seq = be.problem_seq()
+        s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+        rows = [p for p in _problems(be) if "KeyError" in p]
+        self.assertEqual(len(rows), 1, "back in the ring as a new entry")
+        self.assertEqual(be.problem_seq(), seq + 1)
+        self.assertRegex(rows[0], r"at .*\.py:\d+ \w+", "the re-entered row carries the frame chain")
+        self.assertIn("handling stopped there (", rows[0], "…and the consequence")
+        self.assertIn("(repeat 2 this kernel life; its earlier error-center entry was evicted)", rows[0])
+        self.assertEqual(lines[-1], rows[0], "the kernel log got the same full line")
+        s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage)
+        rows = [p for p in _problems(be) if "KeyError" in p]
+        self.assertEqual(len(rows), 1, "the next repeat counts on the re-entered row")
+        self.assertIn("(1 repeat this kernel life", rows[0])
+        self.assertRegex(rows[0], r"at .*\.py:\d+ \w+", "…which keeps its chain")
+        self.assertIn("repeat 3", lines[-1])
+        self.assertNotRegex(lines[-1], r"\.py:\d+", "…while the log line is the short form again")
+        self.assertEqual(be.problem_seq(), seq + 1)
+
+    def test_problem_keyed_reads_the_ring_now(self):
+        be = _backend()
+        self.assertFalse(be.problem_keyed(("k", 1)))
+        be._log("a keyed problem", problem=True, key=("k", 1))
+        self.assertTrue(be.problem_keyed(("k", 1)))
+        self.assertFalse(be.problem_keyed(("k", 2)))
+        for i in range(be.PROBLEM_RING):
+            be._log("unrelated problem %d" % i, problem=True)
+        self.assertFalse(be.problem_keyed(("k", 1)), "evicted → not in the ring")
+
+    def test_a_clean_handler_reports_true_and_logs_nothing(self):
+        be = _backend()
+        s = _session(be)
+        ok = s._handle_stream_message(_SystemMessage("task_notification", {"task_id": "gone1", "status": "completed"}),
+                                      _AssistantMessage, _ResultMessage, _SystemMessage)
+        self.assertTrue(ok)
+        self.assertEqual(_problems(be), [])
+
+    def test_a_reporter_failure_is_one_plain_line_and_never_propagates(self):
+        """An exception whose __str__ raises reached _mask_ids inside the except and ended the drain —
+        the outcome the containment exists to prevent. The reporter is guarded: one plain line from
+        names only, and the stream goes on."""
+        class Unrenderable(Exception):
+            def __str__(self):
+                raise TypeError("unrenderable")
+        be = _backend()
+        s = _session(be)
+        def boom(msg, *a):
+            raise Unrenderable()
+        s._on_message = boom
+        self.assertFalse(s._handle_stream_message(_SystemMessage("hook_started"), _AssistantMessage, _ResultMessage, _SystemMessage))
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("Unrenderable", probs[0])
+        self.assertIn("reporting it failed too (TypeError)", probs[0])
+
+    def test_a_raising_log_callback_does_not_end_the_stream(self):
+        """The kernel's log callback writes stderr; closed under a service restart it raises OSError from
+        inside the report. The ring still has the entry (recorded before the callback), and nothing propagates."""
+        be = _backend()
+        s = _session(be)
+        def badlog(m):
+            raise OSError(32, "Broken pipe")
+        be._log_cb = badlog                            # armed AFTER construction (construction logs too)
+        def boom(msg, *a):
+            raise KeyError("k")
+        s._on_message = boom
+        for _ in range(4):
+            self.assertFalse(s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage))
+        probs = _problems(be)
+        self.assertEqual(len(probs), 2, "the report landed before the callback raised, and the broken "
+                                        "callback is its own entry — each deduped across the repeats: %r" % probs)
+        self.assertIn("KeyError while handling a ResultMessage", probs[0])
+        self.assertIn("(3 repeats this kernel life", probs[0])
+        self.assertIn("reporting it failed too (BrokenPipeError)", probs[1])
+        self.assertIn("(3 repeats this kernel life", probs[1])
+
+
+class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
+    """With per-message containment, an exception in the ResultMessage branch no longer ends the
+    stream — so THE SETTLE (inflight 0, the compaction/clear flags, 'waiting', the turn-end count, the
+    queue wake, the poke, the rename ping, the deferred effort reconnect) must run whatever the
+    result's bookkeeping did, or a gate-held queue stays parked and a deferred reconnect never fires
+    while the session reads 'working'. The rule: the branch is ONE try from its first statement, and
+    its finally is the whole settle. The first cut opened the try only ahead of the rewind steps, so
+    the spend fold and even `inflight = 0` sat outside it: a raise there parked the turn while the
+    failure line claimed it had closed (the probes were a failing spend write and a NaN usage field,
+    both reproduced here)."""
+    def setUp(self):
+        sb.SdkSession._stream_fail_seen.clear()
+
+    def _settle(self, be, s, ok_expected, msg=None):
+        pokes, marks, turns = [], [], []
+        be._poke_cb = lambda: pokes.append(1)
+        orig_mark, orig_turn = s._mark, be._turn_completed
+        s._mark = lambda state: (marks.append(state), orig_mark(state))
+        be._turn_completed = lambda sid: (turns.append(sid), orig_turn(sid))
+        out = {}
+        async def run():
+            s.loop = asyncio.get_running_loop()
+            s._input_wake = asyncio.Event()
+            s._wake = asyncio.Event()
+            out["ok"] = s._handle_stream_message(msg if msg is not None else _ResultMessage(),
+                                                 _AssistantMessage, _ResultMessage, _SystemMessage)
+            await asyncio.sleep(0)
+            out.update(wake=s._input_wake.is_set(), pokes=len(pokes), reconnect=s._reconnect,
+                       still_deferred=s._reconnect_when_idle, wake_event=s._wake.is_set(),
+                       marks=list(marks), turns=len(turns))
+        asyncio.run(run())
+        self.assertEqual(out["ok"], ok_expected)
+        return out
+
+    def _busy(self, be):
+        s = _session(be)
+        s.inflight = 1
+        s._interrupted = True                          # the queue is gate-held behind an interrupted turn
+        s._pending = ["queued during the interrupted turn"]
+        s._reconnect_when_idle = True                  # an /effort change waiting for this turn's end
+        s._compacting = True
+        return s
+
+    def _assert_settled(self, s, out):
+        self.assertEqual(s.inflight, 0, "the turn settled")
+        self.assertFalse(s._compacting or s._clearing or s._interrupted, "the turn's flags are down")
+        self.assertEqual(out["marks"], ["waiting"], "the session reads waiting")
+        self.assertEqual(out["turns"], 1, "the turn-end count moved once")
+        self.assertTrue(out["wake"], "the input feeder was released")
+        self.assertEqual(out["pokes"], 1, "the kernel was poked, once")
+        self.assertTrue(out["reconnect"] and not out["still_deferred"], "the deferred reconnect fired")
+        self.assertTrue(out["wake_event"], "…and the loop was woken for it")
+
+    def test_a_raising_retire_still_settles_the_turn(self):
+        be = _backend()
+        s = self._busy(be)
+        def boom(sid):
+            raise OSError("the sweep's transcript read failed")
+        be.retire_live_work = boom
+        out = self._settle(be, s, ok_expected=False)
+        self._assert_settled(s, out)
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("OSError while handling a ResultMessage", probs[0])
+        self.assertIn("the turn still settled", probs[0])
+
+    def test_a_raising_spend_write_still_settles_the_turn(self):
+        """_record_spend raising on a result that carries a cost — a step that sat
+        BEFORE the try and before inflight = 0 in the first cut, so the turn never settled."""
+        be = _backend()
+        s = self._busy(be)
+        def bad_spend(*a, **k):
+            raise OSError(28, "No space left on device")
+        be._record_spend = bad_spend
+        out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage={"input_tokens": 10}))
+        self._assert_settled(s, out)
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("OSError while handling a ResultMessage", probs[0])
+        self.assertIn("the turn still settled", probs[0])
+        self.assertIn("stopped where it failed", probs[0], "…and says the bookkeeping did not finish")
+
+    def test_a_nan_usage_field_still_settles_the_turn(self):
+        """The other live trigger: json.loads accepts a NaN token and int(float('nan')) raises ValueError
+        inside the fold itself (no stub needed) — the same pre-try position."""
+        import json
+        be = _backend()
+        s = self._busy(be)
+        usage = json.loads('{"input_tokens": NaN, "output_tokens": 5}')
+        out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage=usage))
+        self._assert_settled(s, out)
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("ValueError while handling a ResultMessage", probs[0])
+        self.assertIn("the turn still settled", probs[0])
+
+    def test_a_failure_before_the_branch_is_reported_as_not_settled(self):
+        """The one place a ResultMessage's handling can fail OUTSIDE the branch is the elif chain
+        above it (the move-settle check). No finally covers that, so the line must not claim a settle:
+        the phrase is read from the settle's own marker, not from the class."""
+        be = _backend()
+        s = self._busy(be)
+        def boom(msg):
+            raise RuntimeError("the move check broke")
+        s._consume_move_settle = boom
+        out = self._settle(be, s, ok_expected=False)
+        self.assertEqual(s.inflight, 1)
+        self.assertFalse(out["wake"] or out["pokes"] or out["marks"])
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("the turn did NOT settle", probs[0])
+        self.assertNotIn("still settled", probs[0])
+
+    def test_a_raising_state_write_skips_nothing_else_and_is_reported(self):
+        """The settle's own raise-prone steps (the 'waiting' write, the turn-end count) are guarded and
+        reported after the flags, so a failing one cannot skip the wake, the poke or the reconnect."""
+        be = _backend()
+        s = self._busy(be)
+        def bad_mark(state):
+            raise OSError(28, "No space left on device")
+        s._mark = bad_mark
+        pokes = []
+        be._poke_cb = lambda: pokes.append(1)
+        async def run():
+            s.loop = asyncio.get_running_loop()
+            s._input_wake = asyncio.Event()
+            s._wake = asyncio.Event()
+            self.assertTrue(s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage),
+                            "the bookkeeping ran clean; the settle step's failure is its own report")
+            await asyncio.sleep(0)
+            self.assertEqual(s.inflight, 0)
+            self.assertTrue(s._input_wake.is_set())
+            self.assertEqual(len(pokes), 1)
+            self.assertTrue(s._reconnect and not s._reconnect_when_idle)
+        asyncio.run(run())
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1, probs)
+        self.assertIn("settle (web): the 'waiting' state write failed: OSError", probs[0])
+
+    def test_a_raising_log_callback_in_the_report_loop_keeps_the_bookkeepings_exception(self):
+        """Three failures at once: the bookkeeping raises (a NaN usage field), a settle
+        step fails (the 'waiting' write at ENOSPC) AND the kernel's log callback raises (stderr closed
+        under a service restart). The report loop was the one unguarded step left after the flags, and
+        its raise REPLACED the bookkeeping's exception: the containment reported a BrokenPipeError and
+        the ValueError and its site never reached the ring. The report is guarded now: the settle runs
+        to its end, the step's own report lands (the ring row precedes the callback in _log), and the
+        line the containment files names the fold's failure and its frame."""
+        import json
+        be = _backend()
+        s = self._busy(be)
+        def bad_mark(state):
+            raise OSError(28, "No space left on device")
+        s._mark = bad_mark
+        def badlog(m):
+            raise OSError(32, "Broken pipe")
+        be._log_cb = badlog                            # armed AFTER construction (construction logs too)
+        usage = json.loads('{"input_tokens": NaN, "output_tokens": 5}')
+        out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage=usage))
+        self.assertEqual(s.inflight, 0, "the turn settled")
+        self.assertTrue(out["wake"] and out["pokes"] == 1, "the feeder was released and the kernel poked once")
+        self.assertTrue(out["reconnect"] and not out["still_deferred"] and out["wake_event"],
+                        "the deferred reconnect fired")
+        probs = _problems(be)
+        self.assertTrue([p for p in probs if "settle (web): the 'waiting' state write failed: OSError" in p],
+                        "the settle step's own report landed before the callback raised: %r" % probs)
+        filed = [p for p in probs if "while handling a ResultMessage" in p]
+        self.assertEqual(len(filed), 1, probs)
+        self.assertIn("ValueError while handling a ResultMessage", filed[0],
+                      "the bookkeeping's exception is the one the containment files, not the callback's")
+        self.assertIn("the turn still settled", filed[0])
+        self.assertIn("_on_message", filed[0], "…with the fold's frame")
+        self.assertNotIn("BrokenPipeError while handling", " ".join(probs))
+
+    def test_a_clean_settle_runs_the_same_plumbing_once(self):
+        be = _backend()
+        s = self._busy(be)
+        out = self._settle(be, s, ok_expected=True)
+        self._assert_settled(s, out)
+        self.assertEqual(_problems(be), [])
+
+    def test_the_branch_is_one_try_and_its_finally_is_the_settle_by_source(self):
+        src = inspect.getsource(sb.SdkSession._on_message)
+        i_branch = src.index("elif isinstance(msg, ResultMessage):")
+        i_try = src.index("try:", i_branch)
+        i_finally = src.index("finally:", i_try)
+        i_next = src.index("\n        elif ", i_finally)                 # the next branch of the chain
+        head = src[i_branch:i_try]
+        self.assertFalse([l for l in head.splitlines()[1:] if l.strip() and not l.strip().startswith("#")],
+                         "no statement between the branch head and the try: %r" % head)
+        body, settle = src[i_try:i_finally], src[i_finally:i_next]
+        for step in ("self.backend._record_spend(", "self.backend.retire_live_work(self.sid)",
+                     "self.backend._complete_rewind_wait(self)", "asyncio.ensure_future(self._do_refresh_usage())"):
+            self.assertIn(step, body, "%s is bookkeeping, inside the try" % step)
+            self.assertNotIn(step, settle)
+        for step in ("self.inflight = 0", "self._inflight_texts.clear()", "self._compacting = False",
+                     "self._clearing = False", "self._interrupted = False", 'self._mark("waiting")',
+                     "self.backend._turn_completed(self.sid)", "self._input_wake.set()", "self.backend._poke()",
+                     "self.backend._deliver_rename_ping(self)", "self._reconnect_when_idle and not self.ended",
+                     "self._settled_msg = msg"):
+            self.assertIn(step, settle, "%s is the settle, in the finally" % step)
+            self.assertNotIn(step, body)
+        # nothing that can raise precedes the flag writes in the finally
+        self.assertLess(settle.index("self._input_wake.set()"), settle.index("step()"))
+        self.assertLess(settle.index("self._input_wake.set()"), settle.index("self.backend._poke()"))
+
+
+class TheDeferredReconnectTakesTheHeldQueueWithIt(unittest.TestCase):
+    """Pre-existing, found while reviewing the settle: its finally wakes the input
+    feeder and THEN arms the deferred reconnect, both wakeups queued FIFO on the loop, so the feeder
+    ran first and fed a message gate-held behind the interrupted turn to the client the waker was
+    about to tear down; the teardown stranded it in flight and _reconcile_stranded — on a resumable
+    conversation, where a re-feed could duplicate — flagged it 'never delivered'. A message queued
+    behind a stopped turn while the user changed /effort had to be sent again. inputs() now holds the
+    queue while a reconnect is armed (_reconnect), so the NEW client's feeder takes the head.
+
+    The REAL _amain runs here (its inputs() closure, the teardown, _reconcile_stranded) against a
+    stand-in SDK module whose client records what it was fed and when — installed in sys.modules for
+    the test (the backend imports the SDK lazily, at the top of _amain) and removed after."""
+    FSID = "11111111-2222-3333-4444-ffffffffff01"   # the CLI's own session id, announced by the init
+
+    class _Client:
+        instances = []
+
+        def __init__(self, options=None, transport=None):
+            self.options = options
+            self.no = len(type(self).instances) + 1
+            type(self).instances.append(self)
+            self.writes = []                # (text, when) — when relative to this client's result and teardown
+            self.first_write = asyncio.Event()
+            self.release = asyncio.Event()  # the test releases the turn's ResultMessage
+            self.result_sent = self.torn_down = False
+            self.interrupts = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            self.torn_down = True
+            return False
+
+        async def query(self, prompt, session_id="default"):
+            async for turn in prompt:
+                when = ("after-teardown" if self.torn_down else
+                        "after-result" if self.result_sent else "before-result")
+                self.writes.append((turn["message"]["content"][0]["text"], when))
+                self.first_write.set()
+
+        async def interrupt(self):
+            self.interrupts += 1
+
+        async def get_context_usage(self):
+            return {"percentage": 2, "model": "claude-x"}
+
+        async def get_server_info(self):
+            return {}
+
+        async def receive_messages(self):
+            await self.first_write.wait()
+            yield _SystemMessage("init", {"model": "claude-x", "permissionMode": "acceptEdits",
+                                          "session_id": TheDeferredReconnectTakesTheHeldQueueWithIt.FSID},
+                                 uuid="s-%d" % self.no)
+            yield _AssistantMessage([_TextBlock("working on it")], uuid="a-%d" % self.no)
+            await self.release.wait()
+            self.result_sent = True
+            yield _result(uuid="r-%d" % self.no, subtype="success", is_error=False, num_turns=1,
+                          session_id=TheDeferredReconnectTakesTheHeldQueueWithIt.FSID, duration_ms=1,
+                          duration_api_ms=1, total_cost_usd=0.01, usage={"input_tokens": 1, "output_tokens": 1},
+                          result="ok", parent_tool_use_id=None)
+            await asyncio.Event().wait()    # the stream parks until the teardown cancels it
+
+    class _Options:
+        def __init__(self, **kw):
+            self.session_id = self.resume = None
+            for k, v in kw.items():
+                setattr(self, k, v)
+
+    def setUp(self):
+        sb.SdkSession._stream_fail_seen.clear()
+        self._Client.instances = []
+        fake = types.ModuleType("claude_agent_sdk")
+        fake.__spec__ = ModuleSpec("claude_agent_sdk", loader=None)   # sdk_importable's find_spec reads it
+        fake.ClaudeSDKClient, fake.ClaudeAgentOptions, fake.HookMatcher = self._Client, self._Options, (lambda **kw: kw)
+        fake.AssistantMessage, fake.ResultMessage = _AssistantMessage, _ResultMessage
+        fake.SystemMessage, fake.TextBlock = _SystemMessage, _TextBlock
+        self._saved_sdk = sys.modules.get("claude_agent_sdk")
+        sys.modules["claude_agent_sdk"] = fake
+        self.state = tempfile.mkdtemp()
+        cwd = os.path.join(self.state, "proj")
+        os.makedirs(cwd)
+        self.lines = []
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None,
+                                log=lambda m, **k: self.lines.append(str(m)))
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True, "cwd": cwd}
+        sb.write_reg(self.be.state_dir, SID, reg)
+        self.s = sb.SdkSession(self.be, dict(reg))
+        async def _noop(): pass
+        self.s._do_refresh_usage = _noop            # the stand-in client has no control channel for /usage
+        self.be.sessions[SID] = self.s
+
+    def tearDown(self):
+        self.s.shutdown()
+        if self.s.thread.ident is not None:            # the source pin never starts it
+            self.s.thread.join(timeout=10)
+        if self._saved_sdk is None:
+            sys.modules.pop("claude_agent_sdk", None)
+        else:
+            sys.modules["claude_agent_sdk"] = self._saved_sdk
+        shutil.rmtree(self.state, ignore_errors=True)
+
+    def _wait(self, pred, what, timeout=10.0):
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            if pred():
+                return
+            time.sleep(0.01)
+        self.fail("timed out waiting for %s; clients fed %r; log tail %r"
+                  % (what, [c.writes for c in self._Client.instances], self.lines[-6:]))
+
+    def _echo(self, key, text):
+        echo = _echo(key, text, int(time.time()))
+        self.be._stash_live(SID, key, echo)      # the chat's echo of the send, as send() stashes it
+        return echo
+
+    def _first_turn(self):
+        """Connect and run one turn to its in-flight state: client 1 has the first turn and the init
+        named the conversation (resume_sid), so a later reconnect resumes rather than starts fresh."""
+        s = self.s
+        s.start()
+        self._wait(lambda: s.client is not None, "the first connect")
+        self._echo("echo:first", "first turn")
+        s.enqueue("first turn")
+        self._wait(lambda: s.inflight == 1 and s.resume_sid == self.FSID, "the first turn in flight and its init")
+        c1 = self._Client.instances[0]
+        self.assertEqual(c1.writes, [("first turn", "before-result")])
+        return c1
+
+    def test_a_head_held_behind_an_interrupted_turn_is_fed_to_the_new_client_and_never_flagged(self):
+        s = self.s
+        c1 = self._first_turn()
+        s.interrupt()                                  # the stop button: the queue gate closes (inflight>0 and _interrupted)
+        self.assertTrue(s._interrupted)
+        self._wait(lambda: c1.interrupts == 1, "the interrupt control request")
+        echo = self._echo("echo:head", "queued head")
+        s.enqueue("queued head")
+        time.sleep(0.2)                                # every chance to be (wrongly) fed now
+        self.assertEqual(s.pending(), ["queued head"], "gate-held behind the interrupted turn")
+        self.assertEqual(c1.writes, [("first turn", "before-result")])
+        s.request_reconnect()                          # an /effort change while busy: deferred to the turn's end
+        self._wait(lambda: s._reconnect_when_idle, "the deferred reconnect armed")
+        s.loop.call_soon_threadsafe(c1.release.set)    # the interrupted turn's ResultMessage: the settle runs
+        self._wait(lambda: len(self._Client.instances) == 2 and self._Client.instances[1].writes,
+                   "the reconnected client to be fed")
+        c2 = self._Client.instances[1]
+        self.assertEqual(c1.writes, [("first turn", "before-result")], "nothing fed to the client being torn down")
+        self.assertEqual(c2.writes, [("queued head", "before-result")], "the new client took the head")
+        self.assertEqual(s.pending(), [])
+        self.assertEqual((s.inflight, list(s._inflight_texts)), (1, ["queued head"]), "in flight on the new client")
+        self.assertFalse(echo.get("dropped"), "not flagged never-delivered")
+
+    def test_a_send_racing_an_idle_arm_is_fed_to_the_new_client(self):
+        """The other arm: request_reconnect on an IDLE session sets _reconnect at once, and a send whose
+        wake queued behind the waker's used to be popped by the feeder before the teardown ran — the
+        race _reconcile_stranded's docstring names. Both land in one loop step here, the order the
+        race needs; the hold keeps the head for the new client."""
+        s = self.s
+        c1 = self._first_turn()
+        s.loop.call_soon_threadsafe(c1.release.set)
+        self._wait(lambda: s.inflight == 0, "the first turn to settle")
+        echo = self._echo("echo:late", "late send")
+        def arm_then_send():
+            s._do_request_reconnect(True)              # idle → _reconnect = True and the waker is woken
+            s.enqueue("late send")                     # …its wake queued behind the waker's
+        s.loop.call_soon_threadsafe(arm_then_send)
+        self._wait(lambda: len(self._Client.instances) == 2 and self._Client.instances[1].writes,
+                   "the reconnected client to be fed")
+        self.assertEqual(c1.writes, [("first turn", "before-result")], "nothing fed to the client being torn down")
+        self.assertEqual(self._Client.instances[1].writes, [("late send", "before-result")])
+        self.assertFalse(echo.get("dropped"))
+
+    def test_a_deferred_arm_alone_does_not_hold_mid_turn_forwards(self):
+        """The hold keys on _reconnect (armed: the teardown is next), not on _reconnect_when_idle (an
+        /effort change waiting for the turn to end): a message sent mid-turn with one pending is still
+        forwarded to the running turn's client — the designed forward — and the settle folds it."""
+        s = self.s
+        c1 = self._first_turn()
+        s.request_reconnect()
+        self._wait(lambda: s._reconnect_when_idle, "the deferred reconnect armed")
+        echo = self._echo("echo:mid", "mid-turn note")
+        s.enqueue("mid-turn note")
+        self._wait(lambda: len(c1.writes) == 2, "the mid-turn forward")
+        self.assertEqual(c1.writes[1], ("mid-turn note", "before-result"))
+        s.loop.call_soon_threadsafe(c1.release.set)
+        self._wait(lambda: len(self._Client.instances) == 2 and s.client is self._Client.instances[1], "the reconnect")
+        self.assertEqual(self._Client.instances[1].writes, [], "nothing was held for the new client")
+        self.assertEqual(s.inflight, 0)
+        self.assertFalse(echo.get("dropped"), "folded into the turn, not flagged")
+
+    def test_the_hold_keys_on_the_armed_flag_by_source(self):
+        src = inspect.getsource(sb.SdkSession._amain)
+        i_inputs = src.index("async def inputs():")
+        i_pop = src.index("item = self._pending.pop(0)", i_inputs)
+        gate = src[i_inputs:i_pop]
+        self.assertIn("blocked = blocked or self._reconnect\n", gate, "the armed flag is a hold in the gate")
+        self.assertNotIn("_reconnect_when_idle", gate, "…and the deferred flag is not (mid-turn forwards flow)")
+
+
+class TheDrainLoopOutlivesAHandlerFailure(unittest.TestCase):
+    def setUp(self):
+        sb.SdkSession._stream_fail_seen.clear()
+
+    class _Client:
+        def __init__(self, msgs, then=None):
+            self.msgs, self.then = msgs, then
+        async def receive_messages(self):
+            for m in self.msgs:
+                yield m
+            if self.then is not None:
+                raise self.then
+
+    def test_the_stream_continues_past_the_message_that_failed(self):
+        be = _backend()
+        s = _session(be)
+        seen = []
+        bad = _SystemMessage("vcs_state_changed", {"session_id": UNKNOWN_SID})
+        def handler(msg, *a):
+            if msg is bad:
+                raise KeyError(UNKNOWN_SID)
+            seen.append(msg)
+        s._on_message = handler
+        good1, good2 = _SystemMessage("thinking_tokens"), _ResultMessage()
+        asyncio.run(s._drain(self._Client([good1, bad, good2]), _AssistantMessage, _ResultMessage, _SystemMessage))
+        self.assertEqual(seen, [good1, good2], "the messages after the failure were still handled")
+        self.assertEqual(len(_problems(be)), 1)
+
+    def test_the_stream_continues_past_a_failure_whose_report_fails(self):
+        class Unrenderable(Exception):
+            def __str__(self):
+                raise TypeError("unrenderable")
+        be = _backend()
+        s = _session(be)
+        seen = []
+        bad = _SystemMessage("hook_response")
+        def handler(msg, *a):
+            if msg is bad:
+                raise Unrenderable()
+            seen.append(msg)
+        s._on_message = handler
+        good = _ResultMessage()
+        asyncio.run(s._drain(self._Client([bad, good]), _AssistantMessage, _ResultMessage, _SystemMessage))
+        self.assertEqual(seen, [good])
+
+    def test_a_stream_fault_still_ends_the_loop(self):
+        """The transport closing (the SDK re-raises it out of receive_messages) is the stream ending:
+        the loop propagates it as before, so the client teardown and the crash heal still run."""
+        be = _backend()
+        s = _session(be)
+        s._on_message = lambda *a: None
+        with self.assertRaises(RuntimeError):
+            asyncio.run(s._drain(self._Client([_ResultMessage()], then=RuntimeError("transport closed")),
+                                 _AssistantMessage, _ResultMessage, _SystemMessage))
+
+    def test_ended_stops_the_loop(self):
+        be = _backend()
+        s = _session(be)
+        seen = []
+        s._on_message = lambda msg, *a: seen.append(msg)
+        s.ended = True
+        asyncio.run(s._drain(self._Client([_ResultMessage(), _ResultMessage()]), _AssistantMessage, _ResultMessage, _SystemMessage))
+        self.assertEqual(seen, [])
+
+    def test_amain_routes_the_receive_loop_through_drain(self):
+        src = inspect.getsource(sb.SdkSession._amain)
+        self.assertIn("self._drain(client, AssistantMessage, ResultMessage, SystemMessage)", src)
+        self.assertNotIn("self._on_message(msg", src, "no bare dispatch is left in the loop")
+        self.assertIn("_compact_tb(e)", src, "the transport catch names the frame chain")
+        self.assertIn("_mask_ids(e)", src, "…and masks ids in the exception text")
+
+
+class UnknownIdsInTheNewSdkShapesDoNotRaise(unittest.TestCase):
+    """The shapes the newer CLI emits, each carrying an id the kernel has no record for, through the
+    REAL handler: nothing raises and the live tail stays clean."""
+    def _run(self, s, msg):
+        return s._handle_stream_message(msg, _AssistantMessage, _ResultMessage, _SystemMessage)
+
+    def test_sidechain_messages_of_an_unregistered_subagent(self):
+        be = _backend()
+        s = _session(be)
+        self.assertTrue(self._run(s, _UserMessage([_TextBlock("kickoff")], uuid="u9", parent_tool_use_id="toolu_unreg")))
+        self.assertTrue(self._run(s, _AssistantMessage([_TextBlock("reply")], model="claude-tiny", uuid="a9",
+                                                       parent_tool_use_id="toolu_unreg")))
+        self.assertEqual(be.live_atoms(SID), [], "sidechain traffic never enters the parent's tail")
+        self.assertNotEqual(s.model, "claude-tiny", "a subagent's model is never learned")
+        self.assertEqual(_problems(be), [])
+
+    def test_new_system_subtypes_with_an_unknown_session_id_do_not_raise(self):
+        lines = []
+        be = _backend(lines)
+        s = _session(be)
+        for st in ("background_tasks_changed", "thinking_tokens", "vcs_state_changed"):
+            for _ in range(2):
+                self.assertTrue(self._run(s, _SystemMessage(st, {"session_id": UNKNOWN_SID, "tasks": []})))
+        for st in ("hook_started", "hook_response"):
+            for _ in range(2):
+                self.assertTrue(self._run(s, _HookEventMessage(st, {"session_id": UNKNOWN_SID, "hook_id": MSG_UUID})))
+        self.assertEqual(_problems(be), [], "a subtype without a handler branch is not a failure")
+        self.assertEqual(be.live_atoms(SID), [], "…and produces no atom")
+        for l in lines:
+            self.assertNotIn(UNKNOWN_SID, l, "never the payload's values in the log")
+
+    def test_task_events_for_a_task_the_kernel_never_recorded(self):
+        be = _backend()
+        s = _session(be)
+        for st, data in (("task_notification", {"task_id": "b_gone", "status": "completed"}),
+                         ("task_updated", {"task_id": "b_gone", "patch": {"status": "killed"}}),
+                         ("task_progress", {"task_id": "b_new", "description": "d"})):
+            self.assertTrue(self._run(s, _SystemMessage(st, data)))
+        self.assertEqual([t["desc"] for t in s._live_bg_tasks()], ["d"],
+                         "an unknown id ENDING is a no-op; progress on an unknown id self-heals an entry")
+        self.assertEqual(_problems(be), [])
+
+
+class LogHelpers(unittest.TestCase):
+    def test_mask_ids_keeps_eight_characters_of_a_uuid_and_clips(self):
+        self.assertEqual(sb._mask_ids(KeyError(MSG_UUID)), "'%s…'" % MSG_UUID[:8])
+        self.assertEqual(sb._mask_ids("x" * 200, cap=10), "x" * 10 + "…")
+        self.assertEqual(sb._mask_ids("plain"), "plain")
+
+    def test_compact_tb_is_a_file_line_chain_without_locals(self):
+        secret = "the message content"      # noqa: F841 — a local that must NOT appear
+        def inner():
+            raise ValueError("v")
+        try:
+            inner()
+        except ValueError as e:
+            chain = sb._compact_tb(e)
+        self.assertRegex(chain, r"^test_sdk_stream_survives_handler_errors\.py:\d+ test_compact_tb_is_a_file_line_chain_without_locals"
+                                r" > test_sdk_stream_survives_handler_errors\.py:\d+ inner$")
+        self.assertNotIn("secret", chain)
+        self.assertNotIn(secret, chain)
+        self.assertEqual(sb._compact_tb(ValueError("no traceback")), "?")
+
+    def test_compact_tb_is_bounded_to_the_innermost_frames_and_a_length_cap(self):
+        """A RecursionError's chain ran to 18 KB — into the error-center ring and every feed payload that
+        carries it. The chain keeps the innermost COMPACT_TB_FRAMES frames (the failing site is at that
+        end), says how many outer ones it dropped, and fits COMPACT_TB_CHARS by dropping MORE outer
+        frames — never by clipping its tail, which is the failing frame."""
+        def rec(n):
+            return rec(n + 1)
+        try:
+            rec(0)
+        except RecursionError as exc:
+            e = exc                                    # the except clause unbinds its own name on exit
+            chain = sb._compact_tb(e)
+            depth = len(traceback.extract_tb(e.__traceback__))
+        self.assertGreater(depth, 100)
+        self.assertLessEqual(len(chain), sb.COMPACT_TB_CHARS)
+        self.assertRegex(chain, r"^…%d outer frames dropped… > " % (depth - sb.COMPACT_TB_FRAMES))
+        self.assertEqual(chain.count(" > "), sb.COMPACT_TB_FRAMES, "the prefix plus the kept frames")
+        self.assertTrue(chain.endswith(" rec"), "the innermost frame is kept: %r" % chain[-40:])
+        # a tight cap with every frame allowed: the cap drops outer frames and the failing one stays
+        # (150: room for the prefix and two of this file's ~50-character frames, not three)
+        tight = sb._compact_tb(e, max_frames=depth, cap=150)
+        self.assertLessEqual(len(tight), 150)
+        self.assertTrue(tight.endswith(" rec"), "the innermost frame survives the cap: %r" % tight)
+        kept = tight.count(" > ")                      # the prefix plus the kept frames
+        self.assertEqual(kept, 2, "two frames fit in 150 characters, and both are kept whole: %r" % tight)
+        self.assertRegex(tight, r"^…%d outer frames dropped… > " % (depth - kept), "the prefix counts every drop")
+        # one dropped frame reads as one (an unbounded cap, so only the frame bound drops)
+        self.assertRegex(sb._compact_tb(e, max_frames=depth - 1, cap=10 ** 6), r"^…1 outer frame dropped… > ")
+
+    @staticmethod
+    def _long_named_chain(depth, tail="a_failing_function_with_a_long_name", module="a_module_name_of_ordinary_length.py"):
+        """An exception raised through `depth` frames whose names are ~40 characters (a plugin, a hook, a
+        test) — eight of them overflow COMPACT_TB_CHARS. Returns (exception, innermost function name)."""
+        names = ["a_handler_frame_with_a_realistic_name_%02d" % i for i in range(depth - 1)] + [tail]
+        src = "".join("def %s(x):\n    return %s(x)\n" % (names[i], names[i + 1]) for i in range(depth - 1))
+        src += "def %s(x):\n    raise KeyError('k')\n" % tail
+        ns = {}
+        exec(compile(src, module, "exec"), ns)
+        try:
+            ns[names[0]](1)
+        except KeyError as e:
+            return e, tail
+
+    def test_the_cap_drops_outer_frames_and_keeps_the_failing_one(self):
+        """The first cut clipped the chain's TAIL at the cap — the innermost frame —
+        so a chain through long-named frames lost its failing site."""
+        e, tail = self._long_named_chain(10)
+        frames = traceback.extract_tb(e.__traceback__)          # the builder's own frame + the ten exec'd ones
+        full = " > ".join(sb._frame_step(f) for f in frames[-sb.COMPACT_TB_FRAMES:])
+        self.assertGreater(len(full), sb.COMPACT_TB_CHARS, "the shape engages the cap")
+        chain = sb._compact_tb(e)
+        self.assertLessEqual(len(chain), sb.COMPACT_TB_CHARS)
+        self.assertTrue(chain.endswith(" " + tail), "the failing frame is the chain's last step: %r" % chain[-80:])
+        kept = chain.count(" > ")
+        self.assertRegex(chain, r"^…%d outer frames dropped… > " % (len(frames) - kept))
+        self.assertLess(kept, sb.COMPACT_TB_FRAMES, "the cap dropped frames the frame bound had kept")
+        self.assertNotIn("…", chain[chain.index(" > "):], "no step is clipped")
+        self.assertEqual(sb._failing_frame(e), ("a_module_name_of_ordinary_length.py", 20, tail))
+
+    def test_an_innermost_frame_wider_than_the_cap_keeps_its_file_and_line(self):
+        e, tail = self._long_named_chain(3)
+        site = "%s:%d" % ("a_module_name_of_ordinary_length.py", 6)
+        one = sb._compact_tb(e, cap=80)
+        self.assertEqual(len(one), 80)
+        dropped = len(traceback.extract_tb(e.__traceback__)) - 1
+        self.assertTrue(one.startswith("…%d outer frames dropped… > %s " % (dropped, site)), "prefix and file:line stand: %r" % one)
+        self.assertTrue(one.endswith("…") and tail[:8] in one, "the function name is what gets clipped: %r" % one)
+        self.assertEqual(sb._compact_tb(e, cap=10000), " > ".join(sb._frame_step(f) for f in traceback.extract_tb(e.__traceback__)),
+                         "no cap engaged: the full chain, no prefix")
+        self.assertEqual(sb._failing_frame(ValueError("no traceback")), None)
+
+    def test_two_failing_sites_under_long_chains_are_two_ring_entries(self):
+        """With the cap engaged, the dedupe key read off the rendering was the literal
+        '…', folding every long-chained failure of one type into one entry. The key is the innermost
+        frame's (file, line, function), read from the traceback."""
+        be = _backend()
+        s = _session(be)
+        for tail in ("a_failing_function_with_a_long_name", "a_completely_different_failing_function"):
+            e, _ = self._long_named_chain(10, tail=tail)
+            s._note_message_failure(_ResultMessage(), e)
+        probs = _problems(be)
+        self.assertEqual(len(probs), 2, "one entry per failing site: %r" % [p[-90:] for p in probs])
+        for p, tail in zip(probs, ("a_failing_function_with_a_long_name", "a_completely_different_failing_function")):
+            self.assertTrue(p.endswith(" " + tail), "each entry names its own failing frame: %r" % p[-90:])
+        e, _ = self._long_named_chain(10)
+        s._note_message_failure(_ResultMessage(), e)
+        self.assertEqual(len(_problems(be)), 2, "the same site again counts on its entry")
+        self.assertIn("(1 repeat this kernel life", _problems(be)[0])
+
+    def test_a_recursing_handler_yields_one_bounded_problem_line(self):
+        be = _backend()
+        s = _session(be)
+        def rec(msg, *a):
+            return rec(msg, *a)
+        s._on_message = rec
+        self.assertFalse(s._handle_stream_message(_ResultMessage(), _AssistantMessage, _ResultMessage, _SystemMessage))
+        probs = _problems(be)
+        self.assertEqual(len(probs), 1)
+        self.assertIn("RecursionError", probs[0])
+        self.assertLess(len(probs[0]), 1000, "was 18 KB before the bound")
+
+    def test_describe_msg_names_type_and_subtype_only(self):
+        self.assertEqual(sb._describe_msg(_SystemMessage("api_retry", {"error": "content"})), "SystemMessage/api_retry")
+        self.assertEqual(sb._describe_msg(_AssistantMessage([_TextBlock("content")])), "AssistantMessage")
+        self.assertEqual(sb._describe_msg(_HookEventMessage("hook_started")), "HookEventMessage/hook_started")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -38,6 +38,7 @@ Every id here is synthetic (the placeholder uuid family); no message content is 
 import asyncio
 import inspect
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -108,6 +109,33 @@ class _RacyTail(dict):
     def _other_thread_prunes(self):
         if self.victim in self:
             dict.__delitem__(self, self.victim)
+
+
+class _ProbedTail(dict):
+    """A live tail whose EMPTINESS CHECK (`not d`, `d or {}`, `if d`: all __len__) lets a SECOND thread
+    try the tail lock without blocking and, if it gets in, stash an atom into the dict. Deterministic
+    where the hammers sample: the probe runs inside the sweep's own step and is joined before the check
+    returns, so its outcome is decided by whether the sweep holds the lock at that instant — refused
+    under the lock, landed without it. `__len__` answers the pre-stash length, so a sweep that pops
+    the sid on `not d` pops a dict the probe has just stashed into (the orphan shape)."""
+    def __init__(self, lock, *a, **k):
+        super().__init__(*a, **k)
+        self.lock, self.stashed, self.refused = lock, [], 0
+    def __len__(self):
+        n = super().__len__()
+        def other_thread():
+            if self.lock.acquire(blocking=False):
+                try:
+                    key = "echo:probe%d" % len(self.stashed)
+                    dict.__setitem__(self, key, _echo(key, "a send racing the sweep", 9))
+                    self.stashed.append(key)
+                finally:
+                    self.lock.release()
+            else:
+                self.refused += 1
+        t = threading.Thread(target=other_thread, name="probe")
+        t.start(); t.join()
+        return n
 
 
 def _backend(lines=None, **kw):
@@ -408,6 +436,39 @@ class TheLiveTailLock(unittest.TestCase):
         self.assertFalse([w for w, held in seen if held], "the lock was held across: %r" % [w for w, h in seen if h])
         self.assertNotIn(SID, be._live, "the dismiss emptied the tail and popped the sid entry")
 
+    def test_the_emptiness_check_of_every_sweep_runs_under_the_lock(self):
+        """The deterministic twin of the hammers above, which PASS with the lock dedented out of
+        _persist_echoes and _mark_dropped_echoes (a RuntimeError needs the interleaving to land inside
+        one dict walk, and the hammers only sample for it; the source pin below was the one thing that
+        caught the mutant). Every sweep's first step on the shared dict is its emptiness check, so a
+        dict subclass runs the probe there (_ProbedTail): a second thread tries the lock without
+        blocking. Under the lock the probe is refused, every time; without it the probe's stash lands
+        mid-sweep — and in prune_live and retire_live_work the check right before the sid-level pop
+        then pops a dict the stash just went into, orphaning it (the third refuter finding). Validated
+        against a scratch copy with the two `with self._live_lock:` lines dedented out (2026-09-07)."""
+        sweeps = (
+            ("_persist_echoes", lambda be: be._persist_echoes(SID), {"echo:a": _echo("echo:a", "hello", 5)}),
+            ("_mark_dropped_echoes", lambda be: be._mark_dropped_echoes(SID, [], refeed=False), {"echo:a": _echo("echo:a", "hello", 5)}),
+            ("prune_live", lambda be: be.prune_live(SID, {"landed"}, (), 0), {"landed": _work("landed", 1)}),
+            ("retire_live_work", lambda be: be.retire_live_work(SID), {"w1": _work("w1", 1)}),
+            ("live_atoms", lambda be: be.live_atoms(SID), {"echo:a": _echo("echo:a", "hello", 5)}),
+            ("dismiss_echo", lambda be: be.dismiss_echo(SID, uuid="echo:d"), {"echo:d": _echo("echo:d", "lost", 5, dropped=True)}),
+        )
+        for name, sweep, seed in sweeps:
+            with self.subTest(sweep=name):
+                be = _backend()
+                be._update_reg = lambda sid, **f: None
+                be._reply_on_disk = lambda sid, u: True
+                tail = _ProbedTail(be._live_lock, seed)
+                be._live[SID] = tail
+                sweep(be)
+                reachable = be._live.get(SID)
+                orphaned = [k for k in tail.stashed if reachable is None or k not in reachable]
+                self.assertEqual(tail.stashed, [], "%s ran its emptiness check WITHOUT the tail lock: a concurrent "
+                                                   "stash got in (%r)%s" % (name, tail.stashed,
+                                                                            "; the sid-level pop then orphaned %r" % orphaned if orphaned else ""))
+                self.assertGreaterEqual(tail.refused, 1, "%s checked the tail's emptiness under the lock" % name)
+
     def test_every_sweep_and_stash_is_locked_by_source(self):
         """A pin on the rule's coverage, so a new unlocked walk fails here before it fails live: every
         method that touches `_live` takes the lock (or goes through _stash_live, which does)."""
@@ -509,7 +570,7 @@ class HandlerFailuresStayWithTheirMessage(unittest.TestCase):
         self.assertRegex(probs[0], r"at .*\.py:\d+", "it carries the frame chain from the first")
         self.assertIn("(4 repeats this kernel life", probs[0], "…and the count of the repeats")
         self.assertEqual(be.problem_seq(), seq0 + 1, "one cache bust for the new problem, none per repeat")
-        logged = [l for l in lines if "KeyError while handling" in l]
+        logged = [l for l in lines if re.search(r"KeyError( at \S+:\d+ \w+)? while handling", l)]
         self.assertEqual(len(logged), 5, "every failure is a kernel-log line — nothing silent")
         self.assertIn("repeat 5", logged[4])
         self.assertNotRegex(logged[4], r"\.py:\d+", "repeats do not re-print the chain")
@@ -570,6 +631,30 @@ class HandlerFailuresStayWithTheirMessage(unittest.TestCase):
             be._log("unrelated problem %d" % i, problem=True)
         self.assertFalse(be.problem_keyed(("k", 1)), "evicted → not in the ring")
 
+    def test_the_failing_site_leads_the_line_and_fits_the_error_centers_row(self):
+        """The error center shows a row's first 240 characters (kernel.py _sdk_problem_rows caps the text
+        at 400, badge-mirror.ts at 240) and the chain sat at the END of the line, after the consequence
+        prose — about 335 characters for a settled result — so the user never saw WHERE a handler
+        failed. The failing site now follows the exception type, ahead of the prose; the full chain
+        stays at the tail, innermost first, for the kernel log (2026-09-07 review)."""
+        be = _backend()
+        s = _session(be)
+        e, tail = LogHelpers._long_named_chain(10)
+        msg = _ResultMessage()
+        s._settled_msg = msg                            # the settle ran: the longest consequence prose
+        s._note_message_failure(msg, e)
+        line = _problems(be)[0]
+        site = "a_module_name_of_ordinary_length.py:20 " + tail
+        self.assertIn(site, line[:240], "the failing frame is inside the error center's row: %r" % line[:240])
+        self.assertTrue(line.startswith("sdk session web: KeyError at %s while handling a ResultMessage message; " % site),
+                        "the site follows the type, ahead of the prose: %r" % line[:200])
+        self.assertIn("the turn still settled", line)
+        self.assertRegex(line, r"\. Frames, innermost first: %s < a_module_name_of_ordinary_length\.py:\d+ "
+                               r"a_handler_frame_with_a_realistic_name_08 < " % site.replace(".", r"\."))
+        # a failure with no traceback (a hand-built exception) names no site rather than raising
+        s._note_message_failure(_SystemMessage("status"), ValueError("bare"))
+        self.assertIn("ValueError at ? while handling a SystemMessage/status message", _problems(be)[-1])
+
     def test_a_clean_handler_reports_true_and_logs_nothing(self):
         be = _backend()
         s = _session(be)
@@ -612,7 +697,7 @@ class HandlerFailuresStayWithTheirMessage(unittest.TestCase):
         probs = _problems(be)
         self.assertEqual(len(probs), 2, "the report landed before the callback raised, and the broken "
                                         "callback is its own entry — each deduped across the repeats: %r" % probs)
-        self.assertIn("KeyError while handling a ResultMessage", probs[0])
+        self.assertRegex(probs[0], r"KeyError at \S+:\d+ boom while handling a ResultMessage")
         self.assertIn("(3 repeats this kernel life", probs[0])
         self.assertIn("reporting it failed too (BrokenPipeError)", probs[1])
         self.assertIn("(3 repeats this kernel life", probs[1])
@@ -681,7 +766,7 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
         self._assert_settled(s, out)
         probs = _problems(be)
         self.assertEqual(len(probs), 1)
-        self.assertIn("OSError while handling a ResultMessage", probs[0])
+        self.assertRegex(probs[0], r"OSError at \S+:\d+ boom while handling a ResultMessage")
         self.assertIn("the turn still settled", probs[0])
 
     def test_a_raising_spend_write_still_settles_the_turn(self):
@@ -696,7 +781,7 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
         self._assert_settled(s, out)
         probs = _problems(be)
         self.assertEqual(len(probs), 1)
-        self.assertIn("OSError while handling a ResultMessage", probs[0])
+        self.assertRegex(probs[0], r"OSError at \S+:\d+ bad_spend while handling a ResultMessage")
         self.assertIn("the turn still settled", probs[0])
         self.assertIn("stopped where it failed", probs[0], "…and says the bookkeeping did not finish")
 
@@ -711,8 +796,43 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
         self._assert_settled(s, out)
         probs = _problems(be)
         self.assertEqual(len(probs), 1)
-        self.assertIn("ValueError while handling a ResultMessage", probs[0])
+        self.assertIn("ValueError at ", probs[0])
+        self.assertIn("while handling a ResultMessage", probs[0])
         self.assertIn("the turn still settled", probs[0])
+
+    def test_a_failing_spend_step_skips_neither_the_rewind_consumption_nor_the_live_tail_sweep(self):
+        """The spend accounting ran FIRST inside the try, so a NaN usage field or a failing spend write
+        stopped the body there: the settle still closed the turn, but the rewind flag stayed armed (its
+        registry clear and the branch-take event never ran) and the live tail kept the turn's work atoms —
+        a reply the transcript never got stayed merged, forcing the turn open on the next build. The
+        spend step runs last now (2026-09-07 review): its failure costs the spend readout and nothing else."""
+        import json
+        for trigger in ("a NaN usage field", "a failing spend write"):
+            with self.subTest(trigger=trigger):
+                be = _backend()
+                s = self._busy(be)
+                s._rewind_to = s._rewind_leaf = "11111111-2222-3333-4444-dddddddddd04"
+                s._rewind_armed = True                 # the rewind turn is the one settling: its flag is consumed here
+                resolved = []
+                be.rewind_resolved_cb = lambda sid, outcome: resolved.append(outcome)
+                be._stash_live(SID, "w1", _work("w1", 1))    # a work atom of the turn, never landed
+                if trigger == "a NaN usage field":
+                    usage = json.loads('{"input_tokens": NaN, "output_tokens": 5}')
+                else:
+                    usage = {"input_tokens": 10}
+                    def bad_spend(*a, **k):
+                        raise OSError(28, "No space left on device")
+                    be._record_spend = bad_spend
+                out = self._settle(be, s, ok_expected=False, msg=_result(total_cost_usd=0.5, usage=usage))
+                self._assert_settled(s, out)
+                self.assertEqual(s._rewind_to, "", "the rewind flag was consumed before the spend step failed")
+                self.assertFalse(s._rewind_armed)
+                self.assertEqual(resolved, ["taken"], "the branch-take event reached the kernel")
+                self.assertNotIn("w1", be._live.get(SID) or {}, "the live-tail sweep ran")
+                probs = _problems(be)
+                self.assertEqual(len(probs), 1, probs)
+                self.assertIn("while handling a ResultMessage", probs[0])
+                self.assertIn("the turn still settled", probs[0])
 
     def test_a_failure_before_the_branch_is_reported_as_not_settled(self):
         """The one place a ResultMessage's handling can fail OUTSIDE the branch is the elif chain
@@ -785,8 +905,8 @@ class TheSettleRunsWhateverTheResultsBookkeepingDid(unittest.TestCase):
                         "the settle step's own report landed before the callback raised: %r" % probs)
         filed = [p for p in probs if "while handling a ResultMessage" in p]
         self.assertEqual(len(filed), 1, probs)
-        self.assertIn("ValueError while handling a ResultMessage", filed[0],
-                      "the bookkeeping's exception is the one the containment files, not the callback's")
+        self.assertRegex(filed[0], r"ValueError at \S+:\d+ _turn_usage while handling a ResultMessage",
+                         "the bookkeeping's exception is the one the containment files, not the callback's")
         self.assertIn("the turn still settled", filed[0])
         self.assertIn("_on_message", filed[0], "…with the fold's frame")
         self.assertNotIn("BrokenPipeError while handling", " ".join(probs))
@@ -1151,19 +1271,23 @@ class LogHelpers(unittest.TestCase):
             raise ValueError("v")
         try:
             inner()
-        except ValueError as e:
+        except ValueError as exc:
+            e = exc                                    # the except clause unbinds its own name on exit
             chain = sb._compact_tb(e)
-        self.assertRegex(chain, r"^test_sdk_stream_survives_handler_errors\.py:\d+ test_compact_tb_is_a_file_line_chain_without_locals"
-                                r" > test_sdk_stream_survives_handler_errors\.py:\d+ inner$")
+        self.assertRegex(chain, r"^test_sdk_stream_survives_handler_errors\.py:\d+ inner"
+                                r" < test_sdk_stream_survives_handler_errors\.py:\d+ test_compact_tb_is_a_file_line_chain_without_locals$",
+                         "innermost first: the failing site, then its caller")
         self.assertNotIn("secret", chain)
         self.assertNotIn(secret, chain)
         self.assertEqual(sb._compact_tb(ValueError("no traceback")), "?")
+        self.assertRegex(sb._failing_site(e), r"^test_sdk_stream_survives_handler_errors\.py:\d+ inner$")
+        self.assertEqual(sb._failing_site(ValueError("no traceback")), "?")
 
     def test_compact_tb_is_bounded_to_the_innermost_frames_and_a_length_cap(self):
         """A RecursionError's chain ran to 18 KB — into the error-center ring and every feed payload that
-        carries it. The chain keeps the innermost COMPACT_TB_FRAMES frames (the failing site is at that
-        end), says how many outer ones it dropped, and fits COMPACT_TB_CHARS by dropping MORE outer
-        frames — never by clipping its tail, which is the failing frame."""
+        carries it. The chain keeps the innermost COMPACT_TB_FRAMES frames (the failing site LEADS, since
+        2026-09-07), says how many outer ones it dropped, and fits COMPACT_TB_CHARS by dropping MORE
+        outer frames — never by clipping the failing frame."""
         def rec(n):
             return rec(n + 1)
         try:
@@ -1174,19 +1298,19 @@ class LogHelpers(unittest.TestCase):
             depth = len(traceback.extract_tb(e.__traceback__))
         self.assertGreater(depth, 100)
         self.assertLessEqual(len(chain), sb.COMPACT_TB_CHARS)
-        self.assertRegex(chain, r"^…%d outer frames dropped… > " % (depth - sb.COMPACT_TB_FRAMES))
-        self.assertEqual(chain.count(" > "), sb.COMPACT_TB_FRAMES, "the prefix plus the kept frames")
-        self.assertTrue(chain.endswith(" rec"), "the innermost frame is kept: %r" % chain[-40:])
+        self.assertRegex(chain, r" < …%d outer frames dropped…$" % (depth - sb.COMPACT_TB_FRAMES))
+        self.assertEqual(chain.count(" < "), sb.COMPACT_TB_FRAMES, "the kept frames plus the suffix")
+        self.assertRegex(chain, r"^test_sdk_stream_survives_handler_errors\.py:\d+ rec < ", "the innermost frame leads: %r" % chain[:60])
         # a tight cap with every frame allowed: the cap drops outer frames and the failing one stays
-        # (150: room for the prefix and two of this file's ~50-character frames, not three)
+        # (150: room for the suffix and two of this file's ~50-character frames, not three)
         tight = sb._compact_tb(e, max_frames=depth, cap=150)
         self.assertLessEqual(len(tight), 150)
-        self.assertTrue(tight.endswith(" rec"), "the innermost frame survives the cap: %r" % tight)
-        kept = tight.count(" > ")                      # the prefix plus the kept frames
+        self.assertRegex(tight, r"^test_sdk_stream_survives_handler_errors\.py:\d+ rec < ", "the innermost frame survives the cap: %r" % tight)
+        kept = tight.count(" < ")                      # the kept frames plus the suffix
         self.assertEqual(kept, 2, "two frames fit in 150 characters, and both are kept whole: %r" % tight)
-        self.assertRegex(tight, r"^…%d outer frames dropped… > " % (depth - kept), "the prefix counts every drop")
+        self.assertRegex(tight, r" < …%d outer frames dropped…$" % (depth - kept), "the suffix counts every drop")
         # one dropped frame reads as one (an unbounded cap, so only the frame bound drops)
-        self.assertRegex(sb._compact_tb(e, max_frames=depth - 1, cap=10 ** 6), r"^…1 outer frame dropped… > ")
+        self.assertRegex(sb._compact_tb(e, max_frames=depth - 1, cap=10 ** 6), r" < …1 outer frame dropped…$")
 
     @staticmethod
     def _long_named_chain(depth, tail="a_failing_function_with_a_long_name", module="a_module_name_of_ordinary_length.py"):
@@ -1211,11 +1335,12 @@ class LogHelpers(unittest.TestCase):
         self.assertGreater(len(full), sb.COMPACT_TB_CHARS, "the shape engages the cap")
         chain = sb._compact_tb(e)
         self.assertLessEqual(len(chain), sb.COMPACT_TB_CHARS)
-        self.assertTrue(chain.endswith(" " + tail), "the failing frame is the chain's last step: %r" % chain[-80:])
-        kept = chain.count(" > ")
-        self.assertRegex(chain, r"^…%d outer frames dropped… > " % (len(frames) - kept))
+        self.assertTrue(chain.startswith("a_module_name_of_ordinary_length.py:20 %s < " % tail),
+                        "the failing frame is the chain's first step: %r" % chain[:80])
+        kept = chain.count(" < ")
+        self.assertRegex(chain, r" < …%d outer frames dropped…$" % (len(frames) - kept))
         self.assertLess(kept, sb.COMPACT_TB_FRAMES, "the cap dropped frames the frame bound had kept")
-        self.assertNotIn("…", chain[chain.index(" > "):], "no step is clipped")
+        self.assertNotIn("…", chain[:chain.rindex(" < ")], "no step is clipped")
         self.assertEqual(sb._failing_frame(e), ("a_module_name_of_ordinary_length.py", 20, tail))
 
     def test_an_innermost_frame_wider_than_the_cap_keeps_its_file_and_line(self):
@@ -1224,10 +1349,10 @@ class LogHelpers(unittest.TestCase):
         one = sb._compact_tb(e, cap=80)
         self.assertEqual(len(one), 80)
         dropped = len(traceback.extract_tb(e.__traceback__)) - 1
-        self.assertTrue(one.startswith("…%d outer frames dropped… > %s " % (dropped, site)), "prefix and file:line stand: %r" % one)
-        self.assertTrue(one.endswith("…") and tail[:8] in one, "the function name is what gets clipped: %r" % one)
-        self.assertEqual(sb._compact_tb(e, cap=10000), " > ".join(sb._frame_step(f) for f in traceback.extract_tb(e.__traceback__)),
-                         "no cap engaged: the full chain, no prefix")
+        self.assertTrue(one.startswith(site + " " + tail[:8]), "the file:line stands, then the clipped name: %r" % one)
+        self.assertTrue(one.endswith("… < …%d outer frames dropped…" % dropped), "the function name is what gets clipped, the suffix stands: %r" % one)
+        self.assertEqual(sb._compact_tb(e, cap=10000), " < ".join(sb._frame_step(f) for f in reversed(traceback.extract_tb(e.__traceback__))),
+                         "no cap engaged: the full chain, innermost first, no suffix")
         self.assertEqual(sb._failing_frame(ValueError("no traceback")), None)
 
     def test_two_failing_sites_under_long_chains_are_two_ring_entries(self):
@@ -1240,9 +1365,11 @@ class LogHelpers(unittest.TestCase):
             e, _ = self._long_named_chain(10, tail=tail)
             s._note_message_failure(_ResultMessage(), e)
         probs = _problems(be)
-        self.assertEqual(len(probs), 2, "one entry per failing site: %r" % [p[-90:] for p in probs])
+        self.assertEqual(len(probs), 2, "one entry per failing site: %r" % [p[:120] for p in probs])
         for p, tail in zip(probs, ("a_failing_function_with_a_long_name", "a_completely_different_failing_function")):
-            self.assertTrue(p.endswith(" " + tail), "each entry names its own failing frame: %r" % p[-90:])
+            site = "a_module_name_of_ordinary_length.py:20 " + tail
+            self.assertIn("KeyError at %s while handling" % site, p, "each entry names its own failing frame: %r" % p[:120])
+            self.assertIn("Frames, innermost first: %s < " % site, p, "…and its chain leads with it: %r" % p[-200:])
         e, _ = self._long_named_chain(10)
         s._note_message_failure(_ResultMessage(), e)
         self.assertEqual(len(_problems(be)), 2, "the same site again counts on its entry")

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -1283,6 +1283,41 @@ class LogHelpers(unittest.TestCase):
         self.assertRegex(sb._failing_site(e), r"^test_sdk_stream_survives_handler_errors\.py:\d+ inner$")
         self.assertEqual(sb._failing_site(ValueError("no traceback")), "?")
 
+    def test_the_failing_site_skips_synthetic_scopes_and_names_the_function(self):
+        """Before Python 3.12 (PEP 709) a comprehension runs in its own frame, so a raise inside one has
+        `<dictcomp>` as its innermost frame: the site read `file:line <dictcomp>` on 3.10 and 3.11 and
+        `file:line _turn_usage` on 3.12 and 3.13, and the NaN-usage settle test went red on two of the
+        four interpreters (upstream CI on the 2026-09-07 review). The site names the innermost REAL
+        function: every angle-bracketed scope is skipped, so a generator expression (its own frame on
+        every interpreter) names the function too, at the line the comprehension is on — while the
+        chain keeps every frame the interpreter made. With nothing real to name, the innermost stands."""
+        me = "test_sdk_stream_survives_handler_errors.py"
+        def a_fold_with_a_comprehension(u):
+            return {k: int(u[k]) for k in ("input_tokens",)}
+        def a_count_with_a_generator(u):
+            return sum(int(u[k]) for k in ("input_tokens",))
+        def a_caller(fn):
+            fn({"input_tokens": float("nan")})
+        for fn in (a_fold_with_a_comprehension, a_count_with_a_generator):
+            try:
+                a_caller(fn)
+            except ValueError as exc:
+                e = exc                                # the except clause unbinds its own name on exit
+            line = fn.__code__.co_firstlineno + 1      # the one-line body: the comprehension's line
+            self.assertEqual(sb._failing_frame(e), (me, line, fn.__name__))
+            self.assertEqual(sb._failing_site(e), "%s:%d %s" % (me, line, fn.__name__))
+            chain = sb._compact_tb(e)
+            self.assertIn("%s:%d %s < %s:" % (me, line, fn.__name__, me), chain, "the function is a step of the chain")
+            self.assertEqual(chain.startswith("%s:%d <" % (me, line)),
+                             fn is a_count_with_a_generator or sys.version_info < (3, 12),
+                             "the chain keeps the synthetic frame wherever the interpreter made one: %r" % chain)
+        # nothing real to name: a raise caught at the top level of an exec'd string has only synthetic
+        # frames (`<module>`, and before 3.12 the comprehension's own) — the innermost one is named
+        ns = {}
+        exec(compile("try:\n    [1 // 0 for _ in (0,)]\nexcept ZeroDivisionError as exc:\n    err = exc\n",
+                     "a_string_of_code.py", "exec"), ns)
+        self.assertRegex(sb._failing_site(ns["err"]), r"^a_string_of_code\.py:2 <(listcomp|module)>$")
+
     def test_compact_tb_is_bounded_to_the_innermost_frames_and_a_length_cap(self):
         """A RecursionError's chain ran to 18 KB — into the error-center ring and every feed payload that
         carries it. The chain keeps the innermost COMPACT_TB_FRAMES frames (the failing site LEADS, since

--- a/ui/webview/comment-reply-landed.test.ts
+++ b/ui/webview/comment-reply-landed.test.ts
@@ -63,7 +63,7 @@ test("the client keys the green wash on the kernel's replyOwed; the gesture latc
   assert.match(RENDER, /cmtAwaitBase\.set\(synth\.tid, \{ \.\.\.CMT_LATCH_ZERO \}\);/, "the create gesture latches its synthetic thread");
   assert.match(COMMENTS, /queued\?: number;/); assert.match(COMMENTS, /unreachable\?: boolean \| null;/); assert.match(COMMENTS, /lastUuid\?: string;/);
   assert.match(KERNEL, /"queued": queued,/); assert.match(KERNEL, /"unreachable": unreachable or None,/); assert.match(KERNEL, /"lastUuid": last_uuid,/);
-  assert.match(KERNEL, /held = \[a for a in live if \(a\.get\("_echo_text"\) or ""\)\.strip\(\) and not a\.get\("command"\)/, "echo-held sends count as owed, the chat's own fold");
+  assert.match(KERNEL, /held = \[a for a in live if sb\.echo_text_key\(a\.get\("_echo_text"\)\) and not a\.get\("command"\)/, "echo-held sends count as owed, the chat's own fold (under the one echo text key, session_backend.echo_text_key)");
   assert.match(KERNEL, /def _settle\(a\):/, "the stop's settle record is skipped when reading the landing");
   assert.match(KERNEL, /reply_owed = status == "open" and \(turn_open or queued > 0 or owes_first/);
   assert.match(RENDER, /else if \(m\.type === "commentSendFailed" && m\.tid\) \{\s*\n\s*cmtAwaitBase\.delete\(String\(m\.tid\)\);/, "a refused send releases its latch");

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -10,14 +10,19 @@
 // bubble — retired its own entry in the very call that created it and showed nothing, and (B) the kernel's
 // own PROVISIONAL copy (queued bubble / "echo:" atom) counted as landed and deleted the entry one-way, so
 // when that provisional blinked in the echo→landed handoff nothing was left to cover the gap. Now: a
-// per-send `base` count makes only NEW landed user atoms retire it, kernel provisionals merely SUPPRESS
-// injection for the push they're visible on, and the TTL stays the backstop.
-// render.ts has import-time DOM side effects → source pins + an executed replica of the reconcile decision
-// (user-img-dedup.test.ts precedent).
+// per-send anchor makes only NEW landed user atoms retire it, kernel provisionals merely SUPPRESS
+// injection for the push they're visible on.
+// Reshaped again 2026-09-06 (the send-durability audits): the 20 s TTL backstop is GONE — an entry ends
+// on events only (a landing, the kernel's never-delivered verdict, the user's ✕) — and the decision
+// moved to send-pending.ts, a pure module this file executes directly (see also send-pending.test.ts,
+// which also covers the review's fixes: the anchor replaces the 30-event tail scan, exact text and
+// one landing per send, the lost verdict's anchor, the receipt proof that clears "not confirmed").
+// render.ts has import-time DOM side effects → source pins for the DOM half.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { newPending, reconcilePending, bareGroupLabel, type TailEvent } from "./send-pending";
 
 const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -70,15 +75,20 @@ test("every push entry point re-asserts (or retires) the optimistic tail", () =>
   assert.ok(calls.length >= 4, "reconcile wired into send + all three push paths, got " + calls.length);
 });
 
-test("retire needs a NEW landed atom (base count); kernel provisionals only suppress", () => {
-  // base is stamped on the first reconcile after the send: pre-existing matches are background
-  assert.match(RENDER, /arr\.push\(\{ text, ts: Date\.now\(\), base: -1, imgPaths \}\);/);
-  assert.match(RENDER, /for \(const p of list\) if \(p\.base < 0\) p\.base = landedCount\(p\.text\);/);
-  // a landed atom is a user event WITHOUT the backend's "echo:" uuid prefix
-  assert.match(RENDER, /&& !String\(\(e as any\)\.uuid \|\| ""\)\.startsWith\("echo:"\)\)\.length;/);
-  // retire = TTL or growth past base; suppression is a separate, non-destructive filter
-  assert.match(RENDER, /const keep = list\.filter\(\(p\) => now - p\.ts < OPT_TTL_MS && landedCount\(p\.text\) <= p\.base\);/);
-  assert.match(RENDER, /const inject = keep\.filter\(\(p\) => !shownProvisional\(p\.text\)\);/);
+test("retire needs a NEW landed atom (after the send's anchor); kernel provisionals only suppress", () => {
+  // the entry is minted by the module (unanchored until the first reconcile stamps where the send sits)
+  assert.match(RENDER, /const p = newPending\(text, imgPaths\);\s*\n\s*arr\.push\(p\);/);
+  assert.equal(newPending("x", undefined, 5).at, undefined);
+  // the decision is the module's, read off KERNEL truth after our injections are stripped — the whole
+  // resident array from the anchor on, never a tail count (2026-09-06 review)
+  assert.match(RENDER, /const r = reconcilePending\(s\.events as TailEvent\[\], list\);/);
+  assert.doesNotMatch(RENDER, /OPT_TAIL_SCAN/);
+  assert.match(RENDER, /if \(r\.keep\.length\) pendingSent\.set\(s\.id, r\.keep\); else pendingSent\.delete\(s\.id\);/);
+  assert.match(RENDER, /const inject = r\.inject;/);
+  // and no clock anywhere in the file's decision: the TTL is gone for good
+  assert.doesNotMatch(RENDER, /OPT_TTL_MS/);
+  const SP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "send-pending.ts"), "utf8");
+  assert.doesNotMatch(SP, /Date\.now\(\)(?! *\): PendingSend)/, "the module reads no clock in a decision (only the press stamp's default)");
 });
 
 // The optimistic echo rides the QUEUED idiom (the user 2026-07-16): to the reader an unconfirmed send and a
@@ -87,8 +97,10 @@ test("retire needs a NEW landed atom (base count); kernel provisionals only supp
 // queued send flip solid→dashed (backwards, as if it had un-landed).
 test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — never a solid user bubble", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-  assert.match(RENDER, /const OPT_PREFIX = "optimistic:";/);
-  assert.match(RENDER, /const mk = \(p: \{ text: string; imgPaths\?: string\[\] \}\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths \}\);/);   // the echo carries its dragged-image paths (2026-08-25); cancelable from the press (2026-08-30)
+  const SP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "send-pending.ts"), "utf8");
+  assert.match(SP, /export const OPT_PREFIX = "optimistic:";/);
+  assert.match(RENDER, /const isOptimistic = \(e: ChatEvent\): boolean => isOptimisticUuid\(e\.uuid\);/);
+  assert.match(RENDER, /const mk = \(p: PendingSend\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths, lost: p\.lost, qts: p\.ts \}\);/);   // the echo carries its dragged-image paths (2026-08-25); cancelable from the press (2026-08-30); `lost` after a connection drop, `qts` its identity for the ✕ (2026-09-06)
   // stale ones pop cheaply off the end (always tail-appended)
   assert.match(RENDER, /while \(s\.events\.length && isOptimistic\(s\.events\[s\.events\.length - 1\]\)\) s\.events\.pop\(\);/);
   // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
@@ -108,7 +120,11 @@ test("nothing known-queued → a bare group wearing the honest 'sending…' head
   // bug (a mid-compaction send sat unlabeled and uncuttable): the bare group now states exactly what
   // is known, and the reflow recounts it in the same vocabulary after a ✕
   assert.match(RENDER, /label\.dataset\.bare = "1";/);
-  assert.match(RENDER, /ev\.texts\.length === 1 \? "sending…" : `sending \$\{ev\.texts\.length\}…`/);
+  // the wording is the pure helper's (send-pending.ts bareGroupLabel, per-bubble since 2026-09-06), and
+  // the render feeds it the bubbles' own states
+  assert.match(RENDER, /fillBareLabel\(label, nLost, ev\.texts\.length - nLost\);/);
+  assert.deepEqual(bareGroupLabel(0, 1).parts.map((p) => p.text), ["sending…"]);
+  assert.deepEqual(bareGroupLabel(0, 2).parts.map((p) => p.text), ["sending 2…"]);
   assert.match(RENDER, /if \(label\.dataset\.bare === "1"\) \{/, "reflow keeps the bare vocabulary");
   assert.match(RENDER, /if \(!ev\.bare\) \{/, "the standard 'N queued' header still needs confirmation");
 });
@@ -138,7 +154,9 @@ test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body
   // body (ws ordering puts it after the send it names); a miss comes back through the same loud
   // cancelResult, and the composer restore reverts (pendingCancelRestores).
   assert.match(RENDER, /if \(qmd\) \{/);
-  assert.match(RENDER, /const i = list\.findIndex\(\(p\) => p\.text === qmd\);/);
+  // …by the bubble's OWN identity when it has one (data-qts) — send-pending.test.ts runs the lookup
+  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*if \(dropPending\(list, qmd, qts\)\)/);
+  assert.doesNotMatch(RENDER, /list\.findIndex\(\(p\) => p\.text === qmd\)/, "never 'the first entry with this text' for a bubble that names its entry");
   assert.match(RENDER, /echoShownSig\.delete\(sidQ\);/);
   assert.match(RENDER, /const msg: Record<string, unknown> = \{ type: "cancelQueued", id: sidQ, md: qmd \};/);
 });
@@ -150,61 +168,48 @@ test("chatTail speaks the KERNEL's coordinates — the injected tail is not part
   assert.match(RENDER, /if \(from > kernelLen\) \{/);
 });
 
-// Executed replica of reconcileOptimistic's decision, synced to the reshaped semantics: three outcomes
-// per entry per push — inject (payload has nothing), suppress (a kernel PROVISIONAL is visible: its
-// queued bubble or its "echo:" atom), retire (a NEW landed user atom beyond base, or the TTL).
+// The reconcile decision, EXECUTED through the real module: three outcomes per entry per push — inject
+// (payload has nothing), suppress (a kernel PROVISIONAL is visible: its queued bubble or its "echo:"
+// atom), retire (a NEW landed user atom beyond base). No fourth: the TTL is gone (send-pending.test.ts
+// pins the no-lifetime rule and the other retire event, the kernel's never-delivered verdict).
 test("reconcile: inject on nothing, suppress on kernel provisionals, retire only on NEW landings", () => {
-  type Ev = { kind: string; md?: string; uuid?: string; texts?: { md: string }[] };
-  const OPT_TTL_MS = 20_000, OPT_TAIL_SCAN = 30;
-  type P = { text: string; ts: number; base: number };
-  const reconcile = (events: Ev[], list: P[], now: number) => {
-    const tail = events.slice(-OPT_TAIL_SCAN);
-    const landedCount = (t: string) => tail.filter((e) =>
-      e.kind === "user" && typeof e.md === "string" && e.md.includes(t)
-      && !String(e.uuid || "").startsWith("echo:")).length;
-    const shownProvisional = (t: string) => tail.some((e) =>
-      (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))) ||
-      (e.kind === "user" && typeof e.md === "string" && String(e.uuid || "").startsWith("echo:") && e.md.includes(t)));
-    for (const p of list) if (p.base < 0) p.base = landedCount(p.text);
-    const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && landedCount(p.text) <= p.base);
-    return { keep, inject: keep.filter((p) => !shownProvisional(p.text)) };
-  };
   const T0 = 1_000_000;
-  const fresh = (): P[] => [{ text: "continue", ts: T0, base: -1 }];
+  const fresh = () => [newPending("continue", undefined, T0)];
+  const reconcile = (events: TailEvent[], list = fresh()) => reconcilePending(events, list);
 
   // gap: the payload carries nothing for it → keep AND inject
-  let r = reconcile([{ kind: "assistant", md: "working on the prior turn" }], fresh(), T0 + 500);
+  let r = reconcile([{ kind: "assistant", md: "working on the prior turn" }]);
   assert.equal(r.inject.length, 1);
 
   // DEFECT A (the resend): an OLDER identical message sits in the tail — base counts it as background,
   // so the new send still injects instead of retiring itself in the call that created it
-  r = reconcile([{ kind: "user", md: "continue", uuid: "u-old" }], fresh(), T0 + 500);
+  r = reconcile([{ kind: "user", md: "continue", uuid: "u-old" }]);
   assert.equal(r.inject.length, 1, "a resend must still show its own bubble");
 
   // …and the same protection for a short message that substrings an older bubble
-  r = reconcile([{ kind: "user", md: "test the continue button", uuid: "u-old" }], fresh(), T0 + 500);
+  r = reconcile([{ kind: "user", md: "test the continue button", uuid: "u-old" }]);
   assert.equal(r.inject.length, 1, "substring-of-history must not count as landed");
 
-  // kernel shows its QUEUED bubble → suppressed for this push, but NOT retired…
+  // kernel shows its QUEUED bubble for THIS send → suppressed for this push, but NOT retired… The press
+  // stamped a tail without the copy: a copy already listed AT the press is an older send's, background,
+  // and covers nothing (send-pending.test.ts, "what was already there at the press is background")
   const p = fresh();
-  r = reconcile([{ kind: "queued", texts: [{ md: "continue" }] }], p, T0 + 500);
+  reconcile([{ kind: "assistant", md: "working on the prior turn" }], p);   // the press
+  r = reconcile([{ kind: "queued", texts: [{ md: "continue" }] }], p);
   assert.equal(r.keep.length, 1);
   assert.equal(r.inject.length, 0, "no double render beside the kernel's own copy");
   // …same for the kernel's unlanded echo atom (uuid keeps the backend's echo: prefix)
-  r = reconcile([{ kind: "user", md: "continue", uuid: "echo:abc123" }], p, T0 + 800);
+  r = reconcile([{ kind: "user", md: "continue", uuid: "echo:abc123" }], p);
   assert.equal(r.keep.length, 1);
   assert.equal(r.inject.length, 0);
   // DEFECT B (the flash-out): the provisional blinks away in the echo→landed handoff — the entry
   // survived the suppression, so ours steps straight back in and the message never disappears
-  r = reconcile([{ kind: "assistant", md: "…" }], p, T0 + 1_100);
+  r = reconcile([{ kind: "assistant", md: "…" }], p);
   assert.equal(r.inject.length, 1, "the kept entry covers the kernel's own gap");
   // the real landing (a user atom with a real uuid, beyond base) finally retires it
-  r = reconcile([{ kind: "user", md: "continue", uuid: "u-new" }], p, T0 + 1_400);
+  r = reconcile([{ kind: "user", md: "continue", uuid: "u-new" }], p);
   assert.equal(r.keep.length, 0, "a NEW landed atom is the one retire event");
-
-  // TTL backstop: nothing ever surfaced, but past the window we stop asserting a possibly-dropped send
-  r = reconcile([{ kind: "assistant", md: "…" }], fresh(), T0 + OPT_TTL_MS + 1);
-  assert.equal(r.keep.length, 0);
+  assert.equal(r.landed.length, 1);
 });
 
 test("the echo renders dragged-image THUMBNAILS — composer → provisional → landed, one continuum", () => {

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,7 +13,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {
@@ -247,7 +247,7 @@ test("the kernel flags a romp-injected queued entry from the same markers as a l
 });
 
 test("what romp itself queued wears the LANDED romp grammar, split as landed: notice card vs gray romp bubble (T243)", () => {
-  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/, "the queued text shape carries the flags");
+  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/, "the queued text shape carries the flags");
   const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
   assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\);/);
   // a SYSTEM notice → the landed card's own builder, nested; a one-line notice gets no body repeating its head

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11886,9 +11886,10 @@ function routeUserMessage(sid: string, text: string, cites: Citation[] | undefin
   const quoteCites = cites ? cites.filter((c) => c.quote) : [];
   // EVERY branch echoes optimistically (the user 2026-08-23: quoted and follow-up sends showed
   // nothing until the kernel round-tripped, while plain sends painted instantly — the exact
-  // inconsistency reported). The quote branch echoes the COMPOSED body, which is byte-identical to
-  // what lands (quoteReplyBody IS the send path), so the reconcile's includes() match is exact; the
-  // follow-up echoes the typed words, a substring of the goal-wrapped landing.
+  // inconsistency reported). The reconcile ends a bubble on an EXACT text match with the landed event's
+  // md (send-pending.ts): the quote branch echoes the COMPOSED body, which is byte-identical to what
+  // lands (quoteReplyBody IS the send path); the follow-up echoes the typed words, which is what the
+  // kernel ships as the landed event's md once it strips the goal wrapper (_split_followup).
   if (goalCite?.itemId) { vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid }); registerOptimistic(sid, text, imgPaths); }
   else if (quoteCites.length) { const body = quoteReplyBody(quoteCites, text); vscodeApi.postMessage({ type: "sendMessage", id: sid, text: body }); registerOptimistic(sid, body, imgPaths); }
   else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text, imgPaths); }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -34,6 +34,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, dropPending, cueAnchor, bareGroupLabel } from "./send-pending";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -158,7 +159,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[] }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25)
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: client-only, the pending entry's identity (its press time) so the ✕ removes ITS entry (send-pending.ts)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -290,17 +291,28 @@ const order: string[] = [];           // positional tab order (for cycling)
 // only ever moves provisional→settled: dashed→solid when it lands, dashed→dashed (invisible) when it really
 // was queued. It first shipped as a 0.6-opacity solid bubble, which invented a THIRD look and made a queued
 // send flip solid→dashed — backwards, as if it had un-landed.
-const OPT_PREFIX = "optimistic:";
-const OPT_TTL_MS = 20_000;    // backstop: a real send always echoes within this; past it we stop asserting
-const OPT_TAIL_SCAN = 30;     // the kernel's version (user atom / queued bubble) always lands at the tail
-// sid → in-flight optimistic sends. `base` is how many LANDED user atoms carrying this text the tail
-// already held at send time (stamped on the first reconcile, -1 until then): only a count BEYOND base
-// means THIS send landed. The old retire test was a bare substring scan with no notion of which event
-// carried the text, so a resend — or any short message that substrings an older bubble ("continue",
-// "test") — retired its own entry in the very call that created it, and the send showed nothing at
-// all (the user 2026-08-09, who watched sends vanish for a beat before appearing).
-const pendingSent = new Map<string, { text: string; ts: number; base: number; imgPaths?: string[] }[]>();
-const isOptimistic = (e: ChatEvent): boolean => !!e.uuid && e.uuid.startsWith(OPT_PREFIX);
+// NO LIFETIME (2026-09-06): the 20 s TTL that used to sit here ("a real send always echoes within this")
+// made an unconfirmed send look delivered at exactly the moment the user most needed to see it was not —
+// the audited case had the kernel's echo pruned early and nothing showing the message for 30 s. An entry
+// now ends on events only: a landing, the kernel's never-delivered verdict, or the user's ✕. The decisions
+// live in send-pending.ts (pure, executed by its test); this file owns the DOM and the per-session maps.
+// sid → in-flight pending sends. Each entry is ANCHORED (`at`, stamped on the first reconcile after the
+// press) to the last stable kernel event at the time of the send, plus the uuids of the user events
+// that already carried its text: only an exact-text landing AFTER that anchor, beyond that set, is
+// THIS send's. The old retire test was a bare substring scan with no notion of which event carried the
+// text, so a resend — or any short message that substrings an older bubble ("continue", "test") —
+// retired its own entry in the very call that created it, and the send showed nothing at all (the user
+// 2026-08-09, who watched sends vanish for a beat before appearing); and its successor read only the
+// last 30 events, so an absorbed landing placed above them never ended the bubble (2026-09-06 review).
+const pendingSent = new Map<string, PendingSend[]>();
+const isOptimistic = (e: ChatEvent): boolean => isOptimisticUuid(e.uuid);
+// sid → MID-TURN CUES: where a pending bubble sat when its message landed ABOVE the tail. A send fed
+// into a running turn is taken by the CLI at a later tool boundary and placed at its SEND time (kernel
+// ev.absorbed), so the bubble the user was watching at the bottom vanishes and the message is somewhere
+// higher up. The cue stays under the event the bubble sat under — "delivered into the running turn at
+// HH:MM · jump" — until jump or ✕ (the user 2026-09-05). Keyed on the landing, never on a timer.
+type AbsorbedCue = { after: string; target: string; landedAt: number | null };
+const absorbedCues = new Map<string, AbsorbedCue[]>();
 
 // The kernel's own queued group, if one is at the tail. Ours merges INTO it when present: the session is
 // provably holding messages, so this send will queue behind them — no reason to show it as a separate lone
@@ -341,34 +353,27 @@ function reconcileOptimistic(s: Session): void {
   }
   const list = pendingSent.get(s.id);
   if (!list || !list.length) { settle([]); return; }
-  const now = Date.now();
-  const tail = s.events.slice(-OPT_TAIL_SCAN);
-  // A LANDED copy of the text is a real user atom — never the kernel's own provisional echo, whose
-  // uuid keeps the backend's "echo:" prefix all the way into the payload. Retiring on the echo was
-  // the flash-out: the echo deleted our entry for good, then blinked in its own echo→landed handoff
-  // with nothing left to cover the gap (the user 2026-08-09). The header above always said "until
-  // the payload DEMONSTRABLY carries the message" — an unlanded echo demonstrates nothing yet.
-  const landedCount = (t: string) => tail.filter((e) =>
-    e.kind === "user" && typeof e.md === "string" && e.md.includes(t)
-    && !String((e as any).uuid || "").startsWith("echo:")).length;
-  // The kernel's own PROVISIONAL copy — its queued bubble, or its echo atom — SUPPRESSES our bubble
-  // for this push (injecting beside it would show the send twice) but never retires the entry: if
-  // the provisional blinks out on the next push, ours steps straight back in.
-  const shownProvisional = (t: string) => tail.some((e) =>
-    (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))) ||
-    (e.kind === "user" && typeof e.md === "string" && String((e as any).uuid || "").startsWith("echo:") && e.md.includes(t)));
-  // First reconcile after the send (registerOptimistic calls this synchronously): whatever matching
-  // atoms the tail ALREADY holds are background — an older identical message, a bubble this text
-  // substrings — not this send. Only growth past this count is a landing.
-  for (const p of list) if (p.base < 0) p.base = landedCount(p.text);
-  const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && landedCount(p.text) <= p.base);
-  if (keep.length) pendingSent.set(s.id, keep); else pendingSent.delete(s.id);
-  const inject = keep.filter((p) => !shownProvisional(p.text));
+  // The decision reads KERNEL truth only (our injections are stripped above) — send-pending.ts: a
+  // LANDED user atom after the send's anchor retires the entry (never the kernel's own echo, whose uuid
+  // keeps the backend's "echo:" prefix into the payload — retiring on it was the 2026-08-09 flash-out:
+  // the echo deleted our entry, then blinked in its own echo→landed handoff with nothing left to cover
+  // the gap); the kernel's NEVER-DELIVERED verdict after the anchor retires it (that bubble now carries
+  // the text and the resend); its PROVISIONAL — echo atom or queued bubble — suppresses ours for this
+  // push and nothing more, so if it blinks, ours steps straight back in, and proves the kernel has the
+  // send (a "not confirmed" label is cleared). A landing that retired an ABSORBED atom's bubble may owe
+  // a mid-turn cue (noteAbsorbedLanding).
+  const r = reconcilePending(s.events as TailEvent[], list);
+  if (r.keep.length) pendingSent.set(s.id, r.keep); else pendingSent.delete(s.id);
+  for (const { idx } of r.landed) noteAbsorbedLanding(s, idx);
+  const inject = r.inject;
   if (!inject.length) { settle([]); return; }
   // cancelable from the PRESS (the user 2026-08-30, who sent mid-compaction and sat in an unlabeled,
   // uncancellable beat until the kernel's park round-tripped): the ✕ on an optimistic bubble drops our
   // re-injection and asks the kernel to cancel by body wherever the send landed (see the qx handler).
-  const mk = (p: { text: string; imgPaths?: string[] }) => ({ md: p.text, optimistic: true, cancelable: true, imgPaths: p.imgPaths });
+  // `lost` rides along so the bubble can say "not confirmed" after a connection drop (markPendingLost).
+  // `qts` is the entry's identity: the ✕ removes THAT entry, never the first with the same text (two
+  // identical sends can sit in different states — one lost, one received).
+  const mk = (p: PendingSend) => ({ md: p.text, optimistic: true, cancelable: true, imgPaths: p.imgPaths, lost: p.lost, qts: p.ts });
   const qj = tailQueuedIdx(s.events);
   if (qj >= 0) {
     // something IS queued here → ours queues behind it: show it in that group, under its header, counted
@@ -384,10 +389,15 @@ function reconcileOptimistic(s: Session): void {
 // Record a composer send as in-flight and show its optimistic bubble NOW (before any kernel push).
 function registerOptimistic(id: string, text: string, imgPaths?: string[]): void {
   const arr = pendingSent.get(id) || [];
-  arr.push({ text, ts: Date.now(), base: -1, imgPaths });   // base is stamped by the reconcile just below
+  const p = newPending(text, imgPaths);
+  arr.push(p);   // the anchor (`at`) is stamped by the reconcile just below
   pendingSent.set(id, arr);
   const s = sessions.get(id);
-  if (!s) return;
+  // No resident frame to stamp against: the active tab is a PLACEHOLDER (its meta arrived, its payload
+  // is pending — selectable, composer live). The first upsert stamps the entry, against a frame that may
+  // already hold this send's own echo or landing; `late` tells stampBase to read the events' own stamps,
+  // so only what the kernel stamped before the press is background (send-pending.ts).
+  if (!s) { p.late = true; return; }
   reconcileOptimistic(s);
   // The reconcile can mutate the tail IN PLACE — merging into an existing queued group, or pop+push
   // on a repeat send — which leaves s.events.length unchanged, and syncView's no-op fast path
@@ -409,6 +419,57 @@ function registerOptimistic(id: string, text: string, imgPaths?: string[]): void
     appendActive();
     if (content && wasAtBottom) content.scrollTop = content.scrollHeight;
   }
+}
+
+// A landing just retired a pending bubble. When the landed atom is ABSORBED (kernel ev.absorbed: a
+// mid-turn splice, placed at its send time) and it landed ABOVE the tail, the bubble the user was
+// watching at the bottom is gone and the message is somewhere higher up — leave a cue under the event
+// the bubble sat under (cueAnchor). It landed AT the tail → the swap was in place, no cue owed. Keyed
+// on the landing itself; dismissed by the user's jump or ✕, never by a timer. The anchor is an event
+// the chat DRAWS in its current mode: compact mode (the default) hides thinking, and a cue hung on a
+// hidden event never rendered and could never be dismissed (2026-09-06 review).
+const cueRendered = (e: TailEvent): boolean => !(settings.compact && e.kind === "thinking");
+function noteAbsorbedLanding(s: Session, idx: number): void {
+  const ev = s.events[idx] as (ChatEvent & { absorbed?: boolean; landedAt?: number }) | undefined;
+  if (!ev || !ev.absorbed || !ev.uuid) return;
+  const after = cueAnchor(s.events as TailEvent[], idx, cueRendered);
+  if (!after) return;
+  const cues = absorbedCues.get(s.id) || [];
+  if (cues.some((c) => c.target === ev.uuid)) return;
+  cues.push({ after, target: ev.uuid, landedAt: typeof ev.landedAt === "number" ? ev.landedAt : null });
+  absorbedCues.set(s.id, cues);
+  const v = views.get(s.id);
+  if (v) v.stale = true;
+}
+
+function dismissAbsorbedCue(sid: string, target: string): void {
+  const cues = (absorbedCues.get(sid) || []).filter((c) => c.target !== target);
+  if (cues.length) absorbedCues.set(sid, cues); else absorbedCues.delete(sid);
+}
+
+// The socket (or the VS Code pipe) went DOWN: every send still unconfirmed may never have reached the
+// kernel. The bubble says "not confirmed" — with the ✕ as the way back to the composer — instead of
+// "sending…" for as long as the entry lives. Keyed on the down edge, an event; the kernel's own copy of
+// the send seen afterwards (its echo, its queued bubble) clears the label (send-pending.ts `received`),
+// and the landing retires the entry exactly as before. A send the kernel has already shown it holds is
+// never marked: the drop cannot have lost it.
+// Only a CHANGED entry repaints. The browser shim fires romp:wsdown on every redial while the kernel is
+// down (one per ~1.5 s), and the VS Code pipe posts a down frame per attempt; rebuilding the active chat
+// on each destroyed the reader's selection hundreds of times for a label that changed once
+// (2026-09-06 review).
+function markPendingLost(why: string): void {
+  let activeChanged = false;
+  for (const [sid, list] of pendingSent) {
+    let changed = false;
+    for (const p of list) if (!p.lost && !p.received) { p.lost = why; changed = true; }
+    if (!changed) continue;
+    const s = sessions.get(sid);
+    if (s) reconcileOptimistic(s);        // re-inject the bubbles with the new label
+    const v = views.get(sid);
+    if (v) v.stale = true;                 // same texts, new label: the sig alone would not repaint
+    if (sid === activeId) activeChanged = true;
+  }
+  if (activeChanged) appendActive();
 }
 
 // ── conversation rewind (edit a past message, SDK sessions) ──────────────────────────────────────
@@ -2340,6 +2401,11 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     // a TYPED follow-up (resumed a goal) → a compact "↩ Follow-up · <goal>" header, the romp goal-context
     // quote + markers already stripped server-side. Same header the pending queued render uses (consistency).
     if (ev.followUp && !romp) turn.appendChild(followUpHeader(ev.goal, ev.fuCtx, ev.uuid ? "u:" + ev.uuid : undefined));
+    // "joined mid-turn" (kernel ev.absorbed): the CLI queued this send behind a running turn and took it
+    // at a later tool boundary; the transcript places it at its SEND time, so it reads above steps that
+    // were already running. The header says why; when the session took it (ev.landedAt) is one level
+    // deeper, on hover. Human bubbles only — a romp nudge's own tag row already says what it is.
+    if ((ev as any).absorbed && !romp && !injected && !tagged) turn.appendChild(absorbedHeader((ev as any).landedAt));
     const hasImgs = !!(ev.images && ev.images.length);
     if (ev.md || hasImgs) {
       if (romp) {
@@ -3369,6 +3435,46 @@ function compactTokens(n: number): string {
 // strip is display-only, and this is where the hidden part can be audited. Expansion survives the chat's
 // re-renders via fuExpanded (keyed by the turn's uuid / queue slot), NOT DOM state that a rebuild would lose.
 const fuExpanded = new Set<string>();
+const hhmm = (epoch: number): string => markerLabel(epoch, null, Date.now()).hm;
+
+function absorbedHeader(landedAt?: number | null): HTMLElement {
+  const h = el("div", "absorbed-tag");
+  h.textContent = "joined mid-turn";
+  h.title = "Sent while the session was working; it waited behind the steps in progress"
+    + (typeof landedAt === "number" ? ", and the session took it at " + hhmm(landedAt) : "") + ".";
+  return h;
+}
+
+// The mid-turn cue (absorbedCues): where a pending bubble sat when its message landed higher up. The
+// interrupt marker's chrome — a rail ring and one dim line — plus jump/✕ in the small-button rest.
+// Buttons ride the body delegate (data-act): the tail rebuilds every push.
+function renderAbsorbedCue(c: AbsorbedCue): HTMLElement {
+  const turn = el("div", "turn turn-absorbed-cue");
+  turn.dataset.cueTarget = c.target;
+  turn.appendChild(dot("ring"));
+  const line = el("div", "absorbed-cue-line");
+  line.title = "The session took your message at a tool boundary while it was working, so it appears above the steps that were already running.";
+  line.appendChild(document.createTextNode("delivered into the running turn"
+    + (c.landedAt != null ? " at " + hhmm(c.landedAt) : "")));
+  const jump = el("button", "absorbed-cue-act") as HTMLButtonElement;
+  jump.type = "button"; jump.textContent = "jump"; jump.title = "Scroll to the message";
+  jump.dataset.act = "abjump"; jump.dataset.target = c.target;
+  const x = el("button", "absorbed-cue-act") as HTMLButtonElement;
+  x.type = "button"; x.textContent = "✕"; x.title = "Dismiss this note";
+  x.dataset.act = "abdismiss"; x.dataset.target = c.target;
+  line.appendChild(jump); line.appendChild(x);
+  turn.appendChild(line);
+  return turn;
+}
+
+// The mid-turn cue(s) hung under this item's event(s) — rendered with the item, so the note keeps its
+// place as the tail grows past it.
+function appendAbsorbedCues(v: View, s: Session, uuids: (string | undefined)[], tag: (n: HTMLElement) => HTMLElement): void {
+  const cues = absorbedCues.get(s.id);
+  if (!cues || !cues.length) return;
+  for (const c of cues) if (uuids.includes(c.after)) v.el.appendChild(tag(renderAbsorbedCue(c)));
+}
+
 function followUpHeader(goal?: string, ctx?: string, key?: string): HTMLElement {
   const h = el("div", "followup-tag");
   const k = key || "";
@@ -3451,7 +3557,10 @@ function reflowQueuedGroup(turn: HTMLElement): void {
   const label = turn.querySelector(".queued-count") as HTMLElement | null;
   if (!label) return;
   if (label.dataset.bare === "1") {                       // the pre-confirmation group recounts in its own words
-    label.textContent = bubbles.length === 1 ? "sending…" : `sending ${bubbles.length}…`;
+    // …from the SURVIVING bubbles' own states (data-lost), so a ✕ on the lost bubble leaves the rest
+    // reading "sending…" — the label used to keep "not confirmed" for whoever remained
+    const nLost = bubbles.filter((b) => (b as HTMLElement).dataset.lost === "1").length;
+    fillBareLabel(label, nLost, bubbles.length - nLost);
     return;
   }
   const nCmd = bubbles.filter((b) => b.querySelector(".slash-cmd-chip")).length;
@@ -3469,6 +3578,21 @@ function strHash32(str: string): string {
   return (h >>> 0).toString(36);
 }
 
+// The bare group's label from its bubbles' states (send-pending.ts bareGroupLabel): the lost part wears
+// the warn color, the sending part stays dim. Shared by the render and the ✕'s recount so the two can
+// never disagree.
+function fillBareLabel(label: HTMLElement, nLost: number, nSending: number): void {
+  const { parts, title } = bareGroupLabel(nLost, nSending);
+  label.replaceChildren();
+  parts.forEach((part, i) => {
+    if (i) label.appendChild(document.createTextNode(" · "));
+    const span = el("span", part.lost ? "lost" : "");
+    span.textContent = part.text;
+    label.appendChild(span);
+  });
+  label.title = title;
+}
+
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   const turn = el("div", "turn turn-queued");
   // A BARE group is romp's own optimistic echo with nothing else known-queued: "N queued messages" is a
@@ -3482,8 +3606,12 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     head.appendChild(hourglassIcon());
     const label = el("span", "queued-count");
     label.dataset.bare = "1";     // reflow rewrites this label in its own vocabulary, never "N queued"
-    label.textContent = ev.texts.length === 1 ? "sending…" : `sending ${ev.texts.length}…`;
-    label.title = "on its way to the session — cancellable until the session takes it";
+    // Per BUBBLE state (send-pending.ts `lost`): a send whose connection dropped after the press, with
+    // nothing confirming it since, reads "not confirmed" in warn amber — "sending…" would claim a
+    // progress romp cannot see — and the ✕ is its way back to the composer; the others in the same
+    // group still read "sending…". One label, both counts when both states are present.
+    const nLost = ev.texts.filter((t) => t.lost).length;
+    fillBareLabel(label, nLost, ev.texts.length - nLost);
     head.appendChild(label);
     turn.appendChild(head);
   }
@@ -3527,9 +3655,11 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     if (t.followUp && !t.romp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
     const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "")
                       + (t.romp ? " queued-romp" : "") + (t.rompSystem ? " queued-sys" : ""));
+    if (t.optimistic && t.lost) bubble.dataset.lost = "1";   // the bare label recounts from this after a ✕
     // one phrase separating OUR unconfirmed echo from a real queued message, which the session has accepted
     // and is holding (the user 2026-07-16)
-    if (t.optimistic) bubble.title = "sent just now — romp hasn't confirmed the session has it yet";
+    if (t.optimistic && t.lost) bubble.title = "not confirmed — the connection dropped after this was sent; ✕ moves it back to the composer to send again";
+    else if (t.optimistic) bubble.title = "sent just now — romp hasn't confirmed the session has it yet";
     // a queued entry with NO ✕ (the user 2026-07-20): the queue lives inside the session's own CLI —
     // there is no recall — so instead of a cancel that would only ever say "too late", the tooltip says
     // where the message actually is. (SDK mid-turn forwards and every tmux queued message land here.)
@@ -3616,6 +3746,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       if (t.idx !== undefined) x.dataset.qidx = String(t.idx);
       if (t.park !== undefined) x.dataset.qpark = String(t.park);
       if (t.optimistic) x.dataset.qopt = "1";   // ✕ before confirmation → cancel-by-body (no park/idx yet)
+      if (t.qts !== undefined) x.dataset.qts = String(t.qts);   // OUR entry's identity: the ✕ removes this bubble's entry, not the first with its text
       if (isCmd) x.dataset.qcmd = "1";
       (x as any)._qmd = t.md;   // the bubble's body — the kernel's drift guard + the composer restore read it
       xHost.appendChild(x);
@@ -5810,6 +5941,7 @@ function dropProvisional(): { queued: string[]; draft: string } {
     const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
     draft = (activeId === id && ta) ? ta.value : (drafts.get(id) ?? "");
     pendingSent.delete(id);                // the optimistic bubbles belong to a tab that is going away
+    absorbedCues.delete(id);
     dismissSession(id, "close");           // drops it from sessions/order/views and reselects
   }
   return { queued, draft };
@@ -5849,6 +5981,7 @@ function failProvisional(why: string): void {
   const draft = (activeId === id && ta0) ? ta0.value : (drafts.get(id) ?? "");
   const held = [...queued, draft].filter(Boolean).join("\n\n");
   pendingSent.delete(id);            // the dashed "received" bubbles fold into the held text instead
+  absorbedCues.delete(id);
   failedProvisionals.add(id);
   const s = sessions.get(id);
   // "closed" gives the tab the dead treatment (struck label, plain ✕) — but the composer stays LIVE
@@ -8881,6 +9014,7 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
         v.el.appendChild(tag(child)); adv(i);
       });
     }
+    appendAbsorbedCues(v, s, it.indices.map((i) => s.events[i]?.uuid), tag);
   } else if (it.kind === "retrygroup") {
     const notes = it.indices.map((i) => s.events[i]) as Extract<ChatEvent, { kind: "retried" }>[];
     const key = retryGroupKey(notes[0]);
@@ -8894,9 +9028,11 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
         v.el.appendChild(tag(child)); adv(i);
       });
     }
+    appendAbsorbedCues(v, s, it.indices.map((i) => s.events[i]?.uuid), tag);
   } else {
     v.el.appendChild(tag(renderEvent(s.events[it.index], prevEpoch, turnWorkedSecs(s.events, it.index, working))));
     adv(it.index);
+    appendAbsorbedCues(v, s, [s.events[it.index]?.uuid], tag);
   }
   return prevEpoch;
 }
@@ -11756,6 +11892,11 @@ function routeUserMessage(sid: string, text: string, cites: Citation[] | undefin
   if (goalCite?.itemId) { vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid }); registerOptimistic(sid, text, imgPaths); }
   else if (quoteCites.length) { const body = quoteReplyBody(quoteCites, text); vscodeApi.postMessage({ type: "sendMessage", id: sid, text: body }); registerOptimistic(sid, body, imgPaths); }
   else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text, imgPaths); }
+  // One breadcrumb per composer send (client-diag.jsonl): sid, when, how long, which route — never the
+  // text. A send that "vanished" can then be traced from the press through the kernel's own logs
+  // instead of reconstructed from memory.
+  vscodeApi.postMessage({ type: "clientDiag", surface: "chat", what: "send",
+    data: { sid, ts: Date.now(), len: text.length, route: goalCite?.itemId ? "followup" : quoteCites.length ? "quote" : "plain" } });
 }
 
 /** Release the tab's staged stack (deliver's guards — host down, provisional — run before this in the
@@ -12597,6 +12738,8 @@ function requestFullSession(id: string): void {
 // guaranteed) — but an ask parked against the dead socket would gag the new socket's repair path
 // forever (awaitingFull only clears when the reply lands, and the dead socket's never will).
 window.addEventListener("romp:wsup", () => awaitingFull.clear());
+// A send still unconfirmed at the socket's down edge may never have reached the kernel: say so on its bubble
+window.addEventListener("romp:wsdown", () => markPendingLost("connection"));
 
 function chatTail(msg: any) {
   const s = sessions.get(msg.id);
@@ -13000,7 +13143,8 @@ window.addEventListener("message", (e: MessageEvent) => {
   }
   // the shell's palette / shell-focus chords: the chat owns the nav trail, the shell just asks
   if (m.romp === "chatNav") { navHist.go(m.dir === 1 ? 1 : -1); return; }
-  if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
+  // the pipe's down edge is the VS Code twin of the shim's romp:wsdown: unconfirmed sends say so (markPendingLost)
+  if (m.type === "pipeState") { if (!m.up) markPendingLost("connection"); pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   // any kernel message proves the kernel is reachable again — heal previews whose fetch died in a
   // restart window (preview.ts retryFailedPreviews; a no-op when nothing failed). federation's
   // tunnel poll rides this same path: it dispatches {type:"hostUp"} on a host's down→up transition,
@@ -14376,9 +14520,11 @@ setupSettings();
         // PARKED/backend ✕ it is just as load-bearing: the kernel bubble had been SUPPRESSING our
         // still-live entry (shownProvisional), so cancelling only the kernel op resurrected the
         // cancelled message as a dashed bubble until the TTL (caught by this fix's served-page probe).
+        // OUR bubble's ✕ names its entry (data-qts, the press time); a kernel bubble's ✕ names none, and
+        // drops the first pending send with the text — the one the kernel's first copy covers.
         const list = pendingSent.get(sidQ) || [];
-        const i = list.findIndex((p) => p.text === qmd);
-        if (i >= 0) { list.splice(i, 1); if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
+        const qts = el.dataset.qts !== undefined ? Number(el.dataset.qts) : undefined;
+        if (dropPending(list, qmd, qts)) { if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
         echoShownSig.delete(sidQ);
       }
       const msg: Record<string, unknown> = { type: "cancelQueued", id: sidQ, md: qmd };
@@ -14491,6 +14637,21 @@ setupSettings();
     forkspot: (elx) => {
       const cut = (elx.closest(".fork-spot") as HTMLElement | null)?.dataset.cut || "";
       if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, cut);
+    },
+    // the mid-turn cue (absorbedCues): "jump" scrolls to the absorbed message and retires the note — its
+    // job, explaining the vanished bubble, is done; ✕ retires it in place. Delegated like qx: the tail
+    // rebuilds every push. The node goes NOW (the acknowledgement); the map keeps it gone.
+    abjump: (elx) => {
+      const target = elx.dataset.target || "";
+      const sidC = owningSidOf(elx) || activeId;
+      if (sidC) dismissAbsorbedCue(sidC, target);
+      (elx.closest(".turn-absorbed-cue") as HTMLElement | null)?.remove();
+      if (target) scrollToAnchor(target);
+    },
+    abdismiss: (elx) => {
+      const sidC = owningSidOf(elx) || activeId;
+      if (sidC) dismissAbsorbedCue(sidC, elx.dataset.target || "");
+      (elx.closest(".turn-absorbed-cue") as HTMLElement | null)?.remove();
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -39,12 +39,22 @@ const filler = (n: number, prefix = "f"): TailEvent[] =>
 // ── (1) no lifetime ──────────────────────────────────────────────────────────────────────────────
 
 test("a pending send survives past 20 s — and past any time — without confirmation", () => {
-  const list = press([{ kind: "assistant", md: "still working on the earlier step" }], TEXT);
-  // nothing happens for a minute, then an hour
-  for (const later of [T0 + 21_000, T0 + 60_000, T0 + 3_600_000]) {
-    const r = reconcilePending([{ kind: "assistant", md: "…" }], list);
-    assert.equal(r.keep.length, 1, `still pending at +${(later - T0) / 1000}s`);
-    assert.equal(r.inject.length, 1, "…and still shown: nothing in the payload accounts for it");
+  const list = press([{ kind: "assistant", md: "still working on the earlier step", uuid: "a0" }], TEXT);
+  // nothing happens for a minute, then an hour: the wall clock moves on and the kernel's stamps move on
+  // with it, and the decision reads neither
+  const realNow = Date.now;
+  try {
+    for (const later of [T0 + 21_000, T0 + 60_000, T0 + 3_600_000]) {
+      Date.now = () => later;
+      const r = reconcilePending([
+        { kind: "assistant", md: "still working on the earlier step", uuid: "a0" },
+        { kind: "assistant", md: "…", uuid: "a-" + later, ts: new Date(later).toISOString() },
+      ], list);
+      assert.equal(r.keep.length, 1, `still pending at +${(later - T0) / 1000}s`);
+      assert.equal(r.inject.length, 1, "…and still shown: nothing in the payload accounts for it");
+    }
+  } finally {
+    Date.now = realNow;
   }
   assert.doesNotMatch(RENDER, /OPT_TTL_MS/, "the 20 s backstop is gone from render.ts");
 });
@@ -443,13 +453,12 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   assert.match(RENDER, /const p = newPending\(text, imgPaths\);\s*\n\s*arr\.push\(p\);/);
   assert.match(RENDER, /if \(!s\) \{ p\.late = true; return; \}/);
   // the clock the bound compares against: the kernel stamps the echo atom at its receipt of the send, in
-  // whole seconds, and the chat builder ships every event's stamp as iso(t)
+  // whole seconds (sdk_backend.py send). That the chat builder ships every event's stamp as iso(t) is
+  // proven behaviourally, not pinned here: tests/test_kernel_fed_echo_absorbed.py (ChatEventSaysAbsorbed)
+  // reads a built user event's ts back as iso(t) of its atom.
   const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
   assert.match(SDK, /sent_t = int\(time\.time\(\)\)/);
-  assert.match(SDK, /"type": "user", "uuid": key, "session_id": sid, "t": sent_t,/);
-  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.match(KERNEL, /t = a\.get\("t"\); ts = iso\(t\) if t else None/);
-  assert.match(KERNEL, /def iso\(t\):\s*\n\s*"""Epoch → the ISO-8601 UTC/);
+  assert.match(SDK, /"t": sent_t\b/);
 });
 
 test("a late stamp presumes the first frame's newest queued copy of the text is this send's own (busy and held queues)", () => {
@@ -555,4 +564,42 @@ test("every composer send posts a clientDiag breadcrumb — sid, time, length, r
   // one owner: the breadcrumb sits in routeUserMessage, which every send path (plain, quote, follow-up, staged flush) goes through
   const fn = RENDER.slice(RENDER.indexOf("function routeUserMessage("), RENDER.indexOf("\n}\n", RENDER.indexOf("function routeUserMessage(")));
   assert.ok(fn.includes('what: "send"'));
+});
+
+// ── (15) one record, several sends ───────────────────────────────────────────────────────────────
+
+test("two back-to-back sends the CLI took as ONE record retire both bubbles; a third with other text stays", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "continue", "continue", "and the docstring");
+  // the kernel's user event for the batched record: md is the blocks joined; `blocks` lists each send
+  const rec: TailEvent = { kind: "user", md: "continue continue", uuid: "u1", blocks: ["continue", "continue"] };
+  const r = reconcilePending([...tail, rec], list);
+  assert.deepEqual(r.landed.map((l) => [l.p, l.idx]), [[list[0], 1], [list[1], 1]], "one copy per block, in send order");
+  assert.deepEqual(r.keep, [list[2]], "the third send's text is in no block");
+  assert.equal(landedIn(rec, list[2]), false);
+  assert.equal(landedIn(rec, list[0]), true);
+  // two sends of DIFFERENT texts batched the same way: each block is its own send's landing
+  const list2 = press(tail, "continue", "and the docstring");
+  const rec2: TailEvent = { kind: "user", md: "continue and the docstring", uuid: "u2", blocks: ["continue", "and the docstring"] };
+  const r2 = reconcilePending([...tail, rec2], list2);
+  assert.deepEqual(r2.landed.map((l) => [l.p.text, l.idx]), [["continue", 1], ["and the docstring", 1]]);
+  // a record of two copies that was already there at the press is background twice over
+  const list3 = press([...tail, rec], "continue");
+  assert.deepEqual(list3[0].at?.seen, ["u1", "u1"], "seen counts copies, not events");
+  assert.equal(reconcilePending([...tail, rec], list3).keep.length, 1, "neither copy is this send's");
+  // across pushes: the first of three identical sends retired on its own record earlier; the two-block
+  // record then retires exactly the two that remain — the claims on one record are counted
+  const list4 = press(tail, "continue", "continue", "continue");
+  let r4 = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u0" }], list4);
+  assert.deepEqual(r4.landed.map((l) => l.p), [list4[0]]);
+  r4 = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u0" }, rec], r4.keep);
+  assert.deepEqual(r4.landed.map((l) => l.p), [list4[1], list4[2]]);
+  assert.equal(r4.keep.length, 0);
+  // a fourth identical send pressed later finds every copy already there: the record of two is two
+  const list5 = press([...tail, { kind: "user", md: "continue", uuid: "u0" }, rec], "continue");
+  assert.deepEqual(list5[0].at?.seen, ["u0", "u1", "u1"], "the press lists the two-block record twice");
+  assert.equal(reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u0" }, rec], list5).keep.length, 1);
+  // the same counting for the kernel's copies: a record of several sends is never an echo (one text each)
+  assert.equal(provisionalIn({ kind: "user", md: "continue continue", uuid: "echo:1", blocks: ["continue", "continue"] }, list[0]), true,
+    "…but were one ever shipped with blocks, its copies would be read the same way");
 });

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -1,0 +1,558 @@
+// Send durability on the client (the 2026-09-05/06 audits). Two things went wrong at once: a send fed
+// into a running turn is taken by the CLI at a later tool boundary and placed at its SEND time, so the
+// pending bubble at the bottom vanished and the message reappeared higher up with no cue; and the
+// client's bubble had a 20 s lifetime, so when the kernel's own echo was pruned early the send simply
+// looked delivered. Now: (1) a pending send has NO lifetime — it ends on a landing, the kernel's
+// never-delivered verdict, or the user's ✕; (2) a landed absorbed atom wears a "joined mid-turn" header
+// and, when it landed above the tail, leaves a cue where the bubble sat ("delivered into the running
+// turn at HH:MM · jump"); (3) every composer send posts a clientDiag breadcrumb (never the text).
+// The 2026-09-06 adversarial review then fixed the decision's frame: (4) every verdict is read from the
+// events AFTER the send's anchor, never from a 30-event tail count; (5) the cue anchors on a RENDERED
+// event; (6) the lost verdict shares the anchor; (7) exact text, one landing per send; (8) a connection
+// drop repaints once; (9) the bare label is per bubble; (10) the kernel's own copy clears "not confirmed".
+// Round 3 of that review: (11) receipt is attributed per send, like landings; (12) the ✕ removes the
+// bubble's own entry; (13) a stamp taken late reads the events' own times. Round 4: (14) a late stamp
+// presumes the frame's newest queued copy of its text is its own (the queued bubble carries no stamp).
+// The decisions are executed through send-pending.ts; the DOM half is pinned in render.ts/styles.css.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { newPending, pendingBody, reconcilePending, dropPending, cueAnchor, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = read("render.ts");
+const CSS = read("styles.css");
+const T0 = 1_700_000_000_000;
+const TEXT = "rename this to fetch_notes";
+
+// The press: registerOptimistic reconciles the fresh entry against the tail as it stands BEFORE any
+// kernel round-trip, which stamps the anchor. Every scenario below starts there.
+const press = (tail: TailEvent[], ...texts: string[]): PendingSend[] => {
+  const list = texts.map((t, i) => newPending(t, undefined, T0 + i));
+  reconcilePending(tail, list);
+  return list;
+};
+const filler = (n: number, prefix = "f"): TailEvent[] =>
+  Array.from({ length: n }, (_, i) => (i % 3 === 0 ? { kind: "thinking", uuid: `${prefix}${i}` } : i % 3 === 1 ? { kind: "tool", uuid: `${prefix}${i}` } : { kind: "assistant", md: "…", uuid: `${prefix}${i}` }));
+
+// ── (1) no lifetime ──────────────────────────────────────────────────────────────────────────────
+
+test("a pending send survives past 20 s — and past any time — without confirmation", () => {
+  const list = press([{ kind: "assistant", md: "still working on the earlier step" }], TEXT);
+  // nothing happens for a minute, then an hour
+  for (const later of [T0 + 21_000, T0 + 60_000, T0 + 3_600_000]) {
+    const r = reconcilePending([{ kind: "assistant", md: "…" }], list);
+    assert.equal(r.keep.length, 1, `still pending at +${(later - T0) / 1000}s`);
+    assert.equal(r.inject.length, 1, "…and still shown: nothing in the payload accounts for it");
+  }
+  assert.doesNotMatch(RENDER, /OPT_TTL_MS/, "the 20 s backstop is gone from render.ts");
+});
+
+test("it clears on the kernel's echo (suppressed) and ends on the landing (retired, with the index)", () => {
+  const list = press([{ kind: "assistant", md: "…", uuid: "a1" }], TEXT);
+  let r = reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "user", md: TEXT, uuid: "echo:1" }], list);
+  assert.equal(r.keep.length, 1, "the kernel's provisional never retires the entry");
+  assert.equal(r.inject.length, 0, "…but ours steps aside while it is visible");
+  r = reconcilePending([
+    { kind: "assistant", md: "…", uuid: "a1" },
+    { kind: "user", md: TEXT, uuid: "att1", absorbed: true },
+    { kind: "tool", uuid: "t9" },
+  ], list);
+  assert.equal(r.keep.length, 0, "a landed user atom ends it");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1], "…naming the landed event, for the cue");
+});
+
+test("an image send lands even though the paths are gone from the text", () => {
+  // the composer appends the dragged paths to the typed text; the CLI rewrites them to "[Image #N]" and the
+  // kernel strips the placeholders and renders the pictures — so the sent text can never match verbatim
+  const text = 'compare with the old one\n/tmp/notes-api/docs/before.png "/tmp/notes-api/docs/after one.png"';
+  const imgs = ["/tmp/notes-api/docs/before.png", "/tmp/notes-api/docs/after one.png"];
+  assert.equal(pendingBody(text, imgs), "compare with the old one");
+  const p = newPending(text, imgs, T0);
+  const landed: TailEvent = { kind: "user", uuid: "u7", md: "compare with the old one", images: [{}, {}] };
+  assert.equal(landedIn(landed, p), true);
+  assert.equal(landedIn({ kind: "user", uuid: "u8", md: "compare with the old one" }, p), false,
+    "the body alone is not enough — the landing must carry the pictures");
+  assert.equal(landedIn({ kind: "user", uuid: "u9", md: 'compare with the old one\n""', images: [{}, {}] }, p), true,
+    "a quoted path's leftover quotes do not break the match");
+  assert.equal(landedIn({ kind: "user", uuid: "u10", md: "compare with the old one, then the new", images: [{}] }, p), false,
+    "exact body, not a substring");
+  assert.equal(landedIn({ kind: "user", uuid: "u11", md: text }, p), true, "paths landing verbatim (an SDK session) match the text itself");
+  reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }], [p]);   // the press: anchored on a tail without it
+  const r = reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }, landed], [p]);
+  assert.equal(r.keep.length, 0, "the pictures-bearing atom after the anchor is the landing");
+});
+
+test("the kernel's never-delivered verdict ends the entry — its bubble carries the text and the resend", () => {
+  const list = press([{ kind: "assistant", md: "…", uuid: "a1" }], TEXT);
+  const r = reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "user", md: TEXT, uuid: "echo:1", undelivered: true }], list);
+  assert.equal(r.keep.length, 0);
+  assert.equal(r.lost.length, 1);
+  assert.equal(r.inject.length, 0, "never a 'sending…' bubble beside a 'never delivered' one");
+  // the kernel's undelivered bubble is the resend path: copy to composer / dismiss (undelivered-echo.test.ts)
+  assert.match(RENDER, /re\.dataset\.act = "echorestore";/);
+});
+
+test("a connection drop marks unconfirmed sends 'not confirmed' — an event, and reversible by a confirmation", () => {
+  assert.match(RENDER, /window\.addEventListener\("romp:wsdown", \(\) => markPendingLost\("connection"\)\);/);
+  assert.match(RENDER, /if \(m\.type === "pipeState"\) \{ if \(!m\.up\) markPendingLost\("connection"\);/,
+    "the VS Code pipe's down edge too — it never fires romp:wsdown");
+  assert.match(RENDER, /function markPendingLost\(why: string\): void \{[\s\S]{0,600}?for \(const p of list\) if \(!p\.lost && !p\.received\) \{ p\.lost = why; changed = true; \}/);
+  // the bubble says so, in the bare group's own label and on the bubble; ✕ stays the way back
+  assert.match(RENDER, /if \(t\.optimistic && t\.lost\) bubble\.title = "not confirmed — the connection dropped after this was sent; ✕ moves it back to the composer to send again";/);
+  assert.match(CSS, /\.queued-head \.queued-count \.lost \{ color: var\(--warn\); \}/);
+  // a confirmation after the reconnect retires it like any other: the flag is display-only
+  const list = press([{ kind: "assistant", md: "…", uuid: "a1" }], "go ahead");
+  list[0].lost = "connection";
+  const r = reconcilePending([{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "user", md: "go ahead", uuid: "u1" }], list);
+  assert.equal(r.keep.length, 0);
+});
+
+// ── (4) the anchor: verdicts are read after the send, never from a tail count ─────────────────────
+
+test("a landing 100 events above the tail still ends the bubble — the scan is bounded by the send's anchor, not a count", () => {
+  const before: TailEvent[] = [{ kind: "user", md: "first ask", uuid: "u0" }, ...filler(12, "b"), { kind: "tool", uuid: "t-last" }];
+  const list = press(before, TEXT);
+  assert.equal(list[0].at?.after, "t-last", "anchored on the last stable kernel event at the press");
+  list[0].lost = "connection";                   // the socket dropped while the turn ran on
+  // the reconnect's full frame: the absorbed atom sits at its SEND time, a hundred events above the tail
+  const after: TailEvent[] = [...before, { kind: "user", md: TEXT, uuid: "att1", absorbed: true }, ...filler(100, "g")];
+  const r = reconcilePending(after, list);
+  assert.equal(r.keep.length, 0, "the landing is after the anchor, wherever the tail has grown to");
+  assert.deepEqual(r.landed.map((l) => l.idx), [before.length]);
+  // the same depth for the kernel's never-delivered verdict
+  const list2 = press(before, TEXT);
+  const r2 = reconcilePending([...before, { kind: "user", md: TEXT, uuid: "echo:9", undelivered: true }, ...filler(100, "g")], list2);
+  assert.equal(r2.lost.length, 1);
+});
+
+test("an anchor that left the resident window (the transcript grew past the wire tail) means everything resident is later", () => {
+  const list = press([{ kind: "assistant", md: "…", uuid: "old-anchor" }], TEXT);
+  // the next full frame is a re-windowed tail that no longer holds the anchor event
+  const r = reconcilePending([...filler(40, "w"), { kind: "user", md: TEXT, uuid: "u-new" }, ...filler(5, "z")], list);
+  assert.equal(r.keep.length, 0);
+  assert.equal(r.landed[0].idx, 40);
+  // and a send into an empty transcript has nothing to anchor on: the head is the start
+  const list2 = press([], TEXT);
+  assert.equal(list2[0].at?.after, null);
+  assert.equal(reconcilePending([{ kind: "user", md: TEXT, uuid: "u1" }], list2).landed.length, 1);
+});
+
+test("what was already there at the press is background: an older identical message, a kernel echo, a queued copy", () => {
+  const tail: TailEvent[] = [
+    { kind: "user", md: TEXT, uuid: "u-old" },
+    { kind: "assistant", md: "done", uuid: "a1" },
+    { kind: "user", md: TEXT, uuid: "echo:prev" },
+    { kind: "queued", texts: [{ md: TEXT }] },
+  ];
+  const list = press(tail, TEXT);
+  assert.equal(list[0].at?.after, "a1", "the anchor skips the kernel's echo: it is replaced when its text lands");
+  assert.deepEqual(list[0].at?.seen, ["u-old", "echo:prev"]);
+  assert.equal(list[0].at?.queued, 1);
+  const r = reconcilePending(tail, list);
+  assert.equal(r.keep.length, 1, "not retired by the older copy");
+  assert.equal(list[0].received, undefined, "the old echo and the old queued copy prove nothing about THIS send");
+  assert.equal(r.inject.length, 1, "…and cover nothing: our bubble shows beside the older copies (two sends, two bubbles)");
+});
+
+// ── (5) the cue anchors on a rendered event ──────────────────────────────────────────────────────
+
+test("cueAnchor: the last kernel event after the landed atom, or null when it landed at the tail", () => {
+  const events: TailEvent[] = [
+    { kind: "user", uuid: "u1", md: "first comment" },
+    { kind: "user", uuid: "att1", md: "second comment", absorbed: true },
+    { kind: "tool", uuid: "t1" },
+    { kind: "tool", uuid: "t2" },
+    { kind: "user", uuid: "echo:9", md: "a third send, still pending at the kernel" },
+    { kind: "queued", uuid: "optimistic:123", texts: [{ md: "ours" }] },
+  ];
+  assert.equal(cueAnchor(events, 1), "t2", "under the event the bubble sat under — never our injection or the kernel's echo");
+  assert.equal(cueAnchor(events.slice(0, 2), 1), null, "landed AT the tail: the swap was in place, no cue owed");
+  assert.equal(cueAnchor([events[0], events[1], { kind: "tool" }], 1), null, "nothing stable to hang it on");
+});
+
+test("cueAnchor skips what the chat does not draw: a thinking tail anchors on the tool before it in compact mode", () => {
+  const events: TailEvent[] = [
+    { kind: "user", uuid: "u1", md: "first comment" },
+    { kind: "user", uuid: "att1", md: "second comment", absorbed: true },
+    { kind: "tool", uuid: "t1" },
+    { kind: "thinking", uuid: "th1" },
+  ];
+  const compact = (e: TailEvent) => e.kind !== "thinking";
+  assert.equal(cueAnchor(events, 1, compact), "t1", "compact mode hides thinking — the cue needs an item that renders");
+  assert.equal(cueAnchor(events, 1), "th1", "full mode draws the thinking block, so the bubble did sit under it");
+  assert.equal(cueAnchor([events[0], events[1], events[3]], 1, compact), null, "only hidden events after the landing: no place for a cue");
+  // render.ts hands over the current mode's rule, and compact mode is what hides thinking (compact.ts)
+  assert.match(RENDER, /const cueRendered = \(e: TailEvent\): boolean => !\(settings\.compact && e\.kind === "thinking"\);/);
+  assert.match(RENDER, /const after = cueAnchor\(s\.events as TailEvent\[\], idx, cueRendered\);/);
+});
+
+// ── (6) the lost verdict shares the anchor ───────────────────────────────────────────────────────
+
+test("a resend of a never-delivered message is not retired by the old verdict — only a verdict after the send counts", () => {
+  // the flow the never-delivered bubble offers: copy to composer, Enter — the old bubble is still in the tail
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }, { kind: "user", md: TEXT, uuid: "echo:old", undelivered: true }];
+  const list = press(tail, TEXT);
+  let r = reconcilePending(tail, list);
+  assert.equal(r.lost.length, 0, "the old verdict is about the old send");
+  assert.equal(r.keep.length, 1);
+  assert.equal(r.inject.length, 1, "…and the old verdict is not a provisional either: our bubble shows");
+  assert.equal(provisionalIn(tail[1], list[0]), false, "a never-delivered echo never suppresses");
+  // the kernel's echo for the resend, then ITS verdict — that one ends the entry
+  r = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:new" }], list);
+  assert.equal(r.inject.length, 0);
+  r = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:new", undelivered: true }], list);
+  assert.equal(r.lost.length, 1);
+  // a shorter send that the old never-delivered text merely contains is not its resend at all
+  const list2 = press([{ kind: "user", md: "ok, go ahead and rename it", uuid: "echo:old", undelivered: true }], "go ahead");
+  assert.equal(reconcilePending([{ kind: "user", md: "ok, go ahead and rename it", uuid: "echo:old", undelivered: true }], list2).keep.length, 1);
+});
+
+// ── (7) exact text, one landing per send ─────────────────────────────────────────────────────────
+
+test("two identical sends in flight: the first landing retires the first, the second the second — across pushes", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "continue", "continue");
+  let r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u1", absorbed: true }, { kind: "tool", uuid: "t1" }], list);
+  assert.equal(r.landed.length, 1, "one landing, one entry");
+  assert.equal(r.landed[0].p, list[0], "…the earlier send");
+  assert.equal(r.keep.length, 1);
+  assert.equal(r.inject.length, 1, "the second still shows: its message has not landed");
+  // the next push (the first entry is gone from the list): the claimed landing stays claimed
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u1", absorbed: true }, { kind: "tool", uuid: "t1" }], r.keep);
+  assert.equal(r.keep.length, 1, "the first send's landing does not retire the second");
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u1", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "user", md: "continue", uuid: "u2" }], r.keep);
+  assert.equal(r.landed.length, 1);
+  assert.equal(r.landed[0].idx, 3, "the second landing is the second send's");
+  // both landing in one push: attributed in order
+  const list2 = press(tail, "continue", "continue");
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u1" }, { kind: "user", md: "continue", uuid: "u2" }], list2);
+  assert.deepEqual(r.landed.map((l) => [l.p, l.idx]), [[list2[0], 1], [list2[1], 2]]);
+});
+
+test("exact text: a pending 'test' is not retired when 'test the continue button' lands, nor the reverse", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "test", "test the continue button");
+  let r = reconcilePending([...tail, { kind: "user", md: "test the continue button", uuid: "u1" }], list);
+  assert.deepEqual(r.landed.map((l) => l.p.text), ["test the continue button"]);
+  assert.deepEqual(r.keep.map((p) => p.text), ["test"]);
+  r = reconcilePending([...tail, { kind: "user", md: "test the continue button", uuid: "u1" }, { kind: "user", md: "test", uuid: "u2" }], r.keep);
+  assert.deepEqual(r.landed.map((l) => [l.p.text, l.idx]), [["test", 2]]);
+  // edge whitespace is the one tolerance: the composer trims, the kernel strips
+  assert.equal(landedIn({ kind: "user", md: "  test\n", uuid: "u3" }, newPending("test")), true);
+  // the kernel's echo and queued bubble are matched the same way
+  const p = newPending("test");
+  assert.equal(provisionalIn({ kind: "user", md: "test the continue button", uuid: "echo:1" }, p), false);
+  assert.equal(provisionalIn({ kind: "queued", texts: [{ md: "test the continue button" }] }, p), false);
+  assert.equal(provisionalIn({ kind: "queued", texts: [{ md: "test" }] }, p), true);
+});
+
+// ── (8) a connection drop repaints once ──────────────────────────────────────────────────────────
+
+test("markPendingLost repaints only when an entry actually changed — the shim fires the down edge on every redial", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function markPendingLost("), RENDER.indexOf("\n}\n", RENDER.indexOf("function markPendingLost(")));
+  assert.match(fn, /let changed = false;/);
+  assert.match(fn, /if \(!changed\) continue;/, "an unchanged session is neither reconciled nor marked stale");
+  assert.match(fn, /if \(sid === activeId\) activeChanged = true;/);
+  assert.match(fn, /if \(activeChanged\) appendActive\(\);/, "the active chat rebuilds only for its own change");
+  assert.doesNotMatch(fn, /if \(activeId && pendingSent\.has\(activeId\)\) appendActive\(\);/);
+});
+
+// ── (9) the bare label is per bubble ─────────────────────────────────────────────────────────────
+
+test("the bare group's label counts lost and sending bubbles separately", () => {
+  const texts = (n: number, m: number) => bareGroupLabel(n, m).parts.map((p) => (p.lost ? "!" : "") + p.text);
+  assert.deepEqual(texts(0, 1), ["sending…"]);
+  assert.deepEqual(texts(0, 3), ["sending 3…"]);
+  assert.deepEqual(texts(1, 0), ["!not confirmed"]);
+  assert.deepEqual(texts(2, 0), ["!2 not confirmed"]);
+  assert.deepEqual(texts(1, 1), ["!not confirmed", "sending…"], "a mixed group names both states, the lost one first");
+  assert.deepEqual(texts(1, 2), ["!not confirmed", "sending 2…"]);
+  assert.match(bareGroupLabel(1, 0).title, /^The connection dropped after this was sent/);
+  assert.match(bareGroupLabel(0, 1).title, /^on its way to the session/);
+  assert.match(bareGroupLabel(1, 1).title, /^The connection dropped after this was sent[\s\S]*The rest: on its way/);
+  // render.ts builds the label from the bubbles' own states, and the ✕'s recount reads them back off the
+  // surviving bubbles (data-lost) — never off the label's previous class
+  assert.match(RENDER, /const nLost = ev\.texts\.filter\(\(t\) => t\.lost\)\.length;\s*\n\s*fillBareLabel\(label, nLost, ev\.texts\.length - nLost\);/);
+  assert.match(RENDER, /if \(t\.optimistic && t\.lost\) bubble\.dataset\.lost = "1";/);
+  assert.match(RENDER, /const nLost = bubbles\.filter\(\(b\) => \(b as HTMLElement\)\.dataset\.lost === "1"\)\.length;\s*\n\s*fillBareLabel\(label, nLost, bubbles\.length - nLost\);/);
+  assert.doesNotMatch(RENDER, /label\.classList\.contains\("lost"\)/);
+  assert.match(RENDER, /const span = el\("span", part\.lost \? "lost" : ""\);/, "only the lost part wears the warn color");
+});
+
+// ── (10) the kernel's own copy clears "not confirmed" ────────────────────────────────────────────
+
+test("the kernel's echo or queued copy seen after the press proves receipt: 'not confirmed' clears and never returns", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, TEXT);
+  list[0].lost = "connection";                                   // the drop, as markPendingLost writes it
+  let r = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:1" }], list);
+  assert.equal(list[0].lost, undefined, "the kernel minted this echo on receipt of the send: the drop did not lose it");
+  assert.equal(list[0].received, true);
+  r = reconcilePending(tail, list);                              // the echo blinks in its echo→landed handoff
+  assert.equal(r.inject.length, 1);
+  assert.equal(r.inject[0].lost, undefined, "…and our bubble steps back in as 'sending…', not as a false loss");
+  // a queued copy that was not listed at the press is the same proof
+  const list2 = press([{ kind: "queued", texts: [{ md: TEXT }] }], TEXT);
+  list2[0].lost = "connection";
+  reconcilePending([{ kind: "queued", texts: [{ md: TEXT }] }], list2);
+  assert.equal(list2[0].lost, "connection", "one copy at the press, one copy now: nothing new");
+  reconcilePending([{ kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], list2);
+  assert.equal(list2[0].lost, undefined, "a second copy is this send's");
+  // a later drop leaves a received send alone (render.ts markPendingLost's guard)
+  assert.match(RENDER, /if \(!p\.lost && !p\.received\) \{ p\.lost = why; changed = true; \}/);
+});
+
+// ── (11) receipt is attributed per send, like landings ───────────────────────────────────────────
+
+test("two identical sends, one kernel echo: the first is received and covered; the second still shows, still unconfirmed", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "continue", "continue");
+  let r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }], list);
+  assert.deepEqual(list.map((p) => p.received), [true, undefined], "one echo is one send's receipt");
+  assert.deepEqual(r.inject, [list[1]], "the kernel's copy covers one bubble; ours shows for the other");
+  assert.deepEqual(list[1].at?.seen, ["echo:1"], "the claimed echo is background for the later send");
+  // the drop (as render.ts markPendingLost writes it): only the unconfirmed send is marked
+  for (const p of list) if (!p.lost && !p.received) p.lost = "connection";
+  assert.deepEqual(list.map((p) => p.lost), [undefined, "connection"]);
+  // the same echo on later pushes proves nothing new — even once the first entry is gone (its ✕)
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }], [list[1]]);
+  assert.equal(list[1].received, undefined);
+  assert.equal(list[1].lost, "connection", "the bubble the kernel never received keeps saying so");
+  assert.equal(r.inject.length, 1);
+  // a second echo is the second send's
+  reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }, { kind: "user", md: "continue", uuid: "echo:2" }], list);
+  assert.deepEqual(list.map((p) => p.received), [true, true]);
+  assert.equal(list[1].lost, undefined);
+  // the claimed echo's verdict is the claimant's too: its never-delivered flag ends the first send only
+  const list2 = press(tail, "continue", "continue");
+  reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }], list2);
+  r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1", undelivered: true }], list2);
+  assert.deepEqual(r.lost, [list2[0]]);
+  assert.deepEqual(r.keep, [list2[1]]);
+});
+
+test("both 'not confirmed', one echo arrives: one label clears, the other stays — and the landing retires the received one", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "continue", "continue");
+  list[0].lost = list[1].lost = "connection";
+  reconcilePending([...tail, { kind: "user", md: "continue", uuid: "echo:1" }], list);
+  assert.deepEqual(list.map((p) => p.lost), [undefined, "connection"]);
+  const r = reconcilePending([...tail, { kind: "user", md: "continue", uuid: "u1" }], list);   // the echo→landed handoff
+  assert.deepEqual(r.landed.map((l) => l.p), [list[0]]);
+  assert.deepEqual(r.keep, [list[1]]);
+  assert.equal(list[1].lost, "connection", "still unconfirmed: the kernel has shown one copy, and it landed");
+});
+
+test("queued copies are handed out by position: one new copy confirms one send; the copies a press listed are its background", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "continue", "continue");
+  let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }] }], list);
+  assert.deepEqual(list.map((p) => p.received), [true, undefined]);
+  assert.deepEqual(r.inject, [list[1]], "one kernel copy, one of ours: two bubbles for two sends");
+  r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }, { md: "continue" }] }], list);
+  assert.deepEqual(list.map((p) => p.received), [true, true]);
+  assert.equal(r.inject.length, 0);
+  // a second press that already saw the first send's copy counts it as background, not as its own
+  const a = press(tail, "continue");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }] }], a);
+  const b = newPending("continue", undefined, T0 + 1);
+  const both = [a[0], b];
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }] }], both);   // b's press: one copy listed already
+  assert.equal(b.at?.queued, 1);
+  assert.equal(b.received, undefined, "the copy b's press listed is a's");
+  reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }, { md: "continue" }] }], both);
+  assert.deepEqual(both.map((p) => p.received), [true, true]);
+});
+
+// ── (12) the ✕ removes the bubble's OWN entry ────────────────────────────────────────────────────
+
+test("✕ on one of two identical bubbles removes that bubble's entry, never the first with the text", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const A = newPending("continue", undefined, T0), B = newPending("continue", undefined, T0 + 5000);
+  const list = [A, B];
+  reconcilePending(tail, list);
+  A.lost = "connection";                                   // A dropped; B was sent after the reconnect
+  let r = reconcilePending(tail, list);
+  assert.deepEqual(r.inject.map((p) => p.lost), ["connection", undefined], "the group reads 'not confirmed · sending…'");
+  // the ✕ on B's bubble names B (data-qts) — the first-with-the-text lookup took A
+  assert.equal(dropPending(list, "continue", B.ts), B);
+  assert.deepEqual(list, [A]);
+  r = reconcilePending(tail, list);
+  assert.deepEqual(r.inject.map((p) => p.lost), ["connection"], "the dismissed bubble stays gone; the lost one stays put");
+  // the ✕ on the LOST bubble of the pair
+  const C = newPending("continue", undefined, T0), D = newPending("continue", undefined, T0 + 5000);
+  const list2 = [C, D];
+  reconcilePending(tail, list2);
+  C.lost = "connection";
+  assert.equal(dropPending(list2, "continue", C.ts), C);
+  assert.deepEqual(list2, [D]);
+  // a bubble whose entry a push already retired removes nothing — never a neighbour with the same text
+  assert.equal(dropPending(list2, "continue", T0 + 999), undefined);
+  assert.deepEqual(list2, [D]);
+  // a ✕ on the KERNEL's own queued copy names no entry of ours: the first pending send with the text goes
+  assert.equal(dropPending(list2, "continue"), D);
+  assert.deepEqual(list2, []);
+  // render.ts: the identity rides the bubble's ✕, and the handler removes by it
+  assert.match(RENDER, /const mk = \(p: PendingSend\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths, lost: p\.lost, qts: p\.ts \}\);/);
+  assert.match(RENDER, /if \(t\.qts !== undefined\) x\.dataset\.qts = String\(t\.qts\);/);
+  assert.match(RENDER, /const qts = el\.dataset\.qts !== undefined \? Number\(el\.dataset\.qts\) : undefined;\s*\n\s*if \(dropPending\(list, qmd, qts\)\) \{ if \(list\.length\) pendingSent\.set\(sidQ, list\); else pendingSent\.delete\(sidQ\); \}/);
+  assert.doesNotMatch(RENDER, /list\.findIndex\(\(p\) => p\.text === qmd\)/);
+});
+
+// ── (13) a late stamp reads the events' own times ────────────────────────────────────────────────
+
+test("a send pressed against no frame (a placeholder tab): the first frame's copy of it is this send's, not background", () => {
+  const isoAt = (s: number) => new Date(s * 1000).toISOString();   // kernel.py iso(t): ISO-8601 UTC, whole seconds
+  const pressMs = T0 + 250;                                          // the press, on the client's clock
+  const S = Math.floor(pressMs / 1000);
+  const late = (): PendingSend => ({ ...newPending(TEXT, undefined, pressMs), late: true });   // registerOptimistic, no resident session
+  // the first frame holds an older identical message, the last step before the send, this send's own
+  // echo, and a step after it
+  const frame: TailEvent[] = [
+    { kind: "user", md: TEXT, uuid: "u-old", ts: isoAt(S - 3600) },
+    { kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 2) },
+    { kind: "user", md: TEXT, uuid: "echo:1", ts: isoAt(S) },     // the kernel stamps the echo at its receipt: the press's second, or later
+    { kind: "assistant", md: "…", uuid: "a2", ts: isoAt(S + 1) },
+  ];
+  let list = [late()];
+  let r = reconcilePending(frame, list);
+  assert.equal(list[0].at?.after, "a1", "the anchor is the last stable event stamped BEFORE the press — not a2");
+  assert.deepEqual(list[0].at?.seen, ["u-old"], "the old message is background; this send's echo is not");
+  assert.equal(list[0].received, true);
+  assert.equal(r.inject.length, 0, "the kernel's echo covers our bubble: no double bubble");
+  const landed: TailEvent[] = [frame[0], frame[1], { kind: "user", md: TEXT, uuid: "u1", ts: isoAt(S) }, frame[3]];
+  r = reconcilePending(landed, list);
+  assert.equal(r.keep.length, 0, "the echo→landed handoff retires it");
+  // the CLI was idle: the first frame already holds the LANDED atom
+  list = [late()];
+  r = reconcilePending(landed, list);
+  assert.equal(list[0].at?.after, "a1", "…and the landed atom is not the anchor either");
+  assert.deepEqual(r.landed.map((l) => l.idx), [2], "it is the landing: the bubble ends, instead of never ending");
+  // a first frame that predates the send entirely stamps exactly as a press-time stamp would
+  list = [late()];
+  reconcilePending([frame[0], frame[1]], list);
+  assert.deepEqual(list[0].at, { after: "a1", seen: ["u-old"], queued: 0 });
+  // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
+  // message that landed within the press's own second is still background
+  const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
+  assert.deepEqual(prompt[0].at?.seen, ["u-same-second"]);
+  assert.equal(prompt[0].at?.after, "u-same-second");
+  // render.ts marks the entry when the press finds no resident session, and stamps it nowhere else
+  assert.match(RENDER, /const p = newPending\(text, imgPaths\);\s*\n\s*arr\.push\(p\);/);
+  assert.match(RENDER, /if \(!s\) \{ p\.late = true; return; \}/);
+  // the clock the bound compares against: the kernel stamps the echo atom at its receipt of the send, in
+  // whole seconds, and the chat builder ships every event's stamp as iso(t)
+  const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+  assert.match(SDK, /sent_t = int\(time\.time\(\)\)/);
+  assert.match(SDK, /"type": "user", "uuid": key, "session_id": sid, "t": sent_t,/);
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /t = a\.get\("t"\); ts = iso\(t\) if t else None/);
+  assert.match(KERNEL, /def iso\(t\):\s*\n\s*"""Epoch → the ISO-8601 UTC/);
+});
+
+test("a late stamp presumes the first frame's newest queued copy of the text is this send's own (busy and held queues)", () => {
+  const isoAt = (s: number) => new Date(s * 1000).toISOString();
+  const pressMs = T0 + 250;
+  const S = Math.floor(pressMs / 1000);
+  const late = (): PendingSend => ({ ...newPending(TEXT, undefined, pressMs), late: true });
+  const step: TailEvent = { kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 2) };
+  // the queued bubble carries no stamp: a busy session's queue (the CLI holds the text) and a held one
+  // (an account limit; the kernel holds it, for hours) look the same to the stamp
+  for (const q of [{ kind: "queued", texts: [{ md: TEXT }] }, { kind: "queued", texts: [{ md: TEXT }], held: { reason: "limit" } }] as TailEvent[]) {
+    const list = [late()];
+    let r = reconcilePending([step, q], list);
+    assert.equal(list[0].at?.queued, 0, "the frame's one copy is presumed this press's, not background");
+    assert.equal(r.inject.length, 0, "the kernel's copy covers our bubble for the whole wait: no double bubble beside it");
+    assert.equal(list[0].received, true);
+    // every later push, the same copy keeps covering it — the entry never sat uncovered until the CLI took it
+    r = reconcilePending([step, q], list);
+    assert.equal(r.inject.length, 0);
+    // …and when the CLI takes the text, the landing ends the bubble (a tmux route: no echo in between)
+    r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u1", ts: isoAt(S + 40) }], list);
+    assert.deepEqual(r.landed.map((l) => l.idx), [1]);
+  }
+  // an older identical copy queued BEFORE the press sits at the head: the newest copy is ours, the older
+  // one is background, so a second frame with a third copy would prove nothing about this send
+  const list = [late()];
+  reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], list);
+  assert.equal(list[0].at?.queued, 1);
+  // the frame was built before the kernel received the send: no copy yet, none presumed; the copy that
+  // follows covers it, exactly as at a press-time stamp
+  const early = [late()];
+  let r = reconcilePending([step], early);
+  assert.deepEqual(early[0].at, { after: "a1", seen: [], queued: 0 });
+  assert.equal(r.inject.length, 1);
+  r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
+  assert.equal(r.inject.length, 0);
+  assert.equal(early[0].received, true);
+  // two identical sends pressed against the same placeholder frame own one copy EACH — and when the frame
+  // lists only one of them (the kernel had not received the second), the second waits for its own
+  const pair = [late(), late()];
+  r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], pair);
+  assert.deepEqual(pair.map((p) => p.at?.queued), [0, 0]);
+  assert.equal(r.inject.length, 0, "both copies are the pair's: neither bubble doubles");
+  const pair2 = [late(), late()];
+  r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], pair2);
+  assert.deepEqual(pair2.map((p) => p.at?.queued), [0, 0], "fewer copies than presses: the count floors at zero");
+  assert.equal(r.inject.length, 1, "one copy covers one send; the other waits for its own");
+  r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], pair2);
+  assert.equal(r.inject.length, 0);
+  // a press-time stamp presumes nothing: its frame predates the press, so every listed copy is background
+  const prompt = press([step, { kind: "queued", texts: [{ md: TEXT }] }], TEXT);
+  assert.equal(prompt[0].at?.queued, 1);
+  // the ✕ on the kernel's copy (which names no entry) drops the one it covers — ours — so cancelling the
+  // queued send leaves no orphan bubble behind
+  const covered = [late()];
+  reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], covered);
+  const mine = covered[0];
+  assert.equal(dropPending(covered, TEXT), mine);
+  assert.equal(covered.length, 0);
+});
+
+// ── (2) the absorbed header and the mid-turn cue ─────────────────────────────────────────────────
+
+test("the landed absorbed atom wears the 'joined mid-turn' header, with the taken-at time one level deeper", () => {
+  assert.match(RENDER, /if \(\(ev as any\)\.absorbed && !romp && !injected && !tagged\) turn\.appendChild\(absorbedHeader\(\(ev as any\)\.landedAt\)\);/);
+  assert.match(RENDER, /function absorbedHeader\(landedAt\?: number \| null\): HTMLElement \{\s*\n\s*const h = el\("div", "absorbed-tag"\);\s*\n\s*h\.textContent = "joined mid-turn";/);
+  assert.match(RENDER, /h\.title = "Sent while the session was working[^"]*"\s*\n\s*\+ \(typeof landedAt === "number" \? ", and the session took it at " \+ hhmm\(landedAt\) : ""\)/,
+    "the time rides the tooltip, not the one-line head");
+  // one header family: the follow-up header's size and alignment, dim rather than accent
+  assert.match(CSS, /\.absorbed-tag \{ max-width: 72%; margin-bottom: 1px; font-size: 0\.82em; color: var\(--dim\); \}/);
+});
+
+test("a landing above the tail leaves the cue where the bubble sat; jump scrolls to the atom; both actions retire it", () => {
+  // recorded at the landing that retired the bubble (never re-derived per build), keyed to the anchor event
+  assert.match(RENDER, /for \(const \{ idx \} of r\.landed\) noteAbsorbedLanding\(s, idx\);/);
+  assert.match(RENDER, /function noteAbsorbedLanding\(s: Session, idx: number\): void \{[\s\S]{0,400}?if \(!ev \|\| !ev\.absorbed \|\| !ev\.uuid\) return;\s*\n\s*const after = cueAnchor\(s\.events as TailEvent\[\], idx, cueRendered\);\s*\n\s*if \(!after\) return;/);
+  assert.match(RENDER, /cues\.push\(\{ after, target: ev\.uuid, landedAt: typeof ev\.landedAt === "number" \? ev\.landedAt : null \}\);/);
+  // rendered with the anchor item on every window build (single events, tool groups, retry groups), so it keeps its place
+  assert.equal((RENDER.match(/appendAbsorbedCues\(v, s, /g) || []).length, 3, "hung under every item shape appendItem renders");
+  assert.match(RENDER, /line\.appendChild\(document\.createTextNode\("delivered into the running turn"\s*\n\s*\+ \(c\.landedAt != null \? " at " \+ hhmm\(c\.landedAt\) : ""\)\)\);/);
+  // click-safe: data-act on the body delegate; jump = scrollToAnchor on the atom's uuid, and the cue is done
+  assert.match(RENDER, /jump\.dataset\.act = "abjump"; jump\.dataset\.target = c\.target;/);
+  assert.match(RENDER, /x\.dataset\.act = "abdismiss"; x\.dataset\.target = c\.target;/);
+  assert.match(RENDER, /abjump: \(elx\) => \{[\s\S]{0,400}?dismissAbsorbedCue\(sidC, target\);[\s\S]{0,200}?if \(target\) scrollToAnchor\(target\);/);
+  assert.match(RENDER, /abdismiss: \(elx\) => \{[\s\S]{0,300}?dismissAbsorbedCue\(sidC, elx\.dataset\.target \|\| ""\);/);
+  // the interrupt marker's chrome, shared by selector rather than copied
+  assert.match(CSS, /\.turn-absorbed-cue \.dot, \.turn-interrupt \.dot \{ background: var\(--dim\); border: none; \}/);
+  assert.match(CSS, /\.absorbed-cue-line, \.interrupt-line \{[^}]*font-style: italic/);
+  assert.match(CSS, /\.absorbed-cue-act,\n\.undelivered-act \{/);
+  // the cue leaves with its tab, like the pending sends
+  assert.equal((RENDER.match(/absorbedCues\.delete\(id\);/g) || []).length, 2);
+});
+
+// ── (3) the breadcrumb ───────────────────────────────────────────────────────────────────────────
+
+test("every composer send posts a clientDiag breadcrumb — sid, time, length, route; never the text", () => {
+  const m = RENDER.match(/vscodeApi\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "send",\s*\n\s*data: \{ ([^}]*) \} \}\);/);
+  assert.ok(m, "the breadcrumb is posted from routeUserMessage");
+  const fields = m![1];
+  assert.match(fields, /\bsid\b/); assert.match(fields, /ts: Date\.now\(\)/); assert.match(fields, /len: text\.length/); assert.match(fields, /route:/);
+  assert.doesNotMatch(fields, /\btext\b(?!\.length)/, "the text itself never leaves the client");
+  assert.doesNotMatch(fields, /\bbody\b|\bmd\b/);
+  // one owner: the breadcrumb sits in routeUserMessage, which every send path (plain, quote, follow-up, staged flush) goes through
+  const fn = RENDER.slice(RENDER.indexOf("function routeUserMessage("), RENDER.indexOf("\n}\n", RENDER.indexOf("function routeUserMessage(")));
+  assert.ok(fn.includes('what: "send"'));
+});

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -1,0 +1,329 @@
+// The chat's client-side PENDING SEND (render.ts registerOptimistic / reconcileOptimistic): a composer
+// send shows its bubble the instant Enter is pressed and re-asserts it on every push until the kernel's
+// payload accounts for the message. The DECISIONS live here, pure, so send-pending.test.ts executes
+// them (the repo's extract-for-execution idiom); render.ts owns the DOM and the per-session maps.
+//
+// An entry has NO LIFETIME. It used to expire after 20 s ("a real send always echoes within this"), and
+// the 2026-09-06 audit watched the case that assumption misses: the kernel's own echo was pruned early,
+// nothing showed a message the CLI still held for 30 s, and the client's bubble gave up at 20 s — the
+// send looked lost, then reappeared higher up. An entry now ends on EVENTS only:
+//   - a LANDED user atom carrying the text, placed AFTER the send's anchor (below), that no earlier
+//     pending send with the same text has already claimed,
+//   - the kernel's NEVER-DELIVERED verdict on it, placed after the same anchor (its dropped-echo bubble
+//     takes over, with the copy-to-composer and dismiss actions),
+//   - the user's ✕ (render.ts's qx delegate drops the entry).
+// A kernel PROVISIONAL (its echo atom, its queued bubble) only COVERS one of ours for the push it is
+// visible on — the durable record is the kernel's (a persisted echo, the dropped marking, the fed-text
+// guard in prune_live), but if it blinks, ours steps straight back in; a copy seen after the press also
+// proves the kernel RECEIVED that one send (`received`, attributed per send like a landing). Nothing here
+// reads a clock: the one comparison of stamps (a late stamp, stampBase) orders two events.
+//
+// THE ANCHOR (2026-09-06 review): every decision is read from the events AFTER the send, never from a
+// count of tail events. At the first reconcile after the press the entry records the uuid of the last
+// stable kernel event (`at.after`) and the uuids of the user events that ALREADY carried the text
+// (`at.seen`: an older identical message, an old echo, an undismissed never-delivered bubble). A
+// landing, a verdict or a provisional counts for this send only when it sits after the anchor and is
+// not in `seen`. The old form read the last 30 events and assumed the landing was near the tail — but an
+// absorbed atom is placed at its SEND time, so after a gap in pushes (a sleep, a reconnect, a turn with
+// many thinking and tool events) it sat far above the tail and, with the lifetime gone, the bubble never
+// ended. When the anchor itself has left the resident window (the transcript grew past the wire tail),
+// everything resident is after it, so the scan starts at the head.
+
+export type SendBase = {
+  after: string | null;   // uuid of the last stable kernel event at the press; null → nothing to anchor on, scan from the head
+  seen: string[];         // uuids of the user events carrying the text at the press: background, never this send
+  queued: number;         // copies of the text the kernel's queued bubble(s) already listed at the press
+};
+
+export type PendingSend = {
+  text: string;        // the sent body, byte for byte — what the kernel echoes and the transcript lands
+  body: string;        // `text` minus its image paths, whitespace-collapsed: an image send lands with the
+                       //   paths rewritten to "[Image #N]" and stripped, so `text` itself can never match
+  ts: number;          // press time (ms) — the bubble's identity (the ✕ names it), never a lifetime
+  at?: SendBase;       // the send's place in the events (stamped by the first reconcile after the press)
+  late?: boolean;      // the press found NO resident frame for the session (a placeholder tab, still
+                       //   loading), so the stamp is taken at the first frame — which may already hold this
+                       //   send's own echo or landing; stampBase then reads the events' own stamps
+  imgPaths?: string[]; // dragged images → the bubble's thumbnails, and the image-aware landing match
+  lost?: string;       // an event after the press that makes non-delivery LIKELY ("connection": the
+                       //   socket dropped) — the bubble says "not confirmed" instead of "sending…"
+  received?: boolean;  // the kernel has shown a copy of the text attributed to THIS send (an echo atom or
+                       //   a queued copy after the press that no earlier same-text send claimed): the send
+                       //   reached it, so a connection drop before or after cannot have lost it — `lost` is
+                       //   cleared and never set again
+};
+
+/** The slice of a chat event the decisions read (render.ts's ChatEvent is a superset). */
+export type TailEvent = {
+  kind: string;
+  md?: string;
+  uuid?: string;
+  ts?: string;          // the kernel's stamp for the event, ISO-8601 UTC (kernel.py `iso(t)`, whole seconds)
+  absorbed?: boolean;
+  undelivered?: boolean;
+  images?: unknown[];
+  texts?: { md?: string }[];
+};
+
+export const OPT_PREFIX = "optimistic:";
+export const isOptimisticUuid = (u?: string): boolean => !!u && u.startsWith(OPT_PREFIX);
+export const isKernelEchoUuid = (u?: string): boolean => !!u && u.startsWith("echo:");
+const collapse = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+/** `text` with its shipped image paths removed (quoted or bare, however the composer joined them). */
+export function pendingBody(text: string, imgPaths?: string[]): string {
+  let t = text;
+  for (const p of imgPaths || []) t = t.split('"' + p + '"').join(" ").split(p).join(" ");
+  return collapse(t);
+}
+
+export function newPending(text: string, imgPaths?: string[], now: number = Date.now()): PendingSend {
+  return { text, body: pendingBody(text, imgPaths), ts: now, imgPaths };
+}
+
+/** EXACT text match, trimmed: the composer trims what it sends and the kernel strips what it lands
+ *  (`" ".join(blocks).strip()`; a follow-up's body after `_split_followup`), so the two agree byte for
+ *  byte apart from edge whitespace. Never a substring test — "test" is not "test the continue button",
+ *  and a landing of the longer message must not retire the shorter send (2026-09-06 review). */
+const sameText = (md: string, text: string): boolean => md.trim() === text.trim();
+
+/** A LANDED user atom carrying this send: a user event whose uuid is not the kernel's echo prefix and
+ *  whose md IS the text — or, for an image send, whose md is the body and which carries images (the
+ *  CLI rewrote the paths to "[Image #N]"; the kernel strips the placeholders and renders the pictures,
+ *  so the paths are gone from the text; a quoted path may leave its quotes behind, so those are set
+ *  aside on both sides). */
+export function landedIn(e: TailEvent, p: PendingSend): boolean {
+  if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return false;
+  if (sameText(e.md, p.text)) return true;
+  if (p.imgPaths && p.imgPaths.length && Array.isArray(e.images) && e.images.length > 0) {
+    const noq = (s: string) => collapse(s.replace(/"/g, ""));
+    return noq(e.md) === noq(p.body);
+  }
+  return false;
+}
+
+/** How many copies of the send's text a kernel queued bubble lists. */
+function queuedCopies(e: TailEvent, p: PendingSend): number {
+  if (e.kind !== "queued" || !Array.isArray(e.texts)) return 0;
+  let n = 0;
+  for (const x of e.texts) if (typeof x.md === "string" && sameText(x.md, p.text)) n++;
+  return n;
+}
+
+/** The kernel's own PROVISIONAL copy of the send: its queued bubble or its unlanded echo atom. A
+ *  never-delivered echo is a VERDICT, not a provisional (lostIn), and never suppresses a bubble. */
+export function provisionalIn(e: TailEvent, p: PendingSend): boolean {
+  if (e.kind === "queued") return queuedCopies(e, p) > 0;
+  return e.kind === "user" && isKernelEchoUuid(e.uuid) && !e.undelivered && typeof e.md === "string" && sameText(e.md, p.text);
+}
+
+/** The kernel's verdict that the send was LOST: its echo, flagged never-delivered (the CLI died holding
+ *  it, or the session moved past it). That bubble carries the text and the resend/dismiss actions. */
+export function lostIn(e: TailEvent, p: PendingSend): boolean {
+  return e.kind === "user" && !!e.undelivered && typeof e.md === "string" && sameText(e.md, p.text);
+}
+
+/** A kernel event a pending send can be anchored to: it has a uuid the kernel will keep. The client's own
+ *  injections and the kernel's echo atoms are excluded — an echo is replaced by the landed atom (a new
+ *  uuid) the moment its text lands, so it is not a stable place. */
+const stableUuid = (e: TailEvent): boolean => !!e.uuid && !isOptimisticUuid(e.uuid) && !isKernelEchoUuid(e.uuid);
+
+/** The kernel's second for an event, off its ISO stamp (kernel.py `iso(t)`); null when it carries none. */
+const eventSecond = (e: TailEvent): number | null => {
+  if (!e.ts) return null;
+  const ms = Date.parse(e.ts);
+  return isNaN(ms) ? null : Math.floor(ms / 1000);
+};
+
+/** Where this send sits among the kernel's events, read once at the first reconcile after the press.
+ *
+ *  At a PRESS-TIME stamp (the normal path) everything resident predates the send by construction — the
+ *  frame arrived before the keystroke — so the whole frame is background and no stamp is read. A LATE
+ *  stamp (`p.late`: the press found no frame — a placeholder tab, still loading) reads a frame that may
+ *  already hold this send's own echo or landing, and it used to read them as background: our dashed
+ *  bubble sat beside the kernel's echo, or a landed send's bubble never ended (2026-09-06 review, round
+ *  3). So a late stamp reads the events' own stamps: an event the kernel stamped at or after the press's
+ *  second is not before the send — neither the anchor nor background. Events with no stamp keep the
+ *  press-time reading, with ONE exception, the queued bubble (below).
+ *
+ *  THE QUEUED PRESUMPTION (round 4): the kernel's queued bubble carries no stamp at all — its texts are
+ *  the queue's bodies and positions — so a late stamp cannot read which of its copies predate the press.
+ *  A late entry therefore PRESUMES the newest `own` copies of its text in the frame (one per identical
+ *  send pressed against the same placeholder frame; the caller counts them) are this press's own, not
+ *  background: the press just happened, and a copy of the same text that appeared with the first frame
+ *  is the one the kernel added at its receipt. Without this, a send into a busy or held session whose
+ *  first frame already listed it recorded that copy as background, so the entry never got a position
+ *  until the CLI took the text: our bubble sat beside the kernel's copy for the whole wait, and its ✕
+ *  would have cancelled the real queued send by body. The presumption's cost, stated: when the kernel had
+ *  NOT yet received the send as the frame was built and an older identical message sits in the queue (a
+ *  held queue keeps one for hours), that older copy is read as this send's — receipt is presumed, and a
+ *  send lost on its way to the kernel hides behind the older copy until the queue moves. That case needs
+ *  the same text queued twice around a page load; the double bubble needed only a send into a queue. A
+ *  stamp on each queued text would make the reading exact and remove the presumption.
+ *
+ *  THE CLOCK ASSUMPTION, stated once: the press is the client's clock (ms); the events wear the kernel
+ *  host's clock in whole seconds — the echo atom is stamped `int(time.time())` at the kernel's receipt
+ *  of the send (sdk_backend.py `send`, before the CLI can see the text), the landed atom by the CLI's
+ *  transcript record, at or after that (T237b), and both reach the client as `ts = iso(t)`. The bound
+ *  holds when the two clocks agree to the second: exactly for a client on the kernel's machine (the
+ *  VS Code webview, the served page there), and for a phone as well as its clock is set. A client
+ *  running BEHIND the kernel reads an older identical message stamped inside the skew as this send's;
+ *  one running AHEAD reads this send's own copy as background, which is the pre-fix reading. The bound
+ *  is confined to the late stamp because that is the only stamp that can meet the send's own records,
+ *  and because at a press-time stamp it could only misfire (an identical message that landed within
+ *  the press's second would read as this send's). */
+export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.late ? 1 : 0): SendBase {
+  const pressS = p.late ? Math.floor(p.ts / 1000) : Infinity;
+  const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
+  let after: string | null = null;
+  for (let i = events.length - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
+  const seen: string[] = [];
+  let queued = 0;
+  for (const e of events) {
+    if (e.kind === "queued") { queued += queuedCopies(e, p); continue; }
+    if (e.kind !== "user" || !e.uuid || isOptimisticUuid(e.uuid) || !beforeSend(e)) continue;
+    if (landedIn(e, p) || lostIn(e, p) || provisionalIn(e, p)) seen.push(e.uuid);
+  }
+  // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
+  // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
+  // had not received every press yet; the copies still to come cover those entries in order)
+  return { after, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+}
+
+/** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
+ *  resident window (then everything resident is later than the send). */
+export function scanFrom(events: TailEvent[], at: SendBase): number {
+  if (at.after === null) return 0;
+  for (let i = events.length - 1; i >= 0; i--) if (events[i].uuid === at.after) return i + 1;
+  return 0;
+}
+
+export type Reconciled = {
+  keep: PendingSend[];                        // still pending after this push
+  inject: PendingSend[];                      // …and not covered by a kernel provisional → show ours
+  landed: { p: PendingSend; idx: number }[];  // retired by a landing; idx = the landed event's index
+  lost: PendingSend[];                        // retired by the kernel's never-delivered verdict
+};
+
+/** One push's decision for a session's pending sends, read off the KERNEL's events (the caller has
+ *  already stripped its own injections). Entries are read in registration order, and ONE kernel record
+ *  accounts for ONE entry — the same rule for a landing and for the kernel's provisional copy:
+ *   - the k-th landing after the anchor retires the k-th pending send with that text, and a landing an
+ *     earlier entry took is background (`seen`) for every later entry with the same text — two
+ *     identical sends in flight used to both retire on the first landing (2026-09-06 review);
+ *   - the k-th kernel copy of the text after the anchor — an echo atom no earlier entry claimed, or a
+ *     queued copy beyond the entry's press-time count — covers the k-th pending send with that text: it
+ *     hides that send's bubble for this push and proves the kernel received THAT send (`received`). A
+ *     claimed echo joins later same-text entries' `seen` for good; queued copies carry no identity, so
+ *     they are handed out by position within a push (the copies an entry's press listed are its
+ *     background). One echo used to mark every same-text entry received and clear every "not confirmed"
+ *     (2026-09-06 review, round 3): with two identical sends in flight and one of them lost, the lost
+ *     one read "sending…" for good, and nothing could ever mark it.
+ *  Identical texts carry no identity of their own, so WHICH send a copy belongs to is attributed by
+ *  order, exactly as landings are; the COUNT of confirmed sends is what the kernel's records support.
+ *  When the kernel hides a fed send's echo behind a same-text queued copy (its chat dedups by text), a
+ *  received send can read "not confirmed" after a drop until a copy of its own shows; that clears on the
+ *  next kernel copy, and the error is toward "not confirmed", never toward a false "sending…". */
+export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reconciled {
+  // First reconcile after the send: whatever the events ALREADY hold for this text is background — an
+  // older identical message, an old echo, an undismissed never-delivered bubble — not this send. Only
+  // what appears after the anchor, beyond that set, is this send's (the user 2026-08-09, who watched
+  // resends vanish in the call that created them; the 2026-09-06 review, which watched a resend of a
+  // never-delivered message retired as lost by the old verdict). Late entries stamped against this frame
+  // each presume ONE of its queued copies of their text is their own (stampBase's queued presumption), so
+  // identical sends pressed against the same placeholder frame own as many copies as there were presses.
+  const lateOwn = new Map<string, number>();
+  for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
+  for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
+  const r: Reconciled = { keep: [], inject: [], landed: [], lost: [] };
+  const claimed = new Set<number>();                   // landing indices taken by an earlier entry THIS push
+  const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
+  for (const p of list) {
+    const at = p.at!;
+    const from = scanFrom(events, at);
+    let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0;
+    for (let i = from; i < events.length; i++) {
+      const e = events[i];
+      if (e.uuid && at.seen.includes(e.uuid)) continue;
+      if (e.kind === "queued") { copies += queuedCopies(e, p); continue; }
+      if (landedIdx < 0 && !claimed.has(i) && landedIn(e, p)) { landedIdx = i; continue; }
+      if (lostIdx < 0 && lostIn(e, p)) { lostIdx = i; continue; }
+      if (echoIdx < 0 && provisionalIn(e, p)) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
+    }
+    // ONE kernel copy covers ONE send: an unclaimed echo atom first — its uuid is then background for
+    // every later same-text entry, this push and every push after (the claim must outlive the claimant:
+    // a ✕ on it must not hand its echo to the next entry) — else the first queued copy beyond this
+    // entry's press-time count that no earlier entry took this push.
+    let covered = false;
+    if (echoIdx >= 0) {
+      covered = true;
+      const u = events[echoIdx].uuid;
+      if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+    } else if (copies > at.queued) {
+      const taken = takenCopies.get(p.text) || new Set<number>();
+      for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; break; }
+      takenCopies.set(p.text, taken);
+    }
+    if (covered) p.received = true;             // the kernel holds this send: proven once, latched
+    if (p.received) p.lost = undefined;         // the drop is older news than the kernel's own copy
+    if (landedIdx >= 0) {
+      claimed.add(landedIdx);
+      const u = events[landedIdx].uuid;
+      // this landing is spoken for: background for every later pending send with the same text, on this
+      // push and every push after (the retired entry's claim would otherwise leave with it)
+      if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+      r.landed.push({ p, idx: landedIdx });
+      continue;
+    }
+    if (lostIdx >= 0) { r.lost.push(p); continue; }
+    r.keep.push(p);
+    if (!covered) r.inject.push(p);
+  }
+  return r;
+}
+
+/** The entry a ✕ on a pending bubble removes: the one the bubble NAMES (`ts`, ridden on the ✕ as
+ *  data-qts) — or, for a ✕ on the KERNEL's own queued/parked copy, which names no entry of ours, the
+ *  first pending send with that text, the one the kernel's first copy covers. Same-text entries carry
+ *  different states (lost, received), and the first-with-the-text lookup the ✕ used for every bubble
+ *  dropped the wrong one from a "not confirmed · sending…" pair: the next push brought the dismissed
+ *  bubble back and the other was gone without a gesture (2026-09-06 review, round 3). Returns the removed
+ *  entry; undefined when none matched — a bubble whose entry a push already retired removes nothing,
+ *  never a neighbour with the same text. */
+export function dropPending(list: PendingSend[], text: string, ts?: number): PendingSend | undefined {
+  const i = ts !== undefined ? list.findIndex((p) => p.ts === ts && p.text === text) : list.findIndex((p) => p.text === text);
+  return i >= 0 ? list.splice(i, 1)[0] : undefined;
+}
+
+/** Where the pending bubble SAT when its message landed higher up: the uuid of the last RENDERED kernel
+ *  event after `landedIdx` (the bubble rode the tail, under that event). null when the landed atom is
+ *  itself the tail — the swap happened in place and no cue is owed. The client's own injections and the
+ *  kernel's echo atoms are skipped: neither is a stable place to hang a note. `rendered` says which
+ *  events the chat draws in its current mode — compact mode (the default) hides thinking, and a cue
+ *  anchored to a hidden event is never drawn and can never be dismissed (2026-09-06 review). */
+export function cueAnchor(events: TailEvent[], landedIdx: number, rendered: (e: TailEvent) => boolean = () => true): string | null {
+  for (let j = events.length - 1; j > landedIdx; j--) {
+    const e = events[j];
+    if (!stableUuid(e) || !rendered(e)) continue;
+    return e.uuid!;
+  }
+  return null;
+}
+
+/** The bare group's one-line header, from its bubbles' OWN states: the lost ones (the connection dropped
+ *  after the press and nothing has confirmed them) read "not confirmed", the rest "sending…". A group
+ *  used to read "N not confirmed" when ANY bubble was lost, and kept that label for the survivors after
+ *  a ✕ (2026-09-06 review). */
+export type BareLabelPart = { text: string; lost: boolean };
+export function bareGroupLabel(nLost: number, nSending: number): { parts: BareLabelPart[]; title: string } {
+  const parts: BareLabelPart[] = [];
+  if (nLost > 0) parts.push({ text: nLost === 1 ? "not confirmed" : `${nLost} not confirmed`, lost: true });
+  if (nSending > 0) parts.push({ text: nSending === 1 ? "sending…" : `sending ${nSending}…`, lost: false });
+  const lostTitle = "The connection dropped after " + (nLost === 1 ? "this was" : "these were")
+    + " sent, and romp has not confirmed the session has " + (nLost === 1 ? "it" : "them") + ". ✕ moves "
+    + (nLost === 1 ? "it" : "one") + " back to the composer to send again.";
+  const sendingTitle = "on its way to the session — cancellable until the session takes it";
+  const title = nLost > 0 && nSending > 0 ? lostTitle + " The rest: " + sendingTitle + "."
+    : nLost > 0 ? lostTitle : sendingTitle;
+  return { parts, title };
+}

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -23,7 +23,10 @@
 // stable kernel event (`at.after`) and the uuids of the user events that ALREADY carried the text
 // (`at.seen`: an older identical message, an old echo, an undismissed never-delivered bubble). A
 // landing, a verdict or a provisional counts for this send only when it sits after the anchor and is
-// not in `seen`. The old form read the last 30 events and assumed the landing was near the tail — but an
+// not in `seen`. ONE RECORD CAN CARRY SEVERAL SENDS (2026-09-07 review): the CLI takes back-to-back
+// sends at one boundary as one user record with a text block each, and the kernel ships those blocks
+// (`blocks`); such a record is as many copies as it has matching blocks, and `seen` lists its uuid once
+// per copy already spoken for. The old form read the last 30 events and assumed the landing was near the tail — but an
 // absorbed atom is placed at its SEND time, so after a gap in pushes (a sleep, a reconnect, a turn with
 // many thinking and tool events) it sat far above the tail and, with the lifetime gone, the bubble never
 // ended. When the anchor itself has left the resident window (the transcript grew past the wire tail),
@@ -31,7 +34,9 @@
 
 export type SendBase = {
   after: string | null;   // uuid of the last stable kernel event at the press; null → nothing to anchor on, scan from the head
-  seen: string[];         // uuids of the user events carrying the text at the press: background, never this send
+  seen: string[];         // uuids of the user events carrying the text that are background for this send: what
+                          //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
+                          //   COPY (a record of several sends lists its uuid once per spoken-for block)
   queued: number;         // copies of the text the kernel's queued bubble(s) already listed at the press
 };
 
@@ -63,6 +68,9 @@ export type TailEvent = {
   undelivered?: boolean;
   images?: unknown[];
   texts?: { md?: string }[];
+  blocks?: string[];    // a user record the CLI wrote from SEVERAL sends taken at one boundary: one text per
+                        //   block (kernel.py build_session ships them when there are two or more); `md` is
+                        //   the blocks joined, so each block is a copy of its own send
 };
 
 export const OPT_PREFIX = "optimistic:";
@@ -87,20 +95,34 @@ export function newPending(text: string, imgPaths?: string[], now: number = Date
  *  and a landing of the longer message must not retire the shorter send (2026-09-06 review). */
 const sameText = (md: string, text: string): boolean => md.trim() === text.trim();
 
-/** A LANDED user atom carrying this send: a user event whose uuid is not the kernel's echo prefix and
- *  whose md IS the text — or, for an image send, whose md is the body and which carries images (the
- *  CLI rewrote the paths to "[Image #N]"; the kernel strips the placeholders and renders the pictures,
- *  so the paths are gone from the text; a quoted path may leave its quotes behind, so those are set
- *  aside on both sides). */
-export function landedIn(e: TailEvent, p: PendingSend): boolean {
-  if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return false;
-  if (sameText(e.md, p.text)) return true;
+/** How many COPIES of the send's text a user event carries: one when its md IS the text; otherwise one
+ *  per text block that is. The CLI takes back-to-back sends at one boundary as ONE user record with a
+ *  block per send (the shape the kernel's own echo prune, `_atom_user_texts`, was written for), and the
+ *  event's md is the blocks joined — so with an md-only test none of those sends' bubbles ever ended
+ *  (2026-09-07 review). The kernel ships `blocks` only when there are two or more. */
+function textCopies(e: TailEvent, p: PendingSend): number {
+  if (typeof e.md === "string" && sameText(e.md, p.text)) return 1;
+  let n = 0;
+  if (Array.isArray(e.blocks)) for (const b of e.blocks) if (typeof b === "string" && sameText(b, p.text)) n++;
+  return n;
+}
+
+/** How many copies of this send a LANDED user atom carries: a user event whose uuid is not the kernel's
+ *  echo prefix and whose md (or one of whose blocks) IS the text — or, for an image send, whose md is
+ *  the body and which carries images (the CLI rewrote the paths to "[Image #N]"; the kernel strips the
+ *  placeholders and renders the pictures, so the paths are gone from the text; a quoted path may leave
+ *  its quotes behind, so those are set aside on both sides). */
+export function landedCopies(e: TailEvent, p: PendingSend): number {
+  if (e.kind !== "user" || typeof e.md !== "string" || isKernelEchoUuid(e.uuid)) return 0;
+  const n = textCopies(e, p);
+  if (n) return n;
   if (p.imgPaths && p.imgPaths.length && Array.isArray(e.images) && e.images.length > 0) {
     const noq = (s: string) => collapse(s.replace(/"/g, ""));
-    return noq(e.md) === noq(p.body);
+    return noq(e.md) === noq(p.body) ? 1 : 0;
   }
-  return false;
+  return 0;
 }
+export const landedIn = (e: TailEvent, p: PendingSend): boolean => landedCopies(e, p) > 0;
 
 /** How many copies of the send's text a kernel queued bubble lists. */
 function queuedCopies(e: TailEvent, p: PendingSend): number {
@@ -110,18 +132,29 @@ function queuedCopies(e: TailEvent, p: PendingSend): number {
   return n;
 }
 
-/** The kernel's own PROVISIONAL copy of the send: its queued bubble or its unlanded echo atom. A
- *  never-delivered echo is a VERDICT, not a provisional (lostIn), and never suppresses a bubble. */
-export function provisionalIn(e: TailEvent, p: PendingSend): boolean {
-  if (e.kind === "queued") return queuedCopies(e, p) > 0;
-  return e.kind === "user" && isKernelEchoUuid(e.uuid) && !e.undelivered && typeof e.md === "string" && sameText(e.md, p.text);
+/** The kernel's own PROVISIONAL copies of the send: its queued bubble's, or its unlanded echo atom (one
+ *  text, the send's own — the kernel builds every echo from a single block). A never-delivered echo is a
+ *  VERDICT, not a provisional (lostIn), and never suppresses a bubble. */
+function provisionalCopies(e: TailEvent, p: PendingSend): number {
+  if (e.kind === "queued") return queuedCopies(e, p);
+  return e.kind === "user" && isKernelEchoUuid(e.uuid) && !e.undelivered ? textCopies(e, p) : 0;
 }
+export const provisionalIn = (e: TailEvent, p: PendingSend): boolean => provisionalCopies(e, p) > 0;
 
 /** The kernel's verdict that the send was LOST: its echo, flagged never-delivered (the CLI died holding
  *  it, or the session moved past it). That bubble carries the text and the resend/dismiss actions. */
-export function lostIn(e: TailEvent, p: PendingSend): boolean {
-  return e.kind === "user" && !!e.undelivered && typeof e.md === "string" && sameText(e.md, p.text);
+function lostCopies(e: TailEvent, p: PendingSend): number {
+  return e.kind === "user" && !!e.undelivered ? textCopies(e, p) : 0;
 }
+export const lostIn = (e: TailEvent, p: PendingSend): boolean => lostCopies(e, p) > 0;
+
+/** The copies of the send a USER event carries in whichever role it plays — the roles are disjoint (a
+ *  landed atom is never the kernel's echo; the verdict is the flagged echo), so at most one is non-zero. */
+const copiesIn = (e: TailEvent, p: PendingSend): number =>
+  e.kind !== "user" ? 0 : landedCopies(e, p) || lostCopies(e, p) || provisionalCopies(e, p);
+
+/** How many copies of the event `u` are already spoken for from this send's point of view. */
+const spokenFor = (at: SendBase, u: string): number => { let n = 0; for (const s of at.seen) if (s === u) n++; return n; };
 
 /** A kernel event a pending send can be anchored to: it has a uuid the kernel will keep. The client's own
  *  injections and the kernel's echo atoms are excluded — an echo is replaced by the landed atom (a new
@@ -182,7 +215,8 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   for (const e of events) {
     if (e.kind === "queued") { queued += queuedCopies(e, p); continue; }
     if (e.kind !== "user" || !e.uuid || isOptimisticUuid(e.uuid) || !beforeSend(e)) continue;
-    if (landedIn(e, p) || lostIn(e, p) || provisionalIn(e, p)) seen.push(e.uuid);
+    const n = copiesIn(e, p);
+    for (let k = 0; k < n; k++) seen.push(e.uuid);   // once per COPY: a record of several sends is several
   }
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
@@ -210,7 +244,10 @@ export type Reconciled = {
  *  accounts for ONE entry — the same rule for a landing and for the kernel's provisional copy:
  *   - the k-th landing after the anchor retires the k-th pending send with that text, and a landing an
  *     earlier entry took is background (`seen`) for every later entry with the same text — two
- *     identical sends in flight used to both retire on the first landing (2026-09-06 review);
+ *     identical sends in flight used to both retire on the first landing (2026-09-06 review). A record
+ *     of SEVERAL sends (`blocks`) is as many landings as it has matching blocks, so the claims on one
+ *     record are COUNTED (this push in `claimed`, for good in `seen`), never booleaned — two sends the
+ *     CLI took as one record used to leave both bubbles pending for ever (2026-09-07 review);
  *   - the k-th kernel copy of the text after the anchor — an echo atom no earlier entry claimed, or a
  *     queued copy beyond the entry's press-time count — covers the k-th pending send with that text: it
  *     hides that send's bubble for this push and proves the kernel received THAT send (`received`). A
@@ -236,7 +273,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
   for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
   const r: Reconciled = { keep: [], inject: [], landed: [], lost: [] };
-  const claimed = new Set<number>();                   // landing indices taken by an earlier entry THIS push
+  const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
   for (const p of list) {
     const at = p.at!;
@@ -244,16 +281,19 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     let landedIdx = -1, lostIdx = -1, echoIdx = -1, copies = 0;
     for (let i = from; i < events.length; i++) {
       const e = events[i];
-      if (e.uuid && at.seen.includes(e.uuid)) continue;
       if (e.kind === "queued") { copies += queuedCopies(e, p); continue; }
-      if (landedIdx < 0 && !claimed.has(i) && landedIn(e, p)) { landedIdx = i; continue; }
-      if (lostIdx < 0 && lostIn(e, p)) { lostIdx = i; continue; }
-      if (echoIdx < 0 && provisionalIn(e, p)) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
+      // the copies of this event that are NOT this send's: background at the stamp, or claimed by an
+      // entry retired since (`seen`); a landing an earlier entry took this push is counted in `claimed`
+      const spoken = e.uuid ? spokenFor(at, e.uuid) : 0;
+      if (landedIdx < 0 && landedCopies(e, p) > spoken + (claimed.get(i + "\0" + p.text) || 0)) { landedIdx = i; continue; }
+      if (lostIdx < 0 && lostCopies(e, p) > spoken) { lostIdx = i; continue; }
+      if (echoIdx < 0 && provisionalCopies(e, p) > spoken) echoIdx = i;   // the first echo no earlier entry claimed (`seen`)
     }
     // ONE kernel copy covers ONE send: an unclaimed echo atom first — its uuid is then background for
     // every later same-text entry, this push and every push after (the claim must outlive the claimant:
-    // a ✕ on it must not hand its echo to the next entry) — else the first queued copy beyond this
-    // entry's press-time count that no earlier entry took this push.
+    // a ✕ on it must not hand its echo to the next entry; an echo is one text, so one entry in `seen` is
+    // the whole of it) — else the first queued copy beyond this entry's press-time count that no
+    // earlier entry took this push.
     let covered = false;
     if (echoIdx >= 0) {
       covered = true;
@@ -267,17 +307,22 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
     if (p.received) p.lost = undefined;         // the drop is older news than the kernel's own copy
     if (landedIdx >= 0) {
-      claimed.add(landedIdx);
-      const u = events[landedIdx].uuid;
-      // this landing is spoken for: background for every later pending send with the same text, on this
-      // push and every push after (the retired entry's claim would otherwise leave with it)
-      if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
+      const ck = landedIdx + "\0" + p.text;             // per text: a record of two DIFFERENT sends is one landing for each
+      claimed.set(ck, (claimed.get(ck) || 0) + 1);
       r.landed.push({ p, idx: landedIdx });
       continue;
     }
     if (lostIdx >= 0) { r.lost.push(p); continue; }
     r.keep.push(p);
     if (!covered) r.inject.push(p);
+  }
+  // Every landing claimed this push is spoken for: one copy per claim becomes background for every
+  // pending send with the same text that STAYS, on every push after (the retired entry's claim would
+  // otherwise leave with it, and the next identical send would retire on a record that was never its
+  // own). Once per claim — the claimant leaves the list with this push — so `seen` counts exactly.
+  for (const { p, idx } of r.landed) {
+    const u = events[idx].uuid;
+    if (u) for (const q of r.keep) if (q.text === p.text) q.at!.seen.push(u);
   }
   return r;
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1843,13 +1843,23 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   font-size: 0.82em; color: var(--vscode-errorForeground, #f48771);
   letter-spacing: 0.02em; margin-right: 4px;
 }
+.absorbed-cue-act,
 .undelivered-act {
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
   border: 1px solid var(--card-border); background: transparent; color: var(--dim);   /* T141: the one button rest */
-  cursor: pointer; user-select: none;
+  cursor: pointer; user-select: none; font-style: normal;
   transition: color 0.12s ease, border-color 0.12s ease;
 }
-.undelivered-act:hover { color: var(--fg); border-color: var(--accent); }
+.absorbed-cue-act:hover, .undelivered-act:hover { color: var(--fg); border-color: var(--accent); }
+/* "joined mid-turn" header (kernel ev.absorbed): the CLI took this message at a later tool boundary and the
+   transcript places it at its SEND time, so it reads above steps that were already running — the header says
+   why. The follow-up header's size and alignment (one header family over an outgoing bubble); dim, not the
+   accent: a note, not a link. */
+.absorbed-tag { max-width: 72%; margin-bottom: 1px; font-size: 0.82em; color: var(--dim); }
+/* a pending bubble whose confirmation is in doubt — the connection dropped after the press (send-pending.ts
+   `lost`): the bare group's label counts it in a warn-amber "not confirmed" part; the group's other bubbles
+   keep their dim "sending…" part beside it (one label, per-bubble state) */
+.queued-head .queued-count .lost { color: var(--warn); }
 /* compact "↩ Follow-up · <goal>" header above a message that resumed a goal — landed user turns AND pending
    queued messages, so the two render the same (the user 2026-06-27). Right-aligned with the outgoing bubble. */
 /* ONE font size across the whole header + its context box (the user 2026-07-02: the header was a soup of
@@ -2804,9 +2814,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .chip-interrupting { background: var(--st-working-bg); color: var(--st-working-fg, #332600); opacity: 0.75; }
 /* the stop button's click-ack is now REMOVAL + the optimistic chip flip (the user 2026-07-05): the word
    "interrupting…" no longer rides the fixed-width button (it overflowed onto the elapsed timer). */
-/* the transcript's interrupt MARKER — the compact-divider's language for "you stopped it here" */
-.turn-interrupt .dot { background: var(--dim); border: none; }
-.interrupt-line { display: flex; align-items: center; gap: 6px; color: var(--dim); font-size: 0.82em; font-style: italic; }
+/* the transcript's interrupt MARKER — the compact-divider's language for "you stopped it here". The mid-turn
+   CUE (.turn-absorbed-cue: where a pending bubble sat when its message landed higher up) wears the same
+   chrome — a rail ring and one dim italic line — plus jump/✕ in .absorbed-cue-act's small-button rest. */
+.turn-absorbed-cue .dot, .turn-interrupt .dot { background: var(--dim); border: none; }
+.absorbed-cue-line, .interrupt-line { display: flex; align-items: center; gap: 6px; color: var(--dim); font-size: 0.82em; font-style: italic; }
 .interrupt-square { width: 8px; height: 8px; border-radius: 2px; background: var(--dim); flex: none; }
 
 /* rail dots are nav handles: hover white-highlights this turn's event on the

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\] \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {

--- a/vscode-extension/src/pipe-durability.test.ts
+++ b/vscode-extension/src/pipe-durability.test.ts
@@ -40,7 +40,9 @@ test("chat and feed panels both post pipeState into their webviews", () => {
 
 test("both webviews render the pipe-down banner with the held count", () => {
   for (const [name, src] of [["render.ts", RENDER], ["feed.ts", FEED]] as const) {
-    assert.ok(src.includes('if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }'),
+    // the chat's handler also marks unconfirmed sends "not confirmed" on the down edge (render.ts
+    // markPendingLost); the feed has no sends, so the group is optional and the feed's bare form still matches
+    assert.match(src, /if \(m\.type === "pipeState"\) \{ (?:if \(!m\.up\) markPendingLost\("connection"\); )?pipeBanner\(!!m\.up, Number\(m\.queued\) \|\| 0\); return; \}/,
       `${name} must handle pipeState`);
     assert.ok(src.includes("held, sending when it's back"), `${name} must count held messages`);
   }


### PR DESCRIPTION
Depends on #1006 (the send-durability PR), which depends on #1000; both must merge first. GitHub shows their commits in this diff until then.

Stacks on the send-durability PR (branch echo-durability-offer), which stacks on the live-tail PR: review and merge those first; this PR's own diff is bf4279da..4b6c0e1e.

## What breaks

Both defects show in one scenario. In a `web` session on a `notes-api` project, the user sends a comment at T+38 while a Bash tool is running. The CLI holds the send until the tool's result at T+50, then writes it into the transcript as a `queued_command` attachment stamped with the send time.

1. The chat's pending bubble expired after 20 s (`OPT_TTL_MS` in `ui/webview/render.ts`, "a real send always echoes within this"). A send held behind a running tool can wait longer than that, so the bubble gave up and the send looked delivered while nothing on screen showed it.
2. When the CLI takes the message, its atom is placed at the send time, above the tool calls that streamed while it waited. The bubble the user was watching at the bottom vanished and the message reappeared higher up with nothing explaining the move.

## The fix

**Kernel** (commit 1). `event_model._absorbed_atom` stamps `landedT` on an absorbed atom at emit time: the repaired timestamp of the attachment's file-order predecessor (the tool_result the splice waited for), read off a `(seq, ts)` list appended in ingest order and bisected (`_landing_t`). Attachments are skipped as witnesses, so several sends drained at one boundary all read that boundary. The predecessor rather than the successor, so an assembly fold that sees the attachment as the newest record still stamps it. `landedT` is clamped to never precede the send (whole-second stamps can invert a sub-second gap; anything larger is a shape the CLI does not write), and each clamp is counted as `landedT-clamp` in `_ASM_STATS` beside `ts-repair`, so it is already served in the version route's `parse` dict. `build_session`'s `kind:"user"` event carries `absorbed: true` and `landedAt`. Metadata only: the atom set, seg ids and `PLACEMENTS_V` are unchanged, and the placements canary passes unchanged. The two goldens with absorbed atoms (`multi_input_absorbed.json`, `popall.json`) are regenerated: their scenarios wrote tool_use, queue op, attachment with no tool_result and stamped the attachment at the remove time, a shape the CLI never writes, so they had pinned a `landedT` 30 to 40 s before the send. No other fixture changes.

**Client** (commit 2). `ui/webview/send-pending.ts` (new, pure, executed by its test) owns the decision; `render.ts` owns the DOM and the per-session maps.

- No lifetime. An entry ends on a landing, the kernel's never-delivered verdict, or the user's ✕.
- Anchored. Each entry is anchored at the first reconcile after the press (the last stable kernel event, the user events already carrying the text, the queued copies already listed); every verdict is read from the events after that anchor, so a landing placed far above the tail still ends the bubble (the old 30-event window did not). Exact trimmed text replaces the substring match ("test" is not ended by "test the continue button"); one landing retires one entry (two identical sends end in send order); a kernel echo or queued copy is attributed per send the same way and proves receipt.
- A connection drop (`romp:wsdown`, or the VS Code pipe's down edge) marks unconfirmed sends "not confirmed" (warn color, per-bubble label; ✕ returns the text to the composer). A kernel copy clears it. Only a changed entry repaints, since the shim redials every ~1.5 s while down.
- The ✕ names its own entry (`data-qts`), never the first with the same text.
- A send pressed against a placeholder tab stamps late, reading the events' own stamps. The clock assumption (client and kernel host agree to the second) is stated once in `stampBase`, and its one misread (an older identical copy already queued) is stated where it lives.
- A landed absorbed atom wears a "joined mid-turn" header, with the taken-at time on hover. When its landing retired a bubble at the tail, a cue stays where the bubble sat ("delivered into the running turn at HH:MM", jump / ✕), hung under the event the bubble sat under, in the interrupt marker's chrome, and anchored only on an event the chat draws in its current mode (compact mode hides thinking).
- Every composer send posts a `clientDiag` breadcrumb (sid, ts, length, route; never the text), so a vanished send can be traced in `client-diag.jsonl`.

**Pins** (commit 3). `optimistic-send.test.ts` runs the module instead of a replica; the queued `texts` type pins in `queued-indicator.test.ts` and `followup-render.test.ts` gain `lost` and `qts`; the pipeState pin in `pipe-durability.test.ts` becomes a regex with an optional `markPendingLost` group, so `feed.ts`'s unchanged handler still matches.

## Tests

Python: `AbsorbedAtomCarriesItsLandingTime` (full parse, assembly fold, two splices at one boundary, clamp, no predecessor) and `ChatEventSaysAbsorbed` (build_session wire fields over a hermetic state root) in `tests/test_kernel_fed_echo_absorbed.py`; `AbsorbedLandingNeverPrecedesTheSend` in `tests/test_event_model_golden.py` (every golden; the realistic shape; an inverted witness clamps and is counted; an equal stamp is not a clamp).

Node: `ui/webview/send-pending.test.ts` executes every rule above and pins the header, the cue, the delegates and the breadcrumb in `render.ts`.

Red first: with the event_model hunks reverted, `AbsorbedLandingNeverPrecedesTheSend` fails (KeyError 'landedT') and both goldens fail the tree compare; with only the kernel.py hunk reverted, `ChatEventSaysAbsorbed` fails; against the base `render.ts`, 11 of 25 send-pending tests fail (the first on `OPT_TTL_MS` still present), and the test bundle does not build without `send-pending.ts`.

Local runs: full pytest 7689 passed, 46 skipped; `npm run typecheck` clean; `npm test` 2863/2863; `npm run build` OK; bats 429/429. No Linux-only surface: pure Python (event model, chat builder) and TypeScript, covered by CI's pytest and vscode-extension jobs; bats is untouched.

## Notes for the reviewer

- UI tooltips name romp ("romp hasn't confirmed the session has it yet"), matching the existing copy on the same bubble.
- Adjacent to open PR #961 (renderQueued's `bubble.innerHTML = md(t.md)` line and the import block) and #955 (`queued-indicator.test.ts`): whichever lands second rebases trivially.
- No behaviour change on the tmux route.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

