### PR TITLE
Tests: a run leaves nothing in the system temp dir, and fixture git reads no developer config

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -2425,9 +2425,12 @@ else
     # it's up, so an external watcher is the only way to surface it. Background a
     # check that sets @claude-state=picker if the session stays stuck on the picker
     # (the feed treats that as NEEDS INPUT). We do NOT auto-answer it — guessing the
-    # key / "from summary" loses context; the user clears it by hand.
+    # key / "from summary" loses context; the user clears it by hand. Through the
+    # ROMP_POSTAL_BIN seam like `mail` and `refresh`: this script puts its own directory
+    # first on PATH, so a test can stand in for the service no other way, and the real
+    # one, detached here, minted a serve-token under a test HOME after its teardown.
     if $resume && [[ -n "$sid" ]]; then
-        ( romp-postal-service picker-check --name "$name" --id "$sid" >/dev/null 2>&1 & )
+        ( "${ROMP_POSTAL_BIN:-romp-postal-service}" picker-check --name "$name" --id "$sid" >/dev/null 2>&1 & )
     fi
 
     # Attach — or, when detaching, just report how to get there.

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,5 +55,43 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
   gating, the kernel registry, and the drain-poll handshake. Run:
   `node --test tests/manager-*.test.js`.
 
+**Temp files and git are hermetic, suite-wide.** Two mechanisms, one per half.
+`tests/__init__.py` wraps `tempfile.mkdtemp` so every directory the test process
+mints is recorded and removed when the run ends (under pytest at session end,
+under `python -m unittest` at exit): the in-process half, covering the 300-odd
+module preambles and the per-test `mkdtemp()` calls nobody cleans up.
+`tests/conftest.py` covers what that hook cannot see — directories made by
+child processes (kernels, git, a shell's `mktemp -d`), `mkstemp` files,
+`os.mkdir` paths — by pointing the process temp dir (`tempfile.tempdir` and
+`TMPDIR`, so every child inherits it) at one private `romp-tests-*` root under
+the system temp dir and removing the root when the run ends (before both, a
+full run left ~5,600 entries in `/tmp` and over a million had piled up). Still
+clean up what you create — `with tempfile.TemporaryDirectory()`,
+`self.addCleanup(shutil.rmtree, ...)`, a `tearDownClass` for a class-level
+fixture — so a fixture is gone when its test is, not at exit; bats suites use
+`mktemp -d` in `setup` and `rm -rf` it in `teardown`, and stand in for any
+subject that detaches work (bin/romp's resume picker-check, reached through
+`ROMP_POSTAL_BIN`, re-created four to six test dirs per run by minting a
+serve-token after the teardown). Never give a tempfile call a literal
+directory as its `dir` — by keyword or position, composed (`f"/tmp/{x}"`,
+`os.path.join("/tmp", x)`) or through a name bound to one — and never point
+`mktemp` (`-p`, `--tmpdir`, a `TMPDIR=` prefix) at a path under `/tmp`: that
+bypasses the redirect, and the hygiene test reads every test file for those
+shapes. The one test that must leave the root — an AF_UNIX socket whose path
+would not fit `sun_path` under a nested root — falls back to
+`ROMP_TESTS_SYSTEM_TMPDIR`, the system temp dir conftest recorded once per run
+before redirecting (an xdist worker inherits the controller's record), and
+removes what it made. A root that cannot be removed at run end (a child
+still writing under it, a 000-mode directory a test left behind) is named on
+stderr: `[tests] not removed at run end: <path>`, instead of the run ending
+green over it. The same conftest gives git no global or system config
+(`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`) and a synthetic identity through
+`GIT_AUTHOR_*` / `GIT_COMMITTER_*`; bats suites that run git get the same from
+`load git-hermetic` + `git_hermetic` in `setup`. A fixture must not depend on
+the developer's git configuration (CI has none), and the env identity outranks
+`git config user.*` and `-c user.*` — a test that must pin a particular author
+exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
+and `tests/git-hermetic.bats` pin all of it.
+
 `fixtures/` must stay SYNTHETIC: invented prompts, placeholder UUIDs, hostname
 `TESTHOST` — never real session data.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,18 +9,25 @@ import os
 import shutil
 import tempfile
 
-# Temp-directory hygiene (2026-09-06): the suite used to leak every directory it made. This floor and
-# conftest.py's each minted a state root per process and never removed it (two per pytest process:
-# eighteen for a `pytest -n 8` run), and about three hundred test modules call tempfile.mkdtemp with
-# no cleanup of their own. On a developer machine that ran the suite many times a day that left about
-# 1.9 million directories under the system temp directory, enough that listing it took minutes and
-# tens of gigabytes of memory, and the out-of-memory kills that followed took a running romp kernel
-# down. The fix is at the source: every tempfile.mkdtemp call made in this process is recorded, and
-# everything recorded is removed at interpreter exit (and, under pytest, at session end; see
-# conftest.py). Only directories this process created, and only under the system temp directory, are
-# ever removed. tempfile.TemporaryDirectory goes through the same mkdtemp and cleans itself first, so
-# the exit sweep finds nothing of it. This package imports before conftest.py (pytest imports
-# `tests.conftest` through the package), so conftest's own root is recorded too.
+# Temp-directory hygiene, the in-process half (2026-09-06): the suite used to leak every directory it
+# made. This floor and conftest.py's each minted a state root per process and never removed it (two
+# per pytest process: eighteen for a `pytest -n 8` run), and about three hundred test modules call
+# tempfile.mkdtemp with no cleanup of their own. On a developer machine that ran the suite many times
+# a day that left about 1.9 million directories under the system temp directory, enough that listing
+# it took minutes and tens of gigabytes of memory, and the out-of-memory kills that followed took a
+# running romp kernel down. The fix is at the source: every tempfile.mkdtemp call made in THIS
+# process is recorded, and everything recorded is removed at interpreter exit (and, under pytest, at
+# session end; see conftest.py). Only directories this process created, and only under the process
+# temp dir, are ever removed: tempfile.gettempdir(), which is the system temp dir under a unittest
+# run and conftest's private per-run root under pytest. tempfile.TemporaryDirectory goes through the
+# same mkdtemp and cleans itself first, so the exit sweep finds nothing of it.
+# What this hook cannot see is the other half, conftest.py's: directories made by CHILD processes
+# (kernels, git, a shell's `mktemp -d`), files from mkstemp, and os.mkdir paths under the temp dir.
+# Under pytest those land in conftest's root because TMPDIR points there, and the root is removed
+# whole at run end; the two directories this process mints BEFORE that redirect (this package's
+# state dir below, and the root itself, both recorded here but outside the redirected gettempdir()
+# and so skipped by this sweep) are conftest's to remove. No such cover exists under a bare
+# unittest run, where the per-module cleanups (addCleanup, tearDownClass) are what there is.
 _MADE_DIRS = []
 _REAL_MKDTEMP = tempfile.mkdtemp
 
@@ -53,4 +60,10 @@ def remove_made_dirs():
 atexit.register(remove_made_dirs)
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
+# Recorded by the hook above, which removes it at exit under a unittest run. Under pytest it is
+# minted BEFORE conftest.py redirects the temp root (the package imports first), so it sits beside
+# the root in the system temp dir, outside the hook's redirected scope; conftest reads STATE_DIR
+# and removes it with the root when the run ends. Nothing runs after an os._exit (pytest-timeout's
+# thread method ends a hung run that way), so a hung run leaves this dir beside the root.
+STATE_DIR = os.environ["XDG_STATE_HOME"]
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor

--- a/tests/bootstrap-sh.bats
+++ b/tests/bootstrap-sh.bats
@@ -8,7 +8,10 @@
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,26 +4,85 @@ any test that skips its own rebind writes into the REAL ~/.local/state/romp (the
 judge-errors.jsonl lines from legacy-flag fixtures made that visible). conftest.py imports before every
 test module, so this is a suite-wide floor; per-class _rebind_state/tempdir isolation still layers on
 top exactly as before."""
+import atexit
 import os
+import shutil
 import sys
 import tempfile
 
 import pytest
 
-os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # recorded by tests/__init__.py's hook
-os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
+# Temp-directory hygiene, the child-process half (2026-09-06): every temp path a run creates lives
+# under ONE private root, removed when the run ends. tests/__init__.py's mkdtemp hook (the other
+# half; its comment has the leak's history) records and removes what THIS process mints through
+# tempfile.mkdtemp, but a test's children — kernels, git, `mktemp -d` in a shell — and mkstemp or
+# os.mkdir paths are outside its sight (a full run left ~5,600 of those per run at up to ten a
+# second). So the process's temp dir is redirected: tempfile.tempdir is set directly (gettempdir()
+# caches its first answer, and tests/__init__.py has already called it by the time this runs), and
+# TMPDIR is exported so every child inherits the same root. Import-time, not pytest_configure: this
+# module's own XDG floor below and every module-level mkdtemp at collection must land inside it.
+# The two removals compose without overlap: pytest_sessionfinish runs the hook's sweep, whose scope
+# is gettempdir() and so the inside of this root; pytest_unconfigure then removes the root whole
+# (whatever the sweep could not see) and tests/__init__.py's romp-tests-state-* dir — the package
+# imports first, so that dir and this root were minted before the redirect and are the two things a
+# run puts outside the root; the hook recorded both but skips them as outside its scope. Under
+# pytest-xdist both hooks run in the controller and in every worker: each imported this file and so
+# owns a root of its own (a worker's sits inside the controller's, since it inherits that TMPDIR).
+# The atexit registrations are silent fallbacks for a normal exit that skipped the hooks, each a
+# no-op on what the other removed; nothing runs after an os._exit (pytest-timeout's thread method
+# ends a hung run that way), so a hang leaves two top-level entries in the system temp dir, this
+# root and that state dir, both under the romp-tests- prefix.
+# The system temp dir — the one the RUN was handed, before any redirect — is recorded once, by the
+# first conftest to import: an xdist worker inherits the controller's record along with its TMPDIR
+# (setdefault, not an assignment: a worker's own gettempdir() is the controller's root, and
+# recording that put the worker's fallback one level deeper than a socket path can bear under a
+# long TMPDIR — four socket tests failed at bind under -n 2). A test that must leave the root (an
+# AF_UNIX socket path that would not fit sun_path under a nested root) falls back to it, and only
+# to it — a literal system path in a `dir=` would bypass the redirect (one did).
+os.environ.setdefault("ROMP_TESTS_SYSTEM_TMPDIR", tempfile.gettempdir())
+_TMP_ROOT = tempfile.mkdtemp(prefix="romp-tests-")
+tempfile.tempdir = _TMP_ROOT
+os.environ["TMPDIR"] = _TMP_ROOT
+_PACKAGE_STATE_DIR = getattr(sys.modules.get("tests"), "STATE_DIR", None)
 
 
+def _remove_run_dirs(report=False):
+    """Remove the root and the package state dir. A survivor is named on stderr when asked: rmtree
+    with ignore_errors swallows a child still writing under the root or a 000-mode directory a test
+    left behind, and the run would otherwise end green with the root standing. Only unconfigure
+    asks; the atexit fallback stays silent so it neither repeats the notice nor contradicts it."""
+    for d in (_TMP_ROOT, _PACKAGE_STATE_DIR):
+        if d:
+            shutil.rmtree(d, ignore_errors=True)
+            if report and os.path.isdir(d):
+                print("[tests] not removed at run end: %s" % d, file=sys.stderr)
+
+
+atexit.register(_remove_run_dirs)
+
+
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Temp-directory hygiene (2026-09-06, see tests/__init__.py): remove every directory this
-    process made through tempfile.mkdtemp, this state root included, when the session ends. Runs in
-    the controller and in every xdist worker, since each is its own pytest session. The package's
-    atexit hook does the same at interpreter exit; both are idempotent."""
+    """The in-process half (tests/__init__.py): remove every directory this process made through
+    tempfile.mkdtemp inside the root, this module's state root included, when the session ends. Runs
+    in the controller and in every xdist worker, since each is its own pytest session, and last, after
+    pytest's own runner sessionfinish has performed the deferred teardown an interrupted run leaves
+    behind, so nothing is swept from under a fixture still closing. The package's atexit hook does the
+    same at interpreter exit; both are idempotent, and pytest_unconfigure below takes the root itself
+    afterwards."""
     try:
         from tests import remove_made_dirs
     except Exception:
         return
     remove_made_dirs()
+
+
+def pytest_unconfigure(config):
+    _remove_run_dirs(report=True)
+
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 
 
 # No test may reach a REAL manager control port (2026-08-27): on a machine running a live romp,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,21 @@ def pytest_unconfigure(config):
     _remove_run_dirs(report=True)
 
 
+# No test's git reads the developer's configuration (2026-09-06). Fixture repos are built by `git
+# init` + `git commit` in temp dirs, and those commands honoured the developer's global config: a
+# global core.hooksPath ran their pre-commit hook on every seed commit, an LFS filter would run on
+# every checkout, and a credential helper or insteadOf rewrite could reach a real remote
+# (tests/test_file_github.py pins its own environment for exactly that reason). CI has no global git
+# config, so a test that leans on one is already broken there; this makes every run match.
+# GIT_CONFIG_GLOBAL is honoured by git >= 2.32; the identity is synthetic, and it is set rather than
+# defaulted so a developer's own GIT_AUTHOR_* cannot leak into fixture commits either. The env
+# identity outranks `git config user.*` and `-c user.*`, so a test that must pin a particular author
+# exports its own GIT_AUTHOR_* / GIT_COMMITTER_* per call; other config keys still yield to `-c`.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+os.environ["GIT_AUTHOR_NAME"] = os.environ["GIT_COMMITTER_NAME"] = "romp tests"
+os.environ["GIT_AUTHOR_EMAIL"] = os.environ["GIT_COMMITTER_EMAIL"] = "tests@example.invalid"
+
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 

--- a/tests/docs-serve.bats
+++ b/tests/docs-serve.bats
@@ -8,7 +8,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO/scripts" "$REPO/docs"

--- a/tests/git-hermetic.bash
+++ b/tests/git-hermetic.bash
@@ -1,0 +1,21 @@
+# tests/git-hermetic.bash: git in a bats test reads none of the developer's configuration.
+#
+# Use from a bats file: `load git-hermetic` at the top and `git_hermetic` as the first line of
+# setup(), before any git command runs.
+#
+# Why (2026-09-06): the fixture repos here are built with `git init` + `git commit` in temp dirs,
+# and those commands honoured the developer's global git config. On one box a global
+# core.hooksPath ran a pre-commit hook (a gitleaks scan) on every seed commit and a pre-push hook
+# on every fixture push, an LFS filter would run on every checkout, and a credential helper or
+# url.insteadOf rewrite could reach a real remote. CI has no global git config, so a test that
+# leans on one is already broken there; this makes every run match. GIT_CONFIG_GLOBAL is honoured
+# by git >= 2.32. The identity is synthetic and exported (not defaulted) so a developer's own
+# GIT_AUTHOR_* cannot leak into fixture commits either. The env identity outranks `git config
+# user.*` and `-c user.*`, so a test that must pin a particular author exports its own
+# GIT_AUTHOR_* / GIT_COMMITTER_* after this call; other config keys still yield to `-c`.
+
+git_hermetic() {
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+    export GIT_AUTHOR_NAME="romp tests" GIT_AUTHOR_EMAIL="tests@example.invalid"
+    export GIT_COMMITTER_NAME="romp tests" GIT_COMMITTER_EMAIL="tests@example.invalid"
+}

--- a/tests/git-hermetic.bats
+++ b/tests/git-hermetic.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# tests/git-hermetic.bash: after git_hermetic, git reads no global or system config and every
+# commit has an identity, whatever the box is configured with.
+#
+# Skips on git < 2.32 with the same message as tests/test_tempdir_hygiene.GitFloor: GIT_CONFIG_GLOBAL
+# and GIT_CONFIG_SYSTEM arrived in 2.32, so on an older git the config half of the floor is inert
+# (the identity half still holds) and both proofs say so the same way instead of one going red.
+
+load git-hermetic
+
+git_at_least_2_32() {
+    local v
+    v="$(git --version | awk '{print $3}')"
+    local major="${v%%.*}" rest="${v#*.}"
+    local minor="${rest%%.*}"
+    [ "$major" -gt 2 ] 2>/dev/null || { [ "$major" -eq 2 ] && [ "$minor" -ge 32 ]; } 2>/dev/null
+}
+
+setup() {
+    git_at_least_2_32 || skip "GIT_CONFIG_GLOBAL needs git >= 2.32"
+    TEST_DIR="$(mktemp -d)"
+    # A stand-in for the developer's global config: a hooks directory whose pre-commit refuses
+    # every commit and leaves a marker, wired in through core.hooksPath.
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME" "$TEST_DIR/hooks"
+    printf '#!/bin/sh\necho ran > "%s/hook-ran"\nexit 1\n' "$TEST_DIR" > "$TEST_DIR/hooks/pre-commit"
+    chmod +x "$TEST_DIR/hooks/pre-commit"
+    printf '[core]\n\thooksPath = %s\n[user]\n\tname = Global Person\n\temail = global@example.invalid\n' \
+        "$TEST_DIR/hooks" > "$HOME/.gitconfig"
+    unset GIT_CONFIG_GLOBAL GIT_CONFIG_NOSYSTEM XDG_CONFIG_HOME
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    REPO="$TEST_DIR/repo"
+    git init -q "$REPO"
+    echo a > "$REPO/a.txt"
+    git -C "$REPO" add a.txt
+}
+
+teardown() { rm -rf "${TEST_DIR:-}"; }
+
+@test "the probe is live: without git_hermetic the global hooksPath blocks the commit" {
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -ne 0 ]
+    [ -f "$TEST_DIR/hook-ran" ]
+}
+
+@test "with git_hermetic the global hook never runs and the commit lands" {
+    git_hermetic
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_DIR/hook-ran" ]
+    [ "$(git -C "$REPO" config --global --get core.hooksPath || true)" = "" ]
+}
+
+@test "with git_hermetic a system-config hooksPath never runs either" {
+    # The system half of the floor: GIT_CONFIG_SYSTEM (git >= 2.32) is a root-free stand-in for
+    # /etc/gitconfig, and GIT_CONFIG_NOSYSTEM=1 is what hides it; the global probe above says
+    # nothing about it. The file carries an identity because git resolves the author before it
+    # runs pre-commit, and the live arm has none from the environment or a global config (the
+    # global file is hidden there so the system file is the ONLY source of the hook).
+    printf '[core]\n\thooksPath = %s\n[user]\n\tname = System Person\n\temail = system@example.invalid\n' \
+        "$TEST_DIR/hooks" > "$TEST_DIR/sysconfig"
+    export GIT_CONFIG_SYSTEM="$TEST_DIR/sysconfig"
+    run env GIT_CONFIG_GLOBAL=/dev/null git -C "$REPO" commit -qm seed
+    [ "$status" -ne 0 ]
+    [ -f "$TEST_DIR/hook-ran" ]
+    rm "$TEST_DIR/hook-ran"
+    git_hermetic
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_DIR/hook-ran" ]
+}
+
+@test "the identity is the synthetic one, not the global config's" {
+    git_hermetic
+    git -C "$REPO" commit -qm seed
+    [ "$(git -C "$REPO" log -1 --format='%an <%ae>')" = "romp tests <tests@example.invalid>" ]
+    [ "$(git -C "$REPO" log -1 --format='%cn <%ce>')" = "romp tests <tests@example.invalid>" ]
+}
+
+@test "a test's own identity exports after git_hermetic still win" {
+    git_hermetic
+    # The env identity outranks `git config user.*` and `-c user.*`, so a test that must pin a
+    # particular author exports its own GIT_AUTHOR_* / GIT_COMMITTER_* after git_hermetic.
+    GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e.invalid git -C "$REPO" commit -qm seed
+    [ "$(git -C "$REPO" log -1 --format='%an <%ae>')" = "t <t@e.invalid>" ]
+}

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -8,7 +8,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -12,7 +12,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO/scripts"

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -85,6 +85,19 @@ MOCK
     # modern version; per-test override via _stub_claude.
     _stub_claude "2.1.226"
 
+    # Hermetic postal service (2026-09-06): on every resume bin/romp double-forks
+    # `romp-postal-service picker-check` and returns without waiting for it. The real
+    # service mints a serve-token under $HOME/.local/state/romp when none exists, and did
+    # so after teardown had removed TEST_DIR, so the tree came back with that one file in
+    # it: four to six per run of this file. bin/romp puts its own directory first on PATH,
+    # so a stand-in here cannot shadow the real one through PATH; it reaches bin/romp
+    # through the ROMP_POSTAL_BIN seam, which the picker-check honours like `mail` and
+    # `refresh`. A no-op: the tests that assert on the service's calls overwrite it with
+    # a recording mock.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/romp-postal-service"
+    chmod +x "$MOCK_DIR/romp-postal-service"
+    export ROMP_POSTAL_BIN="$MOCK_DIR/romp-postal-service"
+
     export PATH="$MOCK_DIR:$PATH"
     # The romp-manager tests below start a REAL bin/romp-manager, whose startup runs `tmux start-server`,
     # and `romp new -t` runs `tmux new-session`: the mock above takes both, and the private socket
@@ -137,6 +150,10 @@ _stub_curl() {
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+# drain the token config romp pipes in (`_romp_token_cfg | curl --config - …`): real curl always reads
+# it, but a mock that exits first hands the writer SIGPIPE, and under the script's pipefail that read
+# as a false "not reachable" — one random kernel-API test failed per run
+[[ " $* " == *" --config - "* ]] && cat >/dev/null
 url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ -n "${MOCK_CURL_FAIL_SEND:-}" && "$url" == */send ]]; then exit 22; fi
@@ -215,6 +232,7 @@ MOCK
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ "$url" == */new ]]; then
@@ -284,6 +302,7 @@ MOCK
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 echo '{"ok": true, "id": "11111111-2222-3333-4444-555555555555", "queued": true, "dir": "/srv/notes-api/web"}'
 MOCK
     chmod +x "$MOCK_DIR/curl"
@@ -293,6 +312,7 @@ MOCK
     # a refusal rides the kernel's own words
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 echo '{"ok": false, "error": "directory not found: /nowhere"}'
 MOCK
     chmod +x "$MOCK_DIR/curl"
@@ -801,6 +821,26 @@ _stale_server_globals() {
     [ "$status" -ne 0 ]
     grep -q 'tmux new-session -d -s myproject-2' "$MOCK_LOG"
     grep -qE 'tmux respawn-pane -k -t myproject-2 exec ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject-2" claude --resume abc123-uuid --name "myproject-2"' "$MOCK_LOG"
+}
+
+@test "resume: the background picker-check goes through ROMP_POSTAL_BIN, and the stand-in writes nothing" {
+    # bin/romp double-forks `romp-postal-service picker-check` on a resume and returns at once;
+    # the real service mints ~/.local/state/romp/serve-token when none exists, and did so after
+    # teardown had removed TEST_DIR, re-creating it. bin/romp's own directory leads PATH, so the
+    # seam is the only way a test can stand in for the service. The setup() stand-in leaves the
+    # state dir alone; a recording one for this test shows the resume path reaching the seam —
+    # the call is detached, so the check waits (bounded) for its record instead of racing it.
+    [ "$ROMP_POSTAL_BIN" = "$MOCK_DIR/romp-postal-service" ]
+    run "$ROMP_POSTAL_BIN" picker-check --name myproject --id abc123-uuid
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -e "$HOME/.local/state/romp" ]
+
+    printf '#!/usr/bin/env bash\necho "postal $*" >> "%s"\n' "$TEST_DIR/postal.log" > "$MOCK_DIR/romp-postal-service"
+    run run_romp resume abc123-uuid
+    [ "$status" -eq 0 ]
+    local i; for i in $(seq 1 50); do [ -s "$TEST_DIR/postal.log" ] && break; sleep 0.1; done
+    grep -q '^postal picker-check --name myproject --id abc123-uuid$' "$TEST_DIR/postal.log"
 }
 
 # ─── Detach tests ────────────────────────────────────────────────────

--- a/tests/test_kernel_provisional_command.py
+++ b/tests/test_kernel_provisional_command.py
@@ -18,6 +18,7 @@ data.
 """
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -43,6 +44,7 @@ def _iso(ep):
 class ProvisionalCommand(unittest.TestCase):
     def _session(self, recs):
         td = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, td, ignore_errors=True)
         p = os.path.join(td, SID + ".jsonl")
         open(p, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
         return {"path": p, "sid": SID, "name": "JLD"}

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -6,14 +6,18 @@ message without touching the composer. The kernel uses that leg ONLY for session
 inbound-accept setting, so a held-then-dropped banner can never read as delivered (the socket
 sends no ack). Untagged sessions must keep today's pane injection untouched. Synthetic
 fixtures only."""
+import errno
 import json
 import os
+import shutil
 import socket
+import sys
 import tempfile
 import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from unittest.mock import patch
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
@@ -35,21 +39,69 @@ def _registry_row(dirpath, pid, session_id, sock, started_at=1000):
                    "startedAt": started_at, "cwd": "/tmp/x", "kind": "interactive"}, f)
 
 
+# Where an inbox socket lives (2026-09-06): the run's private temp root — tempfile.gettempdir(),
+# which tests/conftest.py points at a romp-tests-* directory it removes when the run ends — when the
+# socket path fits in sun_path, and the system temp dir the run was handed before that redirect
+# only when it would not. sun_path is 108 bytes on Linux and 104 on macOS, NUL included; an xdist
+# worker's root nested under a macOS TMPDIR puts the socket at 116 bytes
+# (/var/folders/../T/romp-tests-x/romp-tests-x/rompsockx/inbox.sock), the Linux equivalent under
+# /tmp at 72 and under a TMPDIR of 60 bytes or more past 108. conftest records the handed dir once
+# per run as ROMP_TESTS_SYSTEM_TMPDIR and a worker inherits the controller's record — not the
+# controller's root, which under such a TMPDIR is itself too deep (recording that had four tests
+# here failing at bind with "AF_UNIX path too long" under -n 2, 2026-09-06); without conftest,
+# gettempdir() already is that dir. A handed dir too deep to hold the socket at all (about 80
+# bytes) is refused before anything is minted there, loudly (ENAMETOOLONG naming the dir), as a bind
+# under it would fail anyway; the refusal comes first because a caller registers close() only once
+# the constructor returns, so a directory minted for a bind that then failed was one leaked
+# rompsock* directory per test, per run (the round-2 review, 2026-09-06). Either way close()
+# removes the directory. Before this the dir was pinned to "/tmp" and never removed: the pin
+# bypassed the redirect and every run left three rompsock* directories behind.
+_SUN_PATH_MAX = 104 if sys.platform == "darwin" else 108
+_SOCK_NAME = "inbox.sock"
+
+
+def _socket_dir():
+    """The socket's directory: under the private root when the path fits sun_path, else under the
+    dir the run was handed. Refuses (OSError, ENAMETOOLONG) BEFORE minting when the handed dir would
+    not fit either, so a caller that never gets an inbox has nothing to remove."""
+    d = tempfile.mkdtemp(prefix="rompsock")
+    if len(os.fsencode(os.path.join(d, _SOCK_NAME))) < _SUN_PATH_MAX:
+        return d
+    os.rmdir(d)
+    handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+    if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:  # mkdtemp's suffix is 8 chars
+        raise OSError(errno.ENAMETOOLONG, "the temp dir this run was handed is too deep for an AF_UNIX "
+                      "socket path (%d-byte sun_path): %s" % (_SUN_PATH_MAX, handed))
+    return tempfile.mkdtemp(prefix="rompsock", dir=handed)
+
+
 class _OneShotInbox:
     """A real AF_UNIX listener capturing everything one client writes (the CLI parses per
-    line and acks nothing for a plain send, so capture-and-close mirrors it exactly)."""
+    line and acks nothing for a plain send, so capture-and-close mirrors it exactly).
+    close() removes the socket's directory; callers addCleanup it."""
 
     def __init__(self):
-        self.dir = tempfile.mkdtemp(prefix="rompsock", dir="/tmp")
-        self.path = os.path.join(self.dir, "inbox.sock")
+        self.dir = _socket_dir()
+        self.path = os.path.join(self.dir, _SOCK_NAME)
         self.got = []
-        self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self._srv.bind(self.path)
-        self._srv.listen(1)
-        self._srv.settimeout(5.0)                      # can-never-trap backstop: a never-connected inbox's
-        #                                                accept() returns instead of parking the thread
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
+        self._srv = None
+        try:
+            self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._srv.bind(self.path)
+            self._srv.listen(1)
+            self._srv.settimeout(5.0)                  # can-never-trap backstop: a never-connected inbox's
+            #                                            accept() returns instead of parking the thread
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        except BaseException:
+            # Nothing after the mkdtemp may leave the directory standing: the caller registers
+            # close() only once this returns, so a refused bind (a filesystem without AF_UNIX
+            # support, a permission) or a thread that would not start had left one rompsock*
+            # directory per test, per run, in the handed dir.
+            if self._srv is not None:
+                self._srv.close()
+            shutil.rmtree(self.dir, ignore_errors=True)
+            raise
 
     def _run(self):
         try:
@@ -84,6 +136,96 @@ class _OneShotInbox:
         except OSError:
             pass
         self._thread.join(timeout=1.0)
+        shutil.rmtree(self.dir, ignore_errors=True)    # idempotent: a second close finds nothing
+
+
+class InboxDir(unittest.TestCase):
+    """_socket_dir's rule, and that an inbox leaves nothing behind."""
+
+    def test_the_dir_is_under_the_private_root_when_the_path_fits_and_gone_after_close(self):
+        inbox = _OneShotInbox()
+        self.addCleanup(inbox.close)
+        root = tempfile.gettempdir()
+        self.assertLess(len(os.fsencode(inbox.path)), _SUN_PATH_MAX)
+        fits_in_root = len(os.fsencode(os.path.join(root, os.path.basename(inbox.dir), _SOCK_NAME))) < _SUN_PATH_MAX
+        self.assertEqual(os.path.dirname(inbox.dir),
+                         root if fits_in_root else os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or root)
+        self.assertTrue(os.path.exists(inbox.path))
+        inbox.close()
+        self.assertFalse(os.path.exists(inbox.dir), "close() removes the socket's directory")
+        inbox.close()                                      # a second close is a no-op
+
+    def test_a_path_too_long_for_the_private_root_falls_back_to_the_handed_dir(self):
+        # "Handed" is the run's record, not this process's gettempdir(): in an xdist worker the
+        # latter is the worker's root, nested in the controller's, which under a long TMPDIR is
+        # itself too deep for the socket (122 bytes under a 52-byte TMPDIR, seen under -n 8).
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+        if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:
+            self.skipTest("the temp dir this run was handed is itself too deep for sun_path")
+        deep = os.path.join(tempfile.gettempdir(), "d" * 120)   # deep + /rompsockXXXXXXXX/inbox.sock > 108
+        os.mkdir(deep)
+        self.addCleanup(shutil.rmtree, deep, ignore_errors=True)
+        with patch.dict(os.environ, {"ROMP_TESTS_SYSTEM_TMPDIR": handed}), patch.object(tempfile, "tempdir", deep):
+            d = _socket_dir()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        self.assertEqual(os.path.dirname(d), handed)
+        self.assertLess(len(os.fsencode(os.path.join(d, _SOCK_NAME))), _SUN_PATH_MAX)
+        self.assertEqual(os.listdir(deep), [], "the too-long candidate was removed, not left behind")
+
+    def test_a_handed_dir_too_deep_for_the_socket_is_refused_before_anything_is_minted(self):
+        # Both candidates too deep. The constructor raises with the cause and the dir named, and
+        # neither the root nor the handed dir holds a rompsock* entry: a caller that never got an
+        # inbox has nothing to close, so a directory minted for a bind that then failed was one
+        # leaked directory per test, per run.
+        deep = os.path.join(tempfile.gettempdir(), "d" * 120)
+        os.mkdir(deep)
+        self.addCleanup(shutil.rmtree, deep, ignore_errors=True)
+        with patch.dict(os.environ, {"ROMP_TESTS_SYSTEM_TMPDIR": deep}), patch.object(tempfile, "tempdir", deep):
+            with self.assertRaises(OSError) as cm:
+                _OneShotInbox()
+        self.assertEqual(os.listdir(deep), [], "nothing is minted where no socket can bind")
+        self.assertEqual(cm.exception.errno, errno.ENAMETOOLONG)
+        self.assertIn(deep, str(cm.exception))
+
+    def test_a_refused_bind_removes_the_minted_dir(self):
+        # The length check above is the case the suite meets; a bind can be refused for other reasons
+        # (a filesystem without AF_UNIX support, a permission). Stubbed here: the constructor
+        # raises, and the directory _socket_dir minted for it is gone.
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+        if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:
+            self.skipTest("the temp dir this run was handed is itself too deep for sun_path")   # refused before any bind
+        made = []
+        real = _socket_dir
+
+        def recording():
+            made.append(real())
+            return made[-1]
+        with patch.object(sys.modules[__name__], "_socket_dir", recording), \
+                patch.object(socket.socket, "bind", side_effect=OSError(errno.EACCES, "stub")):
+            with self.assertRaises(OSError) as cm:
+                _OneShotInbox()
+        self.assertEqual(cm.exception.errno, errno.EACCES)
+        self.assertEqual(len(made), 1)
+        self.assertFalse(os.path.exists(made[0]), "a refused bind leaves no rompsock* directory")
+
+    def test_the_rule_is_exercised_under_the_limit_by_a_real_bind(self):
+        # The constant is the platform's, not a guess: a socket at exactly _SUN_PATH_MAX - 1 bytes
+        # binds and one at _SUN_PATH_MAX does not, which is what the length check encodes.
+        with tempfile.TemporaryDirectory() as td:
+            if len(os.fsencode(td)) + 2 >= _SUN_PATH_MAX:
+                self.skipTest("the temp root itself is near sun_path's limit")
+            for length, ok in ((_SUN_PATH_MAX - 1, True), (_SUN_PATH_MAX, False)):
+                path = os.path.join(td, "s" * (length - len(td) - 1))
+                self.assertEqual(len(os.fsencode(path)), length)
+                srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    srv.bind(path)
+                    bound = True
+                except OSError:
+                    bound = False
+                finally:
+                    srv.close()
+                self.assertEqual(bound, ok, path)
 
 
 class SocketRegistry(unittest.TestCase):
@@ -128,16 +270,14 @@ class SocketWrite(unittest.TestCase):
 
     def test_writes_one_user_record(self):
         inbox = _OneShotInbox()
-        try:
-            self.assertTrue(km._socket_deliver(inbox.path, "mail body <!-- romp-msg-id: 1 -->"))
-            got = inbox.wait()
-            self.assertEqual(len(got), 1)
-            rec = json.loads(got[0].decode("utf-8"))
-            self.assertEqual(rec["type"], "user")
-            self.assertEqual(rec["message"]["role"], "user")
-            self.assertEqual(rec["message"]["content"], "mail body <!-- romp-msg-id: 1 -->")
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        self.assertTrue(km._socket_deliver(inbox.path, "mail body <!-- romp-msg-id: 1 -->"))
+        got = inbox.wait()
+        self.assertEqual(len(got), 1)
+        rec = json.loads(got[0].decode("utf-8"))
+        self.assertEqual(rec["type"], "user")
+        self.assertEqual(rec["message"]["role"], "user")
+        self.assertEqual(rec["message"]["content"], "mail body <!-- romp-msg-id: 1 -->")
 
     def test_false_when_socket_is_gone(self):
         self.assertFalse(km._socket_deliver("/tmp/rompsock-nonexistent/inbox.sock", "x"))
@@ -187,27 +327,23 @@ class DeliverGate(unittest.TestCase):
 
     def test_tagged_session_delivers_down_the_socket(self):
         inbox = _OneShotInbox()
-        try:
-            _registry_row(self.reg, os.getpid(), SID, inbox.path)
-            be = _StubTmux(accept=True)
-            self.assertTrue(be.deliver(SID, "banner text"))
-            got = inbox.wait()
-            self.assertEqual(json.loads(got[0].decode("utf-8"))["message"]["content"], "banner text")
-            self.assertEqual(be.pane_calls, [])            # the pane was never touched
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        _registry_row(self.reg, os.getpid(), SID, inbox.path)
+        be = _StubTmux(accept=True)
+        self.assertTrue(be.deliver(SID, "banner text"))
+        got = inbox.wait()
+        self.assertEqual(json.loads(got[0].decode("utf-8"))["message"]["content"], "banner text")
+        self.assertEqual(be.pane_calls, [])                # the pane was never touched
 
     def test_untagged_session_keeps_the_pane_path(self):
         inbox = _OneShotInbox()
-        try:
-            _registry_row(self.reg, os.getpid(), SID, inbox.path)
-            be = _StubTmux(accept=False)
-            be.deliver(SID, "banner text")                 # pane stub has no ❯ prompt → undelivered
-            time.sleep(0.2)
-            self.assertEqual(inbox.got, [])                # nothing reached the socket
-            self.assertIn("capture", be.pane_calls)        # the pane path ran instead
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        _registry_row(self.reg, os.getpid(), SID, inbox.path)
+        be = _StubTmux(accept=False)
+        be.deliver(SID, "banner text")                     # pane stub has no ❯ prompt → undelivered
+        time.sleep(0.2)
+        self.assertEqual(inbox.got, [])                    # nothing reached the socket
+        self.assertIn("capture", be.pane_calls)            # the pane path ran instead
 
     def test_tagged_but_dead_socket_falls_back_to_the_pane(self):
         _registry_row(self.reg, os.getpid(), SID, "/tmp/rompsock-nonexistent/inbox.sock")

--- a/tests/test_kernel_worktree_display.py
+++ b/tests/test_kernel_worktree_display.py
@@ -18,6 +18,7 @@ repos with fixture identities.
 """
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -92,6 +93,10 @@ class TreeOf(unittest.TestCase):
         _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.main)
         os.makedirs(os.path.join(cls.wt, "sub"))
 
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
     def test_a_worktree_path_resolves_to_its_own_tree_and_branch(self):
         top, br = km._tree_of(os.path.join(self.wt, "sub"))
         self.assertEqual(os.path.realpath(top), os.path.realpath(self.wt))
@@ -103,7 +108,8 @@ class TreeOf(unittest.TestCase):
         self.assertEqual(br, "main")
 
     def test_a_non_repo_dir_is_no_tree(self):
-        self.assertEqual(km._tree_of(tempfile.mkdtemp()), ("", ""))
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(km._tree_of(d), ("", ""))
         self.assertEqual(km._tree_of(""), ("", ""))
 
 

--- a/tests/test_reg_field_gutting.py
+++ b/tests/test_reg_field_gutting.py
@@ -12,6 +12,7 @@ here against a CORRUPT reg file and pinned: the file's bytes survive untouched. 
 import asyncio
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -34,6 +35,7 @@ CORRUPT = b'{"sid": "trunca'          # a torn read: exists, does not parse
 class ReadRegForRmw(unittest.TestCase):
     def setUp(self):
         self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
 
     def test_absent_reg_is_a_writable_empty(self):
         self.assertEqual(sb.read_reg_for_rmw(self.d, SID), {},
@@ -57,6 +59,7 @@ class _Hooked(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
         self.logs = []
         self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "gut", "cwd": "/tmp", "alive": True,

--- a/tests/test_tempdir_hygiene.py
+++ b/tests/test_tempdir_hygiene.py
@@ -1,18 +1,55 @@
-"""The suite removes every temp directory it makes (tests/__init__.py + tests/conftest.py, 2026-09-06).
+"""A pytest run leaves nothing in the system temp dir, and its git reads none of the developer's
+configuration (2026-09-06).
 
-Three checks. In-process: the package's mkdtemp hook is installed, so a directory a test makes is
-recorded for the exit sweep. Two subprocess checks run this same module's in-process test as a child,
-once under pytest (conftest's session-end sweep) and once under unittest (the package's atexit sweep),
-with ROMP_HYGIENE_MARKER naming a file where the child writes the directory it made and its
-XDG_STATE_HOME root; the parent asserts both are gone once the child exits. That is the behaviour
-that ends the leak (over a million stale fixture directories on one machine before this)."""
+Two mechanisms, one per half. tests/__init__.py wraps tempfile.mkdtemp so every directory the test
+process mints is recorded and removed when the run ends (under pytest at session end, under
+`python -m unittest` at exit): that is the in-process half, and it covers the 300-odd module
+preambles and the per-test mkdtemp calls nobody cleans up. tests/conftest.py covers what the hook
+cannot see — directories made by child processes (kernels, git, a shell's `mktemp -d`), mkstemp
+files, os.mkdir paths — by pointing the process temp dir (tempfile.tempdir and TMPDIR, so children
+inherit it) at one private `romp-tests-*` root and removing the root when the run ends; the
+package's state dir, minted before the redirect, goes with it. Before both, a full run left ~5,600
+entries in /tmp and over a million had piled up. The same conftest points git at no global or
+system config (GIT_CONFIG_GLOBAL, GIT_CONFIG_NOSYSTEM) with a synthetic identity: the seed commits
+had been running the developer's global pre-commit hook.
+
+Pinned four ways. Hygiene (the hook): it is installed, and a child run of this module under pytest
+and under unittest leaves neither the directory it made nor its state root (ROMP_HYGIENE_MARKER
+names the file where the child writes both paths). From inside a run: the floors are in place and
+children inherit them; no test pins a temp path to a literal directory; a root that survives
+removal is named on stderr; a global and a system hooksPath cannot reach a fixture commit. End to
+end: a nested pytest on a leaking module leaves the system temp dir it was given exactly as it
+found it, serial and under xdist. The in-run and end-to-end classes skip under a bare unittest run,
+where conftest never loaded and there is nothing to pin; the hook checks run either way. This
+module loads no romp code, so it needs no state-root preamble.
+"""
+import ast
+import contextlib
+import glob
+import importlib.util
+import io
 import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
+from unittest.mock import patch
 
-REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+IDENT = "romp tests <tests@example.invalid>"
+
+under_conftest = unittest.skipUnless("tests.conftest" in sys.modules,
+                                     "the floors under test are tests/conftest.py's (pytest-only)")
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=60, **kw)
+
+
 MARKER_ENV = "ROMP_HYGIENE_MARKER"
 
 
@@ -31,7 +68,7 @@ class Hygiene(unittest.TestCase):
         scratch = tempfile.mkdtemp(prefix="romp-hygiene-")      # tracked: swept when THIS session ends
         marker = os.path.join(scratch, "paths.txt")
         env = dict(os.environ, **{MARKER_ENV: marker})
-        r = subprocess.run(argv, cwd=REPO, env=env, capture_output=True, text=True, timeout=300)
+        r = subprocess.run(argv, cwd=ROOT, env=env, capture_output=True, text=True, timeout=300)
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         with open(marker) as fh:
             made, state_root = fh.read().split("\n")[:2]
@@ -50,5 +87,462 @@ class Hygiene(unittest.TestCase):
                          "tests.test_tempdir_hygiene.Hygiene.test_mkdtemp_is_tracked_in_process"])
 
 
+@under_conftest
+class PrivateTempRoot(unittest.TestCase):
+    def test_the_process_temp_dir_is_the_private_root(self):
+        root = tempfile.gettempdir()
+        self.assertTrue(os.path.basename(root).startswith("romp-tests-"), root)
+        self.assertTrue(os.path.isdir(root))
+        self.assertEqual(os.environ.get("TMPDIR"), root, "children find the root through TMPDIR")
+
+    def test_module_level_state_roots_land_inside_it(self):
+        # Whichever module's preamble wrote XDG_STATE_HOME last at collection, it minted the dir
+        # after conftest redirected the temp root, so it sits inside.
+        root = tempfile.gettempdir()
+        xdg = os.environ["XDG_STATE_HOME"]
+        self.assertEqual(os.path.commonpath([root, xdg]), root, xdg)
+
+    def test_children_inherit_the_root(self):
+        root = tempfile.gettempdir()
+        py = _run([sys.executable, "-c", "import tempfile, sys; sys.stdout.write(tempfile.gettempdir())"])
+        self.assertEqual(py.stdout, root, "a Python child's tempfile answers with the root")
+        sh = _run(["mktemp", "-d", "-u"])   # -u: name only, nothing created
+        self.assertEqual(os.path.dirname(sh.stdout.strip()), root, "a shell's mktemp -d lands in it")
+
+    def test_the_handed_temp_dir_is_recorded_once_and_the_roots_nest_under_it(self):
+        # The one sanctioned way out of the root (tests/test_kernel_socket_deliver._socket_dir, for
+        # a socket path that would not fit sun_path) goes to the dir the RUN was handed, never to a
+        # literal system path. Recorded once: serially the root sits directly in it; in an xdist
+        # worker the worker's root sits inside the controller's and the record is still the dir
+        # above both — a worker that re-recorded its own gettempdir() would name the controller's
+        # root, one level too deep for the socket under a long TMPDIR.
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR")
+        self.assertTrue(handed, "conftest records the temp dir it replaced")
+        handed, root = os.path.realpath(handed), os.path.realpath(tempfile.gettempdir())
+        self.assertFalse(os.path.basename(handed).startswith("romp-tests-"), handed)
+        self.assertEqual(os.path.commonpath([handed, root]), handed, root)
+        between = os.path.relpath(root, handed).split(os.sep)
+        self.assertTrue(all(p.startswith("romp-tests-") for p in between), between)
+        self.assertEqual(len(between), 2 if os.environ.get("PYTEST_XDIST_WORKER") else 1, between)
+
+    def test_no_test_pins_a_temp_path_to_a_literal_directory(self):
+        # A literal directory as a tempfile call's `dir` bypasses the redirect: the socket tests
+        # carried dir="/tmp" and left three rompsock* directories in the real /tmp per run, where the
+        # nested-run check below could not see them. Static, so it covers every module whether or
+        # not a run exercises it; the rule and its shapes are _python_pins' and _shell_pins' (the
+        # LiteralPinChecker class pins them on synthetic sources), this applies them to the tree.
+        bad = []
+        for path in sorted(glob.glob(os.path.join(HERE, "*.py"))):
+            src = open(path, encoding="utf-8").read()
+            if any(c in src for c in TEMPFILE_DIR_POSITION):     # a text prefilter keeps the parse to candidates
+                bad += _python_pins(src, os.path.relpath(path, ROOT))
+        for path in sorted(glob.glob(os.path.join(HERE, "*.bats")) + glob.glob(os.path.join(HERE, "*.bash"))):
+            bad += _shell_pins(open(path, encoding="utf-8").read(), os.path.relpath(path, ROOT))
+        self.assertEqual(bad, [], "temp paths take the process temp dir (the private root); a test that "
+                         "must leave it falls back to ROMP_TESTS_SYSTEM_TMPDIR — see _socket_dir")
+
+
+# The literal-directory rule, one function per language. Python: the `dir` argument of a tempfile
+# call — the keyword, or the positional slot the module's signatures give it (the third of mkdtemp,
+# mkstemp, mktemp and TemporaryDirectory; the seventh of NamedTemporaryFile and TemporaryFile; the
+# eighth of SpooledTemporaryFile) — is a pin when it is a string literal of any value, when any
+# string literal inside its expression is an absolute path (an f-string piece, an operand of `+`,
+# an os.path.join argument, the default of os.environ.get), or when it is a name or attribute the
+# same file assigns such an expression to (followed through assignments a few levels deep). A
+# relative literal inside a composed expression (os.path.join(self.dir, "sub")) is a component, not
+# a pin; a call that names no absolute path (tempfile.gettempdir(), str(home), self.td.name,
+# os.environ.get("X") or ...) is where a dir should come from. Only the tempfile names are read, so
+# parse_session(dir="/TESTDIR") is not a hit and a call split over lines is. Shell: `mktemp` handed
+# a path under a system temp dir on the same command — as the template, as `-p`'s or `--tmpdir`'s
+# value, spaced, attached or `=`-joined, quoted or bare — and any `TMPDIR=` assignment to one (the
+# `TMPDIR=/tmp mktemp -d` prefix and an `export` alike: both redirect every child there). A trailing
+# comment is not reached and a comment line is skipped. The round-2 review (2026-09-06) found the
+# first version reading only the keyword form and only an unquoted, space-separated shell path.
+TEMPFILE_DIR_POSITION = {"mkdtemp": 2, "mkstemp": 2, "mktemp": 2, "TemporaryDirectory": 2,
+                         "NamedTemporaryFile": 6, "TemporaryFile": 6, "SpooledTemporaryFile": 7}
+_SYSTEM_TEMP = r"/(?:tmp|var/tmp|private/tmp|var/folders|dev/shm)\b"
+_SH_PIN = re.compile(r"\bmktemp\b[^\n|;&#]*(?:\s-p\s*|[\s=])[\"']?" + _SYSTEM_TEMP
+                     + r"|\bTMPDIR=[\"']?" + _SYSTEM_TEMP)
+
+
+def _dir_argument(call):
+    """The `dir` argument's node, from the keyword or the positional slot; None when absent or when a
+    starred argument makes the positions unknowable."""
+    for kw in call.keywords:
+        if kw.arg == "dir":
+            return kw.value
+    pos = TEMPFILE_DIR_POSITION[_call_name(call)]
+    if len(call.args) > pos and not any(isinstance(a, ast.Starred) for a in call.args):
+        return call.args[pos]
+    return None
+
+
+def _call_name(call):
+    f = call.func
+    return f.attr if isinstance(f, ast.Attribute) else f.id if isinstance(f, ast.Name) else None
+
+
+def _assignments(tree):
+    """Every `name = value`, `self.name = value` (annotated or augmented too) in the module, keyed by
+    the target's source text — one scope, since a test module's names are few."""
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        for t in targets:
+            if isinstance(t, (ast.Name, ast.Attribute)):
+                out.setdefault(ast.unparse(t), []).append(value)
+    return out
+
+
+def _pinned(node, assigned, depth=3):
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str)
+    if any(isinstance(sub, ast.Constant) and isinstance(sub.value, str) and sub.value.startswith("/")
+           for sub in ast.walk(node)):
+        return True
+    if depth and isinstance(node, (ast.Name, ast.Attribute)):
+        return any(_pinned(v, assigned, depth - 1) for v in assigned.get(ast.unparse(node), ()))
+    return False
+
+
+def _python_pins(src, label):
+    """`label:line: call` for every tempfile call in `src` whose dir is a literal directory."""
+    tree = ast.parse(src)
+    assigned = _assignments(tree)
+    bad = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _call_name(node) in TEMPFILE_DIR_POSITION:
+            d = _dir_argument(node)
+            if d is not None and _pinned(d, assigned):
+                bad.append("%s:%d: %s" % (label, node.lineno, ast.get_source_segment(src, node).splitlines()[0]))
+    return bad
+
+
+def _shell_pins(text, label):
+    """`label:line: text` for every line of a shell source that points mktemp, or TMPDIR, at a
+    literal system temp dir."""
+    return ["%s:%d: %s" % (label, n, line.strip()) for n, line in enumerate(text.splitlines(), 1)
+            if not line.lstrip().startswith("#") and _SH_PIN.search(line)]
+
+
+class LiteralPinChecker(unittest.TestCase):
+    """The rule on synthetic sources: every shape the round-2 review listed as passing the first
+    version is a hit, and every legitimate spelling in the tree is not."""
+
+    PREAMBLE = textwrap.dedent('''\
+        import os, tempfile
+        from tempfile import mkdtemp
+        PINNED = "/tmp"
+        VIA = PINNED
+        root = tempfile.mkdtemp()
+        home = root
+
+        class T:
+            def setUp(self):
+                self.pinned = "/tmp/" + "x"
+                self.dir = os.path.realpath(tempfile.mkdtemp())
+                self.td = tempfile.TemporaryDirectory()
+                name = "x"
+                CALL
+    ''')
+
+    PINNED_PY = [
+        'tempfile.mkdtemp(dir="/tmp")',
+        'tempfile.mkdtemp(prefix="x",\n                 dir="/tmp")',                 # split over lines
+        'mkdtemp(dir="/tmp")',                                                       # the bare name
+        'tempfile.mkdtemp("", "x", "/tmp")',                                         # by position
+        'tempfile.mkstemp("", "x", "/tmp")',
+        'tempfile.mktemp("", "x", "/tmp")',
+        'tempfile.TemporaryDirectory(None, None, "/tmp")',
+        'tempfile.NamedTemporaryFile("w", -1, None, None, ".jsonl", "x", "/tmp")',  # the seventh
+        'tempfile.TemporaryFile("w+b", -1, None, None, None, None, "/var/tmp")',
+        'tempfile.SpooledTemporaryFile(0, "w+b", -1, None, None, None, None, "/tmp")',
+        'tempfile.mkdtemp(dir=f"/tmp/{name}")',                                       # composed
+        'tempfile.mkdtemp(dir="/tmp/" + name)',
+        'tempfile.mkdtemp(dir=os.path.join("/tmp", name))',
+        'tempfile.mkdtemp(dir=os.environ.get("TMPDIR", "/tmp"))',
+        'tempfile.mkdtemp(dir=PINNED)',                                              # a name bound to one
+        'tempfile.mkdtemp(dir=VIA)',
+        'tempfile.mkdtemp(dir=self.pinned)',
+        'tempfile.mkdtemp(dir="fixtures")',                                          # any plain literal
+        'tempfile.mkdtemp(dir="/TESTDIR")',
+    ]
+    UNPINNED_PY = [
+        'tempfile.mkdtemp()',
+        'tempfile.mkdtemp(prefix="rompsock")',
+        'tempfile.mkdtemp(dir=tempfile.gettempdir())',
+        'tempfile.mkdtemp(prefix="rompsock", dir=os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir())',
+        'tempfile.TemporaryDirectory(dir=str(home))',
+        'tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, dir=self.td.name)',
+        'tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False)',
+        'tempfile.mkdtemp(dir=os.path.join(self.dir, "sub"))',                       # a relative component
+        'tempfile.mkdtemp(dir=None)',
+        'tempfile.mkdtemp("", "x", None)',
+        'tempfile.mkdtemp(dir=root)',                                                # bound to a mkdtemp
+        'tempfile.mkdtemp(dir=self.dir)',
+        'tempfile.mkdtemp(dir=home)',
+        'parse_session(dir="/TESTDIR")',                                             # not a tempfile call
+        'shutil.rmtree("/tmp/x")',
+        'open("/tmp/x").read()',
+    ]
+
+    def _pins(self, call):
+        src = self.PREAMBLE.replace("CALL", textwrap.indent(call, " " * 8).lstrip())
+        return _python_pins(src, "t.py")
+
+    def test_python_shapes_that_pin_are_hits(self):
+        for call in self.PINNED_PY:
+            with self.subTest(call=call):
+                pins = self._pins(call)
+                self.assertEqual(len(pins), 1, pins)
+                self.assertTrue(pins[0].startswith("t.py:%d: " % (self.PREAMBLE[:self.PREAMBLE.index("CALL")].count("\n") + 1)), pins)
+                self.assertIn(call.splitlines()[0], pins[0])
+
+    def test_python_shapes_that_do_not_pin_are_clean(self):
+        for call in self.UNPINNED_PY:
+            with self.subTest(call=call):
+                self.assertEqual(self._pins(call), [])
+
+    PINNED_SH = [
+        'TEST_DIR="$(mktemp -d /tmp/x.XXXX)"',
+        'TEST_DIR="$(mktemp -d "/tmp/x.XXXX")"',                # quoted
+        "TEST_DIR=\"$(mktemp -d '/tmp/x.XXXX')\"",
+        'd=$(mktemp -p /tmp)',
+        'd=$(mktemp -p "/tmp")',
+        'd=$(mktemp -p/tmp -d)',                                 # attached
+        'd=$(mktemp -d --tmpdir=/tmp)',                          # =-joined
+        'd=$(mktemp --tmpdir="/var/tmp" -d)',
+        'd=$(mktemp --tmpdir /private/tmp)',
+        'd=$(TMPDIR=/tmp mktemp -d)',                            # the prefix form
+        'd=$(TMPDIR="/tmp" mktemp -d)',
+        'export TMPDIR=/tmp',                                    # redirects every child there
+        'TMPDIR=/var/folders/x/T',
+        '    mktemp -d /var/tmp/x.XXXX',
+        'run mktemp -d /dev/shm/x.XXXX',
+    ]
+    UNPINNED_SH = [
+        'TEST_DIR="$(mktemp -d)"',
+        'TEST_DIR="$(mktemp -d "$TMPDIR/x.XXXX")"',
+        'd=$(mktemp -p "$TMPDIR")',
+        'd=$(mktemp --tmpdir="$TEST_DIR")',
+        'd=$(TMPDIR="$TEST_DIR" mktemp -d)',
+        'export TMUX_TMPDIR="$TEST_DIR/tmux"',
+        'export TMPDIR=/nonexistent',
+        'TEST_DIR="$(mktemp -d -u)"',
+        '# mktemp -d /tmp/x.XXXX',                               # a comment line
+        '    # d=$(TMPDIR=/tmp mktemp -d)',
+        'TEST_DIR="$(mktemp -d)"   # not /tmp',                  # a trailing comment
+        '[ -d /tmp ]',
+        'grep -qxF "TMUX_TMPDIR=$TEST_DIR/tmux" "$FAKE_TMUX_ENV"',
+    ]
+
+    def test_shell_shapes_that_pin_are_hits(self):
+        for line in self.PINNED_SH:
+            with self.subTest(line=line):
+                self.assertEqual(_shell_pins("setup() {\n" + line + "\n}\n", "t.bats"), ["t.bats:2: " + line.strip()])
+
+    def test_shell_shapes_that_do_not_pin_are_clean(self):
+        for line in self.UNPINNED_SH:
+            with self.subTest(line=line):
+                self.assertEqual(_shell_pins("setup() {\n" + line + "\n}\n", "t.bats"), [])
+
+
+@under_conftest
+class RunEndNotice(unittest.TestCase):
+    """A root that survives the run-end removal is named on stderr, once, rather than left standing
+    with the run green. `shutil.rmtree(..., ignore_errors=True)` swallows a child still writing under
+    the root and a 000-mode directory a test left behind (shutil's fd-based walk cannot open it, so
+    the root's rmdir is never reached); the stand-in here is the latter."""
+
+    def test_the_package_state_dir_is_removed_with_the_root(self):
+        # tests/__init__.py minted it before conftest redirected the temp root, so it is the one
+        # thing outside the root; conftest holds it for the run-end removal rather than leaving it
+        # to __init__'s atexit alone.
+        conftest = sys.modules["tests.conftest"]
+        pkg_dir = conftest._PACKAGE_STATE_DIR
+        self.assertEqual(pkg_dir, sys.modules["tests"].STATE_DIR)
+        self.assertTrue(os.path.isdir(pkg_dir), pkg_dir)
+        root = tempfile.gettempdir()
+        # A sibling of the root, not a child: both were minted in the dir this process started with
+        # (the system temp dir, or the controller's root in an xdist worker) before the redirect.
+        self.assertEqual(os.path.realpath(os.path.dirname(pkg_dir)), os.path.realpath(os.path.dirname(root)))
+        self.assertNotEqual(os.path.commonpath([root, pkg_dir]), root)
+
+    @unittest.skipIf(os.geteuid() == 0, "root can remove a 000-mode directory")
+    def test_a_root_that_survives_removal_is_named_on_stderr(self):
+        conftest = sys.modules["tests.conftest"]
+        root = tempfile.mkdtemp()                       # a stand-in root, inside the real one
+        locked = os.path.join(root, "locked")
+        os.mkdir(locked)
+        open(os.path.join(locked, "f"), "w").close()
+        os.chmod(locked, 0)
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        self.addCleanup(lambda: os.path.isdir(locked) and os.chmod(locked, 0o700))
+
+        # The real hook, on the stand-in only (the package state dir is live and not this test's).
+        with patch.object(conftest, "_TMP_ROOT", root), patch.object(conftest, "_PACKAGE_STATE_DIR", None):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                conftest.pytest_unconfigure(None)
+            self.assertTrue(os.path.isdir(root), "the 000-mode child keeps the root standing")
+            self.assertEqual(err.getvalue(), "[tests] not removed at run end: %s\n" % root)
+
+            err = io.StringIO()                          # the atexit fallback: same survivor, silent
+            with contextlib.redirect_stderr(err):
+                conftest._remove_run_dirs()
+            self.assertEqual(err.getvalue(), "")
+
+            os.chmod(locked, 0o700)                      # control: a removable root says nothing
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                conftest.pytest_unconfigure(None)
+            self.assertFalse(os.path.exists(root))
+            self.assertEqual(err.getvalue(), "")
+
+
+def _git_version():
+    out = _run(["git", "--version"]).stdout.split()
+    m = re.match(r"(\d+)\.(\d+)", out[2] if len(out) > 2 else "")
+    return (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+
+
+@under_conftest
+@unittest.skipIf(_git_version() < (2, 32), "GIT_CONFIG_GLOBAL needs git >= 2.32")
+class GitFloor(unittest.TestCase):
+    def test_git_reads_no_global_config_and_has_the_synthetic_identity(self):
+        self.assertEqual(_run(["git", "config", "--global", "--list"]).stdout, "")
+        self.assertTrue(_run(["git", "var", "GIT_AUTHOR_IDENT"]).stdout.startswith(IDENT + " "))
+        self.assertTrue(_run(["git", "var", "GIT_COMMITTER_IDENT"]).stdout.startswith(IDENT + " "))
+
+    def _hostile_repo(self, td):
+        """A stand-in for the developer's configuration: a pre-commit hook that refuses every commit
+        and leaves a marker, a config file wiring it in through core.hooksPath, and a repo with one
+        staged file. Returns (marker, cfg, repo)."""
+        hooks = os.path.join(td, "hooks")
+        os.makedirs(hooks)
+        marker = os.path.join(td, "hook-ran")
+        with open(os.path.join(hooks, "pre-commit"), "w") as f:
+            f.write("#!/bin/sh\necho ran > '%s'\nexit 1\n" % marker)
+        os.chmod(os.path.join(hooks, "pre-commit"), 0o755)
+        cfg = os.path.join(td, "gitconfig")
+        with open(cfg, "w") as f:
+            f.write("[core]\n\thooksPath = %s\n" % hooks)
+        repo = os.path.join(td, "repo")
+        os.makedirs(repo)
+        _run(["git", "init", "-q"], cwd=repo, check=True)
+        with open(os.path.join(repo, "a.txt"), "w") as f:
+            f.write("a\n")
+        _run(["git", "add", "a.txt"], cwd=repo, check=True)
+        return marker, cfg, repo
+
+    COMMIT = ["git", "commit", "-q", "-m", "seed"]
+
+    def test_a_global_hooks_path_cannot_reach_a_fixture_commit(self):
+        # The hostile config as the GLOBAL file. Live first, then floored (the suite's own env).
+        with tempfile.TemporaryDirectory() as td:
+            marker, cfg, repo = self._hostile_repo(td)
+            live = _run(self.COMMIT, cwd=repo, env=dict(os.environ, GIT_CONFIG_GLOBAL=cfg))
+            self.assertNotEqual(live.returncode, 0, "the probe is live: the hook blocks the commit")
+            self.assertTrue(os.path.exists(marker))
+            os.remove(marker)
+
+            floored = _run(self.COMMIT, cwd=repo)
+            self.assertEqual(floored.returncode, 0, floored.stderr)
+            self.assertFalse(os.path.exists(marker), "no global hook reaches a fixture commit")
+            self.assertEqual(_run(["git", "log", "-1", "--format=%an <%ae>"], cwd=repo).stdout.strip(), IDENT)
+
+    def test_a_system_hooks_path_cannot_reach_a_fixture_commit_either(self):
+        # The hostile config as the SYSTEM file: GIT_CONFIG_SYSTEM (git >= 2.32, like GIT_CONFIG_GLOBAL)
+        # is a root-free stand-in for /etc/gitconfig, and GIT_CONFIG_NOSYSTEM=1 is the half of the
+        # floor that hides it — the global probe above says nothing about it. The assertion is the
+        # commit's outcome: `git config --system --list` prints the file under NOSYSTEM too.
+        with tempfile.TemporaryDirectory() as td:
+            marker, cfg, repo = self._hostile_repo(td)
+            live_env = dict(os.environ, GIT_CONFIG_SYSTEM=cfg)
+            live_env.pop("GIT_CONFIG_NOSYSTEM", None)
+            live = _run(self.COMMIT, cwd=repo, env=live_env)
+            self.assertNotEqual(live.returncode, 0, "the probe is live: the system hook blocks the commit")
+            self.assertTrue(os.path.exists(marker))
+            os.remove(marker)
+
+            floored = _run(self.COMMIT, cwd=repo, env=dict(os.environ, GIT_CONFIG_SYSTEM=cfg))
+            self.assertEqual(floored.returncode, 0, floored.stderr)
+            self.assertFalse(os.path.exists(marker), "no system hook reaches a fixture commit")
+
+
+LEAKY_MODULE = textwrap.dedent('''\
+    import os, subprocess, tempfile, unittest
+    ROOT = os.environ["TMPDIR"]
+    STATE = tempfile.mkdtemp()            # a module preamble's state root: never cleaned by the module
+
+    class Leak(unittest.TestCase):
+        def test_everything_lands_under_the_private_root(self):
+            self.assertTrue(os.path.basename(ROOT).startswith("romp-tests-"), ROOT)
+            d = tempfile.mkdtemp()            # a seed repo, the shape that leaked: never cleaned
+            fd, f = tempfile.mkstemp()
+            os.close(fd)
+            subprocess.run(["git", "init", "-q", d], check=True)
+            open(os.path.join(d, "a.txt"), "w").write("a\\n")
+            subprocess.run(["git", "-C", d, "add", "a.txt"], check=True)
+            subprocess.run(["git", "-C", d, "commit", "-q", "-m", "seed"], check=True)
+            sh = subprocess.run(["mktemp", "-d"], capture_output=True, text=True, check=True).stdout.strip()
+            for p in (STATE, d, f, sh):
+                self.assertEqual(os.path.commonpath([ROOT, p]), ROOT, p)
+''')
+
+
+@under_conftest
+class RunLeavesNothing(unittest.TestCase):
+    """A nested pytest, handed a fresh directory as its system temp dir and loading this repo's
+    conftest as a plugin, runs a module that leaks every way the suite does: after it exits the
+    directory holds exactly what it held before.
+
+    The fresh directory is the whole check; the machine's real system temp dir is not diffed. It
+    would be cheap (a prefix-filtered os.scandir over 101k entries measured 0.10 s, 2026-09-06) but
+    not attributable: that dir is shared with every process on the box, and with other checkouts
+    running this suite beside it, romp-prefixed entries appeared there about twice a minute (345
+    bursts in three hours, measured the same day) — a before/after diff over a nested run of a few
+    seconds would fail a third of the time with nothing wrong. Only a literal path can reach it past
+    TMPDIR, and PrivateTempRoot pins that class statically."""
+
+    def _nested(self, *extra):
+        fresh = tempfile.mkdtemp()
+        case = os.path.join(fresh, "case")
+        os.makedirs(case)
+        with open(os.path.join(case, "test_leak.py"), "w") as f:
+            f.write(LEAKY_MODULE)
+        env = dict(os.environ, TMPDIR=fresh, PYTHONDONTWRITEBYTECODE="1")
+        for var in ("PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTEST_DISABLE_PLUGIN_AUTOLOAD", "PYTEST_CURRENT_TEST",
+            "PYTEST_XDIST_WORKER", "PYTEST_XDIST_WORKER_COUNT",
+            "ROMP_TESTS_SYSTEM_TMPDIR"):        # a fresh run records its own handed dir (conftest setdefaults it)
+            env.pop(var, None)
+        r = subprocess.run([sys.executable, "-m", "pytest", "-p", "tests.conftest", "-p", "no:cacheprovider",
+                            "-q", *extra, os.path.join(case, "test_leak.py")],
+                           cwd=ROOT, env=env, capture_output=True, text=True, timeout=180)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("1 passed", r.stdout)
+        self.assertEqual(sorted(os.listdir(fresh)), ["case"],
+                         "the run must leave the system temp dir as it found it")
+
+    def test_a_run_removes_everything_it_created_under_the_system_temp_dir(self):
+        self._nested()
+
+    @unittest.skipUnless(importlib.util.find_spec("xdist"), "pytest-xdist not installed")
+    def test_under_xdist_the_run_leaves_nothing_either(self):
+        # Pins the outcome, not each process's hook: a worker's root sits inside the controller's
+        # (it inherits that TMPDIR), so the controller's removal alone would satisfy this.
+        self._nested("-n", "2")
+
+
 if __name__ == "__main__":
+    # A direct script run never imports the tests package, so the mkdtemp hook would be absent: the
+    # first Hygiene check failed and the child runs left two romp-hygiene-* directories behind (the
+    # #944 review). Import it here; the package also floors XDG_STATE_HOME, as for a unittest run.
+    sys.path.insert(0, ROOT)
+    import tests  # noqa: F401
     unittest.main()


### PR DESCRIPTION
## What breaks

#944 removes the directories the test process itself makes through `tempfile.mkdtemp`. Four things still leak or misbehave at tip:

1. **Children and non-mkdtemp paths.** Kernels, git and a shell's `mktemp -d` inherit the system temp dir, and `mkstemp` files and `os.mkdir` paths are outside the hook's sight. A full run left about 5,600 such entries on one developer machine before either half existed.
2. **A literal pin.** `tests/test_kernel_socket_deliver.py` minted its inbox directory with `dir="/tmp"` and never removed it: three `rompsock*` directories per run, past any redirect.
3. **Fixture git reads the developer's configuration.** The bats suites and several pytest modules build fixture repos with `git init` and `git commit`, which honour the global config. On a machine with a global `core.hooksPath`, every seed commit ran that pre-commit hook (the four git-fixture bats suites took about 64 s instead of 26 s); an LFS filter or a credential helper would run the same way. CI has no global config, so a test that depends on one is already a CI break.
4. **`tests/romp.bats` leaks and flakes**, both listed as pre-existing in #951's body. On a resume, `bin/romp` double-forks the real `romp-postal-service picker-check` and returns; the service mints `home/.local/state/romp/serve-token` after teardown's `rm -rf`, so four to six `tmp.*` directories come back per run, and no exit-time sweep can catch a write that happens after cleanup. The file's curl mocks also exit without reading stdin: `bin/romp` pipes the token as a curl config (`_romp_token_cfg | curl --config - ...`), so when a mock exits first the writer takes SIGPIPE and `pipefail` turns it into a false "not reachable" (about one random kernel-API failure per run on one developer machine).

## Reproduction (at 6d3ad771)

- Socket pin: `_OneShotInbox().dir` is `/tmp/rompsock...` whatever `TMPDIR` says, and the directory is still there after `close()`.
- romp.bats leak: `TMPDIR=$(mktemp -d) bats tests/romp.bats`, then list `$TMPDIR`: six `tmp.*` directories, each holding `home/.local/state/romp/serve-token`.
- Git: write a gitconfig whose `core.hooksPath` names a `pre-commit` that exits 1, then `GIT_CONFIG_GLOBAL=<that file> bats tests/bootstrap-sh.bats tests/docs-serve.bats tests/install-sh.bats tests/release-sh.bats`: 49 of 71 cases fail.

## The fix

Six commits, each green on its own.

- **`tests/conftest.py`: one private root per run.** At import, before its own XDG floor and every module-level mkdtemp at collection, conftest sets `tempfile.tempdir` and `TMPDIR` to a fresh `romp-tests-*` directory, so the process and every child land inside it. `pytest_unconfigure` removes the root whole after #944's `pytest_sessionfinish` sweep of the inside; the package's state dir, minted before the redirect, goes with it; a root that survives (a child still writing, a 000-mode directory) is named on stderr once. Under xdist the controller and each worker own a root, a worker's nested in the controller's. The directory the run was handed is recorded once as `ROMP_TESTS_SYSTEM_TMPDIR` (setdefault, so a worker inherits the controller's record). `pytest_sessionfinish` is now `@pytest.hookimpl(trylast=True)`, the follow-up from the #944 review.
- **The same conftest floors git**: `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, and a synthetic `GIT_AUTHOR_*`/`GIT_COMMITTER_*` identity. `tests/git-hermetic.bash` gives bats the same floor; bootstrap-sh, docs-serve, install-sh and release-sh call `git_hermetic` as the first line of `setup`. The env identity outranks `-c user.*`; bootstrap-sh.bats uses that form, asserts nothing on the author, and passes.
- **The socket test follows the root.** `_socket_dir()` mints under the process temp dir when the path fits `sun_path` (108 bytes on Linux, 104 on macOS) and otherwise under `ROMP_TESTS_SYSTEM_TMPDIR`; a handed directory too deep for any socket is refused before anything is minted; a refused bind removes what was minted; `close()` removes the directory. `test_kernel_worktree_display.TreeOf` gets a `tearDownClass`, and `test_reg_field_gutting` and `test_kernel_provisional_command` `addCleanup` their per-test directories.
- **`tests/test_tempdir_hygiene.py`** keeps #944's three hook checks and adds the in-run floors, a static check that no test file pins a tempfile call, `mktemp` or `TMPDIR` to a literal system temp dir (with the pinned and unpinned shapes as their own table), the survivor notice, a global and a system `hooksPath` probe, and the nested-run proof below. Its `__main__` block imports the `tests` package first, the other #944 follow-up.
- **`bin/romp` (one line) and `tests/romp.bats`.** The resume picker-check goes through `${ROMP_POSTAL_BIN:-romp-postal-service}`, the seam `mail` and `refresh` already use; nothing changes with the variable unset. `setup()` exports a no-op stand-in there (bin/romp puts its own directory first on PATH, so a PATH mock cannot shadow the service), and one test pins the seam with a recording stand-in. Every curl mock drains stdin when `--config -` is passed.
- **`tests/README.md`**: the rules in one paragraph.

## Tests

Red-first, each against 6d3ad771 with only the new test in place:

- `tests/test_tempdir_hygiene.py`: 10 of 19 fail at tip (PrivateTempRoot x3, including the static check flagging the socket pin; RunEndNotice x2; GitFloor x3; RunLeavesNothing x2); the 9 that pass are #944's hook checks and the checker's own shape table. 19/19 at head, serially and under `-n 2`. `python -m unittest tests.test_tempdir_hygiene` and a direct `python tests/test_tempdir_hygiene.py` both pass and leave no `romp-hygiene-*` directory.
- The socket module: a probe against tip finds `_OneShotInbox().dir` under `/tmp` with `TMPDIR` pointing elsewhere, still present after `close()`; at head the directory is under the process temp dir and gone after `close()`. `InboxDir` (5 tests) pins the rule, including the platform constant by a real bind at the limit.
- The git floor: under the hostile `GIT_CONFIG_GLOBAL` above, the four bats suites fail 49/71 at tip and pass 71/71 at head; `tests/git-hermetic.bats` 5/5.
- `tests/romp.bats`: the new stand-in test fails at tip at its `grep` (the real service is called, so the recording stand-in never is) and passes at head. A full run under a fresh private `TMPDIR` leaves six `tmp.*` directories at tip and none at head (101 and 102 cases, all green). The curl drain fixes a race, so it has no deterministic pin; real curl always reads the config, and the mechanism is the writer's SIGPIPE under `pipefail`.
- The nested-run proof: `RunLeavesNothing` runs a second pytest with this conftest as a plugin, under a fresh `TMPDIR`, on a module that leaks every way the suite does (a preamble mkdtemp, a seed repo, mkstemp, a shell `mktemp -d`); afterwards the fresh directory holds exactly what it held before, serially and under `-n 2`.
- Full suites at head, under a private `TMPDIR`: pytest `-n 8` 7602 passed, 51 skipped, 1 failed (`test_file_github.py::BranchOnOrigin::test_the_cut_kills_the_ssh_git_spawned_not_git_alone`, a 3 s wait for a killed process group's child; it passed three times alone and its module passed alone, with other suites running on the same machine at the time), with nothing left in `TMPDIR`; the touched modules serially, 63 passed; `bats tests/*.bats` 435/435 with nothing left in `TMPDIR`; `npm test` 2838/2838 and `tsc --noEmit` clean.

## Limits

- A run ended by `os._exit` (pytest-timeout's thread method, which CI uses) skips both hooks and leaves two `romp-tests-*` entries in the system temp dir: the root and the package state dir. Accepted on an ephemeral runner.
- The static check reads every `tests/*.py`, `*.bats` and `*.bash`; a later change with a literal `dir="/tmp"` or `mktemp -p /tmp` turns it red. That is the rule's purpose, and the failure message names the alternative.
- The env identity outranks `git config user.*` and `-c user.*`; a test that must pin an author exports its own `GIT_AUTHOR_*` after the floor (git-hermetic.bats pins that this works).
- Both git proofs skip on git < 2.32, where `GIT_CONFIG_GLOBAL` is not honoured; the identity half still holds there.
- Verified on Linux only. For macOS, by reasoning: `_SUN_PATH_MAX` is 104 on darwin and pinned by a real bind; the static checker's system-dir set covers `/var/folders` and `/private/tmp`; BSD `mktemp -d -u` with no template honours `TMPDIR`; git-hermetic.bats parses Apple git's version string. Worth including in the next manual macOS run; if something fails there, the likely spot is `test_children_inherit_the_root`'s `mktemp -d -u` comparison.
- One non-test line, in `bin/romp`: `${ROMP_POSTAL_BIN:-romp-postal-service}` is the seam two sibling call sites already use and changes nothing with the variable unset.

Tier: fix (tests only, no behavior change; the docs tier is documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)