### PR TITLE
PR references in rendered text link to their GitHub pull request

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -45,6 +45,10 @@ never been pushed is asked of origin once and the answer kept until a push or fe
 clone writes its tracking ref; where nothing local could refresh the answer (a
 `--single-branch` clone, or a branch on origin this clone has not fetched) origin is asked on
 each open.
+A pull request number in a message, a card, or a note (`#123`, `PR #123`, or
+`owner/repo#123`) links to that pull request on GitHub, in the repository the session's
+directory has as its `origin` remote; when that remote is not on GitHub, the number stays
+plain text.
 
 **Opening a markdown document.** A markdown link in the chat opens in the file viewer,
 rendered, with **Raw** one click away — a path on the session's machine, or a link to a

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2717,12 +2717,19 @@ def _clear_unresolved_live_note(sid):
 
 
 def _tab_order_frame(order, tabs, live):
-    """The ONE tabOrder frame shape (T258): the shared order, the tabs meta, the viewer's views blob, and
-    `live` — the sids the kernel affirms are LIVE this build (raw tmux/SDK liveness, independent of whether
-    discover could resolve each one's transcript). The pane keeps a live sid on the strip even if this frame's
-    `order` omits it: a transient read failure that drops a session from the order is not a close (render.ts
-    applyTabOrder). Older clients ignore the extra field."""
-    return {"type": "tabOrder", "order": list(order), "tabs": tabs,
+    """The ONE tabOrder frame shape (T258) for its four senders (the pusher's tabs-first send, _push_session_now,
+    _confirm_close_now, and the WS 'ready' handler's connect-time frame): the shared order, the tabs meta, the
+    viewer's views blob, `live` — the sids the kernel affirms are LIVE this build (raw tmux/SDK liveness,
+    independent of whether discover could resolve each one's transcript) — and `selfHost`, this kernel's own
+    name (_self_host). The pane keeps a live sid on the strip even if this frame's `order` omits it: a
+    transient read failure that drops a session from the order is not a close (render.ts applyTabOrder). The
+    chat reads a postal card's sender host against `selfHost` (its postalSenderHost). The session frame
+    carries the name too, but only a LOCAL session's frame teaches it, so a dashboard whose kernel runs no
+    sessions of its own — every session attached from elsewhere — never learned it until the + picker was
+    opened, and a remote card stamped with this kernel's name stayed plain text (review find, 2026-09-06).
+    Every chat client receives a tabOrder frame, first of all on connect (tabs-first), so the name is known
+    before any card renders. Older clients ignore the extra fields."""
+    return {"type": "tabOrder", "order": list(order), "tabs": tabs, "selfHost": _self_host(),
             "views": _views_client(), "live": sorted({str(x) for x in live})}
 
 
@@ -23455,7 +23462,10 @@ def _postal_index():
             continue
         if o.get("ev") == "sent" and o.get("id"):
             idx[o["id"]] = {"id": o["id"], "from": o.get("from", "?"), "fromId": o.get("from_id", ""),
-                            "fromHost": o.get("from_host", ""),
+                            # the sender's host as the log stamped it: "" for this kernel's own sessions,
+                            # a peer's name for relayed mail — and None when the row carries NO field, a
+                            # row from before the field existed, whose sender could be either (2026-09-06)
+                            "fromHost": o.get("from_host"),
                             "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
                             "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
     _postal_index_memo[0] = (key, idx, _postal_body_map(idx))
@@ -23677,12 +23687,21 @@ def _hydrate_postal(events, index, sid=None):
                         frm = _name_of(rec["fromId"]) or (
                             (rec.get("fromHost", "") + ":" if rec.get("fromHost") else "")
                             + (rec["fromId"][:8] if rec["fromId"] else "?"))
-                    cards.append({"kind": "postal-service", "direction": "in", "peer": frm,
-                                  "color": _name_color(rec["fromId"]) if rec["fromId"] else None,
-                                  "body": rec["body"], "summary": caption_for(rec["id"]),   # incoming caption (full body on expand)
-                                  "intent": _postal_intent(rec.get("kind"), rec.get("body")),
-                                  "mid": rec["id"], "t": rec["t"] or None,
-                                  "park": rec["park"], "ts": ev.get("ts"), "uuid": ev.get("uuid")})
+                    card = {"kind": "postal-service", "direction": "in", "peer": frm,
+                            "color": _name_color(rec["fromId"]) if rec["fromId"] else None,
+                            "body": rec["body"], "summary": caption_for(rec["id"]),   # incoming caption (full body on expand)
+                            "intent": _postal_intent(rec.get("kind"), rec.get("body")),
+                            "mid": rec["id"], "t": rec["t"] or None,
+                            "park": rec["park"], "ts": ev.get("ts"), "uuid": ev.get("uuid")}
+                    if rec.get("fromHost") is not None:
+                        # the sender's HOST as the log stamped it ("" = this kernel's own): the chat resolves
+                        # the sender's repository for the body's PR links by host AND name, so a remote
+                        # homonym never borrows a local session's repo (review find, 2026-09-06). A row with
+                        # NO field — from before the log stamped one — gets no peerHost: the chat then
+                        # resolves the name alone, as it did before the field, rather than reading absence
+                        # as "this kernel's own" and presenting a pre-field remote sender as local
+                        card["peerHost"] = rec["fromHost"]
+                    cards.append(card)
             if len(cards) == len(ids):                   # all-or-nothing: a partial log never half-renders
                 out.extend(cards); continue
             # NOT every id resolved. The turn still passes through unhydrated — a half-rendered card run
@@ -28996,6 +29015,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
             # (ui/webview/pr-links.ts; the user 2026-09-06). Top-level like gitBranch, so it is never
             # windowed off the wire; a memoized store-derived value, so the dedup-compared payload holds.
             "githubRepo": _github_repo_of(scwd),
+            # this machine's name, as its peers know it (_self_host; the feed frame carries the same): the
+            # chat reads an inbound postal card's sender host against it (a card stamped with the viewing
+            # kernel's own name resolves to ITS sessions). It learned the name only from the + picker's
+            # reply before, so that reading was inert until the picker had been opened (review find,
+            # 2026-09-06). Stable, so the dedup-compared payload holds.
+            "selfHost": _self_host(),
             "events": events, "status": status, "ledger": ledger,
             # SDK sessions gate the box on the backend's LIVE task set (the CLI's task lifecycle stream —
             # authoritative, terminal-cleared); the spawned_at heuristic remains the tmux/no-snapshot fallback.
@@ -36458,6 +36483,7 @@ def _note_chat_divergence(sid, name, chat_state, row_state, now):
             f.write(json.dumps(rec) + "\n")
     except OSError:
         pass
+
 
 
 def _push(targets, connect=False, tmux=None):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2166,6 +2166,26 @@ def _cwd_of(sid):
     return parts[1] if parts and len(parts) > 1 else ""
 
 
+def _session_cwd(sid, path=None, meta=None):
+    """The directory a session works in, for EVERY frame that names it or derives from it (the chat frame's
+    cwd, gitBranch and githubRepo; the feed's per-session githubRepo): the registry's dir FIRST, the
+    transcript's cwd stamp only as a fallback. The registry is known before the first turn and a move
+    rewrites it at once, while the transcript keeps stamping the old cwd until the model's next turn (and
+    its per-record stamp is the CLI's TRACKED cwd, which a shell `cd` inside a Bash call also moves) — so
+    the registry is the project directory whenever it exists. The stamp matters for a session romp never
+    registered (discovered from its transcript alone, opened read-only): with the registry empty it is the
+    only source, and one derivation here keeps the chat frame and the feed's session rows in agreement —
+    they disagreed when the feed read _cwd_of alone, so `#123` linked in the chat but not on the same
+    session's cards (review find, 2026-09-06). `meta` is a _session_meta already in hand; else it is read
+    from `path` (cached per transcript). "" when neither source names one."""
+    cwd = _cwd_of(sid)
+    if cwd:
+        return cwd
+    if meta is None and path:
+        meta = _session_meta(path)
+    return (meta or {}).get("cwd") or ""
+
+
 def _identity_of(sid):
     """The session's identity colors (bg, fg) from the names registry (3rd/4th tab fields), or ("", ""). Written
     at launch for BOTH backends (tmux launcher + SDK write_name), so it's available without shelling tmux —
@@ -26643,34 +26663,226 @@ def _norm_branch(br):
     return "" if br == "HEAD" else br
 
 
-_tree_cache = {}   # dir -> git toplevel ("" = not a repo) — where a path's tree ROOT is; branch stays live
+_tree_cache = {}   # dir -> (git toplevel or "", the evidence the verdict was filed on, whether that is the toplevel's own .git) — see _tree_of
+_pointer_cache = {}   # a worktree's `.git` pointer FILE -> ((its mtime, inode, device), the gitdir it names) — see _pointer_gitdir
+_top_shape = {}   # toplevel -> the verdict key of its OWN `.git` entry, which its per-tree memos stand under — see _vouch_tree
+
+
+def _pointer_gitdir(dotgit, mt, ino, dev, strict=False):
+    """The directory a worktree's (or a submodule's) `.git` pointer FILE names — its one line is
+    'gitdir: <private-dir>', resolved against the tree when relative — read ONCE per (path, mtime, inode,
+    device): git never rewrites the pointer in normal use (`git worktree repair` does, and that moves the
+    mtime), so the memo holds for the tree's life. The inode and device are in the key because the mtime
+    alone is not the file's identity: one clone's worktree rm -rf'd and another's added at the same path
+    within one mtime tick — a second on HFS+, two on FAT — kept the first clone's target for the kernel's
+    life (review find, 2026-09-06). A re-made pointer is a new file, told apart by the stat the chain walk
+    already made, at no cost; what remains is a filesystem handing the freed inode number straight back
+    within the same tick. Re-read per call, the pointer made a worktree cwd — this repo's own convention,
+    so the shape most builds pay — cost five stats and a file read per _tree_of call against a plain
+    toplevel's two stats (review find, 2026-09-06); it is three stats and no read now. '' for a malformed
+    pointer, memoized (the content is what it is until the file changes); '' and NOT memoized when the
+    file cannot be read — or, `strict`, that OSError raised, for the one reader that names the fault to
+    the operator (_git_head_file). The line is read as BYTES and decoded by the filesystem's own rule
+    (os.fsdecode, surrogateescape), the way git writes and follows it: a non-UTF-8 byte in a path
+    component is a valid worktree, not a torn file, and every os.* call round-trips the bytes; a text-mode
+    read raised UnicodeDecodeError through the push cycle instead (#1028)."""
+    key = (mt, ino, dev)
+    hit = _pointer_cache.get(dotgit)
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    try:
+        with open(dotgit, "rb") as f:
+            line = os.fsdecode(f.readline()).strip()
+    except OSError:
+        if strict:
+            raise
+        return ""
+    gd = ""
+    if line.startswith("gitdir:"):
+        rel = line[len("gitdir:"):].strip()
+        if rel:
+            gd = rel if os.path.isabs(rel) else os.path.normpath(os.path.join(os.path.dirname(dotgit), rel))
+    if len(_pointer_cache) > 512:                        # bounded, like _tree_cache
+        _pointer_cache.clear()
+    _pointer_cache[dotgit] = (key, gd)
+    return gd
+
+
+def _gitdir_of(top, strict=False):
+    """The git directory behind `top/.git`: the entry itself when it is a directory; for a WORKTREE (or a
+    submodule), whose .git is a one-line FILE, the directory that line names (_pointer_gitdir). '' when
+    there is neither. ONE stat — the entry's kind is read off it, where isdir-then-isfile cost two — and
+    the memoized pointer read. The one reader of the pointer for the HEAD file, the config file and
+    _tree_of's evidence, which each parsed it on their own before. `strict` is _pointer_gitdir's: an
+    unreadable pointer file raises its OSError instead of reading as ''."""
+    dotgit = os.path.join(top, ".git")
+    try:
+        st = os.stat(dotgit)
+    except OSError:
+        return ""
+    if stat.S_ISDIR(st.st_mode):
+        return dotgit
+    if stat.S_ISREG(st.st_mode):
+        return _pointer_gitdir(dotgit, st.st_mtime, st.st_ino, st.st_dev, strict)
+    return ""
+
+
+def _is_bare_gitdir(d):
+    """Is `d` itself a git directory — a BARE repository, or a `.git` directory registered as a cwd? git's
+    own test for one (is_git_directory): HEAD, objects/ and refs/ at the path. One stat when it is not."""
+    return (os.path.isfile(os.path.join(d, "HEAD")) and os.path.isdir(os.path.join(d, "objects"))
+            and os.path.isdir(os.path.join(d, "refs")))
+
+
+def _dotgit_on_chain(d):
+    """The first `.git` entry (a directory, or a worktree's pointer file) at `d` or an ancestor, as
+    evidence — (path, mtime, is_pointer_file, inode, device), everything the one stat says that a verdict
+    key may need (_verdict_key) — or None when the chain carries none. One stat per path component up to
+    the hit, no fork. This is NOT git's discovery, only a reason to run it: the walk is
+    lexical (abspath; git walks the physical path), stops at neither GIT_CEILING_DIRECTORIES nor a
+    filesystem boundary, and validates nothing — an empty `.git` directory, or a pointer whose gitdir is
+    gone (a worktree whose main clone was removed), is an entry here and a rejection from git. _tree_of
+    keys its verdict on this evidence, so a `.git` git rejects costs one fork, not one per call."""
+    p = os.path.abspath(d)
+    while True:
+        dg = os.path.join(p, ".git")
+        try:
+            st = os.stat(dg)
+        except OSError:
+            st = None
+        if st is not None:
+            return dg, st.st_mtime, stat.S_ISREG(st.st_mode), st.st_ino, st.st_dev
+        parent = os.path.dirname(p)
+        if parent == p:
+            return None
+        p = parent
+
+
+def _own_dotgit(ev, top):
+    """Is the chain's `.git` entry the found toplevel's OWN — `top/.git` — rather than one git's discovery
+    walked PAST: an empty or otherwise invalid `.git` directory below the toplevel, which git skips and
+    continues upward from? Lexical first (the evidence path is an abspath, git's toplevel a physical path),
+    realpath only when they differ, so a cwd reached through a symlink is still the toplevel's own — and
+    the link re-pointed at another repository is caught by the key, not here: the entry's inode is in it
+    (_verdict_key). Decided once per verdict, on _tree_of's miss path — never per call."""
+    if not top or ev is None:
+        return False
+    d = os.path.dirname(ev[0])
+    return d == top or os.path.realpath(d) == top
+
+
+def _verdict_key(ev, own):
+    """The part of the chain evidence (_dotgit_on_chain) a verdict is filed on, and holds while it is equal.
+    A pointer FILE is keyed on its path, its mtime, its inode and device, and whether the gitdir it names
+    exists, found or not: git never rewrites the pointer in normal use (`git worktree repair` does, and
+    that moves the mtime), a pointer re-made at the same path within one mtime tick is a new file (the
+    inode; review find, 2026-09-06), and its target vanishing (the main clone removed) or reappearing
+    (restored from a backup, the pointer untouched) is exactly what flips git's answer. A `.git`
+    DIRECTORY that is the found toplevel's OWN (`own`, _own_dotgit) is keyed on its path and its identity
+    — inode and device — never its mtime, which churns with every index write: a cwd that is a symlink,
+    or under one, re-pointed at another repository stats a different directory under the same lexical
+    path, and keyed on the path alone it served the old toplevel, branch and repo for the kernel's life
+    (review find, 2026-09-06). Any other directory entry is keyed on its path and mtime, which `git init`
+    filling it moves: one git rejected with no repo above, and one git walked PAST on its way to a
+    toplevel above (an empty `.git` below a valid repo — git skips an invalid directory and continues
+    upward). Keyed on its path alone like the toplevel's own, the walked-past entry served the parent's
+    toplevel, branch and repo forever once `git init` made it a repository of its own (review find,
+    2026-09-06). None when the chain carries no `.git`."""
+    if ev is None:
+        return None
+    path, mt, is_file, ino, dev = ev
+    if is_file:
+        gd = _pointer_gitdir(path, mt, ino, dev)
+        return path, mt, ino, dev, bool(gd) and os.path.isdir(gd)
+    return (path, ino, dev) if own else (path, mt)
+
+
+def _vouch_tree(top):
+    """Called when git has just named `top` as a toplevel: the shape of the tree's OWN `.git` entry — its
+    verdict key: a directory's path; a pointer's path, mtime and whether its target exists — is compared
+    with the shape the tree's per-tree memos (HEAD path, config path, branch, repo) were filed under, and
+    a DIFFERENT shape forgets them. The re-ask that led here is the one event that says the tree behind
+    `top` may have changed: a worktree rm -rf'd and re-made as a plain clone at the same path (the old
+    clone still lists it under .git/worktrees/<name>, so the memoized HEAD and config paths inside THAT
+    clone still resolved and were trusted — the dead worktree's branch and the old clone's repo on every
+    build for the kernel's life, and `git worktree prune` leaves the clone's own config where it is;
+    review find, 2026-09-06), or one clone's worktree replaced by another's. A shape that differs from
+    the record forgets, and so does NO record: the bound below clears every record with every memo, and
+    _tree_of's hit path then refills a live tree's memos with nothing vouching for them, so a re-ask that
+    finds no record must treat the memos as unvouched — read as "unchanged", a reshape whose re-ask was
+    the tree's first after the bound served the dead worktree's branch and the old clone's repo for the
+    kernel's life, the bug above re-opened for every tree at once (review find, 2026-09-06). A first ask
+    for a brand-new tree pops empty memos, a no-op; a subdirectory asked about for the first time under a
+    memoized tree finds its record equal and costs no fork."""
+    shape = _verdict_key(_dotgit_on_chain(top), True)
+    if top not in _top_shape or _top_shape[top] != shape:
+        for memo in (_head_path_cache, _config_path_cache, _branch_cache, _repo_cache):
+            memo.pop(top, None)
+    if len(_top_shape) > 512:                            # bounded; a memo never outlives the shape vouching for it
+        _top_shape.clear()
+        for memo in (_head_path_cache, _config_path_cache, _branch_cache, _repo_cache):
+            memo.clear()
+    _top_shape[top] = shape
 
 
 def _tree_of(d):
-    """(toplevel, branch) of the git tree containing directory `d`, ("", "") when not in one. The toplevel
-    mapping is cached per directory (it changes only if the tree is moved/deleted — then the branch read
-    below comes back empty and every consumer hides the row); the branch rides _git_branch's own
-    HEAD-mtime cache so it stays current without a second discipline."""
+    """(toplevel, branch) of the git tree containing directory `d`, ("", "") when not in one. The verdict is
+    cached per directory WITH THE EVIDENCE it was reached under — the first `.git` on the chain from `d`
+    upward (_dotgit_on_chain), reduced to the part that decides git's answer (_verdict_key) — and trusted
+    while that evidence holds, so a build costs stats and never a fork until something on the chain
+    changes:
+      * a FOUND toplevel re-asks git when its `.git` entry goes (the tree deleted or moved: the walk reaches
+        another entry or none), changes kind (a plain repo replaced by a worktree at the same path, or the
+        reverse) or identity (a symlinked cwd re-pointed at another repository: the entry's inode is in
+        the key), or — for a worktree — when its pointer is rewritten or re-made (its mtime or inode) or
+        the clone it names disappears; a nested repo appearing below the toplevel re-asks too, and so does
+        `git init` filling an empty `.git` that git had walked past (that entry keeps its mtime in the key
+        — _verdict_key). A re-ask that names a toplevel whose own `.git` changed shape forgets that tree's
+        HEAD, config, branch and repo memos (_vouch_tree), so a worktree re-made as a plain clone shows the
+        clone's branch and repo, not the dead worktree's. Before, a found toplevel was trusted for the life
+        of the kernel and a dead one served a stale branch and repo, or forked per build (review find,
+        2026-09-06);
+      * a NOT-A-REPO verdict re-asks when a `.git` appears on the chain, or the one git rejected changes
+        (its mtime, or a pointer's target coming back). So a directory becoming a tree the moment the
+        session runs `git init` (then `gh repo create`) is found on the next call — a cached "" once kept
+        its GitHub repo (and every tree-derived row) hidden until a kernel restart while gitBranch,
+        re-derived per build, showed normally (review find, 2026-09-06) — while a `.git` that git REJECTS
+        (an empty directory; a worktree pointer whose main clone was removed, which this repo's own
+        worktree convention produces) is asked about once and then costs stats only: re-validating it by
+        the entry's mere presence forked `git rev-parse` on every call, forever (review find, 2026-09-06).
+    A git failure that is not a verdict — a timeout, no git binary — caches nothing: the next call asks
+    again rather than serving an answer git never gave. The branch rides _tree_branch's own HEAD-mtime
+    memo so it stays current without a second discipline. Counted, a memoized call costs two stats for a
+    plain toplevel and three for a worktree's (the chain's one, the pointer target's, HEAD's — the pointer
+    itself is read once per mtime, _pointer_gitdir), plus one per directory between the cwd and its
+    `.git`; never a read, never a fork."""
     if not d:
         return "", ""
-    top = _tree_cache.get(d)
-    if top is None:
-        top = ""
+    ev = _dotgit_on_chain(d)
+    hit = _tree_cache.get(d)
+    # the verdict is stored with whether its `.git` entry was the found toplevel's own (_own_dotgit), so the
+    # recomputed key is built the way the stored one was and compares like with like; an entry that
+    # changed kind compares unequal
+    if hit is not None and hit[1] == _verdict_key(ev, hit[2]):
+        top = hit[0]
+    else:
         try:
             r = subprocess.run(["git", "-C", d, "rev-parse", "--show-toplevel"],
                                capture_output=True, text=True, timeout=2)
-            if r.returncode == 0:
-                top = r.stdout.strip()
         except Exception:
-            top = ""
+            return "", ""                              # not git's answer: nothing to cache
+        top = r.stdout.strip() if r.returncode == 0 else ""
+        if top:
+            _vouch_tree(top)                           # BEFORE the branch below reads the tree's memos
         if len(_tree_cache) > 512:                     # bounded: distinct edit dirs, not unbounded growth
             _tree_cache.clear()
-        _tree_cache[d] = top
-    return top, (_git_branch(top) if top else "")
+        own = _own_dotgit(ev, top)
+        _tree_cache[d] = (top, _verdict_key(ev, own), own)
+    return top, (_tree_branch(top) if top else "")
 
 
-_branch_cache = {}   # cwd -> (branch, head_mtime) — git branch derived straight from the FOLDER
-_head_path_cache = {}   # cwd -> the resolved HEAD file path (worktrees indirect through a .git FILE)
+_branch_cache = {}   # toplevel -> (branch, head_mtime) — git branch derived straight from the FOLDER
+_head_path_cache = {}   # toplevel -> the resolved HEAD file path (worktrees indirect through a .git FILE)
 _git_file_faults = {}   # .git pointer-file path -> the fault text of its CURRENT episode; ONE stderr line + bell row per episode
 _git_file_faults_lock = threading.Lock()   # the pusher and a connect push both run _push, on their own threads
 
@@ -26705,75 +26917,179 @@ def _git_head_file(cwd):
     that private dir. Resolved once per cwd (the pointer never moves for a live worktree) — treating the
     worktree shape as uncacheable made _git_branch fork 2-3 `git rev-parse` per session per rebuild
     forever, ~10-40 forks/s on a busy kernel whose convention is one worktree per session (the Mac 66%
-    CPU burn, 2026-08-16, sampled as __fork at 68/2s). '' when there is no resolvable HEAD."""
+    CPU burn, 2026-08-16, sampled as __fork at 68/2s). A BARE repository is its own git directory — HEAD,
+    objects/ and refs/ at the directory itself (_is_bare_gitdir), no `.git` and no work tree — so its HEAD
+    is `cwd/HEAD`: the branch HEAD names shows for a session registered in a bare clone (a
+    bare-plus-worktrees layout), as it did when `_git_branch` forked the query there per build (review
+    find, 2026-09-06). '' when there is no resolvable HEAD — and that answer is NOT memoized: a directory
+    with no `.git` today may carry one on the next call, and the re-resolution is two stats. A memoized
+    path that stops resolving is evicted by its reader (_pointer_mtime). A pointer FILE that cannot be
+    followed — unreadable, or naming a gitdir with no HEAD (torn, or its clone removed) — is '' too, NOT
+    memoized, and named ONCE per fault episode on stderr and the dashboard bell (_git_file_fault): a
+    blank branch alone hid WHICH file, and one undecodable byte in one pointer once raised through the
+    push cycle and staled every pane (#1028). A clean read ends the episode; the pointer's content rides
+    _pointer_gitdir's memo, so the re-check a repair needs is the target's stat, not a read."""
     hp = _head_path_cache.get(cwd)
-    if hp is not None:
+    if hp:
         return hp
-    hp = ""
     dotgit = os.path.join(cwd, ".git")
     try:
-        if os.path.isdir(dotgit):
-            hp = os.path.join(dotgit, "HEAD")
-        elif os.path.isfile(dotgit):
-            # git writes the gitdir path RAW and follows it raw, so the pointer is read as BYTES and decoded
-            # by the filesystem's own rule (os.fsdecode, surrogateescape): a non-UTF-8 byte in a path
-            # component is a valid worktree, not a torn file, and every os.* call below round-trips the
-            # bytes. A strict text-mode read faulted on exactly that case: a false stderr line, no HEAD
-            # path cached (one `git rev-parse` fork per rebuild of that session, the burn this cache exists
-            # to stop) and a file-index key with no git-index mtime (review find, 2026-09-08).
-            with open(dotgit, "rb") as f:
-                line = os.fsdecode(f.readline()).strip()
-            if line.startswith("gitdir:"):
-                gd = line[len("gitdir:"):].strip()
-                if not os.path.isabs(gd):
-                    gd = os.path.normpath(os.path.join(cwd, gd))
-                hp = os.path.join(gd, "HEAD")
-                if not os.path.exists(hp):            # THE fault: a pointer git itself cannot follow (torn, or its
-                    shown = os.fsencode(hp).decode("utf-8", "backslashreplace")   # gitdir gone), shown as the bytes git wrote
-                    raise FileNotFoundError(errno.ENOENT, "the gitdir it names has no HEAD", shown)
+        gd = _gitdir_of(cwd, strict=True)              # strict: an unreadable pointer file RAISES, to be named below
+        if not gd and _is_bare_gitdir(cwd):
+            gd = cwd
+        hp = os.path.join(gd, "HEAD") if gd else ""
+        if hp and gd != dotgit and not os.path.exists(hp):
+            # THE fault: a pointer git itself cannot follow (torn, or its gitdir gone), shown as the bytes git
+            # wrote. A pointer FILE only — `gd` is not the `.git` entry itself: a `.git` DIRECTORY with no HEAD
+            # is git's plain "not a repository" (an empty one, before `git init` fills it), and a bare gitdir
+            # was recognised by its HEAD.
+            shown = os.fsencode(hp).decode("utf-8", "backslashreplace")
+            raise FileNotFoundError(errno.ENOENT, "the gitdir it names has no HEAD", shown)
     except OSError as e:                              # unreadable, or dangling (above): the same episode rule
         _git_file_fault(dotgit, e)                    # never silent: the operator learns WHICH file is bad
         return ""                                     # uncached: the next read retries, so a repair ends the episode
     with _git_file_faults_lock:
         _git_file_faults.pop(dotgit, None)            # a clean read ends the episode
-    if len(_head_path_cache) > 512:                  # bounded, like _tree_cache
-        _head_path_cache.clear()
-    _head_path_cache[cwd] = hp
+    if hp:
+        if len(_head_path_cache) > 512:                  # bounded, like _tree_cache
+            _head_path_cache.clear()
+        _head_path_cache[cwd] = hp
     return hp
 
 
-def _git_branch(cwd):
-    """The git branch for a directory, derived DIRECTLY from the folder — so it shows the instant a session
-    is opened, before any turn writes gitBranch into the transcript (the user 2026-06-24: branch should be a
-    property of the dir, known in advance). Cached per cwd, refreshed when the resolved HEAD file changes
-    (worktrees included — see _git_head_file). '' when not a repo / detached / unavailable. Applies to BOTH
-    backends (a never-run tmux session shows it now too)."""
-    if not cwd:
-        return ""
-    cwd = os.path.expanduser(cwd)
-    mt = None
+def _pointer_mtime(resolve, cache, top):
+    """The mtime of the file `resolve(top)` names — the memo key for what that file holds — or None when
+    there is no such file. A memoized path that no longer resolves is EVICTED from `cache` and resolved
+    once more before giving up: the tree died under a live session, or changed shape (a plain repo's
+    .git directory replaced by a worktree's pointer file at the same path). Left in place, the dead
+    path made every build fork the query its memo should have answered (`rev-parse --abbrev-ref` and
+    `remote get-url`, review find, 2026-09-06). None is git's own "not a repository" for that read."""
+    for _attempt in (0, 1):
+        p = resolve(top)
+        if not p:
+            return None
+        try:
+            return os.path.getmtime(p)
+        except OSError:
+            cache.pop(top, None)
+    return None
+
+
+def _tree_branch(top):
+    """The branch checked out at a tree's toplevel — or the one a BARE repository's HEAD names — derived
+    DIRECTLY from the folder, so it shows the instant a session is opened, before any turn writes
+    gitBranch into the transcript (the user 2026-06-24: branch should be a property of the dir, known in
+    advance). Memoized on the resolved HEAD file's mtime (worktrees and bare clones included — see
+    _git_head_file). '' when detached or unavailable; a HEAD file that cannot be found is git's own "not
+    a repository" and is '' without a fork. A resolver that RAISES (it reports its own faults and yields
+    '' — this is the backstop should one get through) is not that verdict: the fork answers, unmemoized
+    (#1028)."""
     try:
-        hp = _git_head_file(cwd)
-        if hp:
-            mt = os.path.getmtime(hp)
-    except (OSError, UnicodeDecodeError):   # the resolver reports and yields ''; this is the backstop should it raise
-        pass
-    hit = _branch_cache.get(cwd)
+        mt = _pointer_mtime(_git_head_file, _head_path_cache, top)
+    except (OSError, UnicodeDecodeError):   # the resolver reports and yields ''; this is the backstop should it
+        mt = None                            # raise: the fork below still answers, unmemoized (#1028)
+    else:
+        if mt is None:
+            return ""                        # no HEAD file is git's own "not a repository": '' without a fork
+    hit = _branch_cache.get(top)
     if hit is not None and mt is not None and hit[1] == mt:
         return hit[0]
     br = ""
     try:
-        r = subprocess.run(["git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
+        r = subprocess.run(["git", "-C", top, "rev-parse", "--abbrev-ref", "HEAD"],
                            capture_output=True, text=True, timeout=2)
-        if r.returncode == 0:
-            br = r.stdout.strip()
-            if br == "HEAD":          # detached HEAD → no branch name
-                br = ""
     except Exception:
-        br = ""
-    if mt is not None:
-        _branch_cache[cwd] = (br, mt)
+        return ""                                        # not git's answer: nothing to memoize
+    if r.returncode == 0:
+        br = r.stdout.strip()
+        if br == "HEAD":          # detached HEAD → no branch name
+            br = ""
+    if mt is not None:                                   # a backstop answer has no HEAD mtime to memoize under
+        _branch_cache[top] = (br, mt)
     return br
+
+
+def _git_branch(cwd):
+    """The git branch for a directory: the branch of the tree containing it (_tree_of, then
+    _tree_branch), or — when the directory is itself a BARE repository, which has no work tree for
+    `rev-parse --show-toplevel` to name — the branch its HEAD names, through the same HEAD-mtime memo
+    (_git_head_file knows the shape; the direct per-build query this replaced answered there, so a
+    session registered in a bare clone kept its branch). '' when in neither / detached / unavailable.
+    Applies to BOTH backends (a never-run tmux session shows it too). Going through _tree_of means a
+    session cwd that is a SUBDIRECTORY of its tree is memoized like the toplevel — with no `.git` of its
+    own to key on it forked `git rev-parse` on every build — and a directory outside every tree costs
+    the evidence walk plus two stats for the bare shape, never a fork."""
+    if not cwd:
+        return ""
+    d = os.path.expanduser(cwd)
+    top, br = _tree_of(d)
+    return br if top else _tree_branch(d)
+
+
+_repo_cache = {}          # tree toplevel -> (owner/repo or None, config mtime): the GitHub repo its origin names
+_config_path_cache = {}   # tree toplevel -> the git config file holding its remotes
+
+
+def _git_config_file(top):
+    """The config file that holds this tree's remotes — the one `git remote set-url` rewrites, so its
+    mtime is the event a remote change produces. .git/config for a plain repo; a WORKTREE's .git is a
+    one-line FILE naming its private gitdir, whose `commondir` file names the shared dir (relative to
+    that gitdir, usually `..`) carrying the one config every worktree reads. Resolved once per tree, as
+    _git_head_file resolves HEAD: the pointers never move for a live tree. '' when there is none — not
+    memoized, like _git_head_file's ''; a memoized path that stops resolving is evicted by its reader
+    (_pointer_mtime)."""
+    cp = _config_path_cache.get(top)
+    if cp:
+        return cp
+    cp = ""
+    gd = _gitdir_of(top)
+    if gd:
+        common = gd
+        try:
+            with open(os.path.join(gd, "commondir")) as f:
+                rel = f.readline().strip()
+            if rel:
+                common = rel if os.path.isabs(rel) else os.path.normpath(os.path.join(gd, rel))
+        except OSError:
+            pass
+        cp = os.path.join(common, "config")
+    if cp:
+        if len(_config_path_cache) > 512:                # bounded, like _tree_cache
+            _config_path_cache.clear()
+        _config_path_cache[top] = cp
+    return cp
+
+
+def _github_repo_of(cwd):
+    """`owner/repo` when the git tree containing `cwd` has an origin remote on GitHub, else None — the
+    repository a session's `#123` / `PR #123` mentions refer to (the user 2026-09-06: PR references in
+    a session's chat, cards and notes should link to the PR page of the repository it works in). The
+    same parser as the file viewer's GitHub link (_GITHUB_REMOTE) reads the same authoritative source,
+    `git remote get-url origin` in the session's tree: one spelling of what counts as GitHub. None is a
+    VERDICT, not an error — no repo, no origin, or an origin elsewhere (GitLab, a self-hosted host)
+    names no GitHub repository, and the clients then link nothing rather than guess one. Memoized per
+    tree on the config file's mtime — `git remote set-url` writes that file, which is the event a
+    remote change produces — so the pusher's per-build call costs a stat, not a fork (the _git_branch
+    discipline; the toplevel itself rides _tree_of's per-directory cache). A tree whose config file
+    cannot be found has no remote for git to read either: None, without a fork."""
+    if not cwd:
+        return None
+    top, _ = _tree_of(os.path.expanduser(cwd))
+    if not top:
+        return None
+    mt = _pointer_mtime(_git_config_file, _config_path_cache, top)
+    if mt is None:
+        return None
+    hit = _repo_cache.get(top)
+    if hit is not None and hit[1] == mt:
+        return hit[0]
+    remote = _git_out(["remote", "get-url", "origin"], top)
+    m = _GITHUB_REMOTE.match(remote) if remote else None
+    repo = "%s/%s" % (m.group(1), m.group(2)) if m else None
+    if len(_repo_cache) > 512:
+        _repo_cache.clear()
+    _repo_cache[top] = (repo, mt)
+    return repo
 
 
 _EDIT_TOOLS = ("Edit", "Write", "MultiEdit", "NotebookEdit")   # tools whose file_path proves WHERE work lands
@@ -28601,13 +28917,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # effect + this session's model / cwd / branch / permission-mode / version (NOT the harness prompt —
     # see _claudemd_docs). Only when there's a real transcript to describe AND something to show.
     meta = _session_meta(sess["path"])
-    # The registry's dir FIRST (known before the first turn), the transcript's stamp only as a fallback:
-    # a move (SdkBackend.move) rewrites the registry at once, while the transcript keeps stamping the old
-    # cwd until the model's next turn — so the card would name the old folder for as long as the session
-    # sat idle after the move. And the per-record `cwd` stamp is the CLI's TRACKED cwd, which a shell
-    # `cd` inside a Bash tool call also moves (with no transcript move behind it), so it never was the
-    # session's project directory — only the registry (and the CLI's own `relocated` record) is.
-    scwd = _cwd_of(sid) or meta.get("cwd") or ""
+    # The registry's dir FIRST (known before the first turn; a move rewrites it at once), the transcript's
+    # stamp only as a fallback — _session_cwd says why, and the feed's session rows take the same derivation.
+    scwd = _session_cwd(sid, meta=meta)
     docs = _claudemd_docs(scwd)
     # The WORKTREE the session actually works in (the user 2026-08-13): the repo convention here puts real
     # work on per-session worktrees beside the registered clone, so the registered dir's branch read 'main'
@@ -28670,7 +28982,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     _kids = (_be_fk.fork_children().get(sid) if _be_fk and hasattr(_be_fk, "fork_children") else None) or None
     return {"type": "session", "id": sid, "name": sess["name"], "color": _name_color(sid),
             "branch": branch, "branches": _kids,
-            "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # the CURRENT dir (a move rewrites it); lane tab shows it (the user 2026-06-22)
+            "cwd": _tilde(scwd),   # the CURRENT dir (a move rewrites it); lane tab shows it (the user 2026-06-22)
             # git branch as a TOP-LEVEL session field, NOT just inside the head system event: the status-bar
             # branch + tab tooltip must show for EVERY session, but the system event lives at events[0] and the
             # WIRE_TAIL window ships only the last 250 events — so on any session with >250 events the head
@@ -28679,6 +28991,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
             "gitBranch": sysinfo["gitBranch"],
             # the detected worktree rides top-level for the same windowing reason as gitBranch above
             "workTree": sysinfo["workTree"],
+            # the GitHub repository the session works in (owner/repo, or null): the clients turn `#123`
+            # / `PR #123` mentions in its chat, cards and notes into links to that repository's PR page
+            # (ui/webview/pr-links.ts; the user 2026-09-06). Top-level like gitBranch, so it is never
+            # windowed off the wire; a memoized store-derived value, so the dedup-compared payload holds.
+            "githubRepo": _github_repo_of(scwd),
             "events": events, "status": status, "ledger": ledger,
             # SDK sessions gate the box on the backend's LIVE task set (the CLI's task lifecycle stream —
             # authoritative, terminal-cleared); the spawned_at heuristic remains the tmux/no-snapshot fallback.
@@ -30933,7 +31250,12 @@ def build_feed(now, tmux=None):
             # feed footer's session-filter menu lists precisely the tabs (the user 2026-08-08) — including
             # a session with no cards on the board, which filters to an empty board rather than being
             # unlistable. Federation prefixes sid+name per host and concatenates.
-            "sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}
+            "sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"]),
+                          # the session's GitHub repository (owner/repo, or null), so a card's `#123`
+                          # links to ITS repository's PR page (the user 2026-09-06) — the derivation
+                          # the chat frame ships, from the SAME directory (_session_cwd: registry, else
+                          # the transcript's stamp), memoized, a fixed value across unchanged builds
+                          "githubRepo": _github_repo_of(_session_cwd(s["sid"], s.get("path")))}
                          for s in _chat_tab_sessions(now, tmux)],
             # /clear boundary settles, newest per session → the bell logs each once (the user 2026-07-27)
             "clearNotices": _boundary_clear_notices(alive),

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -479,8 +479,9 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         ev["tracked"] = True                         # additive (consumer contract above): report-back
         #                                              delegation — the row is the flag's ONE record;
         #                                              no header, no prose (the recipient reads nothing)
-    if from_host:
-        ev["from_host"] = from_host                  # additive (consumer contract above)
+    ev["from_host"] = from_host or ""                # additive (consumer contract above): "" says LOCAL
+    #                                                  outright — written only when set before, which left
+    #                                                  a local row and a pre-field relayed row the same shape
     if relay_mid:
         ev["originMid"] = relay_mid                  # the SENDER-side id for relayed mail (2026-08-28,
         #                                              the dead-session round): local delivery mints its
@@ -602,7 +603,11 @@ def _queue_read_receipt(meta, unread=False, dmid=""):
 #      kind stays "delegate" — whose sender-side view is primary: the kernel courier reads it off
 #      this row, never off the message prose). A CROSS-HOST relay row has to_id "peer:<host>" and
 #      adds toName ("<host>:<name>") + to_sid (the recipient's stable id — the wait readers key on
-#      it; rows from before 2026-09-08 lack it and fall back to the name alias).
+#      it; rows from before 2026-09-08 lack it and fall back to the name alias). from_host is written
+#      on EVERY row since 2026-09-06 — "" for local delivery, the origin host for relayed mail — so a
+#      row WITHOUT the key is one from before that, whose sender may be either; a reader that needs
+#      the distinction (the kernel's postal card, for the sender's repository) treats absence as
+#      unknown, not as local.
 # The HUMAN-FACING prose (banner text, headers, the "⏸ parked" tag, REPLY_HINT) is
 # NOT a contract — consumers must not parse it, so it stays free to change.
 

--- a/tests/test_git_pointer_file_bytes.py
+++ b/tests/test_git_pointer_file_bytes.py
@@ -327,24 +327,25 @@ class PushCycle(unittest.TestCase):
         return str(p)
 
     def _push_once(self, seen=None):
-        """One push to one chat client; `seen` (a list) collects every OPEN of the torn session's pointer
-        file, so a test can prove the file was re-read rather than the fault served from a cache. A wrapper
-        on the resolver proved only that it was CALLED, which a cached fault satisfies too (review find,
-        2026-09-08); the open is the read."""
+        """One push to one chat client; `seen` (a list) collects every fault REPORT the torn session's pointer
+        file draws — each call of _git_file_fault naming it — so a test can prove the fault was re-derived
+        and handed to the registry rather than served from a cache. A wrapper on the resolver proved only
+        that it was CALLED, which a cached fault satisfies too (review find, 2026-09-08); counting the
+        pointer file's opens proved the re-derivation while the resolver read it per call, but the pointer's
+        CONTENT now rides a memo keyed on the file's identity (_pointer_gitdir) and the fault is re-derived
+        from its target's stat, so the report reaching the registry is what says it was re-derived."""
         sessions = [{"sid": A, "name": "web", "path": self.paths[A], "anchor": 0, "mtime": NOW},
                     {"sid": B, "name": "api", "path": self.paths[B], "anchor": 0, "mtime": NOW}]
         tmux = {A: _tm(), B: _tm()}
         sent = []
         dotgit = str(self.torn / ".git")
-        real_open = open
+        real_fault = km._git_file_fault
 
-        def opened(file, *a, **k):
-            if seen is not None and isinstance(file, str) and file == dotgit:
-                seen.append(file)
-            return real_open(file, *a, **k)
-        # a module-global `open` shadows the builtin for the kernel's functions ONLY (json, subprocess and the
-        # test's own reads keep the real one), and create=True removes it again on exit
-        with mock.patch.object(km, "open", opened, create=True), \
+        def reported(path, exc):
+            if seen is not None and path == dotgit:
+                seen.append(path)
+            return real_fault(path, exc)
+        with mock.patch.object(km, "_git_file_fault", reported), \
                 mock.patch.object(km, "_sessions", lambda now, window=None, forks=True: list(sessions)), \
                 mock.patch.object(km, "_tmux_sessions", lambda: dict(tmux)), \
                 mock.patch.object(km, "_chat_tab_sessions", lambda now, tm: list(sessions)), \
@@ -373,14 +374,15 @@ class PushCycle(unittest.TestCase):
         self.assertEqual(len(named), 1, "exactly one stderr line names the bad file: %r" % err.splitlines())
         # the next cycle has nothing new to say about a fault already on record. An UNCHANGED push serves
         # the chat from _built_chat / the parse cache and never re-derives the branch, which would keep
-        # this quiet with no registry at all — so those caches are cleared and the pointer file's OPENS are
-        # counted: what this pins is the DEDUPE (the file IS re-read, and still no new line). Counting calls
-        # to the resolver was too weak a premise: a fault cached as "no HEAD" is served without a read and
-        # would also log nothing, registry or not (review find, 2026-09-08).
+        # this quiet with no registry at all — so those caches are cleared and the fault REPORTS for the
+        # pointer file are counted: what this pins is the DEDUPE (the fault IS re-derived and handed to the
+        # registry, and still no new line). Counting calls to the resolver was too weak a premise: a fault
+        # cached as "no HEAD" is served without reaching the registry and would also log nothing, registry
+        # or not (review find, 2026-09-08).
         self._clear_build_state()
         seen = []
         _, err2 = self._push_once(seen)
-        self.assertTrue(seen, "premise: the second push re-READ the torn pointer file (a fault is never cached)")
+        self.assertTrue(seen, "premise: the second push re-derived the torn pointer file's fault (a fault is never cached)")
         self.assertEqual([l for l in err2.splitlines() if str(self.torn / ".git") in l], [],
                          "a second push logs nothing new: %r" % err2.splitlines())
 

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -1,0 +1,956 @@
+#!/usr/bin/env python3
+"""_github_repo_of and the frames that carry it — the repository a session's PR references link to
+(the user 2026-09-06: `#123` / `PR #123` in a session's chat, cards and notes should link to the PR
+page of the repository the session works in). The kernel names that repository per session from the
+authoritative source, the session tree's origin remote, through the SAME parser the file viewer's
+GitHub link uses (_GITHUB_REMOTE). None is a VERDICT, not an error: no repo, no origin, or an origin
+elsewhere names no GitHub repository, and the clients then link nothing rather than guess.
+
+Throwaway temp repos with fabricated origins (example-org/notes-api — the demo world); nothing here
+reaches a network (no fetch, no ls-remote — `remote get-url` reads config). The registry-keyed check
+uses a PRIVATE synthetic sid (the goal-store fixture rule, applied to the names registry too).
+
+Also here: _tree_of's evidence-keyed verdict (a directory that becomes a repo after its first build is
+found without a kernel restart; a `.git` git rejects — or walks past — is asked about once, then costs
+stats), the pointer memos of a tree that dies or changes shape under a live session (_pointer_mtime,
+and _vouch_tree forgetting a reshaped tree's memos — or unvouched ones, after its record's own bound; a
+pointer re-made within one mtime tick; a symlinked cwd re-pointed at another repository), what a
+memoized call costs in stats, the branch
+of a BARE repository, _git_config_file's hand-built layouts (a relative gitdir, a gitdir with no
+commondir), and _session_cwd — the one derivation of a session's directory the chat frame and the
+feed's session rows share, so a never-registered session links the same repo on both.
+"""
+import builtins
+import inspect
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the load — the kernel resolves its state root at import time, and only pytest
+# runs conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_github_repo", os.path.join(BIN, "romp-kernel")).load_module()
+
+HTTPS_ORIGIN = "https://github.com/example-org/notes-api.git"
+SSH_ORIGIN = "git@github.com:example-org/notes-api.git"
+ELSEWHERE_ORIGIN = "https://gitlab.example.com/example-org/notes-api.git"
+REPO = "example-org/notes-api"
+# a private synthetic sid: never the shared 11111111-2222-… placeholder (another module's journaled
+# state can land on that one), never a real session's
+PRIVATE_SID = "7a7a7a7a-1a1a-4b4b-8c8c-9d9d9d9d9d9d"
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t"] + list(args),
+                   cwd=cwd, check=True, capture_output=True)
+
+
+def _repo(root, name, origin=None):
+    """A one-commit repo on branch main under `root`, with `origin` set when given."""
+    d = os.path.join(root, name)
+    os.makedirs(d)
+    _git("init", "-q", "-b", "main", cwd=d)
+    with open(os.path.join(d, "f.txt"), "w") as f:
+        f.write("x\n")
+    _git("add", "f.txt", cwd=d)
+    _git("commit", "-q", "-m", "seed", cwd=d)
+    if origin:
+        _git("remote", "add", "origin", origin, cwd=d)
+    return d
+
+
+def _bump_mtime(path):
+    """Move a file's mtime forward by a whole second, so a rewrite within the same clock tick still
+    reads as a change — the memo keys on mtime, and the test must not depend on filesystem resolution."""
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 2))
+
+
+class _Fixtures(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # the kernel's own git runs in the process environment (as in production): pin it to read no
+        # global or system config, so a developer's url.insteadOf rewrite cannot bend a fixture origin
+        cls._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        cls.root = tempfile.mkdtemp()
+        cls.https = _repo(cls.root, "https-repo", HTTPS_ORIGIN)
+        cls.sub = os.path.join(cls.https, "src", "deep")
+        os.makedirs(cls.sub)
+        cls.wt = os.path.join(cls.root, "https-repo-feature")
+        _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.https)
+        cls.ssh = _repo(cls.root, "ssh-repo", SSH_ORIGIN)
+        cls.elsewhere = _repo(cls.root, "elsewhere-repo", ELSEWHERE_ORIGIN)
+        cls.noorigin = _repo(cls.root, "no-origin-repo")
+        cls.plain = os.path.join(cls.root, "not-a-repo")
+        os.makedirs(cls.plain)
+
+    @classmethod
+    def tearDownClass(cls):
+        for k, v in cls._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class GitHubRepoOf(_Fixtures):
+    def test_an_https_origin_names_owner_and_repo_without_the_git_suffix(self):
+        self.assertEqual(km._github_repo_of(self.https), REPO)
+
+    def test_the_ssh_origin_spelling_names_the_same_repo(self):
+        self.assertEqual(km._github_repo_of(self.ssh), REPO)
+
+    def test_a_subdirectory_of_the_tree_resolves_to_the_trees_repo(self):
+        self.assertEqual(km._github_repo_of(self.sub), REPO)
+
+    def test_a_worktree_reads_the_shared_config_through_its_commondir(self):
+        self.assertEqual(km._github_repo_of(self.wt), REPO)
+        cfg = km._git_config_file(os.path.realpath(self.wt))
+        self.assertEqual(os.path.realpath(cfg), os.path.realpath(os.path.join(self.https, ".git", "config")),
+                         "the worktree's remotes live in the main tree's .git/config")
+
+    def test_an_origin_elsewhere_is_no_github_repo(self):
+        self.assertIsNone(km._github_repo_of(self.elsewhere))
+
+    def test_no_origin_remote_is_no_github_repo(self):
+        self.assertIsNone(km._github_repo_of(self.noorigin))
+
+    def test_no_repository_is_no_github_repo(self):
+        self.assertIsNone(km._github_repo_of(self.plain))
+        self.assertIsNone(km._github_repo_of(""))
+        self.assertIsNone(km._github_repo_of(None))
+
+    def test_a_tilde_path_is_expanded_like_every_other_cwd(self):
+        home = os.path.expanduser("~")
+        if not self.https.startswith(home + os.sep):
+            self.skipTest("the fixture root is not under $HOME")
+        self.assertEqual(km._github_repo_of("~" + self.https[len(home):]), REPO)
+
+    def test_the_parser_is_the_file_viewers(self):
+        src = inspect.getsource(km._github_repo_of)
+        self.assertIn("_GITHUB_REMOTE.match(remote)", src, "one spelling of what counts as GitHub")
+        self.assertIn('_git_out(["remote", "get-url", "origin"], top)', src, "the same authoritative read")
+
+
+class Memo(unittest.TestCase):
+    """The answer is memoized per tree on the config file's mtime: a second build forks no git, and a
+    rewritten remote (the file's mtime moving) is re-read."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        self.repo = _repo(self.root, "memo-repo", HTTPS_ORIGIN)
+        self.cfg = os.path.join(self.repo, ".git", "config")
+        self._real_git_out = km._git_out
+        self.calls = []
+
+        def counting(args, cwd, *a, **kw):
+            self.calls.append(list(args))
+            return self._real_git_out(args, cwd, *a, **kw)
+        km._git_out = counting
+
+    def tearDown(self):
+        km._git_out = self._real_git_out
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _remote_reads(self):
+        return [c for c in self.calls if c[:2] == ["remote", "get-url"]]
+
+    def test_a_second_call_reads_the_memo_not_git(self):
+        self.assertEqual(km._github_repo_of(self.repo), REPO)
+        self.assertEqual(len(self._remote_reads()), 1)
+        self.assertEqual(km._github_repo_of(self.repo), REPO)
+        self.assertEqual(len(self._remote_reads()), 1, "an unchanged config is not re-read")
+
+    def test_a_rewritten_remote_is_re_read(self):
+        self.assertEqual(km._github_repo_of(self.repo), REPO)
+        _git("remote", "set-url", "origin", "https://github.com/other-org/other-repo.git", cwd=self.repo)
+        _bump_mtime(self.cfg)
+        self.assertEqual(km._github_repo_of(self.repo), "other-org/other-repo")
+        self.assertEqual(len(self._remote_reads()), 2)
+
+    def test_losing_the_origin_is_a_real_change_to_none(self):
+        self.assertEqual(km._github_repo_of(self.repo), REPO)
+        _git("remote", "remove", "origin", cwd=self.repo)
+        _bump_mtime(self.cfg)
+        self.assertIsNone(km._github_repo_of(self.repo), "a null verdict replaces the memoized repo")
+
+
+class LateRepo(unittest.TestCase):
+    """A directory that becomes a repo AFTER its first build (`git init`, then a GitHub origin) is found on
+    the next call, with no kernel restart: _tree_of trusts a cached "not a repo" verdict only while no
+    `.git` exists on the chain git's discovery walks. Before the re-validation the verdict was cached
+    forever, so gitBranch (re-derived per build) showed while githubRepo stayed null — silent degradation
+    (review find, 2026-09-06). A directory that stays outside any repo is NOT re-asked: one fork, then
+    stats only."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        if km._dotgit_on_chain(self.root):
+            self.skipTest("the temp root sits inside a repository; these need a directory outside every tree")
+        self.proj = os.path.join(self.root, "proj")
+        self.sub = os.path.join(self.proj, "src")
+        os.makedirs(self.sub)
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _init_with_origin(self, d):
+        """What `git init` + a first commit + `gh repo create --push` leave behind (an unborn branch — init
+        with no commit — reads as no branch, like a detached HEAD; the repo is still found)."""
+        _git("init", "-q", "-b", "main", cwd=d)
+        with open(os.path.join(d, "f.txt"), "w") as f:
+            f.write("x\n")
+        _git("add", "f.txt", cwd=d)
+        _git("commit", "-q", "-m", "seed", cwd=d)
+        _git("remote", "add", "origin", HTTPS_ORIGIN, cwd=d)
+
+    def test_a_directory_that_becomes_a_repo_is_found_without_a_restart(self):
+        self.assertIsNone(km._github_repo_of(self.proj))
+        self.assertEqual(km._tree_of(self.proj), ("", ""))
+        self.assertEqual(km._tree_cache.get(self.proj), ("", None, False), "the non-repo verdict is cached, with its evidence: no .git on the chain")
+        self._init_with_origin(self.proj)
+        self.assertEqual(km._github_repo_of(self.proj), REPO, "the next call sees the new tree")
+        top, br = km._tree_of(self.proj)
+        self.assertEqual(os.path.realpath(top), os.path.realpath(self.proj))
+        self.assertEqual(br, "main")
+
+    def test_a_repo_appearing_at_an_ancestor_is_found_from_a_subdirectory(self):
+        # the edit-derived tree (lastEditPath's directory) and a session whose cwd is a subdirectory
+        # of the project both resolve upward, as git does
+        self.assertIsNone(km._github_repo_of(self.sub))
+        self._init_with_origin(self.proj)
+        self.assertEqual(km._github_repo_of(self.sub), REPO)
+        self.assertEqual(os.path.realpath(km._tree_of(self.sub)[0]), os.path.realpath(self.proj))
+
+    def test_a_directory_still_outside_any_repo_is_not_re_asked(self):
+        real_run = km.subprocess.run
+        asks = []
+
+        def counting(*a, **k):
+            argv = a[0] if a else k.get("args")
+            if isinstance(argv, (list, tuple)) and "--show-toplevel" in argv:
+                asks.append(list(argv))
+            return real_run(*a, **k)
+        km.subprocess.run = counting
+        try:
+            self.assertEqual(km._tree_of(self.proj), ("", ""))
+            self.assertEqual(len(asks), 1, "the first call asks git")
+            self.assertEqual(km._tree_of(self.proj), ("", ""))
+            self.assertEqual(km._tree_of(self.sub), ("", ""))
+            self.assertEqual(km._tree_of(self.proj), ("", ""))
+            self.assertEqual(len(asks), 2, "one ask per directory; a still-non-repo verdict costs stats, not forks")
+        finally:
+            km.subprocess.run = real_run
+
+    def test_the_chain_check_is_a_stat_walk_up_to_the_root(self):
+        self.assertIsNone(km._dotgit_on_chain(self.sub))
+        dotgit = os.path.join(self.proj, ".git")
+        os.mkdir(dotgit)                                   # any .git on the chain, a directory here
+        ev = km._dotgit_on_chain(self.sub)
+        self.assertEqual((ev[0], ev[2]), (dotgit, False), "the evidence: the entry's path, and that it is a directory")
+        st = os.stat(dotgit)
+        self.assertEqual(ev[1], st.st_mtime)
+        self.assertEqual((ev[3], ev[4]), (st.st_ino, st.st_dev), "…and its identity, off the same stat: a verdict key may need it")
+        self.assertEqual(km._dotgit_on_chain(self.proj), ev)
+        self.assertIsNone(km._dotgit_on_chain(self.root), "an ancestor of the .git is not on its chain")
+
+
+def _count_git(store):
+    """Patch km.subprocess.run to tally git queries by their distinguishing word; returns the restore."""
+    real_run = km.subprocess.run
+
+    def counting(*a, **k):
+        argv = a[0] if a else k.get("args")
+        if isinstance(argv, (list, tuple)):
+            for key in ("--show-toplevel", "--abbrev-ref", "get-url"):
+                if key in argv:
+                    store[key] = store.get(key, 0) + 1
+        return real_run(*a, **k)
+    km.subprocess.run = counting
+    return lambda: setattr(km.subprocess, "run", real_run)
+
+
+class RejectedDotGit(unittest.TestCase):
+    """A `.git` on the chain that git REJECTS — an empty directory; a worktree pointer whose main clone is
+    gone (this repo's own worktree convention produces it whenever the clone is removed or re-cloned) —
+    is asked about ONCE. The stat walk is a superset of git's discovery, so re-validating a not-a-repo
+    verdict by the entry's mere presence forked `git rev-parse` on every _tree_of call for the life of
+    the kernel, three per chat build and one per session per feed build (review find, 2026-09-06). The
+    verdict is filed on the evidence itself — the entry's path and mtime, and for a pointer whether its
+    gitdir exists — so only a change to that evidence re-asks git."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        if km._dotgit_on_chain(self.root):
+            self.skipTest("the temp root sits inside a repository; these need a directory outside every tree")
+        self.forks = {}
+        self.addCleanup(_count_git(self.forks))
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _build(self, d, n=3):
+        """What the builds cost: n rounds of the two scwd calls build_session makes plus the feed's one."""
+        out = []
+        for _ in range(n):
+            out.append((km._tree_of(d), km._github_repo_of(d), km._github_repo_of(d)))
+        return out
+
+    def test_an_empty_dot_git_directory_is_asked_once_then_costs_stats_until_git_init_fills_it(self):
+        proj = os.path.join(self.root, "proj")
+        sub = os.path.join(proj, "src")
+        os.makedirs(sub)
+        dotgit = os.path.join(proj, ".git")
+        os.mkdir(dotgit)
+        os.utime(dotgit, (1_600_000_000, 1_600_000_000))   # an old mtime: the init below is a definite change
+        self.assertEqual(self._build(sub), [(("", ""), None, None)] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1}, "git rejects the empty .git once; no build after it forks")
+        # `git init` populates the directory (its mtime moves): the next call asks git again and finds the tree
+        _git("init", "-q", "-b", "main", cwd=proj)
+        _git("remote", "add", "origin", HTTPS_ORIGIN, cwd=proj)
+        self.assertEqual(km._github_repo_of(sub), REPO)
+        self.assertEqual(self.forks["--show-toplevel"], 2)
+
+    def test_an_empty_dot_git_below_a_repo_is_walked_past_by_git_and_re_asked_when_git_init_fills_it(self):
+        # git's discovery skips an invalid `.git` directory and continues upward, so this cwd is FOUND —
+        # with the parent's toplevel — through an entry that is not that toplevel's own. Keyed on its path
+        # alone, as the toplevel's own directory is, `git init` filling it changed nothing in the key and
+        # the parent's toplevel, branch and repo were served forever (review find, 2026-09-06)
+        plain = _repo(self.root, "plain", HTTPS_ORIGIN)
+        svc = os.path.join(plain, "svc")
+        os.makedirs(os.path.join(svc, ".git"))
+        os.utime(os.path.join(svc, ".git"), (1_600_000_000, 1_600_000_000))
+        top = os.path.realpath(plain)
+        self.assertEqual(self._build(svc), [((top, "main"), REPO, REPO)] * 3, "found: the PARENT's tree, as git says")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1}, "asked once, then stats")
+        _git("init", "-q", "-b", "svc", cwd=svc)
+        with open(os.path.join(svc, "g.txt"), "w") as f:
+            f.write("y\n")
+        _git("add", "g.txt", cwd=svc)
+        _git("commit", "-q", "-m", "nested", cwd=svc)
+        _git("remote", "add", "origin", "https://github.com/example-org/notes-svc.git", cwd=svc)
+        self.forks.clear()
+        self.assertEqual(self._build(svc), [((os.path.realpath(svc), "svc"), "example-org/notes-svc", "example-org/notes-svc")] * 3,
+                         "the entry git walked past is a repository now: its own toplevel, branch and repo")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1},
+                         "the filled directory's mtime is the evidence that moved: one re-ask, then stats")
+
+    def test_the_toplevels_own_dot_git_directory_is_keyed_on_its_path_and_identity_never_its_mtime_through_a_symlink_too(self):
+        # the evidence path is lexical (abspath), git's toplevel physical: through a symlinked cwd the two
+        # spell the same `.git` differently, and a rule that kept the mtime there would re-fork on every
+        # index write (a review caveat, 2026-09-06); an index write moves the directory's mtime. The
+        # inode and device ARE in the key — they never move for a live repository, and a symlink re-pointed
+        # at another one stats a different directory (the re-point test in DeadOrReshapedTree)
+        plain = _repo(self.root, "real", HTTPS_ORIGIN)
+        link = os.path.join(self.root, "link")
+        os.symlink(plain, link)
+        top = os.path.realpath(plain)
+        st = os.stat(os.path.join(plain, ".git"))
+        for d in (plain, link):
+            self.assertEqual(self._build(d)[0][0], (top, "main"))
+            self.assertEqual(km._tree_cache[d][1], (os.path.join(d, ".git"), st.st_ino, st.st_dev),
+                             "keyed on the path and the directory's identity, no mtime (%s)" % d)
+            self.assertIs(km._tree_cache[d][2], True, "…as the toplevel's own entry (%s)" % d)
+            self.forks.clear()
+            _bump_mtime(os.path.join(d, ".git"))
+            self.assertEqual(self._build(d)[0][0], (top, "main"))
+            self.assertEqual(self.forks, {}, "the toplevel's own .git directory: its mtime churn is no evidence (%s)" % d)
+
+    def test_a_worktree_whose_main_clone_was_removed_is_asked_once_and_found_again_when_the_clone_is_back(self):
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-x")
+        _git("worktree", "add", "-q", "-b", "x", wt, "HEAD", cwd=main)
+        self.assertEqual(km._github_repo_of(wt), REPO, "a live worktree names the clone's repo")
+        backup = os.path.join(self.root, "backup")
+        shutil.copytree(main, backup, symlinks=True)
+        shutil.rmtree(main)                              # the pointer file in wt/.git now names a gitdir that is gone
+        self.forks.clear()
+        self.assertEqual(self._build(wt), [(("", ""), None, None)] * 3,
+                         "a dangling pointer is no tree — the found verdict does not outlive the clone it names")
+        self.assertEqual(self.forks, {"--show-toplevel": 1}, "asked once: the pointer has not changed since git rejected it")
+        # the clone restored from a backup at the same path — the pointer file untouched — makes its gitdir exist
+        # again, which is part of the evidence: the next call asks git again
+        shutil.move(backup, main)
+        self.assertEqual(km._github_repo_of(wt), REPO)
+        self.assertEqual(self.forks["--show-toplevel"], 2)
+        self.assertEqual(km._github_repo_of(wt), REPO)
+        self.assertEqual(self.forks["--show-toplevel"], 2, "and the found verdict holds")
+
+    def test_a_rewritten_pointer_re_asks_git(self):
+        # `git worktree repair` rewrites the worktree's .git file in place; the mtime is the evidence that moved
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-y")
+        _git("worktree", "add", "-q", "-b", "y", wt, "HEAD", cwd=main)
+        pointer = os.path.join(wt, ".git")
+        good = open(pointer).read()
+        with open(pointer, "w") as f:
+            f.write("gitdir: %s\n" % os.path.join(self.root, "nowhere", ".git", "worktrees", "y"))
+        os.utime(pointer, (1_600_000_000, 1_600_000_000))
+        self.assertEqual(self._build(wt), [(("", ""), None, None)] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1})
+        with open(pointer, "w") as f:
+            f.write(good)
+        self.assertEqual(km._github_repo_of(wt), REPO, "the repaired pointer is new evidence")
+        self.assertEqual(self.forks["--show-toplevel"], 2)
+
+    def test_a_git_failure_that_is_no_verdict_is_not_cached(self):
+        # a timeout (or no git binary) is not git's answer: the next call asks again instead of serving ""
+        proj = _repo(self.root, "proj", HTTPS_ORIGIN)
+        real_run = km.subprocess.run
+        state = {"fail": True}
+
+        def flaky(*a, **k):
+            argv = a[0] if a else k.get("args")
+            if state["fail"] and isinstance(argv, (list, tuple)) and "--show-toplevel" in argv:
+                state["fail"] = False
+                raise subprocess.TimeoutExpired(argv, 2)
+            return real_run(*a, **k)
+        km.subprocess.run = flaky
+        try:
+            self.assertEqual(km._tree_of(proj), ("", ""), "this build shows nothing")
+            self.assertNotIn(proj, km._tree_cache, "and nothing is cached")
+            top, br = km._tree_of(proj)
+            self.assertEqual((os.path.realpath(top), br), (os.path.realpath(proj), "main"), "the next build asks again")
+        finally:
+            km.subprocess.run = real_run
+
+
+class DeadOrReshapedTree(unittest.TestCase):
+    """The pointer memos (_head_path_cache, _config_path_cache) name files inside a tree that can die or
+    change shape under a live session — the checkout deleted, a plain repo replaced by a worktree at the
+    same path. Memoized forever, the dead path made every build fork `rev-parse --abbrev-ref` and
+    `remote get-url` (review find, 2026-09-06). Now the reader evicts a path that stops resolving and
+    resolves once more; a tree with no `.git` left is not a tree (_tree_of's evidence sees the entry go)."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        if km._dotgit_on_chain(self.root):
+            self.skipTest("the temp root sits inside a repository; these need a directory outside every tree")
+        self.forks = {}
+        self.addCleanup(_count_git(self.forks))
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _builds(self, d, n=3):
+        return [(km._tree_of(d)[1], km._github_repo_of(d)) for _ in range(n)]
+
+    def test_a_checkout_deleted_under_a_live_session_costs_one_re_ask_then_stats(self):
+        d = _repo(self.root, "web", HTTPS_ORIGIN)
+        self.assertEqual(self._builds(d), [("main", REPO)] * 3)
+        self.forks.clear()
+        shutil.rmtree(d)
+        self.assertEqual(self._builds(d), [("", None)] * 3, "a deleted tree shows nothing — never a stale branch or repo")
+        self.assertEqual(self.forks, {"--show-toplevel": 1},
+                         "the .git entry is gone: one re-ask of the toplevel, then no fork of any kind")
+        # the dead tree's pointer memos are never consulted again (the toplevel verdict is "" now); a tree
+        # re-created at that path re-asks the toplevel first, and a memo path that no longer resolves is
+        # evicted by its reader then (the reshape test below) — nothing here needs a cache sweep
+
+    def test_a_plain_repo_replaced_by_a_worktree_at_the_same_path_re_resolves_its_pointers_once(self):
+        solo = _repo(self.root, "solo", HTTPS_ORIGIN)
+        self.assertEqual(self._builds(solo), [("main", REPO)] * 3)
+        other = _repo(self.root, "other", "https://github.com/other-org/other-repo.git")
+        shutil.rmtree(solo)
+        _git("worktree", "add", "-q", "-b", "reshaped", solo, "HEAD", cwd=other)   # .git is a FILE now
+        self.forks.clear()
+        self.assertEqual(self._builds(solo), [("reshaped", "other-org/other-repo")] * 3,
+                         "the new shape's branch and repo, from its pointer file")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1},
+                         "the .git entry changed kind (new evidence: one re-ask of the toplevel) and each pointer "
+                         "re-resolved once, then everything is memoized")
+        top = os.path.realpath(solo)
+        self.assertEqual(os.path.realpath(km._config_path_cache[top]), os.path.realpath(os.path.join(other, ".git", "config")))
+
+    def test_a_worktree_replaced_by_a_plain_repo_at_the_same_path_forgets_the_old_clones_memos(self):
+        # rm -rf, not `git worktree remove`: the clone keeps .git/worktrees/<name>, so the memoized HEAD
+        # and config paths inside it still resolve — and, trusted, served the dead worktree's branch and
+        # the old clone's repo for the kernel's life (`git worktree prune` leaves the clone's own config
+        # in place, so it did not repair the repo half either; review find, 2026-09-06)
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-web")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        shutil.rmtree(wt)
+        _repo(self.root, "main-web", "https://github.com/other-org/fresh.git")   # a plain clone where the worktree was
+        self.assertTrue(os.path.isdir(os.path.join(main, ".git", "worktrees", "main-web")),
+                        "the old clone still lists the dead worktree: its HEAD and config paths still resolve")
+        self.forks.clear()
+        self.assertEqual(self._builds(wt), [("main", "other-org/fresh")] * 3, "the plain repo's own branch and origin")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1},
+                         "the .git entry changed kind: one re-ask, the tree's memos forgotten and re-derived once")
+        top = os.path.realpath(wt)
+        self.assertEqual(os.path.realpath(km._head_path_cache[top]), os.path.realpath(os.path.join(wt, ".git", "HEAD")))
+        self.assertEqual(os.path.realpath(km._config_path_cache[top]), os.path.realpath(os.path.join(wt, ".git", "config")))
+
+    def test_one_clones_worktree_replaced_by_anothers_at_the_same_path_re_resolves_once(self):
+        # the same kind (a pointer file) but another clone's: the pointer's mtime is the shape that moved
+        a = _repo(self.root, "a", HTTPS_ORIGIN)
+        b = _repo(self.root, "b", "https://github.com/other-org/fork.git")
+        wt = os.path.join(self.root, "shared-name")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=a)
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        shutil.rmtree(wt)
+        _git("worktree", "add", "-q", "-b", "feature", wt, "HEAD", cwd=b)
+        _bump_mtime(os.path.join(wt, ".git"))   # a new pointer; its mtime must differ even within one clock tick
+        self.forks.clear()
+        self.assertEqual(self._builds(wt), [("feature", "other-org/fork")] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1})
+
+    def test_one_clones_worktree_replaced_by_anothers_within_one_mtime_tick_is_re_asked(self):
+        # the same replacement as above with the pointer's mtime NOT moving — what a filesystem with a
+        # one-second (HFS+) or two-second (FAT) mtime tick reports when the rm -rf and the add land in
+        # the same tick: keyed on (path, mtime) alone the verdict hit, _vouch_tree never ran, and the
+        # first clone's branch and origin were served for the kernel's life (review find, 2026-09-06).
+        # The re-made pointer is a new FILE — its inode is in the key. A hard link keeps the old file
+        # allocated across the rm -rf, so the filesystem cannot hand the new pointer the freed inode
+        # number back and the test does not depend on the allocator's mood.
+        a = _repo(self.root, "a", HTTPS_ORIGIN)
+        b = _repo(self.root, "b", "https://github.com/other-org/fork.git")
+        wt = os.path.join(self.root, "shared-name")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=a)
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        pointer = os.path.join(wt, ".git")
+        old = os.stat(pointer)
+        os.link(pointer, os.path.join(self.root, "keep-the-old-pointer-allocated"))
+        shutil.rmtree(wt)
+        _git("worktree", "add", "-q", "-b", "feature", wt, "HEAD", cwd=b)
+        os.utime(pointer, ns=(old.st_atime_ns, old.st_mtime_ns))   # the same tick, as a coarse filesystem reports it
+        new = os.stat(pointer)
+        self.assertEqual(new.st_mtime, old.st_mtime, "the mtime says nothing changed")
+        self.assertNotEqual(new.st_ino, old.st_ino, "the inode says a new file (the old one is still allocated)")
+        self.forks.clear()
+        self.assertEqual(self._builds(wt), [("feature", "other-org/fork")] * 3, "the second clone's branch and origin")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1},
+                         "new evidence (the inode): one re-ask, the tree's memos forgotten and re-derived once")
+        self.assertEqual(os.path.realpath(km._pointer_cache[os.path.abspath(pointer)][1]),
+                         os.path.realpath(os.path.join(b, ".git", "worktrees", "shared-name")),
+                         "the pointer memo names the second clone's private dir")
+
+    def test_a_symlinked_cwd_re_pointed_at_another_repository_is_re_asked(self):
+        # a session registered at ~/proj/current where current -> release-3; the user re-points the link at
+        # release-4, a different repository. The chain stats the same lexical `current/.git`, so a key on
+        # the path alone hit and served release-3's toplevel, branch and repo for the kernel's life (review
+        # find, 2026-09-06; predates the evidence-keyed verdict — a found toplevel was trusted for life
+        # before it). The directory's inode is in the key: the re-pointed link resolves to another one.
+        ra = _repo(self.root, "release-3", HTTPS_ORIGIN)
+        rb = _repo(self.root, "release-4", "https://github.com/other-org/fresh.git")
+        _git("checkout", "-q", "-b", "bee", cwd=rb)
+        link = os.path.join(self.root, "current")
+        os.symlink(ra, link)
+        self.assertEqual(self._builds(link), [("main", REPO)] * 3)
+        self.assertEqual(os.path.realpath(km._tree_of(link)[0]), os.path.realpath(ra))
+        os.remove(link)
+        os.symlink(rb, link)
+        self.forks.clear()
+        self.assertEqual(self._builds(link), [("bee", "other-org/fresh")] * 3, "the repository the link points at now")
+        self.assertEqual(os.path.realpath(km._tree_of(link)[0]), os.path.realpath(rb))
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1},
+                         "a different `.git` under the same path: one re-ask; the new toplevel's own memos, derived once")
+        st = os.stat(os.path.join(rb, ".git"))
+        self.assertEqual(km._tree_cache[link][1], (os.path.join(link, ".git"), st.st_ino, st.st_dev),
+                         "keyed on the lexical path and the directory it resolves to")
+
+    def test_the_shape_records_own_bound_leaves_no_tree_with_unvouched_memos(self):
+        # _top_shape is bounded at 512 toplevels and clears the four memos with itself — but a live tree's
+        # memos are then refilled by _tree_of's HIT path with no record vouching for them, and a re-ask
+        # that found no record treated the current shape as the recorded one: a reshape whose re-ask was
+        # the tree's first after the bound served the dead worktree's branch and the old clone's repo for
+        # the kernel's life — the bug _vouch_tree closes, re-opened for every tree at once (review find,
+        # 2026-09-06). The bound is tripped through the kernel's own vouching: phantom toplevels outside
+        # every tree (a real repository per record would cost seconds of git init for nothing more).
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-web")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        top = os.path.realpath(wt)
+        self.assertIn(top, km._top_shape)
+        i = 0
+        while len(km._top_shape) <= 512:
+            km._vouch_tree(os.path.join(self.root, "phantom-%d" % i))
+            i += 1
+        other = _repo(self.root, "other", "https://github.com/other-org/other-repo.git")
+        self.assertEqual(self._builds(other), [("main", "other-org/other-repo")] * 3, "a new tree's first ask trips the bound")
+        self.assertNotIn(top, km._top_shape, "the bound cleared the worktree's record…")
+        self.assertNotIn(top, km._head_path_cache, "…and its memos")
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        self.assertIn(top, km._head_path_cache, "the hit path refilled the memos…")
+        self.assertNotIn(top, km._top_shape, "…with no record vouching for them")
+        shutil.rmtree(wt)
+        _repo(self.root, "main-web", "https://github.com/other-org/fresh.git")   # a plain clone where the worktree was
+        self.forks.clear()
+        self.assertEqual(self._builds(wt), [("main", "other-org/fresh")] * 3,
+                         "no record is no vouch: the re-ask forgets the unvouched memos, and the plain repo's own branch and origin show")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1})
+        self.assertIn(top, km._top_shape, "the tree is vouched again")
+
+    def test_a_subdirectory_asked_about_for_the_first_time_forgets_nothing_of_its_memoized_tree(self):
+        # forgetting is keyed on the tree's own .git changing shape, not on the re-ask alone — a first ask
+        # for a new edit directory under a known tree (every new lastEditPath directory) must cost no fork
+        d = _repo(self.root, "deep", HTTPS_ORIGIN)
+        sub = os.path.join(d, "src", "pkg")
+        os.makedirs(sub)
+        self.assertEqual(self._builds(d), [("main", REPO)] * 3)
+        self.forks.clear()
+        self.assertEqual(self._builds(sub), [("main", REPO)] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1}, "the tree's shape is unchanged: its branch and repo memos stand")
+
+    def test_a_removed_sibling_worktree_costs_no_fork_after_its_re_ask(self):
+        # the repo convention: registered on the clone, working on a sibling worktree named by lastEditPath;
+        # `git worktree remove` when finished deletes the worktree dir and its private gitdir
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-web")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
+        self.assertEqual(self._builds(main), [("main", REPO)] * 3)
+        self.forks.clear()
+        _git("worktree", "remove", "--force", wt, cwd=main)
+        self.assertEqual(self._builds(wt), [("", None)] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1})
+        self.assertEqual(self._builds(main), [("main", REPO)] * 3, "the clone is untouched")
+        self.assertEqual(self.forks, {"--show-toplevel": 1}, "…and still served from its memos")
+
+    def test_a_subdirectory_cwd_is_memoized_like_the_toplevel(self):
+        # _git_branch(scwd) for a session whose cwd is a subdirectory of its tree forked per build before:
+        # no .git of its own to key on. Through _tree_of it rides the toplevel's HEAD memo.
+        d = _repo(self.root, "deep", HTTPS_ORIGIN)
+        sub = os.path.join(d, "src", "pkg")
+        os.makedirs(sub)
+        self.assertEqual([km._git_branch(sub) for _ in range(3)], ["main"] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1})
+        _git("checkout", "-q", "-b", "topic", cwd=d)
+        self.assertEqual(km._git_branch(sub), "topic", "a HEAD move is still the refresh event")
+
+
+class PerCallCost(unittest.TestCase):
+    """What a memoized verdict costs per call, counted: two stats for a plain toplevel, three for a
+    worktree's and NO read of its pointer file — the pointer's target is memoized on the file's mtime
+    (_pointer_gitdir) and the entry's kind comes off the one stat the chain walk already made. Deriving
+    both per call made a worktree cwd — this repo's own convention, so the shape most builds pay — cost
+    five stats and a file read per call, some 40 us against a plain toplevel's 9 (review find,
+    2026-09-06)."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        if km._dotgit_on_chain(self.root):
+            self.skipTest("the temp root sits inside a repository; these need a directory outside every tree")
+        self.forks = {}
+        self.addCleanup(_count_git(self.forks))
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _cost(self, fn):
+        """(stats, file opens) of one call once every memo is warm — the steady state every build pays."""
+        fn(); fn()
+        n = {"stat": 0, "open": 0}
+        real_stat, real_open = os.stat, builtins.open
+
+        def counting_stat(*a, **k):
+            n["stat"] += 1
+            return real_stat(*a, **k)
+
+        def counting_open(*a, **k):
+            n["open"] += 1
+            return real_open(*a, **k)
+        os.stat, builtins.open = counting_stat, counting_open
+        try:
+            fn()
+        finally:
+            os.stat, builtins.open = real_stat, real_open
+        return n["stat"], n["open"]
+
+    def test_a_plain_toplevel_costs_two_stats_and_a_worktrees_three_with_no_read(self):
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-web")
+        _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        self.assertEqual(self._cost(lambda: km._tree_of(main)), (2, 0), "the chain's stat and HEAD's")
+        self.assertEqual(self._cost(lambda: km._tree_of(wt)), (3, 0), "…plus the pointer target's; the pointer itself is not read")
+        self.assertEqual(self._cost(lambda: km._github_repo_of(wt)), (4, 0), "…plus the config file's")
+        sub = os.path.join(wt, "a", "b")
+        os.makedirs(sub)
+        self.assertEqual(self._cost(lambda: km._tree_of(sub)), (5, 0), "one more per directory between the cwd and its .git")
+        self.assertEqual(km._tree_of(wt), (os.path.realpath(wt), "web"))
+        self.assertEqual(km._github_repo_of(wt), REPO)
+
+    def test_the_pointer_is_read_once_more_only_when_its_mtime_moves(self):
+        main = _repo(self.root, "main", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-x")
+        _git("worktree", "add", "-q", "-b", "x", wt, "HEAD", cwd=main)
+        self.assertEqual(self._cost(lambda: km._tree_of(wt)), (3, 0))
+        pointer = os.path.join(wt, ".git")
+        with open(pointer) as f:
+            line = f.read()
+        with open(pointer, "w") as f:                     # `git worktree repair` rewrites it in place
+            f.write(line)
+        _bump_mtime(pointer)
+        self.forks.clear()
+        self.assertEqual(km._tree_of(wt), (os.path.realpath(wt), "x"))
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1},
+                         "new evidence: one re-ask — and a rewritten pointer may name another clone (_vouch_tree), "
+                         "so the tree's branch memo is re-derived once")
+        self.assertEqual(self._cost(lambda: km._tree_of(wt)), (3, 0), "…and the rewritten pointer is memoized again")
+
+
+class BareRepository(unittest.TestCase):
+    """A session registered in a BARE clone (a bare-plus-worktrees layout) has no work tree for
+    `rev-parse --show-toplevel` to name, so _tree_of says not-a-tree — and _git_branch, derived through
+    it, showed no branch where the direct `--abbrev-ref HEAD` query used to (it answers in a bare repo,
+    and forked per build there: nothing memoized it). The bare shape is recognized by git's own test —
+    HEAD, objects/ and refs/ at the directory — and its branch rides the HEAD-mtime memo like a tree's
+    (review find, 2026-09-06)."""
+
+    def setUp(self):
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.root = tempfile.mkdtemp()
+        if km._dotgit_on_chain(self.root):
+            self.skipTest("the temp root sits inside a repository; these need a directory outside every tree")
+        self.forks = {}
+        self.addCleanup(_count_git(self.forks))
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_a_bare_repositorys_branch_is_the_one_its_head_names_memoized_on_head(self):
+        src = _repo(self.root, "src", HTTPS_ORIGIN)
+        bare = os.path.join(self.root, "bare.git")
+        _git("clone", "-q", "--bare", src, bare, cwd=self.root)
+        self.assertEqual([km._git_branch(bare) for _ in range(3)], ["main"] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1}, "asked once each, then memoized")
+        self.assertIsNone(km._github_repo_of(bare), "no work tree, no tree-derived repo — as before")
+        _git("branch", "other", cwd=bare)
+        _git("symbolic-ref", "HEAD", "refs/heads/other", cwd=bare)
+        _bump_mtime(os.path.join(bare, "HEAD"))
+        self.assertEqual(km._git_branch(bare), "other", "HEAD moving is the refresh event, in a bare clone too")
+        self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 2})
+
+    def test_a_worktree_beside_the_bare_clone_is_an_ordinary_tree(self):
+        src = _repo(self.root, "src", HTTPS_ORIGIN)
+        bare = os.path.join(self.root, "bare.git")
+        _git("clone", "-q", "--bare", src, bare, cwd=self.root)
+        wt = os.path.join(self.root, "topic")
+        _git("worktree", "add", "-q", "-b", "topic", wt, "main", cwd=bare)
+        self.assertEqual(km._git_branch(wt), "topic")
+        self.assertEqual(km._github_repo_of(wt), None, "the bare clone has no origin remote")
+
+    def test_a_directory_outside_every_repository_is_still_no_branch_and_no_fork(self):
+        d = os.path.join(self.root, "notes")
+        os.makedirs(d)
+        self.assertEqual([km._git_branch(d) for _ in range(3)], [""] * 3)
+        self.assertEqual(self.forks, {"--show-toplevel": 1}, "not a tree, not bare: no branch query at all")
+
+
+class ConfigFile(unittest.TestCase):
+    """_git_config_file's layouts, built by hand under a private temp dir: the file is the memo's mtime
+    source, so a layout it cannot resolve forks `git remote get-url` on every build. The live-worktree
+    test above covers an absolute gitdir with a `..`-relative commondir; these are the other branches."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def _layout(self, name, gitdir_line):
+        top = os.path.join(self.root, name)
+        os.makedirs(top)
+        with open(os.path.join(top, ".git"), "w") as f:
+            f.write("gitdir: %s\n" % gitdir_line)
+        return top
+
+    def test_a_relative_gitdir_resolves_against_the_tree(self):
+        gd = os.path.join(self.root, "main", ".git", "worktrees", "wt")
+        os.makedirs(gd)
+        with open(os.path.join(gd, "commondir"), "w") as f:
+            f.write("../..\n")
+        top = self._layout("wt", "../main/.git/worktrees/wt")
+        self.assertEqual(km._git_config_file(top), os.path.join(self.root, "main", ".git", "config"))
+
+    def test_a_gitdir_with_no_commondir_holds_its_own_config(self):
+        # the submodule shape: .git is a file naming <super>/.git/modules/<name>, which has no commondir
+        # and carries the submodule's own remotes
+        gd = os.path.join(self.root, "super", ".git", "modules", "lib")
+        os.makedirs(gd)
+        top = self._layout("lib", gd)
+        self.assertEqual(km._git_config_file(top), os.path.join(gd, "config"))
+
+    def test_a_relative_gitdir_with_no_commondir_resolves_then_holds_its_own_config(self):
+        gd = os.path.join(self.root, "store", "gd")
+        os.makedirs(gd)
+        top = self._layout("tree", "../store/gd")
+        self.assertEqual(km._git_config_file(top), os.path.join(gd, "config"))
+
+    def test_an_absolute_commondir_is_taken_as_is(self):
+        gd = os.path.join(self.root, "private")
+        shared = os.path.join(self.root, "shared")
+        os.makedirs(gd)
+        os.makedirs(shared)
+        with open(os.path.join(gd, "commondir"), "w") as f:
+            f.write(shared + "\n")
+        top = self._layout("abs-common", gd)
+        self.assertEqual(km._git_config_file(top), os.path.join(shared, "config"))
+
+    def test_no_dot_git_at_all_is_no_config_file(self):
+        top = os.path.join(self.root, "bare-dir")
+        os.makedirs(top)
+        self.assertEqual(km._git_config_file(top), "")
+
+    def test_a_live_worktree_with_a_relative_gitdir_keeps_its_memo(self):
+        # a hand-relativized worktree (the .git pointer rewritten relative, as some tooling does): the
+        # repo is named AND a second call forks no `remote get-url` — the config file resolved, so the
+        # mtime memo holds
+        self._saved_env = {k: os.environ.get(k) for k in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM")}
+        os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+        os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+        self.addCleanup(lambda: [os.environ.pop(k, None) if v is None else os.environ.__setitem__(k, v)
+                                 for k, v in self._saved_env.items()])
+        main = _repo(self.root, "main-repo", HTTPS_ORIGIN)
+        wt = os.path.join(self.root, "main-repo-wt")
+        _git("worktree", "add", "-q", "-b", "wtb", wt, "HEAD", cwd=main)
+        with open(os.path.join(wt, ".git")) as f:
+            gd = f.readline().strip()[len("gitdir:"):].strip()
+        self.assertTrue(os.path.isabs(gd), "git writes the pointer absolute")
+        with open(os.path.join(wt, ".git"), "w") as f:
+            f.write("gitdir: %s\n" % os.path.relpath(gd, wt))
+        real = km._git_out
+        reads = []
+
+        def counting(args, cwd, *a, **kw):
+            if list(args[:2]) == ["remote", "get-url"]:
+                reads.append(cwd)
+            return real(args, cwd, *a, **kw)
+        km._git_out = counting
+        try:
+            self.assertEqual(km._github_repo_of(wt), REPO)
+            self.assertEqual(km._github_repo_of(wt), REPO)
+        finally:
+            km._git_out = real
+        self.assertEqual(len(reads), 1, "resolved config file → one read, then the memo")
+        self.assertEqual(os.path.realpath(km._git_config_file(os.path.realpath(wt))),
+                         os.path.realpath(os.path.join(main, ".git", "config")))
+
+
+UNREGISTERED_SID = "00000000-0000-4000-8000-000000000000"   # never written to the names registry
+
+
+class RegistryPath(_Fixtures):
+    """Both frames derive the repo from ONE directory, _session_cwd: the names registry's cwd first, the
+    transcript's cwd stamp for a session romp never registered. The chat frame passes the meta it has in
+    hand, the feed's session rows pass the transcript path; a session with no registry entry must link the
+    same repo on both — before the helper the feed read _cwd_of alone and linked nothing for it (review
+    find, 2026-09-06). A PRIVATE synthetic sid, cleaned up after."""
+
+    def setUp(self):
+        km.NAMES.mkdir(parents=True, exist_ok=True)
+        (km.NAMES / PRIVATE_SID).write_text("web\t%s\t#123456\t#ffffff\n" % self.https)
+        self.transcript = os.path.join(tempfile.mkdtemp(), "transcript.jsonl")
+
+    def tearDown(self):
+        try:
+            (km.NAMES / PRIVATE_SID).unlink()
+        except FileNotFoundError:
+            pass
+
+    def _stamp(self, cwd):
+        """A synthetic transcript whose records stamp `cwd`, the way the CLI stamps every record."""
+        with open(self.transcript, "w") as f:
+            f.write(json.dumps({"type": "user", "uuid": "11111111-2222-3333-4444-555555555555", "cwd": cwd,
+                                "version": "2.1.0", "gitBranch": "main",
+                                "message": {"role": "user", "content": "hello"}}) + "\n")
+        return self.transcript
+
+    def test_the_registered_cwd_names_the_sessions_repo(self):
+        self.assertEqual(km._cwd_of(PRIVATE_SID), self.https)
+        self.assertEqual(km._github_repo_of(km._session_cwd(PRIVATE_SID)), REPO)
+
+    def test_the_registry_outranks_the_transcripts_stamp(self):
+        # a shell `cd` inside a Bash call moves the CLI's tracked cwd, and the stamp with it — the
+        # registry is the project directory whenever it exists
+        path = self._stamp(self.elsewhere)
+        self.assertEqual(km._session_cwd(PRIVATE_SID, path), self.https)
+        self.assertEqual(km._session_cwd(PRIVATE_SID, meta={"cwd": self.elsewhere}), self.https)
+
+    def test_a_never_registered_session_takes_the_transcripts_stamp_on_both_frames(self):
+        path = self._stamp(self.https)
+        self.assertEqual(km._cwd_of(UNREGISTERED_SID), "", "no registry entry")
+        meta = km._session_meta(path)
+        chat_frame = km._session_cwd(UNREGISTERED_SID, meta=meta)        # build_session: the meta in hand
+        feed_row = km._session_cwd(UNREGISTERED_SID, path)               # build_feed: the transcript path
+        self.assertEqual(chat_frame, self.https)
+        self.assertEqual(feed_row, chat_frame, "the chat frame and the feed's session row name one directory")
+        self.assertEqual(km._github_repo_of(feed_row), REPO)
+
+    def test_no_registry_entry_and_no_transcript_is_no_directory_and_no_repo(self):
+        self.assertEqual(km._session_cwd(UNREGISTERED_SID), "")
+        self.assertEqual(km._session_cwd(UNREGISTERED_SID, None, None), "")
+        self.assertIsNone(km._github_repo_of(km._session_cwd(UNREGISTERED_SID)))
+
+
+class FrameWiring(unittest.TestCase):
+    """build_session's and build_feed's wiring, pinned by source (the build_* test pattern)."""
+
+    def test_the_session_frame_carries_the_repo_top_level(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn("scwd = _session_cwd(sid, meta=meta)", src, "the shared derivation, with the meta in hand")
+        self.assertIn('"githubRepo": _github_repo_of(scwd),', src,
+                      "top-level like gitBranch — never windowed off the wire")
+        self.assertLess(src.index('"gitBranch": sysinfo["gitBranch"]'), src.index('"githubRepo": _github_repo_of(scwd)'))
+
+    def test_the_feed_session_rows_carry_the_repo(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('"githubRepo": _github_repo_of(_session_cwd(s["sid"], s.get("path")))', src,
+                      "each tab-strip session row names its repo from the SAME directory the chat frame uses")
+        self.assertNotIn('_github_repo_of(_cwd_of(', src, "never the registry alone — a transcript-only session has none")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -16,12 +16,15 @@ stats), the pointer memos of a tree that dies or changes shape under a live sess
 and _vouch_tree forgetting a reshaped tree's memos — or unvouched ones, after its record's own bound; a
 pointer re-made within one mtime tick; a symlinked cwd re-pointed at another repository), what a
 memoized call costs in stats, the branch
-of a BARE repository, _git_config_file's hand-built layouts (a relative gitdir, a gitdir with no
-commondir), and _session_cwd — the one derivation of a session's directory the chat frame and the
-feed's session rows share, so a never-registered session links the same repo on both.
+of a BARE repository, the inbound postal card's `peerHost` (the chat resolves a sender's repo by host
+and name; a row from before the log stamped a host carries none), the session frame's `selfHost`,
+_git_config_file's hand-built layouts (a relative gitdir, a gitdir with no commondir), and
+_session_cwd — the one derivation of a session's directory the chat frame and the feed's session
+rows share, so a never-registered session links the same repo on both.
 """
 import builtins
 import inspect
+import io
 import json
 import os
 import shutil
@@ -792,6 +795,74 @@ class BareRepository(unittest.TestCase):
         self.assertEqual(self.forks, {"--show-toplevel": 1}, "not a tree, not bare: no branch query at all")
 
 
+class PostalCardSenderHost(unittest.TestCase):
+    """The inbound postal card carries the sender's HOST (`peerHost`, the message log's from_host: "" for
+    this kernel's own sessions, a peer's name otherwise) beside the sender's name, so the chat links the
+    body's `#123` against exactly the sender's session — the name alone let a remote homonym borrow a
+    local session's repo when its host was not attached to the dashboard (review find, 2026-09-06). A
+    log row with NO from_host at all — one from before the log stamped the field on every row — puts no
+    peerHost on the card: read as "", a pre-field REMOTE sender was presented as this kernel's own
+    (review find, 2026-09-06); the chat resolves such a card by the name alone, as before the field.
+    Synthetic records only (invented sessions, placeholder ids, TESTHOST)."""
+    ME = "11111111-2222-3333-4444-555555555555"
+    SENDER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    MID = "1700000000.11111_22222.TESTHOST"
+
+    def _card(self, **rec):
+        row = {"id": self.MID, "from": "api", "fromId": self.SENDER, "fromHost": "", "toId": self.ME,
+               "body": "see #12", "kind": "coordinate", "t": 1700000000, "park": False}
+        row.update(rec)
+        ev = {"kind": "user", "md": "<!-- romp-msg-id: %s -->" % self.MID, "uuid": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+              "ts": "x", "human": False}
+        saved_sum, saved_err = km._msg_summaries, km.sys.stderr
+        km._msg_summaries, km.sys.stderr = (lambda: {}), io.StringIO()
+        try:
+            out = km._hydrate_postal([ev], {self.MID: row}, self.ME)
+        finally:
+            km._msg_summaries, km.sys.stderr = saved_sum, saved_err
+        self.assertEqual([e["kind"] for e in out], ["postal-service"])
+        return out[0]
+
+    def test_a_local_senders_card_names_this_kernels_own_host_as_the_empty_string(self):
+        card = self._card()
+        self.assertEqual((card["direction"], card["peer"], card["peerHost"]), ("in", "api", ""))
+
+    def test_a_remote_senders_card_names_the_host_the_log_stamped(self):
+        card = self._card(fromHost="TESTHOST")
+        self.assertEqual((card["peer"], card["peerHost"]), ("api", "TESTHOST"))
+
+    def test_a_nameless_remote_sender_keeps_its_host_stub_name_and_the_host_field(self):
+        card = self._card(**{"from": "?", "fromHost": "TESTHOST", "fromId": "77777777-8888-9999-aaaa-bbbbbbbbbbbb"})
+        self.assertEqual((card["peer"], card["peerHost"]), ("TESTHOST:77777777", "TESTHOST"))
+
+    def test_a_row_from_before_the_log_stamped_a_host_puts_no_host_on_the_card(self):
+        card = self._card(fromHost=None)
+        self.assertEqual((card["direction"], card["peer"]), ("in", "api"))
+        self.assertNotIn("peerHost", card, "absent, not '': the sender could be anyone's session")
+
+    def test_the_index_tells_a_row_without_the_field_from_a_local_one(self):
+        log = km.jd.STATE / "timeline" / "messages.jsonl"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        rows = [{"t": 1700000000, "ev": "sent", "id": "1700000000.1_1.TESTHOST", "from": "api", "from_id": self.SENDER,
+                 "to_id": self.ME, "body": "see #12"},                                        # before the field
+                {"t": 1700000001, "ev": "sent", "id": "1700000001.1_1.TESTHOST", "from": "api", "from_id": self.SENDER,
+                 "to_id": self.ME, "body": "see #13", "from_host": ""},                       # local, stamped so
+                {"t": 1700000002, "ev": "sent", "id": "1700000002.1_1.TESTHOST", "from": "api", "from_id": self.SENDER,
+                 "to_id": self.ME, "body": "see #14", "from_host": "TESTHOST"}]               # relayed
+        saved = log.read_text() if log.exists() else None
+        km._postal_index_memo[0] = None
+        try:
+            log.write_text("".join(json.dumps(r) + "\n" for r in rows))
+            idx = km._postal_index()
+            self.assertEqual([idx[r["id"]]["fromHost"] for r in rows], [None, "", "TESTHOST"])
+        finally:
+            km._postal_index_memo[0] = None
+            if saved is None:
+                log.unlink()
+            else:
+                log.write_text(saved)
+
+
 class ConfigFile(unittest.TestCase):
     """_git_config_file's layouts, built by hand under a private temp dir: the file is the memo's mtime
     source, so a layout it cannot resolve forks `git remote get-url` on every build. The live-worktree
@@ -944,6 +1015,17 @@ class FrameWiring(unittest.TestCase):
         self.assertIn('"githubRepo": _github_repo_of(scwd),', src,
                       "top-level like gitBranch — never windowed off the wire")
         self.assertLess(src.index('"gitBranch": sysinfo["gitBranch"]'), src.index('"githubRepo": _github_repo_of(scwd)'))
+
+    def test_the_session_frame_names_this_kernels_own_host(self):
+        # the chat reads a postal card's sender host against the viewing kernel's own name; it learned
+        # that name only from the + picker's reply before, so the reading was inert until the picker opened
+        src = inspect.getsource(km.build_session)
+        self.assertIn('"selfHost": _self_host(),', src, "top-level on the frame the chat receives for every session")
+        feed = inspect.getsource(km.build_feed)
+        self.assertIn('"selfHost": _self_host(),', feed, "the same name the feed frame carries")
+        # …and the tabOrder frame, which every chat receives first of all: a dashboard whose kernel runs no
+        # local session has no session frame to learn the name from (tests/test_kernel_tabs_first.py runs it)
+        self.assertEqual(km._tab_order_frame([], [], [])["selfHost"], km._self_host())
 
     def test_the_feed_session_rows_carry_the_repo(self):
         src = inspect.getsource(km.build_feed)

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -45,7 +45,7 @@ class TabsFirst(unittest.TestCase):
         text = open(KPATH).read()
         self.assertEqual(text.count('_send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))'), 2)
         self.assertEqual(text.count("frame = _tab_order_frame(tab_order, tab_meta, tmux)"), 1)
-        self.assertEqual(text.count("json.dumps(_tab_order_frame(_o, _tabs))"), 1)
+        self.assertEqual(text.count("_frame = _tab_order_frame(_o, _tabs, _tm)"), 1)
         self.assertEqual(text.count('{"type": "tabOrder"'), 1, "the literal lives in _tab_order_frame alone")
         self.assertIn("_tab_order_frame(tab_order, tab_meta, tmux)", inspect.getsource(km._push_session_now))
         self.assertIn("_tab_order_frame(tab_order, tab_meta, tmux)", inspect.getsource(km._confirm_close_now))

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -26,12 +26,34 @@ class TabsFirst(unittest.TestCase):
         self.assertIn('tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', src,
                       "the periodic push builds a name+color list per tab")
         self.assertIn('_send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))', src,
-                      "and ships it as the tabs field alongside the sid order")
+                      "and ships it as the tabs field alongside the sid order, in the frame's one spelling")
+
+    def test_every_tab_order_frame_names_this_kernels_own_host(self):
+        # the chat reads a postal card's sender host against the viewing kernel's own name (its
+        # postalSenderHost); the session frame carries the name, but only a LOCAL session's frame teaches
+        # it, so a dashboard whose kernel runs no sessions of its own never learned it until the + picker
+        # opened, and a remote card stamped with this kernel's name stayed plain text (review find,
+        # 2026-09-06). The tabOrder frame is the one every chat receives, first of all on connect.
+        sid = "11111111-2222-3333-4444-555555555555"
+        frame = km._tab_order_frame([sid], [{"id": sid, "name": "web", "color": None}], [sid])
+        self.assertEqual(frame["type"], "tabOrder")
+        self.assertEqual(frame["selfHost"], km._self_host())
+        self.assertEqual(sorted(frame), ["live", "order", "selfHost", "tabs", "type", "views"])
+        # the four senders share the one spelling: the pusher's tabs-first send, the off-cycle session push,
+        # the close confirmation and the WS 'ready' handler's connect-time frame — a fifth inline dict would
+        # drop the field again
+        text = open(KPATH).read()
+        self.assertEqual(text.count('_send_client(c, ("taborder",), _tab_order_frame(tab_order, tab_meta, tmux))'), 2)
+        self.assertEqual(text.count("frame = _tab_order_frame(tab_order, tab_meta, tmux)"), 1)
+        self.assertEqual(text.count("json.dumps(_tab_order_frame(_o, _tabs))"), 1)
+        self.assertEqual(text.count('{"type": "tabOrder"'), 1, "the literal lives in _tab_order_frame alone")
+        self.assertIn("_tab_order_frame(tab_order, tab_meta, tmux)", inspect.getsource(km._push_session_now))
+        self.assertIn("_tab_order_frame(tab_order, tab_meta, tmux)", inspect.getsource(km._confirm_close_now))
 
     def test_connect_ready_handler_also_sends_tabs(self):
         text = open(KPATH).read()
         self.assertIn('_frame = _tab_order_frame(_o, _tabs, _tm)', text,
-                      "the WS 'ready' connect push also carries name+color tabs")
+                      "the WS 'ready' connect push also carries name+color tabs, in the frame's one spelling")
         self.assertIn('_tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', text)
 
     def test_name_color_shape_matches_the_client_color_type(self):

--- a/tests/test_postal_from_host_row.py
+++ b/tests/test_postal_from_host_row.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""deliver() stamps `from_host` on EVERY messages.jsonl "sent" row — "" for local delivery, the origin
+host for relayed mail — so a row says outright which it is. Written only when set before, a local row
+and a relayed row from before the field existed (2026-07-20..26) had the same shape, and the kernel's
+postal card read both as "" = this kernel's own: a pre-field remote sender was presented as local, and
+the chat linked its PR references against a local homonym's repository (review find, 2026-09-06). Now
+a row WITHOUT the key is one from before the stamp, and the card carries no host for it (the kernel
+side: tests/test_github_repo.py PostalCardSenderHost). Synthetic ids and TESTHOST only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)                 # a live kernel's export outranks the XDG floor
+pm = SourceFileLoader("romp_postal_from_host_row", os.path.join(BIN, "romp-postal-service")).load_module()
+
+TO = "11111111-2222-3333-4444-555555555555"
+FROM = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+
+
+def _sent_rows():
+    p = pm.TLDIR / "messages.jsonl"
+    if not p.exists():
+        return {}
+    return {r["id"]: r for r in (json.loads(ln) for ln in p.read_text().splitlines() if ln.strip()) if r.get("ev") == "sent"}
+
+
+class FromHostOnEveryRow(unittest.TestCase):
+    def test_local_delivery_says_local_outright(self):
+        mid = pm.deliver(TO, "api", FROM, "the notes-api tests are green")
+        row = _sent_rows()[mid]
+        self.assertIn("from_host", row, "the key is written, not left to absence")
+        self.assertEqual(row["from_host"], "")
+
+    def test_relayed_mail_keeps_its_origin_host(self):
+        mid = pm.deliver(TO, "api", FROM, "please review #12", from_host="TESTHOST")
+        self.assertEqual(_sent_rows()[mid]["from_host"], "TESTHOST")
+
+    def test_a_caller_passing_none_still_writes_the_empty_string(self):
+        mid = pm.deliver(TO, "api", FROM, "hello", from_host=None)
+        self.assertEqual(_sent_rows()[mid]["from_host"], "")
+
+    def test_the_header_block_is_unchanged_for_local_mail(self):
+        # the maildir header carries X-From-Host only when there is a host; the log row is the durable record
+        mid = pm.deliver(TO, "api", FROM, "hello again")
+        msgs = {m["id"]: m for m in pm.read_box(TO, consume=False)}
+        self.assertEqual(msgs[mid]["from_host"], "", "read_box's default for a header that is absent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -263,6 +263,9 @@ class TimelineViews(unittest.TestCase):
         self.assertIn('"views": _views_client(),', src, "the timeline payload carries the RENDERED shape")
         self.assertIn('"palette": pal.colors(_palette_name()),', src, "and the palette, for tag colors in every host")
         self.assertIn('_tab_order_frame(tab_order, tab_meta, tmux)', src, "tabOrder pushes carry it (the one frame builder, T258)")
+        # every tabOrder frame is built by ONE helper (2026-09-06: the frame also carries selfHost)
+        self.assertIn('return {"type": "tabOrder", "order": list(order), "tabs": tabs, "selfHost": _self_host(),\n'
+                      '            "views": _views_client(), "live": sorted({str(x) for x in live})}', src, "tabOrder frames carry it")
         self.assertIn('"views": _views_client(), "live":', src, "…which carries the blob")
         self.assertIn('_frame = _tab_order_frame(_o, _tabs, _tm)', src, "the connect-time tabOrder carries it")
 

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -78,11 +78,12 @@ test("the singleton stays breaks:false — assistant rendering is unchanged", ()
 });
 
 test("userMd() renders through the breaks:true instance and the SAME DOMPurify profile as md()", () => {
-  const fn = RENDER.match(/function userMd\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  // (both signatures grew an optional repo parameter for PR links — pr-links.ts — so match them loosely)
+  const fn = RENDER.match(/function userMd\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
   assert.ok(fn, "userMd() must exist");
-  assert.match(fn, /DOMPurify\.sanitize\(userMdHtml\(src\), MD_PURIFY\)/);
-  const mdFn = RENDER.match(/function md\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
-  assert.match(mdFn, /DOMPurify\.sanitize\(dirty, MD_PURIFY\)/, "md() sanitizes with the same shared profile");
+  assert.match(fn, /DOMPurify\.sanitize\(userMdHtml\(src\), \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/);
+  const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(mdFn, /DOMPurify\.sanitize\(dirty, \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/, "md() sanitizes with the same shared profile");
   assert.match(RENDER, /const MD_PURIFY: Config = \{ USE_PROFILES: \{ html: true, svg: true \}, ADD_DATA_URI_TAGS: \["img"\], ALLOW_DATA_ATTR: false \};/);
 });
 

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -664,6 +664,7 @@ export class FederationManager {
   private tlViewsRejected: any = null;      // the same for the LOCAL lanes payload's blob (perHostTl[LOCAL].views)
   private localViewsAnnounced: number | null = null;   // the seq the last LOCAL caps frame announced as the kernel's current store when the tabOrder store adopted no kept blob — a LATER blob at exactly that seq is adopted below the stored one (announcedSeq); cleared by the next adoption that changes the stored blob (announcedAfter)
   private tlViewsAnnounced: number | null = null;      // the same for the lanes payload's store
+  private localSelfHost = "";       // the LOCAL kernel's own name (its tabOrder frame's selfHost), carried the same way
   private perHostSids: Record<string, Set<string>> = {};
   private perHostFeed: Record<string, any> = {}; // last feed snapshot per host — merged so they don't clobber
   private perHostFeedAt: Record<string, number> = {}; // host -> local ms its snapshot ARRIVED: the merged frame's clock anchor (mergeHostFeeds `nowAt`), so a re-emit anchors exactly as the arrival did
@@ -889,6 +890,9 @@ export class FederationManager {
         if (adoptViews(this.localViews, m.views, this.localViewsAnnounced)) { this.localViewsAnnounced = announcedAfter(this.localViews, m.views, this.localViewsAnnounced); this.localViews = m.views; this.localViewsRejected = null; }
         else this.localViewsRejected = m.views;
       }
+      // the LOCAL kernel's own name rides its tabOrder frame too (selfHost): the chat reads a postal card's
+      // sender host against it, and a remote kernel's frame names ITSELF, so only the local one is kept
+      if (host === LOCAL && typeof m.selfHost === "string" && m.selfHost) this.localSelfHost = m.selfHost;
       this.ensureHost(host);
       this.absorbHostReport(host, prevOrder, prevTabs);   // a host just reported its sessions → the one
       this.emitMergedOrder(true, host);                   //   moment the stored arrangement may be touched
@@ -1021,7 +1025,7 @@ export class FederationManager {
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     const live = this.hostSeq.flatMap((h) => this.perHostLive[h] || []);   // T258: the union the pane's omission guard reads
     this.publishPending();
-    const data: any = { type: "tabOrder", order, tabs, live, views: this.localViews ?? undefined };
+    const data: any = { type: "tabOrder", order, tabs, live, views: this.localViews ?? undefined, selfHost: this.localSelfHost || undefined };
     // Provenance for the chat's close backstop (T233): a FRESH emission is driven by one host's own
     // tabOrder push and names that host (`freshHost`) — only ITS ids are that kernel's current word; the
     // other hosts' slices ride along from the store. A SYNTHETIC re-emit (a view-order storage event, a

--- a/ui/webview/feed-handoff-badge.test.ts
+++ b/ui/webview/feed-handoff-badge.test.ts
@@ -19,7 +19,9 @@ test("the badge is additive on the type — a payload without it renders exactly
 });
 
 test("the title is the kernel-shipped text verbatim — the de-arrowing lives kernel-side", () => {
-  assert.match(SRC, /a\._title\.textContent = it\.text;/,
+  // setLinkedText writes it.text as-is and only wraps its PR references in anchors (pr-links.ts);
+  // the visible text is still the kernel's, character for character
+  assert.match(SRC, /setLinkedText\(a\._title, it\.text, prRepoOf\(it\.sid\)\);/,
     "no client-side munging: one place (kernel _handoff_card_fields) owns the derivation");
 });
 

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -20,7 +20,10 @@ const U = "11111111-2222-3333-4444-555555555555";
 const V = "99999999-8888-7777-6666-555555555555";
 
 test("the kernel's feed payload carries the chat tab strip's sessions, tab_meta-shaped", () => {
-  assert.ok(KERNEL.includes('"sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}'));
+  assert.ok(KERNEL.includes('"sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"]),'));
+  // …plus the session's GitHub repo (owner/repo or null), for the card text's PR links (pr-links.ts, 2026-09-06),
+  // derived from the SAME cwd the chat frame uses (_session_cwd: the registry's, else the transcript's stamp)
+  assert.ok(KERNEL.includes('"githubRepo": _github_repo_of(_session_cwd(s["sid"], s.get("path")))}'));
   assert.ok(KERNEL.includes("for s in _chat_tab_sessions(now, tmux)]"), "the SAME list the tabs render, in ITS order");
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1510,6 +1510,11 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-md strong { color: var(--fg); font-weight: 600; }
 .fileview-md em { font-style: italic; }
 .fileview-md a { color: var(--link); text-decoration: none; }
+/* PR references linked in plain-text surfaces (pr-links.ts): card titles, distiller lines, checklists,
+   outline goal rows. Inside .md the generic anchor rule already inks them; this covers the rest, in the
+   same hyperlink ink. */
+.pr-link { color: var(--link); text-decoration: none; }
+.pr-link:hover { text-decoration: underline; }
 .fileview-md a:hover { text-decoration: underline; }
 .fileview-md blockquote { margin: 0.5em 0; padding-left: 12px;
   border-left: 2px solid var(--box-border); color: var(--dim); }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,6 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
 import { paintHeld, paintReleased } from "./paint-gate";
+import { linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener } from "./pr-links";
 import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
@@ -441,6 +442,22 @@ function setCardChannels(card: HTMLElement, rgb: [number, number, number]) {
 }
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
+// PR links inside cards open the PR and nothing else: capture-phase on the document, so the card's own
+// click (modal / pin) under the link never fires. Web → the viewer's browser; VS Code → the host's
+// openExternal via `openLink` (view-routing.ts; extension.ts opens it for the feed panel). Once, on the
+// stable document, keyed off the anchor's href across the press (the click-safety rule: the anchors
+// themselves are rebuilt by pushes).
+installPrLinkOpener(document, vscodeApi ? (m) => vscodeApi.postMessage(m) : undefined);
+function linkifyPrRefsIn<T extends HTMLElement>(elm: T, repo: string | null): T { linkifyPrRefs(elm, repo); return elm; }
+// A held message was written by its SENDER (blocked.frm, on host blocked.origin), so its `#123` means
+// the sender's repository — the one the frame's session rows name for that session, never the
+// recipient card's own (pr-links.ts senderPrRepo: a wrong link is worse than none). The origin is the
+// viewing kernel's own host → a local row; another host → its federated row; unknown ("?") → any row
+// by bare name, if exactly one answers to it.
+function prRepoOfSender(frm: string | undefined, origin: string | undefined): string | null {
+  const host = !origin || origin === "?" ? undefined : origin === feedSelfHost ? "" : origin;
+  return senderPrRepo(sessionsMeta, frm || "", host);
+}
 
 // The settings gear (the ⛭ modal + analytics) is part of THIS bundle now —
 // gear.js builds its DOM here and rides our one kernel channel, so both hosts
@@ -490,7 +507,13 @@ let sessionOrder: string[] = [];
 // The chat tab strip's sessions (sid+name+color), riding every feed push: the footer's session-filter
 // menu lists exactly the tabs (the user 2026-08-08) — a session with no cards still appears, and
 // filtering to it shows an empty board. Federation prefixes sid+name per host and concatenates.
-let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null }[] = [];
+let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null; githubRepo?: string | null }[] = [];
+// The GitHub repository a card's session works in (owner/repo, or null) — the kernel ships it on the
+// session rows above, derived from the session tree's origin remote; a `#123` in the card's text links
+// to that repository's PR page (pr-links.ts; the user 2026-09-06). Null → the text stays plain.
+function prRepoOf(sid: string | undefined): string | null {
+  return (sid && sessionsMeta.find((s) => s.sid === sid)?.githubRepo) || null;
+}
 // Attached hosts whose CARD payload hasn't merged yet (the user 2026-08-25: sessions land via the
 // faster channels, cards trail with no cue) — the federation merge names them (pendingHosts), the
 // board hints per host, and the hint retires ONLY on the real events: that host's first contribution
@@ -1656,7 +1679,7 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
       // branch is collapsed — its tooltip points DOWN to the real ask.
       mark.textContent = s.status === "done" ? "✓" : s.status === "question" ? "⏸" : "";
       if (s.status === "question") mark.title = s.qderived ? "a sub-goal inside is blocked — expand to find it" : "blocked — needs you";
-      const txt = el("span", "fcheck-text"); txt.textContent = s.text;
+      const txt = el("span", "fcheck-text"); txt.textContent = s.text; linkifyPrRefs(txt, prRepoOf(it.sid));
       row.append(tri, mark, txt);
       if (s.cleared) row.appendChild(clearedTag());   // the strike alone doesn't say WHY — see CLEARED_TIP
       if (s.parked && s.parked.n && !s.cleared) row.appendChild(parkedTag(s.parked.n));   // leapfrogged — see parkedTag
@@ -1756,7 +1779,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   }
   // a re-check card dims slightly (between a normal card and a provisional ghost) so it reads as "handled, pending"
   if (!it.provisional) card.style.opacity = it.recheck ? ".8" : "";
-  a._title.textContent = it.text;
+  setLinkedText(a._title, it.text, prRepoOf(it.sid));   // `#123` in the goal text → its PR page; keyed, so an unchanged title keeps its anchors across pushes (pr-links.ts)
   a._name.replaceChildren(...hostNameNodes(it.name, it.sid));   // remote "host:" prefix = quiet metadata
   if (it.color) a._name.style.color = it.color.bg;
   setWorkDot(a._name, dotFor(it.name));   // working/awaiting dot before the session name
@@ -2017,6 +2040,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // turn off once — the user 2026-06-29). updateAskCard runs every push, so this re-applies on every refresh.
   const distillShown = applyDistillLine(a._distill as HTMLElement, dCompleted, dBlocked,
                    it.summary, it.blockSummary);
+  if (distillShown) linkifyPrRefs(a._distill as HTMLElement, prRepoOf(it.sid));   // the takeaway's `#123` links too
   // A judge-auth card explains itself ON THE CARD FACE (the user 2026-08-12: a message, not just a
   // chip): no decision brief can exist here — the distiller is one of the very judges that are down —
   // so the distill line carries blocked.what instead of sitting empty. applyDistillLine re-runs every
@@ -2280,7 +2304,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       quarWho(it.blocked.origin || "", it.blocked.frm || "?"),
       Object.assign(el("span", "fq-arrow"), { textContent: "\u2192" }),
       quarWho(toHost, it.blocked.to || it.name || "?", it.color?.bg),
-      Object.assign(el("div", "fq-gist"), { textContent: it.blocked.gist || it.blocked.body || "" }));
+      linkifyPrRefsIn(Object.assign(el("div", "fq-gist"), { textContent: it.blocked.gist || it.blocked.body || "" }), prRepoOfSender(it.blocked.frm, it.blocked.origin)));
     qBody.title = "click to read the whole message and decide";
     a._qApprove.disabled = false; a._qApprove.textContent = "Approve";
     a._qDeny.disabled = false; a._qDeny.textContent = "Deny";
@@ -2534,7 +2558,7 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   card.style.background = `rgba(${r}, ${gg}, ${b}, ${TINT_ALPHA})`;
   // outline in the group's session identity colour (the user 2026-07-15) — CSS: 0.5α rest, bolded on hover/pin
   setCardChannels(card, (g.color && hexToRgb(g.color.bg)) || [r, gg, b]);
-  a._title.textContent = g.title;
+  setLinkedText(a._title, g.title, prRepoOf(g.sid));   // keyed like the ask card's title
   a._name.replaceChildren(...hostNameNodes(g.name, g.sid));
   if (g.color) a._name.style.color = g.color.bg;
   setWorkDot(a._name, dotFor(g.name));   // working/awaiting dot before the session name
@@ -2548,7 +2572,7 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
     for (const m of g.members) {
       const line = el("div", "fgroup-member st-" + memberStatus(m));
       const dot = el("span", "fgroup-dot"); dot.textContent = memberMark(m); line.appendChild(dot);
-      const txt = el("span", "fgroup-mtext"); txt.textContent = m.text; line.appendChild(txt);
+      const txt = el("span", "fgroup-mtext"); txt.textContent = m.text; linkifyPrRefs(txt, prRepoOf(m.sid || g.sid)); line.appendChild(txt);
       host.appendChild(line);
     }
   }
@@ -2878,7 +2902,7 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
   const mark = el("span", "ftree-mark"); mark.textContent = nodeMark(node); line.appendChild(mark);
   // blocked rolls UP (kernel flatten, the user 2026-07-11): a rolled-up ancestor's ⏸ says the block is below
   if (node.status === "question") mark.title = node.qderived ? "a sub-goal inside is blocked — the ⏸ below is the ask" : "blocked — needs you";
-  const txt = el("span", "ftree-text"); txt.textContent = node.text || "(node)"; line.appendChild(txt);
+  const txt = el("span", "ftree-text"); txt.textContent = node.text || "(node)"; linkifyPrRefs(txt, prRepoOf(it.sid)); line.appendChild(txt);
   if (node.cleared) line.appendChild(clearedTag());   // same one-word story as the card checklist
   if (node.parked && node.parked.n && !node.cleared) line.appendChild(parkedTag(node.parked.n));   // and the parked hint
   // (The node's why/blocked/done rationale hover tooltip was removed 2026-06-27 — just the goal text now.)
@@ -3014,7 +3038,7 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
   if (modalBg) {
     const bl = el("div", "ftree-seclabel"); bl.textContent = "background";
     bl.style.paddingLeft = ((depth + 1) * TREE_INDENT_EM) + "em";
-    const bb = el("div", "ftree-summary"); bb.textContent = modalBg;
+    const bb = el("div", "ftree-summary"); bb.textContent = modalBg; linkifyPrRefs(bb, prRepoOf(it.sid));
     bb.style.paddingLeft = ((depth + 1) * TREE_INDENT_EM) + "em";
     const sl = el("div", "ftree-seclabel"); sl.textContent = "summary";
     sl.style.paddingLeft = ((depth + 1) * TREE_INDENT_EM) + "em";
@@ -3024,6 +3048,7 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
     const sum = el("div", "ftree-summary");
     sum.style.paddingLeft = ((depth + 1) * TREE_INDENT_EM) + "em";
     sum.textContent = nodeDistill;
+    linkifyPrRefs(sum, prRepoOf(it.sid));
     // parity with the card's distiller line (the user 2026-06-29): the modal summary is also a LINK — clicking
     // it follows to where the node resolved (its work anchor, the SAME target as the node's mark/time zones).
     // Wired on EITHER anchor: goWork itself falls to the prompt anchor when the work one is cold-null, so

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -19,6 +19,7 @@ import { ageColorReadable } from "./age-color";
 import { liveNow } from "./feed-age";
 import { TIP_GRACE_MS } from "./tip";
 import { perfFrameHandler } from "./perf-telemetry";
+import { linkifyPrRefs, installPrLinkOpener } from "./pr-links";
 
 type Color = { bg: string; fg: string } | null;
 interface LedgerNode {
@@ -36,6 +37,12 @@ interface FleetSession { sid: string; name: string; color: Color; status?: { sta
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
+// A `#123` in a goal row links to the PR page of the repository its session works in (pr-links.ts; the
+// user 2026-09-06). The repo per session rides the feed frame's `sessions` rows (owner/repo, or null).
+let repoBySid = new Map<string, string | null>();
+// The link opens the PR and nothing else: capture-phase on the document, so the row's delegated jump
+// under it never fires. Web → the viewer's browser; VS Code → the host's openExternal (view-routing.ts).
+installPrLinkOpener(document, vscodeApi ? (m) => vscodeApi.postMessage(m) : undefined);
 
 let sessions: FleetSession[] = [];
 // Whether the FIRST feed payload has arrived (the user 2026-06-29): before it has, the fleet must NOT claim
@@ -345,6 +352,7 @@ function renderFleetNode(ctx: SessCtx, n: LedgerNode, depth: number, container: 
   const txt = el("span", "ledger-ttext lz-nav");
   txt.dataset.sid = s.sid; txt.dataset.nid = n.id; txt.dataset.act = "goprompt";   // text → the asking message
   highlightInto(txt, n.text, curSearch);   // search: highlight the matched substring (plain text otherwise)
+  linkifyPrRefs(txt, repoBySid.get(s.sid) || null);   // `#123` in the goal → its PR page; a search hit span is walked, not skipped
   // (The ⊕ distiller-summary expander was removed 2026-06-27 — the user: show just the goals, not the
   //  distiller takeaway / decision brief.)
   const time = el("span", "ledger-ttime");
@@ -744,6 +752,9 @@ window.addEventListener("message", perfFrameHandler("fleet", (m) => vscodeApi?.p
     hostNow = m.now;
     hostNowAt = typeof m.nowAt === "number" ? m.nowAt : Date.now();   // the pair travels together: the frame's clock, and when THAT frame arrived
   }
+  if (Array.isArray(m.sessions))
+    repoBySid = new Map(m.sessions.filter((s: any) => s && typeof s.sid === "string")
+      .map((s: any) => [s.sid as string, typeof s.githubRepo === "string" ? s.githubRepo : null] as const));
   if (!Array.isArray(m.ledgers)) return;
   loaded = true;
   sessions = m.ledgers as FleetSession[];

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -393,8 +393,8 @@ test("rendered markdown never carries data-* attributes into the page, in the vi
   const sanitizes = (MD_FN.match(/DOMPurify\.sanitize\([^)]*\)/g) || []);
   assert.equal(sanitizes.length, 1);
   assert.match(sanitizes[0], /ALLOW_DATA_ATTR: false/);
-  const chatMd = (RENDER.split("function md(src: string): string {")[1] || "").split("\nfunction ")[0];
-  assert.match(chatMd, /DOMPurify\.sanitize\(dirty, MD_PURIFY\)/);
+  const chatMd = (RENDER.split("function md(src: string, repo: string | null = prRepoFor()): string {")[1] || "").split("\nfunction ")[0];   // the signature carries the PR-link repo (pr-links.ts)
+  assert.match(chatMd, /DOMPurify\.sanitize\(dirty, \{ \.\.\.MD_PURIFY, RETURN_DOM: true \}\)/);
   assert.match(RENDER, /const MD_PURIFY: Config = \{.*ALLOW_DATA_ATTR: false \};/, "the chat's shared sanitizer config forbids data-*");
   // the viewer's own stamps are set AFTER the sanitize, so they are unaffected
   assert.ok(MD_FN.indexOf("DOMPurify.sanitize(") < MD_FN.indexOf('a.dataset.act = "fv-open"'));

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -606,6 +606,23 @@ function withManager(fn: (fm: FederationManager, emitted: any[], store: Map<stri
 }
 const lastOrder = (emitted: any[]) => emitted.filter((m) => m && m.type === "tabOrder").pop()!.order;
 
+test("the merged tabOrder frame carries the LOCAL kernel's own name (selfHost), never a remote kernel's, and keeps it on a re-emit", () => {
+  // the chat reads a postal card's sender host against its kernel's own name, learned from the tabOrder
+  // frame every chat receives first; the manager re-emits a MERGED frame in place of each host's own, so the
+  // field has to be carried the way the views blob is — and a remote kernel's frame names ITSELF
+  const lastSelf = (emitted: any[]) => emitted.filter((m) => m && m.type === "tabOrder").pop()!.selfHost;
+  withManager((fm, emitted) => {
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }], selfHost: "TESTHOST" });
+    assert.equal(lastSelf(emitted), undefined, "a remote kernel's own name is not this dashboard's");
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }], selfHost: "SELFHOST" });
+    assert.equal(lastSelf(emitted), "SELFHOST");
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }], selfHost: "TESTHOST" });
+    assert.equal(lastSelf(emitted), "SELFHOST", "a remote host's report re-emits the merge with the local name still on it");
+    fm.inbound("", { type: "tabOrder", order: ["a"], tabs: [{ id: "a", name: "web" }] });
+    assert.equal(lastSelf(emitted), "SELFHOST", "an older local frame without the field does not unlearn it");
+  });
+});
+
 test("a session created after a remote host attached lands at the END of the merged strip", () => {
   // The 2026-08-10 report: the new session's provisional tab rendered last, then the merged push
   // re-slotted it in front of the remote host's block (host-blocked seed, local first).

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -25,12 +25,12 @@ test("the this-machine option wears the machine's REAL name, not 'local' (the us
   assert.match(RENDER, /b\.textContent = h \|\| localSelfHost \|\| "local"/);
   // the Host row is built on open, BEFORE the reply lands — the handler relabels the button in
   // place, so only the first-ever open briefly shows the "local" placeholder
-  assert.match(RENDER, /if \(typeof m\.selfHost === "string" && m\.selfHost && !from\) \{\s*\n\s*localSelfHost = m\.selfHost;/);
+  assert.match(RENDER, /if \(typeof m\.selfHost === "string" && m\.selfHost && !from\) \{\s*\n\s*adoptSelfHost\(m\.selfHost\);/);
   assert.match(RENDER, /querySelector\('#picker \.picker-host \.picker-be-opt\[data-host=""\]'\)/);
   // …and the adoption sits BEFORE the stale-list drop guard: the name is this machine's identity,
   // not list data — switching the picker to a remote host before the local reply lands must not
   // throw the name away with the (rightly dropped) stale list
-  const adopt = RENDER.indexOf("localSelfHost = m.selfHost");
+  const adopt = RENDER.search(/&& !from\) \{\s*\n\s*adoptSelfHost\(m\.selfHost\);/);   // the picker's call of the one adopter (pr-links.test.ts pins the adopter itself)
   const drop = RENDER.indexOf("if (from !== pickerListHost) return;");
   assert.ok(adopt >= 0 && drop >= 0 && adopt < drop, "selfHost is adopted before the stale-list drop");
 });

--- a/ui/webview/pr-links.test.ts
+++ b/ui/webview/pr-links.test.ts
@@ -1,0 +1,699 @@
+// PR references link to GitHub (the user 2026-09-06): `#123`, `PR #123` and `owner/repo#123` in a
+// session's chat, its feed cards and the outline's goal rows become links to the PR page
+// of the repository the session works in — the kernel's `githubRepo` (owner/repo, or null). The text
+// rule and the DOM applier are EXECUTED here (pr-links.ts is pure but for createElement/createTextNode,
+// which a small plain-object DOM stand-in provides); the wiring into render.ts's md(), feed.ts and
+// fleet.ts is pinned at the source, the way the other webview tests pin the chat renderer.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ── a DOM stand-in: text and element nodes with the handful of members the applier touches ─────────
+class T {
+  nodeType = 3;
+  parentNode: E | null = null;
+  constructor(public textContent: string) {}
+}
+class E {
+  nodeType = 1;
+  parentNode: E | null = null;
+  childNodes: Array<E | T> = [];
+  href = ""; target = ""; rel = ""; title = ""; className = "";
+  dataset: Record<string, string | undefined> = {};
+  constructor(public tagName: string) {}
+  get classList() { const cs = this.className.split(/\s+/).filter(Boolean); return { contains: (c: string) => cs.includes(c) }; }
+  get textContent(): string { return this.childNodes.map((c) => c.textContent).join(""); }
+  set textContent(v: string) { for (const c of this.childNodes) c.parentNode = null; this.childNodes = []; if (v) this.appendChild(new T(v)); }
+  appendChild<N extends E | T>(c: N): N { c.parentNode = this; this.childNodes.push(c); return c; }
+  insertBefore<N extends E | T>(n: N, ref: E | T | null): N {
+    const i = ref ? this.childNodes.indexOf(ref) : -1;
+    n.parentNode = this;
+    this.childNodes.splice(i < 0 ? this.childNodes.length : i, 0, n);
+    return n;
+  }
+  removeChild(c: E | T): E | T { const i = this.childNodes.indexOf(c); if (i >= 0) this.childNodes.splice(i, 1); c.parentNode = null; return c; }
+  closest(sel: string): E | null {
+    const tags = sel.split(",").map((s) => s.trim().toUpperCase());
+    for (let n: E | null = this; n; n = n.parentNode) if (tags.includes(n.tagName.toUpperCase())) return n;
+    return null;
+  }
+  /** a compact serialization for assertions: tags lower-case, anchors with their href only */
+  html(): string {
+    const inner = this.childNodes.map((c) => c instanceof T ? c.textContent : c.html()).join("");
+    const t = this.tagName.toLowerCase();
+    const attrs = (this.className ? ` class="${this.className}"` : "") + (this.href ? ` href="${this.href}"` : "");
+    return `<${t}${attrs}>${inner}</${t}>`;
+  }
+}
+(globalThis as any).document = {
+  createElement: (tag: string) => new E(tag.toUpperCase()),
+  createTextNode: (s: string) => new T(s),
+};
+/** build a tree from a tiny tag language: el("p", "text", el("code", "#12")) */
+function el(tag: string, ...kids: Array<string | E>): E {
+  const e = new E(tag.toUpperCase());
+  for (const k of kids) e.appendChild(typeof k === "string" ? new T(k) : k);
+  return e;
+}
+function cls(e: E, c: string): E { e.className = c; return e; }
+const anchors = (root: E): E[] => {
+  const out: E[] = [];
+  const walk = (n: E) => { for (const c of n.childNodes) if (c instanceof E) { if (c.tagName === "A") out.push(c); walk(c); } };
+  walk(root);
+  return out;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { prRefSegments, linkifyPrRefs, setLinkedText, senderPrRepo, postalSenderHost, installPrLinkOpener, validPrRepo, PR_LINK_CLASS } = require("./pr-links") as typeof import("./pr-links");
+
+const REPO = "example-org/notes-api";
+const url = (n: number | string, repo = REPO) => `https://github.com/${repo}/pull/${n}`;
+const links = (text: string, repo: string | null = REPO) => prRefSegments(text, repo).filter((s) => s.href);
+
+// ── the text rule ────────────────────────────────────────────────────────────────────────────────
+
+test("a bare #123 links to the session repo's PR page, the surrounding text untouched", () => {
+  assert.deepEqual(prRefSegments("merged #123 today", REPO), [
+    { text: "merged " },
+    { text: "#123", href: url(123), label: REPO + "#123" },
+    { text: " today" },
+  ]);
+});
+
+test("PR #123 and pull #123 link as a whole phrase, any case, the space optional", () => {
+  for (const t of ["PR #123", "pr #123", "Pr#123", "pull #123", "Pull #123", "PULL#123"]) {
+    const segs = prRefSegments("see " + t + ".", REPO);
+    assert.deepEqual(segs, [{ text: "see " }, { text: t, href: url(123), label: REPO + "#123" }, { text: "." }], t);
+  }
+});
+
+test("owner/repo#123 links into THAT repository", () => {
+  const segs = prRefSegments("see example-org/other-tool#42 for the fix", REPO);
+  assert.deepEqual(segs, [
+    { text: "see " },
+    { text: "example-org/other-tool#42", href: url(42, "example-org/other-tool"), label: "example-org/other-tool#42" },
+    { text: " for the fix" },
+  ]);
+  // a repo name may carry dots and underscores; an owner may not
+  assert.equal(links("x my-org/my.repo_v2#7")[0].href, url(7, "my-org/my.repo_v2"));
+});
+
+test("several references in one run each link, in order", () => {
+  const ls = links("#1, #2 and example-org/other#3; PR #4");
+  assert.deepEqual(ls.map((s) => s.text), ["#1", "#2", "example-org/other#3", "PR #4"]);
+  assert.deepEqual(ls.map((s) => s.href), [url(1), url(2), url(3, "example-org/other"), url(4)]);
+});
+
+test("a word boundary before the reference: start, whitespace, brackets, quotes, punctuation, dashes", () => {
+  for (const t of ["#5", " #5", "(#5)", "[#5]", "{#5}", "\"#5\"", "'#5'", ",#5", ";#5", "re:#5", "<#5>", "“#5”", "‘#5’", "«#5»", "—#5", "–#5"]) {
+    assert.equal(links(t).length, 1, JSON.stringify(t));
+    assert.equal(links(t)[0].text, "#5", JSON.stringify(t));
+  }
+});
+
+test("an em or en dash glued to the reference is a boundary (prose habitually writes one); the ASCII hyphen is not", () => {
+  // the dashes never end a URL path or an identifier, so nothing is lost by admitting them
+  assert.deepEqual(links("Two PRs are up—#12 and #13.").map((s) => s.text), ["#12", "#13"]);
+  assert.deepEqual(links("landed–#123 is merged").map((s) => s.text), ["#123"]);
+  assert.deepEqual(links("merged—example-org/other#3").map((s) => s.href), [url(3, "example-org/other")]);
+  // a hyphen does end them: `https://example.com/a-#12` is a URL with a fragment, `foo-#12` an identifier
+  for (const t of ["https://example.com/a-#12", "x -#12", "foo-#12", "-#12"]) assert.equal(links(t).length, 0, t);
+});
+
+test("a # glued to a word, a path or a URL is not a reference", () => {
+  for (const t of ["foo#12", "docs/x.html#12", "https://example.com/page#12", "github.com/example-org/notes-api#12",
+                   "a/b/c#12", "&#12;", "C#12", "v1.2#3"]) {
+    assert.equal(links(t).length, 0, JSON.stringify(t));
+  }
+});
+
+test("the cross-repo form follows GitHub's name grammar: owner = alphanumerics and single inner hyphens, repo may add . and _", () => {
+  // valid owners link, into the repository named
+  for (const [t, repo] of [["a-b/c-d#1", "a-b/c-d"], ["a1/b_2-v3#1", "a1/b_2-v3"], ["x/y#1", "x/y"], ["ab/c.d.e-f#1", "ab/c.d.e-f"]] as const)
+    assert.equal(links("see " + t)[0]?.href, url(1, repo), t);
+  // (a dotted repo whose tail is extension-shaped — `b_2.3`, `c.d.e` — is the filename refusal below, not the grammar)
+  // two plain words around a slash ARE GitHub's syntax (a directory path never carries a bare numeric
+  // fragment — a line reference is `file.py#L12`), so they link; pinned as the documented reading
+  assert.equal(links("see src/lib#3")[0]?.href, url(3, "src/lib"));
+  assert.equal(links("see kernel/kernel#12")[0]?.href, url(12, "kernel/kernel"));
+  // owners GitHub does not allow never link — and the number after them does not fall through to a bare #n
+  for (const t of ["my.org/repo#1", "-owner/repo#1", "owner-/repo#1", "ow--ner/repo#1", "own_er/repo#1", "a/b/c#1"])
+    assert.equal(links("see " + t).length, 0, t);
+  // an owner longer than GitHub's 39 characters is no owner
+  assert.equal(links("see " + "a".repeat(40) + "/repo#1").length, 0);
+  assert.equal(links("see " + "a".repeat(39) + "/repo#1").length, 1);
+});
+
+test("a repo name never ends in a dot: a/..#12, a/.#12 and owner/repo.#1 stay plain, in the text rule and in validPrRepo", () => {
+  for (const t of ["a/..#12", "a/.#12", "example-org/..#7", "owner/repo.#1", "owner/repo..#1", "example-org/notes-api.#7"])
+    assert.equal(links("see " + t).length, 0, t);
+  // the number after a refused name does not fall through to a bare #n (the scan resumes after the whole)
+  assert.deepEqual(prRefSegments("see example-org/notes-api.#7", REPO), [{ text: "see example-org/notes-api.#7" }]);
+  // with the space prose actually has, the sentence ends and the bare #7 links against the session repo
+  assert.deepEqual(links("see example-org/notes-api. #7").map((s) => s.href), [url(7)]);
+  for (const bad of ["a/..", "a/.", "a/...", "owner/repo.", "owner/repo.."]) assert.equal(validPrRepo(bad), null, bad);
+  assert.equal(validPrRepo("a/.b"), "a/.b", "a leading dot is fine (dotfile-named repos exist)");
+  assert.equal(validPrRepo("a/b.c"), "a/b.c");
+});
+
+test("a cross-repo form whose repo reads like a filename is a path fragment, not a reference — except a GitHub Pages repo", () => {
+  for (const t of ["docs/x.html#12", "src/app.py#3", "notes/todo.md#7", "a/b.c#1"]) assert.equal(links("see " + t).length, 0, t);
+  // the documented cost: a repository literally named like a file stays plain in the cross-repo form
+  for (const t of ["org/tool.dev#4", "org/something.js#4"]) assert.equal(links("see " + t).length, 0, t);
+  // …but a GitHub Pages repo (`*.github.io`) is the one standard dotted repo name, and it links (any case,
+  // any owner — a fork keeps the original's name)
+  assert.equal(links("see org/org.github.io#4")[0]?.href, url(4, "org/org.github.io"));
+  assert.equal(links("see Org/Org.GitHub.IO#4")[0]?.href, url(4, "Org/Org.GitHub.IO"));
+  assert.equal(links("see me/them.github.io#4")[0]?.href, url(4, "me/them.github.io"));
+  assert.equal(links("see x/y.github.io.js#4").length, 0, "only as the tail");
+  // a dotted repo name whose tail is not extension-shaped still links; and the scan resumes after a refused one
+  assert.equal(links("see my-org/my.repo_v2#7")[0].href, url(7, "my-org/my.repo_v2"));
+  assert.deepEqual(links("docs/x.html#12 then #13").map((s) => s.text), ["#13"]);
+});
+
+test("a session's OWN repo is never filename-filtered: a Pages or file-named checkout links its bare #n", () => {
+  assert.equal(links("merged #4", "user/user.github.io")[0]?.href, url(4, "user/user.github.io"));
+  assert.equal(links("merged #4", "org/something.js")[0]?.href, url(4, "org/something.js"));
+});
+
+test("a GitHub URL with a fragment stays as it is (its #issuecomment is no number)", () => {
+  assert.equal(links("https://github.com/example-org/notes-api/pull/12#issuecomment-99").length, 0);
+});
+
+test("color literals never link: hex letters after the digits, or a leading zero, fail the number shape", () => {
+  for (const t of ["#fff", "#FFF", "#000", "#1EA1EB", "#0c1a2e", "#9cd2ff", "#12ab", "#12abcd", "#0", "#01"]) {
+    assert.equal(links("color " + t).length, 0, t);
+  }
+  // the documented cost: an all-decimal six-digit color is indistinguishable from a PR number in prose
+  // (in code or a code-like element it never links — see the applier tests)
+  assert.equal(links("color #123456")[0]?.text, "#123456");
+});
+
+test("a number glued to letters, another # or a slash after it is not a reference", () => {
+  for (const t of ["#12abc", "#12_x", "#12#13", "#12/x"]) assert.equal(links("x " + t).length, 0, t);
+  // sentence punctuation after it is fine
+  for (const t of ["#12.", "#12,", "#12)", "#12;", "#12!", "#12?"]) assert.equal(links("x " + t)[0]?.text, "#12", t);
+});
+
+test("a slash-separated run of references links each one, as GitHub's own autolinker does", () => {
+  // the exact segments: the slashes between the references stay plain text
+  assert.deepEqual(prRefSegments("landed #12/#13.", REPO), [
+    { text: "landed " },
+    { text: "#12", href: url(12), label: REPO + "#12" },
+    { text: "/" },
+    { text: "#13", href: url(13), label: REPO + "#13" },
+    { text: "." },
+  ]);
+  assert.deepEqual(links("PRs #12/#13/#14 are up").map((s) => s.text), ["#12", "#13", "#14"]);
+  assert.deepEqual(links("(#12/#13)").map((s) => s.href), [url(12), url(13)]);
+  // after a `PR #n` phrase the run continues the same way; the phrase stays the first link's text
+  assert.deepEqual(links("PR #12/#13").map((s) => s.text), ["PR #12", "#13"]);
+  assert.deepEqual(links("PR #12/#13").map((s) => s.href), [url(12), url(13)]);
+  // a run that ends in a path is a path, like `#12/x` — nothing links, not even the first
+  for (const t of ["#12/#13/x", "#12/#13abc", "#12/#13#14"]) assert.equal(links("x " + t).length, 0, t);
+  // `/` alone is still no boundary: a URL's fragment never starts a run, and a space breaks one
+  assert.equal(links("https://example.com/y/#12/#13").length, 0);
+  assert.deepEqual(links("#12/ #13").map((s) => s.text), ["#13"]);
+  // after a cross-repo reference a slash refuses the whole: GitHub reads the second against the context, a
+  // writer means the named repo — two readings, no link
+  assert.equal(links("see example-org/other#12/#13").length, 0);
+  // the applier renders the run as sibling anchors with plain slashes between
+  const p = el("p", "landed #12/#13");
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 2);
+  assert.equal(p.html(), `<p>landed <a class="pr-link" href="${url(12)}">#12</a>/<a class="pr-link" href="${url(13)}">#13</a></p>`);
+});
+
+test("without a GitHub repo for the session NOTHING links — the cross-repo form included", () => {
+  for (const repo of [null, undefined, "", "not a repo", "a/b/c", "https://github.com/x/y"]) {
+    assert.deepEqual(prRefSegments("merged #1 and example-org/other#2", repo as any), [{ text: "merged #1 and example-org/other#2" }], String(repo));
+  }
+  assert.equal(validPrRepo("example-org/notes-api"), "example-org/notes-api");
+  assert.equal(validPrRepo("owner/repo.js"), "owner/repo.js");
+  assert.equal(validPrRepo("user/user.github.io"), "user/user.github.io");
+  assert.equal(validPrRepo("-owner/repo"), null, "an owner cannot start with a hyphen");
+  assert.equal(validPrRepo("owner-/repo"), null, "or end with one");
+  assert.equal(validPrRepo("ow--ner/repo"), null, "or double one");
+  assert.equal(validPrRepo("my.org/repo"), null, "or carry a dot");
+  assert.equal(validPrRepo("owner/re po"), null);
+});
+
+test("text with no # at all comes back as one plain segment, fast", () => {
+  assert.deepEqual(prRefSegments("nothing to see", REPO), [{ text: "nothing to see" }]);
+  assert.deepEqual(prRefSegments("", REPO), [{ text: "" }]);
+});
+
+// ── the DOM applier ──────────────────────────────────────────────────────────────────────────────
+
+test("a text node's references become pr-link anchors with href, target, rel and a repo-qualified title", () => {
+  const p = el("p", "merged #12 today");
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 1);
+  assert.equal(p.html(), `<p>merged <a class="${PR_LINK_CLASS}" href="${url(12)}">#12</a> today</p>`);
+  const a = anchors(p)[0];
+  assert.equal(a.target, "_blank");
+  assert.equal(a.rel, "noopener noreferrer");
+  assert.equal(a.title, REPO + "#12 on GitHub");
+  assert.equal(p.textContent, "merged #12 today", "the visible text is unchanged");
+});
+
+test("text inside <code> and <pre> is skipped; the prose around it still links", () => {
+  const p = el("p", "use ", el("code", "#12"), " and #13");
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 1);
+  assert.equal(p.html(), `<p>use <code>#12</code> and <a class="pr-link" href="${url(13)}">#13</a></p>`);
+  const pre = el("pre", el("code", "git log #12"));
+  assert.equal(linkifyPrRefs(pre as unknown as Node, REPO), 0);
+  assert.equal(pre.html(), "<pre><code>git log #12</code></pre>");
+});
+
+test("the other code-like elements are opaque too: kbd, samp, var, tt — a quoted key or token is not a reference", () => {
+  for (const tag of ["kbd", "samp", "var", "tt"]) {
+    const p = el("p", "see ", el(tag, "#12"), " and #13");
+    assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 1, tag);
+    assert.equal(anchors(p).length, 1, tag);
+    assert.equal(anchors(p)[0].textContent, "#13", tag);
+  }
+  // typographic wrappers are walked: a superscripted or emphasized #n is still a reference
+  for (const tag of ["sup", "sub", "em", "strong", "span", "small"]) {
+    const p = el("p", "see ", el(tag, "#12"));
+    assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 1, tag);
+  }
+});
+
+test("text already inside a link is never wrapped again", () => {
+  const a = el("a", "#12"); a.href = "https://github.com/example-org/notes-api/pull/12";
+  const p = el("p", "see ", a);
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 0);
+  assert.equal(anchors(p).length, 1);
+});
+
+test("the chat's path links are skipped, so a docs/x.md#12-shaped path stays the path it is", () => {
+  const p = el("p", cls(el("span", "docs/x.md#12"), "file-uri-link"), " and ", cls(el("span", el("code", "https://x/#1")), "url-code-link"));
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 0);
+});
+
+test("references inside emphasis and list items link (only anchors and code-like elements are opaque)", () => {
+  const li = el("li", el("strong", "PR #7"), " shipped; see ", el("em", "#8"));
+  assert.equal(linkifyPrRefs(li as unknown as Node, REPO), 2);
+  assert.equal(li.html(), `<li><strong><a class="pr-link" href="${url(7)}">PR #7</a></strong> shipped; see <em><a class="pr-link" href="${url(8)}">#8</a></em></li>`);
+});
+
+test("a root that itself sits inside code, a code-like element or a link is left alone", () => {
+  for (const tag of ["code", "pre", "kbd", "samp", "var", "tt", "a"]) {
+    const inner = el("span", "#12");
+    el(tag, inner);
+    assert.equal(linkifyPrRefs(inner as unknown as Node, REPO), 0, tag);
+  }
+});
+
+test("a root whose whole text has no # is not walked at all — one textContent read, no childNodes access", () => {
+  const p = el("p", "a long body ", el("em", "with markup"), " but no reference");
+  let reads = 0;
+  const kids = p.childNodes;
+  // the stand-in's own textContent getter walks childNodes; a browser's is one native read, so stand it in too
+  Object.defineProperty(p, "textContent", { get() { return "a long body with markup but no reference"; } });
+  Object.defineProperty(p, "childNodes", { get() { reads++; return kids; } });
+  assert.equal(linkifyPrRefs(p as unknown as Node, REPO), 0);
+  assert.equal(reads, 0, "the walk was skipped");
+  // …and one WITH a reference is walked as before
+  const q = el("p", "a body ", el("em", "with #12"));
+  assert.equal(linkifyPrRefs(q as unknown as Node, REPO), 1);
+});
+
+test("no repo → the DOM is not touched at all", () => {
+  const p = el("p", "merged #12 and example-org/other#3");
+  assert.equal(linkifyPrRefs(p as unknown as Node, null), 0);
+  assert.equal(p.html(), "<p>merged #12 and example-org/other#3</p>");
+  assert.equal(linkifyPrRefs(null, REPO), 0);
+});
+
+// ── setLinkedText: the keyed in-place update the feed's card titles use ─────────────────────────
+
+test("setLinkedText writes the text with its links once, and leaves the SAME anchor nodes in place while (text, repo) is unchanged", () => {
+  const title = el("div");
+  setLinkedText(title as unknown as HTMLElement, "merged #12 today", REPO);
+  assert.equal(title.html(), `<div>merged <a class="pr-link" href="${url(12)}">#12</a> today</div>`);
+  const first = anchors(title)[0];
+  setLinkedText(title as unknown as HTMLElement, "merged #12 today", REPO);   // the next push, nothing changed
+  setLinkedText(title as unknown as HTMLElement, "merged #12 today", REPO);
+  assert.equal(anchors(title)[0], first, "identity survives the pushes — the press and the release meet one node");
+  assert.deepEqual(title.dataset, { prText: "merged #12 today", prRepo: REPO });
+});
+
+test("setLinkedText re-renders when the text or the repo changes, and renders plain text with no repo", () => {
+  const title = el("div");
+  setLinkedText(title as unknown as HTMLElement, "merged #12", REPO);
+  const first = anchors(title)[0];
+  setLinkedText(title as unknown as HTMLElement, "merged #12 and #13", REPO);
+  assert.equal(anchors(title).length, 2);
+  assert.notEqual(anchors(title)[0], first, "new text, new nodes");
+  setLinkedText(title as unknown as HTMLElement, "merged #12 and #13", "example-org/other");
+  assert.equal(anchors(title)[0].href, url(12, "example-org/other"), "a repo change re-links");
+  setLinkedText(title as unknown as HTMLElement, "merged #12 and #13", null);
+  assert.equal(title.html(), "<div>merged #12 and #13</div>");
+  assert.equal(title.dataset.prRepo, "");
+  setLinkedText(title as unknown as HTMLElement, "merged #12 and #13", "not a repo");
+  assert.equal(title.html(), "<div>merged #12 and #13</div>", "an invalid repo is no repo");
+});
+
+// ── senderPrRepo: a message links against its SENDER's frame-known repo, never a guess ──────────
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+const rows = [
+  { sid: U, name: "web", githubRepo: "example-org/notes-web" },
+  { sid: V, name: "api", githubRepo: "example-org/notes-api" },
+  { sid: "TESTHOST:" + U, name: "TESTHOST:tests", githubRepo: "example-org/notes-tests" },
+  { sid: "TESTHOST:" + V, name: "TESTHOST:api", githubRepo: "other-org/api" },
+  { sid: "22222222-2222-3333-4444-555555555555", name: "norepo", githubRepo: null },
+];
+
+test("with no host named (the chat's postal cards): the one session answering to the name, local or federated by its bare name", () => {
+  assert.equal(senderPrRepo(rows, "web"), "example-org/notes-web");
+  assert.equal(senderPrRepo(rows, "tests"), "example-org/notes-tests", "a federated row matches on its bare name");
+  assert.equal(senderPrRepo(rows, "api"), null, "a homonym on another attached host makes the sender ambiguous: no guess");
+  assert.equal(senderPrRepo(rows, "norepo"), null, "a sender the kernel gave no repo links nothing");
+  assert.equal(senderPrRepo(rows, "nobody"), null, "an unknown sender links nothing — the reader's repo is never substituted");
+  assert.equal(senderPrRepo(rows, ""), null);
+  assert.equal(senderPrRepo(rows, "TESTHOST:api"), null, "the kernel writes the bare name; a prefixed one matches no row");
+});
+
+test("with the sender's host named (the feed's held-mail cards): exactly that host's row", () => {
+  assert.equal(senderPrRepo(rows, "api", ""), "example-org/notes-api", "the viewing kernel's own host → the local row");
+  assert.equal(senderPrRepo(rows, "api", "TESTHOST"), "other-org/api", "another host → its federated row");
+  assert.equal(senderPrRepo(rows, "tests", ""), null, "no local row of that name");
+  assert.equal(senderPrRepo(rows, "web", "OTHERHOST"), null, "a host not in the frame");
+});
+
+test("postalSenderHost: the chat's inbound card names the sender's host, and the sender resolves to exactly one session or none", () => {
+  const SELF = "SELFHOST";
+  assert.equal(postalSenderHost("", SELF), "", "mail from this kernel's own sessions → the local rows");
+  assert.equal(postalSenderHost("TESTHOST", SELF), "TESTHOST", "mail from an attached peer → that host's federated rows");
+  assert.equal(postalSenderHost(SELF, SELF), "", "relayed mail stamped with this kernel's own name → the local rows");
+  assert.equal(postalSenderHost(undefined, SELF), undefined, "a card from a kernel that predates the field → the name-only fallback");
+  assert.equal(postalSenderHost("?", SELF), undefined, "an unknown origin → the name-only fallback, as the feed reads blocked.origin");
+  assert.equal(postalSenderHost(null, SELF), undefined);
+  assert.equal(postalSenderHost(7, SELF), undefined);
+  // through senderPrRepo: the local `api` is no longer shadowed by the attached homonym, and a sender on a
+  // host NOT in the frame is plain text — never the local homonym's repo, which the name alone produced
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("", SELF)), "example-org/notes-api");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("TESTHOST", SELF)), "other-org/api");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("UNATTACHED", SELF)), null, "the sender's host is not in the frame: no guess");
+  assert.equal(senderPrRepo(rows, "web", postalSenderHost("UNATTACHED", SELF)), null);
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost(undefined, SELF)), null, "legacy card: the homonym keeps it plain");
+  assert.equal(senderPrRepo(rows, "web", postalSenderHost(undefined, SELF)), "example-org/notes-web", "legacy card: one session answers to the name");
+  assert.equal(senderPrRepo(rows, "TESTHOST:aaaaaaaa", postalSenderHost("TESTHOST", SELF)), null, "the kernel's host:sid stub for a nameless sender matches no row");
+});
+
+test("postalSenderHost reads peerHost relative to the CARD's kernel: a federated session's card from its own kernel's sender resolves on that host, never against the local rows", () => {
+  const SELF = "SELFHOST";
+  // the card sits in TESTHOST:tests; TESTHOST's log stamped "" for mail from its own `api`
+  assert.equal(postalSenderHost("", SELF, "TESTHOST"), "TESTHOST", "'' means the card's own host");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("", SELF, "TESTHOST")), "other-org/api",
+    "TESTHOST's own api, not the local homonym's repo (which relative-to-the-dashboard reading produced)");
+  // the same card's kernel names THIS dashboard's kernel as the sender's host: the local rows
+  assert.equal(postalSenderHost(SELF, SELF, "TESTHOST"), "", "the dashboard's own name folds to the local rows, whatever session the card sits in");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost(SELF, SELF, "TESTHOST")), "example-org/notes-api");
+  // a third host: matched by name among the frame's rows — attached, its row; not attached, plain text
+  assert.equal(postalSenderHost("OTHERHOST", SELF, "TESTHOST"), "OTHERHOST");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("OTHERHOST", SELF, "TESTHOST")), null, "a host this dashboard has not attached: no guess");
+  assert.equal(postalSenderHost("TESTHOST", SELF, "TESTHOST"), "TESTHOST", "a kernel naming itself reads the same as ''");
+  // the legacy and unknown-origin forms are unchanged by the card's host
+  assert.equal(postalSenderHost(undefined, SELF, "TESTHOST"), undefined);
+  assert.equal(postalSenderHost("?", SELF, "TESTHOST"), undefined);
+  // a LOCAL card (cardHost "" — the default) reads exactly as before
+  assert.equal(postalSenderHost("", SELF, ""), "");
+  assert.equal(postalSenderHost("", SELF), "");
+  assert.equal(postalSenderHost("TESTHOST", SELF, ""), "TESTHOST");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("", SELF, "")), "example-org/notes-api", "a local card from a local sender: the local row");
+});
+
+test("postalSenderHost with the dashboard's own name not yet known (selfHost ''): the card-host and peer readings hold, and nothing folds by accident", () => {
+  assert.equal(postalSenderHost("", "", ""), "", "a local card, local sender");
+  assert.equal(postalSenderHost("", "", "TESTHOST"), "TESTHOST", "a federated card, its kernel's own sender");
+  assert.equal(postalSenderHost("TESTHOST", "", ""), "TESTHOST", "a named peer stays named — '' as selfHost matches no name");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("TESTHOST", "", "")), "other-org/api");
+});
+
+test("peerHost is the card's kernel's OWN name for the sender's host: when the two kernels' names for a host disagree the reference stays text, never a wrong link", () => {
+  // the dashboard's kernel calls itself SELFHOST and declared that at check-in; the card's kernel (TESTHOST)
+  // had attached this machine under an alias of its own, HUBALIAS, so its log stamps mail from here with
+  // that name (the bus files a peer under the local dialable alias when one exists) — the fold does not apply…
+  assert.equal(postalSenderHost("HUBALIAS", "SELFHOST", "TESTHOST"), "HUBALIAS");
+  // …and the alias names no row this dashboard holds (its rows wear the aliases IT attached hosts as), so the
+  // sender is plain text — not the local api's repo, not TESTHOST's api's
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("HUBALIAS", "SELFHOST", "TESTHOST")), null);
+  assert.equal(senderPrRepo(rows, "web", postalSenderHost("HUBALIAS", "SELFHOST", "TESTHOST")), null);
+  // the same disagreement over a third host: TESTHOST's name for it is not the one this dashboard attached it as
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("OTHERBOX", "SELFHOST", "TESTHOST")), null);
+  // agreement — the common topology — folds to the local row; the stamp is compared to selfHost exactly
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("SELFHOST", "SELFHOST", "TESTHOST")), "example-org/notes-api");
+  assert.equal(senderPrRepo(rows, "api", postalSenderHost("selfhost", "SELFHOST", "TESTHOST")), null, "no case folding: a near-name is another name");
+  // the name is all there is to match on: no host id rides the card or the rows
+  assert.doesNotMatch(RENDER, /busId|hostId/, "the chat matches hosts by name alone, as the frames key them");
+});
+
+test("senderPrRepo tolerates malformed rows and an invalid repo value", () => {
+  assert.equal(senderPrRepo([{ sid: U, name: "web", githubRepo: "https://github.com/x/y" }], "web"), null);
+  assert.equal(senderPrRepo([null as any, { sid: 5 as any, name: "web" }, { sid: U, name: "web", githubRepo: "x/y" }], "web"), "x/y");
+});
+
+// ── the opener (feed + outline panes) ───────────────────────────────────────────────────────────
+
+/** a document stand-in recording one capture-phase listener per event type */
+function fakeDoc() {
+  const handlers = new Map<string, (e: Event) => void>();
+  const captures = new Map<string, boolean | undefined>();
+  return {
+    doc: { addEventListener: (type: string, fn: (e: Event) => void, cap?: boolean) => { handlers.set(type, fn); captures.set(type, cap); } },
+    /** dispatch one event; returns the default-prevention calls it made */
+    fire(type: string, target: any, extra: Record<string, unknown> = {}) {
+      const calls: string[] = [];
+      const ev: any = { target, button: 0, isPrimary: true, ...extra,
+        preventDefault: () => calls.push("preventDefault"), stopPropagation: () => calls.push("stopPropagation") };
+      const h = handlers.get(type);
+      assert.ok(h, "a listener for " + type);
+      h!(ev);
+      return calls;
+    },
+    types: () => Array.from(handlers.keys()).sort(),
+    capture: (type: string) => captures.get(type),
+  };
+}
+/** a fresh node standing for a pr-link anchor with `href` — a new object each call, as a rebuilt node is */
+const prAnchor = (href: string) => {
+  const node = { closest: (sel: string) => sel.startsWith("a.pr-link") ? { getAttribute: (k: string) => k === "href" ? href : null } : null, contains: (n: unknown) => n === node };
+  return node;
+};
+/** a node that is not a link and contains nothing (a button, a card body far from the pressed link) */
+const plain = { closest: () => null, contains: () => false };
+/** a node that is not a link and contains exactly `kids` — the common ancestor a native click lands on */
+const ancestorOf = (...kids: unknown[]) => ({ closest: () => null, contains: (n: unknown) => kids.includes(n) });
+const SPENT = ["preventDefault", "stopPropagation"];
+
+function install(protocol = "https:") {
+  const f = fakeDoc(); const opened: string[] = []; const posted: any[] = [];
+  installPrLinkOpener(f.doc, (m) => posted.push(m), { protocol: () => protocol, open: (h) => opened.push(h) });
+  return { f, opened, posted };
+}
+
+test("the opener hangs on the stable document, capture phase, for the press, the release, the click and the clearing events", () => {
+  const { f } = install();
+  assert.deepEqual(f.types(), ["click", "keydown", "pointercancel", "pointerdown", "pointerup"]);
+  for (const t of f.types()) assert.equal(f.capture(t), true, t + " — the card's own handler under the link must not fire");
+});
+
+test("press and release on a pr-link with the same href open it ONCE — through a rebuilt node — and the click that follows is spent", () => {
+  const { f, opened, posted } = install();
+  assert.deepEqual(f.fire("pointerdown", prAnchor(url(12))), []);
+  assert.deepEqual(opened, [], "nothing opens on the press");
+  const twin = prAnchor(url(12));                    // a DIFFERENT node object: the push rebuilt the anchor
+  f.fire("pointerup", twin);
+  assert.deepEqual(opened, [url(12)]);
+  // the native click (here on the common ancestor, the pressed node being gone) is spent: the card's modal never opens
+  assert.deepEqual(f.fire("click", ancestorOf(twin)), SPENT);
+  assert.deepEqual(opened, [url(12)], "no second open");
+  assert.deepEqual(posted, []);
+  // the next click is an ordinary click again
+  assert.deepEqual(f.fire("click", ancestorOf(twin)), []);
+});
+
+test("the spent click is the one on the released node or its ancestors; a click anywhere else passes untouched and clears the flag", () => {
+  const { f, opened } = install();
+  const twin = prAnchor(url(12));
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", twin);
+  assert.deepEqual(opened, [url(12)]);
+  // the browser fired no click (the pressed node was detached); the next click has no press behind it — a
+  // programmatic .click() from a capture-phase key handler, an assistive-technology activation — and it
+  // lands on a card button: it is that button's click, not the link's
+  assert.deepEqual(f.fire("click", plain), [], "an unrelated click is never eaten");
+  assert.deepEqual(f.fire("click", ancestorOf(twin)), [], "and the flag is gone: the released node's ancestor is an ordinary click now");
+  // the same stale state, then an activation of ANOTHER pr-link with no press: it opens
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12)));
+  assert.deepEqual(f.fire("click", prAnchor(url(13))), SPENT, "the click path serves it");
+  assert.deepEqual(opened, [url(12), url(12), url(13)]);
+  // a click on a node that is not an ancestor, even though it reports contains() for others, passes
+  f.fire("pointerdown", prAnchor(url(12))); const up = prAnchor(url(12)); f.fire("pointerup", up);
+  assert.deepEqual(f.fire("click", ancestorOf(prAnchor(url(12)))), [], "an ancestor of some OTHER node is unrelated");
+});
+
+test("when the anchor survives, the same press/release/click sequence still opens exactly once", () => {
+  const { f, opened } = install();
+  const a = prAnchor(url(12));
+  f.fire("pointerdown", a); f.fire("pointerup", a);
+  assert.deepEqual(f.fire("click", a), SPENT);
+  assert.deepEqual(opened, [url(12)]);
+});
+
+test("a release elsewhere, a release on a different link, or a press elsewhere opens nothing — and the click is not touched", () => {
+  const { f, opened } = install();
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", plain);
+  assert.deepEqual(f.fire("click", plain), [], "the card's click stands");
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(13)));
+  assert.deepEqual(f.fire("click", plain), []);
+  f.fire("pointerdown", plain); f.fire("pointerup", prAnchor(url(12)));
+  assert.deepEqual(opened, []);
+});
+
+test("a click on a pr-link with no pointer press behind it (a keyboard activation) opens it through the click path", () => {
+  const { f, opened } = install();
+  assert.deepEqual(f.fire("click", prAnchor(url(12))), SPENT);
+  assert.deepEqual(opened, [url(12)]);
+});
+
+test("the spent flag never eats an unrelated click: a new press or a key clears it when no click followed the open", () => {
+  const { f, opened } = install();
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12)));
+  assert.deepEqual(opened, [url(12)]);
+  // the browser fired no click (the pressed node was detached); the user presses a card next
+  f.fire("pointerdown", plain); f.fire("pointerup", plain);
+  assert.deepEqual(f.fire("click", plain), [], "the card's click lands");
+  // …or activates something by keyboard
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12)));
+  f.fire("keydown", plain);
+  assert.deepEqual(f.fire("click", plain), []);
+  assert.deepEqual(opened, [url(12), url(12)]);
+});
+
+test("a cancelled pointer, a secondary button or a non-primary pointer never opens", () => {
+  const { f, opened } = install();
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointercancel", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12)));
+  f.fire("pointerdown", prAnchor(url(12)), { button: 2 }); f.fire("pointerup", prAnchor(url(12)), { button: 2 });
+  f.fire("pointerdown", prAnchor(url(12)), { isPrimary: false }); f.fire("pointerup", prAnchor(url(12)), { isPrimary: false });
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12)), { button: 1 });
+  assert.deepEqual(opened, []);
+});
+
+test("in a VS Code webview the href goes to the host as openLink, from the release and from a keyboard click alike", () => {
+  const { f, opened, posted } = install("vscode-webview:");
+  f.fire("pointerdown", prAnchor(url(12))); f.fire("pointerup", prAnchor(url(12))); f.fire("click", plain);
+  f.fire("click", prAnchor(url(13)));
+  assert.deepEqual(posted, [{ type: "openLink", href: url(12) }, { type: "openLink", href: url(13) }]);
+  assert.deepEqual(opened, []);
+});
+
+test("targets that are not a pr-link, or whose href is not a GitHub URL, are left alone at every phase", () => {
+  const f = fakeDoc(); const opened: string[] = [];
+  installPrLinkOpener(f.doc, undefined, { protocol: () => "https:", open: (h) => opened.push(h) });
+  for (const t of [plain, prAnchor("javascript:alert(1)"), prAnchor("https://example.com/x"), null]) {
+    f.fire("pointerdown", t); f.fire("pointerup", t);
+    assert.deepEqual(f.fire("click", t), [], String(t && (t as any).closest?.("a.pr-link")?.getAttribute("href")));
+  }
+  assert.deepEqual(opened, []);
+});
+
+// ── wiring pins ──────────────────────────────────────────────────────────────────────────────────
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = read("render.ts");
+const FEED = read("feed.ts");
+const FED = read("federation.ts");
+const OUTLINE = read("fleet.ts");
+
+test("the chat links inside md(): the sanitized tree is walked before it serializes, against the owning session's repo", () => {
+  assert.match(RENDER, /import \{ linkifyPrRefs, senderPrRepo, postalSenderHost \} from "\.\/pr-links";/);
+  assert.match(RENDER, /function md\(src: string, repo: string \| null = prRepoFor\(\)\): string \{/);
+  const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(mdFn, /RETURN_DOM: true \}\) as HTMLElement;[^\n]*\n\s*linkifyPrRefs\(clean, repo\);\s*\n\s*return clean\.innerHTML;/,
+    "DOMPurify's own serialization is replaced by ours, after the walk — the sanitizer's verdicts stand");
+  assert.match(RENDER, /const id = sid \?\? renderingOwnerSid \?\? renderingSid \?\? activeId;/, "the owning session, as relative paths resolve");
+  assert.doesNotMatch(RENDER, /installPrLinkOpener/, "the chat's own a[href] delegate already opens every absolute-scheme anchor");
+});
+
+test("the session frame's githubRepo rides the Session and survives a chatTail delta; a null from the kernel is honored", () => {
+  assert.match(RENDER, /interface Session \{[^\n]*githubRepo\?: string \| null;/);
+  assert.match(RENDER, /githubRepo: \("githubRepo" in msg\) \? \(msg\.githubRepo \?\? null\) : \(prev \? prev\.githubRepo : null\),/);
+});
+
+test("postal bodies link against the SENDER's frame-known repo only: outbound = the writer's own, inbound = senderPrRepo over the session map by the card's host and name, never the reader's as a fallback", () => {
+  assert.match(RENDER, /full\.innerHTML = md\(ev\.body, postalRepoFor\(ev\)\)/);
+  assert.match(RENDER, /body\.innerHTML = md\(ev\.body, postalRepoFor\(ev\)\);/);
+  const fn = RENDER.match(/function postalRepoFor\([\s\S]*?\n\}/)?.[0] || "";
+  assert.match(fn, /if \(ev\.direction === "out"\) return prRepoFor\(\);/);
+  assert.match(fn, /const cardHost = hostOf\(renderingOwnerSid \?\? renderingSid \?\? activeId \?\? ""\);/,
+    "the card's own kernel is the host of the session it sits in — the chain prRepoFor picks the session by");
+  assert.match(fn, /return senderPrRepo\(Array\.from\(sessions\.values\(\), \(s\) => \(\{ sid: s\.id, name: s\.name, githubRepo: s\.githubRepo \}\)\), ev\.peer, postalSenderHost\(ev\.peerHost, localSelfHost, cardHost\)\);/,
+    "the sender's host rides the card (peerHost), read relative to the card's kernel and against this kernel's own name");
+  assert.equal((fn.match(/prRepoFor\(/g) || []).length, 1, "the reading session's repo is used for OUTBOUND mail only");
+  // this dashboard's own name is learned from every LOCAL session frame, not only from the + picker's reply
+  assert.match(RENDER, /if \(typeof msg\.selfHost === "string" && msg\.selfHost && !hostOf\(msg\.id\)\) adoptSelfHost\(msg\.selfHost\);/,
+    "a remote kernel's frame names itself; only a frame with no host prefix is this kernel's");
+  const upsertFn = RENDER.match(/function upsert\(msg: any\) \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(upsertFn, /adoptSelfHost\(msg\.selfHost\);/, "adopted in upsert, the session frame's one ingest point");
+  assert.match(RENDER, /kind: "postal-service";\s*\n\s*direction: "in" \| "out";\s*\n\s*peer: string;\s*\n(?:\s*\/\/[^\n]*\n)*\s*peerHost\?: string;/, "the event type carries the optional host");
+});
+
+test("the chat learns its kernel's own name from every tabOrder frame too, through one adopter that re-renders built views when the name changes; federation carries the LOCAL kernel's name on the merged frame", () => {
+  // tabOrder is the frame every chat receives, first of all on connect; a dashboard whose kernel runs no
+  // local session has no session frame to learn the name from and learned it only when the + picker opened
+  // (review find, 2026-09-06)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);/,
+    "adopted before the strip is applied");
+  const adopt = RENDER.match(/function adoptSelfHost\(name: string\): void \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(adopt, /if \(name === localSelfHost\) return;/, "the same name again is no event");
+  assert.match(adopt, /localSelfHost = name;\s*\n\s*if \(views\.size\) rerenderAll\(\);/,
+    "a postal card rendered before the name was known is re-read against it; nothing built → nothing to redo");
+  // the picker's reply goes through the same adopter, and the name is assigned in exactly one place
+  assert.match(RENDER, /if \(typeof m\.selfHost === "string" && m\.selfHost && !from\) \{\s*\n\s*adoptSelfHost\(m\.selfHost\);/);
+  assert.equal((RENDER.match(/\blocalSelfHost = /g) || []).length, 2, "the declaration and the adopter");
+  // federation re-emits a MERGED tabOrder frame in place of every host's own: the local kernel's name must
+  // ride it, and a remote kernel's — which names itself — must not (multi-kernel-merge.test.ts runs it)
+  assert.match(FED, /if \(host === LOCAL && typeof m\.selfHost === "string" && m\.selfHost\) this\.localSelfHost = m\.selfHost;/);
+  assert.match(FED, /\{ type: "tabOrder", order, tabs, live, views: this\.localViews \?\? undefined, selfHost: this\.localSelfHost \|\| undefined \}/);
+});
+
+test("the feed links card titles (keyed), distiller lines, held-mail gists (by sender), group cards, checklists and the modal — per the card's session", () => {
+  assert.match(FEED, /import \{ linkifyPrRefs, setLinkedText, senderPrRepo, installPrLinkOpener \} from "\.\/pr-links";/);
+  assert.match(FEED, /githubRepo\?: string \| null \}\[\] = \[\];/, "the session rows carry the repo");
+  assert.match(FEED, /function prRepoOf\(sid: string \| undefined\): string \| null \{\s*\n\s*return \(sid && sessionsMeta\.find\(\(s\) => s\.sid === sid\)\?\.githubRepo\) \|\| null;/);
+  // the two in-place titles are KEYED: an unchanged title keeps its anchor nodes across pushes
+  assert.match(FEED, /setLinkedText\(a\._title, it\.text, prRepoOf\(it\.sid\)\);/);
+  assert.match(FEED, /setLinkedText\(a\._title, g\.title, prRepoOf\(g\.sid\)\);/);
+  assert.doesNotMatch(FEED, /a\._title\.textContent = /, "no per-push rewrite of a title");
+  assert.match(FEED, /if \(distillShown\) linkifyPrRefs\(a\._distill as HTMLElement, prRepoOf\(it\.sid\)\);/);
+  // the held message's gist links against its SENDER's repo (blocked.frm on blocked.origin), not the recipient card's
+  assert.match(FEED, /linkifyPrRefsIn\(Object\.assign\(el\("div", "fq-gist"\)[^\n]*prRepoOfSender\(it\.blocked\.frm, it\.blocked\.origin\)\)\);/);
+  const sender = FEED.match(/function prRepoOfSender\([\s\S]*?\n\}/)?.[0] || "";
+  assert.match(sender, /const host = !origin \|\| origin === "\?" \? undefined : origin === feedSelfHost \? "" : origin;/);
+  assert.match(sender, /return senderPrRepo\(sessionsMeta, frm \|\| "", host\);/);
+  assert.match(FEED, /txt\.textContent = m\.text; linkifyPrRefs\(txt, prRepoOf\(m\.sid \|\| g\.sid\)\);/);
+  assert.match(FEED, /el\("span", "fcheck-text"\); txt\.textContent = s\.text; linkifyPrRefs\(txt, prRepoOf\(it\.sid\)\);/);
+  assert.match(FEED, /el\("span", "ftree-text"\); txt\.textContent = node\.text \|\| "\(node\)"; linkifyPrRefs\(txt, prRepoOf\(it\.sid\)\);/);
+  assert.match(FEED, /bb\.textContent = modalBg; linkifyPrRefs\(bb, prRepoOf\(it\.sid\)\);/);
+  assert.match(FEED, /sum\.textContent = nodeDistill;\s*\n\s*linkifyPrRefs\(sum, prRepoOf\(it\.sid\)\);/);
+  assert.match(FEED, /installPrLinkOpener\(document, vscodeApi \? \(m\) => vscodeApi\.postMessage\(m\) : undefined\);/);
+});
+
+test("the outline links goal rows per session and opens them itself", () => {
+  assert.match(OUTLINE, /import \{ linkifyPrRefs, installPrLinkOpener \} from "\.\/pr-links";/);
+  assert.match(OUTLINE, /repoBySid = new Map\(m\.sessions\.filter/);
+  assert.match(OUTLINE, /highlightInto\(txt, n\.text, curSearch\);[^\n]*\n\s*linkifyPrRefs\(txt, repoBySid\.get\(s\.sid\) \|\| null\);/);
+  assert.match(OUTLINE, /installPrLinkOpener\(document, vscodeApi \? \(m\) => vscodeApi\.postMessage\(m\) : undefined\);/);
+});
+
+test("the pr-link anchor wears the hyperlink ink in both sheets", () => {
+  for (const f of ["styles.css", "feed.css"]) {
+    const css = read(f);
+    assert.match(css, /\.pr-link \{ color: var\(--link\); text-decoration: none; \}/, f);
+    assert.match(css, /\.pr-link:hover \{ text-decoration: underline; \}/, f);
+  }
+});

--- a/ui/webview/pr-links.ts
+++ b/ui/webview/pr-links.ts
@@ -1,0 +1,344 @@
+// GitHub pull-request references in rendered text become links to the PR page of the repository the
+// session works in (the user 2026-09-06, whose sessions' chat, feed cards and notes rendered their own
+// PR numbers, `merged #12` say, as plain text). The kernel names the repository per session —
+// `githubRepo` (owner/repo, or null) on the session frame and on the feed's session rows, derived from
+// the session tree's origin remote by the same parser the file viewer's GitHub link uses — and this
+// module does the text work in ONE place for every surface: the chat's markdown (render.ts md()), the
+// feed's card titles, distiller lines, checklists, held-mail gists and modal (feed.ts), and the
+// outline's goal rows (fleet.ts).
+//
+// Shapes that link — each needs a word boundary BEFORE it (start of text, whitespace, an opening
+// bracket or quote, a comma/semicolon/colon, an em or en dash), so a `#` glued to letters, a path or a
+// URL never does:
+//   #123               → https://github.com/<session repo>/pull/123
+//   PR #123 / pull #123 (any case, the space optional) → the same; the whole phrase is the link
+//   owner/repo#123     → https://github.com/owner/repo/pull/123 — a reference into another repository
+// GitHub answers /pull/<n> for an ISSUE number with a redirect to /issues/<n>, so one form covers both.
+// The ASCII hyphen is deliberately NOT a boundary: it ends URL paths and identifiers
+// (`https://example.com/a-#12` must stay plain); the dashes appear in neither.
+//
+// A slash-separated RUN of bare references (`#12/#13`, `PRs #12/#13/#14`) links each one — GitHub's own
+// autolinker does (checked against its markdown renderer, 2026-09-06) — every reference in the run
+// against the session's repository; `/` is still no boundary on its own, so a `/#13` links only as the
+// continuation of a reference before it, never inside a URL, and a run that ends in a path (`#12/#13/x`)
+// stays plain like `#12/x`. After a cross-repo reference a `/` refuses the whole (GitHub would read the
+// `#13` in `owner/repo#12/#13` against the CONTEXT, a writer means owner/repo: two readings, no link).
+//
+// The cross-repo form follows GitHub's own name grammar. An owner (a user or organization login) is
+// alphanumerics and single hyphens — never leading, trailing or doubled — at most 39 characters; a
+// repository name may also carry `.` and `_`, at most 100 characters, and never ENDS in `.` (`.` and
+// `..` are the path names, and GitHub serves no `owner/repo.` — a trailing dot is sentence punctuation
+// glued to a `#`, as in `notes-api.#7`). So `my.org/repo#1` (a dotted owner), `a/..#12` and
+// `owner/repo.#1` are not references. Two plain words around a slash
+// (`src/lib#3`) ARE one — that is GitHub's syntax byte for byte, and a directory path never carries a
+// bare numeric fragment (a line reference is `file.py#L12`, which fails the number shape) — so it
+// links. The one refusal beyond the grammar is a "repo" that reads like a FILENAME (`docs/x.html#12`,
+// `src/app.py#3` — an extension-shaped tail after a dot): that is a path with a fragment, and a wrong
+// link is worse than none. The cost is a repository named like a file (`something.js`, `tool.dev`),
+// which stays plain text in the cross-repo form — except GitHub Pages repos (any `*.github.io`, the one
+// standard dotted repo name; a fork keeps the original's), which link. A session's OWN repo is never
+// filtered this way: the
+// kernel shipped it, so a bare `#12` links in a `user.github.io` or `something.js` checkout too.
+//
+// What never links: text inside code-like elements (<code>, <pre>, <kbd>, <samp>, <var>, <tt> — a
+// color `#fff`, a CSS id, a shell comment, a quoted key or token), text already inside an <a> (a GitHub
+// URL marked autolinked, a [text](url)), a path link (.file-uri-link), and any `#` that is part of a
+// word, a URL fragment or a color literal — `#1EA1EB` and `#0c1a2e` fail the number shape (hex letters
+// after the digits, or a leading zero; a PR number has neither). Typographic wrappers (<em>, <strong>,
+// <sup>) are walked: a `#13` in them is still a reference.
+// A session with no GitHub repository (`githubRepo` null: no repo, no origin, or an origin elsewhere)
+// links NOTHING, the cross-repo form included — the honest rendering is the plain text, never a
+// guessed host.
+
+import { hostPrefix } from "./host-prefix";
+
+/** One run of text; `href` marks a link, `label` its repo-qualified reference for the hover title. */
+export interface PrRefSegment { text: string; href?: string; label?: string }
+
+export const PR_LINK_CLASS = "pr-link";
+
+// GitHub's own name grammar (see the header): the owner rule is GitHub's login rule verbatim — an
+// alphanumeric, then up to 38 more of alphanumerics or a hyphen that is followed by an alphanumeric.
+// A PR number has no leading zero and (with room to spare) at most seven digits.
+const OWNER = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
+const REPO = "[A-Za-z0-9_.-]{1,100}";
+const NUM = "[1-9]\\d{0,6}";
+const DOT_TAIL = /\.$/;                        // `.`, `..`, `repo.`: inside the character class, never a repo
+// group 1 = the boundary character (re-emitted as text; empty at the start of the text)
+// groups 2/3/4 = owner / repo / number of the cross-repo form
+// group 5 = the number of a `PR #n` / `pull #n` phrase; group 6 = the number of a bare `#n`;
+// group 7 = the slash-separated run of further bare references after either (`/#13/#14`, or empty)
+// the trailing lookahead refuses a word character, another `#` or a `/` right after the last number,
+// which is what keeps `#12abc`, `#1EA1EB` and a `#12/x` path fragment out — the run is greedy and the
+// lookahead follows it, so `#12/#13/x` backtracks to nothing rather than to `#12`
+const RUN = "((?:/#" + NUM + ")*)";
+const REF_SRC =
+  "(^|[\\s(\\[{<,;:\"'“‘«—–])(?:" +
+  "(" + OWNER + ")/(" + REPO + ")#(" + NUM + ")" +
+  "|(?:(?:PR|pull)\\s?#(" + NUM + ")|#(" + NUM + "))" + RUN +
+  ")(?![\\w#/])";
+
+const REPO_SHAPE = new RegExp("^" + OWNER + "/" + REPO + "$");
+const FILENAME_TAIL = /\.[A-Za-z0-9]{1,5}$/;   // `x.html`, `app.py`, `notes.md`: a path fragment, not a repo
+const PAGES_REPO = /\.github\.io$/i;            // GitHub Pages: the one standard dotted repo name (any owner's)
+
+/** The cross-repo form's refusal beyond the grammar: a repo that reads like a filename (see the header). */
+function filenameShaped(repo: string): boolean {
+  return FILENAME_TAIL.test(repo) && !PAGES_REPO.test(repo);
+}
+
+/** The session repo as the kernel ships it, or null when it is absent or not owner/repo-shaped by
+ *  GitHub's grammar — a URL is only ever built from a value that passed this. */
+export function validPrRepo(repo: string | null | undefined): string | null {
+  if (typeof repo !== "string" || !REPO_SHAPE.test(repo)) return null;
+  if (DOT_TAIL.test(repo)) return null;
+  return repo;
+}
+
+export function prUrl(repo: string, n: string): string {
+  return "https://github.com/" + repo + "/pull/" + n;
+}
+
+/** Split `text` into plain runs and PR-reference links against `repo`. Pure: no DOM. With no valid
+ *  repo, or no reference in the text, the whole text comes back as one plain segment. */
+export function prRefSegments(text: string, repo: string | null | undefined): PrRefSegment[] {
+  const r = validPrRepo(repo);
+  if (!r || !text || text.indexOf("#") < 0) return [{ text }];
+  const re = new RegExp(REF_SRC, "gi");
+  const out: PrRefSegment[] = [];
+  let last = 0, m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const start = m.index + m[1].length;          // the boundary character stays plain text
+    const end = m.index + m[0].length;
+    let target: string, n: string;
+    if (m[4]) {
+      // `a/..#12` and `a/repo.#12` are no repo; `docs/x.html#12` is a path's fragment — the scan resumes after either
+      if (DOT_TAIL.test(m[3]) || filenameShaped(m[3])) continue;
+      target = m[2] + "/" + m[3]; n = m[4];
+    }
+    else { target = r; n = m[5] || m[6]; }
+    if (start > last) out.push({ text: text.slice(last, start) });
+    const run = m[7] || "";                        // `/#13/#14` after a bare or `PR #n` reference, else ""
+    const first = end - run.length;
+    out.push({ text: text.slice(start, first), href: prUrl(target, n), label: target + "#" + n });
+    for (const more of run.split("/").slice(1)) {  // each `#n` of the run, the slashes between them plain
+      out.push({ text: "/" });
+      out.push({ text: more, href: prUrl(target, more.slice(1)), label: target + more });
+    }
+    last = end;
+  }
+  if (!out.length) return [{ text }];
+  if (last < text.length) out.push({ text: text.slice(last) });
+  return out;
+}
+
+// Elements whose text never links: an existing link, code-like text (inline or fenced code, a key, a
+// sample, a variable, teletype), form controls, and the chat's own path links (a `docs/x.md#12`-shaped
+// path must stay the path it is).
+const CODE_LIKE = "a, code, pre, kbd, samp, var, tt";
+const SKIP_TAGS = new Set(["A", "CODE", "PRE", "KBD", "SAMP", "VAR", "TT", "SCRIPT", "STYLE", "TEXTAREA", "INPUT", "BUTTON", "SELECT", "OPTION", "SVG"]);
+const SKIP_CLASSES = ["file-uri-link", "url-code-link"];
+
+function skipElement(e: Element): boolean {
+  if (SKIP_TAGS.has(String(e.tagName || "").toUpperCase())) return true;
+  const cl = e.classList;
+  return !!cl && SKIP_CLASSES.some((k) => cl.contains(k));
+}
+
+/** Turn the PR references in `root`'s text nodes into anchors (class pr-link, target _blank, rel
+ *  noopener noreferrer, a title naming the repo-qualified reference). Skips code-like subtrees and
+ *  existing anchors (SKIP_TAGS) and the chat's path links; a root that itself sits inside one of those
+ *  is left alone. Returns the number of links made. A root whose whole text has no `#` — the common
+ *  case — costs one native textContent read and no walk. Walks childNodes and edits through
+ *  insertBefore/removeChild only, so a test's plain-object DOM stand-in runs it as the browser does. */
+export function linkifyPrRefs(root: Node | null | undefined, repo: string | null | undefined): number {
+  const r = validPrRepo(repo);
+  if (!r || !root) return 0;
+  if ((root.textContent || "").indexOf("#") < 0) return 0;
+  const rootEl = root as Element;
+  if (root.nodeType === 1 && typeof rootEl.closest === "function" && rootEl.closest(CODE_LIKE)) return 0;
+  let made = 0;
+  const visit = (node: Node): void => {
+    const kids = Array.from(node.childNodes || []);   // snapshot: text children are replaced as we go
+    for (const c of kids) {
+      if (c.nodeType === 3) { made += linkifyTextNode(c, r); continue; }
+      if (c.nodeType !== 1 || skipElement(c as Element)) continue;
+      visit(c);
+    }
+  };
+  visit(root);
+  return made;
+}
+
+function linkifyTextNode(tn: Node, repo: string): number {
+  const text = tn.textContent || "";
+  if (text.indexOf("#") < 0) return 0;
+  const segs = prRefSegments(text, repo);
+  if (!segs.some((s) => s.href)) return 0;
+  const parent = tn.parentNode;
+  if (!parent) return 0;
+  const doc: Document = tn.ownerDocument || document;
+  let made = 0;
+  for (const s of segs) {
+    let node: Node;
+    if (s.href) {
+      const a = doc.createElement("a");
+      a.className = PR_LINK_CLASS;
+      a.href = s.href;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      a.title = s.label + " on GitHub";
+      a.textContent = s.text;
+      node = a;
+      made++;
+    } else {
+      node = doc.createTextNode(s.text);
+    }
+    parent.insertBefore(node, tn);
+  }
+  parent.removeChild(tn);
+  return made;
+}
+
+/** Set `el`'s text to `text` with its PR references linked — and only when (text, repo) differs from
+ *  what `el` already shows, keyed on two data attributes the element carries. The feed updates a card
+ *  IN PLACE on every kernel push; rewriting an unchanged title would replace its anchors under the
+ *  pointer every half-second (the hover title never appears, a press lands on a node that is gone by
+ *  the release). Keeping the node is the click-safety rule's keyed update: identity survives a push. */
+export function setLinkedText(el: HTMLElement, text: string, repo: string | null | undefined): void {
+  const r = validPrRepo(repo) || "";
+  if (el.dataset.prText === text && el.dataset.prRepo === r) return;
+  el.textContent = text;
+  if (r) linkifyPrRefs(el, r);
+  el.dataset.prText = text;
+  el.dataset.prRepo = r;
+}
+
+/** A session row as the frame ships it: the feed's `sessions` rows and the chat's session map both
+ *  carry a sid, a name and the kernel's githubRepo. A federated row wears its host on BOTH (`host:uuid`,
+ *  `host:name`); a local row is bare. */
+export interface SessionRepoRow { sid: string; name: string; githubRepo?: string | null }
+
+/** The repository of the ONE session in `rows` that is the named sender of a message — the frame's own
+ *  githubRepo for that session, never a guess (the reading session's repo is never substituted for the
+ *  sender's; a wrong link is worse than none). `host` is the sender's host when the card names it
+ *  ("" = the viewing kernel's own; the feed's held-mail cards carry `blocked.origin`, the chat's postal
+ *  cards `peerHost` — postalSenderHost); undefined when it does not (a card from a kernel that predates
+ *  the field), in which case every row is a candidate — a local one by its name, a federated one by
+ *  its bare name — so a homonym on any attached host makes the sender ambiguous, and a homonym on a
+ *  host NOT attached to this dashboard is invisible, which is why the host-named form exists. Zero or
+ *  several candidates, or a candidate the kernel gave no repo → null: the text stays plain. */
+export function senderPrRepo(rows: readonly SessionRepoRow[], sender: string, host?: string): string | null {
+  if (!sender) return null;
+  const hit = rows.filter((s) => {
+    if (!s || typeof s.sid !== "string" || typeof s.name !== "string") return false;
+    if (host === undefined) return (hostPrefix(s.name, s.sid)?.rest ?? s.name) === sender;
+    if (host === "") return s.sid.indexOf(":") < 0 && s.name === sender;
+    return s.sid.startsWith(host + ":") && s.name === host + ":" + sender;
+  });
+  return hit.length === 1 ? validPrRepo(hit[0].githubRepo) : null;
+}
+
+/** senderPrRepo's `host` for an inbound postal card, from the `peerHost` the kernel stamps on it — the
+ *  sender's host as the CARD'S OWN kernel's message log recorded the delivery, so it is relative to THAT
+ *  kernel: "" for mail from its own sessions, a peer's name for mail from that host. The chat shows the
+ *  sessions of attached kernels too (their ids and names wear `host:`), and federation hands a remote
+ *  session's events over as its kernel wrote them, so `cardHost` — the host of the session the card sits
+ *  in, "" for a local one — anchors the reading: "" means the card's own host (its local rows for a local
+ *  card, that host's federated rows for a remote one); a named host is that kernel's peer, which may be
+ *  THIS dashboard's own kernel (its name, `selfHost`, folds to "" — the local rows) or a host the
+ *  dashboard may or may not have attached (the same name federation prefixes that host's rows with; not
+ *  attached → no row → plain text, never a local homonym's repo). Read as relative to the dashboard, a
+ *  remote card from its own kernel's session resolved against the LOCAL rows by bare name (review find,
+ *  2026-09-06). An unknown origin ("?") is undefined, as the feed reads `blocked.origin`; a card from a
+ *  kernel that predates the field has no peerHost at all → undefined, the name-only resolution
+ *  senderPrRepo keeps for it.
+ *
+ *  A peer's name is the card's kernel's OWN name for that host, not a name every kernel shares: the bus
+ *  files each peer under the name the local side knows it by — the ssh alias it was attached as when
+ *  there is one, else the name the peer declared at check-in (postal_service.py `_canon_peer_name`) —
+ *  and no host id crosses the wire for the dashboard to match on instead (its rows wear the aliases IT
+ *  attached each host as; the bus id never reaches a frame). So the fold and the row match hold when
+ *  the two kernels agree on the name, which the common topology gives: the dashboard's kernel declares
+ *  its own name (`selfHost`) at check-in and the remote files it under that, unless it attached this
+ *  machine under an alias of its own. When the names disagree the stamp matches no row and the
+ *  reference stays text — the safe direction, pinned by the tests; a WRONG link needs the card's kernel
+ *  to use this dashboard's own name, or an attached host's alias, for a different machine — a collision
+ *  in the user's own naming. */
+export function postalSenderHost(peerHost: unknown, selfHost: string, cardHost = ""): string | undefined {
+  if (typeof peerHost !== "string" || peerHost === "?") return undefined;
+  if (peerHost === "") return cardHost;
+  return peerHost === selfHost ? "" : peerHost;
+}
+
+/** Follow a PR link the way the chat follows its links (render.ts's a[href] delegate): on the web
+ *  dashboard the viewer's own browser opens a tab; in a VS Code webview the href goes to the host,
+ *  which openExternal()s it (view-routing.ts routes `openLink` for every pane; extension.ts consumes it
+ *  for every panel). Installed ONCE per pane document on the CAPTURE phase, so the click never reaches
+ *  the card or row handlers beneath the link — a link inside a feed card must open the PR, not also
+ *  open the card's modal; one inside an outline row must not also jump the chat.
+ *
+ *  Click-safe across re-renders (ui/CLAUDE.md): the action hangs on the STABLE document, keyed off the
+ *  anchor's `href` attribute — never on the anchor node, which every push rebuilds. A native `click`
+ *  needs the press and the release on one node, so a push mid-press would drop it (or hand it to the
+ *  card underneath). So the press is followed by attribute: `pointerdown` remembers the href under the
+ *  primary button, `pointerup` on a pr-link with the SAME href opens it — the rebuilt twin counts, the
+ *  node's identity does not — and the native click that may follow is spent, so the card's own handler
+ *  never sees it. That click can land only on the released node or one of its ancestors (the anchor
+ *  itself, or the common ancestor when the pressed node is gone), so only a click there is spent: one
+ *  arriving anywhere else with no press behind it — the browser fired none, then a programmatic
+ *  .click() or an assistive-technology activation came — passes as the ordinary click it is (the flag
+ *  ate one such click before; review find, 2026-09-06). The click path itself stays for a keyboard
+ *  activation (Enter on a focused link fires click alone). Every flag clears on the next press, key or
+ *  click — an event, never a timer. The chat pane does NOT install this — its own delegate already opens
+ *  every absolute-scheme anchor the same way. */
+export function installPrLinkOpener(
+  doc: { addEventListener(type: string, fn: (e: Event) => void, capture?: boolean): void },
+  post: ((msg: { type: string; href: string }) => void) | undefined,
+  env: { protocol: () => string; open: (href: string) => void } = {
+    protocol: () => (typeof location !== "undefined" ? location.protocol : ""),
+    open: (href) => { window.open(href, "_blank", "noopener,noreferrer"); },
+  },
+): void {
+  /** the pr-link href under an event target, or null — only the hrefs this module writes */
+  const hrefAt = (t: EventTarget | null): string | null => {
+    const el = t as Element | null;
+    const a = el && typeof el.closest === "function" ? (el.closest("a." + PR_LINK_CLASS + "[href]") as HTMLAnchorElement | null) : null;
+    const href = a ? a.getAttribute("href") || "" : "";
+    return /^https:\/\/github\.com\//.test(href) ? href : null;
+  };
+  const open = (href: string): void => {
+    const p = env.protocol();
+    if (p === "http:" || p === "https:") env.open(href);
+    else if (post) post({ type: "openLink", href });
+  };
+  const primary = (e: Event): boolean => {
+    const pe = e as PointerEvent;
+    return (pe.button === undefined || pe.button === 0) && pe.isPrimary !== false;
+  };
+  /** is `t` `node` or one of its ancestors — the only targets the click after a release on `node` can have */
+  const inclusiveAncestor = (t: EventTarget | null, node: EventTarget): boolean =>
+    t === node || (!!t && typeof (t as Node).contains === "function" && (t as Node).contains(node as Node));
+  let pressed: string | null = null;        // the pr-link href under the primary button since pointerdown
+  let served: EventTarget | null = null;    // the node released on when pointerup opened a link: its click is already served
+  doc.addEventListener("pointerdown", (e) => { served = null; pressed = primary(e) ? hrefAt(e.target) : null; }, true);
+  doc.addEventListener("pointercancel", () => { pressed = null; }, true);
+  doc.addEventListener("keydown", () => { served = null; pressed = null; }, true);
+  doc.addEventListener("pointerup", (e) => {
+    const was = pressed;
+    pressed = null;
+    if (!was || !primary(e) || hrefAt(e.target) !== was) return;   // released elsewhere: no click
+    open(was);
+    served = e.target;
+  }, true);
+  doc.addEventListener("click", (e) => {
+    const node = served;
+    served = null;
+    if (node && inclusiveAncestor(e.target, node)) { e.preventDefault(); e.stopPropagation(); return; }
+    const href = hrefAt(e.target);
+    if (!href) return;
+    e.preventDefault();
+    e.stopPropagation();
+    open(href);
+  }, true);
+}

--- a/ui/webview/render-sanitize.test.ts
+++ b/ui/webview/render-sanitize.test.ts
@@ -15,7 +15,8 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 
 test("md() sanitizes marked output with DOMPurify before returning HTML", () => {
   assert.match(RENDER, /import DOMPurify from "dompurify";/);
-  const mdFn = RENDER.match(/function md\(src: string\): string \{[\s\S]*?\n\}/)?.[0] || "";
+  // (the signature grew an optional repo parameter for PR links — pr-links.ts — so match it loosely)
+  const mdFn = RENDER.match(/function md\(src: string[^\n]*?\): string \{[\s\S]*?\n\}/)?.[0] || "";
   assert.ok(mdFn, "md() function not found");
   // marked is still used to parse, but its output must pass through DOMPurify.sanitize
   assert.match(mdFn, /marked\.parse\(/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -67,6 +67,7 @@ import { setTip, pruneTip } from "./tip";
 import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 import { dragSlotIndex } from "./dragslot";
 import { perfFrameHandler } from "./perf-telemetry";
+import { linkifyPrRefs, senderPrRepo, postalSenderHost } from "./pr-links";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -140,6 +141,12 @@ type ChatEvent = (
       kind: "postal-service";
       direction: "in" | "out";
       peer: string;
+      // incoming: the sender's host as the CARD'S kernel's message log stamped it ("" = that kernel's own,
+      // a peer's name for mail from that host — relative to the kernel the card's session lives on) —
+      // with `peer`, names the ONE session whose repo the body's PR references link against
+      // (postalRepoFor); absent on cards from a kernel that predates the field, and on cards whose log
+      // row predates the stamp (the kernel omits it rather than read absence as its own)
+      peerHost?: string;
       color: { bg: string; fg: string } | null;
       body: string;
       summary?: string;  // incoming Haiku caption (≤9 words) — shown instead of the verbose body; body on hover
@@ -258,7 +265,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; githubRepo?: string | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
 // A SUBAGENT VIEWER pseudo-session (plans/subagent-transcripts.md): a read-only tab whose events are one
 // agent's own transcript, fed by {type:"subagent"} frames. Client-only — the kernel never lists it in
 // tabOrder (reconcileTabOrder keeps a known, never-kernel-seen id), so it lives exactly as long as the
@@ -1049,7 +1056,7 @@ function el(tag: string, cls?: string): HTMLElement {
 // message would post an interrupt on a click. Nothing the renderer needs rides data-* through md().
 const MD_PURIFY: Config = { USE_PROFILES: { html: true, svg: true }, ADD_DATA_URI_TAGS: ["img"], ALLOW_DATA_ATTR: false };
 
-function md(src: string): string {
+function md(src: string, repo: string | null = prRepoFor()): string {
   // Transcript text (user prompts, assistant output, subagent reports, postal
   // bodies) is UNTRUSTED and `marked` emits raw HTML verbatim, so its output
   // must be sanitized before it ever reaches .innerHTML — otherwise a payload
@@ -1058,7 +1065,14 @@ function md(src: string): string {
   // strips event-handler attributes and dangerous URL schemes (profile: MD_PURIFY).
   try {
     const dirty = marked.parse(src) as string;
-    return DOMPurify.sanitize(dirty, MD_PURIFY);
+    // RETURN_DOM hands back the sanitized <body> instead of its innerHTML — the same nodes, ours to
+    // walk once before the serialization DOMPurify would otherwise have done itself: PR references
+    // in the prose (`#123`, `PR #123`, `owner/repo#123`) become links to the session's repository
+    // (pr-links.ts; the user 2026-09-06). Text inside code, pre or an existing anchor is skipped, so
+    // the sanitizer's verdicts stand and a marked-autolinked GitHub URL is never wrapped twice.
+    const clean = DOMPurify.sanitize(dirty, { ...MD_PURIFY, RETURN_DOM: true }) as HTMLElement;   // the sanitized <body>
+    linkifyPrRefs(clean, repo);
+    return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
 }
 
@@ -1066,11 +1080,42 @@ function md(src: string): string {
 // but newlines KEPT — Shift+Enter in the composer means a new line, and the singleton's breaks:false
 // (right for assistant markdown, where a lone newline is a soft wrap) ran a multi-line message together
 // into one paragraph once it landed in the chat (the user 2026-09-06). userMarked is the breaks:true
-// instance in chat-md.ts; the singleton and every assistant surface are untouched.
-function userMd(src: string): string {
+// instance in chat-md.ts; the singleton and every assistant surface are untouched. The same PR-reference
+// walk as md(): a `#123` the user typed links to the session's repository too.
+function userMd(src: string, repo: string | null = prRepoFor()): string {
   try {
-    return DOMPurify.sanitize(userMdHtml(src), MD_PURIFY);
+    const clean = DOMPurify.sanitize(userMdHtml(src), { ...MD_PURIFY, RETURN_DOM: true }) as HTMLElement;
+    linkifyPrRefs(clean, repo);
+    return clean.innerHTML;
   } catch { const d = document.createElement("div"); d.textContent = src; return d.innerHTML; }
+}
+
+// The GitHub repository (owner/repo, or null) whose pull requests a `#123` in the text being rendered
+// refers to: the OWNING session's — the same rule relative paths follow (renderingOwnerSid), then the
+// session being built, then the active tab. A session the kernel gave no repo links nothing.
+function prRepoFor(sid?: string | null): string | null {
+  const id = sid ?? renderingOwnerSid ?? renderingSid ?? activeId;
+  return (id && sessions.get(id)?.githubRepo) || null;
+}
+
+// A postal body was written by its SENDER, so its `#123` means the sender's repository — and only a
+// repository the frame actually names for that sender is used; nothing is guessed (a wrong link is worse
+// than none). An OUTBOUND message was written by the reading session: its own repo, as the frame ships
+// it. An INBOUND message names its sender by host AND name (`peerHost` + `peer`, the host as the CARD'S
+// kernel's message log stamped it — relative to that kernel, so it is read against the host of the
+// session the card sits in, postalSenderHost), so the sender is exactly the session in the frame that
+// answers to that pair — a local row for this dashboard's own kernel, a host's federated row otherwise —
+// and the link uses ITS githubRepo. A sender on a host this dashboard has not attached, or one the kernel
+// gave no repo: the text stays plain (the name alone once resolved it, and a remote homonym borrowed a
+// local session's repo; then a remote session's card was read as if its kernel were this one, and its own
+// kernel's sender resolved against the LOCAL rows; review finds, 2026-09-06). Only a card from a kernel
+// that predates the field falls back to the name — the one session, local or federated by its bare name,
+// answering to it; a homonym leaves it plain. The reading session's repo is never substituted for the
+// sender's.
+function postalRepoFor(ev: { direction: "in" | "out"; peer: string; peerHost?: string }): string | null {
+  if (ev.direction === "out") return prRepoFor();
+  const cardHost = hostOf(renderingOwnerSid ?? renderingSid ?? activeId ?? "");   // the card's own kernel, as prRepoFor picks the session
+  return senderPrRepo(Array.from(sessions.values(), (s) => ({ sid: s.id, name: s.name, githubRepo: s.githubRepo })), ev.peer, postalSenderHost(ev.peerHost, localSelfHost, cardHost));
 }
 
 function highlight(container: HTMLElement, lineNos = true) {
@@ -4496,7 +4541,7 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
     const sum = el("div", "postal-service-summary");
     const caret = el("span", "postal-service-expand-caret"); caret.textContent = "▸"; sum.appendChild(caret);
     const sumText = el("span", "postal-service-summary-text"); sumText.textContent = summaryText; sum.appendChild(sumText);
-    const full = el("div", "postal-service-full md"); full.innerHTML = md(ev.body); highlight(full);
+    const full = el("div", "postal-service-full md"); full.innerHTML = md(ev.body, postalRepoFor(ev)); highlight(full);
     // KEYED expand (the user 2026-07-25: "it expands for like a second and then collapses again") —
     // the old hand-rolled classList.toggle lived only on this DOM node, and the next kernel push
     // rebuilds the card, silently closing it. Same openFolds mechanism as every other keyed fold;
@@ -4514,7 +4559,7 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
     body.appendChild(sum);
     body.appendChild(full);
   } else {
-    body.innerHTML = md(ev.body);
+    body.innerHTML = md(ev.body, postalRepoFor(ev));
     highlight(body);
   }
   card.appendChild(body);
@@ -8950,9 +8995,23 @@ function pickerKey(e: KeyboardEvent) {
 // prefilled into the dir field when there's no gear default, so "the default path is written in there".
 let kernelDefaultDir = "";
 // This machine's name as the kernel's peers know it (_self_host — short hostname, ROMP_HOST_NAME
-// override), from the same payload. The + picker's Host row labels its first option with it, so the
-// row reads as a list of machines by name rather than named hosts plus a "local" (the user 2026-08-12).
+// override). The + picker's Host row labels its first option with it, so the row reads as a list of
+// machines by name rather than named hosts plus a "local" (the user 2026-08-12); postalRepoFor reads a
+// postal card's sender host against it. Three sources, one adopter (adoptSelfHost): every tabOrder frame
+// — the one every chat receives, first of all on connect, and the only one a dashboard whose kernel runs
+// no local session gets — every LOCAL session frame (upsert), and the picker's sessionList reply.
 let localSelfHost = "";
+// Adopt the name. A postal card rendered BEFORE the name was known read its own kernel's name for this
+// host as a peer's — it matched no `host:` row and stayed plain — and was rebuilt only on its session's
+// next push (review find, 2026-09-06): so a name that CHANGES re-renders every built view, and each card's
+// body is read against the name once it is known. In practice nothing is built when the name arrives (the
+// tabOrder frame lands before any session frame); a late arrival — a remote kernel's frame ahead of the
+// local strip, or the name learned from the picker alone against an older kernel — is what this covers.
+function adoptSelfHost(name: string): void {
+  if (name === localSelfHost) return;
+  localSelfHost = name;
+  if (views.size) rerenderAll();
+}
 // Is this session already an open tab in THIS dashboard? (loaded session, or a not-yet-loaded placeholder tab
 // the kernel's order carries.) The + picker uses it to hide sessions you can already reach by a tab-click.
 function isOpenTab(id: string): boolean {
@@ -13254,6 +13313,12 @@ function sharesAnyUuid(a: ChatEvent[], b: ChatEvent[]): boolean {
 
 function upsert(msg: any) {
   retryCmtCreates(String(msg.id || ""));   // a session frame = the kernel re-parsed → retry a lag-refused create (T106)
+  // The LOCAL kernel's own machine name rides its session frames (the kernel's _self_host, as the tabOrder
+  // and feed frames carry it): the chat reads a postal card's sender host against it (postalSenderHost). It
+  // was learned only from the + picker's sessionList reply before, so that reading was inert in any chat
+  // whose picker had not been opened (review find, 2026-09-06). A remote kernel's frame names ITSELF — the
+  // id's host prefix says whose frame this is, and only the local kernel's is this dashboard's own name.
+  if (typeof msg.selfHost === "string" && msg.selfHost && !hostOf(msg.id)) adoptSelfHost(msg.selfHost);
   const existed = sessions.has(msg.id);
   const prev = sessions.get(msg.id);
   awaitingFull.delete(msg.id);   // a full session landed → this session is re-based; a later gap may ask again
@@ -13281,6 +13346,11 @@ function upsert(msg: any) {
     // so the branch used to vanish there. A chatTail delta omits it → keep the last-known via prev.
     gitBranch: msg.gitBranch ?? (prev ? prev.gitBranch : ""),
     workTree: msg.workTree ?? (prev ? prev.workTree : null),
+    // the GitHub repository the session works in (owner/repo, or null) — what its `#123` mentions link
+    // to (pr-links.ts). The "in msg" form, like bgTasks: a null from the kernel is a real value (the
+    // tree lost its origin, or never had one) and must not fall back to a stale prev; a chatTail delta
+    // omits the key and keeps the last-known.
+    githubRepo: ("githubRepo" in msg) ? (msg.githubRepo ?? null) : (prev ? prev.githubRepo : null),
     // A trimmed full send carries headFrom/headTotal; a whole-transcript send omits them (headFrom 0).
     headFrom: kept && prev ? prev.headFrom : (msg.headFrom ?? 0),
     headTotal: kept && prev ? prev.headTotal : (msg.headTotal ?? events.length),
@@ -14013,7 +14083,7 @@ window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.po
     // this-machine button in place — the row's first-ever open is the only one that shows the
     // "local" placeholder.
     if (typeof m.selfHost === "string" && m.selfHost && !from) {
-      localSelfHost = m.selfHost;
+      adoptSelfHost(m.selfHost);
       const lb = document.querySelector('#picker .picker-host .picker-be-opt[data-host=""]') as HTMLElement | null;
       if (lb) lb.textContent = localSelfHost;
     }
@@ -14104,6 +14174,7 @@ window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.po
   else if (m.type === "working") { workingSet = new Set(Array.isArray(m.names) ? m.names : []); refreshPostalDots(); }
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null, typeof m.sid === "string" ? m.sid : null);
   else if (m.type === "tabOrder") {
+    if (typeof m.selfHost === "string" && m.selfHost) adoptSelfHost(m.selfHost);   // the LOCAL kernel's own name: federation puts only its own on the merged frame
     captureViews(m.views || null);
     applyTabOrder(m.order, m.tabs, { reemit: m.reemit === true, freshHost: typeof m.freshHost === "string" ? m.freshHost : undefined }, m.live);
   }

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -59,8 +59,9 @@ test("executed: the canonical key ignores list order AND which key the kernel us
 });
 
 test("the tabOrder frame carries the blob and the strip filters on it, composing with #only", () => {
-  // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/,
+  // the frame's provenance rides along since T233 (captureViews still runs before the strip is applied; the
+  // kernel's own name, selfHost, is adopted first of all — pr-links.test.ts pins that line)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/,
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
@@ -110,7 +111,8 @@ test("federation carries the LOCAL kernel's views blob through merged tabOrder r
   // re-derived from the stored blob before it moves — cleared only when the adoption changes it
   // (federation-views-seq.test.ts executes all four rules)
   assert.match(FED, /if \(host === LOCAL && m\.views && typeof m\.views === "object"\) \{\s*\n\s*if \(adoptViews\(this\.localViews, m\.views, this\.localViewsAnnounced\)\) \{ this\.localViewsAnnounced = announcedAfter\(this\.localViews, m\.views, this\.localViewsAnnounced\); this\.localViews = m\.views; this\.localViewsRejected = null; \}\s*\n\s*else this\.localViewsRejected = m\.views;\s*\n\s*\}/);
-  assert.match(FED, /\{ type: "tabOrder", order, tabs, live, views: this\.localViews \?\? undefined \}/,
+  // the merged frame also carries the LOCAL kernel's own name (selfHost), read from its tabOrder frame (pr-links)
+  assert.match(FED, /\{ type: "tabOrder", order, tabs, live, views: this\.localViews \?\? undefined, selfHost: this\.localSelfHost \|\| undefined \}/,
     "without this the browser dashboard's chat never receives the blob at all");
 });
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2463,6 +2463,11 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .md em { font-style: italic; }
 .md a { color: var(--link); text-decoration: none; }
 .md a:hover { text-decoration: underline; }
+/* PR references linked in plain-text surfaces (pr-links.ts): card titles, distiller lines, checklists,
+   outline goal rows. Inside .md the generic anchor rule already inks them; this covers the rest, in the
+   same hyperlink ink. */
+.pr-link { color: var(--link); text-decoration: none; }
+.pr-link:hover { text-decoration: underline; }
 .md blockquote { margin: 0.5em 0; padding-left: 12px; border-left: 2px solid var(--box-border); color: var(--dim); }
 .md hr { border: none; border-top: 1px solid var(--box-border); margin: 1em 0; }
 .md :not(pre) > code {

--- a/ui/webview/tab-meta.test.ts
+++ b/ui/webview/tab-meta.test.ts
@@ -115,7 +115,8 @@ test("both optimistic paths note their expectation: the color swatch and the ren
 test("the tabOrder frame's views land before the strip repaints — a CLI tag edit re-filters the tabs on the same push", () => {
   // captureViews (adopt the pushed views/tags blob) must run BEFORE applyTabOrder (whose renderTabs
   // re-filters via tabInView) in the tabOrder handler — the (c) leg of the live-update fix
-  // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);
+  // the frame's provenance rides along since T233 (captureViews still runs before the strip is applied; the
+  // kernel's own name, selfHost, is adopted first of all — pr-links.test.ts pins that line)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
 });

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -682,7 +682,8 @@ function wireFeedPanel(p: vscode.WebviewPanel) {
     // opens/focuses the tab itself. The rules live in view-routing.ts.
     const r = routeViewMessage("feed", m);
     if (r.revealChat) openPanel(r.revealChat.preserveFocus);
-    pipe.send(m);
+    if (r.openLinkLocally) openLink(r.openLinkLocally);   // a PR link in a card (pr-links.ts): the host opens it; the kernel has no handler
+    if (r.forward) pipe.send(m);
   });
   p.onDidChangeViewState(() => updateStrips());
   p.onDidDispose(() => {
@@ -851,6 +852,7 @@ function wireFleetPanel(p: vscode.WebviewPanel) {
     if (m.type === "ready") pipe.webviewReady = true;
     const r = routeViewMessage("fleet", m);
     if (r.revealChat) openPanel(r.revealChat.preserveFocus);
+    if (r.openLinkLocally) openLink(r.openLinkLocally);   // a PR link in an outline row (pr-links.ts): the host opens it
     if (r.forward) pipe.send(m);
   });
   p.onDidChangeViewState(() => updateStrips());

--- a/vscode-extension/src/open-link-wiring.test.ts
+++ b/vscode-extension/src/open-link-wiring.test.ts
@@ -1,0 +1,45 @@
+// Every webview surface that can carry a link the HOST must open — the timeline's deep links, and the
+// PR links pr-links.ts writes into feed cards and outline rows (2026-09-06) — posts {type:"openLink"}
+// in VS Code, where a webview cannot open a browser itself. view-routing.ts routes it host-side for
+// every pane (view-routing.test.ts pins the pure router); THIS pins the other half, the host's
+// consumption of that verdict: each panel's onDidReceiveMessage must act on `openLinkLocally` and
+// honor `forward`. The router alone was pinned once, and the feed and outline panels forwarded the
+// message to a kernel with no handler for it — a dead click, invisible to every test.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.join(process.cwd(), "src", "extension.ts"), "utf8");
+
+/** the handler text that follows each `const r = routeViewMessage(...)` up to its pipe.send */
+function routedBlocks(): { app: string; body: string }[] {
+  const out: { app: string; body: string }[] = [];
+  const re = /const r = routeViewMessage\(([^,]+), m\);([\s\S]*?)pipe\.send\(m\);/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(SRC))) out.push({ app: m[1].trim(), body: m[2] });
+  return out;
+}
+
+test("every panel routed through view-routing opens a host-side link and drops the message from the kernel pipe", () => {
+  const blocks = routedBlocks();
+  const apps = blocks.map((b) => b.app).sort();
+  assert.deepEqual(apps, ['"chat"', '"feed"', '"fleet"', "app"], "the chat, feed and outline panels, and the sidebar views (timeline/fleet)");
+  for (const b of blocks) {
+    if (b.app === '"chat"') continue;   // the chat panel opens links BEFORE routing (pinned below)
+    assert.match(b.body, /if \(r\.openLinkLocally\) openLink\(r\.openLinkLocally\);/, b.app + ": the host opens the link");
+    assert.match(b.body, /if \(r\.forward\) $/, b.app + ": a locally handled message is not also forwarded (forward:false)");
+  }
+});
+
+test("the chat panel handles openLink itself, ahead of the router", () => {
+  const chat = SRC.slice(SRC.indexOf("function wirePanel("), SRC.indexOf('const r = routeViewMessage("chat", m);'));
+  assert.match(chat, /if \(m\.type === "openLink" && typeof m\.href === "string"\) \{ openLink\(String\(m\.href\)\); return; \}/);
+});
+
+test("openLink sends a normal URL to the OS browser and feeds the extension's own deep links to its URI handler", () => {
+  const fn = SRC.match(/function openLink\(href: string\) \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(fn, /vscode\.Uri\.parse\(href, true\)/);
+  assert.match(fn, /uri\.scheme === "vscode" && uri\.authority\.toLowerCase\(\) === "romp\.romp-chat-view"/);
+  assert.match(fn, /vscode\.env\.openExternal\(uri\);/);
+});

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -19,7 +19,8 @@ test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs
   assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any, report\?: OrderReport, live\?: any\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
   // the frame's provenance rides along since T233 (captureViews still runs FIRST)
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);   // + the frame\'s live set (T258)
+  // (the kernel's own name, selfHost, is adopted first — pr-links.test.ts pins that line)
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);   // + the frame\'s live set (T258)
 });
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {

--- a/vscode-extension/src/view-routing.test.ts
+++ b/vscode-extension/src/view-routing.test.ts
@@ -51,6 +51,17 @@ test("timeline: openLink is handled locally by the host, never forwarded", () =>
   assert.equal(r.revealChat, null);
 });
 
+test("feed and outline panes: a PR link's openLink is handled locally by the host too, never forwarded", () => {
+  // pr-links.ts posts {type:"openLink"} from a feed card or an outline row in VS Code; the kernel has
+  // no handler for it, so a forwarded one would be a dead click
+  for (const app of ["feed", "fleet"] as const) {
+    const r = routeViewMessage(app, { type: "openLink", href: "https://github.com/example-org/notes-api/pull/12" });
+    assert.equal(r.openLinkLocally, "https://github.com/example-org/notes-api/pull/12", app);
+    assert.equal(r.forward, false, app);
+    assert.equal(r.revealChat, null, app);
+  }
+});
+
 test("timeline: drive ops (compact etc.) just forward", () => {
   const r = routeViewMessage("timeline", { type: "compact", name: "sess" });
   assert.equal(r.revealChat, null);

--- a/vscode-extension/src/view-routing.ts
+++ b/vscode-extension/src/view-routing.ts
@@ -29,6 +29,11 @@ const NONE: Routed = { revealChat: null, revealFeed: null, openLinkLocally: null
 export function routeViewMessage(app: App, m: any): Routed {
   if (!m || typeof m.type !== "string") return { ...NONE, forward: false };
 
+  // Any pane may hold a link the host must open (the timeline's, and since 2026-09-06 the PR links in
+  // feed cards and outline rows): the kernel has no openLink handler, so forwarding it is a dead click.
+  if (m.type === "openLink" && typeof m.href === "string")
+    return { ...NONE, openLinkLocally: m.href, forward: false };
+
   if (app === "chat") {
     // reveal side-effects ride along; the kernel does the real work
     if (m.type === "dotOpen") return { ...NONE, revealFeed: { preserveFocus: true } };
@@ -48,8 +53,6 @@ export function routeViewMessage(app: App, m: any): Routed {
 
   // timeline
   if (m.type === "deepLink") return { ...NONE, revealChat: { preserveFocus: true } }; // a lane click jumps the chat there
-  if (m.type === "openLink" && typeof m.href === "string")
-    return { ...NONE, openLinkLocally: m.href, forward: false };
   if (m.type === "usageData") return { ...NONE, forward: false }; // host-consumed (status-bar chrome), not a kernel op
   return NONE;
 }


### PR DESCRIPTION
## What this does

`#123`, `PR #123` / `pull #123` and `owner/repo#123` in rendered text become links to the pull request page of the repository the session works in: the chat's markdown (prompts, replies, subagent reports, postal bodies), feed cards (titles, distiller lines, checklists, group members, held-mail gists, tree rows, the modal) and the outline's goal rows. GitHub redirects an issue number from the pull path, so one form covers both.

The kernel ships `githubRepo` (owner/repo, or null) on the session frame and on the feed's session rows, read from the session directory's `origin` remote through the parser the file viewer's GitHub link already uses (#543), so there is one spelling of what counts as GitHub.

## What breaks today

- A session's own PR numbers in its chat and cards are plain text; a reader copies the number into a browser by hand.
- Before this branch, the kernel's `_tree_of` verdict was cached for the kernel's life: a directory that became a repository after its first build (`git init`, then `gh repo create`) kept a null repository until a restart, a `.git` git rejects (a worktree whose clone was removed) forked `git rev-parse` on every call, and a tree deleted or reshaped under a live session served a stale branch or forked per build.
- In VS Code, `openLink` was routed host-side for the timeline only; the same message from a feed card or outline row was forwarded to a kernel with no handler.

## Reproduction

1. Run a session in a checkout whose `origin` is on GitHub; have it write `see #12 and owner/repo#3`. Before: plain text. After: both link (the first into the session's repository, the second into `owner/repo`).
2. Run a session in a checkout whose `origin` is not on GitHub (or has none): both stay plain text, before and after — by design.
3. In a directory that is not a repository, build once, then `git init` and `git remote add origin https://github.com/example-org/notes-api.git`: before, `githubRepo` stayed null until a kernel restart; after, the next build carries it.

## The fix

**Kernel** (commits 1–2). `_github_repo_of(cwd)` names the repository of the tree containing a session's directory, memoized per tree on the config file's mtime (`git remote set-url` writes that file). `_session_cwd` is one derivation of the session's directory for the chat frame and the feed rows (registry first, transcript stamp as the fallback for a never-registered session). `_tree_of` files each verdict with the evidence it was reached under — the first `.git` on the directory chain, reduced to the part that decides git's answer (a pointer file's path, mtime, inode and whether its target exists; a toplevel's own `.git` directory by path and inode; a walked-past or rejected directory by path and mtime) — so a re-ask costs a fork only when that evidence changes, and `_vouch_tree` forgets a tree's memos when its own `.git` changed shape. `_git_branch` goes through `_tree_of` (a subdirectory cwd is memoized like its toplevel; a bare repository keeps the branch its HEAD names). A memoized call costs two stats for a plain toplevel, three for a worktree; no read, no fork. Existing pins in test_kernel_fork_burn.py, test_kernel_worktree_display.py and test_sdk_kernel.py are unchanged.

Every tabOrder frame — including the connect-time one the ready handler sends — is built by `_tab_order_frame` and carries `selfHost`, so a dashboard learns its kernel's own name before any card renders. The inbound postal card carries `peerHost` (the sender's host as the message log stamped it: "" for that kernel's own sessions, a peer's name otherwise; absent for a log row from before the field). `deliver()` writes `from_host` on every log row ("" = local) — additive under the existing consumer contract; the judge's readers use `.get(...) or ""`.

**Client** (commit 3). `ui/webview/pr-links.ts` holds the rule in one place: GitHub's own owner/repo grammar; a slash-separated run `#12/#13` links each as GitHub's autolinker does; a repo name ending in `.` or shaped like a filename is refused in the cross-repo form (`*.github.io` excepted); hex colour literals and a `#` glued to a word, path or URL fail the number shape; text inside code-like elements, existing anchors and path links never links. `setLinkedText` is keyed so an unchanged card title keeps its anchor nodes across pushes; the opener is capture-phase on the document and keyed on the anchor's href, so a push between press and release still opens the link and the card's own click never fires. `md()` walks DOMPurify's sanitized tree (RETURN_DOM) before serializing, so one hook covers every markdown surface. federation.ts carries the local kernel's `selfHost` on the merged frame.

**VS Code** (commit 4). `openLink` is routed host-side for every pane; the feed and outline panel handlers open it and honor `forward`.

## Two judgment calls, open to your call

1. **A session whose origin is not on GitHub links nothing, the explicit `owner/repo#123` form included.** Plain text rather than a guessed host. Making the cross-repo form link regardless is a few lines in pr-links.ts.
2. **A postal body links only against the sender's repository.** An outbound message uses the writer's own; an inbound card resolves `peerHost` + `peer` to exactly the frame session matching host and name (read relative to the card's own kernel; the dashboard's own name folds to its local rows). Zero or several matches, or a sender with no repository, leave the reference as text; the reader's repository is never a fallback. A card from a kernel that predates the field falls back to the bare name when exactly one session carries it.

One limit to state: `peerHost` is the card's kernel's own name for the sender's host (the bus files a peer under the local alias or its declared name; no host id crosses the wire), so the match holds when the two kernels agree on the name — the usual check-in topology. When they disagree, the reference stays text, never a wrong link.

## Not covered

The file viewer's own markdown pipeline, tooltips, timeline captions.

## Tests

- `tests/test_github_repo.py`: derivation over synthetic repositories, worktrees and bare clones; the memo; each evidence-keyed re-ask (a late `git init`, a rejected `.git`, a walked-past `.git`, a rewritten or re-made pointer within one mtime tick, a re-pointed symlink, a deleted or reshaped tree, the shape record's own bound); per-call stat counts; the postal card's `peerHost`; `_session_cwd`; the frame pins. The inode key exists because HFS+ has one-second mtime granularity — the within-one-tick test simulates the tick with `os.utime`, so it is deterministic on the macOS CI cell too.
- `tests/test_postal_from_host_row.py`; the tabs-first and timeline-views pins move to the helper spelling and count the four senders.
- `ui/webview/pr-links.test.ts`: every pattern and exclusion, the applier on a DOM stand-in, the opener, sender resolution, and the source wiring pins; `multi-kernel-merge.test.ts` (selfHost passthrough); `view-routing.test.ts`; `open-link-wiring.test.ts`; seven existing pins updated.
- One sentence in `docs/guide.md`.

Note: the pre-existing key name `peerHost` on the judge's handoff-origin dict is a different card; the chat's postal-service event now carries a field of the same name with the same meaning (the sender's host).

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)