### PR TITLE
Tests: a failed report shows no process-environment value and no credential-shaped token

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -2425,9 +2425,12 @@ else
     # it's up, so an external watcher is the only way to surface it. Background a
     # check that sets @claude-state=picker if the session stays stuck on the picker
     # (the feed treats that as NEEDS INPUT). We do NOT auto-answer it — guessing the
-    # key / "from summary" loses context; the user clears it by hand.
+    # key / "from summary" loses context; the user clears it by hand. Through the
+    # ROMP_POSTAL_BIN seam like `mail` and `refresh`: this script puts its own directory
+    # first on PATH, so a test can stand in for the service no other way, and the real
+    # one, detached here, minted a serve-token under a test HOME after its teardown.
     if $resume && [[ -n "$sid" ]]; then
-        ( romp-postal-service picker-check --name "$name" --id "$sid" >/dev/null 2>&1 & )
+        ( "${ROMP_POSTAL_BIN:-romp-postal-service}" picker-check --name "$name" --id "$sid" >/dev/null 2>&1 & )
     fi
 
     # Attach — or, when detaching, just report how to get there.

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,5 +55,43 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
   gating, the kernel registry, and the drain-poll handshake. Run:
   `node --test tests/manager-*.test.js`.
 
+**Temp files and git are hermetic, suite-wide.** Two mechanisms, one per half.
+`tests/__init__.py` wraps `tempfile.mkdtemp` so every directory the test process
+mints is recorded and removed when the run ends (under pytest at session end,
+under `python -m unittest` at exit): the in-process half, covering the 300-odd
+module preambles and the per-test `mkdtemp()` calls nobody cleans up.
+`tests/conftest.py` covers what that hook cannot see — directories made by
+child processes (kernels, git, a shell's `mktemp -d`), `mkstemp` files,
+`os.mkdir` paths — by pointing the process temp dir (`tempfile.tempdir` and
+`TMPDIR`, so every child inherits it) at one private `romp-tests-*` root under
+the system temp dir and removing the root when the run ends (before both, a
+full run left ~5,600 entries in `/tmp` and over a million had piled up). Still
+clean up what you create — `with tempfile.TemporaryDirectory()`,
+`self.addCleanup(shutil.rmtree, ...)`, a `tearDownClass` for a class-level
+fixture — so a fixture is gone when its test is, not at exit; bats suites use
+`mktemp -d` in `setup` and `rm -rf` it in `teardown`, and stand in for any
+subject that detaches work (bin/romp's resume picker-check, reached through
+`ROMP_POSTAL_BIN`, re-created four to six test dirs per run by minting a
+serve-token after the teardown). Never give a tempfile call a literal
+directory as its `dir` — by keyword or position, composed (`f"/tmp/{x}"`,
+`os.path.join("/tmp", x)`) or through a name bound to one — and never point
+`mktemp` (`-p`, `--tmpdir`, a `TMPDIR=` prefix) at a path under `/tmp`: that
+bypasses the redirect, and the hygiene test reads every test file for those
+shapes. The one test that must leave the root — an AF_UNIX socket whose path
+would not fit `sun_path` under a nested root — falls back to
+`ROMP_TESTS_SYSTEM_TMPDIR`, the system temp dir conftest recorded once per run
+before redirecting (an xdist worker inherits the controller's record), and
+removes what it made. A root that cannot be removed at run end (a child
+still writing under it, a 000-mode directory a test left behind) is named on
+stderr: `[tests] not removed at run end: <path>`, instead of the run ending
+green over it. The same conftest gives git no global or system config
+(`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`) and a synthetic identity through
+`GIT_AUTHOR_*` / `GIT_COMMITTER_*`; bats suites that run git get the same from
+`load git-hermetic` + `git_hermetic` in `setup`. A fixture must not depend on
+the developer's git configuration (CI has none), and the env identity outranks
+`git config user.*` and `-c user.*` — a test that must pin a particular author
+exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
+and `tests/git-hermetic.bats` pin all of it.
+
 `fixtures/` must stay SYNTHETIC: invented prompts, placeholder UUIDs, hostname
 `TESTHOST` — never real session data.

--- a/tests/README.md
+++ b/tests/README.md
@@ -102,17 +102,23 @@ fix is to test membership and name the key; the report hook in
 It redacts two things from every report's text and captured-output sections,
 whatever the outcome (so `-rA`/`-rP` output for passed tests too), and from
 collection reports: a value present in the process environment that is 16
-characters or longer becomes `[REDACTED-ENV-VALUE]`, whole and per
-whitespace-separated chunk (values are noted at the moment they are written
+characters or longer becomes `[REDACTED-ENV-VALUE]`, whole, per
+whitespace-separated chunk, and per piece left beside a cut pytest or
+unittest made (`'<head>...<tail>'`, `[N chars]`) when that piece is a
+substring of the value (values are noted at the moment they are written
 into `os.environ`, so one set inside `mock.patch.dict` and gone before the
 assertion is caught too; exempt, never when the name is credential-shaped,
 are path-valued names such as `PWD`, `HOME`, `TMPDIR` and the interpreter
-paths GitHub Actions exports, the `XDG_*` and `PYTEST_*` families, and any
-value that is an absolute path this machine has), and a credential-shaped
-token becomes `[REDACTED-CREDENTIAL]` wherever it came from, by the patterns
-in `tests/credential_patterns.py` (public key prefixes, a JWT by its shape, a
+paths GitHub Actions exports, the names whose values are public, the ones
+GitHub Actions describes a run in (`GITHUB_REF`, `GITHUB_REPOSITORY`,
+`GITHUB_ACTOR` and the rest) and the conftest's own synthetic git identity,
+the `XDG_*` and `PYTEST_*` families, and any value that is an absolute path
+this machine has), and a credential-shaped token becomes
+`[REDACTED-CREDENTIAL]` wherever it came from, by the patterns in
+`tests/credential_patterns.py` (public key prefixes, a JWT by its shape, a
 long token where a value sits, pytest's own renderings of a failed comparison
-included). A report the hook changes is rebuilt from the scrubbed text with
+included; a named git sha and a dated Anthropic model id are left alone). A
+report the hook changes is rebuilt from the scrubbed text with
 its crash location kept, so the short test summary still ends in the
 assertion message; that report loses pytest's colour and source highlighting.
 One it leaves alone keeps pytest's own rendering.

--- a/tests/README.md
+++ b/tests/README.md
@@ -93,5 +93,31 @@ the developer's git configuration (CI has none), and the env identity outranks
 exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
 and `tests/git-hermetic.bats` pin all of it.
 
+**No test report shows a process-environment value or a credential-shaped
+token.** An assertion whose container is an environment mapping prints the
+whole mapping when it fails (`assertNotIn("X", os.environ)` renders every
+variable), and on a developer's machine that mapping can hold a live key. The
+fix is to test membership and name the key; the report hook in
+`tests/conftest.py` is the net for an assertion still written the other way.
+It redacts two things from every report's text and captured-output sections,
+whatever the outcome (so `-rA`/`-rP` output for passed tests too), and from
+collection reports: a value present in the process environment that is 16
+characters or longer becomes `[REDACTED-ENV-VALUE]`, whole and per
+whitespace-separated chunk (values are noted at the moment they are written
+into `os.environ`, so one set inside `mock.patch.dict` and gone before the
+assertion is caught too; exempt, never when the name is credential-shaped,
+are path-valued names such as `PWD`, `HOME`, `TMPDIR` and the interpreter
+paths GitHub Actions exports, the `XDG_*` and `PYTEST_*` families, and any
+value that is an absolute path this machine has), and a credential-shaped
+token becomes `[REDACTED-CREDENTIAL]` wherever it came from, by the patterns
+in `tests/credential_patterns.py` (public key prefixes, a JWT by its shape, a
+long token where a value sits, pytest's own renderings of a failed comparison
+included). A report the hook changes is rebuilt from the scrubbed text with
+its crash location kept, so the short test summary still ends in the
+assertion message; that report loses pytest's colour and source highlighting.
+One it leaves alone keeps pytest's own rendering.
+`tests/test_env_value_redaction.py` pins the rule, the write-time capture,
+the patterns, the scrub's cost and the hook end to end.
+
 `fixtures/` must stay SYNTHETIC: invented prompts, placeholder UUIDs, hostname
 `TESTHOST` — never real session data.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,18 +9,25 @@ import os
 import shutil
 import tempfile
 
-# Temp-directory hygiene (2026-09-06): the suite used to leak every directory it made. This floor and
-# conftest.py's each minted a state root per process and never removed it (two per pytest process:
-# eighteen for a `pytest -n 8` run), and about three hundred test modules call tempfile.mkdtemp with
-# no cleanup of their own. On a developer machine that ran the suite many times a day that left about
-# 1.9 million directories under the system temp directory, enough that listing it took minutes and
-# tens of gigabytes of memory, and the out-of-memory kills that followed took a running romp kernel
-# down. The fix is at the source: every tempfile.mkdtemp call made in this process is recorded, and
-# everything recorded is removed at interpreter exit (and, under pytest, at session end; see
-# conftest.py). Only directories this process created, and only under the system temp directory, are
-# ever removed. tempfile.TemporaryDirectory goes through the same mkdtemp and cleans itself first, so
-# the exit sweep finds nothing of it. This package imports before conftest.py (pytest imports
-# `tests.conftest` through the package), so conftest's own root is recorded too.
+# Temp-directory hygiene, the in-process half (2026-09-06): the suite used to leak every directory it
+# made. This floor and conftest.py's each minted a state root per process and never removed it (two
+# per pytest process: eighteen for a `pytest -n 8` run), and about three hundred test modules call
+# tempfile.mkdtemp with no cleanup of their own. On a developer machine that ran the suite many times
+# a day that left about 1.9 million directories under the system temp directory, enough that listing
+# it took minutes and tens of gigabytes of memory, and the out-of-memory kills that followed took a
+# running romp kernel down. The fix is at the source: every tempfile.mkdtemp call made in THIS
+# process is recorded, and everything recorded is removed at interpreter exit (and, under pytest, at
+# session end; see conftest.py). Only directories this process created, and only under the process
+# temp dir, are ever removed: tempfile.gettempdir(), which is the system temp dir under a unittest
+# run and conftest's private per-run root under pytest. tempfile.TemporaryDirectory goes through the
+# same mkdtemp and cleans itself first, so the exit sweep finds nothing of it.
+# What this hook cannot see is the other half, conftest.py's: directories made by CHILD processes
+# (kernels, git, a shell's `mktemp -d`), files from mkstemp, and os.mkdir paths under the temp dir.
+# Under pytest those land in conftest's root because TMPDIR points there, and the root is removed
+# whole at run end; the two directories this process mints BEFORE that redirect (this package's
+# state dir below, and the root itself, both recorded here but outside the redirected gettempdir()
+# and so skipped by this sweep) are conftest's to remove. No such cover exists under a bare
+# unittest run, where the per-module cleanups (addCleanup, tearDownClass) are what there is.
 _MADE_DIRS = []
 _REAL_MKDTEMP = tempfile.mkdtemp
 
@@ -53,4 +60,10 @@ def remove_made_dirs():
 atexit.register(remove_made_dirs)
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
+# Recorded by the hook above, which removes it at exit under a unittest run. Under pytest it is
+# minted BEFORE conftest.py redirects the temp root (the package imports first), so it sits beside
+# the root in the system temp dir, outside the hook's redirected scope; conftest reads STATE_DIR
+# and removes it with the root when the run ends. Nothing runs after an os._exit (pytest-timeout's
+# thread method ends a hung run that way), so a hung run leaves this dir beside the root.
+STATE_DIR = os.environ["XDG_STATE_HOME"]
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor

--- a/tests/bootstrap-sh.bats
+++ b/tests/bootstrap-sh.bats
@@ -8,7 +8,10 @@
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,26 +4,85 @@ any test that skips its own rebind writes into the REAL ~/.local/state/romp (the
 judge-errors.jsonl lines from legacy-flag fixtures made that visible). conftest.py imports before every
 test module, so this is a suite-wide floor; per-class _rebind_state/tempdir isolation still layers on
 top exactly as before."""
+import atexit
 import os
+import shutil
 import sys
 import tempfile
 
 import pytest
 
-os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # recorded by tests/__init__.py's hook
-os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
+# Temp-directory hygiene, the child-process half (2026-09-06): every temp path a run creates lives
+# under ONE private root, removed when the run ends. tests/__init__.py's mkdtemp hook (the other
+# half; its comment has the leak's history) records and removes what THIS process mints through
+# tempfile.mkdtemp, but a test's children — kernels, git, `mktemp -d` in a shell — and mkstemp or
+# os.mkdir paths are outside its sight (a full run left ~5,600 of those per run at up to ten a
+# second). So the process's temp dir is redirected: tempfile.tempdir is set directly (gettempdir()
+# caches its first answer, and tests/__init__.py has already called it by the time this runs), and
+# TMPDIR is exported so every child inherits the same root. Import-time, not pytest_configure: this
+# module's own XDG floor below and every module-level mkdtemp at collection must land inside it.
+# The two removals compose without overlap: pytest_sessionfinish runs the hook's sweep, whose scope
+# is gettempdir() and so the inside of this root; pytest_unconfigure then removes the root whole
+# (whatever the sweep could not see) and tests/__init__.py's romp-tests-state-* dir — the package
+# imports first, so that dir and this root were minted before the redirect and are the two things a
+# run puts outside the root; the hook recorded both but skips them as outside its scope. Under
+# pytest-xdist both hooks run in the controller and in every worker: each imported this file and so
+# owns a root of its own (a worker's sits inside the controller's, since it inherits that TMPDIR).
+# The atexit registrations are silent fallbacks for a normal exit that skipped the hooks, each a
+# no-op on what the other removed; nothing runs after an os._exit (pytest-timeout's thread method
+# ends a hung run that way), so a hang leaves two top-level entries in the system temp dir, this
+# root and that state dir, both under the romp-tests- prefix.
+# The system temp dir — the one the RUN was handed, before any redirect — is recorded once, by the
+# first conftest to import: an xdist worker inherits the controller's record along with its TMPDIR
+# (setdefault, not an assignment: a worker's own gettempdir() is the controller's root, and
+# recording that put the worker's fallback one level deeper than a socket path can bear under a
+# long TMPDIR — four socket tests failed at bind under -n 2). A test that must leave the root (an
+# AF_UNIX socket path that would not fit sun_path under a nested root) falls back to it, and only
+# to it — a literal system path in a `dir=` would bypass the redirect (one did).
+os.environ.setdefault("ROMP_TESTS_SYSTEM_TMPDIR", tempfile.gettempdir())
+_TMP_ROOT = tempfile.mkdtemp(prefix="romp-tests-")
+tempfile.tempdir = _TMP_ROOT
+os.environ["TMPDIR"] = _TMP_ROOT
+_PACKAGE_STATE_DIR = getattr(sys.modules.get("tests"), "STATE_DIR", None)
 
 
+def _remove_run_dirs(report=False):
+    """Remove the root and the package state dir. A survivor is named on stderr when asked: rmtree
+    with ignore_errors swallows a child still writing under the root or a 000-mode directory a test
+    left behind, and the run would otherwise end green with the root standing. Only unconfigure
+    asks; the atexit fallback stays silent so it neither repeats the notice nor contradicts it."""
+    for d in (_TMP_ROOT, _PACKAGE_STATE_DIR):
+        if d:
+            shutil.rmtree(d, ignore_errors=True)
+            if report and os.path.isdir(d):
+                print("[tests] not removed at run end: %s" % d, file=sys.stderr)
+
+
+atexit.register(_remove_run_dirs)
+
+
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Temp-directory hygiene (2026-09-06, see tests/__init__.py): remove every directory this
-    process made through tempfile.mkdtemp, this state root included, when the session ends. Runs in
-    the controller and in every xdist worker, since each is its own pytest session. The package's
-    atexit hook does the same at interpreter exit; both are idempotent."""
+    """The in-process half (tests/__init__.py): remove every directory this process made through
+    tempfile.mkdtemp inside the root, this module's state root included, when the session ends. Runs
+    in the controller and in every xdist worker, since each is its own pytest session, and last, after
+    pytest's own runner sessionfinish has performed the deferred teardown an interrupted run leaves
+    behind, so nothing is swept from under a fixture still closing. The package's atexit hook does the
+    same at interpreter exit; both are idempotent, and pytest_unconfigure below takes the root itself
+    afterwards."""
     try:
         from tests import remove_made_dirs
     except Exception:
         return
     remove_made_dirs()
+
+
+def pytest_unconfigure(config):
+    _remove_run_dirs(report=True)
+
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 
 
 # No test may reach a REAL manager control port (2026-08-27): on a machine running a live romp,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,21 @@ def pytest_unconfigure(config):
     _remove_run_dirs(report=True)
 
 
+# No test's git reads the developer's configuration (2026-09-06). Fixture repos are built by `git
+# init` + `git commit` in temp dirs, and those commands honoured the developer's global config: a
+# global core.hooksPath ran their pre-commit hook on every seed commit, an LFS filter would run on
+# every checkout, and a credential helper or insteadOf rewrite could reach a real remote
+# (tests/test_file_github.py pins its own environment for exactly that reason). CI has no global git
+# config, so a test that leans on one is already broken there; this makes every run match.
+# GIT_CONFIG_GLOBAL is honoured by git >= 2.32; the identity is synthetic, and it is set rather than
+# defaulted so a developer's own GIT_AUTHOR_* cannot leak into fixture commits either. The env
+# identity outranks `git config user.*` and `-c user.*`, so a test that must pin a particular author
+# exports its own GIT_AUTHOR_* / GIT_COMMITTER_* per call; other config keys still yield to `-c`.
+os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+os.environ["GIT_AUTHOR_NAME"] = os.environ["GIT_COMMITTER_NAME"] = "romp tests"
+os.environ["GIT_AUTHOR_EMAIL"] = os.environ["GIT_COMMITTER_EMAIL"] = "tests@example.invalid"
+
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,14 @@ judge-errors.jsonl lines from legacy-flag fixtures made that visible). conftest.
 test module, so this is a suite-wide floor; per-class _rebind_state/tempdir isolation still layers on
 top exactly as before."""
 import atexit
+import importlib.util
 import os
 import shutil
 import sys
 import tempfile
 
 import pytest
+from _pytest._code.code import ReprExceptionInfo, ReprFileLocation, ReprTracebackNative
 
 # Temp-directory hygiene, the child-process half (2026-09-06): every temp path a run creates lives
 # under ONE private root, removed when the run ends. tests/__init__.py's mkdtemp hook (the other
@@ -259,4 +261,249 @@ def _stub_place_llm(monkeypatch):
             if j is not None and id(j) not in seen and getattr(j, "_card_route_subs", None) is not None:
                 seen.add(id(j))
                 monkeypatch.setattr(j, "place_llm", lambda *a, **k: "")
+    yield
+
+
+# No test report may carry a process-environment VALUE, or a credential-shaped token (2026-09-05). A
+# test that renders an env mapping in an assertion (assertNotIn on os.environ, on a _judge_env() copy
+# of it, on a launch env) prints the whole mapping when it fails, and on a developer's box that
+# mapping holds live credentials. Assertions that test membership and name the key are the fix; this
+# hook is the safety net for an assertion still written the other way. Two nets, applied to every
+# report's text (the longrepr and the captured-output sections) whatever the outcome, and to
+# collection reports:
+#   * every value seen in this process's environment, 16 characters or longer, is replaced with one
+#     marker, and so is each whitespace-separated chunk of such a value that is 16 characters or
+#     longer (pprint renders a value with spaces as adjacent literals on separate lines, so a
+#     whole-value replace misses the pieces). Values are noted the moment they are WRITTEN into
+#     os.environ (the mutation path is wrapped below: a plain assignment, update, setdefault,
+#     os.putenv, os.environb, mock.patch.dict), and sampled at import, around each test and at
+#     report time as well, for values that entered by another route (inherited from the parent
+#     process, written by a C extension). Exempt, and never when the name is credential-shaped: a
+#     path-valued variable by NAME (the shell's, this conftest's own dirs, the interpreter and
+#     workspace paths GitHub Actions exports); a name family that is never a credential (XDG_*, and
+#     pytest's own PYTEST_*: PYTEST_CURRENT_TEST holds the running test's node id and is written
+#     for every phase of every test, so noting it grew the set by one value per test, slowed every
+#     report's scrub in step and made the node id of every test already run a target in later
+#     reports); and any value that IS a path this machine has (one absolute path that exists, or a
+#     PATH-style list of them), because a traceback quotes the interpreter's prefix on every frame
+#     and a developer's shell names it under any variable (a pyenv root, a conda prefix).
+#   * credential-shaped tokens by PATTERN (tests/credential_patterns.py: the public key prefixes, and
+#     a long token in a value position), whatever their provenance: a token that never touched the
+#     environment (read from a file, printed by a child) is caught by this one.
+# A report the hook leaves alone keeps pytest's own object and rendering. One it changes is rebuilt
+# from the scrubbed text as a native-style traceback with its crash location kept (its message
+# scrubbed too), so the short test summary still ends in the assertion message, junitxml keeps its
+# message and xdist carries it to the controller; that report loses colour and source highlighting,
+# nothing else (_redacted_longrepr).
+ENV_VALUE_MIN_LEN = 16
+ENV_VALUE_REDACTED = "[REDACTED-ENV-VALUE]"
+_ENV_VALUE_PATH_NAMES = frozenset((
+    "PWD", "OLDPWD", "HOME", "PATH", "TMPDIR", "SHELL", "VIRTUAL_ENV", "PYTHONPATH", "LS_COLORS",
+    "ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV", "ROMP_DIR", "ROMP_STATE_DIR", "ROMP_CLAUDE_BIN",
+    "ROMP_SYSTEMD_DIR", "ROMP_LAUNCHD_DIR", "CLAUDE_CONFIG_DIR", "TMUX_TMPDIR", "ROMP_TESTS_SYSTEM_TMPDIR",
+    # GitHub Actions: the runner's workspace and tool cache, and the interpreter prefix setup-python
+    # exports under six names (every stdlib and site-packages frame of a CI traceback is under it)
+    "GITHUB_WORKSPACE", "RUNNER_WORKSPACE", "RUNNER_TEMP", "RUNNER_TOOL_CACHE", "pythonLocation",
+    "Python_ROOT_DIR", "Python2_ROOT_DIR", "Python3_ROOT_DIR", "LD_LIBRARY_PATH", "PKG_CONFIG_PATH"))
+_ENV_VALUE_EXEMPT_PREFIXES = ("XDG_", "PYTEST_")   # never a credential: the XDG base dirs, pytest's bookkeeping
+_ENV_VALUES_SEEN: set = set()
+
+
+def _load_credential_patterns():
+    """tests/credential_patterns.py, by path beside this file (a subprocess run against a copy of the
+    conftest carries a copy of it too). A missing module is an error, never a silent net less."""
+    p = os.path.join(os.path.dirname(os.path.realpath(__file__)), "credential_patterns.py")
+    spec = importlib.util.spec_from_file_location("romp_tests_credential_patterns", p)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_credpat = _load_credential_patterns()
+CREDENTIAL_REDACTED = _credpat.REDACTED
+
+
+def _credential_shaped(name: str) -> bool:
+    n = name.upper()
+    return (n == "ANTHROPIC_API_KEY" or n.endswith("_API_KEY") or n.endswith("_TOKEN") or n.startswith("ANTHROPIC_")
+            or "SECRET" in n or "PASSWORD" in n or "APIKEY" in n)
+
+
+def _is_existing_path(value: str) -> bool:
+    """Whether `value` is a path this machine has: one absolute path that exists, or a PATH-style list
+    of them (every non-empty os.pathsep chunk). No token is an absolute path that exists, so this
+    exempts no token; a path that does not exist is a value like any other."""
+    chunks = [c for c in value.split(os.pathsep) if c]
+    return bool(chunks) and all(os.path.isabs(c) and os.path.exists(c) for c in chunks)
+
+
+def env_value_qualifies(name: str, value: str) -> bool:
+    """Whether one environment entry's value is one a report must not show: ENV_VALUE_MIN_LEN
+    characters or more, unless the name is exempt (a path-valued variable by name, or a name family
+    that is never a credential) or the value is a path this machine has; a credential-shaped name is
+    never exempt. The one rule, for the sampler and for the write hook."""
+    if len(value) < ENV_VALUE_MIN_LEN:
+        return False
+    if _credential_shaped(name):
+        return True
+    if name in _ENV_VALUE_PATH_NAMES or name.startswith(_ENV_VALUE_EXEMPT_PREFIXES):
+        return False
+    return not _is_existing_path(value)
+
+
+def env_values_to_redact(environ=None) -> set:
+    """The values of `environ` (the process environment by default) a report must not show."""
+    env = os.environ if environ is None else environ
+    return {value for name, value in env.items() if env_value_qualifies(name, value)}
+
+
+def note_env_value(name, value) -> bool:
+    """Note one value at the moment it is written into the environment (the hook below). Bytes
+    (os.environb, os.putenv) are decoded the way os.environ decodes them. Returns whether the value
+    qualified; anything that is not a name and a string value does not."""
+    if isinstance(name, bytes):
+        name = os.fsdecode(name)
+    if isinstance(value, bytes):
+        value = os.fsdecode(value)
+    if not isinstance(name, str) or not isinstance(value, str):
+        return False
+    if not env_value_qualifies(name, value):
+        return False
+    _ENV_VALUES_SEEN.add(value)
+    return True
+
+
+def _install_env_write_hook() -> None:
+    """Wrap the one method every os.environ write goes through and os.putenv beside it. A plain
+    assignment, update, setdefault, mock.patch.dict (an update) and os.environb all reach
+    _Environ.__setitem__; os.putenv is the module global that method calls and the path that writes
+    to the process without touching the mapping. Idempotent: a second import stacks no wrapper."""
+    if getattr(os._Environ.__setitem__, "_romp_notes_values", False):
+        return
+    orig_setitem = os._Environ.__setitem__
+    orig_putenv = os.putenv
+
+    def setitem(self, key, value):
+        note_env_value(key, value)
+        return orig_setitem(self, key, value)
+
+    def putenv(key, value):
+        note_env_value(key, value)
+        return orig_putenv(key, value)
+
+    setitem._romp_notes_values = putenv._romp_notes_values = True
+    os._Environ.__setitem__ = setitem
+    os.putenv = putenv
+
+
+_install_env_write_hook()
+
+
+def redact_env_values(text: str, values) -> str:
+    """`text` with every occurrence of every value replaced by ENV_VALUE_REDACTED, longest first (a
+    value that contains another is replaced whole), and then every whitespace-separated chunk of a
+    value that is ENV_VALUE_MIN_LEN characters or more: pprint renders a long value with spaces as
+    adjacent string literals on separate lines, so the token half of `Authorization: Bearer <token>`
+    survived a whole-value replace, and unittest's shortened repr shows a differing tail on its own."""
+    parts = set()
+    for v in values:
+        if not v:
+            continue
+        parts.add(v)
+        chunks = v.split()
+        if len(chunks) > 1:
+            parts.update(c for c in chunks if len(c) >= ENV_VALUE_MIN_LEN)
+    for v in sorted(parts, key=len, reverse=True):
+        text = text.replace(v, ENV_VALUE_REDACTED)
+    return text
+
+
+def redact_credential_tokens(text):
+    """The pattern net: credential-shaped tokens, whatever their provenance (tests/credential_patterns.py)."""
+    return _credpat.scrub(text)
+
+
+def redact_report_text(text: str, values=None) -> str:
+    """Both nets over one report string: the environment's values (and their chunks), then the
+    credential-shaped tokens. `values` defaults to everything noted so far."""
+    return redact_credential_tokens(redact_env_values(text, _ENV_VALUES_SEEN if values is None else values))
+
+
+def _note_env_values():
+    _ENV_VALUES_SEEN.update(env_values_to_redact())
+
+
+_note_env_values()
+
+
+@pytest.fixture(autouse=True)
+def _remember_env_values():
+    """The sampling half. A value a test writes itself is noted at the write (note_env_value), so one
+    present only between these samples is redacted too; the samples at every test's setup and
+    teardown, and at report time, are for values that entered the environment by a route the write
+    hook does not see (inherited from the parent process before this file loaded, written by a C
+    extension)."""
+    _note_env_values()
+    yield
+    _note_env_values()
+
+
+def _redact_crash_message(message: str) -> str:
+    """A crash message scrubbed as the report body renders it. pytest writes the message's lines under
+    the `E` marker (`E   ` + line), and the pattern net's rules for a failed comparison's diff lines
+    and quoted elements are keyed on that marker; the bare message (`  - <token>` after the diff's
+    header) is a rendering the rules do not know, so it is scrubbed marked and unwrapped. Under CI
+    pytest prints the whole message, every line, in the short test summary."""
+    marked = "\n".join("E   " + line for line in message.split("\n"))
+    return "\n".join(line[4:] if line.startswith("E   ") else line
+                     for line in redact_report_text(marked).split("\n"))
+
+
+def _redacted_longrepr(lr, text: str):
+    """The scrubbed `text` of a longrepr as a longrepr again. A failure's keeps its crash location
+    (pytest's own ReprFileLocation, the message scrubbed too) over a native-style traceback whose one
+    entry is the text: the short test summary ends in reprcrash.message, junitxml's message attribute
+    reads it, and xdist serializes a longrepr with a traceback and a crash structurally, where a plain
+    str showed the traceback's first line in the summary instead (`def test_x():`, or `self = <Case
+    testMethod=...>`). pytest renders a native entry as is, so that report loses colour and source
+    highlighting and nothing else. A longrepr with no crash location (a collection error's) becomes
+    the plain text."""
+    crash = getattr(lr, "reprcrash", None)
+    if crash is None:
+        return text
+    return ReprExceptionInfo(reprtraceback=ReprTracebackNative([text + "\n"]),
+                             reprcrash=ReprFileLocation(crash.path, crash.lineno, _redact_crash_message(crash.message)))
+
+
+def _redact_report(rep) -> None:
+    """Every text a report carries, whatever its outcome: the longrepr (a failure's text; a skip's is
+    a (path, line, reason) tuple, whose reason is the text) and the captured-output sections (which
+    -rA and -rP print for passed tests too). A longrepr the nets leave unchanged keeps pytest's own
+    object and rendering; one they change is rebuilt by _redacted_longrepr."""
+    _note_env_values()
+    lr = getattr(rep, "longrepr", None)
+    if isinstance(lr, tuple) and len(lr) == 3 and isinstance(lr[2], str):
+        red = redact_report_text(lr[2])
+        if red != lr[2]:
+            rep.longrepr = (lr[0], lr[1], red)
+    elif lr is not None:
+        text = str(lr)
+        red = redact_report_text(text)
+        if red != text:
+            rep.longrepr = _redacted_longrepr(lr, red)
+    if getattr(rep, "sections", None):
+        rep.sections = [(name, redact_report_text(content)) for name, content in rep.sections]
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    _redact_report(outcome.get_result())
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_collectreport(report):
+    """A collection error (an import-time exception whose message names a value) is a report too.
+    Redacted BEFORE the other implementations see it: the terminal reporter files it from here."""
+    _redact_report(report)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ top exactly as before."""
 import atexit
 import importlib.util
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -274,19 +275,26 @@ def _stub_place_llm(monkeypatch):
 #   * every value seen in this process's environment, 16 characters or longer, is replaced with one
 #     marker, and so is each whitespace-separated chunk of such a value that is 16 characters or
 #     longer (pprint renders a value with spaces as adjacent literals on separate lines, so a
-#     whole-value replace misses the pieces). Values are noted the moment they are WRITTEN into
+#     whole-value replace misses the pieces), and so is each piece of such a value that pytest or
+#     unittest left beside a cut (`'<head>...<tail>'`, `[N chars]`: a failed `==` keeps 12 and 13
+#     characters of each operand, so most of a 30-character value showed on the assert line and in
+#     the short summary, 2026-09-07). Values are noted the moment they are WRITTEN into
 #     os.environ (the mutation path is wrapped below: a plain assignment, update, setdefault,
 #     os.putenv, os.environb, mock.patch.dict), and sampled at import, around each test and at
 #     report time as well, for values that entered by another route (inherited from the parent
 #     process, written by a C extension). Exempt, and never when the name is credential-shaped: a
 #     path-valued variable by NAME (the shell's, this conftest's own dirs, the interpreter and
-#     workspace paths GitHub Actions exports); a name family that is never a credential (XDG_*, and
-#     pytest's own PYTEST_*: PYTEST_CURRENT_TEST holds the running test's node id and is written
-#     for every phase of every test, so noting it grew the set by one value per test, slowed every
-#     report's scrub in step and made the node id of every test already run a target in later
-#     reports); and any value that IS a path this machine has (one absolute path that exists, or a
-#     PATH-style list of them), because a traceback quotes the interpreter's prefix on every frame
-#     and a developer's shell names it under any variable (a pyenv root, a conda prefix).
+#     workspace paths GitHub Actions exports); a variable whose value is public by NAME (the ones
+#     GitHub Actions exports to describe the run: the server URLs, the sha, the ref, the workflow
+#     and job names, the repository and the actor, each of which a CI failure report was showing as
+#     the marker, 2026-09-07; and the synthetic git identity this conftest sets at import); a name
+#     family that is never a credential (XDG_*, and pytest's own PYTEST_*: PYTEST_CURRENT_TEST holds
+#     the running test's node id and is written for every phase of every test, so noting it grew the
+#     set by one value per test, slowed every report's scrub in step and made the node id of every
+#     test already run a target in later reports); and any value that IS a path this machine has
+#     (one absolute path that exists, or a PATH-style list of them), because a traceback quotes the
+#     interpreter's prefix on every frame and a developer's shell names it under any variable (a
+#     pyenv root, a conda prefix).
 #   * credential-shaped tokens by PATTERN (tests/credential_patterns.py: the public key prefixes, and
 #     a long token in a value position), whatever their provenance: a token that never touched the
 #     environment (read from a file, printed by a child) is caught by this one.
@@ -305,6 +313,20 @@ _ENV_VALUE_PATH_NAMES = frozenset((
     # exports under six names (every stdlib and site-packages frame of a CI traceback is under it)
     "GITHUB_WORKSPACE", "RUNNER_WORKSPACE", "RUNNER_TEMP", "RUNNER_TOOL_CACHE", "pythonLocation",
     "Python_ROOT_DIR", "Python2_ROOT_DIR", "Python3_ROOT_DIR", "LD_LIBRARY_PATH", "PKG_CONFIG_PATH"))
+# Public by name, so never a value a report must hide. GitHub Actions describes the run in these (its
+# secrets are GITHUB_TOKEN, ACTIONS_RUNTIME_TOKEN and ACTIONS_ID_TOKEN_REQUEST_TOKEN, credential-shaped
+# names this set is never consulted for); without them a CI failure read `assert '[REDACTED-ENV-VALUE]'
+# == 'x'` where a test compared the ref, the repository or the actor. Listed by name rather than by the
+# GITHUB_ prefix so that a token GitHub adds under a name this list does not know still qualifies. The
+# GIT_* names are the synthetic identity this conftest writes at import (`romp tests`,
+# `tests@example.invalid`), under which every fixture commit is made.
+_ENV_VALUE_PUBLIC_NAMES = frozenset((
+    "GITHUB_SERVER_URL", "GITHUB_API_URL", "GITHUB_GRAPHQL_URL", "GITHUB_SHA", "GITHUB_REF", "GITHUB_REF_NAME",
+    "GITHUB_HEAD_REF", "GITHUB_BASE_REF", "GITHUB_EVENT_NAME", "GITHUB_WORKFLOW", "GITHUB_WORKFLOW_REF",
+    "GITHUB_WORKFLOW_SHA", "GITHUB_JOB", "GITHUB_ACTION", "GITHUB_ACTION_REF", "GITHUB_ACTION_REPOSITORY",
+    "GITHUB_REPOSITORY", "GITHUB_REPOSITORY_OWNER", "GITHUB_ACTOR", "GITHUB_TRIGGERING_ACTOR", "RUNNER_NAME",
+    "RUNNER_ARCH",
+    "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"))
 _ENV_VALUE_EXEMPT_PREFIXES = ("XDG_", "PYTEST_")   # never a credential: the XDG base dirs, pytest's bookkeeping
 _ENV_VALUES_SEEN: set = set()
 
@@ -339,14 +361,15 @@ def _is_existing_path(value: str) -> bool:
 
 def env_value_qualifies(name: str, value: str) -> bool:
     """Whether one environment entry's value is one a report must not show: ENV_VALUE_MIN_LEN
-    characters or more, unless the name is exempt (a path-valued variable by name, or a name family
-    that is never a credential) or the value is a path this machine has; a credential-shaped name is
-    never exempt. The one rule, for the sampler and for the write hook."""
+    characters or more, unless the name is exempt (a path-valued variable by name, a variable whose
+    value is public by name, or a name family that is never a credential) or the value is a path this
+    machine has; a credential-shaped name is never exempt. The one rule, for the sampler and for the
+    write hook."""
     if len(value) < ENV_VALUE_MIN_LEN:
         return False
     if _credential_shaped(name):
         return True
-    if name in _ENV_VALUE_PATH_NAMES or name.startswith(_ENV_VALUE_EXEMPT_PREFIXES):
+    if name in _ENV_VALUE_PATH_NAMES or name in _ENV_VALUE_PUBLIC_NAMES or name.startswith(_ENV_VALUE_EXEMPT_PREFIXES):
         return False
     return not _is_existing_path(value)
 
@@ -399,12 +422,33 @@ def _install_env_write_hook() -> None:
 _install_env_write_hook()
 
 
+# A piece of a value beside a cut pytest or unittest made: a maximal run of ENV_CUT_FRAGMENT_MIN_LEN or
+# more token characters that abuts `...` or `[N chars]` on at least one side (the marker before it, the
+# marker after it, or a quote on one side and the marker on the other). pytest renders a failed `==` at
+# default verbosity with each operand cut to 12 and 13 characters around `...` (`'abcdefghijkl...rstuvwxyzabcd'`
+# for a 30-character value), its saferepr of a local or a `+  where` operand keeps 117 on each side,
+# the short summary cuts the message at the terminal's width with `...` appended, a long explanation
+# is cut at 640 characters the same way, and unittest shortens a container repr with `[N chars]`; none
+# of those pieces is the whole value or a whitespace chunk of it, so the replace above left them
+# standing (2026-09-07). A candidate is replaced only when it is a substring of a noted value: exact,
+# never a guess from its shape (the pattern net's fragment rule does that for tokens of no known
+# provenance). Two alternatives so each maximal run is tried once from its start, which keeps the pass
+# linear on a long run that reaches no cut.
+ENV_CUT_FRAGMENT_MIN_LEN = 8
+_ENV_CUT_FRAG_RE = re.compile(
+    r"(?:(?<=\.\.\.)|(?<=chars\]))[A-Za-z0-9_\-]{%d,}"                                  # after a cut
+    r"|(?<![A-Za-z0-9_\-])[A-Za-z0-9_\-]{%d,}(?=\.\.\.|\[\d+ chars\])"                    # before one
+    % (ENV_CUT_FRAGMENT_MIN_LEN, ENV_CUT_FRAGMENT_MIN_LEN))
+
+
 def redact_env_values(text: str, values) -> str:
     """`text` with every occurrence of every value replaced by ENV_VALUE_REDACTED, longest first (a
-    value that contains another is replaced whole), and then every whitespace-separated chunk of a
-    value that is ENV_VALUE_MIN_LEN characters or more: pprint renders a long value with spaces as
+    value that contains another is replaced whole), then every whitespace-separated chunk of a
+    value that is ENV_VALUE_MIN_LEN characters or more (pprint renders a long value with spaces as
     adjacent string literals on separate lines, so the token half of `Authorization: Bearer <token>`
-    survived a whole-value replace, and unittest's shortened repr shows a differing tail on its own."""
+    survived a whole-value replace, and unittest's shortened repr shows a differing tail on its own),
+    and then every piece of a value left beside a cut (_ENV_CUT_FRAG_RE: a run of token characters
+    against `...` or `[N chars]` that is a substring of a value)."""
     parts = set()
     for v in values:
         if not v:
@@ -415,7 +459,13 @@ def redact_env_values(text: str, values) -> str:
             parts.update(c for c in chunks if len(c) >= ENV_VALUE_MIN_LEN)
     for v in sorted(parts, key=len, reverse=True):
         text = text.replace(v, ENV_VALUE_REDACTED)
-    return text
+    if not parts:
+        return text
+
+    def cut_piece(m):
+        frag = m.group(0)
+        return ENV_VALUE_REDACTED if any(frag in v for v in parts) else frag
+    return _ENV_CUT_FRAG_RE.sub(cut_piece, text)
 
 
 def redact_credential_tokens(text):

--- a/tests/credential_patterns.py
+++ b/tests/credential_patterns.py
@@ -1,0 +1,263 @@
+"""Credential-shaped tokens, by pattern: the second net of tests/conftest.py's report redaction.
+
+tests/conftest.py's report redaction removes every value seen in the process environment. That net
+cannot see a token that never touched the environment (read from a file, printed by a child process,
+typed into a fixture). This is the second net, independent of provenance: the key formats an
+installation may meet, each as the prefix its provider fixed plus a long tail, one format fixed by
+its shape rather than a prefix (a JWT), and one generic rule for a token of unknown format.
+
+The generic rule fires on a token of 24 characters or more that has a digit (a hex, base64 or random
+token of that length has one with near certainty, while a long identifier does not, so
+`testMethod=test_a_long_descriptive_name` in a failure header stays readable), and on one of 40 or
+more that mixes upper and lower case with no digit. It applies where a value sits (after `=`, after
+`:` or `: `, after `Bearer `, inside the quotes of a dict repr, as an element of a list, tuple or set
+repr: after `[`, `(`, `{` or `, `), to a line that is one such token and nothing else, which is what
+an apiKeyHelper's stdout is, and to pytest's own renderings of a failed comparison, which are value
+positions too though nothing marks them as one: the `- <token>` and `+ <token>` lines of its diff
+under the `E` marker (a container's elements spread over such lines included), the quoted operands
+of `assert '<a>' == '<b>'` (and unittest's `'<a>' != '<b>'`), the haystack of `assert '<a>' in '<b>'`
+(unittest's `'<a>' not found in '<b>'`), the `+  where '<a>' = f()` and `+  and   '<b>' = g()` lines
+that explain an assert's operands, unittest's `Lists differ:` line and the quoted element lines under
+it, and a `--showlocals` line `name = '<token>'`. A match takes the dotted rest of its token with it
+(`.` and more token characters, any number of times), so a dotted token whose first run qualifies is
+taken whole (`<32 hex>.<signature>`, a JWT whose header is longer than the JWT rule's bound) rather
+than up to its first dot; a dot with nothing of a token after it (a sentence's, an ellipsis) is never
+taken. Two shapes it leaves alone: the segment after a pytest node id's `::` (a test's name, not a
+value), and a 40-hex git sha named as a commit (`commit: <sha>`, `{'commit': '<sha>'}`) or sitting
+in a path or after an `@`. It still matches a synthetic uuid in a value position and a test method
+name with a digit in it, so a failing dict comparison may show the marker where a test's placeholder
+sid was, and a digit-bearing file name in a value position loses its extension to the dotted rest
+(`file=<name>.py`, a uuid-named file alone on a line). That is the cost of catching a token of
+unknown format; the failure is still readable.
+
+A JWT (RFC 7519) has no provider prefix but a fixed shape: base64url segments joined by dots, the
+first the JOSE header, a JSON object, whose encoding therefore begins `eyJ` (`{"` in base64). The
+rule takes `eyJ`, the rest of a header segment of 10 to JWT_HEADER_MAX characters (the shortest
+header, `{"alg":"none"}`, encodes to 19), and one to four more segments: a signed token has three,
+an unsecured one two, an encrypted one (JWE) five. Wherever it sits: the value positions, a bare
+line, pytest's diff line, and after a scheme the value positions do not know (`Authorization: vapid
+t=<jwt>, k=<key>` and `WebPush <jwt>`, the header the kernel's push code mints). The header bound
+is what keeps the rule linear (below); a header beyond it is longer than any JOSE header an
+installation meets, and a token carrying one is still taken whole in a value position, on a bare
+line and on a diff line by the generic rule and its dotted rest.
+
+A value pytest has already cut is a piece of a value. At its default verbosity pytest ellipsizes the
+operands of a failed `==`: the repr keeps its head and its tail, 11 to 13 characters each, joined by
+`...` (`'sk-ant-api03...2c3d4a1b2c3d4'`, `['0123456789a...456789abcdef']`); its saferepr of a local
+under `--showlocals`, of a traceback's arguments and of the operands on a `+  where` line keeps 118
+characters of the repr on each side of the `...` (117 of a quoted string, at its default maximum of
+240); the short test summary cuts a message at the terminal's width with `...` appended; and a long
+explanation (over 8 lines or 640 characters) is truncated with `...` appended to its last line, so a
+diff line can end mid-token in `...`, its marker and sign before a piece of the value. unittest
+shortens a long container repr with `[N chars]` in place of the middle and keeps up to 41 characters
+beside it after a common prefix it leaves whole when that is 22 or fewer, so 63 at most. A known
+prefix against either ellipsis is a truncated key, whatever follows, when 1 to CUT_HEAD_MAX (120)
+token characters sit between the prefix and the cut: every cut a tool makes at default verbosity
+leaves a head within that bound. A wider head (pytest's saferepr at `-v` keeps 1198) is a run the
+format rule takes on its own (20 characters or more, 30 for `AIza`), and every format rule takes a cut
+against its run and the run after the cut in the same match, so a cut key is one marker whatever the
+width of its head and wherever it sits, quoted or bare (a line a test or a child process prints itself
+ends the tail with a newline or a space, not the quote the fragment rule below needs; until the format
+rules took the tail, such a line showed it). The bound is there so a prefix inside a long run that
+never reaches a cut costs a bounded scan (an unbounded head made the scrub quadratic: 80 seconds on
+a 200 KB line of repeated `hf_`, which is what the tests/test_env_value_redaction.py timing case
+guards). What a format rule cannot take whole is a body of characters its key does not have. A
+Hugging Face token is `hf_` and 34 letters (gitleaks' rule is `hf_(?i:[a-z]{34})`, and every token that
+rule is tested against is letters only); the `hf_` rule here takes letters and digits, wider than that
+on purpose: narrowing it to letters would exclude nothing more (what ends a match in an identifier is
+the `_` it carries, not a digit), and a token that did carry a digit would show. RunPod publishes the
+`rpa_` prefix and nothing of the body (checked 2026-09-06; gitleaks has no rule for it), and the
+`rpa_` rule is the same class. A body with `_` or `-` in it, whole or cut, is therefore taken up to
+that character under either prefix. Past the bound the rest of such a head shows in bare text, and in
+a quoted repr too once 20 letters and digits precede the `_` or `-` (with fewer the format rule
+fails, the whole head is a fragment between the quote and the cut, and the fragment rule takes it);
+within the bound the cut rule's head class takes it. That shape is no Hugging Face token; a real
+RunPod key carrying `_` or `-` would be the reason to widen the `rpa_` class, and the whole key in
+bare text, not the cut one, is what widening would fix first. The class stays narrow so an
+`hf_`-prefixed identifier of 20 characters or more (`hf_hub_download_to_cache_dir`) is not redacted.
+A cut JWT is the same with dotted segments in its head and tail
+(`'eyJ<header>.eyJ<payload>...<payload>.<signature>'`, and unittest's `['eyJ[35 chars]<rest>']`,
+whose head is the prefix alone). Its header is bounded at JWT_HEADER_MAX, as the whole token's is,
+wherever the cut falls: a cut inside a header of up to that many characters past `eyJ` is the cut
+rule's match, and a cut past the header (a payload cut deep, after a header of any width within the
+bound) is the JWT rule's, which takes the cut and its dotted tail the same way. What neither takes is
+a cut token with more than JWT_HEADER_MAX characters between `eyJ` and the first dot or the cut,
+whichever comes first — a header past the bound with the cut anywhere after its first JWT_HEADER_MAX
+characters (a cut inside such a header within them is the cut rule's match: the bound is on the head,
+not the header): in a quoted repr the fragment rule takes its head and its tail as two matches, in a
+value position the generic rule takes the head and the tail shows, and in bare text the header shows
+— whole, with the cut and the tail, when the cut is inside it; up to its dot when the cut is in the
+payload, where the payload's own `eyJ` (a JSON payload begins with one too) is the cut rule's match
+with the cut and the tail. No enumerated tool leaves a head of that width (pytest's widest default
+cut leaves 118 characters; its `-v` cut of 1198 lands past any real header), so such a line is a
+hand-made one. A run of 8 or more token characters against an ellipsis, with a
+quote or another ellipsis on its far side, or with a diff line's marker and sign before it and the
+ellipsis ending the line, is a fragment of an unknown-format value when it has a digit, or when it
+has a lower-case letter and an upper-case one anywhere after its first character (a base64 tail can
+lack a digit); its dotted rest rides along. So a Capitalised word (`'Connecting...'`) and a
+single-case identifier (`'test_a_long_...'`, `'deadbeef...'`, `'ABCDEFGHIJKL...'`) stay, and a
+camelCase or PascalCase name (`'SessionStart...'`, `'HookEndToEnd...'`), a cut ISO date or timestamp
+(`'2026-09-06...'`, the head of `'2026-09-06T1...6+00:00'`) and an identifier with a digit
+(`'python38...'`) are redacted. That is a readability cost in a cut repr, taken on purpose: a
+PascalCase name's letters are a shape a base64 tail without a digit takes for one 8-character
+fragment in 25 (one in 200 at 13), and a digit-bearing run is the shape of a hex tail, so an
+exclusion for either would pass fragments of a key.
+
+Nothing here is a credential: the file holds prefixes and character classes only.
+"""
+import re
+
+REDACTED = "[REDACTED-CREDENTIAL]"
+
+# Where a value sits. Each alternative is one fixed-width lookbehind (the form Python's re accepts). A
+# colon counts only when it is not the second of a `::` pair: that pair separates a pytest node id's
+# segments, and what follows it is a test's name. The second and third rows are pytest's own rendering
+# of a failed comparison, where the token is a compared value and nothing else marks it: the quoted
+# operands of `assert '<a>' == '<b>'` (unittest's `'<a>' != '<b>'`), a --showlocals line `name = '<a>'`,
+# the `+  where '<a>' = f()` and `+  and   '<b>' = g()` lines that explain the operands, and the
+# haystack of `assert '<a>' in '<b>'` (unittest's `'<a>' not found in '<b>'`). The fourth row is an
+# element of a list, tuple or set repr (`['<a>', '<b>']`, `('<a>',)`, `{'<a>'}`): the first after the
+# opening bracket, the rest after `, `. unittest's `Lists differ:` line is one such repr per side.
+_VALUE_POSITION = (r"(?:(?<=Bearer )|(?<==)|(?<==\")|(?<==')|(?<=: )|(?<=: \")|(?<=: ')|(?<=[^:]:)"
+                   r"|(?<== \")|(?<== ')|(?<=== \")|(?<=== ')|(?<=!= \")|(?<=!= ')|(?<=assert \")|(?<=assert ')"
+                   r"|(?<=where \")|(?<=where ')|(?<=and   \")|(?<=and   ')|(?<=in \")|(?<=in ')"
+                   r"|(?<=[\[({]\")|(?<=[\[({]')|(?<=, \")|(?<=, '))")
+_TOKEN_CHARS = r"[A-Za-z0-9_\-]"
+# The dotted rest of a token: `.` and one or more token characters, any number of times. Appended to a
+# rule, it takes `<payload>.<signature>` along with the run that qualified, and never a dot that no token
+# character follows (an ellipsis, a sentence's end), so `...` is left for the cut rules.
+_DOTTED = r"(?:\." + _TOKEN_CHARS + r"+)*"
+# A token of unknown format: 24 or more characters with a digit, or 40 or more mixing upper and lower case,
+# and the dotted rest of it
+_GENERIC = (r"(?:(?=" + _TOKEN_CHARS + r"*\d)" + _TOKEN_CHARS + r"{24,}"
+            r"|(?=" + _TOKEN_CHARS + r"*[a-z])(?=" + _TOKEN_CHARS + r"*[A-Z])" + _TOKEN_CHARS + r"{40,})" + _DOTTED)
+
+# A bounded run of token characters that, once matched, is never shortened: the lookahead matches the
+# run greedily into a named group and the backreference consumes it. A lookahead is atomic in Python's
+# re, so when what follows the run fails the engine gives up on the alternative instead of retrying
+# every shorter run, which halves the work of a rule tried at each occurrence of its prefix (5 to 10
+# times faster on the adversarial lines the redaction tests time; CI's Python floor has no possessive
+# quantifier). Token characters and what follows a head (`.`, `...`, `[N chars]`) are disjoint, so no
+# shorter run could have matched anyway. Each use needs its own group name; scrub() reads none of them.
+def _atomic_run(name, bounds):
+    return r"(?=(?P<%s>%s%s))(?P=%s)" % (name, _TOKEN_CHARS, bounds, name)
+
+
+# A JWT, by its shape: `eyJ` (a base64url JSON object's first three characters), the rest of the header
+# segment, and one to four more dot-joined segments (JWS: three in all; unsecured: two; JWE: five). The
+# header segment is bounded on both sides: 10 or more so `eyJab.cd` is not a token, JWT_HEADER_MAX at
+# most so that an `eyJ` inside a long run with no dot after it costs a scan of at most that many
+# characters. Without the bound the scrub is quadratic on such a run, for the reason CUT_HEAD_MAX
+# explains. 256 is past every JOSE header an installation meets (a header carrying a kid, x5t and jku
+# encodes to about 220); a longer one falls to the generic rule and its dotted rest.
+JWT_HEADER_MAX = 256
+_JWT = r"eyJ" + _atomic_run("jh", r"{10,%d}" % JWT_HEADER_MAX) + r"(?:\." + _TOKEN_CHARS + r"+){1,4}"
+
+# pytest's diff of two compared values, one line per side: `E         - <a>` and `E         + <a>`, the
+# token alone after the marker and the sign, or one element of a container repr that unittest's diff
+# spreads over lines, quoted and closed by the repr's own punctuation (`E       -  '<a>']`,
+# `E       +  '<a>',`). The prefix is captured (pfx) and kept, so the diff still reads as one; without
+# the marker a `- <token>` line is a bullet in someone's captured output. unittest's `First differing
+# element` lines render each element alone and quoted after the marker: `E       '<a>'`.
+_DIFF_LINE = r"^(?P<pfx>E[ \t]+[-+][ \t]+['\"]?)" + _GENERIC + r"(?=['\"]?[\]),]*$)"
+_QUOTED_LINE = r"^(?P<pfxq>E[ \t]+['\"])" + _GENERIC + r"(?=['\"]$)"
+
+# A value pytest or unittest has already cut (the module docstring measures the widths). The two forms
+# of the cut; a known prefix against one, whatever follows; a JWT against one, its head and tail dotted;
+# and a fragment of an unknown-format value: a run of 8 or more token characters against an ellipsis, a
+# quote or another ellipsis on its far side, with a digit, or with a lower-case letter and an upper-case
+# one after its first, and the dotted rest of it.
+#
+# CUT_HEAD_MAX bounds the head between a prefix and the cut. The widest head a tool leaves is pytest's
+# saferepr at its default 240: 118 characters of the repr, 117 of a quoted string; unittest's `[N chars]`
+# leaves at most 63, pytest's `==` operands 13. The bound is what makes the scrub linear: a prefix rule
+# is tried at every occurrence of its prefix, and inside a long run that never reaches a cut an unbounded
+# head consumed the rest of the run and backtracked through it, once per occurrence. For `sk-ant-`,
+# `sk-or-`, `sk-proj-` and `AIza` the format rule then took the run in one match, so the cost was paid
+# once; for `hf_` and `rpa_` the format rule (`[A-Za-z0-9]{20,}`) fails on a run holding `_` or `-`, the
+# run was never consumed, and every occurrence paid again: 80 seconds for a 200 KB line of repeated `hf_`.
+# A head past the bound is the format rule's match, and _CUT_TAIL (below) gives that match the cut and the
+# run after it, so a cut key of any head width is one match.
+_ELLIPSIS = r"(?:\.\.\.|\[\d+ chars\])"
+CUT_HEAD_MAX = 120
+_CUT_HEAD_BOUNDS = r"{1,%d}" % CUT_HEAD_MAX
+# A cut and the run after it, appended to each format rule and to the JWT rule: optional, so a whole key
+# matches as before, and taken when the run a format rule matched ends at `...` or `[N chars]`
+# (`sk-ant-<130>...<118>`, `hf_<130>[88 chars]<5>`). Without it a cut key whose head is past CUT_HEAD_MAX was
+# two matches, the head by the format rule and the tail by _ELLIPSIZED, which needs a quote or another cut
+# on the tail's far side: in a quoted repr the tail was redacted, but on a line a test or a child process
+# printed itself (end of line, a space, a sentence's dot after the tail) it showed (2026-09-06). The run
+# before it is greedy and its characters are disjoint from a cut's first, so the optional group is tried
+# once where the run ends and never sends the engine back through the run: the scrub stays linear. A
+# sentence's `...` right after a whole key is consumed with it, as _PREFIX_ELLIPSIZED already did for a
+# head within the bound. The JWT's tail is dotted (`...<payload>.<signature>`), so its form takes the
+# dotted rest too; a whole JWT's segment count (one to four after the header) is unchanged, because the
+# dotted rest is inside the optional cut group.
+_CUT_TAIL = r"(?:" + _ELLIPSIS + _TOKEN_CHARS + r"*)?"
+_CUT_TAIL_DOTTED = r"(?:" + _ELLIPSIS + _TOKEN_CHARS + r"*" + _DOTTED + r")?"
+_PREFIX_ELLIPSIZED = (r"(?:sk-ant-|sk-or-|sk-proj-|hf_|AIza|rpa_)" + _atomic_run("hk", _CUT_HEAD_BOUNDS)
+                      + _ELLIPSIS + _TOKEN_CHARS + r"*")
+# A JWT's head is `eyJ` and up to three dotted segments: the header, bounded at JWT_HEADER_MAX like the
+# whole-token rule's, so a cut inside any header an installation meets is taken (atomic: it is the one
+# scanned at every `eyJ` in a run; bounded at CUT_HEAD_MAX until 2026-09-06, which left a cut 121 or more
+# characters into a longer header to no rule in bare text), then up to two more within CUT_HEAD_MAX (they
+# run only after a dot, and a cut deeper in a later segment is _JWT's match with its cut tail); its tail
+# is whatever dotted run follows the cut. Either may be empty (`['eyJ[35 chars]J9.eyJzdWIi']` has the
+# prefix alone before the cut), but not both: `'eyJ...'` shows nothing beyond the prefix and stays, as
+# `'hf_...'` does.
+_JWT_ELLIPSIZED = (r"eyJ(?:" + _atomic_run("hj", r"{1,%d}" % JWT_HEADER_MAX) + r"(?:\." + _TOKEN_CHARS + _CUT_HEAD_BOUNDS + r"){0,2}"
+                   + _ELLIPSIS + _TOKEN_CHARS + r"*" + _DOTTED
+                   + r"|" + _ELLIPSIS + _TOKEN_CHARS + r"+" + _DOTTED + r")")
+_FRAGMENT = (r"(?:(?=" + _TOKEN_CHARS + r"*\d)" + _TOKEN_CHARS + r"{8,}"
+             r"|(?=" + _TOKEN_CHARS + r"*[a-z])(?=" + _TOKEN_CHARS + r"+[A-Z])" + _TOKEN_CHARS + r"{8,})" + _DOTTED)
+_ELLIPSIZED = (r"(?:(?<=['\"])" + _FRAGMENT + r"(?=" + _ELLIPSIS + r")"
+               r"|(?:(?<=\.\.\.)|(?<=chars\]))" + _FRAGMENT + r"(?=" + _ELLIPSIS + r"|['\"]))")
+# The last line of an explanation pytest truncated (over 8 lines or 640 characters: `...` is appended to
+# it, then `use '-vv' to show`). A diff line so cut ends in `...` instead of the token's end, which
+# _DIFF_LINE requires, and nothing before the token marks a fragment position, so what is left of the
+# value showed in the clear (a piece of a compared JWT, 2026-09-06). The marker and sign are kept (pfxc).
+_DIFF_LINE_CUT = r"^(?P<pfxc>E[ \t]+[-+][ \t]+)" + _FRAGMENT + r"(?=\.\.\.$)"
+
+TOKEN_RE = re.compile(
+    _PREFIX_ELLIPSIZED +                            # a key of a known format that pytest or unittest cut
+    r"|" + _JWT_ELLIPSIZED +                        # a JWT so cut
+    r"|sk-ant-[A-Za-z0-9_\-]{20,}" + _CUT_TAIL +    # Anthropic API keys, each format whole or with a cut and its tail
+    r"|sk-or-[A-Za-z0-9_\-]{20,}" + _CUT_TAIL +     # OpenRouter
+    r"|sk-proj-[A-Za-z0-9_\-]{20,}" + _CUT_TAIL +   # OpenAI project keys
+    r"|hf_[A-Za-z0-9]{20,}" + _CUT_TAIL +           # Hugging Face (a token is 34 letters; the class is wider, the docstring says why)
+    r"|AIza[A-Za-z0-9_\-]{30,}" + _CUT_TAIL +       # Google API keys
+    r"|rpa_[A-Za-z0-9]{20,}" + _CUT_TAIL +          # RunPod (the prefix is published, the body is not; the same class)
+    r"|" + _JWT + _CUT_TAIL_DOTTED +                # a JWT (JWS, unsecured or JWE), by its shape, whole or cut with its dotted tail
+    r"|" + _VALUE_POSITION + _GENERIC +             # a token of unknown format where a value sits...
+    r"|^" + _GENERIC + r"$"                         # ...or alone on its line (an apiKeyHelper's stdout)...
+    r"|" + _DIFF_LINE +                             # ...or one side of pytest's diff of two compared values...
+    r"|" + _QUOTED_LINE +                           # ...or unittest's quoted rendering of one differing element...
+    r"|" + _DIFF_LINE_CUT +                         # ...or a diff line pytest's truncation cut mid-token...
+    r"|" + _ELLIPSIZED,                             # ...or a fragment of a value pytest or unittest cut
+    re.MULTILINE,
+)
+
+# A git sha (40 lowercase hex) is no credential when the text says what it is: named as a commit
+# (`commit=<sha>`, `commit: <sha>`, `{'commit': '<sha>'}`), or sitting in a path or after an `@`. Under
+# today's value positions only the commit form can precede a match (a token after `/` or `@` is in no
+# value position); the other two guard the rule should a position be added.
+_GIT_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_GIT_SHA_CONTEXT = re.compile(r"(?:commit\W{0,4}|/|@)$", re.IGNORECASE)
+
+
+def _is_git_sha_in_context(text, m):
+    tok = m.group(0)
+    return bool(_GIT_SHA_RE.fullmatch(tok)) and bool(_GIT_SHA_CONTEXT.search(text[max(0, m.start() - 12):m.start()]))
+
+
+def scrub(text):
+    """`text` with every match replaced by REDACTED (a diff line keeps its marker and sign, a quoted
+    element line its marker and quotes); anything that is not a str comes back as is."""
+    if not isinstance(text, str):
+        return text
+
+    def one(m):
+        if _is_git_sha_in_context(text, m):
+            return m.group(0)
+        return (m.group("pfx") or m.group("pfxq") or m.group("pfxc") or "") + REDACTED
+    return TOKEN_RE.sub(one, text)

--- a/tests/credential_patterns.py
+++ b/tests/credential_patterns.py
@@ -22,13 +22,17 @@ it, and a `--showlocals` line `name = '<token>'`. A match takes the dotted rest 
 (`.` and more token characters, any number of times), so a dotted token whose first run qualifies is
 taken whole (`<32 hex>.<signature>`, a JWT whose header is longer than the JWT rule's bound) rather
 than up to its first dot; a dot with nothing of a token after it (a sentence's, an ellipsis) is never
-taken. Two shapes it leaves alone: the segment after a pytest node id's `::` (a test's name, not a
-value), and a 40-hex git sha named as a commit (`commit: <sha>`, `{'commit': '<sha>'}`) or sitting
-in a path or after an `@`. It still matches a synthetic uuid in a value position and a test method
-name with a digit in it, so a failing dict comparison may show the marker where a test's placeholder
-sid was, and a digit-bearing file name in a value position loses its extension to the dotted rest
-(`file=<name>.py`, a uuid-named file alone on a line). That is the cost of catching a token of
-unknown format; the failure is still readable.
+taken. Three shapes it leaves alone: the segment after a pytest node id's `::` (a test's name, not a
+value); a 40-hex git sha named as a commit (`commit: <sha>`, `{'commit': '<sha>'}`) or sitting in a
+path or after an `@`; and a dated Anthropic model id (`claude-haiku-4-5-20251001`,
+`claude-3-5-sonnet-20241022`: 24 or more characters with digits, so the rule fires on it, and a
+failing comparison of two model ids rendered as one marker against another) when the token is that
+shape and nothing more (a dotted rest or a longer tail attached, and it is taken as any token is). It
+still matches a synthetic uuid in a value position and a test method name with a digit in it, so a
+failing dict comparison may show the marker where a test's placeholder sid was, and a digit-bearing
+file name in a value position loses its extension to the dotted rest (`file=<name>.py`, a uuid-named
+file alone on a line). That is the cost of catching a token of unknown format; the failure is still
+readable.
 
 A JWT (RFC 7519) has no provider prefix but a fixed shape: base64url segments joined by dots, the
 first the JOSE header, a JSON object, whose encoding therefore begins `eyJ` (`{"` in base64). The
@@ -250,6 +254,18 @@ def _is_git_sha_in_context(text, m):
     return bool(_GIT_SHA_RE.fullmatch(tok)) and bool(_GIT_SHA_CONTEXT.search(text[max(0, m.start() - 12):m.start()]))
 
 
+# A dated Anthropic model id is no credential: `claude`, an optional generation (`-3`, `-3-5`), a tier
+# (`-haiku`, `-sonnet`, `-opus`), an optional version (`-4-5`) and an 8-digit date. The dated ids are 24
+# characters or more with digits, so the generic rule fires on each, and a test comparing two of them
+# failed as `assert '[REDACTED-CREDENTIAL]' == '[REDACTED-CREDENTIAL]'` (2026-09-07). Exempt only when
+# the whole token is that shape: an id with a dotted rest or a longer tail attached is taken as before.
+_MODEL_ID_RE = re.compile(r"claude(?:-\d{1,2})*-[a-z]+(?:-\d{1,2})*-\d{8}")
+
+
+def _is_model_id(tok):
+    return bool(_MODEL_ID_RE.fullmatch(tok))
+
+
 def scrub(text):
     """`text` with every match replaced by REDACTED (a diff line keeps its marker and sign, a quoted
     element line its marker and quotes); anything that is not a str comes back as is."""
@@ -257,7 +273,8 @@ def scrub(text):
         return text
 
     def one(m):
-        if _is_git_sha_in_context(text, m):
+        pfx = m.group("pfx") or m.group("pfxq") or m.group("pfxc") or ""
+        if _is_git_sha_in_context(text, m) or _is_model_id(m.group(0)[len(pfx):]):
             return m.group(0)
-        return (m.group("pfx") or m.group("pfxq") or m.group("pfxc") or "") + REDACTED
+        return pfx + REDACTED
     return TOKEN_RE.sub(one, text)

--- a/tests/docs-serve.bats
+++ b/tests/docs-serve.bats
@@ -8,7 +8,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO/scripts" "$REPO/docs"

--- a/tests/git-hermetic.bash
+++ b/tests/git-hermetic.bash
@@ -1,0 +1,21 @@
+# tests/git-hermetic.bash: git in a bats test reads none of the developer's configuration.
+#
+# Use from a bats file: `load git-hermetic` at the top and `git_hermetic` as the first line of
+# setup(), before any git command runs.
+#
+# Why (2026-09-06): the fixture repos here are built with `git init` + `git commit` in temp dirs,
+# and those commands honoured the developer's global git config. On one box a global
+# core.hooksPath ran a pre-commit hook (a gitleaks scan) on every seed commit and a pre-push hook
+# on every fixture push, an LFS filter would run on every checkout, and a credential helper or
+# url.insteadOf rewrite could reach a real remote. CI has no global git config, so a test that
+# leans on one is already broken there; this makes every run match. GIT_CONFIG_GLOBAL is honoured
+# by git >= 2.32. The identity is synthetic and exported (not defaulted) so a developer's own
+# GIT_AUTHOR_* cannot leak into fixture commits either. The env identity outranks `git config
+# user.*` and `-c user.*`, so a test that must pin a particular author exports its own
+# GIT_AUTHOR_* / GIT_COMMITTER_* after this call; other config keys still yield to `-c`.
+
+git_hermetic() {
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+    export GIT_AUTHOR_NAME="romp tests" GIT_AUTHOR_EMAIL="tests@example.invalid"
+    export GIT_COMMITTER_NAME="romp tests" GIT_COMMITTER_EMAIL="tests@example.invalid"
+}

--- a/tests/git-hermetic.bats
+++ b/tests/git-hermetic.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# tests/git-hermetic.bash: after git_hermetic, git reads no global or system config and every
+# commit has an identity, whatever the box is configured with.
+#
+# Skips on git < 2.32 with the same message as tests/test_tempdir_hygiene.GitFloor: GIT_CONFIG_GLOBAL
+# and GIT_CONFIG_SYSTEM arrived in 2.32, so on an older git the config half of the floor is inert
+# (the identity half still holds) and both proofs say so the same way instead of one going red.
+
+load git-hermetic
+
+git_at_least_2_32() {
+    local v
+    v="$(git --version | awk '{print $3}')"
+    local major="${v%%.*}" rest="${v#*.}"
+    local minor="${rest%%.*}"
+    [ "$major" -gt 2 ] 2>/dev/null || { [ "$major" -eq 2 ] && [ "$minor" -ge 32 ]; } 2>/dev/null
+}
+
+setup() {
+    git_at_least_2_32 || skip "GIT_CONFIG_GLOBAL needs git >= 2.32"
+    TEST_DIR="$(mktemp -d)"
+    # A stand-in for the developer's global config: a hooks directory whose pre-commit refuses
+    # every commit and leaves a marker, wired in through core.hooksPath.
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME" "$TEST_DIR/hooks"
+    printf '#!/bin/sh\necho ran > "%s/hook-ran"\nexit 1\n' "$TEST_DIR" > "$TEST_DIR/hooks/pre-commit"
+    chmod +x "$TEST_DIR/hooks/pre-commit"
+    printf '[core]\n\thooksPath = %s\n[user]\n\tname = Global Person\n\temail = global@example.invalid\n' \
+        "$TEST_DIR/hooks" > "$HOME/.gitconfig"
+    unset GIT_CONFIG_GLOBAL GIT_CONFIG_NOSYSTEM XDG_CONFIG_HOME
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    REPO="$TEST_DIR/repo"
+    git init -q "$REPO"
+    echo a > "$REPO/a.txt"
+    git -C "$REPO" add a.txt
+}
+
+teardown() { rm -rf "${TEST_DIR:-}"; }
+
+@test "the probe is live: without git_hermetic the global hooksPath blocks the commit" {
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -ne 0 ]
+    [ -f "$TEST_DIR/hook-ran" ]
+}
+
+@test "with git_hermetic the global hook never runs and the commit lands" {
+    git_hermetic
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_DIR/hook-ran" ]
+    [ "$(git -C "$REPO" config --global --get core.hooksPath || true)" = "" ]
+}
+
+@test "with git_hermetic a system-config hooksPath never runs either" {
+    # The system half of the floor: GIT_CONFIG_SYSTEM (git >= 2.32) is a root-free stand-in for
+    # /etc/gitconfig, and GIT_CONFIG_NOSYSTEM=1 is what hides it; the global probe above says
+    # nothing about it. The file carries an identity because git resolves the author before it
+    # runs pre-commit, and the live arm has none from the environment or a global config (the
+    # global file is hidden there so the system file is the ONLY source of the hook).
+    printf '[core]\n\thooksPath = %s\n[user]\n\tname = System Person\n\temail = system@example.invalid\n' \
+        "$TEST_DIR/hooks" > "$TEST_DIR/sysconfig"
+    export GIT_CONFIG_SYSTEM="$TEST_DIR/sysconfig"
+    run env GIT_CONFIG_GLOBAL=/dev/null git -C "$REPO" commit -qm seed
+    [ "$status" -ne 0 ]
+    [ -f "$TEST_DIR/hook-ran" ]
+    rm "$TEST_DIR/hook-ran"
+    git_hermetic
+    run git -C "$REPO" commit -qm seed
+    [ "$status" -eq 0 ]
+    [ ! -e "$TEST_DIR/hook-ran" ]
+}
+
+@test "the identity is the synthetic one, not the global config's" {
+    git_hermetic
+    git -C "$REPO" commit -qm seed
+    [ "$(git -C "$REPO" log -1 --format='%an <%ae>')" = "romp tests <tests@example.invalid>" ]
+    [ "$(git -C "$REPO" log -1 --format='%cn <%ce>')" = "romp tests <tests@example.invalid>" ]
+}
+
+@test "a test's own identity exports after git_hermetic still win" {
+    git_hermetic
+    # The env identity outranks `git config user.*` and `-c user.*`, so a test that must pin a
+    # particular author exports its own GIT_AUTHOR_* / GIT_COMMITTER_* after git_hermetic.
+    GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e.invalid git -C "$REPO" commit -qm seed
+    [ "$(git -C "$REPO" log -1 --format='%an <%ae>')" = "t <t@e.invalid>" ]
+}

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -8,7 +8,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -12,7 +12,10 @@
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
+load git-hermetic
+
 setup() {
+    git_hermetic
     TEST_DIR="$(mktemp -d)"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO/scripts"

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -85,6 +85,19 @@ MOCK
     # modern version; per-test override via _stub_claude.
     _stub_claude "2.1.226"
 
+    # Hermetic postal service (2026-09-06): on every resume bin/romp double-forks
+    # `romp-postal-service picker-check` and returns without waiting for it. The real
+    # service mints a serve-token under $HOME/.local/state/romp when none exists, and did
+    # so after teardown had removed TEST_DIR, so the tree came back with that one file in
+    # it: four to six per run of this file. bin/romp puts its own directory first on PATH,
+    # so a stand-in here cannot shadow the real one through PATH; it reaches bin/romp
+    # through the ROMP_POSTAL_BIN seam, which the picker-check honours like `mail` and
+    # `refresh`. A no-op: the tests that assert on the service's calls overwrite it with
+    # a recording mock.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$MOCK_DIR/romp-postal-service"
+    chmod +x "$MOCK_DIR/romp-postal-service"
+    export ROMP_POSTAL_BIN="$MOCK_DIR/romp-postal-service"
+
     export PATH="$MOCK_DIR:$PATH"
     # The romp-manager tests below start a REAL bin/romp-manager, whose startup runs `tmux start-server`,
     # and `romp new -t` runs `tmux new-session`: the mock above takes both, and the private socket
@@ -137,6 +150,10 @@ _stub_curl() {
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+# drain the token config romp pipes in (`_romp_token_cfg | curl --config - …`): real curl always reads
+# it, but a mock that exits first hands the writer SIGPIPE, and under the script's pipefail that read
+# as a false "not reachable" — one random kernel-API test failed per run
+[[ " $* " == *" --config - "* ]] && cat >/dev/null
 url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ -n "${MOCK_CURL_FAIL_SEND:-}" && "$url" == */send ]]; then exit 22; fi
@@ -215,6 +232,7 @@ MOCK
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 url=""
 for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ "$url" == */new ]]; then
@@ -284,6 +302,7 @@ MOCK
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$MOCK_LOG"
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 echo '{"ok": true, "id": "11111111-2222-3333-4444-555555555555", "queued": true, "dir": "/srv/notes-api/web"}'
 MOCK
     chmod +x "$MOCK_DIR/curl"
@@ -293,6 +312,7 @@ MOCK
     # a refusal rides the kernel's own words
     cat > "$MOCK_DIR/curl" << 'MOCK'
 #!/usr/bin/env bash
+[[ " $* " == *" --config - "* ]] && cat >/dev/null   # drain the piped token config (see _stub_curl)
 echo '{"ok": false, "error": "directory not found: /nowhere"}'
 MOCK
     chmod +x "$MOCK_DIR/curl"
@@ -801,6 +821,26 @@ _stale_server_globals() {
     [ "$status" -ne 0 ]
     grep -q 'tmux new-session -d -s myproject-2' "$MOCK_LOG"
     grep -qE 'tmux respawn-pane -k -t myproject-2 exec ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject-2" claude --resume abc123-uuid --name "myproject-2"' "$MOCK_LOG"
+}
+
+@test "resume: the background picker-check goes through ROMP_POSTAL_BIN, and the stand-in writes nothing" {
+    # bin/romp double-forks `romp-postal-service picker-check` on a resume and returns at once;
+    # the real service mints ~/.local/state/romp/serve-token when none exists, and did so after
+    # teardown had removed TEST_DIR, re-creating it. bin/romp's own directory leads PATH, so the
+    # seam is the only way a test can stand in for the service. The setup() stand-in leaves the
+    # state dir alone; a recording one for this test shows the resume path reaching the seam —
+    # the call is detached, so the check waits (bounded) for its record instead of racing it.
+    [ "$ROMP_POSTAL_BIN" = "$MOCK_DIR/romp-postal-service" ]
+    run "$ROMP_POSTAL_BIN" picker-check --name myproject --id abc123-uuid
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -e "$HOME/.local/state/romp" ]
+
+    printf '#!/usr/bin/env bash\necho "postal $*" >> "%s"\n' "$TEST_DIR/postal.log" > "$MOCK_DIR/romp-postal-service"
+    run run_romp resume abc123-uuid
+    [ "$status" -eq 0 ]
+    local i; for i in $(seq 1 50); do [ -s "$TEST_DIR/postal.log" ] && break; sleep 0.1; done
+    grep -q '^postal picker-check --name myproject --id abc123-uuid$' "$TEST_DIR/postal.log"
 }
 
 # ─── Detach tests ────────────────────────────────────────────────────

--- a/tests/test_env_value_redaction.py
+++ b/tests/test_env_value_redaction.py
@@ -1,0 +1,1110 @@
+#!/usr/bin/env python3
+"""tests/conftest.py's report redaction (2026-09-05): no test report may print a value from the
+process environment, or a credential-shaped token from anywhere.
+
+The assertion rule the suite follows (never render an environment mapping, never compare a
+credential's value in a message) is what keeps a live key off a terminal; the hook is the safety net
+for the assertion nobody wrote that way. Pinned here:
+  RedactionRule: the value set (16 characters or more; exempt, never when the name is
+    credential-shaped: path-valued names, the shell's and the ones GitHub Actions exports, the XDG_*
+    and PYTEST_* families, and any value that is an absolute path this machine has) and the
+    replacement (every occurrence, longest value first, and each
+    whitespace-separated chunk of a value that is 16 characters or more, because pprint renders a
+    value with spaces as adjacent literals on separate lines and a whole-value replace misses them).
+  WriteTimeCapture: a value is noted the moment it is written into os.environ (a plain assignment,
+    update, setdefault, os.putenv, os.environb, mock.patch.dict), so a value present only between the
+    per-test samples is redacted too.
+  CredentialPattern: the second net, independent of provenance: credential-shaped tokens by pattern
+    (tests/credential_patterns.py) in any report, pytest's own renderings of a failed comparison
+    included (the diff's `- <a>` and `+ <a>` lines under the E marker, the quoted operands of an
+    `assert '<a>' == '<b>'`, a --showlocals line `name = '<a>'`, the `+  where '<a>' = f()` and
+    `+  and   '<b>' = g()` lines, the haystack of `assert '<a>' in '<b>'` and unittest's `'<a>' not
+    found in '<b>'`, the elements of a list, tuple or set repr, unittest's `Lists differ:` line, its
+    quoted per-element lines and its diff of a container spread over lines, and the fragments of a
+    value pytest ellipsized at default verbosity or unittest shortened with `[N chars]`); a JWT by its
+    shape wherever it sits, cut or whole (a cut inside its header up to the header bound, and the stated
+    limit past it); the dotted rest of a token that qualifies; the head of a cut
+    key bounded at the widest cut a tool makes, and a wider head taken with its cut and tail by the
+    format rule, quoted or bare; the `hf_` and `rpa_` rules' letters-and-digits class and its cost;
+    and the fragment rule's documented costs (a camelCase name or a digit-bearing run against a cut is
+    redacted, a Capitalised word or a single-case identifier is not).
+  ScrubCost: the scrub is linear: a 200 KB adversarial line (a run of repeated prefixes, of one case,
+    of digits, of dashes, of dots) is scrubbed within a generous budget; the first of them took 80
+    seconds before the cut-key rule's head was bounded.
+  ReportShapes: the hook's work on a report object of each outcome (a failure's longrepr, a skip's
+    tuple, a passed test's sections); a changed failure keeps its crash location, its message scrubbed
+    in pytest's E-marked rendering, through xdist's serialization round trip.
+  HookEndToEnd: subprocess pytest runs against a copy of the conftest. A test that fails with a probe
+    value in its message and on its stdout prints the marker, never the value, and its short summary
+    line still ends in the assertion message; the same for a value
+    set inside mock.patch.dict and gone before the assertion, a header-shaped value split by
+    assertDictEqual, a pattern-shaped token with no provenance, a passed test's captured output
+    under -rA, a collection error, a failed comparison of two unknown-format tokens under
+    --showlocals (pytest's diff lines, its assert line and the locals all show the marker), and the
+    where/and/in/not-found/Lists-differ/Tuples-differ renderings of two such tokens at default
+    verbosity, and the ellipsized renderings of two keys and two 64-character tokens compared with
+    `==` (as strings, in a list, in a tuple, and through unittest's `[N chars]` shortening).
+
+Every probe value is synthetic and assembled at run time ("romp-test-fixture-" + a uuid; a
+pattern-shaped probe is a public key prefix joined to uuids), so no literal in this file is a
+credential.
+"""
+import base64
+import hashlib
+import json
+import os
+import pprint
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+CONFTEST = os.path.join(HERE, "conftest.py")
+PATTERNS = os.path.join(HERE, "credential_patterns.py")
+
+
+def _conftest():
+    """The loaded conftest module, whatever name pytest gave it; None under a bare unittest run."""
+    for m in list(sys.modules.values()):
+        f = getattr(m, "__file__", None)
+        if f and os.path.realpath(f) == CONFTEST:
+            return m
+    return None
+
+
+def probe_value(tag=""):
+    return "romp-test-fixture-%s%s" % (tag + "-" if tag else "", uuid.uuid4().hex)
+
+
+def patterned_probe(prefix="sk-ant-api03-"):
+    """A token of a public key format, assembled at run time: a prefix and two uuids of tail."""
+    return prefix + uuid.uuid4().hex + uuid.uuid4().hex
+
+
+def _b64url(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def _jwt_parts(claims=1):
+    """A fabricated JWT's three segments, assembled at run time: the public HS256 header, a claim set
+    of invented values (`claims` uuids besides a subject and a timestamp), a signature hashed from a
+    uuid."""
+    hdr = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    body = {"sub": str(uuid.uuid4()), "iat": 1700000000}
+    for i in range(claims):
+        body["c%d" % i] = uuid.uuid4().hex
+    pay = _b64url(json.dumps(body, separators=(",", ":")).encode())
+    sig = _b64url(hashlib.sha256(uuid.uuid4().bytes).digest())
+    return hdr, pay, sig
+
+
+def _jwt_header_of(width):
+    """A fabricated JOSE header of exactly `width` base64url characters (a multiple of 4: unpadded base64url
+    reaches no other width): RS256 with a `kid` of uuid hex padded to fill it. Assembled at run time."""
+    assert width % 4 == 0, width
+    n = width * 3 // 4                                            # bytes of JSON
+    pad_len = n - len('{"alg":"RS256","kid":""}')
+    pad = (uuid.uuid4().hex * (pad_len // 32 + 1))[:pad_len]
+    hdr = _b64url(json.dumps({"alg": "RS256", "kid": pad}, separators=(",", ":")).encode())
+    assert len(hdr) == width and hdr.startswith("eyJ"), (len(hdr), width)
+    return hdr
+
+
+def _copy_hook(d):
+    """The conftest and the pattern module it loads by path, as a subprocess pytest run sees them."""
+    shutil.copy(CONFTEST, os.path.join(d, "conftest.py"))
+    shutil.copy(PATTERNS, os.path.join(d, "credential_patterns.py"))
+
+
+class _WithConftest(unittest.TestCase):
+    def setUp(self):
+        self.cf = _conftest()
+        if self.cf is None:
+            self.skipTest("the redaction hook lives in the pytest conftest")
+
+
+class RedactionRule(_WithConftest):
+    def test_values_of_sixteen_or_more_characters_are_collected(self):
+        long_v, short_v = probe_value("long"), "short-value"
+        env = {"SOME_TOKEN": long_v, "PLAIN": short_v, "OTHER": "x" * 16, "EMPTY": ""}
+        got = self.cf.env_values_to_redact(env)
+        self.assertTrue(long_v in got, "a long value is collected")
+        self.assertTrue("x" * 16 in got, "sixteen characters is the floor")
+        self.assertFalse(short_v in got, "a value under the floor is not")
+        self.assertFalse("" in got)
+        self.assertEqual(self.cf.ENV_VALUE_MIN_LEN, 16)
+
+    def test_path_valued_shell_names_are_exempt_unless_credential_shaped(self):
+        p = "/some/where/deep/enough/to/count"
+        self.assertFalse(os.path.exists(p), "by NAME: the path rule below does not apply to a path that is not there")
+        env = {"PWD": p, "HOME": p, "XDG_STATE_HOME": p, "PATH": p, "CLAUDE_CONFIG_DIR": p,
+               "TMUX_TMPDIR": p, "ROMP_TESTS_SYSTEM_TMPDIR": p,
+               # GitHub Actions: the runner's dirs and the six names setup-python exports the
+               # interpreter prefix under, which every stdlib and site-packages frame of a CI
+               # traceback quotes
+               "GITHUB_WORKSPACE": p, "RUNNER_TEMP": p, "RUNNER_TOOL_CACHE": p, "pythonLocation": p,
+               "Python_ROOT_DIR": p, "Python3_ROOT_DIR": p, "LD_LIBRARY_PATH": p, "PKG_CONFIG_PATH": p,
+               "XDG_DATA_DIRS": p + os.pathsep + p}
+        self.assertEqual(self.cf.env_values_to_redact(env), set(), "a traceback quotes these paths")
+        env = {"PWD_TOKEN": p, "ANTHROPIC_PWD": p, "MY_SECRET_PATH": p}
+        self.assertEqual(self.cf.env_values_to_redact(env), {p}, "a credential-shaped name is never exempt")
+        self.assertTrue(self.cf.env_value_qualifies("SOME_TOKEN", p))
+        self.assertFalse(self.cf.env_value_qualifies("TMUX_TMPDIR", p),
+                         "the private tmux socket dir conftest mints is a path a failure may quote")
+
+    def test_pytests_own_bookkeeping_names_are_exempt(self):
+        # pytest writes PYTEST_CURRENT_TEST (`<node id> (setup|call|teardown)`) for every phase of
+        # every test. Noted, it grew the set by one value per test (23,000 over a full run, 99% of the
+        # set), slowed every report's scrub in step, and made the node id of every test already run a
+        # target in later reports (a quoted child pytest line rendered `FAILED [REDACTED-ENV-VALUE]`).
+        nodeid = "tests/test_x.py::Case::test_method (call)"
+        env = {"PYTEST_CURRENT_TEST": nodeid, "PYTEST_VERSION": "9.1.1-" + "x" * 16,
+               "PYTEST_XDIST_TESTRUNUID": uuid.uuid4().hex, "PYTEST_XDIST_WORKER": "gw" + "0" * 16,
+               "PYTEST_ADDOPTS": "-p no:cacheprovider --strict-markers"}
+        self.assertEqual(self.cf.env_values_to_redact(env), set())
+        self.assertFalse(self.cf.note_env_value("PYTEST_CURRENT_TEST", nodeid), "the write hook applies the same rule")
+        self.assertFalse(nodeid in self.cf._ENV_VALUES_SEEN)
+        live = os.environ.get("PYTEST_CURRENT_TEST")
+        self.assertTrue(live, "pytest sets it for the running test")
+        self.assertFalse(live in self.cf._ENV_VALUES_SEEN, "the running test's own node id was not noted at its write")
+        self.assertTrue(self.cf.env_value_qualifies("PYTEST_API_KEY", probe_value()), "a credential-shaped name is never exempt")
+
+    def test_a_value_that_is_a_path_this_machine_has_is_exempt_under_any_name(self):
+        # a traceback quotes the interpreter's prefix on every stdlib and site-packages frame, and a
+        # developer's shell names that prefix under any variable (a pyenv root, a conda prefix), as
+        # setup-python does on CI; a PATH-style list of existing dirs (LD_LIBRARY_PATH) is the same
+        d = tempfile.mkdtemp(prefix="romp-test-path-value-")
+        try:
+            lib = os.path.join(d, "lib")
+            os.mkdir(lib)
+            self.assertGreaterEqual(len(d), self.cf.ENV_VALUE_MIN_LEN)
+            env = {"PYENV_ROOT": d, "CONDA_PREFIX": lib, "SOME_LIBRARY_PATH": lib + os.pathsep + d}
+            self.assertEqual(self.cf.env_values_to_redact(env), set(), "a path this machine has is not a value")
+            self.assertFalse(self.cf.note_env_value("PYENV_ROOT", d))
+            self.assertFalse(d in self.cf._ENV_VALUES_SEEN)
+            missing = os.path.join(d, "no-such-" + uuid.uuid4().hex)
+            self.assertTrue(self.cf.env_value_qualifies("PYENV_ROOT", missing), "a path that does not exist is a value")
+            self.assertTrue(self.cf.env_value_qualifies("SOME_LIBRARY_PATH", d + os.pathsep + missing),
+                            "every chunk of a list must exist")
+            self.assertTrue(self.cf.env_value_qualifies("PYENV_ROOT", os.path.basename(d) + "/lib"),
+                            "a relative path is a value: its existence depends on the cwd")
+            self.assertTrue(self.cf.env_value_qualifies("MY_API_KEY", d), "a credential-shaped name is never exempt")
+            self.assertTrue(self.cf.env_value_qualifies("PYENV_ROOT", probe_value()), "no token is a path that exists")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_the_replacement_covers_every_occurrence_longest_first(self):
+        a = probe_value("a")
+        b = a + "-suffix"                       # contains a: replaced whole, not as a + "-suffix"
+        text = "first %s then %s and %s again; short ok" % (a, b, a)
+        red = self.cf.redact_env_values(text, {a, b})
+        self.assertFalse(a in red, "the value is gone from the text")
+        self.assertEqual(red.count(self.cf.ENV_VALUE_REDACTED), 3)
+        self.assertEqual(red, "first %s then %s and %s again; short ok" % ((self.cf.ENV_VALUE_REDACTED,) * 3))
+        self.assertEqual(self.cf.redact_env_values("nothing here", {a, ""}), "nothing here")
+
+    def test_a_value_with_whitespace_is_also_redacted_chunk_by_chunk(self):
+        # pprint (assertDictEqual, assertEqual on long containers) renders a value with spaces as
+        # adjacent string literals on separate lines, so the whole value is never contiguous in the
+        # report and a whole-value replace leaves the token half standing
+        tok = probe_value("bearer")
+        v = "Authorization: Bearer " + tok
+        text = pprint.pformat({"h": v}, width=40)
+        self.assertFalse(v in text, "pprint split the value across lines (the case this covers)")
+        self.assertTrue(tok in text)
+        red = self.cf.redact_env_values(text, {v})
+        self.assertFalse(tok in red, "the token chunk is gone")
+        self.assertTrue(self.cf.ENV_VALUE_REDACTED in red)
+        self.assertTrue("Authorization:" in red, "a chunk under the floor is no secret and stays")
+        self.assertTrue("Bearer" in red)
+        # the same value contiguous is still replaced whole, once
+        self.assertEqual(self.cf.redact_env_values("h=" + v + ";", {v}), "h=" + self.cf.ENV_VALUE_REDACTED + ";")
+        # a value without whitespace gains no chunks; a short chunk of a long value is not a value
+        self.assertEqual(self.cf.redact_env_values("keep ab cd", {"ab cd " + tok}), "keep ab cd")
+
+    def test_the_process_environment_is_what_the_hook_reads_by_default(self):
+        v = probe_value("live")
+        os.environ["ROMP_TEST_REDACTION_PROBE"] = v
+        try:
+            self.assertTrue(v in self.cf.env_values_to_redact(), "the default is os.environ")
+        finally:
+            os.environ.pop("ROMP_TEST_REDACTION_PROBE", None)
+
+
+class WriteTimeCapture(_WithConftest):
+    """A value present only between the per-test samples (set inside mock.patch.dict, or exported and
+    popped in a try/finally) used to escape the set; it is noted at the write now."""
+
+    def _gone(self, name):
+        self.assertFalse(name in os.environ, "%s present" % name)
+
+    def test_a_value_set_inside_patch_dict_and_gone_before_the_assertion_is_noted(self):
+        v = probe_value("patchdict")
+        with mock.patch.dict(os.environ, {"ROMP_TEST_REDACTION_PD": v}):
+            self.assertTrue(v in self.cf._ENV_VALUES_SEEN, "noted at the write, inside the block")
+        self._gone("ROMP_TEST_REDACTION_PD")
+        self.assertTrue(v in self.cf._ENV_VALUES_SEEN, "gone from the environment, still redacted")
+        self.assertTrue(v not in self.cf.redact_env_values("x " + v, self.cf._ENV_VALUES_SEEN))
+
+    def test_every_write_path_is_noted(self):
+        vals = {}
+        vals["set"] = probe_value("setitem")
+        os.environ["ROMP_TEST_REDACTION_W1"] = vals["set"]
+        vals["update"] = probe_value("update")
+        os.environ.update({"ROMP_TEST_REDACTION_W2": vals["update"]})
+        vals["setdefault"] = probe_value("setdefault")
+        os.environ.setdefault("ROMP_TEST_REDACTION_W3", vals["setdefault"])
+        vals["putenv"] = probe_value("putenv")
+        os.putenv("ROMP_TEST_REDACTION_W4", vals["putenv"])          # bypasses os.environ entirely
+        vals["bytes"] = probe_value("bytes")
+        os.environb[b"ROMP_TEST_REDACTION_W5"] = vals["bytes"].encode()
+        try:
+            for how, v in vals.items():
+                self.assertTrue(v in self.cf._ENV_VALUES_SEEN, how)
+        finally:
+            for n in ("W1", "W2", "W3", "W5"):
+                os.environ.pop("ROMP_TEST_REDACTION_" + n, None)
+            os.unsetenv("ROMP_TEST_REDACTION_W4")
+
+    def test_the_write_hook_applies_the_same_rule_as_the_sampler(self):
+        short = "short-val"
+        os.environ["ROMP_TEST_REDACTION_SHORT"] = short
+        p = "/a/path/long/enough/to/qualify/by/length"
+        was = os.environ.get("LS_COLORS")
+        os.environ["LS_COLORS"] = p                                  # a path-valued shell name: exempt
+        try:
+            self.assertFalse(short in self.cf._ENV_VALUES_SEEN, "under the floor")
+            self.assertFalse(p in self.cf._ENV_VALUES_SEEN, "a path-valued name is exempt at the write too")
+        finally:
+            os.environ.pop("ROMP_TEST_REDACTION_SHORT", None)
+            if was is None:
+                os.environ.pop("LS_COLORS", None)
+            else:
+                os.environ["LS_COLORS"] = was
+        self.assertTrue(self.cf.note_env_value("A_TOKEN", probe_value("direct")))
+        self.assertFalse(self.cf.note_env_value("A_TOKEN", "tiny"))
+        self.assertFalse(self.cf.note_env_value(b"PWD", b"/x/y/z/long/enough/to/count/twice"))
+        self.assertFalse(self.cf.note_env_value(3, None))
+
+    def test_the_hook_is_installed_once(self):
+        self.assertTrue(getattr(os._Environ.__setitem__, "_romp_notes_values", False))
+        self.assertTrue(getattr(os.putenv, "_romp_notes_values", False))
+        before = (os._Environ.__setitem__, os.putenv)
+        self.cf._install_env_write_hook()
+        self.assertEqual((os._Environ.__setitem__, os.putenv), before, "a second install stacks no wrapper")
+
+
+class CredentialPattern(_WithConftest):
+    def test_credential_shaped_tokens_are_redacted_by_pattern_whatever_their_provenance(self):
+        for prefix in ("sk-ant-api03-", "sk-or-v1-", "sk-proj-", "hf_", "AIza", "rpa_"):
+            tok = patterned_probe(prefix)
+            text = "the child said %s and moved on" % tok
+            red = self.cf.redact_credential_tokens(text)
+            self.assertFalse(tok in red, prefix)
+            self.assertEqual(red, "the child said %s and moved on" % self.cf.CREDENTIAL_REDACTED, prefix)
+
+    def test_a_long_token_where_a_value_sits_is_redacted_and_ordinary_text_is_not(self):
+        tok = uuid.uuid4().hex + uuid.uuid4().hex                   # 64 characters, no known prefix
+        for text in ("KEY=%s" % tok, "Authorization: Bearer %s" % tok, "{'X_TOKEN': '%s'}" % tok,
+                     'header: "%s"' % tok, "x-api-key:%s" % tok):
+            red = self.cf.redact_credential_tokens(text)
+            self.assertFalse(tok in red, text[:12])
+            self.assertTrue(self.cf.CREDENTIAL_REDACTED in red)
+        for text in ("sha256:1a2b3c1a2b3c", "XDG_STATE_HOME=/tmp/romp-tests-state-%s/floor" % tok,
+                     "the word %s alone" % tok, "at: 1700000000", "n=%s" % uuid.uuid4().hex[:23],
+                     "testMethod=test_a_long_descriptive_name_without_a_digit_in_it_stays_readable"):
+            self.assertEqual(self.cf.redact_credential_tokens(text), text, text[:20])
+        self.assertEqual(self.cf.redact_credential_tokens(None), None)
+
+    def test_the_generic_floor_is_24_with_a_digit_and_40_for_mixed_case_without_one(self):
+        # a 31-character hex after `=` slipped through the old floor of 32; 24 is the floor now. A token
+        # of letters only is caught at 40 when it mixes cases (a base64 tail can lack a digit); an
+        # all-lowercase one of any length is an identifier and stays
+        red = self.cf.redact_credential_tokens
+        for n in (24, 31):
+            hexn = uuid.uuid4().hex[:n]
+            self.assertEqual(red("KEY=%s" % hexn), "KEY=" + self.cf.CREDENTIAL_REDACTED, n)
+        hex23 = uuid.uuid4().hex[:23]
+        self.assertEqual(red("KEY=%s" % hex23), "KEY=%s" % hex23, "under the floor")
+        mixed40, mixed39 = "aB" * 20, ("aB" * 20)[:39]
+        self.assertEqual(red("KEY=%s" % mixed40), "KEY=" + self.cf.CREDENTIAL_REDACTED)
+        self.assertEqual(red("KEY=%s" % mixed39), "KEY=%s" % mixed39, "39 mixed-case characters without a digit stay")
+        lower44 = "a" * 44
+        self.assertEqual(red("KEY=%s" % lower44), "KEY=%s" % lower44, "one case, no digit: an identifier")
+        # the cost the docstring names: a test method name with a digit, 24 characters or more, in a value position
+        self.assertEqual(red("testMethod=test_with_2_digits_and_a_long_name"), "testMethod=" + self.cf.CREDENTIAL_REDACTED)
+
+    def test_a_token_alone_on_a_line_is_a_value_position(self):
+        # an apiKeyHelper's stdout contract is one token on one line, with nothing to mark it as a value
+        red = self.cf.redact_credential_tokens
+        tok = uuid.uuid4().hex                                     # 32 characters, no known prefix
+        self.assertEqual(red(tok), self.cf.CREDENTIAL_REDACTED)
+        self.assertEqual(red(tok + "\n"), self.cf.CREDENTIAL_REDACTED + "\n", "a trailing newline is the contract")
+        self.assertEqual(red("line one\n%s\nline three" % tok), "line one\n%s\nline three" % self.cf.CREDENTIAL_REDACTED)
+        self.assertEqual(red("the word %s alone" % tok), "the word %s alone" % tok, "a token among words is not a value")
+        short = uuid.uuid4().hex[:23]
+        self.assertEqual(red(short), short, "the floor applies to a bare line too")
+
+    def test_a_pytest_node_id_and_a_named_git_sha_are_kept(self):
+        red = self.cf.redact_credential_tokens
+        node = "tests/test_x.py::Case::test_method_with_2_digits_and_a_long_name"
+        self.assertEqual(red(node), node, "the segment after :: is a test's name")
+        self.assertEqual(red(node + " FAILED"), node + " FAILED")
+        tok = uuid.uuid4().hex
+        self.assertEqual(red("x-api-key:%s" % tok), "x-api-key:" + self.cf.CREDENTIAL_REDACTED, "one colon is still a value position")
+        sha = hashlib.sha1(b"romp-test-fixture-commit").hexdigest()     # 40 lowercase hex, a commit id's shape
+        self.assertTrue(any(c.isdigit() for c in sha) and len(sha) == 40)
+        for text in ("commit=%s" % sha, "commit: %s" % sha, "{'commit': '%s'}" % sha, "Commit: %s" % sha,
+                     "HEAD_COMMIT=%s" % sha, "objects/%s" % sha, "repo@%s" % sha):
+            self.assertEqual(red(text), text, text[:12])
+        for text in ("KEY=%s" % sha, sha, "sha: %s" % sha):
+            self.assertEqual(red(text), text.replace(sha, self.cf.CREDENTIAL_REDACTED), text[:8])
+        # a 40-hex token that is not a sha's alphabet (upper case, a '-') is not exempted by the commit word
+        other = "A1" * 20
+        self.assertEqual(red("commit=%s" % other), "commit=" + self.cf.CREDENTIAL_REDACTED)
+
+    def test_pytests_own_renderings_of_a_failed_comparison_are_value_positions(self):
+        # a compared token slipped the net: pytest's diff lines, its assert line and a --showlocals line
+        # put the value after nothing the value positions knew (`E         - `, `assert '`, `== '`, `= '`)
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        a, b = uuid.uuid4().hex, uuid.uuid4().hex                  # 32 characters each, no known prefix
+        self.assertEqual(red("E         - %s" % b), "E         - " + R, "the marker and the sign stay")
+        self.assertEqual(red("E         + %s" % a), "E         + " + R)
+        self.assertEqual(red("E       - %s\nE       + %s\nE       ?  ^^\n" % (a, b)),
+                         "E       - %s\nE       + %s\nE       ?  ^^\n" % (R, R), "unittest's diff, as pytest renders it")
+        self.assertEqual(red("E       AssertionError: assert '%s' == '%s'" % (a, b)),
+                         "E       AssertionError: assert '%s' == '%s'" % (R, R), "both operands")
+        self.assertEqual(red('assert "%s" == "%s"' % (a, b)), 'assert "%s" == "%s"' % (R, R))
+        self.assertEqual(red("E       AssertionError: '%s' != '%s'" % (a, b)),
+                         "E       AssertionError: '%s' != '%s'" % (R, R), "unittest's assertEqual line")
+        self.assertEqual(red("a          = '%s'" % a), "a          = '%s'" % R, "a --showlocals line")
+        self.assertEqual(red('name = "%s"' % a), 'name = "%s"' % R)
+        # what stays: a diff line that is more than the token, one under the floor, and a `- <token>` line
+        # without the E marker (a bullet in captured output, not pytest's diff)
+        for text in ("E         - the word %s here" % a, "E         - %s" % uuid.uuid4().hex[:23], "- %s" % a,
+                     "E         - %s and more" % a, "E         -%s" % a):
+            self.assertEqual(red(text), text, text[:16])
+        # a 40-hex sha on a diff line is a value, as on a bare line: nothing there names it a commit
+        sha = hashlib.sha1(b"romp-test-fixture-diff").hexdigest()
+        self.assertEqual(red("E         - %s" % sha), "E         - " + R)
+
+    def test_pytests_where_and_in_lines_and_container_reprs_are_value_positions(self):
+        # the second round of renderings a compared token slipped: the `+  where '<a>' = f()` and
+        # `+  and   '<b>' = g()` lines under an assert, the haystack of `assert '<a>' in '<b>'` (unittest's
+        # `'<a>' not found in '<b>'`), the elements of a list, tuple or set repr (unittest's `Lists differ:`
+        # line), unittest's quoted per-element lines, and its diff of a container spread over lines
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        a, b = uuid.uuid4().hex, uuid.uuid4().hex                  # 32 characters each, no known prefix
+        self.assertEqual(red("E        +  where '%s' = f()" % a), "E        +  where '%s' = f()" % R)
+        self.assertEqual(red('E        +  and   "%s" = g()' % b), 'E        +  and   "%s" = g()' % R)
+        self.assertEqual(red("E       AssertionError: assert '%s' in '%s'" % (a, b)),
+                         "E       AssertionError: assert '%s' in '%s'" % (R, R), "both operands")
+        self.assertEqual(red("E       AssertionError: '%s' not found in '%s'" % (a, b)),
+                         "E       AssertionError: '%s' not found in '%s'" % (R, R), "unittest's assertIn line")
+        self.assertEqual(red("E       AssertionError: Lists differ: ['%s', '%s'] != ['%s']" % (a, b, b)),
+                         "E       AssertionError: Lists differ: ['%s', '%s'] != ['%s']" % (R, R, R))
+        self.assertEqual(red("Tuples differ: ('%s',) != ('%s',)" % (a, b)), "Tuples differ: ('%s',) != ('%s',)" % (R, R))
+        self.assertEqual(red("{'%s'}" % a), "{'%s'}" % R, "a set repr")
+        self.assertEqual(red('["%s", "%s"]' % (a, b)), '["%s", "%s"]' % (R, R), "double quotes")
+        self.assertEqual(red("E       '%s'" % a), "E       '%s'" % R, "unittest's First differing element line")
+        self.assertEqual(red("E       - ['%s',\nE       -  '%s']\nE       + ['%s',\nE       +  '%s']" % (a, b, b, a)),
+                         "E       - ['%s',\nE       -  '%s']\nE       + ['%s',\nE       +  '%s']" % (R, R, R, R),
+                         "unittest's diff of a list, one element per line")
+        # what stays: a token among the words of a haystack (nothing marks it as a value), a quoted line
+        # that is more than the token, an element under the floor
+        for text in ("E       AssertionError: assert 'x' in 'the word %s here'" % a, "E       '%s' and more" % a,
+                     "['%s']" % uuid.uuid4().hex[:23], "the word %s alone" % a):
+            self.assertEqual(red(text), text, text[:24])
+
+    def test_an_ellipsized_value_is_redacted_on_both_sides_of_the_ellipsis(self):
+        # at default verbosity pytest keeps the head and the tail of a compared value's repr, 11 to 13
+        # characters each, joined by `...`; the short summary cuts a message with `...` appended and no
+        # closing quote; unittest shortens a long container repr with `[N chars]`. Each fragment is a piece
+        # of the value: a known prefix against the cut is a truncated key whatever follows it, and 8 or more
+        # token characters against the cut are a fragment when they carry a digit or mixed case
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        k = patterned_probe()                                      # a public prefix and 64 hex
+        a = uuid.uuid4().hex + uuid.uuid4().hex                    # 64 hex, no known prefix
+        # pytest's assert line for two keys: the prefix and 5 characters, the cut, 13 of the tail
+        self.assertEqual(red("assert '%s...%s' == '%s...%s'" % (k[:12], k[-13:], k[:12], k[-13:])),
+                         "assert '%s' == '%s'" % (R, R))
+        # two unknown-format tokens: 12 of the head and 13 of the tail, each a fragment
+        self.assertEqual(red("assert '%s...%s' == '%s...%s'" % (a[:12], a[-13:], a[:12], a[-13:])),
+                         "assert '%s...%s' == '%s...%s'" % (R, R, R, R))
+        # in a list or a tuple the fragments are 11 characters
+        self.assertEqual(red("assert ['%s...%s'] == ['%s...%s']" % (a[:11], a[-12:], a[:11], a[-12:])),
+                         "assert ['%s...%s'] == ['%s...%s']" % (R, R, R, R))
+        self.assertEqual(red("assert ('%s...%s',) == ('%s...%s',)" % (a[:11], a[-11:], a[:11], a[-11:])),
+                         "assert ('%s...%s',) == ('%s...%s',)" % (R, R, R, R))
+        # the short summary's cut: a head against the ellipsis with no closing quote; a key's own cut, cut again
+        self.assertEqual(red("FAILED test_x.py::test_y - AssertionError: assert '%s..." % a[:17]),
+                         "FAILED test_x.py::test_y - AssertionError: assert '%s..." % R)
+        self.assertEqual(red("assert '%s....." % k[:12]), "assert '%s.." % R)
+        # unittest's [N chars]: the head beside it, the tail beside it, a fragment between two of them, and a
+        # key's head against it with the tail it keeps
+        self.assertEqual(red("Lists differ: ['%s[88 chars]%s'] != ['%s[88 chars]%s']" % (a[:41], a[-3:], a[:41], a[-3:])),
+                         "Lists differ: ['%s[88 chars]%s'] != ['%s[88 chars]%s']" % (R, a[-3:], R, a[-3:]))
+        self.assertEqual(red("['sk-[13 chars]%s']" % a[-30:]), "['sk-[13 chars]%s']" % R)
+        self.assertEqual(red("'[13 chars]%s[20 chars]%s'" % (a[:12], a[-9:])), "'[13 chars]%s[20 chars]%s'" % (R, R))
+        self.assertEqual(red("['%s[101 chars]%s']" % (k[:54], k[-3:])), "['%s']" % R)
+        # a mixed-case fragment without a digit qualifies when the upper-case letter is not its first
+        self.assertEqual(red("'abcdEfghijk...'"), "'%s...'" % R)
+        # what stays: a Capitalised word, a single-case identifier, words, a fragment under the floor, a bare
+        # cut, a prefix with nothing before the cut, a cut among words
+        for text in ("'Connecting...'", "'Reconnecting...'", "'test_a_long_...ithout_digits'",
+                     "'the quick br...the lazy dog'", "'abc1234...'", "'...'", "'hf_...'", "loading... done",
+                     "'%s'" % a[:12]):
+            self.assertEqual(red(text), text, text)
+
+    def test_a_cut_keys_head_is_bounded_at_the_widest_cut_a_tool_makes(self):
+        # the head between a known prefix and the cut is matched up to CUT_HEAD_MAX characters. pytest's
+        # saferepr at its default 240 leaves 118 of the repr (117 of a quoted string) on each side of the
+        # `...`: a --showlocals line, a traceback's arguments, the operands on a `+  where` line; unittest's
+        # `[N chars]` leaves at most 63 (a common prefix of up to 22 it does not shorten, then 41); the `==`
+        # operands 13. The bound is what keeps the scrub linear (ScrubCost). A head beyond it (pytest at -v
+        # keeps 1198) is the format rule's own match, and that rule takes the cut and the tail with the run:
+        # one marker at every width, quoted or bare
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        self.assertEqual(self.cf._credpat.CUT_HEAD_MAX, 120)
+        k = "sk-ant-api03-" + uuid.uuid4().hex * 5                  # 173 characters
+        self.assertEqual(red("key        = '%s...%s'" % (k[:117], k[-118:])), "key        = '%s'" % R, "pytest's 240 cut, quoted")
+        self.assertEqual(red("%s...%s" % (k[:118], k[-119:])), R, "the same cut of an unquoted repr")
+        h = "hf_" + uuid.uuid4().hex * 5
+        self.assertEqual(red("E        +  where '%s...%s' = f()" % (h[:117], h[-118:])), "E        +  where '%s' = f()" % R)
+        self.assertEqual(red("['%s[90 chars]%s']" % (k[:61], k[-5:])), "['%s']" % R, "unittest's widest head, 22 + 41")
+        # the head counted after the prefix, within the bound and past it (1191 is pytest's -v cut), quoted
+        run = uuid.uuid4().hex * 80
+        for n in (1, 19, 20, 120, 121, 130, 1191):
+            self.assertEqual(red("key = 'sk-ant-%s...%s'" % (run[:n], k[-100:])), "key = '%s'" % R, n)
+        self.assertEqual(red("'sk-ant-a...'"), "'%s'" % R, "one character of head is a head")
+        # and past the bound in bare text, the shape a test or a child process prints itself: the tail ends
+        # at the end of the text, a space, a newline or a sentence's dot, with no quote for the fragment rule
+        # to see. The head was redacted and the tail showed whole until the format rules took both
+        # (2026-09-06); unittest's form and a JWT cut deep in its payload are the same shape
+        wide = "sk-ant-api03-" + uuid.uuid4().hex * 10               # 333 characters
+        g = "AIza" + run[:136] + "..." + run[-100:]
+        hdr, pay, sig = _jwt_parts(claims=6)
+        jwt = "%s.%s.%s" % (hdr, pay, sig)
+        self.assertGreater(len(pay), 170)
+        for text, want, secret in (("cut: %s...%s" % (wide[:135], wide[-118:]), "cut: %s" % R, wide),
+                                   ("%s...%s " % (wide[:135], wide[-118:]), "%s " % R, wide),
+                                   ("%s...%s\n" % (wide[:135], wide[-118:]), "%s\n" % R, wide),
+                                   ("%s...%s. Next" % (wide[:135], wide[-118:]), "%s. Next" % R, wide),
+                                   ("%s[88 chars]%s" % (wide[:135], wide[-5:]), R, wide),
+                                   ("E         - %s...%s" % (h[:133], h[-40:]), "E         - %s" % R, h),
+                                   ("k=%s" % g, "k=%s" % R, run),
+                                   ("%s...%s" % (jwt[:len(hdr) + 150], jwt[-118:]), R, jwt),
+                                   ("key %s... more" % wide, "key %s more" % R, wide)):   # a sentence's ellipsis after a whole key
+            out = red(text)
+            self.assertEqual(out, want, text[:20])
+            for i in range(0, len(secret) - 8 + 1):
+                self.assertFalse(secret[i:i + 8] in out, "a piece of the key reached the output")
+
+    def test_the_hf_and_rpa_rules_take_a_real_tokens_letters_and_the_wider_class_they_keep(self):
+        # a Hugging Face token is `hf_` and 34 letters (gitleaks' rule: `hf_` then 34 letters of either
+        # case); RunPod publishes the `rpa_` prefix and no body format. Both rules take letters and digits,
+        # wider than gitleaks' class on purpose (the module docstring says why): a real token is one marker
+        # whole, cut within the bound and cut past it, bare or quoted, and so is a body of the same width
+        # with digits in it — pinned so that narrowing the class, or widening it, is a deliberate change.
+        # The class is narrow in the other direction, so an `hf_`-prefixed identifier is not redacted; its
+        # cost is a body no real token has, with `_` or `-` in it: the format rule stops at that character,
+        # so past the bound the rest of such a head shows, while within it the cut rule's head class takes
+        # the whole head
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        letters = "".join(alphabet[b % 52] for b in uuid.uuid4().bytes + uuid.uuid4().bytes + uuid.uuid4().bytes)[:34]
+        with_digits = uuid.uuid4().hex[:17] + uuid.uuid4().hex.upper()[:17]
+        self.assertTrue(letters.isalpha() and any(c.isdigit() for c in with_digits))
+        for prefix in ("hf_", "rpa_"):
+            for body in (letters, with_digits):
+                tok = prefix + body
+                self.assertEqual(len(tok), len(prefix) + 34)
+                long = prefix + (uuid.uuid4().hex + uuid.uuid4().hex.upper()) * 5     # past the bound: no real token is
+                for text, want in (("token %s here" % tok, "token %s here" % R), ("'%s...%s'" % (tok[:12], tok[-13:]), "'%s'" % R),
+                                   ("%s...%s" % (long[:135], long[-118:]), R), ("'%s[88 chars]%s'" % (long[:135], long[-5:]), "'%s'" % R)):
+                    self.assertEqual(red(text), want, text[:12])
+        self.assertEqual(red("at hf_hub_download_to_cache_dir()"), "at hf_hub_download_to_cache_dir()")
+        body = uuid.uuid4().hex * 10
+        fake = "hf_%s_%s" % (body[:40], body[41:])                  # an underscore after 40 letters and digits
+        tail = body[-40:]
+        self.assertEqual(red("'%s...%s'" % (fake[:123], tail)), "'%s'" % R, "120 of head: the cut rule's")
+        self.assertEqual(red("'%s...%s'" % (fake[:124], tail)), "'%s_%s...%s'" % (R, fake[44:124], R), "121: the rest of the head shows")
+        self.assertEqual(red("%s...%s" % (fake[:124], tail)), "%s_%s...%s" % (R, fake[44:124], tail), "and bare, the tail too")
+
+    def test_a_cut_identifier_or_date_is_redacted_when_it_has_a_digit_or_an_interior_capital(self):
+        # the fragment rule cannot tell a camelCase or PascalCase name from a base64 tail without a digit
+        # (one 8-character fragment in 25 has that shape), nor a cut date from a hex tail, so both are
+        # redacted against a cut: a readability cost the module docstring names, pinned so it is a measured
+        # one. A Capitalised word and a single-case identifier stay, with or without dots
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        for text in ("'SessionStart...'", "'HookEndToEnd...'", "'getUserById...'", "'python38...'", "'2026-09-06...'"):
+            self.assertEqual(red(text), "'%s...'" % R, text)
+        self.assertEqual(red("assert 'HookEndToEnd...rTheFirstTime' == 'HookEndToEnd...TheSecondTime'"),
+                         "assert '%s...%s' == '%s...%s'" % (R, R, R, R), "a diff of two hook names loses both")
+        self.assertEqual(red("'2026-09-06T1...6+00:00'"), "'%s...6+00:00'" % R, "the head is a fragment; the tail is under the floor")
+        for text in ("'Connecting...'", "'Abcdefgh...'", "'test_a_long_...ithout_digits'", "'snake_case_id...'", "'deadbeef...'",
+                     "'ABCDEFGHIJKL...'", "'2.1.261...'", "'python3.12.3...'"):
+            self.assertEqual(red(text), text, text)
+
+    def test_a_diff_line_pytest_truncated_mid_token_is_a_fragment_position(self):
+        # pytest truncates an explanation over 8 lines or 640 characters and appends `...` to its last
+        # line; a diff line so cut ends in `...` instead of the token's end the diff rule requires, and its
+        # marker and sign are no fragment position. A piece of a compared JWT showed that way. The marker
+        # and sign stay; the same floor and letter rules as any fragment apply; a `...` that does not end
+        # the line is not pytest's cut
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        a = uuid.uuid4().hex + uuid.uuid4().hex
+        for pre in ("E         + ", "E         - ", "E       -  "):
+            self.assertEqual(red("%s%s..." % (pre, a[:60])), "%s%s..." % (pre, R), pre)
+            self.assertEqual(red("%s%s..." % (pre, a[:8])), "%s%s..." % (pre, R), "8 characters is the floor")
+        self.assertEqual(red("E         + %s.%s..." % (a[:30], a[30:50])), "E         + %s..." % R, "the dotted rest rides along")
+        self.assertEqual(red("E         + %s...\nE         \n" % a[:60]), "E         + %s...\nE         \n" % R)
+        for text in ("E         + abcdefg...", "E         + Connecting...", "E         + test_a_long_...", "E         + %s... more" % a[:30],
+                     "+ %s..." % a[:60]):
+            self.assertEqual(red(text), text, text[:20])
+
+    def test_a_qualifying_token_takes_its_dotted_rest(self):
+        # a dotted token in a value position was matched to its first dot; the `.<more>` segments ride along
+        # once the first run qualifies. A dot with no token character after it (a sentence's, an ellipsis)
+        # is not taken, and a run that does not qualify on its own is not helped by its dots
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        tok, sig = uuid.uuid4().hex, uuid.uuid4().hex[:20]
+        for text, want in (("KEY=%s.%s" % (tok, sig), "KEY=" + R), ("E         - %s.%s" % (tok, sig), "E         - " + R),
+                           ("%s.%s" % (tok, sig), R), ("KEY=%s. Next" % tok, "KEY=%s. Next" % R), ("KEY=%s..." % tok, "KEY=%s..." % R),
+                           ("['%s.x.y', 'b']" % tok, "['%s', 'b']" % R)):
+            self.assertEqual(red(text), want, text[:12])
+        # the costs the docstring names: a digit-bearing file name in a value position loses its extension,
+        # a uuid-named file alone on a line is redacted
+        self.assertEqual(red("file=test_kernel_webpush_2026.py"), "file=" + R)
+        self.assertEqual(red("%s.jsonl" % uuid.uuid4()), R)
+        for text in ("version=2.1.261.3", "module: kernel.sdk_backend.thing", "n=%s.%s" % (uuid.uuid4().hex[:23], sig)):
+            self.assertEqual(red(text), text, text)
+
+    def test_a_jwt_is_redacted_whole_wherever_it_sits(self):
+        # a JWT has no provider prefix; its shape is the format: `eyJ` (a base64url JSON object) and dotted
+        # segments. Before the rule a JWT in a value position lost only its header, a public constant, and
+        # kept its payload and signature; alone on a line or on a diff line nothing of it was matched
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        hdr, pay, sig = _jwt_parts()
+        jwt = "%s.%s.%s" % (hdr, pay, sig)
+        for text, want in (("token=%s" % jwt, "token=" + R), ("Authorization: Bearer %s" % jwt, "Authorization: Bearer " + R),
+                           ("{'token': '%s'}" % jwt, "{'token': '%s'}" % R), ("E       assert '%s' == 'x'" % jwt, "E       assert '%s' == 'x'" % R),
+                           ("E         - %s" % jwt, "E         - " + R), (jwt, R), (jwt + "\n", R + "\n"),
+                           ("Authorization: WebPush %s" % jwt, "Authorization: WebPush " + R),     # a scheme no value position knows
+                           ("token=%s. Next" % jwt, "token=%s. Next" % R)):                        # a sentence's dot is not a segment
+            self.assertEqual(red(text), want, text[:24])
+        # the header the kernel's push code mints: a JWT after `t=`, a public key after `k=`
+        self.assertEqual(red("Authorization: vapid t=%s, k=%s" % (jwt, _b64url(hashlib.sha512(uuid.uuid4().bytes).digest()))),
+                         "Authorization: vapid t=%s, k=%s" % (R, R))
+        # two segments (unsecured), five (JWE), a 20-character header ({"alg":"ES256"}), the shortest ({"alg":"none"})
+        es = _b64url(json.dumps({"alg": "ES256"}, separators=(",", ":")).encode())
+        none_hdr = _b64url(json.dumps({"alg": "none"}, separators=(",", ":")).encode())
+        self.assertEqual((len(es), len(none_hdr)), (20, 19))
+        for tok in ("%s.%s" % (hdr, pay), ".".join([hdr] + [_b64url(hashlib.sha256(uuid.uuid4().bytes).digest()[:n]) for n in (32, 12, 30, 16)]),
+                    "%s.%s.%s" % (es, pay, sig), "%s.%s." % (none_hdr, pay)):
+            self.assertEqual(red("t=%s" % tok), "t=" + R + ("." if tok.endswith(".") else ""), tok[:8])
+        # a header past JWT_HEADER_MAX falls to the generic rule and its dotted rest: whole in a value
+        # position, alone on a line and on a diff line
+        self.assertEqual(self.cf._credpat.JWT_HEADER_MAX, 256)
+        long_hdr = _b64url(json.dumps({"alg": "RS256", "kid": uuid.uuid4().hex, "x5c": [_b64url(uuid.uuid4().bytes * 14)]},
+                                      separators=(",", ":")).encode())
+        self.assertGreater(len(long_hdr), 256)
+        lj = "%s.%s.%s" % (long_hdr, pay, sig)
+        for text, want in (("token=%s" % lj, "token=" + R), (lj, R), ("E         - %s" % lj, "E         - " + R)):
+            self.assertEqual(red(text), want, text[:12])
+        # what stays: too little after the prefix to be a header, the prefix alone, a header with no dot after it
+        for text in ("x eyJab.cd y", "'eyJ'", "a %s b" % hdr):
+            self.assertEqual(red(text), text, text)
+
+    def test_an_ellipsized_jwt_is_redacted_with_its_dotted_head_and_tail(self):
+        # pytest's cuts of a JWT: the `==` operands (12 and 13 characters), saferepr's 240 (a head of 117
+        # holding the header, a dot and part of the payload; a tail of 118 that may begin at a dot), the
+        # short summary's cut with no tail; unittest's `[N chars]` with the prefix alone before it, its
+        # 5 + 41 head, and a fragment between two cuts. No 8-character piece of any segment survives
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        hdr, pay, sig = _jwt_parts(claims=6)
+        jwt = "%s.%s.%s" % (hdr, pay, sig)
+        self.assertGreater(len(jwt), 240)
+        for text, want in (("assert '%s...%s' == '%s...%s'" % (jwt[:12], jwt[-13:], jwt[:12], jwt[-13:]), "assert '%s' == '%s'" % (R, R)),
+                           ("j          = '%s...%s'" % (jwt[:117], jwt[-118:]), "j          = '%s'" % R),
+                           ("E        +  where '%s...%s' = f()" % (jwt[:117], jwt[-118:]), "E        +  where '%s' = f()" % R),
+                           ("j = '%s...%s'" % (jwt[:117], jwt[jwt.rindex("."):]), "j = '%s'" % R),
+                           ("FAILED t.py::t - AssertionError: assert '%s..." % jwt[:60], "FAILED t.py::t - AssertionError: assert '%s" % R),
+                           ("Lists differ: ['eyJ[35 chars]%s'] != ['eyJ[35 chars]%s']" % (jwt[38:90], jwt[38:80]),
+                            "Lists differ: ['%s'] != ['%s']" % (R, R)),
+                           ("['%s[101 chars]%s']" % (jwt[:54], jwt[-3:]), "['%s']" % R),
+                           ("'[13 chars]%s[20 chars]%s'" % (jwt[40:75], jwt[-12:]), "'[13 chars]%s[20 chars]%s'" % (R, R))):
+            out = red(text)
+            self.assertEqual(out, want, text[:30])
+            for seg in (hdr, pay, sig):
+                for i in range(0, len(seg) - 8 + 1):
+                    self.assertFalse(seg[i:i + 8] in out, "a piece of a segment reached the output")
+        self.assertEqual(red("'eyJ...'"), "'eyJ...'", "the prefix alone around a cut shows nothing")
+
+    def test_a_jwt_cut_inside_its_header_is_taken_up_to_the_header_bound(self):
+        # the cut rule's header is bounded at JWT_HEADER_MAX, the whole-token rule's bound, so a JWT cut
+        # anywhere inside any header an installation meets is one marker, bare or quoted, on a diff line
+        # and in a value position (bounded at CUT_HEAD_MAX until 2026-09-06, a cut 121 or more characters
+        # past `eyJ` inside a longer header was taken by no rule in bare text, head and tail shown). A
+        # whole header of any width within the bound with the cut in the payload is the JWT rule's match,
+        # as before. The bound is on the head, not the header: a cut within the first JWT_HEADER_MAX
+        # characters of a longer header is taken too. What is not: a head with more than JWT_HEADER_MAX
+        # characters between `eyJ` and the first dot or the cut — a cut deeper than that inside such a
+        # header, or a payload cut after a whole header past the bound. In a value position the generic
+        # rule takes the head and the tail shows; quoted, the fragment rule takes both; in bare text the
+        # header shows, whole with the cut and tail when the cut is inside it, and up to its dot when the
+        # cut is in the payload, whose own `eyJ` (a JSON payload begins with one too) starts the cut
+        # rule's match. The limit the docstring states, pinned as a measured cost (no enumerated tool
+        # leaves a head of that width)
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        M = self.cf._credpat.JWT_HEADER_MAX
+        _hdr, pay, sig = _jwt_parts(claims=6)
+
+        def check(tok, where):
+            for text, want in (("x %s y" % tok, "x %s y" % R), ("%s\n" % tok, "%s\n" % R), ("log: %s" % tok, "log: %s" % R),
+                               ("'%s'" % tok, "'%s'" % R), ("E         - %s" % tok, "E         - %s" % R)):
+                out = red(text)
+                self.assertEqual(out, want, (where, text[:12]))
+                for piece in (tok[:tok.index("...")], tok[tok.index("...") + 3:]):
+                    for i in range(0, len(piece) - 8 + 1):
+                        self.assertFalse(piece[i:i + 8] in out, (where, "a piece of the token reached the output"))
+
+        for width in (124, 200, M):                      # 124 = `eyJ` + 121, the first width past the old bound
+            hdr = _jwt_header_of(width)
+            jwt = "%s.%s.%s" % (hdr, pay, sig)
+            for cut in sorted({100, 124, 150, width - 1, width}):
+                if cut <= width:                          # inside the header, up to and including its last character
+                    check("%s...%s" % (jwt[:cut], jwt[-40:]), (width, cut))
+            check("%s...%s" % (jwt[:width + 1 + 150], jwt[-40:]), (width, "payload"))
+        wide = "%s.%s.%s" % (_jwt_header_of(M + 4), pay, sig)
+        for cut in (150, M + 3):                          # inside a header past the bound, within the head bound
+            check("%s...%s" % (wide[:cut], wide[-40:]), ("wide header", cut))
+        hdr = wide[:M + 4]
+        tok = "%s...%s" % (hdr, wide[-40:])                 # the whole header before the cut: a head past the bound
+        self.assertEqual(red("x %s y" % tok), "x %s y" % tok, "bare: nothing takes it")
+        self.assertEqual(red("log: %s" % tok), "log: %s...%s" % (R, wide[-40:]), "a value position: the head; the tail shows")
+        self.assertEqual(red("'%s'" % tok), "'%s...%s'" % (R, R), "quoted: the fragment rule, twice")
+        self.assertTrue(pay.startswith("eyJ"), "a JSON payload begins with `eyJ` as the header does")
+        tok = "%s...%s" % (wide[:M + 4 + 1 + 150], wide[-40:])   # the same header whole, a payload cut deep
+        self.assertEqual(red("x %s y" % tok), "x %s.%s y" % (hdr, R), "bare: the header shows; the payload's `eyJ` starts the cut rule's match")
+        self.assertEqual(red("log: %s" % tok), "log: %s...%s" % (R, wide[-40:]))
+        self.assertEqual(red("'%s'" % tok), "'%s...%s'" % (R, R))
+
+    def test_the_two_nets_are_applied_in_order_and_the_conftest_loads_the_pattern_file(self):
+        v = probe_value("env")
+        tok = patterned_probe()
+        text = "env %s and token %s" % (v, tok)
+        red = self.cf.redact_report_text(text, {v})
+        self.assertEqual(red, "env %s and token %s" % (self.cf.ENV_VALUE_REDACTED, self.cf.CREDENTIAL_REDACTED))
+        self.assertEqual(self.cf.CREDENTIAL_REDACTED, "[REDACTED-CREDENTIAL]")
+        self.assertEqual(os.path.realpath(self.cf._credpat.__file__), PATTERNS, "the conftest loads this file")
+        self.assertIs(self.cf.redact_credential_tokens("x"), "x")
+
+
+class ScrubCost(_WithConftest):
+    """The scrub is linear in its input. A rule tried at every occurrence of its prefix inside a long run
+    it never consumes must do bounded work per occurrence: the cut-key rule's unbounded head made the
+    scrub quadratic (80 seconds for a 200 KB line of repeated `hf_`, 0.8 for 20 KB), and the JWT rule's
+    header would have been the same on repeated `eyJ`. The budget is generous for CI; each line here
+    took 0.16 seconds or less on the development box after the fix, minutes before it."""
+
+    BUDGET_SECONDS = 5.0
+
+    def test_a_200_kb_adversarial_line_is_scrubbed_within_the_budget(self):
+        n = 200 * 1024
+
+        def rep(unit):
+            return unit * (n // len(unit) + 1)
+        hexrun = rep("a1b2c3d4e5f6")
+        lines = {
+            "repeated hf_": rep("hf_"), "repeated rpa_": rep("rpa_"), "repeated hf_-": rep("hf_-"),
+            "hf_1 off a value position": " " + rep("hf_1"), "repeated sk-ant-": rep("sk-ant-"), "repeated AIza": rep("AIza"),
+            "repeated eyJ": rep("eyJ"), "eyJ1 off a value position": " " + rep("eyJ1"), "dotted eyJa.": rep("eyJa."),
+            "one case": rep("a") + " x", "mixed case": rep("aB") + " x", "digits": rep("1") + " x",
+            "underscores": rep("_"), "dashes": rep("-"),
+            "hex after a quote": "'" + hexrun, "hex after a cut": "..." + hexrun, "hex on a diff line": "E         - " + hexrun + " x",
+            "hex on a cut diff line": "E         - " + hexrun + "...",
+            "dotted segments": rep(".a"), "dotted after =": "=" + hexrun[:24] + rep(".a") + " x",
+            "repeated cuts": rep("..."), "repeated [N chars]": rep("[1 chars]"),
+            # a format match and then a cut, or a `..` or `[x chars]` that is not one, repeated; one huge key cut once
+            "sk-ant- + 121 + ...": rep("sk-ant-" + "a" * 121 + "..."), "hf_ + 121 + [1 chars]": rep("hf_" + "a" * 121 + "[1 chars]"),
+            "sk-ant- + 20 + ..": rep("sk-ant-" + "a" * 20 + ".."), "sk-ant- + 20 + [x chars]": rep("sk-ant-" + "a" * 20 + "[x chars]"),
+            "eyJ + 300 + ...": rep("eyJ" + "a" * 300 + ".b" + "..."), "one huge cut key": "sk-ant-" + "a" * (n // 2) + "..." + "b" * (n // 2),
+        }
+        for name, line in lines.items():
+            t0 = time.perf_counter()
+            self.cf.redact_credential_tokens(line)
+            dt = time.perf_counter() - t0
+            self.assertLess(dt, self.BUDGET_SECONDS, "%s: %.1f s for %d characters" % (name, dt, len(line)))
+
+
+class ReportShapes(_WithConftest):
+    """_redact_report on report objects of each outcome: the values it knows are gone from every text."""
+
+    def _seen(self, v):
+        self.cf._ENV_VALUES_SEEN.add(v)
+
+    def test_a_failures_longrepr_and_sections_are_redacted(self):
+        v = probe_value("fail")
+        self._seen(v)
+        rep = SimpleNamespace(failed=True, longrepr="AssertionError: got " + v,
+                              sections=[("Captured stdout call", "printed " + v + "\n")])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.longrepr, "AssertionError: got " + self.cf.ENV_VALUE_REDACTED)
+        self.assertEqual(rep.sections, [("Captured stdout call", "printed " + self.cf.ENV_VALUE_REDACTED + "\n")])
+
+    def test_a_passed_tests_sections_are_redacted_too(self):
+        v = probe_value("pass")
+        self._seen(v)
+        rep = SimpleNamespace(failed=False, longrepr=None, sections=[("Captured stderr call", v)])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.sections, [("Captured stderr call", self.cf.ENV_VALUE_REDACTED)], "-rA shows these")
+        self.assertIsNone(rep.longrepr)
+
+    def test_a_skips_reason_tuple_keeps_its_shape(self):
+        v = probe_value("skip")
+        self._seen(v)
+        rep = SimpleNamespace(failed=False, longrepr=("tests/test_x.py", 12, "Skipped: no auth for " + v), sections=[])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.longrepr, ("tests/test_x.py", 12, "Skipped: no auth for " + self.cf.ENV_VALUE_REDACTED))
+        rep = SimpleNamespace(failed=False, longrepr=("tests/test_x.py", 12, "Skipped: fine"), sections=[])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.longrepr, ("tests/test_x.py", 12, "Skipped: fine"), "unchanged when nothing matched")
+
+    def test_an_unchanged_longrepr_object_is_left_as_pytests_own(self):
+        obj = object()
+        rep = SimpleNamespace(failed=True, longrepr=obj, sections=[])
+        self.cf._redact_report(rep)
+        self.assertIs(rep.longrepr, obj, "no match: pytest's rich rendering is kept")
+        tok = patterned_probe()
+        rep = SimpleNamespace(failed=True, longrepr="the child printed " + tok, sections=[])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.longrepr, "the child printed " + self.cf.CREDENTIAL_REDACTED, "the pattern net runs here too")
+
+    def test_a_changed_failures_longrepr_keeps_its_crash_location(self):
+        # the short test summary ends in reprcrash.message, junitxml's message attribute reads it, and
+        # xdist serializes a longrepr with a traceback and a crash structurally; a plain str has
+        # neither, so a scrubbed failure's summary line showed the traceback's first line instead
+        # (`def test_x():`, `self = <Case testMethod=...>`) and lost the message under -n
+        import pytest
+        tok = patterned_probe()
+        try:
+            raise AssertionError("the message carries " + tok)
+        except AssertionError:
+            lr = pytest.ExceptionInfo.from_current().getrepr(style="long")
+        self.assertTrue(tok in str(lr) and tok in lr.reprcrash.message, "the shape under test")
+        rep = SimpleNamespace(failed=True, longrepr=lr, sections=[])
+        self.cf._redact_report(rep)
+        self.assertIsNot(rep.longrepr, lr)
+        self.assertFalse(isinstance(rep.longrepr, str), "a longrepr, not plain text")
+        text = str(rep.longrepr)
+        self.assertFalse(tok in text)
+        self.assertEqual(text, self.cf.redact_report_text(str(lr)), "rendered as the scrubbed text, as is")
+        crash = rep.longrepr.reprcrash
+        self.assertEqual((crash.path, crash.lineno), (lr.reprcrash.path, lr.reprcrash.lineno))
+        self.assertEqual(crash.message, "AssertionError: the message carries " + self.cf.CREDENTIAL_REDACTED)
+        # xdist's round trip, the one a worker's report takes to the controller
+        report = pytest.TestReport("tests/test_x.py::test_x", ("tests/test_x.py", 3, "test_x"), {}, "failed",
+                                   rep.longrepr, "call")
+        back = pytest.TestReport._from_json(report._to_json())
+        self.assertEqual(back.longrepr.reprcrash.message, crash.message, "the message reaches the controller")
+        self.assertEqual(str(back.longrepr), text)
+        self.assertFalse(tok in str(back.longrepr))
+        # the message of a failed comparison carries pytest's diff without the `E` marker the pattern
+        # net's diff-line rule is keyed on; under CI the short summary prints every line of it
+        x, y = uuid.uuid4().hex * 2, uuid.uuid4().hex * 2
+        try:
+            assert x == y
+        except AssertionError:
+            lr = pytest.ExceptionInfo.from_current().getrepr(style="long")
+        self.assertTrue(any(line.lstrip().startswith("- ") for line in lr.reprcrash.message.split("\n")),
+                        "the shape under test: a diff line in the message, unmarked")
+        rep = SimpleNamespace(failed=True, longrepr=lr, sections=[])
+        self.cf._redact_report(rep)
+        for v in (x, y):
+            for i in range(0, len(v) - 8 + 1):
+                self.assertFalse(v[i:i + 8] in rep.longrepr.reprcrash.message, "a piece reached the crash message")
+                self.assertFalse(v[i:i + 8] in str(rep.longrepr))
+        self.assertFalse(any(line.startswith("E") for line in rep.longrepr.reprcrash.message.split("\n")),
+                         "unwrapped: the marker is not left in")
+        self.assertTrue(rep.longrepr.reprcrash.message.lstrip().startswith(("assert '", "AssertionError: assert '")))
+        self.assertGreaterEqual(rep.longrepr.reprcrash.message.count(self.cf.CREDENTIAL_REDACTED), 4,
+                                "both operands and both diff lines")
+        # a longrepr with no crash location (a collection error's) is the plain text, as before
+        class _CollectErrorRepr:
+            def __str__(self):
+                return "the child printed " + tok
+        rep = SimpleNamespace(failed=True, longrepr=_CollectErrorRepr(), sections=[])
+        self.cf._redact_report(rep)
+        self.assertEqual(rep.longrepr, "the child printed " + self.cf.CREDENTIAL_REDACTED)
+
+    def test_both_hooks_are_declared(self):
+        self.assertTrue(callable(getattr(self.cf, "pytest_runtest_makereport", None)))
+        self.assertTrue(callable(getattr(self.cf, "pytest_collectreport", None)))
+
+
+class HookEndToEnd(unittest.TestCase):
+    def _run(self, d, *args, env=None):
+        """A child pytest over the files in `d`. Its environment is this process's without CI and
+        BUILD_NUMBER: with either set (pytest's `running_on_ci`) pytest neither truncates a long
+        assertion explanation nor trims the short summary's message to the terminal width, and the
+        tests here pin the truncated rendering wherever the suite runs. `env` adds variables on top
+        (a probe value; CI itself, for the untruncated rendering)."""
+        child = dict(os.environ)
+        for name in ("CI", "BUILD_NUMBER"):
+            child.pop(name, None)
+        child.update(env or {})
+        # The copied conftest mints its own private temp root under TMPDIR and removes it at run end;
+        # pointed at `d`, that root and the state dir inside it go with the scratch dir even when the
+        # child is killed before its unconfigure runs (the timeout below).
+        child["TMPDIR"] = d
+        r = subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "--rootdir", d] + list(args),
+                           cwd=d, env=child, capture_output=True, text=True, timeout=180)
+        return r.returncode, r.stdout + r.stderr
+
+    def test_a_failing_test_that_renders_an_environment_value_prints_the_marker(self):
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            with open(os.path.join(d, "test_probe_leak.py"), "w") as fh:
+                fh.write("import os\n\n"
+                         "def test_leak():\n"
+                         "    v = os.environ['ROMP_TEST_REDACTION_PROBE']\n"
+                         "    print('stdout carries ' + v)\n"
+                         "    assert v == 'something else', 'the message carries ' + v\n")
+            v = probe_value("probe")
+            rc, out = self._run(d, "test_probe_leak.py", env={"ROMP_TEST_REDACTION_PROBE": v})
+            self.assertNotEqual(rc, 0, "the probe test fails by design")
+            self.assertTrue("1 failed" in out, "the run reports the failure")
+            self.assertFalse(v in out, "the probe value reached no line of the report")
+            self.assertGreaterEqual(out.count("[REDACTED-ENV-VALUE]"), 2, "the message and the captured stdout both show the marker")
+            self.assertTrue("FAILED test_probe_leak.py::test_leak - AssertionError: the message carries" in out,
+                            "the short test summary still ends in the assertion message, not the traceback's first line")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_patch_dict_value_a_split_header_and_a_patterned_token_all_print_markers(self):
+        # three leaks the first hook missed, one run: a value set inside mock.patch.dict and gone
+        # before the assertion (never in the environment at a sample); a header-shaped value that
+        # assertDictEqual's pprint splits so the token half stands alone; a pattern-shaped token
+        # that never touched the environment at all (read from a file)
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            probes = {"pd": probe_value("patchdict"), "hdr_tok": probe_value("header"), "pat": patterned_probe()}
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_three.py"), "w") as fh:
+                fh.write("import json, os, unittest\n"
+                         "from unittest import mock\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_patch_dict():\n"
+                         "    with mock.patch.dict(os.environ, {'ROMP_TEST_PROBE_PD': P['pd']}):\n"
+                         "        pass\n"
+                         "    assert 'ROMP_TEST_PROBE_PD' not in os.environ\n"
+                         "    assert P['pd'] == 'something else', 'the message carries ' + P['pd']\n\n"
+                         "class Header(unittest.TestCase):\n"
+                         "    def test_header(self):\n"
+                         "        os.environ['ROMP_TEST_PROBE_HDR'] = 'Authorization: Bearer ' + P['hdr_tok']\n"
+                         "        self.assertDictEqual({'Authorization': 'Bearer ' + P['hdr_tok']},\n"
+                         "                             {'Authorization': 'Bearer other'})\n\n"
+                         "def test_pattern():\n"
+                         "    assert P['pat'] == 'something else', 'the message carries ' + P['pat']\n")
+            rc, out = self._run(d, "test_probe_three.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("3 failed" in out, out[-600:])
+            for name, v in probes.items():
+                self.assertFalse(v in out, "%s reached the report" % name)
+            self.assertGreaterEqual(out.count("[REDACTED-ENV-VALUE]"), 2, "the patch.dict message and the header chunk")
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 1, "the patterned token, with no provenance")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_failing_comparison_of_two_tokens_prints_the_marker_on_every_rendering(self):
+        # a plain `assert a == b` on two tokens of unknown format, under --showlocals: pytest renders the
+        # pair on its assert line (abbreviated at -q), one per diff line, and once more per local. The
+        # unittest form renders `'<a>' != '<b>'` and the same diff lines. No line shows either token.
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            probes = {"a": uuid.uuid4().hex, "b": uuid.uuid4().hex}
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_compare.py"), "w") as fh:
+                fh.write("import json, os, unittest\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_plain():\n"
+                         "    a = P['a']\n"
+                         "    b = P['b']\n"
+                         "    assert a == b\n\n"
+                         "class Cmp(unittest.TestCase):\n"
+                         "    def test_unittest(self):\n"
+                         "        self.assertEqual(P['a'], P['b'])\n")
+            rc, out = self._run(d, "--showlocals", "test_probe_compare.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("2 failed" in out, out[-600:])
+            for name, v in probes.items():
+                self.assertFalse(v in out, "%s reached the report" % name)
+            # the plain assert: two diff lines and two locals; the unittest one: its message and two diff lines
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 8, out[-1200:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_the_where_and_in_and_container_renderings_of_two_tokens_print_the_marker(self):
+        # the renderings the comparison test above does not reach: `where '<a>' = f()` (the operands are
+        # not both str, so there is no diff), `and   '<b>' = g()`, the haystack of `assert '<a>' in '<b>'`,
+        # unittest's `'<a>' not found in '<b>'`, and its `Lists differ:` / `Tuples differ:` blocks (the
+        # container line, the quoted per-element lines, the diff spread over lines). 32-character tokens:
+        # pytest renders each of these in full at default verbosity, so no line depends on the ellipsis rule
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            probes = {"a": uuid.uuid4().hex, "b": uuid.uuid4().hex}
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_forms.py"), "w") as fh:
+                fh.write("import json, os, unittest\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def f():\n    return P['a']\n\n"
+                         "def g():\n    return P['b']\n\n"
+                         "def h():\n    return 3\n\n"
+                         "def test_where():\n    assert f() == 3\n\n"
+                         "def test_and():\n    assert h() == g()\n\n"
+                         "def test_in():\n    assert f() in g()\n\n"
+                         "class Cmp(unittest.TestCase):\n"
+                         "    def test_not_found(self):\n        self.assertIn(P['a'], P['b'])\n"
+                         "    def test_lists(self):\n        self.assertEqual([P['a'], P['b']], [P['b'], P['a']])\n"
+                         "    def test_tuple(self):\n        self.assertEqual((P['a'],), (P['b'],))\n")
+            rc, out = self._run(d, "test_probe_forms.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("6 failed" in out, out[-600:])
+            for name, v in probes.items():
+                self.assertFalse(v in out, "%s reached the report" % name)
+                for i in range(0, len(v) - 8 + 1):
+                    self.assertFalse(v[i:i + 8] in out, "a fragment of %s reached the report" % name)
+            # where + its assert line (2), and + its (2), in + where + and (4), not found (2), the lists block
+            # (the container line 4, two element lines, four diff lines), the tuples block (2 + 2 + 2)
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 26, out[-2000:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_an_ellipsized_comparison_prints_the_marker_on_every_fragment(self):
+        # at default verbosity pytest ellipsizes the operands of a failed `==`: two keys of a public format
+        # render as the prefix, 5 characters, `...` and 13 of the tail; two unknown-format tokens as 12- and
+        # 13-character fragments; a list or a tuple of them as 11-character ones. unittest shortens a long
+        # list's repr with `[N chars]` and spreads its diff over lines. No 8-character piece of any value
+        # survives on any line
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            probes = {"k1": patterned_probe(), "k2": patterned_probe(),
+                      "a": uuid.uuid4().hex + uuid.uuid4().hex, "b": uuid.uuid4().hex + uuid.uuid4().hex}
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(probes, fh)
+            with open(os.path.join(d, "test_probe_ellipsis.py"), "w") as fh:
+                fh.write("import json, os, unittest\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_keys():\n    assert P['k1'] == P['k2']\n\n"
+                         "def test_tokens():\n    assert P['a'] == P['b']\n\n"
+                         "def test_list():\n    assert [P['a']] == [P['b']]\n\n"
+                         "def test_tuple():\n    assert (P['k1'],) == (P['k2'],)\n\n"
+                         "class Cmp(unittest.TestCase):\n"
+                         "    def test_three(self):\n"
+                         "        self.assertEqual([P['a'], P['b'], P['a']], [P['b'], P['a'], P['b']])\n"
+                         "    def test_keys(self):\n        self.assertEqual([P['k1'], P['k2']], [P['k2'], P['k1']])\n")
+            rc, out = self._run(d, "test_probe_ellipsis.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("6 failed" in out, out[-600:])
+            for name, v in probes.items():
+                for i in range(0, len(v) - 8 + 1):
+                    self.assertFalse(v[i:i + 8] in out, "a piece of %s reached the report" % name)
+            # the keys' assert line (2) and diff (2); the tokens' four fragments and diff (6); the list's (6);
+            # the tuple's (4); the three-element block (2 heads, 2 elements, 6 diff lines); the keys' block (8)
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 30, out[-2500:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_failing_comparison_of_two_jwts_prints_the_marker_on_every_rendering(self):
+        # two fabricated JWTs, long enough for every cut: pytest's `==` operands and diff lines (which skip
+        # the identical header, and which its 640-character truncation cuts mid-token with `...` appended),
+        # the 240 cut of --showlocals, a list through unittest's `[N chars]`, and a bare print; and two long
+        # unknown-format tokens, whose diff's second line that truncation always cuts. No 8-character piece
+        # of any segment of any token survives on any line. The child runs twice, because pytest switches
+        # the truncation off when CI or BUILD_NUMBER is set (`running_on_ci`; GitHub Actions sets CI) and
+        # then also prints each failure's whole message in the short summary instead of one trimmed line:
+        # once without them (the cut renderings) and once with CI set (the whole diff lines, and the
+        # summary's repeat of every message)
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            j = {name: "%s.%s.%s" % _jwt_parts(claims=6) for name in ("a", "b")}
+            j.update({name: uuid.uuid4().hex * 14 for name in ("x", "y")})              # 448 characters each
+            with open(os.path.join(d, "probes.json"), "w") as fh:
+                json.dump(j, fh)
+            with open(os.path.join(d, "test_probe_jwt.py"), "w") as fh:
+                fh.write("import json, os, unittest\n"
+                         "P = json.load(open(os.path.join(os.path.dirname(__file__), 'probes.json')))\n\n"
+                         "def test_plain():\n    a = P['a']\n    b = P['b']\n"
+                         "    print('Authorization: Bearer ' + a)\n    assert a == b\n\n"
+                         "def test_hex():\n    assert P['x'] == P['y']\n\n"
+                         "class Cmp(unittest.TestCase):\n"
+                         "    def test_lists(self):\n        self.assertEqual([P['a'], P['b']], [P['b'], P['a']])\n")
+
+            def no_piece(out):
+                for name, v in j.items():
+                    for seg in v.split("."):
+                        for i in range(0, len(seg) - 8 + 1):
+                            self.assertFalse(seg[i:i + 8] in out, "a piece of %s reached the report" % name)
+
+            rc, out = self._run(d, "--showlocals", "test_probe_jwt.py")
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("3 failed" in out, out[-600:])
+            no_piece(out)
+            self.assertTrue("Full output truncated" in out, "the JWT diff is long enough for pytest's truncation")
+            # the JWT test: the print, the assert line (2), two diff lines, two locals; the hex test: the assert
+            # line (4: each operand is ellipsized into two fragments), two diff lines; the unittest one: the
+            # Lists differ line (2) and two element lines (its diff is over maxDiff and not shown)
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 17, out[-2500:])
+            # the untruncated rendering: the same lines, whole, and the short summary's repeat of each failure's
+            # message (the captured print is a section and the locals are the traceback's, so neither is in
+            # it): the JWT test's assert line (2) and diff lines (2), the hex test's (4 + 2), the unittest
+            # one's (2 + 2)
+            rc, out = self._run(d, "--showlocals", "test_probe_jwt.py", env={"CI": "1"})
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("3 failed" in out, out[-600:])
+            no_piece(out)
+            self.assertFalse("Full output truncated" in out, "with CI set pytest shows the whole diff")
+            self.assertGreaterEqual(out.count("[REDACTED-CREDENTIAL]"), 17 + 14, out[-2500:])
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_passed_tests_output_under_rA_and_a_collection_error_print_the_marker(self):
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            with open(os.path.join(d, "test_probe_pass.py"), "w") as fh:
+                fh.write("import os\n\n"
+                         "def test_pass():\n"
+                         "    print('a passing test prints ' + os.environ['ROMP_TEST_REDACTION_PROBE'])\n")
+            with open(os.path.join(d, "test_probe_broken.py"), "w") as fh:
+                fh.write("import os\n"
+                         "raise RuntimeError('collection carries ' + os.environ['ROMP_TEST_REDACTION_PROBE'])\n")
+            v = probe_value("outcomes")
+            rc, out = self._run(d, "-rA", "--continue-on-collection-errors", "test_probe_pass.py", "test_probe_broken.py",
+                                env={"ROMP_TEST_REDACTION_PROBE": v})
+            self.assertNotEqual(rc, 0, "the collection error fails the run")
+            self.assertTrue("1 passed" in out and "1 error" in out, out[-600:])
+            self.assertFalse(v in out, "neither the passed test's captured stdout nor the collection error shows the value")
+            self.assertGreaterEqual(out.count("[REDACTED-ENV-VALUE]"), 2)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_env_value_redaction.py
+++ b/tests/test_env_value_redaction.py
@@ -6,11 +6,15 @@ The assertion rule the suite follows (never render an environment mapping, never
 credential's value in a message) is what keeps a live key off a terminal; the hook is the safety net
 for the assertion nobody wrote that way. Pinned here:
   RedactionRule: the value set (16 characters or more; exempt, never when the name is
-    credential-shaped: path-valued names, the shell's and the ones GitHub Actions exports, the XDG_*
-    and PYTEST_* families, and any value that is an absolute path this machine has) and the
-    replacement (every occurrence, longest value first, and each
+    credential-shaped: path-valued names, the shell's and the ones GitHub Actions exports, the names
+    whose values are public, the ones GitHub Actions describes a run in and the conftest's own
+    synthetic git identity, the XDG_* and PYTEST_* families, and any value that is an absolute path
+    this machine has) and the replacement (every occurrence, longest value first, each
     whitespace-separated chunk of a value that is 16 characters or more, because pprint renders a
-    value with spaces as adjacent literals on separate lines and a whole-value replace misses them).
+    value with spaces as adjacent literals on separate lines and a whole-value replace misses them,
+    and each piece of a value left beside a cut pytest or unittest made, `'<head>...<tail>'` and
+    `[N chars]`, when it is a substring of a value: pytest keeps 12 and 13 characters of a failed
+    `==`'s operands, so most of a 30-character value stood on the assert line).
   WriteTimeCapture: a value is noted the moment it is written into os.environ (a plain assignment,
     update, setdefault, os.putenv, os.environb, mock.patch.dict), so a value present only between the
     per-test samples is redacted too.
@@ -26,8 +30,9 @@ for the assertion nobody wrote that way. Pinned here:
     limit past it); the dotted rest of a token that qualifies; the head of a cut
     key bounded at the widest cut a tool makes, and a wider head taken with its cut and tail by the
     format rule, quoted or bare; the `hf_` and `rpa_` rules' letters-and-digits class and its cost;
-    and the fragment rule's documented costs (a camelCase name or a digit-bearing run against a cut is
-    redacted, a Capitalised word or a single-case identifier is not).
+    the fragment rule's documented costs (a camelCase name or a digit-bearing run against a cut is
+    redacted, a Capitalised word or a single-case identifier is not); and the two shapes the generic
+    rule fires on but leaves alone, a named git sha and a dated Anthropic model id.
   ScrubCost: the scrub is linear: a 200 KB adversarial line (a run of repeated prefixes, of one case,
     of digits, of dashes, of dots) is scrubbed within a generous budget; the first of them took 80
     seconds before the cut-key rule's head was bounded.
@@ -43,7 +48,9 @@ for the assertion nobody wrote that way. Pinned here:
     --showlocals (pytest's diff lines, its assert line and the locals all show the marker), and the
     where/and/in/not-found/Lists-differ/Tuples-differ renderings of two such tokens at default
     verbosity, and the ellipsized renderings of two keys and two 64-character tokens compared with
-    `==` (as strings, in a list, in a tuple, and through unittest's `[N chars]` shortening).
+    `==` (as strings, in a list, in a tuple, and through unittest's `[N chars]` shortening); a cut
+    comparison of a 30-character environment value shows the marker for both of its pieces; and a
+    comparison of a GitHub Actions variable, or of the conftest's own git identity, shows the value.
 
 Every probe value is synthetic and assembled at run time ("romp-test-fixture-" + a uuid; a
 pattern-shaped probe is a public key prefix joined to uuids), so no literal in this file is a
@@ -114,6 +121,17 @@ def _jwt_header_of(width):
     hdr = _b64url(json.dumps({"alg": "RS256", "kid": pad}, separators=(",", ":")).encode())
     assert len(hdr) == width and hdr.startswith("eyJ"), (len(hdr), width)
     return hdr
+
+
+def _letters(n):
+    """`n` lower-case letters from uuid bytes: a token with no digit and one case, which the pattern
+    net's fragment rule (a digit, or mixed case) never takes, so what catches its pieces is the
+    environment net alone. Assembled at run time."""
+    alphabet = "abcdefghijklmnopqrstuvwxyz"
+    out = ""
+    while len(out) < n:
+        out += "".join(alphabet[b % 26] for b in uuid.uuid4().bytes)
+    return out[:n]
 
 
 def _copy_hook(d):
@@ -199,6 +217,42 @@ class RedactionRule(_WithConftest):
         finally:
             shutil.rmtree(d, ignore_errors=True)
 
+    def test_names_whose_values_are_public_are_exempt_unless_credential_shaped(self):
+        # GitHub Actions describes a run in variables no secret ever sits in (the server URLs, the sha,
+        # the ref, the workflow and job names, the repository, the actor, the runner), and the conftest
+        # writes a synthetic git identity at import; the length rule alone made every one of them a
+        # marker in a CI failure report (`assert '[REDACTED-ENV-VALUE]' == 'x'` where a test compared
+        # the ref, 2026-09-07). Exempt by NAME, each listed rather than the GITHUB_ prefix, and consulted
+        # after the credential-shaped check, so the tokens GitHub exports still qualify
+        q = self.cf.env_value_qualifies
+        sha = hashlib.sha1(b"romp-test-fixture-head").hexdigest()
+        public = {"GITHUB_SERVER_URL": "https://github.com", "GITHUB_API_URL": "https://api.github.com",
+                  "GITHUB_GRAPHQL_URL": "https://api.github.com/graphql", "GITHUB_SHA": sha, "GITHUB_WORKFLOW_SHA": sha,
+                  "GITHUB_REF": "refs/pull/1005/merge", "GITHUB_REF_NAME": "1005/merge-of-a-long-name",
+                  "GITHUB_HEAD_REF": "feature/a-long-branch-name", "GITHUB_BASE_REF": "main-of-a-long-name",
+                  "GITHUB_EVENT_NAME": "pull_request_target", "GITHUB_WORKFLOW": "Python tests on Linux",
+                  "GITHUB_WORKFLOW_REF": "notes-api/notes-api/.github/workflows/tests.yml@refs/pull/1005/merge",
+                  "GITHUB_JOB": "tests-python-3-12", "GITHUB_ACTION": "__notes-api_setup-tests",
+                  "GITHUB_ACTION_REF": "v4-with-a-long-tag", "GITHUB_ACTION_REPOSITORY": "notes-api/setup-tests",
+                  "GITHUB_REPOSITORY": "notes-api/notes-api", "GITHUB_REPOSITORY_OWNER": "notes-api-organisation",
+                  "GITHUB_ACTOR": "notes-api-contributor", "GITHUB_TRIGGERING_ACTOR": "notes-api-maintainer",
+                  "RUNNER_NAME": "GitHub Actions 1000000001", "RUNNER_ARCH": "X64-of-a-long-name",
+                  "GIT_AUTHOR_NAME": "romp tests of a long name", "GIT_AUTHOR_EMAIL": "tests@example.invalid",
+                  "GIT_COMMITTER_NAME": "romp tests of a long name", "GIT_COMMITTER_EMAIL": "tests@example.invalid"}
+        for name, value in public.items():
+            self.assertGreaterEqual(len(value), self.cf.ENV_VALUE_MIN_LEN, "%s: at the floor, so the name is what exempts it" % name)
+            self.assertFalse(q(name, value), name)
+        self.assertEqual(self.cf.env_values_to_redact(public), set())
+        self.assertEqual(set(public), set(self.cf._ENV_VALUE_PUBLIC_NAMES), "every name in the set is pinned here")
+        tok = uuid.uuid4().hex
+        for name in ("GITHUB_TOKEN", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "INPUT_GITHUB_TOKEN"):
+            self.assertTrue(q(name, tok), "%s: credential-shaped, never exempt" % name)
+        self.assertTrue(q("GITHUB_SOMETHING_ELSE", tok), "a GITHUB_ name the list does not know is a value")
+        self.assertFalse(self.cf.note_env_value("GITHUB_REF", "refs/pull/1005/merge"), "the write hook applies the same rule")
+        self.assertFalse("refs/pull/1005/merge" in self.cf._ENV_VALUES_SEEN)
+        self.assertEqual(os.environ.get("GIT_AUTHOR_EMAIL"), "tests@example.invalid", "the conftest set it at import")
+        self.assertFalse("tests@example.invalid" in self.cf._ENV_VALUES_SEEN, "and the import-time sample did not note it")
+
     def test_the_replacement_covers_every_occurrence_longest_first(self):
         a = probe_value("a")
         b = a + "-suffix"                       # contains a: replaced whole, not as a + "-suffix"
@@ -227,6 +281,43 @@ class RedactionRule(_WithConftest):
         self.assertEqual(self.cf.redact_env_values("h=" + v + ";", {v}), "h=" + self.cf.ENV_VALUE_REDACTED + ";")
         # a value without whitespace gains no chunks; a short chunk of a long value is not a value
         self.assertEqual(self.cf.redact_env_values("keep ab cd", {"ab cd " + tok}), "keep ab cd")
+
+    def test_a_piece_of_a_value_beside_a_cut_is_redacted_when_it_is_a_substring(self):
+        # pytest renders a failed `==` at default verbosity with each operand cut to 12 and 13 characters
+        # around `...`, so most of a 30-character value stood on the assert line and in the short summary
+        # while its whole form on the diff line was replaced (2026-09-07); its saferepr of a local keeps
+        # 117 on each side, the short summary and a long explanation are cut with `...` appended, and
+        # unittest shortens a container repr with `[N chars]`. A run of 8 or more token characters against
+        # a cut is replaced when it is a substring of a noted value (or of a chunk of one): exact, never a
+        # guess from its shape. The value is digit-free and single-case, so the pattern net's fragment
+        # rule, which needs a digit or mixed case, cannot be what catches the pieces
+        red, R = self.cf.redact_env_values, self.cf.ENV_VALUE_REDACTED
+        self.assertEqual(self.cf.ENV_CUT_FRAGMENT_MIN_LEN, 8)
+        v = _letters(30)
+        self.assertTrue(v.isalpha() and v.islower() and len(v) == 30)
+        for text, want in (("assert '%s...%s' == 'something else'" % (v[:12], v[-13:]), "assert '%s...%s' == 'something else'" % (R, R)),
+                           ("FAILED t.py::t - AssertionError: assert '%s...%s..." % (v[:12], v[-13:-5]),
+                            "FAILED t.py::t - AssertionError: assert '%s...%s..." % (R, R)),
+                           ("v          = '%s...%s'" % (v[:20], v[-9:]), "v          = '%s...%s'" % (R, R)),
+                           ("['%s[5 chars]%s']" % (v[:12], v[-13:]), "['%s[5 chars]%s']" % (R, R)),
+                           ("'[13 chars]%s[3 chars]%s'" % (v[5:15], v[-9:]), "'[13 chars]%s[3 chars]%s'" % (R, R)),
+                           ("E         + %s..." % v[:20], "E         + %s..." % R),
+                           ("{'X': '%s..." % v[:11], "{'X': '%s..." % R)):
+            out = red(text, {v})
+            self.assertEqual(out, want, text)
+            for i in range(0, len(v) - 8 + 1):
+                self.assertFalse(v[i:i + 8] in out, "a piece of the value reached the output")
+        hv = "Authorization: Bearer " + v                          # a chunk's piece is a value's piece too
+        self.assertEqual(red("'Bearer %s...%s'" % (v[:12], v[-13:]), {hv}), "'Bearer %s...%s'" % (R, R))
+        # what stays: a run under the floor, a run that is a piece of no value (a word before a sentence's
+        # ellipsis, a piece of another token), a piece with no cut beside it (pytest renders none; a test
+        # that slices a value itself is not this net's business), and any text when no value is noted
+        other = _letters(30)
+        for text in ("x = '%s...%s'" % (v[:7], v[-7:]), "'Connecting...' and loading... done",
+                     "'%s...%s'" % (other[:12], other[-13:]), "'%s'" % v[:12], "the word %s here" % v[:12]):
+            self.assertEqual(red(text, {v}), text, text)
+        self.assertEqual(red("'%s...'" % v[:12], set()), "'%s...'" % v[:12])
+        self.assertEqual(red("'%s...'" % v[:12], {""}), "'%s...'" % v[:12])
 
     def test_the_process_environment_is_what_the_hook_reads_by_default(self):
         v = probe_value("live")
@@ -368,6 +459,27 @@ class CredentialPattern(_WithConftest):
         # a 40-hex token that is not a sha's alphabet (upper case, a '-') is not exempted by the commit word
         other = "A1" * 20
         self.assertEqual(red("commit=%s" % other), "commit=" + self.cf.CREDENTIAL_REDACTED)
+
+    def test_a_dated_model_id_is_kept_whole_and_taken_with_anything_attached(self):
+        # a dated Anthropic model id is 24 or more token characters with digits, the generic rule's shape,
+        # so a failing comparison of two rendered as one marker against another on the assert line and on
+        # both diff lines, the one thing the failure was about (2026-09-07). A token that is exactly that
+        # shape stays on every rendering; one with a dotted rest or a longer tail attached is taken as
+        # before, and so is any other token of the generic rule's shape
+        red, R = self.cf.redact_credential_tokens, self.cf.CREDENTIAL_REDACTED
+        ids = ("claude-haiku-4-5-20251001", "claude-opus-4-5-20251101", "claude-3-5-sonnet-20241022", "claude-sonnet-4-20250514")
+        for mid in ids:
+            self.assertGreaterEqual(len(mid), 24, "the generic rule's floor: the exemption is what keeps it")
+            for text in ("assert '%s' == 'x'" % mid, "E         - %s" % mid, "E         + %s" % mid, "model=%s" % mid,
+                         "{'model': '%s'}" % mid, mid, "E        +  where '%s' = f()" % mid, "['%s', 'x']" % mid, "E       '%s'" % mid):
+                self.assertEqual(red(text), text, text)
+        a, b = ids[0], ids[1]
+        text = "E       AssertionError: assert '%s' == '%s'\nE         \nE         - %s\nE         + %s" % (a, b, b, a)
+        self.assertEqual(red(text), text, "pytest's rendering of the failed comparison, whole")
+        for text, want in (("model=%s.json" % a, "model=" + R), ("model=%sabcdef" % a, "model=" + R), ("model=%s99" % a, "model=" + R),
+                           ("E         - %s.x1" % a, "E         - " + R), ("KEY=%s" % ("aB" * 20), "KEY=" + R),
+                           ("model=%s" % uuid.uuid4().hex, "model=" + R), ("model=claude-%s" % uuid.uuid4().hex[:20], "model=" + R)):
+            self.assertEqual(red(text), want, text)
 
     def test_pytests_own_renderings_of_a_failed_comparison_are_value_positions(self):
         # a compared token slipped the net: pytest's diff lines, its assert line and a --showlocals line
@@ -886,6 +998,64 @@ class HookEndToEnd(unittest.TestCase):
             self.assertGreaterEqual(out.count("[REDACTED-ENV-VALUE]"), 2, "the message and the captured stdout both show the marker")
             self.assertTrue("FAILED test_probe_leak.py::test_leak - AssertionError: the message carries" in out,
                             "the short test summary still ends in the assertion message, not the traceback's first line")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_cut_comparison_of_an_environment_value_prints_the_marker_on_both_pieces(self):
+        # a plain `assert v == 'something else'` on a 30-character value from the environment: at default
+        # verbosity pytest cuts each operand of the assert line to 12 and 13 characters around `...`, and
+        # the short summary repeats that line; the whole value on the diff line was replaced and the two
+        # pieces were not (2026-09-07). The value is digit-free and single-case, so the pattern net's
+        # fragment rule cannot be what catches them. No 8-character piece survives on any line
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            with open(os.path.join(d, "test_probe_cut.py"), "w") as fh:
+                fh.write("import os\n\n"
+                         "def test_cut():\n"
+                         "    v = os.environ['ROMP_TEST_REDACTION_PROBE']\n"
+                         "    assert v == 'something else'\n")
+            v = _letters(30)
+            rc, out = self._run(d, "test_probe_cut.py", env={"ROMP_TEST_REDACTION_PROBE": v})
+            self.assertNotEqual(rc, 0, "the probe test fails by design")
+            self.assertTrue("1 failed" in out, out[-600:])
+            for i in range(0, len(v) - 8 + 1):
+                self.assertFalse(v[i:i + 8] in out, "a piece of the value reached the report")
+            self.assertTrue("assert '[REDACTED-ENV-VALUE]...[REDACTED-ENV-VALUE]' == 'something else'" in out,
+                            "the assert line: pytest's cut, a marker on each side of it")
+            self.assertTrue("FAILED test_probe_cut.py::test_cut - AssertionError: assert '[REDACTED-ENV-VA" in out,
+                            "the short summary repeats the assert line, cut at the terminal's width")
+            self.assertGreaterEqual(out.count("[REDACTED-ENV-VALUE]"), 3, "both pieces and the diff line")
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def test_a_github_actions_value_and_the_conftests_git_identity_print_in_the_clear(self):
+        # the variables GitHub Actions exports to describe a run, and the synthetic git identity the
+        # conftest itself writes at import, are exempt by name: a failed comparison of one shows the
+        # value, where a CI failure read `assert '[REDACTED-ENV-VALUE]' == 'x'` (2026-09-07). The child's
+        # environment carries synthetic values under two of the names; the identity is the copied
+        # conftest's own. GITHUB_TOKEN is credential-shaped and still redacted (28 characters, so
+        # pytest renders its operand whole)
+        d = tempfile.mkdtemp()
+        try:
+            _copy_hook(d)
+            tok = uuid.uuid4().hex[:28]
+            with open(os.path.join(d, "test_probe_public.py"), "w") as fh:
+                fh.write("import os\n\n"
+                         "def test_url():\n    assert os.environ['GITHUB_SERVER_URL'] == 'x'\n\n"
+                         "def test_ref():\n    assert os.environ['GITHUB_REF'] == 'x'\n\n"
+                         "def test_identity():\n    assert os.environ['GIT_AUTHOR_EMAIL'] == 'x'\n\n"
+                         "def test_token():\n    assert os.environ['GITHUB_TOKEN'] == 'x'\n")
+            rc, out = self._run(d, "test_probe_public.py",
+                                env={"GITHUB_SERVER_URL": "https://github.com", "GITHUB_REF": "refs/pull/1005/merge", "GITHUB_TOKEN": tok})
+            self.assertNotEqual(rc, 0)
+            self.assertTrue("4 failed" in out, out[-600:])
+            for value in ("https://github.com", "refs/pull/1005/merge", "tests@example.invalid"):
+                self.assertTrue("assert '%s' == 'x'" % value in out, "%s: the value, not the marker" % value)
+            self.assertFalse(tok in out, "the token reached the report")
+            self.assertTrue("assert '[REDACTED-ENV-VALUE]' == 'x'" in out, "the token's assert line")
+            self.assertEqual(out.count("[REDACTED-ENV-VALUE]"), out.count("[REDACTED-ENV-VALUE]", out.index("test_token")),
+                             "no marker before the token test's report")
         finally:
             shutil.rmtree(d, ignore_errors=True)
 

--- a/tests/test_kernel_provisional_command.py
+++ b/tests/test_kernel_provisional_command.py
@@ -18,6 +18,7 @@ data.
 """
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -43,6 +44,7 @@ def _iso(ep):
 class ProvisionalCommand(unittest.TestCase):
     def _session(self, recs):
         td = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, td, ignore_errors=True)
         p = os.path.join(td, SID + ".jsonl")
         open(p, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
         return {"path": p, "sid": SID, "name": "JLD"}

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -6,14 +6,18 @@ message without touching the composer. The kernel uses that leg ONLY for session
 inbound-accept setting, so a held-then-dropped banner can never read as delivered (the socket
 sends no ack). Untagged sessions must keep today's pane injection untouched. Synthetic
 fixtures only."""
+import errno
 import json
 import os
+import shutil
 import socket
+import sys
 import tempfile
 import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+from unittest.mock import patch
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
@@ -35,21 +39,69 @@ def _registry_row(dirpath, pid, session_id, sock, started_at=1000):
                    "startedAt": started_at, "cwd": "/tmp/x", "kind": "interactive"}, f)
 
 
+# Where an inbox socket lives (2026-09-06): the run's private temp root — tempfile.gettempdir(),
+# which tests/conftest.py points at a romp-tests-* directory it removes when the run ends — when the
+# socket path fits in sun_path, and the system temp dir the run was handed before that redirect
+# only when it would not. sun_path is 108 bytes on Linux and 104 on macOS, NUL included; an xdist
+# worker's root nested under a macOS TMPDIR puts the socket at 116 bytes
+# (/var/folders/../T/romp-tests-x/romp-tests-x/rompsockx/inbox.sock), the Linux equivalent under
+# /tmp at 72 and under a TMPDIR of 60 bytes or more past 108. conftest records the handed dir once
+# per run as ROMP_TESTS_SYSTEM_TMPDIR and a worker inherits the controller's record — not the
+# controller's root, which under such a TMPDIR is itself too deep (recording that had four tests
+# here failing at bind with "AF_UNIX path too long" under -n 2, 2026-09-06); without conftest,
+# gettempdir() already is that dir. A handed dir too deep to hold the socket at all (about 80
+# bytes) is refused before anything is minted there, loudly (ENAMETOOLONG naming the dir), as a bind
+# under it would fail anyway; the refusal comes first because a caller registers close() only once
+# the constructor returns, so a directory minted for a bind that then failed was one leaked
+# rompsock* directory per test, per run (the round-2 review, 2026-09-06). Either way close()
+# removes the directory. Before this the dir was pinned to "/tmp" and never removed: the pin
+# bypassed the redirect and every run left three rompsock* directories behind.
+_SUN_PATH_MAX = 104 if sys.platform == "darwin" else 108
+_SOCK_NAME = "inbox.sock"
+
+
+def _socket_dir():
+    """The socket's directory: under the private root when the path fits sun_path, else under the
+    dir the run was handed. Refuses (OSError, ENAMETOOLONG) BEFORE minting when the handed dir would
+    not fit either, so a caller that never gets an inbox has nothing to remove."""
+    d = tempfile.mkdtemp(prefix="rompsock")
+    if len(os.fsencode(os.path.join(d, _SOCK_NAME))) < _SUN_PATH_MAX:
+        return d
+    os.rmdir(d)
+    handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+    if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:  # mkdtemp's suffix is 8 chars
+        raise OSError(errno.ENAMETOOLONG, "the temp dir this run was handed is too deep for an AF_UNIX "
+                      "socket path (%d-byte sun_path): %s" % (_SUN_PATH_MAX, handed))
+    return tempfile.mkdtemp(prefix="rompsock", dir=handed)
+
+
 class _OneShotInbox:
     """A real AF_UNIX listener capturing everything one client writes (the CLI parses per
-    line and acks nothing for a plain send, so capture-and-close mirrors it exactly)."""
+    line and acks nothing for a plain send, so capture-and-close mirrors it exactly).
+    close() removes the socket's directory; callers addCleanup it."""
 
     def __init__(self):
-        self.dir = tempfile.mkdtemp(prefix="rompsock", dir="/tmp")
-        self.path = os.path.join(self.dir, "inbox.sock")
+        self.dir = _socket_dir()
+        self.path = os.path.join(self.dir, _SOCK_NAME)
         self.got = []
-        self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self._srv.bind(self.path)
-        self._srv.listen(1)
-        self._srv.settimeout(5.0)                      # can-never-trap backstop: a never-connected inbox's
-        #                                                accept() returns instead of parking the thread
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
+        self._srv = None
+        try:
+            self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._srv.bind(self.path)
+            self._srv.listen(1)
+            self._srv.settimeout(5.0)                  # can-never-trap backstop: a never-connected inbox's
+            #                                            accept() returns instead of parking the thread
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        except BaseException:
+            # Nothing after the mkdtemp may leave the directory standing: the caller registers
+            # close() only once this returns, so a refused bind (a filesystem without AF_UNIX
+            # support, a permission) or a thread that would not start had left one rompsock*
+            # directory per test, per run, in the handed dir.
+            if self._srv is not None:
+                self._srv.close()
+            shutil.rmtree(self.dir, ignore_errors=True)
+            raise
 
     def _run(self):
         try:
@@ -84,6 +136,96 @@ class _OneShotInbox:
         except OSError:
             pass
         self._thread.join(timeout=1.0)
+        shutil.rmtree(self.dir, ignore_errors=True)    # idempotent: a second close finds nothing
+
+
+class InboxDir(unittest.TestCase):
+    """_socket_dir's rule, and that an inbox leaves nothing behind."""
+
+    def test_the_dir_is_under_the_private_root_when_the_path_fits_and_gone_after_close(self):
+        inbox = _OneShotInbox()
+        self.addCleanup(inbox.close)
+        root = tempfile.gettempdir()
+        self.assertLess(len(os.fsencode(inbox.path)), _SUN_PATH_MAX)
+        fits_in_root = len(os.fsencode(os.path.join(root, os.path.basename(inbox.dir), _SOCK_NAME))) < _SUN_PATH_MAX
+        self.assertEqual(os.path.dirname(inbox.dir),
+                         root if fits_in_root else os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or root)
+        self.assertTrue(os.path.exists(inbox.path))
+        inbox.close()
+        self.assertFalse(os.path.exists(inbox.dir), "close() removes the socket's directory")
+        inbox.close()                                      # a second close is a no-op
+
+    def test_a_path_too_long_for_the_private_root_falls_back_to_the_handed_dir(self):
+        # "Handed" is the run's record, not this process's gettempdir(): in an xdist worker the
+        # latter is the worker's root, nested in the controller's, which under a long TMPDIR is
+        # itself too deep for the socket (122 bytes under a 52-byte TMPDIR, seen under -n 8).
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+        if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:
+            self.skipTest("the temp dir this run was handed is itself too deep for sun_path")
+        deep = os.path.join(tempfile.gettempdir(), "d" * 120)   # deep + /rompsockXXXXXXXX/inbox.sock > 108
+        os.mkdir(deep)
+        self.addCleanup(shutil.rmtree, deep, ignore_errors=True)
+        with patch.dict(os.environ, {"ROMP_TESTS_SYSTEM_TMPDIR": handed}), patch.object(tempfile, "tempdir", deep):
+            d = _socket_dir()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        self.assertEqual(os.path.dirname(d), handed)
+        self.assertLess(len(os.fsencode(os.path.join(d, _SOCK_NAME))), _SUN_PATH_MAX)
+        self.assertEqual(os.listdir(deep), [], "the too-long candidate was removed, not left behind")
+
+    def test_a_handed_dir_too_deep_for_the_socket_is_refused_before_anything_is_minted(self):
+        # Both candidates too deep. The constructor raises with the cause and the dir named, and
+        # neither the root nor the handed dir holds a rompsock* entry: a caller that never got an
+        # inbox has nothing to close, so a directory minted for a bind that then failed was one
+        # leaked directory per test, per run.
+        deep = os.path.join(tempfile.gettempdir(), "d" * 120)
+        os.mkdir(deep)
+        self.addCleanup(shutil.rmtree, deep, ignore_errors=True)
+        with patch.dict(os.environ, {"ROMP_TESTS_SYSTEM_TMPDIR": deep}), patch.object(tempfile, "tempdir", deep):
+            with self.assertRaises(OSError) as cm:
+                _OneShotInbox()
+        self.assertEqual(os.listdir(deep), [], "nothing is minted where no socket can bind")
+        self.assertEqual(cm.exception.errno, errno.ENAMETOOLONG)
+        self.assertIn(deep, str(cm.exception))
+
+    def test_a_refused_bind_removes_the_minted_dir(self):
+        # The length check above is the case the suite meets; a bind can be refused for other reasons
+        # (a filesystem without AF_UNIX support, a permission). Stubbed here: the constructor
+        # raises, and the directory _socket_dir minted for it is gone.
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir()
+        if len(os.fsencode(os.path.join(handed, "rompsock" + "x" * 8, _SOCK_NAME))) >= _SUN_PATH_MAX:
+            self.skipTest("the temp dir this run was handed is itself too deep for sun_path")   # refused before any bind
+        made = []
+        real = _socket_dir
+
+        def recording():
+            made.append(real())
+            return made[-1]
+        with patch.object(sys.modules[__name__], "_socket_dir", recording), \
+                patch.object(socket.socket, "bind", side_effect=OSError(errno.EACCES, "stub")):
+            with self.assertRaises(OSError) as cm:
+                _OneShotInbox()
+        self.assertEqual(cm.exception.errno, errno.EACCES)
+        self.assertEqual(len(made), 1)
+        self.assertFalse(os.path.exists(made[0]), "a refused bind leaves no rompsock* directory")
+
+    def test_the_rule_is_exercised_under_the_limit_by_a_real_bind(self):
+        # The constant is the platform's, not a guess: a socket at exactly _SUN_PATH_MAX - 1 bytes
+        # binds and one at _SUN_PATH_MAX does not, which is what the length check encodes.
+        with tempfile.TemporaryDirectory() as td:
+            if len(os.fsencode(td)) + 2 >= _SUN_PATH_MAX:
+                self.skipTest("the temp root itself is near sun_path's limit")
+            for length, ok in ((_SUN_PATH_MAX - 1, True), (_SUN_PATH_MAX, False)):
+                path = os.path.join(td, "s" * (length - len(td) - 1))
+                self.assertEqual(len(os.fsencode(path)), length)
+                srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    srv.bind(path)
+                    bound = True
+                except OSError:
+                    bound = False
+                finally:
+                    srv.close()
+                self.assertEqual(bound, ok, path)
 
 
 class SocketRegistry(unittest.TestCase):
@@ -128,16 +270,14 @@ class SocketWrite(unittest.TestCase):
 
     def test_writes_one_user_record(self):
         inbox = _OneShotInbox()
-        try:
-            self.assertTrue(km._socket_deliver(inbox.path, "mail body <!-- romp-msg-id: 1 -->"))
-            got = inbox.wait()
-            self.assertEqual(len(got), 1)
-            rec = json.loads(got[0].decode("utf-8"))
-            self.assertEqual(rec["type"], "user")
-            self.assertEqual(rec["message"]["role"], "user")
-            self.assertEqual(rec["message"]["content"], "mail body <!-- romp-msg-id: 1 -->")
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        self.assertTrue(km._socket_deliver(inbox.path, "mail body <!-- romp-msg-id: 1 -->"))
+        got = inbox.wait()
+        self.assertEqual(len(got), 1)
+        rec = json.loads(got[0].decode("utf-8"))
+        self.assertEqual(rec["type"], "user")
+        self.assertEqual(rec["message"]["role"], "user")
+        self.assertEqual(rec["message"]["content"], "mail body <!-- romp-msg-id: 1 -->")
 
     def test_false_when_socket_is_gone(self):
         self.assertFalse(km._socket_deliver("/tmp/rompsock-nonexistent/inbox.sock", "x"))
@@ -187,27 +327,23 @@ class DeliverGate(unittest.TestCase):
 
     def test_tagged_session_delivers_down_the_socket(self):
         inbox = _OneShotInbox()
-        try:
-            _registry_row(self.reg, os.getpid(), SID, inbox.path)
-            be = _StubTmux(accept=True)
-            self.assertTrue(be.deliver(SID, "banner text"))
-            got = inbox.wait()
-            self.assertEqual(json.loads(got[0].decode("utf-8"))["message"]["content"], "banner text")
-            self.assertEqual(be.pane_calls, [])            # the pane was never touched
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        _registry_row(self.reg, os.getpid(), SID, inbox.path)
+        be = _StubTmux(accept=True)
+        self.assertTrue(be.deliver(SID, "banner text"))
+        got = inbox.wait()
+        self.assertEqual(json.loads(got[0].decode("utf-8"))["message"]["content"], "banner text")
+        self.assertEqual(be.pane_calls, [])                # the pane was never touched
 
     def test_untagged_session_keeps_the_pane_path(self):
         inbox = _OneShotInbox()
-        try:
-            _registry_row(self.reg, os.getpid(), SID, inbox.path)
-            be = _StubTmux(accept=False)
-            be.deliver(SID, "banner text")                 # pane stub has no ❯ prompt → undelivered
-            time.sleep(0.2)
-            self.assertEqual(inbox.got, [])                # nothing reached the socket
-            self.assertIn("capture", be.pane_calls)        # the pane path ran instead
-        finally:
-            inbox.close()
+        self.addCleanup(inbox.close)
+        _registry_row(self.reg, os.getpid(), SID, inbox.path)
+        be = _StubTmux(accept=False)
+        be.deliver(SID, "banner text")                     # pane stub has no ❯ prompt → undelivered
+        time.sleep(0.2)
+        self.assertEqual(inbox.got, [])                    # nothing reached the socket
+        self.assertIn("capture", be.pane_calls)            # the pane path ran instead
 
     def test_tagged_but_dead_socket_falls_back_to_the_pane(self):
         _registry_row(self.reg, os.getpid(), SID, "/tmp/rompsock-nonexistent/inbox.sock")

--- a/tests/test_kernel_worktree_display.py
+++ b/tests/test_kernel_worktree_display.py
@@ -18,6 +18,7 @@ repos with fixture identities.
 """
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -92,6 +93,10 @@ class TreeOf(unittest.TestCase):
         _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.main)
         os.makedirs(os.path.join(cls.wt, "sub"))
 
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
     def test_a_worktree_path_resolves_to_its_own_tree_and_branch(self):
         top, br = km._tree_of(os.path.join(self.wt, "sub"))
         self.assertEqual(os.path.realpath(top), os.path.realpath(self.wt))
@@ -103,7 +108,8 @@ class TreeOf(unittest.TestCase):
         self.assertEqual(br, "main")
 
     def test_a_non_repo_dir_is_no_tree(self):
-        self.assertEqual(km._tree_of(tempfile.mkdtemp()), ("", ""))
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(km._tree_of(d), ("", ""))
         self.assertEqual(km._tree_of(""), ("", ""))
 
 

--- a/tests/test_reg_field_gutting.py
+++ b/tests/test_reg_field_gutting.py
@@ -12,6 +12,7 @@ here against a CORRUPT reg file and pinned: the file's bytes survive untouched. 
 import asyncio
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -34,6 +35,7 @@ CORRUPT = b'{"sid": "trunca'          # a torn read: exists, does not parse
 class ReadRegForRmw(unittest.TestCase):
     def setUp(self):
         self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
 
     def test_absent_reg_is_a_writable_empty(self):
         self.assertEqual(sb.read_reg_for_rmw(self.d, SID), {},
@@ -57,6 +59,7 @@ class _Hooked(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
         self.logs = []
         self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "gut", "cwd": "/tmp", "alive": True,

--- a/tests/test_tempdir_hygiene.py
+++ b/tests/test_tempdir_hygiene.py
@@ -1,18 +1,55 @@
-"""The suite removes every temp directory it makes (tests/__init__.py + tests/conftest.py, 2026-09-06).
+"""A pytest run leaves nothing in the system temp dir, and its git reads none of the developer's
+configuration (2026-09-06).
 
-Three checks. In-process: the package's mkdtemp hook is installed, so a directory a test makes is
-recorded for the exit sweep. Two subprocess checks run this same module's in-process test as a child,
-once under pytest (conftest's session-end sweep) and once under unittest (the package's atexit sweep),
-with ROMP_HYGIENE_MARKER naming a file where the child writes the directory it made and its
-XDG_STATE_HOME root; the parent asserts both are gone once the child exits. That is the behaviour
-that ends the leak (over a million stale fixture directories on one machine before this)."""
+Two mechanisms, one per half. tests/__init__.py wraps tempfile.mkdtemp so every directory the test
+process mints is recorded and removed when the run ends (under pytest at session end, under
+`python -m unittest` at exit): that is the in-process half, and it covers the 300-odd module
+preambles and the per-test mkdtemp calls nobody cleans up. tests/conftest.py covers what the hook
+cannot see — directories made by child processes (kernels, git, a shell's `mktemp -d`), mkstemp
+files, os.mkdir paths — by pointing the process temp dir (tempfile.tempdir and TMPDIR, so children
+inherit it) at one private `romp-tests-*` root and removing the root when the run ends; the
+package's state dir, minted before the redirect, goes with it. Before both, a full run left ~5,600
+entries in /tmp and over a million had piled up. The same conftest points git at no global or
+system config (GIT_CONFIG_GLOBAL, GIT_CONFIG_NOSYSTEM) with a synthetic identity: the seed commits
+had been running the developer's global pre-commit hook.
+
+Pinned four ways. Hygiene (the hook): it is installed, and a child run of this module under pytest
+and under unittest leaves neither the directory it made nor its state root (ROMP_HYGIENE_MARKER
+names the file where the child writes both paths). From inside a run: the floors are in place and
+children inherit them; no test pins a temp path to a literal directory; a root that survives
+removal is named on stderr; a global and a system hooksPath cannot reach a fixture commit. End to
+end: a nested pytest on a leaking module leaves the system temp dir it was given exactly as it
+found it, serial and under xdist. The in-run and end-to-end classes skip under a bare unittest run,
+where conftest never loaded and there is nothing to pin; the hook checks run either way. This
+module loads no romp code, so it needs no state-root preamble.
+"""
+import ast
+import contextlib
+import glob
+import importlib.util
+import io
 import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
+from unittest.mock import patch
 
-REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+IDENT = "romp tests <tests@example.invalid>"
+
+under_conftest = unittest.skipUnless("tests.conftest" in sys.modules,
+                                     "the floors under test are tests/conftest.py's (pytest-only)")
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=60, **kw)
+
+
 MARKER_ENV = "ROMP_HYGIENE_MARKER"
 
 
@@ -31,7 +68,7 @@ class Hygiene(unittest.TestCase):
         scratch = tempfile.mkdtemp(prefix="romp-hygiene-")      # tracked: swept when THIS session ends
         marker = os.path.join(scratch, "paths.txt")
         env = dict(os.environ, **{MARKER_ENV: marker})
-        r = subprocess.run(argv, cwd=REPO, env=env, capture_output=True, text=True, timeout=300)
+        r = subprocess.run(argv, cwd=ROOT, env=env, capture_output=True, text=True, timeout=300)
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         with open(marker) as fh:
             made, state_root = fh.read().split("\n")[:2]
@@ -50,5 +87,462 @@ class Hygiene(unittest.TestCase):
                          "tests.test_tempdir_hygiene.Hygiene.test_mkdtemp_is_tracked_in_process"])
 
 
+@under_conftest
+class PrivateTempRoot(unittest.TestCase):
+    def test_the_process_temp_dir_is_the_private_root(self):
+        root = tempfile.gettempdir()
+        self.assertTrue(os.path.basename(root).startswith("romp-tests-"), root)
+        self.assertTrue(os.path.isdir(root))
+        self.assertEqual(os.environ.get("TMPDIR"), root, "children find the root through TMPDIR")
+
+    def test_module_level_state_roots_land_inside_it(self):
+        # Whichever module's preamble wrote XDG_STATE_HOME last at collection, it minted the dir
+        # after conftest redirected the temp root, so it sits inside.
+        root = tempfile.gettempdir()
+        xdg = os.environ["XDG_STATE_HOME"]
+        self.assertEqual(os.path.commonpath([root, xdg]), root, xdg)
+
+    def test_children_inherit_the_root(self):
+        root = tempfile.gettempdir()
+        py = _run([sys.executable, "-c", "import tempfile, sys; sys.stdout.write(tempfile.gettempdir())"])
+        self.assertEqual(py.stdout, root, "a Python child's tempfile answers with the root")
+        sh = _run(["mktemp", "-d", "-u"])   # -u: name only, nothing created
+        self.assertEqual(os.path.dirname(sh.stdout.strip()), root, "a shell's mktemp -d lands in it")
+
+    def test_the_handed_temp_dir_is_recorded_once_and_the_roots_nest_under_it(self):
+        # The one sanctioned way out of the root (tests/test_kernel_socket_deliver._socket_dir, for
+        # a socket path that would not fit sun_path) goes to the dir the RUN was handed, never to a
+        # literal system path. Recorded once: serially the root sits directly in it; in an xdist
+        # worker the worker's root sits inside the controller's and the record is still the dir
+        # above both — a worker that re-recorded its own gettempdir() would name the controller's
+        # root, one level too deep for the socket under a long TMPDIR.
+        handed = os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR")
+        self.assertTrue(handed, "conftest records the temp dir it replaced")
+        handed, root = os.path.realpath(handed), os.path.realpath(tempfile.gettempdir())
+        self.assertFalse(os.path.basename(handed).startswith("romp-tests-"), handed)
+        self.assertEqual(os.path.commonpath([handed, root]), handed, root)
+        between = os.path.relpath(root, handed).split(os.sep)
+        self.assertTrue(all(p.startswith("romp-tests-") for p in between), between)
+        self.assertEqual(len(between), 2 if os.environ.get("PYTEST_XDIST_WORKER") else 1, between)
+
+    def test_no_test_pins_a_temp_path_to_a_literal_directory(self):
+        # A literal directory as a tempfile call's `dir` bypasses the redirect: the socket tests
+        # carried dir="/tmp" and left three rompsock* directories in the real /tmp per run, where the
+        # nested-run check below could not see them. Static, so it covers every module whether or
+        # not a run exercises it; the rule and its shapes are _python_pins' and _shell_pins' (the
+        # LiteralPinChecker class pins them on synthetic sources), this applies them to the tree.
+        bad = []
+        for path in sorted(glob.glob(os.path.join(HERE, "*.py"))):
+            src = open(path, encoding="utf-8").read()
+            if any(c in src for c in TEMPFILE_DIR_POSITION):     # a text prefilter keeps the parse to candidates
+                bad += _python_pins(src, os.path.relpath(path, ROOT))
+        for path in sorted(glob.glob(os.path.join(HERE, "*.bats")) + glob.glob(os.path.join(HERE, "*.bash"))):
+            bad += _shell_pins(open(path, encoding="utf-8").read(), os.path.relpath(path, ROOT))
+        self.assertEqual(bad, [], "temp paths take the process temp dir (the private root); a test that "
+                         "must leave it falls back to ROMP_TESTS_SYSTEM_TMPDIR — see _socket_dir")
+
+
+# The literal-directory rule, one function per language. Python: the `dir` argument of a tempfile
+# call — the keyword, or the positional slot the module's signatures give it (the third of mkdtemp,
+# mkstemp, mktemp and TemporaryDirectory; the seventh of NamedTemporaryFile and TemporaryFile; the
+# eighth of SpooledTemporaryFile) — is a pin when it is a string literal of any value, when any
+# string literal inside its expression is an absolute path (an f-string piece, an operand of `+`,
+# an os.path.join argument, the default of os.environ.get), or when it is a name or attribute the
+# same file assigns such an expression to (followed through assignments a few levels deep). A
+# relative literal inside a composed expression (os.path.join(self.dir, "sub")) is a component, not
+# a pin; a call that names no absolute path (tempfile.gettempdir(), str(home), self.td.name,
+# os.environ.get("X") or ...) is where a dir should come from. Only the tempfile names are read, so
+# parse_session(dir="/TESTDIR") is not a hit and a call split over lines is. Shell: `mktemp` handed
+# a path under a system temp dir on the same command — as the template, as `-p`'s or `--tmpdir`'s
+# value, spaced, attached or `=`-joined, quoted or bare — and any `TMPDIR=` assignment to one (the
+# `TMPDIR=/tmp mktemp -d` prefix and an `export` alike: both redirect every child there). A trailing
+# comment is not reached and a comment line is skipped. The round-2 review (2026-09-06) found the
+# first version reading only the keyword form and only an unquoted, space-separated shell path.
+TEMPFILE_DIR_POSITION = {"mkdtemp": 2, "mkstemp": 2, "mktemp": 2, "TemporaryDirectory": 2,
+                         "NamedTemporaryFile": 6, "TemporaryFile": 6, "SpooledTemporaryFile": 7}
+_SYSTEM_TEMP = r"/(?:tmp|var/tmp|private/tmp|var/folders|dev/shm)\b"
+_SH_PIN = re.compile(r"\bmktemp\b[^\n|;&#]*(?:\s-p\s*|[\s=])[\"']?" + _SYSTEM_TEMP
+                     + r"|\bTMPDIR=[\"']?" + _SYSTEM_TEMP)
+
+
+def _dir_argument(call):
+    """The `dir` argument's node, from the keyword or the positional slot; None when absent or when a
+    starred argument makes the positions unknowable."""
+    for kw in call.keywords:
+        if kw.arg == "dir":
+            return kw.value
+    pos = TEMPFILE_DIR_POSITION[_call_name(call)]
+    if len(call.args) > pos and not any(isinstance(a, ast.Starred) for a in call.args):
+        return call.args[pos]
+    return None
+
+
+def _call_name(call):
+    f = call.func
+    return f.attr if isinstance(f, ast.Attribute) else f.id if isinstance(f, ast.Name) else None
+
+
+def _assignments(tree):
+    """Every `name = value`, `self.name = value` (annotated or augmented too) in the module, keyed by
+    the target's source text — one scope, since a test module's names are few."""
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        for t in targets:
+            if isinstance(t, (ast.Name, ast.Attribute)):
+                out.setdefault(ast.unparse(t), []).append(value)
+    return out
+
+
+def _pinned(node, assigned, depth=3):
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str)
+    if any(isinstance(sub, ast.Constant) and isinstance(sub.value, str) and sub.value.startswith("/")
+           for sub in ast.walk(node)):
+        return True
+    if depth and isinstance(node, (ast.Name, ast.Attribute)):
+        return any(_pinned(v, assigned, depth - 1) for v in assigned.get(ast.unparse(node), ()))
+    return False
+
+
+def _python_pins(src, label):
+    """`label:line: call` for every tempfile call in `src` whose dir is a literal directory."""
+    tree = ast.parse(src)
+    assigned = _assignments(tree)
+    bad = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _call_name(node) in TEMPFILE_DIR_POSITION:
+            d = _dir_argument(node)
+            if d is not None and _pinned(d, assigned):
+                bad.append("%s:%d: %s" % (label, node.lineno, ast.get_source_segment(src, node).splitlines()[0]))
+    return bad
+
+
+def _shell_pins(text, label):
+    """`label:line: text` for every line of a shell source that points mktemp, or TMPDIR, at a
+    literal system temp dir."""
+    return ["%s:%d: %s" % (label, n, line.strip()) for n, line in enumerate(text.splitlines(), 1)
+            if not line.lstrip().startswith("#") and _SH_PIN.search(line)]
+
+
+class LiteralPinChecker(unittest.TestCase):
+    """The rule on synthetic sources: every shape the round-2 review listed as passing the first
+    version is a hit, and every legitimate spelling in the tree is not."""
+
+    PREAMBLE = textwrap.dedent('''\
+        import os, tempfile
+        from tempfile import mkdtemp
+        PINNED = "/tmp"
+        VIA = PINNED
+        root = tempfile.mkdtemp()
+        home = root
+
+        class T:
+            def setUp(self):
+                self.pinned = "/tmp/" + "x"
+                self.dir = os.path.realpath(tempfile.mkdtemp())
+                self.td = tempfile.TemporaryDirectory()
+                name = "x"
+                CALL
+    ''')
+
+    PINNED_PY = [
+        'tempfile.mkdtemp(dir="/tmp")',
+        'tempfile.mkdtemp(prefix="x",\n                 dir="/tmp")',                 # split over lines
+        'mkdtemp(dir="/tmp")',                                                       # the bare name
+        'tempfile.mkdtemp("", "x", "/tmp")',                                         # by position
+        'tempfile.mkstemp("", "x", "/tmp")',
+        'tempfile.mktemp("", "x", "/tmp")',
+        'tempfile.TemporaryDirectory(None, None, "/tmp")',
+        'tempfile.NamedTemporaryFile("w", -1, None, None, ".jsonl", "x", "/tmp")',  # the seventh
+        'tempfile.TemporaryFile("w+b", -1, None, None, None, None, "/var/tmp")',
+        'tempfile.SpooledTemporaryFile(0, "w+b", -1, None, None, None, None, "/tmp")',
+        'tempfile.mkdtemp(dir=f"/tmp/{name}")',                                       # composed
+        'tempfile.mkdtemp(dir="/tmp/" + name)',
+        'tempfile.mkdtemp(dir=os.path.join("/tmp", name))',
+        'tempfile.mkdtemp(dir=os.environ.get("TMPDIR", "/tmp"))',
+        'tempfile.mkdtemp(dir=PINNED)',                                              # a name bound to one
+        'tempfile.mkdtemp(dir=VIA)',
+        'tempfile.mkdtemp(dir=self.pinned)',
+        'tempfile.mkdtemp(dir="fixtures")',                                          # any plain literal
+        'tempfile.mkdtemp(dir="/TESTDIR")',
+    ]
+    UNPINNED_PY = [
+        'tempfile.mkdtemp()',
+        'tempfile.mkdtemp(prefix="rompsock")',
+        'tempfile.mkdtemp(dir=tempfile.gettempdir())',
+        'tempfile.mkdtemp(prefix="rompsock", dir=os.environ.get("ROMP_TESTS_SYSTEM_TMPDIR") or tempfile.gettempdir())',
+        'tempfile.TemporaryDirectory(dir=str(home))',
+        'tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, dir=self.td.name)',
+        'tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False)',
+        'tempfile.mkdtemp(dir=os.path.join(self.dir, "sub"))',                       # a relative component
+        'tempfile.mkdtemp(dir=None)',
+        'tempfile.mkdtemp("", "x", None)',
+        'tempfile.mkdtemp(dir=root)',                                                # bound to a mkdtemp
+        'tempfile.mkdtemp(dir=self.dir)',
+        'tempfile.mkdtemp(dir=home)',
+        'parse_session(dir="/TESTDIR")',                                             # not a tempfile call
+        'shutil.rmtree("/tmp/x")',
+        'open("/tmp/x").read()',
+    ]
+
+    def _pins(self, call):
+        src = self.PREAMBLE.replace("CALL", textwrap.indent(call, " " * 8).lstrip())
+        return _python_pins(src, "t.py")
+
+    def test_python_shapes_that_pin_are_hits(self):
+        for call in self.PINNED_PY:
+            with self.subTest(call=call):
+                pins = self._pins(call)
+                self.assertEqual(len(pins), 1, pins)
+                self.assertTrue(pins[0].startswith("t.py:%d: " % (self.PREAMBLE[:self.PREAMBLE.index("CALL")].count("\n") + 1)), pins)
+                self.assertIn(call.splitlines()[0], pins[0])
+
+    def test_python_shapes_that_do_not_pin_are_clean(self):
+        for call in self.UNPINNED_PY:
+            with self.subTest(call=call):
+                self.assertEqual(self._pins(call), [])
+
+    PINNED_SH = [
+        'TEST_DIR="$(mktemp -d /tmp/x.XXXX)"',
+        'TEST_DIR="$(mktemp -d "/tmp/x.XXXX")"',                # quoted
+        "TEST_DIR=\"$(mktemp -d '/tmp/x.XXXX')\"",
+        'd=$(mktemp -p /tmp)',
+        'd=$(mktemp -p "/tmp")',
+        'd=$(mktemp -p/tmp -d)',                                 # attached
+        'd=$(mktemp -d --tmpdir=/tmp)',                          # =-joined
+        'd=$(mktemp --tmpdir="/var/tmp" -d)',
+        'd=$(mktemp --tmpdir /private/tmp)',
+        'd=$(TMPDIR=/tmp mktemp -d)',                            # the prefix form
+        'd=$(TMPDIR="/tmp" mktemp -d)',
+        'export TMPDIR=/tmp',                                    # redirects every child there
+        'TMPDIR=/var/folders/x/T',
+        '    mktemp -d /var/tmp/x.XXXX',
+        'run mktemp -d /dev/shm/x.XXXX',
+    ]
+    UNPINNED_SH = [
+        'TEST_DIR="$(mktemp -d)"',
+        'TEST_DIR="$(mktemp -d "$TMPDIR/x.XXXX")"',
+        'd=$(mktemp -p "$TMPDIR")',
+        'd=$(mktemp --tmpdir="$TEST_DIR")',
+        'd=$(TMPDIR="$TEST_DIR" mktemp -d)',
+        'export TMUX_TMPDIR="$TEST_DIR/tmux"',
+        'export TMPDIR=/nonexistent',
+        'TEST_DIR="$(mktemp -d -u)"',
+        '# mktemp -d /tmp/x.XXXX',                               # a comment line
+        '    # d=$(TMPDIR=/tmp mktemp -d)',
+        'TEST_DIR="$(mktemp -d)"   # not /tmp',                  # a trailing comment
+        '[ -d /tmp ]',
+        'grep -qxF "TMUX_TMPDIR=$TEST_DIR/tmux" "$FAKE_TMUX_ENV"',
+    ]
+
+    def test_shell_shapes_that_pin_are_hits(self):
+        for line in self.PINNED_SH:
+            with self.subTest(line=line):
+                self.assertEqual(_shell_pins("setup() {\n" + line + "\n}\n", "t.bats"), ["t.bats:2: " + line.strip()])
+
+    def test_shell_shapes_that_do_not_pin_are_clean(self):
+        for line in self.UNPINNED_SH:
+            with self.subTest(line=line):
+                self.assertEqual(_shell_pins("setup() {\n" + line + "\n}\n", "t.bats"), [])
+
+
+@under_conftest
+class RunEndNotice(unittest.TestCase):
+    """A root that survives the run-end removal is named on stderr, once, rather than left standing
+    with the run green. `shutil.rmtree(..., ignore_errors=True)` swallows a child still writing under
+    the root and a 000-mode directory a test left behind (shutil's fd-based walk cannot open it, so
+    the root's rmdir is never reached); the stand-in here is the latter."""
+
+    def test_the_package_state_dir_is_removed_with_the_root(self):
+        # tests/__init__.py minted it before conftest redirected the temp root, so it is the one
+        # thing outside the root; conftest holds it for the run-end removal rather than leaving it
+        # to __init__'s atexit alone.
+        conftest = sys.modules["tests.conftest"]
+        pkg_dir = conftest._PACKAGE_STATE_DIR
+        self.assertEqual(pkg_dir, sys.modules["tests"].STATE_DIR)
+        self.assertTrue(os.path.isdir(pkg_dir), pkg_dir)
+        root = tempfile.gettempdir()
+        # A sibling of the root, not a child: both were minted in the dir this process started with
+        # (the system temp dir, or the controller's root in an xdist worker) before the redirect.
+        self.assertEqual(os.path.realpath(os.path.dirname(pkg_dir)), os.path.realpath(os.path.dirname(root)))
+        self.assertNotEqual(os.path.commonpath([root, pkg_dir]), root)
+
+    @unittest.skipIf(os.geteuid() == 0, "root can remove a 000-mode directory")
+    def test_a_root_that_survives_removal_is_named_on_stderr(self):
+        conftest = sys.modules["tests.conftest"]
+        root = tempfile.mkdtemp()                       # a stand-in root, inside the real one
+        locked = os.path.join(root, "locked")
+        os.mkdir(locked)
+        open(os.path.join(locked, "f"), "w").close()
+        os.chmod(locked, 0)
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        self.addCleanup(lambda: os.path.isdir(locked) and os.chmod(locked, 0o700))
+
+        # The real hook, on the stand-in only (the package state dir is live and not this test's).
+        with patch.object(conftest, "_TMP_ROOT", root), patch.object(conftest, "_PACKAGE_STATE_DIR", None):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                conftest.pytest_unconfigure(None)
+            self.assertTrue(os.path.isdir(root), "the 000-mode child keeps the root standing")
+            self.assertEqual(err.getvalue(), "[tests] not removed at run end: %s\n" % root)
+
+            err = io.StringIO()                          # the atexit fallback: same survivor, silent
+            with contextlib.redirect_stderr(err):
+                conftest._remove_run_dirs()
+            self.assertEqual(err.getvalue(), "")
+
+            os.chmod(locked, 0o700)                      # control: a removable root says nothing
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                conftest.pytest_unconfigure(None)
+            self.assertFalse(os.path.exists(root))
+            self.assertEqual(err.getvalue(), "")
+
+
+def _git_version():
+    out = _run(["git", "--version"]).stdout.split()
+    m = re.match(r"(\d+)\.(\d+)", out[2] if len(out) > 2 else "")
+    return (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+
+
+@under_conftest
+@unittest.skipIf(_git_version() < (2, 32), "GIT_CONFIG_GLOBAL needs git >= 2.32")
+class GitFloor(unittest.TestCase):
+    def test_git_reads_no_global_config_and_has_the_synthetic_identity(self):
+        self.assertEqual(_run(["git", "config", "--global", "--list"]).stdout, "")
+        self.assertTrue(_run(["git", "var", "GIT_AUTHOR_IDENT"]).stdout.startswith(IDENT + " "))
+        self.assertTrue(_run(["git", "var", "GIT_COMMITTER_IDENT"]).stdout.startswith(IDENT + " "))
+
+    def _hostile_repo(self, td):
+        """A stand-in for the developer's configuration: a pre-commit hook that refuses every commit
+        and leaves a marker, a config file wiring it in through core.hooksPath, and a repo with one
+        staged file. Returns (marker, cfg, repo)."""
+        hooks = os.path.join(td, "hooks")
+        os.makedirs(hooks)
+        marker = os.path.join(td, "hook-ran")
+        with open(os.path.join(hooks, "pre-commit"), "w") as f:
+            f.write("#!/bin/sh\necho ran > '%s'\nexit 1\n" % marker)
+        os.chmod(os.path.join(hooks, "pre-commit"), 0o755)
+        cfg = os.path.join(td, "gitconfig")
+        with open(cfg, "w") as f:
+            f.write("[core]\n\thooksPath = %s\n" % hooks)
+        repo = os.path.join(td, "repo")
+        os.makedirs(repo)
+        _run(["git", "init", "-q"], cwd=repo, check=True)
+        with open(os.path.join(repo, "a.txt"), "w") as f:
+            f.write("a\n")
+        _run(["git", "add", "a.txt"], cwd=repo, check=True)
+        return marker, cfg, repo
+
+    COMMIT = ["git", "commit", "-q", "-m", "seed"]
+
+    def test_a_global_hooks_path_cannot_reach_a_fixture_commit(self):
+        # The hostile config as the GLOBAL file. Live first, then floored (the suite's own env).
+        with tempfile.TemporaryDirectory() as td:
+            marker, cfg, repo = self._hostile_repo(td)
+            live = _run(self.COMMIT, cwd=repo, env=dict(os.environ, GIT_CONFIG_GLOBAL=cfg))
+            self.assertNotEqual(live.returncode, 0, "the probe is live: the hook blocks the commit")
+            self.assertTrue(os.path.exists(marker))
+            os.remove(marker)
+
+            floored = _run(self.COMMIT, cwd=repo)
+            self.assertEqual(floored.returncode, 0, floored.stderr)
+            self.assertFalse(os.path.exists(marker), "no global hook reaches a fixture commit")
+            self.assertEqual(_run(["git", "log", "-1", "--format=%an <%ae>"], cwd=repo).stdout.strip(), IDENT)
+
+    def test_a_system_hooks_path_cannot_reach_a_fixture_commit_either(self):
+        # The hostile config as the SYSTEM file: GIT_CONFIG_SYSTEM (git >= 2.32, like GIT_CONFIG_GLOBAL)
+        # is a root-free stand-in for /etc/gitconfig, and GIT_CONFIG_NOSYSTEM=1 is the half of the
+        # floor that hides it — the global probe above says nothing about it. The assertion is the
+        # commit's outcome: `git config --system --list` prints the file under NOSYSTEM too.
+        with tempfile.TemporaryDirectory() as td:
+            marker, cfg, repo = self._hostile_repo(td)
+            live_env = dict(os.environ, GIT_CONFIG_SYSTEM=cfg)
+            live_env.pop("GIT_CONFIG_NOSYSTEM", None)
+            live = _run(self.COMMIT, cwd=repo, env=live_env)
+            self.assertNotEqual(live.returncode, 0, "the probe is live: the system hook blocks the commit")
+            self.assertTrue(os.path.exists(marker))
+            os.remove(marker)
+
+            floored = _run(self.COMMIT, cwd=repo, env=dict(os.environ, GIT_CONFIG_SYSTEM=cfg))
+            self.assertEqual(floored.returncode, 0, floored.stderr)
+            self.assertFalse(os.path.exists(marker), "no system hook reaches a fixture commit")
+
+
+LEAKY_MODULE = textwrap.dedent('''\
+    import os, subprocess, tempfile, unittest
+    ROOT = os.environ["TMPDIR"]
+    STATE = tempfile.mkdtemp()            # a module preamble's state root: never cleaned by the module
+
+    class Leak(unittest.TestCase):
+        def test_everything_lands_under_the_private_root(self):
+            self.assertTrue(os.path.basename(ROOT).startswith("romp-tests-"), ROOT)
+            d = tempfile.mkdtemp()            # a seed repo, the shape that leaked: never cleaned
+            fd, f = tempfile.mkstemp()
+            os.close(fd)
+            subprocess.run(["git", "init", "-q", d], check=True)
+            open(os.path.join(d, "a.txt"), "w").write("a\\n")
+            subprocess.run(["git", "-C", d, "add", "a.txt"], check=True)
+            subprocess.run(["git", "-C", d, "commit", "-q", "-m", "seed"], check=True)
+            sh = subprocess.run(["mktemp", "-d"], capture_output=True, text=True, check=True).stdout.strip()
+            for p in (STATE, d, f, sh):
+                self.assertEqual(os.path.commonpath([ROOT, p]), ROOT, p)
+''')
+
+
+@under_conftest
+class RunLeavesNothing(unittest.TestCase):
+    """A nested pytest, handed a fresh directory as its system temp dir and loading this repo's
+    conftest as a plugin, runs a module that leaks every way the suite does: after it exits the
+    directory holds exactly what it held before.
+
+    The fresh directory is the whole check; the machine's real system temp dir is not diffed. It
+    would be cheap (a prefix-filtered os.scandir over 101k entries measured 0.10 s, 2026-09-06) but
+    not attributable: that dir is shared with every process on the box, and with other checkouts
+    running this suite beside it, romp-prefixed entries appeared there about twice a minute (345
+    bursts in three hours, measured the same day) — a before/after diff over a nested run of a few
+    seconds would fail a third of the time with nothing wrong. Only a literal path can reach it past
+    TMPDIR, and PrivateTempRoot pins that class statically."""
+
+    def _nested(self, *extra):
+        fresh = tempfile.mkdtemp()
+        case = os.path.join(fresh, "case")
+        os.makedirs(case)
+        with open(os.path.join(case, "test_leak.py"), "w") as f:
+            f.write(LEAKY_MODULE)
+        env = dict(os.environ, TMPDIR=fresh, PYTHONDONTWRITEBYTECODE="1")
+        for var in ("PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTEST_DISABLE_PLUGIN_AUTOLOAD", "PYTEST_CURRENT_TEST",
+            "PYTEST_XDIST_WORKER", "PYTEST_XDIST_WORKER_COUNT",
+            "ROMP_TESTS_SYSTEM_TMPDIR"):        # a fresh run records its own handed dir (conftest setdefaults it)
+            env.pop(var, None)
+        r = subprocess.run([sys.executable, "-m", "pytest", "-p", "tests.conftest", "-p", "no:cacheprovider",
+                            "-q", *extra, os.path.join(case, "test_leak.py")],
+                           cwd=ROOT, env=env, capture_output=True, text=True, timeout=180)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("1 passed", r.stdout)
+        self.assertEqual(sorted(os.listdir(fresh)), ["case"],
+                         "the run must leave the system temp dir as it found it")
+
+    def test_a_run_removes_everything_it_created_under_the_system_temp_dir(self):
+        self._nested()
+
+    @unittest.skipUnless(importlib.util.find_spec("xdist"), "pytest-xdist not installed")
+    def test_under_xdist_the_run_leaves_nothing_either(self):
+        # Pins the outcome, not each process's hook: a worker's root sits inside the controller's
+        # (it inherits that TMPDIR), so the controller's removal alone would satisfy this.
+        self._nested("-n", "2")
+
+
 if __name__ == "__main__":
+    # A direct script run never imports the tests package, so the mkdtemp hook would be absent: the
+    # first Hygiene check failed and the child runs left two romp-hygiene-* directories behind (the
+    # #944 review). Import it here; the package also floors XDG_STATE_HOME, as for a unittest run.
+    sys.path.insert(0, ROOT)
+    import tests  # noqa: F401
     unittest.main()


### PR DESCRIPTION
Depends on #999 (the temp-root PR), which must merge first; GitHub shows its commits in this diff until then.

Stacks on the temp-root PR (branch tmp-hygiene-offer): review and merge that first; this PR's own diff is f043b17d..9ab300aa.

## What breaks

An assertion whose container is an environment mapping prints the whole mapping when it fails. unittest's `assertNotIn` renders `'ANTHROPIC_API_KEY' unexpectedly found in {<every variable>}`, and the suite has about twenty such sites over `os.environ`, a `_judge_env()` copy or a launch env (`tests/test_session_auth.py`, `test_keyswap.py`, `test_judge_auth_billing.py`, `test_judge_engine.py`). On a developer's machine that mapping can hold a live key or token exported in the shell: the service.env floor keeps the real key file out of tests, but not an inherited variable. A child process's output (an apiKeyHelper's stdout, a CLI's headers) can also reach a report without touching the environment.

Reproduction on a clean checkout: `export ROMP_PROBE=romp-test-fixture-<any 32 hex>`, then a test that does `self.assertNotIn("ROMP_PROBE", os.environ)` prints the value in its failure message, and `print(os.environ["ROMP_PROBE"])` in a failing test shows it in the captured stdout. `tests/test_env_value_redaction.py::HookEndToEnd` automates this against a copy of the conftest.

## The fix

Two nets in `tests/conftest.py`, applied by a hookwrapper on `pytest_runtest_makereport` to every report's longrepr and captured-output sections whatever the outcome (so `-rA` / `-rP` output for passed tests too) and by one on `pytest_collectreport` to collection errors:

1. **Environment values.** Every value present in this process's environment, 16 characters or longer, is replaced with `[REDACTED-ENV-VALUE]`, whole and per whitespace-separated chunk (pprint splits a long value across lines, so the token half of `Authorization: Bearer <token>` survived a whole-value replace). Values are noted at the moment they are written: `os._Environ.__setitem__` and `os.putenv` are wrapped once, idempotently, so a value set inside `mock.patch.dict` and gone before the assertion is still caught; samples at import, around each test and at report time cover values that entered another way (inherited, written by a C extension). Path-valued shell names (`PWD`, `HOME`, `PATH`, `XDG_*`, `TMPDIR`, `ROMP_DIR`, `ROMP_STATE_DIR`, `CLAUDE_CONFIG_DIR`, `ROMP_SYSTEMD_DIR`, `TMUX_TMPDIR`, ...) are exempt by name, never when the name is credential-shaped.
2. **Credential-shaped tokens** (`tests/credential_patterns.py`), by pattern whatever their provenance: public key prefixes (`sk-ant-`, `sk-or-`, `sk-proj-`, `hf_`, `AIza`, `rpa_`), a JWT by its shape, and a generic long-token rule where a value sits, including pytest's own renderings of a failed comparison (diff lines under the `E` marker, the quoted operands of `assert a == b`, `--showlocals` lines, `+ where` / `+ and` lines, container reprs, unittest's `Lists differ`) and the fragments pytest ellipsizes or unittest shortens with `[N chars]`. Replacement is `[REDACTED-CREDENTIAL]`. The scrub is linear: heads are bounded (`CUT_HEAD_MAX`, `JWT_HEADER_MAX`) and runs are matched atomically through a lookahead and a backreference, so no possessive quantifier is needed and Python 3.10 stays supported; a 200 KB adversarial line scrubs in about 2 s.

## Two costs to know about

- **A process-wide monkeypatch.** `os._Environ.__setitem__` and `os.putenv` are replaced for the pytest process (installed once; a second import stacks no wrapper). A test asserting identity of either would break; none does. Bytes keys and values are decoded with `os.fsdecode`; a non-str key is passed through unnoted.
- **A changed report becomes plain text.** A report the nets leave unchanged keeps pytest's own object and rendering; one they change becomes a plain `str` for that report only, without pytest's rich (coloured) rendering. Readability costs of the generic and fragment rules are pinned as measured ones: a uuid-shaped placeholder in a failed dict comparison, a digit-bearing test-method name in a value position, or a camelCase name against an ellipsis may show a marker; a single-case identifier or a Capitalised word does not.

## Tests

`tests/test_env_value_redaction.py` (39 tests): the rule and the replacement, write-time capture through every write path, the pattern cases including every pytest/unittest rendering above, the scrub-cost budget, the report shapes, and seven end-to-end subprocess pytest runs against a copy of the conftest with synthetic probes assembled at run time (a uuid behind `romp-test-fixture-`, or a public prefix joined to uuids; no literal in the file is a credential, so the repo's secret scan stays clean). The JWT end-to-end case runs its child with and without `CI` set, because pytest switches its truncation off under `running_on_ci`. Children point `TMPDIR` at their scratch dir, so the temp-root PR's run-end cleanliness holds even when a timeout kills a child before its unconfigure runs.

Red first: against the base conftest all 39 fail (the end-to-end probe value reaches the child's report; the unit classes find no hook functions). With the hook: 39 pass, and the full suite passes (7642 passed, 51 skipped, `-n 8`). The conftest source pins (`test_cli_scope_floor`, `test_state_isolation_order`, `test_model_catalog_floor`, `test_tempdir_hygiene`) still pass: the block is appended after the last fixture, so the AST pins still find the module-level set and the autouse fixture, and the state-isolation ratchet does not list the new module.

## Composition

Additive to the temp-root PR (different hooks: `makereport`/`collectreport` here, `sessionfinish`/`unconfigure` there; the import block gains `importlib.util`). Old-style `hookwrapper=True` is deliberate: it runs on pytest 7 through 9, where `wrapper=True` needs 8. Nothing is platform-specific (pure Python, pytest hooks, `os.putenv` / `os.environb`). The `assertNotIn` sites themselves are left as they are; converting them to name-only assertions is a separate small follow-up, and this hook is the net for any that stay.

One paragraph in `tests/README.md` states the rule beside the temp-dir and git ones.

Tier: fix (tests only, no behavior change; the docs tier is documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
