### PR TITLE
Tag edits are targeted, acknowledged writes with a write sequence, so a rename typed after a create no longer reverts

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -358,6 +358,278 @@ The exact project directory defines a **comms group**; a directory→tag rule de
 the coarser **display label**. Both default from where you launched, both
 adjustable.
 
+Every dashboard write of the views blob is acknowledged on the socket that posted
+it. A tag edit from the timeline's tag table, its lane gear menu, or a tab's Tags
+flyout is one `tagEdit` WS op, `{writeId, edit: {op, tid, …}}`, where `op` is
+create, rename, recolor, addMember, removeMember, delete or move. It is applied
+through the same read-modify-write merge as `romp tag`, so the stale-writer guard
+never refuses it. Every op but create names the tag by its stored id, never by
+name; a create takes an optional name, and the kernel mints the id and, given no
+name, the lowest free "tag N". A move (off one tag, onto another) is one write:
+both halves land or neither does. The kernel answers `tagEditAck` with `ok`, the
+post-write client blob, the tag's `tid` and `name`, or a plain refusal. A lens or
+order change still posts the whole blob (`setTimelineViews`) together with
+`edited`, the tag ids the write changed (none for a lens or order write).
+`edited` bounds what the write may change. An empty list changes no tag: the
+store's tags stand whatever tags the blob carries, and only the lens, order and
+active fields land, with nothing judged and nothing logged (a lens write built
+from a copy taken in the same second as a targeted edit used to revert that
+edit, since the guard's stamps have one-second resolution). A list of ids may
+change those tags only; a differing copy of any other tag, or its absence, is
+kept from the store and listed in the ack. The guard may also keep the store's
+copy of a stale edited tag; the kernel answers `viewsAck` listing each kept tag
+with a reason, and `ok` is false only when a kept tag is one the client edited.
+The kernel's own dashboard notice follows the same rule: a kept tag the client
+edited is a lost edit and raises a dashboard notice; a kept tag it did not edit
+is one stderr line and nothing on the dashboard. A write without `edited` (an
+older client) is judged whole by the stamps, as before.
+The lens, order and active fields are not judged under any value of `edited`:
+the write's copies land whole, with no comparison of its `seq` or `at` to the
+store's, so across dashboards the last writer wins for them. They are display
+preferences a user sets by gesture, not tag data, and a surface's lens should
+read as the last gesture made on it. The cost is stated here rather than
+hidden: a dashboard whose adopted base predates another dashboard's lens
+change carries the older lenses for the other surfaces along with its own
+change and writes them back, so the other dashboard's filter reverts on its
+next frame. Tightening this would mean naming the surfaces a write changed,
+the way `edited` names tags. The one check made is on `active`: it is
+validated against the tags that stand after the write, so a stale copy whose
+active names a tag deleted since stores "all", not a dangling id.
+`edited` also settles a case the guard could not judge before: a tag absent
+from the store. Named in `edited`, it is a create (the no-capability path's
+client-minted `g…` id) and lands; not named, it is a stale copy re-creating a
+tag another dashboard deleted, and is kept out with a reason. A write without
+`edited` keeps every unknown tag as new. The door also refuses a tag renamed to,
+or created under, a name another tag in the resulting set holds, with a reason
+naming the collision: a renamed tag stands as the store has it and keeps its claim
+on that name, so a tag created under it in the same write is refused too; a new one
+is kept out. Names address edits, so the store holds one tag per name, and a
+name is clamped and stripped at both doors, so a padded spelling is the same
+name. The store caps at 32 tags, and the cap never drops a kept store tag: when
+the tags that stand after a write would exceed it, the write's own creates are
+refused instead, last in array order first, each with a reason naming the cap
+(`_edit_tag` refuses a 33rd create the same way). The door reads a posted blob
+to 64 tags, so a 33rd reaches that pass, and a posted entry with a valid id
+past that bound is always reported. The first 64 such entries get a row each:
+one the store lacks is not created ("a write is read to 64 tags and it was past
+that bound, so it was not created"), one the store holds keeps the store's copy
+("a write is read to 64 tags and its copy was past that bound, so the store's
+copy was kept"). Past those 64, the rest are counted in one summary row with no
+`tid` or `name`, `{reason, more, moreEdited}`, whose reason reads "N more
+entries past the 64-tag read bound were not read", with " (M of them this write
+edited)" appended when `edited` names any of them; the reason stands on its own
+because it can lead the ack's one-line `error`. The bound exists because the rows,
+the loud notice and the ack's `error` all grew with the posted array: a
+100k-entry post drew an ack of about 22 MB, which overran the socket's queue
+and dropped the poster's own socket. Every unread store tag is kept, wherever
+its copy sat past the read bound, and nothing past the read bound is stored. A
+duplicate entry consumes a slot. `ok` is false when a refused tag is one
+`edited` names or the summary row counts one (`moreEdited`), and on any refusal
+when the write carries no `edited`. The ack's one-line `error` leads with the
+rows for the tags `edited` names (or the summary row when it counts one), then
+the rest, joined with "; " (a nameless row is its reason alone) up to 1000
+characters, then "and N more"; without `edited` the rows appear in the judge's
+order. The rows carry every reason in full and are never reordered; a client
+composes the same shape from them, in their order, when the line is absent.
+Until the 2026-09-05 review the line followed the judge's order,
+which files rows in the posted array's order, quiet (kept copies of tags the
+poster did not edit) and loud interleaved, with the cap pass last, so with
+enough quiet rows ahead of it the bound cut the one row that made `ok` false
+and the line named only tags the poster never edited. The loud notice gives the
+count of refused tags and lists each with its cause. A remote tag's rendered name is on the
+same stored basis (clamped, then stripped; "tag" when empty) as the lens and
+order entries, so a padded name a remote kernel serves raw reads as the name a
+lens stores: a lens can select it, and it joins the union of a local tag of that
+name. A lens or order write (`edited: []`) touches no tag whatever the blob carries and
+files none of these rows; it is built from the store's blob the client last
+adopted plus the fields it sets. It never carries a targeted edit still in
+flight, which is that edit's own claim; the copy the client shows keeps such
+edits, and a refusal of one reverts it alone. Both acks carry the write's `writeId` and the blob's `seq`.
+
+`seq` is the store's write sequence. `_set_timeline_views` stamps every accepted
+write with a number greater than the last (seeded from the clock, so a store
+recreated from nothing starts past what any connected client holds), and every
+frame that embeds the blob (the timeline skeleton, the feed frame, the tabOrder
+frames) carries it. A client adopts a blob only when its `seq` is at least the
+one it holds, or when either side carries no seq, so a frame the pusher built
+from its warmed cache before a write cannot replace the ack's newer blob,
+whatever order the socket delivered them in. The gate keeps the last blob it
+turned away and lets it go on its next adoption; the caps frame is the one
+event that adopts a kept blob, and the one that announces a seq at which the
+gate adopts a later blob even below the held one. The optimistic copy a gesture shows clears
+on the ack; a refusal reverts
+its own write at once and shows the reason (a notice in the dialog and the lane
+gear menu, a toast in the chat pane), and a later write still in flight keeps
+its change: the copy is re-derived from the store's blob plus the remaining
+writes. Each surface allows one create in flight at a time: the dialog's
+[+ New tag] reads "creating…" and the new-tag inputs are disabled until the
+ack. The row the create draws meanwhile takes no gesture (no rename, delete,
+recolor, drag, join, or move) until the ack names the tag's id. The join menu's
+new-tag draft belongs to the open [+], survives repaints however the listed rows
+change, and is dropped when the menu or the dialog closes. No count
+of frames settles a write. The one frame-driven clear left is the exact-echo
+match, kept together with the old three-frame yield for blobs without a `seq`:
+a kernel from before the stamp acks nothing.
+
+Reader-side rules keep the sequence consistent. A store from before the stamp
+is stamped once on its first read, so the gate protects the first write after
+an upgrade (a store that does not exist is left alone: its first write starts
+past whatever a client holds). The same first read gives every tag the file
+holds an mtime (the file's `at`, else the time of the stamp), and the
+hidden-to-archived migration does the same for the tags it carries over, so
+every stored tag carries the mark that tells it from a client's own create.
+That stamp is the file's last write time, not each tag's own (a legacy store
+recorded no per-tag time, so there is nothing truer to use), and it has a
+one-time cost: a whole-blob writer whose copy predates the store's last
+pre-upgrade write is refused on any legacy tag it edits, even one that write
+never touched, because the guard compares the tag's mtime to the writer's
+evidence. The refusal is loud, the client adopts the ack's blob, and its next
+write carries the new `at`, so it happens once per stale copy; a copy taken
+at that last write lands (the comparison is strict). Targeted edits read the
+store first and are never affected. For the first-read stamp and the migration
+the file is normalized under the disk cap of 32 before the judge sees it, as
+every read normalizes what it serves, so a read never runs the door's
+create-refusal pass and never files a refusal worded as a dashboard's. What the
+cap leaves out is named once per file state, in a sync notice worded as a fact
+about the file, whether or not the stamp's write lands. The count holds when
+readers race: a reader that waited for the file lock re-checks the read cache
+under it and serves the blob the first reader judged and cached, so when two
+readers that start with the cache empty race on a full disk, the notice is
+filed once. Until the 2026-09-05 review each judged the file, failed
+the write and filed it. The notice is a
+template that puts the cause and the count first and the dropped tags after.
+It opens "the views file held N tags, over the store's 32-tag cap; no dashboard
+wrote this." When the stamp was written it continues "K tags were dropped when
+it was re-stamped on read (<why the file was stamped>): " and lists the dropped
+tags, each with its member count. When the stamp's write failed (an unwritable
+or full state dir) it continues "Its re-stamp could not be written — K tags are
+not served and are lost at the next write unless the file is brought under the
+cap first: " and the same list, because the served blob is what the next write
+persists. The verbs agree with the count: one tag reads "1 tag was dropped" and
+"1 tag is not served and is lost". Stderr carries the notice and every dropped
+tag's members. The judge
+carries a `writer` label apart from `foreign`, because `foreign` is also the
+judging mode for unknown tags and would refuse every freshly stamped tag as a
+re-creation. The loud notice is a template of the same shape: the writer, the
+count and the remedy first, the refused tags after. It reads "<writer> was
+partially refused: its changes to N tags were not applied and the store's state
+was kept; <remedy>. Refused: " and then each refused tag with its cause. The
+writer is "a stale dashboard write", "a stale write to the views file from
+outside the kernel" or "the views file's re-stamp on read". The remedy is
+offered only when there is something to reload: "reload that dashboard to
+resync" for a dashboard's, "reload the panel that wrote it to resync" for a
+foreign file's, and none for the re-stamp's, whose head ends at "kept." One tag
+reads "its changes to 1 tag were not applied". Each label carries its cause:
+"(stale copy)", "(deletion)", "(re-creation)", "(unread)", "(name collision)"
+or "(over the cap)". The quiet stderr line for kept tags the client did not
+edit carries the same kind of label on every tag, "(differing copy)" among
+them; until the 2026-09-05 review a kept differing copy was the one
+entry on it without a cause. Both notices bound their lists to fit the 240 characters
+the dashboard's bell shows, under the 300 the kernel serves (`SYNC_NOTICE_FIT`,
+`_notice_list`): as many entries as fit, then "and M more" for the rest, and
+when not even the first fits, the head alone, which carries the count. Until
+the 2026-09-05 review both notices put the cause clause and the
+remedy last, after one entry per tag, and with two or more tags the bell cut
+them away. A file written
+outside the kernel (the timeline's Electron branch writes `timeline-views.json`
+itself, with the seq it holds) can carry a seq behind the last one served. By its own seq the writer
+held an older copy, so the reader judges the file against the last served blob
+through the stale-writer guard, then re-stamps it past that seq: a tag deleted
+since is not brought back (an unknown tag carrying an mtime existed in a store
+once; one without is the writer's own create and lands), a member added since
+is kept, and each refusal is reported through the sync notice. With nothing
+served, the file is ordered as written: the highest seq the kernel has served
+or written outlives the read cache's entry (a store read as missing forgets the
+entry), so a file restored from an older copy is still re-stamped past it, and
+every write orders past it. A kernel write also refreshes the read
+cache with the blob it wrote, so the ack's blob is never a stale cache hit. The
+hidden-to-archived migration works on a copy of the file, so the tag it fills
+is stamped and a pre-migration copy cannot strip it. It finds an existing
+archived tag on the stored name basis (a padded spelling is the same tag), so
+the hidden entries land in it rather than in a second archived tag the
+collision pass would refuse. When the re-stamp write
+itself fails (an unwritable or full state dir), the read serves the judged
+blob when the file was judged (the judgment is a step apart from the write,
+so the refused foreign copy is neither served nor cached, and the next write
+that lands persists the judged state) and the file as read otherwise, logs
+once per distinct error, and stops retrying until the file changes or a
+write succeeds.
+
+The kernel announces what it can do in a `{type: "caps", caps, viewsSeq}` frame
+in reply to every `ready` and lists the caps on `/version`; `tagEdit` covers the
+targeted op, the acks and the `seq`. A client uses the targeted op only when the
+cap is present and posts the whole blob otherwise. A message no handler takes is
+answered `{type: "unknownOp", op, writeId}`, which the client treats as a refusal
+of that write and as withdrawing the cap. The caps frame is also the reconnect
+signal, and the `ready` handler sends it after its own connect push. `viewsSeq`
+is the write seq of the views blob that push put on the socket: the tabOrder
+frame's, the timeline skeleton's or the feed frame's, the highest when the push
+carried more than one. When the push carried no views frame (a chat page that
+reconnects on a sentinel cycle gets no tabOrder), it is the store's current
+seq at the time of the caps frame, the seq the next push serves. It is null
+only when the store has no seq: no store at all, or a legacy store whose first
+stamp could not be written. The kernel reads a
+served seq from the frames the handler's own thread enqueued, so a write
+landing between the push and the caps frame does not skew it, and a
+pusher-thread frame is never what it names. A client applies one rule to the
+frame. It adopts the blob its gate kept when that blob's seq equals `viewsSeq`
+and discards the kept blob otherwise. When nothing kept matches, a numeric
+`viewsSeq` is remembered as the seq the kernel announced for its current store:
+one slot per store, overwritten by each caps frame and cleared by the client's
+next adoption that changes the held blob. An adoption counts as changing it
+when the blob arrives at a seq other than the held one, without a seq, or at
+the announced seq itself; a re-arrival of the blob the client already holds,
+at the same seq, is otherwise not new information and leaves the slot
+standing. A later blob whose seq equals the announced seq is
+adopted even below the held one, because the kernel said at connect which store
+it holds and a blob carrying that seq is that store, not a stale frame. Null
+and a missing field announce nothing; a frame without the field still adopts
+the kept blob outright (a kernel from before the field). The kernel's seq floor
+lives for its process, so a store restored from an older copy while the kernel
+was down is served under its old seq after the restart. A page that stayed open
+holds the higher seq. When its connect push carried the blob, the gate turns
+the push away and keeps it, the caps frame names that blob, and the restored
+store is adopted on the caps frame itself, with nothing to wait for. When the
+push carried no blob, nothing is kept to match, and the announced seq covers
+it: the pusher's next frame carries the restored store under that seq and is
+adopted, and a frame at any other lower seq is still turned away. A pusher
+frame built before a concurrent write carries a seq older than the connect
+push's, so whether it lands before the caps frame (kept, then discarded) or
+after it (turned away), it is never adopted: the gate is never open. Clearing
+the slot when the held blob changes rules out a wrong adoption later: a write
+that lands first stamps the store past the announced seq (a write's seq is
+seeded from the clock), and a frame at the announced seq is then stale. Writes still
+in flight when the caps frame arrives cannot be answered, so the client drops
+them after that adoption, reverts the copy to the adopted base, and says so. A
+remote kernel's caps frame describes that kernel and is dropped by the
+federation router before it reaches a pane. The router's own two replayed
+stores, the merged tabOrder's blob and the merged lanes payload's, keep, adopt
+and remember by the same rule. A store that adopted on the caps frame re-emits
+before it hands the frame on: a pane sees the local blob only through those
+re-emits, so the restored blob must meet the pane's own gate, and be turned
+away there, before the pane's caps door adopts it. A pane fills the same
+announced slot from the same frame. The router re-emits on a remote host's
+push or lanes payload, a `closed` frame, a view-order storage event and a host
+drop; every merged re-emit between that frame and the pusher's next one hands
+the pane the router's stored blob at the pane's own held seq, and that
+re-arrival leaves the pane's slot standing, so when the router adopts the
+pusher's frame at the announced seq and re-emits it, the pane adopts it by the
+same rule. Until the
+2026-09-05 review any adoption cleared the slot, so a re-emit in that window
+cleared the pane's; the pane turned the restored store away while the router
+held it, and the two diverged until the next write.
+
+The Outline pane's tag filter posts its lens the same way: the frame copy it
+holds with only the outline lens changed, with a `writeId` and `edited: []`, so
+the kernel applies the lens only. It ignores the ack and settles from the next
+feed frame.
+
+Until 2026-09-05 the dialog posted the whole blob for every edit from its own
+un-echoed copy, so the guard refused a rename typed right after a create against
+the dialog's own first write, the refusal reached only stderr and the sync
+notices, and the dialog dropped its copy after three frames; renames and
+assignments made in a burst were lost.
+
 ## The UI progress surface
 
 When the kernel is catching up on a backlog (an old session opened that needs its

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -867,6 +867,9 @@ def _version_info():
     return {"kernel_sha": _kernel_sha(), "kernel_ver": _kernel_ver(), "pid": os.getpid(), "started": int(_STARTED),
             "boot": _BOOT_ID,   # lets a page retire update offers from a previous kernel life (2026-08-15)
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
+            # the WS ops beyond the base protocol this kernel answers (KERNEL_WS_CAPS) — the same list
+            # the `caps` frame carries at `ready`; `romp version` and a curl can read it here
+            "caps": list(KERNEL_WS_CAPS),
             # THIS kernel process's transcript-assembly counters (event_model._ASM_STATS: full/fold/
             # serve/bypass/fallback + per-gate g:<reason> demotes + ts-repair) — the designed home for
             # runtime observability: /healthz's body is a frozen liveness contract ("ok"), while this
@@ -3060,6 +3063,16 @@ def _ordered_alive(now, tmux):
 _VIEWS_MAX_TAGS = 32
 _VIEWS_MAX_NAME = 40
 _views_lock = threading.Lock()   # read-modify-write on the views blob from handler threads (_comments_lock precedent)
+# The store's write door — judgment AND file write, as one step (_set_timeline_views) — and the
+# reader's re-stamp of a file it found changed under it (_timeline_views), serialized together, so
+# a re-stamp is judged against the file as it is at that moment and can never land over an edit
+# written in between, and no writer's blob, judged against the store before a re-stamp, lands over
+# the re-stamp (the 2026-09-05 review: the door judged outside this lock and took it for
+# the write alone). Re-entrant: the judge's own read of the store may re-stamp the file, taking it
+# again on the same thread. Readers never take _views_lock (a plain Lock a locked writer already
+# holds when it reads), so the order is always _views_lock → _views_file_lock and nothing waits
+# the other way.
+_views_file_lock = threading.RLock()
 
 
 def _views_path():
@@ -3091,6 +3104,21 @@ def _member_str(m):
 _LENS_SURFACES = ("chat", "timeline", "outline")   # per-surface selections (the user 2026-08-25); the feed's is client-local
 
 
+def _tag_name_basis(n):
+    """The STORED spelling of a tag name — clamped to _VIEWS_MAX_NAME, then stripped (the
+    2026-09-05 review gave the tag rows this basis; then every name-keyed field). A
+    lens entry or an order entry read on any other basis names nothing: a store that already held a
+    padded twin ("web " beside "web") read both rows as "web" on the first post-upgrade read while
+    its lens and order still carried "web ", so the surface filtered to it showed no session and the
+    tag fell to the end of the order. A REMOTE tag's rendered name is on it too (_views_client), and
+    so is a pending edit's name (_queue_pending_tag_edit): a remote kernel on an older build, or a
+    padded remote store, serves "web " raw, and a lens stored as "web" — every entry is — never
+    matched the rendered "web ", so the surface filtered to that tag showed none of its members and
+    the name-keyed union kept the padded twin apart from the local tag. Every name a client sees or
+    a lens compares is on this one basis. "" for a non-string or an all-whitespace name."""
+    return str(n)[:_VIEWS_MAX_NAME].strip() if isinstance(n, str) else ""
+
+
 def _norm_lens(x, tags):
     """One surface's selection in the shared TagLens shape ({all} | {none?, tags?:[names]} — the
     feed-authored model, manager-sanctioned as the shared shape 2026-08-25). Tag entries are NAMES
@@ -3101,8 +3129,9 @@ def _norm_lens(x, tags):
         return {"all": True}
     names = []
     for n in (x.get("tags") if isinstance(x.get("tags"), list) else []):
-        if isinstance(n, str) and n[:_VIEWS_MAX_NAME] not in names:
-            names.append(n[:_VIEWS_MAX_NAME])
+        nm = _tag_name_basis(n)                  # the stored basis, so the entry names the stored tag
+        if nm and nm not in names:
+            names.append(nm)
     lens = {}
     if x.get("none"):
         lens["none"] = True
@@ -3122,9 +3151,14 @@ def _lens_seed(active, tags):
     return {"tags": [t["name"]]} if t else {"all": True}
 
 
-def _norm_timeline_views(d):
+def _norm_timeline_views(d, tag_cap=_VIEWS_MAX_TAGS):
     """Validate + normalize a views blob from disk or a client: always returns the full shape, drops
     junk quietly, clamps sizes, and falls back active→"all" when the named tag does not exist.
+    `tag_cap` bounds the tag list (the store's cap by default); the write door reads a posted blob
+    under a wider bound so ITS cap pass can refuse the excess with a reason instead of this slice
+    dropping a posted create in silence (the 2026-09-05 review), and whatever a blob
+    carries past the bound is listed by _views_unread, so the door and the reader's re-stamp can
+    say what this slice left unread.
     "all" and "untagged" are the two built-in sentinels; "untagged" must pass the whitelist below,
     or a picked untagged view silently reverts on the next read (the client's optimistic hold makes
     that failure read as flicker three pushes later, not as an error).
@@ -3147,14 +3181,22 @@ def _norm_timeline_views(d):
     # echoed hidden array is tolerated and dropped; _timeline_views migrated existing entries into
     # the "archived" tag once. Nothing hides from All anymore: that is All's meaning now.)
     tags = []
+    seen = set()   # ids are addresses: a blob carrying one id twice reads as the first entry (the 2026-09-05 review)
     raw = d.get("tags") if isinstance(d.get("tags"), list) else d.get("groups")
-    for g in _lst(raw)[:_VIEWS_MAX_TAGS]:
+    for g in _lst(raw)[:tag_cap]:
         if not isinstance(g, dict) or not g.get("id") or not isinstance(g.get("id"), str):
             continue
+        if g["id"][:64] in seen:
+            continue
+        seen.add(g["id"][:64])
         members = [m for m in (_member_pair(x) for x in _lst(g.get("members"))) if m]
         dedup = {(m["host"], m["sid"]): m for m in members}
+        # the NAME BASIS (the 2026-09-05 review): clamped to _VIEWS_MAX_NAME and stripped,
+        # the spelling the targeted door already gives a rename (_edit_tag) — a whole-blob write
+        # carrying "web " beside "web" passed the door's collision pass as two names and the store
+        # held a padded twin every name-keyed surface showed as one. Empty after the strip → "tag".
         rec = {"id": g["id"][:64],
-               "name": str(g.get("name") or "tag")[:_VIEWS_MAX_NAME],
+               "name": str(g.get("name") or "")[:_VIEWS_MAX_NAME].strip() or "tag",
                "color": str(g.get("color") or "")[:16],
                "members": [dedup[k] for k in sorted(dedup)]}
         if g.get("mtime"):                       # v2's edit stamp survives the rebuild (absent = 0 = legacy)
@@ -3180,14 +3222,16 @@ def _norm_timeline_views(d):
     # TAG ORDER (the user 2026-08-25): the union DISPLAY order — a NAME list, viewer-side, so a
     # remote-homed tag holds its dragged position without any cross-kernel write (a display
     # preference must not need another kernel up; the lane order's viewer-side philosophy). Local
-    # tags ALSO keep their array order (the drag rewrites both); this list extends the same order
+    # tags' ARRAY order follows it too: the write door sorts the stored array by the write's
+    # tagOrder under an empty `edited` (the drag's write); this list extends the same order
     # across the whole name-keyed union. Names are not validated against the local store — a
     # remote name is unknowable here by design; junk entries cost nothing and age out on the next
     # drag. Absent stays absent, so pre-order blobs round-trip byte-identical.
     order = []
     for n in _lst(d.get("tagOrder"))[:_VIEWS_MAX_TAGS * 2]:
-        if isinstance(n, str) and n and n[:_VIEWS_MAX_NAME] not in order:
-            order.append(n[:_VIEWS_MAX_NAME])
+        nm = _tag_name_basis(n)                  # the stored basis, so the entry ranks the stored tag
+        if nm and nm not in order:
+            order.append(nm)
     if order:
         out["tagOrder"] = order
     # `at` — the store's write stamp, served to every client and echoed back with its blob: the
@@ -3198,7 +3242,85 @@ def _norm_timeline_views(d):
             out["at"] = int(d["at"])
     except (TypeError, ValueError):
         pass
+    # `seq` — the store's WRITE SEQUENCE (2026-09-05): strictly increasing across writes, stamped
+    # by _set_timeline_views and carried on every frame and ack the blob rides. Clients adopt a
+    # blob only when its seq is at least the one they hold, so a frame built before a write (the
+    # pusher's warmed cache, a federation re-emit) can never replace the ack's newer blob. Preserved
+    # through the rebuild like `at`; absent stays absent (a blob from before the stamp).
+    try:
+        if d.get("seq"):
+            out["seq"] = int(d["seq"])
+    except (TypeError, ValueError):
+        pass
     return out
+
+
+def _views_unread(d, kept):
+    """The tag entries of a blob that a normalization under a bound left UNREAD — every entry carrying
+    a valid id that none of the `kept` (normalized) tags has — as (id, name, member count) triples in
+    array order, one per id (the 2026-09-05 review). The write door lists them in the ack
+    as refusal rows and the reader's re-stamp names them in a notice; neither stores them. Until now
+    the normalizer's slice was the one place a posted tag could vanish with nothing said: the door
+    reads a blob under twice the cap, and a client whose `edited` named only ids past that bound was
+    acked ok with a blob missing its own creates (a duplicate entry consumes a slot too, so 33
+    distinct tags posted twice reach it). Junk entries (no id, not a dict) drop quietly here as in
+    the normalizer; the name is on the stored basis, "tag" when empty."""
+    if not isinstance(d, dict):
+        return []
+    raw = d.get("tags") if isinstance(d.get("tags"), list) else d.get("groups")
+    have = {t["id"] for t in kept if isinstance(t, dict) and t.get("id")}
+    out = []
+    for g in (raw if isinstance(raw, list) else []):
+        if not isinstance(g, dict) or not g.get("id") or not isinstance(g.get("id"), str):
+            continue
+        i = g["id"][:64]
+        if i in have:
+            continue
+        have.add(i)
+        m = g.get("members")
+        out.append((i, _tag_name_basis(g.get("name")) or "tag", len(m) if isinstance(m, list) else 0))
+    return out
+
+
+_VIEWS_RESTAMP_ERR = [None]   # the last OSError the reader's re-stamp write hit, as text — one stderr line per distinct error
+# The highest seq this kernel has served or written (the 2026-09-05 review), kept apart
+# from the read cache: a store read as MISSING forgets its cache entry (rightly — a file that then
+# appears must not be judged against a store that no longer exists), and with it forgot the seq
+# floor, so a file restored from an older copy was served under its old seq and every dashboard
+# holding a higher one ignored it until the next kernel write. The floor outlives the entry: a
+# recreated file whose seq fell behind it is re-stamped past it (ordered, not judged), and every
+# write orders past it. Set wherever a blob is cached (_views_cache_put); never lowered. KEYED BY
+# STORE PATH like the read cache (the 2026-09-05 review): one process can serve more
+# than one state dir (a test suite; a kernel rebound to another root), and a floor shared across
+# them made a cold read of a small-seq file in a fresh state dir a re-stamp write, ordered past
+# another store's seq. The live kernel has one store, so one entry.
+_VIEWS_SEQ_FLOOR = {}
+
+
+def _views_seq_floor(p=None):
+    """The seq floor of the store at `p` (the current store by default): the highest seq this process
+    has served or written from THAT file, 0 for one it has not touched."""
+    return _VIEWS_SEQ_FLOOR.get(str(p if p is not None else _views_path()), 0)
+
+
+def _views_cache_put(p, key, d):
+    """Cache a served or written blob under the file's (mtime, size) key and raise the seq floor to
+    its seq — the two facts every later read and write order themselves against."""
+    _flags_cache[str(p)] = (key, d)
+    try:
+        _VIEWS_SEQ_FLOOR[str(p)] = max(_views_seq_floor(p), int(d.get("seq") or 0))
+    except (TypeError, ValueError):
+        pass
+
+
+def _views_lost_notice(note, members):
+    """The reader's file-fact notice — a views file over the cap, read under it (_timeline_views): one
+    stderr line carrying the notice and every dropped tag's members, and the sync notice, red."""
+    sys.stderr.write("romp-kernel: %s [%s]\n" % (note, members))
+    try:
+        _sync_notice(note, ok=False)
+    except Exception:
+        pass
 
 
 def _timeline_views():
@@ -3206,50 +3328,345 @@ def _timeline_views():
     try:
         st = p.stat(); key = (st.st_mtime_ns, st.st_size)
     except OSError:
+        # No store: nothing served before it describes this one. The cache entry is the last blob
+        # this kernel served or wrote, and a file written outside the kernel after a delete or a
+        # restore is judged against it (_views_restamp's third case) — forgetting it here is what
+        # keeps a recreated store from being judged against a store that no longer exists. The seq
+        # floor is kept (_VIEWS_SEQ_FLOOR): a recreated file is still ORDERED past what was served.
+        _flags_cache.pop(str(p), None)
         return _norm_timeline_views({})
     hit = _flags_cache.get(str(p))
     if hit is not None and hit[0] == key:
         return hit[1]
     try:
         d = json.loads(p.read_text())
+        parsed = isinstance(d, dict)
     except Exception:
+        d, parsed = {}, False
+    if not parsed:
         d = {}
-    # ONE-TIME MIGRATION (the user 2026-08-24, retiring hide-from-chat outright: "we want to get
-    # rid of that hide from chat thing"): a stored blob still carrying hidden entries maps them
-    # into an "archived" TAG on THIS kernel — preserving the user's intent record and keeping them
-    # out of the untagged view. They WILL show under All: nothing can hide from All
-    # post-retirement — that is All's meaning now, and the feed's needs-you machinery carries
-    # anything that matters. Minted only when hidden entries exist; idempotent (the write drops the
-    # hidden key, so the next read has nothing to migrate).
-    hid = [str(x) for x in (d.get("hidden") or []) if isinstance(x, str) and x] if isinstance(d, dict) else []
+    fix = _views_restamp(d, hit) if parsed else None
+    if fix is not None:
+        # The file goes back through the write door BEFORE it is served (the cases in
+        # _views_restamp), as ONE write: the setter is handed its diff base explicitly, because
+        # reading it through this function would find the same un-stamped file and re-enter here
+        # (until 2026-09-05 the hidden migration did exactly that — 321 nested writes for one read,
+        # ending only when Python's recursion limit tripped inside the setter's own try). The base
+        # is the file's OWN content for the migration and the first stamp: those order the file
+        # (its seq moves past the last one this kernel served or wrote, the floor) without judging
+        # it — the stale-writer guard rules on dashboard writes at the door. A write outside the
+        # kernel whose seq fell behind is the exception (the 2026-09-05 review): the
+        # writer held an older copy by its own seq, so the guard judges the file against the LAST
+        # SERVED blob (the cache entry it missed against) — a tag it deleted since is not brought
+        # back, a member added since is not lost, and each refusal is reported (the setter's
+        # notice, naming the tag). With nothing served (a fresh kernel; a store deleted and read
+        # as missing, which forgets the entry) there is nothing to judge against and the file is
+        # ordered as written. Under the file lock, with a re-check: a writer may have replaced
+        # the file since the stat above — its own edit, or this same re-stamp from another
+        # thread — and that newer content is judged afresh rather than written over.
+        why, d2, judge = fix
+        with _views_file_lock:
+            try:
+                st2 = p.stat()
+            except OSError:
+                return _norm_timeline_views({})
+            if (st2.st_mtime_ns, st2.st_size) != key:
+                return _timeline_views()
+            hit2 = _flags_cache.get(str(p))
+            if hit2 is not None and hit2[0] == key:
+                # The same file state, served and cached by a reader that held the lock while this one
+                # waited (the 2026-09-05 review): the failed-write path below caches the
+                # served blob under the file's UNCHANGED key — a write that never reached its replace
+                # leaves the stat alone — so the re-check above could not tell that read had happened,
+                # and two cold readers racing on a full disk each judged the file, each failed the
+                # write, and each filed the file-fact notice. The check the function opens with, run
+                # again under the lock; it serves nothing that check would not.
+                return hit2[1]
+            try:
+                floor = int(hit[1].get("seq") or 0) if hit is not None else 0
+            except (TypeError, ValueError):
+                floor = 0
+            floor = max(floor, _views_seq_floor(p))
+            base = hit[1] if (judge and hit is not None) else _norm_timeline_views(d)
+            lost = []
+            if not judge:
+                # The file's OWN content, under the DISK cap (the 2026-09-05 review): the
+                # migration and the first stamp are reads, not writes, and the door's wider read
+                # bound is for a dashboard's posted creates — read through it, a file holding more
+                # than the cap had its excess (the migration's appended "archived" tag first) judged
+                # as creates and refused by the cap pass, under a notice blaming a stale dashboard
+                # write. The normalizer bounds every read to the cap, so the file's tags past it were
+                # never served; the stamp writes what every read served, as it did before the door
+                # bound — and what the cap leaves out is NAMED (`lost`, below), as a fact about the
+                # file, where until now it was dropped with nothing said.
+                d2n = _norm_timeline_views(d2)
+                lost = _views_unread(d2, d2n["tags"])
+                d2raw, d2 = d2, d2n
+            judged, _rows = _judge_timeline_views(
+                d2, base=base, seq_floor=floor,
+                foreign="a stale write to the views file from outside the kernel" if judge else None,
+                writer=None if judge else "the views file's re-stamp on read")
+            names, members, fact = [], "", ""
+            if lost:
+                # No dashboard wrote this — the file itself was over the cap (an edit outside the
+                # kernel, or a kernel from before the cap that held 32 tags plus hidden entries,
+                # which the migration's archived tag then puts over). Said once, as a fact about the
+                # file, whether or not the stamp below lands (the 2026-09-05 review: it
+                # was said only after a successful write, so an unwritable store served the capped
+                # blob in silence and the next RMW write, built from that cache, made the drop
+                # permanent with nothing ever said). Cause and count first, the dropped tags after,
+                # as many as fit the served notice (_notice_list — the same review found the cause
+                # clause LAST, after one entry per tag, cut away by the dashboard's bell on any drop
+                # of two or more); stderr lists every dropped tag with its members.
+                held = len(d2["tags"]) + len(lost)
+                names = ['"%s" (%d member%s)' % (nm, n, "" if n == 1 else "s") for _i, nm, n in lost]
+                fact = ("the views file held %d tags, over the store's %d-tag cap; no dashboard wrote this."
+                        % (held, _VIEWS_MAX_TAGS))
+                ids = set(i for i, _nm, _n in lost)
+                raw = [g for g in (d2raw.get("tags") or []) if isinstance(g, dict)
+                       and isinstance(g.get("id"), str) and g["id"][:64] in ids]
+                members = "; ".join('"%s": %s' % (_tag_name_basis(g.get("name")) or "tag",
+                                                   ", ".join(_member_str(m) for m in
+                                                             (_member_pair(x) for x in (g.get("members") or []))
+                                                             if m) or "no members")
+                                    for g in raw)
+            try:
+                _write_timeline_views(judged)
+                sys.stderr.write("romp-kernel: views store re-stamped on read: %s\n" % why)
+                if lost:
+                    # the drop is permanent once the stamp is written
+                    _views_lost_notice(_notice_list(
+                        "%s %d tag%s dropped when it was re-stamped on read (%s)"
+                        % (fact, len(lost), " was" if len(lost) == 1 else "s were", why), ": ", names), members)
+            except OSError as e:
+                # The state dir is unwritable or full: a READ must still answer (every frame builds
+                # on it), so a blob is served and cached under the file's key — the next read is a
+                # hit, not another failing write — and the failure is logged once per distinct
+                # error (a full disk would otherwise log on every read). The next write that
+                # succeeds clears the note, so a recurrence is logged again. WHICH blob: the JUDGED
+                # one when the file was judged (the 2026-09-05 review — serving the file
+                # as read served the foreign copy the judgment had just refused, cached it, and
+                # the next RMW write, built from that cache, persisted it: the deleted tag back,
+                # the newer member gone); the file as read, unstamped, for the migration and the
+                # first stamp, whose write changes no tag's state. The judged blob carries a seq
+                # past the floor that the file does not, which is the point: dashboards adopt it,
+                # and the next write that lands (a RMW built from this cache) persists it.
+                # the key is the error's kind, not its text: the atomic write's temp name differs
+                # per call, so the text would read as a new error every time
+                kind = "%s errno=%s" % (type(e).__name__, getattr(e, "errno", None))
+                if _VIEWS_RESTAMP_ERR[0] != kind:
+                    _VIEWS_RESTAMP_ERR[0] = kind
+                    sys.stderr.write("romp-kernel: views store could not be re-stamped on read (%s) — "
+                                     "serving %s: %s: %s\n"
+                                     % (why, "the judged blob, unwritten" if judge
+                                        else "the file as read, under the cap, unstamped",
+                                        type(e).__name__, e))
+                if lost:
+                    # The file still holds the excess and the served blob does not, and the next
+                    # write that lands (a RMW built from this cache) persists the served blob: the
+                    # drop becomes permanent THEN, unless the file is brought under the cap first.
+                    # Named now, once per file state (the cache entry below keeps every further read
+                    # a hit, and a reader that raced this one to the lock finds it there), with that
+                    # consequence in the notice.
+                    _views_lost_notice(_notice_list(
+                        "%s Its re-stamp could not be written — %d tag%s not served and %s lost at the next "
+                        "write unless the file is brought under the cap first"
+                        % (fact, len(lost), " is" if len(lost) == 1 else "s are",
+                           "is" if len(lost) == 1 else "are"), ": ", names), members)
+                d = _norm_timeline_views(json.loads(json.dumps(judged)) if judge else d2)
+                _views_cache_put(p, key, d)
+                return d
+        return _timeline_views()          # the write refreshed the cache under the file's new key
+    d = _norm_timeline_views(d)
+    _views_cache_put(p, key, d)
+    return d
+
+
+def _views_stamp_legacy_tags(tags, d):
+    """Every tag of a file going through the first-read stamp or the migration is given an mtime if
+    it lacks one — the file's `at` (the last write the store recorded), else now (the
+    2026-09-05 review). The mtime is the one mark that tells a tag a store once held from a client's
+    own create in a write the kernel cannot otherwise judge (the `foreign` rule in
+    _judge_timeline_views: an unknown tag carrying one existed in a store and is not re-created). The
+    write door stamps changed tags only, and a first-read stamp changes nothing, so a tag from before
+    the per-tag stamp never got one and, once deleted, could come back through a file written outside
+    the kernel. Mutates and returns `tags` (a copy at every call site)."""
+    try:
+        at = int(d.get("at") or 0)
+    except (TypeError, ValueError):
+        at = 0
+    stamp = at or int(time.time())
+    for t in tags:
+        if isinstance(t, dict) and not t.get("mtime"):
+            t["mtime"] = stamp
+    return tags
+
+
+def _views_restamp(d, hit):
+    """Why a views file just read (a parsed dict) must go back through the write door before it is
+    served, and the dict to write — or None when it is fine as-is. Each case is one write and then
+    never again for that content, so a clean store round-trips byte-identical.
+    - ONE-TIME MIGRATION (the user 2026-08-24, retiring hide-from-chat outright): a stored blob
+      still carrying hidden entries maps them into an "archived" TAG on THIS kernel — preserving
+      the user's intent record and keeping them out of the untagged view. They WILL show under
+      All: nothing can hide from All post-retirement — that is All's meaning now, and the feed's
+      needs-you machinery carries anything that matters. Minted only when hidden entries exist;
+      idempotent (the write drops the hidden key, so the next read has nothing to migrate). The
+      archived tag is appended LAST, so a store already at the cap loses it to the disk cap when
+      the reader stamps the file — named in the reader's notice as a fact about the file (the 2026-09-05 review), never dropped in silence.
+    - A STORE WITHOUT A WRITE SEQUENCE (every install upgrading to the 2026-09-05 stamp): served
+      seq-less, it would leave every client on the null rule — adopt anything — until the first
+      write, so the seq gate could not protect that first write against a frame the pusher built
+      before it. Stamped once, on the first read; a store that does not exist stays unstamped (the
+      null rule is right for a deleted or recreated store, which starts past what any client holds
+      on its first write).
+    - A WRITE OUTSIDE THE KERNEL whose seq fell BEHIND the last one served (the
+      2026-09-05 review): the timeline's Electron branch writes the file itself with the seq it
+      holds, and a panel holding an older frame publishes a seq lower than what every dashboard
+      holds — they would all ignore the file until the next kernel write. `hit` is the cache entry
+      the changed file missed against: the last blob this kernel served or wrote, whose seq is the
+      floor the re-stamp moves past. Equal seqs are left alone (a writer holding the newest frame
+      writes the newest seq back; every client adopts an equal seq), so an mtime-only change never
+      costs a write. This is the one case JUDGED (the third element, True): the file goes through
+      the stale-writer guard against that last served blob, since by its own seq the writer held
+      an older copy than the store.
+    - A FILE THAT APPEARED with a seq behind the last one served and NO cache entry to judge it
+      against (the 2026-09-05 review): a store read as missing forgets its entry, so a
+      file restored from an older copy would be served under its old seq and ignored by every
+      dashboard holding a higher one. The seq floor outlives the entry (_VIEWS_SEQ_FLOOR), and the
+      file is re-stamped past it, as written — ordered, not judged.
+    Returns (why, dict-to-write, judge). The dict is a COPY: `d` is also the diff base the migration
+    is stamped against, and mutating its tag dicts in place (an earlier aliasing bug) left the
+    base already migrated — an existing "archived" tag gained its members with no fresh mtime, and
+    a whole-blob post from a dashboard holding the pre-migration copy stripped them again with no
+    refusal (the 2026-09-05 review)."""
+    hid = [str(x) for x in (d.get("hidden") or []) if isinstance(x, str) and x]
     if hid:
-        raw = d.get("tags") if isinstance(d.get("tags"), list) else (d.get("groups") if isinstance(d.get("groups"), list) else [])
+        d2 = json.loads(json.dumps(d))                     # a parsed file: the round trip is a deep copy
+        raw = d2.get("tags") if isinstance(d2.get("tags"), list) else (d2.get("groups") if isinstance(d2.get("groups"), list) else [])
         tags = [t for t in raw if isinstance(t, dict)]
-        arch = next((t for t in tags if t.get("name") == "archived"), None)
+        # on the STORED basis (the 2026-09-05 review): the file's raw spelling can be padded
+        # ("archived "), which the normalizer reads as "archived" — compared raw, the lookup missed it,
+        # a second archived tag was minted, the door's collision pass refused that one, and the hidden
+        # entries migrated into nothing
+        arch = next((t for t in tags if _tag_name_basis(t.get("name")) == "archived"), None)
         if arch is None:
             arch = {"id": "archived", "name": "archived", "color": "#6b7280", "members": []}   # muted slate — never a status color
             tags = tags + [arch]
         arch["members"] = [m for m in (arch.get("members") or []) if m] + hid
-        d = dict(d); d["tags"] = tags; d.pop("groups", None); d.pop("hidden", None)
-        _set_timeline_views(d)                       # persist the mapping; the fresh mtime re-keys the cache
-    d = _norm_timeline_views(d)
-    _flags_cache[str(p)] = (key, d)
-    return d
+        d2["tags"] = _views_stamp_legacy_tags(tags, d); d2.pop("groups", None); d2.pop("hidden", None)
+        return "hidden entries migrated into the archived tag", d2, False
+    try:
+        seq = int(d.get("seq") or 0)
+    except (TypeError, ValueError):
+        seq = 0
+    if not seq:
+        # a copy, like the migration's: `d` is the diff base, and every tag the file holds is given
+        # an mtime here (_views_stamp_legacy_tags) — the base keeps none, so the stamp is the one
+        # change the setter sees, and it preserves the given mtime on an otherwise unchanged tag
+        d2 = json.loads(json.dumps(d))
+        raw = d2.get("tags") if isinstance(d2.get("tags"), list) else (d2.get("groups") if isinstance(d2.get("groups"), list) else [])
+        d2["tags"] = _views_stamp_legacy_tags([t for t in raw if isinstance(t, dict)], d); d2.pop("groups", None)
+        return "a store from before the write sequence, stamped once", d2, False
+    floor = _views_seq_floor()                     # this store's own floor (the reader reads _views_path())
+    if hit is None and floor and seq < floor:
+        # no served blob to judge against (the store was read as missing, or the cache is cold),
+        # but a floor to order past (the 2026-09-05 review): a file restored from an
+        # older copy is re-stamped past the last seq this kernel served, as written — every
+        # dashboard holding that seq adopts it, where under its own seq they all ignored it
+        return ("a file with seq %d appeared behind the last served %d" % (seq, floor)), d, False
+    if hit is not None:
+        try:
+            last = int(hit[1].get("seq") or 0)
+        except (TypeError, ValueError):
+            last = 0
+        if last and seq < last:
+            return ("a write outside the kernel carried seq %d, behind the last served %d" % (seq, last)), d, True
+    return None
 
 
-def _set_timeline_views(blob):
+def _set_timeline_views(blob, base=None, seq_floor=0, edited=None, foreign=None):
+    """The views store's ONE write door: judge the blob against the store (_judge_timeline_views —
+    the stale-writer guard, the `edited` bound, the name-collision pass, the stamps), then write
+    what stands (_write_timeline_views). Returns the refused rows. The judgment is a separate step
+    (the 2026-09-05 review) so the reader's re-stamp can serve the JUDGED blob when the
+    write itself fails: serving the file as read served, cached, and let the next write persist, the
+    foreign copy the judgment had refused. Both steps run under _views_file_lock (the
+    2026-09-05 review): the reader's re-stamp holds that lock across its own judge and write, but this
+    door took it for the write alone, so a re-stamp landing between the judge here and the write here
+    was written over by a blob judged against the pre-re-stamp store — the foreign write's lens
+    change and its creates gone, under a seq no higher than the re-stamp's (both computed from the
+    same base), with no refusal filed. The lock is re-entrant, and every caller holding _views_lock
+    takes it first, so the documented order stands."""
+    with _views_file_lock:
+        v, rows = _judge_timeline_views(blob, base=base, seq_floor=seq_floor, edited=edited, foreign=foreign)
+        _write_timeline_views(v)
+    return rows
+
+
+def _write_timeline_views(v):
+    """Write a judged, stamped blob (from _judge_timeline_views) to the store and refresh the read
+    cache with it. Raises the OSError of an unwritable or full state dir to the caller."""
+    text = json.dumps(v, sort_keys=True)
+    with _views_file_lock:
+        _atomic_write(_views_path(), text)
+        _views_cache_refresh(text)
+    _VIEWS_RESTAMP_ERR[0] = None      # the store is writable again: a later failure logs afresh
+
+
+def _judge_timeline_views(blob, base=None, seq_floor=0, edited=None, foreign=None, writer=None):
+    # The write door's judgment, without the write: returns (blob-to-store, refused rows). The blob
+    # carries every stamp a write puts on it (per-tag mtimes, `at`, `seq`) so the caller stores it
+    # as is — or, when it cannot (the reader's re-stamp of an unwritable store), serves it as is.
     # Per-tag mtime, stamped at the store's ONE write door by diffing against the previous blob
     # (tag federation v2, the user 2026-08-29): a pending edit queued for an unreachable host must
     # be able to tell, at late-apply time, whether the host's copy changed AFTER the user's ruling —
     # a writer whose evidence predates newer information stands down (the cards-move corollary).
-    # The stamp rides /views to every peer for free. Only set when a tag actually changes, so
-    # untouched legacy stores round-trip byte-identical; a client echoing a blob without mtimes
+    # The stamp rides /views to every peer for free. Set when a tag changes — and once for every tag
+    # a legacy store holds, when its first read stamps it (_views_stamp_legacy_tags, the
+    # 2026-09-05 review), so every stored tag carries one; a client echoing a blob without mtimes
     # merely resets the field, which reads as "no newer information" — the safe direction.
-    v = _norm_timeline_views(blob)
-    try:
-        prev = {t["id"]: t for t in (_timeline_views().get("tags") or [])}
-    except Exception:
-        prev = {}
+    # `base` — the previous blob to diff against, when the caller already holds it: the reader's
+    # re-stamp path (_timeline_views) passes the file's own content, since reading it here would
+    # find the same un-stamped file and re-enter the reader; `seq_floor` is the last seq that path
+    # served, so the re-stamped file orders after it. Every other caller leaves both alone.
+    # `edited` — the WS door's whole-blob path passes the tag ids the posting client CHANGED; None
+    # from every other caller and from an older client. It bounds what the write may change (the 2026-09-05 review): an EMPTY list is a lens or order write and changes NO tag — the
+    # store's tags stand whole, whatever tags the blob carries, and only its other fields land; a
+    # list of ids may change those tags only, and a differing copy of any other tag is the store's
+    # to keep, quietly (the ack lists it, nothing is said to the user — before this change the benign case
+    # still filed a red "reload that dashboard" notice); a kept tag the poster DID edit is a LOST
+    # EDIT (the notice below fires, the ack is not ok). Before this change the empty list was judged like
+    # any whole blob, by the second-resolution `at` stamp, so a lens write built from a copy taken in
+    # the same second as a targeted edit reverted it (the rename undone, the create deleted, the
+    # member lost) with nothing said.
+    # `foreign` — set by the reader's re-stamp of a file written OUTSIDE the kernel whose seq fell
+    # behind the last served blob (the 2026-09-05 review), as the words the notice uses
+    # for the writer. Such a write carries no `edited`, so its unknown tags are judged by the one
+    # mark only the kernel puts on a tag: an mtime. A tag the store lacks that carries one existed
+    # in a store once — the writer's copy of a tag deleted since — and is not re-created; one
+    # without is the writer's own create (a client-minted row) and lands.
+    # `writer` — the words the loud notice below uses for the writer when it is not a dashboard and
+    # not a foreign file: the reader's re-stamp of the file's own content (the 2026-09-05
+    # review — its refusals, when the cap pass fired on a file over the cap, were filed as "a stale
+    # dashboard write ... reload that dashboard", on a read, blaming a dashboard that wrote nothing).
+    # Separate from `foreign` on purpose: `foreign` is also the judging mode for unknown tags above,
+    # and a re-stamp under it would refuse every freshly stamped tag as a re-creation.
+    # Read under a wider bound than the store's cap (twice it: a client holds at most the store's 32
+    # plus its own creates), so a posted 33rd tag reaches the cap pass below and is refused with a
+    # reason — the normalizer's own slice dropped it before the judge saw it. Whatever the blob
+    # carries PAST that bound is unread, and listed (`unread`, below) rather than dropped in silence.
+    bound = _VIEWS_MAX_TAGS * 2
+    v = _norm_timeline_views(blob, tag_cap=bound)
+    unread = _views_unread(blob, v["tags"])
+    ed = set(x for x in edited if isinstance(x, str)) if isinstance(edited, list) else None
+    if base is None:
+        try:
+            base = _timeline_views()
+        except Exception:
+            base = {}
+    prev_blob = base
+    prev = {t["id"]: t for t in (prev_blob.get("tags") or [])}
     now = int(time.time())
     # ── the stale-writer guard (the user 2026-08-31: a tag silently lost all 7 of its members) ──
     # The full-blob path (setTimelineViews) is last-writer-wins by design, so a dashboard whose
@@ -3271,30 +3688,241 @@ def _set_timeline_views(blob):
             ev = 0
     ev = max([ev] + [int(t.get("mtime") or 0) for t in v["tags"]])
     incoming = {t["id"] for t in v["tags"]}
-    refused, kept = [], []
-    for t in v["tags"]:
+    refused, kept, rows = [], [], []
+    # `rows` — the same refusals as (name, plain reason) pairs, RETURNED to the caller: the WS
+    # door answers the posting dashboard with them (the user 2026-09-05, who lost a batch of
+    # renames and assignments the dialog kept re-posting from a refused copy, because the refusal
+    # reached stderr and the sync notices but never the client that needed to revert).
+    lens_only = ed is not None and not ed
+    if lens_only:
+        # A LENS OR ORDER WRITE (the 2026-09-05 review): `edited` is an empty list, the
+        # client's word that it changed no tag — so no tag changes. The store's tags stand whole,
+        # mtimes with them, whatever tags the blob carries; the write's other fields (the lenses,
+        # the order, the active) land below. Nothing to judge, nothing to log: this is the normal
+        # lens path. The judged path below is for a write that names the tags it changed, or for a
+        # writer that cannot say (an older client, a file written outside the kernel).
+        kept = [json.loads(json.dumps(pt)) for pt in prev.values()]
+        # …in the write's ORDER (the 2026-09-05 review): the array order is an order
+        # field, this write's to set like `tagOrder` itself — the pill drag's contract is that the
+        # stored array reads in the dragged order too, since a reader without this kernel's tagOrder
+        # (a peer's dashboard, whose own order lacks these names) falls back to the array. Until now
+        # the store's order was copied and the posted array order discarded, so a drag reordered
+        # tagOrder and left the array as it was. Names the order lacks follow, in store order.
+        ord_ix = {n: i for i, n in enumerate(v.get("tagOrder") or [])}
+        kept.sort(key=lambda t: ord_ix.get(t.get("name"), len(ord_ix)))
+        incoming = set(prev)
+    for t in ([] if lens_only else v["tags"]):
         pt = prev.get(t["id"])
-        if pt and pt.get("mtime") and int(pt["mtime"]) > ev and \
-                (pt.get("name"), pt.get("color"), pt.get("members")) != \
-                (t.get("name"), t.get("color"), t.get("members")):
-            refused.append('"%s"' % pt.get("name"))
+        if pt is None and ((ed is not None and t["id"] not in ed) or (ed is None and foreign and t.get("mtime"))):
+            # A tag the store does not have, from a client that says it did not create it: the
+            # client's copy predates a DELETION made elsewhere, and posting the whole blob would
+            # re-create the deleted tag (the 2026-09-05 review — the guard refused a
+            # stale deletion but not a stale resurrection; only with `edited` can the two creates
+            # be told apart: a legacy-path create names its new id there). Kept OUT, with a reason
+            # the ack carries; a write without `edited` keeps the old reading (every unknown tag
+            # is new), since an older client cannot say which it meant — except a file written
+            # outside the kernel (`foreign`), whose unknown tags are told apart by the mtime only a
+            # kernel stamps (the comment on `foreign` above).
+            refused.append(('"%s" (re-creation)' % t.get("name"), t["id"]))
+            rows.append({"tid": t["id"], "name": t.get("name"),
+                         "reason": "it was deleted after your copy was taken, so it was not re-created"})
+            continue
+        same = pt is None or (pt.get("name"), pt.get("color"), pt.get("members")) == \
+            (t.get("name"), t.get("color"), t.get("members"))
+        if not same and ed is not None and t["id"] not in ed:
+            # A differing copy of a tag this write did not claim to edit: the change is
+            # not the client's, whatever the stamps say — the same-second race the empty list
+            # closes above would otherwise land it here too. The store's copy stands, quietly, under
+            # a label that carries its cause like every other (the 2026-09-05 review: this
+            # was the one bare label, beside "(deletion)" and "(unread)" on the quiet stderr line).
+            refused.append(('"%s" (differing copy)' % pt.get("name"), t["id"]))
+            rows.append({"tid": t["id"], "name": pt.get("name"),
+                         "reason": "your copy of it differs from the store's and this write did not edit it, "
+                                   "so the store's copy was kept"})
+            kept.append(json.loads(json.dumps(pt)))
+        elif not same and pt.get("mtime") and int(pt["mtime"]) > ev:
+            # the label carries its cause like every other (the 2026-09-05 review): the
+            # loud notice no longer spells the causes out — it puts the count and the remedy first and
+            # the labels after, as many as fit the served text, so each label must say why on its own
+            refused.append(('"%s" (stale copy)' % pt.get("name"), t["id"]))
+            # the reason names no tag: the ack composes '"<name>": <reason>' once (_ack_views_write),
+            # so a toast or notice never says the name twice (the 2026-09-05 review)
+            rows.append({"tid": t["id"], "name": pt.get("name"),
+                         "reason": "your copy predates a newer edit to it, so your change was not applied "
+                                   "and the newer state was kept"})
             kept.append(json.loads(json.dumps(pt)))       # the store's newer truth stands
         else:
             kept.append(t)
+    more, more_ed = 0, 0
+    for k, (tid, nm, _n) in enumerate([] if lens_only else unread):
+        # PAST THE DOOR'S BOUND (the 2026-09-05 review): an entry the normalizer's slice
+        # left unread is neither a create nor a deletion — it was not read. A store tag whose copy
+        # fell past the bound is KEPT (its absence from `incoming` would have read as a deletion
+        # below); anything else is not created. Each gets a row, so a client whose `edited` names
+        # only ids past the bound is acked not-ok with the reason, where it was acked ok with a
+        # blob missing its own creates. Rows only, never stored — the bound stands.
+        # ROWS ARE BOUNDED to `bound` of them (the 2026-09-05 review): the rows, the loud
+        # notice and the ack's `error` were O(N) in the posted array, so a 100k-entry post (a client
+        # bug, or any page holding the socket) drew a ~22 MB ack that overran WS_QUEUE_BYTES and
+        # dropped the poster's own socket before the ack was queued. Every unread store tag is still
+        # kept, however far past the bound its copy sat (at most the store's 32); past the first
+        # `bound` unread entries the rest are ONE summary row carrying their count and how many of
+        # them `edited` names (`moreEdited`), which the door's ok rule reads — a client whose own
+        # create sits past both bounds is still acked not ok.
+        pt = prev.get(tid)
+        if pt is not None:
+            incoming.add(tid)
+            kept.append(json.loads(json.dumps(pt)))
+        if k >= bound:
+            more += 1
+            if ed is not None and tid in ed:
+                more_ed += 1
+            continue
+        if pt is not None:
+            refused.append(('"%s" (unread)' % pt.get("name"), tid))
+            rows.append({"tid": tid, "name": pt.get("name"),
+                         "reason": "a write is read to %d tags and its copy was past that bound, "
+                                   "so the store's copy was kept" % bound})
+        else:
+            refused.append(('"%s" (unread)' % nm, tid))
+            rows.append({"tid": tid, "name": nm,
+                         "reason": "a write is read to %d tags and it was past that bound, "
+                                   "so it was not created" % bound})
+    if more:
+        # the reason is self-contained (the 2026-09-05 review): since the 2026-09-05 review this row can
+        # LEAD the ack's error line, where a continuation clause ("and N more ... past that bound")
+        # continued nothing and named a bound the reader had not been told
+        rows.append({"reason": "%d more entries past the %d-tag read bound were not read%s"
+                               % (more, bound, (" (%d of them this write edited)" % more_ed) if more_ed else ""),
+                     "more": more, "moreEdited": more_ed})
     for tid, pt in prev.items():
-        if tid not in incoming and pt.get("mtime") and int(pt["mtime"]) > ev:
-            refused.append('"%s" (deletion)' % pt.get("name"))
+        if tid in incoming:
+            continue
+        if ed is not None and tid not in ed:
+            # absent from a write that did not claim to edit it: not a deletion the
+            # client made, so not one — the store's copy stands, quietly
+            refused.append(('"%s" (deletion)' % pt.get("name"), tid))
+            rows.append({"tid": tid, "name": pt.get("name"),
+                         "reason": "this write did not edit it, so it was not deleted"})
+            kept.append(json.loads(json.dumps(pt)))
+        elif pt.get("mtime") and int(pt["mtime"]) > ev:
+            refused.append(('"%s" (deletion)' % pt.get("name"), tid))
+            rows.append({"tid": tid, "name": pt.get("name"),
+                         "reason": "it was edited after your copy was taken, so it was not deleted"})
             kept.append(json.loads(json.dumps(pt)))       # a stale writer cannot delete newer state
-    v["tags"] = kept[:_VIEWS_MAX_TAGS]
-    if refused:
-        why = ("a stale dashboard write was partially refused: its copy of %s predates newer "
-               "edits (the newer state was kept — reload that dashboard to resync)"
-               % ", ".join(sorted(set(refused))))
+    # NAME COLLISIONS (the 2026-09-05 review): a whole-blob write can carry a tag
+    # renamed to, or created under, a name another tag in the resulting set already has — the
+    # verifier's reproduction was a lens write built from a dialog's pending copy, still carrying
+    # a rename the targeted op had refused as a duplicate; the door let it through and the store
+    # held two tags with one name, which every name-keyed surface then showed as one. Names
+    # address edits here (the /tag route, the union), so the door refuses the colliding CHANGE:
+    # a tag whose name the write did not change keeps its claim on that name; a renamed or new tag
+    # whose name is already claimed is refused with a reason naming the collision — a renamed tag
+    # stands as the store has it, a new one is kept out. Two unchanged tags sharing a name (a
+    # store already holding twins) are left as they are: nothing in this write changed them.
+    # Run to a FIXPOINT (the 2026-09-05 review): `settled` holds the names this write
+    # does not change — a tag's stored name it keeps, and, after a refusal, the stored name a
+    # renamed tag returns to; `takers` are the tags whose resulting name is new to them (renamed
+    # or created), in array order. A taker whose name is settled, or granted to an earlier taker,
+    # is refused; a refused RENAME settles its stored name and the pass runs again from the top,
+    # so a taker that had been granted that very name is refused too. Before this change the pass ran
+    # once and a refused rename never claimed the name it kept: B (api → web, refused against A =
+    # web) stood as "api" while a new C named "api" in the same write landed beside it — twins.
+    # Each pass either refuses one taker or ends, so the loop is bounded by the taker count.
+    by_id = {t["id"]: t for t in kept}
+    settled = {}
+    for t in kept:
+        pt = prev.get(t["id"])
+        if pt is not None and pt.get("name") == t.get("name"):
+            settled.setdefault(t["name"], t["id"])
+    takers = [t["id"] for t in kept if prev.get(t["id"]) is None or prev[t["id"]].get("name") != t.get("name")]
+    while True:
+        granted, struck = {}, None
+        for tid in takers:
+            nm = by_id[tid]["name"]
+            holder = settled.get(nm, granted.get(nm))
+            if holder is not None and holder != tid:
+                struck = tid
+                break
+            granted[nm] = tid
+        if struck is None:
+            break
+        takers.remove(struck)
+        t, pt = by_id[struck], prev.get(struck)
+        refused.append(('"%s" (name collision)' % (pt.get("name") if pt else t.get("name")), struck))
+        rows.append({"tid": struck, "name": pt.get("name") if pt else t.get("name"),
+                     "reason": 'a tag named "%s" already exists, so it was not %s'
+                               % (t["name"], "renamed to it" if pt else "created")})
+        if pt is not None:
+            by_id[struck] = json.loads(json.dumps(pt))     # the store's copy, under its own name…
+            settled.setdefault(pt["name"], struck)          # …which no taker in this write can have
+        else:
+            del by_id[struck]                               # a new tag under a taken name is kept out
+    stands = [by_id[t["id"]] for t in kept if t["id"] in by_id]
+    # THE CAP (the 2026-09-05 review): the set that stands can exceed _VIEWS_MAX_TAGS when
+    # the store's kept copies join the blob's tags — the store-only keeps sit at the END of `kept`
+    # (blob order first), so a slice here dropped exactly the tag the ack had just said was kept,
+    # and the client's own create took its place, acked ok. A kept store tag always survives: the
+    # write's CREATES are refused instead, last in array order first, with a reason naming the cap
+    # (_edit_tag refuses its 33rd the same way). With no create left to refuse, what stands is the
+    # store's own set, which the normalizer bounds to the cap on every read — so a remaining excess
+    # is a broken invariant, and the write fails loudly (the door acks the error) rather than
+    # truncating a tag somebody holds.
+    while len(stands) > _VIEWS_MAX_TAGS:
+        i = next((i for i in range(len(stands) - 1, -1, -1) if prev.get(stands[i]["id"]) is None), None)
+        if i is None:
+            raise ValueError("the views store would hold %d tags, over its cap of %d, with no new tag to refuse"
+                             % (len(stands), _VIEWS_MAX_TAGS))
+        t = stands.pop(i)
+        refused.append(('"%s" (over the cap)' % t.get("name"), t["id"]))
+        rows.append({"tid": t["id"], "name": t.get("name"),
+                     "reason": "the views blob caps at %d tags, so it was not created" % _VIEWS_MAX_TAGS})
+    v["tags"] = stands
+    # `active` is validated against the tags that STAND, not the blob's (the 2026-09-05
+    # review): the normalizer checked it against the posted set, so a stale copy whose active named
+    # a tag deleted since — kept out above, or standing aside for the store's set under an empty
+    # `edited` — stored a dangling id; every read re-normalized it to "all", so nothing showed, but
+    # the file was wrong. The lens, order and active fields themselves are the write's to set, whole
+    # and unjudged (last writer wins across dashboards; docs/read-side.md states the trade).
+    act = v.get("active") or "all"
+    if act not in ("all", "untagged") and ":" not in act and not any(t["id"] == act for t in stands):
+        v["active"] = "all"
+    # The refusal's two audiences: a kept tag the poster EDITED is a lost edit — stderr plus a red
+    # dashboard notice (the user 2026-08-31's silent loss, never again silent). A kept tag the
+    # poster did not edit (`edited` names the ones it did) is a stale copy of an untouched tag,
+    # acked ok with the refusal listed and adopted from the ack: nothing the user did was refused,
+    # so no notice — one stderr line is the whole record. Without `edited` (an older client, the
+    # RMW callers, the reader's re-stamp) every refusal reads as loud, as before.
+    loud = sorted(set(lb for lb, tid in refused if ed is None or tid in ed))
+    quiet = sorted(set(lb for lb, tid in refused if ed is not None and tid not in ed))
+    # the summary row's entries (past the row bound, never labelled) fall on the same two sides
+    loud_more = more if ed is None else more_ed
+    quiet_more = 0 if ed is None else more - more_ed
+    loud_n = len(set(tid for lb, tid in refused if ed is None or tid in ed)) + loud_more
+    if loud_n:
+        # The sentence names the writer — a foreign file's panel, the reader's own re-stamp (`writer`,
+        # nothing to reload: no dashboard wrote it), else a dashboard — and puts the count and the
+        # remedy FIRST, the refused tags after, as many as fit the served notice (_notice_list). The 2026-09-05 review: the remedy sat last, after one label per tag and a clause
+        # spelling out every cause, and the dashboard's bell cut it away; each label now carries its
+        # own cause instead, and the ack's rows carry the reasons in full.
+        remedy = ("reload the panel that wrote it to resync" if foreign
+                  else None if writer else "reload that dashboard to resync")
+        why = _notice_list("%s was partially refused: its changes to %d tag%s were not applied and the store's "
+                           "state was kept%s."
+                           % (foreign or writer or "a stale dashboard write", loud_n, "" if loud_n == 1 else "s",
+                              ("; " + remedy) if remedy else ""),
+                           " Refused: ", loud, extra=loud_more)
         sys.stderr.write("romp-kernel: %s\n" % why)
         try:
             _sync_notice(why, ok=False)
         except Exception:
             pass
+    if quiet or quiet_more:
+        quiet_n = len(set(tid for lb, tid in refused if ed is not None and tid not in ed)) + quiet_more
+        sys.stderr.write("romp-kernel: %s\n" % _notice_list(
+            "kept the store's copy of %d tag%s over a dashboard's stale copy (tags that dashboard did not edit; "
+            "the ack carries the newer state)" % (quiet_n, "" if quiet_n == 1 else "s"),
+            ": ", quiet, extra=quiet_more, cap=2000))
     for t in v["tags"]:
         pt = prev.get(t["id"])
         if pt is None or (pt.get("name"), pt.get("color"), pt.get("members")) != \
@@ -3303,7 +3931,36 @@ def _set_timeline_views(blob):
         elif pt.get("mtime"):
             t["mtime"] = pt["mtime"]
     v["at"] = now
-    _atomic_write(_views_path(), json.dumps(v, sort_keys=True))
+    # The write sequence (2026-09-05): every accepted write — targeted or whole-blob, partially
+    # refused or clean — moves it forward, and every frame and ack that carries the blob carries
+    # it, so a client can order what it receives (the ack's blob against a frame the pusher built
+    # from its warmed cache before the write; a federation re-emit of a stored blob). Seeded from
+    # the clock and then +1 per write: a store recreated from nothing (a deleted file, a new state
+    # dir) starts past anything a connected client can hold, so no client is left ignoring every
+    # frame until it reloads. The comparison is on this one number everywhere.
+    try:
+        prev_seq = int(prev_blob.get("seq") or 0)
+    except (TypeError, ValueError):
+        prev_seq = 0
+    v["seq"] = max(prev_seq + 1, int(seq_floor or 0) + 1, _views_seq_floor() + 1, int(time.time() * 1000))
+    return v, rows
+
+
+def _views_cache_refresh(text):
+    """After a write of the views store: the read cache holds the blob just written, keyed on the
+    file's new (mtime, size), so the very next read — the ack's blob, the pusher's frame — is this
+    write and never a stale hit (2026-09-05 review: the (mtime, size) key was never invalidated on
+    write, and the kernel's mtime clock is coarse, so two same-size writes a few ms apart shared a
+    key and the second's ack could serve the first's blob). Replacing the entry rather than popping
+    it keeps the LAST blob this kernel wrote or served in the cache, which is what the reader
+    compares a changed file against (a write outside the kernel, _timeline_views). A stat failure
+    (the file vanished under us) drops the entry instead — the next read starts from the file."""
+    p = _views_path()
+    try:
+        st = p.stat()
+        _views_cache_put(p, (st.st_mtime_ns, st.st_size), _norm_timeline_views(json.loads(text)))
+    except Exception:
+        _flags_cache.pop(str(p), None)
 
 
 def _remote_tag_member_str(owner_host, m):
@@ -3399,7 +4056,10 @@ def _queue_pending_tag_edit(host, body):
     for its (host, name) and refuses later ones (the delete already rules); removes merge; a
     rename replaces a prior rename. Only ATTACHED hosts queue — a detached host has no reattach
     event coming, and detach was its own intent."""
-    name = str(body.get("name") or "")
+    # the NAME BASIS (the 2026-09-05 review): the row's name is matched against the
+    # host's tag names at capture and at late-apply, and joined to the rendered row for the
+    # pending badge — every one of those is on the stored basis, so the row is too
+    name = _tag_name_basis(body.get("name"))
     qual = bool(body.get("delete")) or isinstance(body.get("rename"), str) \
         or (isinstance(body.get("remove"), list) and body.get("remove"))
     if not (host and name and qual):
@@ -3410,20 +4070,20 @@ def _queue_pending_tag_edit(host, body):
     if r is None:
         return False
     tid = next((str(t.get("id") or "") for t in (cached.get("tags") or [])
-                if isinstance(t, dict) and t.get("name") == name), "")
+                if isinstance(t, dict) and _tag_name_basis(t.get("name")) == name), "")
     rows = _pending_tag_rows()
-    mine = [x for x in rows if x.get("host") == host and x.get("name") == name]
+    same = lambda x: x.get("host") == host and _tag_name_basis(x.get("name")) == name   # a journal from before the basis may hold a padded name
+    mine = [x for x in rows if same(x)]
     if any(x.get("delete") for x in mine):
         return True                              # the delete already rules this name; nothing to add
     row = {"host": host, "name": name, "tagId": tid, "ruledAt": int(time.time()), "at": int(time.time())}
     if body.get("delete"):
-        rows = [x for x in rows if not (x.get("host") == host and x.get("name") == name)]
+        rows = [x for x in rows if not same(x)]
         row["delete"] = True
     else:
         if isinstance(body.get("rename"), str) and body["rename"].strip():
             row["rename"] = body["rename"]
-            rows = [x for x in rows if not (x.get("host") == host and x.get("name") == name
-                                            and x.get("rename"))]
+            rows = [x for x in rows if not (same(x) and x.get("rename"))]
         if isinstance(body.get("remove"), list) and body.get("remove"):
             merged = []
             for x in mine:
@@ -3467,13 +4127,13 @@ def _apply_pending_tag_edits(r):
                     pending=len(rows))
         return 0
     r["views"] = rv
-    by_name = {}
+    by_name = {}                                 # keyed on the name basis: the host's raw name may be padded
     for t in (rv.get("tags") or []):
         if isinstance(t, dict):
-            by_name.setdefault(str(t.get("name") or ""), []).append(t)
+            by_name.setdefault(_tag_name_basis(t.get("name")), []).append(t)
     retired, applied = [], 0
     for row in rows:
-        cand = by_name.get(row.get("name") or "") or []
+        cand = by_name.get(_tag_name_basis(row.get("name"))) or []
         t = next((x for x in cand if row.get("tagId") and x.get("id") == row["tagId"]), None)
         if t is None and cand:
             # same name, different identity: NEW if its id says it was created after the ruling;
@@ -3547,8 +4207,11 @@ def _views_client():
             if not isinstance(t, dict) or not t.get("id"):
                 continue
             members = [m for m in (_member_pair(x) for x in (t.get("members") or [])) if m]
+            # the NAME BASIS (the 2026-09-05 review): an older remote build, or a padded
+            # remote store, serves "web " raw; rendered raw, no lens entry (all on the basis) could
+            # pick it and the union kept it apart from a local "web" — see _tag_name_basis
             remote.append({"id": host + ":" + str(t["id"])[:64], "host": host,
-                           "name": str(t.get("name") or "tag")[:_VIEWS_MAX_NAME],
+                           "name": _tag_name_basis(t.get("name")) or "tag",
                            "color": str(t.get("color") or "")[:16],
                            "members": [_remote_tag_member_str(host, m) for m in members]})
     if remote:
@@ -3559,9 +4222,11 @@ def _views_client():
     # still surfaces.
     pend = _pending_tag_rows()
     if pend:
-        v["pendingTagEdits"] = [{"host": x.get("host") or "", "name": x.get("name") or "",
+        v["pendingTagEdits"] = [{"host": x.get("host") or "", "name": _tag_name_basis(x.get("name")),
                                  "op": _row_op(x)} for x in pend]
-        by_hn = {(x.get("host"), x.get("name")): _row_op(x) for x in pend}
+        # joined on the name basis, like the rendered row (a journal from before the basis may hold
+        # a padded name; the row's name is the client's word, the rendered name the remote's)
+        by_hn = {(x.get("host"), _tag_name_basis(x.get("name"))): _row_op(x) for x in pend}
         for t in (v.get("remoteTags") or []):
             op = by_hn.get((t.get("host"), t.get("name")))
             if op:
@@ -3651,24 +4316,58 @@ def _b36(n):
     return out or "0"
 
 
-def _edit_tag(name, add=(), remove=(), color=None, delete=False, rename=None):
-    """Targeted edit of ONE named tag in the views blob — the merge op behind POST /tag. The WS
-    setTimelineViews op replaces the whole blob, which is right for the dashboard (it holds the
-    current one) and wrong for an agent: replaying a stale read would clobber the active view and
-    every tag it never looked at. So: read, edit the one tag, write back through the
-    normalizer. The tag is addressed by NAME (the id is a UI-internal mint); two same-named
-    tags refuse rather than guess. Members are stored ids — the route resolves live names before
-    calling. A missing tag is created on any edit, never on delete. Returns
-    (tag-or-None, error-or-None); the returned row is the post-normalize one."""
+_TAG_GONE = "that tag no longer exists — it may have been deleted from another dashboard"
+
+
+def _default_tag_name(tags):
+    """The name a create without one gets: the lowest "tag N" no existing tag carries. Minted HERE,
+    never by the dialog from a count of its rows (the 2026-09-05 review: a leftover default-named
+    tag made the dialog's next "tag N" collide, and the create was refused as a duplicate)."""
+    taken = {t.get("name") for t in tags}
+    n = 1
+    while "tag %d" % n in taken:
+        n += 1
+    return "tag %d" % n
+
+
+def _edit_tag(name=None, add=(), remove=(), color=None, delete=False, rename=None, tid=None, exists=None):
+    """Targeted edit of ONE tag in the views blob — the merge op behind POST /tag and, since
+    2026-09-05, behind the dashboards' WS tagEdit op (_apply_tag_edit). The WS setTimelineViews op
+    replaces the whole blob, which is right for a lens or order edit (the client holds the current
+    one) and wrong for a tag edit from ANY client: an agent replaying a stale read would clobber the
+    active view and every tag it never looked at, and a dashboard mid-burst posts its own un-echoed
+    copy, which the stale-writer guard then refuses against the dashboard's own previous write. So:
+    read, edit the one tag, write back through the normalizer — a writer built from the store always
+    carries the newest evidence.
+    Addressing: `tid` names the tag by its stored id (the dashboards, whose rows carry the id — a
+    refused rename must leave no window in which a follow-up gesture addresses SOME OTHER tag by the
+    name the rename would have given it); else `name` (the /tag route, where the user types names;
+    two same-named tags refuse rather than guess). Members are stored ids — the route resolves live
+    names before calling. By name, a missing tag is created on any edit, never on delete — unless
+    `exists` says otherwise: True refuses a missing tag (a rename of a tag another dashboard just
+    deleted must not resurrect it), False refuses an existing one (a create). By tid, a missing tag is
+    always refused (a tid is never minted by a client). A create with no name gets the kernel's
+    default (_default_tag_name). Returns (tag-or-None, error-or-None); the returned row is the
+    post-normalize one, so a create's caller learns the minted id and name from it."""
     # Clamp the name into the STORED basis before the lookup: the normalizer clamps names to
-    # _VIEWS_MAX_NAME on write, so matching on the raw name would miss the stored tag and mint an
-    # unaddressable same-named duplicate on every subsequent edit.
-    name = str(name)[:_VIEWS_MAX_NAME]
+    # _VIEWS_MAX_NAME and strips them on write (the 2026-09-05 review), so matching on
+    # the raw name would miss the stored tag and mint an unaddressable same-named duplicate on every
+    # subsequent edit. A name that is empty after the strip is no name: a create takes the default.
+    name = (str(name)[:_VIEWS_MAX_NAME].strip() or None) if name is not None else None
     with _views_lock:   # the server is threaded; two unlocked merges would both copy the same pre-state
         v = json.loads(json.dumps(_timeline_views()))     # deep copy: never mutate the cached blob
-        hits = [t for t in v["tags"] if t["name"] == name]
-        if len(hits) > 1:
-            return None, 'two tags are named "%s" — rename one in the dashboard first' % name
+        if tid is not None:
+            hits = [t for t in v["tags"] if t["id"] == tid]
+            if not hits:
+                return None, _TAG_GONE
+        else:
+            hits = [t for t in v["tags"] if t["name"] == name] if name is not None else []
+            if len(hits) > 1:
+                return None, 'two tags are named "%s" — rename one in the dashboard first' % name
+            if exists is True and not hits:
+                return None, 'no tag named "%s"' % name
+            if exists is False and hits:
+                return None, 'a tag named "%s" already exists' % name
         if delete:
             if not hits:
                 return None, 'no tag named "%s"' % name
@@ -3684,7 +4383,7 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False, rename=None):
             taken = {t2["id"] for t2 in v["tags"]}
             while "g" + _b36(n) in taken:   # same-ms creates must not share an id — delete filters by id
                 n += 1
-            t = {"id": "g" + _b36(n), "name": name, "color": "", "members": []}
+            t = {"id": "g" + _b36(n), "name": name if name else _default_tag_name(v["tags"]), "color": "", "members": []}
             v["tags"].append(t)
         if rename is not None:
             rn = str(rename)[:_VIEWS_MAX_NAME].strip()
@@ -3706,6 +4405,155 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False, rename=None):
         out = json.loads(json.dumps(next(t2 for t2 in v["tags"] if t2["id"] == t["id"])))
         out["members"] = [_member_str(m) for m in out["members"]]   # the route's reply speaks strings
         return out, None
+
+
+def _move_tag_member(tid_from, tid_to, sids):
+    """A session's MOVE between two local tags — off `tid_from`, onto `tid_to` — as ONE write under
+    _views_lock: both halves land or neither does (the 2026-09-05 review: as two targeted ops, a
+    refused second half left the session in no group, and the tab strip showed the half-moved state
+    until the user noticed). No client gesture posts it yet; a tab-strip "Move to <tag>" row is the
+    intended caller. Members arrive as the viewer-relative id strings every client posts
+    (_member_pair canonicalizes). Returns
+    (tag-or-None, error-or-None) like _edit_tag; the tag is the destination's post-write row."""
+    with _views_lock:
+        v = json.loads(json.dumps(_timeline_views()))     # deep copy: never mutate the cached blob
+        by_id = {t["id"]: t for t in v["tags"]}
+        src, dst = by_id.get(tid_from), by_id.get(tid_to)
+        if src is None:
+            return None, "the tag to move out of no longer exists — it may have been deleted from another dashboard"
+        if dst is None:
+            return None, "the tag to move into no longer exists — it may have been deleted from another dashboard"
+        pairs = [m for m in (_member_pair(x) for x in sids) if m]
+        keys = {(m["host"], m["sid"]) for m in pairs}
+        src["members"] = [m for m in src["members"] if (m["host"], m["sid"]) not in keys]
+        have = {(m["host"], m["sid"]) for m in dst["members"]}
+        dst["members"] = list(dst["members"]) + [m for m in pairs if (m["host"], m["sid"]) not in have]
+        v = _norm_timeline_views(v)
+        _set_timeline_views(v)
+        out = json.loads(json.dumps(next(t for t in v["tags"] if t["id"] == tid_to)))
+        out["members"] = [_member_str(m) for m in out["members"]]
+        return out, None
+
+
+_TAG_EDIT_OPS = ("create", "rename", "recolor", "addMember", "removeMember", "delete", "move")
+
+
+def _apply_tag_edit(e):
+    """One targeted tag edit from a dashboard — the WS tagEdit message's `edit`: {op, tid?, name?,
+    newName?, color?, sid?|sids?} — applied through _edit_tag. Every op but create addresses the tag
+    by `tid`, the stored id the dashboard's rows carry (the 2026-09-05 review: addressed by name, a
+    recolor queued behind a refused rename went looking for the name the rename would have given
+    the tag, and found the OTHER tag that already had it). A create takes an optional `name`; with
+    none the kernel mints the default. Returns (ok, error, info): the error is a plain sentence the
+    dialog shows as-is; info carries the tag's `tid` and `name` after the edit (a create's caller
+    learns both from it). Every dashboard tag gesture posts this instead of the whole blob (the user
+    2026-09-05: a create followed by typing the tag's name lost the name, because the second
+    whole-blob post was judged stale against the first). Members arrive as the viewer-relative id
+    strings every client already posts; _member_pair canonicalizes them."""
+    if not isinstance(e, dict):
+        return False, "the edit is missing", None
+    op = str(e.get("op") or "")
+    if op not in _TAG_EDIT_OPS:
+        return False, 'unknown tag edit "%s"' % op[:20], None
+    tid = e.get("tid") if isinstance(e.get("tid"), str) and e.get("tid") else None
+    sids = [str(x) for x in (e.get("sids") if isinstance(e.get("sids"), list) else [])
+            if isinstance(x, str) and x.strip()]
+    if isinstance(e.get("sid"), str) and e["sid"].strip():
+        sids.append(e["sid"])
+    color = e.get("color") if isinstance(e.get("color"), str) else None
+    if op == "create":
+        name = str(e.get("name") or "").strip() or None
+        t, err = _edit_tag(name, add=sids, color=color or "", exists=False)
+    elif op == "move":
+        # {tid_from, tid_to, sid|sids}: off one tag, onto another, as ONE write — both or neither
+        tf, tt = e.get("tid_from"), e.get("tid_to")
+        if not (isinstance(tf, str) and tf and isinstance(tt, str) and tt):
+            return False, "the edit named no tag", None
+        if not sids:
+            return False, "the edit named no session", None
+        t, err = _move_tag_member(tf, tt, sids)
+        return err is None, err, ({"tid": t["id"], "name": t["name"]} if t else {"tid": tt})
+    elif tid is None:
+        return False, "the edit named no tag", None
+    elif op == "rename":
+        t, err = _edit_tag(tid=tid, rename=str(e.get("newName") or ""))
+    elif op == "recolor":
+        if color is None:
+            return False, "no color given", None
+        t, err = _edit_tag(tid=tid, color=color)
+    elif op == "delete":
+        t, err = _edit_tag(tid=tid, delete=True)
+    else:
+        if not sids:
+            return False, "the edit named no session", None
+        if op == "addMember":
+            t, err = _edit_tag(tid=tid, add=sids)
+        else:
+            t, err = _edit_tag(tid=tid, remove=sids)
+    info = {"tid": t["id"], "name": t["name"]} if t else ({"tid": tid} if tid else None)
+    return err is None, err, info
+
+
+_ACK_ERROR_CAP = 1000   # the ack's one-line `error`: the rows carry every reason in full; this is the toast's copy
+
+
+def _refusal_is_the_posters(row, edited):
+    """Whether a refusal row is the POSTER'S OWN: a tag `edited` names, or the past-the-bound summary
+    row counting one (`moreEdited`). The door's `ok` rule and the ack's one-line `error` read the rows
+    by this one predicate — `ok` is false when any row is the poster's, and the line names those first."""
+    return row.get("tid") in edited or bool(row.get("moreEdited"))
+
+
+def _ack_views_write(client, kind, write_id, ok, error=None, refused=None, info=None, edited=None):
+    """Answer a dashboard's views write ON ITS OWN SOCKET: {type: kind, writeId, ok, views, seq,
+    error?, refused?, tid?, name?}. `views` is the post-write client blob (stamped), which the poster
+    adopts as its new base — clearing its optimistic copy on this event rather than on a frame
+    count — and reverts to when ok is false. `refused` (the whole-blob path) lists the tags the
+    stale-writer guard kept the store's copy of, each with its reason; `error` is the one-line form
+    of either. `info` (a targeted edit) names the tag the edit touched — a create's caller learns the
+    kernel-minted `tid` and `name` here and opens its rename input on that id. `edited` is the
+    write's own list (the whole-blob path): it orders the not-ok `error`, the poster's own refusals
+    first. A dead socket is the client's problem, never the write's: the edit landed before this
+    runs."""
+    if not client or not callable(client.get("send")):
+        return
+    views = _views_client()
+    ack = {"type": kind, "writeId": write_id if isinstance(write_id, str) else None,
+           "ok": bool(ok), "views": views,
+           # the store's write sequence after this write (the blob carries it too): the poster
+           # orders this against the frames it receives — a frame with a lower seq predates the
+           # write and is ignored, whatever order the socket delivered them in
+           "seq": views.get("seq")}
+    for k in ("tid", "name"):
+        if isinstance(info, dict) and info.get(k):
+            ack[k] = info[k]
+    if refused is not None:                    # the whole-blob path: always a list, empty when clean
+        ack["refused"] = [dict(r) for r in refused]
+        # the one-line form, ONLY when the write is refused (ok false): each refused tag named ONCE,
+        # then its name-free reason. An ok ack with refusals listed (stale copies of tags the client
+        # did not edit) carries no `error` — there is nothing to tell the user.
+        if not ok:
+            # bounded (the 2026-09-05 review — it was one entry per row, O(N) in the posted
+            # array); a row without a name (the past-the-bound summary) is its reason alone.
+            # THE POSTER'S OWN ROWS FIRST (the same review): the judge appends the quiet rows
+            # (copies of tags the poster did not edit, acked ok on their own) before the cap pass, so
+            # in judge order the bound cut the one row that made `ok` false — a refused create behind
+            # eight quiet rows — and the toast named only refusals the user never made. With `edited`,
+            # the rows it names (or the summary row counting one, _refusal_is_the_posters) lead, in
+            # judge order among themselves, and the quiet rows follow as far as the cap allows; with
+            # none of the poster's among them, or no `edited` (every row is loud), judge order stands.
+            mine, rest = [], []
+            for r in refused:
+                (mine if edited is not None and _refusal_is_the_posters(r, edited) else rest).append(r)
+            error = error or _notice_list("", "", [(('"%s": ' % r["name"]) if r.get("name") else "")
+                                                    + (r.get("reason") or "refused") for r in mine + rest],
+                                          cap=_ACK_ERROR_CAP, joiner="; ") or "refused"
+    if error:
+        ack["error"] = str(error)
+    try:
+        client["send"](json.dumps(ack))
+    except Exception:
+        pass
 
 
 # ── per-session view flags (the user 2026-06-19) ──────────────────────────────────────────────────
@@ -15782,6 +16630,32 @@ def _sync_notice_rows(limit=20, cap=300):
         rows = list(_SYNC_NOTICES[-limit:])
     return [{"sig": "sync|%d|%d" % (int(_STARTED), r["seq"]), "t": float(r["t"]),
              "text": r["text"][:cap], "ok": bool(r["ok"]), "kind": str(r.get("kind") or "sync")} for r in rows]
+
+
+# A notice built to this length reaches the user whole: the dashboard's bell shows a sync notice cut
+# at 240 characters (ui/webview/badge-mirror.ts), under the 300 _sync_notice_rows serves. A notice
+# that names a list puts its point first and bounds the list to fit (_notice_list) — the
+# 2026-09-05 review found the views re-stamp's cause clause LAST, after one entry per dropped tag,
+# so with two or more dropped the served text never reached it.
+SYNC_NOTICE_FIT = 240
+
+
+def _notice_list(head, sep, items, extra=0, cap=SYNC_NOTICE_FIT, joiner=", "):
+    """`head`, then `sep` and as many of `items` (joined by `joiner`) as keep the whole text within
+    `cap`, then " and N more" for the items left unnamed plus `extra` — things the caller counted but
+    never listed. When not even the first item fits, `head` alone: a head carries its own count, so
+    the point of the notice is never what gets cut."""
+    out, named = head, 0
+    for i, it in enumerate(items):
+        cand = out + (sep if i == 0 else joiner) + it
+        rest = len(items) - i - 1 + extra
+        if len(cand) + (len(" and %d more" % rest) if rest else 0) > cap:
+            break
+        out, named = cand, i + 1
+    rest = len(items) - named + extra
+    if named and rest:
+        out += " and %d more" % rest
+    return out
 
 
 def _auto_push_remote(host):
@@ -30767,6 +31641,92 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
     c.setdefault("sent", {})[key] = (sig, now)          # the dedup slot follows, so a later full send dedups honestly
 
 
+# What THIS kernel can do for a dashboard beyond the base protocol, announced on the socket in reply to
+# every `ready` (the page's own at load, and the shim's re-send on a reconnected socket) as
+# {type: "caps", caps: [...]} and listed on /version. Until 2026-09-05 nothing told a dashboard what its
+# kernel could take, and a dashboard newer than its kernel posted ops the kernel silently dropped. A
+# client uses a targeted op only when the cap is present and takes the pre-cap path otherwise.
+#   tagEdit — the targeted `tagEdit` op (create / rename / recolor / addMember / removeMember /
+#             delete / move, by tag id), the `tagEditAck` / `viewsAck` answers on the poster's socket,
+#             and the write sequence (`seq`) on every views blob.
+KERNEL_WS_CAPS = ("tagEdit",)
+# The caps frame: {type: "caps", caps: [...], viewsSeq: int|null}. `viewsSeq` (the 2026-09-05
+# review) is the write seq of the views blob the READY HANDLER'S OWN connect push served this client — the
+# tabOrder frame's for a chat page, the timeline skeleton's (`data.views`), the feed frame's — read from
+# the frames that push enqueued (_VIEWS_SERVED, captured in _send_client on the handler's thread), never
+# from a fresh cache read, so a write landing between the push and this frame cannot skew it; the highest
+# when the push carried more than one. When the push carried NONE (a chat page on a sentinel cycle gets no
+# tabOrder frame) it is the store's current seq at caps time — the seq the next push serves (the
+# same review); null only when there is no store at all, which has no seq. A client that kept a blob
+# its seq gate turned away adopts it on this frame only when the kept blob's seq equals viewsSeq — the
+# restore case (the store's seq fell behind what the page holds, and the connect push IS the kept blob) —
+# and adopts a LATER frame whose seq equals viewsSeq even when that is below the seq it holds (the same
+# restore, met on a sentinel cycle); never a pusher-thread frame built before a concurrent write and
+# enqueued between the connect push and this frame — its seq is older than the connect push's, so it does
+# not match, and the next pusher cycle carries the newer blob.
+
+_VIEWS_SERVED = threading.local()   # .seqs: a list while the ready handler captures its connect push, else absent/None
+
+
+def _views_seq_of(msg):
+    """The write seq of the views blob a frame carries, or None: `views` rides at the top level of the
+    tabOrder and feed frames and under `data` in the timeline skeleton."""
+    if not isinstance(msg, dict):
+        return None
+    v = msg.get("views")
+    if not isinstance(v, dict) and isinstance(msg.get("data"), dict):
+        v = msg["data"].get("views")
+    if not isinstance(v, dict) or v.get("seq") is None:
+        return None
+    try:
+        return int(v["seq"])
+    except (TypeError, ValueError):
+        return None
+
+
+def _send_caps(client, views_seq=None):
+    """The caps frame, on the client's own socket: {type: "caps", caps, viewsSeq} (the comment on
+    KERNEL_WS_CAPS has the field). Sent AFTER the ready handler's pushes: the shim clears its stale banner
+    on the first non-keepalive frame after a reconnect, which must stay the resync frame itself and not
+    this one. `views_seq` is the seq of the views blob those pushes served, else the store's current seq
+    (the comment on KERNEL_WS_CAPS), None only with no store."""
+    try:
+        client["send"](json.dumps({"type": "caps", "caps": list(KERNEL_WS_CAPS),
+                                   "viewsSeq": views_seq if isinstance(views_seq, int) else None}))
+    except Exception:
+        pass
+
+
+# Ops the browser's panes post for a HOST to consume (the VS Code extension takes them; the kernel-served
+# page has no host, so they reach the kernel, which has nothing to do with them). Not unknown, not the
+# kernel's: the terminal arm below neither logs nor answers them.
+_HOST_ONLY_OPS = frozenset({"openLink", "readClipboard", "usageData", "colorSync", "settingsSync",
+                            "editorSelection", "answerPickerChoice"})
+_UNKNOWN_OPS_SEEN = set()
+
+
+def _note_unknown_op(msg, client):
+    """_dispatch_ws's terminal arm: a message no handler took — an op this kernel does not know (a
+    dashboard newer than its kernel), or a known op missing the field its arm requires. Logged ONCE per
+    type (one line of version skew, not one per gesture) and ANSWERED on the poster's socket with
+    {type: "unknownOp", op, writeId?}: a client waiting on an ack for that writeId learns the op is
+    unsupported and treats the answer as a refusal, instead of pinning its optimistic copy on an
+    answer that never comes (the 2026-09-05 review). An undecodable frame (msg None) was already
+    reported by the recv loop; a host-directed op is not the kernel's to answer."""
+    t = msg.get("type") if isinstance(msg, dict) else None
+    if not isinstance(t, str) or not t or t in _HOST_ONLY_OPS:
+        return
+    op = t[:40]
+    if op not in _UNKNOWN_OPS_SEEN:
+        _UNKNOWN_OPS_SEEN.add(op)
+        sys.stderr.write("ws: no handler took op %r from a %s client (unknown type, or a required field missing) "
+                         "— answered unknownOp; logged once per type\n" % (op, (client or {}).get("app") or "?"))
+    reply = {"type": "unknownOp", "op": op}
+    if isinstance(msg.get("writeId"), str):
+        reply["writeId"] = msg["writeId"]
+    _reply(client, reply)
+
+
 def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
@@ -30789,6 +31749,14 @@ def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
     whole frame) or "delta" for a caller whose frame is a suffix or a diff (_send_chat's chatTail)."""
     s = pre if pre is not None else json.dumps(msg)
     sig = sig if sig is not None else _dedup_sig(msg, s)
+    seqs = getattr(_VIEWS_SERVED, "seqs", None)
+    if seqs is not None:
+        # the ready handler is capturing ITS connect push (the caps frame's viewsSeq, see KERNEL_WS_CAPS):
+        # a frame this thread enqueues, deduped or not — a deduped frame is one the client already holds
+        # byte-for-byte, so its blob is what the client has either way
+        sq = _views_seq_of(msg)
+        if sq is not None:
+            seqs.append(sq)
     with _client_lock(c):    # the dedup dict is shared with the handler thread's `ready`
         prev = c.setdefault("sent", {}).get(key)      # reset (_client_reset_chat_base) — one writer at a time
         now = time.time()
@@ -34605,6 +35573,9 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
 else if(m.type==="models"&&panel.refreshModels)panel.refreshModels();
 else if(m.type==="settingRefused"&&panel.settingRefused)panel.settingRefused(m);
+else if((m.type==="tagEditAck"||m.type==="viewsAck")&&panel.viewsAck)panel.viewsAck(m);
+else if(m.type==="caps"&&panel.setCaps)panel.setCaps(m);
+else if(m.type==="unknownOp"&&panel.unknownOp)panel.unknownOp(m);
 else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
 else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);};
 window.addEventListener("message",(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)?window.__rompPerf.wrapFrameHandler(onFrame):onFrame);
@@ -34615,7 +35586,8 @@ window.__rompTimelineWriteOrder=function(order){if(window.__rompWriteOrder)windo
 window.__rompTimelineCompact=function(name){post({type:"compact",name:name});};
 window.__rompTimelineSendCommand=function(name,cmd,extra){post(Object.assign({type:"sendCommand",name:name,cmd:cmd},extra||{}));};
 window.__rompTimelineSetFlag=function(id,flag,value){post({type:"setSessionFlag",id:id,flag:flag,value:!!value});};
-window.__rompTimelineSetViews=function(views){post({type:"setTimelineViews",views:views});};
+window.__rompTimelineSetViews=function(views,writeId,edited){post({type:"setTimelineViews",views:views,writeId:writeId,edited:edited||[]});};
+window.__rompTimelineTagEdit=function(writeId,edit){post({type:"tagEdit",writeId:writeId,edit:edit});};
 window.__rompTimelineEditTag=function(edit){post({type:"editTag",edit:edit});};
 window.__rompTimelineDismiss=function(id){post({type:"dismissLane",id:id});};
 window.__rompTimelineHover=function(sid,segIds,t0,t1){post(sid?{type:"timelineHover",sid:sid,segIds:segIds||[],t0:t0,t1:t1}:{type:"timelineHover",off:true});};
@@ -39951,19 +40923,49 @@ class Handler(BaseHTTPRequestHandler):
             # because cached bundles win the race). Same repair as needFull above, client-wide;
             # ready is posted once per renderer life, so this cannot loop.
             _client_reset_chat_base(client)
-            self._push_one(client)
-            # Push the SHARED, STABLE tab order so the UI honors it on connect/reload. Without this
-            # the webview only learns the order from a live drag, loses it on every reload, and falls
-            # back to ordering tabs by session STATE — so they drift on their own (worse now that the
-            # heartbeat auto-reloads). _ordered_alive is the same order chat tabs + timeline lanes use.
+            # Capture the seq of the views blob the pushes below serve — from the frames THIS thread
+            # enqueues, so a pusher-thread frame landing meanwhile is not mistaken for the connect push's
+            # (the caps frame's viewsSeq, see KERNEL_WS_CAPS)
+            _VIEWS_SERVED.seqs = []
             try:
-                _alive = _ordered_alive(int(time.time()), _tmux_sessions())
-                _o = [s["sid"] for s in _alive]
-                # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
-                _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
-                client["send"](json.dumps({"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}))
-            except Exception:
-                pass
+                self._push_one(client)
+                # Push the SHARED, STABLE tab order so the UI honors it on connect/reload. Without this
+                # the webview only learns the order from a live drag, loses it on every reload, and falls
+                # back to ordering tabs by session STATE — so they drift on their own (worse now that the
+                # heartbeat auto-reloads). _ordered_alive is the same order chat tabs + timeline lanes use.
+                try:
+                    _alive = _ordered_alive(int(time.time()), _tmux_sessions())
+                    _o = [s["sid"] for s in _alive]
+                    # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
+                    _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
+                    _frame = {"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _views_client()}
+                    client["send"](json.dumps(_frame))
+                    # sent on the raw socket, not through _send_client — so its views seq is captured here
+                    _sq = _views_seq_of(_frame)
+                    if _sq is not None:
+                        _VIEWS_SERVED.seqs.append(_sq)
+                except Exception:
+                    pass
+            finally:
+                seqs, _VIEWS_SERVED.seqs = _VIEWS_SERVED.seqs, None
+            # What this kernel can do for the page (KERNEL_WS_CAPS), after the pushes above and on every
+            # `ready` — so a reconnected socket learns them again, and a page whose views writes were
+            # in flight across the drop learns, by this frame, that their answers may never come. It
+            # carries the seq of the views blob those pushes served (viewsSeq), read above — or, when
+            # they served none (a chat page on a sentinel cycle gets no tabOrder frame), the STORE's
+            # current seq, the seq the next push serves (the 2026-09-05 review: with null here nothing
+            # re-armed a page's gate after a restart over a restored older store, and it rejected every
+            # later push under the old seq until the next write). Null only when there is no store at
+            # all — a fresh install, or a legacy store whose first stamp could not be written — which
+            # has no seq.
+            if seqs:
+                views_seq = max(seqs)
+            else:
+                try:
+                    views_seq = _timeline_views().get("seq")
+                except Exception:
+                    views_seq = None
+            _send_caps(client, views_seq=views_seq)
             # a push tap parked a reveal for this window's chat pane → deliver it now, AFTER the
             # ready push, so the tab it names already exists on the client (ordered socket)
             _consume_pending_reveal(client)
@@ -39995,8 +40997,57 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "setTimelineViews" and isinstance(msg.get("views"), dict):
             # timeline corner panel → replace the whole views blob (tiny; last-write-wins across
             # dashboards, like colormap). Validation/normalization happens in the setter.
-            _set_timeline_views(msg["views"])
+            # UNDER _views_lock, like every other writer of the blob: _edit_tag (the /tag route and the
+            # tagEdit arm below) and _heal_timeline_views read-then-write inside the lock, and this
+            # full-blob write landing INSIDE that window either clobbered their edit or had its own
+            # clobbered — with the lock it lands before or after, and the stale-writer guard in the
+            # setter judges it whole.
+            # ANSWERED on the poster's socket (viewsAck) with the guard's refusals, if any: until
+            # 2026-09-05 a refusal reached stderr and the sync notices but never the client, which
+            # kept building its next post from the refused copy. Tag edits themselves no longer come
+            # through here from the dashboards — see tagEdit below; this door serves lens and order.
+            # `edited` — the tag ids the client CHANGED in this write (a lens or order write names none):
+            # a refusal on a tag the client did not touch is a stale copy of an unedited tag, not a lost
+            # edit — the write is acked ok with the refusal listed, and the client adopts the newer blob
+            # without a notice (the 2026-09-05 review: a lens change from a dashboard that had slept
+            # through another's tag edit toasted a refusal for a tag the user never edited). A write
+            # without `edited` (an older client) keeps the strict reading: any refusal, ok false.
+            edited = msg.get("edited")
+            edited = [x for x in edited if isinstance(x, str)] if isinstance(edited, list) else None
+            try:
+                with _views_lock:
+                    refused = _set_timeline_views(msg["views"], edited=edited)   # the setter files the notice by the same rule
+                if edited is not None:
+                    # …or the past-the-bound summary row counts an edited id among the entries it
+                    # stands for (`moreEdited`); the ack orders its one-line `error` by the same predicate
+                    ok = not any(_refusal_is_the_posters(r, edited) for r in refused)
+                else:
+                    ok = not refused
+                err = None
+            except Exception as e:
+                sys.stderr.write("setTimelineViews: %s\n" % traceback.format_exc())
+                refused, ok, err = [], False, "the write failed on the kernel: %s" % (str(e) or type(e).__name__)
             _mark_views_dirty()
+            _ack_views_write(client, "viewsAck", msg.get("writeId"), ok, error=err, refused=refused or [], edited=edited)
+        elif msg and msg.get("type") == "tagEdit":
+            # a dashboard's tag gesture — {writeId, edit: {op, tid, …}}: create / rename / recolor /
+            # addMember / removeMember / delete, by the tag's stored id — as a TARGETED edit through
+            # _edit_tag, the /tag route's merge, which deep-copies the store and so is never judged
+            # stale; answered on the same socket (tagEditAck) with the post-write blob, the tag's tid
+            # and name, or a plain refusal. The op rides NESTED under `edit` so the message has no
+            # top-level `name` or `session` for the dashboard's federation router to mistake for a
+            # remote session's address (views are per kernel; the router sends tagEdit local).
+            # _edit_tag takes _views_lock itself. Frames pushed to every other client are unchanged
+            # (the dirty mark below). A handler exception is ACKED as a refusal rather than left to
+            # the recv loop's log: an unanswered write would pin the poster's optimistic copy.
+            try:
+                ok, err, info = _apply_tag_edit(msg.get("edit"))
+            except Exception as e:
+                sys.stderr.write("tagEdit: %s\n" % traceback.format_exc())
+                ok, err, info = False, "the edit failed on the kernel: %s" % (str(e) or type(e).__name__), None
+            if ok:
+                _mark_views_dirty()
+            _ack_views_write(client, "tagEditAck", msg.get("writeId"), ok, error=err, info=info)
         elif msg and msg.get("type") == "openTagsDialog":
             # any pane's "Configure tags…" opens THE tags dialog — which lives on the timeline pane
             # (one dialog, one implementation; the user 2026-08-25). Routed to the SAME dashboard's
@@ -40677,6 +41728,9 @@ class Handler(BaseHTTPRequestHandler):
                                  args=({"commentFast": str(msg["fast"]), "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
+        else:
+            # no arm took it: say so once per type, and answer the poster (see _note_unknown_op)
+            _note_unknown_op(msg, client)
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/tests/test_tag_edit_ack.py
+++ b/tests/test_tag_edit_ack.py
@@ -1,0 +1,2492 @@
+#!/usr/bin/env python3
+"""The tags dialog's write path is acknowledged (the user 2026-09-05, who lost a batch of tag
+renames and assignments made in "Manage tags").
+
+Root cause: the dialog posted the WHOLE views blob for every edit, built from its own un-echoed
+optimistic copy, so a burst of edits carried the pre-burst `at` stamp. The store's stale-writer
+guard (test_views_stale_writer.py) stamps a tag on its first edit and then judges the second edit
+to the same tag — a create followed by typing its name — stale against the client's OWN previous
+write, refuses it, and tells only stderr and the sync notices; the poster never learned, kept
+building from the refused copy, and the dialog snapped to the store ("tag N", no members) once the
+user paused.
+
+Two changes at the kernel's door, both pinned here through the real WS dispatcher:
+  - `tagEdit` — a TARGETED op (create / rename / recolor / addMember / removeMember / delete, by
+    tag NAME) applied through _edit_tag, the read-modify-write merge the /tag route already uses,
+    which deep-copies the store and so always carries the newest evidence. Never refused as stale.
+  - every views write is ANSWERED on the posting socket: {tagEditAck|viewsAck, writeId, ok,
+    views, error?, refused?}. The blob in the ack is the post-write client blob, the poster's new
+    base; a refusal names what was refused and why, in plain words.
+The whole-blob `setTimelineViews` stays for lens and order edits, with the guard unchanged (its
+stderr and sync-notice paths still fire) plus the ack. Frames pushed to other clients are unchanged.
+Synthetic sids only."""
+import contextlib
+import errno
+import io
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_tagack", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID1 = "11111111-2222-3333-4444-555555555501"
+SID2 = "11111111-2222-3333-4444-555555555502"
+SID3 = "11111111-2222-3333-4444-555555555503"
+WEB = {"id": "gA", "name": "web", "color": "#3b82f6", "members": [SID1]}
+
+
+def store_tag(name):
+    return next((t for t in km._timeline_views()["tags"] if t["name"] == name), None)
+
+
+class _Wire(unittest.TestCase):
+    """A dashboard's timeline socket, through the real dispatcher; every ack it receives is kept."""
+
+    def setUp(self):
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        self.notices = []
+        self._sync = km._sync_notice
+        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+        self.handler = object.__new__(km.Handler)
+        self.sent = []
+        self.client = {"app": "timeline", "wid": "w-dash", "alive": True,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+
+    def tearDown(self):
+        km._sync_notice = self._sync
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+
+    @contextlib.contextmanager
+    def real_notices(self):
+        """The notices as a dashboard receives them: filed through the REAL ring for the block's duration
+        (the harness captures them in-process otherwise), so the test reads them back through
+        _sync_notice_rows — the served row, under the kernel's cap — while the block is open."""
+        km._sync_notice = self._sync
+        with km._SYNC_LOCK:
+            saved = list(km._SYNC_NOTICES)
+            km._SYNC_NOTICES.clear()
+        try:
+            yield
+        finally:
+            km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+            with km._SYNC_LOCK:
+                km._SYNC_NOTICES[:] = saved
+
+    def post(self, msg, client=None):
+        """Dispatch one client frame; return the reply it produced on that socket (or None)."""
+        c = client or self.client
+        before = len(self.sent) if c is self.client else None
+        km.Handler._dispatch_ws(self.handler, msg, c)
+        if before is None:
+            return None
+        new = self.sent[before:]
+        self.assertLessEqual(len(new), 1, "one write, at most one reply")
+        return new[0] if new else None
+
+    def seed(self):
+        """Tag `web` holding SID1, written through the door so it is stamped (any earlier edit does this)."""
+        ack = self.post({"type": "setTimelineViews", "writeId": "w0",
+                         "views": {"active": "all", "tags": [dict(WEB)]}})
+        self.assertEqual((ack["type"], ack["ok"], ack["refused"]), ("viewsAck", True, []))
+        return ack["views"]
+
+
+class TargetedTagEdits(_Wire):
+    """The tagEdit message: {type, writeId, edit: {op, tid?, name?, newName?, color?, sid?|sids?}}.
+    Every op but create addresses the tag by its stored id (the 2026-09-05 review):
+    a create's ack returns the kernel-minted `tid` and `name`; the op rides nested under `edit` so
+    the message has no top-level `name` or `session` a federation router could read as an address."""
+
+    def edit(self, write_id, edit, client=None):
+        return self.post({"type": "tagEdit", "writeId": write_id, "edit": edit}, client=client)
+
+    def test_the_users_burst_create_then_rename_then_assign_before_any_frame_all_land_and_each_is_acked(self):
+        """The exact gesture sequence that was lost, as targeted ops: nothing waits for an echo, and
+        the store ends up holding the typed name and the assigned sessions."""
+        self.seed()
+        a1 = self.edit("w1", {"op": "create", "color": "#1EA1EB"})
+        self.assertEqual((a1["type"], a1["writeId"], a1["ok"]), ("tagEditAck", "w1", True))
+        tid = a1["tid"]
+        self.assertTrue(isinstance(tid, str) and tid.startswith("g"), "the KERNEL mints the id and the ack returns it")
+        self.assertEqual(a1["name"], "tag 1", "…and the default name, minted unique in the store")
+        self.assertEqual(store_tag("tag 1")["id"], tid)
+        a2 = self.edit("w2", {"op": "rename", "tid": tid, "newName": "notes-api"})
+        self.assertEqual((a2["writeId"], a2["ok"], a2["tid"], a2["name"]), ("w2", True, tid, "notes-api"))
+        self.assertEqual(store_tag("notes-api")["id"], tid, "the rename typed before any echo LANDS")
+        self.assertIsNone(store_tag("tag 1"))
+        a3 = self.edit("w3", {"op": "addMember", "tid": tid, "sids": [SID2, SID3]})
+        self.assertEqual((a3["writeId"], a3["ok"]), ("w3", True))
+        self.assertEqual(sorted(m["sid"] for m in store_tag("notes-api")["members"]), sorted([SID2, SID3]),
+                         "the assignment lands too — the second half of the report")
+        self.assertEqual(self.notices, [], "a targeted edit is never judged stale: it is built from the store")
+        # the ack carries the poster's NEW BASE: the rendered client blob, stamped, with the edit in it
+        v = a3["views"]
+        self.assertTrue(v.get("at"), "the ack blob carries the store's write stamp")
+        t = next(x for x in v["tags"] if x["id"] == tid)
+        self.assertEqual((t["name"], sorted(t["members"])), ("notes-api", sorted([SID2, SID3])))
+        self.assertTrue(t.get("mtime"), "…and the per-tag mtime the guard reads")
+        self.assertNotIn("error", a3)
+
+    def test_a_create_is_named_around_a_leftover_default_named_tag(self):
+        """The round trip the dialog's own "tag N" from a row count could not make: with a leftover
+        "tag 1" (and a "tag 3") in the store, the kernel mints "tag 2", then "tag 4" — never a
+        duplicate the create would be refused for."""
+        self.seed()
+        self.assertTrue(self.edit("w0", {"op": "create", "name": "tag 1", "color": "#000000"})["ok"])
+        self.assertTrue(self.edit("w0b", {"op": "create", "name": "tag 3", "color": "#000000"})["ok"])
+        a = self.edit("w1", {"op": "create", "color": "#1EA1EB"})
+        self.assertEqual((a["ok"], a["name"]), (True, "tag 2"))
+        b = self.edit("w2", {"op": "create", "color": "#1EA1EB"})
+        self.assertEqual((b["ok"], b["name"]), (True, "tag 4"))
+        self.assertNotEqual(a["tid"], b["tid"])
+        self.assertEqual(next(t["name"] for t in b["views"]["tags"] if t["id"] == b["tid"]), "tag 4",
+                         "the ack's blob carries the new row under the returned tid — the dialog opens its rename input there")
+        self.assertEqual(store_tag("tag 2")["id"], a["tid"])
+
+    def test_a_rename_to_an_existing_name_is_refused_and_no_gesture_in_the_refusal_window_reaches_the_other_tag(self):
+        """Addressed by NAME, a recolor queued behind a refused rename went looking for the
+        name the rename would have given the tag — and found the OTHER tag that already had it."""
+        self.seed()                                                        # web = gA, #3b82f6
+        tid = self.edit("w1", {"op": "create", "name": "api", "color": "#54B204"})["tid"]
+        r = self.edit("w2", {"op": "rename", "tid": tid, "newName": "web"})
+        self.assertEqual((r["ok"], r["error"], r["tid"]), (False, 'a tag named "web" already exists', tid))
+        c = self.edit("w3", {"op": "recolor", "tid": tid, "color": "#DD42FF"})   # the gesture queued behind the rename
+        self.assertTrue(c["ok"])
+        self.assertEqual(store_tag("api")["color"], "#DD42FF", "lands on the tag the user was editing")
+        self.assertEqual(store_tag("web")["color"], "#3b82f6", "the tag that owns the refused name is untouched")
+        m = self.edit("w4", {"op": "addMember", "tid": tid, "sids": [SID2]})
+        self.assertTrue(m["ok"])
+        self.assertEqual([x["sid"] for x in store_tag("web")["members"]], [SID1], "…by every op in the window")
+
+    def test_recolor_remove_member_and_delete(self):
+        self.seed()
+        self.edit("w1", {"op": "addMember", "tid": "gA", "sid": SID2})
+        self.assertEqual(len(store_tag("web")["members"]), 2, "a single `sid` spelling works beside `sids`")
+        a = self.edit("w2", {"op": "recolor", "tid": "gA", "color": "#DD42FF"})
+        self.assertTrue(a["ok"])
+        self.assertEqual(store_tag("web")["color"], "#DD42FF")
+        a = self.edit("w3", {"op": "removeMember", "tid": "gA", "sids": [SID1]})
+        self.assertTrue(a["ok"])
+        self.assertEqual([m["sid"] for m in store_tag("web")["members"]], [SID2])
+        a = self.edit("w4", {"op": "delete", "tid": "gA"})
+        self.assertEqual((a["ok"], a["views"]["tags"], a["tid"]), (True, [], "gA"))
+        self.assertEqual(self.notices, [])
+
+    def test_a_create_with_members_is_one_op_the_join_menus_new_tag_input(self):
+        self.seed()
+        a = self.edit("w1", {"op": "create", "name": "qa", "color": "#54B204", "sids": [SID2, SID3]})
+        self.assertTrue(a["ok"])
+        self.assertEqual((a["name"], store_tag("qa")["id"]), ("qa", a["tid"]))
+        self.assertEqual(sorted(m["sid"] for m in store_tag("qa")["members"]), sorted([SID2, SID3]))
+
+    def test_a_refused_edit_acks_a_plain_reason_and_changes_nothing(self):
+        self.seed()
+        api = self.edit("w1", {"op": "create", "name": "api", "color": "#54B204"})["tid"]
+        before = json.dumps(km._timeline_views(), sort_keys=True)
+        gone = "that tag no longer exists — it may have been deleted from another dashboard"
+        cases = [
+            ({"op": "rename", "tid": api, "newName": "web"}, 'a tag named "web" already exists'),
+            ({"op": "rename", "tid": "gghost", "newName": "x"}, gone),
+            ({"op": "create", "name": "web", "color": "#000000"}, 'a tag named "web" already exists'),
+            ({"op": "addMember", "tid": "gghost", "sids": [SID2]}, gone),
+            ({"op": "addMember", "tid": "gA", "sids": []}, "the edit named no session"),
+            ({"op": "addMember", "sids": [SID2]}, "the edit named no tag"),
+            ({"op": "recolor", "tid": "gA"}, "no color given"),
+            ({"op": "rename", "tid": "gA", "newName": "   "}, "the new name is empty"),
+            ({"op": "delete", "tid": "gghost"}, gone),
+            ({"op": "explode", "tid": "gA"}, 'unknown tag edit "explode"'),
+            (None, "the edit is missing"),
+            ("web", "the edit is missing"),
+        ]
+        for i, (edit, why) in enumerate(cases):
+            a = self.edit("r%d" % i, edit)
+            self.assertEqual((a["type"], a["writeId"], a["ok"]), ("tagEditAck", "r%d" % i, False), edit)
+            self.assertEqual(a["error"], why, edit)
+            self.assertIn("views", a, "a refusal still carries the store's blob — the poster's revert base")
+            self.assertEqual(json.dumps(km._timeline_views(), sort_keys=True), before, "a refused edit writes nothing")
+        # a tag that no longer exists is REFUSED, never resurrected: the dialog's rename of a tag
+        # another dashboard deleted must not quietly mint a new one under the old id
+        self.assertIsNone(next((t for t in km._timeline_views()["tags"] if t["id"] == "gghost"), None))
+
+    def test_the_message_carries_the_op_nested_under_edit_and_no_top_level_field_is_read(self):
+        """The op's fields sit under `edit` so the message has no top-level `name` or `session`
+        (federation routes those as a remote lane's address). A stray top-level field is ignored."""
+        self.seed()
+        a = self.post({"type": "tagEdit", "writeId": "w1", "name": "web", "session": SID2,
+                       "edit": {"op": "create", "color": "#000000"}})
+        self.assertEqual((a["ok"], a["name"]), (True, "tag 1"), "the create read nothing from the top level")
+        self.assertEqual(store_tag("web")["members"], [{"host": "", "sid": SID1}], "…and touched no other tag")
+
+    def test_a_handler_exception_is_acked_as_a_refusal_never_left_unanswered(self):
+        """An unanswered write would pin the poster's optimistic copy: the arm acks the failure."""
+        self.seed()
+        real = km._apply_tag_edit
+
+        def boom(e):
+            raise RuntimeError("disk on fire")
+        km._apply_tag_edit = boom
+        try:
+            a = self.edit("w1", {"op": "create", "color": "#000000"})
+        finally:
+            km._apply_tag_edit = real
+        self.assertEqual((a["type"], a["writeId"], a["ok"]), ("tagEditAck", "w1", False))
+        self.assertEqual(a["error"], "the edit failed on the kernel: disk on fire")
+        self.assertIn("views", a)
+
+    def test_the_ack_answers_the_posting_socket_only(self):
+        self.seed()
+        other_sent = []
+        other = {"app": "timeline", "wid": "w-other", "alive": True, "send": lambda s: other_sent.append(json.loads(s))}
+        n = len(self.sent)
+        self.edit("w9", {"op": "create", "name": "api", "color": "#54B204"}, client=other)
+        self.assertEqual([m["type"] for m in other_sent], ["tagEditAck"])
+        self.assertEqual(len(self.sent), n, "no other socket sees the ack — their pushed frames are unchanged")
+        # …and a send failure on the poster's socket never escapes the handler (the client is dead, not the kernel)
+        def boom(s):
+            raise OSError("client gone")
+        dead = {"app": "timeline", "wid": "w-dead", "alive": True, "send": boom}
+        self.edit("w10", {"op": "create", "name": "qa", "color": "#54B204"}, client=dead)
+        self.assertIsNotNone(store_tag("qa"), "the edit landed even though the ack could not be delivered")
+
+    def test_an_edit_without_a_write_id_is_still_acked_with_a_null_id(self):
+        self.seed()
+        a = self.post({"type": "tagEdit", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        self.assertEqual((a["ok"], a["writeId"]), (True, None))
+        self.assertTrue(store_tag("api")["id"].startswith("g"), "the kernel mints the id, /tag's shape")
+
+    def test_a_move_is_one_write_both_halves_or_neither(self):
+        """The `move` op (no client gesture posts it yet; a tab strip's "Move to <tag>" row is the intended
+        caller): off the source tag, onto the target, as ONE write under the lock — a refused destination
+        leaves the source's membership exactly as it was, and the store moves its write sequence once per
+        move."""
+        self.seed()                                                        # web = gA holding SID1
+        api = self.edit("w1", {"op": "create", "name": "api", "color": "#54B204"})["tid"]
+        writes, real = [], km._set_timeline_views
+        km._set_timeline_views = lambda blob: (writes.append(1), real(blob))[1]
+        try:
+            a = self.edit("w2", {"op": "move", "tid_from": "gA", "tid_to": api, "sid": SID1})
+        finally:
+            km._set_timeline_views = real
+        self.assertEqual((a["ok"], a["tid"], a["name"]), (True, api, "api"))
+        self.assertEqual(store_tag("web")["members"], [], "off the source tag…")
+        self.assertEqual([m["sid"] for m in store_tag("api")["members"]], [SID1], "…onto the target")
+        self.assertEqual(len(writes), 1, "ONE store write for the move, not one per half")
+        # a refused DESTINATION: nothing moves — the source keeps the session
+        before = json.dumps(km._timeline_views(), sort_keys=True)
+        r = self.edit("w3", {"op": "move", "tid_from": api, "tid_to": "gghost", "sid": SID1})
+        self.assertFalse(r["ok"])
+        self.assertIn("move into", r["error"])
+        self.assertEqual([m["sid"] for m in store_tag("api")["members"]], [SID1], "the source membership is intact")
+        self.assertEqual(json.dumps(km._timeline_views(), sort_keys=True), before, "nothing was written")
+        # a refused SOURCE, and the two malformed shapes
+        r = self.edit("w4", {"op": "move", "tid_from": "gghost", "tid_to": "gA", "sid": SID1})
+        self.assertEqual((r["ok"], "move out of" in r["error"]), (False, True))
+        self.assertEqual(store_tag("web")["members"], [], "the destination is untouched")
+        self.assertEqual(self.edit("w5", {"op": "move", "tid_from": api, "tid_to": "gA"})["error"], "the edit named no session")
+        self.assertEqual(self.edit("w6", {"op": "move", "tid_to": "gA", "sid": SID1})["error"], "the edit named no tag")
+        self.assertEqual(json.dumps(km._timeline_views(), sort_keys=True), before)
+        # a move onto a tag already holding the session, off one that does not: still one clean write
+        m = self.edit("w7", {"op": "move", "tid_from": "gA", "tid_to": api, "sids": [SID1]})
+        self.assertTrue(m["ok"])
+        self.assertEqual([x["sid"] for x in store_tag("api")["members"]], [SID1], "no duplicate member")
+        self.assertEqual(self.notices, [], "a move is built from the store — never judged stale")
+
+    def test_the_tag_route_still_addresses_by_name_and_creates_on_first_use(self):
+        """_edit_tag's name path is unchanged for `romp tag`: a missing name is created on any
+        edit, an existing one is edited, a duplicate name refuses rather than guesses."""
+        self.seed()
+        t, err = km._edit_tag("qa", add=[SID2])
+        self.assertIsNone(err)
+        self.assertEqual((t["name"], t["members"]), ("qa", [SID2]))
+        t, err = km._edit_tag("qa", color="#DD42FF")
+        self.assertEqual((err, t["color"]), (None, "#DD42FF"))
+
+
+class WholeBlobAcks(_Wire):
+
+    def test_a_clean_whole_blob_write_acks_ok_with_no_refusals(self):
+        served = self.seed()
+        nv = json.loads(json.dumps(served))
+        nv["actives"] = {"timeline": {"tags": ["web"]}}                # a lens edit, built from the echo
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": nv})
+        self.assertEqual((a["type"], a["writeId"], a["ok"], a["refused"]), ("viewsAck", "w1", True, []))
+        self.assertEqual(a["views"]["actives"]["timeline"], {"tags": ["web"]})
+        self.assertNotIn("error", a)
+        self.assertEqual(self.notices, [])
+
+    def test_a_genuinely_stale_whole_blob_gets_a_refusal_ack_naming_the_tag_and_the_rest_lands(self):
+        served = self.seed()
+        stale = json.loads(json.dumps(served))                           # this dashboard's copy…
+        time.sleep(1.1)                                                  # int-second stamps: land in a later second
+        t, err = km._edit_tag("web", add=[SID2])                         # …then another writer adds a member
+        self.assertIsNone(err)
+        stale["actives"] = {"timeline": {"tags": ["web"]}}               # the stale dashboard changes its lens…
+        stale["tags"][0]["members"] = []                                 # …and its copy of web has no members at all
+        a = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale})
+        self.assertEqual((a["type"], a["writeId"], a["ok"]), ("viewsAck", "w2", False))
+        self.assertEqual([r["name"] for r in a["refused"]], ["web"])
+        self.assertIn("predates", a["refused"][0]["reason"])
+        self.assertIn('"web"', a["error"], "one plain sentence the dialog can show as-is")
+        v = a["views"]
+        self.assertEqual(sorted(next(x for x in v["tags"] if x["id"] == "gA")["members"]), sorted([SID1, SID2]),
+                         "the store's newer members stand — the guard is unchanged")
+        self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]}, "the rest of the write (the lens) landed")
+        # the guard's other two witnesses still fire — the ack is an addition, not a replacement
+        self.assertEqual(len(self.notices), 1)
+        self.assertFalse(self.notices[0][1])
+        self.assertIn("stale dashboard write", self.notices[0][0])
+
+    def test_a_refusal_on_a_tag_the_client_did_not_edit_is_ok_with_the_refusal_listed(self):
+        """A lens change from a dashboard that had slept through another's tag edit was
+        acked as a refusal and toasted — for a tag the user never touched. `edited` names the tag
+        ids the write changed; a refusal outside them is a stale copy, not a lost edit. A
+        lens write (`edited` empty) changes no tag at all, so its stale copy is not even judged —
+        the ack is clean and its blob carries the store's web; a write naming ANOTHER tag as edited
+        still lists the untouched tag's kept copy."""
+        served = self.seed()
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        km._edit_tag("web", add=[SID2])                                   # another writer edits web
+        stale["actives"] = {"timeline": {"tags": ["web"]}}                # this dashboard changes only its lens…
+        stale["tags"][0]["members"] = []                                  # …carrying its stale copy of web
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []),
+                         "ok, nothing listed: a lens write changes no tag, so there is nothing to refuse")
+        self.assertNotIn("error", a, "no one-line refusal to show: there is nothing to tell the user")
+        self.assertEqual(a["views"]["actives"]["timeline"], {"tags": ["web"]}, "the lens landed")
+        self.assertEqual(sorted(next(t for t in a["views"]["tags"] if t["id"] == "gA")["members"]), sorted([SID1, SID2]),
+                         "…and the ack's blob carries the newer web the client adopts")
+        # the same stale copy of web riding a write that edits a DIFFERENT tag: web is kept, listed, ok
+        c0 = self.post({"type": "tagEdit", "writeId": "w1b", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        w = json.loads(json.dumps(c0["views"]))                                  # a fresh copy (its `at` is the store's)…
+        next(t for t in w["tags"] if t["id"] == "gA")["members"] = []            # …whose web differs from the store's anyway
+        next(t for t in w["tags"] if t["id"] == c0["tid"])["color"] = "#000000"  # this write recolors api
+        a2 = self.post({"type": "setTimelineViews", "writeId": "w1c", "views": w, "edited": [c0["tid"]]})
+        self.assertEqual((a2["ok"], [r["tid"] for r in a2["refused"]]), (True, ["gA"]),
+                         "ok — nothing the user did was refused — with the kept tag listed")
+        self.assertIn("did not edit it", a2["refused"][0]["reason"])
+        self.assertNotIn("error", a2)
+        self.assertEqual(store_tag("api")["color"], "#000000", "the edited tag landed")
+        self.assertEqual(sorted(m["sid"] for m in store_tag("web")["members"]), sorted([SID1, SID2]),
+                         "the untouched tag was kept, whatever the stamps say (the copy is not stale by them)")
+        self.assertIsNone(km._edit_tag(tid=c0["tid"], delete=True)[1])
+        # the same write naming web as EDITED is a lost edit: refused, with the reason
+        b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale, "edited": ["gA"]})
+        self.assertFalse(b["ok"])
+        self.assertIn('"web"', b["error"])
+        # no `edited` at all (an older client): the strict reading stands
+        c = self.post({"type": "setTimelineViews", "writeId": "w3", "views": stale})
+        self.assertFalse(c["ok"])
+
+    def test_the_notice_is_filed_only_when_the_poster_edited_the_kept_tag(self):
+        """The 2026-09-05 review: the benign case — a kept tag outside `edited`, acked ok —
+        still filed a red "reload that dashboard to resync" notice plus stderr for every kept tag.
+        Now the notice follows the ack's verdict: a lost edit is loud; a stale copy of an untouched tag
+        is one quiet stderr line and nothing on the dashboard. A lens write (`edited` empty)
+        changes no tag and logs nothing at all — the quiet line is for a write that names other tags."""
+        import contextlib
+        import io
+        served = self.seed()
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        km._edit_tag("web", add=[SID2])
+        stale["actives"] = {"timeline": {"tags": ["web"]}}
+        stale["tags"][0]["members"] = []
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []))
+        self.assertEqual(self.notices, [], "nothing the user did was refused, so no notice")
+        self.assertEqual([ln for ln in err.getvalue().splitlines() if ln.strip()], [],
+                         "a lens write is the normal path: nothing is logged")
+        # the same stale web riding a write that edits another tag: one quiet stderr line, no notice
+        c0 = self.post({"type": "tagEdit", "writeId": "w1b", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        w = json.loads(json.dumps(c0["views"]))
+        next(t for t in w["tags"] if t["id"] == "gA")["members"] = []
+        next(t for t in w["tags"] if t["id"] == c0["tid"])["color"] = "#000000"
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a2 = self.post({"type": "setTimelineViews", "writeId": "w1c", "views": w, "edited": [c0["tid"]]})
+        self.assertEqual((a2["ok"], [r["tid"] for r in a2["refused"]]), (True, ["gA"]))
+        self.assertEqual(self.notices, [], "nothing the user did was refused, so no notice")
+        lines = [ln for ln in err.getvalue().splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1, "one quiet stderr line is the whole record")
+        self.assertIn('"web" (differing copy)', lines[0], "the quiet label carries its cause like every other")
+        self.assertNotIn("reload that dashboard", lines[0])
+        self.assertIsNone(km._edit_tag(tid=c0["tid"], delete=True)[1])
+        # the same write naming web as edited: the lost-edit notice, as before
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale, "edited": ["gA"]})
+        self.assertFalse(b["ok"])
+        self.assertEqual(len(self.notices), 1)
+        self.assertFalse(self.notices[0][1])
+        self.assertIn('"web"', self.notices[0][0])
+        self.assertIn("reload that dashboard", self.notices[0][0])
+        # a mixed write — one kept tag edited, one not — names only the edited one on the dashboard
+        self.notices.clear()
+        self.assertTrue(self.post({"type": "tagEdit", "writeId": "w3", "edit": {"op": "create", "name": "api", "color": "#54B204", "sids": [SID3]}})["ok"])
+        stale2 = json.loads(json.dumps(km._views_client()))
+        time.sleep(1.1)
+        km._edit_tag("web", color="#DD42FF")
+        km._edit_tag("api", color="#DD42FF")
+        for t in stale2["tags"]:
+            t["color"] = "#000000"
+        api_tid = next(t["id"] for t in stale2["tags"] if t["name"] == "api")
+        with contextlib.redirect_stderr(io.StringIO()):
+            c = self.post({"type": "setTimelineViews", "writeId": "w4", "views": stale2, "edited": [api_tid]})
+        self.assertFalse(c["ok"])
+        self.assertEqual(sorted(r["name"] for r in c["refused"]), ["api", "web"], "both kept; the ack lists both")
+        self.assertEqual(len(self.notices), 1)
+        self.assertIn('"api"', self.notices[0][0])
+        self.assertNotIn('"web"', self.notices[0][0], "the untouched tag is not the user's problem")
+
+    def test_every_quiet_label_carries_its_cause(self):
+        """The 2026-09-05 review: the quiet stderr line labelled a kept deletion "(deletion)"
+        and an unread copy "(unread)", but a differing copy of an unedited tag stood bare beside them —
+        the one label without a cause. Now it reads "(differing copy)", so the line is uniform."""
+        self.seed()
+        api = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        tests = self.post({"type": "tagEdit", "writeId": "w2", "edit": {"op": "create", "name": "tests", "color": "#54B204"}})
+        w = json.loads(json.dumps(tests["views"]))
+        next(t for t in w["tags"] if t["id"] == "gA")["members"] = []                 # web: a differing copy…
+        w["tags"] = [t for t in w["tags"] if t["id"] != api["tid"]]                    # api: absent, a deletion…
+        next(t for t in w["tags"] if t["id"] == tests["tid"])["color"] = "#000000"    # …and this write edits tests only
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a = self.post({"type": "setTimelineViews", "writeId": "w3", "views": w, "edited": [tests["tid"]]})
+        self.assertTrue(a["ok"], "nothing the user did was refused")
+        self.assertEqual(sorted(r["tid"] for r in a["refused"]), sorted(["gA", api["tid"]]))
+        self.assertEqual(self.notices, [])
+        lines = [ln for ln in err.getvalue().splitlines() if ln.strip()]
+        self.assertEqual(lines, ["romp-kernel: kept the store's copy of 2 tags over a dashboard's stale copy (tags that "
+                                 "dashboard did not edit; the ack carries the newer state): "
+                                 '"api" (deletion), "web" (differing copy)'],
+                         "every label on the quiet line says why")
+        self.assertEqual(store_tag("tests")["color"], "#000000", "the edited tag landed")
+        self.assertIsNotNone(store_tag("api"), "the unedited absence was not a deletion")
+
+    def test_a_stale_copy_cannot_resurrect_a_tag_deleted_elsewhere_but_a_named_create_lands(self):
+        """The 2026-09-05 review, a pre-existing hole: the guard refused a stale DELETION
+        (a tag absent from the copy) but not a stale RESURRECTION (a tag absent from the store) — an
+        incoming unknown tag was always kept as new. With `edited`, the two creates a whole-blob write
+        can carry are distinguishable: a tag the client did not name as edited is something another
+        dashboard deleted after the copy was taken, and is kept out; a tag it did name is a genuine
+        create (the legacy path's client-minted id); a write without `edited` keeps the old reading.
+        A lens write (`edited` empty) changes no tag, so the deleted tag is not even judged —
+        the re-creation refusal is for a write that names OTHER tags as edited."""
+        import contextlib
+        import io
+        self.seed()
+        c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204", "sids": [SID2]}})
+        api_tid = c["tid"]
+        stale = json.loads(json.dumps(c["views"]))                  # this dashboard's copy: web and api
+        self.assertIsNone(km._edit_tag(tid=api_tid, delete=True)[1])   # another dashboard deletes api
+        self.assertIsNone(store_tag("api"))
+        # a lens change from the stale copy changes no tag: api stays deleted, nothing is listed or logged
+        stale["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []), "nothing the user did was refused, and no tag was judged")
+        self.assertNotIn("error", a)
+        self.assertIsNone(store_tag("api"), "the deleted tag stays deleted")
+        self.assertEqual([t["name"] for t in a["views"]["tags"]], ["web"], "…and the ack's blob, which the client adopts, has no api")
+        self.assertEqual(a["views"]["actives"]["timeline"], {"tags": ["web"]}, "the lens landed")
+        self.assertEqual(self.notices, [], "a stale copy of a deleted tag is not the user's problem")
+        self.assertEqual([ln for ln in err.getvalue().splitlines() if ln.strip()], [], "nothing logged")
+        # the same stale copy riding a write that edits web (a recolor): api is kept OUT with a reason, the write is ok
+        stale_w = json.loads(json.dumps(stale))
+        next(t for t in stale_w["tags"] if t["id"] == "gA")["color"] = "#000000"
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a2 = self.post({"type": "setTimelineViews", "writeId": "w2b", "views": stale_w, "edited": ["gA"]})
+        self.assertTrue(a2["ok"], "nothing the user did was refused")
+        self.assertEqual([(r["tid"], r["name"]) for r in a2["refused"]], [(api_tid, "api")])
+        self.assertEqual(a2["refused"][0]["reason"], "it was deleted after your copy was taken, so it was not re-created")
+        self.assertNotIn("error", a2)
+        self.assertIsNone(store_tag("api"), "the deleted tag stays deleted")
+        self.assertEqual(store_tag("web")["color"], "#000000", "the edited tag landed")
+        self.assertEqual(self.notices, [], "a stale copy of a deleted tag is not the user's problem")
+        self.assertEqual(len([ln for ln in err.getvalue().splitlines() if ln.strip()]), 1, "one quiet line")
+        # the same api, on a copy of the store, named as EDITED: a create (the legacy path's client-minted id), it lands
+        api_row = next(t for t in stale["tags"] if t["id"] == api_tid)
+        fresh = json.loads(json.dumps(km._views_client()))
+        fresh["tags"].append(dict(api_row))
+        b = self.post({"type": "setTimelineViews", "writeId": "w3", "views": fresh, "edited": [api_tid]})
+        self.assertEqual((b["ok"], b["refused"]), (True, []))
+        self.assertEqual(store_tag("api")["id"], api_tid)
+        self.assertTrue(store_tag("api").get("mtime"), "a created tag is stamped like any edit")
+        # no `edited` at all (an older client): every unknown tag is new, as before
+        self.assertIsNone(km._edit_tag(tid=api_tid, delete=True)[1])
+        fresh = json.loads(json.dumps(km._views_client()))
+        fresh["tags"].append(dict(api_row))
+        d = self.post({"type": "setTimelineViews", "writeId": "w4", "views": fresh})
+        self.assertEqual((d["ok"], d["refused"]), (True, []))
+        self.assertEqual(store_tag("api")["id"], api_tid, "the old reading stands for a client that cannot say")
+
+    def test_the_refusal_names_the_tag_once_and_says_what_was_kept(self):
+        """The reason carried the name and the client prefixed it again."""
+        served = self.seed()
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        km._edit_tag("web", add=[SID2])
+        stale["tags"][0]["members"] = []
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": ["gA"]})
+        row = a["refused"][0]
+        self.assertNotIn("web", row["reason"], "the reason names no tag — the composer adds the name once")
+        self.assertIn("newer state was kept", row["reason"], "…and says what was kept")
+        self.assertIn("not applied", row["reason"], "…and what was refused")
+        self.assertEqual(a["error"], '"web": %s' % row["reason"])
+        self.assertEqual(a["error"].count("web"), 1, "the one-line form names the tag exactly once")
+        stale["tags"] = []
+        d = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale, "edited": ["gA"]})
+        self.assertEqual(d["error"], '"web": it was edited after your copy was taken, so it was not deleted')
+
+    def test_a_setter_exception_is_acked_as_a_refusal_never_left_unanswered(self):
+        self.seed()
+        real = km._set_timeline_views
+
+        def boom(blob, **kw):
+            raise RuntimeError("disk on fire")
+        km._set_timeline_views = boom
+        try:
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": []}})
+        finally:
+            km._set_timeline_views = real
+        self.assertEqual((a["type"], a["ok"], a["error"]), ("viewsAck", False, "the write failed on the kernel: disk on fire"))
+
+    def test_a_stale_deletion_is_named_as_such(self):
+        served = self.seed()
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        km._edit_tag("web", add=[SID2])
+        stale["tags"] = []
+        a = self.post({"type": "setTimelineViews", "writeId": "w3", "views": stale})
+        self.assertFalse(a["ok"])
+        self.assertEqual(len(a["refused"]), 1)
+        self.assertEqual(a["refused"][0]["name"], "web")
+        self.assertIn("not deleted", a["refused"][0]["reason"])
+        self.assertEqual([t["name"] for t in a["views"]["tags"]], ["web"])
+
+    def test_the_dialogs_old_burst_is_what_the_whole_blob_door_refuses(self):
+        """The mechanism, pinned so the targeted op's reason for existing stays legible: a rename built
+        from the client's un-echoed copy of its own create is refused as stale. (The dialog no longer
+        posts this shape for tag edits; this is the door's behavior, and the ack now reports it.)"""
+        S0 = self.seed()
+        time.sleep(1.1)
+        P1 = json.loads(json.dumps(S0))                                  # the pending copy: pre-burst `at`
+        P1["tags"].append({"id": "gnew1", "name": "tag 2", "color": "#1EA1EB", "members": []})
+        a1 = self.post({"type": "setTimelineViews", "writeId": "p1", "views": P1})
+        self.assertTrue(a1["ok"], "a new id is never refused")
+        P2 = json.loads(json.dumps(P1))                                  # built from the pending, not the echo
+        P2["tags"][1]["name"] = "notes-api"
+        a2 = self.post({"type": "setTimelineViews", "writeId": "p2", "views": P2})
+        self.assertEqual((a2["ok"], [r["name"] for r in a2["refused"]]), (False, ["tag 2"]),
+                         "judged stale against the client's OWN previous write — the reported loss")
+        self.assertEqual(store_tag("tag 2")["name"], "tag 2")
+
+
+class EditedBoundsTheWrite(_Wire):
+    """The 2026-09-05 review (the HIGH finding): a lens or order write carries `edited: []`
+    and is built from the store's blob the client last adopted, and the door still applied its tag
+    set as a whole-blob replacement judged by the guard's second-resolution stamps — so a targeted
+    edit that landed in the SAME second as that blob's `at` (its mtime equal to the writer's
+    evidence, not newer by the guard's clock) was silently reverted by the next lens change: a rename
+    undone, a create deleted, a member lost. Now `edited` bounds what a write may change: an empty
+    list changes no tag; a list of ids changes those tags only, a differing copy of any other tag
+    kept from the store quietly; no `edited` at all keeps the legacy reading."""
+
+    def test_the_reproduction_a_same_second_targeted_edit_survives_a_lens_write(self):
+        served = self.seed()                                           # the dashboard's adopted copy: web[SID1]
+        lens = json.loads(json.dumps(served))
+        # three targeted edits from another surface, landing right after the copy was taken
+        self.assertIsNone(km._edit_tag(tid="gA", rename="api")[1])
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID2])[1])
+        d, err = km._edit_tag("docs", add=[SID3])
+        self.assertIsNone(err)
+        store = km._timeline_views()
+        # the same-second case made exact rather than left to the test's timing: by the guard's clock
+        # the copy's evidence equals the edits' stamps, so nothing about it reads as stale
+        lens["at"] = max(t["mtime"] for t in store["tags"])
+        lens["actives"] = {"timeline": {"tags": ["api"]}, "chat": {"all": True}, "outline": {"all": True}}
+        lens["tagOrder"] = ["docs", "api"]
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": lens, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []))
+        self.assertNotIn("error", a)
+        web = next(t for t in km._timeline_views()["tags"] if t["id"] == "gA")
+        self.assertEqual(web["name"], "api", "the rename survives the lens write")
+        self.assertEqual(sorted(m["sid"] for m in web["members"]), sorted([SID1, SID2]), "the member survives")
+        self.assertEqual(store_tag("docs")["id"], d["id"], "the create survives")
+        self.assertEqual(km._timeline_views()["actives"]["timeline"], {"tags": ["api"]}, "the lens landed")
+        self.assertEqual(km._timeline_views()["tagOrder"], ["docs", "api"], "…and the order")
+        self.assertEqual(sorted(t["id"] for t in a["views"]["tags"]), sorted(t["id"] for t in store["tags"]),
+                         "the ack's blob is the store's tag set (in the write's order)")
+        self.assertEqual(self.notices, [], "the normal lens path: nothing said")
+        self.assertGreater(a["seq"], store["seq"], "the write moved the store")
+
+    def test_an_order_write_orders_the_stored_array_too_the_pill_drags_contract(self):
+        """The 2026-09-05 review: under an empty `edited` the door copied the store's tags
+        in STORE order and discarded the posted array order, so a pill drag moved tagOrder and left
+        the array as it was — a reader without this kernel's tagOrder (a peer's dashboard) kept
+        showing the old order, and the clients' comments promised a re-sort that never landed. The
+        array order is an order field, the write's to set: it follows the write's tagOrder; names the
+        order lacks trail in store order."""
+        self.seed()                                                        # web (gA)
+        api, err = km._edit_tag("api", add=[SID2])
+        self.assertIsNone(err)
+        docs, err = km._edit_tag("docs", add=[SID3])
+        self.assertIsNone(err)
+        self.assertEqual([t["name"] for t in km._timeline_views()["tags"]], ["web", "api", "docs"])
+        drag = json.loads(json.dumps(km._views_client()))
+        drag["tagOrder"] = ["docs", "web", "remote-only"]                   # the drop: a union order, a remote name included
+        drag["tags"] = list(reversed(drag["tags"]))                         # the client's own re-sort: ignored, the order decides
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": drag, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []))
+        store = km._timeline_views()
+        self.assertEqual([t["name"] for t in store["tags"]], ["docs", "web", "api"],
+                         "the array follows the order; the name the order lacks trails in store order")
+        self.assertEqual(store["tagOrder"], ["docs", "web", "remote-only"])
+        self.assertEqual([t["name"] for t in a["views"]["tags"]], ["docs", "web", "api"], "the ack's blob agrees")
+        self.assertEqual([t["mtime"] for t in store["tags"]].count(None), 0)
+        self.assertTrue(all(t["id"] in ("gA", api["id"], docs["id"]) for t in store["tags"]), "the same three tags: nothing changed but order")
+        # a lens write carrying the same order keeps the array where it is
+        lens = json.loads(json.dumps(a["views"]))
+        lens["actives"] = {"timeline": {"tags": ["api"]}, "chat": {"all": True}, "outline": {"all": True}}
+        b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": lens, "edited": []})
+        self.assertEqual((b["ok"], [t["name"] for t in km._timeline_views()["tags"]]), (True, ["docs", "web", "api"]))
+        self.assertEqual(self.notices, [])
+
+    def test_a_lens_write_cannot_store_a_dangling_active_it_is_validated_against_the_tags_that_stand(self):
+        """The 2026-09-05 review: the normalizer validated `active` against the POSTED
+        blob's tags, so a copy whose active named a tag deleted elsewhere wrote that id to disk under
+        an empty `edited` (the store's tags stood; the blob's active did not point at any of them).
+        Served as "all" by every read's re-normalization, but stored wrong. Validated against what
+        stands now — and the lens, order and active fields still land whole, last writer wins."""
+        served = self.seed()
+        d, err = km._edit_tag("docs", add=[SID2])                           # a second tag…
+        self.assertIsNone(err)
+        stale = json.loads(json.dumps(km._views_client()))
+        self.assertIsNone(km._edit_tag(tid=d["id"], delete=True)[1])       # …deleted elsewhere after the copy was taken
+        stale["active"] = d["id"]                                          # the copy still selects it
+        stale["actives"] = {"timeline": {"tags": ["docs"]}, "chat": {"all": True}, "outline": {"all": True}}
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []))
+        on_disk = json.loads(km._views_path().read_text())
+        self.assertEqual(on_disk["active"], "all", "no dangling id on disk: the active named no tag that stands")
+        self.assertEqual([t["id"] for t in on_disk["tags"]], ["gA"], "the store's tags stood")
+        self.assertEqual(on_disk["actives"]["timeline"], {"tags": ["docs"]},
+                         "the lens lands whole, unknown name and all (it may exist on a linked kernel): last writer wins")
+        self.assertEqual(self.notices, [])
+
+    def test_a_write_naming_its_edited_tags_changes_those_only(self):
+        self.seed()
+        c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        b_tid = c["tid"]
+        w = json.loads(json.dumps(c["views"]))                          # a fresh copy: not stale by any stamp
+        for t in w["tags"]:
+            t["color"] = "#000000"                                       # …recoloring BOTH tags…
+        a = self.post({"type": "setTimelineViews", "writeId": "w2", "views": w, "edited": [b_tid]})   # …claiming only B
+        self.assertEqual((a["ok"], [r["tid"] for r in a["refused"]]), (True, ["gA"]))
+        self.assertNotIn("error", a)
+        self.assertEqual(store_tag("api")["color"], "#000000", "B, the edited tag, is applied")
+        self.assertEqual(store_tag("web")["color"], "#3b82f6", "A is kept from the store, whatever the copy says")
+        self.assertEqual(self.notices, [], "a kept tag outside `edited` is nobody's lost edit: quiet")
+        # a tag omitted by a write that did not edit it is not deleted either
+        w2 = json.loads(json.dumps(a["views"]))
+        w2["tags"] = [t for t in w2["tags"] if t["id"] == b_tid]
+        w2["tags"][0]["color"] = "#DD42FF"
+        a2 = self.post({"type": "setTimelineViews", "writeId": "w3", "views": w2, "edited": [b_tid]})
+        self.assertEqual((a2["ok"], [(r["tid"], r["reason"]) for r in a2["refused"]]),
+                         (True, [("gA", "this write did not edit it, so it was not deleted")]))
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["api", "web"])
+        self.assertEqual(store_tag("api")["color"], "#DD42FF")
+        self.assertEqual(self.notices, [])
+
+    def test_a_write_without_edited_keeps_the_legacy_reading(self):
+        served = self.seed()
+        w = json.loads(json.dumps(served))
+        w["tags"][0]["name"] = "api"                                    # a fresh copy renames web…
+        w["tags"].append({"id": "gnew", "name": "docs", "color": "#DD42FF", "members": [SID2]})   # …and creates docs
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w})
+        self.assertEqual((a["ok"], a["refused"]), (True, []), "a fresh whole-blob write lands whole, as before")
+        self.assertEqual(store_tag("api")["id"], "gA")
+        self.assertEqual(store_tag("docs")["id"], "gnew")
+        # …and a stale one is judged by the stamps alone, loudly
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID3])[1])
+        b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": stale})
+        self.assertFalse(b["ok"])
+        self.assertIn("gA", [r["tid"] for r in b["refused"]])
+        self.assertTrue(self.notices and not self.notices[0][1], "loud, as before")
+
+
+class WriteSequence(_Wire):
+    """The store's WRITE SEQUENCE (the 2026-09-05 review): every accepted write
+    moves `seq` forward, the blob carries it, so every frame that embeds the blob (the timeline
+    skeleton, the feed frame, the tabOrder frames — all built from _views_client) and every ack
+    carries the same number. A client adopts a blob only when its seq is at least the one it
+    holds, so the order the socket delivered frames and acks in decides nothing: the pusher's
+    warmed cache can predate a write whose ack already arrived, and the exact-echo heuristic could
+    not tell that frame from the write's own echo."""
+
+    def test_every_accepted_write_moves_the_seq_forward_and_a_refusal_does_not(self):
+        served = self.seed()
+        s0 = served.get("seq")
+        self.assertIsInstance(s0, int, "the served blob carries the stamp")
+        _, err = km._edit_tag("web", add=[SID2])                            # a targeted (RMW) write
+        self.assertIsNone(err)
+        s1 = km._timeline_views()["seq"]
+        self.assertGreater(s1, s0, "a targeted write moves it")
+        nv = json.loads(json.dumps(km._views_client()))
+        nv["actives"] = {"timeline": {"tags": ["web"]}}
+        a = self.post({"type": "setTimelineViews", "writeId": "w2", "views": nv})
+        self.assertTrue(a["ok"])
+        self.assertGreater(a["seq"], s1, "a whole-blob write moves it, and the ack returns the seq the write produced")
+        self.assertEqual(a["seq"], a["views"]["seq"], "the ack's seq IS the blob's")
+        self.assertEqual(a["seq"], km._timeline_views()["seq"])
+        _, err = km._edit_tag("ghost", rename="x", exists=True)              # refused: no write
+        self.assertTrue(err)
+        self.assertEqual(km._timeline_views()["seq"], a["seq"], "a refused edit writes nothing, so it moves nothing")
+        # a PARTIALLY refused whole-blob write still lands the rest of the write — so it moves
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        km._edit_tag("web", color="#DD42FF")
+        s2 = km._timeline_views()["seq"]
+        stale["tags"][0]["members"] = []
+        stale["actives"] = {"chat": {"tags": ["web"]}}
+        b = self.post({"type": "setTimelineViews", "writeId": "w3", "views": stale})
+        self.assertEqual([r["name"] for r in b["refused"]], ["web"])
+        self.assertGreater(b["seq"], s2, "the lens landed, so the store moved")
+        self.assertEqual(b["views"]["seq"], b["seq"])
+
+    def test_the_seq_rides_every_frame_that_carries_the_blob_and_survives_the_normalizer(self):
+        served = self.seed()
+        self.assertEqual(km._views_client()["seq"], served["seq"],
+                         "the rendered client blob every frame embeds carries it")
+        self.assertEqual(km._norm_timeline_views(json.loads(json.dumps(served)))["seq"], served["seq"],
+                         "clients echo the blob wholesale — the stamp survives the round trip")
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertGreaterEqual(src.count('"views": _views_client()'), 3,
+                                "the timeline skeleton, the feed frame and the tabOrder frames all embed the "
+                                "rendered blob — one carrier, so the seq rides every one of them")
+
+    def test_a_store_recreated_from_nothing_starts_past_what_a_connected_client_holds(self):
+        """The seq is seeded from the clock, then +1 per write: a deleted views file (or a new
+        state dir) must not restart at 1 — a dashboard holding the old store's seq would then
+        ignore every frame until it reloaded."""
+        s0 = self.seed()["seq"]
+        km._views_path().unlink()
+        time.sleep(0.002)
+        a = self.post({"type": "setTimelineViews", "writeId": "w9", "views": {"active": "all", "tags": []}})
+        self.assertGreater(a["seq"], s0)
+        b = self.post({"type": "setTimelineViews", "writeId": "w10", "views": a["views"]})
+        self.assertGreater(b["seq"], a["seq"], "…and strictly increasing within a store, same-ms writes included")
+
+
+class Capability(_Wire):
+    """The kernel says what it can do (the 2026-09-05 review): {type: "caps"} in
+    reply to every `ready`, after the pushes; the same list on /version. A message no handler took
+    is logged once per type and answered {type: "unknownOp", op, writeId?} on the poster's socket,
+    so a client waiting on an ack learns the op is unsupported instead of pinning its copy."""
+
+    def setUp(self):
+        super().setUp()
+        km._UNKNOWN_OPS_SEEN.clear()
+        # the `ready` arm sends its own tabOrder frame after the connect push, built from a live-session
+        # read; pinned empty so the frame goes out the same way with or without tmux on the box
+        self._tmux = km._tmux_sessions
+        km._tmux_sessions = lambda: {}
+
+    def tearDown(self):
+        km._tmux_sessions = self._tmux
+        super().tearDown()
+
+    def test_ready_is_answered_with_the_caps_frame_after_the_pushes(self):
+        self.handler._push_one = lambda c: self.sent.append({"type": "_pushed"})   # the connect push, in order
+        km.Handler._dispatch_ws(self.handler, {"type": "ready"}, self.client)
+        types = [m["type"] for m in self.sent]
+        self.assertIn("caps", types)
+        self.assertLess(types.index("_pushed"), types.index("tabOrder"), "the handler's own tabOrder frame follows the push…")
+        self.assertLess(types.index("tabOrder"), types.index("caps"),
+                        "…and the caps frame follows both: the shim's stale banner clears on the first real frame "
+                        "after a reconnect, which must stay the resync frame itself")
+        caps = next(m for m in self.sent if m["type"] == "caps")
+        self.assertEqual(caps, {"type": "caps", "caps": ["tagEdit"], "viewsSeq": None},
+                         "no store exists yet: no frame carried a seq and the store has none — viewsSeq is null, the key always present")
+        # a RE-SENT ready (the shim, on a reconnected socket) gets the caps again — the event a page
+        # with writes in flight across the drop keys on
+        n = len(self.sent)
+        km.Handler._dispatch_ws(self.handler, {"type": "ready"}, self.client)
+        self.assertEqual([m["type"] for m in self.sent[n:] if m["type"] == "caps"], ["caps"])
+
+    def test_version_lists_the_same_caps(self):
+        self.assertEqual(km._version_info()["caps"], list(km.KERNEL_WS_CAPS))
+        self.assertIn("tagEdit", km.KERNEL_WS_CAPS)
+
+    def test_an_unknown_op_is_answered_every_time_and_logged_once_per_type(self):
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a = self.post({"type": "noSuchOp", "writeId": "w1"})
+            b = self.post({"type": "noSuchOp", "writeId": "w2"})
+            c = self.post({"type": "noSuchOp"})
+        self.assertEqual(a, {"type": "unknownOp", "op": "noSuchOp", "writeId": "w1"},
+                         "the poster learns the op is unsupported — a client waiting on that writeId treats it as a refusal")
+        self.assertEqual(b, {"type": "unknownOp", "op": "noSuchOp", "writeId": "w2"})
+        self.assertEqual(c, {"type": "unknownOp", "op": "noSuchOp"}, "no writeId → none echoed")
+        lines = [ln for ln in err.getvalue().splitlines() if "noSuchOp" in ln]
+        self.assertEqual(len(lines), 1, "one line of version skew per type, not one per gesture")
+        self.assertIn("unknownOp", lines[0])
+        # a KNOWN op missing the field its arm requires falls to the same terminal arm
+        with contextlib.redirect_stderr(io.StringIO()):
+            d = self.post({"type": "setSessionFlag", "id": "", "flag": "eye"})
+        self.assertEqual(d["type"], "unknownOp")
+        self.assertEqual(d["op"], "setSessionFlag")
+
+    def test_a_host_directed_op_and_an_undecodable_frame_are_neither_logged_nor_answered(self):
+        import contextlib
+        import io
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(self.post({"type": "openLink", "href": "https://example.invalid/x"}),
+                              "the browser shim has no host to consume it; it is not the kernel's to answer")
+            self.assertIsNone(self.post({"type": "readClipboard"}))
+            self.assertIsNone(self.post(None), "an undecodable frame was already reported by the recv loop")
+            self.assertIsNone(self.post({"type": ""}))
+        self.assertEqual(err.getvalue(), "")
+
+    def _ready(self):
+        km.Handler._dispatch_ws(self.handler, {"type": "ready"}, self.client)
+        return next(m for m in reversed(self.sent) if m["type"] == "caps")
+
+    def test_the_caps_frame_carries_the_seq_of_the_connect_pushs_own_views_blob_not_a_fresh_read(self):
+        """The 2026-09-05 review: a client that kept the blob its seq gate last turned away
+        adopts it on the caps frame; it must do so only when that blob IS the connect push's (the
+        restore case), so the frame names the connect push's seq — read from the frame the push
+        enqueued, not from the store, which a write between the push and the caps frame moves on."""
+        s0 = self.seed()["seq"]
+
+        def push(c):                                     # the connect push's tabOrder frame, then a write lands
+            km._send_client(c, ("taborder",), {"type": "tabOrder", "order": [], "tabs": [], "views": km._views_client()})
+            self.assertIsNone(km._edit_tag(tid="gA", add=[SID2])[1])
+        self.handler._push_one = push
+        # the `ready` arm then sends ITS OWN tabOrder frame, built after the push (so it carries the
+        # write above), on the raw socket; a second write lands the moment that frame is out — between
+        # the last frame the handler served and its caps frame
+        real_send = self.client["send"]
+
+        def send(raw):
+            real_send(raw)
+            m = json.loads(raw)
+            if m.get("type") == "tabOrder" and m["views"].get("seq") != s0:
+                self.assertIsNone(km._edit_tag(tid="gA", color="#123456")[1])
+        self.client["send"] = send
+        caps = self._ready()
+        seqs = [m["views"]["seq"] for m in self.sent if m["type"] == "tabOrder"]
+        self.assertEqual(len(seqs), 2, "the stubbed push's frame and the handler's own")
+        s1 = seqs[1]
+        self.assertGreater(s1, s0, "the handler's own frame carries the first write")
+        s2 = km._views_client()["seq"]
+        self.assertGreater(s2, s1, "the second write moved the store on after every frame the handler served")
+        self.assertEqual(caps["viewsSeq"], s1, "the highest seq the handler's own frames served, not the store's current seq")
+        self.assertEqual([m["type"] for m in self.sent if m["type"] in ("tabOrder", "caps")], ["tabOrder", "tabOrder", "caps"])
+
+    def test_a_pusher_thread_frame_enqueued_between_the_push_and_the_caps_is_not_what_the_caps_names(self):
+        """The residual race the client cannot see: a pusher-thread frame built before a concurrent write
+        is enqueued after the handler's connect push and before its caps frame. The client rejects it
+        and keeps it; caps must not name its seq, or the client would adopt a stale blob."""
+        served = self.seed()
+        stale = json.loads(json.dumps(served))           # the pusher's frame, built before the write below
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID2])[1])
+        s_new = km._views_client()["seq"]
+
+        def push(c):
+            km._send_client(c, ("taborder",), {"type": "tabOrder", "order": [], "tabs": [], "views": km._views_client()})
+            t = threading.Thread(target=lambda: km._send_client(
+                c, ("taborder",), {"type": "tabOrder", "order": ["x"], "tabs": [], "views": stale}))
+            t.start(); t.join()
+        self.handler._push_one = push
+        caps = self._ready()
+        seqs = [m["views"]["seq"] for m in self.sent if m["type"] == "tabOrder"]
+        self.assertEqual(seqs, [s_new, served["seq"], s_new],
+                         "the stale frame went out after the connect push's and before the handler's own tabOrder")
+        self.assertEqual(caps["viewsSeq"], s_new, "the caps names the connect push's seq, never the pusher thread's")
+        self.assertNotEqual(caps["viewsSeq"], served["seq"])
+
+    def test_the_timeline_skeletons_nested_views_blob_is_read_and_a_push_without_one_names_the_stores_seq(self):
+        s0 = self.seed()["seq"]
+        self.handler._push_one = lambda c: km._send_client(
+            c, ("timeline",), {"type": "data", "data": {"sessions": [], "views": km._views_client()}})
+        self.assertEqual(self._ready()["viewsSeq"], s0, "the skeleton carries views under `data`")
+        self.handler._push_one = lambda c: km._send_client(c, ("working",), {"type": "working", "names": []})
+        self.assertEqual(self._ready()["viewsSeq"], s0,
+                         "a push that served no views blob: the handler's own tabOrder frame carries the store's blob")
+        saved = km._ordered_alive
+        km._ordered_alive = lambda now, tmux: (_ for _ in ()).throw(RuntimeError("no live read"))
+        try:
+            self.assertEqual(self._ready()["viewsSeq"], s0,
+                             "…and when that frame cannot be built either, the store's current seq — the one the next "
+                             "push serves (null here left a page's gate armed at a pre-restore seq)")
+        finally:
+            km._ordered_alive = saved
+        km._views_path().unlink()
+        km._flags_cache.clear()
+        self.assertIsNone(self._ready()["viewsSeq"], "no store at all: nothing has a seq, null")
+        self.assertIsNone(km._views_seq_of({"type": "tabOrder", "views": {"tags": []}}), "a seq-less blob: null")
+        self.assertIsNone(km._views_seq_of({"type": "tabOrder", "views": {"seq": "x"}}))
+        self.assertEqual(km._views_seq_of({"type": "tabOrder", "views": {"seq": 7}}), 7)
+
+    def test_the_real_connect_push_and_the_caps_frame_agree_on_the_seq(self):
+        """End to end through the real _push (the test_tab_meta_push.py stubs): the tabOrder frame the
+        connect push sends a chat page carries the same seq the caps frame that follows it names."""
+        import tempfile as _tf
+        from pathlib import Path as _P
+        s0 = self.seed()["seq"]
+        tmp = _tf.mkdtemp()
+        names = _P(tmp) / "names"
+        names.mkdir()
+        (names / SID1).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        saved = (km.NAMES, km._tmux_sessions, km._mark_views_dirty, km._chat_tab_sessions, km._cached_feed)
+        try:
+            km.NAMES = names
+            km._tmux_sessions = lambda: {}
+            km._mark_views_dirty = lambda: None
+            km._chat_tab_sessions = lambda now, tmux: [{"sid": SID1, "name": "web", "path": os.path.join(tmp, "none.jsonl"),
+                                                         "anchor": SID1}]
+            km._cached_feed = lambda *a, **k: None
+            self.client["app"] = "chat"
+            self.client["sent"] = {}
+            caps = self._ready()
+            tab = [m for m in self.sent if m["type"] == "tabOrder"]
+            self.assertEqual(len(tab), 2, "the real connect push's tabOrder frame, then the handler's own")
+            self.assertEqual([t["views"]["seq"] for t in tab], [s0, s0])
+            self.assertEqual(caps["viewsSeq"], s0)
+            types = [m["type"] for m in self.sent]
+            self.assertLess(types.index("tabOrder"), types.index("caps"))
+        finally:
+            (km.NAMES, km._tmux_sessions, km._mark_views_dirty, km._chat_tab_sessions, km._cached_feed) = saved
+
+    def test_the_inline_boot_routes_caps_and_unknown_op_to_the_panel(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('else if(m.type==="caps"&&panel.setCaps)panel.setCaps(m);', src)
+        self.assertIn('else if(m.type==="unknownOp"&&panel.unknownOp)panel.unknownOp(m);', src)
+
+
+class SetterReturnsRefusals(unittest.TestCase):
+    """_set_timeline_views now RETURNS the refused rows (tid + name + plain reason); callers that
+    ignored None keep ignoring a list."""
+
+    def setUp(self):
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        self._sync = km._sync_notice
+        km._sync_notice = lambda text, ok=True: None
+
+    def tearDown(self):
+        km._sync_notice = self._sync
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+
+    def test_clean_writes_return_an_empty_list_and_stale_ones_the_rows(self):
+        self.assertEqual(km._set_timeline_views({"active": "all", "tags": [dict(WEB)]}), [])
+        stale = json.loads(json.dumps(km._timeline_views()))
+        time.sleep(1.1)
+        km._edit_tag("web", add=[SID2])
+        stale["tags"][0]["members"] = []
+        rows = km._set_timeline_views(stale)
+        self.assertEqual([sorted(r.keys()) for r in rows], [["name", "reason", "tid"]])
+        self.assertEqual((rows[0]["tid"], rows[0]["name"]), ("gA", "web"))
+
+
+class ReadCacheAfterWrite(_Wire):
+    """The views read cache is keyed on the file's (mtime_ns, size) and was never touched by a write
+    (the 2026-09-05 review). The kernel's file mtime clock is coarse (a few ms), so two
+    same-size writes in one tick shared a key, and the second write's ack — built by reading the store
+    — could serve the FIRST write's blob. Now the write itself refreshes the cache entry with the blob
+    it wrote. This harness runs with the production cache (no clears): every ack in this file is
+    served through it."""
+
+    def test_the_cache_holds_the_blob_just_written_and_a_shared_stat_key_cannot_serve_the_older_one(self):
+        self.seed()                                                          # web = #3b82f6
+        p = km._views_path()
+        st1 = p.stat()
+        first = km._timeline_views()
+        self.assertIs(km._flags_cache[str(p)][1], first, "the read warmed the cache")
+        # a same-size write (a 7-char colour for a 7-char colour): the file's size does not change
+        _, err = km._edit_tag("web", color="#54B204")
+        self.assertIsNone(err)
+        self.assertEqual(km._flags_cache[str(p)][1]["tags"][0]["color"], "#54B204",
+                         "the write replaced the cache entry with what it wrote — no read needed")
+        self.assertEqual(p.stat().st_size, st1.st_size, "(the write is the same size: the key's other half cannot tell them apart)")
+        # the coarse-clock case, forced: give the second write the first's mtime, so the stat key is
+        # exactly the one the first read was cached under
+        os.utime(p, ns=(st1.st_mtime_ns, st1.st_mtime_ns))
+        self.assertEqual(km._timeline_views()["tags"][0]["color"], "#54B204",
+                         "the next read serves the newer write — never the older blob under a shared key")
+
+    def test_a_targeted_edits_ack_is_fresh_through_the_production_cache(self):
+        self.seed()
+        a = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "recolor", "tid": "gA", "color": "#54B204"}})
+        self.assertTrue(a["ok"])
+        self.assertEqual(next(t for t in a["views"]["tags"] if t["id"] == "gA")["color"], "#54B204",
+                         "the ack's blob is the post-write store, read through the cache the write refreshed")
+        b = self.post({"type": "tagEdit", "writeId": "w2", "edit": {"op": "recolor", "tid": "gA", "color": "#DD42FF"}})
+        self.assertEqual(next(t for t in b["views"]["tags"] if t["id"] == "gA")["color"], "#DD42FF")
+        self.assertGreater(b["seq"], a["seq"])
+
+
+class LegacyStoreStampedOnce(_Wire):
+    """A store from before the write sequence (every install upgrading, the 2026-09-05
+    review): served seq-less, it left every client on the null rule — adopt anything — until the
+    first write, so the seq gate could not protect that first write against a frame the pusher built
+    before it. The first READ stamps it once, through the setter (one write); after that the file is
+    left alone. A store that does not exist is NOT created: the null rule is right for a deleted or
+    recreated store, whose first write starts past what any client holds."""
+
+    def _writes(self):
+        n = [0]
+        real = km._atomic_write
+
+        def counting(path, text, mode=None):
+            n[0] += 1
+            return real(path, text, mode)
+        km._atomic_write = counting
+        return n, lambda: setattr(km, "_atomic_write", real)
+
+    def test_a_seq_less_file_is_stamped_on_its_first_read_and_only_then(self):
+        p = km._views_path()
+        legacy = {"active": "all", "tags": [{"id": "gL", "name": "legacy", "color": "#3b82f6",
+                                              "members": [{"host": "", "sid": SID1}]}]}
+        p.write_text(json.dumps(legacy))
+        n, restore = self._writes()
+        try:
+            v = km._timeline_views()
+            self.assertEqual(n[0], 1, "exactly one write: the stamp")
+            self.assertIsInstance(v.get("seq"), int, "the served blob carries a seq from its first read")
+            self.assertTrue(v["seq"] > 0)
+            on_disk = json.loads(p.read_text())
+            self.assertEqual(on_disk["seq"], v["seq"], "…and the file does too")
+            self.assertEqual(on_disk["tags"][0]["members"], [{"host": "", "sid": SID1}], "nothing else changed")
+            self.assertTrue(on_disk["tags"][0].get("mtime"), "every tag is given an mtime by the stamp: "
+                            "the mark that tells a tag a store once held from a client's own create")
+            self.assertLessEqual(on_disk["tags"][0]["mtime"], on_disk["at"], "a file without `at`: the stamp's own time")
+            self.assertEqual(self.notices, [], "a stamp is not a refusal: nothing is said")
+            before = p.read_bytes()
+            km._flags_cache.clear()                      # a cold cache (a restart): the stamped file is fine as-is
+            v2 = km._timeline_views()
+            self.assertEqual(n[0], 1, "the second read writes nothing")
+            self.assertEqual(p.read_bytes(), before, "byte-identical")
+            self.assertEqual(v2["seq"], v["seq"])
+            self.assertEqual(km._views_client()["seq"], v["seq"], "every frame now carries it — the gate protects the first write")
+            # …and that first write orders after it
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": km._views_client()})
+            self.assertGreater(a["seq"], v["seq"])
+        finally:
+            restore()
+
+    def test_a_missing_store_is_served_seq_less_and_not_created(self):
+        n, restore = self._writes()
+        try:
+            v = km._timeline_views()
+            self.assertNotIn("seq", v, "no file → the null rule: a client adopts whatever the first write brings")
+            self.assertEqual(n[0], 0)
+            self.assertFalse(km._views_path().exists(), "reading does not create the store")
+        finally:
+            restore()
+
+    def test_an_unreadable_file_is_served_empty_and_never_overwritten(self):
+        p = km._views_path()
+        p.write_text("{not json")
+        n, restore = self._writes()
+        try:
+            self.assertEqual(km._timeline_views()["tags"], [])
+            self.assertEqual(n[0], 0, "a corrupt file is left for a human — the stamp never replaces it with an empty store")
+            self.assertEqual(p.read_text(), "{not json")
+        finally:
+            restore()
+
+
+class LegacyTagsStampedOnFirstRead(_Wire):
+    """The 2026-09-05 review: the write door stamps an mtime on a tag only when it changes,
+    and the first-read stamp changes nothing, so a tag from before the per-tag stamp never got one —
+    and the foreign-file rule (an unknown tag WITH an mtime existed in a store once and is not
+    re-created; one without is the writer's own create) let a deleted legacy tag come back through
+    a file written outside the kernel. The first-read stamp (and the migration) now give every tag
+    an mtime: the file's `at`, else the time of the stamp."""
+
+    def test_every_legacy_tag_gets_an_mtime_so_a_deleted_one_cannot_come_back_through_a_foreign_file(self):
+        p = km._views_path()
+        legacy = {"active": "all", "at": 1700000000, "tags": [
+            {"id": "gL1", "name": "web", "color": "#3b82f6", "members": [{"host": "", "sid": SID1}]},
+            {"id": "gL2", "name": "api", "color": "#54B204", "members": [{"host": "", "sid": SID2}]}]}
+        p.write_text(json.dumps(legacy))
+        v = km._timeline_views()                                       # the first read: the stamp
+        self.assertEqual([t.get("mtime") for t in v["tags"]], [1700000000, 1700000000], "every tag carries the file's `at`")
+        self.assertEqual([t["mtime"] for t in json.loads(p.read_text())["tags"]], [1700000000, 1700000000], "…on disk too")
+        self.assertEqual(self.notices, [], "a stamp is not a refusal")
+        panel = json.loads(p.read_text())                              # a panel's copy, taken after the stamp
+        time.sleep(1.1)
+        self.assertIsNone(km._edit_tag(tid="gL2", delete=True)[1])    # api deleted since
+        s_served = km._timeline_views()["seq"]
+        foreign = json.loads(json.dumps(panel))                        # the panel writes its copy: seq behind, judged
+        foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        time.sleep(0.01)
+        km._atomic_write(p, json.dumps(foreign))
+        v2 = km._timeline_views()
+        self.assertGreater(v2["seq"], s_served)
+        self.assertEqual([t["id"] for t in v2["tags"]], ["gL1"],
+                         "the deleted legacy tag does not come back: its mtime says a store once held it")
+        self.assertEqual(v2["actives"]["timeline"], {"tags": ["web"]}, "the panel's lens change lands")
+        self.assertTrue(self.notices and not self.notices[0][1])
+        self.assertIn('"api" (re-creation)', self.notices[0][0])
+        # a legacy file without `at`: the stamp's own time
+        p.unlink()
+        self.assertEqual(km._timeline_views()["tags"], [])
+        p.write_text(json.dumps({"active": "all", "tags": [{"id": "gL3", "name": "docs", "color": "", "members": []}]}))
+        before = int(time.time())
+        v3 = km._timeline_views()
+        self.assertGreaterEqual(v3["tags"][0]["mtime"], before)
+        self.assertLessEqual(v3["tags"][0]["mtime"], v3["at"])
+
+
+class SeqFloorOutlivesTheCacheEntry(_Wire):
+    """The 2026-09-05 review: a store read as missing forgets its cache entry (rightly: a
+    file that then appears must not be judged against a store that no longer exists), and with it
+    forgot the seq floor — so a file restored from an older copy was served under its old seq, and
+    every dashboard holding a higher one ignored it until the next kernel write. The floor is kept
+    apart from the entry now (_VIEWS_SEQ_FLOOR): the restored file is re-stamped past it, as written,
+    and every write orders past it."""
+
+    def test_a_store_deleted_and_recreated_with_an_older_seq_is_restamped_past_the_floor(self):
+        served = self.seed()
+        s1 = served["seq"]
+        p = km._views_path()
+        content = json.loads(p.read_text())
+        p.unlink()
+        self.assertEqual(km._timeline_views()["tags"], [], "read as missing: the cache entry is forgotten")
+        self.assertNotIn(str(p), km._flags_cache)
+        self.assertGreaterEqual(km._views_seq_floor(), s1, "…the floor is not")
+        restored = json.loads(json.dumps(content))
+        restored["seq"] = s1 - 5                                       # a restore from an older copy
+        km._atomic_write(p, json.dumps(restored))
+        v = km._timeline_views()
+        self.assertGreater(v["seq"], s1, "re-stamped past the last served seq: a dashboard holding s1 adopts it")
+        self.assertEqual([t["name"] for t in v["tags"]], ["web"], "kept as written: nothing served to judge it against")
+        self.assertEqual(json.loads(p.read_text())["seq"], v["seq"], "…and the file carries the new seq")
+        self.assertEqual(self.notices, [], "ordering a file is not a refusal")
+        # a restored file at or past the floor is left alone
+        p.unlink()
+        self.assertEqual(km._timeline_views()["tags"], [])
+        ahead = json.loads(json.dumps(content))
+        ahead["seq"] = v["seq"] + 100
+        km._atomic_write(p, json.dumps(ahead))
+        before = p.read_bytes()
+        self.assertEqual(km._timeline_views()["seq"], v["seq"] + 100)
+        self.assertEqual(p.read_bytes(), before, "byte-identical")
+        # a write after a delete orders past the floor too, not just past the (empty) previous blob
+        p.unlink()
+        self.assertEqual(km._timeline_views()["tags"], [])
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": []}})
+        self.assertGreater(a["seq"], v["seq"] + 100)
+
+    def test_the_floor_is_per_store_so_two_state_dirs_in_one_process_do_not_share_one(self):
+        """The 2026-09-05 review: the floor was one module-wide number keyed on nothing,
+        while the read cache beside it is keyed by path — so a process serving two state dirs (a test
+        suite; a kernel rebound to another root) re-stamped a cold read of a small-seq file in the
+        fresh dir past the OTHER store's seq: a write on read, ordered against a store it never held."""
+        from pathlib import Path
+        s1 = self.seed()["seq"]
+        home = km.jd.STATE
+        self.assertGreaterEqual(km._views_seq_floor(), s1, "the first store's floor is raised by its own writes")
+        other = tempfile.mkdtemp()
+        km.jd.STATE = Path(other)
+        p2 = km._views_path()
+        try:
+            km._atomic_write(p2, json.dumps({"active": "all", "tags": [dict(WEB)], "seq": 5, "at": 100}))
+            before = p2.read_bytes()
+            v = km._timeline_views()
+            self.assertEqual(v["seq"], 5, "served as written: this store has no floor of its own")
+            self.assertEqual(p2.read_bytes(), before, "…and the file is not rewritten")
+            self.assertEqual(km._views_seq_floor(), 5, "the read raised THIS store's floor…")
+            self.assertGreaterEqual(km._views_seq_floor(home / "timeline-views.json"), s1, "…and left the other's alone")
+            self.assertEqual(self.notices, [])
+        finally:
+            km.jd.STATE = home
+            km._flags_cache.pop(str(p2), None)
+            km._VIEWS_SEQ_FLOOR.pop(str(p2), None)
+
+
+class ForeignWriteReStamped(_Wire):
+    """A write to timeline-views.json OUTSIDE the kernel (the 2026-09-05 review): the
+    timeline's Electron branch writes the file itself with the seq it holds, so a panel holding an
+    older frame publishes a seq lower than what every dashboard holds, and they all ignore the file
+    until the next kernel write. The reader treats a changed file whose seq fell behind the last one
+    served as such a write and re-stamps it through the setter: seq = max(last + 1, now), the content
+    kept as written. A changed file whose seq is not behind is served as-is."""
+
+    def test_a_file_whose_seq_fell_behind_is_re_stamped_past_the_last_served_seq(self):
+        served = self.seed()
+        s1 = served["seq"]
+        self.assertEqual(km._timeline_views()["seq"], s1, "served: the cache holds it")
+        p = km._views_path()
+        # the panel's write: its held (older) blob with a lens change, seq behind the store's
+        foreign = json.loads(p.read_text())
+        foreign["seq"] = s1 - 5
+        foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        time.sleep(0.01)                                  # a new mtime, so the file changes under the cache
+        km._atomic_write(p, json.dumps(foreign))
+        v = km._timeline_views()
+        self.assertGreater(v["seq"], s1, "re-stamped past the last served seq — every dashboard adopts it")
+        self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]}, "the content is kept as written")
+        on_disk = json.loads(p.read_text())
+        self.assertEqual(on_disk["seq"], v["seq"], "…and the file carries the new seq: the next kernel read is a plain hit")
+        self.assertEqual(self.notices, [], "ordering a file is not a refusal")
+        self.assertEqual(km._views_client()["seq"], v["seq"])
+        # a kernel write after it orders after the re-stamp
+        a = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "recolor", "tid": "gA", "color": "#54B204"}})
+        self.assertGreater(a["seq"], v["seq"])
+
+    def test_a_changed_file_whose_seq_is_not_behind_is_served_as_is(self):
+        served = self.seed()
+        s1 = served["seq"]
+        km._timeline_views()
+        p = km._views_path()
+        foreign = json.loads(p.read_text())                # a panel holding the NEWEST frame writes it back
+        foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        time.sleep(0.01)
+        km._atomic_write(p, json.dumps(foreign))
+        before = p.read_bytes()
+        v = km._timeline_views()
+        self.assertEqual(v["seq"], s1, "an equal seq is not behind: no write")
+        self.assertEqual(p.read_bytes(), before, "byte-identical")
+        self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]})
+        ahead = json.loads(p.read_text()); ahead["seq"] = s1 + 100
+        time.sleep(0.01)
+        km._atomic_write(p, json.dumps(ahead))
+        self.assertEqual(km._timeline_views()["seq"], s1 + 100, "a seq ahead of the last served is adopted as the new floor")
+
+
+class MigrationStampsTheArchivedTag(_Wire):
+    """The 2026-09-05 review: the hidden-to-archived migration built its diff base from the
+    same tag dicts it mutated (the archived tag's dict was aliased, and the dict copy was shallow), so
+    the base already carried the migration and an EXISTING archived tag gained its members with no
+    fresh mtime. A dashboard holding the pre-migration copy could then post the whole blob and strip
+    the migrated members with no refusal. The migration now works on a deep copy: the moved members
+    stamp the tag, and the guard refuses the stale copy."""
+
+    def test_an_existing_archived_tag_is_stamped_by_the_migration_and_a_stale_copy_cannot_strip_it(self):
+        p = km._views_path()
+        pre = {"active": "all", "tags": [dict(WEB), {"id": "archived", "name": "archived", "color": "#6b7280",
+                                                     "members": [SID2]}], "hidden": [SID3]}
+        p.write_text(json.dumps(pre))
+        v = km._timeline_views()
+        arch = next(t for t in v["tags"] if t["name"] == "archived")
+        self.assertEqual([m["sid"] for m in arch["members"]], sorted([SID2, SID3]), "the hidden entry joined the existing tag")
+        self.assertTrue(arch.get("mtime"), "the migrated tag carries a FRESH edit stamp: its members changed")
+        self.assertTrue(next(t for t in v["tags"] if t["id"] == "gA").get("mtime"),
+                        "an untouched tag is given one too: every tag a migrated store holds carries an mtime")
+        self.assertNotIn("hidden", json.loads(p.read_text()))
+        # the pre-migration dashboard posts its whole copy (no `at`, no mtimes): the guard refuses
+        # the archived hunk — the migrated members stand — and the ack says so
+        stale = {"active": "all", "tags": [dict(WEB), {"id": "archived", "name": "archived", "color": "#6b7280", "members": [SID2]}]}
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": ["archived"]})
+        self.assertFalse(a["ok"])
+        self.assertEqual([r["tid"] for r in a["refused"]], ["archived"])
+        self.assertEqual(sorted(m["sid"] for m in store_tag("archived")["members"]), sorted([SID2, SID3]),
+                         "the migrated members survive the stale copy")
+        self.assertTrue(self.notices and not self.notices[0][1], "and the refusal is loud")
+
+
+class ReaderRestampUnwritable(_Wire):
+    """The 2026-09-05 review: the reader's re-stamp write had no error handling, so an
+    unwritable or full state dir made every READ raise, and the feed's build aborted with it. Now an
+    OSError on that write is logged once per distinct error, the file is served as read (normalized)
+    and cached under its own key so reads stop retrying the write, and the next successful write
+    clears the note so a recurrence is logged again."""
+
+    def setUp(self):
+        super().setUp()
+        km._VIEWS_RESTAMP_ERR[0] = None
+
+    def test_a_read_only_state_dir_is_served_not_raised_and_logged_once(self):
+        import contextlib
+        import io
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        p = km._views_path()
+        d = p.parent
+        legacy = {"active": "all", "tags": [dict(WEB)]}                # seq-less: the first read wants to stamp it
+        p.write_text(json.dumps(legacy))
+        n = [0]
+        real = km._atomic_write
+
+        def counting(path, text, mode=None):
+            n[0] += 1
+            return real(path, text, mode)
+        km._atomic_write = counting
+        os.chmod(d, 0o555)
+        try:
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                v = km._timeline_views()                                # does not raise
+                self.assertEqual([t["name"] for t in v["tags"]], ["web"], "the file is served as read")
+                self.assertNotIn("seq", v, "…unstamped: the write did not land")
+                self.assertEqual(n[0], 1, "one write attempted")
+                v2 = km._timeline_views()
+                self.assertIs(v2, v, "the second read is a cache hit under the file's key")
+                self.assertEqual(n[0], 1, "…and does not retry the write")
+                km._flags_cache.clear()                                # a cold cache retries…
+                km._timeline_views()
+                self.assertEqual(n[0], 2)
+            lines = [ln for ln in err.getvalue().splitlines() if "could not be re-stamped" in ln]
+            self.assertEqual(len(lines), 1, "one stderr line for one distinct error, however many reads")
+            self.assertIn("PermissionError", lines[0])
+            self.assertEqual(p.read_text(), json.dumps(legacy), "the file is untouched")
+            self.assertEqual(self.notices, [], "an unwritable store is a log line, not a refusal notice")
+            # writable again: a kernel write succeeds and clears the note, so the next failure logs afresh
+            os.chmod(d, 0o755)
+            km._flags_cache.clear()
+            a = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "recolor", "tid": "gA", "color": "#54B204"}})
+            self.assertTrue(a["ok"])
+            self.assertIsNone(km._VIEWS_RESTAMP_ERR[0], "a successful write clears the note")
+            p.write_text(json.dumps(legacy))                           # seq-less again, then unwritable again
+            km._flags_cache.clear()
+            os.chmod(d, 0o555)
+            err2 = io.StringIO()
+            with contextlib.redirect_stderr(err2):
+                km._timeline_views()
+            self.assertEqual(len([ln for ln in err2.getvalue().splitlines() if "could not be re-stamped" in ln]), 1,
+                             "the same error logs again after a write cleared the note")
+        finally:
+            os.chmod(d, 0o755)
+            km._atomic_write = real
+            km._VIEWS_RESTAMP_ERR[0] = None
+
+    def test_a_judged_foreign_file_on_an_unwritable_store_is_served_judged_and_the_next_write_persists_it(self):
+        """The 2026-09-05 review: the OSError branch served and cached the file AS READ in
+        every case — in the judged case that is the foreign copy the judgment had just refused, so an
+        unwritable store served the deleted tag back and the newer member gone, and the next RMW write,
+        built from that cache, persisted them. The judgment is now a step apart from the write, and
+        the judged blob is what an unwritable store serves and caches."""
+        import contextlib
+        import io
+        if os.geteuid() == 0:
+            self.skipTest("root ignores directory permissions")
+        self.seed()
+        c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204", "sids": [SID2]}})
+        api_tid = c["tid"]
+        p = km._views_path()
+        d = p.parent
+        panel = json.loads(p.read_text())                              # the panel's copy: web[SID1], api
+        time.sleep(1.1)
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID3])[1])       # a member added since
+        self.assertIsNone(km._edit_tag(tid=api_tid, delete=True)[1])   # a tag deleted since
+        s_served = km._timeline_views()["seq"]
+        foreign = json.loads(json.dumps(panel))                        # seq behind: judged on read
+        foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        time.sleep(0.01)
+        km._atomic_write(p, json.dumps(foreign))
+        os.chmod(d, 0o555)
+        try:
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                v = km._timeline_views()
+                web = next(t for t in v["tags"] if t["id"] == "gA")
+                self.assertEqual(sorted(m["sid"] for m in web["members"]), sorted([SID1, SID3]), "the newer member is served")
+                self.assertNotIn("api", [t["name"] for t in v["tags"]], "the deleted tag stays absent")
+                self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]}, "the panel's lens change is served")
+                self.assertGreater(v["seq"], s_served, "…under a seq past the last served, so dashboards adopt it")
+                self.assertIs(km._timeline_views(), v, "cached: the judged blob, under the file's key")
+            lines = [ln for ln in err.getvalue().splitlines() if "could not be re-stamped" in ln]
+            self.assertEqual(len(lines), 1)
+            self.assertIn("the judged blob", lines[0])
+            self.assertEqual(json.loads(p.read_text())["tags"], foreign["tags"], "the file is still the foreign copy: nothing landed")
+            self.assertEqual(len(self.notices), 1, "the judgment's refusals are reported once")
+            self.assertFalse(self.notices[0][1])
+            # writable again: the next write is built from the judged cache and persists the judged state
+            os.chmod(d, 0o755)
+            a = self.post({"type": "tagEdit", "writeId": "w2", "edit": {"op": "recolor", "tid": "gA", "color": "#DD42FF"}})
+            self.assertTrue(a["ok"])
+            on_disk = json.loads(p.read_text())
+            web_disk = next(t for t in on_disk["tags"] if t["id"] == "gA")
+            self.assertEqual(sorted(m["sid"] for m in web_disk["members"]), sorted([SID1, SID3]), "the newer member persists")
+            self.assertEqual([t["name"] for t in on_disk["tags"]], ["web"], "the deleted tag does not come back")
+            self.assertEqual(web_disk["color"], "#DD42FF")
+            self.assertEqual(on_disk["actives"]["timeline"], {"tags": ["web"]})
+            self.assertGreater(on_disk["seq"], v["seq"])
+        finally:
+            os.chmod(d, 0o755)
+            km._VIEWS_RESTAMP_ERR[0] = None
+
+
+class ForeignWriteJudged(_Wire):
+    """The 2026-09-05 review: the re-stamp of a file written outside the kernel whose seq
+    fell behind used the file's own content as the guard's base, so a stale Electron blob was blessed
+    wholesale — a tag deleted since came back, a member added since was lost, silently. The writer's
+    own seq says it held an older copy, so the file is now judged against the LAST SERVED blob: the
+    refused hunks are kept from it, the writer's own creates land, and the refusals are reported
+    through the sync notice naming each tag. With no served blob (a fresh kernel; a store read as
+    missing) there is nothing to judge against and the file is ordered as written, as before."""
+
+    def test_a_seq_behind_file_is_judged_against_the_last_served_blob(self):
+        self.seed()
+        c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204", "sids": [SID2]}})
+        api_tid = c["tid"]
+        p = km._views_path()
+        panel = json.loads(p.read_text())                              # the panel's copy: web[SID1], api, this seq and `at`
+        time.sleep(1.1)
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID3])[1])       # a member added since
+        self.assertIsNone(km._edit_tag(tid=api_tid, delete=True)[1])   # a tag deleted since
+        served = km._timeline_views()
+        s_served = served["seq"]
+        # the panel writes the file itself: its stale copy plus a lens change, plus a tag it created
+        # (a client-minted id, no mtime — the one mark a kernel puts on a tag)
+        foreign = json.loads(json.dumps(panel))
+        foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        foreign["tags"].append({"id": "gdocs", "name": "docs", "color": "#DD42FF", "members": [SID2]})
+        time.sleep(0.01)
+        km._atomic_write(p, json.dumps(foreign))
+        v = km._timeline_views()
+        self.assertGreater(v["seq"], s_served, "re-stamped past the last served seq")
+        web = next(t for t in v["tags"] if t["id"] == "gA")
+        self.assertEqual(sorted(m["sid"] for m in web["members"]), sorted([SID1, SID3]), "the member added since is KEPT")
+        self.assertIsNone(store_tag("api"), "the tag deleted since is not brought back")
+        self.assertEqual(store_tag("docs")["id"], "gdocs", "the panel's own create lands")
+        self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]}, "the lens change lands")
+        self.assertEqual(json.loads(p.read_text())["tags"], v["tags"], "the file holds the judged result")
+        self.assertEqual(len(self.notices), 1)
+        text, ok = self.notices[0]
+        self.assertFalse(ok, "the refusals are loud")
+        self.assertIn("outside the kernel", text)
+        self.assertIn('"web"', text)
+        self.assertIn('"api" (re-creation)', text, "…naming each tag")
+        # no served blob: a store read as missing forgets what was served, and a file that then
+        # appears is kept as written — nothing to judge it against — but ORDERED past the last
+        # served seq, which outlives the entry (SeqFloorOutlivesTheCacheEntry)
+        p.unlink()
+        self.assertEqual(km._timeline_views()["tags"], [])
+        recreated = json.loads(json.dumps(foreign))
+        recreated["seq"] = 5
+        km._atomic_write(p, json.dumps(recreated))
+        v2 = km._timeline_views()
+        self.assertEqual(sorted(t["name"] for t in v2["tags"]), ["api", "docs", "web"], "kept as written")
+        self.assertGreater(v2["seq"], v["seq"], "re-stamped past the last served seq")
+        self.assertEqual(len(self.notices), 1, "no second notice")
+
+
+class WholeBlobNameCollisions(_Wire):
+    """The 2026-09-05 review (the verifier's reproduction): a rename the targeted op refused
+    as a duplicate landed anyway through a whole-blob lens write the dialog built from its PENDING
+    copy, and neither the whole-blob door nor the normalizer deduped names — two tags with one name,
+    which every name-keyed surface shows as one. The door now refuses a renamed or new tag whose name
+    another tag in the resulting set holds, with a reason naming the collision, and the normalizer
+    drops a second entry under one id."""
+
+    def test_the_reproduction_a_refused_rename_cannot_land_through_a_lens_write(self):
+        self.seed()
+        c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204", "sids": [SID2]}})
+        api_tid = c["tid"]
+        r = self.post({"type": "tagEdit", "writeId": "w2", "edit": {"op": "rename", "tid": api_tid, "newName": "web"}})
+        self.assertEqual((r["ok"], r["error"]), (False, 'a tag named "web" already exists'))
+        pending = json.loads(json.dumps(c["views"]))                    # the dialog's pending copy still carries the rename
+        next(t for t in pending["tags"] if t["id"] == api_tid)["name"] = "web"
+        pending["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+        a = self.post({"type": "setTimelineViews", "writeId": "w3", "views": pending, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []),
+                         "a lens write changes no tag, so the pending rename is not even judged")
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["api", "web"], "ONE tag per name")
+        self.assertEqual(km._timeline_views()["actives"]["timeline"], {"tags": ["web"]}, "the lens landed")
+        self.assertEqual(self.notices, [], "nothing the user did in THIS write was refused")
+        # the same pending copy riding a write that edits web (a recolor): the rename is a tag this
+        # write did not claim to edit — kept as the store has it, listed with the collision's reason
+        pending_w = json.loads(json.dumps(pending))
+        next(t for t in pending_w["tags"] if t["id"] == "gA")["color"] = "#000000"
+        a2 = self.post({"type": "setTimelineViews", "writeId": "w3b", "views": pending_w, "edited": ["gA"]})
+        self.assertTrue(a2["ok"], "the refused hunk is a tag this write did not claim to edit")
+        self.assertEqual([(x["tid"], x["name"]) for x in a2["refused"]], [(api_tid, "api")])
+        self.assertIn("did not edit it", a2["refused"][0]["reason"])
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["api", "web"], "ONE tag per name")
+        self.assertEqual(store_tag("web")["color"], "#000000", "the recolor landed")
+        self.assertEqual(self.notices, [], "nothing the user did in THIS write was refused")
+        # the rename on a copy of the store, naming the tag as edited (an older client's whole-blob rename): refused, loud
+        pending2 = json.loads(json.dumps(km._views_client()))
+        next(t for t in pending2["tags"] if t["id"] == api_tid)["name"] = "web"
+        b = self.post({"type": "setTimelineViews", "writeId": "w4", "views": pending2, "edited": [api_tid]})
+        self.assertFalse(b["ok"])
+        self.assertEqual(b["error"], '"api": a tag named "web" already exists, so it was not renamed to it')
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["api", "web"])
+        self.assertTrue(self.notices and not self.notices[0][1])
+        self.assertIn('"api" (name collision)', self.notices[0][0])
+
+    def test_a_new_tag_under_a_taken_name_is_kept_out_and_a_swap_of_two_names_lands(self):
+        served = self.seed()
+        blob = json.loads(json.dumps(served))
+        blob["tags"].append({"id": "gnew", "name": "web", "color": "#000000", "members": []})
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": blob, "edited": ["gnew"]})
+        self.assertEqual((a["ok"], a["refused"][0]["tid"]), (False, "gnew"))
+        self.assertEqual(a["refused"][0]["reason"], 'a tag named "web" already exists, so it was not created')
+        self.assertEqual([t["id"] for t in km._timeline_views()["tags"]], ["gA"])
+        # two tags trading names in one write collide with nothing: both changed, neither name is held
+        c = self.post({"type": "tagEdit", "writeId": "w2", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+        swap = json.loads(json.dumps(c["views"]))
+        for t in swap["tags"]:
+            t["name"] = "api" if t["id"] == "gA" else "web"
+        b = self.post({"type": "setTimelineViews", "writeId": "w3", "views": swap, "edited": ["gA", c["tid"]]})
+        self.assertEqual((b["ok"], b["refused"]), (True, []))
+        self.assertEqual(store_tag("api")["id"], "gA")
+        self.assertEqual(store_tag("web")["id"], c["tid"])
+
+    def test_a_refused_rename_settles_its_stored_name_so_a_new_tag_under_it_is_refused_too(self):
+        """The 2026-09-05 review: B (api → web, refused against A = web) stood as "api" but
+        never claimed it, so a new C named "api" in the same write landed beside it — twins under the
+        kept name. The pass now runs to a fixpoint: a refused rename settles its stored name and the
+        takers are re-checked, in either array order, with or without `edited`."""
+        for order, named in (("ABC", True), ("ACB", True), ("ABC", False), ("ACB", False)):
+            with self.subTest(order=order, edited=named):
+                try:
+                    km._views_path().unlink()                              # a fresh store per case
+                except OSError:
+                    pass
+                self.notices.clear()
+                self.seed()
+                c = self.post({"type": "tagEdit", "writeId": "w1", "edit": {"op": "create", "name": "api", "color": "#54B204"}})
+                b_tid = c["tid"]
+                blob = json.loads(json.dumps(c["views"]))
+                a_row = next(t for t in blob["tags"] if t["id"] == "gA")
+                b_row = next(t for t in blob["tags"] if t["id"] == b_tid)
+                b_row["name"] = "web"                                       # B renamed to A's name
+                c_row = {"id": "gC", "name": "api", "color": "#DD42FF", "members": []}   # C created under B's stored name
+                blob["tags"] = [a_row, b_row, c_row] if order == "ABC" else [a_row, c_row, b_row]
+                msg = {"type": "setTimelineViews", "writeId": "w2", "views": blob}
+                if named:
+                    msg["edited"] = [b_tid, "gC"]
+                a = self.post(msg)
+                self.assertFalse(a["ok"])
+                self.assertEqual(sorted((r["tid"], r["name"]) for r in a["refused"]), sorted([(b_tid, "api"), ("gC", "api")]))
+                reasons = {r["tid"]: r["reason"] for r in a["refused"]}
+                self.assertEqual(reasons[b_tid], 'a tag named "web" already exists, so it was not renamed to it')
+                self.assertEqual(reasons["gC"], 'a tag named "api" already exists, so it was not created')
+                self.assertEqual(sorted((t["id"], t["name"]) for t in km._timeline_views()["tags"]),
+                                 sorted([("gA", "web"), (b_tid, "api")]), "one tag per name: B kept under api, C kept out")
+                self.assertTrue(self.notices and not self.notices[0][1], "both refusals are the poster's: loud")
+                self.assertIn('"api" (name collision)', self.notices[0][0])
+
+    def test_names_are_stripped_at_the_door_so_a_padded_spelling_is_the_same_name(self):
+        """The 2026-09-05 review: the targeted door stripped a rename, the whole-blob door
+        stripped nothing, so "web " beside "web" passed the collision pass as two names. Names are
+        now clamped and stripped in the normalizer — the first step of every write and every read —
+        and the targeted door's lookup uses the same basis."""
+        served = self.seed()
+        blob = json.loads(json.dumps(served))
+        blob["tags"].append({"id": "gpad", "name": "web ", "color": "#000000", "members": []})
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": blob, "edited": ["gpad"]})
+        self.assertEqual((a["ok"], [r["tid"] for r in a["refused"]]), (False, ["gpad"]))
+        self.assertEqual(a["refused"][0]["reason"], 'a tag named "web" already exists, so it was not created')
+        self.assertEqual([t["name"] for t in km._timeline_views()["tags"]], ["web"], "no padded twin")
+        blob["tags"][-1]["name"] = "  api  "
+        b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": blob, "edited": ["gpad"]})
+        self.assertEqual((b["ok"], b["refused"]), (True, []))
+        self.assertEqual(store_tag("api")["id"], "gpad", "stored stripped")
+        self.assertEqual(next(t for t in b["views"]["tags"] if t["id"] == "gpad")["name"], "api", "…and served stripped")
+        # the targeted door addresses the stored spelling from a padded one, rather than minting a twin
+        t, err = km._edit_tag(" web ", add=[SID2])
+        self.assertIsNone(err)
+        self.assertEqual(t["id"], "gA")
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"]), ["api", "web"])
+        # a name that is only padding is no name: the whole-blob door stores the default, the targeted door mints one
+        blob2 = json.loads(json.dumps(km._views_client()))
+        blob2["tags"].append({"id": "gblank", "name": "   ", "color": "", "members": []})
+        c = self.post({"type": "setTimelineViews", "writeId": "w3", "views": blob2, "edited": ["gblank"]})
+        self.assertTrue(c["ok"])
+        self.assertEqual(store_tag("tag")["id"], "gblank")
+        t2, err = km._edit_tag("   ", add=[SID3])
+        self.assertIsNone(err)
+        self.assertTrue(t2["name"].strip() and t2["id"] not in ("gA", "gpad", "gblank"), "a create with no name takes the default")
+
+    def test_the_normalizer_drops_a_second_entry_under_one_id(self):
+        v = km._norm_timeline_views({"active": "all", "tags": [
+            {"id": "g1", "name": "web", "members": [SID1]}, {"id": "g1", "name": "web", "members": [SID2]},
+            {"id": "g2", "name": "api", "members": []}]})
+        self.assertEqual([t["id"] for t in v["tags"]], ["g1", "g2"])
+        self.assertEqual([m["sid"] for m in v["tags"][0]["members"]], [SID1], "the first entry is the one kept")
+
+
+class SetterJudgesUnderTheFileLock(_Wire):
+    """The 2026-09-05 review: the reader's re-stamp of a file written outside the kernel
+    holds _views_file_lock across its judge and write, but the write door judged first and took the
+    lock for the write alone. A re-stamp landing in between was written over by a blob judged
+    against the pre-re-stamp store: the foreign write's lens change and its creates gone, under a
+    seq no higher than the re-stamp's (both computed from the same base), no refusal anywhere, and
+    every dashboard that had adopted the re-stamp's seq ignoring the store until the next write.
+    The door holds the lock across both steps now, so a re-stamp waits for the write to finish."""
+
+    def test_a_re_stamp_cannot_land_between_a_writers_judge_and_its_write(self):
+        s0 = self.seed()["seq"]
+        real = km._judge_timeline_views
+        in_judge, release, paused = threading.Event(), threading.Event(), [False]
+
+        def slow(blob, base=None, seq_floor=0, edited=None, foreign=None):
+            out = real(blob, base=base, seq_floor=seq_floor, edited=edited, foreign=foreign)
+            if base is None and foreign is None and not paused[0]:       # the writer's own judgment, once
+                paused[0] = True
+                in_judge.set()
+                release.wait(5)
+            return out
+        km._judge_timeline_views = slow
+        try:
+            w_blob = json.loads(json.dumps(km._timeline_views()))
+            w_blob["tags"][0]["color"] = "#DD42FF"                          # a recolor, as _edit_tag writes it
+
+            def writer():
+                with km._views_lock:                                      # the RMW writers hold this one
+                    km._set_timeline_views(w_blob)
+            w = threading.Thread(target=writer)
+            w.start()
+            self.assertTrue(in_judge.wait(5), "the writer is inside its judgment")
+            # a panel writes the file itself meanwhile, from an older copy: its lens change and a create
+            p = km._views_path()
+            foreign = json.loads(p.read_text())
+            foreign["seq"] = s0 - 1
+            foreign["actives"] = {"timeline": {"tags": ["web"]}, "chat": {"all": True}, "outline": {"all": True}}
+            foreign["tags"].append({"id": "gP", "name": "panel", "color": "", "members": []})
+            km._atomic_write(p, json.dumps(foreign))
+            served = []
+            r = threading.Thread(target=lambda: served.append(km._timeline_views()))   # any frame build
+            r.start()
+            r.join(0.5)
+            self.assertTrue(r.is_alive(), "the reader's re-stamp waits on the lock the writer holds across judge and write")
+            release.set()
+            w.join(5)
+            r.join(5)
+            self.assertFalse(w.is_alive() or r.is_alive())
+        finally:
+            km._judge_timeline_views = real
+            release.set()
+        final = km._timeline_views()
+        self.assertEqual(final["tags"][0]["color"], "#DD42FF", "the writer's edit stands")
+        self.assertGreater(final["seq"], s0)
+        self.assertEqual(served[0], final, "what the reader served IS the store: nothing it handed out carries a seq the store fell behind")
+        self.assertEqual(json.loads(p.read_text())["seq"], final["seq"])
+        # (the panel's own file write was replaced by the writer's atomic write before it was judged, as any
+        # file write racing a kernel write is; the point here is the order — the reader can no longer hand
+        # out a blob the very next kernel write lands behind)
+
+
+class CapNeverDropsAKeptStoreTag(_Wire):
+    """The 2026-09-05 review (the MEDIUM finding): the door assembled the set that stands
+    as the blob's tags first and the store's kept copies after, then sliced it to _VIEWS_MAX_TAGS —
+    so when a stale client's tags plus the store's keeps exceeded the cap, the tag dropped was
+    exactly the one the ack had just said was kept ("this write did not edit it, so it was not
+    deleted"), and the client's own create took its place under an ok ack. Now a kept store tag
+    always survives: the write's creates are refused instead, with a reason naming the cap, the same
+    way _edit_tag refuses a 33rd."""
+
+    def _seed_many(self, n):
+        tags = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(n)]
+        ack = self.post({"type": "setTimelineViews", "writeId": "w0", "views": {"active": "all", "tags": tags}})
+        self.assertEqual((ack["ok"], ack["refused"], len(ack["views"]["tags"])), (True, [], n))
+        return ack["views"]
+
+    def test_edited_path_a_create_over_the_cap_is_refused_and_the_quietly_kept_tag_survives(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS)                       # the store is full
+        stale = json.loads(json.dumps(served))
+        stale["tags"] = [t for t in stale["tags"] if t["id"] != "g31"]      # a copy from before the 32nd…
+        stale["tags"].append({"id": "gnew", "name": "mine", "color": "#DD42FF", "members": [SID1]})   # …plus a create
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": ["gnew"]})
+        self.assertFalse(a["ok"], "the client's own create was refused, so the ack is not ok")
+        rows = {r["tid"]: r["reason"] for r in a["refused"]}
+        self.assertEqual(rows, {"gnew": "the views blob caps at 32 tags, so it was not created",
+                                "g31": "this write did not edit it, so it was not deleted"})
+        ids = [t["id"] for t in km._timeline_views()["tags"]]
+        self.assertEqual(len(ids), km._VIEWS_MAX_TAGS)
+        self.assertIn("g31", ids, "the kept tag the ack names is in the store")
+        self.assertNotIn("gnew", ids, "the create is not")
+        self.assertEqual([t["id"] for t in a["views"]["tags"]], ids, "the ack's blob is the store")
+        self.assertEqual(len(self.notices), 1, "a refused create is the poster's lost edit: loud")
+        self.assertIn('"mine" (over the cap)', self.notices[0][0])
+        self.assertIn("its changes to 1 tag were not applied", self.notices[0][0])
+
+    def test_edited_less_path_the_loudly_kept_tag_survives_and_the_create_is_refused(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS - 1)                   # 31 in the store
+        t31, err = km._edit_tag("t31", add=[SID2])                         # another surface's create: 32
+        self.assertIsNone(err)
+        stale = json.loads(json.dumps(served))                             # an older client's copy of the 31…
+        stale["at"] -= 10                                                  # …with evidence older than the create
+        for t in stale["tags"]:
+            t["mtime"] -= 10
+        stale["tags"].append({"id": "gnew", "name": "mine", "color": "", "members": []})
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale})   # no `edited`: the legacy reading
+        self.assertFalse(a["ok"])
+        rows = {r["tid"]: r["reason"] for r in a["refused"]}
+        self.assertEqual(rows, {"gnew": "the views blob caps at 32 tags, so it was not created",
+                                t31["id"]: "it was edited after your copy was taken, so it was not deleted"})
+        ids = [t["id"] for t in km._timeline_views()["tags"]]
+        self.assertEqual(len(ids), km._VIEWS_MAX_TAGS)
+        self.assertIn(t31["id"], ids, "the store's newer tag stands, as the notice says it does")
+        self.assertNotIn("gnew", ids)
+        self.assertEqual(len(self.notices), 1)
+        self.assertIn('"t31" (deletion)', self.notices[0][0])
+        self.assertIn('"mine" (over the cap)', self.notices[0][0])
+
+    def test_creates_that_fit_land_and_only_the_excess_is_refused_last_first(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS - 2)                   # room for two
+        w = json.loads(json.dumps(served))
+        w["tags"] += [{"id": "gx", "name": "x", "color": "", "members": []},
+                      {"id": "gy", "name": "y", "color": "", "members": []}]
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w, "edited": ["gx", "gy"]})
+        self.assertEqual((a["ok"], a["refused"]), (True, []), "both creates fit")
+        self.assertEqual(len(km._timeline_views()["tags"]), km._VIEWS_MAX_TAGS)
+        w2 = json.loads(json.dumps(a["views"]))
+        w2["tags"].append({"id": "gz", "name": "z", "color": "", "members": []})
+        b = self.post({"type": "setTimelineViews", "writeId": "w2", "views": w2, "edited": ["gz"]})
+        self.assertEqual((b["ok"], [(r["tid"], r["reason"]) for r in b["refused"]]),
+                         (False, [("gz", "the views blob caps at 32 tags, so it was not created")]))
+        self.assertEqual(len(km._timeline_views()["tags"]), km._VIEWS_MAX_TAGS)
+        self.assertIsNone(store_tag("z"))
+        self.assertEqual(self.notices[-1][1], False)
+        # two creates where only one fits: the later one in array order is the one refused
+        w3 = json.loads(json.dumps(served))
+        w3["tags"] += [{"id": "ga", "name": "a", "color": "", "members": []},
+                       {"id": "gb", "name": "b", "color": "", "members": []},
+                       {"id": "gc", "name": "c", "color": "", "members": []}]
+        try:
+            km._views_path().unlink()
+        except OSError:
+            pass
+        self._seed_many(km._VIEWS_MAX_TAGS - 2)
+        c = self.post({"type": "setTimelineViews", "writeId": "w3", "views": w3, "edited": ["ga", "gb", "gc"]})
+        self.assertEqual([r["tid"] for r in c["refused"]], ["gc"])
+        self.assertEqual(sorted(t["name"] for t in km._timeline_views()["tags"] if t["id"] in ("ga", "gb", "gc")), ["a", "b"])
+
+    def test_a_posted_33rd_tag_reaches_the_door_and_is_refused_not_sliced_off_by_the_normalizer(self):
+        """The normalizer bounds a blob to the cap on every read, and the door read the posted blob
+        through it — so a client's 33rd tag was gone before the judge saw it, no row, no notice. The
+        door reads under a wider bound and its cap pass refuses the excess; disk reads keep the cap."""
+        many = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(km._VIEWS_MAX_TAGS + 1)]
+        self.assertEqual(len(km._norm_timeline_views({"tags": many})["tags"]), km._VIEWS_MAX_TAGS, "a read is bounded, as before")
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many}})
+        self.assertEqual((a["ok"], [(r["tid"], r["reason"]) for r in a["refused"]]),
+                         (False, [("g32", "the views blob caps at 32 tags, so it was not created")]))
+        self.assertEqual(len(km._timeline_views()["tags"]), km._VIEWS_MAX_TAGS)
+
+
+class PastTheDoorBoundNothingVanishesSilently(_Wire):
+    """The 2026-09-05 review: the door reads a posted blob under twice the cap so a 33rd
+    tag reaches the cap pass — but the normalizer's slice still dropped everything past
+    the 64th BEFORE the judge saw it: no row, absent from the ack's blob, invisible to the ack's
+    `ok` (computed from rows), so a client whose `edited` named only ids past the bound was acked
+    ok and adopted a blob missing its own creates. Now every posted entry the slice leaves unread
+    gets a row — "not created" for a new id, "the store's copy was kept" for a store tag whose copy
+    fell past the bound (it is not a deletion either) — and nothing is stored past the bound."""
+
+    def _seed_many(self, n):
+        tags = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(n)]
+        ack = self.post({"type": "setTimelineViews", "writeId": "w0", "views": {"active": "all", "tags": tags}})
+        self.assertEqual((ack["ok"], ack["refused"], len(ack["views"]["tags"])), (True, [], n))
+        return ack["views"]
+
+    def test_seventy_creates_all_edited_every_posted_id_is_in_the_ack_blob_or_in_a_row(self):
+        many = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(70)]
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many},
+                       "edited": [t["id"] for t in many]})
+        self.assertFalse(a["ok"])
+        in_blob = {t["id"] for t in a["views"]["tags"]}
+        rows = {r["tid"]: r["reason"] for r in a["refused"]}
+        self.assertEqual(in_blob, {"g%d" % i for i in range(32)})
+        self.assertEqual(set(rows), {"g%d" % i for i in range(32, 70)}, "every posted id is in the blob or in a row")
+        self.assertEqual(rows["g32"], "the views blob caps at 32 tags, so it was not created")
+        self.assertEqual(rows["g64"], "a write is read to 64 tags and it was past that bound, so it was not created")
+        self.assertEqual(rows["g69"], rows["g64"])
+        self.assertEqual(len(km._timeline_views()["tags"]), 32, "nothing past the bound is stored")
+        self.assertEqual(len(self.notices), 1)
+        text = self.notices[0][0]
+        self.assertIn("its changes to 38 tags were not applied", text)
+        self.assertIn("reload that dashboard to resync", text)
+        self.assertIn('Refused: "t32" (over the cap), "t33" (over the cap), "t34" (over the cap) and 35 more', text,
+                      "the labels after the point, as many as fit; the rows carry every reason")
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT)
+
+    def test_creates_past_the_bound_that_edited_names_are_refused_never_acked_ok(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS)
+        w = json.loads(json.dumps(served))
+        w["tags"] += [{"id": "h%d" % i, "name": "h%d" % i, "color": "", "members": []} for i in range(38)]
+        tail = ["h%d" % i for i in range(32, 38)]
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w, "edited": tail})
+        self.assertFalse(a["ok"], "the client's own creates were refused, so the ack is not ok")
+        rows = {r["tid"]: r["reason"] for r in a["refused"]}
+        for h in tail:
+            self.assertEqual(rows[h], "a write is read to 64 tags and it was past that bound, so it was not created")
+        self.assertEqual(rows["h0"], "it was deleted after your copy was taken, so it was not re-created",
+                         "h0..h31 sat within the bound and were not in `edited`: re-creations, quietly")
+        self.assertEqual([t["id"] for t in a["views"]["tags"]], [t["id"] for t in served["tags"]])
+        self.assertEqual(len(self.notices), 1, "the refused creates were the poster's: loud")
+        self.assertIn("(unread)", self.notices[0][0])
+
+    def test_a_duplicate_entry_consumes_a_slot_and_the_create_it_pushes_past_the_bound_gets_a_row(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS)
+        w = json.loads(json.dumps(served))
+        w["tags"] = w["tags"] + json.loads(json.dumps(w["tags"])) \
+            + [{"id": "h0", "name": "mine", "color": "", "members": []}]        # the 65th entry
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w, "edited": ["h0"]})
+        self.assertEqual((a["ok"], [(r["tid"], r["name"]) for r in a["refused"]]), (False, [("h0", "mine")]))
+        self.assertIsNone(store_tag("mine"))
+
+    def test_a_store_tags_copy_past_the_bound_is_kept_not_deleted(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS)
+        creates = [{"id": "n%d" % i, "name": "n%d" % i, "color": "", "members": []} for i in range(33)]
+        w = json.loads(json.dumps(served))
+        w["tags"] = creates + w["tags"]                    # 65 entries: the store's g31 is the 65th
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w})   # no `edited`: an older client
+        self.assertFalse(a["ok"])
+        rows = {r["tid"]: r["reason"] for r in a["refused"]}
+        self.assertEqual(rows["g31"],
+                         "a write is read to 64 tags and its copy was past that bound, so the store's copy was kept")
+        self.assertEqual(sorted(k for k in rows if k.startswith("n")), sorted("n%d" % i for i in range(33)),
+                         "every create is refused by the cap: the store is full")
+        ids = [t["id"] for t in km._timeline_views()["tags"]]
+        self.assertEqual(sorted(ids), sorted(t["id"] for t in served["tags"]), "the store is intact, g31 included")
+        self.assertIn("its changes to 34 tags were not applied", self.notices[0][0])
+        self.assertLessEqual(len(self.notices[0][0]), km.SYNC_NOTICE_FIT)
+
+    def test_a_lens_only_write_touches_no_tag_whatever_the_blob_carries_by_design(self):
+        served = self._seed_many(3)
+        w = json.loads(json.dumps(served))
+        w["tags"] += [{"id": "h%d" % i, "name": "h%d" % i, "color": "", "members": []} for i in range(70)]
+        w["actives"] = {"timeline": {"tags": ["t1"]}, "chat": {"all": True}, "outline": {"all": True}}
+        a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w, "edited": []})
+        self.assertEqual((a["ok"], a["refused"]), (True, []),
+                         "edited=[] is the client's word that it changed no tag (docs/read-side.md): no rows")
+        self.assertEqual(len(km._timeline_views()["tags"]), 3)
+        self.assertEqual(km._timeline_views()["actives"]["timeline"], {"tags": ["t1"]})
+        self.assertEqual(self.notices, [])
+
+
+class ReaderRestampKeepsTheDiskCap(_Wire):
+    """The 2026-09-05 review: the reader's first-read stamp and the hidden migration judged
+    the file's own content through the door, which since the 2026-09-05 review reads its blob under twice the cap
+    while the base is normalized under the cap — so a file holding more than 32 tags had its excess
+    (the migration's appended "archived" tag first) judged as creates and refused by the cap pass,
+    under a red notice worded as a stale DASHBOARD write ("reload that dashboard to resync"), on a
+    read, blaming a dashboard that wrote nothing. The re-stamp now reads the file under the disk cap,
+    as every read does, and what the cap leaves out is named in a notice as a fact about the file."""
+
+    def _file(self, n, **extra):
+        tags = [{"id": "t%d" % i, "name": "t%d" % i, "color": "", "members": [{"host": "", "sid": "s%d" % i}]}
+                for i in range(n)]
+        d = dict({"active": "all", "tags": tags}, **extra)
+        km._views_path().write_text(json.dumps(d))
+        return d
+
+    def test_a_seq_less_40_tag_file_with_hidden_entries_migrates_stamps_and_names_the_drop_as_a_file_fact(self):
+        p = km._views_path()
+        self._file(40, hidden=[SID3])
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            v = km._timeline_views()
+        self.assertEqual(len(v["tags"]), km._VIEWS_MAX_TAGS, "served under the cap, as every read")
+        self.assertIsInstance(v.get("seq"), int, "stamped")
+        on_disk = json.loads(p.read_text())
+        self.assertNotIn("hidden", on_disk, "the migration landed: the hidden key is consumed")
+        self.assertEqual(len(on_disk["tags"]), km._VIEWS_MAX_TAGS)
+        self.assertTrue(all(t.get("mtime") for t in on_disk["tags"]))
+        self.assertEqual(len(self.notices), 1, "one notice: the file fact")
+        text, ok = self.notices[0]
+        self.assertFalse(ok)
+        self.assertEqual(text, "the views file held 41 tags, over the store's 32-tag cap; no dashboard wrote this. "
+                               "9 tags were dropped when it was re-stamped on read (hidden entries migrated into the "
+                               "archived tag): \"t32\" (1 member), \"t33\" (1 member) and 7 more",
+                         "cause and count first, the dropped tags after, as many as fit")
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT)
+        self.assertNotIn("dashboard write", text)
+        self.assertNotIn("reload", text)
+        self.assertNotIn("refused", text)
+        line = next(ln for ln in err.getvalue().splitlines() if "no dashboard wrote this" in ln)
+        for nm in ("t32", "t39"):
+            self.assertIn('"%s": s%s' % (nm, nm[1:]), line, "stderr names every dropped tag with its members")
+        self.assertIn('"archived": %s' % SID3, line, "the migrated hidden entry is named as what was dropped")
+        # idempotent: a cold second read writes nothing and says nothing more
+        before = p.read_bytes()
+        km._flags_cache.clear()
+        km._timeline_views()
+        self.assertEqual(p.read_bytes(), before)
+        self.assertEqual(len(self.notices), 1)
+
+    def test_a_full_store_with_hidden_entries_the_kernel_once_wrote_loses_only_the_archived_tag_and_says_so(self):
+        # kernel-producible: the cap and the hidden field were born together (2026-08-18), hidden retired 08-24
+        p = km._views_path()
+        self._file(km._VIEWS_MAX_TAGS, hidden=[SID2, SID3], seq=7)
+        v = km._timeline_views()
+        self.assertEqual([t["id"] for t in v["tags"]], ["t%d" % i for i in range(32)], "every real tag stands")
+        self.assertIsNone(store_tag("archived"))
+        self.assertNotIn("hidden", json.loads(p.read_text()))
+        self.assertEqual(len(self.notices), 1)
+        text, ok = self.notices[0]
+        self.assertFalse(ok)
+        self.assertIn('1 tag was dropped when it was re-stamped on read (hidden entries migrated into the archived '
+                      'tag): "archived" (2 members)', text)
+        self.assertNotIn("dashboard write", text)
+
+    def test_a_31_tag_file_with_hidden_entries_fits_and_nothing_is_said(self):
+        self._file(km._VIEWS_MAX_TAGS - 1, hidden=[SID3])
+        v = km._timeline_views()
+        self.assertEqual([m["sid"] for m in store_tag("archived")["members"]], [SID3])
+        self.assertEqual(len(v["tags"]), km._VIEWS_MAX_TAGS)
+        self.assertEqual(self.notices, [], "the migration fits: a stamp is not a refusal")
+
+    def test_a_seq_less_file_over_the_cap_is_stamped_under_the_cap_and_the_drop_is_a_file_fact(self):
+        p = km._views_path()
+        self._file(40, at=1000)
+        v = km._timeline_views()
+        self.assertEqual(len(v["tags"]), 32)
+        self.assertEqual(len(json.loads(p.read_text())["tags"]), 32)
+        self.assertEqual(len(self.notices), 1)
+        text, ok = self.notices[0]
+        self.assertFalse(ok)
+        self.assertIn("the views file held 40 tags", text)
+        self.assertIn("a store from before the write sequence, stamped once", text)
+        self.assertNotIn("partially refused", text)
+        self.assertNotIn("dashboard", text.replace("no dashboard wrote this", ""))
+        self.assertIn("8 tags were dropped", text)
+
+    def test_the_served_row_carries_the_cause_whole_however_many_tags_were_dropped(self):
+        """The 2026-09-05 review: the notice put its point — no dashboard wrote this — LAST,
+        after one entry per dropped tag; the kernel serves a sync notice cut at 300 (_sync_notice_rows)
+        and the dashboard's bell cuts it again at 240 (SYNC_NOTICE_FIT), so with two or more tags
+        dropped the user saw a list of names and never the cause. The served row is the whole notice."""
+        self._file(40, hidden=[SID3])
+        with self.real_notices():
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._timeline_views()
+            rows = km._sync_notice_rows()
+            with km._SYNC_LOCK:
+                full = km._SYNC_NOTICES[-1]["text"]
+        self.assertEqual(len(rows), 1)
+        text = rows[0]["text"]
+        self.assertFalse(rows[0]["ok"])
+        self.assertEqual(text, full, "nothing the kernel's cap could cut")
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT, "…and nothing the bell's cap will")
+        self.assertTrue(text.startswith("the views file held 41 tags, over the store's 32-tag cap; no dashboard wrote this. "
+                                        "9 tags were dropped when it was re-stamped on read"))
+        self.assertTrue(text.endswith(' and 7 more'))
+
+    def test_the_served_loud_notice_carries_the_count_and_the_remedy_whole(self):
+        many = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(70)]
+        with self.real_notices():
+            with contextlib.redirect_stderr(io.StringIO()):
+                a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many},
+                               "edited": [t["id"] for t in many]})
+            rows = km._sync_notice_rows()
+        self.assertFalse(a["ok"])
+        self.assertEqual(len(rows), 1)
+        text = rows[0]["text"]
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT)
+        self.assertTrue(text.startswith("a stale dashboard write was partially refused: its changes to 38 tags were not "
+                                        "applied and the store's state was kept; reload that dashboard to resync. Refused: "))
+        self.assertTrue(text.endswith(" and 35 more"))
+        self.assertEqual(len(a["refused"]), 38, "every reason is in the ack's rows, whole")
+
+    def test_notice_list_names_what_fits_and_counts_the_rest(self):
+        nl = km._notice_list
+        self.assertEqual(nl("head", ": ", ["a", "b", "c"], cap=100), "head: a, b, c")
+        self.assertEqual(nl("head", ": ", [], cap=100), "head")
+        self.assertEqual(nl("head", ": ", ["aaaa", "bbbb", "cccc"], cap=len("head: aaaa and 2 more")), "head: aaaa and 2 more")
+        self.assertEqual(nl("head", ": ", ["aaaa", "bbbb", "cccc"], cap=len("head: aaaa, bbbb and 1 more") - 1),
+                         "head: aaaa and 2 more", "an item is named only with room left for the tail that follows it")
+        self.assertEqual(nl("head", ": ", ["aaaa", "bbbb", "c" * 16], cap=len("head: aaaa, bbbb and 1 more")),
+                         "head: aaaa, bbbb and 1 more")
+        self.assertEqual(nl("head", ": ", ["aaaa", "bbbb"], cap=8), "head", "not even the first fits: the head alone")
+        self.assertEqual(nl("head", ": ", ["a"], extra=5, cap=100), "head: a and 5 more", "`extra` counts things never listed")
+        self.assertEqual(nl("head", ": ", [], extra=5, cap=100), "head", "…but with nothing named the head carries the count")
+        self.assertEqual(nl("", "", ["x: 1", "y: 2"], cap=100, joiner="; "), "x: 1; y: 2")
+        self.assertLessEqual(km.SYNC_NOTICE_FIT, 300, "the bell's cap is under the kernel's served cap")
+
+    def test_the_judges_loud_notice_names_the_writer_and_offers_a_reload_only_to_a_dashboard(self):
+        self.seed()
+        self.assertIsNone(km._edit_tag(tid="gA", add=[SID2])[1])            # newer state in the store
+        stale = {"active": "all", "at": 1, "tags": [dict(WEB, mtime=1)]}    # a copy predating it
+        km._judge_timeline_views(json.loads(json.dumps(stale)), writer="the views file's re-stamp on read")
+        self.assertEqual(len(self.notices), 1)
+        self.assertTrue(self.notices[0][0].startswith("the views file's re-stamp on read was partially refused"))
+        self.assertNotIn("reload", self.notices[0][0], "no dashboard wrote it: nothing to reload")
+        km._judge_timeline_views(json.loads(json.dumps(stale)))
+        self.assertTrue(self.notices[1][0].startswith("a stale dashboard write was partially refused"))
+        self.assertIn("reload that dashboard to resync", self.notices[1][0])
+
+
+class ReaderRestampUnwritableNamesTheDrop(_Wire):
+    """The 2026-09-05 review: the file-fact notice fired only after the stamp WRITE succeeded.
+    On an unwritable or full state dir the reader served and cached the capped blob and said nothing
+    about what the cap left out, and the next RMW writer (a tag edit through _edit_tag) wrote
+    that cached blob: the file's excess tags were dropped for good with no notice ever filed. The
+    notice now fires whether or not the write lands, once per file state, and on the failed write it
+    says the drop becomes permanent at the next write unless the file is brought under the cap."""
+
+    def setUp(self):
+        super().setUp()
+        km._VIEWS_RESTAMP_ERR[0] = None
+        self._real_write = km._atomic_write
+
+    def tearDown(self):
+        km._atomic_write = self._real_write
+        km._VIEWS_RESTAMP_ERR[0] = None
+        super().tearDown()
+
+    def _file(self, n, **extra):
+        tags = [{"id": "t%d" % i, "name": "t%d" % i, "color": "", "members": [{"host": "", "sid": "s%d" % i}]}
+                for i in range(n)]
+        km._views_path().write_text(json.dumps(dict({"active": "all", "tags": tags}, **extra)))
+
+    def _full_disk(self):
+        def failing(path, text, mode=None):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        km._atomic_write = failing
+
+    def test_the_drop_is_named_when_the_stamp_cannot_be_written_and_the_notice_says_it_becomes_permanent(self):
+        p = km._views_path()
+        self._file(40, at=1000)
+        self._full_disk()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            v = km._timeline_views()
+            self.assertEqual(len(v["tags"]), 32, "served under the cap, as every read")
+            self.assertNotIn("seq", v, "unstamped: the write did not land")
+            self.assertEqual(len(json.loads(p.read_text())["tags"]), 40, "the file still holds the excess")
+            self.assertEqual(len(self.notices), 1, "the file fact is said although the stamp did not land")
+            text, ok = self.notices[0]
+            self.assertFalse(ok)
+            self.assertEqual(text, "the views file held 40 tags, over the store's 32-tag cap; no dashboard wrote this. "
+                                   "Its re-stamp could not be written — 8 tags are not served and are lost at the next "
+                                   "write unless the file is brought under the cap first",
+                             "cause and count first; with no room left for a name the head stands alone")
+            self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT)
+            self.assertIs(km._timeline_views(), v, "the next read is a cache hit under the file's key…")
+            self.assertEqual(len(self.notices), 1, "…so the fact is said once per file state")
+        lines = err.getvalue().splitlines()
+        self.assertEqual(len([ln for ln in lines if "could not be re-stamped" in ln]), 1)
+        self.assertIn("the file as read, under the cap, unstamped", next(ln for ln in lines if "could not be re-stamped" in ln))
+        fact = next(ln for ln in lines if "no dashboard wrote this" in ln)
+        for i in range(32, 40):
+            self.assertIn('"t%d": s%d' % (i, i), fact, "stderr names every dropped tag with its members")
+        # the writer is back: the next RMW write persists the served blob — the drop the notice announced
+        km._atomic_write = self._real_write
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertIsNone(km._edit_tag(tid="t0", add=[SID2])[1])
+        on_disk = json.loads(p.read_text())
+        self.assertEqual(len(on_disk["tags"]), 32)
+        self.assertNotIn("t39", [t["id"] for t in on_disk["tags"]], "permanent now, as the notice said it would be")
+        self.assertEqual(len(self.notices), 1, "said when it could still be prevented; the write that makes it so adds nothing")
+        km._flags_cache.clear()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._timeline_views()
+        self.assertEqual(len(self.notices), 1, "a clean 32-tag stamped store: nothing left to name")
+
+    def test_one_dropped_tag_is_named_in_the_unwritable_notice(self):
+        self._file(33, at=1000)
+        self._full_disk()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._timeline_views()
+        self.assertEqual(len(self.notices), 1)
+        text, ok = self.notices[0]
+        self.assertFalse(ok)
+        self.assertTrue(text.endswith("Its re-stamp could not be written — 1 tag is not served and is lost at the next "
+                                      'write unless the file is brought under the cap first: "t32" (1 member)'), text)
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT)
+
+    def test_a_file_under_the_cap_on_a_full_disk_files_no_file_fact(self):
+        self._file(5, at=1000)
+        self._full_disk()
+        with contextlib.redirect_stderr(io.StringIO()):
+            v = km._timeline_views()
+        self.assertEqual(len(v["tags"]), 5)
+        self.assertEqual(self.notices, [], "an unwritable store alone is a log line, not a notice")
+
+    def test_a_cold_read_while_the_disk_stays_full_says_it_again_the_file_state_is_unchanged_and_unfixed(self):
+        self._file(40, at=1000)
+        self._full_disk()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._timeline_views()
+            km._flags_cache.clear()                            # a restart: the file is as it was, still over the cap
+            km._timeline_views()
+        self.assertEqual(len(self.notices), 2, "once per file state: a cold read of the same unfixed file names it again")
+        self.assertEqual(self.notices[0], self.notices[1])
+
+    def test_two_cold_readers_racing_to_the_lock_on_a_full_disk_name_the_drop_once(self):
+        """The 2026-09-05 review: the cache hit check runs before the file lock, and the
+        in-lock re-check compared the stat key alone — which a FAILED write leaves unchanged. Two readers
+        that both missed a cold cache (the pusher and a handler, on a kernel starting over a full disk)
+        serialized on the lock, and the loser re-stated the same key, judged again, failed again and
+        filed the file-fact notice again: two identical red notices for one file state. The loser now
+        finds the winner's cache entry under the lock and serves it, as the next read would."""
+        self._file(40, at=1000)
+        self._full_disk()
+        real = km._views_restamp
+        gate = threading.Barrier(2)
+
+        def restamp(d, hit):
+            # runs after the hit check and before the lock: both readers pass the check before either
+            # takes the lock, the window the race needs
+            try:
+                gate.wait(timeout=10)
+            except threading.BrokenBarrierError:
+                pass
+            return real(d, hit)
+        km._views_restamp = restamp
+        served, failures = [], []
+
+        def read():
+            try:
+                served.append(len(km._timeline_views()["tags"]))
+            except Exception as e:                            # pragma: no cover - the assertion below reports it
+                failures.append(repr(e))
+        err = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                readers = [threading.Thread(target=read) for _ in range(2)]
+                for t in readers:
+                    t.start()
+                for t in readers:
+                    t.join(timeout=30)
+        finally:
+            km._views_restamp = real
+        self.assertEqual(failures, [])
+        self.assertEqual(served, [32, 32], "both readers are answered, under the cap")
+        self.assertEqual(len(self.notices), 1, "one file state, one notice: the loser serves the winner's cache entry")
+        lines = err.getvalue().splitlines()
+        self.assertEqual(len([ln for ln in lines if "no dashboard wrote this" in ln]), 1, "…and one stderr file fact")
+        self.assertEqual(len([ln for ln in lines if "could not be re-stamped" in ln]), 1)
+        self.assertEqual(len(json.loads(km._views_path().read_text())["tags"]), 40, "the file is as it was")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(len(km._timeline_views()["tags"]), 32)
+        self.assertEqual(len(self.notices), 1, "a warm read adds nothing")
+
+
+class RefusalRowsAreBounded(_Wire):
+    """The 2026-09-05 review: the review gave every posted entry past the door's read bound a
+    refusal row of its own, and with it the rows, the loud notice and the ack's `error` became O(N) in
+    the posted array. A 100k-entry post (a client bug, or any local page holding the socket — the WS
+    reader takes frames of any length) drew a ~22 MB ack that overran WS_QUEUE_BYTES: the poster's own
+    ack marked its socket dead before the ack was queued, so it never learned the write's outcome. Now
+    the first 64 unread entries get rows, the rest are one summary row carrying their count and how
+    many of them `edited` named, `ok` still reads the summary, and the ack stays small."""
+
+    N = 10000
+
+    def _many(self, n, start=0):
+        return [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(start, start + n)]
+
+    def _real_client(self):
+        """A client built the way the accept path builds one — the byte budget and its drop rule live in
+        its `send` — with no sender thread and a socket that only records a shutdown."""
+        class Sock:
+            shut = 0
+
+            def shutdown(self, how):
+                self.shut += 1
+        sock = Sock()
+        client, q, _lock = km._new_ws_client("timeline", "w-dash", sock, start_sender=False)
+        return client, q, sock
+
+    def test_a_10000_entry_post_is_acked_in_bounded_rows_on_a_socket_that_stays_alive(self):
+        client, q, sock = self._real_client()
+        many = self._many(self.N)
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(self.handler, {"type": "setTimelineViews", "writeId": "w1",
+                                                   "views": {"active": "all", "tags": many},
+                                                   "edited": [t["id"] for t in many]}, client)
+        self.assertTrue(client["alive"], "the poster's own ack no longer drops it")
+        self.assertEqual(sock.shut, 0)
+        self.assertEqual(q.qsize(), 1, "the ack was queued")
+        frame = q.get_nowait()
+        ack = json.loads(frame)
+        self.assertEqual((ack["type"], ack["writeId"], ack["ok"]), ("viewsAck", "w1", False))
+        bound = km._VIEWS_MAX_TAGS * 2
+        self.assertLess(len(frame), 100_000, "bounded — a 10k post drew a ~2 MB ack before, a 100k post ~22 MB")
+        self.assertLessEqual(len(ack["refused"]), 2 * bound + km._VIEWS_MAX_TAGS + 1,
+                             "the cap pass's rows, 64 named unread rows, one summary — never one per posted entry")
+        named = [r for r in ack["refused"] if r.get("tid")]
+        summary = [r for r in ack["refused"] if not r.get("tid")]
+        self.assertEqual([r["tid"] for r in named if "read to" in r["reason"]], ["g%d" % i for i in range(bound, 2 * bound)],
+                         "the first 64 unread entries, in array order, get rows of their own")
+        self.assertEqual(summary, [{"reason": "9872 more entries past the %d-tag read bound were not read "
+                                              "(9872 of them this write edited)" % bound,
+                                    "more": 9872, "moreEdited": 9872}])
+        self.assertLessEqual(len(ack["error"]), km._ACK_ERROR_CAP)
+        self.assertRegex(ack["error"], r" and \d+ more$", "the one-line form is bounded the same way")
+        self.assertEqual(len(km._timeline_views()["tags"]), 32, "nothing past the bound is stored")
+        self.assertEqual(len(self.notices), 1)
+        text = self.notices[0][0]
+        self.assertLessEqual(len(text), km.SYNC_NOTICE_FIT, "the loud notice is bounded too")
+        self.assertIn("its changes to 9968 tags were not applied", text)
+        self.assertIn("reload that dashboard to resync", text)
+
+    def test_ok_is_false_when_the_clients_only_create_sits_past_the_row_bound(self):
+        many = self._many(self.N)
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many},
+                           "edited": ["g9999"]})
+        self.assertFalse(a["ok"], "the client's own create was not read: never acked ok, row or no row")
+        self.assertNotIn("g9999", [r.get("tid") for r in a["refused"]], "no row of its own: it is counted in the summary")
+        summary = next(r for r in a["refused"] if not r.get("tid"))
+        self.assertEqual((summary["more"], summary["moreEdited"]), (9872, 1))
+        self.assertIn("(1 of them this write edited)", summary["reason"])
+        self.assertEqual(len(self.notices), 1, "a lost edit is loud…")
+        self.assertEqual(self.notices[0][0], "a stale dashboard write was partially refused: its changes to 1 tag were not "
+                                             "applied and the store's state was kept; reload that dashboard to resync.",
+                         "…counted, with nothing to name: the summary's entries carry no label")
+
+    def test_ok_is_true_when_nothing_past_the_bound_is_the_clients_own(self):
+        many = self._many(self.N)
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many},
+                           "edited": ["g0"]})
+        self.assertTrue(a["ok"], "its one create landed; every other entry is a stale copy it did not edit")
+        self.assertEqual([t["id"] for t in a["views"]["tags"]], ["g0"])
+        summary = next(r for r in a["refused"] if not r.get("tid"))
+        self.assertEqual(summary["moreEdited"], 0)
+        self.assertEqual(self.notices, [], "quiet: nothing the user did was refused")
+
+    def test_store_tags_whose_copies_sit_past_the_row_bound_are_all_kept(self):
+        tags = self._many(km._VIEWS_MAX_TAGS, start=50000)
+        served = self.post({"type": "setTimelineViews", "writeId": "w0", "views": {"active": "all", "tags": tags}})["views"]
+        w = {"active": "all", "at": served["at"], "tags": self._many(self.N) + json.loads(json.dumps(served["tags"]))}
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": w})     # no `edited`: an older client
+        self.assertFalse(a["ok"])
+        ids = sorted(t["id"] for t in km._timeline_views()["tags"])
+        self.assertEqual(ids, sorted(t["id"] for t in served["tags"]),
+                         "every store tag sat past the row bound and every one was kept: the bound is on rows, not keeps")
+        self.assertLessEqual(len(a["refused"]), 2 * km._VIEWS_MAX_TAGS * 2 + km._VIEWS_MAX_TAGS + 1)
+        self.assertEqual(next(r for r in a["refused"] if not r.get("tid"))["moreEdited"], 0, "no `edited`: nothing to count")
+
+
+class AckErrorNamesThePostersRefusalFirst(_Wire):
+    """The 2026-09-05 review: the review bounded the ack's one-line `error` at 1000 characters
+    but kept the judge's order, in which the quiet rows (differing copies of tags the poster did not
+    edit, acked ok on their own) precede the cap pass. With eight or more quiet rows the toast named
+    only refusals the user never made and cut the one row that made `ok` false. Now the rows `edited`
+    names — or the summary row counting one — lead, and the quiet rows follow as far as the cap allows;
+    the rows themselves keep the judge's order, and so does the line when the write carries no
+    `edited`."""
+
+    QUIET = "your copy of it differs from the store's and this write did not edit it, so the store's copy was kept"
+    CAP = "the views blob caps at 32 tags, so it was not created"
+
+    def _seed_many(self, n):
+        tags = [{"id": "g%d" % i, "name": "tag-name-%02d" % i, "color": "", "members": []} for i in range(n)]
+        ack = self.post({"type": "setTimelineViews", "writeId": "w0", "views": {"active": "all", "tags": tags}})
+        self.assertEqual((ack["ok"], ack["refused"], len(ack["views"]["tags"])), (True, [], n))
+        return ack["views"]
+
+    def test_the_finders_scenario_a_create_over_the_cap_behind_ten_differing_copies(self):
+        """The store is full; a dashboard that slept through a batch of recolors elsewhere posts its whole
+        blob with its one create as `edited`: ten of its copies differ, and the create is refused by the
+        cap. The rows list the ten quiet refusals then the create's, and the line leads with the create."""
+        served = self._seed_many(km._VIEWS_MAX_TAGS)
+        stale = json.loads(json.dumps(served))
+        for t in stale["tags"][:10]:
+            t["color"] = "#000000"
+        stale["tags"].append({"id": "mine", "name": "mine", "color": "#DD42FF", "members": []})
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale, "edited": ["mine"]})
+        self.assertFalse(a["ok"], "the poster's own create was refused")
+        self.assertEqual([r["tid"] for r in a["refused"]], ["g%d" % i for i in range(10)] + ["mine"],
+                         "the rows keep the judge's order: the quiet ten, then the cap pass")
+        self.assertEqual(a["refused"][-1]["reason"], self.CAP)
+        self.assertTrue(a["error"].startswith('"mine": %s; "tag-name-00": %s' % (self.CAP, self.QUIET)),
+                        "the line leads with the refusal the user made, then the quiet rows in judge order: " + a["error"])
+        self.assertLessEqual(len(a["error"]), km._ACK_ERROR_CAP)
+        self.assertRegex(a["error"], r" and \d+ more$", "the quiet rows overflow the cap, not the poster's")
+        self.assertEqual(len(self.notices), 1)
+        self.assertIn('"mine" (over the cap)', self.notices[0][0], "the notice agrees with the line")
+        self.assertNotIn("mine", [t["id"] for t in km._timeline_views()["tags"]])
+
+    def test_the_summary_row_counting_the_posters_create_leads_the_line(self):
+        many = [{"id": "g%d" % i, "name": "t%d" % i, "color": "", "members": []} for i in range(10000)]
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": {"active": "all", "tags": many},
+                           "edited": ["g9999"]})
+        self.assertFalse(a["ok"])
+        summary = next(r for r in a["refused"] if not r.get("tid"))
+        self.assertTrue(a["error"].startswith(summary["reason"] + "; "),
+                        "the row that made ok false leads, nameless as it is: " + a["error"][:200])
+        self.assertIn("(1 of them this write edited)", a["error"])
+        self.assertLessEqual(len(a["error"]), km._ACK_ERROR_CAP)
+
+    def test_without_edited_every_row_is_loud_and_the_line_keeps_the_judges_order(self):
+        served = self._seed_many(km._VIEWS_MAX_TAGS)
+        stale = json.loads(json.dumps(served))
+        time.sleep(1.1)
+        with contextlib.redirect_stderr(io.StringIO()):
+            for i in range(10):
+                self.assertIsNone(km._edit_tag(tid="g%d" % i, color="#DD42FF")[1])     # newer edits elsewhere
+        stale["tags"].append({"id": "mine", "name": "mine", "color": "", "members": []})
+        with contextlib.redirect_stderr(io.StringIO()):
+            a = self.post({"type": "setTimelineViews", "writeId": "w1", "views": stale})      # an older client
+        self.assertFalse(a["ok"])
+        self.assertEqual([r["tid"] for r in a["refused"]], ["g%d" % i for i in range(10)] + ["mine"])
+        self.assertTrue(a["error"].startswith('"tag-name-00": your copy predates a newer edit'),
+                        "no `edited`: every refusal is the poster's, so the judge's order stands: " + a["error"][:120])
+
+    def test_the_rule_at_the_ack_itself(self):
+        """The ordering rule without the door: the poster's rows (a tid `edited` names, or the summary row
+        with `moreEdited`) first in judge order, then the rest; judge order when `edited` is absent or
+        names none of them; the rows in the ack are never reordered."""
+        quiet = [{"tid": "g%d" % i, "name": "tag-name-%02d" % i, "reason": self.QUIET} for i in range(10)]
+        mine = {"tid": "mine", "name": "mine", "reason": self.CAP}
+        summary = {"reason": "5 more entries past the 64-tag read bound were not read (1 of them this write edited)",
+                   "more": 5, "moreEdited": 1}
+
+        def ack(refused, edited):
+            sent = []
+            km._ack_views_write({"send": lambda s: sent.append(json.loads(s))}, "viewsAck", "w", False,
+                                refused=refused, edited=edited)
+            self.assertEqual(sent[0]["refused"], refused, "the rows keep the judge's order")
+            return sent[0]["error"]
+        line = ack(quiet + [mine], ["mine"])
+        self.assertTrue(line.startswith('"mine": %s; "tag-name-00": %s; "tag-name-01"' % (self.CAP, self.QUIET)), line)
+        self.assertRegex(line, r" and \d+ more$")
+        self.assertLessEqual(len(line), km._ACK_ERROR_CAP)
+        line = ack(quiet[:3] + [mine, summary], ["mine"])
+        self.assertTrue(line.startswith('"mine": %s; %s; "tag-name-00"' % (self.CAP, summary["reason"])), line)
+        line = ack(quiet + [summary], ["g9999"])
+        self.assertTrue(line.startswith(summary["reason"] + '; "tag-name-00"'), line)
+        self.assertTrue(ack(quiet + [mine], None).startswith('"tag-name-00"'), "no `edited`: judge order")
+        self.assertTrue(ack(quiet + [mine], ["absent"]).startswith('"tag-name-00"'), "none of the poster's: judge order")
+        self.assertTrue(ack(quiet + [mine], []).startswith('"tag-name-00"'))
+
+
+class BlobLessConnectPushCaps(_Wire):
+    """A connect push that serves NO views blob — a pane whose push carries none, on a socket where the
+    `ready` arm's own tabOrder frame could not be built either (its live read raised) — leaves the caps
+    frame nothing to name from the served frames. It then carries the STORE's current seq, the seq the
+    next push serves, and is null only with no store at all: with null, after a restart over a store
+    restored from an older copy, nothing re-armed the page's gate — the next pusher tabOrder (the
+    store's older seq) was rejected and kept, and no second caps frame ever came."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved = (km._tmux_sessions, km._ordered_alive)
+        km._tmux_sessions = lambda: {}
+        km._ordered_alive = lambda now, tmux: (_ for _ in ()).throw(RuntimeError("no live read"))   # the handler's own frame cannot be built
+
+    def tearDown(self):
+        km._tmux_sessions, km._ordered_alive = self._saved
+        super().tearDown()
+
+    def _ready(self):
+        km.Handler._dispatch_ws(self.handler, {"type": "ready"}, self.client)
+        return next(m for m in reversed(self.sent) if m["type"] == "caps")
+
+    def test_a_blob_less_connect_push_names_the_stores_seq_and_the_pushers_next_frame_carries_it(self):
+        import tempfile as _tf
+        from pathlib import Path as _P
+        s0 = self.seed()["seq"]
+        self.handler._push_one = lambda c: km._send_client(c, ("working",), {"type": "working", "names": []})
+        n = len(self.sent)                                             # the seed's own ack sits before this
+        with contextlib.redirect_stderr(io.StringIO()):
+            caps = self._ready()
+        self.assertEqual([m for m in self.sent[n:] if km._views_seq_of(m) is not None], [],
+                         "no frame of the connect push carried a views blob, and the handler's own frame was not built")
+        self.assertEqual(caps["viewsSeq"], s0, "the store's current seq: the one the next push serves")
+        # the pusher's next tabOrder carries the store's blob under that very seq, which the client's gate
+        # adopts because the caps frame named it (the real pusher, through the test_tab_meta_push.py stubs)
+        tmp = _tf.mkdtemp()
+        names = _P(tmp) / "names"
+        names.mkdir()
+        (names / SID1).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        saved = (km.NAMES, km._mark_views_dirty, km._chat_tab_sessions, km._cached_feed, km._ordered_alive)
+        try:
+            km.NAMES = names
+            km._mark_views_dirty = lambda: None
+            km._chat_tab_sessions = lambda now, tmux: [{"sid": SID1, "name": "web", "path": os.path.join(tmp, "none.jsonl"),
+                                                         "anchor": SID1}]
+            km._cached_feed = lambda *a, **k: None
+            km._ordered_alive = self._saved[1]
+            self.client["app"] = "chat"
+            self.client["sent"] = {}
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._push([self.client])
+        finally:
+            (km.NAMES, km._mark_views_dirty, km._chat_tab_sessions, km._cached_feed, km._ordered_alive) = saved
+        tab = [m for m in self.sent if m["type"] == "tabOrder"]
+        self.assertEqual(len(tab), 1)
+        self.assertEqual(tab[0]["views"]["seq"], s0)
+        self.assertEqual([m["type"] for m in self.sent if m["type"] == "caps"], ["caps"], "no second caps frame: none is needed")
+
+    def test_a_write_between_a_blob_less_push_and_the_caps_frame_moves_what_the_caps_names(self):
+        """With no blob served there is no served blob to name: the caps frame names the store as of the
+        caps frame — the post-write seq, which is what the next push carries (Capability pins the
+        served-blob case, where a write after the last served frame is NOT what the caps names)."""
+        s0 = self.seed()["seq"]
+
+        def push(c):
+            km._send_client(c, ("working",), {"type": "working", "names": []})
+            self.assertIsNone(km._edit_tag(tid="gA", add=[SID2])[1])
+        self.handler._push_one = push
+        caps = self._ready()
+        s1 = km._views_client()["seq"]
+        self.assertGreater(s1, s0, "the write moved the store on")
+        self.assertEqual(caps["viewsSeq"], s1)
+
+    def test_a_restored_older_store_after_a_restart_is_what_the_caps_names(self):
+        """The failure's shape end to end on the kernel side: the page holds a seq from before the restore,
+        the restarted kernel (a cold cache, no floor) serves the restored file under its old seq, the
+        connect push carries no blob — and the caps frame names that old seq, which the next pusher frame
+        carries, so the client's rule (adopt a later frame whose seq equals viewsSeq even below the held
+        one) has the event it needs."""
+        s_page = self.seed()["seq"]
+        p = km._views_path()
+        older = json.loads(p.read_text())
+        older["seq"] = s_page - 1000
+        p.write_text(json.dumps(older))
+        km._flags_cache.clear()
+        km._VIEWS_SEQ_FLOOR.clear()                                    # a fresh process: nothing served, no floor
+        self.assertEqual(km._timeline_views()["seq"], s_page - 1000, "served under its old seq, no re-stamp")
+        self.handler._push_one = lambda c: km._send_client(c, ("working",), {"type": "working", "names": []})
+        caps = self._ready()
+        self.assertEqual(caps["viewsSeq"], s_page - 1000)
+        self.assertEqual(self.notices, [])
+
+
+class WebBootWiring(unittest.TestCase):
+    """The kernel-served timeline page: the inline _TIMELINE_BOOT twin of timeline-boot.ts exposes
+    the targeted-edit bridge and routes both acks to the panel (timeline-boot.test.ts pins the two
+    bridge sets equal)."""
+
+    def test_the_bridge_and_the_ack_dispatch(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('window.__rompTimelineTagEdit=function(writeId,edit){post({type:"tagEdit",writeId:writeId,edit:edit});};', src)
+        self.assertIn('window.__rompTimelineSetViews=function(views,writeId,edited){post({type:"setTimelineViews",views:views,writeId:writeId,edited:edited||[]});};', src)
+        self.assertIn('else if((m.type==="tagEditAck"||m.type==="viewsAck")&&panel.viewsAck)panel.viewsAck(m);', src)
+
+
+if __name__ == "__main__":
+    raise SystemExit("run under pytest: ~/.venvs/romptest/bin/python -m pytest %s -q -p no:cacheprovider" % __file__)

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -141,9 +141,12 @@ class TagRoute(unittest.TestCase):
         self.assertEqual(v["tags"], [], "a refused edit writes nothing — no member no session matches")
 
     def test_two_same_named_tags_refuse_any_edit(self):
-        km._set_timeline_views({"active": "all", "hidden": [], "tags": [
+        # a store ALREADY holding twins, written to the file: since the 2026-09-05 review
+        # the write door refuses a second tag under a taken name, so twins come only from an older
+        # kernel's store (or a hand edit)
+        km._atomic_write(km._views_path(), json.dumps({"active": "all", "tags": [
             {"id": "g1", "name": "dup", "color": "", "members": []},
-            {"id": "g2", "name": "dup", "color": "", "members": []}]})
+            {"id": "g2", "name": "dup", "color": "", "members": []}]}))
         km._flags_cache.clear()
         st, r = self._post({"name": "dup", "add": ["web"]})
         self.assertFalse(r.get("ok"))

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -63,6 +63,25 @@ class TagOrderRoundTrip(unittest.TestCase):
         n = km._norm_timeline_views({"tags": [G1], "tagOrder": "pool"})
         self.assertNotIn("tagOrder", n, "a wrong-typed order drops whole, never raises")
 
+    def test_lens_and_order_entries_read_on_the_stored_name_basis(self):
+        """The 2026-09-05 review: tag rows were clamped AND stripped while lens
+        and order entries were only clamped, so a store that already held a padded twin ("web "
+        beside "web") read both rows as "web" on its first post-upgrade read while its lens and
+        order still said "web " — the surface filtered to it showed no session, the tag fell to the
+        end of the order. One basis everywhere: cap, then strip; empty after the strip drops."""
+        padded = {"id": "g2", "name": "web ", "color": "", "members": ["s1"]}
+        n = km._norm_timeline_views({"tags": [padded], "tagOrder": ["web ", " pool", "   "],
+                                     "actives": {"timeline": {"tags": ["web "]}, "chat": {"tags": ["  "]},
+                                                 "outline": {"tags": ["x" * 60 + "  "]}}})
+        self.assertEqual(n["tags"][0]["name"], "web")
+        self.assertEqual(n["tagOrder"], ["web", "pool"], "order entries strip like the rows; blanks drop")
+        self.assertEqual(n["actives"]["timeline"], {"tags": ["web"]}, "the lens names the stored tag again")
+        self.assertEqual(n["actives"]["chat"], {"all": True}, "a lens of blanks is no selection: All")
+        self.assertEqual(n["actives"]["outline"], {"tags": ["x" * km._VIEWS_MAX_NAME]}, "cap first, then strip — the row's own order")
+        rendered = {"tags": [{"id": "g2", "name": "web", "members": ["s1"]}]}       # the client shape _lens_visible reads
+        self.assertTrue(km._lens_visible(rendered, n["actives"]["timeline"], "s1"),
+                        "the padded lens admits the tag's member: the two spellings are one name")
+
 
 class TimelineViews(unittest.TestCase):
     def setUp(self):
@@ -175,7 +194,17 @@ class TimelineViews(unittest.TestCase):
         raw = {"active": "all", "hidden": ["s7", "s8"], "tags": [{"id": "g1", "name": "pool", "members": ["s2"]}]}
         (jd.STATE / "timeline-views.json").write_text(json.dumps(raw))
         km._flags_cache.clear()
-        v = km._timeline_views()
+        # ONE write (the 2026-09-05 review): the migration used to persist through the
+        # setter, whose own read of the previous blob found the same un-migrated file and re-entered
+        # the migration — 321 nested writes for one read, ending only at the recursion limit
+        writes = []
+        real = km._atomic_write
+        km._atomic_write = lambda path, text, mode=None: (writes.append(1), real(path, text, mode))[1]
+        try:
+            v = km._timeline_views()
+        finally:
+            km._atomic_write = real
+        self.assertEqual(len(writes), 1, "the migration is one write")
         self.assertNotIn("hidden", v)
         arch = next(t for t in v["tags"] if t["name"] == "archived")
         self.assertEqual(arch["members"], [{"host": "", "sid": "s7"}, {"host": "", "sid": "s8"}])
@@ -195,6 +224,29 @@ class TimelineViews(unittest.TestCase):
         km._flags_cache.clear()
         self.assertEqual(km._timeline_views()["tags"], [], "minted only when hidden entries exist")
 
+    def test_a_padded_archived_tag_is_found_on_the_stored_basis_so_the_hidden_entries_migrate_into_it(self):
+        # the 2026-09-05 review: the lookup compared the file's RAW spelling, so a legacy
+        # store holding "archived " (a padded twin from before the name basis) missed it, a second
+        # archived tag was minted, the door's collision pass refused that one, and the hidden entries
+        # migrated into nothing — the hide intent lost under a "name collision" notice
+        raw = {"active": "all", "hidden": ["s7"], "tags": [{"id": "g9", "name": "archived ", "color": "#123456", "members": []}]}
+        (jd.STATE / "timeline-views.json").write_text(json.dumps(raw))
+        km._flags_cache.clear()
+        notices = []
+        saved = km._sync_notice
+        km._sync_notice = lambda text, ok=True: notices.append((text, ok))
+        try:
+            v = km._timeline_views()
+        finally:
+            km._sync_notice = saved
+        self.assertEqual([(t["id"], t["name"]) for t in v["tags"]], [("g9", "archived")],
+                         "one archived tag, the file's own, read on the stored basis")
+        self.assertEqual(v["tags"][0]["members"], [{"host": "", "sid": "s7"}], "the hidden entry migrated into it")
+        self.assertEqual(notices, [], "a migration that fits is a stamp, not a refusal")
+        on_disk = json.loads((jd.STATE / "timeline-views.json").read_text())
+        self.assertNotIn("hidden", on_disk)
+        self.assertEqual(len(on_disk["tags"]), 1)
+
     def test_ws_op_persists_via_normalizer(self):
         # the handler body is _set_timeline_views + _mark_views_dirty; pin the setter's normalization
         km._set_timeline_views({"active": "g9", "hidden": ["x"], "tags": []})
@@ -202,7 +254,7 @@ class TimelineViews(unittest.TestCase):
         self.assertEqual(v["active"], "all")
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('msg.get("type") == "setTimelineViews"', src)
-        self.assertIn('_set_timeline_views(msg["views"])', src)
+        self.assertIn('_set_timeline_views(msg["views"], edited=edited)', src, "the door passes the edited ids down: the setter files its notice by the ack's rule")
 
     def test_payloads_echo_the_views_blob(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
@@ -213,8 +265,10 @@ class TimelineViews(unittest.TestCase):
 
     def test_web_boot_exposes_the_set_views_hook(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("window.__rompTimelineSetViews=function(views)", src)
-        self.assertIn('post({type:"setTimelineViews",views:views});', src)
+        # the hook carries the write's id since 2026-09-05, so the kernel's viewsAck can name it, and the
+        # tag ids the write changed (`edited`), so a refusal on an untouched tag is acked ok
+        self.assertIn("window.__rompTimelineSetViews=function(views,writeId,edited)", src)
+        self.assertIn('post({type:"setTimelineViews",views:views,writeId:writeId,edited:edited||[]});', src)
 
     # ── tag federation v0 (the user 2026-08-24): canonical pairs, the rendered union, remote views ──
 
@@ -295,6 +349,95 @@ class TimelineViews(unittest.TestCase):
             self.assertEqual(ids, ["alpha:g1", "beta:g1"], "host-disambiguated — never a silent merge")
         finally:
             km._remotes.clear(); km._remotes.update(saved)
+
+    def test_a_padded_remote_name_renders_on_the_stored_basis_so_a_lens_can_pick_it(self):
+        """The 2026-09-05 review: the review put every lens and order entry on the stored name
+        basis (cap, then strip) while a REMOTE tag's name still rendered clamped only — so a remote
+        kernel on an older build (or a padded remote store) serving "web " rendered "web ", the lens
+        that picked it stored "web", and _lens_visible (exact equality, mirrored by tag-lens.ts)
+        admitted none of its members: the surface filtered to that tag showed no session, silently."""
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("peer", {"tags": [
+                {"id": "r1", "name": "web ", "color": "", "members": [{"host": "", "sid": "s9"}]},
+                {"id": "r2", "name": "x" * 60 + "  ", "color": "", "members": []},
+                {"id": "r3", "name": "   ", "color": "", "members": []}]})
+            km._set_timeline_views({"active": "all",
+                                    "tags": [{"id": "gL", "name": "api", "color": "", "members": ["s1"]}],
+                                    "actives": {"timeline": {"tags": ["web "]}}, "tagOrder": ["web ", "api"]})
+            km._flags_cache.clear()
+            v = km._views_client()
+            self.assertEqual([t["name"] for t in v["remoteTags"]], ["web", "x" * km._VIEWS_MAX_NAME, "tag"],
+                             "cap, then strip — the rows' own basis; empty after the strip is the default name")
+            self.assertEqual(v["actives"]["timeline"], {"tags": ["web"]})
+            self.assertTrue(km._view_visible(v, "peer:s9", "timeline"),
+                            "the lens stored as \"web\" admits the remote tag's member")
+            self.assertFalse(km._view_visible(v, "s1", "timeline"), "…and only it")
+            self.assertEqual(v["tagOrder"], ["web", "api"], "the order entry ranks the rendered remote name")
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+    def test_the_union_joins_a_padded_remote_twin_to_the_local_tag(self):
+        saved = dict(km._remotes)
+        try:
+            km._remotes.clear()
+            self._attach("peer", {"tags": [{"id": "r1", "name": "web ", "color": "",
+                                            "members": [{"host": "", "sid": "s9"}]}]})
+            km._set_timeline_views({"active": "all",
+                                    "tags": [{"id": "gL", "name": "web", "color": "", "members": ["local1"]}]})
+            km._flags_cache.clear()
+            v = km._views_client()
+            v["active"] = "gL"
+            self.assertTrue(km._view_visible(v, "peer:s9"),
+                            "a tag is its name: the padded remote twin joins the local tag's view")
+            v["active"] = "peer:r1"
+            self.assertTrue(km._view_visible(v, "local1"), "…from either id")
+            self.assertTrue(km._lens_visible(v, {"tags": ["web"]}, "peer:s9"))
+            self.assertFalse(km._lens_visible(v, {"none": True}, "peer:s9"), "its member is tagged, so not untagged")
+        finally:
+            km._remotes.clear(); km._remotes.update(saved)
+
+    def test_a_pending_edit_on_a_padded_remote_name_is_captured_joined_and_applied_on_the_basis(self):
+        """The pending-edit journal (tag federation v2) matched a row's name to the host's raw tag name
+        at capture and at late-apply, and joined it to the rendered row for the `pending` badge —
+        every one of those is on the stored basis now, so a padded remote name is one name there too."""
+        saved = dict(km._remotes)
+        seams = (km._poll_remote_views, km._remote_forward)
+
+        def fresh_journal():
+            try:
+                km._pending_tag_path().unlink()
+            except OSError:
+                pass
+            with km._PENDING_TAG_LOCK:
+                km._PENDING_TAG_CACHE["rows"] = None
+        fresh_journal()
+        try:
+            km._remotes.clear()
+            r = {"host": "peer", "status": "up", "local_port": 1, "token": "",
+                 "views": {"tags": [{"id": "r1", "name": "web ", "color": "", "members": []}]}}
+            km._remotes["peer"] = r
+            self.assertTrue(km._queue_pending_tag_edit("peer", {"name": " web", "delete": True}),
+                            "the user's spelling, padded differently again")
+            row = km._pending_tag_rows()[-1]
+            self.assertEqual((row["name"], row["tagId"]), ("web", "r1"),
+                             "journaled on the basis, with the cached tag's id")
+            v = km._views_client()
+            self.assertEqual(v["remoteTags"][0].get("pending"), "delete", "the badge joins the rendered row")
+            self.assertEqual(v["pendingTagEdits"], [{"host": "peer", "name": "web", "op": "delete"}])
+            forwarded = []
+            km._poll_remote_views = lambda r: {"tags": [{"id": "r1", "name": "web ", "color": "", "members": []}]}
+            km._remote_forward = lambda r, path, body: (forwarded.append((path, body))
+                                                        or {"ok": True, "deleted": True})
+            self.assertEqual(km._apply_pending_tag_edits(r), 1, "the late apply finds the padded tag by its basis")
+            self.assertEqual(forwarded, [("/tag", {"name": "web ", "delete": True})],
+                             "…and addresses the host in its own spelling, which its door strips")
+            self.assertEqual(km._pending_tag_rows(), [])
+        finally:
+            km._poll_remote_views, km._remote_forward = seams
+            km._remotes.clear(); km._remotes.update(saved)
+            fresh_journal()
 
     def test_a_down_kernels_CACHE_keeps_contributing_and_active_hidden_stay_local(self):
         # REVERSED from v0 (the user 2026-08-24, the untagged-view bug): visibility must not flap

--- a/tests/test_views_stale_writer.py
+++ b/tests/test_views_stale_writer.py
@@ -113,17 +113,29 @@ class StaleWriterGuard(unittest.TestCase):
         self.assertEqual(km._timeline_views()["tags"], [])
         self.assertEqual(len(self.notices), 0)
 
-    def test_an_mtime_less_legacy_tag_keeps_last_writer_wins(self):
-        # a tag never touched since before the mtime feature has no stamp — the guard cannot
-        # prove staleness, so the legacy behavior stands for it (any future edit stamps it)
+    def test_a_legacy_tag_is_stamped_on_its_first_read_so_an_evidence_less_writer_stands_down(self):
+        # a tag never touched since before the mtime feature has no stamp in the FILE; the first
+        # read gives it one (the 2026-09-05 review — so the foreign-file rule can tell it
+        # from a client's own create), and from then on the guard judges it like any other tag: a
+        # blob with no evidence at all (no `at`, no mtimes) cannot de-member it, loudly, while a
+        # copy echoing the served `at` can. Before this change the file's tag stayed unstamped and the
+        # legacy last-writer-wins stood for it.
         km._atomic_write(km._views_path(), json.dumps(
             {"active": "all", "tags": [{"id": "gL", "name": "legacy", "color": "",
                                         "members": [{"host": "", "sid": "s1"}]}]}))
         km._flags_cache.clear()
+        served = km._timeline_views()
+        self.assertTrue(served["tags"][0].get("mtime"), "stamped on the first read")
         km._set_timeline_views({"active": "all", "tags": [
             {"id": "gL", "name": "legacy", "color": "", "members": []}]})
         km._flags_cache.clear()
-        self.assertEqual(km._timeline_views()["tags"][0]["members"], [])
+        self.assertEqual(len(km._timeline_views()["tags"][0]["members"]), 1, "no evidence, no de-membering")
+        self.assertTrue(self.notices and not self.notices[0][1], "…and the refusal is loud")
+        fresh = json.loads(json.dumps(km._timeline_views()))
+        fresh["tags"][0]["members"] = []
+        km._set_timeline_views(fresh)
+        km._flags_cache.clear()
+        self.assertEqual(km._timeline_views()["tags"][0]["members"], [], "an informed removal lands")
 
     def test_the_at_stamp_is_served_and_survives_the_normalizer(self):
         self._seed()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -39,6 +39,129 @@ function _rompOnlyTag() {
 // record; this is its mirror for the lanes. The kernel emits `tags`; `groups` is honored as the
 // pre-rename key an un-updated kernel still pushes, in ONE place so every rule reads through it.
 function viewTags(views) { return (views && (views.tags || views.groups)) || []; }
+// the views blob's write sequence (the kernel stamps one per accepted write, 2026-09-05), or null for a
+// blob from a kernel that does not — and whether an incoming blob may replace the held one: yes when
+// its seq is at least the held seq, or when either side carries none, or when its seq is the one the
+// kernel ANNOUNCED as its current store at connect (`announced`, the slot setCaps fills; a blob
+// carrying it IS that store, not a stale frame, however far below the held seq). The hand-mirror of
+// views-writes.ts seqOf/adoptViews (this file cannot import TS; timeline-views-ack.test.ts pins them).
+function viewsSeq(v) { const s = v && v.seq; return (typeof s === 'number' && isFinite(s)) ? s : null; }
+// a union's stable key for the dialog's open rename editor: its first tag id (the local tag's when one
+// exists — the id a create's ack hands back), else its name (a remote-only union). An id survives the
+// rename the editor exists to make; the name it replaced would not.
+function unionKey(g) { return (g && g.ids && g.ids[0]) || (g && g.name) || ''; }
+function viewsAdopts(held, incoming, announced) {
+  if (!incoming) return false;
+  const h = viewsSeq(held), i = viewsSeq(incoming);
+  return h === null || i === null || i >= h || (typeof announced === 'number' && i === announced);
+}
+// whether the kernel's `caps` frame, the reconnect event, adopts the blob the gate last REJECTED since
+// its last adoption — the hand-mirror of views-writes.ts capsAdopts (the 2026-09-05
+// review). The connect push precedes the caps frame and `served` is the frame's viewsSeq, the seq of the
+// views blob that push put on this socket (null when it carried none; undefined on a frame from a kernel
+// before the field). A push a restarted kernel served under an OLDER seq (a store restored while it was
+// down; its seq floor lives for its process) was turned away a frame ago and is the kept blob: its seq
+// matches, it is adopted. A pusher-thread frame built before a concurrent write and kept because it
+// arrived between the push and the caps frame carries an older seq: no match, discarded, the gate stands.
+// A frame without the field adopts the kept blob outright (the pre-field rule).
+function viewsCapsAdopts(rejected, served) {
+  if (!rejected) return false;
+  if (served === undefined) return true;
+  return typeof served === 'number' && isFinite(served) && viewsSeq(rejected) === served;
+}
+// the seq a caps frame ANNOUNCES as the kernel's current store, remembered when the frame adopted no kept
+// blob — the hand-mirror of views-writes.ts announcedSeq (the 2026-09-05 review): its viewsSeq
+// when a number (the served blob's seq, or the store's current seq when the push carried no views frame),
+// null when null (no store at all) or absent (a kernel from before the field). Kept in one slot per store
+// (_announcedViewsSeq), overwritten by each caps frame and cleared by the next adoption that changes the
+// held blob (viewsAnnouncedAfter); a LATER blob at exactly that seq is adopted below the held one (_takeViews). Without it, a restart over a store restored
+// from an older copy, met by a reconnect whose push carried no blob, left nothing kept for the caps frame
+// to match: the pusher's next frame was turned away and no second caps frame comes.
+function viewsAnnouncedSeq(served) { return (typeof served === 'number' && isFinite(served)) ? served : null; }
+// the slot AFTER an adoption — the hand-mirror of views-writes.ts announcedAfter (the review):
+// cleared only by an adoption that CHANGES the held blob (a seq other than the held one — a newer write, or
+// the announced seq itself below it — a seq-less side, or the announced seq arriving at the held seq), and
+// left standing through a re-arrival of the blob already held, which is no new information. The federation
+// router replays its stored blob into the merged lanes payload on every re-emit (a remote host's lanes, a
+// view-order storage event, a host drop); the earlier clear on any adoption let such a re-emit, landing between
+// the caps frame and the pusher's next frame, spend the slot, and the restored store the router then adopted
+// and re-emitted at the announced seq was turned away here: router and pane silently diverged until the next
+// write.
+function viewsAnnouncedAfter(held, incoming, announced) {
+  if (typeof announced !== 'number') return null;
+  const h = viewsSeq(held), i = viewsSeq(incoming);
+  return (i !== null && i === h && i !== announced) ? announced : null;
+}
+// The hand-mirror of views-writes.ts applyTagEdit / rederiveViews (the 2026-09-05
+// review): one targeted op applied to a blob's LOCAL tags the way the gesture applied it (a copy;
+// an unknown tid is a no-op — the kernel refuses it), and the optimistic copy rebuilt from the base
+// plus the writes still in flight, oldest first — a whole-blob write IS the state it posted, a
+// targeted op applies on top — so a refusal of ONE write reverts only that write's change. Null
+// when nothing is in flight: the base itself is what shows.
+function applyTagEditOp(v, edit, newId) {
+  const nv = JSON.parse(JSON.stringify(v || {}));
+  const tags = viewTags(nv).slice(); delete nv.groups;
+  const byId = (tid) => tags.find((t) => t.id === tid);
+  const sids = (edit.sids || []).concat(edit.sid ? [edit.sid] : []);
+  let t;
+  switch (edit.op) {
+    case 'create': tags.push({ id: newId || 'pending-' + Date.now().toString(36), name: edit.name || '', color: edit.color || '', members: sids.slice() }); break;
+    case 'rename': t = byId(edit.tid); if (t && edit.newName) t.name = edit.newName; break;
+    case 'recolor': t = byId(edit.tid); if (t && edit.color) t.color = edit.color; break;
+    case 'delete': { const i = tags.findIndex((x) => x.id === edit.tid); if (i >= 0) tags.splice(i, 1); if (nv.active === edit.tid) nv.active = 'all'; break; }
+    case 'addMember': t = byId(edit.tid); if (t) t.members = Array.from(new Set((t.members || []).concat(sids))); break;
+    case 'removeMember': t = byId(edit.tid); if (t) t.members = (t.members || []).filter((m) => sids.indexOf(m) < 0); break;
+    case 'move': {
+      const from = byId(edit.tid_from), to = byId(edit.tid_to);
+      if (from) from.members = (from.members || []).filter((m) => sids.indexOf(m) < 0);
+      if (to) to.members = Array.from(new Set((to.members || []).concat(sids)));
+      break;
+    }
+  }
+  nv.tags = tags;
+  return nv;
+}
+function rederiveViews(base, writes) {
+  if (!writes || !writes.length) return null;
+  let p = JSON.parse(JSON.stringify(base || { active: 'all', tags: [] }));
+  for (const w of writes) {
+    if (w.lens) p = applyLensFields(p, w.lens);
+    else if (w.blob) p = JSON.parse(JSON.stringify(w.blob));
+    else if (w.edit) p = applyTagEditOp(p, w.edit, w.newId);
+  }
+  return p;
+}
+// The placeholder id an optimistic create's row wears until the kernel's ack names the real one
+// (views-writes.ts isPlaceholderId): such a row takes no gesture — an op addressed by it is
+// refused as a tag that does not exist (the 2026-09-05 review).
+function isPendingTagId(id) { return typeof id === 'string' && /^pending-/.test(id); }
+// A lens or order write's own content — {active?, actives?, tagOrder?} — applied to a blob (a copy),
+// and the blob such a write POSTS: the STORE's blob (the last one adopted, never the pending copy)
+// with the fields set, the tags array re-sorted to a given order — the pill-drag contract that the
+// stored array reads in the dragged order too: over the socket the kernel's door orders the stored
+// array by the write's tagOrder itself; on the Electron path, where the posted blob IS the file,
+// this re-sort does it. The
+// hand-mirrors of views-writes.ts applyLensFields / lensBlob (the 2026-09-05 review: a
+// whole-blob write built from the pending copy carried every targeted edit still in flight as this
+// page's claim on those tags, and a rename the kernel had refused landed through a lens toggle).
+function applyLensFields(v, fields) {
+  const nv = JSON.parse(JSON.stringify(v || { active: 'all', tags: [] }));
+  nv.tags = viewTags(nv).slice(); delete nv.groups;
+  if (fields.active !== undefined) nv.active = fields.active;
+  if (fields.actives !== undefined) nv.actives = JSON.parse(JSON.stringify(fields.actives));
+  if (fields.tagOrder !== undefined) nv.tagOrder = fields.tagOrder.slice();
+  return nv;
+}
+function lensBlob(base, fields) {
+  const v = applyLensFields(base, fields);
+  if (fields.tagOrder) {
+    const pos = Object.create(null);           // null-prototype (the prototype-key name hazard)
+    fields.tagOrder.forEach((n, i) => { if (!(n in pos)) pos[n] = i; });
+    const n = fields.tagOrder.length;
+    v.tags = v.tags.slice().sort((a, b) => ((a.name in pos) ? pos[a.name] : n) - ((b.name in pos) ? pos[b.name] : n));
+  }
+  return v;
+}
 // A tag IS its NAME, everywhere (user ruling 2026-08-24: "if the UX requires understanding that
 // tags exist across different kernels, it is not good"): one name = one identity, membership the
 // UNION across every kernel defining that name, the LOCAL store's color winning the render. The
@@ -53,7 +176,9 @@ function viewTagUnion(views) {
   for (const t of viewTags(views)) {
     const g = byName[t.name] || (byName[t.name] = { name: t.name || 'tag', color: '', members: [],
                                                     ids: [], localId: null, homes: [], remotes: [] });
-    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; }
+    // `pending`: the local tag is a create still in flight (its placeholder id) — the union renders
+    // and takes no gesture until the ack (isPendingTagId); every action builder checks it
+    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; if (isPendingTagId(t.id)) g.pending = true; }
     g.ids.push(t.id);
     for (const m of (t.members || [])) if (g.members.indexOf(m) < 0) g.members.push(m);
     if (out.indexOf(g) < 0) out.push(g);
@@ -872,10 +997,15 @@ class TimelinePanel {
     this._laneMenuBuild = null;  // the last-opened lane gear's rebuild-in-place, so a refusal arriving while it is open repaints it (like _viewsDialogBuild; every use is gated on _laneMenu being open)
     this._dismissed = new Set(); // sids cleared via the dead-lane Clear pill, held STICKY the same way (see _reconcileDismissed)
     this._views = null;          // the kernel-echoed views blob (data.views); null until the first push
-    this._pendingViews = null;   // an optimistic edit held sticky until a push echoes it (see _reconcileViews)
+    this._rejectedViews = null;  // the last blob the seq gate turned away since it last adopted one — what the caps frame adopts (setCaps)
+    this._announcedViewsSeq = null; // the seq the last caps frame announced as the kernel's current store when it adopted no kept blob — a LATER blob at exactly that seq is adopted below the held one (_takeViews); cleared by the next adoption that changes the held blob (viewsAnnouncedAfter)
+    this._pendingViews = null;   // an optimistic edit held until the kernel ACKS the write (viewsAck) or echoes it exactly (_reconcileViews)
+    this._viewsWrites = [];      // the writes in flight, oldest first: {id, name, tid, op, openRename} — the pending copy clears when the LAST one is acked
+    this._viewsWriteSeq = 0;     // writeId mint — a per-page counter beside the ms stamp, so two same-ms gestures never share one
+    this._legacyViewsAge = 0;    // LEGACY kernels only (no `seq`, no acks): frames since the write — the old three-frame yield (_reconcileViews)
+    this._caps = new Set();      // what the LOCAL kernel announced at `ready` ({type:"caps"}); 'tagEdit' = targeted ops, acks, seq (setCaps)
     this._pendingTagEdits = {};  // remote-tag edits held optimistically until the owner's poll echoes (federation v1): id → {tag: shape|null(=deleted), age}
-    this._tagEditErr = null;     // the LOUD failure of the last remote-tag edit ({host, name, error}), shown in the dialog until dismissed
-    this._pendingViewsAge = 0;   // pushes since the edit — the kernel is authoritative, so a stale pending yields
+    this._tagEditErr = null;     // the LOUD failure of the last tag edit ({host, name, error}), shown in the dialog until dismissed
     this._viewsMenu = null;      // the Show-dropdown element, when open
     this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
     this._viewsDialogKey = null; // its Escape hook {doc, fn}, removed on every close path
@@ -1860,7 +1990,7 @@ class TimelinePanel {
     }
     this.data = data;
     if (data.cmapGrad) this._cmapGrad = data.cmapGrad;   // compaction-sweep colormap gradient (persists across the lighter {type:bars} pushes)
-    if (data.views) this._views = data.views;            // the views blob rides every push (skeleton included)
+    if (data.views) this._takeViews(data.views);         // the views blob rides every push (skeleton included) — adopted in store order, never wire order
     if (Array.isArray(data.palette) && data.palette.length) this._palette = data.palette;
     this._reconcilePendingFlags();   // hold an optimistic eye-toggle sticky until THIS push (or a later one) confirms it
     this._reconcileDismissed();      // ...and a Cleared dead lane, so a stale/merged push can't pop it back
@@ -2858,7 +2988,13 @@ class TimelinePanel {
     this._metaMenu = menu;
   }
 
-  _closeLaneMenu() { if (this._laneMenu) { this._laneMenu.remove(); this._laneMenu = null; } }
+  // closing a surface that held the join menu drops its new-tag draft (the 2026-09-05
+  // review: the draft outlived the menu and reappeared in the next one opened for the same rows)
+  _closeLaneMenu() {
+    if (!this._laneMenu) return;
+    this._laneMenu.remove(); this._laneMenu = null;
+    this._tagNewDraft = null; this._tagNewInput = null;
+  }
 
   // The per-lane settings drop-down is BACK (the user 2026-07-28, superseding their 2026-06-22 removal:
   // that rule held for ONE flag, where a direct icon beat a menu — at THREE flags the icons crowded the
@@ -2956,7 +3092,7 @@ class TimelinePanel {
     for (const id of Object.keys(this._pendingTagEdits || {}))
       if (id.split(':')[0] === m.host) delete this._pendingTagEdits[id];   // edits are name-addressed per host — revert them all
     this._tagEditErr = { host: m.host || '', name: m.name || '', error: m.error || 'refused' };
-    if (this._viewsDialog && this._viewsDialogBuild) this._viewsDialogBuild();
+    this._repaintTagSurfaces();
     this.draw();
   }
 
@@ -2996,14 +3132,27 @@ class TimelinePanel {
   // One union group = one tag identity. Edits stay routed under the hood: an ADD lands on the LOCAL
   // store when the name exists locally, else the tag's single home; a REMOVE removes the
   // (name, member) pair from EVERY store holding it — a removal never half-works; rename/recolor/
-  // delete fan out to every home the same way. Local writes post the whole blob (unchanged);
-  // remote writes ride _editRemoteTag (optimistic overlay + loud tagEditFailed, federation v1).
+  // delete fan out to every home the same way. Local writes are TARGETED ops addressed by the local
+  // tag's stored id (_postTagEdit — the user 2026-09-05: posting the whole blob from the un-echoed
+  // copy made the kernel judge a create-then-rename burst stale against this dialog's own first
+  // write, and the renames and assignments were lost; by NAME, a recolor queued behind a refused
+  // rename went looking for the name the rename would have given the tag and found the other tag
+  // that already had it); remote writes ride _editRemoteTag (optimistic overlay + loud
+  // tagEditFailed, federation v1).
   _editTagUnion(g, edit) {
+    // a create still in flight has no id to address (its row wears the placeholder the ack
+    // replaces): the builders offer no gesture on it, and one that arrives anyway does nothing
+    // rather than posting a tid the kernel refuses as a tag that does not exist
+    if (g.pending) return;
+    const meta = { name: g.name, tid: g.localId };
     if (edit.add && edit.add.length) {
       if (g.localId) {
         const nv = JSON.parse(JSON.stringify(this._curViews()));
         const t = viewTags(nv).find((x) => x.id === g.localId);
-        if (t) { t.members = Array.from(new Set((t.members || []).concat(edit.add))); this._setViews(nv); }
+        if (t) {
+          t.members = Array.from(new Set((t.members || []).concat(edit.add)));
+          this._postTagEdit(nv, { op: 'addMember', tid: g.localId, sids: edit.add.slice() }, meta);
+        }
       } else if (g.remotes.length) this._editRemoteTag(g.remotes[0], { add: edit.add.slice() });
     }
     if (edit.remove && edit.remove.length) {
@@ -3012,7 +3161,7 @@ class TimelinePanel {
         const t = viewTags(nv).find((x) => x.id === g.localId);
         if (t && (t.members || []).some((m) => edit.remove.indexOf(m) >= 0)) {
           t.members = (t.members || []).filter((m) => edit.remove.indexOf(m) < 0);
-          this._setViews(nv);
+          this._postTagEdit(nv, { op: 'removeMember', tid: g.localId, sids: edit.remove.slice() }, meta);
         }
       }
       for (const rt of g.remotes)
@@ -3025,11 +3174,16 @@ class TimelinePanel {
         if (edit.delete) {
           nv.tags = viewTags(nv).filter((x) => x.id !== g.localId); delete nv.groups;
           if (nv.active === g.localId) nv.active = 'all';
+          this._postTagEdit(nv, { op: 'delete', tid: g.localId }, meta);
         } else {
           const t = viewTags(nv).find((x) => x.id === g.localId);
-          if (t) { if (edit.rename) t.name = edit.rename; if (edit.color) t.color = edit.color; }
+          if (t) {
+            // two ops when both arrive (the kernel applies them in order on one socket), each by
+            // the tag's id — a refused rename leaves the recolor addressing the SAME tag
+            if (edit.rename) { t.name = edit.rename; this._postTagEdit(nv, { op: 'rename', tid: g.localId, newName: edit.rename }, meta); }
+            if (edit.color) { t.color = edit.color; this._postTagEdit(nv, { op: 'recolor', tid: g.localId, color: edit.color }, meta); }
+          }
         }
-        this._setViews(nv);
       }
       for (const rt of g.remotes)
         this._editRemoteTag(rt, { rename: edit.rename, color: edit.color, delete: !!edit.delete });
@@ -3049,6 +3203,14 @@ class TimelinePanel {
       ch.addEventListener('mouseenter', () => { ch.style.background = HOVER_BG; });
       ch.addEventListener('mouseleave', () => { ch.style.background = 'transparent'; });
       ch.createSpan({ text: g.name });
+      if (g.pending) {
+        // a create still in flight: the chip shows, with no ✕ and no click, until the ack names the
+        // tag (the 2026-09-05 review) — the "creating…" the inputs read, in the tooltip
+        ch.style.cursor = 'default';
+        ch.setAttribute('title', 'creating "' + g.name + '"…');
+        ch.setAttribute('aria-disabled', 'true');
+        continue;
+      }
       const chx = ch.createSpan({ text: '✕' });
       chx.setAttribute('style', 'color:' + MODEL_FG + ';opacity:0.75;font-size:0.9em;');
       ch.setAttribute('title', 'tagged "' + g.name + '"'
@@ -3059,9 +3221,13 @@ class TimelinePanel {
   }
 
   // the join menu for one-or-many sessions: one option per union tag some rowId lacks, plus the
-  // new-tag input (a new tag mints LOCALLY, as always)
-  _tagJoinMenu(box, rowIds, rebuild) {
+  // new-tag input (a new tag mints LOCALLY, as always). `menuKey` is the menu's identity for the
+  // new-tag draft below: which [+] is open (this._tagAddFor — a sid, or '*' for the bulk bar),
+  // stable across repaints however the row set changes; callers that build the menu for other
+  // rows name their own.
+  _tagJoinMenu(box, rowIds, rebuild, menuKey) {
     for (const g of viewTagUnion(this._curViews())) {
+      if (g.pending) continue;   // a create still in flight cannot be joined yet: no id to address
       if (!rowIds.some((id) => g.members.indexOf(id) < 0)) continue;
       const tc = g.color || MENU_FG;
       const opt = box.createSpan({ text: g.name });
@@ -3070,48 +3236,260 @@ class TimelinePanel {
       opt.addEventListener('mouseenter', () => { opt.style.background = HOVER_BG; });
       opt.addEventListener('mouseleave', () => { opt.style.background = 'transparent'; });
       opt.addEventListener('click', () => {
-        this._tagAddFor = null;
+        this._tagAddFor = null; this._tagNewDraft = null;
         this._editTagUnion(g, { add: rowIds.filter((id) => g.members.indexOf(id) < 0) }); rebuild();
       });
     }
+    // The new-tag input's text and caret SURVIVE a repaint (the 2026-09-05 review — the
+    // rename draft did not cover it): an ack or refusal for some other write rebuilds the whole
+    // surface while the user is typing here. The draft is kept on the instance per MENU (the [+]
+    // that is open, not the rows it lists — before this change keyed by the row set, the bulk menu's draft
+    // hid whenever the search filter or a session's liveness changed the rows, and came back when
+    // they changed back); the live input is read before the rebuild tears it down, and the rebuilt
+    // input restores text and caret. Submitting, or closing the menu or the dialog, drops it.
+    const key = menuKey !== undefined ? String(menuKey) : String(this._tagAddFor);
+    const live = this._tagNewInput && this._tagNewInput.key === key ? this._tagNewInput.el : null;   // another row's input says nothing about this draft
+    if (live && this._tagNewDraft && this._tagNewDraft.key === key) {
+      this._tagNewDraft.value = live.value;
+      if (typeof live.selectionStart === 'number') { this._tagNewDraft.selStart = live.selectionStart; this._tagNewDraft.selEnd = live.selectionEnd; }
+    }
+    this._tagNewInput = null;
+    const draft = this._tagNewDraft && this._tagNewDraft.key === key ? this._tagNewDraft : null;
     const ni = document.createElement('input');
     ni.placeholder = 'new tag…'; ni.maxLength = 40;
     ni.setAttribute('style', 'width:90px;background:' + INPUT_BG + ';color:' + INPUT_FG + ';border:1px solid ' + HAIRLINE + ';'
       + 'border-radius:9px;padding:1px 7px;font:inherit;font-size:0.82em;');
+    if (draft) ni.value = draft.value;
+    // one create at a time: while one is in flight the input is disabled and says so; the ack's
+    // repaint re-arms it (a second Enter before the ack made a second tag)
+    if (this._createInFlight()) { ni.disabled = true; ni.placeholder = 'creating…'; }
+    ni.addEventListener('input', () => {
+      this._tagNewDraft = { key, value: ni.value, selStart: ni.selectionStart, selEnd: ni.selectionEnd };
+    });
     ni.addEventListener('keydown', (e) => {
-      if (e.key !== 'Enter' || !ni.value.trim()) return;
+      if (e.key !== 'Enter' || !ni.value.trim() || ni.disabled || this._createInFlight()) return;
       const nv = JSON.parse(JSON.stringify(this._curViews()));
       const used = new Set(viewTags(nv).map((t) => t.color));
       const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
-      nv.tags = viewTags(nv).concat([{ id: 'g' + Date.now().toString(36),
-        name: ni.value.trim().slice(0, 40), color, members: rowIds.slice() }]);
+      // the optimistic row wears a PLACEHOLDER id: the kernel mints the tag's id, and the ack's blob
+      // (which carries it) replaces this copy — no client-minted id can collide with a store it has
+      // not read (the legacy path re-ids it: _postTagEdit)
+      const tg = { id: 'pending-' + Date.now().toString(36), name: ni.value.trim().slice(0, 40), color, members: rowIds.slice() };
+      nv.tags = viewTags(nv).concat([tg]);
       delete nv.groups;
-      this._tagAddFor = null;
-      this._setViews(nv); rebuild();
+      this._tagAddFor = null; this._tagNewDraft = null; this._tagNewInput = null;
+      ni.disabled = true; ni.placeholder = 'creating…';
+      // ONE targeted create carrying the first members — the tag and its membership land together
+      this._postTagEdit(nv, { op: 'create', name: tg.name, color, sids: rowIds.slice() }, { name: tg.name, newId: tg.id }); rebuild();
     });
     box.appendChild(ni);
+    this._tagNewInput = { key, el: ni };   // the live input, read at the next repaint of the SAME menu for its text and caret
     ni.focus();
+    if (draft && typeof draft.selStart === 'number' && typeof draft.selEnd === 'number') {
+      try { ni.setSelectionRange(draft.selStart, draft.selEnd); } catch (e) {}
+    }
   }
 
+  // An arriving views blob (a frame's or an ack's) becomes the base only if its write sequence is at
+  // least the held one (the hand-mirror of views-writes.ts adoptViews, 2026-09-05): the pusher builds
+  // frames from a warmed cache that can predate a write whose ack already arrived, and federation
+  // re-emits stored blobs, so wire order decides nothing — the store's own order does. An ignored
+  // blob logs once per page, so a kernel serving stale frames is a visible fact. The last ignored blob
+  // is KEPT (and let go by the next adoption): a kernel restarted over a store restored from an older
+  // copy serves it under the old seq, so its connect push is turned away here — and the caps frame
+  // that follows it adopts it (setCaps; the 2026-09-05 review). When that push carried no
+  // blob to keep, the caps frame's viewsSeq is remembered instead (_announcedViewsSeq) and the later
+  // blob carrying exactly that seq is adopted below the held one (viewsAnnouncedSeq). The slot
+  // clears when an adoption CHANGES the held blob, never on a re-arrival of the blob already held — the
+  // federation router replays its stored blob into the merged lanes payload on every re-emit, and a slot
+  // spent on one of those missed the restored store the router adopted next (viewsAnnouncedAfter).
+  _takeViews(v) {
+    if (!v) return false;
+    if (viewsAdopts(this._views, v, this._announcedViewsSeq)) { this._announcedViewsSeq = viewsAnnouncedAfter(this._views, v, this._announcedViewsSeq); this._views = v; this._rejectedViews = null; return true; }
+    this._rejectedViews = v;
+    if (!this._staleViewsLogged) {
+      this._staleViewsLogged = true;
+      try { console.warn('romp timeline: ignored a views blob older than the one held (seq ' + viewsSeq(v) + ' < ' + viewsSeq(this._views) + ')'); } catch (e) {}
+    }
+    return false;
+  }
+
+  // LEGACY kernels only — a blob without a write sequence comes from a kernel that acks nothing, so
+  // the PRE-2026-09-05 reconciliation stays for that path alone: the write's own exact echo clears the
+  // copy, and three silent frames yield it (with no ack ever coming, an unechoed copy would otherwise
+  // pin forever). A kernel that stamps `seq` answers every write (viewsAck below), and the ack is the
+  // event that settles the copy: a frame, matching or not, says nothing about a write it cannot name —
+  // a net-zero burst (add, then remove) leaves frames equal to the copy while its writes are still in
+  // flight, so an exact match there cleared them early (the user 2026-09-05) — and a count of frames
+  // is not information: it dropped good edits and kept refused ones alike.
   _reconcileViews() {
     if (!this._pendingViews) return;
-    if (this._views && this._viewsKey(this._views) === this._viewsKey(this._pendingViews)) {
-      this._pendingViews = null; this._pendingViewsAge = 0; return;
+    if (this._views && viewsSeq(this._views) === null
+        && (this._viewsKey(this._views) === this._viewsKey(this._pendingViews)
+            || (this._legacyViewsAge = (this._legacyViewsAge || 0) + 1) >= 3)) {
+      this._pendingViews = null; this._viewsWrites = []; this._legacyViewsAge = 0;
     }
-    // the kernel is authoritative: if three pushes came back without echoing the edit (it normalized
-    // differently, or another dashboard overwrote it), adopt the kernel's blob rather than pinning
-    // a stale optimistic view forever
-    if (++this._pendingViewsAge >= 3) { this._pendingViews = null; this._pendingViewsAge = 0; }
   }
 
-  // Persist the whole views blob. Web/VS Code: the host WS hook (→ kernel setTimelineViews, which
-  // normalizes + rebroadcasts). Obsidian/headless fallback: write the same timeline-views.json the
-  // kernel reads (it re-normalizes on read). Optimistic + sticky, like the lane flags.
-  _setViews(v) {
-    this._pendingViews = v; this._pendingViewsAge = 0;
+  // The LOCAL kernel's capabilities ({type:"caps", caps:[...]}), sent on every `ready` — the page's
+  // own at load, and the shim's re-send on a reconnected socket. A reconnect is the one event that
+  // can lose an ack (the socket died between the write and its answer), so writes still in flight
+  // when this frame arrives are unknowable: they are dropped, the copy reverts to what the kernel's
+  // frames show, and the dialog says so — never a pinned copy faking success, never a silent revert.
+  // It is also the event that adopts the blob the gate last turned away, when the frame names it
+  // (viewsCapsAdopts, on its `viewsSeq`): the connect push a restarted kernel served under an OLDER
+  // seq (a store restored while it was down) was rejected a frame ago and is adopted here, the gate
+  // re-arming at its seq; a healthy reconnect's push was adopted, nothing is kept, and the gate stands;
+  // a pusher frame kept because it arrived between the push and this frame carries a seq the frame
+  // does not name and is discarded. When nothing kept matches, viewsSeq (a number: the served blob's
+  // seq, or the store's current seq when the push carried no views frame) is remembered as the
+  // kernel's announced store and _takeViews adopts the later blob that carries it even below the held
+  // seq (viewsAnnouncedSeq): one slot, overwritten by each caps frame, cleared by the next
+  // adoption that changes the held blob; null (no store at all) and a missing field announce nothing. A write in flight is
+  // dropped whatever the base became: its ack cannot reach this socket, and one that somehow did is
+  // an ack for a write this page no longer tracks — its blob meets the gate like any other arrival,
+  // and nothing is re-pinned (viewsAck).
+  setCaps(m) {
+    this._caps = new Set((m && Array.isArray(m.caps)) ? m.caps.filter((c) => typeof c === 'string') : []);
+    const served = m ? m.viewsSeq : undefined;
+    const adopted = viewsCapsAdopts(this._rejectedViews, served);
+    if (adopted) this._views = this._rejectedViews;
+    this._announcedViewsSeq = adopted ? null : viewsAnnouncedSeq(served);
+    this._rejectedViews = null;
+    if (this._viewsWrites.length) {
+      this._viewsWrites = []; this._pendingViews = null;
+      this._tagEditErr = { host: '', name: '', error: 'the connection was re-established; an edit made just before it may not have landed — check the list' };
+    } else if (!adopted) return;   // nothing in flight, nothing adopted: the caps changed, nothing shown did
+    this._repaintTagSurfaces();
+    this.draw();
+  }
+
+  // the two surfaces that show a tag-edit notice, repainted in place when one arrives or clears: the
+  // dialog (its build closure) and the lane gear menu (menu._build) — whichever is open
+  _repaintTagSurfaces() {
+    if (this._viewsDialog && this._viewsDialogBuild) this._viewsDialogBuild();
+    if (this._laneMenu && typeof this._laneMenu._build === 'function') this._laneMenu._build();
+  }
+
+  // the kernel does not know an op this page posted (a dashboard newer than its kernel): the write is
+  // refused — the copy reverts and the dialog says why — and the capability is withdrawn, so the next
+  // gesture takes the path that kernel does know (the whole-blob write, below)
+  unknownOp(m) {
+    if (!m) return;
+    if (typeof m.op === 'string' && this._caps) this._caps.delete(m.op);
+    if (typeof m.writeId === 'string' && this._viewsWrites.some((w) => w.id === m.writeId))
+      this.viewsAck({ type: 'unknownOp', writeId: m.writeId, ok: false,
+                      error: 'the kernel does not know the ' + m.op + ' operation, so the edit was not applied — try again; this dialog now uses the older path' });
+  }
+
+  // targeted tag ops need both the kernel's `tagEdit` capability and a host bridge to carry them; with
+  // either missing (an older kernel; an Obsidian panel writing the file) a gesture takes the whole-blob path
+  _tagEditsTargeted() {
+    return !!(this._caps && this._caps.has('tagEdit')
+      && typeof window !== 'undefined' && typeof window.__rompTimelineTagEdit === 'function');
+  }
+
+  // One TARGETED tag edit: `nv` is the optimistic copy (the gesture already applied) shown until
+  // the kernel answers — null when there is nothing to show yet (a create the kernel names and
+  // ids); `edit` is the op — {op: create|rename|recolor|addMember|removeMember|delete, tid?, name?,
+  // newName?, color?, sids?} — which the kernel applies by the tag's stored id through its /tag
+  // merge, so it is never judged stale against this dialog's own earlier writes (the 2026-09-05
+  // loss); `meta` rides on the in-flight record: {name, tid} for the refusal notice, `openRename`
+  // to open the rename input on the tid the create's ack returns, `newId` a create's optimistic row
+  // id (the `pending-…` placeholder the ack's blob replaces). The record keeps the op itself, so a
+  // refusal of some OTHER write can rebuild the copy without it (rederiveViews). Answered on this
+  // socket by tagEditAck → viewsAck below. No `tagEdit` capability or no targeted bridge (an older
+  // kernel; an Obsidian panel writing the file; a headless run) → the PRE-2026-09-05 whole-blob
+  // write, reconciled by _reconcileViews's legacy branch (_tagEditsTargeted).
+  _postTagEdit(nv, edit, meta) {
+    if (!this._tagEditsTargeted()) {
+      if (!nv) return;
+      // LEGACY: the whole blob IS the store write here, so a create's placeholder id would be
+      // persisted as-is (the 2026-09-05 review) — the row takes a client-minted `g…` id,
+      // the scheme the dialog's own pre-2026-09-05 create used, and the write names it as edited,
+      // which a kernel that reads `edited` needs to tell a create from a stale copy re-creating a
+      // deleted tag
+      const edited = [edit.tid, edit.tid_from, edit.tid_to].filter(Boolean);
+      const row = meta && meta.newId ? viewTags(nv).find((t) => t.id === meta.newId) : null;
+      if (row) { if (/^pending-/.test(row.id)) row.id = 'g' + Date.now().toString(36); edited.push(row.id); }
+      this._setViews(nv, edited);
+      return;
+    }
+    if (nv) this._pendingViews = nv;
+    const writeId = this._mintWriteId();
+    this._viewsWrites.push(Object.assign({ id: writeId, name: '', op: edit.op, edit }, meta || {}));
+    try { window.__rompTimelineTagEdit(writeId, edit); } catch (e) { /* the host hook threw — the ack never comes; the reconnect's caps frame clears what is left in flight */ }
+    this.draw();
+  }
+
+  // a create is in flight: the gate on a second [+ New tag] or new-tag Enter before the first is
+  // answered (the 2026-09-05 review: two clicks before the ack made two tags)
+  _createInFlight() {
+    return this._viewsWrites.some((w) => w.edit && w.edit.op === 'create');
+  }
+
+  _mintWriteId() {
+    this._viewsWriteSeq = (this._viewsWriteSeq || 0) + 1;
+    return 'w' + Date.now().toString(36) + '-' + this._viewsWriteSeq.toString(36);
+  }
+
+  // The kernel's answer to ONE of this page's writes — {type: tagEditAck|viewsAck, writeId, ok,
+  // views, seq, error?, refused?: [{tid, name, reason}], tid?, name?}. `views` is the post-write
+  // client blob: adopted as the base whatever the verdict, unless a newer frame already overtook it
+  // (the seq decides). ok → this write is settled; the optimistic copy clears once NOTHING is in
+  // flight (a later gesture may still be pending); a create's ack names the kernel-minted tag, and
+  // a [+ New tag] create opens the rename input on that id — unless the user is already renaming
+  // some other row, whose editor is left alone. Refused → THIS write's change reverts AT ONCE: with
+  // nothing else in flight the store's blob is what stands; with other writes still pending the copy
+  // is rebuilt from that blob plus them (rederiveViews), so a later gesture never flaps off and back
+  // on (the 2026-09-05 review: a refusal cleared the whole list). The reason shows in the
+  // dialog, rebuilt in place if open (the tagEditFailed door's rendering).
+  viewsAck(m) {
+    if (!m) return;
+    const i = this._viewsWrites.findIndex((w) => w.id === m.writeId);
+    const mine = i >= 0 ? this._viewsWrites.splice(i, 1)[0] : null;
+    this._takeViews(m.views);
+    if (m.ok === false) {
+      this._pendingViews = this._viewsWrites.length ? rederiveViews(this._views, this._viewsWrites) : null;
+      const names = (m.refused || []).map((r) => r && r.name).filter(Boolean);
+      this._tagEditErr = { host: '', name: names.join(', ') || (mine && mine.name) || '',
+                           error: m.error || (m.refused || []).map((r) => r.reason).filter(Boolean).join('; ') || 'refused' };
+      this._repaintTagSurfaces();
+    } else {
+      if (!this._viewsWrites.length) this._pendingViews = null;
+      if (mine && mine.op === 'create' && typeof m.tid === 'string') {
+        if (mine.openRename && !this._tagEditorFor) this._tagEditorFor = m.tid;   // the new row opens straight into its rename input
+        this._repaintTagSurfaces();   // the row exists now; a [+ New tag] or join input gated on the create re-arms
+      }
+    }
+    this.draw();
+  }
+
+  // Persist the whole views blob — the lens and order edits, which have no targeted op. Web/VS
+  // Code: the host WS hook (→ kernel setTimelineViews, which normalizes + rebroadcasts, and answers
+  // viewsAck with the stale-writer guard's refusals, if any). Obsidian/headless fallback: write the
+  // same timeline-views.json the kernel reads (it re-normalizes on read) — the write IS the store
+  // write there, so the copy is adopted as the base on the spot. Optimistic, like the lane flags.
+  // A LENS or ORDER write — {active?, actives?, tagOrder?}: the whole blob is built from the STORE's
+  // blob (this._views, the last one adopted) plus these fields, never from the pending copy (the 2026-09-05 review: a copy carrying targeted edits still in flight posted them as this
+  // dialog's claim on those tags, and a rename the kernel had refused as a duplicate landed through
+  // the next lens toggle). The pending copy SHOWN is the current one with the same fields applied,
+  // so in-flight edits stay visible; the in-flight record keeps the fields for rederiveViews.
+  _setLens(fields) {
+    this._setViews(lensBlob(this._views, fields), [], fields);
+  }
+
+  _setViews(v, edited, lens) {
+    this._pendingViews = lens ? applyLensFields(this._curViews(), lens) : v; this._legacyViewsAge = 0;
     try {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSetViews === 'function') {
-        window.__rompTimelineSetViews(v);
+        const writeId = this._mintWriteId();
+        // the record is what this write DID: its lens/order fields, else the blob IS its state (rederiveViews)
+        this._viewsWrites.push(lens ? { id: writeId, name: '', lens } : { id: writeId, name: '', blob: v });
+        // `edited`: the tag ids this write CHANGED — none for a lens or order edit — so the kernel acks a
+        // refusal on a tag this dialog never touched (a stale copy of it) as ok, with the refusal listed:
+        // the newer blob is adopted and no notice shows, since nothing the user did was refused
+        window.__rompTimelineSetViews(v, writeId, Array.isArray(edited) ? edited : []);
       } else if (typeof process !== 'undefined' && process.versions && process.versions.electron) {
         // Obsidian only — the Electron guard keeps a bare-node test run from ever touching the real
         // file (the 2026-07-02 _persistOrder lesson). Resolve the state root the way the kernel does
@@ -3124,6 +3502,7 @@ class TimelinePanel {
         const fp = path.join(root, 'timeline-views.json');
         fs.writeFileSync(fp + '.tmp', JSON.stringify(v));
         fs.renameSync(fp + '.tmp', fp);
+        this._views = v; this._pendingViews = null;   // the file IS the store: the write settled, no ack to wait for
       }
     } catch (e) { /* no host hook + no Node fs → session-local only */ }
     this.draw();
@@ -3222,9 +3601,7 @@ class TimelinePanel {
       x.title = 'remove \u201c' + c.label + '\u201d from this timeline\u2019s filter';
       x.addEventListener('pointerdown', (e) => {
         e.preventDefault(); e.stopPropagation();
-        const nv = JSON.parse(JSON.stringify(v));
-        nv.actives = Object.assign({}, nv.actives, { timeline: lensToggle(lens, c.pick) });
-        this._setViews(nv);
+        this._setLens({ actives: Object.assign({}, v.actives, { timeline: lensToggle(lens, c.pick) }) });
       });
       x.addEventListener('click', (e) => e.stopPropagation());
       chip.appendChild(x);
@@ -3248,6 +3625,7 @@ class TimelinePanel {
   _closeViewsDialog() {
     if (!this._viewsDialog) return;
     this._viewsDialog.remove(); this._viewsDialog = null; this._viewsDialogBuild = null;
+    this._tagNewDraft = null; this._tagNewInput = null;   // the join menu's draft dies with the dialog (_closeLaneMenu's rule)
     if (this._viewsDialogKey) {   // the Escape hook dies with the dialog on EVERY close path, not just Escape
       try { this._viewsDialogKey.doc.removeEventListener('keydown', this._viewsDialogKey.fn); } catch (e) {}
       this._viewsDialogKey = null;
@@ -3300,9 +3678,7 @@ class TimelinePanel {
       const v = this._curViews();
       const lens = timelineLens(v);
       const apply = (nl, close) => {
-        const nv = JSON.parse(JSON.stringify(v));
-        nv.actives = Object.assign({}, nv.actives, { timeline: nl });
-        this._setViews(nv);
+        this._setLens({ actives: Object.assign({}, v.actives, { timeline: nl }) });
         if (close) this._closeViewsMenu(); else build();
       };
       item('All', { current: lensAll(lens) }).addEventListener('click', () => apply({ all: true }, true));
@@ -3416,6 +3792,14 @@ class TimelinePanel {
       return [null, s.name || String(s.id || '').slice(0, 8)];
     };
     const build = () => {
+      // the open rename input's text and caret, read from the live element before it is torn down —
+      // the `input` listener keeps the text current, but the caret can move without one (arrow keys)
+      const live = this._tagRenameInput;
+      if (live && this._tagRenameDraft && this._tagRenameDraft.key === this._tagEditorFor) {
+        this._tagRenameDraft.value = live.value;
+        if (typeof live.selectionStart === 'number') { this._tagRenameDraft.selStart = live.selectionStart; this._tagRenameDraft.selEnd = live.selectionEnd; }
+      }
+      this._tagRenameInput = null;
       card.textContent = '';
       const v = this._curViews();
       // NAME-KEYED (user ruling 2026-08-24): whichever store's id opened this, the header is the
@@ -3459,18 +3843,22 @@ class TimelinePanel {
           return a;
         };
         for (const tg of viewTagUnion(v)) {
-          const editable = tg.localId || canEdit;
+          // a create still in flight (`pending`) is not editable and not draggable: its row wears
+          // the placeholder id the ack replaces, and an op addressed by it would be refused as a tag
+          // that does not exist (the 2026-09-05 review) — it reads "creating…" instead
+          const editable = !tg.pending && (tg.localId || canEdit);
           const tc = tg.color || MODEL_FG;
           // the tag itself: the normal pill, NO ✕ — actions live beside it, never on it.
           // DRAGGABLE (the user 2026-08-25): grab a pill to reorder the tags — the drop writes
-          // tagOrder (the union display order, viewer-side) AND re-sorts the local tags array to
-          // match (the natural store for local-only readers). The membership drag's discipline:
+          // tagOrder (the union display order, viewer-side); the kernel orders the stored tags
+          // array by it, so a reader without this tagOrder sees the same order. The membership
+          // drag's discipline:
           // pointer capture, an accent border cue that moves WITHOUT rebuilding mid-drag (the
           // redraw-eats-pointer rule); the rebuild and the write happen on the drop. The rename
           // input keeps the cell — no drag while editing.
           const pillCell = tgrid.createDiv();
           pillCell._tname = tg.name;
-          if (this._tagEditorFor !== tg.name || !editable) {
+          if (!tg.pending && (this._tagEditorFor !== unionKey(tg) || !editable)) {
             pillCell.style.cursor = 'grab';
             pillCell.addEventListener('pointerdown', (e) => {
               e.preventDefault();
@@ -3500,14 +3888,10 @@ class TimelinePanel {
                 if (toIdx === fromIdx) return;
                 const names = cells.map((c) => c._tname);
                 names.splice(toIdx, 0, names.splice(fromIdx, 1)[0]);
-                const nv = JSON.parse(JSON.stringify(this._curViews()));
-                nv.tagOrder = names;                       // the union display order, remote-homed names included
-                const pos = Object.create(null);           // null-prototype (the prototype-key name hazard)
-                names.forEach((n, i) => { pos[n] = i; });
-                nv.tags = viewTags(nv).slice().sort((a, b) =>
-                  ((a.name in pos) ? pos[a.name] : names.length) - ((b.name in pos) ? pos[b.name] : names.length));
-                delete nv.groups;
-                this._setViews(nv);
+                // the union display order, remote-homed names included; the kernel orders the
+                // stored tags array by it (lensBlob's own re-sort matters on the Electron path,
+                // where the posted blob is the file)
+                this._setLens({ tagOrder: names });
                 build();
               };
               pillCell.addEventListener('pointermove', onMove);
@@ -3515,20 +3899,38 @@ class TimelinePanel {
               pillCell.addEventListener('pointercancel', onUp);
             });
           }
-          if (this._tagEditorFor === tg.name && editable) {
+          if (this._tagEditorFor === unionKey(tg) && editable) {
             const nameIn = document.createElement('input');
-            nameIn.value = tg.name; nameIn.maxLength = 40;
+            // an in-progress rename SURVIVES a repaint (the 2026-09-05 review): a refusal or an ack for
+            // some other row rebuilds the whole dialog while the user is typing here, and a fresh input
+            // seeded with the stored name would throw the typed text away. The draft (text and caret)
+            // is kept on the instance per editor key; a rebuild restores it and puts the caret back
+            // rather than selecting all, which the NEXT keystroke would have replaced.
+            const draft = this._tagRenameDraft && this._tagRenameDraft.key === unionKey(tg) ? this._tagRenameDraft : null;
+            nameIn.value = draft ? draft.value : tg.name; nameIn.maxLength = 40;
             nameIn.setAttribute('style', 'width:130px;background:' + INPUT_BG + ';color:' + INPUT_FG + ';'
               + 'border:1px solid ' + HAIRLINE + ';border-radius:5px;padding:2px 6px;font:inherit;');
+            const noteDraft = () => {
+              this._tagRenameDraft = { key: unionKey(tg), value: nameIn.value,
+                                       selStart: nameIn.selectionStart, selEnd: nameIn.selectionEnd };
+            };
+            nameIn.addEventListener('input', noteDraft);
             nameIn.addEventListener('change', () => {
               const nv2 = nameIn.value.slice(0, 40).trim();
-              this._tagEditorFor = null;
+              this._tagEditorFor = null; this._tagRenameDraft = null; this._tagRenameInput = null;
               if (nv2 && nv2 !== tg.name) this._editTagUnion(tg, { rename: nv2 });
               build();
             });
-            nameIn.addEventListener('keydown', (e) => { if (e.key === 'Escape') { this._tagEditorFor = null; build(); } });
+            nameIn.addEventListener('keydown', (e) => { if (e.key === 'Escape') { this._tagEditorFor = null; this._tagRenameDraft = null; this._tagRenameInput = null; build(); } });
             pillCell.appendChild(nameIn);
-            setTimeout(() => { try { nameIn.focus(); nameIn.select(); } catch (e) {} }, 0);
+            this._tagRenameInput = nameIn;   // the live input, read at the next repaint for its caret
+            setTimeout(() => {
+              try {
+                nameIn.focus();
+                if (draft && typeof draft.selStart === 'number' && typeof draft.selEnd === 'number') nameIn.setSelectionRange(draft.selStart, draft.selEnd);
+                else nameIn.select();
+              } catch (e) {}
+            }, 0);
           } else {
             const pill = pillCell.createSpan({ text: tg.name });
             pill.setAttribute('style', 'display:inline-flex;align-items:center;padding:2px 9px;'
@@ -3544,6 +3946,12 @@ class TimelinePanel {
                 text: pend.map((rt) => 'pending ' + rt.pending + ' on ' + (rt.host || '?')).join(', ') });
               note.setAttribute('style', 'margin-left:6px;font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
             }
+            if (tg.pending) {
+              // the create is in flight: the row shows the tag and says so, with no actions beside
+              // it until the ack (the same words the [+ New tag] row and the inputs use)
+              const note = pillCell.createSpan({ text: 'creating…' });
+              note.setAttribute('style', 'margin-left:6px;font-size:0.82em;opacity:0.6;font-style:italic;white-space:nowrap;');
+            }
           }
           // delete — the destructive convention: dim at rest, red on hover
           const del = tgrid.createDiv();
@@ -3552,7 +3960,7 @@ class TimelinePanel {
             d.addEventListener('mouseenter', () => { d.style.color = '#F85B5A'; d.style.opacity = '1'; });
             d.addEventListener('mouseleave', () => { d.style.color = MENU_FG; d.style.opacity = '0.7'; });
             d.addEventListener('click', () => {
-              if (this._tagEditorFor === tg.name) this._tagEditorFor = null;
+              if (this._tagEditorFor === unionKey(tg)) { this._tagEditorFor = null; this._tagRenameDraft = null; }
               this._editTagUnion(tg, { delete: true });
               build();
             });
@@ -3563,7 +3971,7 @@ class TimelinePanel {
             const r = action(ren, 'rename', 'rename this tag (everywhere it is defined)');
             r.addEventListener('mouseenter', () => { r.style.opacity = '1'; });
             r.addEventListener('mouseleave', () => { r.style.opacity = '0.7'; });
-            r.addEventListener('click', () => { this._tagEditorFor = this._tagEditorFor === tg.name ? null : tg.name; build(); });
+            r.addEventListener('click', () => { this._tagEditorFor = this._tagEditorFor === unionKey(tg) ? null : unionKey(tg); this._tagRenameDraft = null; build(); });
           }
           // the color — the identity-palette swatches inline in the row's last column
           const colCell = tgrid.createDiv();
@@ -3582,23 +3990,47 @@ class TimelinePanel {
             }
           }
         }
-        // [+ New tag] — the table's final row, at the dialog's own scale
+        // [+ New tag] — the table's final row, at the dialog's own scale. While a create is in flight
+        // the row reads "creating…" and takes no click (the 2026-09-05 review: a second
+        // click before the ack made a second tag); the ack's repaint brings the button back.
         const ntRow = tgrid.createDiv();
         ntRow.setAttribute('style', 'grid-column:1 / -1;');
+        if (this._createInFlight()) {
+          const busy = ntRow.createSpan({ text: 'creating…' });
+          busy.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;padding:1px 9px;'
+            + 'border-radius:5px;border:1px solid ' + OUTLINE_FG + ';color:' + MENU_FG + ';opacity:0.45;cursor:default;background:transparent;');
+          busy.setAttribute('aria-disabled', 'true');
+        } else {
         const ntBtn = ntRow.createSpan({ text: '+ New tag' });
         ntBtn.setAttribute('style', 'display:inline-flex;align-items:center;justify-content:center;padding:1px 9px;'
           + 'border-radius:5px;border:1px solid ' + OUTLINE_FG + ';color:' + MENU_FG + ';opacity:0.7;cursor:pointer;background:transparent;');
         hover(ntBtn, 'background:' + HOVER_BG + ';opacity:1;', 'background:transparent;opacity:0.7;');
         ntBtn.addEventListener('click', () => {
-          const nv = JSON.parse(JSON.stringify(this._curViews()));
-          const used = new Set(viewTags(nv).map((t) => t.color));
+          if (this._createInFlight()) return;   // a click that beat the repaint
+          const used = new Set(viewTags(v).map((t) => t.color));
           const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
-          const tg = { id: 'g' + Date.now().toString(36), name: 'tag ' + (viewTags(nv).length + 1), color, members: [] };
+          // a TARGETED create the KERNEL names and ids: the ack returns the minted tid and name, and
+          // the row opens straight into its rename input on that tid (openRename). Nothing is drawn
+          // optimistically — there is no id to draw it under, and a dialog-minted "tag N" from a row
+          // count collided with a leftover default-named tag (the 2026-09-05 review). The name
+          // typed next is a rename by tid — never a whole-blob post the kernel could judge stale
+          // against this very create (the 2026-09-05 loss).
+          if (this._tagEditsTargeted()) { this._postTagEdit(null, { op: 'create', color }, { openRename: true }); build(); return; }
+          // LEGACY (no `tagEdit` capability, or no bridge — an older kernel, an Obsidian panel): the
+          // pre-2026-09-05 whole-blob create, named and id'd here, the row opened for renaming. The
+          // name skips the ones in use rather than counting rows. The write names the new id as
+          // edited: a kernel that reads `edited` takes an unnamed unknown tag for a stale copy
+          // re-creating a deleted one.
+          const nv = JSON.parse(JSON.stringify(v));
+          const names = new Set(viewTags(nv).map((t) => t.name));
+          let n = 1; while (names.has('tag ' + n)) n++;
+          const tg = { id: 'g' + Date.now().toString(36), name: 'tag ' + n, color, members: [] };
           nv.tags = viewTags(nv).concat([tg]); delete nv.groups;
-          this._tagEditorFor = tg.name;   // a new tag opens straight into its rename input
-          this._setViews(nv);
+          this._tagEditorFor = tg.id;
+          this._setViews(nv, [tg.id]);
           build();
         });
+        }
       }
       // ── PANE FILTERS — five rows (the user 2026-08-25 redesign, superseding the one-line
       // strip): All surfaces, then Chat / Sessions / Outline / Feed — the pane names. Each row is
@@ -3627,11 +4059,9 @@ class TimelinePanel {
         };
         const applyFor = (key, lens) => {
           if (key === '*' || key !== 'feed') {
-            const nv = JSON.parse(JSON.stringify(this._curViews()));
             const upd = key === '*' ? { chat: lens, timeline: lens, outline: lens } : {};
             if (key !== '*') upd[key] = lens;
-            nv.actives = Object.assign({}, nv.actives, upd);
-            this._setViews(nv);
+            this._setLens({ actives: Object.assign({}, this._curViews().actives, upd) });
           }
           if (key === '*' || key === 'feed') {
             try { localStorage.setItem('romp:feedTags-set', JSON.stringify({ lens, t: Date.now() })); } catch (e) {}
@@ -3698,7 +4128,7 @@ class TimelinePanel {
       tagAll.setAttribute('style', btnStyle);
       hover(tagAll, 'background:' + HOVER_BG + ';', 'background:transparent;');
       tagAll.setAttribute('title', 'add a tag to every session the search shows');
-      tagAll.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === '*' ? null : '*'; renderRows(); });
+      tagAll.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === '*' ? null : '*'; this._tagNewDraft = null; renderRows(); });
       // (the mute-feed-for-all control left with the feed column, the user 2026-08-25 — the
       // per-session flag lives on in the lane gear)
       const gridBox = card.createDiv();
@@ -3785,7 +4215,7 @@ class TimelinePanel {
             + 'border-radius:5px;border:1px solid ' + OUTLINE_FG + ';color:' + MENU_FG + ';opacity:0.7;cursor:pointer;background:transparent;');
           hover(plus, 'background:' + HOVER_BG + ';opacity:1;', 'background:transparent;opacity:0.7;');
           plus.setAttribute('title', 'add a tag');
-          plus.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === s.id ? null : s.id; renderRows(); });
+          plus.addEventListener('click', () => { this._tagAddFor = this._tagAddFor === s.id ? null : s.id; this._tagNewDraft = null; renderRows(); });
           // TAGS — one solid chip per union tag holding this session (user ruling 2026-08-24:
           // a tag is its NAME; kernels are plumbing — the twin dashed/solid render is gone), ✕ =
           // remove-everywhere. The shared builder; the lane gear renders the identical editor.
@@ -3885,16 +4315,29 @@ class TimelinePanel {
       plus.setAttribute('title', 'add a tag');
       plus.addEventListener('click', (e) => {
         e.stopPropagation();
-        this._tagAddFor = this._tagAddFor === s.id ? null : s.id; build();
+        this._tagAddFor = this._tagAddFor === s.id ? null : s.id; this._tagNewDraft = null; build();
       });
       if (this._tagAddFor === s.id) {
         const am = menu.createDiv();
         am.setAttribute('style', 'display:flex;gap:5px;flex-wrap:wrap;align-items:center;padding:2px 10px 6px 24px;');
         this._tagJoinMenu(am, [s.id], build);
       }
+      // a refused tag edit made FROM this menu shows here too (the 2026-09-05 review): the dialog's
+      // notice, in the menu's compact idiom — the reason, ✕ to dismiss. viewsAck and setCaps repaint
+      // the open menu (menu._build) the way they repaint the open dialog.
+      if (this._tagEditErr) {
+        const er = menu.createDiv();
+        er.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:2px 8px 4px;padding:3px 8px;'
+          + 'border:1px solid #F85B5A;border-radius:5px;color:#F85B5A;font-size:0.82em;');
+        er.createSpan({ text: '⚠ ' + (this._tagEditErr.host ? this._tagEditErr.host + ': ' : '') + this._tagEditErr.error });
+        const ex = er.createSpan({ text: '✕' });
+        ex.setAttribute('style', 'margin-left:auto;cursor:pointer;opacity:0.7;');
+        ex.addEventListener('click', (e) => { e.stopPropagation(); this._tagEditErr = null; build(); });
+      }
     };
     build();
     this._laneMenuBuild = build;    // a settingRefused arriving while the gear is open repaints it in place
+    menu._build = build;   // viewsAck / setCaps / tagEditFailed repaint the open menu with a refusal
     const h = this._menuHost(anchorEl.getBoundingClientRect());
     h.doc.body.appendChild(menu);   // a cross-document append ADOPTS the node; its listeners are kept
     const left = Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 300);   // clamp on-screen

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -59,7 +59,7 @@ test("menu rows toggle with the SAME optimistic + sticky + reconcile-before-draw
 });
 
 test("the gear menu closes on outside click / Escape / teardown, alongside the meta menu", () => {
-  assert.match(SRC, /_closeLaneMenu\(\) \{ if \(this\._laneMenu\) \{ this\._laneMenu\.remove\(\); this\._laneMenu = null; \} \}/);
+  assert.match(SRC, /_closeLaneMenu\(\) \{\s*\n\s*if \(!this\._laneMenu\) return;\s*\n\s*this\._laneMenu\.remove\(\); this\._laneMenu = null;/);
   assert.match(SRC, /this\._onDocClick = \(\) => \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \};/);
   assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \}/);
 });

--- a/ui/timeline-tagorder-drag.test.ts
+++ b/ui/timeline-tagorder-drag.test.ts
@@ -1,7 +1,8 @@
 // TAG DRAG-TO-REORDER (the user 2026-08-25): grab a pill in the Sessions & tags dialog's tag
 // table to put the tags in your order. The drop writes tagOrder — the union DISPLAY order,
 // viewer-side, so a REMOTE-HOMED tag holds its dragged position without any cross-kernel write —
-// and re-sorts the local tags array to match (the natural store for local-only readers). This
+// and the posted local tags array re-sorts to match (over the socket the kernel orders the stored
+// array by the write's tagOrder itself; on the Electron path the posted blob is the file). This
 // EXECUTES the drag over the house fake-DOM shim: dialog open, pointer capture, cue math, drop,
 // and asserts the posted blob + that a rebuild from that blob (the reload) keeps the order.
 import { test } from "node:test";

--- a/ui/timeline-views-ack.test.ts
+++ b/ui/timeline-views-ack.test.ts
@@ -1,0 +1,1155 @@
+// THE TAGS DIALOG'S WRITES ARE ACKNOWLEDGED (the user 2026-09-05, who lost a batch of renames and
+// assignments made in "Manage tags"). Before: every gesture posted the WHOLE views blob built from
+// the dialog's own un-echoed optimistic copy, so a burst carried the pre-burst `at` stamp; the
+// kernel's stale-writer guard refused the second edit to a tag (a create, then typing its name)
+// against the client's OWN first write, told only stderr, and the client — which cleared its
+// optimistic copy on an exact echo match or after THREE frames — kept re-posting the refused copy
+// until the user paused, when the dialog snapped to the store: "tag N", no members.
+// Now: tag gestures post TARGETED ops ({op, name, …, writeId}) the kernel applies by name and
+// answers on the same socket ({tagEditAck, writeId, ok, views}); lens and order edits keep the
+// whole-blob post, answered by viewsAck. The optimistic copy clears on the ACK (an event), never
+// on a frame count; a refusal reverts it at once and shows the reason in the dialog.
+// EXECUTED over the house fake-DOM shim with the real TimelinePanel: the dialog is opened, the
+// [+ New tag] row clicked, the name typed — the exact gestures that were lost. Synthetic ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+// the real federation router, for the test that drives this panel behind it; its module-tail bootstrap runs only
+// with a window AND a document defined at import time, and this file defines its fake DOM after its imports
+import { FederationManager } from "./webview/federation";
+
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, _text: "", parentNode: null, value: "",
+    // the real DOM's setter REPLACES the children; the builders clear a container with `textContent = ''`
+    // before repainting it, so a fake that kept the children let post-rebuild assertions match stale nodes
+    get textContent() { return this._text; },
+    set textContent(v: any) { this._text = v == null ? "" : String(v); for (const c of this.children) c.parentNode = null; this.children.length = 0; },
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) {
+      if (c.parentNode) { const i = c.parentNode.children.indexOf(c); if (i >= 0) c.parentNode.children.splice(i, 1); }
+      c.parentNode = n; this.children.push(c); return c;
+    },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    get firstChild() { return this.children[0] || null; },
+    remove() { if (n.parentNode) n.parentNode.removeChild(n); },
+    _listeners: {} as any,
+    addEventListener(t: string, fn: any) { n._listeners[t] = fn; }, removeEventListener(t: string) { delete n._listeners[t]; },
+    setPointerCapture() {}, releasePointerCapture() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return n._rect || { width: 200, height: 20, left: 0, top: 0, right: 200, bottom: 20 }; },
+    closest() { return null; },
+    // focus and caret are OBSERVABLE (the rename-draft assertions read them): focus records the active
+    // element on the fake document; select() and setSelectionRange() record the selection
+    focus() { g.document.activeElement = n; }, select() { n._sel = "all"; n.selectionStart = 0; n.selectionEnd = String(n.value || "").length; },
+    setSelectionRange(a: number, b: number) { n._sel = [a, b]; n.selectionStart = a; n.selectionEnd = b; },
+    selectionStart: 0, selectionEnd: 0,
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+const g: any = global;
+g.document = {
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  createTextNode(text: string) { const n = makeNode("#text"); n.textContent = text; return n; },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener() {}, removeEventListener() {},
+};
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)", fontFamily: "sans-serif" });
+g.requestAnimationFrame = () => 0;
+g.setTimeout = (fn: any) => { try { fn(); } catch { /* focus on a fake node */ } return 0; };
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+// the two host bridges, recording every post: whole-blob writes (views, writeId) and targeted edits
+// (writeId, edit) — recorded flat as {writeId, ...edit} for the assertions
+const posted: any[] = [];
+g.__rompTimelineSetViews = (v: any, writeId: string, edited: string[]) => posted.push({ kind: "views", v: JSON.parse(JSON.stringify(v)), writeId, edited });
+g.__rompTimelineTagEdit = (writeId: string, e: any) => posted.push({ kind: "tag", e: Object.assign({ writeId }, JSON.parse(JSON.stringify(e))) });
+
+const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const SRC = fs.readFileSync(VIEW_PATH, "utf8");
+const { TimelinePanel, viewTagUnion } = createRequire(__filename)(VIEW_PATH);
+
+const now = 1_781_000_000;
+const SID1 = "11111111-2222-3333-4444-555555555501";
+const SID2 = "11111111-2222-3333-4444-555555555502";
+const PALETTE = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221"];
+const sess = (id: string, name: string, color: string) => ({
+  id, name, color, state: "working", live: true, model: "Opus", effort: "high",
+  context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+});
+const actives = { chat: { all: true }, outline: { all: true }, timeline: { all: true } };
+// the kernel's last echo: one stamped tag, the store's `at`, and its write sequence (`seq` — every
+// frame and ack carries the blob's own; a client adopts a blob only when its seq is at least the held one)
+const S0 = { active: "all", actives, at: 100, seq: 1000, tags: [{ id: "gA", name: "web", color: "#3b82f6", members: [SID1], mtime: 100 }] };
+const copy = (v: any) => JSON.parse(JSON.stringify(v));
+
+// a drawn panel, connected to a kernel that announced the `tagEdit` capability at `ready` (the caps
+// frame, as the kernel sends it); `views` overrides the first frame's blob (a seq-less one = a legacy kernel)
+function drawnPanel(views: any = S0, caps: string[] = ["tagEdit"]): any {
+  posted.length = 0;
+  const panel = new TimelinePanel(makeNode("div"));
+  panel.update({
+    now, sessions: [sess(SID1, "web", "#f7768e"), sess(SID2, "api", "#7aa2f7")],
+    turns: { [SID1]: [{ id: "t1", start: now - 400, end: now - 100, prompt: "do the thing", tid: "f1", mids: [] }] },
+    messages: [], judging: [], views: copy(views), palette: PALETTE.slice(),
+  });
+  // the caps frame names the seq of the views blob the connect push above served (viewsSeq; null for a seq-less one)
+  panel.setCaps({ type: "caps", caps, viewsSeq: typeof views.seq === "number" ? views.seq : null });
+  return panel;
+}
+// a kernel push carrying a views blob (the two-message path's skeleton frame)
+function frame(panel: any, views: any) {
+  panel.update({ now, sessions: [sess(SID1, "web", "#f7768e"), sess(SID2, "api", "#7aa2f7")], views: copy(views) });
+}
+function walk(x: any, out: any[] = []): any[] { for (const c of x.children || []) { out.push(c); walk(c, out); } return out; }
+const textOf = (n: any): string => (n.textContent || "") + (n.children || []).map(textOf).join("");
+function clickNewTag(panel: any) {
+  const btn = walk(panel._viewsDialog).find((n) => n.textContent === "+ New tag");
+  assert.ok(btn, "the [+ New tag] row renders");
+  btn._listeners.click();
+}
+function findNameInput(panel: any) { return walk(panel._viewsDialog).find((n) => n.tag === "input" && n._listeners.change); }
+function nameInput(panel: any) {
+  const inp = findNameInput(panel);
+  assert.ok(inp, "a new tag opens straight into its rename input");
+  return inp;
+}
+function tagOps() { return posted.filter((p) => p.kind === "tag").map((p) => p.e); }
+// the kernel answers a [+ New tag] create: the minted tid and default name, and the blob with the new row
+const NEW_TID = "g7";
+function ackCreate(panel: any, seq = 1001, name = "tag 1", color = "#1EA1EB") {
+  const S1 = copy(S0); S1.at = 113; S1.seq = seq; S1.tags.push({ id: NEW_TID, name, color, members: [], mtime: 113 });
+  const c = tagOps()[0];
+  panel.viewsAck({ type: "tagEditAck", writeId: c.writeId, ok: true, seq, tid: NEW_TID, name, views: copy(S1) });
+  return S1;
+}
+
+test("harness: setting textContent replaces the children, as the real DOM does — a rebuilt container holds no stale nodes", () => {
+  const box = makeNode("div");
+  const a = box.createSpan({ text: "old" }); box.createDiv({ text: "older" });
+  assert.equal(walk(box).length, 2);
+  box.textContent = "";
+  assert.deepEqual(walk(box), [], "the builders clear a container this way before repainting it");
+  assert.equal(a.parentNode, null, "…and the removed nodes no longer point at it");
+  box.createSpan({ text: "new" });
+  assert.deepEqual(walk(box).map((n) => n.textContent), ["new"], "a find() over the walk can only match the current build");
+  box.textContent = "plain";
+  assert.equal(box.textContent, "plain"); assert.deepEqual(walk(box), []);
+});
+
+test("executed: [+ New tag] posts a create the KERNEL names and ids; the ack's tid opens the rename input; typing posts a rename by tid", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  assert.equal(posted.length, 1, "one post for the create");
+  const c = posted[0];
+  assert.equal(c.kind, "tag", "a tag gesture is a targeted edit, not a whole-blob write");
+  assert.equal(c.e.op, "create");
+  assert.equal(c.e.color, "#1EA1EB", "the first unused palette colour, as before");
+  assert.equal(c.e.name, undefined, "no dialog-minted name: a 'tag N' from a row count collided with a leftover default-named tag");
+  assert.equal(c.e.id, undefined, "no dialog-minted id either — the kernel mints it");
+  assert.ok(typeof c.e.writeId === "string" && c.e.writeId, "every write carries a writeId the ack names");
+  assert.equal(panel._pendingViews, null, "nothing is drawn optimistically — there is no id to draw it under");
+  assert.equal(findNameInput(panel), undefined, "…and no rename input yet");
+  const S1 = ackCreate(panel);
+  assert.equal(panel._tagEditorFor, NEW_TID, "the ack's tid is where the rename input opens");
+  assert.deepEqual(panel._views, S1);
+  const inp = nameInput(panel);
+  assert.equal(inp.value, "tag 1", "the kernel's default name, ready to be typed over");
+  // the user types the name before ANY frame — the lost gesture
+  inp.value = "notes-api"; inp._listeners.change();
+  const ops = tagOps();
+  assert.equal(ops.length, 2);
+  assert.deepEqual([ops[1].op, ops[1].tid, ops[1].newName], ["rename", NEW_TID, "notes-api"],
+    "the rename addresses the tag by its stored id — no `at`, nothing for the guard to judge stale, and no name to mistake");
+  assert.equal(ops[1].name, undefined, "no name field on a rename");
+  assert.notEqual(ops[1].writeId, ops[0].writeId);
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === NEW_TID).name, "notes-api", "the optimistic copy shows the typed name at once");
+  assert.equal(posted.filter((p) => p.kind === "views").length, 0, "no whole-blob write anywhere in the burst");
+});
+
+test("executed: a rename posted before any frame SURVIVES — frames never yield the optimistic copy (no frame count)", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  const S1 = ackCreate(panel);
+  const inp = nameInput(panel); inp.value = "notes-api"; inp._listeners.change();
+  // the pusher's frames of the CREATE land (the store: "tag 1", stamped, `at` moved — the rename not yet in them)
+  frame(panel, S1);
+  assert.ok(panel._pendingViews, "a frame that does not carry the rename says nothing about it → the pending copy stays");
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === NEW_TID).name, "notes-api");
+  for (let i = 0; i < 6; i++) { const e = copy(S1); e.at = 120 + i; frame(panel, e); }
+  assert.ok(panel._pendingViews, "six silent frames later the user's rename is STILL showing — nothing counts frames");
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === NEW_TID).name, "notes-api");
+});
+
+test("executed: the pending copy clears on the ACK — the rename's ack settles it, and the dialog reads the kernel's blob", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  const S1 = ackCreate(panel);
+  assert.equal(panel._pendingViews, null, "the create had no optimistic copy; its ack leaves nothing pending");
+  const inp = nameInput(panel); inp.value = "notes-api"; inp._listeners.change();
+  const w2 = tagOps()[1].writeId;
+  assert.ok(panel._pendingViews, "the rename is in flight → its optimistic copy holds");
+  const S2 = copy(S1); S2.at = 114; S2.seq = 1002; S2.tags[1].name = "notes-api"; S2.tags[1].mtime = 114;
+  panel.viewsAck({ type: "tagEditAck", writeId: w2, ok: true, seq: 1002, tid: NEW_TID, name: "notes-api", views: copy(S2) });
+  assert.equal(panel._pendingViews, null, "the last in-flight write's ack clears the pending copy");
+  assert.deepEqual(panel._curViews(), S2, "…and the dialog now reads the kernel's blob, which holds the name");
+  assert.equal(panel._viewsWrites.length, 0, "nothing left in flight");
+});
+
+test("executed: a refusal reverts the optimistic copy at once and shows the reason in the open dialog; the next gesture still addresses the SAME tag", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  const S1 = ackCreate(panel);
+  const inp = nameInput(panel); inp.value = "web"; inp._listeners.change();   // a name that already exists
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === NEW_TID).name, "web", "optimistic until the kernel rules");
+  const why = 'a tag named "web" already exists';
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[1].writeId, ok: false, error: why, tid: NEW_TID, seq: 1001, views: copy(S1) });
+  assert.equal(panel._pendingViews, null, "the refused copy is dropped at once");
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === NEW_TID).name, "tag 1", "the dialog shows the store's truth");
+  assert.deepEqual(panel._tagEditErr, { host: "", name: "tag 1", error: why }, "the refusal names the tag and the reason");
+  const shown = walk(panel._viewsDialog).map(textOf).find((s) => s.startsWith("⚠ "));
+  assert.ok(shown && shown.startsWith("⚠ " + why), "…in the dialog, rebuilt in place (the tagEditFailed door's rendering, dismiss ✕ beside it)");
+  // A recolor in the refusal window addresses the tag by ID — never by the name the
+  // rename would have given it (which is the OTHER tag's name)
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.ids.includes(NEW_TID));
+  panel._editTagUnion(u, { color: "#DD42FF" });
+  const rc = tagOps()[2];
+  assert.deepEqual([rc.op, rc.tid, rc.color, rc.name], ["recolor", NEW_TID, "#DD42FF", undefined]);
+  assert.equal(panel._curViews().tags.find((t: any) => t.id === "gA").color, "#3b82f6", "\"web\" is untouched in the copy too");
+});
+
+// ── DIALOG BEHAVIOUR (the 2026-09-05 review)
+test("executed: a refusal's rebuild preserves another row's in-progress rename — text, caret and focus", () => {
+  const S = copy(S0); S.tags.push({ id: "gB", name: "api", color: "#54B204", members: [SID2], mtime: 100 });
+  const panel = drawnPanel(S);
+  panel._openViewsDialog(null);
+  // the user opens the rename input on "api" and types a new name, caret mid-word
+  const renameBtn = walk(panel._viewsDialog).filter((n) => n.textContent === "rename")[1];
+  assert.ok(renameBtn, "the api row's rename action");
+  renameBtn._listeners.click();
+  assert.equal(panel._tagEditorFor, "gB");
+  let inp = nameInput(panel);
+  assert.equal(inp.value, "api");
+  assert.equal(g.document.activeElement, inp, "the input took focus on open");
+  assert.equal(inp._sel, "all", "…with the stored name selected, ready to be typed over");
+  inp.value = "api-v2"; inp._listeners.input(); inp.setSelectionRange(4, 4);
+  // meanwhile a recolor of "web" (another row) posted earlier is REFUSED — the dialog repaints
+  panel._editTagUnion(viewTagUnion(panel._curViews()).find((x: any) => x.name === "web"), { color: "#DD42FF" });
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[0].writeId, ok: false, tid: "gA", seq: 1000, error: "that tag no longer exists — it may have been deleted from another dashboard", views: copy(S) });
+  const inp2 = nameInput(panel);
+  assert.notEqual(inp2, inp, "the dialog WAS rebuilt (a fresh input)");
+  assert.equal(inp2.value, "api-v2", "the typed text survives the rebuild");
+  assert.equal(g.document.activeElement, inp2, "focus is back in the input");
+  assert.deepEqual(inp2._sel, [4, 4], "the caret is where it was — not select-all, which the next keystroke would replace");
+  assert.equal(panel._tagEditorFor, "gB", "the editor stays on the same row");
+  // finishing the rename posts it by tid and clears the draft; the next open starts from the stored name
+  inp2._listeners.change();
+  const ren = tagOps()[1];
+  assert.deepEqual([ren.op, ren.tid, ren.newName], ["rename", "gB", "api-v2"]);
+  assert.equal(panel._tagRenameDraft, null);
+  // Escape drops a draft too
+  walk(panel._viewsDialog).filter((n) => n.textContent === "rename")[1]._listeners.click();
+  inp = nameInput(panel); inp.value = "zzz"; inp._listeners.input();
+  inp._listeners.keydown({ key: "Escape" });
+  assert.equal(panel._tagRenameDraft, null);
+  assert.equal(findNameInput(panel), undefined, "the editor closed");
+});
+
+test("executed: the lane gear menu shows a refusal inline, repaints on it, and ✕ dismisses it", () => {
+  const panel = drawnPanel();
+  const s = panel.data.sessions.find((x: any) => x.id === SID2);
+  const anchor = makeNode("g"); anchor._rect = { left: 40, top: 60, right: 60, bottom: 76, width: 20, height: 16 };
+  panel._openLaneMenu(s, anchor);
+  assert.ok(panel._laneMenu, "the gear menu is open");
+  assert.equal(typeof panel._laneMenu._build, "function", "…and exposes its repaint");
+  const notices = () => walk(panel._laneMenu).map((n) => n.textContent as string).filter((t) => t.startsWith("⚠ "));   // the notice spans themselves
+  assert.deepEqual(notices(), [], "no notice at rest");
+  // a tag gesture made FROM the menu (the [+] join option) is refused by the kernel
+  const plus = walk(panel._laneMenu).find((n) => n.textContent === "+" && n._attrs.title === "add a tag");
+  assert.ok(plus, "the menu's [+]");
+  plus._listeners.click({ stopPropagation() {} });
+  const opt = walk(panel._laneMenu).find((n) => n.textContent === "web");
+  assert.ok(opt, "the join option for the tag this session lacks");
+  opt._listeners.click();
+  const w = tagOps()[0];
+  assert.deepEqual([w.op, w.tid, w.sids], ["addMember", "gA", [SID2]]);
+  const why = "that tag no longer exists — it may have been deleted from another dashboard";
+  panel.viewsAck({ type: "tagEditAck", writeId: w.writeId, ok: false, tid: "gA", seq: 1000, error: why, views: copy(S0) });
+  const shown = notices();
+  assert.equal(shown.length, 1, "the refusal shows in the open menu — the dialog is not the only surface that edits tags");
+  assert.ok(shown[0].startsWith("⚠ " + why), shown[0]);
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1], "the optimistic add reverted");
+  // ✕ dismisses it and repaints the menu without it
+  const x = walk(panel._laneMenu).find((n) => n.textContent === "✕" && n.parentNode && textOf(n.parentNode).startsWith("⚠ "));
+  assert.ok(x, "the notice has its dismiss");
+  x._listeners.click({ stopPropagation() {} });
+  assert.equal(panel._tagEditErr, null);
+  assert.deepEqual(notices(), [], "gone");
+  // a remote refusal (tagEditFailed) lands there too
+  panel.tagEditFailed({ type: "tagEditFailed", host: "TESTHOST", name: "web", error: "refused" });
+  assert.deepEqual(notices(), ["⚠ TESTHOST: refused"]);
+  panel._closeLaneMenu();
+  assert.equal(panel._laneMenu, null);
+});
+
+test("executed: membership edits are targeted too — the join menu's option adds by tid; its new-tag input is ONE create with members, no client id", () => {
+  const panel = drawnPanel();
+  const box = makeNode("div");
+  let rebuilt = 0;
+  panel._tagJoinMenu(box, [SID2], () => rebuilt++);
+  const opt = walk(box).find((n) => n.textContent === "web");
+  opt._listeners.click();
+  assert.deepEqual([tagOps()[0].op, tagOps()[0].tid, tagOps()[0].sids], ["addMember", "gA", [SID2]]);
+  assert.equal(rebuilt, 1);
+  assert.deepEqual(panel._curViews().tags[0].members.slice().sort(), [SID1, SID2].sort(), "optimistic at once");
+  const box2 = makeNode("div");
+  panel._tagJoinMenu(box2, [SID1, SID2], () => rebuilt++);
+  const ni = walk(box2).find((n) => n.tag === "input");
+  ni.value = "qa"; ni._listeners.keydown({ key: "Enter" });
+  const c = tagOps()[1];
+  assert.deepEqual([c.op, c.name, c.sids, c.id, c.tid], ["create", "qa", [SID1, SID2], undefined, undefined], "one op: the tag and its first members together; the kernel mints the id");
+  const drawn = panel._curViews().tags.find((t: any) => t.name === "qa");
+  assert.match(drawn.id, /^pending-/, "the optimistic row wears a placeholder id until the ack's blob replaces it");
+  // a chip's ✕ (remove-everywhere) and the row actions ride the same door, by tid
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { remove: [SID2] });
+  panel._editTagUnion(u, { color: "#DD42FF" });
+  panel._editTagUnion(u, { delete: true });
+  assert.deepEqual(tagOps().slice(2).map((e) => [e.op, e.tid, e.sids || e.color || null, e.name]),
+    [["removeMember", "gA", [SID2], undefined], ["recolor", "gA", "#DD42FF", undefined], ["delete", "gA", null, undefined]]);
+  assert.equal(posted.filter((p) => p.kind === "views").length, 0, "still no whole-blob write for any tag gesture");
+});
+
+test("executed: lens and order edits keep the whole-blob post, now with a writeId, and the viewsAck settles or reverts them", () => {
+  const panel = drawnPanel();
+  const nv = copy(S0); nv.actives = Object.assign({}, nv.actives, { timeline: { tags: ["web"] } });
+  panel._setViews(nv);
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].kind, "views", "a lens edit is still the whole blob (the kernel owns no lens op)");
+  assert.deepEqual(posted[0].v.actives.timeline, { tags: ["web"] });
+  assert.ok(typeof posted[0].writeId === "string" && posted[0].writeId, "…carrying its writeId");
+  assert.deepEqual(posted[0].edited, [], "…and naming no edited tag: a refusal on a stale, untouched tag is acked ok, no notice");
+  assert.ok(panel._pendingViews);
+  frame(panel, S0); frame(panel, S0); frame(panel, S0); frame(panel, S0);
+  assert.ok(panel._pendingViews, "stale frames never yield it");
+  const S1 = copy(nv); S1.at = 130;
+  panel.viewsAck({ type: "viewsAck", writeId: posted[0].writeId, ok: true, refused: [], views: copy(S1) });
+  assert.equal(panel._pendingViews, null, "the viewsAck clears it");
+  assert.deepEqual(panel._views, S1);
+  // a genuinely stale whole-blob write (another dashboard edited `web` meanwhile): the guard kept
+  // the store's copy and the ack says so; the dialog shows the kernel's blob and the reason
+  const nv2 = copy(S1); nv2.tags[0].members = [];
+  panel._setViews(nv2);
+  const S2 = copy(S1); S2.at = 140; S2.tags[0].members = [SID1, SID2]; S2.tags[0].mtime = 140;
+  const reason = "your copy predates a newer edit to it, so your change was not applied and the newer state was kept";
+  panel._viewsDialog = makeNode("div"); let rebuilt = 0; panel._viewsDialogBuild = () => rebuilt++;
+  panel.viewsAck({ type: "viewsAck", writeId: posted[1].writeId, ok: false, refused: [{ tid: "gA", name: "web", reason }], error: '"web": ' + reason, views: copy(S2) });
+  assert.equal(panel._pendingViews, null);
+  assert.deepEqual(panel._curViews(), S2, "reverted to the store's blob");
+  assert.deepEqual(panel._tagEditErr, { host: "", name: "web", error: '"web": ' + reason }, "the kernel's line: the name once, what was refused, what was kept");
+  assert.equal(rebuilt, 1, "the open dialog repaints with the refusal");
+  // ok WITH refusals listed — a stale copy of a tag this write did not edit: settled, no notice
+  panel._tagEditErr = null;
+  panel._setViews(copy(S2));
+  const S3 = copy(S2); S3.seq = 1003;
+  panel.viewsAck({ type: "viewsAck", writeId: posted[2].writeId, ok: true, refused: [{ tid: "gA", name: "web", reason }], views: copy(S3) });
+  assert.equal(panel._pendingViews, null);
+  assert.equal(panel._tagEditErr, null, "nothing the user did was refused, so nothing is said");
+});
+
+// The 2026-09-05 review (a coverage gap): the door bounds a whole-blob write's refusal rows to 64 plus ONE
+// nameless summary row whose reason counts the rest (`more`, `moreEdited`). The chat pane's rendering of that row is
+// pinned in views-writes.test.ts (ackOutcome); the dialog's is here, on the real panel: the kernel's bounded `error`
+// line when it comes, the rows' reasons joined without it, and a nameless row alone as its reason — never a name read
+// off a row that has none, and never an exception before the notice is set and the dialog repainted.
+test("executed: a refusal's nameless summary row renders in the dialog as its reason alone — with the kernel's error line, without it, and as the only row", () => {
+  const panel = drawnPanel();
+  const bound = 'a write is read to 64 tags; "qa" lay past that bound and was not read, so the stored copy was kept';
+  const more = "3 more entries past the 64-tag read bound were not read (1 of them this write edited)";
+  const summary = { reason: more, more: 3, moreEdited: 1 };
+  panel._viewsDialog = makeNode("div"); let rebuilt = 0; panel._viewsDialogBuild = () => rebuilt++;
+  // the kernel's shape: the bounded `error` names each refused tag once; the rows carry the summary
+  panel._setLens({ tagOrder: ["web"] });
+  panel.viewsAck({ type: "viewsAck", writeId: posted[0].writeId, ok: false, refused: [{ tid: "g9", name: "qa", reason: bound }, summary], error: '"qa": ' + bound + "; " + more, views: copy(S0) });
+  assert.deepEqual(panel._tagEditErr, { host: "", name: "qa", error: '"qa": ' + bound + "; " + more }, "the kernel's line stands; the summary row adds no name");
+  assert.equal(rebuilt, 1, "the open dialog repaints with it");
+  // no `error` line: the rows' reasons, joined — the nameless row's after the named one's
+  panel._setLens({ tagOrder: ["web"] });
+  panel.viewsAck({ type: "viewsAck", writeId: posted[1].writeId, ok: false, refused: [{ tid: "g9", name: "qa", reason: bound }, summary], views: copy(S0) });
+  assert.deepEqual(panel._tagEditErr, { host: "", name: "qa", error: bound + "; " + more });
+  // the nameless row alone: its reason, and no name
+  panel._setLens({ tagOrder: ["web"] });
+  panel.viewsAck({ type: "viewsAck", writeId: posted[2].writeId, ok: false, refused: [summary], views: copy(S0) });
+  assert.deepEqual(panel._tagEditErr, { host: "", name: "", error: more });
+  assert.equal(panel._pendingViews, null, "each refusal reverted its write");
+  assert.deepEqual(panel._viewsWrites, []);
+  assert.equal(rebuilt, 3);
+});
+
+// ── ORDERING (the 2026-09-05 review): the store's write sequence decides which blob is
+// newer, never the order the socket delivered them in. The pusher builds frames from a warmed cache that
+// can predate a write whose ack already arrived; federation re-emits stored blobs; a net-zero burst leaves
+// frames EQUAL to the copy while its writes are still in flight. The seq is exact where the exact-echo
+// heuristic guessed.
+test("executed: a frame carrying an OLDER write sequence than the ack's blob is ignored — store order, not wire order", () => {
+  const panel = drawnPanel();                       // holds S0 (seq 1000)
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    const S2 = copy(S0); S2.seq = 1002; S2.at = 120; S2.tags[0].members = [SID1, SID2]; S2.tags[0].mtime = 120;
+    panel.viewsAck({ type: "tagEditAck", writeId: "w-x", ok: true, seq: 1002, views: copy(S2) });
+    assert.equal(panel._views.seq, 1002);
+    const stale = copy(S0); stale.seq = 1001;       // the pusher's warmed cache: built before the write, delivered after the ack
+    frame(panel, stale);
+    assert.equal(panel._views.seq, 1002, "the older blob does not replace the newer one");
+    assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2], "the dialog keeps showing the write");
+    frame(panel, stale);
+    assert.equal(warned.length, 1, "the ignored blob is logged once per page, not once per frame");
+    assert.match(warned[0], /older than the one held/);
+    const S3 = copy(S2); S3.seq = 1003; frame(panel, S3);
+    assert.equal(panel._views.seq, 1003, "a newer frame is adopted as before");
+    const legacy = copy(S3); delete legacy.seq;
+    frame(panel, legacy);
+    assert.equal(panel._views.seq, undefined, "a blob without a seq (a kernel from before the stamp) still adopts — nothing is gated on a field it never sends");
+  } finally { console.warn = cw; }
+});
+
+test("executed: a NET-ZERO burst (add, then remove) is not cleared early by frames that happen to equal the copy", () => {
+  const panel = drawnPanel();
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { add: [SID2] });
+  const u2 = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u2, { remove: [SID2] });
+  assert.equal(panel._viewsWrites.length, 2, "two writes in flight");
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1], "the copy is back to the pre-burst state — net zero");
+  frame(panel, copy(S0));                           // a frame equal to the copy: seq 1000, built before either write
+  assert.equal(panel._viewsWrites.length, 2, "an exact match is NOT a write's echo when the blob carries a seq — nothing clears");
+  assert.ok(panel._pendingViews);
+  const S1 = copy(S0); S1.seq = 1001; S1.tags[0].members = [SID1, SID2];   // the add landed on the kernel
+  frame(panel, S1);
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1], "the half-applied state never shows: the copy holds until the acks");
+  const [w1, w2] = panel._viewsWrites.map((w: any) => w.id);
+  panel.viewsAck({ type: "tagEditAck", writeId: w1, ok: true, seq: 1001, views: copy(S1) });
+  assert.ok(panel._pendingViews, "the first ack leaves the second write pending");
+  const S2 = copy(S0); S2.seq = 1002;
+  panel.viewsAck({ type: "tagEditAck", writeId: w2, ok: true, seq: 1002, views: copy(S2) });
+  assert.equal(panel._pendingViews, null, "the last ack settles the burst");
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1]);
+});
+
+test("executed: an ack whose blob a newer frame already overtook still settles its write, and does not roll the base back", () => {
+  const panel = drawnPanel();
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { color: "#DD42FF" });
+  const w = panel._viewsWrites[0].id;
+  const S2 = copy(S0); S2.seq = 1002; S2.tags[0].color = "#DD42FF"; S2.tags[0].members = [SID1, SID2];   // our recolor plus another dashboard's add
+  frame(panel, S2);
+  const S1 = copy(S0); S1.seq = 1001; S1.tags[0].color = "#DD42FF";
+  panel.viewsAck({ type: "tagEditAck", writeId: w, ok: true, seq: 1001, views: copy(S1) });   // the ack, delivered after the newer frame
+  assert.equal(panel._pendingViews, null, "the ack settles the write");
+  assert.equal(panel._views.seq, 1002, "…without replacing the newer blob");
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2]);
+});
+
+test("executed: an ack for a write this page never made still refreshes the base and never strands a pending copy", () => {
+  const panel = drawnPanel();
+  const S1 = copy(S0); S1.at = 150;
+  panel.viewsAck({ type: "viewsAck", writeId: "w-from-a-previous-load", ok: true, refused: [], views: copy(S1) });
+  assert.deepEqual(panel._views, S1);
+  assert.equal(panel._pendingViews, null);
+});
+
+test("executed: without the targeted-edit bridge (an Obsidian panel), a tag gesture falls back to the whole-blob write", () => {
+  const panel = drawnPanel();
+  const saved = g.__rompTimelineTagEdit;
+  delete g.__rompTimelineTagEdit;
+  try {
+    const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+    panel._editTagUnion(u, { rename: "site" });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].kind, "views");
+    assert.equal(posted[0].v.tags[0].name, "site");
+  } finally {
+    g.__rompTimelineTagEdit = saved;
+  }
+});
+
+// ── CAPABILITY (the 2026-09-05 review): the kernel announces `tagEdit` at every `ready`;
+// without it the panel takes the pre-cap path (the whole blob, reconciled by the legacy exact echo and
+// three-frame yield, since no ack will come); an op the kernel does not know is answered unknownOp.
+test("executed: against a kernel WITHOUT the tagEdit capability, a tag gesture posts the whole blob — the legacy path — and legacy frames settle it by exact echo or three silent frames", () => {
+  const L0 = copy(S0); delete L0.seq;                    // an older kernel stamps no seq…
+  const panel = drawnPanel(L0, []);                      // …and announces no tagEdit
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { rename: "site" });
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].kind, "views", "no capability → the pre-cap whole-blob write");
+  assert.equal(posted[0].v.tags[0].name, "site");
+  assert.ok(typeof posted[0].writeId === "string", "the writeId rides anyway — an older kernel ignores it");
+  assert.deepEqual(posted[0].edited, ["gA"], "…and the tag it changed, for a kernel new enough to read it");
+  // LEGACY reconciliation, for this path only: a frame that echoes the edit clears it…
+  const echo = copy(L0); echo.tags[0].name = "site";
+  frame(panel, echo);
+  assert.equal(panel._pendingViews, null, "the exact echo clears the copy (legacy)");
+  // …and three silent seq-less frames yield an unechoed one (with no ack coming, it would pin forever)
+  panel._editTagUnion(viewTagUnion(panel._curViews()).find((x: any) => x.name === "site"), { color: "#DD42FF" });
+  assert.ok(panel._pendingViews);
+  frame(panel, echo); frame(panel, echo);
+  assert.ok(panel._pendingViews, "two silent frames: still holding");
+  frame(panel, echo);
+  assert.equal(panel._pendingViews, null, "the third yields — the legacy kernel's only clear");
+  // [+ New tag] on the legacy path: a whole-blob create the dialog names and ids, the row opened for renaming
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  const last = posted[posted.length - 1];
+  assert.equal(last.kind, "views");
+  const added = last.v.tags.find((t: any) => t.name === "tag 1");
+  assert.ok(added && /^g[0-9a-z]+$/.test(added.id), "legacy: the dialog mints the id and the lowest free 'tag N'");
+  assert.deepEqual(last.edited, [added.id], "…names it as edited (a kernel that reads `edited` takes an unnamed unknown tag for a stale re-creation)");
+  assert.equal(panel._tagEditorFor, added.id, "…and opens the rename input on it");
+  // a New tag when the capability is present posts the targeted create (the same panel, the cap arriving)
+  panel.setCaps({ type: "caps", caps: ["tagEdit"] });
+  clickNewTag(panel);
+  assert.equal(posted[posted.length - 1].kind, "tag");
+});
+
+test("executed: an unknownOp reply surfaces as a refusal, withdraws the capability, and the next gesture takes the older path", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { rename: "site" });
+  const w = tagOps()[0].writeId;
+  assert.equal(panel._curViews().tags[0].name, "site", "optimistic");
+  panel.unknownOp({ type: "unknownOp", op: "tagEdit", writeId: w });
+  assert.equal(panel._pendingViews, null, "the copy reverts — the kernel did nothing with the write");
+  assert.equal(panel._curViews().tags[0].name, "web");
+  assert.match(panel._tagEditErr.error, /does not know the tagEdit operation/, "…and the dialog says why");
+  assert.equal(panel._caps.has("tagEdit"), false, "the capability is withdrawn");
+  panel._editTagUnion(viewTagUnion(panel._curViews())[0], { color: "#DD42FF" });
+  assert.equal(posted[posted.length - 1].kind, "views", "the next gesture is a whole-blob write that kernel does know");
+  // an unknownOp for a write this page never made changes nothing but the cap
+  const n = posted.length; const before = panel._pendingViews;
+  panel.unknownOp({ type: "unknownOp", op: "somethingElse", writeId: "w-not-ours" });
+  assert.equal(posted.length, n); assert.equal(panel._pendingViews, before);
+});
+
+test("executed: a lost ack — the caps frame the kernel sends at every ready (a re-established socket) drops what was in flight, says so, and the next frame is adopted", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { rename: "site" });
+  assert.equal(panel._viewsWrites.length, 1, "the rename is in flight");
+  // the socket dropped between the write and its ack; the shim reconnected and re-sent `ready`; the
+  // kernel answered with its caps — the ONE event that says the in-flight answer may never come
+  panel.setCaps({ type: "caps", caps: ["tagEdit"] });
+  assert.deepEqual(panel._viewsWrites, [], "nothing pins: the writes are unknowable and are dropped");
+  assert.equal(panel._pendingViews, null, "the copy reverts to the store's truth");
+  assert.equal(panel._curViews().tags[0].name, "web");
+  assert.match(panel._tagEditErr.error, /re-established.*may not have landed/, "the user is told — never a fake success, never a silent revert");
+  const shown = walk(panel._viewsDialog).map(textOf).find((s) => s.startsWith("⚠ "));
+  assert.ok(shown, "…in the open dialog");
+  const S2 = copy(S0); S2.seq = 1002; S2.tags[0].name = "site";      // the write HAD landed: the next frame shows it
+  frame(panel, S2);
+  assert.equal(panel._curViews().tags[0].name, "site", "the next frame is adopted as the truth");
+  // a caps frame with nothing in flight (the page's own load) changes nothing but the caps
+  const before = panel._tagEditErr;
+  panel.setCaps({ type: "caps", caps: ["tagEdit"] });
+  assert.equal(panel._tagEditErr, before);
+});
+
+// ── The 2026-09-05 review: the caps frame adopts the blob the gate last
+// turned away when its viewsSeq (the seq of the blob the kernel's own connect push served) names it, and never
+// opens the gate.
+test("executed: a restored store lands on the caps frame itself — the connect push the restarted kernel serves under an older seq is turned away, then adopted on the caps frame that names it, with nothing to wait for", () => {
+  const panel = drawnPanel();                       // the load: S0's frame (adopted), then the caps frame (nothing kept: inert)
+  assert.equal(panel._views.seq, 1000, "the load-time caps frame leaves the held seq alone");
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    // the kernel was down; timeline-views.json was restored from an older copy (seq 900) while this page held 1000;
+    // the kernel restarted; the shim reconnected and re-sent `ready`: the kernel's connect push comes FIRST…
+    const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";
+    frame(panel, restored);
+    assert.equal(panel._views.seq, 1000, "…and the gate turns it away, as it must before the reconnect event");
+    assert.equal(warned.length, 1);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });   // …then its caps frame, naming what that push served
+    assert.equal(panel._views.seq, 900, "the caps frame adopts exactly the blob the gate turned away — no repost to wait for");
+    assert.equal(panel._curViews().tags[0].name, "site", "the page shows the restored store at once");
+    assert.equal(panel._tagEditErr, null, "nothing was in flight: nothing is said");
+    frame(panel, Object.assign(copy(restored), { seq: 899 }));
+    assert.equal(panel._views.seq, 900, "and the store's own order gates again from its seq");
+    frame(panel, restored);
+    assert.equal(panel._views.seq, 900);
+  } finally { console.warn = cw; }
+});
+
+test("executed: a healthy reconnect keeps the gate — the connect push is adopted, the caps frame names it and adopts nothing, and a pusher frame built before a concurrent write is turned away whether it lands before or after the caps frame", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    // the socket dropped and came back on the same kernel; meanwhile another dashboard's write landed (seq 1001)
+    const S1 = copy(S0); S1.seq = 1001; S1.tags[0].members = [SID1, SID2];
+    frame(panel, S1);                                 // the connect push: current, adopted
+    // the pusher thread's frame, built from its cache BEFORE that write and enqueued between the connect push and
+    // the caps frame — the window an earlier fix left open: the client turns it away and keeps it…
+    frame(panel, S0);
+    assert.equal(panel._views.seq, 1001);
+    assert.equal(warned.length, 1);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 1001 });   // …and the caps frame names the connect push, not it
+    assert.equal(panel._views.seq, 1001, "the kept frame's seq is not the one named: discarded, the gate stands");
+    assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2], "no flap: the other dashboard's member never blinks out");
+    frame(panel, S0);                                 // the same stale frame landing AFTER the caps frame instead
+    assert.equal(panel._views.seq, 1001, "turned away by the gate, which never opened");
+    frame(panel, S1);
+    assert.equal(panel._views.seq, 1001, "the next cycle's frame is the same write, seen again — and lets the kept blob go");
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 1001 });
+    assert.equal(panel._views.seq, 1001);
+    assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2]);
+  } finally { console.warn = cw; }
+});
+
+test("executed: a caps frame whose connect push served no views blob (viewsSeq null) adopts nothing, and lets a kept blob go", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    frame(panel, Object.assign(copy(S0), { seq: 999 }));   // a stale frame turned away just before the socket dropped: kept
+    assert.equal(panel._views.seq, 1000);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: null });   // the reconnect's push carried no views (a sentinel cycle)
+    assert.equal(panel._views.seq, 1000, "nothing named, nothing adopted: the gate stands");
+    panel.setCaps({ type: "caps", caps: ["tagEdit"] });                    // even a field-less frame now: the kept blob was let go
+    assert.equal(panel._views.seq, 1000);
+  } finally { console.warn = cw; }
+});
+
+// The 2026-09-05 review: the caps frame's viewsSeq is also the kernel's ANNOUNCEMENT of its current
+// store (the served blob's seq, or the store's current seq when the connect push carried no views frame; null
+// only when the kernel has no store at all). A restart over a store restored from an older copy, met by a
+// reconnect whose push carried no blob (a chat page's sentinel cycle sends no tabOrder), kept nothing for the earlier
+// rule to match: the pusher's next frame — the restored store, under its old seq — was turned away, and no
+// second caps frame comes. The announced seq is remembered in one slot until the next adoption that changes the
+// held blob, and a later
+// blob carrying exactly that seq is adopted below the held one.
+test("executed: a sentinel-cycle reconnect over a restored store — the caps frame announces the store's seq with nothing kept, the pusher's next frame at that seq is adopted below the held one, another lower seq is still turned away, and the slot clears on the adoption", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });   // the connect push carried no views blob; the restored store's current seq is 900
+    assert.equal(panel._views.seq, 1000, "nothing kept, nothing adopted on the frame itself");
+    assert.equal(panel._announcedViewsSeq, 900, "…but the announced seq is remembered");
+    frame(panel, Object.assign(copy(S0), { seq: 899 }));
+    assert.equal(panel._views.seq, 1000, "a frame at another lower seq is a stale frame: turned away");
+    assert.equal(panel._announcedViewsSeq, 900, "…and the slot stands");
+    const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";
+    frame(panel, restored);                            // the pusher's next cycle: the restored store under its old seq
+    assert.equal(panel._views.seq, 900, "the announced seq IS the store the kernel said it holds: adopted below the held one");
+    assert.equal(panel._curViews().tags[0].name, "site", "the page shows the restored store");
+    assert.equal(panel._announcedViewsSeq, null, "the slot cleared on the adoption");
+    assert.equal(panel._rejectedViews, null, "…and so did the kept blob");
+    frame(panel, Object.assign(copy(S0), { seq: 899 }));
+    assert.equal(panel._views.seq, 900, "the store's own order gates again from the adopted seq");
+    assert.equal(panel._tagEditErr, null, "nothing was in flight: nothing is said");
+  } finally { console.warn = cw; }
+});
+
+test("executed: the announced slot clears on an adoption that changes the held blob — a write landing before the announced blob arrives stamps the store past it, and that blob is then the stale frame it looks like; a caps frame that adopts its kept blob leaves no slot; viewsSeq null and a missing field announce nothing", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    assert.equal(panel._announcedViewsSeq, 900);
+    const written = copy(S0); written.seq = 1100; written.tags[0].name = "notes";   // another dashboard's write on the restored store: a write's seq is seeded from the clock, past everything a page holds
+    frame(panel, written);
+    assert.equal(panel._views.seq, 1100, "adopted by the ordinary rule…");
+    assert.equal(panel._announcedViewsSeq, null, "…and the slot cleared with it");
+    frame(panel, Object.assign(copy(S0), { seq: 900 }));   // the pusher's frame built before that write
+    assert.equal(panel._views.seq, 1100, "the announced seq is no longer a door: the store moved past it");
+    assert.equal(panel._curViews().tags[0].name, "notes");
+    // the caps frame that adopts its kept blob (the earlier case) leaves no slot either
+    const restored = copy(S0); restored.seq = 800;
+    frame(panel, restored);
+    assert.equal(panel._views.seq, 1100);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 800 });
+    assert.equal(panel._views.seq, 800, "the kept blob is what the frame names: adopted");
+    assert.equal(panel._announcedViewsSeq, null, "nothing left to remember");
+    // null — the kernel has no store at all — announces nothing, and an earlier announcement does not outlive the frame
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 700 });
+    assert.equal(panel._announcedViewsSeq, 700);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: null });
+    assert.equal(panel._announcedViewsSeq, null, "null announces nothing");
+    frame(panel, Object.assign(copy(S0), { seq: 700 }));
+    assert.equal(panel._views.seq, 800, "…so a blob at the seq an earlier frame named is turned away");
+    // a frame without the field (a kernel from before it) announces nothing either
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 600 });
+    assert.equal(panel._announcedViewsSeq, 600);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"] });
+    assert.equal(panel._announcedViewsSeq, null);
+    frame(panel, Object.assign(copy(S0), { seq: 600 }));
+    assert.equal(panel._views.seq, 800);
+  } finally { console.warn = cw; }
+});
+
+// The 2026-09-05 review: the slot is cleared only by an adoption that CHANGES the held blob. In the browser
+// dashboard this pane sees the local blob only through the federation router's merged lanes payload, which replays the
+// router's stored blob on every re-emit (a remote host's lanes, a view-order storage event, a host drop) — a re-arrival
+// of the blob this pane already holds, at its own seq. The earlier clear on any adoption spent the slot on that
+// re-arrival, and the restored store the router adopted and re-emitted next at the announced seq was turned away here:
+// router 900, pane 1000, silently, until the next write. Executed on the real panel frame by frame, then on the real
+// panel behind the real router (ui/webview/federation.ts) fed the same sequence.
+test("executed: a re-arrival of the held blob leaves the announced slot standing, and the restored store at the announced seq is still adopted after it; the announced seq itself, a newer blob, and a seq-less blob clear it", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    assert.equal(panel._announcedViewsSeq, 900);
+    frame(panel, S0);                                  // the router's re-emit of its stored blob: what this pane already holds
+    assert.equal(panel._views.seq, 1000);
+    assert.equal(panel._announcedViewsSeq, 900, "no new information: the slot stands");
+    frame(panel, S0);
+    assert.equal(panel._announcedViewsSeq, 900, "…however often it arrives");
+    assert.equal(warned.length, 0, "nothing was turned away");
+    const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";
+    frame(panel, restored);
+    assert.equal(panel._views.seq, 900, "the restored store, at the announced seq, is adopted below the held one");
+    assert.equal(panel._curViews().tags[0].name, "site");
+    assert.equal(panel._announcedViewsSeq, null, "the adoption changed the held blob: the slot is spent");
+    // the announced seq arriving at the held seq spends the slot too: the announced store has arrived
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    assert.equal(panel._announcedViewsSeq, 900);
+    frame(panel, restored);
+    assert.equal(panel._announcedViewsSeq, null);
+    // a newer blob clears it, as before
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 850 });
+    frame(panel, restored);                            // held again: the slot stands
+    assert.equal(panel._announcedViewsSeq, 850);
+    frame(panel, Object.assign(copy(S0), { seq: 1100 }));
+    assert.equal(panel._announcedViewsSeq, null, "a newer write moved the store: cleared");
+    frame(panel, Object.assign(copy(S0), { seq: 850 }));
+    assert.equal(panel._views.seq, 1100, "…and the seq once announced is the stale frame it looks like");
+    // a seq-less blob (a kernel from before the stamp) changes the held one too
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 840 });
+    const legacy = copy(S0); delete legacy.seq;
+    frame(panel, legacy);
+    assert.equal(panel._announcedViewsSeq, null);
+  } finally { console.warn = cw; }
+});
+
+test("executed: behind the real federation router, a re-emit between the caps frame and the pusher's frame — a remote host's lanes payload, a view-order re-emit — does not cost this pane the restored store", () => {
+  const remoteLanes = { type: "data", data: { sessions: [{ id: SID2, name: "api" }], turns: {}, messages: [], judging: [], now, views: { active: "all", tags: [], seq: 5 } } };
+  const betweens: [string, (fm: any) => void][] = [
+    ["a remote host's lanes payload", (fm) => fm.inbound("TESTHOST", remoteLanes)],
+    ["a view-order re-emit", (fm) => fm.emitMergedTimeline(false)],
+  ];
+  for (const [what, between] of betweens) {
+    const panel = new TimelinePanel(makeNode("div"));
+    const fm: any = new FederationManager();
+    // the router's window is this global: hand its merged frames to the panel the way the page's boot glue does
+    g.dispatchEvent = (ev: any) => {
+      const m = ev && ev.data; if (!m) return;
+      if (m.type === "data" && m.data) panel.update(m.data);
+      else if (m.type === "caps") panel.setCaps(m);
+    };
+    const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+    try {
+      const lanes = (v: any) => ({ type: "data", data: { now, sessions: [sess(SID1, "web", "#f7768e")], turns: {}, messages: [], judging: [], views: copy(v), palette: PALETTE.slice() } });
+      fm.inbound("", lanes(S0));
+      fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });
+      assert.equal(panel._views.seq, 1000, what + ": the load");
+      fm.inbound("TESTHOST", remoteLanes);                                    // a remote host federated in
+      assert.equal(panel._views.seq, 1000);
+      fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 900 });   // the restart over a restored store, met on a sentinel cycle
+      assert.equal(panel._announcedViewsSeq, 900, what + ": the slot is filled from the frame the router hands on");
+      between(fm);                                                            // the router replays its stored blob — this pane's own held one
+      assert.equal(panel._views.seq, 1000);
+      assert.equal(panel._announcedViewsSeq, 900, what + ": the re-arrival leaves the slot");
+      const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";
+      fm.inbound("", lanes(restored));                                        // the pusher's next frame: the router adopts through its slot and re-emits
+      assert.equal(panel._views.seq, 900, what + ": the pane adopts the restored store from the router's re-emit");
+      assert.equal(panel._curViews().tags[0].name, "site");
+      assert.equal(panel._announcedViewsSeq, null);
+      between(fm);
+      assert.equal(panel._views.seq, 900, what + ": and holds it through the next re-emit");
+      assert.equal(warned.length, 0, what + ": nothing was ever turned away");
+    } finally { console.warn = cw; delete g.dispatchEvent; }
+  }
+});
+
+test("executed: a caps frame without viewsSeq (a kernel from before the field) adopts the kept blob outright — the pre-field rule", () => {
+  const panel = drawnPanel();
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";
+    frame(panel, restored);
+    assert.equal(panel._views.seq, 1000);
+    panel.setCaps({ type: "caps", caps: ["tagEdit"] });
+    assert.equal(panel._views.seq, 900, "no field to match against: the kept blob is adopted");
+    assert.equal(panel._curViews().tags[0].name, "site");
+  } finally { console.warn = cw; }
+});
+
+test("executed: a write in flight at a restored-store reconnect is dropped and said so, and the copy reverts to the ADOPTED base, not the pre-restore one", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { rename: "notes" });
+  assert.equal(panel._viewsWrites.length, 1, "the rename is in flight");
+  assert.equal(panel._curViews().tags[0].name, "notes", "…and shows");
+  const warned: string[] = []; const cw = console.warn; console.warn = (s: any) => { warned.push(String(s)); };
+  try {
+    const restored = copy(S0); restored.seq = 900; restored.tags[0].name = "site";   // the store the restarted kernel serves
+    frame(panel, restored);                            // the connect push, turned away
+    assert.equal(panel._curViews().tags[0].name, "notes", "the copy still shows until the reconnect event");
+    panel.setCaps({ type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    assert.deepEqual(panel._viewsWrites, [], "the write is dropped: its ack cannot reach this socket");
+    assert.equal(panel._pendingViews, null);
+    assert.equal(panel._views.seq, 900, "the base is the restored store…");
+    assert.equal(panel._curViews().tags[0].name, "site", "…and that is what shows — never the pre-restore blob the copy was drawn over");
+    assert.match(panel._tagEditErr.error, /re-established.*may not have landed/, "the user is told");
+    const shown = walk(panel._viewsDialog).map(textOf).find((s) => s.startsWith("⚠ "));
+    assert.ok(shown, "…in the open dialog, rebuilt over the adopted base");
+    // an ack for the dropped write — unreachable on the socket it was posted on; if one arrived it is an ack for
+    // a write this page no longer tracks: its blob meets the gate like any arrival (899 < 900: turned away), and
+    // nothing is re-pinned
+    const late = copy(restored); late.seq = 899; late.tags[0].name = "notes";
+    panel.viewsAck({ type: "tagEditAck", writeId: "w-dropped", ok: true, tid: "gA", seq: 899, views: late });
+    assert.equal(panel._views.seq, 900); assert.equal(panel._curViews().tags[0].name, "site");
+    assert.deepEqual(panel._viewsWrites, []); assert.equal(panel._pendingViews, null);
+  } finally { console.warn = cw; }
+});
+
+// ── The 2026-09-05 review: the in-flight create gate, the legacy create's
+// id, the join input's draft, the create ack and an open editor, and a refusal reverting only its own write.
+test("executed: [+ New tag] takes ONE click per create — the row reads creating… until the ack, then the button is back", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  clickNewTag(panel);
+  assert.equal(tagOps().length, 1, "one create posted");
+  const busy = walk(panel._viewsDialog).find((n) => n.textContent === "creating…");
+  assert.ok(busy, "the row says a create is in flight");
+  assert.equal(busy._attrs["aria-disabled"], "true");
+  assert.equal(busy._listeners.click, undefined, "…and takes no click");
+  assert.equal(walk(panel._viewsDialog).find((n) => n.textContent === "+ New tag"), undefined, "the button is gone while one is in flight");
+  assert.equal(tagOps().length, 1, "a second click before the ack posts nothing — no second tag");
+  ackCreate(panel);
+  assert.ok(walk(panel._viewsDialog).find((n) => n.textContent === "+ New tag"), "the ack's repaint brings the button back");
+  assert.equal(walk(panel._viewsDialog).find((n) => n.textContent === "creating…"), undefined);
+  clickNewTag(panel);
+  assert.equal(tagOps().length, 2, "…and the next click is a new create");
+  // a refusal re-arms it too
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[1].writeId, ok: false, error: "the views blob caps at 32 tags", seq: 1001, views: copy(panel._views) });
+  assert.ok(walk(panel._viewsDialog).find((n) => n.textContent === "+ New tag"));
+});
+
+test("executed: the join menu's new-tag input takes ONE Enter per create — disabled and saying so until the ack repaints the menu", () => {
+  const panel = drawnPanel();
+  const s = panel.data.sessions.find((x: any) => x.id === SID2);
+  const anchor = makeNode("g"); anchor._rect = { left: 40, top: 60, right: 60, bottom: 76, width: 20, height: 16 };
+  panel._openLaneMenu(s, anchor);
+  const plus = () => walk(panel._laneMenu).find((n) => n.textContent === "+" && n._attrs.title === "add a tag");
+  plus()._listeners.click({ stopPropagation() {} });
+  const ni = walk(panel._laneMenu).find((n) => n.tag === "input");
+  assert.ok(ni, "the join menu's input");
+  assert.equal(ni.disabled, undefined);
+  ni.value = "qa"; ni._listeners.keydown({ key: "Enter" });
+  assert.equal(tagOps().length, 1);
+  assert.deepEqual([tagOps()[0].op, tagOps()[0].name], ["create", "qa"]);
+  ni._listeners.keydown({ key: "Enter" });                          // the same node, again, before the ack
+  assert.equal(tagOps().length, 1, "a second Enter before the ack posts nothing");
+  assert.equal(ni.disabled, true, "the input went dead on submit");
+  // the menu was rebuilt without the join box (it closes on submit); opening it again while the
+  // create is in flight shows a disabled input that says so
+  plus()._listeners.click({ stopPropagation() {} });
+  const ni2 = walk(panel._laneMenu).find((n) => n.tag === "input");
+  assert.notEqual(ni2, ni);
+  assert.equal(ni2.disabled, true);
+  assert.equal(ni2.placeholder, "creating…");
+  ni2.value = "docs"; ni2._listeners.keydown({ key: "Enter" });
+  assert.equal(tagOps().length, 1, "Enter on the disabled input posts nothing");
+  // the create's ack repaints the open menu: the input is live again
+  const S1 = copy(S0); S1.seq = 1001; S1.tags.push({ id: "g8", name: "qa", color: "#1EA1EB", members: [SID2], mtime: 113 });
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[0].writeId, ok: true, seq: 1001, tid: "g8", name: "qa", views: S1 });
+  const ni3 = walk(panel._laneMenu).find((n) => n.tag === "input");
+  assert.ok(ni3 && ni3 !== ni2, "the menu was rebuilt on the ack");
+  assert.equal(ni3.disabled, undefined);
+  assert.equal(ni3.placeholder, "new tag…");
+  ni3.value = "docs"; ni3._listeners.keydown({ key: "Enter" });
+  assert.equal(tagOps().length, 2, "…and takes the next create");
+  panel._closeLaneMenu();
+});
+
+test("executed: the join menu's new-tag input keeps its text and caret across a repaint; submit and close drop the draft", () => {
+  const panel = drawnPanel();
+  const box = makeNode("div");
+  panel._tagJoinMenu(box, [SID2], () => {}, SID2);   // the menu's identity: which [+] is open
+  const ni = walk(box).find((n) => n.tag === "input");
+  assert.equal(g.document.activeElement, ni, "the input took focus");
+  ni.value = "do"; ni.selectionStart = 1; ni.selectionEnd = 1; ni._listeners.input();
+  ni.value = "doc"; ni.selectionStart = 2; ni.selectionEnd = 2;            // the caret moved without an input event (arrow keys)
+  // a refusal for some other write repaints the surface that holds the menu — here, the builder runs again
+  const box2 = makeNode("div");
+  panel._tagJoinMenu(box2, [SID2], () => {}, SID2);
+  const ni2 = walk(box2).find((n) => n.tag === "input");
+  assert.notEqual(ni2, ni, "a fresh input");
+  assert.equal(ni2.value, "doc", "the typed text survives — read from the live input, not the last input event");
+  assert.deepEqual(ni2._sel, [2, 2], "the caret is where it was");
+  assert.equal(g.document.activeElement, ni2, "focus is back in the input");
+  // a menu for OTHER rows starts empty; the draft for these rows is kept
+  const box3 = makeNode("div");
+  panel._tagJoinMenu(box3, [SID1], () => {}, SID1);
+  assert.equal(walk(box3).find((n) => n.tag === "input").value, "", "another [+]'s menu does not inherit the draft");
+  const box4 = makeNode("div");
+  panel._tagJoinMenu(box4, [SID2], () => {}, SID2);
+  const ni4 = walk(box4).find((n) => n.tag === "input");
+  assert.equal(ni4.value, "doc");
+  // submit posts the drafted name and drops the draft
+  ni4.value = "docs"; ni4._listeners.input(); ni4._listeners.keydown({ key: "Enter" });
+  assert.equal(tagOps()[0].name, "docs");
+  assert.equal(panel._tagNewDraft, null);
+  ackCreate(panel, 1001, "docs");
+  // closing the menu from the lane gear's [+] drops a draft too
+  const s = panel.data.sessions.find((x: any) => x.id === SID2);
+  const anchor = makeNode("g"); anchor._rect = { left: 40, top: 60, right: 60, bottom: 76, width: 20, height: 16 };
+  panel._openLaneMenu(s, anchor);
+  const plus = () => walk(panel._laneMenu).find((n) => n.textContent === "+" && n._attrs.title === "add a tag");
+  plus()._listeners.click({ stopPropagation() {} });
+  const li = walk(panel._laneMenu).find((n) => n.tag === "input");
+  li.value = "zz"; li._listeners.input();
+  assert.equal(panel._tagNewDraft.value, "zz");
+  plus()._listeners.click({ stopPropagation() {} });                       // toggles the join box closed
+  assert.equal(panel._tagNewDraft, null, "closing the menu drops the draft");
+  panel._closeLaneMenu();
+});
+
+test("executed: LEGACY (no cap): a create from the join menu ships a client-minted g… id, never the pending- placeholder, and names it as edited", () => {
+  const L0 = copy(S0); delete L0.seq;
+  const panel = drawnPanel(L0, []);
+  const box = makeNode("div");
+  panel._tagJoinMenu(box, [SID1, SID2], () => {});
+  const ni = walk(box).find((n) => n.tag === "input");
+  ni.value = "qa"; ni._listeners.keydown({ key: "Enter" });
+  assert.equal(posted.length, 1);
+  assert.equal(posted[0].kind, "views", "the whole blob — the store write itself on this path");
+  const row = posted[0].v.tags.find((t: any) => t.name === "qa");
+  assert.ok(row, "the new row is in the blob");
+  assert.match(row.id, /^g[0-9a-z]+$/, "a proper id (the dialog's pre-2026-09-05 scheme) — nothing pending- is ever persisted");
+  assert.deepEqual(row.members, [SID1, SID2]);
+  assert.deepEqual(posted[0].edited, [row.id], "…and the write names it: a kernel that reads `edited` would otherwise keep an unknown tag out as a stale re-creation");
+  assert.equal(panel._curViews().tags.find((t: any) => t.name === "qa").id, row.id, "the optimistic copy shows the same id");
+  assert.equal(JSON.stringify(posted).indexOf("pending-"), -1, "no placeholder anywhere on the wire");
+});
+
+test("executed: a create's ack opens the rename input on the new tid ONLY when no editor is open — the user's rename elsewhere is left alone", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  // the user is renaming "web"…
+  walk(panel._viewsDialog).find((n) => n.textContent === "rename")._listeners.click();
+  assert.equal(panel._tagEditorFor, "gA");
+  const inp = nameInput(panel); inp.value = "site"; inp._listeners.input();
+  // …and clicks [+ New tag] meanwhile (its ack arrives while the editor is still open)
+  clickNewTag(panel);
+  ackCreate(panel);
+  assert.equal(panel._tagEditorFor, "gA", "the editor stays on the row the user is renaming");
+  const inp2 = nameInput(panel);
+  assert.equal(inp2.value, "site", "…with the typed text (the rebuild kept the draft)");
+  assert.ok(walk(panel._viewsDialog).some((n) => n.textContent === "tag 1"), "the new row shows under its default name, unopened");
+  inp2._listeners.change();
+  assert.deepEqual([tagOps()[1].op, tagOps()[1].tid, tagOps()[1].newName], ["rename", "gA", "site"]);
+  assert.equal(panel._tagEditorFor, null);
+  // with no editor open, a create's ack opens the new row's — as before
+  clickNewTag(panel);
+  const S2 = copy(panel._views); S2.seq = 1002; S2.tags.push({ id: "g9", name: "tag 2", color: "#54B204", members: [], mtime: 114 });
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[2].writeId, ok: true, seq: 1002, tid: "g9", name: "tag 2", views: S2 });
+  assert.equal(panel._tagEditorFor, "g9");
+});
+
+test("executed: a refusal reverts ONLY its own write — a later write still in flight keeps its optimistic change, and its own ack settles it", () => {
+  const panel = drawnPanel();
+  const u = viewTagUnion(panel._curViews()).find((x: any) => x.name === "web");
+  panel._editTagUnion(u, { color: "#DD42FF" });                                           // A: recolor
+  panel._editTagUnion(viewTagUnion(panel._curViews()).find((x: any) => x.name === "web"), { add: [SID2] });   // B: add, from the copy showing A
+  const [wA, wB] = panel._viewsWrites.map((w: any) => w.id);
+  assert.deepEqual([panel._curViews().tags[0].color, panel._curViews().tags[0].members], ["#DD42FF", [SID1, SID2]], "both show");
+  // A is refused (say, the tag was recoloured elsewhere first — a targeted op the kernel refused)
+  panel.viewsAck({ type: "tagEditAck", writeId: wA, ok: false, tid: "gA", seq: 1000, error: "that tag no longer exists — it may have been deleted from another dashboard", views: copy(S0) });
+  assert.deepEqual(panel._viewsWrites.map((w: any) => w.id), [wB], "only A is dropped; B is still in flight");
+  assert.ok(panel._pendingViews, "B's copy still shows");
+  assert.equal(panel._curViews().tags[0].color, "#3b82f6", "A's recolor reverted");
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2], "B's add did NOT flap off");
+  assert.match(panel._tagEditErr.error, /no longer exists/, "the refusal is still shown");
+  // B's ack settles it
+  const S1 = copy(S0); S1.seq = 1001; S1.tags[0].members = [SID1, SID2];
+  panel.viewsAck({ type: "tagEditAck", writeId: wB, ok: true, seq: 1001, tid: "gA", views: S1 });
+  assert.equal(panel._pendingViews, null);
+  assert.deepEqual(panel._curViews().tags[0].members, [SID1, SID2]);
+  // a whole-blob write in flight after a refused targeted one: the copy IS that write's blob
+  panel._editTagUnion(viewTagUnion(panel._curViews()).find((x: any) => x.name === "web"), { rename: "site" });   // C
+  const nv = copy(panel._curViews()); nv.actives = Object.assign({}, nv.actives, { timeline: { tags: ["site"] } });
+  panel._setViews(nv);                                                                   // D: a lens write built from the copy showing C
+  const wC = panel._viewsWrites[0].id;
+  panel.viewsAck({ type: "tagEditAck", writeId: wC, ok: false, tid: "gA", seq: 1001, error: 'a tag named "site" already exists', views: copy(S1) });
+  assert.equal(panel._viewsWrites.length, 1, "D is still in flight");
+  assert.deepEqual(panel._curViews().actives.timeline, { tags: ["site"] }, "D's lens still shows");
+  assert.equal(panel._curViews().tags[0].name, "site", "D posted the whole blob with C's rename in it — what the kernel will judge D by, so that is what shows");
+});
+
+test("pins: no frame count settles a stamped kernel's write; the legacy exact echo and three-frame yield live in the seq-less branch only", () => {
+  assert.doesNotMatch(SRC, /_pendingViewsAge/, "the old counter is gone");
+  const rec = SRC.slice(SRC.indexOf("  _reconcileViews() {"), SRC.indexOf("  // The LOCAL kernel's capabilities"));
+  assert.match(rec, /viewsSeq\(this\._views\) === null\s*\n\s*&& \(this\._viewsKey\(this\._views\) === this\._viewsKey\(this\._pendingViews\)\s*\n\s*\|\| \(this\._legacyViewsAge = \(this\._legacyViewsAge \|\| 0\) \+ 1\) >= 3\)\)/,
+    "both legacy clears sit under the seq-less condition — a blob with a seq comes from a kernel that acks, and only the ack settles");
+  assert.equal((rec.match(/>= 3/g) || []).length, 1, "one legacy yield, nowhere else");
+  assert.match(SRC, /_postTagEdit\(nv, edit, meta\) \{\s*\n\s*if \(!this\._tagEditsTargeted\(\)\) \{\s*\n\s*if \(!nv\) return;[\s\S]{0,1200}?const edited = \[edit\.tid, edit\.tid_from, edit\.tid_to\]\.filter\(Boolean\);[\s\S]{0,400}?this\._setViews\(nv, edited\);\s*\n\s*return;\s*\n\s*\}/,
+    "a targeted op needs the capability AND a bridge; otherwise the whole-blob write, naming the tags it changed (a create's row included)");
+  assert.match(SRC, /window\.__rompTimelineSetViews\(v, writeId, Array\.isArray\(edited\) \? edited : \[\]\);/, "the whole-blob hook carries the writeId and the edited tag ids");
+  assert.match(SRC, /window\.__rompTimelineTagEdit\(writeId, edit\);/, "the targeted hook carries the writeId beside the NESTED op");
+  assert.doesNotMatch(SRC, /op: '(?:rename|recolor|addMember|removeMember|delete)', name:/, "no op but create carries a name — every one addresses by tid");
+});
+
+// ── The 2026-09-05 review ──────────────────────────────────────────────────────────────────
+test("executed: a lens or order write is built from the STORE's blob — a rename still in flight never rides it, and its refusal reverts only the rename", () => {
+  const panel = drawnPanel();
+  const web = viewTagUnion(panel._curViews()).find((g: any) => g.name === "web");
+  panel._editTagUnion(web, { rename: "notes" });
+  assert.deepEqual([tagOps().length, tagOps()[0].op, tagOps()[0].newName], [1, "rename", "notes"]);
+  assert.equal(panel._curViews().tags[0].name, "notes", "the copy shows the rename");
+  // a lens toggle while the rename is in flight (the dialog's pane-filter row, the corner chip, the menu)
+  panel._setLens({ actives: Object.assign({}, panel._curViews().actives, { timeline: { tags: ["web"] } }) });
+  const w = posted.filter((p) => p.kind === "views");
+  assert.equal(w.length, 1);
+  assert.equal(w[0].v.tags[0].name, "web", "the POSTED blob carries the store's name — the rename in flight is not this write's claim");
+  assert.deepEqual([w[0].v.seq, w[0].v.at], [S0.seq, S0.at], "…with the store's stamps, the guard's evidence time");
+  assert.deepEqual(w[0].v.actives.timeline, { tags: ["web"] });
+  assert.deepEqual(w[0].edited, []);
+  assert.equal(panel._curViews().tags[0].name, "notes", "the copy SHOWN keeps the rename…");
+  assert.deepEqual(panel._curViews().actives.timeline, { tags: ["web"] }, "…and the lens");
+  // the rename is refused as a duplicate: only it reverts; the lens write's fields stay shown
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[0].writeId, ok: false, error: 'a tag named "notes" already exists', seq: 1000, views: copy(S0) });
+  assert.equal(panel._curViews().tags[0].name, "web");
+  assert.deepEqual(panel._curViews().actives.timeline, { tags: ["web"] });
+  assert.match(panel._tagEditErr.error, /already exists/);
+  const S1 = copy(S0); S1.seq = 1001; S1.actives = Object.assign({}, actives, { timeline: { tags: ["web"] } });
+  panel.viewsAck({ type: "viewsAck", writeId: w[0].writeId, ok: true, refused: [], views: S1 });
+  assert.equal(panel._pendingViews, null, "the lens ack settles it");
+  // an ORDER write: the store's tags re-sorted to the order, tagOrder set — from the store's blob
+  const S2 = copy(S1); S2.seq = 1002; S2.tags.push({ id: "gB", name: "api", color: "#54B204", members: [SID2], mtime: 120 });
+  frame(panel, S2);
+  panel._setLens({ tagOrder: ["api", "web"] });
+  const o = posted.filter((p) => p.kind === "views")[1];
+  assert.deepEqual(o.v.tags.map((t: any) => t.id), ["gB", "gA"]);
+  assert.deepEqual(o.v.tagOrder, ["api", "web"]);
+  assert.deepEqual(panel._curViews().tagOrder, ["api", "web"]);
+  // every lens and order site goes through _setLens: the pane-filter row, the pill drag, the corner chip, the menu
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, this\._curViews\(\)\.actives, upd\) \}\);/, "the dialog's pane filters");
+  assert.match(SRC, /this\._setLens\(\{ tagOrder: names \}\);/, "the pill drag");
+  assert.equal((SRC.match(/this\._setViews\(nv\);/g) || []).length, 0, "no whole-blob write from a copy remains outside the legacy tag path");
+  assert.match(SRC, /_setLens\(fields\) \{\s*\n\s*this\._setViews\(lensBlob\(this\._views, fields\), \[\], fields\);/, "built from this._views, the store's blob");
+});
+
+test("executed: a tag whose create is in flight takes no gesture — the dialog row reads creating… with no actions, its chip has no ✕, the join menu does not offer it; the ack restores them", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  const plusFor = (i: number) => walk(panel._viewsDialog).filter((n) => n._attrs.title === "add a tag")[i];
+  plusFor(1)._listeners.click();                                   // SID2's [+]
+  const ni = walk(panel._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "new tag…");
+  ni.value = "qa"; ni._listeners.keydown({ key: "Enter" });
+  assert.deepEqual([tagOps().length, tagOps()[0].op, tagOps()[0].sids], [1, "create", [SID2]]);
+  let nodes = walk(panel._viewsDialog);
+  const qaCell = nodes.find((n) => n._tname === "qa");
+  assert.ok(qaCell, "the optimistic row renders");
+  assert.ok(walk(qaCell).some((n) => n.textContent === "creating…"), "…and says the create is in flight");
+  assert.equal(qaCell._listeners.pointerdown, undefined, "…and is not draggable");
+  const delTitle = (name: string) => (n: any) => typeof n._attrs.title === "string" && n._attrs.title.startsWith("DELETE the tag “" + name);
+  assert.equal(nodes.find(delTitle("qa")), undefined, "no delete action on it");
+  assert.ok(nodes.find(delTitle("web")), "…while the settled tag keeps its actions");
+  assert.equal(nodes.filter((n) => n._attrs.title === "rename this tag (everywhere it is defined)").length, 1, "one rename action: the settled tag's");
+  const chip = nodes.find((n) => n._attrs.title === 'creating "qa"…');
+  assert.ok(chip, "the session's chip for it shows");
+  assert.equal(chip._listeners.click, undefined, "…with no ✕ and no click");
+  // the union says so, and a gesture that reaches the editor anyway posts nothing addressed to the placeholder
+  const pend = viewTagUnion(panel._curViews()).find((g: any) => g.name === "qa");
+  assert.equal(pend.pending, true);
+  panel._editTagUnion(pend, { rename: "quality" });
+  panel._editTagUnion(pend, { delete: true });
+  panel._editTagUnion(pend, { add: [SID1] });
+  panel._editTagUnion(pend, { remove: [SID2] });
+  assert.equal(tagOps().length, 1, "nothing posted");
+  assert.ok(!posted.some((p) => p.kind === "tag" && /^pending-/.test(String(p.e.tid || p.e.tid_from || p.e.tid_to || ""))), "no op ever names the placeholder");
+  // SID1's join menu does not offer it while pending
+  plusFor(0)._listeners.click();
+  nodes = walk(panel._viewsDialog);
+  // the join menu's box (grid-spanning, indented) — the pane-filter rows also render a clickable "qa" pill, a lens pick by name
+  const joinBox = () => walk(panel._viewsDialog).find((n) => String(n._attrs.style || "").startsWith("grid-column:1 / -1;margin:2px 0 4px 8px"));
+  const joinOptions = () => walk(joinBox()).filter((n) => n._listeners.click && n.textContent === "qa");
+  assert.equal(joinOptions().length, 0, "not joinable before the ack");
+  // the lane gear menu's chips follow the same rule
+  const s2 = panel.data.sessions.find((x: any) => x.id === SID2);
+  const anchor = makeNode("g"); anchor._rect = { left: 40, top: 60, right: 60, bottom: 76, width: 20, height: 16 };
+  panel._closeViewsDialog();
+  panel._openLaneMenu(s2, anchor);
+  const laneChip = walk(panel._laneMenu).find((n) => n._attrs.title === 'creating "qa"…');
+  assert.ok(laneChip && laneChip._listeners.click === undefined, "the lane menu's chip takes no click either");
+  panel._closeLaneMenu();
+  // the ack names the tag: actions, chip ✕ and the join option are back
+  panel._openViewsDialog(null);
+  const S1 = copy(S0); S1.seq = 1001; S1.at = 113; S1.tags.push({ id: "g7", name: "qa", color: "#54B204", members: [SID2], mtime: 113 });
+  panel.viewsAck({ type: "tagEditAck", writeId: tagOps()[0].writeId, ok: true, seq: 1001, tid: "g7", name: "qa", views: S1 });
+  nodes = walk(panel._viewsDialog);
+  assert.ok(nodes.find(delTitle("qa")), "delete is back");
+  assert.equal(nodes.find((n) => n._attrs.title === 'creating "qa"…'), undefined);
+  assert.ok(nodes.find((n) => typeof n._attrs.title === "string" && n._attrs.title.startsWith('tagged "qa"')), "the chip carries its ✕ again");
+  assert.equal(joinOptions().length, 1, "…and SID1's menu offers it");
+  assert.equal(viewTagUnion(panel._curViews()).find((g: any) => g.name === "qa").pending, undefined);
+});
+
+test("executed: the join menu's new-tag draft is keyed by the open [+], survives a change of the rows it lists, and dies with the menu or the dialog", () => {
+  const panel = drawnPanel();
+  panel._openViewsDialog(null);
+  walk(panel._viewsDialog).find((n) => n.textContent === "tag all")._listeners.click();     // the bulk [+]
+  const input = () => walk(panel._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "new tag…");
+  const ni = input();
+  ni.value = "do"; ni._listeners.input();
+  assert.equal(panel._tagNewDraft.key, "*", "the draft belongs to the MENU (the bulk [+]), not to the rows it lists");
+  // the search filter changes the row set under the open menu: the draft is still this menu's
+  const q = walk(panel._viewsDialog).find((n) => n.tag === "input" && n.placeholder === "search name or host…");
+  q.value = "we"; q._listeners.input();
+  const ni2 = input();
+  assert.notEqual(ni2, ni, "the menu was rebuilt for fewer rows");
+  assert.equal(ni2.value, "do", "…and the draft came with it (keyed by the row set it hid here)");
+  q.value = ""; q._listeners.input();
+  assert.equal(input().value, "do");
+  // closing the dialog drops it — it does not reappear in the next menu opened for the same rows
+  panel._closeViewsDialog();
+  assert.equal(panel._tagNewDraft, null);
+  assert.equal(panel._tagNewInput, null);
+  panel._openViewsDialog(null);                                                            // the bulk [+] is still the open one (the key rides the instance)
+  assert.equal(input().value, "", "…the reopened menu starts empty");
+  panel._closeViewsDialog();
+  // the lane gear menu: closing the MENU (not only toggling its [+]) drops the draft too
+  const s2 = panel.data.sessions.find((x: any) => x.id === SID2);
+  const anchor = makeNode("g"); anchor._rect = { left: 40, top: 60, right: 60, bottom: 76, width: 20, height: 16 };
+  panel._openLaneMenu(s2, anchor);
+  walk(panel._laneMenu).find((n) => n.textContent === "+" && n._attrs.title === "add a tag")._listeners.click({ stopPropagation() {} });
+  const li = walk(panel._laneMenu).find((n) => n.tag === "input");
+  li.value = "zz"; li._listeners.input();
+  assert.equal(panel._tagNewDraft.key, SID2);
+  panel._onDocClick();                                                                      // a click outside closes the menu
+  assert.equal(panel._laneMenu, null);
+  assert.equal(panel._tagNewDraft, null, "the draft died with the menu");
+  assert.equal(panel._tagNewInput, null);
+});

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -48,22 +48,32 @@ test("executed: the trigger label and the N-more cue (live sessions outside the 
   assert.equal(viewMoreCount(V("untagged", ["s1"]), sessions), 1, "tagged s2 sits outside untagged; legacy-hidden s1 shows");
 });
 
-test("executed: an optimistic edit holds until the kernel echoes it — then yields to authority", () => {
+test("executed: an optimistic edit holds until the kernel echoes it exactly — and a frame that does not match never yields it", () => {
   const p: any = Object.create(TimelinePanel.prototype);
-  p._views = null; p._pendingViews = V("g1"); p._pendingViewsAge = 0;
+  p._views = null; p._pendingViews = V("g1"); p._viewsWrites = [{ id: "w1", name: "" }];
   p._reconcileViews();
   assert.ok(p._pendingViews, "no echo yet → still pending");
   // the kernel echoes the same shape with re-sorted lists → canonical comparison clears it
   p._views = { active: "g1", hidden: [], tags: [{ id: "g1", name: "pool", color: "#DD42FF", members: ["s3", "s2"] }] };
   p._reconcileViews();
   assert.equal(p._pendingViews, null, "echo match (order-insensitive) clears the pending edit");
-  // a pending edit the kernel never echoes yields after three pushes — the kernel is authoritative
-  p._pendingViews = V("g1"); p._pendingViewsAge = 0;
+  assert.deepEqual(p._viewsWrites, [], "…and nothing is in flight any more");
+  // a frame that does NOT echo the edit says nothing about it (it may predate the write, or the
+  // kernel may have refused it) — so no number of them yields the copy when the kernel STAMPS its
+  // blobs (`seq`: such a kernel acks every write, and the ack settles it — timeline-views-ack.test.ts).
+  // The three-frame yield that lived here dropped good edits and kept refused ones alike (the user
+  // 2026-09-05).
+  p._pendingViews = V("g1"); p._viewsWrites = [{ id: "w2", name: "" }];
+  p._views = { active: "all", hidden: [], tags: [], seq: 5 };
+  for (let i = 0; i < 6; i++) p._reconcileViews();
+  assert.ok(p._pendingViews, "six silent pushes → still holding the user's edit");
+  // LEGACY: a kernel that stamps no seq acks nothing either, so for its frames alone the old
+  // three-frame yield stays — with no ack ever coming, an unechoed copy would otherwise pin forever
   p._views = { active: "all", hidden: [], tags: [] };
   p._reconcileViews(); p._reconcileViews();
-  assert.ok(p._pendingViews, "two silent pushes → still holding");
+  assert.ok(p._pendingViews, "two silent legacy pushes → still holding");
   p._reconcileViews();
-  assert.equal(p._pendingViews, null, "the third silent push adopts the kernel's blob");
+  assert.equal(p._pendingViews, null, "the third legacy push yields (that kernel's only clear)");
 });
 
 test("executed: the echo key compares per-surface lenses and ignores the retired hidden set", () => {
@@ -73,7 +83,7 @@ test("executed: the echo key compares per-surface lenses and ignores the retired
   // visibly flapped (revert-then-jump-back) until the kernel's real echo arrived
   const p: any = Object.create(TimelinePanel.prototype);
   p._pendingViews = { active: "all", tags: [G], actives: { timeline: { tags: ["pool"] } } };
-  p._pendingViewsAge = 0;
+  p._viewsWrites = [];
   p._views = { active: "all", tags: [G] };   // the pre-edit blob — no lens on it yet
   p._reconcileViews();
   assert.ok(p._pendingViews, "a stale frame without the lens edit must not clear the pending copy");
@@ -84,8 +94,8 @@ test("executed: the echo key compares per-surface lenses and ignores the retired
   assert.equal(p._pendingViews, null, "the echo carrying the lens clears the pending edit");
   // …and the RETIRED hidden set (2026-08-24) is OUT of the key: the kernel drops it, so a local
   // copy still carrying a legacy hidden entry must compare EQUAL to the echo that shed it —
-  // serializing hidden made every such edit ride the 3-push yield instead of clearing on echo
-  p._pendingViews = { active: "all", hidden: ["s9"], tags: [] }; p._pendingViewsAge = 0;
+  // serializing hidden held every such edit's optimistic copy hostage instead of clearing on echo
+  p._pendingViews = { active: "all", hidden: ["s9"], tags: [] }; p._viewsWrites = [];
   p._views = { active: "all", tags: [] };
   p._reconcileViews();
   assert.equal(p._pendingViews, null, "hidden is retired — it cannot hold an echo hostage");
@@ -143,7 +153,7 @@ test("the trigger sits in the corner strip and opens on pointerdown, like every 
 test("an active tag is a REMOVABLE CHIP: outline only in its colour, a dim separate ✕, air below (the user 2026-08-24)", () => {
   // the chip's own pointerdown clears the filter without a menu trip; stopPropagation keeps the
   // text element's menu handler out of it (both are pointerdown — the redraw-eats-click rule)
-  assert.match(SRC, /nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: lensToggle\(lens, c\.pick\) \}\);/,
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, v\.actives, \{ timeline: lensToggle\(lens, c\.pick\) \}\) \}\);/,
     "each chip's ✕ unselects THAT pick (per-selection chips, the user 2026-08-25)");
   // OUTLINE only on the page's own ground (the tinted fill was too much — the user 2026-08-24),
   // and the ✕ is dim and SEPARATE, the composer context chip's read — never baked into the name
@@ -341,7 +351,10 @@ test("_setViews posts through the host hook with a GUARDED, atomic Obsidian fall
   assert.match(SRC, /process\.versions && process\.versions\.electron/);
   assert.match(SRC, /process\.env\.ROMP_STATE_DIR\n?\s*\|\| path\.join\(process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\), 'romp'\)/);
   assert.match(SRC, /fs\.renameSync\(fp \+ '\.tmp', fp\);/);
-  assert.match(SRC, /this\._pendingViews = v; this\._pendingViewsAge = 0;/);
+  // the file IS the store on that path: the write settles on the spot (no kernel ack to wait for)
+  assert.match(SRC, /fs\.renameSync\(fp \+ '\.tmp', fp\);\s*\n\s*this\._views = v; this\._pendingViews = null;/);
+  assert.match(SRC, /_setViews\(v, edited, lens\) \{\s*\n\s*this\._pendingViews = lens \? applyLensFields\(this\._curViews\(\), lens\) : v;/,
+    "a lens or order write shows the current copy with its fields applied; a whole-blob write shows the blob");
   assert.match(SRC, /this\._reconcileViews\(\);\s*\/\/ \.\.\.and an optimistic view edit/);
 });
 
@@ -603,7 +616,7 @@ test("the corner grew two icon buttons and the menus split (the user 2026-08-25)
   assert.match(SRC, /apply\(lensToggle\(lens, \{ tag: g\.name \}\), false\)/,
     "tag rows TOGGLE and the menu stays open (repaint in place)");
   assert.match(SRC, /apply\(\{ all: true \}, true\)/, "All is a plain pick and closes");
-  assert.match(SRC, /nv\.actives = Object\.assign\(\{\}, nv\.actives, \{ timeline: nl \}\)/,
+  assert.match(SRC, /this\._setLens\(\{ actives: Object\.assign\(\{\}, v\.actives, \{ timeline: nl \}\) \}\)/,
     "writes land on THIS surface's lens only");
 });
 
@@ -637,7 +650,8 @@ test("the dialog redesign: tag TABLE with delete/rename/color actions, five filt
   // destructive convention (dim at rest, red on hover); [+ New tag] is the table's FINAL row
   assert.match(SRC, /grid-template-columns:max-content max-content max-content 1fr;/, "the tag table's four columns");
   assert.match(SRC, /the tag itself: the normal pill, NO ✕ — actions live beside it, never on it/);
-  assert.match(SRC, /this\._tagEditorFor = this\._tagEditorFor === tg\.name \? null : tg\.name;/, "rename toggles the pill into an input");
+  assert.match(SRC, /this\._tagEditorFor = this\._tagEditorFor === unionKey\(tg\) \? null : unionKey\(tg\);/,
+    "rename toggles the pill into an input — keyed by the union's stable id, which survives the rename it makes");
   assert.match(SRC, /d\.style\.color = '#F85B5A'/, "delete goes red on hover — destructive, unlike membership ✕");
   assert.match(SRC, /DELETE the tag/, "the hover says what delete does");
   assert.match(SRC, /text: '\+ New tag'/, "creation is the table's final row");

--- a/ui/webview/federation-views-seq.test.ts
+++ b/ui/webview/federation-views-seq.test.ts
@@ -1,0 +1,335 @@
+// The federation manager REPLAYS the local kernel's views blob — on every merged tabOrder re-emit
+// (localViews) and inside the merged lanes payload (perHostTl[LOCAL].views). Both stores adopt a
+// blob only when its write sequence is at least the stored one (the 2026-09-05 review): the kernel's
+// pusher builds frames from a warmed cache that can predate a write whose ack the pane already
+// adopted, and a replay of that older blob would roll the pane back behind the ack. Executed against
+// the real manager. Synthetic only (placeholder ids).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FederationManager } from "./federation";
+import { adoptViews, capsAdopts, announcedSeq, announcedAfter } from "./views-writes";
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+
+function withManager(fn: (fm: any, emitted: any[]) => void): void {
+  const emitted: any[] = [];
+  const store = new Map<string, string>();
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  try { fn(new FederationManager(), emitted); } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+const lastOf = (emitted: any[], type: string) => emitted.filter((m) => m && m.type === type).pop()!;
+const views = (seq: number | undefined, active = "all") => ({ active, tags: [], ...(seq === undefined ? {} : { seq }) });
+
+test("the replayed LOCAL views blob keeps the newest write sequence across tabOrder frames", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], views: views(5) });
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 5);
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], views: views(4) });
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 5, "an older blob (the pusher's cache, delivered after a newer one) does not replace the stored one");
+    fm.emitMergedOrder();
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 5, "a synthetic re-emit replays the newest");
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], views: views(6) });
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 6, "a newer blob lands as before");
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], views: views(undefined, "untagged") });
+    assert.equal(lastOf(emitted, "tabOrder").views.active, "untagged", "a blob without a seq (a kernel from before the stamp) still adopts");
+  });
+});
+
+test("a kernel's `caps` frame describes THAT kernel: the local one reaches the panes, a remote's is dropped", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("TESTHOST", { type: "caps", caps: ["tagEdit"] });
+    assert.equal(emitted.filter((m) => m.type === "caps").length, 0, "a remote kernel's capabilities would read as the local kernel's — the panes write only the local views store");
+    fm.inbound("", { type: "caps", caps: ["tagEdit"] });
+    assert.deepEqual(emitted.filter((m) => m.type === "caps"), [{ type: "caps", caps: ["tagEdit"] }], "the local kernel's frame is handed to the panes as-is");
+  });
+});
+
+// The 2026-09-05 review: the local caps frame adopts the blob each store's
+// gate last turned away when its viewsSeq (the seq of the blob the kernel's own connect push served) names it,
+// and RE-EMITS before the caps frame is handed on — the panes see the local blob only through these re-emits,
+// so the restored blob must meet their own gate before their caps door adopts it.
+const typesOf = (emitted: any[]) => emitted.map((m) => m && m.type);
+const lanes = (v: any) => ({ type: "data", data: { sessions: [{ id: U, name: "web" }], turns: {}, messages: [], judging: [], now: 1000, views: v } });
+const order = (v: any) => ({ type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }], views: v });
+test("the local kernel's `caps` frame adopts the blob each replayed store turned away when viewsSeq names it — the restarted kernel's connect push under an older seq — and re-emits it BEFORE the caps frame reaches the panes", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });   // the load's caps frame: nothing was turned away, nothing is re-emitted
+    assert.deepEqual(typesOf(emitted), ["tabOrder", "data", "caps"]);
+    // the kernel restarted over a store restored from an older copy: its connect push carries seq 900
+    fm.inbound("", order(views(900, "untagged")));
+    fm.inbound("", lanes(views(900, "untagged")));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1000, "the gate turns the push away, as it must before the reconnect event…");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1000, "…so the panes saw it wearing the stored blob");
+    const n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    assert.deepEqual(typesOf(emitted.slice(n)), ["tabOrder", "data", "caps"], "one re-emit per store that adopted, then the caps frame — in that order");
+    const o = emitted[n], d = emitted[n + 1];
+    assert.equal(o.views.seq, 900, "the merged order now carries the restored store's blob…");
+    assert.equal(o.views.active, "untagged");
+    assert.equal(o.reemit, true, "…as a synthetic re-emit (no host reported anything)");
+    assert.equal(d.data.views.seq, 900, "…and so does the lanes payload");
+    assert.deepEqual(d.data.sessions.map((s: any) => s.id), [U], "with its lanes intact");
+    fm.inbound("", order(views(899)));
+    fm.inbound("", lanes(views(899)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "the store's own order gates again from the adopted seq");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+    // a REMOTE kernel's caps frame is inert: it neither adopts the blobs just turned away nor re-emits
+    const k = emitted.length;
+    fm.inbound("TESTHOST", { type: "caps", caps: ["tagEdit"], viewsSeq: 899 });
+    assert.equal(emitted.length, k, "a remote's caps frame emits nothing here");
+    fm.emitMergedOrder();
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "…and the replayed stores stand");
+    fm.emitMergedTimeline(false);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+    // the LOCAL caps frame naming them does adopt them — the same blobs a remote's frame left alone
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 899 });
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 899);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 899);
+  });
+});
+
+test("a healthy reconnect keeps both stores' gates: the connect push is adopted, the caps frame names it and re-emits nothing, and a pusher frame built before a concurrent write is turned away whether it lands before or after the caps frame", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    // the socket came back on the same kernel; another dashboard's write landed meanwhile (seq 1001): the connect push is current
+    fm.inbound("", order(views(1001, "untagged")));
+    fm.inbound("", lanes(views(1001, "untagged")));
+    // the pusher thread's frame, built from its cache before that write and enqueued BETWEEN the push and the caps
+    // frame — the window an earlier fix left open: turned away and kept…
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1001);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1001);
+    const n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 1001 });   // …and the caps frame names the connect push, not it
+    assert.deepEqual(typesOf(emitted.slice(n)), ["caps"], "the kept frames' seq is not the one named: discarded, no re-emit, just the caps frame handed on");
+    fm.emitMergedOrder();
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1001, "the stores stand");
+    fm.inbound("", order(views(1000)));                // the same stale frame landing AFTER the caps frame instead
+    fm.inbound("", lanes(views(1000)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1001, "turned away: the gate never opened, so the panes never see the older blob");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1001);
+    fm.inbound("", order(views(1001, "untagged")));
+    fm.inbound("", lanes(views(1001, "untagged")));
+    // that adoption let the kept blobs go: a later caps frame (another reconnect, same store) has nothing to adopt
+    const k = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 1001 });
+    assert.deepEqual(typesOf(emitted.slice(k)), ["caps"]);
+  });
+});
+
+test("a caps frame whose push served no views blob (viewsSeq null) adopts nothing and lets the kept blobs go; a frame without the field (an older kernel) adopts them outright", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    fm.inbound("", order(views(900)));                 // the restarted kernel's connect push under the restored store's seq: kept
+    fm.inbound("", lanes(views(900)));
+    let n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: null });
+    assert.deepEqual(typesOf(emitted.slice(n)), ["caps"], "nothing named: nothing adopted, nothing re-emitted");
+    fm.emitMergedOrder();
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1000);
+    n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"] });
+    assert.deepEqual(typesOf(emitted.slice(n)), ["caps"], "the kept blobs were let go: a field-less frame finds nothing to adopt");
+    // kept again, and a frame from a kernel before the field adopts it — the pre-field rule
+    fm.inbound("", order(views(900, "untagged")));
+    fm.inbound("", lanes(views(900, "untagged")));
+    n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"] });
+    assert.deepEqual(typesOf(emitted.slice(n)), ["tabOrder", "data", "caps"]);
+    assert.equal(emitted[n].views.seq, 900); assert.equal(emitted[n + 1].data.views.seq, 900);
+  });
+});
+
+// The 2026-09-05 review: the caps frame's viewsSeq is also the kernel's announcement of its current store (the served blob's seq, or
+// the store's current seq when the connect push carried no views frame; null only when the kernel has no store at
+// all). A reconnect whose push carried no blob (a chat page's sentinel cycle sends no tabOrder) keeps nothing for
+// the earlier rule to match; each replayed store remembers the announced seq in one slot until its next adoption that
+// moves the store (a re-arrival of the stored blob leaves it), and
+// the later blob at exactly that seq — the pusher's next frame after a restart over a store restored from an older
+// copy — is adopted below the stored one.
+test("the local caps frame's viewsSeq is remembered when a store kept nothing it names: the LATER blob at that seq is adopted below the stored one, another lower seq is turned away, the slot clears on an adoption that moves the store, and null, a missing field and a remote's frame announce nothing", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    let n = emitted.length;
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 900 });   // the sentinel cycle's push carried no blob; the restored store's current seq is 900
+    assert.deepEqual(typesOf(emitted.slice(n)), ["caps"], "nothing kept: nothing adopted, nothing re-emitted on the frame itself");
+    fm.inbound("", order(views(899)));
+    fm.inbound("", lanes(views(899)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1000, "a frame at another lower seq is a stale frame: turned away");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1000);
+    fm.inbound("", order(views(900, "untagged")));     // the pusher's next cycle: the restored store under its old seq
+    fm.inbound("", lanes(views(900, "untagged")));
+    const o = lastOf(emitted, "tabOrder"), d = lastOf(emitted, "data");
+    assert.equal(o.views.seq, 900, "the announced seq IS the store the kernel said it holds: adopted below the stored one, and the merged order carries it");
+    assert.equal(o.views.active, "untagged");
+    assert.equal(d.data.views.seq, 900, "…and so does the lanes payload");
+    assert.deepEqual(d.data.sessions.map((s: any) => s.id), [U]);
+    fm.inbound("", order(views(899)));
+    fm.inbound("", lanes(views(899)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "the store's own order gates again from the adopted seq");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+    fm.emitMergedOrder(); fm.emitMergedTimeline(false);
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "a synthetic re-emit replays the adopted store");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+    // the slot clears on an adoption that moves the store: a write landing before the announced blob arrives stamps the store past it
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 800 });
+    fm.inbound("", order(views(1100)));
+    fm.inbound("", lanes(views(1100)));
+    fm.inbound("", order(views(800)));                 // the pusher's frame built before that write
+    fm.inbound("", lanes(views(800)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1100, "the announced seq is no longer a door once the store moved past it");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1100);
+    // null (the kernel has no store at all) announces nothing, and an earlier announcement does not outlive the frame
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 700 });
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: null });
+    fm.inbound("", order(views(700)));
+    fm.inbound("", lanes(views(700)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1100);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1100);
+    // a frame without the field (a kernel from before it) announces nothing either
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 650 });
+    fm.inbound("", { type: "caps", caps: ["tagEdit"] });
+    fm.inbound("", order(views(650)));
+    fm.inbound("", lanes(views(650)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1100);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1100);
+    // a REMOTE kernel's caps frame announces nothing here: the panes' stores are the local kernel's
+    fm.inbound("TESTHOST", { type: "caps", caps: ["tagEdit"], viewsSeq: 600 });
+    fm.inbound("", order(views(600)));
+    fm.inbound("", lanes(views(600)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1100);
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1100);
+  });
+});
+
+test("…and across lanes payloads: an older LOCAL data frame keeps the stored views while its lanes still land", () => {
+  withManager((fm, emitted) => {
+    const lanes = (ids: string[], now: number, v: any) => ({ type: "data", data: { sessions: ids.map((id) => ({ id, name: id.slice(0, 4) })), turns: {}, messages: [], judging: [], now, views: v } });
+    fm.inbound("", lanes([U], 1000, views(5)));
+    fm.inbound("", lanes([U, V], 1001, views(4)));
+    const d = lastOf(emitted, "data").data;
+    assert.equal(d.views.seq, 5, "the stored blob stands");
+    assert.deepEqual(d.sessions.map((s: any) => s.id), [U, V], "…and the frame's lanes still land — the blob is the only field the seq governs");
+    assert.equal(d.now, 1001);
+    fm.inbound("", lanes([U, V], 1002, views(7)));
+    assert.equal(lastOf(emitted, "data").data.views.seq, 7);
+    // a REMOTE host's lanes payload is not the local blob's store at all
+    fm.inbound("TESTHOST", lanes([V], 900, views(1)));
+    assert.equal(lastOf(emitted, "data").data.views.seq, 7, "a remote kernel's views are its own dashboards' prefs; the merge carries the local blob");
+  });
+});
+
+// The 2026-09-05 review: the slot is cleared only by an adoption that CHANGES the stored blob. A re-arrival of the blob a store
+// already holds (the same seq) is no new information and leaves the slot, so the blob at the announced seq is still
+// adopted after it; a newer write still clears it (the earlier honesty rule).
+test("a same-seq re-arrival leaves each store's announced slot standing — the announced blob is still adopted after it; a newer blob clears it", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", order(views(1000)));
+    fm.inbound("", lanes(views(1000)));
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 900 });
+    fm.inbound("", order(views(1000, "untagged")));   // the blob each store holds, arriving again
+    fm.inbound("", lanes(views(1000, "untagged")));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1000);
+    assert.equal(lastOf(emitted, "tabOrder").views.active, "untagged", "adopted (equal seq), as ever");
+    assert.equal(lastOf(emitted, "data").data.views.active, "untagged");
+    fm.inbound("", order(views(900, "site")));        // the pusher's next frame: the restored store under its old seq
+    fm.inbound("", lanes(views(900, "site")));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "the slot stood through the re-arrival: the announced store is adopted below the stored one");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+    fm.inbound("", order(views(900)));                // the adopted blob again: the ordinary rule, nothing to a spent slot
+    fm.inbound("", lanes(views(900)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 900);
+    // a newer write still clears it
+    fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 800 });
+    fm.inbound("", order(views(900)));                // held again: the slot stands…
+    fm.inbound("", lanes(views(900)));
+    fm.inbound("", order(views(1100)));               // …until the store moves
+    fm.inbound("", lanes(views(1100)));
+    fm.inbound("", order(views(800)));                // the pusher's frame built before that write
+    fm.inbound("", lanes(views(800)));
+    assert.equal(lastOf(emitted, "tabOrder").views.seq, 1100, "the newer write cleared the slot: 800 is the stale frame it looks like");
+    assert.equal(lastOf(emitted, "data").data.views.seq, 1100);
+  });
+});
+
+// The 2026-09-05 review's last failure, executed end to end. A PANE behind the router fills its slot from the same caps frame the router
+// does, but sees the local blob only through the router's re-emits — and every merged re-emit (a remote host's push
+// or lanes payload, a `closed` frame, a view-order storage event, a host drop) hands it the router's STORED blob at
+// the pane's own held seq. The earlier clear on any adoption spent the pane's slot on that same-seq adoption; the pusher's frame then reached
+// the router (adopted through its intact slot, re-emitted at the announced seq) and the pane turned it away: router
+// 900, pane 1000, silently, until the next write. The gates below are the composition render.ts's takeViews /
+// onKernelCaps and the timeline's _takeViews / setCaps use (views-writes.test.ts pins the former; timeline-views-
+// ack.test.ts drives the real panel behind the real router), fed every frame the real manager dispatches.
+function paneGate() {
+  const p = {
+    held: null as any, rejected: null as any, slot: null as number | null,
+    take(v: any) { if (!v) return; if (adoptViews(p.held, v, p.slot)) { p.slot = announcedAfter(p.held, v, p.slot); p.held = v; p.rejected = null; } else p.rejected = v; },
+    caps(m: any) { const adopted = capsAdopts(p.rejected, m.viewsSeq); if (adopted) p.held = p.rejected; p.slot = adopted ? null : announcedSeq(m.viewsSeq); p.rejected = null; },
+  };
+  return p;
+}
+function withPanes(fn: (fm: any, chat: any, tl: any, emitted: any[]) => void): void {
+  withManager((fm, emitted) => {
+    const chat = paneGate(), tl = paneGate();
+    const w = (globalThis as any).window, dispatch = w.dispatchEvent;
+    w.dispatchEvent = (ev: any) => {
+      dispatch(ev);
+      const m = ev && ev.data; if (!m) return;
+      if (m.type === "tabOrder") chat.take(m.views);
+      else if (m.type === "data" && m.data) tl.take(m.data.views);
+      else if (m.type === "caps") { chat.caps(m); tl.caps(m); }
+    };
+    fn(fm, chat, tl, emitted);
+  });
+}
+const remoteOrder = () => ({ type: "tabOrder", order: [V], tabs: [{ id: V, name: "api" }], views: views(5) });
+const remoteLanes = () => ({ type: "data", data: { sessions: [{ id: V, name: "api" }], turns: {}, messages: [], judging: [], now: 1000, views: views(5) } });
+const betweens: [string, (fm: any) => void][] = [
+  ["no re-emit between (the earlier case)", () => {}],
+  ["a remote host's tabOrder push", (fm) => fm.inbound("TESTHOST", remoteOrder())],
+  ["a remote host's lanes payload", (fm) => fm.inbound("TESTHOST", remoteLanes())],
+  ["a `closed` frame", (fm) => fm.inbound("", { type: "closed", id: U })],
+  ["a synthetic re-emit (a view-order storage event, a host drop)", (fm) => { fm.emitMergedOrder(); fm.emitMergedTimeline(false); }],
+];
+for (const [what, between] of betweens) {
+  test("the panes behind the router adopt the restored store after a sentinel-cycle reconnect with " + what, () => {
+    withPanes((fm, chat, tl, emitted) => {
+      fm.inbound("", order(views(1000)));
+      fm.inbound("", lanes(views(1000)));
+      fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 1000 });
+      fm.inbound("TESTHOST", remoteOrder()); fm.inbound("TESTHOST", remoteLanes());   // a remote host federated in
+      assert.equal(chat.held.seq, 1000); assert.equal(tl.held.seq, 1000);
+      assert.equal(chat.slot, null); assert.equal(tl.slot, null);
+      fm.inbound("", { type: "caps", caps: ["tagEdit"], viewsSeq: 900 });   // the restart over a restored store, met on a sentinel cycle: nothing kept anywhere
+      assert.equal(chat.slot, 900); assert.equal(tl.slot, 900);
+      between(fm);
+      assert.equal(chat.held.seq, 1000); assert.equal(tl.held.seq, 1000);
+      assert.equal(chat.slot, 900, "a re-emit hands the pane its own held blob again: the slot stands");
+      assert.equal(tl.slot, 900);
+      fm.inbound("", order(views(900, "site")));   // the local pusher's next frame: the restored store under its old seq
+      fm.inbound("", lanes(views(900, "site")));
+      assert.equal(lastOf(emitted, "tabOrder").views.seq, 900, "the router adopts it through its slot…");
+      assert.equal(lastOf(emitted, "data").data.views.seq, 900);
+      assert.equal(chat.held.seq, 900, "…and so does the chat pane, from the router's re-emit");
+      assert.equal(chat.held.active, "site");
+      assert.equal(tl.held.seq, 900, "…and the timeline pane, from the merged lanes payload");
+      assert.equal(chat.slot, null); assert.equal(tl.slot, null);
+      between(fm);
+      assert.equal(chat.held.seq, 900); assert.equal(tl.held.seq, 900);
+    });
+  });
+}

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -13,6 +13,7 @@
 
 import { adoptArrivals, applyViewOrder, applyViewOrderTo, churnSwaps, healOrder, pruneViewOrder,
          readViewOrder, writeViewOrder, VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
+import { adoptViews, capsAdopts, announcedSeq, announcedAfter } from "./views-writes";
 import { hostOf, bareId } from "./host-prefix";
 import { installPerfTelemetry, classifyFrame, type RompPerf } from "./perf-telemetry";
 
@@ -234,6 +235,13 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
     const { host, ...rest } = msg;
     return [{ host: host || LOCAL, msg: rest }];
   }
+
+  // The VIEWS store is per kernel and a dashboard edits only its LOCAL one: a tag edit or a whole-blob
+  // views write goes to the local socket whatever fields it carries (the 2026-09-05 review: the tag
+  // op's fields rode at the top level, so a tag `name` that happened to look like a remote lane's
+  // display name would have taken the name-addressed route below to that host — tag names and
+  // session names share a field name, not a meaning).
+  if (msg.type === "tagEdit" || msg.type === "setTimelineViews") return [{ host: LOCAL, msg }];
 
   // order[] (reorderTabs / the timeline's writeOrder): split across the hosts it touches.
   if (Array.isArray(msg.order) && msg.order.some((x: any) => typeof x === "string")) {
@@ -645,6 +653,10 @@ export class FederationManager {
   private perHostOrder: Record<string, string[]> = {};
   private perHostTabs: Record<string, any[]> = {};
   private localViews: any = null;   // the LOCAL kernel's session-views blob, carried on merged tabOrder re-emits
+  private localViewsRejected: any = null;   // the last LOCAL tabOrder blob the seq gate turned away since it last adopted one — the caps frame adopts it (inbound)
+  private tlViewsRejected: any = null;      // the same for the LOCAL lanes payload's blob (perHostTl[LOCAL].views)
+  private localViewsAnnounced: number | null = null;   // the seq the last LOCAL caps frame announced as the kernel's current store when the tabOrder store adopted no kept blob — a LATER blob at exactly that seq is adopted below the stored one (announcedSeq); cleared by the next adoption that changes the stored blob (announcedAfter)
+  private tlViewsAnnounced: number | null = null;      // the same for the lanes payload's store
   private perHostSids: Record<string, Set<string>> = {};
   private perHostFeed: Record<string, any> = {}; // last feed snapshot per host — merged so they don't clobber
   private perHostFeedAt: Record<string, number> = {}; // host -> local ms its snapshot ARRIVED: the merged frame's clock anchor (mergeHostFeeds `nowAt`), so a re-emit anchors exactly as the arrival did
@@ -792,6 +804,42 @@ export class FederationManager {
     if (m && m.type === "session" && typeof m.id === "string") {
       (this.perHostSids[host] ||= new Set()).add(m.id);
     }
+    // a kernel's `caps` frame describes THAT kernel; the panes hold only the LOCAL kernel's (its views
+    // store is the one they write). A remote's would read as the local kernel's — dropped here.
+    if (m && m.type === "caps" && host !== LOCAL) return;
+    // The local kernel's caps frame is the reconnect event: each replayed views store adopts the blob its
+    // gate last turned away when the frame names it (the 2026-09-05 review; capsAdopts),
+    // as the panes do — the kernel sends its connect push before this frame and `viewsSeq` is the seq of
+    // the views blob that push served, so a push a restarted kernel served under an OLDER seq (a store
+    // restored while it was down) was rejected a frame ago and is adopted here; a healthy reconnect's push
+    // was adopted, nothing is kept, and the stores stand; a pusher frame kept because it arrived between
+    // the push and this frame carries a seq the frame does not name and is discarded. A store that adopted
+    // RE-EMITS before the caps frame is handed on: the panes see the local blob only through these re-emits
+    // (a rejected push reached them wearing the stored blob), so the restored blob must meet their own gate
+    // — and be turned away there — before their caps door adopts it. Nothing is re-emitted otherwise. When a
+    // store kept nothing the frame names (the connect push carried no blob for it — a sentinel cycle sends no
+    // tabOrder), the frame's viewsSeq is remembered as the kernel's announced store for that store, and the
+    // later blob carrying exactly that seq is adopted below the stored one on arrival (the review;
+    // announcedSeq): one slot per store, overwritten by each local caps frame, cleared by the next adoption
+    // that CHANGES the stored blob and never by a re-arrival of the blob already stored (announcedAfter);
+    // null (no store at all) and a missing field announce nothing. The panes hold the same slot from the same
+    // frame, handed on below; the merged re-emits between that frame and the pusher's next one (a remote host's
+    // push, a `closed` frame, a storage event, a host drop) hand them the STORED blob at their own held seq,
+    // which leaves their slot standing by the same rule, so the re-emit of that later adoption meets an open
+    // door there too.
+    if (m && m.type === "caps") {
+      if (capsAdopts(this.localViewsRejected, m.viewsSeq)) {
+        this.localViews = this.localViewsRejected; this.localViewsAnnounced = null;
+        this.emitMergedOrder();
+      } else this.localViewsAnnounced = announcedSeq(m.viewsSeq);
+      this.localViewsRejected = null;
+      const tl = this.perHostTl[LOCAL];
+      if (tl && capsAdopts(this.tlViewsRejected, m.viewsSeq)) {
+        this.perHostTl[LOCAL] = { ...tl, views: this.tlViewsRejected }; this.tlViewsAnnounced = null;
+        this.emitMergedTimeline(false);
+      } else this.tlViewsAnnounced = announcedSeq(m.viewsSeq);
+      this.tlViewsRejected = null;
+    }
     // A kernel's `closed` frame is ITS OWN report that the session is gone — the one other writer allowed
     // to touch the per-host store (T233, the user 2026-09-03). The 2026-08-02 rule below forbids
     // ARRANGEMENT writes on a re-emit (a stale pane pruning another pane's drag); a `closed` frame is new
@@ -818,8 +866,15 @@ export class FederationManager {
       // session VIEWS (the user 2026-08-18): the blob is the LOCAL kernel's viewer pref (ids arrive
       // host-prefixed inside it already) — remote kernels' copies are their own dashboards' prefs.
       // Without this passthrough the merged re-emit silently dropped the field and the browser
-      // dashboard's chat never learned the views at all.
-      if (host === LOCAL && m.views && typeof m.views === "object") this.localViews = m.views;
+      // dashboard's chat never learned the views at all. Kept ONLY when its write sequence is at
+      // least the stored one (2026-09-05): the re-emit below replays this copy on every merged order,
+      // and a frame the kernel built before a write must not roll the replayed blob back behind an
+      // ack the pane already adopted. The last blob turned away is kept for the caps frame (above), and a
+      // blob at the seq the last caps frame announced is adopted below the stored one.
+      if (host === LOCAL && m.views && typeof m.views === "object") {
+        if (adoptViews(this.localViews, m.views, this.localViewsAnnounced)) { this.localViewsAnnounced = announcedAfter(this.localViews, m.views, this.localViewsAnnounced); this.localViews = m.views; this.localViewsRejected = null; }
+        else this.localViewsRejected = m.views;
+      }
       this.ensureHost(host);
       this.absorbHostReport(host, prevOrder, prevTabs);   // a host just reported its sessions → the one
       this.emitMergedOrder(true, host);                   //   moment the stored arrangement may be touched
@@ -834,7 +889,18 @@ export class FederationManager {
     }
     // timeline snapshots replace the panel's state wholesale (update/applyBars) — merge per host like the feed.
     if (m && m.type === "data" && m.data && typeof m.data === "object") {
-      this.perHostTl[host] = m.data;
+      // the LOCAL lanes payload carries the views blob the merged re-emit replays: a payload whose blob
+      // has a LOWER write sequence than the stored one keeps the stored blob (its lanes still land) —
+      // the same rule the tabOrder store applies above (2026-09-05), the same keep of the last blob
+      // turned away, for the caps frame, the same door for the blob at the announced seq, and the same
+      // slot rule on adoption (a re-arrival of the stored blob leaves the slot)
+      const held = host === LOCAL ? this.perHostTl[LOCAL] : null;
+      if (held && held.views && m.data.views && !adoptViews(held.views, m.data.views, this.tlViewsAnnounced)) {
+        this.perHostTl[host] = { ...m.data, views: held.views }; this.tlViewsRejected = m.data.views;
+      } else {
+        this.perHostTl[host] = m.data;
+        if (host === LOCAL && m.data.views) { this.tlViewsRejected = null; this.tlViewsAnnounced = announcedAfter(held && held.views, m.data.views, this.tlViewsAnnounced); }
+      }
       this.ensureHost(host);
       this.emitMergedTimeline(false);
       return;

--- a/ui/webview/fleet.test.ts
+++ b/ui/webview/fleet.test.ts
@@ -348,3 +348,17 @@ test("the strip's styles live in the fleet's own sheet, mirroring feed.css — t
   assert.match(FEEDCSS, /\.hostload-line \{ display: flex; align-items: center; gap: 7px; color: var\(--dim\); font-size: 0\.82em; \}/,
     "the feed's rule this mirrors is still the reference");
 });
+
+test("the outline's lens write carries a writeId and `edited: []`, so the kernel applies the lens only (the 2026-09-05 review)", () => {
+  // before this change this was the one views write posted without either: the kernel judged its tag set as a
+  // whole blob, and a targeted edit that landed in the same second as the pane's frame copy was reverted
+  // by the next lens change. The empty list is the kernel's word that the write changes no tag.
+  assert.match(SRC, /import \{ mintWriteId \} from "\.\/views-writes";/);
+  assert.match(SRC, /function postOutlineLens\(v: SessionViews\) \{\s*\n\s*vscodeApi\?\.postMessage\(\{ type: "setTimelineViews", views: v, writeId: mintWriteId\(\+\+outlineViewsWriteSeq\), edited: \[\] \}\);/);
+  // both lens paths (the tag menu's apply, the chips' remove) post through it, from the frame copy the pane
+  // holds with only the outline lens changed
+  const sites = SRC.match(/const v = JSON\.parse\(JSON\.stringify\(fleetViews \|\| \{ active: "all", tags: \[\] \}\)\);\s*\n\s*v\.actives = Object\.assign\(\{\}, v\.actives, \{ outline: l \}\);\s*\n\s*fleetViews = v;[^\n]*\n\s*postOutlineLens\(v\);/g) || [];
+  assert.equal(sites.length, 2, "the two lens gestures post the same shape");
+  assert.equal((SRC.match(/type: "setTimelineViews"/g) || []).length, 1, "one post site: no views write leaves this pane without the two fields");
+  assert.doesNotMatch(SRC, /type: "setTimelineViews", views: v \}/);
+});

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -11,6 +11,7 @@ import { loadSettings, installSettingsSync, onExternalSettingsChange } from "./s
 import { SessionViews, viewTagUnion } from "./session-views";
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
+import { mintWriteId } from "./views-writes";
 import { fleetVisibleRoots } from "./fleet-roots";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostPrefix } from "./host-prefix";
@@ -52,6 +53,15 @@ let pendingHosts: string[] = [];
 let pendingDead: string[] = [];
 let searchQuery = "";     // #fleet-search filter (the user 2026-06-29): show only sessions whose NAME matches
 let fleetViews: SessionViews | null = null;   // the rendered views blob off the feed payload — the outline lens reads it (2026-08-25)
+let outlineViewsWriteSeq = 0;                   // per-page counter behind this pane's lens-write ids (mintWriteId)
+// This pane's lens write: the frame copy it holds with only the outline lens changed, posted with a
+// writeId and `edited: []` (the 2026-09-05 review) — the empty list is the kernel's word
+// that the write changes NO tag, so the tags the copy carries are never applied over a newer store;
+// only the lens lands. The pane ignores the viewsAck and settles from the next feed frame, as it
+// always has (docs/read-side.md, the views contract).
+function postOutlineLens(v: SessionViews) {
+  vscodeApi?.postMessage({ type: "setTimelineViews", views: v, writeId: mintWriteId(++outlineViewsWriteSeq), edited: [] });
+}
 let syncFleetTagBtn: (() => void) | null = null;   // re-dress the tag button per the shared convention on each render
 // Provisional cards (the user 2026-06-29): a session working a brand-new prompt the planner hasn't classified
 // into a goal yet has NO ledger node, so it's invisible in the fleet — exactly the "things about to appear" the
@@ -941,7 +951,7 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
           const v = JSON.parse(JSON.stringify(fleetViews || { active: "all", tags: [] }));
           v.actives = Object.assign({}, v.actives, { outline: l });
           fleetViews = v;                                        // optimistic: the next feed push echoes it
-          vscodeApi?.postMessage({ type: "setTimelineViews", views: v });
+          postOutlineLens(v);
           render();
         },
         onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
@@ -957,7 +967,7 @@ function showHoverCard(row: HTMLElement, sid: string, nid: string): void {
       const v = JSON.parse(JSON.stringify(fleetViews || { active: "all", tags: [] }));
       v.actives = Object.assign({}, v.actives, { outline: l });
       fleetViews = v;
-      vscodeApi?.postMessage({ type: "setTimelineViews", views: v });
+      postOutlineLens(v);
       render();
     });
     syncFleetTagBtn();

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -179,6 +179,21 @@ test("routeOutbound: a global message (no session id) goes local", () => {
   assert.deepEqual(routes, [{ host: "", msg: { type: "setColormap", name: "viridis" } }]);
 });
 
+test("routeOutbound: a views write goes to the LOCAL kernel whatever it carries — the views store is per kernel", () => {
+  const hosts = new Set(["gpu1"]);
+  // the tag op rides NESTED under `edit`; even a tag named like a remote lane cannot take the name-addressed route
+  const edit = { type: "tagEdit", writeId: "w1", edit: { op: "rename", tid: "g7", newName: "gpu1:api" } };
+  assert.deepEqual(routeOutbound(edit, hosts), [{ host: "", msg: edit }]);
+  // and the router routes the TYPE local explicitly: a flat legacy shape with a remote-looking name stays local too
+  const flat = { type: "tagEdit", writeId: "w2", name: "gpu1:api", newName: "x" };
+  assert.deepEqual(routeOutbound(flat, hosts), [{ host: "", msg: flat }], "tag names and session names share a field name, not a meaning");
+  const whole = { type: "setTimelineViews", writeId: "w3", views: { active: "all", tags: [] } };
+  assert.deepEqual(routeOutbound(whole, hosts), [{ host: "", msg: whole }]);
+  // …while a remote session's edit inside a LOCAL tag keeps its viewer-relative id: the local kernel stores the pair as-is
+  const member = { type: "tagEdit", writeId: "w4", edit: { op: "addMember", tid: "g7", sids: ["gpu1:" + U] } };
+  assert.deepEqual(routeOutbound(member, hosts), [{ host: "", msg: member }]);
+});
+
 test("routeOutbound: a cross-host reorder fans out one route per host with its own sids", () => {
   const order = [U, "gpu1:" + V, "gpu1:" + U, V]; // local U, gpu1 V, gpu1 U, local V
   const routes = routeOutbound({ type: "reorderTabs", order });

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -35,19 +35,26 @@ test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no
   assert.match(RENDER, /let peekId: string \| null = null;/);
   // …and the DERIVATION call sites, each named (the census, extended 2026-08-24 with the two
   // views-arrival paths): setActive (every activation), the focus fast path (already-active),
-  // captureViews (kernel-pushed views), postViews (local optimistic edit). Nothing else derives.
+  // captureViews (kernel-pushed views), holdViews (local optimistic edit — postViews/postTagEdit),
+  // onViewsAck (the kernel's answer to a write, 2026-09-05), onKernelCaps (a reconnect dropping the
+  // in-flight copy — a views arrival in effect). Nothing else derives.
   const sites = RENDER.match(/assertPeekFor\(/g) || [];
   // 6 → 7 on 2026-09-05: the subagent viewer's PIN control re-derives its own tab (pinned → in the chat
   // lens → sheds the peek dress; unpinned → back to a peek) through the same derivation — no second
-  // peek mechanism (plans/subagent-transcripts.md; chatVisible() answers pinnedSubs for a viewer id)
-  assert.equal(sites.length, 7, "definition + 6 call sites: setActive, focus fast path, captureViews, postViews, the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame), and the subagent viewer's pin toggle (2026-09-05)");
+  // peek mechanism (plans/subagent-transcripts.md; chatVisible() answers pinnedSubs for a viewer id).
+  // 7 → 8 with the acknowledged views writes: holdViews, onViewsAck and onKernelCaps replace the
+  // single postViews site.
+  assert.equal(sites.length, 9, "definition + 8 call sites: setActive, focus fast path, captureViews, holdViews, onViewsAck, onKernelCaps, the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame), and the subagent viewer's pin toggle (2026-09-05)");
 });
 
 test("a view change that excludes the ACTIVE session converts it into the peek — never a bounce (the user 2026-08-24)", () => {
   // both views-arrival paths re-derive the active session's peek: the kernel-pushed blob…
-  assert.match(RENDER, /pendingSessionViews = null; pendingViewsAge = 0;\s*\n\s*\}[\s\S]{0,700}?if \(activeId\) assertPeekFor\(activeId\);\s*\n\}/);
-  // …and the local optimistic edit, BEFORE its renderTabs so the repaint sees the fresh peek state
-  assert.match(RENDER, /pendingSessionViews = v; pendingViewsAge = 0;\s*\n\s*if \(activeId\) assertPeekFor\(activeId\);[\s\S]{0,200}?renderTabs\(\);/);
+  assert.match(RENDER, /pendingSessionViews = null; viewsWrites = \[\]; legacyViewsAge = 0;\s*\n\s*\}[\s\S]{0,700}?if \(activeId\) assertPeekFor\(activeId\);\s*\n\}/);
+  // …and the local optimistic edit (holdViews, shared by postViews/postTagEdit), BEFORE the
+  // renderTabs that follows in either poster so the repaint sees the fresh peek state
+  assert.match(RENDER, /pendingSessionViews = v; legacyViewsAge = 0;\s*\n\s*if \(activeId\) assertPeekFor\(activeId\);[\s\S]{0,900}?renderTabs\(\);/);
+  // …and the kernel's ack, a views arrival like the pushed frame
+  assert.match(RENDER, /if \(out\.clearPending\) pendingSessionViews = null;[\s\S]{0,300}?if \(activeId\) assertPeekFor\(activeId\);[\s\S]{0,200}?renderTabs\(\);/);
   // the derivation is symmetric, so a view that now INCLUDES the active peek sheds the dress — the
   // same next-null branch the auto-close pin above holds; and the fallback's fire-time revalidation
   // (below) re-checks tabInView, so a converted peek can never be bounced by an in-flight timeout
@@ -97,5 +104,6 @@ test("the peek is a PEEK, not a view edit: the client never posts a views change
   const focusBlock = (RENDER.match(/else if \(m\.type === "focus"\) \{[\s\S]*?\n  \}/) || [""])[0];
   assert.ok(focusBlock.length > 100, "found the focus handler");
   assert.doesNotMatch(focusBlock, /postViews|setTimelineViews|revealSession/);
-  assert.match(RENDER, /function revealSession\(id: string\) \{ postViews\(revealIn\(effViews\(\), id\)\); \}/);
+  assert.match(RENDER, /function revealSession\(id: string\) \{ const r = revealIn\(effViews\(\), id\); postLens\(\{ active: r\.active, actives: r\.actives \}\); \}/,
+    "the reveal is a LENS write: its fields ride on the store's blob, never the pending copy (the 2026-09-05 review)");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -17,6 +17,7 @@ import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./ta
 import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
+import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
@@ -555,20 +556,64 @@ const pendingTabMeta = new Map<string, PendingTabMeta>();
 // A hidden session is a BACKGROUND session — still running, judged and carded; the + picker lists it
 // under "Hidden" and the timeline's corner panel counts it, so it is always one glance away.
 // Captured from every tabOrder push; a local gesture (hide from the tab menu, reveal from the
-// picker) applies optimistically and holds sticky until a push echoes it — yielding to the kernel
-// after three silent pushes, the same machinery the timeline's copy runs.
+// picker) applies optimistically and holds until the kernel ANSWERS the write (viewsAck /
+// tagEditAck → onViewsAck below) or echoes it exactly — never yielding on a frame count (the user
+// 2026-09-05: the three-frame yield dropped good edits and kept refused ones alike). The same
+// machinery the timeline's copy runs (views-writes.ts is the shared decision).
 let sessionViews: SessionViews | null = null;
 let pendingSessionViews: SessionViews | null = null;
-let pendingViewsAge = 0;
+let viewsWrites: InflightWrite[] = [];   // this page's views writes in flight, oldest first: {id, edit?|blob?, newId?} — what each did, so a refusal reverts only its own change
+let viewsWriteSeq = 0;
+let legacyViewsAge = 0;           // LEGACY kernels only (no `seq`, no acks): frames since the write — the old three-frame yield (captureViews)
+let kernelCaps = new Set<string>();   // what the LOCAL kernel announced at `ready` ({type:"caps"}); "tagEdit" = targeted ops, acks, seq
 let allHiddenBlanked = false;   // the active transcript was blanked because EVERY session is view-hidden
+let staleViewsDiagSent = false; // one breadcrumb per page load for an out-of-order views blob (below)
+let rejectedViews: SessionViews | null = null;   // the last blob the gate turned away since it last adopted one — what the caps frame adopts (onKernelCaps)
+let announcedViewsSeq: number | null = null;   // the seq the last caps frame announced as the kernel's current store when it adopted no kept blob — a LATER blob at exactly that seq is adopted below the held one (takeViews); cleared by the next adoption that changes the held blob (announcedAfter) — a re-arrival of the blob already held leaves it
 function effViews(): SessionViews | null { return pendingSessionViews ?? sessionViews; }
+// an arriving views blob (a frame's or an ack's) becomes the base only if its write sequence is at
+// least the held one — a frame the pusher built from its warmed cache before a write, delivered
+// after that write's ack, must not put the older blob back (2026-09-05). Ignored blobs leave one
+// breadcrumb per page load (the kernel's client-diag log), so a kernel serving stale frames is a
+// visible fact rather than a flicker nobody can explain. The last ignored blob is KEPT (and let go
+// by the next adoption): a kernel restarted over a store restored from an older copy serves it under
+// the old seq, so its connect push is turned away here — and the caps frame that follows it, naming
+// that push's seq, is the event that adopts it (the 2026-09-05 review; capsAdopts).
+// When that push carried no blob to keep (a sentinel cycle sends no tabOrder), the caps frame's
+// viewsSeq is instead REMEMBERED as the kernel's announced store (announcedViewsSeq), and the later
+// blob carrying exactly that seq — the pusher's next frame — is adopted below the held one
+// (announcedSeq). The slot clears when an adoption CHANGES the held blob, never on a
+// re-arrival of the blob already held: in the browser this pane sees the local blob only through the
+// federation router, which replays its stored blob on every merged re-emit (a remote host's push, a
+// `closed` frame, a view-order storage event, a host drop), and a slot spent on one of those missed
+// the restored store the router adopted and re-emitted next (announcedAfter).
+function takeViews(v: SessionViews | null | undefined): boolean {
+  if (!v) return false;
+  if (adoptViews(sessionViews, v, announcedViewsSeq)) { announcedViewsSeq = announcedAfter(sessionViews, v, announcedViewsSeq); sessionViews = v; rejectedViews = null; return true; }
+  rejectedViews = v;
+  if (!staleViewsDiagSent) {
+    staleViewsDiagSent = true;
+    vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "views-stale-blob",
+      data: { held: seqOf(sessionViews), got: seqOf(v) } });
+  }
+  return false;
+}
 function captureViews(v: SessionViews | null) {
-  if (v) sessionViews = v;
-  // v null = a tabOrder frame WITHOUT the blob (an older kernel in a mixed-version mesh): it still
-  // ages a pending edit, or the optimistic state would fake success forever against a kernel that
-  // will never confirm it
-  if (pendingSessionViews && ((v && viewsKey(v) === viewsKey(pendingSessionViews)) || ++pendingViewsAge >= 3)) {
-    pendingSessionViews = null; pendingViewsAge = 0;
+  takeViews(v);
+  // a copy held with NO write in flight is a remote entry's mirror alone (the Tags flyout's editUnion:
+  // the remote's edit rides the editTag wire, which is not acked here) — it shows until the next
+  // frame, whose blob carries the remote's own truth, the lifetime it had before the acks
+  if (pendingSessionViews && v && !viewsWrites.length) pendingSessionViews = null;
+  // LEGACY kernels only (a blob without a write sequence comes from a kernel that acks nothing): the
+  // PRE-2026-09-05 reconciliation stays for that path alone — the write's exact echo clears the copy,
+  // and three silent frames yield it (with no ack ever coming, an unechoed copy would otherwise pin
+  // forever). A kernel that stamps `seq` answers every write, and the ack is the event that settles
+  // the copy — a frame, matching or not, says nothing about a write it cannot name (a net-zero
+  // burst's frames match the copy while its writes are still in flight), and no count of frames is
+  // information. (v null = a tabOrder frame without the blob, an older kernel: nothing to compare.)
+  if (pendingSessionViews && v && seqOf(v) === null
+      && (viewsKey(v) === viewsKey(pendingSessionViews) || ++legacyViewsAge >= 3)) {
+    pendingSessionViews = null; viewsWrites = []; legacyViewsAge = 0;
   }
   // A VIEW CHANGE that excludes the ACTIVE session converts it into the peek instead of bouncing
   // (the user 2026-08-24: open All, pick a session, re-apply the tag filter — keep reading it in
@@ -578,13 +623,134 @@ function captureViews(v: SessionViews | null) {
   // the deferred first-tab bounce never fires (its fire-time revalidation re-checks tabInView).
   if (activeId) assertPeekFor(activeId);
 }
-// (postViews below runs the same re-derivation for the LOCAL optimistic edit — both views-arrival
-// paths keep the active session's peek state current.)
-function postViews(v: SessionViews) {
-  pendingSessionViews = v; pendingViewsAge = 0;
+// (holdViews below runs the same re-derivation for the LOCAL optimistic edit — both views-arrival
+// paths keep the active session's peek state current.) The shared half of postViews / postTagEdit:
+// show the optimistic copy, mint and track the write — with what it did (`rec`: the op, or the
+// blob), so a refusal of some OTHER write can rebuild the copy without it.
+function holdViews(v: SessionViews, rec: Omit<InflightWrite, "id">): string {
+  pendingSessionViews = v; legacyViewsAge = 0;
   if (activeId) assertPeekFor(activeId);   // the optimistic edit re-derives the active session's peek too
-  if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v });
+  const writeId = mintWriteId(++viewsWriteSeq);
+  viewsWrites.push({ id: writeId, ...rec });
+  return writeId;
+}
+// a WHOLE-BLOB write — the lens and order edits, which have no targeted op; the kernel's viewsAck
+// reports the stale-writer guard's refusals, if any
+function postViews(v: SessionViews, edited: string[] = []) {
+  const writeId = holdViews(v, { blob: v });
+  // `edited`: the tag ids this write CHANGED — none for a lens or order edit — so the kernel acks a
+  // refusal on a tag this page never touched (a stale copy of it) as ok, with the refusal listed, and
+  // no toast follows: nothing the user did was refused, and the ack's blob carries the newer tag
+  if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v, writeId, edited });
   renderTabs();
+}
+// a LENS or ORDER write — the whole blob, built from the STORE's blob (sessionViews, the last one
+// adopted) plus the fields set, never from the pending copy: a copy carrying targeted edits still
+// in flight posted them as this page's claim on those tags, and a rename the kernel had refused as
+// a duplicate landed through the next lens toggle (the 2026-09-05 review). The pending
+// copy the page SHOWS is the current one with the same fields applied, so in-flight edits stay
+// visible; the in-flight record keeps the fields, so a re-derivation re-applies exactly them.
+function postLens(fields: LensFields) {
+  const v = lensBlob(sessionViews, fields);
+  const writeId = holdViews(applyLensFields(effViews(), fields), { lens: fields });
+  if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v, writeId, edited: [] });
+  renderTabs();
+}
+// a TARGETED tag edit (the tab menu's Tags flyout): `nv` is the optimistic copy with the gesture
+// applied, `edit` the op the kernel applies by the tag's stored id through its /tag merge — never
+// judged stale against this page's own earlier writes (the 2026-09-05 loss: a New tag… then a Move
+// to, posted as whole blobs from the un-echoed copy, had the second refused). The op rides NESTED
+// under `edit`: the federation router sends the message to the local kernel, and no top-level field
+// of it can read as a session's address. Answered by tagEditAck. `newId` is a create's optimistic
+// row id (the `pending-…` placeholder the ack's blob replaces).
+function postTagEdit(nv: SessionViews, edit: TagEditOp, newId?: string) {
+  // no `tagEdit` capability announced (a kernel from before it): the PRE-2026-09-05 path — the whole
+  // blob, reconciled by the legacy exact-echo clear and three-frame yield in captureViews, since no
+  // ack will come. The copy already carries the gesture, so nothing else changes — except a create's
+  // row: the whole blob IS the store write on this path, so the placeholder id would be persisted
+  // as-is (the 2026-09-05 review); the row takes a client-minted `g…` id, the scheme the
+  // dialog's own pre-2026-09-05 create used, and the write names it as edited, which a kernel that
+  // reads `edited` needs in order to tell a create from a stale copy re-creating a deleted tag.
+  if (!kernelCaps.has("tagEdit")) {
+    const edited = [edit.tid, edit.tid_from, edit.tid_to].filter((t): t is string => !!t);
+    const row = newId ? viewTags(nv).find((t) => t.id === newId) : undefined;
+    if (row) { if (/^pending-/.test(row.id)) row.id = "g" + Date.now().toString(36); edited.push(row.id); }
+    postViews(nv, edited);
+    return;
+  }
+  const writeId = holdViews(nv, { edit, newId });
+  if (vscodeApi) vscodeApi.postMessage({ type: "tagEdit", writeId, edit });
+  renderTabs();
+}
+// the LOCAL kernel's capabilities, sent on every `ready` — the page's own at load, and the shim's
+// re-send on a reconnected socket. A reconnect is the one event that can lose an ack (the socket died
+// between the write and its answer), so writes still in flight when this frame arrives are unknowable:
+// they are dropped, the copy reverts to what the kernel's frames show, and the user is told — never a
+// pinned copy faking success, never a silent revert. It is also the event that adopts the blob the
+// gate last turned away, when the frame names it (the 2026-09-05 review;
+// capsAdopts): the kernel sends its connect push before this frame and `viewsSeq` is the seq of the
+// views blob that push served, so a push a restarted kernel served under an OLDER seq (a store
+// restored while it was down) was rejected a frame ago and is adopted here, the gate re-arming at its
+// seq; a healthy reconnect's push was adopted, nothing is kept, and the gate stands; a pusher frame
+// built before a concurrent write, kept because it arrived between the push and this frame, carries a
+// seq the frame does not name and is discarded. When nothing kept matches, `viewsSeq` (a number: the
+// served blob's seq, or the store's current seq when the push carried no views frame — a sentinel
+// cycle) is remembered as the kernel's announced store, and takeViews adopts the later blob that
+// carries it even below the held seq (the review; announcedSeq) — the slot is one per
+// store, overwritten by each caps frame, cleared by the next adoption that changes the held blob
+// (announcedAfter); null (no store at all) and a
+// missing field announce nothing. A write in flight is dropped whatever the base became: its ack
+// cannot reach this socket, and one that somehow did would be an ack for a write this page no longer
+// tracks — its blob meets the gate like any other arrival, and nothing is re-pinned (onViewsAck).
+function onKernelCaps(m: { caps?: unknown; viewsSeq?: unknown }) {
+  kernelCaps = new Set(Array.isArray(m.caps) ? m.caps.filter((c): c is string => typeof c === "string") : []);
+  const adopted = capsAdopts(rejectedViews, m.viewsSeq);
+  if (adopted) sessionViews = rejectedViews;
+  announcedViewsSeq = adopted ? null : announcedSeq(m.viewsSeq);
+  rejectedViews = null;
+  if (viewsWrites.length) {
+    viewsWrites = []; pendingSessionViews = null;
+    warnToast("The connection to romp was re-established; a tag edit made just before it may not have landed. Check the tag.");
+    syncNewTagInput();                     // a dropped create no longer gates the flyout's input
+  } else if (!adopted) return;             // nothing in flight, nothing adopted: the caps changed, nothing shown did
+  if (activeId) assertPeekFor(activeId);   // a views arrival like any other: re-derive the active session's peek
+  renderTabs();
+}
+// the kernel does not know an op this page posted (a dashboard newer than its kernel): the write is
+// refused — the copy reverts and the toast says why — and the capability is withdrawn, so the next
+// gesture takes the path that kernel does know
+function onUnknownOp(m: { op?: unknown; writeId?: unknown }) {
+  if (typeof m.op === "string") kernelCaps.delete(m.op);
+  if (typeof m.writeId === "string" && viewsWrites.some((w) => w.id === m.writeId))
+    onViewsAck({ type: "unknownOp", writeId: m.writeId, ok: false,
+                 error: "the kernel does not know the " + String(m.op) + " operation, so the edit was not applied — try again; this dashboard now uses the older path" });
+}
+// the kernel's answer to one of this page's writes: the returned blob is the base whatever the
+// verdict; the pending copy settles once nothing is in flight; a refusal reverts ITS change at once
+// — the copy is rebuilt from the base plus the writes still in flight, so a later gesture never
+// flaps off and back on — and says why: the warn toast, since the flyout has no error surface of
+// its own
+function onViewsAck(m: ViewsAck) {
+  const out = ackOutcome(viewsWrites, m);
+  viewsWrites = out.inflight;
+  takeViews(m.views);   // the ack's blob is the base unless a newer frame already overtook it (the seq decides)
+  if (out.clearPending) pendingSessionViews = null;
+  else if (out.rederive) pendingSessionViews = rederivePending(sessionViews, viewsWrites);
+  // the reason already names the tag once and says what was kept (the kernel composes it); no second prefix naming it
+  if (out.refusal) warnToast("Tag edit not applied — " + out.refusal);
+  if (activeId) assertPeekFor(activeId);   // a views arrival like any other: re-derive the active session's peek
+  syncNewTagInput();                       // a create's ack re-arms the flyout's New tag… input in place
+  renderTabs();
+}
+// The Tags flyout's New tag… input, while the flyout is open: DISABLED while a create is in flight
+// (the 2026-09-05 review: a second Enter before the ack made a second tag), re-armed in
+// place by the ack — never by rebuilding the flyout, which would throw away text typed meanwhile.
+let tagsFlyNewInput: HTMLInputElement | null = null;
+function syncNewTagInput() {
+  if (!tagsFlyNewInput) return;
+  const busy = createInFlight(viewsWrites);
+  tagsFlyNewInput.disabled = busy;
+  tagsFlyNewInput.placeholder = busy ? "creating…" : "New tag…";
 }
 // ── EPHEMERAL PEEK TAB (the user 2026-08-24, superseding the kernel's reveal-rule view mutation):
 // activating a session the current view HIDES opens it as a TEMPORARY tab — real and scrollable,
@@ -616,7 +782,7 @@ function assertPeekFor(id: string): void {
 }
 function tabInView(id: string): boolean { return id === peekId || chatVisible(id); }
 function visibleOrder(): string[] { return order.filter(tabInView); }
-function revealSession(id: string) { postViews(revealIn(effViews(), id)); }
+function revealSession(id: string) { const r = revealIn(effViews(), id); postLens({ active: r.active, actives: r.actives }); }
 
 let paletteColors: string[] = [];
 fetch(kernelUrl("/palette"), { cache: "no-store" }).then((r) => r.json())
@@ -5055,11 +5221,7 @@ function renderTabs() {
     openTagMenu(btn, {
       lens: () => surfaceLens(effViews(), "chat"),
       unions: () => viewTagUnion(effViews()),
-      onApply: (l) => {
-        const v = JSON.parse(JSON.stringify(effViews() || { active: "all", tags: [] }));
-        v.actives = Object.assign({}, v.actives, { chat: l });
-        postViews(v);
-      },
+      onApply: (l) => { postLens({ actives: Object.assign({}, (effViews() || {}).actives, { chat: l }) }); },
       onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
     });
   });
@@ -5079,9 +5241,7 @@ function renderTabs() {
   {
     const v = effViews();
     syncTagFilter(tagBtn, tagChipsHost, surfaceLens(v, "chat"), viewTagUnion(v), (l) => {
-      const nv = JSON.parse(JSON.stringify(v || { active: "all", tags: [] }));
-      nv.actives = Object.assign({}, nv.actives, { chat: l });
-      postViews(nv);
+      postLens({ actives: Object.assign({}, (v || {}).actives, { chat: l }) });
     });
   }
   // T161 (the user 2026-08-28, Android: no tag control on mobile): the phone chat page hides the whole
@@ -5098,11 +5258,7 @@ function renderTabs() {
         openTagMenu(btn, {
           lens: () => surfaceLens(effViews(), "chat"),
           unions: () => viewTagUnion(effViews()),
-          onApply: (l) => {
-            const mv = JSON.parse(JSON.stringify(effViews() || { active: "all", tags: [] }));
-            mv.actives = Object.assign({}, mv.actives, { chat: l });
-            postViews(mv);
-          },
+          onApply: (l) => { postLens({ actives: Object.assign({}, (effViews() || {}).actives, { chat: l }) }); },
           onConfigure: () => { vscodeApi?.postMessage({ type: "openTagsDialog" }); },
         });
       });
@@ -5115,9 +5271,7 @@ function renderTabs() {
     const mv2 = effViews();
     syncTagFilter(mslot.children[0] as HTMLElement, mslot.children[1] as HTMLElement,
       surfaceLens(mv2, "chat"), viewTagUnion(mv2), (l) => {
-        const nv = JSON.parse(JSON.stringify(mv2 || { active: "all", tags: [] }));
-        nv.actives = Object.assign({}, nv.actives, { chat: l });
-        postViews(nv);
+        postLens({ actives: Object.assign({}, (mv2 || {}).actives, { chat: l }) });
       });
   }
   paintTabRowLines(bar);
@@ -5147,6 +5301,7 @@ let ctxMenuEl: HTMLElement | null = null;
 function dismissTabMenu() {
   ctxMenuEl?.remove();
   ctxMenuEl = null;
+  tagsFlyNewInput = null;
 }
 
 // Right-clicking a SELECTION in the transcript pops a small menu with Reply (quote
@@ -5395,9 +5550,11 @@ function showTabMenu(e: MouseEvent, id: string) {
   // no host prefixes): an ADD lands on the local store when the name exists locally, else the
   // tag's single home over the editTag wire; a REMOVE removes the (name, member) pair from EVERY
   // store holding it; New tag… creates locally with the next unused palette colour. Local writes
-  // post the whole blob (postViews — pendingSessionViews echoes instantly); remote writes ride the
-  // editTag op and settle on the next push (a refused edit re-appears — the kernel's loud
-  // tagEditFailed lands on the timeline dialog, 628's surface).
+  // are TARGETED tagEdit ops on one optimistic blob (postTagEdit — pendingSessionViews shows it
+  // instantly, the kernel's ack settles it; the user 2026-09-05, whose whole-blob burst was
+  // refused as stale against itself); remote writes ride the editTag op and settle on the next
+  // push (a refused edit re-appears — the kernel's loud tagEditFailed lands on the timeline
+  // dialog, 628's surface).
   {
     const unionFor = () => viewTagUnion(effViews());
     const holding = () => unionFor().filter((g) => g.members.includes(id));
@@ -5416,35 +5573,50 @@ function showTabMenu(e: MouseEvent, id: string) {
       // land in pendingSessionViews so the flyout reads true instantly. Echoed remoteTags are
       // DERIVED — the kernel drops them from the echo — so mutating the copy is presentation-only;
       // the remote's own next push is the durable truth (a refused edit re-appears there).
+      // The local store's half is a TARGETED op by the tag's stored id (postTagEdit), never the
+      // whole blob: posted whole from the un-echoed copy, a second gesture in a burst was judged
+      // stale against the page's own first write and refused (2026-09-05).
       const nv = JSON.parse(JSON.stringify(effViews() || {})) as SessionViews;
-      let dirty = false;
+      const ops: TagEditOp[] = [];
+      let mirrored = false;   // a remote entry's mirror changed (presentation only — the remote's own next push is the truth)
       const nvRemote = (rt: SessionTag) => (nv.remoteTags || []).find((x) => x.id === rt.id);
+      // a union whose local tag is a create still in flight (`pending`) takes no op: its id is the
+      // placeholder the ack replaces, and the kernel would refuse it as a tag that does not exist.
+      // The rows below offer no gesture on it either.
       if (edit.add?.length) {
-        if (g.localId) {
+        if (g.localId && !g.pending) {
           const t = viewTags(nv).find((x) => x.id === g.localId);
-          if (t) { t.members = Array.from(new Set((t.members || []).concat(edit.add))); dirty = true; }
+          if (t) {
+            t.members = Array.from(new Set((t.members || []).concat(edit.add)));
+            ops.push({ op: "addMember", tid: g.localId, sids: edit.add.slice() });
+          }
         } else if (g.remotes.length) {
           vscodeApi?.postMessage({ type: "editTag", edit: { host: g.remotes[0].host || "", name: g.name, add: edit.add.slice() } });
           const mine = nvRemote(g.remotes[0]);
-          if (mine) { mine.members = Array.from(new Set((mine.members || []).concat(edit.add))); dirty = true; }
+          if (mine) { mine.members = Array.from(new Set((mine.members || []).concat(edit.add))); mirrored = true; }
         }
       }
       if (edit.remove?.length) {
-        if (g.localId) {
+        if (g.localId && !g.pending) {
           const t = viewTags(nv).find((x) => x.id === g.localId);
           if (t && (t.members || []).some((m) => edit.remove!.includes(m))) {
             t.members = (t.members || []).filter((m) => !edit.remove!.includes(m));
-            dirty = true;
+            ops.push({ op: "removeMember", tid: g.localId, sids: edit.remove.slice() });
           }
         }
         for (const rt of g.remotes) {
           if (!(rt.members || []).some((m) => edit.remove!.includes(m))) continue;
           vscodeApi?.postMessage({ type: "editTag", edit: { host: rt.host || "", name: g.name, remove: edit.remove!.slice() } });
           const mine = nvRemote(rt);
-          if (mine) { mine.members = (mine.members || []).filter((m) => !edit.remove!.includes(m)); dirty = true; }
+          if (mine) { mine.members = (mine.members || []).filter((m) => !edit.remove!.includes(m)); mirrored = true; }
         }
       }
-      if (dirty) postViews(nv);
+      // the writes for one gesture: N targeted ops, the ONE optimistic copy shown for all of them (the
+      // kernel applies them in order on this socket). A remote-only edit has no local op: its mirror
+      // shows until the next frame (captureViews lets a copy with no write in flight go on any frame)
+      // — exactly the lifetime it had before.
+      if (ops.length) { for (const op of ops) postTagEdit(nv, op); }
+      else if (mirrored) { pendingSessionViews = nv; renderTabs(); }
     };
     // HOVER-INTENT open (T163, the user 2026-08-28: hovering down to Tags should open the submenu
     // without another click): the feed's 120ms intent debounce — enough to skip a graze, never a
@@ -5472,13 +5644,21 @@ function showTabMenu(e: MouseEvent, id: string) {
           const bodyE = el("span", "ctx-item-body");
           const lb = el("span", "ctx-item-label"); lb.textContent = g.name; bodyE.appendChild(lb);
           row.appendChild(bodyE);
+          if (g.pending) {
+            // a create still in flight: the row shows, and takes no gesture until the ack names the
+            // tag (a ✕ here posted the placeholder id and was refused as a tag that does not exist)
+            // — the same "creating…" the input reads
+            const busy = el("span", "ctx-item-sub"); busy.textContent = "creating…"; row.appendChild(busy);
+            sub.appendChild(row);
+            continue;
+          }
           const x = el("button", "ctx-tag-x") as HTMLButtonElement;
           x.type = "button"; x.textContent = "✕"; x.title = "remove this tag from the session — everywhere it holds it";
           x.addEventListener("click", (e2) => { e2.stopPropagation(); editUnion(g, { remove: [id] }); build(); sb.textContent = subText(); });
           row.appendChild(x);
           sub.appendChild(row);
         }
-        const others = unionFor().filter((g) => !g.members.includes(id));
+        const others = unionFor().filter((g) => !g.members.includes(id) && !g.pending);   // a tag being created is not joinable yet
         if (holding().length && others.length) sub.appendChild(el("div", "ctx-sep"));
         for (const g of others) {
           const row = el("div", "ctx-item ctx-item-toggle");
@@ -5497,6 +5677,7 @@ function showTabMenu(e: MouseEvent, id: string) {
         inp.addEventListener("click", (e2) => e2.stopPropagation());
         inp.addEventListener("keydown", (e2) => {
           if (e2.key !== "Enter") return;
+          if (createInFlight(viewsWrites)) return;   // one create at a time: the ack re-arms the input (syncNewTagInput)
           const name = inp.value.trim();
           if (!name) return;
           const existing = unionFor().find((g) => g.name === name);
@@ -5504,12 +5685,18 @@ function showTabMenu(e: MouseEvent, id: string) {
           const nv = JSON.parse(JSON.stringify(effViews() || {})) as SessionViews;
           const used = new Set(viewTags(nv).map((t) => t.color));
           const color = paletteColors.find((c) => !used.has(c)) || paletteColors[0] || "#1EA1EB";
-          nv.tags = viewTags(nv).concat([{ id: "g" + Date.now().toString(36), name, color, members: [id] }]);
+          // the optimistic row wears a PLACEHOLDER id: the kernel mints the tag's id and the ack's
+          // blob (which carries it) replaces this copy — no client-minted id can collide with a
+          // store it has not read (the legacy path re-ids it: postTagEdit)
+          const tg = { id: "pending-" + Date.now().toString(36), name, color, members: [id] };
+          nv.tags = viewTags(nv).concat([tg]);
           delete nv.groups;
-          postViews(nv);
+          // ONE targeted create carrying the session — the tag and its first member land together
+          postTagEdit(nv, { op: "create", name, color, sids: [id] }, tg.id);
           build(); sb.textContent = subText();
         });
         nrow.appendChild(inp);
+        tagsFlyNewInput = inp; syncNewTagInput();
         sub.appendChild(nrow);
       };
       build();
@@ -13330,6 +13517,12 @@ window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.po
   // The identity palette changed (gear → Session colors): refresh the right-click menu's swatch set so a
   // menu opened after the switch offers the NEW palette (the kernel remaps + repaints sessions itself).
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
+  // the kernel's answer to one of THIS page's views writes (a targeted tag edit, or a whole-blob
+  // lens/order write) — the optimistic copy settles or reverts on it, never on a frame count
+  else if (m.type === "viewsAck" || m.type === "tagEditAck") onViewsAck(m);
+  // what the local kernel can do for this page (every `ready`, reconnects included); an op it does not know
+  else if (m.type === "caps") onKernelCaps(m);
+  else if (m.type === "unknownOp") onUnknownOp(m);
   // The kernel's pick memory moved (a pin, a Latest un-pin, a refused pin dropped) or its catalog grew:
   // re-read /models so the family rows send the fresh default — the models-list twin of the palette frame.
   else if (m.type === "models") loadModelChoices();

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -76,9 +76,12 @@ test("every cycling path walks the VISIBLE order — keyboard can never land on 
     "no raw-order cycle survives");
 });
 
-test("optimistic edits hold sticky and yield to the kernel after three silent pushes", () => {
-  assert.match(RENDER, /function captureViews\(v: SessionViews \| null\) \{[\s\S]{0,600}\+\+pendingViewsAge >= 3/);
-  assert.match(RENDER, /function postViews\(v: SessionViews\) \{[\s\S]{0,300}setTimelineViews/);
+test("optimistic edits hold until the kernel echoes them exactly or acks the write — never a frame count (2026-09-05)", () => {
+  // the three-frame yield that lived here dropped good edits and kept refused ones alike; the
+  // write's ack (views-writes.test.ts) is the event that settles the copy
+  assert.match(RENDER, /function captureViews\(v: SessionViews \| null\) \{[\s\S]{0,1300}viewsKey\(v\) === viewsKey\(pendingSessionViews\)/);
+  assert.doesNotMatch(RENDER, /pendingViewsAge/);
+  assert.match(RENDER, /function postViews\(v: SessionViews, edited: string\[\] = \[\]\) \{[\s\S]{0,600}setTimelineViews", views: v, writeId, edited/);
 });
 
 test("a view-filtered session keeps one visible home: the picker's other-view section, and picking jumps views", () => {
@@ -93,12 +96,17 @@ test("a view-filtered session keeps one visible home: the picker's other-view se
 test("the hide MECHANISM is fully retired (the user 2026-08-24) — reveal survives as the view jump", () => {
   assert.doesNotMatch(RENDER, /Hide from chat & timeline/);
   assert.doesNotMatch(RENDER, /hideIn\(/, "no hide gesture anywhere");
-  assert.match(RENDER, /function revealSession\(id: string\) \{ postViews\(revealIn\(effViews\(\), id\)\); \}/);
+  assert.match(RENDER, /function revealSession\(id: string\) \{ const r = revealIn\(effViews\(\), id\); postLens\(\{ active: r\.active, actives: r\.actives \}\); \}/,
+    "the reveal is a lens write on the store's blob (the 2026-09-05 review)");
 });
 
 test("federation carries the LOCAL kernel's views blob through merged tabOrder re-emits", () => {
   const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
-  assert.match(FED, /if \(host === LOCAL && m\.views && typeof m\.views === "object"\) this\.localViews = m\.views;/);
+  // stored only when its write sequence is at least the stored one (or the one the local kernel's caps frame
+  // announced), the last blob turned away is kept for that caps frame to adopt, and the announced slot is
+  // re-derived from the stored blob before it moves — cleared only when the adoption changes it
+  // (federation-views-seq.test.ts executes all four rules)
+  assert.match(FED, /if \(host === LOCAL && m\.views && typeof m\.views === "object"\) \{\s*\n\s*if \(adoptViews\(this\.localViews, m\.views, this\.localViewsAnnounced\)\) \{ this\.localViewsAnnounced = announcedAfter\(this\.localViews, m\.views, this\.localViewsAnnounced\); this\.localViews = m\.views; this\.localViewsRejected = null; \}\s*\n\s*else this\.localViewsRejected = m\.views;\s*\n\s*\}/);
   assert.match(FED, /\{ type: "tabOrder", order, tabs, views: this\.localViews \?\? undefined \}/,
     "without this the browser dashboard's chat never receives the blob at all");
 });
@@ -170,4 +178,21 @@ test("executed: the union renders in the USER'S order — tagOrder governs, remo
   // builder crashed on {}["constructor"] resolving to Function — null-prototype lookups now
   assert.deepEqual(viewTagUnion({ tags: [{ id: "p1", name: "constructor", members: [] }], tagOrder: ["constructor"] })
     .map((u) => u.name), ["constructor"], "a prototype-key tag name builds and orders cleanly");
+});
+
+test("executed: a union whose local tag wears a create's placeholder id is marked pending — it renders and takes no gesture (the 2026-09-05 review)", () => {
+  const A = "11111111-2222-3333-4444-555555555501", B = "11111111-2222-3333-4444-555555555502";
+  const v: any = { active: "all", tags: [{ id: "gA", name: "web", color: "#3b82f6", members: [A] }, { id: "pending-abc", name: "api", color: "#54B204", members: [B] }] };
+  const u = viewTagUnion(v);
+  assert.equal(u.find((g) => g.name === "web")!.pending, undefined);
+  assert.equal(u.find((g) => g.name === "api")!.pending, true);
+  assert.equal(u.find((g) => g.name === "api")!.localId, "pending-abc", "the placeholder still rides for rendering");
+  assert.deepEqual(u.find((g) => g.name === "api")!.members, [B], "…and the row shows its members");
+  // the ack's blob replaces the row with the kernel's id: no longer pending
+  const after = viewTagUnion({ ...v, tags: [v.tags[0], { id: "g9", name: "api", color: "#54B204", members: [B] }] });
+  assert.equal(after.find((g) => g.name === "api")!.pending, undefined);
+  // a same-named REAL tag ahead of the placeholder owns the union: not pending
+  const twin = viewTagUnion({ ...v, tags: [{ id: "g9", name: "api", color: "", members: [] }, v.tags[1]] });
+  assert.equal(twin.find((g) => g.name === "api")!.pending, undefined);
+  assert.equal(twin.find((g) => g.name === "api")!.localId, "g9");
 });

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -25,12 +25,22 @@ export interface SessionViews {
    *  viewer-side so remote-homed names hold position without cross-kernel writes; locals also
    *  keep array order (the drag rewrites both). Unlisted names follow, in natural order. */
   tagOrder?: string[];
+  /** the store's write stamp (epoch s) — the stale-writer guard's evidence time, echoed back as-is */
+  at?: number;
+  /** the store's WRITE SEQUENCE (2026-09-05): strictly increasing per accepted write, on every frame
+   *  and ack the blob rides. A client adopts a blob only when its seq is at least the held one, so a
+   *  frame built before a write can never replace the ack's newer blob (views-writes.ts adoptViews). */
+  seq?: number;
 }
 // One union group = one tag NAME across every kernel defining it (user ruling 2026-08-24: kernels
 // are plumbing — no host prefixes in any tag presentation). The typed mirror of the timeline's
 // viewTagUnion over the same client blob (local tags + remoteTags); the local store's colour wins.
 // The chat's tab-menu Tags section reads and edits through this exact shape.
-export interface TagUnion { name: string; color: string; members: string[]; ids: string[]; localId: string | null; remotes: SessionTag[] }
+// `pending`: the union's local tag is an optimistic create's row, wearing the placeholder id the
+// kernel's ack replaces (views-writes.ts isPlaceholderId) — it renders, and takes no gesture: an
+// op addressed by that id would be refused as a tag that does not exist (the
+// 2026-09-05 review). Every builder of an action on a union checks it.
+export interface TagUnion { name: string; color: string; members: string[]; ids: string[]; localId: string | null; remotes: SessionTag[]; pending?: boolean }
 export function viewTagUnion(views: SessionViews | null | undefined): TagUnion[] {
   // byName is null-prototype: a user-typed tag NAME can be "constructor"/"toString", which a
   // plain {} resolves through the prototype chain (the lookup returned a Function and the
@@ -39,7 +49,7 @@ export function viewTagUnion(views: SessionViews | null | undefined): TagUnion[]
   for (const t of viewTags(views)) {
     const key = t.name || "tag";
     const g = byName[key] || (byName[key] = { name: key, color: "", members: [], ids: [], localId: null, remotes: [] });
-    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; }
+    if (!g.localId) { g.localId = t.id; g.color = t.color || g.color; if (/^pending-/.test(t.id)) g.pending = true; }
     g.ids.push(t.id);
     for (const m of (t.members || [])) if (!g.members.includes(m)) g.members.push(m);
     if (!out.includes(g)) out.push(g);

--- a/ui/webview/tab-meta.ts
+++ b/ui/webview/tab-meta.ts
@@ -12,7 +12,12 @@
 // labels): an OPTIMISTIC local edit (the color-swatch click; the kernel's one-shot renamed confirm)
 // records what it expects here, and a push built BEFORE the kernel applied that edit cannot revert
 // the strip while the expectation stands. Cleared by the echo (the push agreeing), or yielded after
-// three silent pushes — the sessionViews pendingViewsAge machinery's constants and reasoning.
+// three silent pushes: the rename and colour routes answer with no per-write ack the strip could
+// key on, so a push that still disagrees after three cycles is the best evidence available that the
+// kernel did not take the edit, and the kernel's view must win (it is the store of record). The
+// views blob's optimistic copy ran the same count until 2026-09-05 and now settles on the kernel's
+// ack and write sequence instead (views-writes.ts); this guard keeps the count until those routes
+// carry an ack of their own.
 
 export interface TabColor { bg: string; fg: string }
 export interface TabSessionMeta { name: string; color: TabColor | null }

--- a/ui/webview/tab-tags.test.ts
+++ b/ui/webview/tab-tags.test.ts
@@ -43,16 +43,20 @@ test("the Tags row sits with the session controls ABOVE the divider; Browse stay
     "the compact one-line row: current names, or the honest empty state");
 });
 
-test("edits reuse the wire — never a fork: local adds post the whole blob, remote edits ride editTag", () => {
+test("edits reuse the wire — never a fork: local edits post TARGETED tagEdit ops, remote edits ride editTag", () => {
   const at = RENDER.indexOf("const editUnion = (g: TagUnion");
-  const body = RENDER.slice(at, at + 2400);
-  assert.ok(body.includes("t.members = Array.from(new Set((t.members || []).concat(edit.add))); dirty = true;"),
-    "local add edits the whole blob (posted once below — pendingSessionViews echoes instantly)");
+  const body = RENDER.slice(at, at + 4200);
+  assert.ok(body.includes('ops.push({ op: "addMember", tid: g.localId, sids: edit.add.slice() });'),
+    "a local add is an addMember by the tag's stored id (2026-09-05: the whole-blob post was refused as stale against the page's own earlier write; by name, a refused rename left the next gesture addressing the other tag)");
+  assert.ok(body.includes('ops.push({ op: "removeMember", tid: g.localId, sids: edit.remove.slice() });'), "…and a local remove");
   assert.ok(body.includes('vscodeApi?.postMessage({ type: "editTag", edit: { host: g.remotes[0].host || "", name: g.name, add: edit.add.slice() } });'),
     "an add with no local home routes to the tag's single home over the editTag wire");
   assert.ok(body.includes("for (const rt of g.remotes) {"),
     "a REMOVE walks every remote store holding the pair — remove-everywhere, never half");
-  assert.ok(body.includes("if (dirty) postViews(nv);"), "ONE optimistic blob per gesture — the flyout reads true instantly");
+  assert.ok(body.includes("if (ops.length) { for (const op of ops) postTagEdit(nv, op); }"), "ONE optimistic blob per gesture — the flyout reads true instantly");
+  assert.ok(body.includes("else if (mirrored) { pendingSessionViews = nv; renderTabs(); }"),
+    "a remote-only edit has no local op: its mirror shows until the next frame, as before");
+  assert.ok(body.includes("if (g.localId && !g.pending) {"), "a union whose create is still in flight takes no op (its id is the placeholder the ack replaces)");
   assert.ok(body.includes("const nvRemote = (rt: SessionTag)"),
     "the remote entries mirror optimistically too — echoed remoteTags are derived, kernel-dropped, presentation-only");
   assert.match(RENDER, /x\.title = "remove this tag from the session — everywhere it holds it";/);
@@ -62,7 +66,9 @@ test("New tag… is an inline input (menu vocabulary, no native prompt) that cre
   assert.match(RENDER, /inp\.placeholder = "New tag…"; inp\.maxLength = 40;/);
   assert.doesNotMatch(RENDER.slice(RENDER.indexOf("const editUnion")), /window\.prompt/);
   assert.match(RENDER, /const color = paletteColors\.find\(\(c\) => !used\.has\(c\)\) \|\| paletteColors\[0\] \|\| "#1EA1EB";/);
-  assert.match(RENDER, /nv\.tags = viewTags\(nv\)\.concat\(\[\{ id: "g" \+ Date\.now\(\)\.toString\(36\), name, color, members: \[id\] \}\]\);/);
+  assert.match(RENDER, /const tg = \{ id: "pending-" \+ Date\.now\(\)\.toString\(36\), name, color, members: \[id\] \};\s*\n\s*nv\.tags = viewTags\(nv\)\.concat\(\[tg\]\);/,
+    "the optimistic row wears a placeholder id — the kernel mints the real one");
+  assert.match(RENDER, /postTagEdit\(nv, \{ op: "create", name, color, sids: \[id\] \}, tg\.id\);/, "one targeted create, the session in it, no client id on the op (the placeholder rides beside it for the legacy path to re-id)");
   // an existing name typed into the box ADDS to that union instead of minting a duplicate tag
   assert.match(RENDER, /const existing = unionFor\(\)\.find\(\(g\) => g\.name === name\);/);
 });

--- a/ui/webview/tag-mounts.test.ts
+++ b/ui/webview/tag-mounts.test.ts
@@ -55,7 +55,7 @@ test("the phone gets the chat tag control too — the SHARED button mounted into
   const mnt = RENDER.slice(RENDER.indexOf('const mslot = document.getElementById("mtag-slot")'),
                            RENDER.indexOf("paintTabRowLines(bar);"));
   assert.match(mnt, /tagMenuButton\("filter sessions by tag"/, "the SHARED component, never a copy");
-  assert.match(mnt, /Object\.assign\(\{\}, mv\.actives, \{ chat: l \}\)/, "writes land on the chat lens — per-surface semantics");
+  assert.match(mnt, /postLens\(\{ actives: Object\.assign\(\{\}, \(effViews\(\) \|\| \{\}\)\.actives, \{ chat: l \}\) \}\)/, "writes land on the chat lens — per-surface semantics — as a lens write on the store's blob (the 2026-09-05 review)");
   assert.match(mnt, /syncTagFilter\(mslot\.children\[0\] as HTMLElement, mslot\.children\[1\] as HTMLElement,/,
     "the mobile pair re-syncs every render like the desktop one");
 });
@@ -66,7 +66,7 @@ test("the chat strip and the outline both mount the shared component (source pin
     "tabs + peeks decide through actives.chat");
   assert.match(RENDER, /tagMenuButton\("filter these tabs by tag"/,
     "the tooltip names the surface — the ONE scope carrier since the menu caption retired (2026-08-25)");
-  assert.match(RENDER, /Object\.assign\(\{\}, v\.actives, \{ chat: l \}\)/, "writes land on chat's lens only");
+  assert.match(RENDER, /postLens\(\{ actives: Object\.assign\(\{\}, \(v \|\| \{\}\)\.actives, \{ chat: l \}\) \}\)/, "writes land on chat's lens only");
   assert.match(FLEET, /tagMenuButton\("filter this outline by tag"/,
     "ditto — the outline tooltip names its surface");
   assert.match(FLEET, /Object\.assign\(\{\}, v\.actives, \{ outline: l \}\)/);

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -50,15 +50,24 @@ test("dispatchFrame routes kernel frames to the panel", () => {
     setActiveChat: (a: any) => calls.push(["setActiveChat", a]),
     setHover: (m: any) => calls.push(["setHover", m.type]),
     refreshModels: () => calls.push(["refreshModels"]),   // the kernel's models frame: the pick memory moved
+    viewsAck: (m: any) => calls.push(["viewsAck", m.type, m.writeId]),   // the kernel's answer to one of this page's views writes
+    setCaps: (m: any) => calls.push(["setCaps", m.caps]),                // what the kernel can do for this page (every `ready`)
+    unknownOp: (m: any) => calls.push(["unknownOp", m.op, m.writeId]),  // an op the kernel does not know: a refusal, and the cap withdrawn
   };
   assert.equal(dispatchFrame(panel, { type: "data", data: { lanes: [] } }), true);
   assert.equal(dispatchFrame(panel, { type: "bars" }), true);
   assert.equal(dispatchFrame(panel, { type: "activeChat", activeChat: "s1" }), true);
   assert.equal(dispatchFrame(panel, { type: "hover", sid: "s1" }), true);
   assert.equal(dispatchFrame(panel, { type: "models", rev: 3 }), true);
+  assert.equal(dispatchFrame(panel, { type: "tagEditAck", writeId: "w1", ok: true }), true, "a targeted tag edit's ack");
+  assert.equal(dispatchFrame(panel, { type: "viewsAck", writeId: "w2", ok: false }), true, "a whole-blob write's ack");
+  assert.equal(dispatchFrame(panel, { type: "caps", caps: ["tagEdit"] }), true, "the kernel's capabilities");
+  assert.equal(dispatchFrame(panel, { type: "unknownOp", op: "tagEdit", writeId: "w3" }), true, "an op the kernel does not know");
   assert.equal(dispatchFrame(panel, { type: "ka" }), false);
   assert.equal(dispatchFrame(null, { type: "data" }), false);
-  assert.deepEqual(calls.map((c) => c[0]), ["update", "applyBars", "setActiveChat", "setHover", "refreshModels"]);
+  assert.deepEqual(calls.map((c) => c[0]), ["update", "applyBars", "setActiveChat", "setHover", "refreshModels", "viewsAck", "viewsAck", "setCaps", "unknownOp"]);
+  assert.deepEqual(calls.slice(5), [["viewsAck", "tagEditAck", "w1"], ["viewsAck", "viewsAck", "w2"], ["setCaps", ["tagEdit"]], ["unknownOp", "tagEdit", "w3"]],
+    "both acks land on the one panel door; caps and unknownOp on their own");
 });
 
 test("dispatchFrame tolerates a panel without the optional methods", () => {
@@ -90,6 +99,8 @@ test("bridges post the same kernel ops as the web boot", () => {
   b.__rompTimelineDismiss("id2");
   b.__rompTimelineHover("s1", ["g1"], 5, 9);
   b.__rompTimelineHover();
+  b.__rompTimelineSetViews({ active: "all", tags: [] }, "w7");
+  b.__rompTimelineTagEdit("w8", { op: "rename", tid: "g7", newName: "notes-api" });
   assert.deepEqual(sent, [
     { type: "compact", name: "sess" },
     { type: "sendCommand", name: "sess", cmd: "/model" },
@@ -97,6 +108,10 @@ test("bridges post the same kernel ops as the web boot", () => {
     { type: "dismissLane", id: "id2" },
     { type: "timelineHover", sid: "s1", segIds: ["g1"], t0: 5, t1: 9 },
     { type: "timelineHover", off: true },
+    // the views writes carry the id the kernel's ack names; a targeted edit's op rides NESTED under
+    // `edit`, so no field of it (a tag name) sits where the federation router reads session addresses
+    { type: "setTimelineViews", views: { active: "all", tags: [] }, writeId: "w7", edited: [] },
+    { type: "tagEdit", writeId: "w8", edit: { op: "rename", tid: "g7", newName: "notes-api" } },
   ]);
 });
 

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -49,6 +49,13 @@ export function dispatchFrame(panel: any, m: any): boolean {
   // ends its optimistic state on this event and shows the reason in the gear
   if (m.type === "settingRefused" && panel.settingRefused) { panel.settingRefused(m); return true; }
   if (m.type === "tagEditFailed" && panel.tagEditFailed) { panel.tagEditFailed(m); return true; }
+  // the kernel's answer to one of THIS page's views writes (a targeted tag edit, or a whole-blob lens/
+  // order write): the panel adopts the returned blob and settles or reverts its optimistic copy
+  if ((m.type === "tagEditAck" || m.type === "viewsAck") && panel.viewsAck) { panel.viewsAck(m); return true; }
+  // what the kernel can do for this page, sent on every `ready` (a reconnect re-sends it); and the
+  // kernel's answer to an op it does not know — a refusal of that write, and the cap is withdrawn
+  if (m.type === "caps" && panel.setCaps) { panel.setCaps(m); return true; }
+  if (m.type === "unknownOp" && panel.unknownOp) { panel.unknownOp(m); return true; }
   return false;
 }
 
@@ -91,7 +98,13 @@ export function bridgeFunctions(post: Post): Record<string, (...a: any[]) => voi
     // `{ floating: true }` so the kernel forgets the family's remembered pin
     __rompTimelineSendCommand: (name: string, cmd: string, extra?: Record<string, unknown>) => post({ type: "sendCommand", name, cmd, ...(extra || {}) }),
     __rompTimelineSetFlag: (id: string, flag: string, value: unknown) => post({ type: "setSessionFlag", id, flag, value: !!value }),
-    __rompTimelineSetViews: (views: unknown) => post({ type: "setTimelineViews", views }),
+    // a whole-blob write; `edited` names the tag ids the gesture changed (a lens or order write: none), so
+    // the kernel acks a refusal on an untouched tag as ok with the refusal listed
+    __rompTimelineSetViews: (views: unknown, writeId?: unknown, edited?: unknown) =>
+      post({ type: "setTimelineViews", views, writeId, edited: Array.isArray(edited) ? edited : [] }),
+    // one targeted tag edit: the op {op, tid, …} rides NESTED under `edit` (the kernel's tagEdit message),
+    // so no field of it sits at the top level where the federation router reads session addresses
+    __rompTimelineTagEdit: (writeId: unknown, edit: unknown) => post({ type: "tagEdit", writeId, edit }),
     __rompTimelineEditTag: (edit: unknown) => post({ type: "editTag", edit }),
     __rompTimelineDismiss: (id: string) => post({ type: "dismissLane", id }),
     __rompTimelineHover: (sid?: string, segIds?: unknown[], t0?: number, t1?: number) =>

--- a/ui/webview/views-writes.test.ts
+++ b/ui/webview/views-writes.test.ts
@@ -1,0 +1,330 @@
+// THE CHAT PANE'S VIEWS WRITES ARE ACKNOWLEDGED (the user 2026-09-05, who lost a batch of tag
+// renames and assignments). The tab menu's Tags flyout had the timeline dialog's shape: every
+// gesture posted the WHOLE blob from the pane's own un-echoed optimistic copy, so a New tag… then a
+// second gesture on it carried the pre-burst `at` stamp and the kernel's stale-writer guard refused the
+// second against the first; the copy cleared on an exact echo or after THREE frames, whichever came first.
+// Now: tag gestures post TARGETED tagEdit ops; lens and order edits keep the whole-blob write; both
+// carry a writeId the kernel's ack names, and the optimistic copy clears on the ACK — never on a
+// frame count. Executed tests on the pure module (views-writes.ts) plus source pins on render.ts
+// (the tab-order.ts pattern; no jsdom for render.ts). Synthetic ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ackOutcome, adoptViews, applyTagEdit, createInFlight, mintWriteId, rederivePending, seqOf, lensBlob, applyLensFields, isPlaceholderId, capsAdopts, announcedSeq, announcedAfter, type InflightWrite } from "./views-writes";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const S1 = { active: "all", at: 113, tags: [{ id: "g1", name: "qa", color: "#DD42FF", members: ["tests"], mtime: 113 }] };
+
+const W1: InflightWrite = { id: "w1", edit: { op: "create", name: "qa", color: "#DD42FF", sids: ["tests"] }, newId: "pending-1" };
+const W2: InflightWrite = { id: "w2", edit: { op: "rename", tid: "g1", newName: "quality" } };
+
+test("executed: an ok ack settles ITS write; the copy clears only when nothing else is in flight", () => {
+  // the burst: a create (w1) and the rename typed before its echo (w2), both in flight
+  const a = ackOutcome([W1, W2], { type: "tagEditAck", writeId: "w1", ok: true, views: S1 });
+  assert.deepEqual(a, { inflight: [W2], clearPending: false, rederive: false, refusal: null },
+    "the create's ack leaves the rename's optimistic copy showing — the user's typed name never blinks to 'tag N'");
+  const b = ackOutcome(a.inflight, { type: "tagEditAck", writeId: "w2", ok: true, views: S1 });
+  assert.deepEqual(b, { inflight: [], clearPending: true, rederive: false, refusal: null }, "the last ack settles the copy");
+});
+
+test("executed: a refusal drops ITS write only and names the tag and the reason; a later in-flight write keeps its copy", () => {
+  const why = 'a tag named "web" already exists';
+  const r = ackOutcome([W1, W2], { type: "tagEditAck", writeId: "w1", ok: false, error: why, views: S1 });
+  assert.deepEqual(r, { inflight: [W2], clearPending: false, rederive: true, refusal: why },
+    "the refused write is dropped; the rename still in flight is not — the copy is re-derived without the refused change (the 2026-09-05 review: a refusal cleared the whole list, and a later write flapped off and back on)");
+  assert.deepEqual(ackOutcome([W1], { type: "tagEditAck", writeId: "w1", ok: false, error: why, views: S1 }),
+    { inflight: [], clearPending: true, rederive: false, refusal: why }, "with nothing else in flight the store's blob (in the ack) is what stands");
+  // the whole-blob path's refusal lists the tags the guard kept, each with a NAME-FREE reason; the
+  // kernel's one-line `error` names each tag once — and the page never prefixes the name a second time
+  const reason = "your copy predates a newer edit to it, so your change was not applied and the newer state was kept";
+  const w = ackOutcome([{ id: "w3", blob: S1 }], { type: "viewsAck", writeId: "w3", ok: false, refused: [{ tid: "gA", name: "web", reason }], error: '"web": ' + reason, views: S1 });
+  assert.equal(w.refusal, '"web": ' + reason, "the kernel's line as-is: the name once, then what was refused and what was kept");
+  assert.equal(w.clearPending, true);
+  // no error text at all → still a plain word, never an empty toast
+  assert.equal(ackOutcome([{ id: "w4" }], { writeId: "w4", ok: false }).refusal, "refused");
+  assert.equal(ackOutcome([{ id: "w5" }], { writeId: "w5", ok: false, refused: [{ name: "qa", reason: "kept" }] }).refusal, '"qa": kept',
+    "with only the rows, the same shape is composed here");
+  // ok WITH refusals listed (the guard kept the store's copy of tags this write did not edit — a lens
+  // write from a stale copy): the write is settled, nothing is toasted, the ack's blob is the base
+  assert.deepEqual(ackOutcome([{ id: "w6", blob: S1 }], { type: "viewsAck", writeId: "w6", ok: true, refused: [{ tid: "gA", name: "web", reason }], views: S1 }),
+    { inflight: [], clearPending: true, rederive: false, refusal: null }, "nothing the user did was refused");
+});
+
+test("executed: the pending copy re-derives from the store's blob plus the writes still in flight — only the refused change reverts", () => {
+  const base = { active: "all", seq: 5, tags: [{ id: "gA", name: "web", color: "#3b82f6", members: ["s1"] }] };
+  // A (recolor) refused, B (addMember, posted after A from the copy that showed the recolor) still in flight
+  const B: InflightWrite = { id: "wB", edit: { op: "addMember", tid: "gA", sids: ["s2"] } };
+  const p = rederivePending(base, [B])!;
+  assert.deepEqual(p.tags, [{ id: "gA", name: "web", color: "#3b82f6", members: ["s1", "s2"] }], "the add shows, the refused recolor does not");
+  assert.deepEqual(base.tags[0].members, ["s1"], "the base is never mutated");
+  assert.equal(rederivePending(base, []), null, "nothing in flight → the base itself shows");
+  // a whole-blob write in flight IS the state it posted; a targeted op after it applies on top
+  const blob = { active: "all", tags: [{ id: "gA", name: "web", color: "#000000", members: [] }], actives: { chat: { tags: ["web"] } } };
+  const q = rederivePending(base, [{ id: "wL", blob }, { id: "wC", edit: { op: "create", name: "qa", color: "#DD42FF", sids: ["s3"] }, newId: "pending-x" }])!;
+  assert.deepEqual(q.actives, { chat: { tags: ["web"] } });
+  assert.deepEqual(q.tags, [{ id: "gA", name: "web", color: "#000000", members: [] }, { id: "pending-x", name: "qa", color: "#DD42FF", members: ["s3"] }],
+    "the create's row wears the placeholder id its gesture drew");
+  // every op, applied the way the gesture applied it; an unknown tid is a no-op
+  const t2 = { active: "gA", tags: [{ id: "gA", name: "web", members: ["s1", "s2"] }, { id: "gB", name: "api", members: ["s3"] }] };
+  assert.equal(applyTagEdit(t2, { op: "rename", tid: "gA", newName: "site" }).tags![0].name, "site");
+  assert.equal(applyTagEdit(t2, { op: "recolor", tid: "gB", color: "#54B204" }).tags![1].color, "#54B204");
+  const del = applyTagEdit(t2, { op: "delete", tid: "gA" });
+  assert.deepEqual([del.tags!.map((t) => t.id), del.active], [["gB"], "all"], "a deleted active tag falls back to All, as the gesture did");
+  assert.deepEqual(applyTagEdit(t2, { op: "removeMember", tid: "gA", sids: ["s1"] }).tags![0].members, ["s2"]);
+  const mv = applyTagEdit(t2, { op: "move", tid_from: "gA", tid_to: "gB", sid: "s2" });
+  assert.deepEqual([mv.tags![0].members, mv.tags![1].members], [["s1"], ["s3", "s2"]]);
+  assert.deepEqual(applyTagEdit(t2, { op: "rename", tid: "gZ", newName: "x" }).tags, t2.tags, "an unknown tid changes nothing — the kernel refuses it");
+  assert.equal(createInFlight([B]), false);
+  assert.equal(createInFlight([B, W1]), true, "a create in flight gates the next New tag…");
+});
+
+test("executed: a refusal's nameless summary row (the entries past the door's row bound, the 2026-09-05 review) renders as its reason alone, after the named rows", () => {
+  const rows = [
+    { tid: "g9", name: "qa", reason: "a write is read to 64 tags and it was past that bound, so it was not created" },
+    { reason: "3 more entries past the 64-tag read bound were not read (1 of them this write edited)", more: 3, moreEdited: 1 },
+  ];
+  const out = ackOutcome([W2], { type: "viewsAck", writeId: "w2", ok: false, refused: rows });
+  assert.equal(out.refusal, '"qa": a write is read to 64 tags and it was past that bound, so it was not created; 3 more entries past the 64-tag read bound were not read (1 of them this write edited)',
+    "no name prefix on the summary row — the same shape the kernel's own bounded `error` line has");
+  assert.equal(ackOutcome([W2], { type: "viewsAck", writeId: "w2", ok: false, error: "bounded by the kernel", refused: rows }).refusal, "bounded by the kernel",
+    "the kernel's one-line error wins when present");
+});
+
+test("executed: an ack for a write this page never made counts as information — nothing stays pinned", () => {
+  assert.deepEqual(ackOutcome([], { type: "viewsAck", writeId: "w-from-a-previous-load", ok: true, views: S1 }),
+    { inflight: [], clearPending: true, rederive: false, refusal: null });
+  assert.deepEqual(ackOutcome([{ id: "w9" }], { type: "viewsAck", writeId: "w-other", ok: true, views: S1 }),
+    { inflight: [{ id: "w9" }], clearPending: false, rederive: false, refusal: null }, "…but our own in-flight write still holds its copy");
+});
+
+test("executed: a blob is adopted by write SEQUENCE, never by arrival order — older is ignored, equal or newer lands, no seq adopts", () => {
+  const held = { active: "all", tags: [], seq: 12 };
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 11 }), false, "the pusher's warmed cache, delivered after the ack: ignored");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 12 }), true, "the same write, seen again (the ack's blob then its frame): fine");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 13 }), true);
+  assert.equal(adoptViews(held, { active: "all", tags: [] }), true, "a kernel from before the stamp sends no seq — nothing is gated on a field it never sends");
+  assert.equal(adoptViews(null, { active: "all", tags: [], seq: 3 }), true, "nothing held yet");
+  assert.equal(adoptViews({ active: "all", tags: [] }, { active: "all", tags: [], seq: 3 }), true, "a seq-less base yields to the first stamped blob");
+  assert.equal(adoptViews(held, null), false);
+  assert.equal(seqOf({ seq: 7 } as any), 7);
+  assert.equal(seqOf({ seq: "7" } as any), null, "a non-number is no seq");
+  assert.equal(seqOf(null), null);
+});
+
+test("executed: capsAdopts — the caps frame adopts the kept blob only when viewsSeq (what the kernel's own connect push served) names its seq; an older kernel's frame, without the field, adopts it outright", () => {
+  // the kernel restarted over a store restored from an older copy: its connect push carries seq 900 where the page holds 1000
+  const held = { active: "all", tags: [{ id: "g1", name: "qa", color: "", members: [] }], seq: 1000 } as any;
+  const restored = { active: "all", tags: [], seq: 900 } as any;
+  assert.equal(adoptViews(held, restored), false, "the connect push meets the gate first and is turned away…");
+  assert.equal(capsAdopts(restored, 900), true, "…and the caps frame that follows names it (viewsSeq 900): adopted, zero residual, no wait on the pusher's repost");
+  assert.equal(adoptViews(restored, { active: "all", tags: [], seq: 899 }), false, "the gate re-arms at its seq: the store's own order gates again");
+  // the residual an earlier fix left: a pusher-thread frame built before a concurrent write (seq 1000), enqueued
+  // between the connect push (seq 1001, adopted) and the caps frame — turned away and kept
+  const stale = { active: "all", tags: [], seq: 1000 } as any;
+  assert.equal(capsAdopts(stale, 1001), false, "the caps frame names the connect push's seq, not the stale frame's: discarded, the gate stands at 1001");
+  assert.equal(capsAdopts(stale, null), false, "the connect push carried no views blob (viewsSeq null): nothing to match, nothing adopted");
+  assert.equal(capsAdopts(stale, "1000"), false, "a non-number is no seq");
+  assert.equal(capsAdopts(stale, undefined), true, "a caps frame without the field (a kernel from before it) adopts the kept blob — the pre-field rule");
+  assert.equal(capsAdopts(null, 900), false); assert.equal(capsAdopts(undefined, undefined), false, "nothing kept: nothing to adopt, whatever the frame says");
+  assert.equal(capsAdopts({ active: "all", tags: [] } as any, 900), false, "a kept blob without a seq cannot match (unreachable: the gate adopts every seq-less blob)");
+});
+
+// The 2026-09-05 review: the caps frame's viewsSeq is also the kernel's ANNOUNCEMENT of its current store
+// (the served blob's seq, or the store's current seq when the connect push carried no views frame — a chat page's
+// sentinel cycle sends no tabOrder; null only when the kernel has no store at all). A restart over a store restored
+// from an older copy, met by such a reconnect, kept nothing for capsAdopts to match: the pusher's next frame (the
+// restored store, under its old seq) was turned away and no second caps frame comes. The client remembers the
+// announced seq in one slot per store and adopts the LATER blob that carries it, below the held one.
+test("executed: announcedSeq + adoptViews(announced) — a caps frame that adopted no kept blob names the kernel's current store, and the later blob at exactly that seq is adopted below the held one; another lower seq is still turned away; a cleared slot is the old verdict; null and a missing field announce nothing", () => {
+  const held = { active: "all", tags: [{ id: "g1", name: "qa", color: "", members: [] }], seq: 1000 } as any;
+  assert.equal(capsAdopts(null, 900), false, "the sentinel cycle's push carried no blob, so nothing is kept: the caps frame adopts nothing…");
+  const announced = announcedSeq(900);
+  assert.equal(announced, 900, "…and its viewsSeq — the restored store's current seq — is remembered as the kernel's announced store");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 899 }, announced), false, "a frame at another lower seq is a stale frame: turned away");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 900 }, announced), true, "the pusher's next frame carries the announced seq: that IS the store the kernel said it holds — adopted below the held one");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 900 }), false, "…and only because it was announced: the same blob with no slot meets the old verdict");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 900 }, null), false, "a cleared slot (the caller clears it on every adoption that changes the held blob — announcedAfter): a write that landed first stamped the store past the announcement, and 900 is the stale frame it looks like");
+  assert.equal(adoptViews(held, { active: "all", tags: [], seq: 1100 }, announced), true, "a newer blob adopts as ever");
+  assert.equal(adoptViews(held, { active: "all", tags: [] }, announced), true, "a seq-less blob adopts as ever");
+  assert.equal(adoptViews(held, null, announced), false);
+  assert.equal(announcedSeq(null), null, "viewsSeq null — the kernel has no store at all — announces nothing");
+  assert.equal(announcedSeq(undefined), null, "a frame without the field (a kernel from before it) announces nothing");
+  assert.equal(announcedSeq("900"), null); assert.equal(announcedSeq(NaN), null, "a non-number is no seq");
+});
+
+// The 2026-09-05 review: the slot is cleared only by an adoption that CHANGES the held blob. In the browser a pane sees the local
+// blob only through the federation router, which replays its stored blob on every merged re-emit (a remote host's
+// push, a `closed` frame, a view-order storage event, a host drop) — a re-arrival of the blob the pane already holds,
+// at its own seq. The earlier clear on any adoption spent the slot on that re-arrival, and the restored store the
+// router adopted and re-emitted next at the announced seq was turned away by the pane: router 900, pane 1000,
+// silently, until the next write (federation-views-seq.test.ts executes the failure against the real router).
+test("executed: announcedAfter — a re-arrival of the held blob (the same seq) leaves the slot; a different seq, a seq-less side, or the announced seq itself clears it; null stays null", () => {
+  const held = { active: "all", tags: [], seq: 1000 } as any;
+  const v = (seq?: number) => ({ active: "all", tags: [], ...(seq === undefined ? {} : { seq }) }) as any;
+  assert.equal(announcedAfter(held, v(1000), 900), 900, "the blob already held, arriving again (the router's re-emit of its stored blob): no new information, the slot stands");
+  assert.equal(announcedAfter(held, v(900), 900), null, "the announced store itself, adopted below the held one: the announcement is spent");
+  assert.equal(announcedAfter(held, v(1100), 900), null, "a newer write stamped the store past the announcement: cleared");
+  assert.equal(announcedAfter(held, v(), 900), null, "a seq-less blob changes the held one: cleared");
+  assert.equal(announcedAfter(null, v(900), 900), null, "nothing held yet: the arrival is the store, cleared");
+  assert.equal(announcedAfter(null, v(1000), 900), null);
+  assert.equal(announcedAfter(v(), v(), 900), null, "two seq-less blobs cannot be told apart: cleared, the old verdict");
+  assert.equal(announcedAfter(held, v(1000), 1000), null, "the announced seq arriving at the held seq: the announced store has arrived, the slot is spent");
+  assert.equal(announcedAfter(held, v(1000), null), null, "no slot in, none out");
+  // the composition every gate uses: the same-seq re-arrival is adopted (i >= h) and leaves the slot, so the announced blob still lands after it
+  let slot: number | null = 900;
+  assert.equal(adoptViews(held, v(1000), slot), true); slot = announcedAfter(held, v(1000), slot);
+  assert.equal(slot, 900);
+  assert.equal(adoptViews(held, v(900), slot), true, "…and the restored store, re-emitted after it, is adopted below the held one"); slot = announcedAfter(held, v(900), slot);
+  assert.equal(slot, null);
+  assert.equal(adoptViews(v(900), v(900), slot), true, "the same blob again meets the ordinary rule");
+});
+
+test("pins: render.ts keeps the last blob its gate turned away, lets it go on the next adoption, and on the caps frame adopts it only when viewsSeq names it — before anything else it does there", () => {
+  const take = RENDER.slice(RENDER.indexOf("function takeViews("), RENDER.indexOf("\n}\n", RENDER.indexOf("function takeViews(")));
+  assert.match(take, /if \(adoptViews\(sessionViews, v, announcedViewsSeq\)\) \{ announcedViewsSeq = announcedAfter\(sessionViews, v, announcedViewsSeq\); sessionViews = v; rejectedViews = null; return true; \}\s*\n\s*rejectedViews = v;/,
+    "an adoption lets the kept blob go and re-derives the announced slot from the held blob BEFORE it moves (cleared only when the adoption changes it); a rejection keeps this one (the LAST turned away — the connect push is the last frame before caps on the handler's thread); the gate reads the announced seq");
+  const caps = RENDER.slice(RENDER.indexOf("function onKernelCaps("), RENDER.indexOf("function onUnknownOp("));
+  assert.match(caps, /kernelCaps = new Set\([\s\S]*?\);\n\s*const adopted = capsAdopts\(rejectedViews, m\.viewsSeq\);\n\s*if \(adopted\) sessionViews = rejectedViews;\n\s*announcedViewsSeq = adopted \? null : announcedSeq\(m\.viewsSeq\);\n\s*rejectedViews = null;\n\s*if \(viewsWrites\.length\) \{/,
+    "the verdict runs on EVERY caps frame, in-flight writes or not, on the frame's viewsSeq, and before the in-flight drop: the dropped copy reverts to the adopted base; the kept blob is let go either way; a frame that adopted nothing leaves the announced seq in the one slot");
+  assert.equal((RENDER.match(/announcedViewsSeq = /g) || []).length, 2, "past its declaration the slot is written in exactly two places: the gate's re-derivation on adoption, and the caps frame");
+  assert.match(caps, /\} else if \(!adopted\) return;/, "nothing in flight and nothing adopted: the caps frame changes nothing shown");
+  assert.match(caps, /if \(activeId\) assertPeekFor\(activeId\);[^\n]*\n\s*renderTabs\(\);\n\}/, "an adoption renders like any views arrival: the peek is re-derived and the strip redrawn");
+  assert.doesNotMatch(RENDER, /forgetSeq|adoptOnCaps/, "the held seq is never forgotten and no kept blob is adopted unnamed: the gate is never left open (the one-cycle flap window an earlier fix left)");
+});
+
+test("executed: write ids are unique per page across same-ms gestures", () => {
+  const a = mintWriteId(1), b = mintWriteId(2);
+  assert.notEqual(a, b);
+  assert.match(a, /^w[0-9a-z]+-1$/);
+});
+
+test("pins: render.ts posts a writeId on every views write and routes both acks to onViewsAck", () => {
+  const pv = RENDER.slice(RENDER.indexOf("function postViews(v: SessionViews, edited: string[] = [])"), RENDER.indexOf("\n}\n", RENDER.indexOf("function postViews(")));
+  assert.match(pv, /const writeId = holdViews\(v, \{ blob: v \}\);/, "the record keeps the blob it posted: a refusal elsewhere re-derives from it");
+  assert.match(pv, /vscodeApi\.postMessage\(\{ type: "setTimelineViews", views: v, writeId, edited \}\);/,
+    "a lens/order edit is still the whole blob (the kernel owns no lens op), with its writeId and the tag ids it changed (none) — a refusal on an untouched tag is acked ok, no toast");
+  assert.match(RENDER, /warnToast\("Tag edit not applied — " \+ out\.refusal\);/, "the toast adds no second name: the reason names the tag once and says what was kept");
+  const pte = RENDER.slice(RENDER.indexOf("function postTagEdit("), RENDER.indexOf("\n}\n", RENDER.indexOf("function postTagEdit(")));
+  assert.match(pte, /if \(!kernelCaps\.has\("tagEdit"\)\) \{\s*\n\s*const edited = \[edit\.tid, edit\.tid_from, edit\.tid_to\]\.filter\(\(t\): t is string => !!t\);\s*\n\s*const row = newId \? viewTags\(nv\)\.find\(\(t\) => t\.id === newId\) : undefined;\s*\n\s*if \(row\) \{ if \(\/\^pending-\/\.test\(row\.id\)\) row\.id = "g" \+ Date\.now\(\)\.toString\(36\); edited\.push\(row\.id\); \}\s*\n\s*postViews\(nv, edited\);\s*\n\s*return;\s*\n\s*\}/,
+    "no `tagEdit` capability announced (an older kernel) → the pre-cap whole-blob write naming the tags it changed; a create's row takes a client-minted g… id, never the pending- placeholder, and is named as edited (the 2026-09-05 review)");
+  assert.match(pte, /const writeId = holdViews\(nv, \{ edit, newId \}\);\s*\n\s*if \(vscodeApi\) vscodeApi\.postMessage\(\{ type: "tagEdit", writeId, edit \}\);/,
+    "a tag gesture is a targeted op, NESTED under `edit` so no tag name sits at the top level where the federation router reads session addresses");
+  assert.match(RENDER, /else if \(m\.type === "viewsAck" \|\| m\.type === "tagEditAck"\) onViewsAck\(m\);/);
+  assert.match(RENDER, /else if \(m\.type === "caps"\) onKernelCaps\(m\);\s*\n\s*else if \(m\.type === "unknownOp"\) onUnknownOp\(m\);/,
+    "the kernel's caps (every `ready`) and its answer to an op it does not know both have a door");
+  const caps = RENDER.slice(RENDER.indexOf("function onKernelCaps("), RENDER.indexOf("\n}\n", RENDER.indexOf("function onKernelCaps(")));
+  assert.match(caps, /kernelCaps = new Set\(/);
+  assert.match(caps, /if \(viewsWrites\.length\) \{\s*\n\s*viewsWrites = \[\]; pendingSessionViews = null;\s*\n\s*warnToast\(/,
+    "a caps frame with writes in flight is a re-established socket: their acks may never come, so they are dropped and the user is told");
+  const unk = RENDER.slice(RENDER.indexOf("function onUnknownOp("), RENDER.indexOf("\n}\n", RENDER.indexOf("function onUnknownOp(")));
+  assert.match(unk, /if \(typeof m\.op === "string"\) kernelCaps\.delete\(m\.op\);/, "the capability is withdrawn");
+  assert.match(unk, /viewsWrites\.some\(\(w\) => w\.id === m\.writeId\)\)\s*\n\s*onViewsAck\(\{ type: "unknownOp", writeId: m\.writeId, ok: false,/, "…and the write is refused, through the one ack door");
+  const ack = RENDER.slice(RENDER.indexOf("function onViewsAck("), RENDER.indexOf("\n}\n", RENDER.indexOf("function onViewsAck(")));
+  assert.match(ack, /const out = ackOutcome\(viewsWrites, m\);/, "the pure module decides; render.ts applies");
+  assert.match(ack, /takeViews\(m\.views\);/, "the ack's blob is the new base unless a newer frame already overtook it (the seq decides), verdict regardless");
+  assert.match(ack, /if \(out\.clearPending\) pendingSessionViews = null;\s*\n\s*else if \(out\.rederive\) pendingSessionViews = rederivePending\(sessionViews, viewsWrites\);/,
+    "a refusal with other writes in flight re-derives the copy from the base plus them — only the refused change reverts");
+  assert.match(ack, /if \(out\.refusal\) warnToast\(/, "a refusal is LOUD — the flyout has no error surface of its own");
+  assert.match(ack, /syncNewTagInput\(\);/, "…and the flyout's New tag… input is re-armed in place — never by rebuilding the flyout, which would drop typed text");
+  const sync = RENDER.slice(RENDER.indexOf("function syncNewTagInput("), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncNewTagInput(")));
+  assert.match(sync, /const busy = createInFlight\(viewsWrites\);\s*\n\s*tagsFlyNewInput\.disabled = busy;\s*\n\s*tagsFlyNewInput\.placeholder = busy \? "creating…" : "New tag…";/,
+    "disabled and saying so while a create is in flight (a second Enter before the ack made a second tag)");
+  assert.match(RENDER, /function dismissTabMenu\(\) \{\s*\n\s*ctxMenuEl\?\.remove\(\);\s*\n\s*ctxMenuEl = null;\s*\n\s*tagsFlyNewInput = null;/, "a closed menu forgets its input");
+});
+
+test("pins: every views arrival in render.ts goes through the ONE seq-gated adopter, and the exact-echo clear is legacy-only", () => {
+  const take = RENDER.slice(RENDER.indexOf("function takeViews("), RENDER.indexOf("\n}\n", RENDER.indexOf("function takeViews(")));
+  assert.match(take, /if \(adoptViews\(sessionViews, v, announcedViewsSeq\)\) \{ announcedViewsSeq = announcedAfter\(sessionViews, v, announcedViewsSeq\); sessionViews = v; rejectedViews = null; return true; \}/, "adopt by write sequence, never by arrival order — or by the seq the caps frame announced; the slot is re-derived from the held blob before it moves");
+  assert.match(take, /what: "views-stale-blob"/, "an ignored blob leaves one breadcrumb per page load — a visible fact, not a flicker");
+  assert.doesNotMatch(RENDER, /pendingViewsAge/, "no frame counter anywhere in render.ts");
+  const cap = RENDER.slice(RENDER.indexOf("function captureViews("), RENDER.indexOf("\n}\n", RENDER.indexOf("function captureViews(")));
+  assert.match(cap, /^\s*takeViews\(v\);/m, "a pushed frame is adopted through the gate");
+  assert.match(cap, /if \(pendingSessionViews && v && seqOf\(v\) === null\s*\n\s*&& \(viewsKey\(v\) === viewsKey\(pendingSessionViews\) \|\| \+\+legacyViewsAge >= 3\)\) \{\s*\n\s*pendingSessionViews = null; viewsWrites = \[\]; legacyViewsAge = 0;/,
+    "the exact-echo clear and the three-frame yield survive ONLY for a blob without a seq (a kernel that acks nothing); a stamped kernel's frames never clear a write they cannot name");
+  assert.equal((cap.match(/>= 3/g) || []).length, 1, "one legacy yield, under the seq-less condition, nowhere else");
+  assert.equal((RENDER.match(/(?<!pending)(?<!\w)sessionViews = /g) || []).length, 2,
+    "the base is assigned in exactly two places: inside the gate, and the caps frame's adoption of the blob the gate last turned away");
+  assert.match(RENDER, /if \(adopted\) sessionViews = rejectedViews;/, "…that second one is the reconnect event's adoption and nothing else");
+});
+
+test("pins: the Tags flyout's local edits are targeted ops on ONE optimistic blob", () => {
+  const at = RENDER.indexOf("const editUnion = (g: TagUnion");
+  const body = RENDER.slice(at, at + 4200);   // the union editor's two op sites and its post (the pending-union comment sits inside this window)
+  const fly = RENDER.slice(at, RENDER.indexOf("// BROWSE FILES", at));
+  assert.ok(body.includes('ops.push({ op: "addMember", tid: g.localId, sids: edit.add.slice() });'), "a local add is an addMember by the tag's stored id");
+  assert.ok(body.includes('ops.push({ op: "removeMember", tid: g.localId, sids: edit.remove.slice() });'), "a local remove is a removeMember by id");
+  assert.doesNotMatch(body, /op: "(?:addMember|removeMember|rename|recolor|delete)", name:/, "no op but create carries a tag name");
+  assert.match(body, /for \(const op of ops\) postTagEdit\(nv, op\);/, "N ops, the one copy shown for all of them");
+  assert.match(body, /else if \(mirrored\) \{ pendingSessionViews = nv; renderTabs\(\); \}/,
+    "a remote-only edit has no local op: its mirror shows until the next frame");
+  assert.match(RENDER, /if \(pendingSessionViews && v && !viewsWrites\.length\) pendingSessionViews = null;/,
+    "…which captureViews lets go on any frame, seq or not — a copy with no write in flight is that mirror alone");
+  assert.match(RENDER, /postTagEdit\(nv, \{ op: "create", name, color, sids: \[id\] \}, tg\.id\);/,
+    "New tag… is ONE create carrying the session — the tag and its first member land together; the kernel mints the id (the placeholder rides along for the legacy path's re-id)");
+  assert.match(fly, /if \(e2\.key !== "Enter"\) return;\s*\n\s*if \(createInFlight\(viewsWrites\)\) return;/, "one create at a time: Enter is ignored while one is in flight");
+  assert.match(fly, /nrow\.appendChild\(inp\);\s*\n\s*tagsFlyNewInput = inp; syncNewTagInput\(\);/, "the input renders disabled when a create is already in flight");
+  assert.doesNotMatch(fly, /postViews\(/, "no whole-blob write anywhere in the flyout's tag edits");
+});
+
+// ── The 2026-09-05 review: a lens or order write is built from the STORE's blob, never the
+// pending copy. Built from the pending copy, the whole-blob write carried every targeted edit still in
+// flight as this page's claim on those tags, and a rename the kernel had refused as a duplicate landed
+// through the next lens toggle (two tags, one name). The copy the page SHOWS still includes the in-flight
+// edits: the write's record keeps its fields, and a re-derivation re-applies exactly them.
+test("executed: a lens or order write posts the store's blob plus its fields, shows the current copy plus the same fields, and a refused edit in flight reverts alone", () => {
+  const base: any = { active: "all", actives: { chat: { all: true }, timeline: { all: true }, outline: { all: true } }, at: 100, seq: 5,
+                      tags: [{ id: "gA", name: "web", color: "#3b82f6", members: ["s1"], mtime: 100 }, { id: "gB", name: "api", color: "#54B204", members: ["s2"], mtime: 100 }] };
+  const rename: InflightWrite = { id: "w1", edit: { op: "rename", tid: "gA", newName: "notes" } };
+  const fields = { actives: { ...base.actives, chat: { tags: ["web"] } } };
+  const posted = lensBlob(base, fields);
+  assert.equal(posted.tags![0].name, "web", "the POSTED blob carries the store's tags — never an edit still in flight");
+  assert.deepEqual(posted.actives!.chat, { tags: ["web"] });
+  assert.equal((posted as any).seq, 5); assert.equal((posted as any).at, 100);   // the store's stamps ride along: the guard's evidence time
+  const shown = rederivePending(base, [rename, { id: "w2", lens: fields }])!;
+  assert.equal(shown.tags![0].name, "notes", "the copy SHOWN keeps the in-flight rename…");
+  assert.deepEqual(shown.actives!.chat, { tags: ["web"] }, "…and the lens");
+  const out = ackOutcome([rename, { id: "w2", lens: fields }], { writeId: "w1", ok: false, error: 'a tag named "notes" already exists', views: base });
+  assert.ok(out.rederive);
+  const after = rederivePending(base, out.inflight)!;
+  assert.equal(after.tags![0].name, "web", "the refused rename reverts…");
+  assert.deepEqual(after.actives!.chat, { tags: ["web"] }, "…and the lens write still in flight keeps its fields");
+  // an ORDER write: tagOrder rides, the posted tags array re-sorts to it (the pill-drag contract), the copy shown takes the order
+  const ordered = lensBlob(base, { tagOrder: ["api", "web"] });
+  assert.deepEqual(ordered.tags!.map((t) => t.id), ["gB", "gA"]);
+  assert.deepEqual(ordered.tagOrder, ["api", "web"]);
+  assert.deepEqual(rederivePending(base, [{ id: "w3", lens: { tagOrder: ["api", "web"] } }])!.tagOrder, ["api", "web"]);
+  // copies, never the input; a page holding no blob yet writes onto the empty shape
+  assert.deepEqual(base.tags.map((t: any) => t.id), ["gA", "gB"]); assert.deepEqual(base.actives.chat, { all: true });
+  assert.deepEqual(lensBlob(null, { actives: { chat: { none: true } } }), { active: "all", tags: [], actives: { chat: { none: true } } });
+  assert.deepEqual(applyLensFields({ active: "all", groups: [{ id: "g1", name: "x", color: "", members: [] }] } as any, { active: "g1" }),
+    { active: "g1", tags: [{ id: "g1", name: "x", color: "", members: [] }] }, "the legacy key reads as tags");
+});
+
+test("executed: isPlaceholderId names an optimistic create's row and nothing else", () => {
+  assert.equal(isPlaceholderId("pending-abc"), true);
+  assert.equal(isPlaceholderId("g7"), false);
+  assert.equal(isPlaceholderId("xpending-1"), false);
+  assert.equal(isPlaceholderId(null), false);
+  assert.equal(isPlaceholderId(undefined), false);
+});
+
+test("pins: render.ts builds every lens and order write from the store's blob (postLens), and the Tags flyout offers no gesture on a create still in flight", () => {
+  assert.match(RENDER, /function postLens\(fields: LensFields\) \{\s*\n\s*const v = lensBlob\(sessionViews, fields\);\s*\n\s*const writeId = holdViews\(applyLensFields\(effViews\(\), fields\), \{ lens: fields \}\);\s*\n\s*if \(vscodeApi\) vscodeApi\.postMessage\(\{ type: "setTimelineViews", views: v, writeId, edited: \[\] \}\);/,
+    "the posted blob is the STORE's (sessionViews) plus the fields; the copy shown is the current one plus the fields; the record keeps the fields");
+  assert.equal((RENDER.match(/\bpostViews\(/g) || []).length, 2, "postViews (a whole blob as posted) has ONE caller left: the no-capability tag path");
+  assert.match(RENDER, /if \(!kernelCaps\.has\("tagEdit"\)\) \{[\s\S]{0,700}postViews\(nv, edited\);/);
+  for (const site of [
+    /postLens\(\{ actives: Object\.assign\(\{\}, \(v \|\| \{\}\)\.actives, \{ chat: l \}\) \}\);/,
+    /postLens\(\{ actives: Object\.assign\(\{\}, \(mv2 \|\| \{\}\)\.actives, \{ chat: l \}\) \}\);/,
+    /function revealSession\(id: string\) \{ const r = revealIn\(effViews\(\), id\); postLens\(\{ active: r\.active, actives: r\.actives \}\); \}/,
+  ]) assert.match(RENDER, site);
+  assert.equal((RENDER.match(/onApply: \(l\) => \{ postLens\(\{ actives: Object\.assign\(\{\}, \(effViews\(\) \|\| \{\}\)\.actives, \{ chat: l \}\) \}\); \},/g) || []).length, 2,
+    "both tag-lens menus (desktop and phone)");
+  const at = RENDER.indexOf("const editUnion = (g: TagUnion");
+  const fly = RENDER.slice(at, RENDER.indexOf("// BROWSE FILES", at));
+  assert.equal((fly.match(/if \(g\.localId && !g\.pending\) \{/g) || []).length, 2, "a pending union takes no add or remove op");
+  assert.match(fly, /if \(g\.pending\) \{[\s\S]{0,500}busy\.textContent = "creating…"; row\.appendChild\(busy\);\s*\n\s*sub\.appendChild\(row\);\s*\n\s*continue;/,
+    "a held tag whose create is in flight renders with no ✕");
+  assert.match(fly, /const others = unionFor\(\)\.filter\(\(g\) => !g\.members\.includes\(id\) && !g\.pending\);/, "…and is not offered to join");
+});

--- a/ui/webview/views-writes.ts
+++ b/ui/webview/views-writes.ts
@@ -1,0 +1,280 @@
+// A page's VIEWS WRITES in flight, and what the kernel's answer to one of them means (the user
+// 2026-09-05, who lost a batch of tag renames and assignments): every write of the views blob —
+// a targeted tag edit (`tagEdit`) or a whole-blob lens/order write (`setTimelineViews`) — carries
+// a writeId, and the kernel answers it on the same socket with {tagEditAck|viewsAck, writeId, ok,
+// views, error?, refused?}. The optimistic copy a gesture showed clears on that ACK — an event —
+// never on a count of frames: a frame that does not echo the edit says nothing about it (it may
+// predate the write, or the kernel may have refused it), and the three-frame yield this replaces
+// dropped good edits and kept refused ones alike. Pure, shared by render.ts (the tab strip) and
+// mirrored by hand in ui/romp-timeline-view.js (which cannot import TS).
+import type { SessionTag, SessionViews } from "./session-views";
+
+/** one targeted tag edit — the kernel applies it through its /tag merge, which reads the store first
+ *  and so is never judged stale against this page's own earlier writes. Every op but create addresses
+ *  the tag by its stored id (`tid`): a name is what a refused rename would have changed, so a
+ *  follow-up addressed by name could land on whichever OTHER tag already had it. The message nests
+ *  this under `edit`, so no top-level `name` can read as a session address to the federation router. */
+export interface TagEditOp {
+  op: "create" | "rename" | "recolor" | "addMember" | "removeMember" | "delete" | "move";
+  /** the tag's stored id — every op but create and move */
+  tid?: string;
+  /** move only: off `tid_from`, onto `tid_to`, as ONE write on the kernel — both halves or neither */
+  tid_from?: string;
+  tid_to?: string;
+  /** create only: the typed name, or none for the kernel's default ("tag N", minted unique there) */
+  name?: string;
+  newName?: string;
+  color?: string;
+  sid?: string;
+  sids?: string[];
+}
+
+export interface ViewsAck {
+  type?: string;
+  writeId?: unknown;
+  ok?: boolean;
+  views?: SessionViews | null;
+  /** the store's write sequence after this write — the blob's own `seq`, repeated for the poster */
+  seq?: number | null;
+  error?: string;
+  /** the whole-blob path: each tag the stale-writer guard kept the store's copy of, with its reason —
+   *  and, past the door's row bound, ONE nameless summary row whose reason counts the rest (`more`) and
+   *  how many of them the write edited (`moreEdited`); a row without a name renders as its reason alone */
+  refused?: { tid?: string; name?: string; reason?: string; more?: number; moreEdited?: number }[];
+  /** a targeted edit: the tag it touched — a create's caller learns the kernel-minted id and name here */
+  tid?: string;
+  name?: string;
+}
+
+/** the blob's write sequence, or null for a blob from a kernel that does not stamp one */
+export function seqOf(v: SessionViews | null | undefined): number | null {
+  const s = v && (v as any).seq;
+  return typeof s === "number" && Number.isFinite(s) ? s : null;
+}
+
+/** Whether an incoming blob may replace the held one: yes when its seq is at least the held seq, or
+ *  when either side carries no seq (a kernel from before the stamp, or nothing held yet), or when its
+ *  seq is the one the kernel ANNOUNCED as its current store at connect (`announced`: the slot the
+ *  caller fills from the caps frame through announcedSeq, one per store, cleared by the next
+ *  adoption that CHANGES the held blob — announcedAfter) — a blob carrying that seq IS the announced
+ *  store, not a stale frame, however far below the held seq it sits (the 2026-09-05 review). The order the socket delivered them in
+ *  decides nothing — the pusher builds frames from a warmed cache that can predate a write whose ack
+ *  already arrived, and federation re-emits stored blobs; the seq is the store's own order, so an
+ *  older blob is ignored wherever it turns up. */
+export function adoptViews(held: SessionViews | null | undefined, incoming: SessionViews | null | undefined, announced: number | null = null): boolean {
+  if (!incoming) return false;
+  const h = seqOf(held), i = seqOf(incoming);
+  return h === null || i === null || i >= h || (typeof announced === "number" && i === announced);
+}
+
+/** Whether the kernel's `caps` frame — the reconnect event — adopts the blob the gate last REJECTED
+ *  since its last adoption (the 2026-09-05 review). The kernel's seq floor lives
+ *  for its process, so a store restored while the kernel was down is served under its old seq after
+ *  the restart, and a page that stayed open across it holds the higher seq: its gate turns the
+ *  kernel's connect push away. The kernel sends that push BEFORE the caps frame, and the frame names
+ *  what the push served: `served` is its `viewsSeq`, the write seq of the views blob the ready
+ *  handler's own push put on this socket (read from the frames that handler's thread enqueued, so a
+ *  pusher-thread frame is never what it names), null when the push carried none, undefined when the
+ *  frame has no such field (a kernel from before it). The kept blob is adopted when its seq equals
+ *  `served`: the restore case (the kept blob IS the connect push), the gate re-arming at its seq. A
+ *  pusher frame built before a concurrent write and enqueued between the push and the caps frame is
+ *  kept too, but its seq is older than the push's, so it never matches and is discarded — the gate
+ *  stands, and the next pusher cycle carries the newer blob. A frame without the field adopts the
+ *  kept blob outright, the pre-field rule. Nothing kept: nothing to adopt, whatever the frame says —
+ *  but the frame's viewsSeq is then the kernel's announcement of its current store, which the caller
+ *  remembers (announcedSeq) for the blob that carries it later. */
+export function capsAdopts(rejected: SessionViews | null | undefined, served: unknown): boolean {
+  if (!rejected) return false;
+  if (served === undefined) return true;
+  return typeof served === "number" && Number.isFinite(served) && seqOf(rejected) === served;
+}
+
+/** The seq the caps frame ANNOUNCES as the kernel's current views store, for the client to remember
+ *  when the frame adopted no kept blob (the 2026-09-05 review): its `viewsSeq` when that
+ *  is a number — the seq of the views blob the connect push served, or the store's current seq when
+ *  the push carried no views frame (a chat page's sentinel cycle sends no tabOrder) — and null when
+ *  it is null (the kernel has no store at all) or the frame has no such field (a kernel from before
+ *  it). The caller keeps it in ONE slot per store, overwritten by each caps frame and cleared by the
+ *  next adoption that CHANGES the held blob (announcedAfter), and hands it to adoptViews as
+ *  `announced`, so a LATER blob carrying
+ *  exactly that seq is adopted even below the held one. Without it, a restart over a store restored
+ *  from an older copy met by a sentinel-cycle reconnect left nothing kept for capsAdopts to match:
+ *  the pusher's next frame (the restored store, under its old seq) was turned away, and no second
+ *  caps frame comes. The clear on a changing adoption is what keeps the slot honest: a write that
+ *  lands first stamps the store past what was announced, and a frame at the announced seq is then
+ *  the stale frame it looks like. */
+export function announcedSeq(served: unknown): number | null {
+  return typeof served === "number" && Number.isFinite(served) ? served : null;
+}
+
+/** The announced slot AFTER the gate adopts `incoming` over `held` (the 2026-09-05 review).
+ *  The slot is cleared only by an adoption that CHANGES the held blob: a seq other than the held one
+ *  (a newer write by the ordinary rule, or the announced seq itself below the held one), a seq-less
+ *  side, or the announced seq arriving at the held seq (the announced store has arrived; the
+ *  announcement is spent). A re-arrival of the blob already held — the same seq on both sides — is no
+ *  new information and leaves the slot standing. That case is not rare: in the browser a pane sees the
+ *  local blob only through the federation router, which replays its stored blob on every merged
+ *  re-emit (a remote host's push, a `closed` frame, a view-order storage event, a host drop). An earlier
+ *  rule cleared the slot on ANY adoption, so a re-emit landing between the caps frame and the pusher's next
+ *  frame spent the pane's slot, and when the router adopted the pusher's frame at the announced seq
+ *  and re-emitted it, the pane turned it away: the router carried the restored store and the pane the
+ *  pre-restore one, silently, until the next write. The honesty argument stands as it was: a write
+ *  that lands first stamps the store strictly past the held seq and clears the slot; only an arrival
+ *  that changes nothing leaves it. Null in is null out. */
+export function announcedAfter(held: SessionViews | null | undefined, incoming: SessionViews | null | undefined, announced: number | null): number | null {
+  if (typeof announced !== "number") return null;
+  const h = seqOf(held), i = seqOf(incoming);
+  return i !== null && i === h && i !== announced ? announced : null;
+}
+
+/** the fields a lens or order write sets — the whole-blob write's only content of its own: the
+ *  legacy scalar, the per-surface lenses, and the union display order */
+export type LensFields = Partial<Pick<SessionViews, "active" | "actives" | "tagOrder">>;
+
+/** whether a tag id is the placeholder an optimistic create's row wears until the kernel's ack
+ *  names the real one — such a row takes no gesture (the 2026-09-05 review: a rename
+ *  or delete on it posted the placeholder as the tid and was refused as "no longer exists") */
+export function isPlaceholderId(id: string | null | undefined): boolean {
+  return typeof id === "string" && /^pending-/.test(id);
+}
+
+/** one write in flight: its id, and what it did — the targeted op (with the placeholder id its
+ *  optimistic row wears, for a create), the lens/order fields it set, or the whole blob it posted
+ *  (the no-capability path's tag edits) — so the pending copy can be re-derived without it when
+ *  another write is refused (the 2026-09-05 review) */
+export interface InflightWrite {
+  id: string;
+  edit?: TagEditOp;
+  blob?: SessionViews;
+  lens?: LensFields;
+  /** a create's optimistic row id (the `pending-…` placeholder the ack's blob replaces) */
+  newId?: string;
+}
+
+/** The blob a lens or order write POSTS: the store's blob (`base`, the last one adopted — never
+ *  the pending copy) with the fields set. A whole-blob write built from the pending copy carried
+ *  every targeted edit still in flight as if it were the client's own claim on those tags, and a
+ *  rename the kernel had refused as a duplicate landed through the next lens toggle (the
+ *  2026-09-05 review). The kernel keeps the store's copy of any tag a write with an empty
+ *  `edited` differs on, so what rides here must be exactly what the store served. The tags
+ *  array re-sorts to `tagOrder` when one is given — the pill-drag contract that the stored array
+ *  reads in the dragged order too: over the socket the kernel's door orders the stored array by
+ *  the write's `tagOrder` itself (the array is not the write's to set under an empty `edited`),
+ *  and on the Electron path, where the posted blob IS the file, this re-sort is what does it. */
+export function lensBlob(base: SessionViews | null | undefined, fields: LensFields): SessionViews {
+  const v = applyLensFields(base || { active: "all", tags: [] }, fields);
+  if (fields.tagOrder) {
+    const ix = new Map(fields.tagOrder.map((n, i) => [n, i] as const));
+    const rank = (name: string | undefined) => (name !== undefined && ix.has(name) ? ix.get(name)! : fields.tagOrder!.length);
+    v.tags = (Array.isArray(v.tags) ? v.tags : []).slice().sort((a, b) => rank(a.name) - rank(b.name));
+  }
+  return v;
+}
+
+/** the same fields applied to a blob the page SHOWS (the pending copy, in-flight edits included) —
+ *  a copy, never the input */
+export function applyLensFields(v: SessionViews | null | undefined, fields: LensFields): SessionViews {
+  const nv = JSON.parse(JSON.stringify(v || { active: "all", tags: [] })) as SessionViews;
+  if (!Array.isArray(nv.tags)) nv.tags = Array.isArray(nv.groups) ? nv.groups : [];
+  delete nv.groups;
+  if (fields.active !== undefined) nv.active = fields.active;
+  if (fields.actives !== undefined) nv.actives = JSON.parse(JSON.stringify(fields.actives));
+  if (fields.tagOrder !== undefined) nv.tagOrder = fields.tagOrder.slice();
+  return nv;
+}
+
+export interface AckOutcome {
+  /** the writes still in flight after this ack */
+  inflight: InflightWrite[];
+  /** drop the optimistic copy now: nothing is in flight any more (settled, or the last one refused) */
+  clearPending: boolean;
+  /** this write was refused while others are still in flight: rebuild the copy from the store's
+   *  blob plus those writes (rederivePending), so only the refused change reverts */
+  rederive: boolean;
+  /** a refusal's one-line reason for the user, else null */
+  refusal: string | null;
+}
+
+/** a write id: the ms stamp plus a per-page counter, so two same-ms gestures never share one */
+export function mintWriteId(seq: number): string {
+  return "w" + Date.now().toString(36) + "-" + seq.toString(36);
+}
+
+/** What one ack means for the page. ok → this write is settled; the copy clears once NOTHING is in
+ *  flight (a later gesture may still be pending). Refused → THIS write is dropped and its change
+ *  reverts: with nothing else in flight the store's blob (the ack carries it) is what stands; with
+ *  other writes still pending the copy is re-derived from that blob plus those writes, so a later
+ *  in-flight gesture never flaps off and back on (the 2026-09-05 review: a refusal
+ *  cleared the whole list). The reason surfaces either way. An ack for a write this page never made
+ *  (a previous load's) still counts as information: with nothing of ours in flight, the returned
+ *  blob is the base and no copy stays pinned. */
+export function ackOutcome(inflight: readonly InflightWrite[], m: ViewsAck): AckOutcome {
+  const rest = inflight.filter((w) => w.id !== m.writeId);
+  if (m.ok === false) {
+    // the kernel's one-line `error` already names each refused tag ONCE before its reason; with only
+    // the rows, compose the same shape here — never a name prefix on top of a reason that carries it
+    const rows = (m.refused || []).filter((r) => r && (r.reason || r.name))
+      .map((r) => (r.name ? '"' + r.name + '": ' : "") + (r.reason || "refused"));
+    return { inflight: rest, clearPending: rest.length === 0, rederive: rest.length > 0,
+             refusal: m.error || rows.join("; ") || "refused" };
+  }
+  // ok with refusals listed: the guard kept the store's copy of tags this write did not edit (a stale
+  // copy, not a lost edit) — the ack's blob carries them, and there is nothing to tell the user
+  return { inflight: rest, clearPending: rest.length === 0, rederive: false, refusal: null };
+}
+
+/** whether a create is in flight — the gate on a second [+ New tag] / New tag… before the first is
+ *  answered (the 2026-09-05 review: two clicks before the ack made two tags) */
+export function createInFlight(inflight: readonly InflightWrite[]): boolean {
+  return inflight.some((w) => !!w.edit && w.edit.op === "create");
+}
+
+/** One targeted op applied to a client blob's LOCAL tags, the way the gesture applied it
+ *  optimistically — a copy, never the input. Unknown tids are no-ops (the kernel will refuse them);
+ *  a create's row wears `newId` (the placeholder its ack replaces) so a re-derived copy shows the
+ *  same row the gesture drew. Members are the viewer-relative id strings every client holds. */
+export function applyTagEdit(v: SessionViews, edit: TagEditOp, newId?: string): SessionViews {
+  const nv = JSON.parse(JSON.stringify(v || {})) as SessionViews;
+  const tags: SessionTag[] = (Array.isArray(nv.tags) ? nv.tags : (Array.isArray(nv.groups) ? nv.groups : [])).slice();
+  delete nv.groups;
+  const byId = (tid?: string) => tags.find((t) => t.id === tid);
+  const sids = (edit.sids || []).concat(edit.sid ? [edit.sid] : []);
+  switch (edit.op) {
+    case "create":
+      tags.push({ id: newId || "pending-" + Date.now().toString(36), name: edit.name || "", color: edit.color || "", members: sids.slice() });
+      break;
+    case "rename": { const t = byId(edit.tid); if (t && edit.newName) t.name = edit.newName; break; }
+    case "recolor": { const t = byId(edit.tid); if (t && edit.color) t.color = edit.color; break; }
+    case "delete": {
+      const i = tags.findIndex((t) => t.id === edit.tid);
+      if (i >= 0) tags.splice(i, 1);
+      if (nv.active === edit.tid) nv.active = "all";
+      break;
+    }
+    case "addMember": { const t = byId(edit.tid); if (t) t.members = Array.from(new Set((t.members || []).concat(sids))); break; }
+    case "removeMember": { const t = byId(edit.tid); if (t) t.members = (t.members || []).filter((m) => !sids.includes(m)); break; }
+    case "move": {
+      const from = byId(edit.tid_from), to = byId(edit.tid_to);
+      if (from) from.members = (from.members || []).filter((m) => !sids.includes(m));
+      if (to) to.members = Array.from(new Set((to.members || []).concat(sids)));
+      break;
+    }
+  }
+  nv.tags = tags;
+  return nv;
+}
+
+/** The optimistic copy the page should show for the writes still in flight, rebuilt from `base`
+ *  (the store's blob) oldest write first: a lens or order write sets its fields; a targeted op
+ *  applies on top; a whole-blob write (the no-capability path) IS the state it posted. Null when
+ *  nothing is in flight — the base itself is what shows. */
+export function rederivePending(base: SessionViews | null | undefined, inflight: readonly InflightWrite[]): SessionViews | null {
+  if (!inflight.length) return null;
+  let p: SessionViews = JSON.parse(JSON.stringify(base || { active: "all", tags: [] }));
+  for (const w of inflight) {
+    if (w.lens) p = applyLensFields(p, w.lens);
+    else if (w.blob) p = JSON.parse(JSON.stringify(w.blob));
+    else if (w.edit) p = applyTagEdit(p, w.edit, w.newId);
+  }
+  return p;
+}

--- a/vscode-extension/src/pipe-intent.test.ts
+++ b/vscode-extension/src/pipe-intent.test.ts
@@ -12,8 +12,11 @@ test("typed-text ops are intent — losing them loses the user's words", () => {
 });
 
 test("explicit state-changing picks are intent", () => {
+  // setTimelineViews and tagEdit are the two views writes (a lens/order blob; a targeted tag edit,
+  // 2026-09-05) — a tag renamed during a reconnect window must still land
   for (const t of ["setModel", "setEffort", "setMode", "setFast", "interrupt", "endSession",
-    "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession", "moveSession"]) {
+    "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession", "moveSession",
+    "setTimelineViews", "tagEdit"]) {
     assert.ok(intentOp(t), `${t} must survive a reconnect`);
   }
 });

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -14,7 +14,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "renameSession", "moveSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
-  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "openTagsDialog",
+  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "tagEdit", "openTagsDialog",
   "reorderTabs", "closeTab",
 ]);
 


### PR DESCRIPTION
## What breaks

Create a tag in the timeline's Manage tags dialog (or a tab's Tags flyout), type its name at once, and assign two sessions from the join menu. After the third push the tag reads "tag 1" again with no members, and the UI says nothing.

Reproduction on a `notes-api` dashboard: `[+ New tag]`, type `infra`, add `web` and `api` from the join menu, wait ten seconds. The name snaps back to the default and the members vanish.

## Why

Every gesture posted the whole views blob, built from the client's own un-echoed optimistic copy, so a burst of edits carried the pre-burst `at` stamp. The stale-writer guard stamped the tag on the first write (the create) and judged the second (the rename) stale against the client's own write. The refusal reached stderr and the sync notice only; the client kept posting from the refused copy and dropped it after three frames, falling back to the store. A second cause: the dialog minted default names from its row count, so a leftover "tag N" made the next create a refused duplicate.

## The fix

Kernel (`kernel/kernel.py`):

- A `tagEdit` WS op, `{writeId, edit: {op, tid, ...}}`, with create, rename, recolor, addMember, removeMember, delete and move, addressed by the tag's stored id and applied through `_edit_tag`, the read-modify-write merge behind `romp tag`, which is never judged stale. The `/tag` route's callers are unchanged: the new keyword arguments (`tid`, `exists`) default to the old behaviour. The kernel mints a create's id and, given no name, the lowest free "tag N".
- Every views write is answered on the posting socket. `tagEditAck` and `viewsAck` carry the writeId, `ok`, the post-write blob and its `seq`, a create's tid and name, and the guard's kept tags with plain reasons.
- The store stamps a strictly increasing `seq` on every accepted write, and every frame carries it. A store from before the stamp is stamped once on its first read (its tags get an mtime); a file written outside the kernel whose seq fell behind is judged against the last served blob and re-stamped; the judgment and the write run as one step under a re-entrant file lock, and an unwritable store serves the judged blob.
- A whole-blob write may carry `edited`, the tag ids it changed (`[]` for a lens or order write). An empty list changes no tag, so a lens write cannot revert a concurrent tag edit; a refusal on a tag the client did not edit is acked ok with the refusal listed. The whole-blob arm now runs under `_views_lock` like the other writers.
- The name-collision pass runs to a fixpoint; the 32-tag cap refuses a write's creates with a reason and never drops a kept store tag; entries past the door's 64-tag read bound get refusal rows (bounded to 64 plus one summary row); `active` is validated against the tags that stand; notices put their point first and fit the bell's 240 characters.
- A `caps` frame after every `ready` announces `tagEdit` (also listed on `/version`) with `viewsSeq`, the seq of the views blob the connect push served, captured from the frames the handler's own thread enqueued, including the handler's own tabOrder frame. A restart over a restored older store is adopted on that frame. A message no arm takes is answered `unknownOp`, logged once per type.

Clients:

- The timeline dialog, the lane gear menu and the chat pane's Tags flyout post targeted ops when the kernel announced the capability and the whole blob otherwise, so an older kernel keeps working and an older client keeps working against a newer kernel.
- A blob is adopted only when its seq is at least the held one: on frames, on acks, and in the federation router's two replayed views stores. The optimistic copy settles on the ack; a refusal reverts only its own write and shows its reason (a notice in the dialog and the lane gear menu, a toast in the chat pane). The exact-echo clear and the three-frame yield remain for seq-less blobs only.
- One create is in flight at a time per surface, and a row whose create is pending takes no gesture. Lens and order writes are built from the store's blob plus their fields, with a writeId and `edited: []` (the Outline pane's lens write too).
- `ui/webview/views-writes.ts` holds the shared decision logic (the seq gate, the ack outcome, the re-derivation of the pending copy from the store's blob plus the writes still in flight, the caps adoption); `ui/romp-timeline-view.js` mirrors it by hand, since the kernel-served page cannot import it.

## Judgment calls

1. `tagEdit` sits beside the existing `editTag` op. `editTag` forwards a remote host's tag edit by name over the federation channel and fails loudly with `tagEditFailed`; `tagEdit` edits the local store by id and is acked. Both stay; nothing is renamed.
2. The `move` op (two tags, one write under the lock, both halves or neither) ships in the kernel and the shared client module with tests, but no client gesture posts it in this PR. A follow-up to the tab strip uses it; keeping it here saves that change a kernel edit.
3. The lens, order and active fields stay last-writer-wins across dashboards; `docs/read-side.md` states the trade and its cost.
4. Every pane gets one extra `caps` frame per `ready`, and `/version` gains a `caps` field.
5. The first-read stamp has a one-time cost: a whole-blob writer whose copy predates the store's last pre-upgrade write is refused once, with a notice, on any legacy tag it edits; its next write lands.
6. The whole-blob door now refuses a second tag under a taken name. A store that already holds twins is left alone; only a write that creates or renames into a taken name is refused, with a reason.

## Tests

- `tests/test_tag_edit_ack.py` (new) drives the real `_dispatch_ws`: the burst (create, rename before any frame, assign) lands and each write is acked; refusals carry plain reasons and change nothing; a stale whole-blob post is acked with the refusal while the rest lands; `seq` moves per accepted write and not on a refusal; the caps frame's `viewsSeq` from the connect push and from the store when no served frame carried a blob; the legacy stamp, the re-stamp, the seq floor, the cap, the past-the-bound rows, the notice fit and the under-lock reader race; `unknownOp` once per type; the inline boot bridge. On the base, its `TargetedTagEdits` and `WriteSequence` classes fail 15 of 15 (no `tagEdit` arm, no `seq`).
- `ui/timeline-views-ack.test.ts` (new) runs the real `TimelinePanel` over the fake DOM through the gestures that were lost: `[+ New tag]`, type the name before any echo, six frames later the name still shows; a refusal reverts and shows its reason; a stale frame after an ack is ignored; a net-zero burst is not cleared early; the caps, lost-ack and in-flight-create cases. On the base dialog, 36 of 37 fail.
- `ui/webview/views-writes.test.ts` and `ui/webview/federation-views-seq.test.ts` (new) execute the shared module and the router's two stores and pin `render.ts`; the existing views tests' source pins follow the new shapes, and the `/tag` route test seeds same-named twins by writing the file, since the door now refuses them.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)