### PR TITLE
Kernel start reports an env-file key source that ROMP_EXPECTED_AUTH=login contradicts, once, by name

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -277,6 +277,17 @@ on: the remembered pick becomes the box's expectation and the env var goes
 inert (it described the unpicked design), so re-seeded spawns are judged
 against your pick, never against stale doctrine.
 
+The declaration is also checked against `service.env` once, when the kernel
+starts. Under `ROMP_EXPECTED_AUTH=login`, a file that selects an API key
+source (an `ANTHROPIC_API_KEY=` line with a value, or a `ROMP_API_KEY_REF=`
+line) is a contradiction: that source is injected at launch for every session
+without an explicit Billing pick, so those sessions bill the key. One problem
+line in the Log panel says so before anything launches, naming the file and
+the variable but never a value; fix whichever side is wrong. Under `key`, a
+key source in the file agrees with the declaration and nothing is said. With
+no declaration, or once a Billing pick has made it inert, nothing is said
+either. The per-init check above still confirms each landing.
+
 The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
 Fable 5) are drawn once, aggregated across every connected host's login as the
 worst reading per window, and an `API` cell beside them carries the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -279,14 +279,20 @@ against your pick, never against stale doctrine.
 
 The declaration is also checked against `service.env` once, when the kernel
 starts. Under `ROMP_EXPECTED_AUTH=login`, a file that selects an API key
-source (an `ANTHROPIC_API_KEY=` line with a value, or a `ROMP_API_KEY_REF=`
-line) is a contradiction: that source is injected at launch for every session
-without an explicit Billing pick, so those sessions bill the key. One problem
-line in the Log panel says so before anything launches, naming the file and
-the variable but never a value; fix whichever side is wrong. Under `key`, a
-key source in the file agrees with the declaration and nothing is said. With
-no declaration, or once a Billing pick has made it inert, nothing is said
-either. The per-init check above still confirms each landing.
+source (a `ROMP_API_KEY_CMD=` line, a `ROMP_API_KEY_REF=` line, or an
+`ANTHROPIC_API_KEY=` line with a value) is a contradiction: that source is
+injected at launch for every session without an explicit Billing pick, so
+those sessions bill the key. One problem line in the Log panel says so before
+anything launches, naming the file and the variable but never a value; fix
+whichever side is wrong. A file whose source configuration is invalid (both
+provider lines, say) is still a selection, and the line says so instead: those
+sessions will try the source and fail to launch rather than bill the login.
+Under `key`, a key source in the file agrees with the declaration and nothing
+is said. With no key source selected, Romp injects nothing and Claude Code's
+own credential applies (see [API keys from a secret manager at
+runtime](#api-keys-from-a-secret-manager-at-runtime)), so nothing is said;
+nor with no declaration, nor once a Billing pick has made it inert. The
+per-init check above still confirms each landing.
 
 The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
 Fable 5) are drawn once, aggregated across every connected host's login as the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2118,21 +2118,26 @@ _ENV_FILE_AUTH_CHECKED = False   # the env-file-vs-declaration check (one line, 
 def _check_env_file_vs_declaration(log, state_dir, path: str | None = None) -> str:
     """Say ONCE per process, as a problem-ring line, when the env file selects an API key source while
     ROMP_EXPECTED_AUTH=login declares that the sessions bill the machine login. The two cannot both
-    hold: a source the file selects — an `ANTHROPIC_API_KEY=` line with a value, or a `ROMP_API_KEY_REF=`
-    line — is injected at launch for every session without an explicit Billing pick (effective_auth and
-    default_auth answer "key" whenever a source is configured), so those sessions bill the key. Without
-    this line the first sign is _note_auth_source's per-init mismatch, after a launch has already
-    billed the wrong account, and that line names the helper and the file without saying which line.
+    hold: a source the file selects — an `ANTHROPIC_API_KEY=` line with a value, a `ROMP_API_KEY_REF=`
+    line, or a `ROMP_API_KEY_CMD=` line — is injected at launch for every session without an explicit
+    Billing pick (effective_auth and default_auth answer "key" whenever a source is configured), so
+    those sessions bill the key. Without this line the first sign is _note_auth_source's per-init
+    mismatch, after a launch has already billed the wrong account, and that line names the helper and
+    the file without saying which line. A file whose source configuration is INVALID (both provider
+    lines; a garbled line) is still a selection — `configured` is True, so nothing falls back to the
+    login — and gets its own sentence: those sessions will try the source and fail to launch, not bill
+    the login. keysource's error strings are static by design, so quoting one names no value.
 
     Gated on _declared_auth, not _expected_auth: one explicit gear Billing pick makes the declaration
     inert everywhere else, and under a remembered login pick every spawn is seeded auth=login (spawn),
     so the sentence above would be false there. =key is never a contradiction: a key source in the
     file lands the sessions keyed, as declared (the reference shape docs/reference.md recommends
     included), so nothing is said. Undeclared, nothing is said either: a key line in service.env
-    with no declaration is the ordinary shape. The file is read through keysource, so the only names
-    this can ever say are its two (a token another service keeps in the file is never one of them),
-    and the line names the file and the variable, never a value. Returns the variable named ("" when
-    quiet) so the caller and the tests can see what it decided."""
+    with no declaration is the ordinary shape. The file is read through keysource and the variable is
+    named through keysource.source_var, so the only names this can ever say are its three (a token
+    another service keeps in the file is never one of them), and the line names the file and the
+    variable, never a value. Returns the variable named ("error" for an invalid file, "" when quiet)
+    so the caller and the tests can see what it decided."""
     global _ENV_FILE_AUTH_CHECKED
     if _ENV_FILE_AUTH_CHECKED:
         return ""
@@ -2141,10 +2146,16 @@ def _check_env_file_vs_declaration(log, state_dir, path: str | None = None) -> s
         return ""
     p = path or _keysrc.service_env_path()
     source = _keysrc.read_source(p)
-    if source.kind not in ("file", "op") or not source.configured:
-        return ""                    # no source selected (a missing file, an empty key line) or a file the
-    _ENV_FILE_AUTH_CHECKED = True    # launch itself will report as unreadable: nothing to weigh against the declaration
-    var = _keysrc.REF_VAR if source.kind == "op" else _keysrc.KEY_VAR
+    if not source.configured:
+        return ""                    # no source selected (a missing file, an empty key line): the sessions fall
+    _ENV_FILE_AUTH_CHECKED = True    # to Claude Code's own credential, and there is nothing to weigh against the declaration
+    if source.kind == "error":
+        log("auth: %s selects an API key source that cannot be used (%s) while ROMP_EXPECTED_AUTH=login. Every "
+            "session without an explicit Billing pick will try that source and fail to launch rather than bill "
+            "the machine login. Fix the file, or change the declaration to match what it should select."
+            % (p, source.error or "invalid API key source configuration"), problem=True)
+        return "error"
+    var = _keysrc.source_var(source.kind)
     log("auth: %s sets %s while ROMP_EXPECTED_AUTH=login. The declaration says the sessions bill the machine "
         "login, but the key source this file selects is injected at launch for every session without an "
         "explicit Billing pick, so they bill the key. Fix whichever side is wrong: remove the line, or change "

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2112,6 +2112,46 @@ def _check_key_file_agrees(startup: str, live: str) -> None:
            _keysrc.service_env_path(), _keysrc.KEY_VAR))
 
 
+_ENV_FILE_AUTH_CHECKED = False   # the env-file-vs-declaration check (one line, once per process)
+
+
+def _check_env_file_vs_declaration(log, state_dir, path: str | None = None) -> str:
+    """Say ONCE per process, as a problem-ring line, when the env file selects an API key source while
+    ROMP_EXPECTED_AUTH=login declares that the sessions bill the machine login. The two cannot both
+    hold: a source the file selects — an `ANTHROPIC_API_KEY=` line with a value, or a `ROMP_API_KEY_REF=`
+    line — is injected at launch for every session without an explicit Billing pick (effective_auth and
+    default_auth answer "key" whenever a source is configured), so those sessions bill the key. Without
+    this line the first sign is _note_auth_source's per-init mismatch, after a launch has already
+    billed the wrong account, and that line names the helper and the file without saying which line.
+
+    Gated on _declared_auth, not _expected_auth: one explicit gear Billing pick makes the declaration
+    inert everywhere else, and under a remembered login pick every spawn is seeded auth=login (spawn),
+    so the sentence above would be false there. =key is never a contradiction: a key source in the
+    file lands the sessions keyed, as declared (the reference shape docs/reference.md recommends
+    included), so nothing is said. Undeclared, nothing is said either: a key line in service.env
+    with no declaration is the ordinary shape. The file is read through keysource, so the only names
+    this can ever say are its two (a token another service keeps in the file is never one of them),
+    and the line names the file and the variable, never a value. Returns the variable named ("" when
+    quiet) so the caller and the tests can see what it decided."""
+    global _ENV_FILE_AUTH_CHECKED
+    if _ENV_FILE_AUTH_CHECKED:
+        return ""
+    exp, src = _declared_auth(state_dir)
+    if exp != "login" or src != "env":
+        return ""
+    p = path or _keysrc.service_env_path()
+    source = _keysrc.read_source(p)
+    if source.kind not in ("file", "op") or not source.configured:
+        return ""                    # no source selected (a missing file, an empty key line) or a file the
+    _ENV_FILE_AUTH_CHECKED = True    # launch itself will report as unreadable: nothing to weigh against the declaration
+    var = _keysrc.REF_VAR if source.kind == "op" else _keysrc.KEY_VAR
+    log("auth: %s sets %s while ROMP_EXPECTED_AUTH=login. The declaration says the sessions bill the machine "
+        "login, but the key source this file selects is injected at launch for every session without an "
+        "explicit Billing pick, so they bill the key. Fix whichever side is wrong: remove the line, or change "
+        "the declaration to match what the file selects." % (p, var), problem=True)
+    return var
+
+
 def _expected_auth() -> str:
     """The box-wide INTENDED auth, declared in the manager's environment (service.env):
     ROMP_EXPECTED_AUTH=key|login; unset or any other value declares nothing. On a machine whose
@@ -5478,6 +5518,10 @@ class SdkBackend:
         self._problems: list[dict] = []
         self._problem_seq = 0
         self._problem_lock = threading.Lock()
+        # The env file's key source against the auth declaration (_check_env_file_vs_declaration): said
+        # once, here, where the problem ring exists to carry it, before the boot reconcile below can
+        # launch a session on the account the declaration says it does not bill.
+        _check_env_file_vs_declaration(self._log, self.state_dir)
         # The dependency check, done ONCE here: absent → every session this backend owns reports the same
         # launch error (launch_error), instead of each one silently dying at its own lazy import.
         self._sdk_missing = not sdk_importable()

--- a/tests/test_env_file_vs_declaration.py
+++ b/tests/test_env_file_vs_declaration.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""The env file's API key source against ROMP_EXPECTED_AUTH, checked once at kernel start.
+
+A `service.env` that selects a key source — an `ANTHROPIC_API_KEY=` line with a value, or a
+`ROMP_API_KEY_REF=` line — while `ROMP_EXPECTED_AUTH=login` is in force sends every session without
+an explicit Billing pick to the key (effective_auth and default_auth answer "key" whenever a source is
+configured). Before this check the first sign was _note_auth_source's per-init line, after a launch had
+billed the wrong account. What these tests pin (sdk_backend._check_env_file_vs_declaration):
+
+  * =login over a key line, or over a reference line, is one problem-ring line naming the file and the
+    variable — never a value — said once per process (a re-constructed backend says nothing new);
+  * =key is never a contradiction: a key source in the file lands the sessions keyed, as declared;
+  * undeclared is quiet, as is a declaration over a file that selects no source, whatever else the
+    file carries (another service's token beside a reference is the documented shape);
+  * a remembered gear Billing pick makes the declaration inert here too (_declared_auth);
+  * the sentence describes what the code does: default_auth answers "key" under the flagged shape.
+
+Synthetic keys (`sk-ant-TEST-…`), a synthetic reference, temp paths. The env-file path is pointed at
+a temp dir before the loads so nothing here can read the machine's real one.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_SERVICE_ENV_FILE"] = os.path.join(os.environ["XDG_STATE_HOME"], "no-such-service.env")
+os.environ["ROMP_SERVICE_ENV"] = os.environ["ROMP_SERVICE_ENV_FILE"]
+
+sb = SourceFileLoader("romp_sdk_backend_env_file_vs_declaration",
+                      os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+ks = sb._keysrc
+
+KEY = "sk-ant-TEST-0000"
+REF = "op://test-vault/test-item/api-key"
+
+
+class _Env(unittest.TestCase):
+    """A temp env file at the path every reader resolves, the declaration cleared, the one-shot reset."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.path = os.path.join(self.d, "service.env")
+        self._before = {v: os.environ.get(v) for v in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
+                                                       "ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY",
+                                                       "ROMP_API_KEY_REF")}
+        os.environ["ROMP_SERVICE_ENV_FILE"] = self.path
+        os.environ["ROMP_SERVICE_ENV"] = self.path
+        for v in ("ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF"):
+            os.environ.pop(v, None)
+        self._checked = sb._ENV_FILE_AUTH_CHECKED
+        sb._ENV_FILE_AUTH_CHECKED = False
+        ks._CACHE = ((), "")          # the stat-identity cache is module-global
+
+    def tearDown(self):
+        for v, was in self._before.items():
+            if was is None:
+                os.environ.pop(v, None)
+            else:
+                os.environ[v] = was
+        sb._ENV_FILE_AUTH_CHECKED = self._checked
+        ks._CACHE = ((), "")
+        ks._AUTHORITATIVE_PATHS.pop(self.path, None)
+
+    def write_env(self, body, path=None):
+        p = path or self.path
+        with open(p, "w") as fh:
+            fh.write(body)
+        os.chmod(p, 0o600)
+        ks._CACHE = ((), "")          # a same-second rewrite in a test can reuse the stat identity
+        return p
+
+
+class _Backend(_Env):
+    """A backend on a manager whose environment carried no key at startup, so the env file is the only
+    place a key source can come from. The startup stash is module-global; each test re-arms it."""
+
+    def setUp(self):
+        super().setUp()
+        self.state = tempfile.mkdtemp()
+        self._stash = sb._WORK_KEY
+        self._file_checked = sb._KEY_FILE_CHECKED
+        self._seen_fp = sb._FILE_KEY_SEEN_FP
+        sb._WORK_KEY = ""                     # the startup claim, already made, found nothing
+        sb._KEY_FILE_CHECKED = True           # the startup-vs-file line is asserted in tests/test_keyswap.py
+        sb._FILE_KEY_SEEN_FP = ""
+        self._fetch = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None      # never a real HTTPS GET from a test
+        sb._FAST_ORG_VERDICTS.clear()
+        self.logged = []
+
+    def tearDown(self):
+        sb._WORK_KEY = self._stash
+        sb._KEY_FILE_CHECKED = self._file_checked
+        sb._FILE_KEY_SEEN_FP = self._seen_fp
+        sb._fetch_key_fast_org = self._fetch
+        sb._FAST_ORG_VERDICTS.clear()
+        super().tearDown()
+
+    def construct(self):
+        # `log=` is a keyword: the third positional is `notify`. A line reaches self.logged only through
+        # the log wire, which is what the no-value assertions read.
+        return sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None,
+                             log=lambda m: self.logged.append(str(m)))
+
+    @staticmethod
+    def flagged(be):
+        return [p["text"] for p in be.problems() if "while ROMP_EXPECTED_AUTH=" in p["text"]]
+
+
+class EnvFileVsDeclaration(_Backend):
+    def test_login_declared_over_a_key_line_is_one_line_naming_the_file_and_the_variable(self):
+        self.write_env("ROMP_PERF=1\n%s=%s\n" % (ks.KEY_VAR, KEY))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        lines = self.flagged(be)
+        self.assertEqual(len(lines), 1, be.problems())
+        self.assertIn(self.path, lines[0])
+        self.assertIn(ks.KEY_VAR, lines[0])
+        self.assertIn("ROMP_EXPECTED_AUTH=login", lines[0])
+        self.assertIn("Billing pick", lines[0], "the line says what happens to billing and why")
+        self.assertFalse(any(KEY in m for m in self.logged), "no log line carries the value")
+        self.assertTrue(sb._ENV_FILE_AUTH_CHECKED)
+        # once per process: a re-constructed backend (the WS handler's lazy build, tests) says nothing new
+        self.assertEqual(self.flagged(self.construct()), [])
+        self.assertEqual(sb._check_env_file_vs_declaration(be._log, self.state), "")
+
+    def test_login_declared_over_a_reference_line_names_the_reference_variable(self):
+        self.write_env("ROMP_PERF=1\n%s=%s\n" % (ks.REF_VAR, REF))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        lines = self.flagged(be)
+        self.assertEqual(len(lines), 1, be.problems())
+        self.assertIn(ks.REF_VAR, lines[0])
+        self.assertNotIn(ks.KEY_VAR, lines[0])
+        self.assertFalse(any(REF in m for m in self.logged), "names, never values: the reference included")
+
+    def test_the_direct_call_returns_the_variable_it_named_and_files_a_problem(self):
+        self.write_env("%s=%s\n" % (ks.REF_VAR, REF))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        said = []
+        log = lambda m, problem=None: said.append((str(m), problem))
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), ks.REF_VAR)
+        self.assertEqual([p for _, p in said], [True], "a problem-ring line, not a plain log line")
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), "")
+        self.assertEqual(len(said), 1)
+
+    def test_the_sentence_describes_what_the_code_does(self):
+        self.write_env("%s=%s\n" % (ks.KEY_VAR, KEY))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        self.assertEqual(len(self.flagged(be)), 1)
+        self.assertEqual(be.default_auth({}), "key", "a session without an explicit pick launches keyed")
+
+    def test_key_declared_over_a_key_source_is_quiet(self):
+        for body in ("%s=%s\n" % (ks.KEY_VAR, KEY), "%s=%s\n" % (ks.REF_VAR, REF)):
+            self.write_env(body)
+            os.environ["ROMP_EXPECTED_AUTH"] = "key"
+            be = self.construct()
+            self.assertEqual(self.flagged(be), [], "the sessions land keyed, as declared: %r" % body)
+            self.assertFalse(sb._ENV_FILE_AUTH_CHECKED, "a quiet pass does not spend the one shot")
+
+    def test_undeclared_is_quiet(self):
+        self.write_env("%s=%s\n" % (ks.KEY_VAR, KEY))
+        be = self.construct()
+        self.assertEqual(self.flagged(be), [])
+        self.assertEqual(sb._check_env_file_vs_declaration(be._log, self.state), "")
+        self.assertFalse(sb._ENV_FILE_AUTH_CHECKED)
+
+    def test_login_declared_over_a_file_that_selects_no_source_is_quiet(self):
+        # Other services' credentials are the installer's invited shape for this file, and the 1Password
+        # service-account token beside a reference is the documented one; none of them is what a launch
+        # injects as the sessions' key, so none contradicts the declaration. An EMPTY key line selects
+        # nothing either (keysource: a file source with no value is not configured).
+        self.write_env("ROMP_PERF=1\nROMP_DIR=/nonexistent/x\nHF_TOKEN=x\nOP_SERVICE_ACCOUNT_TOKEN=x\n"
+                       "FOO_API_KEY=x\n%s=\n" % ks.KEY_VAR)
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        self.assertEqual(self.flagged(be), [], be.problems())
+        self.assertFalse(sb._ENV_FILE_AUTH_CHECKED)
+
+    def test_a_missing_file_is_quiet(self):
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()                 # no file was ever written at self.path
+        self.assertEqual(self.flagged(be), [])
+        self.assertFalse(sb._ENV_FILE_AUTH_CHECKED)
+
+    def test_a_remembered_billing_pick_makes_the_declaration_inert_here_too(self):
+        # Q3: set_auth's durable trace (the remembered auth default) is the pick event; from then on the
+        # env declaration is stale doctrine and _note_auth_source judges against the pick. Under a login
+        # pick every spawn is seeded auth=login, so the file's key wins for nobody: nothing to say.
+        for pick in ("login", "key"):
+            self.write_env("%s=%s\n" % (ks.KEY_VAR, KEY))
+            os.environ["ROMP_EXPECTED_AUTH"] = "login"
+            sb.write_sdk_default(Path(self.state), auth=pick)
+            be = self.construct()
+            self.assertEqual(self.flagged(be), [], "pick=%s: %r" % (pick, be.problems()))
+            self.assertFalse(sb._ENV_FILE_AUTH_CHECKED)
+            self.assertEqual(sb._declared_auth(Path(self.state)), (pick, "pick"))
+
+    def test_the_check_reads_the_installers_path_variable(self):
+        other = self.write_env("%s=%s\n" % (ks.KEY_VAR, KEY), path=os.path.join(self.d, "elsewhere.env"))
+        os.environ["ROMP_SERVICE_ENV_FILE"] = other
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        lines = self.flagged(be)
+        self.assertEqual(len(lines), 1, be.problems())
+        self.assertIn(other, lines[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_env_file_vs_declaration.py
+++ b/tests/test_env_file_vs_declaration.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """The env file's API key source against ROMP_EXPECTED_AUTH, checked once at kernel start.
 
-A `service.env` that selects a key source — an `ANTHROPIC_API_KEY=` line with a value, or a
-`ROMP_API_KEY_REF=` line — while `ROMP_EXPECTED_AUTH=login` is in force sends every session without
+A `service.env` that selects a key source — an `ANTHROPIC_API_KEY=` line with a value, a
+`ROMP_API_KEY_REF=` line, or a `ROMP_API_KEY_CMD=` line — while `ROMP_EXPECTED_AUTH=login` is in force sends every session without
 an explicit Billing pick to the key (effective_auth and default_auth answer "key" whenever a source is
 configured). Before this check the first sign was _note_auth_source's per-init line, after a launch had
 billed the wrong account. What these tests pin (sdk_backend._check_env_file_vs_declaration):
 
-  * =login over a key line, or over a reference line, is one problem-ring line naming the file and the
-    variable — never a value — said once per process (a re-constructed backend says nothing new);
+  * =login over a key line, a reference line, or a key-command line is one problem-ring line naming the
+    file and the variable (keysource.source_var) — never a value — said once per process (a
+    re-constructed backend says nothing new); over an INVALID source configuration (both provider
+    lines) the line says the file is invalid instead of naming a variable it does not select;
   * =key is never a contradiction: a key source in the file lands the sessions keyed, as declared;
   * undeclared is quiet, as is a declaration over a file that selects no source, whatever else the
     file carries (another service's token beside a reference is the documented shape);
@@ -41,6 +43,7 @@ ks = sb._keysrc
 
 KEY = "sk-ant-TEST-0000"
 REF = "op://test-vault/test-item/api-key"
+CMD = "/opt/test/fetch-api-key --profile test"
 
 
 class _Env(unittest.TestCase):
@@ -51,10 +54,12 @@ class _Env(unittest.TestCase):
         self.path = os.path.join(self.d, "service.env")
         self._before = {v: os.environ.get(v) for v in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
                                                        "ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY",
-                                                       "ROMP_API_KEY_REF")}
+                                                       "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD")}
         os.environ["ROMP_SERVICE_ENV_FILE"] = self.path
         os.environ["ROMP_SERVICE_ENV"] = self.path
-        for v in ("ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF"):
+        # every source variable, the key command included: a box that runs its manager on
+        # ROMP_API_KEY_CMD exports it to every shell, and the environment fallback would read it
+        for v in ("ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD"):
             os.environ.pop(v, None)
         self._checked = sb._ENV_FILE_AUTH_CHECKED
         sb._ENV_FILE_AUTH_CHECKED = False
@@ -142,6 +147,40 @@ class EnvFileVsDeclaration(_Backend):
         self.assertIn(ks.REF_VAR, lines[0])
         self.assertNotIn(ks.KEY_VAR, lines[0])
         self.assertFalse(any(REF in m for m in self.logged), "names, never values: the reference included")
+
+    def test_login_declared_over_a_key_command_line_names_the_command_variable(self):
+        # the recommended route (ROMP_API_KEY_CMD, the apiKeyHelper contract) is a source like any other:
+        # configured, so default_auth answers key, so it contradicts =login the same way
+        self.write_env("ROMP_PERF=1\n%s=%s\n" % (ks.CMD_VAR, CMD))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        lines = self.flagged(be)
+        self.assertEqual(len(lines), 1, be.problems())
+        self.assertIn(ks.CMD_VAR, lines[0])
+        self.assertNotIn(ks.KEY_VAR, lines[0])
+        self.assertNotIn(ks.REF_VAR, lines[0])
+        self.assertFalse(any(CMD in m for m in self.logged), "names, never values: the command line included")
+        self.assertEqual(be.default_auth({}), "key")
+
+    def test_login_declared_over_an_invalid_source_says_the_file_is_invalid(self):
+        # both provider lines is kind "error": still configured (nothing falls back to the login), so
+        # the sessions will try the source and fail to launch. The line says that, and names no variable
+        # the file does not select.
+        self.write_env("%s=%s\n%s=%s\n" % (ks.CMD_VAR, CMD, ks.REF_VAR, REF))
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        said = []
+        log = lambda m, problem=None: said.append((str(m), problem))
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), "error")
+        self.assertEqual(len(said), 1)
+        text, problem = said[0]
+        self.assertTrue(problem)
+        self.assertIn("cannot be used", text)
+        self.assertIn(ks.BOTH_PROVIDERS_ERROR, text)
+        self.assertNotIn(" sets ", text, "an invalid file selects no variable to name")
+        self.assertNotIn(REF, text)
+        self.assertNotIn(CMD, text)
+        self.assertTrue(sb._ENV_FILE_AUTH_CHECKED, "said once: the one shot is spent")
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), "")
 
     def test_the_direct_call_returns_the_variable_it_named_and_files_a_problem(self):
         self.write_env("%s=%s\n" % (ks.REF_VAR, REF))


### PR DESCRIPTION
Under `ROMP_EXPECTED_AUTH=login`, a `service.env` that selects an API key source sends every session without an explicit Billing pick to the key. This PR says so once, at kernel start, before anything launches.

## What breaks

`ROMP_EXPECTED_AUTH=login` declares that the sessions bill the machine login. A key source selected in `service.env` (an `ANTHROPIC_API_KEY=` line with a value, or a `ROMP_API_KEY_REF=` line) is injected at launch for every session without an explicit Billing pick: `effective_auth` and `default_auth` answer `key` whenever a source is configured. Today the first sign of the contradiction is `_note_auth_source`'s per-init mismatch line, which arrives after a launch has already billed the key, and which points at the helper and `service.env` without naming the line.

Reproduction (synthetic): a machine declaring `login` whose `service.env` still carried an `ANTHROPIC_API_KEY=` line launched every session keyed; the Log panel filled with one mismatch line per init, and the operator had to find the key line by reading the file.

## The fix

`_check_env_file_vs_declaration` runs once at `SdkBackend` construction, right after the problem ring exists and before the boot reconcile can launch anything. When `_declared_auth` says `login` from the environment and `keysource.read_source` finds a configured source in the file, it files one problem-ring line naming the file and the variable (`ANTHROPIC_API_KEY` or `ROMP_API_KEY_REF`), never a value:

> auth: /path/to/service.env sets ANTHROPIC_API_KEY while ROMP_EXPECTED_AUTH=login. The declaration says the sessions bill the machine login, but the key source this file selects is injected at launch for every session without an explicit Billing pick, so they bill the key. Fix whichever side is wrong: remove the line, or change the declaration to match what the file selects.

Said once per process (a re-constructed backend says nothing new), the same one-shot shape as `_check_key_file_agrees` beside it. A quiet pass does not spend the one-shot.

Design choices, each one edit away if you read it differently:

- **Gated on `_declared_auth`, not `_expected_auth`.** One explicit gear Billing pick makes the declaration inert everywhere else (the inertness rule in `_declared_auth`), and under a remembered login pick every spawn is seeded `auth=login`, so the sentence "the file's key wins for every session without a pick" would be false. A test pins it for both picks.
- **`=key` is not a contradiction.** A key source in the file lands the sessions keyed, as declared; the 1Password reference shape reference.md recommends is that shape. So nothing is said under `=key`. If you want a line for a static `ANTHROPIC_API_KEY=` value under `=key` (reading `=key` as the apiKeyHelper design, where the value never sits in the file), it is one more branch on `exp` with its own sentence. I left it out because it would ring at every start on `tests/test_keyswap.py`'s own fixture shape (`ROMP_EXPECTED_AUTH=key` beside a key line) and on any static-key installation that declared `key`.
- **The file is read through `keysource.read_source`.** The check knows only the two names keysource knows, so the `OP_SERVICE_ACCOUNT_TOKEN` line the 1Password route puts in `service.env` is never named, and there is no second parser to drift from the launch path's. A test pins that a file carrying other services' tokens and no key source is quiet.
- **Undeclared says nothing.** A key line in `service.env` with no declaration is the ordinary installation.

Unchanged: launch paths, wire shapes, the per-init mismatch check (still runs, now as the confirmation after this line). Pure Python over `os.environ`, a file path and the state dir; no platform branch, so the Linux matrix covers the only code path.

Adjacency: the call sits after `self._problem_lock = threading.Lock()` in `SdkBackend.__init__`, on the #962 tree; the helper sits between `_check_key_file_agrees` and `_expected_auth`.

## Tests

`tests/test_env_file_vs_declaration.py` (new, 10 tests): both flagged shapes under `=login`; the direct call returns the variable it named and files a problem (not a plain log line); `default_auth` answers `key` under the flagged shape, so the sentence describes what the code does; quiet under `=key` (both shapes), undeclared, over a file that selects no source (other services' tokens and an empty key line included), over a missing file, and after a remembered Billing pick (both picks); the installer's `ROMP_SERVICE_ENV_FILE` is honoured. Red first: with the call site removed the four "fires" tests fail and the six quiet tests pass; with the whole hunk removed all ten error on the missing symbol.

Targeted: `pytest -n 8 tests/test_env_file_vs_declaration.py tests/test_keyswap.py tests/test_expected_auth.py tests/test_session_auth.py tests/test_state_isolation_order.py tests/test_tempdir_hygiene.py`: 178 passed. Full `pytest -n 8` on Linux: 7593 passed, 50 skipped. No shell surface changed, so no bats change.

Docs: one paragraph under the `ROMP_EXPECTED_AUTH` paragraph of "Per-session billing (login vs API key)" in `docs/reference.md`.


Scope note from review: the check reads the service env file only, through the same `keysource.read_source` the launch path uses. A manager whose file selects no source but whose own environment carries a key or a reference (the environment fallback in `keysource.select_source`) is not covered here; that is a separate declaration to design if wanted.

## Brought to current main by the maintainer's session (2026-09-08)

Rebased onto main after the key-source work of 2026-09-06/07 (runtime 1Password references, the fall-through to Claude Code's own credential when no source is selected, and the generic `ROMP_API_KEY_CMD` route). Three adjustments, each with a test that was red against the original hunk:

- **The key command is named too.** A `ROMP_API_KEY_CMD=` line is a source like any other: configured, so `default_auth` answers `key`, so under `=login` it contradicts the declaration the same way. The check names the variable through `keysource.source_var` instead of its own two-way map, so the names it can say are exactly keysource's three.
- **An invalid file is said to be invalid.** Both provider lines (kind `error`) is still a selection: `configured` is True and nothing falls back to the login, so those sessions will try the source and fail to launch. The line says that, quoting keysource's static error text, rather than naming a variable the file does not select or staying quiet.
- **The docs paragraph** names all three lines and the invalid case, and keeps the wording that with no source selected Romp injects nothing and Claude Code's own credential applies.

The test fixture also scrubs `ROMP_API_KEY_CMD` from the environment (a box whose manager runs on the key command exports it to every shell). Verified on the rebased tree with the shell's key variables unset: the twelve tests here plus the key-source, session-auth, expected-auth, keyswap, runtime-key, credential-boundary, session-env, state-isolation, tempdir-hygiene and injected-voice suites, 379 passed. Unchanged from the author's design: the gate on `_declared_auth`, `=key` says nothing, undeclared says nothing, one line per process.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
