### PR TITLE
Kernel performance counters: GET /perf, a runtime switch for the romp-perf log, and romp perf

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -660,6 +660,7 @@ For scripts / agents:
 EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
+    _romp_cmd "romp perf [--interval <s>|--json|log on|off]" - "Kernel performance counters as rates over two snapshots (pusher cycles, stage times, build cache hits, bytes sent, goal loads, judge passes, rss, cpu); --json one raw snapshot; log on|off flips the romp-perf stderr log without a restart"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp move <session> <dir>"   -           "Move an SDK session's working directory (its conversation follows; mid-turn it waits for the turn to end)"
@@ -843,6 +844,166 @@ for r in rows:
                                      r.get("backend") or "", r.get("dir") or ""))
 '
     exit 0
+fi
+
+# `romp perf [--interval <s>] [--json]` / `romp perf log on|off` — the kernel's performance counters
+# (GET /perf), read as RATES from two snapshots taken <s> seconds apart (default 10): pusher cycles and
+# wakes per second, cycle time percentiles, the share of cycle time per stage, CPU split between the
+# pusher thread, the judge threads and the rest of the process, build cache hits vs rebuilds, bytes
+# sent per slot kind, goal-store loads per second, judge passes, rss. It exists so an optimization can
+# be checked against the LIVE kernel after each restart without attaching a profiler. --json prints one
+# raw snapshot (the shape is documented on the kernel's _PerfStats). `log on|off` flips the romp-perf
+# stderr log (POST /perf): before this the log needed ROMP_PERF in the kernel's environment at start,
+# so turning it on meant a restart. Same contract as `sessions`: the token on stdin, a dead kernel
+# fails loudly, an unknown flag is refused. Two snapshots from different kernel processes (a restart
+# inside the window resets the counters) are refused rather than subtracted into negative rates.
+if [[ "${1:-}" == "perf" ]]; then
+    shift
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    _usage="usage: romp perf [--interval <s>] [--json] | romp perf log on|off"
+    # One kernel round trip: the body on stdout and 0 when the kernel answered 2xx. curl's -f folds a
+    # refused token (403) into the same exit as a dead kernel, and on a diagnostic verb that sends the
+    # user off to restart a kernel that is up and answering — so the status rides -w and is read here.
+    _perf_curl() {
+        local _out _code
+        _out="$(_romp_token_cfg | curl -s -m 10 --config - -w '\n%{http_code}' "$@")" \
+            || { echo "romp perf: kernel not reachable on :$_kport (is romp running?)" >&2; return 1; }
+        _code="${_out##*$'\n'}"
+        case "$_code" in
+            2??)     printf '%s' "${_out%$'\n'*}"; return 0 ;;
+            401|403) echo "romp perf: the kernel on :$_kport refused the serve token (HTTP $_code); is ROMP_KERNEL_PORT pointing at another kernel?" >&2; return 1 ;;
+            *)       echo "romp perf: the kernel on :$_kport answered HTTP $_code: ${_out%$'\n'*}" >&2; return 1 ;;
+        esac
+    }
+    if [[ "${1:-}" == "log" ]]; then
+        case "${2:-}" in
+            on)  _v=true ;;
+            off) _v=false ;;
+            *)   echo "$_usage" >&2; exit 2 ;;
+        esac
+        if [[ $# -gt 2 ]]; then echo "$_usage" >&2; exit 2; fi
+        _resp="$(_perf_curl -X POST "http://127.0.0.1:$_kport/perf" -H 'Content-Type: application/json' -d "{\"log\": $_v}")" || exit 1
+        if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+            # where the lines land: the manager's stderr goes to the journal under systemd and to
+            # $STATE/manager.log under launchd (bin/romp-service writes StandardErrorPath there)
+            if [[ "$(uname -s)" == "Darwin" ]]; then
+                _hint="tail -f ${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/manager.log | grep romp-perf"
+            else
+                _hint="journalctl --user -u romp-manager -f | grep romp-perf"
+            fi
+            echo "romp perf: log $2 (read it with: $_hint)"
+            exit 0
+        fi
+        echo "romp perf: refused — $_resp" >&2
+        exit 1
+    fi
+    _json=false; _ival=10
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) _json=true; shift ;;
+            --interval)
+                if [[ ! "${2:-}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then echo "$_usage" >&2; exit 2; fi
+                _ival="$2"; shift 2 ;;
+            --interval=*)
+                _ival="${1#--interval=}"
+                if [[ ! "$_ival" =~ ^[0-9]+([.][0-9]+)?$ ]]; then echo "$_usage" >&2; exit 2; fi
+                shift ;;
+            *) echo "$_usage" >&2; exit 2 ;;
+        esac
+    done
+    _a="$(_perf_curl "http://127.0.0.1:$_kport/perf")" || exit 1
+    if $_json; then
+        printf '%s\n' "$_a"
+        exit 0
+    fi
+    sleep "$_ival"
+    _b="$(_perf_curl "http://127.0.0.1:$_kport/perf")" || exit 1
+    python3 - "$_a" "$_b" <<'PY'
+import json, sys
+a, b = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+
+
+def g(d, *ks):
+    for k in ks:
+        d = d.get(k, {}) if isinstance(d, dict) else {}
+    return d if isinstance(d, (int, float)) else 0
+
+
+def dl(*ks):                      # delta of a counter between the two snapshots
+    return g(b, *ks) - g(a, *ks)
+
+
+if a.get("since") != b.get("since") or g(a, "process", "pid") != g(b, "process", "pid"):
+    # the counters live in the kernel process and start over with it: a subtraction across a
+    # restart is a page of negative rates that look like measurements
+    sys.stderr.write("romp perf: the kernel restarted during the window (pid %d -> %d), so the counters "
+                     "reset and there are no rates to print; run it again\n"
+                     % (g(a, "process", "pid"), g(b, "process", "pid")))
+    sys.exit(1)
+
+dt = max(g(b, "now") - g(a, "now"), 1e-9)
+cyc = dl("pusher", "cycles")
+cyc_ms = dl("pusher", "cycle_ms_sum")
+wakes = dl("pusher", "wakes")
+ev, bs = dl("pusher", "wakes_event"), dl("pusher", "wakes_backstop")
+cpu_proc = 100.0 * dl("process", "cpu_s") / dt
+cpu_pusher = 100.0 * dl("pusher", "cycle_cpu_ms_sum") / (dt * 1000.0)
+cpu_judge = 100.0 * dl("judge", "cpu_ms_sum") / (dt * 1000.0)
+up = int(g(b, "uptime_s"))
+
+
+def hms(sec):
+    h, m = divmod(sec // 60, 60)
+    return "%dh%02dm" % (h, m) if h else "%dm%02ds" % (m, sec % 60)
+
+
+def kb(n):                        # bytes over the window as a rate
+    return "%.0f KB/s" % (n / 1024.0 / dt) if n < 1024 * 1024 * dt else "%.1f MB/s" % (n / 1048576.0 / dt)
+
+
+def share(ms):                    # a stage's share of the window's cycle time
+    return "%3.0f%%" % (100.0 * ms / cyc_ms) if cyc_ms else "  -"
+
+
+print("romp perf: %.1f s window, kernel up %s, pid %d, romp-perf log %s"
+      % (dt, hms(up), g(b, "process", "pid"), "on" if b.get("log") else "off"))
+print("process   rss %d MB   threads %d   cpu %.1f%% of one core (pusher %.1f%%, judge %.1f%%, other %.1f%%)"
+      % (g(b, "process", "rss_kb") // 1024, g(b, "process", "threads"), cpu_proc, cpu_pusher, cpu_judge,
+         cpu_proc - cpu_pusher - cpu_judge))
+print("pusher    %.2f cycles/s   %.2f wakes/s (event %d, backstop %d)   busy %.0f%% of wall"
+      % (cyc / dt, wakes / dt, ev, bs, 100.0 * cyc_ms / (dt * 1000.0)))
+print("cycle ms  p50 %.0f   p90 %.0f   max %.0f (over the last %d cycles)   last %.0f"
+      % (g(b, "pusher", "cycle_ms_p50"), g(b, "pusher", "cycle_ms_p90"), g(b, "pusher", "cycle_ms_ring_max"),
+         g(b, "pusher", "ring_n"), g(b, "pusher", "cycle_ms_last")))
+st = {k: dl("stages_ms", k) for k in ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")}
+print("stages    jobs %s   push %s  (chat %s  feed %s  timeline %s  send %s)"
+      % tuple(share(st[k]) for k in ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")))
+parts = []
+for k in ("chat", "feed", "timeline"):
+    built, cached, ms = dl("builds", k, "built"), dl("builds", k, "cached"), dl("builds", k, "ms")
+    parts.append("%s %d built / %d cached%s" % (k, built, cached, (" (%.0f ms avg)" % (ms / built)) if built else ""))
+print("builds    " + "   ".join(parts))
+parts = []
+for kind in ("full", "delta", "deduped"):
+    slots = set((b.get("sends") or {}).get(kind, {})) | set((a.get("sends") or {}).get(kind, {}))
+    tot = sum(dl("sends", kind, sl, "bytes") for sl in slots)
+    top = sorted(slots, key=lambda sl: -dl("sends", kind, sl, "bytes"))[:3]
+    detail = "; ".join("%s %d frames %s" % (sl, dl("sends", kind, sl, "count"), kb(dl("sends", kind, sl, "bytes")))
+                       for sl in top if dl("sends", kind, sl, "count"))
+    parts.append("%s %s%s" % (kind, kb(tot), (" (%s)" % detail) if detail else ""))
+print("sends     " + "   ".join(parts))
+print("goals     %.1f loads/s   %.1f saves/s   %.1f writes/s"
+      % (dl("goals", "loads") / dt, dl("goals", "saves") / dt, dl("goals", "writes") / dt))
+jp = dl("judge", "passes")
+print("judge     %d passes (%.2f/s)   last %.0f ms   mean %s ms"
+      % (jp, jp / dt, g(b, "judge", "ms_last"), ("%.0f" % (dl("judge", "ms_sum") / jp)) if jp else "-"))
+paths = set(b.get("http") or {}) | set(a.get("http") or {})
+rows = sorted(((dl("http", pth, "count"), dl("http", pth, "ms"), pth) for pth in paths), reverse=True)
+rows = [r for r in rows if r[0]][:6]
+print("http      " + ("   ".join(("%s %d" % (pth, n)) if pth.endswith("/ws") else ("%s %d (%.1f ms avg)" % (pth, n, ms / n))
+                                 for n, ms, pth in rows) or "no requests in the window"))
+PY
+    exit $?
 fi
 
 # Fork a session into a NEW parallel one (the user 2026-08-19, via the lab workflow: per-stage

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,6 +33,7 @@ These are for scripting and for agents rather than daily use:
 |---|---|
 | `romp url` | Print only the tokened dashboard URL, for piping |
 | `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
+| `romp perf [--interval <s>] [--json]`, `romp perf log on\|off` | The kernel's performance counters as rates over two snapshots (below); `--json` prints one raw snapshot; `log on\|off` turns the `romp-perf` stderr log on or off without a restart |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}` — a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
 | `romp new --env NAME=VALUE <name>` | A per-session env var for the SDK session, repeatable; a re-run against a running `<name>` replaces the whole set — vars not re-named are dropped |
@@ -667,6 +668,61 @@ reason); when the scopes were wanted on Linux and the box cannot provide them
 also appears in the dashboard's error center, since every session then runs
 inside the service cgroup. The macOS launchd path is unchanged: there is no cgroup kill there,
 and the tmux server keeps its launchd lineage.
+
+## Kernel performance counters
+
+`GET /perf` returns one JSON document of counters the kernel keeps at all
+times: what its pusher, judge and HTTP threads have done since the process
+started. The route takes the serve token. The counters cost a lock and a few
+dictionary increments per event, so they stay on; nothing is formatted or
+serialized until a request reads them. `romp perf` takes two snapshots
+`--interval` seconds apart (default 10) and prints the difference as rates on
+one screen: pusher cycles and wakes per second, cycle time percentiles, the
+share of cycle time in each stage, CPU split between the pusher thread, the
+judge threads and the rest of the process, builds served from cache against
+rebuilds, bytes sent per slot as full frames, deltas and deduplicated frames,
+goal-store loads and writes per second, judge passes and their durations,
+memory and thread count. `romp perf --json` prints one raw snapshot. If the
+kernel restarted between the two snapshots the counters have started over, so
+the command says so and exits non-zero instead of printing negative rates; a
+refused token is reported as such, not as a dead kernel.
+
+The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
+
+- `now`, `since`, `uptime_s`, `log`: the clock, when the counters started,
+  seconds since the process started, and whether the `romp-perf` log is on.
+- `process`: `rss_kb`, `threads`, `cpu_s`, `pid`.
+- `pusher`: `cycles`, `wakes` (every wake call; a burst of wakes runs one
+  cycle), `wakes_event` and `wakes_backstop` (how the loop's wait ended),
+  `cycle_ms_sum`, `cycle_ms_max` (since start), `cycle_ms_last`,
+  `cycle_cpu_ms_sum` (the pusher thread's own CPU time), and `cycle_ms_p50`,
+  `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` from the last 256 cycles.
+- `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
+  inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
+  `push.*` stages count every push, including the one a connecting page gets,
+  so they can add up to more than `push`.
+- `builds`: `chat`, `feed`, `timeline`, each with `cached`, `built`, `ms`.
+- `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
+  `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
+  was built and compared, then not sent.
+- `goals`: `loads`, `saves`, `writes` on the goal stores. A save that would
+  rewrite identical bytes is a save without a write.
+- `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
+  on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
+  per-session worker they run; the workers' share is `cpu_ms_workers`).
+- `http`: request `count` and `ms` per `METHOD /path` for GET, POST, HEAD and
+  OPTIONS, the query string removed and `/dist/*`, `/media/*` and
+  `/remote/*/…` collapsed to one key each, for at most 64 keys; further keys
+  fold into `other`. A WebSocket upgrade is counted when it arrives and not
+  timed, since its handler runs for the life of the socket.
+
+`POST /perf` with the body `{"log": true}` or `{"log": false}` turns the
+`romp-perf` stderr log on or off in the running kernel (`romp perf log on|off`).
+The log prints one line per chat build and per frame sent or deduplicated. It
+goes where the manager's stderr goes: under systemd, `journalctl --user -u
+romp-manager -f | grep romp-perf`; under launchd (macOS), `tail -f
+~/.local/state/romp/manager.log | grep romp-perf`. Setting `ROMP_PERF=1` in the
+kernel's environment still turns it on at start.
 
 ## Where things live
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -18,6 +18,44 @@ from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
+# ── the judge workers' CPU, for the kernel's GET /perf ─────────────────────────────────────────────
+# Every tier fans its per-session work (parses, store loads, the model call's framing) out through a
+# ThreadPoolExecutor, so the tier thread's own CPU says little about what the judges cost; the
+# workers' does. _TimedPool wraps each submitted callable with a time.thread_time() delta into one
+# counter, and the name below rebinds so every `ThreadPoolExecutor(...)` in this module builds the
+# timed pool without touching the dozen pool sites. A worker blocked on a model call adds nothing:
+# thread_time is CPU, not wall.
+_JUDGE_CPU = {"worker_ms": 0.0}
+_JUDGE_CPU_LOCK = threading.Lock()
+
+
+def _judge_cpu_add(cpu_s):
+    with _JUDGE_CPU_LOCK:
+        _JUDGE_CPU["worker_ms"] += cpu_s * 1000.0
+
+
+def judge_worker_cpu_ms():
+    """CPU milliseconds spent so far in this module's pool workers (every future any tier submitted)."""
+    with _JUDGE_CPU_LOCK:
+        return _JUDGE_CPU["worker_ms"]
+
+
+class _TimedPool(ThreadPoolExecutor):
+    """ThreadPoolExecutor whose submitted callables account their CPU to _JUDGE_CPU."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        def run():
+            c0 = time.thread_time()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _judge_cpu_add(time.thread_time() - c0)
+        return super().submit(run)
+
+
+ThreadPoolExecutor = _TimedPool      # every pool below is a timed one (see above)
+
 HERE = Path(__file__).resolve().parent
 em = SourceFileLoader("romp_event_model", str(HERE / "event_model.py")).load_module()
 _keysrc = sys.modules.get("romp_keysource") or SourceFileLoader(
@@ -3004,6 +3042,27 @@ def _guard_nodes(store):
     return store
 
 
+# ── goal-store I/O counters (the kernel's GET /perf reads them through goal_io_stats) ─────────────
+# How often the stores are read and written is the first question when the kernel is busy: every
+# judge stage, the feed build and the nudge tick load stores, so the load rate says whether a change
+# added a pass over every session. Plain counters, one lock, no formatting on the path.
+_GOAL_IO = {"loads": 0, "saves": 0, "writes": 0}
+_GOAL_IO_LOCK = threading.Lock()
+
+
+def _goal_io_bump(key):
+    with _GOAL_IO_LOCK:
+        _GOAL_IO[key] += 1
+
+
+def goal_io_stats():
+    """A copy of the goal-store I/O counters: load_goals calls (`loads`), save_goals calls (`saves`),
+    and the saves that wrote a file (`writes`; save_goals skips a byte-identical republish). The
+    counters stay private to this module; readers get a copy."""
+    with _GOAL_IO_LOCK:
+        return dict(_GOAL_IO)
+
+
 def _quarantine_store(path, reason, st):
     """Move an unparseable store file ASIDE (never delete it) so the evidence survives the fresh start
     that follows. The sidecar keeps the original name plus `.corrupt-<utc stamp>`, so the `*.json` globs
@@ -3087,6 +3146,7 @@ def _read_store_json(path, *, quarantine=False, _tries=3):
 
 
 def load_goals(fsid):
+    _goal_io_bump("loads")
     raw = _read_store_json(GOALDIR / (fsid + ".json"), quarantine=True)
     if raw is None:
         # a FRESH store is born at the current identity version — only stores with history recorded
@@ -3613,6 +3673,7 @@ def save_goals(fsid, store):
     fleet forever. Skipping is safe precisely BECAUSE nothing changed: we have no events to contribute, so
     declining to publish can neither lose our work nor clobber a concurrent writer's. `rev` does not advance
     on a no-op, which is the honest reading of a counter that means "publications"."""
+    _goal_io_bump("saves")
     GOALDIR.mkdir(parents=True, exist_ok=True)
     if "_baseRev" in store and _matches_disk(fsid, store):
         return                                       # nothing of ours to publish → leave the file (and its
@@ -3627,6 +3688,7 @@ def save_goals(fsid, store):
         store["rev"] = _disk_rev(fsid) + 1
     else:
         store["rev"] = int(store.get("rev") or 0) + 1
+    _goal_io_bump("writes")
     tmp = _publish_tmp(GOALDIR, fsid)
     tmp.write_text(json.dumps(store))
     tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
@@ -134,6 +134,287 @@ def _perf_slot(key):
         return str(key)
     except Exception:
         return "?"
+
+
+def _set_perf_log(on):
+    """Turn the `romp-perf` stderr log on or off while the kernel runs (POST /perf {"log": bool}; `romp
+    perf log on|off`). ROMP_PERF still seeds the value at import. Before this the only way to turn the
+    log on was a restart with the variable set, and on a machine whose sessions run inside this kernel
+    a restart cuts every open turn. `_perf` keeps reading the module global, so the off path costs what
+    it always did: one name lookup and a return."""
+    global _PERF
+    _PERF = bool(on)
+    return _PERF
+
+
+def _process_stats():
+    """rss_kb, thread count, CPU seconds and pid for the /perf snapshot. VmRSS from /proc is the CURRENT
+    resident size; where /proc is absent (macOS) ru_maxrss is the PEAK, in bytes there, so it is scaled
+    to KB and the field is still called rss_kb."""
+    rss = 0
+    try:
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1])
+                    break
+    except Exception:
+        try:
+            import resource
+            r = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            rss = int(r // 1024) if sys.platform == "darwin" else int(r)
+        except Exception:
+            rss = 0
+    return {"rss_kb": rss, "threads": threading.active_count(), "cpu_s": time.process_time(),
+            "pid": os.getpid()}
+
+
+class _PerfStats:
+    """Always-on counters behind GET /perf (`romp perf`): where the kernel's threads spend their time,
+    kept cheap enough to leave running. Every writer takes the lock and does a few dict operations;
+    none formats, serializes or reads a clock on the caller's behalf (callers pass time.monotonic()
+    deltas in seconds). snapshot() does the only real work, the percentiles and the process reads,
+    once per HTTP request on the handler's thread.
+
+    The ROMP_PERF log answers "what happened on that one push"; these answer "what is the kernel doing
+    per second" and let two snapshots N seconds apart give rates, which is how an optimization is
+    checked against the live kernel after a restart without attaching a profiler.
+
+    snapshot() shape — every value a plain number or a flat dict of numbers; `ms` fields are
+    milliseconds of wall time, `*_s` seconds:
+      now, since, uptime_s, log    clock; when the counters started (a restart resets them); seconds
+                                   since the process started; whether the romp-perf stderr log is on
+      process                      rss_kb, threads, cpu_s (time.process_time), pid
+      pusher                       cycles (one per _pusher_cycle), wakes (every _pusher_wake.set()
+                                   call; a burst coalesces into one cycle), wakes_event /
+                                   wakes_backstop (how the loop's wait ended: flag set, or the 0.5 s
+                                   timeout), cycle_ms_sum / cycle_ms_max (since start) /
+                                   cycle_ms_last, cycle_cpu_ms_sum (the pusher thread's own CPU,
+                                   time.thread_time, so a forked tmux read is excluded), and
+                                   cycle_ms_p50 / cycle_ms_p90 / cycle_ms_ring_max / ring_n from a
+                                   ring of the last RING cycle durations
+      stages_ms                    jobs: the cycle's tick jobs outside _push_all; push: _push_all as
+                                   the cycle calls it; push.chat (the tab strip, the build_session
+                                   loop and the chat sends), push.feed (the view signature,
+                                   _cached_feed and the ledgers attach), push.timeline (the skeleton
+                                   and _cached_timeline), push.send (the feed/bars serialization and
+                                   sends). The push.* stages are measured inside _push for EVERY
+                                   caller, connect pushes on handler threads included, so their sum
+                                   can exceed `push`
+      builds                       chat / feed / timeline -> {cached, built, ms}: served from the
+                                   build cache vs rebuilt, and the rebuild time
+      sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
+                                   name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
+                                   under "other"). A deduped frame was built and compared, not sent
+      goals                        loads, saves, writes: judge.load_goals calls, save_goals calls,
+                                   and the saves that reached the disk (a byte-identical republish
+                                   is a save without a write)
+      judge                        passes (one per _producer pass), ms_sum / ms_last / ms_mean (wall:
+                                   a pass is a join over the tier threads, so this is mostly model
+                                   latency), cpu_ms_sum (CPU: the two tier threads' own time, from
+                                   _run_tier, plus every per-session worker the tiers run in
+                                   judge.py's thread pools; the split rides as cpu_ms_workers)
+      http                         "METHOD /path" -> {count, ms}, the query string stripped and the
+                                   path normalized by _perf_http_key (/dist/*, /media/*,
+                                   /remote/*/…), at most HTTP_PATHS keys with the rest folded into
+                                   "other" (so a scanner cannot grow it, and a static file or a host
+                                   name never takes a slot or appears in the output). A WebSocket
+                                   upgrade (a path ending in /ws) is counted when it ARRIVES and adds
+                                   no ms: its handler returns when the socket closes, which is a
+                                   connection's lifetime, not a request's."""
+    RING = 256
+    HTTP_PATHS = 64
+    SLOTS = 32
+    STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
+    BUILDS = ("chat", "feed", "timeline")
+    SEND_KINDS = ("full", "delta", "deduped")
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.reset()
+
+    def reset(self):
+        with self.lock:
+            self.since = time.time()
+            self.pusher = {"cycles": 0, "wakes": 0, "wakes_event": 0, "wakes_backstop": 0,
+                           "cycle_ms_sum": 0.0, "cycle_ms_max": 0.0, "cycle_ms_last": 0.0,
+                           "cycle_cpu_ms_sum": 0.0}
+            self.ring = collections.deque(maxlen=self.RING)
+            self.stages = {k: 0.0 for k in self.STAGES}
+            self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
+            self.sends = {k: {} for k in self.SEND_KINDS}
+            self.judge = {"passes": 0, "ms_sum": 0.0, "ms_last": 0.0, "cpu_ms_sum": 0.0}
+            self.http = {}
+
+    # ── writers (hot paths) ──
+    def wake(self):
+        with self.lock:
+            self.pusher["wakes"] += 1
+
+    def wake_kind(self, by_event):
+        with self.lock:
+            self.pusher["wakes_event" if by_event else "wakes_backstop"] += 1
+
+    def cycle(self, dt, cpu_dt=0.0):
+        """dt: the cycle's wall seconds; cpu_dt: the pusher thread's own CPU seconds over it."""
+        ms = dt * 1000.0
+        with self.lock:
+            p = self.pusher
+            p["cycles"] += 1
+            p["cycle_ms_sum"] += ms
+            p["cycle_ms_last"] = ms
+            p["cycle_cpu_ms_sum"] += cpu_dt * 1000.0
+            if ms > p["cycle_ms_max"]:
+                p["cycle_ms_max"] = ms
+            self.ring.append(ms)
+
+    def stage(self, name, dt):
+        with self.lock:
+            self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
+
+    def build(self, kind, cached, dt=0.0):
+        with self.lock:
+            b = self.builds[kind]
+            if cached:
+                b["cached"] += 1
+            else:
+                b["built"] += 1
+                b["ms"] += dt * 1000.0
+
+    def send(self, key, kind, nbytes):
+        slot = key[0] if isinstance(key, tuple) else key
+        with self.lock:
+            d = self.sends[kind]
+            e = d.get(slot)
+            if e is None:
+                if len(d) >= self.SLOTS:
+                    slot = "other"
+                    e = d.get(slot)
+                if e is None:
+                    e = d[slot] = [0, 0]
+            e[0] += 1
+            e[1] += nbytes
+
+    def judge_pass(self, dt):
+        ms = dt * 1000.0
+        with self.lock:
+            j = self.judge
+            j["passes"] += 1
+            j["ms_sum"] += ms
+            j["ms_last"] = ms
+
+    def judge_cpu(self, cpu_dt):
+        """A judge tier thread's own CPU seconds for one tier run (_run_tier)."""
+        with self.lock:
+            self.judge["cpu_ms_sum"] += cpu_dt * 1000.0
+
+    def http_request(self, path, dt):
+        """dt None: count the request, add no time (the WebSocket upgrade case)."""
+        with self.lock:
+            e = self.http.get(path)
+            if e is None:
+                if len(self.http) >= self.HTTP_PATHS:
+                    path = "other"
+                    e = self.http.get(path)
+                if e is None:
+                    e = self.http[path] = [0, 0.0]
+            e[0] += 1
+            if dt is not None:
+                e[1] += dt * 1000.0
+
+    # ── the reader ──
+    @staticmethod
+    def _pct(sorted_ms, q):
+        n = len(sorted_ms)
+        return sorted_ms[min(n - 1, int(q * n))] if n else 0.0
+
+    def snapshot(self):
+        with self.lock:
+            ring = sorted(self.ring)
+            pusher = dict(self.pusher)
+            stages = dict(self.stages)
+            builds = {k: dict(v) for k, v in self.builds.items()}
+            sends = {k: {sl: {"count": e[0], "bytes": e[1]} for sl, e in d.items()}
+                     for k, d in self.sends.items()}
+            judge = dict(self.judge)
+            http = {pth: {"count": e[0], "ms": e[1]} for pth, e in self.http.items()}
+            since = self.since
+        pusher["ring_n"] = len(ring)
+        pusher["cycle_ms_p50"] = self._pct(ring, 0.5)
+        pusher["cycle_ms_p90"] = self._pct(ring, 0.9)
+        pusher["cycle_ms_ring_max"] = ring[-1] if ring else 0.0
+        judge["ms_mean"] = (judge["ms_sum"] / judge["passes"]) if judge["passes"] else 0.0
+        try:
+            workers = float(jd.judge_worker_cpu_ms())
+        except Exception:
+            workers = 0.0
+        judge["cpu_ms_workers"] = workers
+        judge["cpu_ms_sum"] += workers                     # tier threads + their pool workers
+        try:
+            goals = jd.goal_io_stats()
+        except Exception:
+            goals = {}
+        now = time.time()
+        return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
+                "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
+                "builds": builds, "sends": sends, "goals": goals, "judge": judge, "http": http}
+
+
+_PERF_STATS = _PerfStats()
+
+
+class _CountedEvent(threading.Event):
+    """A threading.Event whose set() also counts in _PERF_STATS: the pusher's wake. Counting at the
+    event keeps every existing call site as it is, including the bound-method callbacks
+    (`push=_pusher_wake.set`) the backends hold and the tests that pin `_pusher_wake.set()` in the
+    source."""
+
+    def set(self):
+        _PERF_STATS.wake()
+        super().set()
+
+
+def _perf_http_key(method, path):
+    """The `http` counter key for one request: "METHOD /path" with the query string gone and the
+    high-cardinality families collapsed — /dist/* and /media/* (the bundles, fonts, icons and source
+    maps a dashboard loads: dozens of names that would otherwise fill the HTTP_PATHS slots before a
+    script's first /sessions call) and /remote/<host>/… (a host name per attached kernel; a tailnet
+    host name is not something `romp perf` should print). The route table's fixed paths stay as they
+    are, so GET /perf and POST /perf are separate rows."""
+    if path.startswith("/dist/"):
+        path = "/dist/*"
+    elif path.startswith("/media/"):
+        path = "/media/*"
+    elif path.startswith("/remote/"):
+        rest = path[len("/remote/"):]
+        i = rest.find("/")
+        path = "/remote/*" + (rest[i:] if i >= 0 else "")
+    return (method + " " + path) if method else path
+
+
+def _perf_http_timed(fn):
+    """Wrap a Handler.do_* method: count the request and its wall ms in _PERF_STATS under
+    _perf_http_key(method, path). A WebSocket upgrade (a path ending in /ws) is counted when it arrives
+    and not timed: its do_GET returns when the socket closes, so a count taken then would lag by the
+    connection's lifetime and its duration would not be a request's. functools.wraps keeps
+    inspect.getsource on the real route table, which the auth tests read."""
+    @functools.wraps(fn)
+    def timed(self):
+        try:
+            path = str(getattr(self, "path", "") or "").split("?", 1)[0]
+            key = _perf_http_key(str(getattr(self, "command", "") or ""), path)
+            is_ws = path.endswith("/ws")
+        except Exception:
+            key, is_ws = "other", False
+        if is_ws:
+            _PERF_STATS.http_request(key, None)
+            return fn(self)
+        t0 = time.monotonic()
+        try:
+            return fn(self)
+        finally:
+            _PERF_STATS.http_request(key, time.monotonic() - t0)
+    return timed
 
 
 # ── host-suspend (laptop sleep) awareness ─────────────────────────────────────────────────────────
@@ -30049,7 +30330,8 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
             frame["coll"][name] = entry; changed = True
     if not changed:
         if now - st.get("at", 0) < _DEDUP_REPOST_S:    # unchanged: nothing to send (the repost keeps the fade alive)
-            return
+            _PERF_STATS.send(key, "deduped", len(pre))   # built and compared, not sent — the same fact
+            return                                         # _send_client's dedup records for a whole-frame client
     s = json.dumps(frame, default=str)
     if len(s) >= _DELTA_MAX_FRACTION * len(pre):       # not worth a delta → the full frame, rebased
         states.pop(ftype, None)
@@ -30057,6 +30339,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         _send_slot(c, ftype, payload, pre, sig)
         return
     _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0, delta=1)
+    _PERF_STATS.send(key, "delta", len(s))
     if not _client_send(c, s, key):
         return
     st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
@@ -30066,7 +30349,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
     c.setdefault("sent", {})[key] = (sig, now)          # the dedup slot follows, so a later full send dedups honestly
 
 
-def _send_client(c, key, msg, pre=None, sig=None):
+def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
     `pre` is the already-serialized msg (json.dumps(msg)) when the caller has it cached — passing it lets
@@ -30082,7 +30365,10 @@ def _send_client(c, key, msg, pre=None, sig=None):
     ROMP_PERF=1 logs every send AND every dedup hit. That asymmetry is the point: a payload carrying a
     field that ticks with the clock looks perfectly normal from the outside — the UI just feels slow —
     and the only visible symptom is this dedup never hitting. Finding the last one took a hand-written
-    WebSocket client; the log makes the next one obvious."""
+    WebSocket client; the log makes the next one obvious.
+
+    `kind` is the /perf sends class the frame is counted under when it goes: "full" (the default: a
+    whole frame) or "delta" for a caller whose frame is a suffix or a diff (_send_chat's chatTail)."""
     s = pre if pre is not None else json.dumps(msg)
     sig = sig if sig is not None else _dedup_sig(msg, s)
     with _client_lock(c):    # the dedup dict is shared with the handler thread's `ready`
@@ -30090,9 +30376,11 @@ def _send_client(c, key, msg, pre=None, sig=None):
         now = time.time()
         if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
             _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
+            _PERF_STATS.send(key, "deduped", len(s))
             return
         c["sent"][key] = (sig, now)
         _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
+        _PERF_STATS.send(key, kind, len(s))
         _client_send(c, s, key)                       # enqueue only (never blocks): the lock is held for microseconds
 
 
@@ -30136,7 +30424,7 @@ def _send_chat_locked(c, m, ms, change_from, led_changed):
                 "events": evs[change_from:], "total": total, "status": m.get("status")}
         if led_changed:                               # the TOC only changed on a judge pass → usually omitted
             tail["ledger"] = m.get("ledger")
-        _send_client(c, ("chat", sid), tail)
+        _send_client(c, ("chat", sid), tail, kind="delta")   # the chat's delta form, for /perf's sends split
         st[sid] = (pc[0], pc[1])                       # same tail base, now caught up through `total`
         return ms
     head_from = max(0, total - WIRE_TAIL)
@@ -31660,6 +31948,7 @@ def _push(targets, connect=False, tmux=None):
         # The FEED's per-session Fleet ledger slice still rides along, attached AFTER the builds (want_chat —
         # we do NOT build all sessions just for a feed/fleet push: the user 2026-06-24 slow-load regression).
         chat_sessions = []
+        _t_stage = time.monotonic()                      # /perf stage clock: chat, then feed, then timeline
         if want_chat or want_fleet:   # the fleet needs every session's ledger slice (built below, attached to feed)
             # TABS-FIRST (the user 2026-06-26): ship name+color per tab so the client can paint the WHOLE strip
             # as placeholders up front (no tab popping in one-by-one as each build_session lands). The full
@@ -31695,6 +31984,7 @@ def _push(targets, connect=False, tmux=None):
                     m, ms, asig, started = hit[1], hit[2], hit[3], hit[4]   # unchanged → reuse, no reshape/serialize
                     _VIEW_STATS["chatServeActive" if is_active else "chatServeBg"] += 1
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
+                    _PERF_STATS.build("chat", True)
                 else:
                     _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
                     started = time.time()                # the _views_dirty floor for this build (start-keyed)
@@ -31710,12 +32000,15 @@ def _push(targets, connect=False, tmux=None):
                     # The ACTIVE tab skips the cache above by design, so this build is what the watched
                     # session pays on every single push. If chat ever feels slow again, this number and
                     # the deduped= on the matching send say which half is at fault.
-                    _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
-                          ms=round((time.monotonic() - _t0) * 1000, 1),
-                          events=(len(m.get("events") or []) if m else 0),
-                          fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
-                          prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
-                          why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
+                    _dt = time.monotonic() - _t0
+                    _PERF_STATS.build("chat", False, _dt)
+                    if _PERF:                            # the keyword values below cost lookups; skip them when off
+                        _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
+                              ms=round(_dt * 1000, 1),
+                              events=(len(m.get("events") or []) if m else 0),
+                              fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
+                              prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
+                              why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
                 if not m:
                     continue
                 _note_chat_divergence(s["sid"], m.get("name") or "",
@@ -31776,6 +32069,8 @@ def _push(targets, connect=False, tmux=None):
             # OPEN SUBAGENT VIEWERS (plans/subagent-transcripts.md): each rides its own per-client dedup slot
             # like the comment frames, rebuilt only when the agent's file or liveness moved.
             _push_subagents(chat_clients, now, tmux)
+        _PERF_STATS.stage("push.chat", time.monotonic() - _t_stage)
+        _t_stage = time.monotonic()
         fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
         feed_src = _cached_feed(now, tmux, fsig, connect) if want_feed else None
         feed = feed_src
@@ -31806,6 +32101,8 @@ def _push(targets, connect=False, tmux=None):
         # LIVE-FIRST (the user 2026-06-26): the very first paint after a kernel start reads NO dead session — it
         # builds live sessions only (lanes + bars) so the main UI is up at once; the producer warms the full
         # build (live + dead-within-12h) and the next pusher push folds the dead lanes in, in the background.
+        _PERF_STATS.stage("push.feed", time.monotonic() - _t_stage)
+        _t_stage = time.monotonic()
         timeline = None
         tl_warming = False
         if want_tl:
@@ -31821,6 +32118,7 @@ def _push(targets, connect=False, tmux=None):
                 #                                                     "no activity"; a later warmed push (tl_warming False) settles it (the user 2026-07-03)
             else:
                 timeline = _cached_timeline(now, tmux, fsig, connect)
+        _PERF_STATS.stage("push.timeline", time.monotonic() - _t_stage)
     except Exception:
         sys.stderr.write("push build: %s\n" % traceback.format_exc())
         return
@@ -31836,6 +32134,7 @@ def _push(targets, connect=False, tmux=None):
     # moved — dict == is C-speed and allocation-free, far cheaper than re-serializing).
     global _feed_wire, _bars_wire
     feed_ms = feed_sig = bars = bars_ms = bars_sig = None
+    _t_stage = time.monotonic()
     for c in targets:
         if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
             if feed_ms is None:
@@ -31859,6 +32158,7 @@ def _push(targets, connect=False, tmux=None):
                     bars_sig = _dedup_sig(bars, bars_ms)
                     _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig)
             _send_slot(c, "bars", bars, bars_ms, bars_sig)
+    _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
@@ -31984,7 +32284,7 @@ _producer_wake = threading.Event()
 # Same idea for the CHAT PUSHER: the SDK live-tail (and any caller) sets this to push the chat NOW
 # instead of waiting out the 4s poll — the SDK stream leads the transcript on disk, so an immediate push
 # of the in-memory live atoms makes messages appear instantly. 4s stays as the backstop.
-_pusher_wake = threading.Event()
+_pusher_wake = _CountedEvent()      # a threading.Event; set() also counts the wake for /perf
 # The last kernel-side OPTIMISTIC mutation (a parked-op chip, a follow-up card reopen, a model-pending
 # stamp, an interrupt click): state that lives in MEMORY or a goal store, which NO file-mtime signature
 # sees. _cached_feed/_cached_timeline must rebuild past this mark — even inside REBUILD_MIN_S and even on
@@ -32186,11 +32486,14 @@ def _cached_feed(now, tmux, sig, connect=False):
     dirty = not connect and _views_dirty[0] > e[3]        # connect still serves the warmed build (never rebuilds)
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         _VIEW_STATS["feedServe"] += 1
+        _PERF_STATS.build("feed", True)
         return e[1]
     _VIEW_STATS["feedBuild"] += 1
     bid = _next_feed_build_id()          # claimed BEFORE the read, so an ack issued during this build outranks it
     started = time.time()                # …and the dirty floor for the NEXT check: mutations after this
+    _t0 = time.monotonic()
     feed = build_feed(now, tmux)         # instant may be invisible to the build below → must rebuild
+    _PERF_STATS.build("feed", False, time.monotonic() - _t0)
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
@@ -32898,21 +33201,29 @@ def _cached_timeline(now, tmux, sig, connect=False):
     dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         _VIEW_STATS["tlServe"] += 1
+        _PERF_STATS.build("timeline", True)
         return e[1]
     _VIEW_STATS["tlBuild"] += 1
     started = time.time()
+    _t0 = time.monotonic()
     tl = build_timeline(now, tmux)
+    _PERF_STATS.build("timeline", False, time.monotonic() - _t0)
     _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
 
 
 def _run_tier(fn):
     """Run one judge tier (run_index / run_triage) in its own thread, logging a crash instead of letting
-    the thread die silently (the per-session futures inside already swallow + log their own errors)."""
+    the thread die silently (the per-session futures inside already swallow + log their own errors).
+    The thread's own CPU over the run goes to /perf's judge.cpu_ms_sum; the per-session workers the
+    tier runs in judge.py's pools account for theirs there (judge_worker_cpu_ms)."""
+    _c0 = time.thread_time()
     try:
         fn()
     except Exception:
         sys.stderr.write("producer tier: %s\n" % traceback.format_exc())
+    finally:
+        _PERF_STATS.judge_cpu(time.thread_time() - _c0)
 
 
 def _producer():
@@ -32925,6 +33236,7 @@ def _producer():
         _prev_wall, _prev_mono = _nw, _nm
         _producer_wake.clear()   # consume; a /tick arriving DURING this pass re-sets it → we run again (no lost wake)
         _own_frame = False       # set once the pass frame opens; the finally below can then never leak it
+        _t_pass = time.monotonic()
         try:
             # Two tiers, run in PARALLEL (the user 2026-06-17) — they share no store and triage never
             # reads the captioner's output, so the only cost of overlap is each tier parsing a transcript
@@ -32988,6 +33300,7 @@ def _producer():
         finally:
             _end_goals_pass()      # safety net: never leave a pass's snapshot stuck if the pass raised mid-flight
             jd.end_pass_frame(_own_frame)   # …nor the evidence frame (idempotent with the normal-path end above)
+            _PERF_STATS.judge_pass(time.monotonic() - _t_pass)
         # Event-driven: wake the instant a hook pokes /tick (turn ended / prompt landed / postal msg)
         # instead of waiting out the backstop. The 3s is only a BACKSTOP — for changes we don't get poked
         # for (e.g. a segment closing mid-turn) and a safety net if a poke is ever missed. A pass is cheap
@@ -33010,6 +33323,8 @@ def _pusher_cycle():
     design; they now all receive the same one, taken once at cycle start. The jobs tolerate the
     few-hundred-ms staleness by construction — they always saw a snapshot aged by however many jobs
     ran before them."""
+    _t_cycle = time.monotonic()
+    _c_cycle = time.thread_time()           # this thread's CPU: the wall above includes the tmux fork and lock waits
     with _clients_lock:
         any_client = bool(_clients)
     now = int(time.time())
@@ -33030,9 +33345,12 @@ def _pusher_cycle():
         _live_scope.snapshot = None
         _live_scope.names = None
         _live_scope.paths = None
+        _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle)
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
+    _t_jobs = time.monotonic()            # /perf: this function minus the _push_all below is the `jobs` stage
+    _t_push = 0.0
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
         _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
         #                                   the parked-parse refresh runs inside, per sid, after the
@@ -33040,7 +33358,12 @@ def _pusher_cycle_jobs(now, tmux, any_client):
     except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
         sys.stderr.write("pending-ops: %s\n" % traceback.format_exc())   # never behind a judge pass (2026-09-03)
     if any_client:
-        _push_all(tmux=tmux)
+        _t_push = time.monotonic()
+        try:
+            _push_all(tmux=tmux)
+        finally:
+            _t_push = time.monotonic() - _t_push
+            _PERF_STATS.stage("push", _t_push)
     try:                                  # the turn-finished push (bell popover): AFTER the feed build above,
         _turn_notify_tick(now, tmux)      # so a bell event the same settle produced files its buzz first
     except Exception:
@@ -33104,6 +33427,7 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _clear_done_working_notes(now, tmux)
     except Exception:
         sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
+    _PERF_STATS.stage("jobs", (time.monotonic() - _t_jobs) - _t_push)
 
 
 def _pusher():
@@ -33113,8 +33437,9 @@ def _pusher():
         # poll, so tmux sessions — which have no per-message event for mid-turn streaming — still refresh
         # responsively as the model generates, instead of waiting out a multi-second tick (the user 2026-06-22).
         # Cheap when nothing changed: _parse is cached and _send_client dedups, so a no-change poll sends nothing.
-        _pusher_wake.wait(0.5)
+        _woke = _pusher_wake.wait(0.5)    # True: the flag was set (an event); False: the backstop timed out
         _pusher_wake.clear()
+        _PERF_STATS.wake_kind(_woke)
 
 
 # ───────────────────────── HTTP / page serving ─────────────────────────
@@ -37294,6 +37619,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.wfile.write(chunk)
                 remaining -= len(chunk)
 
+    @_perf_http_timed
     def do_OPTIONS(self):
         """CORS preflight. The strip's tunnel actions POST JSON (Content-Type:
         application/json is not a 'simple' request, so the webview's browser asks
@@ -37313,6 +37639,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Max-Age", "86400")
         self.end_headers()
 
+    @_perf_http_timed
     def do_HEAD(self):
         # HEAD exists for ONE route: /file (the preview existence probe). Without this the base handler
         # 501s every HEAD, which the client would read as "gone" and hide a live chip.
@@ -37343,6 +37670,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    @_perf_http_timed
     def do_GET(self):
         u = urlparse(self.path)
         p = u.path
@@ -37455,6 +37783,8 @@ class Handler(BaseHTTPRequestHandler):
                 if (q.get("threads") or [""])[0] == "1":       # opt-in: comment-thread rows for the postal
                     rows = rows + _thread_rows()               # bus (the user 2026-08-22); every existing
                 return self._send(200, json.dumps(rows), "application/json", cache="no-cache")   # consumer unchanged
+            if p == "/perf":                                  # the kernel's performance counters (`romp perf`); shape: _PerfStats
+                return self._send(200, json.dumps(_PERF_STATS.snapshot()), "application/json", cache="no-cache")
             if p == "/commands":                              # slash-command list for the composer's "/" autocomplete (SDK get_server_info, per-cwd cached)
                 sid = (q.get("sid") or [""])[0]
                 cmds, warming = _commands_for_cwd(_cwd_of(sid) if sid else "")
@@ -37774,6 +38104,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    @_perf_http_timed
     def do_POST(self):
         u = urlparse(self.path)
         q = parse_qs(u.query)
@@ -38052,6 +38383,21 @@ class Handler(BaseHTTPRequestHandler):
                 _producer_wake.set()
                 _pusher_wake.set()
                 return self._send(200, json.dumps({"ok": True, "woke": True}), "application/json")
+            if u.path == "/perf":
+                # The runtime switch for the romp-perf stderr log: {"log": true|false} (`romp perf log
+                # on|off`). The log used to need ROMP_PERF in the process environment at start, so turning
+                # it on meant a kernel restart, which cuts every open turn on a machine whose sessions run
+                # inside this kernel. The counters GET /perf serves are always on and need no switch.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = None
+                if not isinstance(b, dict) or not isinstance(b.get("log"), bool):
+                    return self._send(400, json.dumps({"ok": False, "error": 'body must be {"log": true|false}'}),
+                                      "application/json")
+                _set_perf_log(b["log"])
+                sys.stderr.write("romp-perf: log %s (POST /perf)\n" % ("on" if _PERF else "off"))
+                return self._send(200, json.dumps({"ok": True, "log": _PERF}), "application/json")
             if u.path == "/send":
                 # Human→agent input channel — the SAME delivery the chat composer's WS
                 # sendMessage uses, exposed as a one-shot POST so an external local tool (the

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+
+# `romp perf [--interval <s>] [--json]` and `romp perf log on|off` — the kernel's performance counters
+# for a terminal: two GET /perf snapshots printed as rates, one raw snapshot, or the POST that flips the
+# romp-perf stderr log without a restart.
+#
+# Same contract as `romp sessions`: the token travels on stdin (never argv), a dead kernel fails
+# LOUDLY rather than printing something a reader could mistake for a quiet kernel, and an unknown
+# flag is refused. Two more refusals are this verb's own: two snapshots from different kernel
+# processes (a restart inside the window) are not subtracted into negative rates, and a refused
+# token is named as such rather than reported as a dead kernel. Nothing here touches a real kernel:
+# curl is a stub that serves synthetic snapshots in turn and emits the status trailer the real one
+# is asked for (-w).
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
+    export ROMP_KERNEL_PORT=29855
+
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export CURL_LOG="$TEST_DIR/curl.log"
+    export CURL_STDIN="$TEST_DIR/curl.stdin"
+    export CURL_CALLS="$TEST_DIR/curl.calls"
+    export SNAP_A="$TEST_DIR/a.json"
+    export SNAP_B="$TEST_DIR/b.json"
+    export SNAP_C="$TEST_DIR/c.json"
+    # A and B: the same kernel process ten seconds apart. Over the window: 20 cycles, 60 wakes, 6 s of
+    # cycle time (4 s of it in push, 3 s of that in the chat block), 300 ms of pusher CPU and 50 ms of
+    # judge CPU inside 500 ms of process CPU, 2 chat rebuilds against 18 cache hits, 1 MB sent as chat
+    # full frames, 100 goal loads, 2 judge passes totalling 2400 ms, 5 /tick requests and 3 WebSocket
+    # connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
+    # (ring max 700, mean 1200) so a line printing the wrong one is caught.
+    cat > "$SNAP_A" <<'JSON'
+{"now": 1000.0, "since": 900.0, "uptime_s": 100.0, "log": false,
+ "process": {"rss_kb": 409600, "threads": 40, "cpu_s": 60.0, "pid": 4242},
+ "pusher": {"cycles": 100, "wakes": 300, "wakes_event": 250, "wakes_backstop": 50, "cycle_ms_sum": 30000.0,
+            "cycle_ms_max": 900.0, "cycle_ms_last": 200.0, "cycle_cpu_ms_sum": 10000.0,
+            "cycle_ms_p50": 180.0, "cycle_ms_p90": 400.0, "cycle_ms_ring_max": 900.0, "ring_n": 100},
+ "stages_ms": {"jobs": 5000.0, "push": 20000.0, "push.chat": 15000.0, "push.feed": 3000.0, "push.timeline": 1000.0, "push.send": 500.0},
+ "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}},
+ "sends": {"full": {"chat": {"count": 10, "bytes": 1000000}}, "delta": {"chat": {"count": 100, "bytes": 50000}}, "deduped": {"feed": {"count": 90, "bytes": 9000000}}},
+ "goals": {"loads": 1000, "saves": 200, "writes": 50},
+ "judge": {"passes": 30, "ms_sum": 30000.0, "ms_last": 1000.0, "ms_mean": 1000.0, "cpu_ms_sum": 2000.0, "cpu_ms_workers": 1500.0},
+ "http": {"GET /tick": {"count": 50, "ms": 25.0}, "GET /sessions": {"count": 5, "ms": 10.0}}}
+JSON
+    cat > "$SNAP_B" <<'JSON'
+{"now": 1010.0, "since": 900.0, "uptime_s": 110.0, "log": false,
+ "process": {"rss_kb": 419840, "threads": 41, "cpu_s": 60.5, "pid": 4242},
+ "pusher": {"cycles": 120, "wakes": 360, "wakes_event": 300, "wakes_backstop": 60, "cycle_ms_sum": 36000.0,
+            "cycle_ms_max": 900.0, "cycle_ms_last": 250.0, "cycle_cpu_ms_sum": 10300.0,
+            "cycle_ms_p50": 190.0, "cycle_ms_p90": 420.0, "cycle_ms_ring_max": 700.0, "ring_n": 120},
+ "stages_ms": {"jobs": 6000.0, "push": 24000.0, "push.chat": 18000.0, "push.feed": 3600.0, "push.timeline": 1200.0, "push.send": 600.0},
+ "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}},
+ "sends": {"full": {"chat": {"count": 12, "bytes": 2048576}}, "delta": {"chat": {"count": 120, "bytes": 60000}}, "deduped": {"feed": {"count": 108, "bytes": 10800000}}},
+ "goals": {"loads": 1100, "saves": 220, "writes": 55},
+ "judge": {"passes": 32, "ms_sum": 32400.0, "ms_last": 1200.0, "ms_mean": 1012.5, "cpu_ms_sum": 2050.0, "cpu_ms_workers": 1540.0},
+ "http": {"GET /tick": {"count": 55, "ms": 27.5}, "GET /sessions": {"count": 5, "ms": 10.0}, "GET /ws": {"count": 3, "ms": 0.0}}}
+JSON
+    # C: a kernel that restarted five seconds into the window — new pid, new `since`, counters reset
+    sed -e 's/"since": 900.0/"since": 1005.0/' -e 's/"uptime_s": 110.0/"uptime_s": 5.0/' \
+        -e 's/"pid": 4242/"pid": 4343/' -e 's/"cycles": 120/"cycles": 4/' "$SNAP_B" > "$SNAP_C"
+    # Stub curl: records argv AND stdin (the auth header rides stdin as a curl config) and emits the
+    # body followed by the -w status trailer the script asks for. A POST answers the toggle's ack; a
+    # GET serves snapshot A first, then B (or C under CURL_RESTART), so two reads see counters move.
+    cat > "$MOCK/curl" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$CURL_LOG"
+cat >> "$CURL_STDIN" 2>/dev/null
+[ -n "${CURL_FAIL:-}" ] && exit 7
+if [ -n "${CURL_403:-}" ]; then printf 'forbidden: token required\n403'; exit 0; fi
+if [[ "$*" == *"-X POST"* ]]; then
+    printf '{"ok": true, "log": %s}\n200' "$([[ "$*" == *'"log": true'* ]] && echo true || echo false)"
+    exit 0
+fi
+n=0; [ -f "$CURL_CALLS" ] && n="$(cat "$CURL_CALLS")"
+echo $((n + 1)) > "$CURL_CALLS"
+if [ "$n" -eq 0 ]; then cat "$SNAP_A"; elif [ -n "${CURL_RESTART:-}" ]; then cat "$SNAP_C"; else cat "$SNAP_B"; fi
+printf '\n200'
+MOCK
+    chmod +x "$MOCK/curl"
+    export PATH="$MOCK:$PATH"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp perf: prints rates computed from two snapshots" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"10.0 s window"* ]]                 # the window is the snapshots' own clocks, not the sleep
+    [[ "$output" == *"2.00 cycles/s"* ]]                 # 20 cycles over 10 s
+    [[ "$output" == *"6.00 wakes/s (event 50, backstop 10)"* ]]
+    [[ "$output" == *"busy 60% of wall"* ]]              # 6 s of cycle time in a 10 s window
+    [[ "$output" == *"rss 410 MB"* ]]
+    [[ "$output" == *"pid 4242"* ]]
+}
+
+@test "romp perf: the process line splits the window's CPU between the pusher, the judge and the rest" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    # 0.5 s of process CPU in 10 s; 300 ms of it on the pusher thread, 50 ms in the judge threads
+    [[ "$output" == *"cpu 5.0% of one core (pusher 3.0%, judge 0.5%, other 1.5%)"* ]]
+}
+
+@test "romp perf: the cycle line's max is the ring's, and the parenthetical names the ring" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"p50 190   p90 420   max 700 (over the last 120 cycles)   last 250"* ]]
+    [[ "$output" != *"max 900"* ]]                       # the lifetime max is not printed as a window figure
+}
+
+@test "romp perf: the stage line shows each stage's share of cycle time" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    # 1 s of jobs, 4 s of push (3 s chat, 0.6 s feed, 0.2 s timeline, 0.1 s send) out of 6 s of cycles
+    [[ "$output" == *"jobs  17%"* ]]
+    [[ "$output" == *"push  67%"* ]]
+    [[ "$output" == *"chat  50%"* ]]
+    [[ "$output" == *"feed  10%"* ]]
+}
+
+@test "romp perf: builds, sends, goals, judge and http lines carry the window's deltas" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg)"* ]]
+    [[ "$output" == *"full 102 KB/s (chat 2 frames 102 KB/s)"* ]]        # 1048576 bytes over 10 s, bytes beside the count
+    [[ "$output" == *"deduped 176 KB/s (feed 18 frames 176 KB/s)"* ]]
+    [[ "$output" == *"10.0 loads/s   2.0 saves/s   0.5 writes/s"* ]]
+    [[ "$output" == *"2 passes (0.20/s)   last 1200 ms   mean 1200 ms"* ]]   # the WINDOW mean: 2400 ms over 2 passes
+    [[ "$output" != *"1012"* ]]                          # not the lifetime ms_mean
+    [[ "$output" == *"GET /tick 5 (0.5 ms avg)"* ]]
+    [[ "$output" == *"GET /ws 3"* ]]                     # a WebSocket row: count only …
+    [[ "$output" != *"GET /ws 3 ("* ]]                   # … never a fabricated 0.0 ms avg
+    [[ "$output" != *"/sessions"* ]]                     # no requests in the window: not listed
+}
+
+@test "romp perf: a restart inside the window is said, not subtracted into negative rates" {
+    CURL_RESTART=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the kernel restarted during the window (pid 4242 -> 4343)"* ]]
+    [[ "$output" != *"cycles/s"* ]]
+}
+
+@test "romp perf --json: prints one raw snapshot verbatim and reads the kernel once" {
+    run "$ROMP_SCRIPT" perf --json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["pusher"]["cycles"] == 100; assert d["process"]["pid"] == 4242'
+    [ "$(cat "$CURL_CALLS")" -eq 1 ]
+}
+
+@test "romp perf: reads GET /perf on the kernel, authorizing on stdin, twice" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [ "$(grep -c "127.0.0.1:29855/perf" "$CURL_LOG")" -eq 2 ]
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    # never in argv: /proc/<pid>/cmdline is world-readable
+    run grep -q "TESTTOKEN123" "$CURL_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "romp perf log on|off: POSTs the toggle to /perf and names the journal on systemd" {
+    run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"log on"* ]]
+    [[ "$output" == *"journalctl --user -u romp-manager"* ]]
+    grep -q -- "-X POST http://127.0.0.1:29855/perf" "$CURL_LOG"
+    grep -q '"log": true' "$CURL_LOG"
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    run "$ROMP_SCRIPT" perf log off
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"log off"* ]]
+    grep -q '"log": false' "$CURL_LOG"
+}
+
+@test "romp perf log on: under launchd the hint names the manager.log file, not journalctl" {
+    printf '#!/usr/bin/env bash\necho Darwin\n' > "$MOCK/uname"; chmod +x "$MOCK/uname"
+    run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tail -f $XDG_STATE_HOME/romp/manager.log"* ]]
+    [[ "$output" != *"journalctl"* ]]
+}
+
+@test "romp perf log: anything but on|off is refused" {
+    run "$ROMP_SCRIPT" perf log maybe
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf"* ]]
+    run "$ROMP_SCRIPT" perf log
+    [ "$status" -eq 2 ]
+    [ ! -f "$CURL_LOG" ]                                 # nothing reached the kernel
+}
+
+@test "romp perf: a dead kernel fails LOUDLY" {
+    CURL_FAIL=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+    CURL_FAIL=1 run "$ROMP_SCRIPT" perf log on
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+}
+
+@test "romp perf: a refused token is named as such, not reported as a dead kernel" {
+    CURL_403=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    CURL_403=1 run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+}
+
+@test "romp perf: an unknown flag or a bad interval is refused rather than silently ignored" {
+    run "$ROMP_SCRIPT" perf --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf"* ]]
+    run "$ROMP_SCRIPT" perf --interval soon
+    [ "$status" -eq 2 ]
+    run "$ROMP_SCRIPT" perf --interval
+    [ "$status" -eq 2 ]
+}
+
+@test "romp perf: listed in help, under the scripting group" {
+    run "$ROMP_SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp perf"* ]]
+}

--- a/tests/test_color_route.py
+++ b/tests/test_color_route.py
@@ -63,10 +63,17 @@ class ColorRoute(unittest.TestCase):
         km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
 
     def _post(self, body):
+        # km.TOKEN, not os.environ: pytest imports every collected module before any test runs, and
+        # test_kernel.py assigns ROMP_SERVE_TOKEN at import. When this module was the FIRST collected
+        # module to set the variable (a two-file or small-subset run), its kernel captured the default
+        # here and test_kernel.py's later write changed what the env held at request time, so the
+        # request was refused with a 403 (found 2026-09-06). In the full suite some forty earlier
+        # modules setdefault the same value test_kernel.py writes, which is why it passed there. The
+        # kernel's own token is the one the handler checks.
         req = urllib.request.Request(
             "http://127.0.0.1:%d/color" % self.port, data=json.dumps(body).encode(),
             headers={"Content-Type": "application/json",
-                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+                     "X-Romp-Token": km.TOKEN})
         try:
             with urllib.request.urlopen(req, timeout=10) as r:
                 return r.status, json.loads(r.read().decode())

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -1,0 +1,807 @@
+#!/usr/bin/env python3
+"""The kernel's always-on performance counters (`_PerfStats`, GET /perf, `romp perf`) and the runtime
+switch for the romp-perf stderr log (POST /perf {"log": bool}).
+
+Before this the only instrumentation was `_perf()`, gated on ROMP_PERF at process start, so turning it
+on meant a kernel restart; and nothing reported rates, so an optimization was checked with a hand-run
+profiler. The collector counts pusher cycles and wakes, cycle durations (a ring for percentiles) and
+the pusher thread's CPU, per-stage time, build cache hits, bytes sent per slot kind, goal-store I/O,
+judge passes with their threads' CPU, and HTTP requests per method and path, with a lock and dict
+increments on the hot paths and no formatting until a read.
+
+Drives the REAL Handler over HTTP and the REAL _push with stubbed builders (the test_color_route.py
+and test_tab_meta_push.py patterns). Synthetic fixtures only: placeholder UUIDs, invented names."""
+import concurrent.futures
+import inspect
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+from unittest import mock
+from contextlib import redirect_stderr
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_perf", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+# A PRIVATE synthetic sid for the goal-store tests: load_goals replays the per-sid override journal,
+# and node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures).
+GOAL_SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms", "builds", "sends",
+            "goals", "judge", "http"}
+
+
+def _burn_cpu(seconds):
+    """Spin this thread for `seconds` of its own CPU time (thread_time, so a descheduled thread still burns
+    the asked amount rather than merely waiting it out)."""
+    t = time.thread_time()
+    while time.thread_time() - t < seconds:
+        pass
+
+
+class _HttpWatch:
+    """Wait for the HTTP wrapper's record instead of racing it. _perf_http_timed counts a request in its
+    `finally`, AFTER the handler put the response on the wire, so a test that reads the snapshot as soon
+    as urlopen returns can see the count land a moment later (it did, about one run in five). Patching
+    the collector's http_request on the instance (the class method stays) makes every record observable:
+    the real method runs, then the key is appended and an Event set, and wait_for blocks on the event
+    until the key has been recorded `n` times or the bound passes."""
+
+    def __enter__(self):
+        st = km._PERF_STATS
+        real = km._PerfStats.http_request
+        self.keys, self.ev = [], threading.Event()
+
+        def wrapped(key, dt):
+            real(st, key, dt)
+            self.keys.append(key)           # append BEFORE set: an observed set implies a visible append
+            self.ev.set()
+        st.http_request = wrapped
+        return self
+
+    def __exit__(self, *a):
+        del km._PERF_STATS.http_request     # the instance attribute goes; the class method shows again
+
+    def wait_for(self, key, n, timeout=2.0):
+        deadline = time.monotonic() + timeout
+        while self.keys.count(key) < n:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                return False
+            self.ev.wait(left)
+            self.ev.clear()
+        return True
+
+
+class Collector(unittest.TestCase):
+    """_PerfStats on its own: every writer lands where the docstring says, and the read-time work
+    (percentiles, the goals and judge reads, the process reads) produces the documented shape."""
+
+    def setUp(self):
+        self.st = km._PerfStats()
+
+    def test_snapshot_has_the_documented_shape_and_starts_at_zero(self):
+        snap = self.st.snapshot()
+        self.assertEqual(set(snap), TOP_KEYS)
+        p = snap["pusher"]
+        self.assertEqual(p["cycles"], 0)
+        for k in ("cycle_ms_p50", "cycle_ms_p90", "cycle_ms_ring_max", "cycle_ms_max", "cycle_cpu_ms_sum"):
+            self.assertEqual(p[k], 0.0, k)
+        self.assertEqual(p["ring_n"], 0)
+        self.assertEqual(set(snap["stages_ms"]), set(km._PerfStats.STAGES))
+        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline"})
+        self.assertEqual(set(snap["sends"]), {"full", "delta", "deduped"})
+        self.assertEqual(snap["judge"]["ms_mean"], 0.0, "no passes: the mean is 0, not a division error")
+        self.assertIn("cpu_ms_sum", snap["judge"])
+        self.assertIn("cpu_ms_workers", snap["judge"])
+        self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
+        for k in ("rss_kb", "threads", "cpu_s", "pid"):
+            self.assertIn(k, snap["process"])
+        self.assertGreater(snap["process"]["threads"], 0)
+        self.assertGreaterEqual(snap["process"]["rss_kb"], 0)
+        self.assertGreaterEqual(snap["uptime_s"], 0)
+        json.dumps(snap)                                     # the whole thing serializes as-is
+
+    def test_pusher_counters(self):
+        self.st.wake(); self.st.wake(); self.st.wake()
+        self.st.wake_kind(True); self.st.wake_kind(False); self.st.wake_kind(False)
+        self.st.cycle(0.010, 0.004); self.st.cycle(0.030, 0.006); self.st.cycle(0.020)
+        p = self.st.snapshot()["pusher"]
+        self.assertEqual(p["wakes"], 3)
+        self.assertEqual((p["wakes_event"], p["wakes_backstop"]), (1, 2))
+        self.assertEqual(p["cycles"], 3)
+        self.assertAlmostEqual(p["cycle_ms_sum"], 60.0)
+        self.assertAlmostEqual(p["cycle_cpu_ms_sum"], 10.0, msg="the thread's own CPU rides beside the wall")
+        self.assertAlmostEqual(p["cycle_ms_max"], 30.0)
+        self.assertAlmostEqual(p["cycle_ms_last"], 20.0)
+        self.assertEqual(p["ring_n"], 3)
+
+    def test_ring_percentiles_and_max_come_from_the_last_256_cycles(self):
+        self.st.cycle(5.0)                                   # one slow boot cycle: 5000 ms
+        for i in range(300):                                 # 0..299 ms; the ring keeps 44..299
+            self.st.cycle(i / 1000.0)
+        p = self.st.snapshot()["pusher"]
+        self.assertEqual(p["ring_n"], 256)
+        self.assertEqual(p["cycles"], 301, "the count is lifetime; only the percentile window is bounded")
+        self.assertAlmostEqual(p["cycle_ms_p50"], 44 + 128)  # sorted ring[int(0.5 * 256)]
+        self.assertAlmostEqual(p["cycle_ms_p90"], 44 + 230)  # sorted ring[int(0.9 * 256)]
+        self.assertAlmostEqual(p["cycle_ms_ring_max"], 299.0, msg="the window's max: the ring's largest")
+        self.assertAlmostEqual(p["cycle_ms_max"], 5000.0, msg="the lifetime max keeps the boot cycle")
+
+    def test_stages_builds_judge(self):
+        self.st.stage("push.chat", 0.5); self.st.stage("push.chat", 0.25); self.st.stage("jobs", 0.1)
+        self.st.build("chat", True); self.st.build("chat", False, 0.040); self.st.build("feed", False, 1.0)
+        self.st.judge_pass(2.0); self.st.judge_pass(4.0); self.st.judge_cpu(0.25)
+        snap = self.st.snapshot()
+        self.assertAlmostEqual(snap["stages_ms"]["push.chat"], 750.0)
+        self.assertAlmostEqual(snap["stages_ms"]["jobs"], 100.0)
+        self.assertEqual(snap["builds"]["chat"], {"cached": 1, "built": 1, "ms": 40.0})
+        self.assertEqual(snap["builds"]["feed"]["built"], 1)
+        self.assertEqual(snap["builds"]["timeline"], {"cached": 0, "built": 0, "ms": 0.0})
+        self.assertEqual(snap["judge"]["passes"], 2)
+        self.assertAlmostEqual(snap["judge"]["ms_last"], 4000.0)
+        self.assertAlmostEqual(snap["judge"]["ms_mean"], 3000.0)
+        self.assertAlmostEqual(snap["judge"]["cpu_ms_sum"] - snap["judge"]["cpu_ms_workers"], 250.0,
+                               msg="the tier threads' CPU, apart from the pool workers' share")
+
+    def test_sends_classify_by_kind_and_slot_name(self):
+        self.st.send(("chat", SID), "full", 1000)            # a tuple dedup key: the slot is its first element
+        self.st.send(("chat", SID), "full", 500)
+        self.st.send(("chat", SID), "deduped", 1000)
+        self.st.send("feed", "delta", 20)                    # a bare string key (the feed's own delta path)
+        s = self.st.snapshot()["sends"]
+        self.assertEqual(s["full"], {"chat": {"count": 2, "bytes": 1500}})
+        self.assertEqual(s["deduped"], {"chat": {"count": 1, "bytes": 1000}})
+        self.assertEqual(s["delta"], {"feed": {"count": 1, "bytes": 20}})
+
+    def test_send_slots_are_capped(self):
+        for i in range(40):
+            self.st.send(("slot%d" % i,), "full", 1)
+        d = self.st.snapshot()["sends"]["full"]
+        self.assertEqual(len(d), km._PerfStats.SLOTS + 1)
+        self.assertEqual(d["other"]["count"], 40 - km._PerfStats.SLOTS)
+
+    def test_http_keys_are_capped_and_ws_adds_no_time(self):
+        for i in range(100):
+            self.st.http_request("GET /scan/%d" % i, 0.001)
+        self.st.http_request("GET /ws", None)
+        h = self.st.snapshot()["http"]
+        self.assertEqual(len(h), km._PerfStats.HTTP_PATHS + 1, "64 keys plus the fold")
+        self.assertEqual(h["other"]["count"], 100 - km._PerfStats.HTTP_PATHS + 1,
+                         "the 36 keys past the cap and /ws, which arrived after it")
+        st2 = km._PerfStats()
+        st2.http_request("GET /ws", None); st2.http_request("POST /tick", 0.002)
+        h = st2.snapshot()["http"]
+        self.assertEqual(h["GET /ws"], {"count": 1, "ms": 0.0}, "a socket's lifetime is not a request time")
+        self.assertEqual(h["POST /tick"]["count"], 1)
+        self.assertAlmostEqual(h["POST /tick"]["ms"], 2.0)
+
+    def test_http_key_is_method_plus_normalized_path(self):
+        key = km._perf_http_key
+        self.assertEqual(key("GET", "/sessions"), "GET /sessions")
+        self.assertEqual(key("POST", "/perf"), "POST /perf", "GET /perf and POST /perf are separate rows")
+        self.assertEqual(key("GET", "/dist/render.js"), "GET /dist/*")
+        self.assertEqual(key("GET", "/dist/fonts/a-b-c.woff2"), "GET /dist/*", "sixty font files: one key")
+        self.assertEqual(key("GET", "/media/romp-app-192.png"), "GET /media/*")
+        self.assertEqual(key("GET", "/remote/TESTHOST/ws"), "GET /remote/*/ws", "no host name in a key")
+        self.assertEqual(key("HEAD", "/remote/TESTHOST/file"), "HEAD /remote/*/file")
+        self.assertEqual(key("GET", "/remote/TESTHOST"), "GET /remote/*")
+        self.assertEqual(key("", "/version"), "/version", "a handler without a method: the path alone")
+
+    def test_reset_starts_over_and_moves_since(self):
+        self.st.cycle(0.1); self.st.http_request("GET /x", 0.1)
+        before = self.st.snapshot()["since"]
+        time.sleep(0.01)
+        self.st.reset()
+        snap = self.st.snapshot()
+        self.assertEqual(snap["pusher"]["cycles"], 0)
+        self.assertEqual(snap["http"], {})
+        self.assertGreater(snap["since"], before)
+
+    def test_writers_are_thread_safe(self):
+        def hammer():
+            for _ in range(2000):
+                self.st.wake(); self.st.send(("chat", SID), "full", 1); self.st.http_request("GET /p", 0.0)
+        ts = [threading.Thread(target=hammer) for _ in range(8)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        snap = self.st.snapshot()
+        self.assertEqual(snap["pusher"]["wakes"], 16000)
+        self.assertEqual(snap["sends"]["full"]["chat"]["count"], 16000)
+        self.assertEqual(snap["http"]["GET /p"]["count"], 16000)
+
+
+class ProcessStatsFallback(unittest.TestCase):
+    """_process_stats reads VmRSS from /proc/self/status; a platform without /proc (macOS) gets
+    ru_maxrss, which the kernel there reports in bytes and Linux in KB, so only the darwin branch
+    scales. Both branches are driven here: /proc is made to fail on every platform, and the
+    platform name and the rusage read are patched so the figure is exact."""
+
+    class _Usage:
+        ru_maxrss = 2048 * 1024                              # bytes on darwin, KB on linux
+
+    def _stats(self, platform):
+        real_open = open
+
+        def no_proc(path, *a, **kw):
+            if path == "/proc/self/status":
+                raise FileNotFoundError(path)
+            return real_open(path, *a, **kw)
+        import resource
+        with mock.patch("builtins.open", side_effect=no_proc), \
+                mock.patch.object(resource, "getrusage", return_value=self._Usage()), \
+                mock.patch.object(sys, "platform", platform):
+            return km._process_stats()
+
+    def test_without_proc_rss_comes_from_ru_maxrss(self):
+        st = self._stats("linux")
+        self.assertIsInstance(st["rss_kb"], int)
+        self.assertEqual(st["rss_kb"], 2048 * 1024, "linux reports ru_maxrss in KB: taken as is")
+        for k in ("threads", "cpu_s", "pid"):
+            self.assertIn(k, st)
+        self.assertEqual(st["pid"], os.getpid())
+
+    def test_on_darwin_ru_maxrss_is_bytes_and_is_scaled_to_kb(self):
+        st = self._stats("darwin")
+        self.assertEqual(st["rss_kb"], 2048, "ru_maxrss // 1024")
+
+    def test_with_proc_present_the_fallback_is_not_used(self):
+        import resource
+        with mock.patch.object(resource, "getrusage", side_effect=AssertionError("fallback taken")):
+            try:
+                with open("/proc/self/status"):
+                    pass
+            except OSError:
+                self.skipTest("no /proc on this platform")
+            self.assertGreater(km._process_stats()["rss_kb"], 0, "VmRSS read from /proc")
+
+
+class WakeCounting(unittest.TestCase):
+    """_pusher_wake is a threading.Event whose set() counts: every existing call site — including the
+    bound-method callbacks the backends hold — counts a wake without being touched."""
+
+    def test_the_pusher_wake_counts_sets(self):
+        self.assertIsInstance(km._pusher_wake, threading.Event)
+        self.assertIsInstance(km._pusher_wake, km._CountedEvent)
+        was_set = km._pusher_wake.is_set()
+        before = km._PERF_STATS.snapshot()["pusher"]["wakes"]
+        km._pusher_wake.set()
+        cb = km._pusher_wake.set                             # the shape the backends are handed (push=_pusher_wake.set)
+        cb()
+        self.assertTrue(km._pusher_wake.is_set())
+        self.assertEqual(km._PERF_STATS.snapshot()["pusher"]["wakes"], before + 2)
+        if not was_set:
+            km._pusher_wake.clear()
+
+    def test_wake_helpers_still_set_the_event(self):
+        km._pusher_wake.clear()
+        km._push_soon()
+        self.assertTrue(km._pusher_wake.is_set())
+        km._pusher_wake.clear()
+
+
+class PerfLogToggle(unittest.TestCase):
+    """_perf() writes only when the switch is on, and the switch flips at runtime."""
+
+    def setUp(self):
+        self.saved = km._PERF
+        km._set_perf_log(False)
+
+    def tearDown(self):
+        km._set_perf_log(self.saved)
+
+    def test_off_writes_nothing_on_writes_one_line(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "")
+        self.assertTrue(km._set_perf_log(True))
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "romp-perf probe a=1 b=2\n")
+        km._set_perf_log(False)
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "", "off again: nothing")
+
+    def test_the_off_path_reads_one_module_global(self):
+        src = inspect.getsource(km._perf)
+        self.assertIn("if not _PERF:\n        return", src, "the hot path stays a name lookup and a return")
+
+
+class GoalIoCounters(unittest.TestCase):
+    """judge.load_goals / save_goals count calls and disk writes; the kernel reads them via goal_io_stats."""
+
+    def setUp(self):
+        self.jd = km.jd
+        self.jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(self._clean)
+
+    def _clean(self):
+        for p in (self.jd.GOALDIR / (GOAL_SID + ".json"), self.jd.STATE / "overrides" / (GOAL_SID + ".jsonl")):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    def test_loads_saves_and_writes(self):
+        before = self.jd.goal_io_stats()
+        store = self.jd.load_goals(GOAL_SID)                 # no file yet: a fresh store, still one load
+        after = self.jd.goal_io_stats()
+        self.assertEqual(after["loads"], before["loads"] + 1)
+        self.jd.save_goals(GOAL_SID, store)                  # the first publish writes the file
+        after = self.jd.goal_io_stats()
+        self.assertEqual(after["saves"], before["saves"] + 1)
+        self.assertEqual(after["writes"], before["writes"] + 1)
+        store = self.jd.load_goals(GOAL_SID)
+        self.jd.save_goals(GOAL_SID, store)                  # byte-identical: a save, not a write
+        after2 = self.jd.goal_io_stats()
+        self.assertEqual(after2["saves"], after["saves"] + 1)
+        self.assertEqual(after2["writes"], after["writes"], "the no-op republish skip is visible as saves without writes")
+        self.assertEqual(km._PERF_STATS.snapshot()["goals"], after2, "the kernel's snapshot carries the judge counters")
+
+    def test_the_getter_returns_a_copy(self):
+        d = self.jd.goal_io_stats()
+        d["loads"] = -1
+        self.assertNotEqual(self.jd.goal_io_stats()["loads"], -1)
+
+
+class JudgeCpu(unittest.TestCase):
+    """The judge's CPU is attributed from two places: the tier threads (_run_tier) and every future the
+    tiers submit to judge.py's pools (_TimedPool, bound to the module's ThreadPoolExecutor name)."""
+
+    def test_pool_workers_account_their_cpu(self):
+        jd = km.jd
+        self.assertTrue(issubclass(jd.ThreadPoolExecutor, concurrent.futures.ThreadPoolExecutor),
+                        "every pool in judge.py is a real executor that also accounts")
+        before = jd.judge_worker_cpu_ms()
+        with jd.ThreadPoolExecutor(max_workers=2) as ex:
+            self.assertEqual(ex.submit(lambda a, b=1: a + b, 2, b=3).result(), 5, "args and kwargs pass through")
+            ex.submit(_burn_cpu, 0.005).result()
+        grew = jd.judge_worker_cpu_ms() - before
+        self.assertGreaterEqual(grew, 4.0, "about 5 ms of a worker's CPU landed")
+        self.assertLess(grew, 500.0)
+        self.assertEqual(km._PERF_STATS.snapshot()["judge"]["cpu_ms_workers"], jd.judge_worker_cpu_ms())
+
+    def test_run_tier_accounts_the_tier_threads_cpu(self):
+        def tier_cpu():
+            j = km._PERF_STATS.snapshot()["judge"]
+            return j["cpu_ms_sum"] - j["cpu_ms_workers"]
+        before = tier_cpu()
+        km._run_tier(lambda: _burn_cpu(0.005))
+        self.assertGreaterEqual(tier_cpu() - before, 4.0)
+        before = tier_cpu()
+        with redirect_stderr(io.StringIO()):
+            km._run_tier(lambda: (_burn_cpu(0.005), (_ for _ in ()).throw(RuntimeError("tier died"))))
+        self.assertGreaterEqual(tier_cpu() - before, 4.0, "a raising tier still accounts (the finally)")
+
+
+class PusherRecords(unittest.TestCase):
+    """The pusher's seams record into _PERF_STATS: a cycle lands in the ring with its thread's CPU, the
+    cycle jobs split into push and jobs, the cached and rebuilt feed/timeline paths count, and the
+    send paths classify full / delta / deduped for whole-frame, delta-capable and chat-tail clients."""
+
+    JOBS = ("_apply_pending_ops", "_turn_notify_tick", "_lift_spent_awaiting", "_death_sweep_tick",
+            "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
+            "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+            "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+            "_clear_done_working_notes", "_push_all")
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        names = Path(self.td.name) / "names"
+        names.mkdir()
+        self.saved = (km.NAMES, km._tmux_sessions, km._pusher_cycle_jobs, list(km._built_feed),
+                      list(km._built_timeline), km.build_feed, km.build_timeline, km._needs_you_count,
+                      km._feed_notifications, km._badge_push, km._views_dirty[0])
+        self.saved_jobs = {nm: getattr(km, nm) for nm in self.JOBS}
+        km.NAMES = names
+        km._tmux_sessions = lambda: {}
+        self.addCleanup(self._restore)
+        self.addCleanup(self.td.cleanup)
+
+    def _restore(self):
+        (km.NAMES, km._tmux_sessions, km._pusher_cycle_jobs, bf, bt, km.build_feed, km.build_timeline,
+         km._needs_you_count, km._feed_notifications, km._badge_push, vd) = self.saved
+        km._built_feed[:] = bf
+        km._built_timeline[:] = bt
+        km._views_dirty[0] = vd
+        for nm, fn in self.saved_jobs.items():
+            setattr(km, nm, fn)
+
+    def _pusher(self):
+        return km._PERF_STATS.snapshot()["pusher"]
+
+    def test_a_cycle_is_counted_and_timed(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.005)
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertEqual(after["cycles"], before["cycles"] + 1)
+        self.assertGreaterEqual(after["cycle_ms_last"], 5.0)
+        self.assertEqual(after["ring_n"], min(before["ring_n"] + 1, km._PerfStats.RING))
+
+    def test_a_cycle_records_its_threads_cpu_not_its_waits(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.020)   # a wait, no CPU
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertGreaterEqual(after["cycle_ms_last"], 20.0)
+        self.assertLess(after["cycle_cpu_ms_sum"] - before["cycle_cpu_ms_sum"], 15.0,
+                        "a sleeping cycle adds far less CPU than wall")
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: _burn_cpu(0.005)     # CPU, no wait
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertGreaterEqual(after["cycle_cpu_ms_sum"] - before["cycle_cpu_ms_sum"], 4.0,
+                                "a spinning cycle's CPU lands in cycle_cpu_ms_sum")
+
+    def test_a_raising_cycle_is_still_counted(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: (_ for _ in ()).throw(RuntimeError("job died"))
+        before = self._pusher()["cycles"]
+        with self.assertRaises(RuntimeError):
+            km._pusher_cycle()
+        self.assertEqual(self._pusher()["cycles"], before + 1)
+
+    def test_cycle_jobs_split_into_push_and_jobs(self):
+        # the REAL _pusher_cycle_jobs with every tick job a no-op and _push_all a 5 ms sleep: `push` is the
+        # _push_all call, `jobs` the rest of the function, so push >= 5 and 0 <= jobs < push
+        for nm in self.JOBS:
+            setattr(km, nm, lambda *a, **k: None)
+        km._push_all = lambda tmux=None: time.sleep(0.005)
+        before = km._PERF_STATS.snapshot()["stages_ms"]
+        km._pusher_cycle_jobs(int(time.time()), {}, True)
+        after = km._PERF_STATS.snapshot()["stages_ms"]
+        push, jobs = after["push"] - before["push"], after["jobs"] - before["jobs"]
+        self.assertGreaterEqual(push, 5.0)
+        self.assertGreaterEqual(jobs, 0.0, "jobs is the function minus the push, never negative")
+        self.assertLess(jobs, push, "no-op jobs cost less than a 5 ms push")
+        before = km._PERF_STATS.snapshot()["stages_ms"]
+        km._pusher_cycle_jobs(int(time.time()), {}, False)   # no client: no push, the jobs still run
+        after = km._PERF_STATS.snapshot()["stages_ms"]
+        self.assertEqual(after["push"], before["push"])
+        self.assertGreaterEqual(after["jobs"], before["jobs"])
+
+    def test_feed_and_timeline_builds_count_cached_and_rebuilt(self):
+        km.build_feed = lambda now, tmux: {"working": [], "items": []}
+        km.build_timeline = lambda now, tmux, **kw: {"turns": [], "judging": [], "messages": [], "now": now}
+        km._needs_you_count = lambda feed: 0
+        km._feed_notifications = lambda feed: []
+        km._badge_push = lambda n: None
+        km._views_dirty[0] = 0.0
+        km._built_feed[:] = [None, None, 0.0, 0.0]
+        km._built_timeline[:] = [None, None, 0.0, 0.0]
+        b0 = km._PERF_STATS.snapshot()["builds"]
+        now = int(time.time())
+        km._cached_feed(now, {}, "sig-a")                    # nothing warmed: a rebuild
+        km._cached_feed(now, {}, "sig-a")                    # unchanged sig: served from the cache
+        km._cached_timeline(now, {}, "sig-a")
+        km._cached_timeline(now, {}, "sig-a", connect=True)  # a connecting page never rebuilds
+        b1 = km._PERF_STATS.snapshot()["builds"]
+        self.assertEqual(b1["feed"]["built"] - b0["feed"]["built"], 1)
+        self.assertEqual(b1["feed"]["cached"] - b0["feed"]["cached"], 1)
+        self.assertGreaterEqual(b1["feed"]["ms"], b0["feed"]["ms"])
+        self.assertEqual(b1["timeline"]["built"] - b0["timeline"]["built"], 1)
+        self.assertEqual(b1["timeline"]["cached"] - b0["timeline"]["cached"], 1)
+
+    @staticmethod
+    def _sends():
+        s = km._PERF_STATS.snapshot()["sends"]
+        return {(kind, slot): e["count"] for kind, d in s.items() for slot, e in d.items()}
+
+    def test_a_whole_frame_client_counts_full_then_deduped(self):
+        sent = []
+        c = {"app": "chat", "alive": True, "send": sent.append, "sent": {}}
+        s0 = self._sends()
+        km._send_client(c, ("working", SID), {"type": "working", "names": ["web"]})
+        km._send_client(c, ("working", SID), {"type": "working", "names": ["web"]})
+        s1 = self._sends()
+        self.assertEqual(len(sent), 1, "the second identical frame was deduped")
+        self.assertEqual(s1[("full", "working")] - s0.get(("full", "working"), 0), 1)
+        self.assertEqual(s1[("deduped", "working")] - s0.get(("deduped", "working"), 0), 1)
+        bytes_full = km._PERF_STATS.snapshot()["sends"]["full"]["working"]["bytes"]
+        self.assertGreaterEqual(bytes_full, len(sent[0]))
+
+    def test_a_delta_client_counts_the_suppressed_bars_frame_as_deduped(self):
+        # every browser pane connects with delta=1, so the bars slot's dedup happens in _send_slot_delta's
+        # unchanged path, not in _send_client — it must count there too, or deduped.timelinebars stays 0
+        sent = []
+        c = {"app": "timeline", "alive": True, "send": sent.append, "sent": {}, "delta": True}
+        bars = {"type": "bars", "turns": {"lane": [{"id": "t1", "a": 1}]}, "judging": [], "messages": [],
+                "now": 1, "warming": False}
+        pre = json.dumps(bars)
+        sig = km._dedup_sig(bars, pre)
+        s0 = self._sends()
+        km._send_slot(c, "bars", bars, pre, sig)
+        km._send_slot(c, "bars", bars, pre, sig)
+        s1 = self._sends()
+        self.assertEqual(len(sent), 1, "the keyed full went once; the unchanged repeat sent nothing")
+        self.assertEqual(s1[("full", "timelinebars")] - s0.get(("full", "timelinebars"), 0), 1)
+        self.assertEqual(s1[("deduped", "timelinebars")] - s0.get(("deduped", "timelinebars"), 0), 1)
+        self.assertEqual(s1.get(("delta", "timelinebars"), 0) - s0.get(("delta", "timelinebars"), 0), 0)
+
+    def test_a_caught_up_chat_client_counts_its_tail_as_delta(self):
+        sent = []
+        c = {"app": "chat", "alive": True, "send": sent.append, "sent": {}}
+        m1 = {"type": "session", "id": SID, "name": "web", "events": [{"uuid": "e1", "type": "user"}],
+              "status": {"state": "working"}}                # the shape build_session returns: a {type: session} frame
+        m2 = {"type": "session", "id": SID, "name": "web", "events": m1["events"] + [{"uuid": "e2", "type": "assistant"}],
+              "status": {"state": "waiting"}}
+        s0 = self._sends()
+        km._send_chat(c, m1, None, 0, False)                # nothing held: the whole session
+        km._send_chat(c, m2, None, 1, False)                # caught up through e1: the suffix from 1
+        s1 = self._sends()
+        self.assertEqual([json.loads(x)["type"] for x in sent], ["session", "chatTail"])
+        self.assertEqual(s1[("full", "chat")] - s0.get(("full", "chat"), 0), 1)
+        self.assertEqual(s1[("delta", "chat")] - s0.get(("delta", "chat"), 0), 1, "the tail is the chat's delta")
+
+
+class PushStages(unittest.TestCase):
+    """_push driven for real (the test_tab_meta_push.py pattern) with builders stubbed to sleep 5 ms
+    each: every push.* stage grows by at least its builder's sleep, the chat build counts as built on
+    the first push and as cached on the second (same transcript, background tab), and the timeline
+    client's bars go out in the send stage."""
+
+    STUBS = ("NAMES", "_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
+             "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
+             "_retry_parked_creates")
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        names = Path(self.tmp) / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        self.transcript = Path(self.tmp) / (SID + ".jsonl")
+        self.transcript.write_text('{"type": "user"}\n')       # exists → _chat_build_sig is a real signature
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (km.jd.STATE, dict(km._built_chat), dict(km._prev_chat_events),
+                            dict(km._prev_chat_ledger), list(km._last_tab_order))
+        km.NAMES = names
+        km.jd.STATE = Path(self.tmp) / "state"
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": SID, "name": "web", "path": str(self.transcript),
+                                                    "anchor": SID}]
+        km.build_session = self._build_session
+        km._cached_feed = lambda now, tmux, sig, connect=False: self._slow({"working": [], "awaiting": [], "now": now})
+        km._cached_timeline = lambda now, tmux, sig, connect=False: self._slow(
+            {"turns": {}, "judging": [], "messages": [], "now": now})
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.builds = 0
+        self.chat_frames, self.tl_frames = [], []
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: self.chat_frames.append(json.loads(s))}
+        self.tl = {"app": "timeline", "alive": True, "sent": {}, "send": lambda s: self.tl_frames.append(json.loads(s))}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, bc, pe, pl, lo = self.saved_state
+        km.jd.STATE = st
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+
+    @staticmethod
+    def _slow(value):
+        time.sleep(0.005)
+        return value
+
+    def _build_session(self, sid, now, tmux):
+        self.builds += 1
+        return self._slow({"type": "session", "id": sid, "name": "web", "events": [{"uuid": "e1", "type": "user"}],
+                           "ledger": None, "status": {"state": "waiting"}, "color": None})
+
+    def test_stages_and_chat_builds_are_recorded_by_the_real_push(self):
+        snap0 = km._PERF_STATS.snapshot()
+        km._push([self.chat, self.tl])
+        snap1 = km._PERF_STATS.snapshot()
+        self.assertEqual(self.builds, 1)
+        d = {k: snap1["stages_ms"][k] - snap0["stages_ms"][k] for k in snap0["stages_ms"]}
+        self.assertGreaterEqual(d["push.chat"], 5.0, "the build_session sleep lands in the chat stage")
+        self.assertGreaterEqual(d["push.feed"], 5.0, "the _cached_feed sleep lands in the feed stage")
+        self.assertGreaterEqual(d["push.timeline"], 5.0, "the _cached_timeline sleep lands in the timeline stage")
+        self.assertGreater(d["push.send"], 0.0, "the bars serialization and send took time")
+        self.assertEqual(d["jobs"], 0.0, "a bare _push is not a cycle: jobs and push stay")
+        self.assertEqual(d["push"], 0.0)
+        self.assertEqual(snap1["builds"]["chat"]["built"] - snap0["builds"]["chat"]["built"], 1)
+        self.assertEqual(snap1["builds"]["chat"]["cached"] - snap0["builds"]["chat"]["cached"], 0)
+        self.assertGreaterEqual(snap1["builds"]["chat"]["ms"] - snap0["builds"]["chat"]["ms"], 5.0)
+        self.assertIn("session", [f["type"] for f in self.chat_frames])
+        self.assertIn("bars", [f["type"] for f in self.tl_frames])
+        # the same transcript again: the background tab's build is served from the cache
+        km._push([self.chat, self.tl])
+        snap2 = km._PERF_STATS.snapshot()
+        self.assertEqual(self.builds, 1, "no rebuild")
+        self.assertEqual(snap2["builds"]["chat"]["cached"] - snap1["builds"]["chat"]["cached"], 1)
+        self.assertEqual(snap2["builds"]["chat"]["built"] - snap1["builds"]["chat"]["built"], 0)
+        self.assertLess(snap2["stages_ms"]["push.chat"] - snap1["stages_ms"]["push.chat"], 5.0,
+                        "a cached tab costs the chat stage no build")
+
+    def test_the_seams_stay_where_the_stages_are_defined(self):
+        # the order of the four stage records in _push is the definition of the split; pinned beside the
+        # behavioural test above so a re-ordering is caught even when every stage still grows
+        push = inspect.getsource(km._push)
+        idx = [push.index('_PERF_STATS.stage("%s"' % st) for st in ("push.chat", "push.feed", "push.timeline", "push.send")]
+        self.assertEqual(idx, sorted(idx))
+        self.assertIn("_PERF_STATS.judge_pass(", inspect.getsource(km._producer))
+        loop = inspect.getsource(km._pusher)
+        self.assertIn("_woke = _pusher_wake.wait(0.5)", loop)
+        self.assertIn("_PERF_STATS.wake_kind(_woke)", loop)
+
+
+class PerfRoutes(unittest.TestCase):
+    """GET /perf and POST /perf through the real Handler: token-gated, the documented shape, the toggle,
+    and every request method counted under METHOD /path."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        self.saved_log = km._PERF
+        km._set_perf_log(False)
+
+    def tearDown(self):
+        km._set_perf_log(self.saved_log)
+
+    def _req(self, method, path, body=None, token=True):
+        headers = {"Content-Type": "application/json"}
+        if token:
+            # km.TOKEN, not os.environ: under xdist every worker imports every test module at
+            # collection, and a later module's import-time ROMP_SERVE_TOKEN write changes the env
+            # after this module's kernel captured its token (the test_kernel_attach_on_behalf pattern)
+            headers["X-Romp-Token"] = km.TOKEN
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), data=data,
+                                     headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                raw = r.read().decode()
+                return r.status, (json.loads(raw) if raw.startswith(("{", "[")) else raw)
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode()
+            return e.code, (json.loads(raw) if raw.startswith(("{", "[")) else raw)
+
+    @staticmethod
+    def _http(key):
+        return km._PERF_STATS.snapshot()["http"].get(key, {"count": 0, "ms": 0.0})
+
+    def test_get_perf_serves_the_snapshot(self):
+        with _HttpWatch() as w:
+            st, snap = self._req("GET", "/perf")
+            self.assertEqual(st, 200)
+            self.assertEqual(set(snap), TOP_KEYS)
+            self.assertIs(snap["log"], False)
+            self.assertEqual(snap["process"]["pid"], os.getpid())
+            self.assertTrue(w.wait_for("GET /perf", 1), "the request's own record lands after the response")
+            st, snap2 = self._req("GET", "/perf?x=1")
+        self.assertEqual(st, 200)
+        self.assertGreaterEqual(snap2["http"]["GET /perf"]["count"], 1, "counted under METHOD /path, query stripped")
+        self.assertFalse([k for k in snap2["http"] if "?" in k])
+
+    def test_get_perf_requires_the_token(self):
+        st, body = self._req("GET", "/perf", token=False)
+        self.assertEqual(st, 403)
+        self.assertNotIn("cycles", str(body))
+
+    def test_post_perf_requires_the_token(self):
+        st, body = self._req("POST", "/perf", {"log": True}, token=False)
+        self.assertEqual(st, 403)
+        self.assertFalse(km._PERF, "a refused POST flips nothing")
+
+    def test_post_perf_flips_the_log_and_perf_emits_only_after(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "", "off before the POST")
+        with redirect_stderr(io.StringIO()):                 # the route's own "log on" notice goes to stderr
+            st, r = self._req("POST", "/perf", {"log": True})
+        self.assertEqual((st, r), (200, {"ok": True, "log": True}))
+        self.assertTrue(km._PERF)
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "romp-perf probe n=1\n", "on after the POST, no restart")
+        st, snap = self._req("GET", "/perf")
+        self.assertIs(snap["log"], True, "the snapshot reports the switch")
+        with redirect_stderr(io.StringIO()):
+            st, r = self._req("POST", "/perf", {"log": False})
+        self.assertEqual((st, r), (200, {"ok": True, "log": False}))
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_post_perf_refuses_a_malformed_body(self):
+        for body in ({}, {"log": "yes"}, {"log": 1}, [], "log"):
+            st, r = self._req("POST", "/perf", body)
+            self.assertEqual(st, 400, body)
+            self.assertFalse(r["ok"])
+        self.assertFalse(km._PERF)
+
+    def test_the_routes_sit_after_the_gate_in_the_source(self):
+        get = inspect.getsource(km.Handler.do_GET)
+        gate = "ok, self._set_cookie, why = self._authorize(q)"
+        self.assertEqual(get.count(gate), 1)
+        self.assertGreater(get.index('p == "/perf"'), get.index(gate))
+        post = inspect.getsource(km.Handler.do_POST)
+        self.assertEqual(post.count(gate), 1)
+        self.assertGreater(post.index('u.path == "/perf"'), post.index(gate))
+
+    def test_every_request_is_timed_per_method_and_path(self):
+        before = self._http("GET /version")
+        with _HttpWatch() as w:
+            self._req("GET", "/version?probe=1", token=False)   # an exempt route counts too
+            self._req("GET", "/version", token=False)
+            self.assertTrue(w.wait_for("GET /version", 2), "both records landed (waited on, not raced)")
+        after = self._http("GET /version")
+        self.assertEqual(after["count"], before["count"] + 2)
+        self.assertGreater(after["ms"], before["ms"])
+
+    def test_head_and_options_are_counted_too(self):
+        head0, opt0 = self._http("HEAD /version"), self._http("OPTIONS /perf")
+        with _HttpWatch() as w:
+            self._req("HEAD", "/version", token=False)
+            self._req("OPTIONS", "/perf")
+            self.assertTrue(w.wait_for("HEAD /version", 1))
+            self.assertTrue(w.wait_for("OPTIONS /perf", 1))
+        self.assertEqual(self._http("HEAD /version")["count"], head0["count"] + 1, "a /file probe storm is visible")
+        self.assertEqual(self._http("OPTIONS /perf")["count"], opt0["count"] + 1, "a preflight burst is visible")
+
+    def test_a_ws_upgrade_is_counted_when_it_arrives(self):
+        # the wrapper on a stand-in handler: for a /ws path the count is taken BEFORE the handler runs,
+        # since do_GET returns only when the socket closes, and no time is added after
+        seen = {}
+
+        class H:
+            path = "/ws?token=x"
+            command = "GET"
+
+            @km._perf_http_timed
+            def do_GET(self):
+                seen["during"] = PerfRoutes._http("GET /ws")["count"]
+        before = self._http("GET /ws")
+        H().do_GET()
+        after = self._http("GET /ws")
+        self.assertEqual(seen["during"], before["count"] + 1, "counted at arrival, not at socket close")
+        self.assertEqual(after["count"], before["count"] + 1, "and not a second time in the finally")
+        self.assertEqual(after["ms"], before["ms"], "a socket's lifetime is not a request time")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -712,10 +712,10 @@ class TwoThreadsOneClient(unittest.TestCase):
         gate, inside = threading.Event(), threading.Event()
         real = km._send_client
 
-        def parked(c, key, msg, pre=None, sig=None):    # the tail branch was chosen; park before the bytes go
-            inside.set()
+        def parked(c, key, msg, pre=None, sig=None, **kw):    # the tail branch was chosen; park before the bytes go
+            inside.set()                                    # (**kw: the tail send names its /perf kind, "delta")
             gate.wait(5)
-            return real(c, key, msg, pre=pre, sig=sig)
+            return real(c, key, msg, pre=pre, sig=sig, **kw)
         done = []
         with mock.patch.object(km, "_send_client", parked):
             ts = threading.Thread(target=lambda: km._send_chat(client, m, None, 1, False), daemon=True); ts.start()


### PR DESCRIPTION
## Summary

The kernel now keeps performance counters at all times and serves them at `GET /perf`. `romp perf` prints the difference between two snapshots as rates on one screen, and `POST /perf {"log": bool}` turns the `romp-perf` stderr log on or off in the running kernel. Additive: no existing route, payload or frame changes.

## Why

The kernel is one CPython process. With a few dozen sessions it can average a full core, and the only instrumentation is the `ROMP_PERF` stderr log, read once at import. Turning it on means a restart, and where sessions run inside the kernel a restart cuts every open turn. Profiling otherwise means a hand-run profiler under sudo, which is how the pusher CPU fixes of 2026-08-10 were each checked. This makes the check a command: restart, run `romp perf`, read the rates.

## What is counted

`_PerfStats` is one lock and a few dict increments on the hot paths; nothing is formatted or serialized until a read.

- Pusher cycles and wakes (event vs the 0.5 s backstop), a 256-entry ring of cycle durations for p50/p90 at read time, and the pusher thread's own CPU (`time.thread_time`, so the tmux fork is excluded).
- Per-stage ms: `jobs`, `push`, and inside `_push` the `push.chat`, `push.feed`, `push.timeline` and `push.send` blocks.
- Chat, feed and timeline builds served from cache vs rebuilt, with rebuild time.
- Bytes per slot as full, delta and deduped frames. A deduped frame was built and compared, then not sent.
- Goal-store loads, saves and writes (`judge.goal_io_stats`). A byte-identical republish is a save without a write.
- Judge passes with wall and CPU: the tier threads from `_run_tier`, plus the pool workers through a timed `ThreadPoolExecutor` subclass.
- HTTP count and ms per `METHOD /path`, query string stripped, with `/dist/*`, `/media/*` and `/remote/*/…` collapsed to one key each, 64 keys then `other`. A WebSocket upgrade is counted when it arrives and not timed, since its handler runs for the life of the socket.
- rss, thread count, process CPU, pid.

## Payload contract

`GET /perf` returns one JSON document with exactly these twelve top-level keys. Every value is a number or a flat map of numbers; `ms` is milliseconds of wall time, `*_s` seconds.

| key | contents |
|---|---|
| `now`, `since`, `uptime_s`, `log` | the clock; when the counters started (a restart resets them); seconds since process start; whether the romp-perf log is on |
| `process` | `rss_kb`, `threads`, `cpu_s`, `pid` |
| `pusher` | `cycles`, `wakes`, `wakes_event`, `wakes_backstop`, `cycle_ms_sum`, `cycle_ms_max`, `cycle_ms_last`, `cycle_cpu_ms_sum`; from the ring: `cycle_ms_p50`, `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` |
| `stages_ms` | `jobs`, `push`, `push.chat`, `push.feed`, `push.timeline`, `push.send` |
| `builds` | `chat`, `feed`, `timeline`, each `{cached, built, ms}` |
| `sends` | `full`, `delta`, `deduped`, each `{slot: {count, bytes}}` (at most 32 slots, then `other`) |
| `goals` | `loads`, `saves`, `writes` |
| `judge` | `passes`, `ms_sum`, `ms_last`, `ms_mean`, `cpu_ms_sum`, `cpu_ms_workers` |
| `http` | `"METHOD /path"` to `{count, ms}` (at most 64 keys, then `other`) |

Counters are lifetime totals since process start; a consumer subtracts two snapshots. `since` and `process.pid` identify the process, so a restart between snapshots is detectable (`romp perf` refuses to subtract across one). The `push.*` stages are measured inside `_push` for every caller, connect pushes on handler threads included, so their sum can exceed `push`. Adding a key later is compatible; renaming or removing one breaks `romp perf` and any script reading the document. The same field list is in `docs/reference.md` under "Kernel performance counters".

## `romp perf`

`romp perf [--interval N]` takes two snapshots N seconds apart (default 10) and prints rates. `--json` prints one raw snapshot. `romp perf log on|off` posts the toggle and prints where the lines land (`journalctl` under systemd, `manager.log` under launchd). Sample output from the test fixture's synthetic snapshots:

```
romp perf: 10.0 s window, kernel up 1m50s, pid 4242, romp-perf log off
process   rss 410 MB   threads 41   cpu 5.0% of one core (pusher 3.0%, judge 0.5%, other 1.5%)
pusher    2.00 cycles/s   6.00 wakes/s (event 50, backstop 10)   busy 60% of wall
cycle ms  p50 190   p90 420   max 700 (over the last 120 cycles)   last 250
stages    jobs  17%   push  67%  (chat  50%  feed  10%  timeline   3%  send   2%)
builds    chat 2 built / 18 cached (40 ms avg)   feed 2 built / 18 cached (500 ms avg)   timeline 1 built / 19 cached (800 ms avg)
sends     full 102 KB/s (chat 2 frames 102 KB/s)   delta 1 KB/s (chat 20 frames 1 KB/s)   deduped 176 KB/s (feed 18 frames 176 KB/s)
goals     10.0 loads/s   2.0 saves/s   0.5 writes/s
judge     2 passes (0.20/s)   last 1200 ms   mean 1200 ms
http      GET /tick 5 (0.5 ms avg)   GET /ws 3
```

Same contract as `romp sessions`: the token on stdin, a dead kernel fails loudly, an unknown flag is refused. Two refusals are this verb's own: snapshots from two kernel processes are refused rather than subtracted into negative rates, and a refused token (403) is named as such. `curl -f` folds a 403 into the same exit as a dead kernel, so the status rides `-w` and the script reads it.

## Design points for review

- `kernel/judge.py` rebinds its module-level name `ThreadPoolExecutor` to the timed subclass, so every pool site in the module is covered without editing them. The subclass passes `issubclass` against the stdlib class. A per-site change is a dozen edits doing the same thing; I can make it explicit if you prefer.
- `_pusher_wake` becomes a `threading.Event` subclass whose `set()` also counts, so every call site and the bound-method callbacks the backends hold (`push=_pusher_wake.set`) stay as they are, and the tests that pin `_pusher_wake.set()` in the source still pass.
- The `do_*` methods are wrapped with `functools.wraps`; `inspect.getsource` unwraps, so the auth tests that read the route tables keep reading them.
- `_send_client` gains an optional `kind="full"`; the chat tail passes `"delta"`. No other signature changes.
- The HTTP wrapper records in a `finally` after the response is on the wire; the tests wait for the record instead of reading the snapshot right after `urlopen` returns.
- The uncached chatbuild `_perf` line now evaluates its keyword arguments only when the log is on.

## macOS

`_process_stats` reads `/proc/self/status` for rss and falls back to `ru_maxrss` where `/proc` is absent, which is the peak and in bytes on macOS, so it is scaled to KB there. The fallback is tested with `/proc` made to fail and `sys.platform` patched to `darwin`. The CLI's log hint picks `tail -f …/manager.log` under a `uname` stub that answers `Darwin`. `time.thread_time` and `resource` exist on both platforms; nothing else is OS-specific.

## Tests

- `tests/test_perf_stats.py` (40 tests): the collector's shape and writers; ring percentiles and the slot and path caps; the counted `_pusher_wake`; the log toggle; goal-store I/O on a private synthetic sid; judge CPU through the timed pool and `_run_tier`; send classes on whole-frame, delta-capable and chat-tail clients; stage and build counters through the real `_push` and `_pusher_cycle_jobs`; `GET`/`POST /perf` through the real `Handler` (auth refusal, malformed bodies, every method counted, the WebSocket arrival count); the `_process_stats` fallback on both branches.
- `tests/romp-perf.bats` (15 tests): rates from two stub snapshots, the restart refusal, `--json`, the token on stdin twice and never in argv, `log on|off` with the systemd and launchd hints, a dead kernel, a 403, bad flags, the help row.
- `tests/test_view_deltas.py`: the `_send_client` shim accepts the new keyword.
- `tests/test_color_route.py` (in the tests commit, unrelated to the counters): the test sends `km.TOKEN` instead of `os.environ["ROMP_SERVE_TOKEN"]`. pytest imports every collected module before any test runs and `tests/test_kernel.py` assigns the variable at import, so a small-subset run that collected this module first had its kernel capture one value and the request carry another, and got a 403. I can split it out if you want the PR pure.

Against the base, 39 of the 40 Python tests fail (the one that passes pins `_perf`'s existing off-path source), all 15 bats tests fail, and the base view-deltas shim raises `TypeError` on `kind=`. On this branch: full `pytest tests/ -n 8` 7627 passed, 46 skipped; the four bats files above all pass; `npm run typecheck` clean (no UI files change).

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)