### PR TITLE
Panes: browser-side performance telemetry, client-diag.jsonl rotation, and romp perf client

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -660,6 +660,7 @@ For scripts / agents:
 EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
+    _romp_cmd "romp perf [--interval <s>|--json|log on|off]" - "Kernel performance counters as rates over two snapshots (pusher cycles, stage times, build cache hits, bytes sent, goal loads, judge passes, rss, cpu); --json one raw snapshot; log on|off flips the romp-perf stderr log without a restart"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp move <session> <dir>"   -           "Move an SDK session's working directory (its conversation follows; mid-turn it waits for the turn to end)"
@@ -843,6 +844,166 @@ for r in rows:
                                      r.get("backend") or "", r.get("dir") or ""))
 '
     exit 0
+fi
+
+# `romp perf [--interval <s>] [--json]` / `romp perf log on|off` — the kernel's performance counters
+# (GET /perf), read as RATES from two snapshots taken <s> seconds apart (default 10): pusher cycles and
+# wakes per second, cycle time percentiles, the share of cycle time per stage, CPU split between the
+# pusher thread, the judge threads and the rest of the process, build cache hits vs rebuilds, bytes
+# sent per slot kind, goal-store loads per second, judge passes, rss. It exists so an optimization can
+# be checked against the LIVE kernel after each restart without attaching a profiler. --json prints one
+# raw snapshot (the shape is documented on the kernel's _PerfStats). `log on|off` flips the romp-perf
+# stderr log (POST /perf): before this the log needed ROMP_PERF in the kernel's environment at start,
+# so turning it on meant a restart. Same contract as `sessions`: the token on stdin, a dead kernel
+# fails loudly, an unknown flag is refused. Two snapshots from different kernel processes (a restart
+# inside the window resets the counters) are refused rather than subtracted into negative rates.
+if [[ "${1:-}" == "perf" ]]; then
+    shift
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    _usage="usage: romp perf [--interval <s>] [--json] | romp perf log on|off"
+    # One kernel round trip: the body on stdout and 0 when the kernel answered 2xx. curl's -f folds a
+    # refused token (403) into the same exit as a dead kernel, and on a diagnostic verb that sends the
+    # user off to restart a kernel that is up and answering — so the status rides -w and is read here.
+    _perf_curl() {
+        local _out _code
+        _out="$(_romp_token_cfg | curl -s -m 10 --config - -w '\n%{http_code}' "$@")" \
+            || { echo "romp perf: kernel not reachable on :$_kport (is romp running?)" >&2; return 1; }
+        _code="${_out##*$'\n'}"
+        case "$_code" in
+            2??)     printf '%s' "${_out%$'\n'*}"; return 0 ;;
+            401|403) echo "romp perf: the kernel on :$_kport refused the serve token (HTTP $_code); is ROMP_KERNEL_PORT pointing at another kernel?" >&2; return 1 ;;
+            *)       echo "romp perf: the kernel on :$_kport answered HTTP $_code: ${_out%$'\n'*}" >&2; return 1 ;;
+        esac
+    }
+    if [[ "${1:-}" == "log" ]]; then
+        case "${2:-}" in
+            on)  _v=true ;;
+            off) _v=false ;;
+            *)   echo "$_usage" >&2; exit 2 ;;
+        esac
+        if [[ $# -gt 2 ]]; then echo "$_usage" >&2; exit 2; fi
+        _resp="$(_perf_curl -X POST "http://127.0.0.1:$_kport/perf" -H 'Content-Type: application/json' -d "{\"log\": $_v}")" || exit 1
+        if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+            # where the lines land: the manager's stderr goes to the journal under systemd and to
+            # $STATE/manager.log under launchd (bin/romp-service writes StandardErrorPath there)
+            if [[ "$(uname -s)" == "Darwin" ]]; then
+                _hint="tail -f ${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/manager.log | grep romp-perf"
+            else
+                _hint="journalctl --user -u romp-manager -f | grep romp-perf"
+            fi
+            echo "romp perf: log $2 (read it with: $_hint)"
+            exit 0
+        fi
+        echo "romp perf: refused — $_resp" >&2
+        exit 1
+    fi
+    _json=false; _ival=10
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) _json=true; shift ;;
+            --interval)
+                if [[ ! "${2:-}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then echo "$_usage" >&2; exit 2; fi
+                _ival="$2"; shift 2 ;;
+            --interval=*)
+                _ival="${1#--interval=}"
+                if [[ ! "$_ival" =~ ^[0-9]+([.][0-9]+)?$ ]]; then echo "$_usage" >&2; exit 2; fi
+                shift ;;
+            *) echo "$_usage" >&2; exit 2 ;;
+        esac
+    done
+    _a="$(_perf_curl "http://127.0.0.1:$_kport/perf")" || exit 1
+    if $_json; then
+        printf '%s\n' "$_a"
+        exit 0
+    fi
+    sleep "$_ival"
+    _b="$(_perf_curl "http://127.0.0.1:$_kport/perf")" || exit 1
+    python3 - "$_a" "$_b" <<'PY'
+import json, sys
+a, b = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+
+
+def g(d, *ks):
+    for k in ks:
+        d = d.get(k, {}) if isinstance(d, dict) else {}
+    return d if isinstance(d, (int, float)) else 0
+
+
+def dl(*ks):                      # delta of a counter between the two snapshots
+    return g(b, *ks) - g(a, *ks)
+
+
+if a.get("since") != b.get("since") or g(a, "process", "pid") != g(b, "process", "pid"):
+    # the counters live in the kernel process and start over with it: a subtraction across a
+    # restart is a page of negative rates that look like measurements
+    sys.stderr.write("romp perf: the kernel restarted during the window (pid %d -> %d), so the counters "
+                     "reset and there are no rates to print; run it again\n"
+                     % (g(a, "process", "pid"), g(b, "process", "pid")))
+    sys.exit(1)
+
+dt = max(g(b, "now") - g(a, "now"), 1e-9)
+cyc = dl("pusher", "cycles")
+cyc_ms = dl("pusher", "cycle_ms_sum")
+wakes = dl("pusher", "wakes")
+ev, bs = dl("pusher", "wakes_event"), dl("pusher", "wakes_backstop")
+cpu_proc = 100.0 * dl("process", "cpu_s") / dt
+cpu_pusher = 100.0 * dl("pusher", "cycle_cpu_ms_sum") / (dt * 1000.0)
+cpu_judge = 100.0 * dl("judge", "cpu_ms_sum") / (dt * 1000.0)
+up = int(g(b, "uptime_s"))
+
+
+def hms(sec):
+    h, m = divmod(sec // 60, 60)
+    return "%dh%02dm" % (h, m) if h else "%dm%02ds" % (m, sec % 60)
+
+
+def kb(n):                        # bytes over the window as a rate
+    return "%.0f KB/s" % (n / 1024.0 / dt) if n < 1024 * 1024 * dt else "%.1f MB/s" % (n / 1048576.0 / dt)
+
+
+def share(ms):                    # a stage's share of the window's cycle time
+    return "%3.0f%%" % (100.0 * ms / cyc_ms) if cyc_ms else "  -"
+
+
+print("romp perf: %.1f s window, kernel up %s, pid %d, romp-perf log %s"
+      % (dt, hms(up), g(b, "process", "pid"), "on" if b.get("log") else "off"))
+print("process   rss %d MB   threads %d   cpu %.1f%% of one core (pusher %.1f%%, judge %.1f%%, other %.1f%%)"
+      % (g(b, "process", "rss_kb") // 1024, g(b, "process", "threads"), cpu_proc, cpu_pusher, cpu_judge,
+         cpu_proc - cpu_pusher - cpu_judge))
+print("pusher    %.2f cycles/s   %.2f wakes/s (event %d, backstop %d)   busy %.0f%% of wall"
+      % (cyc / dt, wakes / dt, ev, bs, 100.0 * cyc_ms / (dt * 1000.0)))
+print("cycle ms  p50 %.0f   p90 %.0f   max %.0f (over the last %d cycles)   last %.0f"
+      % (g(b, "pusher", "cycle_ms_p50"), g(b, "pusher", "cycle_ms_p90"), g(b, "pusher", "cycle_ms_ring_max"),
+         g(b, "pusher", "ring_n"), g(b, "pusher", "cycle_ms_last")))
+st = {k: dl("stages_ms", k) for k in ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")}
+print("stages    jobs %s   push %s  (chat %s  feed %s  timeline %s  send %s)"
+      % tuple(share(st[k]) for k in ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")))
+parts = []
+for k in ("chat", "feed", "timeline"):
+    built, cached, ms = dl("builds", k, "built"), dl("builds", k, "cached"), dl("builds", k, "ms")
+    parts.append("%s %d built / %d cached%s" % (k, built, cached, (" (%.0f ms avg)" % (ms / built)) if built else ""))
+print("builds    " + "   ".join(parts))
+parts = []
+for kind in ("full", "delta", "deduped"):
+    slots = set((b.get("sends") or {}).get(kind, {})) | set((a.get("sends") or {}).get(kind, {}))
+    tot = sum(dl("sends", kind, sl, "bytes") for sl in slots)
+    top = sorted(slots, key=lambda sl: -dl("sends", kind, sl, "bytes"))[:3]
+    detail = "; ".join("%s %d frames %s" % (sl, dl("sends", kind, sl, "count"), kb(dl("sends", kind, sl, "bytes")))
+                       for sl in top if dl("sends", kind, sl, "count"))
+    parts.append("%s %s%s" % (kind, kb(tot), (" (%s)" % detail) if detail else ""))
+print("sends     " + "   ".join(parts))
+print("goals     %.1f loads/s   %.1f saves/s   %.1f writes/s"
+      % (dl("goals", "loads") / dt, dl("goals", "saves") / dt, dl("goals", "writes") / dt))
+jp = dl("judge", "passes")
+print("judge     %d passes (%.2f/s)   last %.0f ms   mean %s ms"
+      % (jp, jp / dt, g(b, "judge", "ms_last"), ("%.0f" % (dl("judge", "ms_sum") / jp)) if jp else "-"))
+paths = set(b.get("http") or {}) | set(a.get("http") or {})
+rows = sorted(((dl("http", pth, "count"), dl("http", pth, "ms"), pth) for pth in paths), reverse=True)
+rows = [r for r in rows if r[0]][:6]
+print("http      " + ("   ".join(("%s %d" % (pth, n)) if pth.endswith("/ws") else ("%s %d (%.1f ms avg)" % (pth, n, ms / n))
+                                 for n, ms, pth in rows) or "no requests in the window"))
+PY
+    exit $?
 fi
 
 # Fork a session into a NEW parallel one (the user 2026-08-19, via the lab workflow: per-stage

--- a/bin/romp
+++ b/bin/romp
@@ -661,6 +661,7 @@ EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
     _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp perf [--interval <s>|--json|log on|off]" - "Kernel performance counters as rates over two snapshots (pusher cycles, stage times, build cache hits, bytes sent, goal loads, judge passes, rss, cpu); --json one raw snapshot; log on|off flips the romp-perf stderr log without a restart"
+    _romp_cmd "romp perf client [--minutes <n>|--json]" - "Browser-side performance of the open dashboards (client-diag.jsonl, surface perf): handler ms/min by frame type with window p50/p90/p99 and max, main-thread-free p90, long animation frames and their attributed callbacks, the worst minute, heap and DOM, the slowest frames — per dashboard and pane over the last <n> minutes (default 10)"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp move <session> <dir>"   -           "Move an SDK session's working directory (its conversation follows; mid-turn it waits for the turn to end)"
@@ -860,7 +861,7 @@ fi
 if [[ "${1:-}" == "perf" ]]; then
     shift
     _kport="${ROMP_KERNEL_PORT:-29855}"
-    _usage="usage: romp perf [--interval <s>] [--json] | romp perf log on|off"
+    _usage="usage: romp perf [--interval <s>] [--json] | romp perf log on|off | romp perf client [--minutes <n>] [--json]"
     # One kernel round trip: the body on stdout and 0 when the kernel answered 2xx. curl's -f folds a
     # refused token (403) into the same exit as a dead kernel, and on a diagnostic verb that sends the
     # user off to restart a kernel that is up and answering — so the status rides -w and is read here.
@@ -896,6 +897,276 @@ if [[ "${1:-}" == "perf" ]]; then
         fi
         echo "romp perf: refused — $_resp" >&2
         exit 1
+    fi
+    # `romp perf client [--minutes <n>] [--json]` — the BROWSER side of the same question (2026-09-06): each
+    # pane that receives frames (feed, Outline, chat, timeline) posts one clientDiag row a
+    # minute (surface "perf", what "minute"; ui/webview/perf-telemetry.ts) with its frame counts and handler
+    # times by type (a log2 histogram per type, additive across minutes), the main-thread-free gap after a
+    # frame, the browser's long-animation-frame reports with the callbacks they name, heap and DOM size — plus
+    # a "slowframe" row the moment a frame's whole handling runs 100 ms or more, five a minute at most, the
+    # rest counted in the minute row. The kernel appends them to $STATE/client-diag.jsonl with the dashboard
+    # id (wid) and its clock, and rotates that file to .1 past 8 MB; this reads both, folds the last <n>
+    # minutes per dashboard and pane (window percentiles from the summed histograms, the worst minute, the
+    # slowest frames) and prints one screen. No kernel round trip: the files are read directly, so it works
+    # with the kernel down. An absent file or one with no perf rows is said plainly: the bundles predate the
+    # telemetry, or no dashboard has been open since.
+    if [[ "${1:-}" == "client" ]]; then
+        shift
+        _cusage="usage: romp perf client [--minutes <n>] [--json]"
+        _cjson=false; _cmin=10
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --json) _cjson=true; shift ;;
+                --minutes)
+                    if [[ ! "${2:-}" =~ ^[0-9]+$ || "${2:-0}" -eq 0 ]]; then echo "$_cusage" >&2; exit 2; fi
+                    _cmin="$2"; shift 2 ;;
+                --minutes=*)
+                    _cmin="${1#--minutes=}"
+                    if [[ ! "$_cmin" =~ ^[0-9]+$ || "$_cmin" -eq 0 ]]; then echo "$_cusage" >&2; exit 2; fi
+                    shift ;;
+                *) echo "$_cusage" >&2; exit 2 ;;
+            esac
+        done
+        _cfile="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/client-diag.jsonl"
+        python3 - "$_cfile" "$_cmin" "$_cjson" <<'PY'
+import json, math, os, sys, time
+path, minutes, as_json = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "true"
+RELOAD = "no browser telemetry yet: rebuild the bundles and reload the dashboard"
+EDGES = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]   # perf-telemetry.ts HIST_EDGES: bucket i is [EDGES[i-1], EDGES[i])
+NBUCKETS = len(EDGES) + 1
+TYPES_SHOWN, SLOW_SHOWN = 8, 5
+older = path + ".1"                        # the kernel rotates the file past its size cap; the previous run is .1
+now = time.time()
+cutoff = now - minutes * 60
+rows, newest, files = [], 0, []
+for fp in (older, path):
+    try:
+        f = open(fp, encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        continue                            # never written, or the kernel is renaming it this instant: the next run sees it
+    files.append(fp)
+    with f:
+        for line in f:
+            if '"perf"' not in line:        # cheap prefilter: the file also holds the shim's and the panes' breadcrumbs
+                continue
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(r, dict) or r.get("surface") != "perf" or not isinstance(r.get("data"), dict):
+                continue
+            t = r.get("t") or 0
+            newest = max(newest, t)
+            if t >= cutoff:
+                rows.append(r)
+if not files:
+    sys.stderr.write("romp perf client: %s (%s does not exist)\n" % (RELOAD, path))
+    sys.exit(1)
+shown = path + (" and .1" if older in files else "")
+if not newest:
+    sys.stderr.write("romp perf client: %s (%s has no surface \"perf\" rows)\n" % (RELOAD, shown))
+    sys.exit(1)
+if not rows:
+    sys.stderr.write("romp perf client: no browser telemetry in the last %d min (the newest perf row is %d min old); "
+                     "is a dashboard open? (--minutes to widen the window)\n" % (minutes, (now - newest) // 60))
+    sys.exit(1)
+
+groups = {}                                 # (dashboard id, pane app) -> its minute rows and slowframe rows
+for r in rows:
+    key = ((str(r.get("wid") or ""))[:8] or "-", str(r["data"].get("app") or "?"))
+    g = groups.setdefault(key, {"minute": [], "slow": []})
+    if r.get("what") == "minute":
+        g["minute"].append(r)
+    elif r.get("what") == "slowframe":
+        g["slow"].append(r)
+
+
+def num(d, k, default=0.0):
+    v = d.get(k) if isinstance(d, dict) else None
+    return float(v) if isinstance(v, (int, float)) else default
+
+
+def hist_of(st):
+    h = st.get("hist") if isinstance(st, dict) else None
+    if isinstance(h, list) and len(h) == NBUCKETS and all(isinstance(x, (int, float)) for x in h):
+        return [int(x) for x in h]
+    return [0] * NBUCKETS
+
+
+def hist_q(h, q):                           # nearest-rank quantile of a histogram -> its bucket index; -1 when empty
+    total = sum(h)
+    if not total:
+        return -1
+    rank = min(total, max(1, math.ceil(q * total)))
+    cum = 0
+    for i, c in enumerate(h):
+        cum += c
+        if cum >= rank:
+            return i
+    return NBUCKETS - 1
+
+
+def edge_label(i):                          # the bucket's upper bound, the figure a percentile is printed as
+    if i < 0:
+        return "-"
+    if i >= len(EDGES):
+        return ">=%d" % EDGES[-1]
+    return "<%d" % EDGES[i]
+
+
+def edge_num(i):                            # the same for --json: the exclusive upper edge, None for empty or the top bucket
+    return EDGES[i] if 0 <= i < len(EDGES) else None
+
+
+def clock(t):
+    return time.strftime("%H:%M:%S", time.localtime(t))
+
+
+def span(m):                                # a minute's span on the clock: its start (the browser's since) to the kernel's receipt of its row
+    s = m.get("since")
+    return (clock(s / 1000.0) + "-" if isinstance(s, (int, float)) and s > 0 else "ending ") + clock(m["t"])
+
+
+panes = []
+for (wid, app), g in sorted(groups.items()):
+    mins = sorted(g["minute"], key=lambda r: r.get("t") or 0)
+    span_min = sum(num(r["data"], "span_ms") for r in mins) / 60000.0
+    if span_min <= 0:
+        span_min = float(len(mins))
+    rate_min = max(span_min, 1.0 / 60)
+    frames, free_p90, loaf_n, blocking, worst, top, top_inv, srcs = {}, None, 0, 0.0, 0.0, {}, {}, set()
+    per_minute, slow_suppressed, slow_suppressed_worst = [], 0, 0.0
+    for r in mins:
+        d = r["data"]
+        total_ms = 0.0
+        for typ, st in (d.get("frames") or {}).items():
+            if not isinstance(st, dict):
+                continue
+            f = frames.setdefault(str(typ), {"n": 0, "ms_sum": 0.0, "max": 0.0, "n16": 0, "n100": 0, "hist": [0] * NBUCKETS})
+            f["n"] += int(num(st, "n"))
+            f["ms_sum"] += num(st, "ms_sum")
+            f["max"] = max(f["max"], num(st, "ms_max"))
+            f["n16"] += int(num(st, "n16"))
+            f["n100"] += int(num(st, "n100"))
+            for i, c in enumerate(hist_of(st)):
+                f["hist"][i] += c
+            total_ms += num(st, "ms_sum")
+        fr = d.get("free")
+        if isinstance(fr, dict) and num(fr, "n"):
+            free_p90 = max(free_p90 or 0.0, num(fr, "p90"))
+        lo = d.get("loaf") or {}
+        lo_n, lo_block = 0, 0.0
+        if isinstance(lo, dict):
+            lo_n, lo_block = int(num(lo, "n")), num(lo, "blocking_ms")
+            loaf_n += lo_n
+            blocking += lo_block
+            worst = max(worst, num(lo, "worst_ms"))
+            srcs.add(str(lo.get("src") or "none"))
+            for tp in lo.get("top") or []:
+                if isinstance(tp, dict) and tp.get("k"):
+                    top[str(tp["k"])] = top.get(str(tp["k"]), 0.0) + num(tp, "ms")
+                    if tp.get("inv"):
+                        top_inv[str(tp["k"])] = str(tp["inv"])
+        sl = d.get("slow")
+        if isinstance(sl, dict):
+            slow_suppressed += int(num(sl, "suppressed"))
+            slow_suppressed_worst = max(slow_suppressed_worst, num(sl, "suppressed_worst_ms"))
+        per_minute.append({"t": r.get("t") or 0, "since": d.get("since"), "total_ms": round(total_ms, 1),
+                           "loaf_n": lo_n, "blocking_ms": round(lo_block, 1), "frames": d.get("frames") or {}})
+    for f in frames.values():
+        f["per_min"] = f["n"] / rate_min
+        f["ms_per_min"] = f["ms_sum"] / rate_min
+        for q, k in ((0.5, "p50"), (0.9, "p90"), (0.99, "p99")):
+            f[k + "_bucket"] = hist_q(f["hist"], q)
+            f[k + "_lt"] = edge_num(f[k + "_bucket"])
+    total_ms_all = sum(f["ms_sum"] for f in frames.values())
+    worst_minute = max(per_minute, key=lambda m: m["total_ms"]) if per_minute else None
+    last = mins[-1]["data"] if mins else {}
+    slow = []
+    for r in g["slow"]:
+        d = r["data"]
+        lo = d.get("loaf") if isinstance(d.get("loaf"), dict) else None
+        slow.append({"t": r.get("t") or 0, "type": str(d.get("type") or "?"), "ms": num(d, "ms"), "dom": d.get("dom"),
+                     "loaf": [{"k": str(tp.get("k")), "ms": num(tp, "ms")} for tp in (lo or {}).get("top") or [] if isinstance(tp, dict)]})
+    slow.sort(key=lambda sl: -sl["ms"])
+    panes.append({
+        "wid": wid, "app": app, "ua": str(last.get("ua") or "?"), "minutes": round(span_min, 1), "rows": len(mins),
+        "total_ms_per_min": total_ms_all / rate_min, "frames": frames, "free_p90": free_p90,
+        "loaf": {"per_min": loaf_n / rate_min, "blocking_ms_per_min": blocking / rate_min, "worst_ms": worst,
+                 "src": "loaf" if "loaf" in srcs else ("longtask" if "longtask" in srcs else "none")},
+        "top": [{"k": k, "ms": ms, "inv": top_inv.get(k, "")} for k, ms in sorted(top.items(), key=lambda kv: -kv[1])[:5]],
+        "minutes_detail": [{k: m[k] for k in ("t", "since", "total_ms", "loaf_n", "blocking_ms")} for m in per_minute],
+        "worst_minute": worst_minute,
+        "heap_mb": last.get("heap_mb"), "dom": last.get("dom"),
+        "visible": last.get("visible"), "hidden_pane": last.get("hidden_pane"),
+        "slow": slow, "slow_suppressed": slow_suppressed, "slow_suppressed_worst_ms": slow_suppressed_worst,
+    })
+
+if as_json:
+    for p in panes:
+        p["minutes_detail"] = p.pop("minutes_detail")
+        if p["worst_minute"]:
+            p["worst_minute"] = {k: p["worst_minute"][k] for k in ("t", "since", "total_ms", "loaf_n", "blocking_ms")}
+    print(json.dumps({"window_min": minutes, "path": path, "files": files, "panes": panes}, indent=1, sort_keys=True))
+    sys.exit(0)
+
+n_slow = sum(len(p["slow"]) for p in panes)
+n_dash = len({p["wid"] for p in panes})
+print("romp perf client: browser telemetry from the last %d min (%s): %d dashboard%s, %d pane%s, %d minute row%s, %d slow frame row%s"
+      % (minutes, shown, n_dash, "" if n_dash == 1 else "s", len(panes), "" if len(panes) == 1 else "s",
+         len(rows) - n_slow, "" if len(rows) - n_slow == 1 else "s", n_slow, "" if n_slow == 1 else "s"))
+print("handler time is the pane's own, by frame type (fed:<type> is the federation layer's share, additive with the pane's);\n"
+      "percentiles are histogram bucket upper bounds over the window; attribution names the callback the browser ran;\n"
+      "heap and DOM are the last sample's")
+for p in panes:
+    if p["visible"] is False:
+        vis = "hidden"
+    elif p["hidden_pane"]:
+        vis = "hidden (no viewport)"
+    else:
+        vis = "visible"
+    heap = ("heap %.1f MB" % p["heap_mb"]) if isinstance(p["heap_mb"], (int, float)) else "heap n/a"
+    dom = ("dom %d" % p["dom"]) if isinstance(p["dom"], (int, float)) else "dom n/a"
+    print("dashboard %s · %s   %s   %g min reported   %s   %s   %s" % (p["wid"], p["app"], p["ua"], p["minutes"], heap, dom, vis))
+    fl = sorted(p["frames"].items(), key=lambda kv: -kv[1]["ms_sum"])
+    print("  handler      %.0f ms/min total" % p["total_ms_per_min"] if fl else "  handler      no frames")
+    for t, f in fl[:TYPES_SHOWN]:
+        print("    %-12s %6.1f/min %6.0f ms/min   p50 %s   p90 %s   p99 %s ms   max %.0f   >16.7 ms %.0f%%   >=100 ms %.0f%%"
+              % (t, f["per_min"], f["ms_per_min"], edge_label(f["p50_bucket"]), edge_label(f["p90_bucket"]), edge_label(f["p99_bucket"]),
+                 f["max"], 100.0 * f["n16"] / f["n"] if f["n"] else 0.0, 100.0 * f["n100"] / f["n"] if f["n"] else 0.0))
+    if len(fl) > TYPES_SHOWN:
+        print("    and %d more type%s" % (len(fl) - TYPES_SHOWN, "" if len(fl) - TYPES_SHOWN == 1 else "s"))
+    # each minute row's free p90 is over that minute's samples; the fold keeps the largest, so this is the worst
+    # minute's figure, not a window percentile like the handler columns
+    free = ("free after a frame, worst minute's p90 %.0f ms" % p["free_p90"]) if p["free_p90"] is not None else "free after a frame p90 n/a"
+    lo = p["loaf"]
+    if lo["src"] == "none":
+        longf = "long frames: not reported by this browser"
+    else:
+        longf = "long frames %.1f/min   blocking %.0f ms/min   worst %.0f ms" % (lo["per_min"], lo["blocking_ms_per_min"], lo["worst_ms"])
+        if lo["src"] == "longtask":
+            longf += " (longtask: no attribution)"
+    print("  main thread  %s   %s" % (free, longf))
+    print("  attribution  " + ("   ".join("%s %.0f ms%s" % (t["k"], t["ms"], (" (%s)" % t["inv"]) if t["inv"] else "") for t in p["top"]) or "none"))
+    wm = p["worst_minute"]
+    if wm:
+        wf = sorted(((typ, st) for typ, st in wm["frames"].items() if isinstance(st, dict)), key=lambda kv: -num(kv[1], "ms_sum"))[:3]
+        parts = ["%s %d (p90 %s ms, max %.0f)" % (typ, int(num(st, "n")), edge_label(hist_q(hist_of(st), 0.9)), num(st, "ms_max")) for typ, st in wf]
+        print("  worst minute %s   %.0f ms handler   %s   long frames %d, blocking %.0f ms"
+              % (span(wm), wm["total_ms"], "   ".join(parts) or "no frames", wm["loaf_n"], wm["blocking_ms"]))
+    if p["slow"] or p["slow_suppressed"]:
+        for sl in p["slow"][:SLOW_SHOWN]:
+            dom_s = (" (dom %d)" % sl["dom"]) if isinstance(sl["dom"], (int, float)) else ""
+            attr = ("  " + "  ".join("%s %.0f ms" % (a["k"], a["ms"]) for a in sl["loaf"])) if sl["loaf"] else ""
+            print("  slow frames  %s %s %.0f ms%s%s" % (clock(sl["t"]), sl["type"], sl["ms"], dom_s, attr))
+        more = max(0, len(p["slow"]) - SLOW_SHOWN) + p["slow_suppressed"]
+        if more:
+            print("               and %d more%s" % (more, (" (%d not sent by the pane past its per-minute cap; worst %.0f ms)"
+                                                          % (p["slow_suppressed"], p["slow_suppressed_worst_ms"])) if p["slow_suppressed"] else ""))
+    else:
+        print("  slow frames  none")
+PY
+        exit $?
     fi
     _json=false; _ival=10
     while [[ $# -gt 0 ]]; do

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -77,13 +77,14 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   push did; and a row in the dashboard's bell (at most five drop rows, none older
   than an hour, so they never crowd out a backend problem). Every close the
   browser reports for a socket that opened leaves a `wsclose` breadcrumb (code,
-  reason, socket age) in `client-diag.jsonl`; a socket the shim abandons leaves
-  none — the watchdog's own `watchdog-close` row went down the quiet socket
-  before the abandon (the foreground path's abandon sends none, but its `return`
-  row queues for the redial), so an armed socket's raise, `reconnect-quiet` or
-  `foreground-quiet`, queued for the redial, is the record that survives; the
-  redials an outage refuses are counted and reported as one `wsconnfail` row on
-  the next open, and at most 20 breadcrumbs wait in the shim's queue for it.
+  reason, socket age) in `client-diag.jsonl` (rotated to `.1` at 8 MB); a socket
+  the shim abandons leaves none — the watchdog's own `watchdog-close` row went
+  down the quiet socket before the abandon (the foreground path's abandon sends
+  none, but its `return` row queues for the redial), so an armed socket's raise,
+  `reconnect-quiet` or `foreground-quiet`, queued for the redial, is the record
+  that survives; the redials an outage refuses are counted and reported as one
+  `wsconnfail` row on the next open, and at most 20 breadcrumbs wait in the
+  shim's queue for it.
   Every return to the tab leaves its own rows: `return` with the decision
   (`keep`, `redial-closed` or `redial-stale`) and the hidden, frozen and quiet
   gaps, `return-fresh` with the wait for the first fresh frame, and `page-load`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -692,7 +692,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 
 - `now`, `since`, `uptime_s`, `log`: the clock, when the counters started,
   seconds since the process started, and whether the `romp-perf` log is on.
-- `process`: `rss_kb`, `threads`, `cpu_s`, `pid`.
+- `process`: `rss_kb` (resident set size in KB: the current size on Linux,
+  read from `/proc`; the peak, `ru_maxrss`, on macOS, which has no `/proc`),
+  `threads`, `cpu_s`, `pid`.
 - `pusher`: `cycles`, `wakes` (every wake call; a burst of wakes runs one
   cycle), `wakes_event` and `wakes_backstop` (how the loop's wait ended),
   `cycle_ms_sum`, `cycle_ms_max` (since start), `cycle_ms_last`,
@@ -713,7 +715,7 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   per-session worker they run; the workers' share is `cpu_ms_workers`).
 - `http`: request `count` and `ms` per `METHOD /path` for GET, POST, HEAD and
   OPTIONS, the query string removed and `/dist/*`, `/media/*` and
-  `/remote/*/…` collapsed to one key each, for at most 64 keys; further keys
+  `/remote/*/…` collapsed to one key each, for at most 256 keys; further keys
   fold into `other`. A WebSocket upgrade is counted when it arrives and not
   timed, since its handler runs for the life of the socket.
 
@@ -732,10 +734,15 @@ frames it received is measured in the panes themselves, by
 `ui/webview/perf-telemetry.ts`:
 
 - The feed, Outline and chat bundles wrap their window `message` handler, so
-  each frame's synchronous handling time is recorded by frame type (`feed`,
-  `chatTail`, `session`, `tabOrder`, `bars`, a shell message as `shell`, a raw
-  delta as `delta:<slot>`, anything else as `other`; frames the handler ignores
-  count too). The federation layer, which every kernel page loads, times its
+  each frame's synchronous handling time is recorded by frame type: the
+  frame's `type` string as it is (`feed`, `chatTail`, `session`, `tabOrder`,
+  `bars`, or any other type that is a short identifier: letters, digits,
+  `_ . : -`, at most 32 characters), a raw delta as `delta:<slot>`
+  (`delta:other` when the slot is not such an identifier), a shell message (a
+  `romp` field and no `type`) as `shell`, and `other` for a frame with
+  neither, a `type` that is not a short identifier, or any type past the 32
+  distinct types a minute the pane tracks; frames the handler ignores count
+  too. The federation layer, which every kernel page loads, times its
   own prefixing, delta application and merge of each frame as `fed:<type>`,
   nested outside the pane's handler; each level records its own time, so
   `fed:feed` and `feed` add up to the frame's cost. The timeline's listener is
@@ -761,8 +768,9 @@ frames it received is measured in the panes themselves, by
   function, so a key is `<file>:<function>@<character position>`
   (`feed.js:render@1200`, `feed.js:(anonymous)@48213`), and an inline page
   script (the pane shim, whose socket callback runs for every frame) is
-  `page:<function>@<position>`. The release build keeps identifiers so a key
-  means the same thing after a rebuild; whitespace and syntax are still
+  `page:<function>@<position>`. The release build keeps identifiers, which
+  keeps the function name in a key readable across rebuilds (the position
+  still moves with any edit to the bundle); whitespace and syntax are still
   minified.
 - Once a minute the pane posts ONE `clientDiag` row on the socket it already
   uses for breadcrumbs, only when something happened that minute (a frame

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,6 +33,7 @@ These are for scripting and for agents rather than daily use:
 |---|---|
 | `romp url` | Print only the tokened dashboard URL, for piping |
 | `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
+| `romp perf [--interval <s>] [--json]`, `romp perf log on\|off` | The kernel's performance counters as rates over two snapshots (below); `--json` prints one raw snapshot; `log on\|off` turns the `romp-perf` stderr log on or off without a restart |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}` — a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
 | `romp new --env NAME=VALUE <name>` | A per-session env var for the SDK session, repeatable; a re-run against a running `<name>` replaces the whole set — vars not re-named are dropped |
@@ -667,6 +668,61 @@ reason); when the scopes were wanted on Linux and the box cannot provide them
 also appears in the dashboard's error center, since every session then runs
 inside the service cgroup. The macOS launchd path is unchanged: there is no cgroup kill there,
 and the tmux server keeps its launchd lineage.
+
+## Kernel performance counters
+
+`GET /perf` returns one JSON document of counters the kernel keeps at all
+times: what its pusher, judge and HTTP threads have done since the process
+started. The route takes the serve token. The counters cost a lock and a few
+dictionary increments per event, so they stay on; nothing is formatted or
+serialized until a request reads them. `romp perf` takes two snapshots
+`--interval` seconds apart (default 10) and prints the difference as rates on
+one screen: pusher cycles and wakes per second, cycle time percentiles, the
+share of cycle time in each stage, CPU split between the pusher thread, the
+judge threads and the rest of the process, builds served from cache against
+rebuilds, bytes sent per slot as full frames, deltas and deduplicated frames,
+goal-store loads and writes per second, judge passes and their durations,
+memory and thread count. `romp perf --json` prints one raw snapshot. If the
+kernel restarted between the two snapshots the counters have started over, so
+the command says so and exits non-zero instead of printing negative rates; a
+refused token is reported as such, not as a dead kernel.
+
+The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
+
+- `now`, `since`, `uptime_s`, `log`: the clock, when the counters started,
+  seconds since the process started, and whether the `romp-perf` log is on.
+- `process`: `rss_kb`, `threads`, `cpu_s`, `pid`.
+- `pusher`: `cycles`, `wakes` (every wake call; a burst of wakes runs one
+  cycle), `wakes_event` and `wakes_backstop` (how the loop's wait ended),
+  `cycle_ms_sum`, `cycle_ms_max` (since start), `cycle_ms_last`,
+  `cycle_cpu_ms_sum` (the pusher thread's own CPU time), and `cycle_ms_p50`,
+  `cycle_ms_p90`, `cycle_ms_ring_max`, `ring_n` from the last 256 cycles.
+- `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
+  inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
+  `push.*` stages count every push, including the one a connecting page gets,
+  so they can add up to more than `push`.
+- `builds`: `chat`, `feed`, `timeline`, each with `cached`, `built`, `ms`.
+- `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
+  `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
+  was built and compared, then not sent.
+- `goals`: `loads`, `saves`, `writes` on the goal stores. A save that would
+  rewrite identical bytes is a save without a write.
+- `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
+  on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
+  per-session worker they run; the workers' share is `cpu_ms_workers`).
+- `http`: request `count` and `ms` per `METHOD /path` for GET, POST, HEAD and
+  OPTIONS, the query string removed and `/dist/*`, `/media/*` and
+  `/remote/*/…` collapsed to one key each, for at most 64 keys; further keys
+  fold into `other`. A WebSocket upgrade is counted when it arrives and not
+  timed, since its handler runs for the life of the socket.
+
+`POST /perf` with the body `{"log": true}` or `{"log": false}` turns the
+`romp-perf` stderr log on or off in the running kernel (`romp perf log on|off`).
+The log prints one line per chat build and per frame sent or deduplicated. It
+goes where the manager's stderr goes: under systemd, `journalctl --user -u
+romp-manager -f | grep romp-perf`; under launchd (macOS), `tail -f
+~/.local/state/romp/manager.log | grep romp-perf`. Setting `ROMP_PERF=1` in the
+kernel's environment still turns it on at start.
 
 ## Where things live
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,7 @@ These are for scripting and for agents rather than daily use:
 | `romp url` | Print only the tokened dashboard URL, for piping |
 | `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
 | `romp perf [--interval <s>] [--json]`, `romp perf log on\|off` | The kernel's performance counters as rates over two snapshots (below); `--json` prints one raw snapshot; `log on\|off` turns the `romp-perf` stderr log on or off without a restart |
+| `romp perf client [--minutes <n>] [--json]` | What the open dashboards' browsers spent on the frames they received (below): handler milliseconds per minute by frame type with window p50/p90/p99 and max, the worst minute's main-thread-free p90, long animation frames and their attributed callbacks, the worst minute, heap and DOM, the slowest frames — per dashboard and pane over the last `<n>` minutes (default 10) |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}` — a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
 | `romp new --env NAME=VALUE <name>` | A per-session env var for the SDK session, repeatable; a re-run against a running `<name>` replaces the whole set — vars not re-named are dropped |
@@ -723,6 +724,117 @@ goes where the manager's stderr goes: under systemd, `journalctl --user -u
 romp-manager -f | grep romp-perf`; under launchd (macOS), `tail -f
 ~/.local/state/romp/manager.log | grep romp-perf`. Setting `ROMP_PERF=1` in the
 kernel's environment still turns it on at start.
+
+## Browser-side performance telemetry
+
+The counters above say what the kernel spent. What the browser spent on the
+frames it received is measured in the panes themselves, by
+`ui/webview/perf-telemetry.ts`:
+
+- The feed, Outline and chat bundles wrap their window `message` handler, so
+  each frame's synchronous handling time is recorded by frame type (`feed`,
+  `chatTail`, `session`, `tabOrder`, `bars`, a shell message as `shell`, a raw
+  delta as `delta:<slot>`, anything else as `other`; frames the handler ignores
+  count too). The federation layer, which every kernel page loads, times its
+  own prefixing, delta application and merge of each frame as `fed:<type>`,
+  nested outside the pane's handler; each level records its own time, so
+  `fed:feed` and `feed` add up to the frame's cost. The timeline's listener is
+  wrapped the same way on both hosts (the VS Code bundle directly; the kernel
+  page's inline boot through the `window.__rompPerf` that `federation.js`
+  publishes before it runs), so `data`, `bars`, `hover`, `activeChat`,
+  `revealEvent` and `models` are timed like any pane's frames.
+- Per type and minute: count, summed and maximum handler time, the exact
+  number of frames over 16.7 ms (one dropped frame at 60 Hz) and at or over
+  100 ms, and a 14-bucket log2 histogram (under 1 ms, 1-2, 2-4, ..., 2048-4096,
+  4096 and over) that is additive across minutes, so `romp perf client`
+  computes window percentiles from it.
+- Two `requestAnimationFrame` callbacks after the outermost handler it records
+  how long the main thread stayed busy with the work the handler queued (a
+  deferred render, layout, paint). A hidden document or a pane the shell has
+  set to `display:none` takes no sample, and a sample armed before such a hide
+  is cancelled (on `visibilitychange`, or on the `resize` that takes the
+  pane's viewport to zero).
+- A `PerformanceObserver` on `long-animation-frame` entries (Chrome 123+;
+  `longtask` where that is missing, with no attribution) records each frame
+  over 50 ms with its blocking time and the scripts the browser attributes it
+  to. The browser names the top-level callback it invoked, not the hottest
+  function, so a key is `<file>:<function>@<character position>`
+  (`feed.js:render@1200`, `feed.js:(anonymous)@48213`), and an inline page
+  script (the pane shim, whose socket callback runs for every frame) is
+  `page:<function>@<position>`. The release build keeps identifiers so a key
+  means the same thing after a rebuild; whitespace and syntax are still
+  minified.
+- Once a minute the pane posts ONE `clientDiag` row on the socket it already
+  uses for breadcrumbs, only when something happened that minute (a frame
+  arrived or a long frame was observed); the kernel appends it to
+  `client-diag.jsonl` under the state directory with the dashboard id (`wid`)
+  and its own clock. A frame whose whole synchronous handling ran 100 ms or
+  more also posts a `slowframe` row at once, carrying the long-frame
+  attribution when the browser reports one for that frame; at most five such
+  rows a minute per pane, the rest counted in the minute row.
+- The kernel rotates `client-diag.jsonl` once it reaches 8 MB: the file
+  becomes `client-diag.jsonl.1` (replacing the previous one) and a new file
+  starts, so at most two files, about 16 MB, are kept. A minute row is about
+  1 KB, so one open dashboard writes a few MB a day.
+
+Rows carry numbers and code identifiers only, never card text, session names,
+file paths or transcript content: an element id inside an invoker name is
+stripped (`DIV#tab-web.onclick` is recorded as `DIV.onclick`), an element
+source as `[src]`, and a script URL as its basename.
+
+The two rows, as the kernel writes them (`t` its clock, `wid` the dashboard id):
+
+- `{"t", "wid", "surface": "perf", "what": "minute", "data": {app, since,
+  span_ms, frames: {<type>: {n, ms_sum, ms_max, n16, n100, hist}}, free: {n,
+  p50, p90, max} | null, loaf: {n, blocking_ms, worst_ms, top: [{k, ms, n,
+  inv}], src}, slow: {sent, suppressed, suppressed_worst_ms}, heap_mb?, dom,
+  visible, hidden_pane, ua}}`. `app` is the pane (`chat`, `feed`, `fleet`,
+  `timeline`); `since` is the minute's start on the browser's clock (epoch ms)
+  and `span_ms` its length (shorter than a minute when the page was
+  hidden or closed); `hist` is the 14 bucket counts; `free` is null when no
+  sample was taken; `loaf.top` is the five largest keys by summed duration,
+  `inv` the last invoker seen for each (`WebSocket.onmessage`,
+  `Window.requestAnimationFrame`, `DIV.onclick`), `src` is `loaf`, `longtask`
+  or `none`; `slow` counts the slowframe rows sent and the slow frames past
+  the cap, with the worst of those; `heap_mb` is
+  `performance.memory.usedJSHeapSize` and is absent outside Chrome; `dom` is
+  the element count; `visible` is the document's visibility, `hidden_pane`
+  the zero-viewport test the pane shim uses for a pane the shell has set to
+  `display:none`; `ua` is `chrome-desktop`, `safari-ios` or `other`.
+- `{"t", "wid", "surface": "perf", "what": "slowframe", "data": {app, type, ms,
+  dom, loaf?: {ms, blocking_ms, top: [{k, ms, inv}]}}}`. `type` is the frame
+  as received on the wire and `ms` its whole synchronous handling, the
+  federation layer included.
+
+`romp perf client [--minutes <n>] [--json]` reads the file and its `.1`
+predecessor (no kernel round trip, so it works with the kernel down) and folds
+the last `<n>` minutes (default 10) per dashboard id and pane into one screen:
+the pane's total handler milliseconds per minute, then each frame type sorted
+by its share, with frames per minute, milliseconds per minute, p50/p90/p99 as
+histogram bucket upper bounds over the whole window, the maximum, and the
+share of frames over 16.7 ms and at or over 100 ms; the worst minute's
+main-thread-free p90 (each minute row's p90 is over that minute's samples, and
+the screen shows the largest, so it is not a window percentile like the handler
+columns); long frames and blocking milliseconds per minute with the worst
+entry; the top attributed keys with their invokers; the worst minute (the one
+with the most handler time: its span from the minute's start to the row's
+arrival at the kernel, frame counts and long frames); heap and DOM at the last
+sample; and the five slowest slow frames in the window with their attribution,
+plus how many more there were. An absent file or one without perf rows is
+reported as no browser telemetry yet (the bundles predate it or no dashboard
+has loaded them: rebuild the bundles and reload the dashboard); perf rows all
+older than the window are reported with their age. `--json` prints the folded
+panes, with a per-minute array (`t`, `since`, `total_ms`, `loaf_n`,
+`blocking_ms`) so a spike is visible without re-reading the file.
+
+In DevTools, `window.__rompPerf.snapshot()` in a pane's frame is the minute
+in progress in the same shape, plus a derived `p90_le` per type, `active`
+(whether it will be sent), `observer` (`loaf`, `longtask`, `none`),
+`pending_slow` (slow frames waiting for their long-frame report) and
+`free_pending` (a main-thread sample armed). A page without `performance.now`
+(the node test stand-ins) gets no telemetry and an unwrapped handler; every
+other browser API is behind a feature check, and nothing in the module throws
+into the pane.
 
 ## Where things live
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -18,6 +18,44 @@ from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+
+# ── the judge workers' CPU, for the kernel's GET /perf ─────────────────────────────────────────────
+# Every tier fans its per-session work (parses, store loads, the model call's framing) out through a
+# ThreadPoolExecutor, so the tier thread's own CPU says little about what the judges cost; the
+# workers' does. _TimedPool wraps each submitted callable with a time.thread_time() delta into one
+# counter, and the name below rebinds so every `ThreadPoolExecutor(...)` in this module builds the
+# timed pool without touching the dozen pool sites. A worker blocked on a model call adds nothing:
+# thread_time is CPU, not wall.
+_JUDGE_CPU = {"worker_ms": 0.0}
+_JUDGE_CPU_LOCK = threading.Lock()
+
+
+def _judge_cpu_add(cpu_s):
+    with _JUDGE_CPU_LOCK:
+        _JUDGE_CPU["worker_ms"] += cpu_s * 1000.0
+
+
+def judge_worker_cpu_ms():
+    """CPU milliseconds spent so far in this module's pool workers (every future any tier submitted)."""
+    with _JUDGE_CPU_LOCK:
+        return _JUDGE_CPU["worker_ms"]
+
+
+class _TimedPool(ThreadPoolExecutor):
+    """ThreadPoolExecutor whose submitted callables account their CPU to _JUDGE_CPU."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        def run():
+            c0 = time.thread_time()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _judge_cpu_add(time.thread_time() - c0)
+        return super().submit(run)
+
+
+ThreadPoolExecutor = _TimedPool      # every pool below is a timed one (see above)
+
 HERE = Path(__file__).resolve().parent
 em = SourceFileLoader("romp_event_model", str(HERE / "event_model.py")).load_module()
 _keysrc = sys.modules.get("romp_keysource") or SourceFileLoader(
@@ -3004,6 +3042,27 @@ def _guard_nodes(store):
     return store
 
 
+# ── goal-store I/O counters (the kernel's GET /perf reads them through goal_io_stats) ─────────────
+# How often the stores are read and written is the first question when the kernel is busy: every
+# judge stage, the feed build and the nudge tick load stores, so the load rate says whether a change
+# added a pass over every session. Plain counters, one lock, no formatting on the path.
+_GOAL_IO = {"loads": 0, "saves": 0, "writes": 0}
+_GOAL_IO_LOCK = threading.Lock()
+
+
+def _goal_io_bump(key):
+    with _GOAL_IO_LOCK:
+        _GOAL_IO[key] += 1
+
+
+def goal_io_stats():
+    """A copy of the goal-store I/O counters: load_goals calls (`loads`), save_goals calls (`saves`),
+    and the saves that wrote a file (`writes`; save_goals skips a byte-identical republish). The
+    counters stay private to this module; readers get a copy."""
+    with _GOAL_IO_LOCK:
+        return dict(_GOAL_IO)
+
+
 def _quarantine_store(path, reason, st):
     """Move an unparseable store file ASIDE (never delete it) so the evidence survives the fresh start
     that follows. The sidecar keeps the original name plus `.corrupt-<utc stamp>`, so the `*.json` globs
@@ -3087,6 +3146,7 @@ def _read_store_json(path, *, quarantine=False, _tries=3):
 
 
 def load_goals(fsid):
+    _goal_io_bump("loads")
     raw = _read_store_json(GOALDIR / (fsid + ".json"), quarantine=True)
     if raw is None:
         # a FRESH store is born at the current identity version — only stores with history recorded
@@ -3613,6 +3673,7 @@ def save_goals(fsid, store):
     fleet forever. Skipping is safe precisely BECAUSE nothing changed: we have no events to contribute, so
     declining to publish can neither lose our work nor clobber a concurrent writer's. `rev` does not advance
     on a no-op, which is the honest reading of a counter that means "publications"."""
+    _goal_io_bump("saves")
     GOALDIR.mkdir(parents=True, exist_ok=True)
     if "_baseRev" in store and _matches_disk(fsid, store):
         return                                       # nothing of ours to publish → leave the file (and its
@@ -3627,6 +3688,7 @@ def save_goals(fsid, store):
         store["rev"] = _disk_rev(fsid) + 1
     else:
         store["rev"] = int(store.get("rev") or 0) + 1
+    _goal_io_bump("writes")
     tmp = _publish_tmp(GOALDIR, fsid)
     tmp.write_text(json.dumps(store))
     tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -924,6 +924,30 @@ def _version_info():
             "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
 
+# client-diag.jsonl held rare breadcrumbs (a wsclose, a stale-banner raise) until the pane bundles began posting
+# a performance row per pane per active minute (ui/webview/perf-telemetry.ts, 2026-09-06): about 1 KB each, so
+# an open dashboard adds several MB a day and nothing pruned it. Past this many bytes the file is renamed to
+# client-diag.jsonl.1 (replacing the previous .1) and a new file starts, so at most two files, about 16 MB,
+# are ever kept; `romp perf client` reads both. Checked on every append: one stat, under one lock.
+CLIENT_DIAG_MAX_BYTES = 8 * 1024 * 1024
+_client_diag_lock = threading.Lock()
+
+
+def _client_diag_append(fp, line):
+    """Append one row to client-diag.jsonl, rotating it first once it is at the cap. One lock across the size
+    check, the rename and the write: every pane's socket is its own handler thread, so rows arrive
+    concurrently, and two threads finding the file at the cap at once would both rename, the second moving
+    the file the first had just started over the run the first had just rotated, and that run was gone."""
+    with _client_diag_lock:
+        try:
+            if fp.stat().st_size >= CLIENT_DIAG_MAX_BYTES:
+                os.replace(str(fp), str(fp) + ".1")
+        except OSError:
+            pass   # no file yet (fresh state) or a failed rename: the append below still goes to the current file
+        with open(fp, "a", encoding="utf-8") as f:
+            f.write(line)
+
+
 def _dist_ver():
     """A cache-bust token = the newest mtime across the built bundles (dist/*.js + *.css). Appended as
     `?v=<token>` to every <script>/<link> URL so a rebuilt bundle gets a NEW url → the browser is
@@ -34173,7 +34197,10 @@ if(!P.createDiv)P.createDiv=function(o){return this.createEl('div',o);};
 if(!P.createSpan)P.createSpan=function(o){return this.createEl('span',o);};})();
 (function(){var api=window.acquireVsCodeApi(),panel=null;
 function post(m){api.postMessage(m);}
-window.addEventListener("message",function(ev){var m=ev.data;if(!m||!panel)return;
+// the frame listener, wrapped like every pane's through the page's performance collector when there is one
+// (ui/webview/perf-telemetry.ts, published on window.__rompPerf by federation.js, which loads before this boot),
+// so each frame's handling is timed by type; without a collector the plain listener
+var onFrame=function(ev){var m=ev.data;if(!m||!panel)return;
 if(m.type==="data")panel.update(m.data);
 else if(m.type==="bars"&&panel.applyBars)panel.applyBars(m);
 else if(m.type==="activeChat"&&panel.setActiveChat)panel.setActiveChat(m.activeChat);
@@ -34184,7 +34211,8 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
 else if(m.type==="models"&&panel.refreshModels)panel.refreshModels();
 else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
-else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);});
+else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);};
+window.addEventListener("message",(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)?window.__rompPerf.wrapFrameHandler(onFrame):onFrame);
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
 post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined,anchorT:Number(q.get("anchorT"))||undefined,anchorKind:q.get("anchorKind")||undefined,compose:q.get("compose")==="1"});
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};
@@ -39788,8 +39816,9 @@ class Handler(BaseHTTPRequestHandler):
                 rec = {"t": int(time.time()), "wid": str(client.get("wid") or ""),
                        "surface": str(msg.get("surface") or ""), "what": str(msg.get("what") or ""),
                        "data": msg.get("data")}
-                with open(jd.STATE / "client-diag.jsonl", "a", encoding="utf-8") as f:
-                    f.write(json.dumps(rec) + "\n")
+                # past the size cap the file becomes .1 and a new one starts; the check, rename and write are one
+                # locked step, since every pane's socket posts from its own handler thread
+                _client_diag_append(jd.STATE / "client-diag.jsonl", json.dumps(rec) + "\n")
             except OSError:
                 pass
         elif msg and msg.get("type") == "orderAudit":

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
@@ -134,6 +134,287 @@ def _perf_slot(key):
         return str(key)
     except Exception:
         return "?"
+
+
+def _set_perf_log(on):
+    """Turn the `romp-perf` stderr log on or off while the kernel runs (POST /perf {"log": bool}; `romp
+    perf log on|off`). ROMP_PERF still seeds the value at import. Before this the only way to turn the
+    log on was a restart with the variable set, and on a machine whose sessions run inside this kernel
+    a restart cuts every open turn. `_perf` keeps reading the module global, so the off path costs what
+    it always did: one name lookup and a return."""
+    global _PERF
+    _PERF = bool(on)
+    return _PERF
+
+
+def _process_stats():
+    """rss_kb, thread count, CPU seconds and pid for the /perf snapshot. VmRSS from /proc is the CURRENT
+    resident size; where /proc is absent (macOS) ru_maxrss is the PEAK, in bytes there, so it is scaled
+    to KB and the field is still called rss_kb."""
+    rss = 0
+    try:
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1])
+                    break
+    except Exception:
+        try:
+            import resource
+            r = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            rss = int(r // 1024) if sys.platform == "darwin" else int(r)
+        except Exception:
+            rss = 0
+    return {"rss_kb": rss, "threads": threading.active_count(), "cpu_s": time.process_time(),
+            "pid": os.getpid()}
+
+
+class _PerfStats:
+    """Always-on counters behind GET /perf (`romp perf`): where the kernel's threads spend their time,
+    kept cheap enough to leave running. Every writer takes the lock and does a few dict operations;
+    none formats, serializes or reads a clock on the caller's behalf (callers pass time.monotonic()
+    deltas in seconds). snapshot() does the only real work, the percentiles and the process reads,
+    once per HTTP request on the handler's thread.
+
+    The ROMP_PERF log answers "what happened on that one push"; these answer "what is the kernel doing
+    per second" and let two snapshots N seconds apart give rates, which is how an optimization is
+    checked against the live kernel after a restart without attaching a profiler.
+
+    snapshot() shape — every value a plain number or a flat dict of numbers; `ms` fields are
+    milliseconds of wall time, `*_s` seconds:
+      now, since, uptime_s, log    clock; when the counters started (a restart resets them); seconds
+                                   since the process started; whether the romp-perf stderr log is on
+      process                      rss_kb, threads, cpu_s (time.process_time), pid
+      pusher                       cycles (one per _pusher_cycle), wakes (every _pusher_wake.set()
+                                   call; a burst coalesces into one cycle), wakes_event /
+                                   wakes_backstop (how the loop's wait ended: flag set, or the 0.5 s
+                                   timeout), cycle_ms_sum / cycle_ms_max (since start) /
+                                   cycle_ms_last, cycle_cpu_ms_sum (the pusher thread's own CPU,
+                                   time.thread_time, so a forked tmux read is excluded), and
+                                   cycle_ms_p50 / cycle_ms_p90 / cycle_ms_ring_max / ring_n from a
+                                   ring of the last RING cycle durations
+      stages_ms                    jobs: the cycle's tick jobs outside _push_all; push: _push_all as
+                                   the cycle calls it; push.chat (the tab strip, the build_session
+                                   loop and the chat sends), push.feed (the view signature,
+                                   _cached_feed and the ledgers attach), push.timeline (the skeleton
+                                   and _cached_timeline), push.send (the feed/bars serialization and
+                                   sends). The push.* stages are measured inside _push for EVERY
+                                   caller, connect pushes on handler threads included, so their sum
+                                   can exceed `push`
+      builds                       chat / feed / timeline -> {cached, built, ms}: served from the
+                                   build cache vs rebuilt, and the rebuild time
+      sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
+                                   name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
+                                   under "other"). A deduped frame was built and compared, not sent
+      goals                        loads, saves, writes: judge.load_goals calls, save_goals calls,
+                                   and the saves that reached the disk (a byte-identical republish
+                                   is a save without a write)
+      judge                        passes (one per _producer pass), ms_sum / ms_last / ms_mean (wall:
+                                   a pass is a join over the tier threads, so this is mostly model
+                                   latency), cpu_ms_sum (CPU: the two tier threads' own time, from
+                                   _run_tier, plus every per-session worker the tiers run in
+                                   judge.py's thread pools; the split rides as cpu_ms_workers)
+      http                         "METHOD /path" -> {count, ms}, the query string stripped and the
+                                   path normalized by _perf_http_key (/dist/*, /media/*,
+                                   /remote/*/…), at most HTTP_PATHS keys with the rest folded into
+                                   "other" (so a scanner cannot grow it, and a static file or a host
+                                   name never takes a slot or appears in the output). A WebSocket
+                                   upgrade (a path ending in /ws) is counted when it ARRIVES and adds
+                                   no ms: its handler returns when the socket closes, which is a
+                                   connection's lifetime, not a request's."""
+    RING = 256
+    HTTP_PATHS = 64
+    SLOTS = 32
+    STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
+    BUILDS = ("chat", "feed", "timeline")
+    SEND_KINDS = ("full", "delta", "deduped")
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.reset()
+
+    def reset(self):
+        with self.lock:
+            self.since = time.time()
+            self.pusher = {"cycles": 0, "wakes": 0, "wakes_event": 0, "wakes_backstop": 0,
+                           "cycle_ms_sum": 0.0, "cycle_ms_max": 0.0, "cycle_ms_last": 0.0,
+                           "cycle_cpu_ms_sum": 0.0}
+            self.ring = collections.deque(maxlen=self.RING)
+            self.stages = {k: 0.0 for k in self.STAGES}
+            self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
+            self.sends = {k: {} for k in self.SEND_KINDS}
+            self.judge = {"passes": 0, "ms_sum": 0.0, "ms_last": 0.0, "cpu_ms_sum": 0.0}
+            self.http = {}
+
+    # ── writers (hot paths) ──
+    def wake(self):
+        with self.lock:
+            self.pusher["wakes"] += 1
+
+    def wake_kind(self, by_event):
+        with self.lock:
+            self.pusher["wakes_event" if by_event else "wakes_backstop"] += 1
+
+    def cycle(self, dt, cpu_dt=0.0):
+        """dt: the cycle's wall seconds; cpu_dt: the pusher thread's own CPU seconds over it."""
+        ms = dt * 1000.0
+        with self.lock:
+            p = self.pusher
+            p["cycles"] += 1
+            p["cycle_ms_sum"] += ms
+            p["cycle_ms_last"] = ms
+            p["cycle_cpu_ms_sum"] += cpu_dt * 1000.0
+            if ms > p["cycle_ms_max"]:
+                p["cycle_ms_max"] = ms
+            self.ring.append(ms)
+
+    def stage(self, name, dt):
+        with self.lock:
+            self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
+
+    def build(self, kind, cached, dt=0.0):
+        with self.lock:
+            b = self.builds[kind]
+            if cached:
+                b["cached"] += 1
+            else:
+                b["built"] += 1
+                b["ms"] += dt * 1000.0
+
+    def send(self, key, kind, nbytes):
+        slot = key[0] if isinstance(key, tuple) else key
+        with self.lock:
+            d = self.sends[kind]
+            e = d.get(slot)
+            if e is None:
+                if len(d) >= self.SLOTS:
+                    slot = "other"
+                    e = d.get(slot)
+                if e is None:
+                    e = d[slot] = [0, 0]
+            e[0] += 1
+            e[1] += nbytes
+
+    def judge_pass(self, dt):
+        ms = dt * 1000.0
+        with self.lock:
+            j = self.judge
+            j["passes"] += 1
+            j["ms_sum"] += ms
+            j["ms_last"] = ms
+
+    def judge_cpu(self, cpu_dt):
+        """A judge tier thread's own CPU seconds for one tier run (_run_tier)."""
+        with self.lock:
+            self.judge["cpu_ms_sum"] += cpu_dt * 1000.0
+
+    def http_request(self, path, dt):
+        """dt None: count the request, add no time (the WebSocket upgrade case)."""
+        with self.lock:
+            e = self.http.get(path)
+            if e is None:
+                if len(self.http) >= self.HTTP_PATHS:
+                    path = "other"
+                    e = self.http.get(path)
+                if e is None:
+                    e = self.http[path] = [0, 0.0]
+            e[0] += 1
+            if dt is not None:
+                e[1] += dt * 1000.0
+
+    # ── the reader ──
+    @staticmethod
+    def _pct(sorted_ms, q):
+        n = len(sorted_ms)
+        return sorted_ms[min(n - 1, int(q * n))] if n else 0.0
+
+    def snapshot(self):
+        with self.lock:
+            ring = sorted(self.ring)
+            pusher = dict(self.pusher)
+            stages = dict(self.stages)
+            builds = {k: dict(v) for k, v in self.builds.items()}
+            sends = {k: {sl: {"count": e[0], "bytes": e[1]} for sl, e in d.items()}
+                     for k, d in self.sends.items()}
+            judge = dict(self.judge)
+            http = {pth: {"count": e[0], "ms": e[1]} for pth, e in self.http.items()}
+            since = self.since
+        pusher["ring_n"] = len(ring)
+        pusher["cycle_ms_p50"] = self._pct(ring, 0.5)
+        pusher["cycle_ms_p90"] = self._pct(ring, 0.9)
+        pusher["cycle_ms_ring_max"] = ring[-1] if ring else 0.0
+        judge["ms_mean"] = (judge["ms_sum"] / judge["passes"]) if judge["passes"] else 0.0
+        try:
+            workers = float(jd.judge_worker_cpu_ms())
+        except Exception:
+            workers = 0.0
+        judge["cpu_ms_workers"] = workers
+        judge["cpu_ms_sum"] += workers                     # tier threads + their pool workers
+        try:
+            goals = jd.goal_io_stats()
+        except Exception:
+            goals = {}
+        now = time.time()
+        return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
+                "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
+                "builds": builds, "sends": sends, "goals": goals, "judge": judge, "http": http}
+
+
+_PERF_STATS = _PerfStats()
+
+
+class _CountedEvent(threading.Event):
+    """A threading.Event whose set() also counts in _PERF_STATS: the pusher's wake. Counting at the
+    event keeps every existing call site as it is, including the bound-method callbacks
+    (`push=_pusher_wake.set`) the backends hold and the tests that pin `_pusher_wake.set()` in the
+    source."""
+
+    def set(self):
+        _PERF_STATS.wake()
+        super().set()
+
+
+def _perf_http_key(method, path):
+    """The `http` counter key for one request: "METHOD /path" with the query string gone and the
+    high-cardinality families collapsed — /dist/* and /media/* (the bundles, fonts, icons and source
+    maps a dashboard loads: dozens of names that would otherwise fill the HTTP_PATHS slots before a
+    script's first /sessions call) and /remote/<host>/… (a host name per attached kernel; a tailnet
+    host name is not something `romp perf` should print). The route table's fixed paths stay as they
+    are, so GET /perf and POST /perf are separate rows."""
+    if path.startswith("/dist/"):
+        path = "/dist/*"
+    elif path.startswith("/media/"):
+        path = "/media/*"
+    elif path.startswith("/remote/"):
+        rest = path[len("/remote/"):]
+        i = rest.find("/")
+        path = "/remote/*" + (rest[i:] if i >= 0 else "")
+    return (method + " " + path) if method else path
+
+
+def _perf_http_timed(fn):
+    """Wrap a Handler.do_* method: count the request and its wall ms in _PERF_STATS under
+    _perf_http_key(method, path). A WebSocket upgrade (a path ending in /ws) is counted when it arrives
+    and not timed: its do_GET returns when the socket closes, so a count taken then would lag by the
+    connection's lifetime and its duration would not be a request's. functools.wraps keeps
+    inspect.getsource on the real route table, which the auth tests read."""
+    @functools.wraps(fn)
+    def timed(self):
+        try:
+            path = str(getattr(self, "path", "") or "").split("?", 1)[0]
+            key = _perf_http_key(str(getattr(self, "command", "") or ""), path)
+            is_ws = path.endswith("/ws")
+        except Exception:
+            key, is_ws = "other", False
+        if is_ws:
+            _PERF_STATS.http_request(key, None)
+            return fn(self)
+        t0 = time.monotonic()
+        try:
+            return fn(self)
+        finally:
+            _PERF_STATS.http_request(key, time.monotonic() - t0)
+    return timed
 
 
 # ── host-suspend (laptop sleep) awareness ─────────────────────────────────────────────────────────
@@ -30049,7 +30330,8 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
             frame["coll"][name] = entry; changed = True
     if not changed:
         if now - st.get("at", 0) < _DEDUP_REPOST_S:    # unchanged: nothing to send (the repost keeps the fade alive)
-            return
+            _PERF_STATS.send(key, "deduped", len(pre))   # built and compared, not sent — the same fact
+            return                                         # _send_client's dedup records for a whole-frame client
     s = json.dumps(frame, default=str)
     if len(s) >= _DELTA_MAX_FRACTION * len(pre):       # not worth a delta → the full frame, rebased
         states.pop(ftype, None)
@@ -30057,6 +30339,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
         _send_slot(c, ftype, payload, pre, sig)
         return
     _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0, delta=1)
+    _PERF_STATS.send(key, "delta", len(s))
     if not _client_send(c, s, key):
         return
     st["rev"] += 1; st["rest"] = rest_sig; st["at"] = now
@@ -30066,7 +30349,7 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig):
     c.setdefault("sent", {})[key] = (sig, now)          # the dedup slot follows, so a later full send dedups honestly
 
 
-def _send_client(c, key, msg, pre=None, sig=None):
+def _send_client(c, key, msg, pre=None, sig=None, kind="full"):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
     `pre` is the already-serialized msg (json.dumps(msg)) when the caller has it cached — passing it lets
@@ -30082,7 +30365,10 @@ def _send_client(c, key, msg, pre=None, sig=None):
     ROMP_PERF=1 logs every send AND every dedup hit. That asymmetry is the point: a payload carrying a
     field that ticks with the clock looks perfectly normal from the outside — the UI just feels slow —
     and the only visible symptom is this dedup never hitting. Finding the last one took a hand-written
-    WebSocket client; the log makes the next one obvious."""
+    WebSocket client; the log makes the next one obvious.
+
+    `kind` is the /perf sends class the frame is counted under when it goes: "full" (the default: a
+    whole frame) or "delta" for a caller whose frame is a suffix or a diff (_send_chat's chatTail)."""
     s = pre if pre is not None else json.dumps(msg)
     sig = sig if sig is not None else _dedup_sig(msg, s)
     with _client_lock(c):    # the dedup dict is shared with the handler thread's `ready`
@@ -30090,9 +30376,11 @@ def _send_client(c, key, msg, pre=None, sig=None):
         now = time.time()
         if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
             _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
+            _PERF_STATS.send(key, "deduped", len(s))
             return
         c["sent"][key] = (sig, now)
         _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
+        _PERF_STATS.send(key, kind, len(s))
         _client_send(c, s, key)                       # enqueue only (never blocks): the lock is held for microseconds
 
 
@@ -30136,7 +30424,7 @@ def _send_chat_locked(c, m, ms, change_from, led_changed):
                 "events": evs[change_from:], "total": total, "status": m.get("status")}
         if led_changed:                               # the TOC only changed on a judge pass → usually omitted
             tail["ledger"] = m.get("ledger")
-        _send_client(c, ("chat", sid), tail)
+        _send_client(c, ("chat", sid), tail, kind="delta")   # the chat's delta form, for /perf's sends split
         st[sid] = (pc[0], pc[1])                       # same tail base, now caught up through `total`
         return ms
     head_from = max(0, total - WIRE_TAIL)
@@ -31660,6 +31948,7 @@ def _push(targets, connect=False, tmux=None):
         # The FEED's per-session Fleet ledger slice still rides along, attached AFTER the builds (want_chat —
         # we do NOT build all sessions just for a feed/fleet push: the user 2026-06-24 slow-load regression).
         chat_sessions = []
+        _t_stage = time.monotonic()                      # /perf stage clock: chat, then feed, then timeline
         if want_chat or want_fleet:   # the fleet needs every session's ledger slice (built below, attached to feed)
             # TABS-FIRST (the user 2026-06-26): ship name+color per tab so the client can paint the WHOLE strip
             # as placeholders up front (no tab popping in one-by-one as each build_session lands). The full
@@ -31695,6 +31984,7 @@ def _push(targets, connect=False, tmux=None):
                     m, ms, asig, started = hit[1], hit[2], hit[3], hit[4]   # unchanged → reuse, no reshape/serialize
                     _VIEW_STATS["chatServeActive" if is_active else "chatServeBg"] += 1
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
+                    _PERF_STATS.build("chat", True)
                 else:
                     _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
                     started = time.time()                # the _views_dirty floor for this build (start-keyed)
@@ -31710,12 +32000,15 @@ def _push(targets, connect=False, tmux=None):
                     # The ACTIVE tab skips the cache above by design, so this build is what the watched
                     # session pays on every single push. If chat ever feels slow again, this number and
                     # the deduped= on the matching send say which half is at fault.
-                    _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
-                          ms=round((time.monotonic() - _t0) * 1000, 1),
-                          events=(len(m.get("events") or []) if m else 0),
-                          fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
-                          prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
-                          why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
+                    _dt = time.monotonic() - _t0
+                    _PERF_STATS.build("chat", False, _dt)
+                    if _PERF:                            # the keyword values below cost lookups; skip them when off
+                        _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
+                              ms=round(_dt * 1000, 1),
+                              events=(len(m.get("events") or []) if m else 0),
+                              fold=_chat_fold_last_info().get("fold", 0), k=_chat_fold_last_info().get("k", 0),
+                              prefix=_chat_fold_last_info().get("prefix", 0),   # events reused from the sealed prefix
+                              why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
                 if not m:
                     continue
                 _note_chat_divergence(s["sid"], m.get("name") or "",
@@ -31776,6 +32069,8 @@ def _push(targets, connect=False, tmux=None):
             # OPEN SUBAGENT VIEWERS (plans/subagent-transcripts.md): each rides its own per-client dedup slot
             # like the comment frames, rebuilt only when the agent's file or liveness moved.
             _push_subagents(chat_clients, now, tmux)
+        _PERF_STATS.stage("push.chat", time.monotonic() - _t_stage)
+        _t_stage = time.monotonic()
         fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
         feed_src = _cached_feed(now, tmux, fsig, connect) if want_feed else None
         feed = feed_src
@@ -31806,6 +32101,8 @@ def _push(targets, connect=False, tmux=None):
         # LIVE-FIRST (the user 2026-06-26): the very first paint after a kernel start reads NO dead session — it
         # builds live sessions only (lanes + bars) so the main UI is up at once; the producer warms the full
         # build (live + dead-within-12h) and the next pusher push folds the dead lanes in, in the background.
+        _PERF_STATS.stage("push.feed", time.monotonic() - _t_stage)
+        _t_stage = time.monotonic()
         timeline = None
         tl_warming = False
         if want_tl:
@@ -31821,6 +32118,7 @@ def _push(targets, connect=False, tmux=None):
                 #                                                     "no activity"; a later warmed push (tl_warming False) settles it (the user 2026-07-03)
             else:
                 timeline = _cached_timeline(now, tmux, fsig, connect)
+        _PERF_STATS.stage("push.timeline", time.monotonic() - _t_stage)
     except Exception:
         sys.stderr.write("push build: %s\n" % traceback.format_exc())
         return
@@ -31836,6 +32134,7 @@ def _push(targets, connect=False, tmux=None):
     # moved — dict == is C-speed and allocation-free, far cheaper than re-serializing).
     global _feed_wire, _bars_wire
     feed_ms = feed_sig = bars = bars_ms = bars_sig = None
+    _t_stage = time.monotonic()
     for c in targets:
         if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
             if feed_ms is None:
@@ -31859,6 +32158,7 @@ def _push(targets, connect=False, tmux=None):
                     bars_sig = _dedup_sig(bars, bars_ms)
                     _bars_wire = (timeline, tl_warming, bars, bars_ms, bars_sig)
             _send_slot(c, "bars", bars, bars_ms, bars_sig)
+    _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
@@ -31984,7 +32284,7 @@ _producer_wake = threading.Event()
 # Same idea for the CHAT PUSHER: the SDK live-tail (and any caller) sets this to push the chat NOW
 # instead of waiting out the 4s poll — the SDK stream leads the transcript on disk, so an immediate push
 # of the in-memory live atoms makes messages appear instantly. 4s stays as the backstop.
-_pusher_wake = threading.Event()
+_pusher_wake = _CountedEvent()      # a threading.Event; set() also counts the wake for /perf
 # The last kernel-side OPTIMISTIC mutation (a parked-op chip, a follow-up card reopen, a model-pending
 # stamp, an interrupt click): state that lives in MEMORY or a goal store, which NO file-mtime signature
 # sees. _cached_feed/_cached_timeline must rebuild past this mark — even inside REBUILD_MIN_S and even on
@@ -32186,11 +32486,14 @@ def _cached_feed(now, tmux, sig, connect=False):
     dirty = not connect and _views_dirty[0] > e[3]        # connect still serves the warmed build (never rebuilds)
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         _VIEW_STATS["feedServe"] += 1
+        _PERF_STATS.build("feed", True)
         return e[1]
     _VIEW_STATS["feedBuild"] += 1
     bid = _next_feed_build_id()          # claimed BEFORE the read, so an ack issued during this build outranks it
     started = time.time()                # …and the dirty floor for the NEXT check: mutations after this
+    _t0 = time.monotonic()
     feed = build_feed(now, tmux)         # instant may be invisible to the build below → must rebuild
+    _PERF_STATS.build("feed", False, time.monotonic() - _t0)
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
@@ -32898,21 +33201,29 @@ def _cached_timeline(now, tmux, sig, connect=False):
     dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         _VIEW_STATS["tlServe"] += 1
+        _PERF_STATS.build("timeline", True)
         return e[1]
     _VIEW_STATS["tlBuild"] += 1
     started = time.time()
+    _t0 = time.monotonic()
     tl = build_timeline(now, tmux)
+    _PERF_STATS.build("timeline", False, time.monotonic() - _t0)
     _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
 
 
 def _run_tier(fn):
     """Run one judge tier (run_index / run_triage) in its own thread, logging a crash instead of letting
-    the thread die silently (the per-session futures inside already swallow + log their own errors)."""
+    the thread die silently (the per-session futures inside already swallow + log their own errors).
+    The thread's own CPU over the run goes to /perf's judge.cpu_ms_sum; the per-session workers the
+    tier runs in judge.py's pools account for theirs there (judge_worker_cpu_ms)."""
+    _c0 = time.thread_time()
     try:
         fn()
     except Exception:
         sys.stderr.write("producer tier: %s\n" % traceback.format_exc())
+    finally:
+        _PERF_STATS.judge_cpu(time.thread_time() - _c0)
 
 
 def _producer():
@@ -32925,6 +33236,7 @@ def _producer():
         _prev_wall, _prev_mono = _nw, _nm
         _producer_wake.clear()   # consume; a /tick arriving DURING this pass re-sets it → we run again (no lost wake)
         _own_frame = False       # set once the pass frame opens; the finally below can then never leak it
+        _t_pass = time.monotonic()
         try:
             # Two tiers, run in PARALLEL (the user 2026-06-17) — they share no store and triage never
             # reads the captioner's output, so the only cost of overlap is each tier parsing a transcript
@@ -32988,6 +33300,7 @@ def _producer():
         finally:
             _end_goals_pass()      # safety net: never leave a pass's snapshot stuck if the pass raised mid-flight
             jd.end_pass_frame(_own_frame)   # …nor the evidence frame (idempotent with the normal-path end above)
+            _PERF_STATS.judge_pass(time.monotonic() - _t_pass)
         # Event-driven: wake the instant a hook pokes /tick (turn ended / prompt landed / postal msg)
         # instead of waiting out the backstop. The 3s is only a BACKSTOP — for changes we don't get poked
         # for (e.g. a segment closing mid-turn) and a safety net if a poke is ever missed. A pass is cheap
@@ -33010,6 +33323,8 @@ def _pusher_cycle():
     design; they now all receive the same one, taken once at cycle start. The jobs tolerate the
     few-hundred-ms staleness by construction — they always saw a snapshot aged by however many jobs
     ran before them."""
+    _t_cycle = time.monotonic()
+    _c_cycle = time.thread_time()           # this thread's CPU: the wall above includes the tmux fork and lock waits
     with _clients_lock:
         any_client = bool(_clients)
     now = int(time.time())
@@ -33030,9 +33345,12 @@ def _pusher_cycle():
         _live_scope.snapshot = None
         _live_scope.names = None
         _live_scope.paths = None
+        _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle)
 
 
 def _pusher_cycle_jobs(now, tmux, any_client):
+    _t_jobs = time.monotonic()            # /perf: this function minus the _push_all below is the `jobs` stage
+    _t_push = 0.0
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
         _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
         #                                   the parked-parse refresh runs inside, per sid, after the
@@ -33040,7 +33358,12 @@ def _pusher_cycle_jobs(now, tmux, any_client):
     except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
         sys.stderr.write("pending-ops: %s\n" % traceback.format_exc())   # never behind a judge pass (2026-09-03)
     if any_client:
-        _push_all(tmux=tmux)
+        _t_push = time.monotonic()
+        try:
+            _push_all(tmux=tmux)
+        finally:
+            _t_push = time.monotonic() - _t_push
+            _PERF_STATS.stage("push", _t_push)
     try:                                  # the turn-finished push (bell popover): AFTER the feed build above,
         _turn_notify_tick(now, tmux)      # so a bell event the same settle produced files its buzz first
     except Exception:
@@ -33104,6 +33427,7 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _clear_done_working_notes(now, tmux)
     except Exception:
         sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
+    _PERF_STATS.stage("jobs", (time.monotonic() - _t_jobs) - _t_push)
 
 
 def _pusher():
@@ -33113,8 +33437,9 @@ def _pusher():
         # poll, so tmux sessions — which have no per-message event for mid-turn streaming — still refresh
         # responsively as the model generates, instead of waiting out a multi-second tick (the user 2026-06-22).
         # Cheap when nothing changed: _parse is cached and _send_client dedups, so a no-change poll sends nothing.
-        _pusher_wake.wait(0.5)
+        _woke = _pusher_wake.wait(0.5)    # True: the flag was set (an event); False: the backstop timed out
         _pusher_wake.clear()
+        _PERF_STATS.wake_kind(_woke)
 
 
 # ───────────────────────── HTTP / page serving ─────────────────────────
@@ -37294,6 +37619,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.wfile.write(chunk)
                 remaining -= len(chunk)
 
+    @_perf_http_timed
     def do_OPTIONS(self):
         """CORS preflight. The strip's tunnel actions POST JSON (Content-Type:
         application/json is not a 'simple' request, so the webview's browser asks
@@ -37313,6 +37639,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Max-Age", "86400")
         self.end_headers()
 
+    @_perf_http_timed
     def do_HEAD(self):
         # HEAD exists for ONE route: /file (the preview existence probe). Without this the base handler
         # 501s every HEAD, which the client would read as "gone" and hide a live chip.
@@ -37343,6 +37670,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    @_perf_http_timed
     def do_GET(self):
         u = urlparse(self.path)
         p = u.path
@@ -37455,6 +37783,8 @@ class Handler(BaseHTTPRequestHandler):
                 if (q.get("threads") or [""])[0] == "1":       # opt-in: comment-thread rows for the postal
                     rows = rows + _thread_rows()               # bus (the user 2026-08-22); every existing
                 return self._send(200, json.dumps(rows), "application/json", cache="no-cache")   # consumer unchanged
+            if p == "/perf":                                  # the kernel's performance counters (`romp perf`); shape: _PerfStats
+                return self._send(200, json.dumps(_PERF_STATS.snapshot()), "application/json", cache="no-cache")
             if p == "/commands":                              # slash-command list for the composer's "/" autocomplete (SDK get_server_info, per-cwd cached)
                 sid = (q.get("sid") or [""])[0]
                 cmds, warming = _commands_for_cwd(_cwd_of(sid) if sid else "")
@@ -37774,6 +38104,7 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    @_perf_http_timed
     def do_POST(self):
         u = urlparse(self.path)
         q = parse_qs(u.query)
@@ -38052,6 +38383,21 @@ class Handler(BaseHTTPRequestHandler):
                 _producer_wake.set()
                 _pusher_wake.set()
                 return self._send(200, json.dumps({"ok": True, "woke": True}), "application/json")
+            if u.path == "/perf":
+                # The runtime switch for the romp-perf stderr log: {"log": true|false} (`romp perf log
+                # on|off`). The log used to need ROMP_PERF in the process environment at start, so turning
+                # it on meant a kernel restart, which cuts every open turn on a machine whose sessions run
+                # inside this kernel. The counters GET /perf serves are always on and need no switch.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = None
+                if not isinstance(b, dict) or not isinstance(b.get("log"), bool):
+                    return self._send(400, json.dumps({"ok": False, "error": 'body must be {"log": true|false}'}),
+                                      "application/json")
+                _set_perf_log(b["log"])
+                sys.stderr.write("romp-perf: log %s (POST /perf)\n" % ("on" if _PERF else "off"))
+                return self._send(200, json.dumps({"ok": True, "log": _PERF}), "application/json")
             if u.path == "/send":
                 # Human→agent input channel — the SAME delivery the chat composer's WS
                 # sendMessage uses, exposed as a one-shot POST so an external local tool (the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -184,7 +184,9 @@ class _PerfStats:
     milliseconds of wall time, `*_s` seconds:
       now, since, uptime_s, log    clock; when the counters started (a restart resets them); seconds
                                    since the process started; whether the romp-perf stderr log is on
-      process                      rss_kb, threads, cpu_s (time.process_time), pid
+      process                      rss_kb (the CURRENT resident size on Linux, from /proc; the PEAK,
+                                   ru_maxrss, on macOS: _process_stats), threads, cpu_s
+                                   (time.process_time), pid
       pusher                       cycles (one per _pusher_cycle), wakes (every _pusher_wake.set()
                                    call; a burst coalesces into one cycle), wakes_event /
                                    wakes_backstop (how the loop's wait ended: flag set, or the 0.5 s
@@ -223,7 +225,12 @@ class _PerfStats:
                                    no ms: its handler returns when the socket closes, which is a
                                    connection's lifetime, not a request's."""
     RING = 256
-    HTTP_PATHS = 64
+    # The kernel's own route table is 88 fixed "METHOD /path" pairs (35 GET, 1 HEAD and 52 POST literals in
+    # the do_* dispatches, counted 2026-09-07), plus the collapsed /dist/*, /media/* and /remote/*/… families
+    # and an OPTIONS preflight per cross-origin POST route. The cap has to clear all of that with room, or
+    # routes that first arrive after it land in "other" for the kernel's lifetime (the first cap, 64, was
+    # below the table itself). test_perf_stats pins it at 1.5x the literal count.
+    HTTP_PATHS = 256
     SLOTS = 32
     STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
     BUILDS = ("chat", "feed", "timeline")
@@ -931,19 +938,35 @@ def _version_info():
 # are ever kept; `romp perf client` reads both. Checked on every append: one stat, under one lock.
 CLIENT_DIAG_MAX_BYTES = 8 * 1024 * 1024
 _client_diag_lock = threading.Lock()
+# Set once a rotation rename has been refused, so the stderr line in _client_diag_append is written once per
+# kernel: a rename that stays refused (an unwritable state directory, a directory sitting at the .1 name) would
+# otherwise say so on every row, a line a minute per pane.
+_client_diag_rotate_failed = False
 
 
 def _client_diag_append(fp, line):
     """Append one row to client-diag.jsonl, rotating it first once it is at the cap. One lock across the size
     check, the rename and the write: every pane's socket is its own handler thread, so rows arrive
     concurrently, and two threads finding the file at the cap at once would both rename, the second moving
-    the file the first had just started over the run the first had just rotated, and that run was gone."""
+    the file the first had just started over the run the first had just rotated, and that run was gone.
+    A refused rename is said on stderr (once, see _client_diag_rotate_failed) and the row is appended anyway:
+    the bound has failed, and a file growing past the cap with nothing saying why is the silent kind of
+    failure (review, 2026-09-07). Only the absent-file case of the size check is quiet: a fresh state
+    directory has no file yet, and the append creates it."""
+    global _client_diag_rotate_failed
     with _client_diag_lock:
         try:
-            if fp.stat().st_size >= CLIENT_DIAG_MAX_BYTES:
+            size = fp.stat().st_size
+        except FileNotFoundError:
+            size = 0
+        if size >= CLIENT_DIAG_MAX_BYTES:
+            try:
                 os.replace(str(fp), str(fp) + ".1")
-        except OSError:
-            pass   # no file yet (fresh state) or a failed rename: the append below still goes to the current file
+            except OSError as e:
+                if not _client_diag_rotate_failed:
+                    _client_diag_rotate_failed = True
+                    print("[client-diag] could not rotate %s to %s.1 (%s): the file keeps growing past %d bytes"
+                          % (fp, fp, e, CLIENT_DIAG_MAX_BYTES), file=sys.stderr)
         with open(fp, "a", encoding="utf-8") as f:
             f.write(line)
 

--- a/tests/romp-perf-client.bats
+++ b/tests/romp-perf-client.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+# `romp perf client [--minutes <n>] [--json]` — the browser side of `romp perf`: folds the surface "perf"
+# rows the pane bundles post (ui/webview/perf-telemetry.ts: one "minute" row per pane per minute, a
+# "slowframe" row per frame at or over 100 ms, five a minute at most) out of $STATE/client-diag.jsonl and
+# its rotated predecessor client-diag.jsonl.1, per dashboard id (the first eight characters of the wid) and
+# pane app, over the last <n> minutes, and prints one screen.
+#
+# Nothing here touches a kernel: the verb reads the files directly, and a curl on PATH that fails proves
+# it never tried. The fixture is synthetic (placeholder wids, the pane apps the kernel names, invented
+# numbers), written relative to the wall clock so the window arithmetic is exercised for real; one minute
+# row is a half minute (a pagehide flush), so a rate that divided by the row count would be caught. Every
+# refusal is loud and specific: an absent file, an empty file, a file with no perf rows, perf rows all
+# older than the window, an unknown flag or a zero window.
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    export DIAG="$XDG_STATE_HOME/romp/client-diag.jsonl"
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export CURL_LOG="$TEST_DIR/curl.log"
+    printf '#!/usr/bin/env bash\necho "$*" >> "$CURL_LOG"; exit 7\n' > "$MOCK/curl"; chmod +x "$MOCK/curl"
+    export PATH="$MOCK:$PATH"
+    # Dashboard 11111111: a feed pane with three minute rows, the last a half minute (2.5 min in all): 36 feed
+    # frames (14.4/min) costing 900 ms (360 ms/min), whose summed histogram puts the window p50 under 4 ms,
+    # the p90 under 32 and the p99 under 128, 9 of them over 16.7 ms (25%) and 2 at or over 100 ms (6%);
+    # the federation layer's own share as fed:feed (40 ms); 9 long frames with 1230 ms of blocking; the
+    # attribution feed.js:render@1200 (1200 + 900 ms) and the shim's inline callback page:(anonymous)@31245;
+    # one slow frame row with its attribution and a minute in which 45 more slow frames went unsent past the
+    # pane's cap. The second minute (400 ms of handler time) is the worst. A chat pane the shell has hidden
+    # (a zero viewport) in a browser that reports no long frames. Dashboard 22222222: a phone's feed pane,
+    # with a stale row an hour old that the default window must exclude. Two lines that are not perf rows
+    # (a shim breadcrumb; a malformed line) are skipped.
+    python3 - "$DIAG" <<'PY'
+import json, sys, time
+now = int(time.time())
+W1, W2 = "11111111-2222-3333-4444-555555555555", "22222222-3333-4444-5555-666666666666"
+def row(t, wid, what, data): return json.dumps({"t": t, "wid": wid, "surface": "perf", "what": what, "data": data})
+def H(**at):
+    h = [0] * 14
+    for k, v in at.items(): h[int(k[1:])] = v
+    return h
+def st(n, ms_sum, ms_max, n16, n100, hist): return {"n": n, "ms_sum": ms_sum, "ms_max": ms_max, "n16": n16, "n100": n100, "hist": hist}
+NOSLOW = {"sent": 0, "suppressed": 0, "suppressed_worst_ms": 0}
+feed_a = {"app": "feed", "since": (now - 210) * 1000, "span_ms": 60000,
+          "frames": {"feed": st(10, 300, 120, 3, 1, H(b1=2, b2=3, b3=2, b4=1, b5=1, b7=1)),
+                     "fed:feed": st(10, 40, 8, 0, 0, H(b0=2, b1=3, b2=3, b3=2)),
+                     "chatTail": st(1, 2, 2, 0, 0, H(b2=1))},
+          "free": {"n": 5, "p50": 20, "p90": 61, "max": 80},
+          "loaf": {"n": 3, "blocking_ms": 410, "worst_ms": 320, "top": [{"k": "feed.js:render@1200", "ms": 1200, "n": 3, "inv": "WebSocket.onmessage"}], "src": "loaf"},
+          "slow": NOSLOW, "heap_mb": 140.0, "dom": 8000, "visible": True, "hidden_pane": False, "ua": "chrome-desktop"}
+feed_b = {"app": "feed", "since": (now - 150) * 1000, "span_ms": 60000,
+          "frames": {"feed": st(14, 400, 130, 4, 1, H(b1=3, b2=4, b3=3, b4=2, b5=1, b7=1))},
+          "free": {"n": 7, "p50": 15, "p90": 50, "max": 70},
+          "loaf": {"n": 6, "blocking_ms": 820, "worst_ms": 300, "top": [{"k": "feed.js:render@1200", "ms": 900, "n": 5, "inv": "WebSocket.onmessage"}, {"k": "page:(anonymous)@31245", "ms": 300, "n": 6, "inv": "WebSocket.onmessage"}], "src": "loaf"},
+          "slow": {"sent": 1, "suppressed": 45, "suppressed_worst_ms": 380},
+          "heap_mb": 141.0, "dom": 8200, "visible": True, "hidden_pane": False, "ua": "chrome-desktop"}
+feed_c = {"app": "feed", "since": (now - 60) * 1000, "span_ms": 30000,
+          "frames": {"feed": st(12, 200, 90, 2, 0, H(b1=4, b2=4, b3=2, b4=1, b6=1))},
+          "free": None,
+          "loaf": {"n": 0, "blocking_ms": 0, "worst_ms": 0, "top": [], "src": "loaf"},
+          "slow": NOSLOW, "heap_mb": 142.5, "dom": 8412, "visible": True, "hidden_pane": False, "ua": "chrome-desktop"}
+slow = {"app": "feed", "type": "feed", "ms": 130, "dom": 8400,
+        "loaf": {"ms": 140, "blocking_ms": 90, "top": [{"k": "feed.js:render@1200", "ms": 110, "inv": "WebSocket.onmessage"}]}}
+chat = {"app": "chat", "since": (now - 100) * 1000, "span_ms": 60000,
+        "frames": {"chatTail": st(30, 60, 5, 0, 0, H(b0=10, b1=10, b2=8, b3=2))},
+        "free": {"n": 3, "p50": 8, "p90": 12, "max": 20},
+        "loaf": {"n": 0, "blocking_ms": 0, "worst_ms": 0, "top": [], "src": "none"},
+        "slow": NOSLOW, "heap_mb": 90.0, "dom": 3000, "visible": True, "hidden_pane": True, "ua": "chrome-desktop"}
+phone = {"app": "feed", "since": (now - 80) * 1000, "span_ms": 60000,
+         "frames": {"feed": st(2, 50, 30, 2, 0, H(b5=2))},       # 20 and 30 ms: both in the 16-32 bucket, both over 16.7
+         "free": {"n": 2, "p50": 40, "p90": 45, "max": 45},
+         "loaf": {"n": 0, "blocking_ms": 0, "worst_ms": 0, "top": [], "src": "none"},
+         "slow": NOSLOW, "dom": 5000, "visible": True, "hidden_pane": False, "ua": "safari-ios"}
+stale = dict(phone, frames={"feed": st(999, 5, 5, 0, 0, H(b0=999))}, since=(now - 3660) * 1000)
+lines = [
+    row(now - 3600, W2, "minute", stale),
+    json.dumps({"t": now - 200, "wid": W1, "surface": "pane-shim", "what": "wsclose", "data": {"app": "feed", "code": 1006}}),
+    row(now - 150, W1, "minute", feed_a),
+    "this line is not json",
+    row(now - 100, W1, "slowframe", slow),
+    row(now - 90, W1, "minute", feed_b),
+    row(now - 40, W1, "minute", chat),
+    row(now - 30, W1, "minute", feed_c),
+    row(now - 20, W2, "minute", phone),
+]
+open(sys.argv[1], "w").write("\n".join(lines) + "\n")
+PY
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp perf client: one screen per dashboard and pane, folded over the window" {
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"browser telemetry from the last 10 min"* ]]
+    [[ "$output" == *"2 dashboards, 3 panes, 5 minute rows, 1 slow frame row"* ]]
+    # the feed pane of dashboard 11111111: 2.5 min of rows, the last sample's heap and DOM
+    [[ "$output" == *"dashboard 11111111 · feed   chrome-desktop   2.5 min reported   heap 142.5 MB   dom 8412   visible"* ]]
+    # the pane's total, then each type by its share: rate, ms/min, window percentiles from the summed histogram, max, shares
+    [[ "$output" == *"handler      377 ms/min total"* ]]
+    [[ "$output" == *"feed           14.4/min    360 ms/min   p50 <4   p90 <32   p99 <128 ms   max 130   >16.7 ms 25%   >=100 ms 6%"* ]]
+    [[ "$output" == *"fed:feed        4.0/min     16 ms/min   p50 <2   p90 <8   p99 <8 ms   max 8   >16.7 ms 0%   >=100 ms 0%"* ]]
+    [[ "$output" == *"chatTail        0.4/min      1 ms/min"* ]]
+    # feed before fed:feed before chatTail: sorted by handler time, not by count. Panes print in (dashboard,
+    # app) order, so the chat pane and its own chatTail line come first; the check is within the feed pane's block.
+    feed_block="$(echo "$output" | sed -n '/^dashboard 11111111 · feed/,/^dashboard 22222222/p')"
+    feed_line="$(echo "$feed_block" | grep -n '^    feed ' | head -1 | cut -d: -f1)"
+    fed_line="$(echo "$feed_block" | grep -n '^    fed:feed ' | head -1 | cut -d: -f1)"
+    chat_line="$(echo "$feed_block" | grep -n '^    chatTail ' | head -1 | cut -d: -f1)"
+    [ -n "$feed_line" ] && [ -n "$fed_line" ] && [ -n "$chat_line" ]
+    [ "$feed_line" -lt "$fed_line" ] && [ "$fed_line" -lt "$chat_line" ]
+    [[ "$output" == *"free after a frame, worst minute's p90 61 ms"* ]]
+    [[ "$output" == *"long frames 3.6/min   blocking 492 ms/min   worst 320 ms"* ]]
+    [[ "$output" == *"feed.js:render@1200 2100 ms (WebSocket.onmessage)   page:(anonymous)@31245 300 ms (WebSocket.onmessage)"* ]]
+    # the worst minute is the second one: its span (the browser's minute start to the kernel's receipt), its own
+    # counts and percentiles, its long frames
+    [[ "$output" =~ 'worst minute '[0-9][0-9]:[0-9][0-9]:[0-9][0-9]-[0-9][0-9]:[0-9][0-9]:[0-9][0-9]'   400 ms handler' ]]
+    [[ "$output" == *"400 ms handler   feed 14 (p90 <32 ms, max 130)   long frames 6, blocking 820 ms"* ]]
+    # the slow frame row, then the ones the pane did not send
+    [[ "$output" == *"feed 130 ms (dom 8400)  feed.js:render@1200 110 ms"* ]]
+    [[ "$output" == *"and 45 more (45 not sent by the pane past its per-minute cap; worst 380 ms)"* ]]
+    # the hidden chat pane, in a browser without long-frame reports
+    [[ "$output" == *"dashboard 11111111 · chat   chrome-desktop   1 min reported   heap 90.0 MB   dom 3000   hidden (no viewport)"* ]]
+    [[ "$output" == *"chatTail       30.0/min     60 ms/min   p50 <2   p90 <4   p99 <8 ms   max 5"* ]]
+    [[ "$output" == *"long frames: not reported by this browser"* ]]
+    # the phone: its hour-old row is outside the window, and a row without heap says so
+    [[ "$output" == *"dashboard 22222222 · feed   safari-ios   1 min reported   heap n/a   dom 5000   visible"* ]]
+    [[ "$output" == *"feed            2.0/min     50 ms/min   p50 <32   p90 <32   p99 <32 ms   max 30   >16.7 ms 100%   >=100 ms 0%"* ]]
+    [[ "$output" != *"999"* ]]
+    [[ "$output" == *"slow frames  none"* ]]
+    [ ! -f "$CURL_LOG" ]                                 # no kernel round trip
+}
+
+@test "romp perf client --minutes: narrows the window, and a half-minute row is rated by its span" {
+    run "$ROMP_SCRIPT" perf client --minutes 1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"from the last 1 min"* ]]
+    [[ "$output" == *"2 dashboards, 3 panes, 3 minute rows, 0 slow frame rows"* ]]
+    [[ "$output" == *"0.5 min reported"* ]]              # only the newest feed minute is inside, and it is half a minute
+    [[ "$output" == *"feed           24.0/min    400 ms/min   p50 <4   p90 <16   p99 <64 ms   max 90"* ]]   # 12 frames: rank 11 of [0,4,4,2,1,0,1] is the 8-16 bucket
+    [[ "$output" != *"feed.js:render"* ]]
+    [[ "$output" == *"slow frames  none"* ]]
+    run "$ROMP_SCRIPT" perf client --minutes=2
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"4 minute rows, 1 slow frame row"* ]]   # the 150 s old minute is outside; the 100 s old slow frame is inside
+    [[ "$output" == *"feed.js:render@1200 900 ms (WebSocket.onmessage)   page:(anonymous)@31245 300 ms (WebSocket.onmessage)"* ]]
+}
+
+@test "romp perf client --json: the folded panes as JSON, with the per-minute array" {
+    run "$ROMP_SCRIPT" perf client --json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert d["window_min"] == 10
+panes = {(p["wid"], p["app"]): p for p in d["panes"]}
+assert set(panes) == {("11111111", "feed"), ("11111111", "chat"), ("22222222", "feed")}, set(panes)
+f = panes[("11111111", "feed")]
+ff = f["frames"]["feed"]
+assert ff["n"] == 36 and ff["ms_sum"] == 900 and abs(ff["per_min"] - 14.4) < 1e-9 and abs(ff["ms_per_min"] - 360) < 1e-9
+assert ff["p50_lt"] == 4 and ff["p90_lt"] == 32 and ff["p99_lt"] == 128 and ff["max"] == 130 and ff["n16"] == 9 and ff["n100"] == 2
+assert ff["hist"] == [0, 9, 11, 7, 4, 2, 1, 2, 0, 0, 0, 0, 0, 0], ff["hist"]
+assert abs(f["total_ms_per_min"] - 376.8) < 1e-9 and f["minutes"] == 2.5
+assert f["free_p90"] == 61 and f["heap_mb"] == 142.5 and f["dom"] == 8412
+assert abs(f["loaf"]["per_min"] - 3.6) < 1e-9 and abs(f["loaf"]["blocking_ms_per_min"] - 492) < 1e-9 and f["loaf"]["worst_ms"] == 320
+assert f["top"][0] == {"k": "feed.js:render@1200", "ms": 2100, "inv": "WebSocket.onmessage"}
+assert [m["total_ms"] for m in f["minutes_detail"]] == [342, 400, 200], f["minutes_detail"]
+assert f["worst_minute"]["total_ms"] == 400 and f["worst_minute"]["loaf_n"] == 6 and f["worst_minute"]["blocking_ms"] == 820
+assert f["worst_minute"]["t"] - f["worst_minute"]["since"] // 1000 == 60, f["worst_minute"]   # the minute began 60 s before its row arrived
+assert f["slow_suppressed"] == 45 and f["slow_suppressed_worst_ms"] == 380
+assert len(f["slow"]) == 1 and f["slow"][0]["ms"] == 130 and f["slow"][0]["loaf"] == [{"k": "feed.js:render@1200", "ms": 110}]
+c = panes[("11111111", "chat")]
+assert c["hidden_pane"] is True and c["loaf"]["src"] == "none"
+p = panes[("22222222", "feed")]
+assert p["frames"]["feed"]["n"] == 2 and p["heap_mb"] is None and p["ua"] == "safari-ios"
+'
+}
+
+@test "romp perf client: reads the rotated .1 file before the current one and says so" {
+    mv "$DIAG" "$DIAG.1"
+    python3 - "$DIAG" <<'PY'
+import json, sys, time
+now = int(time.time())
+h = [0] * 14; h[3] = 4
+open(sys.argv[1], "w").write(json.dumps({"t": now - 10, "wid": "22222222-3333-4444-5555-666666666666", "surface": "perf", "what": "minute",
+    "data": {"app": "chat", "since": (now - 70) * 1000, "span_ms": 60000,
+             "frames": {"chatTail": {"n": 4, "ms_sum": 20, "ms_max": 7, "n16": 0, "n100": 0, "hist": h}},
+             "free": None, "loaf": {"n": 0, "blocking_ms": 0, "worst_ms": 0, "top": [], "src": "none"},
+             "slow": {"sent": 0, "suppressed": 0, "suppressed_worst_ms": 0}, "dom": 900, "visible": True, "hidden_pane": False, "ua": "safari-ios"}}) + "\n")
+PY
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"($DIAG and .1)"* ]]
+    [[ "$output" == *"2 dashboards, 4 panes, 6 minute rows, 1 slow frame row"* ]]
+    [[ "$output" == *"dashboard 22222222 · chat"* ]]
+    [[ "$output" == *"dashboard 11111111 · feed"* ]]
+}
+
+@test "romp perf client: reads the file under ROMP_STATE_DIR when it is set" {
+    mkdir -p "$TEST_DIR/other"
+    mv "$DIAG" "$TEST_DIR/other/client-diag.jsonl"
+    ROMP_STATE_DIR="$TEST_DIR/other" run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"($TEST_DIR/other/client-diag.jsonl)"* ]]
+    [[ "$output" == *"3 panes"* ]]
+}
+
+@test "romp perf client: an absent file says the bundles need rebuilding and the dashboard reloading" {
+    rm "$DIAG"
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no browser telemetry yet: rebuild the bundles and reload the dashboard"* ]]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "romp perf client: an empty file, or one with breadcrumbs but no perf rows, says the same, naming the rows" {
+    : > "$DIAG"
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no browser telemetry yet: rebuild the bundles and reload the dashboard"* ]]
+    [[ "$output" == *'no surface "perf" rows'* ]]
+    printf '{"t": %d, "wid": "11111111-2222-3333-4444-555555555555", "surface": "pane-shim", "what": "wsclose", "data": {"app": "feed"}}\n' "$(date +%s)" > "$DIAG"
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'no surface "perf" rows'* ]]
+}
+
+@test "romp perf client: perf rows all older than the window are said with their age, not shown as an empty screen" {
+    python3 - "$DIAG" <<'PY'
+import json, sys, time
+t = int(time.time()) - 3600
+h = [0] * 14; h[1] = 1
+open(sys.argv[1], "w").write(json.dumps({"t": t, "wid": "22222222-3333-4444-5555-666666666666", "surface": "perf", "what": "minute",
+                                        "data": {"app": "feed", "span_ms": 60000, "frames": {"feed": {"n": 1, "ms_sum": 1, "ms_max": 1, "n16": 0, "n100": 0, "hist": h}},
+                                                 "free": None, "loaf": {"n": 0, "blocking_ms": 0, "worst_ms": 0, "top": [], "src": "none"},
+                                                 "slow": {"sent": 0, "suppressed": 0, "suppressed_worst_ms": 0},
+                                                 "dom": 1, "visible": True, "hidden_pane": False, "ua": "other"}}) + "\n")
+PY
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no browser telemetry in the last 10 min (the newest perf row is 60 min old)"* ]]
+    [[ "$output" == *"--minutes to widen the window"* ]]
+    run "$ROMP_SCRIPT" perf client --minutes 120
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 dashboard, 1 pane, 1 minute row, 0 slow frame rows"* ]]
+}
+
+@test "romp perf client: an unknown flag, a zero window or a non-numeric window is refused" {
+    run "$ROMP_SCRIPT" perf client --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf client"* ]]
+    run "$ROMP_SCRIPT" perf client --minutes 0
+    [ "$status" -eq 2 ]
+    run "$ROMP_SCRIPT" perf client --minutes soon
+    [ "$status" -eq 2 ]
+    run "$ROMP_SCRIPT" perf client --minutes
+    [ "$status" -eq 2 ]
+}
+
+@test "romp perf: the two-snapshot verb is untouched — its usage now names client, and help lists the sub-verb" {
+    run "$ROMP_SCRIPT" perf --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf [--interval <s>] [--json] | romp perf log on|off | romp perf client"* ]]
+    run "$ROMP_SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp perf client"* ]]
+}

--- a/tests/romp-perf-client.bats
+++ b/tests/romp-perf-client.bats
@@ -16,6 +16,9 @@
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
 setup() {
+    # bin/romp resolves the state directory as ${ROMP_STATE_DIR:-$XDG_STATE_HOME/romp} and the token as
+    # ${ROMP_SERVE_TOKEN:-<state>/serve-token}: a live kernel's exports outrank the redirection below
+    unset ROMP_STATE_DIR ROMP_SERVE_TOKEN
     TEST_DIR="$(mktemp -d)"
     export XDG_STATE_HOME="$TEST_DIR/state"
     mkdir -p "$XDG_STATE_HOME/romp"

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+
+# `romp perf [--interval <s>] [--json]` and `romp perf log on|off` — the kernel's performance counters
+# for a terminal: two GET /perf snapshots printed as rates, one raw snapshot, or the POST that flips the
+# romp-perf stderr log without a restart.
+#
+# Same contract as `romp sessions`: the token travels on stdin (never argv), a dead kernel fails
+# LOUDLY rather than printing something a reader could mistake for a quiet kernel, and an unknown
+# flag is refused. Two more refusals are this verb's own: two snapshots from different kernel
+# processes (a restart inside the window) are not subtracted into negative rates, and a refused
+# token is named as such rather than reported as a dead kernel. Nothing here touches a real kernel:
+# curl is a stub that serves synthetic snapshots in turn and emits the status trailer the real one
+# is asked for (-w).
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
+    export ROMP_KERNEL_PORT=29855
+
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export CURL_LOG="$TEST_DIR/curl.log"
+    export CURL_STDIN="$TEST_DIR/curl.stdin"
+    export CURL_CALLS="$TEST_DIR/curl.calls"
+    export SNAP_A="$TEST_DIR/a.json"
+    export SNAP_B="$TEST_DIR/b.json"
+    export SNAP_C="$TEST_DIR/c.json"
+    # A and B: the same kernel process ten seconds apart. Over the window: 20 cycles, 60 wakes, 6 s of
+    # cycle time (4 s of it in push, 3 s of that in the chat block), 300 ms of pusher CPU and 50 ms of
+    # judge CPU inside 500 ms of process CPU, 2 chat rebuilds against 18 cache hits, 1 MB sent as chat
+    # full frames, 100 goal loads, 2 judge passes totalling 2400 ms, 5 /tick requests and 3 WebSocket
+    # connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
+    # (ring max 700, mean 1200) so a line printing the wrong one is caught.
+    cat > "$SNAP_A" <<'JSON'
+{"now": 1000.0, "since": 900.0, "uptime_s": 100.0, "log": false,
+ "process": {"rss_kb": 409600, "threads": 40, "cpu_s": 60.0, "pid": 4242},
+ "pusher": {"cycles": 100, "wakes": 300, "wakes_event": 250, "wakes_backstop": 50, "cycle_ms_sum": 30000.0,
+            "cycle_ms_max": 900.0, "cycle_ms_last": 200.0, "cycle_cpu_ms_sum": 10000.0,
+            "cycle_ms_p50": 180.0, "cycle_ms_p90": 400.0, "cycle_ms_ring_max": 900.0, "ring_n": 100},
+ "stages_ms": {"jobs": 5000.0, "push": 20000.0, "push.chat": 15000.0, "push.feed": 3000.0, "push.timeline": 1000.0, "push.send": 500.0},
+ "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}},
+ "sends": {"full": {"chat": {"count": 10, "bytes": 1000000}}, "delta": {"chat": {"count": 100, "bytes": 50000}}, "deduped": {"feed": {"count": 90, "bytes": 9000000}}},
+ "goals": {"loads": 1000, "saves": 200, "writes": 50},
+ "judge": {"passes": 30, "ms_sum": 30000.0, "ms_last": 1000.0, "ms_mean": 1000.0, "cpu_ms_sum": 2000.0, "cpu_ms_workers": 1500.0},
+ "http": {"GET /tick": {"count": 50, "ms": 25.0}, "GET /sessions": {"count": 5, "ms": 10.0}}}
+JSON
+    cat > "$SNAP_B" <<'JSON'
+{"now": 1010.0, "since": 900.0, "uptime_s": 110.0, "log": false,
+ "process": {"rss_kb": 419840, "threads": 41, "cpu_s": 60.5, "pid": 4242},
+ "pusher": {"cycles": 120, "wakes": 360, "wakes_event": 300, "wakes_backstop": 60, "cycle_ms_sum": 36000.0,
+            "cycle_ms_max": 900.0, "cycle_ms_last": 250.0, "cycle_cpu_ms_sum": 10300.0,
+            "cycle_ms_p50": 190.0, "cycle_ms_p90": 420.0, "cycle_ms_ring_max": 700.0, "ring_n": 120},
+ "stages_ms": {"jobs": 6000.0, "push": 24000.0, "push.chat": 18000.0, "push.feed": 3600.0, "push.timeline": 1200.0, "push.send": 600.0},
+ "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}},
+ "sends": {"full": {"chat": {"count": 12, "bytes": 2048576}}, "delta": {"chat": {"count": 120, "bytes": 60000}}, "deduped": {"feed": {"count": 108, "bytes": 10800000}}},
+ "goals": {"loads": 1100, "saves": 220, "writes": 55},
+ "judge": {"passes": 32, "ms_sum": 32400.0, "ms_last": 1200.0, "ms_mean": 1012.5, "cpu_ms_sum": 2050.0, "cpu_ms_workers": 1540.0},
+ "http": {"GET /tick": {"count": 55, "ms": 27.5}, "GET /sessions": {"count": 5, "ms": 10.0}, "GET /ws": {"count": 3, "ms": 0.0}}}
+JSON
+    # C: a kernel that restarted five seconds into the window — new pid, new `since`, counters reset
+    sed -e 's/"since": 900.0/"since": 1005.0/' -e 's/"uptime_s": 110.0/"uptime_s": 5.0/' \
+        -e 's/"pid": 4242/"pid": 4343/' -e 's/"cycles": 120/"cycles": 4/' "$SNAP_B" > "$SNAP_C"
+    # Stub curl: records argv AND stdin (the auth header rides stdin as a curl config) and emits the
+    # body followed by the -w status trailer the script asks for. A POST answers the toggle's ack; a
+    # GET serves snapshot A first, then B (or C under CURL_RESTART), so two reads see counters move.
+    cat > "$MOCK/curl" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$CURL_LOG"
+cat >> "$CURL_STDIN" 2>/dev/null
+[ -n "${CURL_FAIL:-}" ] && exit 7
+if [ -n "${CURL_403:-}" ]; then printf 'forbidden: token required\n403'; exit 0; fi
+if [[ "$*" == *"-X POST"* ]]; then
+    printf '{"ok": true, "log": %s}\n200' "$([[ "$*" == *'"log": true'* ]] && echo true || echo false)"
+    exit 0
+fi
+n=0; [ -f "$CURL_CALLS" ] && n="$(cat "$CURL_CALLS")"
+echo $((n + 1)) > "$CURL_CALLS"
+if [ "$n" -eq 0 ]; then cat "$SNAP_A"; elif [ -n "${CURL_RESTART:-}" ]; then cat "$SNAP_C"; else cat "$SNAP_B"; fi
+printf '\n200'
+MOCK
+    chmod +x "$MOCK/curl"
+    export PATH="$MOCK:$PATH"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp perf: prints rates computed from two snapshots" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"10.0 s window"* ]]                 # the window is the snapshots' own clocks, not the sleep
+    [[ "$output" == *"2.00 cycles/s"* ]]                 # 20 cycles over 10 s
+    [[ "$output" == *"6.00 wakes/s (event 50, backstop 10)"* ]]
+    [[ "$output" == *"busy 60% of wall"* ]]              # 6 s of cycle time in a 10 s window
+    [[ "$output" == *"rss 410 MB"* ]]
+    [[ "$output" == *"pid 4242"* ]]
+}
+
+@test "romp perf: the process line splits the window's CPU between the pusher, the judge and the rest" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    # 0.5 s of process CPU in 10 s; 300 ms of it on the pusher thread, 50 ms in the judge threads
+    [[ "$output" == *"cpu 5.0% of one core (pusher 3.0%, judge 0.5%, other 1.5%)"* ]]
+}
+
+@test "romp perf: the cycle line's max is the ring's, and the parenthetical names the ring" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"p50 190   p90 420   max 700 (over the last 120 cycles)   last 250"* ]]
+    [[ "$output" != *"max 900"* ]]                       # the lifetime max is not printed as a window figure
+}
+
+@test "romp perf: the stage line shows each stage's share of cycle time" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    # 1 s of jobs, 4 s of push (3 s chat, 0.6 s feed, 0.2 s timeline, 0.1 s send) out of 6 s of cycles
+    [[ "$output" == *"jobs  17%"* ]]
+    [[ "$output" == *"push  67%"* ]]
+    [[ "$output" == *"chat  50%"* ]]
+    [[ "$output" == *"feed  10%"* ]]
+}
+
+@test "romp perf: builds, sends, goals, judge and http lines carry the window's deltas" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg)"* ]]
+    [[ "$output" == *"full 102 KB/s (chat 2 frames 102 KB/s)"* ]]        # 1048576 bytes over 10 s, bytes beside the count
+    [[ "$output" == *"deduped 176 KB/s (feed 18 frames 176 KB/s)"* ]]
+    [[ "$output" == *"10.0 loads/s   2.0 saves/s   0.5 writes/s"* ]]
+    [[ "$output" == *"2 passes (0.20/s)   last 1200 ms   mean 1200 ms"* ]]   # the WINDOW mean: 2400 ms over 2 passes
+    [[ "$output" != *"1012"* ]]                          # not the lifetime ms_mean
+    [[ "$output" == *"GET /tick 5 (0.5 ms avg)"* ]]
+    [[ "$output" == *"GET /ws 3"* ]]                     # a WebSocket row: count only …
+    [[ "$output" != *"GET /ws 3 ("* ]]                   # … never a fabricated 0.0 ms avg
+    [[ "$output" != *"/sessions"* ]]                     # no requests in the window: not listed
+}
+
+@test "romp perf: a restart inside the window is said, not subtracted into negative rates" {
+    CURL_RESTART=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the kernel restarted during the window (pid 4242 -> 4343)"* ]]
+    [[ "$output" != *"cycles/s"* ]]
+}
+
+@test "romp perf --json: prints one raw snapshot verbatim and reads the kernel once" {
+    run "$ROMP_SCRIPT" perf --json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["pusher"]["cycles"] == 100; assert d["process"]["pid"] == 4242'
+    [ "$(cat "$CURL_CALLS")" -eq 1 ]
+}
+
+@test "romp perf: reads GET /perf on the kernel, authorizing on stdin, twice" {
+    run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 0 ]
+    [ "$(grep -c "127.0.0.1:29855/perf" "$CURL_LOG")" -eq 2 ]
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    # never in argv: /proc/<pid>/cmdline is world-readable
+    run grep -q "TESTTOKEN123" "$CURL_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "romp perf log on|off: POSTs the toggle to /perf and names the journal on systemd" {
+    run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"log on"* ]]
+    [[ "$output" == *"journalctl --user -u romp-manager"* ]]
+    grep -q -- "-X POST http://127.0.0.1:29855/perf" "$CURL_LOG"
+    grep -q '"log": true' "$CURL_LOG"
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    run "$ROMP_SCRIPT" perf log off
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"log off"* ]]
+    grep -q '"log": false' "$CURL_LOG"
+}
+
+@test "romp perf log on: under launchd the hint names the manager.log file, not journalctl" {
+    printf '#!/usr/bin/env bash\necho Darwin\n' > "$MOCK/uname"; chmod +x "$MOCK/uname"
+    run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tail -f $XDG_STATE_HOME/romp/manager.log"* ]]
+    [[ "$output" != *"journalctl"* ]]
+}
+
+@test "romp perf log: anything but on|off is refused" {
+    run "$ROMP_SCRIPT" perf log maybe
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf"* ]]
+    run "$ROMP_SCRIPT" perf log
+    [ "$status" -eq 2 ]
+    [ ! -f "$CURL_LOG" ]                                 # nothing reached the kernel
+}
+
+@test "romp perf: a dead kernel fails LOUDLY" {
+    CURL_FAIL=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+    CURL_FAIL=1 run "$ROMP_SCRIPT" perf log on
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+}
+
+@test "romp perf: a refused token is named as such, not reported as a dead kernel" {
+    CURL_403=1 run "$ROMP_SCRIPT" perf --interval 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    CURL_403=1 run "$ROMP_SCRIPT" perf log on
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+}
+
+@test "romp perf: an unknown flag or a bad interval is refused rather than silently ignored" {
+    run "$ROMP_SCRIPT" perf --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp perf"* ]]
+    run "$ROMP_SCRIPT" perf --interval soon
+    [ "$status" -eq 2 ]
+    run "$ROMP_SCRIPT" perf --interval
+    [ "$status" -eq 2 ]
+}
+
+@test "romp perf: listed in help, under the scripting group" {
+    run "$ROMP_SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp perf"* ]]
+}

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -15,6 +15,9 @@
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
 setup() {
+    # bin/romp resolves the state directory as ${ROMP_STATE_DIR:-$XDG_STATE_HOME/romp} and the token as
+    # ${ROMP_SERVE_TOKEN:-<state>/serve-token}: a live kernel's exports outrank the redirection below
+    unset ROMP_STATE_DIR ROMP_SERVE_TOKEN
     TEST_DIR="$(mktemp -d)"
     export XDG_STATE_HOME="$TEST_DIR/state"
     mkdir -p "$XDG_STATE_HOME/romp"

--- a/tests/test_bundle_build_mode.py
+++ b/tests/test_bundle_build_mode.py
@@ -30,11 +30,17 @@ def _read(p):
 
 class BundleBuildMode(unittest.TestCase):
     def test_esbuild_ties_minify_and_sourcemaps_to_the_production_flag(self):
-        """The flag has to actually mean something — this is what the other two rely on."""
+        """The flag has to actually mean something — this is what the other two rely on. The webview build
+        minifies whitespace and syntax only: identifiers are kept in every mode, because the browser's
+        long-frame attribution (ui/webview/perf-telemetry.ts) names a callback by its compile-time name, and
+        a mangled build reports a different letter after every rebuild. The extension host keeps `minify`."""
         src = _read(ESBUILD)
         self.assertIn('const production = process.argv.includes("--production")', src)
-        self.assertIn("minify: production", src)
+        self.assertIn("minify: production", src)              # the extension-host bundle
         self.assertIn("sourcemap: !production", src)
+        self.assertIn("minifyWhitespace: production", src)    # the webview bundles: whitespace and syntax…
+        self.assertIn("minifySyntax: production", src)
+        self.assertIn("minifyIdentifiers: false", src)        # …but never identifiers
 
     def test_the_installer_builds_production(self):
         src = _read(EXT_INSTALL)

--- a/tests/test_client_diag_rotation.py
+++ b/tests/test_client_diag_rotation.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""client-diag.jsonl is bounded (2026-09-06): the pane bundles post a performance row per pane per active minute
+(ui/webview/perf-telemetry.ts), about 1 KB each, into a file that used to hold rare breadcrumbs and that nothing
+pruned. The kernel's clientDiag handler now rotates it past CLIENT_DIAG_MAX_BYTES: the file is renamed to
+client-diag.jsonl.1 (replacing the previous .1) and a new file starts, so at most two files are ever kept, and
+`romp perf client` reads both.
+
+Drives the REAL Handler's WS dispatch (_dispatch_ws with a clientDiag message, the way the pane shim delivers
+one) against a hermetic state directory, with the cap lowered for the test. Synthetic fixtures only: a
+placeholder dashboard id, invented numbers."""
+import json
+import os
+import pathlib
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_cdiag", os.path.join(BIN, "romp-kernel")).load_module()
+
+WID = "11111111-2222-3333-4444-555555555555"
+
+
+class ClientDiagRotationTest(unittest.TestCase):
+    def setUp(self):
+        self.fp = km.jd.STATE / "client-diag.jsonl"
+        self.fp1 = km.jd.STATE / "client-diag.jsonl.1"
+        for f in (self.fp, self.fp1):
+            if f.exists():
+                f.unlink()
+        self.cap = km.CLIENT_DIAG_MAX_BYTES
+        km.CLIENT_DIAG_MAX_BYTES = 600           # a handful of rows; the production value is asserted below
+
+    def tearDown(self):
+        km.CLIENT_DIAG_MAX_BYTES = self.cap
+        for f in (self.fp, self.fp1):
+            if f.exists():
+                f.unlink()
+
+    def post(self, i):
+        """One breadcrumb through the real dispatch: what the shim sends for a pane's minute row."""
+        km.Handler._dispatch_ws(None, {"type": "clientDiag", "surface": "perf", "what": "minute",
+                                       "data": {"app": "feed", "i": i, "frames": {"feed": {"n": i}}}},
+                                {"wid": WID})
+
+    @staticmethod
+    def rows(path):
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    def test_a_row_lands_with_the_kernel_stamp(self):
+        self.post(1)
+        rows = self.rows(self.fp)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(sorted(rows[0]), ["data", "surface", "t", "what", "wid"])
+        self.assertEqual(rows[0]["wid"], WID)
+        self.assertEqual(rows[0]["surface"], "perf")
+        self.assertEqual(rows[0]["what"], "minute")
+        self.assertEqual(rows[0]["data"]["i"], 1)
+        self.assertFalse(self.fp1.exists())
+
+    def test_past_the_cap_the_file_rotates_to_dot_one_and_a_second_rotation_replaces_it(self):
+        i = 0
+        while not self.fp1.exists():
+            i += 1
+            self.post(i)
+            self.assertLess(i, 100, "the cap never tripped")
+        first = self.rows(self.fp1)
+        self.assertGreaterEqual(sum(len(json.dumps(r)) + 1 for r in first), km.CLIENT_DIAG_MAX_BYTES,
+                                "the rename happens only once the file is at the cap")
+        self.assertEqual([r["data"]["i"] for r in first], list(range(1, i)), "the older rows moved whole")
+        self.assertEqual([r["data"]["i"] for r in self.rows(self.fp)], [i], "the row that tripped it starts the new file")
+        # keep going: the second rotation REPLACES .1 rather than stacking a .2
+        n1 = i
+        while self.rows(self.fp1)[0]["data"]["i"] == 1:
+            i += 1
+            self.post(i)
+            self.assertLess(i, 200, "the second rotation never happened")
+        second = self.rows(self.fp1)
+        self.assertEqual(second[0]["data"]["i"], n1, "the .1 file is now the second run")
+        self.assertEqual(self.rows(self.fp)[0]["data"]["i"], i)
+        self.assertFalse((km.jd.STATE / "client-diag.jsonl.2").exists())
+        # nothing is lost between the two files at any moment: every row is in exactly one
+        seen = [r["data"]["i"] for r in second] + [r["data"]["i"] for r in self.rows(self.fp)]
+        self.assertEqual(seen, list(range(n1, i + 1)))
+
+    def test_the_production_cap_is_eight_megabytes(self):
+        self.assertEqual(self.cap, 8 * 1024 * 1024)
+
+    def test_a_rename_failure_still_appends(self):
+        self.post(1)
+        real = os.replace
+        km.CLIENT_DIAG_MAX_BYTES = 1
+
+        def refuse(*a, **k):
+            raise OSError("read-only")
+        os.replace = refuse
+        try:
+            self.post(2)
+        finally:
+            os.replace = real
+        self.assertEqual([r["data"]["i"] for r in self.rows(self.fp)], [1, 2])
+        self.assertFalse(self.fp1.exists())
+
+    def test_concurrent_posts_rename_only_a_file_at_the_cap_and_lose_no_row(self):
+        """Every pane's socket is its own handler thread, so rows arrive concurrently. Without one lock across
+        the size check, the rename and the append, two threads at the cap at once both renamed: the second
+        moved the file the first had just started (a row or two) over the run the first had just rotated, and
+        that run was gone. Two properties, checked with os.replace recording what it moved: every rename moves
+        a file at the cap, and every row posted ends up in exactly one place (the current file, .1, or a .1 that
+        a later rotation replaced)."""
+        km.CLIENT_DIAG_MAX_BYTES = 3000
+        real_replace = os.replace
+        renamed_sizes, discarded, book = [], [], threading.Lock()
+        fp, fp1 = self.fp, self.fp1
+
+        def recording_replace(src, dst, *a, **k):
+            if src == str(fp):
+                size = os.stat(src).st_size
+                before = len(self.rows(fp1)) if fp1.exists() else 0
+                with book:
+                    renamed_sizes.append(size)
+                    discarded.append(before)
+            return real_replace(src, dst, *a, **k)
+
+        n_threads, per_thread = 6, 1500
+
+        def worker(k):
+            for j in range(per_thread):
+                self.post(k * per_thread + j)
+
+        os.replace = recording_replace
+        try:
+            threads = [threading.Thread(target=worker, args=(k,), name="poster-%d" % k) for k in range(n_threads)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(60)
+        finally:
+            os.replace = real_replace
+        self.assertGreater(len(renamed_sizes), 20, "the cap tripped many times")
+        self.assertEqual([s for s in renamed_sizes if s < km.CLIENT_DIAG_MAX_BYTES], [],
+                         "a rename of a file below the cap is the race: it moved the just-started file over the rotated run")
+        kept = self.rows(fp1) + self.rows(fp)
+        self.assertEqual(len(kept) + sum(discarded), n_threads * per_thread, "every row is in exactly one place")
+        self.assertGreaterEqual(fp1.stat().st_size, km.CLIENT_DIAG_MAX_BYTES, "the .1 file is a whole rotated run")
+
+    def test_two_threads_at_the_cap_at_once_keep_the_rotated_run(self):
+        """The interleaving that lost a run, forced rather than raced: A and B both see the file at the cap, A
+        rotates it and starts the new file, and B, whose size check predates A's rename, must not rename again.
+        Thread B's stat and thread A's rename are gated on each other with two events, so the order is fixed.
+        The waits end early on their event; their bound only keeps the serialized order (B cannot reach its stat
+        while A holds the lock, so the event never comes) from hanging. Four rows sit in the file before the cap
+        drops to a value one row is under and four rows are over."""
+        for i in range(1, 5):
+            self.post(i)
+        km.CLIENT_DIAG_MAX_BYTES = 300
+        b_statted, a_written = threading.Event(), threading.Event()
+        real_replace, real_stat = os.replace, pathlib.Path.stat
+        fp = self.fp
+
+        def gated_replace(src, dst, *a, **k):
+            if src == str(fp) and threading.current_thread().name == "A":
+                b_statted.wait(2.0)
+            return real_replace(src, dst, *a, **k)
+
+        def gated_stat(self_, *a, **k):
+            st = real_stat(self_, *a, **k)
+            if self_ == fp and threading.current_thread().name == "B":
+                b_statted.set()
+                a_written.wait(2.0)
+            return st
+
+        def post_a():
+            self.post(5)
+            a_written.set()
+
+        os.replace, pathlib.Path.stat = gated_replace, gated_stat
+        try:
+            ta = threading.Thread(target=post_a, name="A")
+            tb = threading.Thread(target=self.post, args=(6,), name="B")
+            ta.start()
+            tb.start()
+            ta.join(10)
+            tb.join(10)
+        finally:
+            os.replace, pathlib.Path.stat = real_replace, real_stat
+        self.assertEqual([r["data"]["i"] for r in self.rows(self.fp1)], [1, 2, 3, 4], "the rotated run is intact")
+        self.assertEqual(sorted(r["data"]["i"] for r in self.rows(self.fp)), [5, 6], "both new rows are in the current file")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client_diag_rotation.py
+++ b/tests/test_client_diag_rotation.py
@@ -8,6 +8,8 @@ client-diag.jsonl.1 (replacing the previous .1) and a new file starts, so at mos
 Drives the REAL Handler's WS dispatch (_dispatch_ws with a clientDiag message, the way the pane shim delivers
 one) against a hermetic state directory, with the cap lowered for the test. Synthetic fixtures only: a
 placeholder dashboard id, invented numbers."""
+import contextlib
+import io
 import json
 import os
 import pathlib
@@ -41,6 +43,7 @@ class ClientDiagRotationTest(unittest.TestCase):
                 f.unlink()
         self.cap = km.CLIENT_DIAG_MAX_BYTES
         km.CLIENT_DIAG_MAX_BYTES = 600           # a handful of rows; the production value is asserted below
+        km._client_diag_rotate_failed = False    # the once-per-kernel stderr latch: each test is its own kernel
 
     def tearDown(self):
         km.CLIENT_DIAG_MAX_BYTES = self.cap
@@ -59,7 +62,10 @@ class ClientDiagRotationTest(unittest.TestCase):
         return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
     def test_a_row_lands_with_the_kernel_stamp(self):
-        self.post(1)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.post(1)
+        self.assertEqual(err.getvalue(), "", "a fresh state directory has no file yet: that is not a refused rotation")
         rows = self.rows(self.fp)
         self.assertEqual(len(rows), 1)
         self.assertEqual(sorted(rows[0]), ["data", "surface", "t", "what", "wid"])
@@ -97,20 +103,33 @@ class ClientDiagRotationTest(unittest.TestCase):
     def test_the_production_cap_is_eight_megabytes(self):
         self.assertEqual(self.cap, 8 * 1024 * 1024)
 
-    def test_a_rename_failure_still_appends(self):
+    def test_a_rename_failure_still_appends_and_is_said_once_on_stderr(self):
+        """A refused rotation (an unwritable state directory, a directory sitting at the .1 name) used to share one
+        silent `except OSError` with the absent-file case, so the size bound could fail with nothing saying so.
+        Now the rows still append, and stderr gets ONE line naming the file and the error, latched for the
+        kernel's lifetime: a rename that stays refused is a line per kernel, not a line per row (a minute per
+        pane)."""
         self.post(1)
         real = os.replace
         km.CLIENT_DIAG_MAX_BYTES = 1
 
         def refuse(*a, **k):
             raise OSError("read-only")
+        err = io.StringIO()
         os.replace = refuse
         try:
-            self.post(2)
+            with contextlib.redirect_stderr(err):
+                self.post(2)
+                self.post(3)
         finally:
             os.replace = real
-        self.assertEqual([r["data"]["i"] for r in self.rows(self.fp)], [1, 2])
+        self.assertEqual([r["data"]["i"] for r in self.rows(self.fp)], [1, 2, 3], "both rows past the cap still appended")
         self.assertFalse(self.fp1.exists())
+        lines = err.getvalue().splitlines()
+        self.assertEqual(len(lines), 1, "two refused renames, one stderr line: %r" % lines)
+        self.assertIn(str(self.fp), lines[0], "the line names the file")
+        self.assertIn("read-only", lines[0], "the line carries the error")
+        self.assertTrue(km._client_diag_rotate_failed)
 
     def test_concurrent_posts_rename_only_a_file_at_the_cap_and_lose_no_row(self):
         """Every pane's socket is its own handler thread, so rows arrive concurrently. Without one lock across

--- a/tests/test_color_route.py
+++ b/tests/test_color_route.py
@@ -63,10 +63,17 @@ class ColorRoute(unittest.TestCase):
         km._pal_cache.update({"name": km.pal.DEFAULT, "mt": None})
 
     def _post(self, body):
+        # km.TOKEN, not os.environ: pytest imports every collected module before any test runs, and
+        # test_kernel.py assigns ROMP_SERVE_TOKEN at import. When this module was the FIRST collected
+        # module to set the variable (a two-file or small-subset run), its kernel captured the default
+        # here and test_kernel.py's later write changed what the env held at request time, so the
+        # request was refused with a 403 (found 2026-09-06). In the full suite some forty earlier
+        # modules setdefault the same value test_kernel.py writes, which is why it passed there. The
+        # kernel's own token is the one the handler checks.
         req = urllib.request.Request(
             "http://127.0.0.1:%d/color" % self.port, data=json.dumps(body).encode(),
             headers={"Content-Type": "application/json",
-                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+                     "X-Romp-Token": km.TOKEN})
         try:
             with urllib.request.urlopen(req, timeout=10) as r:
                 return r.status, json.loads(r.read().decode())

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -38,6 +38,18 @@ class BuildGating(unittest.TestCase):
         self.assertIn('m.type==="bars"', boot)
         self.assertIn("panel.applyBars(m)", boot)
 
+    def test_the_host_shim_wraps_its_listener_through_the_page_collector_when_there_is_one(self):
+        # The page's performance collector (ui/webview/perf-telemetry.ts) is published on window.__rompPerf by
+        # federation.js, which the timeline page loads before this boot (test_browser_owned_order pins the
+        # order). Wrapped, the frames the boot dispatches are timed by type like every pane's, so the view's
+        # hover/activeChat/revealEvent/models handling is not left inside federation's fed:<type> bracket
+        # (2026-09-06); without a collector the plain listener is registered.
+        boot = km._TIMELINE_BOOT
+        self.assertIn("var onFrame=function(ev){var m=ev.data;if(!m||!panel)return;", boot)
+        self.assertIn('window.addEventListener("message",(window.__rompPerf&&window.__rompPerf.wrapFrameHandler)'
+                      "?window.__rompPerf.wrapFrameHandler(onFrame):onFrame);", boot)
+        self.assertEqual(boot.count('addEventListener("message"'), 1, "one listener, the wrapped one")
+
     def test_the_lanes_skeleton_does_not_parse_any_transcript(self):
         # cold-start speed (the user 2026-06-26): a fresh kernel (the refresh button = POST /restart) re-parses
         # every transcript (~1.3s). The lanes don't need it — derive them from tmux + goals + the transcript

--- a/tests/test_pane_shim_return.py
+++ b/tests/test_pane_shim_return.py
@@ -494,7 +494,8 @@ out({pre:pre,ret:rows(sock(),"return").length,kinds:rows(sock()).map(function(m)
         src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
         self.assertIn('elif msg and msg.get("type") == "clientDiag":', src)
         self.assertIn('"data": msg.get("data")}', src)
-        self.assertIn('with open(jd.STATE / "client-diag.jsonl", "a", encoding="utf-8") as f:', src)
+        # #1009 routes the append through _client_diag_append (rotation at the cap); the pin follows the call
+        self.assertIn('_client_diag_append(jd.STATE / "client-diag.jsonl", json.dumps(rec) + "\\n")', src)
 
 
 class TimeSlicedFlush(unittest.TestCase):

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -1,0 +1,807 @@
+#!/usr/bin/env python3
+"""The kernel's always-on performance counters (`_PerfStats`, GET /perf, `romp perf`) and the runtime
+switch for the romp-perf stderr log (POST /perf {"log": bool}).
+
+Before this the only instrumentation was `_perf()`, gated on ROMP_PERF at process start, so turning it
+on meant a kernel restart; and nothing reported rates, so an optimization was checked with a hand-run
+profiler. The collector counts pusher cycles and wakes, cycle durations (a ring for percentiles) and
+the pusher thread's CPU, per-stage time, build cache hits, bytes sent per slot kind, goal-store I/O,
+judge passes with their threads' CPU, and HTTP requests per method and path, with a lock and dict
+increments on the hot paths and no formatting until a read.
+
+Drives the REAL Handler over HTTP and the REAL _push with stubbed builders (the test_color_route.py
+and test_tab_meta_push.py patterns). Synthetic fixtures only: placeholder UUIDs, invented names."""
+import concurrent.futures
+import inspect
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+from unittest import mock
+from contextlib import redirect_stderr
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_perf", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+# A PRIVATE synthetic sid for the goal-store tests: load_goals replays the per-sid override journal,
+# and node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures).
+GOAL_SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms", "builds", "sends",
+            "goals", "judge", "http"}
+
+
+def _burn_cpu(seconds):
+    """Spin this thread for `seconds` of its own CPU time (thread_time, so a descheduled thread still burns
+    the asked amount rather than merely waiting it out)."""
+    t = time.thread_time()
+    while time.thread_time() - t < seconds:
+        pass
+
+
+class _HttpWatch:
+    """Wait for the HTTP wrapper's record instead of racing it. _perf_http_timed counts a request in its
+    `finally`, AFTER the handler put the response on the wire, so a test that reads the snapshot as soon
+    as urlopen returns can see the count land a moment later (it did, about one run in five). Patching
+    the collector's http_request on the instance (the class method stays) makes every record observable:
+    the real method runs, then the key is appended and an Event set, and wait_for blocks on the event
+    until the key has been recorded `n` times or the bound passes."""
+
+    def __enter__(self):
+        st = km._PERF_STATS
+        real = km._PerfStats.http_request
+        self.keys, self.ev = [], threading.Event()
+
+        def wrapped(key, dt):
+            real(st, key, dt)
+            self.keys.append(key)           # append BEFORE set: an observed set implies a visible append
+            self.ev.set()
+        st.http_request = wrapped
+        return self
+
+    def __exit__(self, *a):
+        del km._PERF_STATS.http_request     # the instance attribute goes; the class method shows again
+
+    def wait_for(self, key, n, timeout=2.0):
+        deadline = time.monotonic() + timeout
+        while self.keys.count(key) < n:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                return False
+            self.ev.wait(left)
+            self.ev.clear()
+        return True
+
+
+class Collector(unittest.TestCase):
+    """_PerfStats on its own: every writer lands where the docstring says, and the read-time work
+    (percentiles, the goals and judge reads, the process reads) produces the documented shape."""
+
+    def setUp(self):
+        self.st = km._PerfStats()
+
+    def test_snapshot_has_the_documented_shape_and_starts_at_zero(self):
+        snap = self.st.snapshot()
+        self.assertEqual(set(snap), TOP_KEYS)
+        p = snap["pusher"]
+        self.assertEqual(p["cycles"], 0)
+        for k in ("cycle_ms_p50", "cycle_ms_p90", "cycle_ms_ring_max", "cycle_ms_max", "cycle_cpu_ms_sum"):
+            self.assertEqual(p[k], 0.0, k)
+        self.assertEqual(p["ring_n"], 0)
+        self.assertEqual(set(snap["stages_ms"]), set(km._PerfStats.STAGES))
+        self.assertEqual(set(snap["builds"]), {"chat", "feed", "timeline"})
+        self.assertEqual(set(snap["sends"]), {"full", "delta", "deduped"})
+        self.assertEqual(snap["judge"]["ms_mean"], 0.0, "no passes: the mean is 0, not a division error")
+        self.assertIn("cpu_ms_sum", snap["judge"])
+        self.assertIn("cpu_ms_workers", snap["judge"])
+        self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
+        for k in ("rss_kb", "threads", "cpu_s", "pid"):
+            self.assertIn(k, snap["process"])
+        self.assertGreater(snap["process"]["threads"], 0)
+        self.assertGreaterEqual(snap["process"]["rss_kb"], 0)
+        self.assertGreaterEqual(snap["uptime_s"], 0)
+        json.dumps(snap)                                     # the whole thing serializes as-is
+
+    def test_pusher_counters(self):
+        self.st.wake(); self.st.wake(); self.st.wake()
+        self.st.wake_kind(True); self.st.wake_kind(False); self.st.wake_kind(False)
+        self.st.cycle(0.010, 0.004); self.st.cycle(0.030, 0.006); self.st.cycle(0.020)
+        p = self.st.snapshot()["pusher"]
+        self.assertEqual(p["wakes"], 3)
+        self.assertEqual((p["wakes_event"], p["wakes_backstop"]), (1, 2))
+        self.assertEqual(p["cycles"], 3)
+        self.assertAlmostEqual(p["cycle_ms_sum"], 60.0)
+        self.assertAlmostEqual(p["cycle_cpu_ms_sum"], 10.0, msg="the thread's own CPU rides beside the wall")
+        self.assertAlmostEqual(p["cycle_ms_max"], 30.0)
+        self.assertAlmostEqual(p["cycle_ms_last"], 20.0)
+        self.assertEqual(p["ring_n"], 3)
+
+    def test_ring_percentiles_and_max_come_from_the_last_256_cycles(self):
+        self.st.cycle(5.0)                                   # one slow boot cycle: 5000 ms
+        for i in range(300):                                 # 0..299 ms; the ring keeps 44..299
+            self.st.cycle(i / 1000.0)
+        p = self.st.snapshot()["pusher"]
+        self.assertEqual(p["ring_n"], 256)
+        self.assertEqual(p["cycles"], 301, "the count is lifetime; only the percentile window is bounded")
+        self.assertAlmostEqual(p["cycle_ms_p50"], 44 + 128)  # sorted ring[int(0.5 * 256)]
+        self.assertAlmostEqual(p["cycle_ms_p90"], 44 + 230)  # sorted ring[int(0.9 * 256)]
+        self.assertAlmostEqual(p["cycle_ms_ring_max"], 299.0, msg="the window's max: the ring's largest")
+        self.assertAlmostEqual(p["cycle_ms_max"], 5000.0, msg="the lifetime max keeps the boot cycle")
+
+    def test_stages_builds_judge(self):
+        self.st.stage("push.chat", 0.5); self.st.stage("push.chat", 0.25); self.st.stage("jobs", 0.1)
+        self.st.build("chat", True); self.st.build("chat", False, 0.040); self.st.build("feed", False, 1.0)
+        self.st.judge_pass(2.0); self.st.judge_pass(4.0); self.st.judge_cpu(0.25)
+        snap = self.st.snapshot()
+        self.assertAlmostEqual(snap["stages_ms"]["push.chat"], 750.0)
+        self.assertAlmostEqual(snap["stages_ms"]["jobs"], 100.0)
+        self.assertEqual(snap["builds"]["chat"], {"cached": 1, "built": 1, "ms": 40.0})
+        self.assertEqual(snap["builds"]["feed"]["built"], 1)
+        self.assertEqual(snap["builds"]["timeline"], {"cached": 0, "built": 0, "ms": 0.0})
+        self.assertEqual(snap["judge"]["passes"], 2)
+        self.assertAlmostEqual(snap["judge"]["ms_last"], 4000.0)
+        self.assertAlmostEqual(snap["judge"]["ms_mean"], 3000.0)
+        self.assertAlmostEqual(snap["judge"]["cpu_ms_sum"] - snap["judge"]["cpu_ms_workers"], 250.0,
+                               msg="the tier threads' CPU, apart from the pool workers' share")
+
+    def test_sends_classify_by_kind_and_slot_name(self):
+        self.st.send(("chat", SID), "full", 1000)            # a tuple dedup key: the slot is its first element
+        self.st.send(("chat", SID), "full", 500)
+        self.st.send(("chat", SID), "deduped", 1000)
+        self.st.send("feed", "delta", 20)                    # a bare string key (the feed's own delta path)
+        s = self.st.snapshot()["sends"]
+        self.assertEqual(s["full"], {"chat": {"count": 2, "bytes": 1500}})
+        self.assertEqual(s["deduped"], {"chat": {"count": 1, "bytes": 1000}})
+        self.assertEqual(s["delta"], {"feed": {"count": 1, "bytes": 20}})
+
+    def test_send_slots_are_capped(self):
+        for i in range(40):
+            self.st.send(("slot%d" % i,), "full", 1)
+        d = self.st.snapshot()["sends"]["full"]
+        self.assertEqual(len(d), km._PerfStats.SLOTS + 1)
+        self.assertEqual(d["other"]["count"], 40 - km._PerfStats.SLOTS)
+
+    def test_http_keys_are_capped_and_ws_adds_no_time(self):
+        for i in range(100):
+            self.st.http_request("GET /scan/%d" % i, 0.001)
+        self.st.http_request("GET /ws", None)
+        h = self.st.snapshot()["http"]
+        self.assertEqual(len(h), km._PerfStats.HTTP_PATHS + 1, "64 keys plus the fold")
+        self.assertEqual(h["other"]["count"], 100 - km._PerfStats.HTTP_PATHS + 1,
+                         "the 36 keys past the cap and /ws, which arrived after it")
+        st2 = km._PerfStats()
+        st2.http_request("GET /ws", None); st2.http_request("POST /tick", 0.002)
+        h = st2.snapshot()["http"]
+        self.assertEqual(h["GET /ws"], {"count": 1, "ms": 0.0}, "a socket's lifetime is not a request time")
+        self.assertEqual(h["POST /tick"]["count"], 1)
+        self.assertAlmostEqual(h["POST /tick"]["ms"], 2.0)
+
+    def test_http_key_is_method_plus_normalized_path(self):
+        key = km._perf_http_key
+        self.assertEqual(key("GET", "/sessions"), "GET /sessions")
+        self.assertEqual(key("POST", "/perf"), "POST /perf", "GET /perf and POST /perf are separate rows")
+        self.assertEqual(key("GET", "/dist/render.js"), "GET /dist/*")
+        self.assertEqual(key("GET", "/dist/fonts/a-b-c.woff2"), "GET /dist/*", "sixty font files: one key")
+        self.assertEqual(key("GET", "/media/romp-app-192.png"), "GET /media/*")
+        self.assertEqual(key("GET", "/remote/TESTHOST/ws"), "GET /remote/*/ws", "no host name in a key")
+        self.assertEqual(key("HEAD", "/remote/TESTHOST/file"), "HEAD /remote/*/file")
+        self.assertEqual(key("GET", "/remote/TESTHOST"), "GET /remote/*")
+        self.assertEqual(key("", "/version"), "/version", "a handler without a method: the path alone")
+
+    def test_reset_starts_over_and_moves_since(self):
+        self.st.cycle(0.1); self.st.http_request("GET /x", 0.1)
+        before = self.st.snapshot()["since"]
+        time.sleep(0.01)
+        self.st.reset()
+        snap = self.st.snapshot()
+        self.assertEqual(snap["pusher"]["cycles"], 0)
+        self.assertEqual(snap["http"], {})
+        self.assertGreater(snap["since"], before)
+
+    def test_writers_are_thread_safe(self):
+        def hammer():
+            for _ in range(2000):
+                self.st.wake(); self.st.send(("chat", SID), "full", 1); self.st.http_request("GET /p", 0.0)
+        ts = [threading.Thread(target=hammer) for _ in range(8)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        snap = self.st.snapshot()
+        self.assertEqual(snap["pusher"]["wakes"], 16000)
+        self.assertEqual(snap["sends"]["full"]["chat"]["count"], 16000)
+        self.assertEqual(snap["http"]["GET /p"]["count"], 16000)
+
+
+class ProcessStatsFallback(unittest.TestCase):
+    """_process_stats reads VmRSS from /proc/self/status; a platform without /proc (macOS) gets
+    ru_maxrss, which the kernel there reports in bytes and Linux in KB, so only the darwin branch
+    scales. Both branches are driven here: /proc is made to fail on every platform, and the
+    platform name and the rusage read are patched so the figure is exact."""
+
+    class _Usage:
+        ru_maxrss = 2048 * 1024                              # bytes on darwin, KB on linux
+
+    def _stats(self, platform):
+        real_open = open
+
+        def no_proc(path, *a, **kw):
+            if path == "/proc/self/status":
+                raise FileNotFoundError(path)
+            return real_open(path, *a, **kw)
+        import resource
+        with mock.patch("builtins.open", side_effect=no_proc), \
+                mock.patch.object(resource, "getrusage", return_value=self._Usage()), \
+                mock.patch.object(sys, "platform", platform):
+            return km._process_stats()
+
+    def test_without_proc_rss_comes_from_ru_maxrss(self):
+        st = self._stats("linux")
+        self.assertIsInstance(st["rss_kb"], int)
+        self.assertEqual(st["rss_kb"], 2048 * 1024, "linux reports ru_maxrss in KB: taken as is")
+        for k in ("threads", "cpu_s", "pid"):
+            self.assertIn(k, st)
+        self.assertEqual(st["pid"], os.getpid())
+
+    def test_on_darwin_ru_maxrss_is_bytes_and_is_scaled_to_kb(self):
+        st = self._stats("darwin")
+        self.assertEqual(st["rss_kb"], 2048, "ru_maxrss // 1024")
+
+    def test_with_proc_present_the_fallback_is_not_used(self):
+        import resource
+        with mock.patch.object(resource, "getrusage", side_effect=AssertionError("fallback taken")):
+            try:
+                with open("/proc/self/status"):
+                    pass
+            except OSError:
+                self.skipTest("no /proc on this platform")
+            self.assertGreater(km._process_stats()["rss_kb"], 0, "VmRSS read from /proc")
+
+
+class WakeCounting(unittest.TestCase):
+    """_pusher_wake is a threading.Event whose set() counts: every existing call site — including the
+    bound-method callbacks the backends hold — counts a wake without being touched."""
+
+    def test_the_pusher_wake_counts_sets(self):
+        self.assertIsInstance(km._pusher_wake, threading.Event)
+        self.assertIsInstance(km._pusher_wake, km._CountedEvent)
+        was_set = km._pusher_wake.is_set()
+        before = km._PERF_STATS.snapshot()["pusher"]["wakes"]
+        km._pusher_wake.set()
+        cb = km._pusher_wake.set                             # the shape the backends are handed (push=_pusher_wake.set)
+        cb()
+        self.assertTrue(km._pusher_wake.is_set())
+        self.assertEqual(km._PERF_STATS.snapshot()["pusher"]["wakes"], before + 2)
+        if not was_set:
+            km._pusher_wake.clear()
+
+    def test_wake_helpers_still_set_the_event(self):
+        km._pusher_wake.clear()
+        km._push_soon()
+        self.assertTrue(km._pusher_wake.is_set())
+        km._pusher_wake.clear()
+
+
+class PerfLogToggle(unittest.TestCase):
+    """_perf() writes only when the switch is on, and the switch flips at runtime."""
+
+    def setUp(self):
+        self.saved = km._PERF
+        km._set_perf_log(False)
+
+    def tearDown(self):
+        km._set_perf_log(self.saved)
+
+    def test_off_writes_nothing_on_writes_one_line(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "")
+        self.assertTrue(km._set_perf_log(True))
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "romp-perf probe a=1 b=2\n")
+        km._set_perf_log(False)
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", b=2, a=1)
+        self.assertEqual(buf.getvalue(), "", "off again: nothing")
+
+    def test_the_off_path_reads_one_module_global(self):
+        src = inspect.getsource(km._perf)
+        self.assertIn("if not _PERF:\n        return", src, "the hot path stays a name lookup and a return")
+
+
+class GoalIoCounters(unittest.TestCase):
+    """judge.load_goals / save_goals count calls and disk writes; the kernel reads them via goal_io_stats."""
+
+    def setUp(self):
+        self.jd = km.jd
+        self.jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(self._clean)
+
+    def _clean(self):
+        for p in (self.jd.GOALDIR / (GOAL_SID + ".json"), self.jd.STATE / "overrides" / (GOAL_SID + ".jsonl")):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    def test_loads_saves_and_writes(self):
+        before = self.jd.goal_io_stats()
+        store = self.jd.load_goals(GOAL_SID)                 # no file yet: a fresh store, still one load
+        after = self.jd.goal_io_stats()
+        self.assertEqual(after["loads"], before["loads"] + 1)
+        self.jd.save_goals(GOAL_SID, store)                  # the first publish writes the file
+        after = self.jd.goal_io_stats()
+        self.assertEqual(after["saves"], before["saves"] + 1)
+        self.assertEqual(after["writes"], before["writes"] + 1)
+        store = self.jd.load_goals(GOAL_SID)
+        self.jd.save_goals(GOAL_SID, store)                  # byte-identical: a save, not a write
+        after2 = self.jd.goal_io_stats()
+        self.assertEqual(after2["saves"], after["saves"] + 1)
+        self.assertEqual(after2["writes"], after["writes"], "the no-op republish skip is visible as saves without writes")
+        self.assertEqual(km._PERF_STATS.snapshot()["goals"], after2, "the kernel's snapshot carries the judge counters")
+
+    def test_the_getter_returns_a_copy(self):
+        d = self.jd.goal_io_stats()
+        d["loads"] = -1
+        self.assertNotEqual(self.jd.goal_io_stats()["loads"], -1)
+
+
+class JudgeCpu(unittest.TestCase):
+    """The judge's CPU is attributed from two places: the tier threads (_run_tier) and every future the
+    tiers submit to judge.py's pools (_TimedPool, bound to the module's ThreadPoolExecutor name)."""
+
+    def test_pool_workers_account_their_cpu(self):
+        jd = km.jd
+        self.assertTrue(issubclass(jd.ThreadPoolExecutor, concurrent.futures.ThreadPoolExecutor),
+                        "every pool in judge.py is a real executor that also accounts")
+        before = jd.judge_worker_cpu_ms()
+        with jd.ThreadPoolExecutor(max_workers=2) as ex:
+            self.assertEqual(ex.submit(lambda a, b=1: a + b, 2, b=3).result(), 5, "args and kwargs pass through")
+            ex.submit(_burn_cpu, 0.005).result()
+        grew = jd.judge_worker_cpu_ms() - before
+        self.assertGreaterEqual(grew, 4.0, "about 5 ms of a worker's CPU landed")
+        self.assertLess(grew, 500.0)
+        self.assertEqual(km._PERF_STATS.snapshot()["judge"]["cpu_ms_workers"], jd.judge_worker_cpu_ms())
+
+    def test_run_tier_accounts_the_tier_threads_cpu(self):
+        def tier_cpu():
+            j = km._PERF_STATS.snapshot()["judge"]
+            return j["cpu_ms_sum"] - j["cpu_ms_workers"]
+        before = tier_cpu()
+        km._run_tier(lambda: _burn_cpu(0.005))
+        self.assertGreaterEqual(tier_cpu() - before, 4.0)
+        before = tier_cpu()
+        with redirect_stderr(io.StringIO()):
+            km._run_tier(lambda: (_burn_cpu(0.005), (_ for _ in ()).throw(RuntimeError("tier died"))))
+        self.assertGreaterEqual(tier_cpu() - before, 4.0, "a raising tier still accounts (the finally)")
+
+
+class PusherRecords(unittest.TestCase):
+    """The pusher's seams record into _PERF_STATS: a cycle lands in the ring with its thread's CPU, the
+    cycle jobs split into push and jobs, the cached and rebuilt feed/timeline paths count, and the
+    send paths classify full / delta / deduped for whole-frame, delta-capable and chat-tail clients."""
+
+    JOBS = ("_apply_pending_ops", "_turn_notify_tick", "_lift_spent_awaiting", "_death_sweep_tick",
+            "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
+            "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
+            "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
+            "_clear_done_working_notes", "_push_all")
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        names = Path(self.td.name) / "names"
+        names.mkdir()
+        self.saved = (km.NAMES, km._tmux_sessions, km._pusher_cycle_jobs, list(km._built_feed),
+                      list(km._built_timeline), km.build_feed, km.build_timeline, km._needs_you_count,
+                      km._feed_notifications, km._badge_push, km._views_dirty[0])
+        self.saved_jobs = {nm: getattr(km, nm) for nm in self.JOBS}
+        km.NAMES = names
+        km._tmux_sessions = lambda: {}
+        self.addCleanup(self._restore)
+        self.addCleanup(self.td.cleanup)
+
+    def _restore(self):
+        (km.NAMES, km._tmux_sessions, km._pusher_cycle_jobs, bf, bt, km.build_feed, km.build_timeline,
+         km._needs_you_count, km._feed_notifications, km._badge_push, vd) = self.saved
+        km._built_feed[:] = bf
+        km._built_timeline[:] = bt
+        km._views_dirty[0] = vd
+        for nm, fn in self.saved_jobs.items():
+            setattr(km, nm, fn)
+
+    def _pusher(self):
+        return km._PERF_STATS.snapshot()["pusher"]
+
+    def test_a_cycle_is_counted_and_timed(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.005)
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertEqual(after["cycles"], before["cycles"] + 1)
+        self.assertGreaterEqual(after["cycle_ms_last"], 5.0)
+        self.assertEqual(after["ring_n"], min(before["ring_n"] + 1, km._PerfStats.RING))
+
+    def test_a_cycle_records_its_threads_cpu_not_its_waits(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: time.sleep(0.020)   # a wait, no CPU
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertGreaterEqual(after["cycle_ms_last"], 20.0)
+        self.assertLess(after["cycle_cpu_ms_sum"] - before["cycle_cpu_ms_sum"], 15.0,
+                        "a sleeping cycle adds far less CPU than wall")
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: _burn_cpu(0.005)     # CPU, no wait
+        before = self._pusher()
+        km._pusher_cycle()
+        after = self._pusher()
+        self.assertGreaterEqual(after["cycle_cpu_ms_sum"] - before["cycle_cpu_ms_sum"], 4.0,
+                                "a spinning cycle's CPU lands in cycle_cpu_ms_sum")
+
+    def test_a_raising_cycle_is_still_counted(self):
+        km._pusher_cycle_jobs = lambda now, tmux, any_client: (_ for _ in ()).throw(RuntimeError("job died"))
+        before = self._pusher()["cycles"]
+        with self.assertRaises(RuntimeError):
+            km._pusher_cycle()
+        self.assertEqual(self._pusher()["cycles"], before + 1)
+
+    def test_cycle_jobs_split_into_push_and_jobs(self):
+        # the REAL _pusher_cycle_jobs with every tick job a no-op and _push_all a 5 ms sleep: `push` is the
+        # _push_all call, `jobs` the rest of the function, so push >= 5 and 0 <= jobs < push
+        for nm in self.JOBS:
+            setattr(km, nm, lambda *a, **k: None)
+        km._push_all = lambda tmux=None: time.sleep(0.005)
+        before = km._PERF_STATS.snapshot()["stages_ms"]
+        km._pusher_cycle_jobs(int(time.time()), {}, True)
+        after = km._PERF_STATS.snapshot()["stages_ms"]
+        push, jobs = after["push"] - before["push"], after["jobs"] - before["jobs"]
+        self.assertGreaterEqual(push, 5.0)
+        self.assertGreaterEqual(jobs, 0.0, "jobs is the function minus the push, never negative")
+        self.assertLess(jobs, push, "no-op jobs cost less than a 5 ms push")
+        before = km._PERF_STATS.snapshot()["stages_ms"]
+        km._pusher_cycle_jobs(int(time.time()), {}, False)   # no client: no push, the jobs still run
+        after = km._PERF_STATS.snapshot()["stages_ms"]
+        self.assertEqual(after["push"], before["push"])
+        self.assertGreaterEqual(after["jobs"], before["jobs"])
+
+    def test_feed_and_timeline_builds_count_cached_and_rebuilt(self):
+        km.build_feed = lambda now, tmux: {"working": [], "items": []}
+        km.build_timeline = lambda now, tmux, **kw: {"turns": [], "judging": [], "messages": [], "now": now}
+        km._needs_you_count = lambda feed: 0
+        km._feed_notifications = lambda feed: []
+        km._badge_push = lambda n: None
+        km._views_dirty[0] = 0.0
+        km._built_feed[:] = [None, None, 0.0, 0.0]
+        km._built_timeline[:] = [None, None, 0.0, 0.0]
+        b0 = km._PERF_STATS.snapshot()["builds"]
+        now = int(time.time())
+        km._cached_feed(now, {}, "sig-a")                    # nothing warmed: a rebuild
+        km._cached_feed(now, {}, "sig-a")                    # unchanged sig: served from the cache
+        km._cached_timeline(now, {}, "sig-a")
+        km._cached_timeline(now, {}, "sig-a", connect=True)  # a connecting page never rebuilds
+        b1 = km._PERF_STATS.snapshot()["builds"]
+        self.assertEqual(b1["feed"]["built"] - b0["feed"]["built"], 1)
+        self.assertEqual(b1["feed"]["cached"] - b0["feed"]["cached"], 1)
+        self.assertGreaterEqual(b1["feed"]["ms"], b0["feed"]["ms"])
+        self.assertEqual(b1["timeline"]["built"] - b0["timeline"]["built"], 1)
+        self.assertEqual(b1["timeline"]["cached"] - b0["timeline"]["cached"], 1)
+
+    @staticmethod
+    def _sends():
+        s = km._PERF_STATS.snapshot()["sends"]
+        return {(kind, slot): e["count"] for kind, d in s.items() for slot, e in d.items()}
+
+    def test_a_whole_frame_client_counts_full_then_deduped(self):
+        sent = []
+        c = {"app": "chat", "alive": True, "send": sent.append, "sent": {}}
+        s0 = self._sends()
+        km._send_client(c, ("working", SID), {"type": "working", "names": ["web"]})
+        km._send_client(c, ("working", SID), {"type": "working", "names": ["web"]})
+        s1 = self._sends()
+        self.assertEqual(len(sent), 1, "the second identical frame was deduped")
+        self.assertEqual(s1[("full", "working")] - s0.get(("full", "working"), 0), 1)
+        self.assertEqual(s1[("deduped", "working")] - s0.get(("deduped", "working"), 0), 1)
+        bytes_full = km._PERF_STATS.snapshot()["sends"]["full"]["working"]["bytes"]
+        self.assertGreaterEqual(bytes_full, len(sent[0]))
+
+    def test_a_delta_client_counts_the_suppressed_bars_frame_as_deduped(self):
+        # every browser pane connects with delta=1, so the bars slot's dedup happens in _send_slot_delta's
+        # unchanged path, not in _send_client — it must count there too, or deduped.timelinebars stays 0
+        sent = []
+        c = {"app": "timeline", "alive": True, "send": sent.append, "sent": {}, "delta": True}
+        bars = {"type": "bars", "turns": {"lane": [{"id": "t1", "a": 1}]}, "judging": [], "messages": [],
+                "now": 1, "warming": False}
+        pre = json.dumps(bars)
+        sig = km._dedup_sig(bars, pre)
+        s0 = self._sends()
+        km._send_slot(c, "bars", bars, pre, sig)
+        km._send_slot(c, "bars", bars, pre, sig)
+        s1 = self._sends()
+        self.assertEqual(len(sent), 1, "the keyed full went once; the unchanged repeat sent nothing")
+        self.assertEqual(s1[("full", "timelinebars")] - s0.get(("full", "timelinebars"), 0), 1)
+        self.assertEqual(s1[("deduped", "timelinebars")] - s0.get(("deduped", "timelinebars"), 0), 1)
+        self.assertEqual(s1.get(("delta", "timelinebars"), 0) - s0.get(("delta", "timelinebars"), 0), 0)
+
+    def test_a_caught_up_chat_client_counts_its_tail_as_delta(self):
+        sent = []
+        c = {"app": "chat", "alive": True, "send": sent.append, "sent": {}}
+        m1 = {"type": "session", "id": SID, "name": "web", "events": [{"uuid": "e1", "type": "user"}],
+              "status": {"state": "working"}}                # the shape build_session returns: a {type: session} frame
+        m2 = {"type": "session", "id": SID, "name": "web", "events": m1["events"] + [{"uuid": "e2", "type": "assistant"}],
+              "status": {"state": "waiting"}}
+        s0 = self._sends()
+        km._send_chat(c, m1, None, 0, False)                # nothing held: the whole session
+        km._send_chat(c, m2, None, 1, False)                # caught up through e1: the suffix from 1
+        s1 = self._sends()
+        self.assertEqual([json.loads(x)["type"] for x in sent], ["session", "chatTail"])
+        self.assertEqual(s1[("full", "chat")] - s0.get(("full", "chat"), 0), 1)
+        self.assertEqual(s1[("delta", "chat")] - s0.get(("delta", "chat"), 0), 1, "the tail is the chat's delta")
+
+
+class PushStages(unittest.TestCase):
+    """_push driven for real (the test_tab_meta_push.py pattern) with builders stubbed to sleep 5 ms
+    each: every push.* stage grows by at least its builder's sleep, the chat build counts as built on
+    the first push and as cached on the second (same transcript, background tab), and the timeline
+    client's bars go out in the send stage."""
+
+    STUBS = ("NAMES", "_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
+             "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
+             "_retry_parked_creates")
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        names = Path(self.tmp) / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        self.transcript = Path(self.tmp) / (SID + ".jsonl")
+        self.transcript.write_text('{"type": "user"}\n')       # exists → _chat_build_sig is a real signature
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (km.jd.STATE, dict(km._built_chat), dict(km._prev_chat_events),
+                            dict(km._prev_chat_ledger), list(km._last_tab_order))
+        km.NAMES = names
+        km.jd.STATE = Path(self.tmp) / "state"
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": SID, "name": "web", "path": str(self.transcript),
+                                                    "anchor": SID}]
+        km.build_session = self._build_session
+        km._cached_feed = lambda now, tmux, sig, connect=False: self._slow({"working": [], "awaiting": [], "now": now})
+        km._cached_timeline = lambda now, tmux, sig, connect=False: self._slow(
+            {"turns": {}, "judging": [], "messages": [], "now": now})
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.builds = 0
+        self.chat_frames, self.tl_frames = [], []
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: self.chat_frames.append(json.loads(s))}
+        self.tl = {"app": "timeline", "alive": True, "sent": {}, "send": lambda s: self.tl_frames.append(json.loads(s))}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, bc, pe, pl, lo = self.saved_state
+        km.jd.STATE = st
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+
+    @staticmethod
+    def _slow(value):
+        time.sleep(0.005)
+        return value
+
+    def _build_session(self, sid, now, tmux):
+        self.builds += 1
+        return self._slow({"type": "session", "id": sid, "name": "web", "events": [{"uuid": "e1", "type": "user"}],
+                           "ledger": None, "status": {"state": "waiting"}, "color": None})
+
+    def test_stages_and_chat_builds_are_recorded_by_the_real_push(self):
+        snap0 = km._PERF_STATS.snapshot()
+        km._push([self.chat, self.tl])
+        snap1 = km._PERF_STATS.snapshot()
+        self.assertEqual(self.builds, 1)
+        d = {k: snap1["stages_ms"][k] - snap0["stages_ms"][k] for k in snap0["stages_ms"]}
+        self.assertGreaterEqual(d["push.chat"], 5.0, "the build_session sleep lands in the chat stage")
+        self.assertGreaterEqual(d["push.feed"], 5.0, "the _cached_feed sleep lands in the feed stage")
+        self.assertGreaterEqual(d["push.timeline"], 5.0, "the _cached_timeline sleep lands in the timeline stage")
+        self.assertGreater(d["push.send"], 0.0, "the bars serialization and send took time")
+        self.assertEqual(d["jobs"], 0.0, "a bare _push is not a cycle: jobs and push stay")
+        self.assertEqual(d["push"], 0.0)
+        self.assertEqual(snap1["builds"]["chat"]["built"] - snap0["builds"]["chat"]["built"], 1)
+        self.assertEqual(snap1["builds"]["chat"]["cached"] - snap0["builds"]["chat"]["cached"], 0)
+        self.assertGreaterEqual(snap1["builds"]["chat"]["ms"] - snap0["builds"]["chat"]["ms"], 5.0)
+        self.assertIn("session", [f["type"] for f in self.chat_frames])
+        self.assertIn("bars", [f["type"] for f in self.tl_frames])
+        # the same transcript again: the background tab's build is served from the cache
+        km._push([self.chat, self.tl])
+        snap2 = km._PERF_STATS.snapshot()
+        self.assertEqual(self.builds, 1, "no rebuild")
+        self.assertEqual(snap2["builds"]["chat"]["cached"] - snap1["builds"]["chat"]["cached"], 1)
+        self.assertEqual(snap2["builds"]["chat"]["built"] - snap1["builds"]["chat"]["built"], 0)
+        self.assertLess(snap2["stages_ms"]["push.chat"] - snap1["stages_ms"]["push.chat"], 5.0,
+                        "a cached tab costs the chat stage no build")
+
+    def test_the_seams_stay_where_the_stages_are_defined(self):
+        # the order of the four stage records in _push is the definition of the split; pinned beside the
+        # behavioural test above so a re-ordering is caught even when every stage still grows
+        push = inspect.getsource(km._push)
+        idx = [push.index('_PERF_STATS.stage("%s"' % st) for st in ("push.chat", "push.feed", "push.timeline", "push.send")]
+        self.assertEqual(idx, sorted(idx))
+        self.assertIn("_PERF_STATS.judge_pass(", inspect.getsource(km._producer))
+        loop = inspect.getsource(km._pusher)
+        self.assertIn("_woke = _pusher_wake.wait(0.5)", loop)
+        self.assertIn("_PERF_STATS.wake_kind(_woke)", loop)
+
+
+class PerfRoutes(unittest.TestCase):
+    """GET /perf and POST /perf through the real Handler: token-gated, the documented shape, the toggle,
+    and every request method counted under METHOD /path."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        self.saved_log = km._PERF
+        km._set_perf_log(False)
+
+    def tearDown(self):
+        km._set_perf_log(self.saved_log)
+
+    def _req(self, method, path, body=None, token=True):
+        headers = {"Content-Type": "application/json"}
+        if token:
+            # km.TOKEN, not os.environ: under xdist every worker imports every test module at
+            # collection, and a later module's import-time ROMP_SERVE_TOKEN write changes the env
+            # after this module's kernel captured its token (the test_kernel_attach_on_behalf pattern)
+            headers["X-Romp-Token"] = km.TOKEN
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), data=data,
+                                     headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                raw = r.read().decode()
+                return r.status, (json.loads(raw) if raw.startswith(("{", "[")) else raw)
+        except urllib.error.HTTPError as e:
+            raw = e.read().decode()
+            return e.code, (json.loads(raw) if raw.startswith(("{", "[")) else raw)
+
+    @staticmethod
+    def _http(key):
+        return km._PERF_STATS.snapshot()["http"].get(key, {"count": 0, "ms": 0.0})
+
+    def test_get_perf_serves_the_snapshot(self):
+        with _HttpWatch() as w:
+            st, snap = self._req("GET", "/perf")
+            self.assertEqual(st, 200)
+            self.assertEqual(set(snap), TOP_KEYS)
+            self.assertIs(snap["log"], False)
+            self.assertEqual(snap["process"]["pid"], os.getpid())
+            self.assertTrue(w.wait_for("GET /perf", 1), "the request's own record lands after the response")
+            st, snap2 = self._req("GET", "/perf?x=1")
+        self.assertEqual(st, 200)
+        self.assertGreaterEqual(snap2["http"]["GET /perf"]["count"], 1, "counted under METHOD /path, query stripped")
+        self.assertFalse([k for k in snap2["http"] if "?" in k])
+
+    def test_get_perf_requires_the_token(self):
+        st, body = self._req("GET", "/perf", token=False)
+        self.assertEqual(st, 403)
+        self.assertNotIn("cycles", str(body))
+
+    def test_post_perf_requires_the_token(self):
+        st, body = self._req("POST", "/perf", {"log": True}, token=False)
+        self.assertEqual(st, 403)
+        self.assertFalse(km._PERF, "a refused POST flips nothing")
+
+    def test_post_perf_flips_the_log_and_perf_emits_only_after(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "", "off before the POST")
+        with redirect_stderr(io.StringIO()):                 # the route's own "log on" notice goes to stderr
+            st, r = self._req("POST", "/perf", {"log": True})
+        self.assertEqual((st, r), (200, {"ok": True, "log": True}))
+        self.assertTrue(km._PERF)
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "romp-perf probe n=1\n", "on after the POST, no restart")
+        st, snap = self._req("GET", "/perf")
+        self.assertIs(snap["log"], True, "the snapshot reports the switch")
+        with redirect_stderr(io.StringIO()):
+            st, r = self._req("POST", "/perf", {"log": False})
+        self.assertEqual((st, r), (200, {"ok": True, "log": False}))
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            km._perf("probe", n=1)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_post_perf_refuses_a_malformed_body(self):
+        for body in ({}, {"log": "yes"}, {"log": 1}, [], "log"):
+            st, r = self._req("POST", "/perf", body)
+            self.assertEqual(st, 400, body)
+            self.assertFalse(r["ok"])
+        self.assertFalse(km._PERF)
+
+    def test_the_routes_sit_after_the_gate_in_the_source(self):
+        get = inspect.getsource(km.Handler.do_GET)
+        gate = "ok, self._set_cookie, why = self._authorize(q)"
+        self.assertEqual(get.count(gate), 1)
+        self.assertGreater(get.index('p == "/perf"'), get.index(gate))
+        post = inspect.getsource(km.Handler.do_POST)
+        self.assertEqual(post.count(gate), 1)
+        self.assertGreater(post.index('u.path == "/perf"'), post.index(gate))
+
+    def test_every_request_is_timed_per_method_and_path(self):
+        before = self._http("GET /version")
+        with _HttpWatch() as w:
+            self._req("GET", "/version?probe=1", token=False)   # an exempt route counts too
+            self._req("GET", "/version", token=False)
+            self.assertTrue(w.wait_for("GET /version", 2), "both records landed (waited on, not raced)")
+        after = self._http("GET /version")
+        self.assertEqual(after["count"], before["count"] + 2)
+        self.assertGreater(after["ms"], before["ms"])
+
+    def test_head_and_options_are_counted_too(self):
+        head0, opt0 = self._http("HEAD /version"), self._http("OPTIONS /perf")
+        with _HttpWatch() as w:
+            self._req("HEAD", "/version", token=False)
+            self._req("OPTIONS", "/perf")
+            self.assertTrue(w.wait_for("HEAD /version", 1))
+            self.assertTrue(w.wait_for("OPTIONS /perf", 1))
+        self.assertEqual(self._http("HEAD /version")["count"], head0["count"] + 1, "a /file probe storm is visible")
+        self.assertEqual(self._http("OPTIONS /perf")["count"], opt0["count"] + 1, "a preflight burst is visible")
+
+    def test_a_ws_upgrade_is_counted_when_it_arrives(self):
+        # the wrapper on a stand-in handler: for a /ws path the count is taken BEFORE the handler runs,
+        # since do_GET returns only when the socket closes, and no time is added after
+        seen = {}
+
+        class H:
+            path = "/ws?token=x"
+            command = "GET"
+
+            @km._perf_http_timed
+            def do_GET(self):
+                seen["during"] = PerfRoutes._http("GET /ws")["count"]
+        before = self._http("GET /ws")
+        H().do_GET()
+        after = self._http("GET /ws")
+        self.assertEqual(seen["during"], before["count"] + 1, "counted at arrival, not at socket close")
+        self.assertEqual(after["count"], before["count"] + 1, "and not a second time in the finally")
+        self.assertEqual(after["ms"], before["ms"], "a socket's lifetime is not a request time")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -16,6 +16,7 @@ import inspect
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import threading
@@ -180,12 +181,13 @@ class Collector(unittest.TestCase):
         self.assertEqual(d["other"]["count"], 40 - km._PerfStats.SLOTS)
 
     def test_http_keys_are_capped_and_ws_adds_no_time(self):
-        for i in range(100):
+        cap = km._PerfStats.HTTP_PATHS
+        for i in range(cap + 36):
             self.st.http_request("GET /scan/%d" % i, 0.001)
         self.st.http_request("GET /ws", None)
         h = self.st.snapshot()["http"]
-        self.assertEqual(len(h), km._PerfStats.HTTP_PATHS + 1, "64 keys plus the fold")
-        self.assertEqual(h["other"]["count"], 100 - km._PerfStats.HTTP_PATHS + 1,
+        self.assertEqual(len(h), cap + 1, "the cap's keys plus other")
+        self.assertEqual(h["other"]["count"], 36 + 1,
                          "the 36 keys past the cap and /ws, which arrived after it")
         st2 = km._PerfStats()
         st2.http_request("GET /ws", None); st2.http_request("POST /tick", 0.002)
@@ -193,6 +195,26 @@ class Collector(unittest.TestCase):
         self.assertEqual(h["GET /ws"], {"count": 1, "ms": 0.0}, "a socket's lifetime is not a request time")
         self.assertEqual(h["POST /tick"]["count"], 1)
         self.assertAlmostEqual(h["POST /tick"]["ms"], 2.0)
+
+    def test_the_http_cap_clears_the_kernels_own_route_table(self):
+        """HTTP_PATHS bounds the distinct keys for the kernel's LIFETIME (a scanner must not grow the dict), so it
+        has to sit comfortably above the kernel's own fixed routes, or a real route that first arrives after
+        the cap lands in "other" for good. The first cap, 64, was below the route table itself (88 literals
+        on 2026-09-07). The count comes from the do_* dispatch source (`p == "/x"`, `u.path == "/x"` and the
+        `in ("/x", "/y")` tuples; inspect.getsource unwraps the timing decorator), so this trips when routes
+        outgrow the headroom: 1.5x the literal count, room for the collapsed /dist/*, /media/* and /remote/*/…
+        families and an OPTIONS preflight per cross-origin POST route."""
+        lit = re.compile(r'(?:\bp|u\.path) (?:==|in) (?:"(/[^"]*)"|\(((?:"/[^"]*"(?:, )?)+)\))')
+        n = 0
+        for meth in ("do_GET", "do_HEAD", "do_OPTIONS", "do_POST"):
+            src = inspect.getsource(getattr(km.Handler, meth))
+            paths = set()
+            for m in lit.finditer(src):
+                paths.update([m.group(1)] if m.group(1) is not None else re.findall(r'"(/[^"]*)"', m.group(2)))
+            n += len(paths)
+        self.assertGreaterEqual(n, 80, "the derivation lost the route table (did the dispatch shape change?)")
+        self.assertGreaterEqual(km._PerfStats.HTTP_PATHS, int(n * 1.5),
+                                "%d fixed routes: raise HTTP_PATHS, or routes land in other for the kernel's lifetime" % n)
 
     def test_http_key_is_method_plus_normalized_path(self):
         key = km._perf_http_key

--- a/tests/test_view_deltas.py
+++ b/tests/test_view_deltas.py
@@ -712,10 +712,10 @@ class TwoThreadsOneClient(unittest.TestCase):
         gate, inside = threading.Event(), threading.Event()
         real = km._send_client
 
-        def parked(c, key, msg, pre=None, sig=None):    # the tail branch was chosen; park before the bytes go
-            inside.set()
+        def parked(c, key, msg, pre=None, sig=None, **kw):    # the tail branch was chosen; park before the bytes go
+            inside.set()                                    # (**kw: the tail send names its /perf kind, "delta")
             gate.wait(5)
-            return real(c, key, msg, pre=pre, sig=sig)
+            return real(c, key, msg, pre=pre, sig=sig, **kw)
         done = []
         with mock.patch.object(km, "_send_client", parked):
             ts = threading.Thread(target=lambda: km._send_chat(client, m, None, 1, False), daemon=True); ts.start()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -14,6 +14,7 @@
 import { adoptArrivals, applyViewOrder, applyViewOrderTo, churnSwaps, healOrder, pruneViewOrder,
          readViewOrder, writeViewOrder, VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
 import { hostOf, bareId } from "./host-prefix";
+import { installPerfTelemetry, classifyFrame, type RompPerf } from "./perf-telemetry";
 
 export const SEP = ":";
 export const LOCAL = ""; // the local kernel's host key — no prefix, so the single-kernel path is untouched
@@ -652,10 +653,18 @@ export class FederationManager {
   private hostSeq: string[] = [LOCAL]; // local first, then attach order — fixes the group order in the strip
   private downHosts = new Set<string>(); // attached, but its tunnel isn't up: what's on screen is a memory
   private lastSeen: Record<string, number> = {}; // host -> epoch secs of its last `up` poll
+  // the page's performance collector (ui/webview/perf-telemetry.ts), set by start(); inbound() times its own
+  // merge and dispatch through it as fed:<type>, nested outside the pane's handler. Public so a test can hand
+  // it a stand-in.
+  perf: RompPerf | null = null;
 
   start(): void {
     const w = window as any;
     this.app = w.__rompApp || "chat";
+    // the page's performance collector (perf-telemetry.ts), published as window.__rompPerf: the pane bundle
+    // installs its own on load, but the kernel-served timeline page has no bundle beyond this one, and its
+    // inline boot (kernel.py _TIMELINE_BOOT) wraps its message listener through the window slot
+    this.perf = installPerfTelemetry(this.app);
     w.__rompFed = {
       inbound: (h: string, m: any) => this.inbound(h, m),
       outbound: (m: any) => this.outbound(m),
@@ -770,6 +779,15 @@ export class FederationManager {
 
   // kernel → browser: prefix this host's ids, merge tab orders, hand the rest to the panes.
   inbound(host: string, msg: any): void {
+    // timed as fed:<wire type>: the prefixing, delta application and merge this layer does on a frame before
+    // the pane's own handler runs (that handler is timed under <type>, nested inside; the collector records
+    // each level's own time, so the two add up to the frame's cost). No collector: the plain path.
+    const p = this.perf;
+    if (!p) { this.inboundNow(host, msg); return; }
+    p.timed("fed:" + classifyFrame(msg), () => this.inboundNow(host, msg));
+  }
+
+  private inboundNow(host: string, msg: any): void {
     const m = prefixInbound(host, msg);
     if (m && m.type === "session" && typeof m.id === "string") {
       (this.perHostSids[host] ||= new Set()).add(m.id);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -30,6 +30,7 @@ import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 import { wireTip, setTip, pruneTip } from "./tip";
+import { perfFrameHandler } from "./perf-telemetry";
 
 // (The standalone-deliverable "FeedItem" subsystem was REMOVED 2026-07-07: the kernel had emitted
 // items: [] permanently — goal cards are the only feed unit — so its types, renderers, expand/detail
@@ -5259,7 +5260,9 @@ function applyFeedPayload(m: any): void {
 }
 
 
-window.addEventListener("message", (e: MessageEvent) => {
+// every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
+// minute, read by `romp perf client`); the handler itself is unchanged
+window.addEventListener("message", perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
@@ -5385,7 +5388,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       ackFollowMove(top ? top.itemId : raw, !!m.ok, bid, ackHost);
     }
   }
-});
+}));
 
 // ---- quarantine decision dialog (the user 2026-07-26): the card is compact, so THIS is where the
 // whole held message is read and decided. Step 1: the full body, read-only (peer content, never

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -17,6 +17,7 @@ import { hostPrefix } from "./host-prefix";
 import { ageColorReadable } from "./age-color";
 import { liveNow } from "./feed-age";
 import { TIP_GRACE_MS } from "./tip";
+import { perfFrameHandler } from "./perf-telemetry";
 
 type Color = { bg: string; fg: string } | null;
 interface LedgerNode {
@@ -704,7 +705,9 @@ function mountControls() {
   foot.append(left, right);
 }
 
-window.addEventListener("message", (e: MessageEvent) => {
+// every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
+// minute, read by `romp perf client`); the handler itself is unchanged
+window.addEventListener("message", perfFrameHandler("fleet", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   if (m.type === "delta") {
@@ -741,7 +744,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     .filter((a: any) => a && a.itemId && !a.provisional)
     .map((a: any) => [a.itemId as string, a] as const));
   render();
-});
+}));
 window.addEventListener("storage", (e: StorageEvent) => { if (e.key === "romp:settings") { applyTheme(document, loadSettings()); render(); } });   // theme/colormap change → reskin + recolour
 applyTheme(document, loadSettings());   // the persisted theme applies at boot (2026-08-28)
 // VS Code webviews have per-origin storage and never see another pane's `storage` events — gear

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -33,7 +33,8 @@ test("the recovery set is computed BEFORE downHosts is overwritten with this pol
 });
 
 test("render.ts's message listener heals previews unconditionally at the top, so hostUp needs no case of its own", () => {
-  const at = RENDER.indexOf('window.addEventListener("message", (e: MessageEvent) => {');
+  // the listener is installed through perf-telemetry's per-frame timing wrapper; the handler body is unchanged
+  const at = RENDER.indexOf('window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {');
   assert.ok(at >= 0);
   const heal = RENDER.indexOf("retryFailedPreviews();", at);
   const firstCase = RENDER.indexOf('if (m.type === "session")', at);

--- a/ui/webview/outline-visibility.test.ts
+++ b/ui/webview/outline-visibility.test.ts
@@ -44,7 +44,8 @@ test("BOTH release events run the same synchronous release: the observer's callb
 
 test("the payload is applied whatever the visibility — only the rebuild waits", () => {
   // the message handler swaps the model before render() decides whether to paint; no visibility check on the way
-  const handler = /window\.addEventListener\("message", \(e: MessageEvent\) => \{[\s\S]*?\n\}\);/.exec(SRC)![0];
+  // (the listener is installed through perf-telemetry's per-frame timing wrapper; the handler body is unchanged)
+  const handler = /window\.addEventListener\("message", perfFrameHandler\("fleet", \(m\) => vscodeApi\?\.postMessage\(m\), \(e: MessageEvent\) => \{[\s\S]*?\n\}\)\);/.exec(SRC)![0];
   assert.match(handler, /loaded = true;\n\s*sessions = m\.ledgers as FleetSession\[\];/);
   assert.doesNotMatch(handler, /document\.hidden|paneVisible|paneDirty|paintHeld/);
 });

--- a/ui/webview/perf-telemetry.test.ts
+++ b/ui/webview/perf-telemetry.test.ts
@@ -10,6 +10,8 @@
 // window the way federation-closed-store.test.ts does.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   Ring, percentile, histBucket, histQuantileBucket, classifyFrame, scriptKey, sanitizeInvoker, uaClass, attributeScripts,
   createPerfTelemetry, installPerfTelemetry, perfFrameHandler,
@@ -686,4 +688,43 @@ test("installPerfTelemetry: one collector per page on window.__rompPerf, wired t
     delete g.window;
     delete g.document;
   }
+});
+
+// ── the wraps themselves ──
+// Everything above drives the collector through PerfDeps, so nothing in it fails when a pane bundle stops
+// wrapping its listener: the whole suite stayed green with a wrap removed (review, 2026-09-07). These pin the
+// source text, the way heal-on-hostup.test.ts pins the chat pane's listener, for all four panes and for the
+// collector install in federation's start().
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const readUi = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+
+test("each pane bundle's one window message listener is installed through perfFrameHandler under its own app name", () => {
+  const panes: Array<[string, string]> = [["render.ts", "chat"], ["feed.ts", "feed"], ["fleet.ts", "fleet"], ["timeline-main.ts", "timeline"]];
+  for (const [file, app] of panes) {
+    const src = readUi(file);
+    assert.match(src, /import \{ perfFrameHandler \} from "\.\/perf-telemetry";/, file + " imports the wrapper");
+    const listeners = src.match(/window\.addEventListener\("message", /g) || [];
+    assert.equal(listeners.length, 1, file + " has one window message listener");
+    assert.ok(src.includes('window.addEventListener("message", perfFrameHandler("' + app + '", '),
+      file + " installs it through perfFrameHandler as app " + app);
+  }
+});
+
+test("federation's start() installs the page collector first: before __rompFed, whose inbound path times through it", () => {
+  const src = readUi("federation.ts");
+  assert.ok(src.includes('import { installPerfTelemetry, classifyFrame, type RompPerf } from "./perf-telemetry";'));
+  const at = src.indexOf("\n  start(): void {");
+  assert.ok(at > 0, "start() found");
+  const end = src.indexOf("\n  }\n", at);
+  assert.ok(end > at, "start() closes");
+  const body = src.slice(at, end);
+  const install = body.indexOf("this.perf = installPerfTelemetry(this.app);");
+  assert.ok(install > 0, "start() installs the collector");
+  const app = body.indexOf('this.app = w.__rompApp || "chat";');
+  assert.ok(app > 0 && app < install, "the app name is read first: the collector is keyed by it");
+  const fed = body.indexOf("w.__rompFed = {");
+  assert.ok(fed > install, "__rompFed (the shim's inbound entry, which runs inbound() and its fed: brackets) is published after the collector");
+  // nothing else runs before the install: the two lines above it are the window handle and the app name
+  const before = body.slice(0, install).split("\n").map((l) => l.trim()).filter((l) => l && !l.startsWith("//"));
+  assert.deepEqual(before, ["start(): void {", "const w = window as any;", 'this.app = w.__rompApp || "chat";']);
 });

--- a/ui/webview/perf-telemetry.test.ts
+++ b/ui/webview/perf-telemetry.test.ts
@@ -1,0 +1,689 @@
+// perf-telemetry.ts on a fake clock: the frame classifier, the per-type log2 histogram and its quantiles,
+// the minute flush (one row, its shape; an idle minute sends nothing), the free-main-thread sample two
+// animation frames after a handler and every way it is cancelled or dropped, nested brackets recording each
+// level's own time, the slowframe threshold, cap and long-frame attribution, the long-animation-frame
+// aggregation from synthetic entries (with and without `scripts`, the key cap, the longtask fallback), the
+// identifier-only contract for attribution keys and invokers, and the feature guards when
+// performance.memory, PerformanceObserver, requestAnimationFrame or performance.now itself are absent. The
+// collector takes every browser dependency through PerfDeps, so nothing here touches a real window except the
+// install tests, which stand one in the way fleet-live-clock.test.ts does; the federation test stands in a
+// window the way federation-closed-store.test.ts does.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  Ring, percentile, histBucket, histQuantileBucket, classifyFrame, scriptKey, sanitizeInvoker, uaClass, attributeScripts,
+  createPerfTelemetry, installPerfTelemetry, perfFrameHandler,
+  HIST_EDGES, HIST_BUCKETS, MAX_FRAME_TYPES, MAX_TOP_KEYS, SLOW_FRAME_MS, SLOW_ROWS_PER_MINUTE, FREE_RING, type PerfDeps,
+} from "./perf-telemetry";
+import { FederationManager } from "./federation";
+
+const PAGE = "http://h:1/feed";
+
+function harness(over: Partial<PerfDeps> = {}) {
+  const clock = { t: 1000, wall: 1_700_000_000_000 };
+  const posted: any[] = [];
+  const rafQueue: Array<(t: number) => void> = [];
+  const cancelled: number[] = [];
+  const deps: PerfDeps = {
+    now: () => clock.t,
+    wallNow: () => clock.wall,
+    post: (m) => posted.push(m),
+    raf: (cb) => { rafQueue.push(cb); return rafQueue.length; },
+    caf: (id) => cancelled.push(id),
+    setInterval: null,
+    observer: null,
+    supportedEntryTypes: [],
+    heapBytes: () => 200 * 1048576,
+    domCount: () => 1234,
+    visible: () => true,
+    hiddenPane: () => false,
+    ua: "chrome-desktop",
+    pageUrl: PAGE,
+    windowEvents: null,
+    documentEvents: null,
+    ...over,
+  };
+  /** run the animation-frame callbacks queued so far (one frame); a callback that queues another leaves it for the next call */
+  const runRafs = () => { for (const cb of rafQueue.splice(0)) cb(clock.t); };
+  /** a frame whose handler takes `ms` on the fake clock */
+  const frame = (p: ReturnType<typeof createPerfTelemetry>, msg: unknown, ms: number) =>
+    p.frame(msg, () => { clock.t += ms; });
+  return { deps, clock, posted, rafQueue, cancelled, runRafs, frame };
+}
+
+const minuteRows = (posted: any[]) => posted.filter((m) => m.what === "minute");
+const slowRows = (posted: any[]) => posted.filter((m) => m.what === "slowframe");
+/** a histogram with the given counts in the given buckets */
+const hist = (at: Record<number, number>) => { const h = new Array(HIST_BUCKETS).fill(0); for (const k of Object.keys(at)) h[Number(k)] = at[Number(k)]; return h; };
+const stat = (n: number, ms_sum: number, ms_max: number, n16: number, n100: number, h: number[]) => ({ n, ms_sum, ms_max, n16, n100, hist: h });
+
+// ── pure pieces ──
+
+test("classifyFrame: the type, a raw delta by slot, shell messages, and everything else as other", () => {
+  assert.equal(classifyFrame({ type: "feed", asks: [] }), "feed");
+  assert.equal(classifyFrame({ type: "chatTail", from: 3 }), "chatTail");
+  assert.equal(classifyFrame({ type: "delta", slot: "bars", rev: 4 }), "delta:bars");
+  assert.equal(classifyFrame({ type: "delta" }), "delta:other");
+  assert.equal(classifyFrame({ romp: "paneFocus" }), "shell");
+  assert.equal(classifyFrame({ type: "not an identifier!" }), "other");
+  assert.equal(classifyFrame({ type: "x".repeat(40) }), "other");
+  assert.equal(classifyFrame({}), "other");
+  assert.equal(classifyFrame(null), "other");
+  assert.equal(classifyFrame("feed"), "other");
+});
+
+test("Ring keeps the newest samples; percentile is nearest-rank", () => {
+  const r = new Ring(FREE_RING);
+  for (let i = 1; i <= 100; i++) r.push(i);
+  assert.equal(r.n, 100);
+  const v = r.values();
+  assert.equal(v.length, 64);
+  assert.equal(Math.min(...v), 37);
+  assert.equal(Math.max(...v), 100);
+  assert.equal(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.9), 9);
+  assert.equal(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.5), 5);
+  assert.equal(percentile([7], 0.9), 7);
+  assert.equal(percentile([], 0.9), 0);
+});
+
+test("histBucket is log2 with 14 buckets; histQuantileBucket is nearest-rank over the counts", () => {
+  assert.equal(HIST_BUCKETS, 14);
+  assert.deepEqual([0, 0.99, 1, 1.5, 2, 3.9, 4, 16, 16.7, 31.9, 32, 100, 128, 4095.9, 4096, 1e9].map(histBucket),
+    [0, 0, 1, 1, 2, 2, 3, 5, 5, 5, 6, 7, 8, 12, 13, 13]);
+  assert.equal(HIST_EDGES[histBucket(100)], 128);              // 100 ms lands in the 64..128 bucket, read as "under 128"
+  const h = hist({ 1: 9, 2: 11, 3: 7, 4: 4, 5: 2, 6: 1, 7: 2 });   // 36 frames
+  assert.equal(histQuantileBucket(h, 0.5), 2);                 // rank 18: 9 + 11 covers it
+  assert.equal(histQuantileBucket(h, 0.9), 5);                 // rank 33: 9+11+7+4+2 = 33
+  assert.equal(histQuantileBucket(h, 0.99), 7);                // rank 36: the last frame
+  assert.equal(histQuantileBucket(h, 1), 7);
+  assert.equal(histQuantileBucket(hist({}), 0.9), -1);
+  assert.equal(histQuantileBucket(hist({ 13: 3 }), 0.5), 13);
+});
+
+test("scriptKey: basename plus function and character position; the page's own scripts are page:; empty is unknown:", () => {
+  assert.equal(scriptKey({ sourceURL: "http://h:1/dist/feed.js?v=1757100000", sourceFunctionName: "render", sourceCharPosition: 48213 }, PAGE), "feed.js:render@48213");
+  assert.equal(scriptKey({ sourceURL: "http://h:1/dist/feed.js?v=1", sourceFunctionName: "", sourceCharPosition: 7 }, PAGE), "feed.js:(anonymous)@7");
+  assert.equal(scriptKey({ sourceURL: "http://h:1/dist/render.js#x", sourceFunctionName: "chatTail" }, PAGE), "render.js:chatTail");
+  // an inline script's sourceURL is the document URL (query stripped): the shim, the shell's boot code
+  assert.equal(scriptKey({ sourceURL: "http://h:1/feed?token=abc", sourceFunctionName: "", sourceCharPosition: 31245 }, PAGE), "page:(anonymous)@31245");
+  assert.equal(scriptKey({ sourceURL: "http://h:1/", sourceFunctionName: "boot" }, "http://h:1/"), "page:boot");
+  assert.equal(scriptKey({ sourceURL: "http://h:1/", sourceFunctionName: "boot" }), "page:boot", "a directory URL is a page even with no pageUrl to compare");
+  assert.equal(scriptKey({ sourceURL: "http://h:1/fleet", sourceFunctionName: "x" }, PAGE), "fleet:x", "another page's script keeps its basename");
+  assert.equal(scriptKey({ sourceURL: "", sourceFunctionName: "" }), "unknown:(anonymous)");
+  assert.equal(scriptKey({ sourceURL: "http://h/a.js", sourceFunctionName: "f", sourceCharPosition: -1 }), "a.js:f", "a negative position is not one");
+});
+
+test("sanitizeInvoker reduces ids, element sources and script URLs to identifiers", () => {
+  assert.equal(sanitizeInvoker("DIV#tab-web.onclick"), "DIV.onclick");
+  assert.equal(sanitizeInvoker("WebSocket.onmessage"), "WebSocket.onmessage");
+  assert.equal(sanitizeInvoker("Window.requestAnimationFrame"), "Window.requestAnimationFrame");
+  // a classic/module script's invoker is the script's URL: host, port and dist token included
+  assert.equal(sanitizeInvoker("http://h:1/dist/feed.js?v=1757100000"), "feed.js");
+  assert.equal(sanitizeInvoker("https://example.test:8443/dist/render.js#frag"), "render.js");
+  assert.equal(sanitizeInvoker("/dist/federation.js?v=2"), "federation.js");
+  assert.equal(sanitizeInvoker("http://h:1/"), "page");
+  // an id-less element with a src: the source (a data: URL, a file route with a path and sid) never survives
+  assert.equal(sanitizeInvoker("IMG[src=data:image/png;base64,iVBORw0KGgo].onload"), "IMG[src].onload");
+  assert.equal(sanitizeInvoker("IMG[src=/file?path=%2Fsrc%2Fapp.py&sid=11111111-2222].onerror"), "IMG[src].onerror");
+  assert.equal(sanitizeInvoker("IMG#logo[src=/media/x.svg].onload"), "IMG[src].onload");
+  assert.equal(sanitizeInvoker(undefined), "");
+  assert.equal(sanitizeInvoker("x".repeat(100)).length, 64);
+});
+
+test("uaClass is coarse", () => {
+  assert.equal(uaClass("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"), "chrome-desktop");
+  assert.equal(uaClass("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"), "safari-ios");
+  assert.equal(uaClass("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15", 5), "safari-ios");
+  assert.equal(uaClass("Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36"), "other");
+  assert.equal(uaClass("Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"), "other");
+});
+
+test("attributeScripts sums per key, largest first, keeps the latest sanitized invoker, and keys page scripts as page:", () => {
+  const rows = attributeScripts([
+    { sourceURL: "http://h:1/dist/feed.js?v=1", sourceFunctionName: "render", sourceCharPosition: 10, invoker: "DIV#c1.onclick", duration: 30 },
+    { sourceURL: "http://h:1/dist/feed.js?v=1", sourceFunctionName: "render", sourceCharPosition: 10, invoker: "WebSocket.onmessage", duration: 50 },
+    { sourceURL: "http://h:1/feed?token=t", sourceFunctionName: "", sourceCharPosition: 31245, invoker: "WebSocket.onmessage", duration: 10 },
+    { sourceURL: "http://h:1/dist/federation.js?v=1", sourceFunctionName: "", invoker: "http://h:1/dist/federation.js?v=1", duration: 5 },
+    { sourceURL: "x", duration: "nope" },
+  ], PAGE);
+  assert.deepEqual(rows, [
+    { k: "feed.js:render@10", ms: 80, inv: "WebSocket.onmessage" },
+    { k: "page:(anonymous)@31245", ms: 10, inv: "WebSocket.onmessage" },
+    { k: "federation.js:(anonymous)", ms: 5, inv: "federation.js" },
+  ]);
+});
+
+// ── frames and the minute flush ──
+
+/** every value in a row is a number, a boolean, null, or a string of code identifiers */
+function assertIdentifiersOnly(v: any): void {
+  if (v === null || typeof v === "number" || typeof v === "boolean") return;
+  if (typeof v === "string") { assert.match(v, /^[A-Za-z0-9_.:()@[\]-]*$/, "not an identifier: " + v); return; }
+  for (const x of Object.values(v)) assertIdentifiersOnly(x);
+}
+
+test("a minute with frames sends ONE row in the documented shape; an idle minute sends nothing", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  h.frame(p, { type: "feed" }, 10);
+  h.frame(p, { type: "feed" }, 20);
+  h.frame(p, { type: "chatTail" }, 2);
+  h.frame(p, { romp: "paneFocus" }, 0.5);
+  h.frame(p, { type: "delta", slot: "bars" }, 1);
+  h.frame(p, null, 0);                       // a frame the handler ignores still counts
+  // the main thread frees 45 ms after the first frame's handler returned: two animation frames later
+  h.clock.t += 45;
+  h.runRafs(); h.runRafs();
+  h.clock.wall += 60_000;
+  p.tick();
+  const rows = minuteRows(h.posted);
+  assert.equal(rows.length, 1);
+  const row = rows[0];
+  assert.equal(row.type, "clientDiag");
+  assert.equal(row.surface, "perf");
+  assert.equal(row.what, "minute");
+  const d = row.data;
+  assert.equal(d.app, "feed");
+  assert.equal(d.since, 1_700_000_000_000);
+  assert.equal(d.span_ms, 60_000);
+  assert.deepEqual(d.frames.feed, stat(2, 30, 20, 1, 0, hist({ 4: 1, 5: 1 })));
+  assert.deepEqual(d.frames.chatTail, stat(1, 2, 2, 0, 0, hist({ 2: 1 })));
+  assert.deepEqual(d.frames.shell, stat(1, 0.5, 0.5, 0, 0, hist({ 0: 1 })));
+  assert.deepEqual(d.frames["delta:bars"], stat(1, 1, 1, 0, 0, hist({ 1: 1 })));
+  assert.deepEqual(d.frames.other, stat(1, 0, 0, 0, 0, hist({ 0: 1 })));
+  // one free sample: scheduled after the first frame (t=1010), resolved at 1010+20+2+0.5+1+0+45
+  assert.deepEqual(d.free, { n: 1, p50: 68.5, p90: 68.5, max: 68.5 });
+  assert.deepEqual(d.loaf, { n: 0, blocking_ms: 0, worst_ms: 0, top: [], src: "none" });
+  assert.deepEqual(d.slow, { sent: 0, suppressed: 0, suppressed_worst_ms: 0 });
+  assert.equal(d.heap_mb, 200);
+  assert.equal(d.dom, 1234);
+  assert.equal(d.visible, true);
+  assert.equal(d.hidden_pane, false);
+  assert.equal(d.ua, "chrome-desktop");
+  assert.deepEqual(Object.keys(d).sort(),
+    ["app", "dom", "frames", "free", "heap_mb", "hidden_pane", "loaf", "since", "slow", "span_ms", "ua", "visible"]);
+  assertIdentifiersOnly(d);
+  // the next minute: nothing happened, nothing sent, and the bucket restarted at the new wall time
+  assert.equal(slowRows(h.posted).length, 0);
+  h.clock.wall += 60_000;
+  p.tick();
+  assert.equal(h.posted.length, 1);
+  assert.equal(p.snapshot().since, 1_700_000_120_000);
+});
+
+test("a partial minute (pagehide) carries its own span; the histogram is exact over every frame of a busy type", () => {
+  const win = new EventTarget();
+  const h = harness({ windowEvents: win });
+  const p = createPerfTelemetry("chat", h.deps);
+  for (let i = 1; i <= 100; i++) h.frame(p, { type: "chatTail" }, i);   // 1..100 ms
+  h.clock.wall += 30_000;
+  win.dispatchEvent(new Event("pagehide"));
+  const d = minuteRows(h.posted)[0].data;
+  assert.equal(d.span_ms, 30_000);
+  const f = d.frames.chatTail;
+  assert.equal(f.n, 100);
+  assert.equal(f.ms_sum, 5050);
+  assert.equal(f.ms_max, 100);
+  assert.equal(f.n16, 84);                    // 17..100
+  assert.equal(f.n100, 1);
+  assert.deepEqual(f.hist, hist({ 1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32, 7: 37 }));   // [1,2) [2,4) [4,8) [8,16) [16,32) [32,64) [64,128)
+  assert.equal(histQuantileBucket(f.hist, 0.9), 7);   // rank 90 lands in 64..128: the exact p90 is 90 ms
+  assert.equal((p.snapshot() as any).frames.chatTail?.p90_le, undefined, "the bucket rolled over on the flush");
+});
+
+test("distinct frame types are capped per minute, wire types and fed: keys each; the overflow folds into other / fed:other", () => {
+  const h = harness();
+  const p = createPerfTelemetry("chat", h.deps);
+  for (let i = 0; i < MAX_FRAME_TYPES + 3; i++) h.frame(p, { type: "t" + i }, 1);
+  for (let i = 0; i < MAX_FRAME_TYPES + 2; i++) p.timed("fed:f" + i, () => { h.clock.t += 1; });
+  h.clock.wall += 60_000;
+  p.tick();
+  const frames = minuteRows(h.posted)[0].data.frames;
+  assert.equal(Object.keys(frames).length, 2 * (MAX_FRAME_TYPES + 1));
+  assert.equal(frames.other.n, 3);
+  assert.equal(frames["fed:other"].n, 2);
+});
+
+test("the type cap does not count the fed: keys against the wire types, and a folded frame's slowframe row names its type", () => {
+  const h = harness();
+  const p = createPerfTelemetry("chat", h.deps);
+  // 20 wire types, each inside its federation bracket: 40 keys, none folded
+  for (let i = 0; i < 20; i++) p.timed("fed:t" + i, () => h.frame(p, { type: "t" + i }, 1));
+  let s: any = p.snapshot();
+  assert.equal(Object.keys(s.frames).length, 40);
+  assert.equal("other" in s.frames, false);
+  // fill the wire-type cap, then a slow frame of a new type: counted under other, reported as itself
+  for (let i = 20; i < MAX_FRAME_TYPES; i++) h.frame(p, { type: "t" + i }, 1);
+  p.timed("fed:zzz", () => h.frame(p, { type: "zzz" }, 150));
+  s = p.snapshot();
+  assert.equal(s.frames.other.n, 1);
+  assert.equal("zzz" in s.frames, false);
+  assert.equal(s.frames["fed:zzz"].n, 1, "the federation key had room of its own");
+  assert.deepEqual(slowRows(h.posted)[0].data, { app: "chat", type: "zzz", ms: 150, dom: 1234 });
+  // the same fold without a federation bracket (VS Code): the slowframe row still names the type
+  h.frame(p, { type: "yyy" }, 120);
+  assert.equal(slowRows(h.posted)[1].data.type, "yyy");
+  assert.equal((p.snapshot() as any).frames.other.n, 2);
+});
+
+test("nested brackets: each level records its own time, and they add up to the frame", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  // federation's inbound (3 ms of merge, 2 ms of post-dispatch bookkeeping) around the pane's handler (4 ms)
+  p.timed("fed:feedDelta", () => { h.clock.t += 3; p.frame({ type: "feed" }, () => { h.clock.t += 4; }); h.clock.t += 2; });
+  const s: any = p.snapshot();
+  assert.equal(s.frames["fed:feedDelta"].ms_sum, 5);
+  assert.equal(s.frames["fed:feedDelta"].n, 1);
+  assert.equal(s.frames.feed.ms_sum, 4);
+  assert.equal(s.frames.feed.n, 1);
+  assert.equal(s.frames.feed.p90_le, 8);
+  // the pane's own exception propagates through both levels and both still record
+  assert.throws(() => p.timed("fed:feed", () => { h.clock.t += 1; p.frame({ type: "feed" }, () => { h.clock.t += 5; throw new Error("pane bug"); }); }), /pane bug/);
+  const s2: any = p.snapshot();
+  assert.equal(s2.frames["fed:feed"].ms_sum, 1);
+  assert.equal(s2.frames.feed.ms_sum, 9);
+  assert.equal(s2.frames.feed.n, 2);
+});
+
+test("the slowframe test and the free sample belong to the outermost bracket, with the frame's whole time", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  // 60 ms of federation merge around a 60 ms handler: neither level alone is slow, the frame is
+  p.timed("fed:feed", () => { h.clock.t += 60; p.frame({ type: "feed" }, () => { h.clock.t += 60; }); });
+  const rows = slowRows(h.posted);
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].data, { app: "feed", type: "feed", ms: 120, dom: 1234 });   // the wire type, not fed:feed
+  assert.equal(h.rafQueue.length, 1, "one free sample armed, by the outer bracket");
+});
+
+test("wrapFrameHandler hands the event through and times by its data", () => {
+  const h = harness();
+  const p = createPerfTelemetry("fleet", h.deps);
+  const seen: any[] = [];
+  const wrapped = p.wrapFrameHandler((e) => { seen.push(e.data); h.clock.t += 2; });
+  wrapped({ data: { type: "feed" } } as MessageEvent);
+  wrapped({ data: { type: "warn", text: "x" } } as MessageEvent);
+  assert.deepEqual(seen.map((m) => m.type), ["feed", "warn"]);
+  const s: any = p.snapshot();
+  assert.equal(s.frames.feed.n, 1);
+  assert.equal(s.frames.warn.n, 1);
+});
+
+// ── the free-main-thread sample ──
+
+test("free: one sample in flight; frames landing before it resolves share it; hidden panes take none", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  h.frame(p, { type: "feed" }, 10);          // ends at 1010, sample armed
+  h.frame(p, { type: "feed" }, 10);          // ends at 1020: the thread is still busy, no second sample
+  assert.equal(h.rafQueue.length, 1);
+  h.clock.t += 30;                           // 1050
+  h.runRafs();                               // first rAF queues the second
+  assert.equal(h.rafQueue.length, 1);
+  h.clock.t += 10;                           // 1060
+  h.runRafs();
+  const s: any = p.snapshot();
+  assert.deepEqual(s.free, { n: 1, p50: 50, p90: 50, max: 50 });   // 1060 - 1010
+  assert.equal(s.free_pending, false);
+  // a pane with no viewport (the shell's display:none) arms nothing: rAF does not run there
+  const hidden = harness({ hiddenPane: () => true });
+  const q = createPerfTelemetry("feed", hidden.deps);
+  hidden.frame(q, { type: "feed" }, 10);
+  assert.equal(hidden.rafQueue.length, 0);
+});
+
+test("free: a sample that resolves after the document went hidden, or the pane lost its viewport, is dropped", () => {
+  let vis = true;
+  const flip = harness({ visible: () => vis });
+  const r = createPerfTelemetry("feed", flip.deps);
+  flip.frame(r, { type: "feed" }, 10);
+  vis = false;
+  flip.clock.t += 5000;
+  flip.runRafs(); flip.runRafs();
+  assert.equal((r.snapshot() as any).free, null);
+  assert.equal((r.snapshot() as any).free_pending, false, "and the slot is free for the next sample");
+  let zero = false;
+  const shrink = harness({ hiddenPane: () => zero });
+  const q = createPerfTelemetry("feed", shrink.deps);
+  shrink.frame(q, { type: "feed" }, 10);
+  shrink.runRafs();                          // the first callback ran while visible
+  zero = true;                               // the shell hid the pane before the second
+  shrink.clock.t += 60_000;
+  shrink.runRafs();
+  assert.equal((q.snapshot() as any).free, null);
+});
+
+test("visibilitychange to hidden, and a resize to a zero viewport, cancel the armed sample; pagehide flushes", () => {
+  const win = new EventTarget();
+  const doc = new EventTarget();
+  let vis = true;
+  let zero = false;
+  const h = harness({ windowEvents: win, documentEvents: doc, visible: () => vis, hiddenPane: () => zero });
+  const p = createPerfTelemetry("feed", h.deps);
+  h.frame(p, { type: "feed" }, 10);
+  assert.equal((p.snapshot() as any).free_pending, true);
+  vis = false;
+  doc.dispatchEvent(new Event("visibilitychange"));
+  assert.equal((p.snapshot() as any).free_pending, false);
+  assert.deepEqual(h.cancelled, [1]);
+  vis = true;
+  // a resize that leaves the pane with a viewport cancels nothing; one to zero size does
+  h.frame(p, { type: "feed" }, 10);
+  win.dispatchEvent(new Event("resize"));
+  assert.equal((p.snapshot() as any).free_pending, true);
+  zero = true;
+  win.dispatchEvent(new Event("resize"));
+  assert.equal((p.snapshot() as any).free_pending, false);
+  assert.deepEqual(h.cancelled, [1, 2]);
+  win.dispatchEvent(new Event("pagehide"));
+  assert.equal(minuteRows(h.posted).length, 1);
+  assert.equal(minuteRows(h.posted)[0].data.frames.feed.n, 2);
+});
+
+// ── slow frames ──
+
+test("slowframe: a handler at the threshold sends a row at once when no long-frame observer exists", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  h.frame(p, { type: "feed" }, SLOW_FRAME_MS - 0.1);
+  assert.equal(slowRows(h.posted).length, 0);
+  h.frame(p, { type: "feed" }, SLOW_FRAME_MS);
+  const rows = slowRows(h.posted);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].surface, "perf");
+  assert.deepEqual(rows[0].data, { app: "feed", type: "feed", ms: 100, dom: 1234 });
+});
+
+test("slowframe cap: 50 slow frames in a minute send at most the cap; the rest are counted with their worst", () => {
+  const h = harness();
+  const p = createPerfTelemetry("feed", h.deps);
+  for (let i = 0; i < 50; i++) h.frame(p, { type: "feed" }, 100 + i);
+  assert.equal(slowRows(h.posted).length, SLOW_ROWS_PER_MINUTE);
+  assert.deepEqual(slowRows(h.posted).map((r) => r.data.ms), [100, 101, 102, 103, 104], "the minute's first");
+  h.clock.wall += 60_000;
+  p.tick();
+  const d = minuteRows(h.posted)[0].data;
+  assert.deepEqual(d.slow, { sent: 5, suppressed: 45, suppressed_worst_ms: 149 });
+  assert.equal(d.frames.feed.n100, 50);
+  // the cap is per minute: the next minute sends again
+  h.frame(p, { type: "feed" }, 200);
+  assert.equal(slowRows(h.posted).length, SLOW_ROWS_PER_MINUTE + 1);
+});
+
+class FakeObserver {
+  static cb: ((list: { getEntries(): any[] }) => void) | null = null;
+  static opts: any = null;
+  static constructed = 0;
+  constructor(cb: (list: { getEntries(): any[] }) => void) { FakeObserver.cb = cb; FakeObserver.constructed++; }
+  observe(o: any): void { FakeObserver.opts = o; }
+  disconnect(): void {}
+  static deliver(entries: any[]): void { FakeObserver.cb!({ getEntries: () => entries }); }
+}
+
+test("slowframe with a long-frame observer: held for the report covering it, then sent with its attribution", () => {
+  const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["long-animation-frame", "longtask"] });
+  const p = createPerfTelemetry("feed", h.deps);
+  assert.equal(p.observerKind, "loaf");
+  assert.deepEqual(FakeObserver.opts, { type: "long-animation-frame", buffered: false });
+  h.frame(p, { type: "feed" }, 130);         // 1000..1130
+  assert.equal(slowRows(h.posted).length, 0, "held for the browser's report");
+  assert.equal((p.snapshot() as any).pending_slow, 1);
+  FakeObserver.deliver([{
+    startTime: 995, duration: 140, blockingDuration: 90,
+    scripts: [
+      { sourceURL: "http://h:1/feed?token=t", sourceFunctionName: "", sourceCharPosition: 31245, invoker: "WebSocket.onmessage", duration: 110 },
+      { sourceURL: "http://h:1/dist/feed.js?v=1", sourceFunctionName: "", sourceCharPosition: 48213, invoker: "Window.requestAnimationFrame", duration: 20 },
+    ],
+  }]);
+  const rows = slowRows(h.posted);
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].data, {
+    app: "feed", type: "feed", ms: 130, dom: 1234,
+    loaf: { ms: 140, blocking_ms: 90, top: [{ k: "page:(anonymous)@31245", ms: 110, inv: "WebSocket.onmessage" }, { k: "feed.js:(anonymous)@48213", ms: 20, inv: "Window.requestAnimationFrame" }] },
+  });
+  assert.equal((p.snapshot() as any).pending_slow, 0);
+  assertIdentifiersOnly(rows[0].data);
+});
+
+test("slowframe backstops: a later report that starts after it, or the minute tick, sends it without attribution; the cap bounds the held rows", () => {
+  const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["long-animation-frame"] });
+  const p = createPerfTelemetry("chat", h.deps);
+  h.frame(p, { type: "chatTail" }, 120);     // 1000..1120
+  FakeObserver.deliver([{ startTime: 1500, duration: 60, blockingDuration: 10, scripts: [] }]);
+  let rows = slowRows(h.posted);
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].data, { app: "chat", type: "chatTail", ms: 120, dom: 1234 });
+  for (let i = 0; i < 10; i++) h.frame(p, { type: "chatTail" }, 150);
+  assert.equal(slowRows(h.posted).length, 1);
+  assert.equal((p.snapshot() as any).pending_slow, SLOW_ROWS_PER_MINUTE - 1, "the cap counts the one already sent");
+  h.clock.wall += 60_000;
+  p.tick();
+  rows = slowRows(h.posted);
+  assert.equal(rows.length, SLOW_ROWS_PER_MINUTE);
+  assert.equal(rows[1].data.ms, 150);
+  assert.equal("loaf" in rows[1].data, false);
+  assert.equal(minuteRows(h.posted)[0].data.slow.suppressed, 6);
+});
+
+// ── long-frame aggregation ──
+
+test("long frames: entries over 50 ms aggregate into count, blocking, worst and the top attributed keys", () => {
+  const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["long-animation-frame"] });
+  const p = createPerfTelemetry("feed", h.deps);
+  FakeObserver.deliver([
+    { startTime: 10, duration: 40, blockingDuration: 0, scripts: [{ sourceURL: "a.js", sourceFunctionName: "x", duration: 40 }] },   // under 50: ignored
+    { startTime: 100, duration: 120, blockingDuration: 70, scripts: [
+      { sourceURL: "http://h:1/dist/feed.js?v=2", sourceFunctionName: "render", sourceCharPosition: 1200, invoker: "WebSocket.onmessage", duration: 100 },
+      { sourceURL: "http://h:1/dist/feed.js?v=2", sourceFunctionName: "paintFreezeBadges", sourceCharPosition: 900, invoker: "WebSocket.onmessage", duration: 15 },
+    ] },
+    { startTime: 400, duration: 80, blockingDuration: 30 },                                                                            // no scripts field
+    { startTime: 700, duration: 300, blockingDuration: 250, scripts: [
+      { sourceURL: "http://h:1/dist/feed.js?v=2", sourceFunctionName: "render", sourceCharPosition: 1200, invoker: "Window.requestAnimationFrame", duration: 280 },
+    ] },
+  ]);
+  h.clock.wall += 60_000;
+  p.tick();
+  const rows = minuteRows(h.posted);
+  assert.equal(rows.length, 1, "a long frame alone makes the minute worth a row");
+  assert.deepEqual(rows[0].data.frames, {});
+  assert.deepEqual(rows[0].data.loaf, {
+    n: 3, blocking_ms: 350, worst_ms: 300, src: "loaf",
+    top: [
+      { k: "feed.js:render@1200", ms: 380, n: 2, inv: "Window.requestAnimationFrame" },
+      { k: "feed.js:paintFreezeBadges@900", ms: 15, n: 1, inv: "WebSocket.onmessage" },
+    ],
+  });
+});
+
+test("long frames: distinct attribution keys are capped per minute; the overflow folds into other", () => {
+  const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["long-animation-frame"] });
+  const p = createPerfTelemetry("feed", h.deps);
+  // one report fills the 64 keys the minute tracks (a distinct character position each) …
+  const scripts = [];
+  for (let i = 0; i < MAX_TOP_KEYS; i++) scripts.push({ sourceURL: "http://h:1/dist/feed.js", sourceFunctionName: "", sourceCharPosition: i, duration: 1 });
+  FakeObserver.deliver([{ startTime: 0, duration: 200, blockingDuration: 150, scripts }]);
+  // … and the next report's new key has nowhere to go but other, with its time
+  FakeObserver.deliver([{ startTime: 500, duration: 150, blockingDuration: 100, scripts: [{ sourceURL: "http://h:1/dist/render.js", sourceFunctionName: "chatTail", duration: 100 }] }]);
+  const s: any = p.snapshot();
+  assert.equal(s.loaf.top.length, 5);
+  assert.deepEqual(s.loaf.top[0], { k: "other", ms: 100, n: 1, inv: "" }, "the 65th key folded, with its time");
+  assert.equal(s.loaf.n, 2);
+});
+
+test("longtask fallback: no long-animation-frame support observes longtask, blocking is time over 50 ms, no attribution", () => {
+  const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["longtask", "mark"] });
+  const p = createPerfTelemetry("feed", h.deps);
+  assert.equal(p.observerKind, "longtask");
+  assert.deepEqual(FakeObserver.opts, { type: "longtask", buffered: false });
+  FakeObserver.deliver([{ startTime: 0, duration: 130, attribution: [{ containerType: "iframe" }] }]);
+  // a slow handler sends at once under this observer: longtask entries carry no scripts to wait for
+  h.frame(p, { type: "feed" }, 110);
+  assert.equal(slowRows(h.posted).length, 1);
+  assert.equal("loaf" in slowRows(h.posted)[0].data, false);
+  const s: any = p.snapshot();
+  assert.deepEqual(s.loaf, { n: 1, blocking_ms: 80, worst_ms: 130, top: [], src: "longtask" });
+});
+
+// ── feature guards ──
+
+test("guards: no observer, no heap, a throwing DOM count, no rAF: the row still goes out, minus those fields", () => {
+  const h = harness({ observer: null, heapBytes: () => null, domCount: () => { throw new Error("no document"); }, raf: null });
+  const p = createPerfTelemetry("feed", h.deps);
+  assert.equal(p.observerKind, "none");
+  h.frame(p, { type: "feed" }, 3);
+  assert.equal(h.rafQueue.length, 0);
+  h.clock.wall += 60_000;
+  p.tick();
+  const d = minuteRows(h.posted)[0].data;
+  assert.equal("heap_mb" in d, false);
+  assert.equal(d.dom, null);
+  assert.equal(d.free, null);
+  assert.equal(d.loaf.src, "none");
+  // an observer whose support list is empty is not constructed at all
+  FakeObserver.constructed = 0;
+  const q = createPerfTelemetry("feed", harness({ observer: FakeObserver as any, supportedEntryTypes: [] }).deps);
+  assert.equal(q.observerKind, "none");
+  assert.equal(FakeObserver.constructed, 0);
+  // an observer whose constructor throws leaves the collector working without it
+  class Broken { constructor() { throw new Error("no observer here"); } observe() {} disconnect() {} }
+  const r = createPerfTelemetry("feed", harness({ observer: Broken as any, supportedEntryTypes: ["long-animation-frame"] }).deps);
+  assert.equal(r.observerKind, "none");
+});
+
+test("a post that throws never reaches the pane; a null post keeps measuring", () => {
+  const h = harness({ post: () => { throw new Error("socket gone"); } });
+  const p = createPerfTelemetry("feed", h.deps);
+  h.frame(p, { type: "feed" }, 200);
+  h.clock.wall += 60_000;
+  assert.doesNotThrow(() => p.tick());
+  p.setPost(null);
+  h.frame(p, { type: "feed" }, 200);
+  assert.equal((p.snapshot() as any).frames.feed.n, 1);
+});
+
+test("the timer, when given, is unref'd for a node host and drives tick()", () => {
+  let cb: (() => void) | null = null;
+  let unrefd = false;
+  const h = harness({ setInterval: (fn, ms) => { assert.equal(ms, 60_000); cb = fn; return { unref: () => { unrefd = true; } }; } });
+  const p = createPerfTelemetry("feed", h.deps);
+  assert.equal(unrefd, true);
+  h.frame(p, { type: "feed" }, 1);
+  cb!();
+  assert.equal(minuteRows(h.posted).length, 1);
+});
+
+// ── federation's bracket ──
+
+test("federation times its inbound work as fed:<wire type> around the pane's handler, only when a collector is set", () => {
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  const emitted: any[] = [];
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: () => null, setItem: () => {} };
+  try {
+    const fm = new FederationManager();
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    assert.equal(emitted.filter((m) => m.type === "tabOrder").length, 1, "no collector: the frame still flows");
+    const timed: string[] = [];
+    fm.perf = {
+      timed: <T,>(type: string, fn: () => T): T => { timed.push(type); return fn(); },
+      frame: <T,>(_m: unknown, fn: () => T): T => fn(),
+      wrapFrameHandler: (h: any) => h, snapshot: () => ({}), tick: () => {}, setPost: () => {},
+    };
+    fm.inbound("", { type: "tabOrder", order: [], tabs: [] });
+    fm.inbound("", { type: "session", id: "11111111-2222-3333-4444-555555555555", events: [] });
+    assert.deepEqual(timed, ["fed:tabOrder", "fed:session"]);
+    assert.equal(emitted.filter((m) => m.type === "tabOrder").length, 2, "the bracket wraps the same work");
+  } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+});
+
+// ── the browser install ──
+
+test("installPerfTelemetry: null without a window or without performance.now; the handler is handed back unwrapped", () => {
+  const g: any = globalThis;
+  assert.equal(typeof g.window, "undefined");
+  assert.equal(installPerfTelemetry("feed"), null);
+  const handler = () => {};
+  assert.equal(perfFrameHandler("feed", undefined, handler), handler);
+  // a stand-in page with no performance object (the node DOM stand-ins): nothing installed
+  g.window = new EventTarget();
+  g.document = new EventTarget();
+  try {
+    assert.equal(installPerfTelemetry("feed"), null);
+    assert.equal(g.window.__rompPerf, undefined);
+    assert.equal(perfFrameHandler("feed", undefined, handler), handler);
+  } finally {
+    delete g.window;
+    delete g.document;
+  }
+});
+
+test("installPerfTelemetry: one collector per page on window.__rompPerf, wired to the page's rAF, timer, URL and transport", () => {
+  const g: any = globalThis;
+  const win: any = new EventTarget();
+  let t = 0;
+  win.performance = { now: () => t };
+  win.navigator = { userAgent: "Mozilla/5.0 (Macintosh) Chrome/128.0.0.0 Safari/537.36", maxTouchPoints: 0 };
+  win.location = { href: "http://h:1/timeline?token=abc&wid=11111111" };
+  win.parent = win;
+  win.innerWidth = 800; win.innerHeight = 600;
+  const rafs: Array<(t: number) => void> = [];
+  const cancelled: number[] = [];
+  win.requestAnimationFrame = (cb: (t: number) => void) => { rafs.push(cb); return rafs.length; };
+  win.cancelAnimationFrame = (id: number) => cancelled.push(id);
+  let intervalCb: (() => void) | null = null;
+  let intervalMs = 0;
+  let unrefd = false;
+  win.setInterval = (cb: () => void, ms: number) => { intervalCb = cb; intervalMs = ms; return { unref: () => { unrefd = true; } }; };
+  const sent: any[] = [];
+  win.__rompLocalSend = (m: any) => sent.push({ via: "shim", m });
+  const doc: any = new EventTarget();
+  doc.visibilityState = "visible";
+  doc.getElementsByTagName = () => ({ length: 42 });
+  g.window = win;
+  g.document = doc;
+  try {
+    const a = installPerfTelemetry("timeline");
+    assert.ok(a);
+    assert.equal(win.__rompPerf, a);
+    assert.equal(intervalMs, 60_000);
+    assert.equal(unrefd, true);
+    // the default transport is the shim's send; a frame arms a free sample through the page's rAF
+    a!.timed("bars", () => { t += 10; });
+    assert.equal(rafs.length, 1);
+    for (const cb of rafs.splice(0)) cb(t);
+    t += 5;
+    for (const cb of rafs.splice(0)) cb(t);
+    assert.deepEqual((a!.snapshot() as any).free, { n: 1, p50: 5, p90: 5, max: 5 });
+    // a hide cancels through the page's cancelAnimationFrame
+    a!.timed("bars", () => { t += 1; });
+    doc.visibilityState = "hidden";
+    doc.dispatchEvent(new Event("visibilitychange"));
+    assert.deepEqual(cancelled, [1]);
+    doc.visibilityState = "visible";
+    // the page's URL, query stripped, keys its inline scripts as page:
+    intervalCb!();
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].m.what, "minute");
+    assert.equal(sent[0].m.data.app, "timeline");
+    // a pane's own transport takes over, and a slow frame is timed on the page's clock
+    const posted: any[] = [];
+    const wrapped = perfFrameHandler("timeline", (m) => posted.push(m), () => { t += 150; });
+    wrapped({ data: { type: "bars" } } as MessageEvent);
+    assert.equal(sent.length, 1);
+    assert.equal(posted.length, 1);
+    assert.deepEqual(posted[0].data, { app: "timeline", type: "bars", ms: 150, dom: 42 });
+    assert.equal(installPerfTelemetry("timeline"), a);
+    const s: any = a!.snapshot();
+    assert.equal(s.ua, "chrome-desktop");
+    assert.equal(s.observer, "none");
+    assert.equal(s.frames.bars.n, 1);
+  } finally {
+    delete g.window;
+    delete g.document;
+  }
+});

--- a/ui/webview/perf-telemetry.ts
+++ b/ui/webview/perf-telemetry.ts
@@ -1,0 +1,576 @@
+// Browser-side performance telemetry for the dashboard panes (2026-09-06). The kernel's own counters
+// (`romp perf`, GET /perf) say what the kernel spent; nothing said what the BROWSER spent on the frames it
+// received, so a dashboard that felt slow could not be attributed to a pane, a frame type or a function.
+// The feed, Outline, chat and timeline bundles wrap their window "message" handler through
+// this module (the kernel-served timeline page has no bundle of its own: its inline boot wraps through the
+// window.__rompPerf that federation.js publishes before it runs); federation times its own merge and
+// dispatch of every frame as `fed:<type>`, nested outside the pane's handler, and the collector records
+// each level's OWN time (the outer minus what its inner brackets took), so the per-type figures add up.
+// Per frame type the module keeps a count, the summed and maximum handler time, exact counts over 16.7 ms
+// (one dropped frame at 60 Hz) and at or over 100 ms, and a fixed log2 histogram (one increment per frame),
+// which is additive across minutes so `romp perf client` computes true window percentiles. Two
+// requestAnimationFrame callbacks after the outermost handler it records how long the main thread stayed
+// busy with the work the handler queued, and it observes the browser's long-animation-frame reports with
+// their script attribution. Once a minute it folds all of that into ONE clientDiag row (surface "perf",
+// what "minute") on the channel the panes already use for breadcrumbs, so the kernel appends it to
+// client-diag.jsonl beside the shim's wsclose rows. A frame whose whole synchronous handling ran 100 ms or
+// more also sends a "slowframe" row at once, carrying the long-frame attribution when the browser reports
+// one for that frame; at most SLOW_ROWS_PER_MINUTE of those a minute, the rest counted in the minute row.
+//
+// Rows carry numbers and code identifiers only: frame type strings, script file basenames, function names
+// with their character position, and invoker names reduced to a tag and event (element ids and any URL
+// removed). Never card text, session names, file paths or transcript content.
+//
+// Idle cost: a 60 s interval that checks one flag, plus an observer callback that runs only when the
+// browser reports a long frame. Every browser API is behind a feature check; a page without
+// performance.now (the node test stand-ins) gets no telemetry and an unwrapped handler; nothing in here
+// throws into the pane. DevTools: window.__rompPerf.snapshot() is the minute in progress.
+//
+// Two facts about the transport shape the frame types this module sees on a kernel page. The pane shim
+// (kernel.py `_shim`) swallows `ka` frames before dispatch, and reassembles `{type:"delta"}` frames into
+// the full slot message the bundle always received, so a local delta is counted under its slot's type
+// (`bars`, `feed`). A federated remote socket hands frames straight to federation's inbound, where a
+// raw delta can still appear; those count as `delta:<slot>`. The shim's JSON.parse and delta reassembly
+// run before any bracket here and are visible only through the long-frame attribution (`page:` keys).
+
+export const SLOW_FRAME_MS = 100;      // a frame whose whole handling is at or over this sends a slowframe row
+export const LONG_FRAME_MS = 50;       // the browser's own long-frame threshold; entries under it are ignored
+export const DROPPED_FRAME_MS = 16.7;  // one frame at 60 Hz: handlers over this drop at least one paint
+export const SLOW_ROWS_PER_MINUTE = 5; // slowframe rows sent per pane per minute; the rest are counted in the minute row
+export const FREE_RING = 64;           // main-thread-free samples kept for the minute's percentiles
+export const MAX_FRAME_TYPES = 32;     // distinct wire frame types per minute, the rest fold into "other"; the federation layer's fed:<type> keys have the same cap of their own (fed:other)
+export const MAX_TOP = 5;              // attributed keys reported per minute
+export const MAX_TOP_KEYS = 64;        // distinct attribution keys tracked per minute; the rest fold into "other"
+export const FLUSH_MS = 60_000;
+/** Upper edges (exclusive) of the histogram's buckets 0..12; bucket 13 is everything at or over 4096 ms. */
+export const HIST_EDGES: readonly number[] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+export const HIST_BUCKETS = HIST_EDGES.length + 1;
+
+export type PerfPost = (m: Record<string, unknown>) => void;
+export type UaClass = "chrome-desktop" | "safari-ios" | "other";
+
+/** A PerformanceObserver-shaped constructor: what the module needs of the real one. */
+export interface ObserverCtor {
+  new (cb: (list: { getEntries(): any[] }) => void): { observe(opts: any): void; disconnect(): void };
+}
+
+/** Everything the module reads from the page, injectable so the tests run it on a fake clock. */
+export interface PerfDeps {
+  now(): number;                     // performance.now(): the handler clock, and the clock long-frame entries carry
+  wallNow(): number;                 // Date.now(): stamps the minute
+  post: PerfPost | null;             // the clientDiag transport; null keeps measuring and sends nothing
+  raf: ((cb: (t: number) => void) => number) | null;
+  caf: ((id: number) => void) | null;
+  setInterval: ((cb: () => void, ms: number) => unknown) | null;
+  observer: ObserverCtor | null;
+  supportedEntryTypes: readonly string[];
+  heapBytes(): number | null;        // performance.memory.usedJSHeapSize (Chrome); null when absent
+  domCount(): number | null;         // document.getElementsByTagName("*").length; null when absent
+  visible(): boolean;                // document.visibilityState !== "hidden"
+  hiddenPane(): boolean;             // the shim's zero-viewport test: a framed pane the shell has display:none'd
+  ua: UaClass;
+  pageUrl: string;                   // location.href without query or fragment: an inline script's sourceURL
+  windowEvents: EventTarget | null;  // pagehide flushes the minute; resize cancels a free sample when the viewport goes to zero
+  documentEvents: EventTarget | null; // visibilitychange cancels a free-thread sample the hide would inflate
+}
+
+/** The object every pane, federation and the kernel page's timeline boot reach through window.__rompPerf. */
+export interface RompPerf {
+  timed<T>(type: string, fn: () => T): T;
+  frame<T>(msg: unknown, fn: () => T): T;
+  wrapFrameHandler(handler: (e: MessageEvent) => void): (e: MessageEvent) => void;
+  snapshot(): Record<string, unknown>;
+  tick(): void;
+  setPost(post: PerfPost | null): void;
+}
+
+// ── pure pieces ─────────────────────────────────────────────────────────────────────────────────────
+
+/** A fixed-capacity ring of numbers: the newest `cap` samples, in arrival order once full. */
+export class Ring {
+  private buf: number[] = [];
+  private at = 0;
+  n = 0;                              // samples pushed, beyond the capacity too
+  constructor(readonly cap: number) {}
+  push(v: number): void {
+    if (this.buf.length < this.cap) this.buf.push(v);
+    else this.buf[this.at] = v;
+    this.at = (this.at + 1) % this.cap;
+    this.n++;
+  }
+  values(): number[] { return this.buf.slice(); }
+}
+
+/** Nearest-rank percentile (p in 0..1) over the values; 0 for none. */
+export function percentile(vals: readonly number[], p: number): number {
+  if (!vals.length) return 0;
+  const s = vals.slice().sort((a, b) => a - b);
+  const rank = Math.min(s.length, Math.max(1, Math.ceil(p * s.length)));
+  return s[rank - 1];
+}
+
+/** The histogram bucket a duration falls in: 0 for under 1 ms, 13 for 4096 ms and over. */
+export function histBucket(ms: number): number {
+  let i = 0;
+  while (i < HIST_EDGES.length && ms >= HIST_EDGES[i]) i++;
+  return i;
+}
+
+/** Nearest-rank quantile of a histogram, as the index of the bucket it lands in; -1 for an empty one.
+ *  The bucket's upper edge (HIST_EDGES[i], or "4096 and over" for the last) is the figure to print. */
+export function histQuantileBucket(hist: readonly number[], q: number): number {
+  let total = 0;
+  for (const c of hist) total += c;
+  if (!total) return -1;
+  const rank = Math.min(total, Math.max(1, Math.ceil(q * total)));
+  let cum = 0;
+  for (let i = 0; i < hist.length; i++) {
+    cum += hist[i];
+    if (cum >= rank) return i;
+  }
+  return hist.length - 1;
+}
+
+/** One decimal place; keeps the rows short. */
+export function round1(x: number): number { return Math.round(x * 10) / 10; }
+
+/** A code identifier a row may carry: letters, digits, `_ . : -`, at most 32 chars; anything else is "other". */
+function ident(s: unknown): string {
+  const v = String(s ?? "");
+  return /^[A-Za-z0-9_.:-]{1,32}$/.test(v) ? v : "other";
+}
+
+function stripQuery(url: string): string {
+  const cut = url.search(/[?#]/);
+  return cut >= 0 ? url.slice(0, cut) : url;
+}
+
+/** The frame-type key a message counts under: its `type`, a raw delta as `delta:<slot>`, a shell message
+ *  (`romp:` field, no type) as "shell", anything else as "other". */
+export function classifyFrame(m: unknown): string {
+  if (!m || typeof m !== "object") return "other";
+  const o = m as Record<string, unknown>;
+  if (o.type === "delta") return "delta:" + ident(o.slot);
+  if (typeof o.type === "string" && o.type) return ident(o.type);
+  if (typeof o.romp === "string" && o.romp) return "shell";
+  return "other";
+}
+
+/** The attribution key of one long-frame script entry: `<script basename>:<function>@<char position>`.
+ *  The browser names the top-level callback it invoked, not the hottest function, so most keys are an
+ *  anonymous arrow; the character position tells those apart and resolves against the bundle. A script
+ *  whose sourceURL is the page itself (an inline script: the pane shim, the shell's boot code) is
+ *  `page:<fn>`, never the page path, which would read like a frame type; an empty sourceURL is `unknown:`. */
+export function scriptKey(s: { sourceURL?: unknown; sourceFunctionName?: unknown; sourceCharPosition?: unknown }, pageUrl = ""): string {
+  const url = stripQuery(String(s.sourceURL ?? ""));
+  const fn = (String(s.sourceFunctionName ?? "") || "(anonymous)").slice(0, 48);
+  const pos = typeof s.sourceCharPosition === "number" && s.sourceCharPosition >= 0 ? "@" + Math.floor(s.sourceCharPosition) : "";
+  if (!url) return "unknown:" + fn + pos;
+  const base = url.slice(url.lastIndexOf("/") + 1);
+  if ((pageUrl && url === pageUrl) || !base) return "page:" + fn + pos;
+  return base.slice(0, 48) + ":" + fn + pos;
+}
+
+/** An invoker name reduced to code identifiers: `DIV#tab-web.onclick` becomes `DIV.onclick` (an element id
+ *  can embed a session name); `IMG[src=/file?path=...].onload` becomes `IMG[src].onload` (a source URL can
+ *  carry a file path); a classic or module script's invoker, which the browser reports as the script's URL
+ *  (host, port and dist token included), becomes the script's basename. */
+export function sanitizeInvoker(inv: unknown): string {
+  let s = String(inv ?? "");
+  s = s.replace(/\[src=[^\]]*\]/g, "[src]");
+  s = s.replace(/#[^.\s[]*/g, "");
+  if (s.includes("://") || s.startsWith("/")) {
+    s = stripQuery(s);
+    s = s.slice(s.lastIndexOf("/") + 1) || "page";
+  }
+  return s.slice(0, 64);
+}
+
+/** A coarse browser class; iPadOS reports a Macintosh UA and is told apart by its touch points. */
+export function uaClass(ua: string, maxTouchPoints = 0): UaClass {
+  if (/iPhone|iPad|iPod/.test(ua) || (/Macintosh/.test(ua) && maxTouchPoints > 1)) return "safari-ios";
+  if (/Chrome\//.test(ua) && !/Mobile|Android/.test(ua)) return "chrome-desktop";
+  return "other";
+}
+
+/** The scripts of one long-frame entry as `{k, ms, inv}` rows, summed per key, largest first. */
+export function attributeScripts(scripts: any[], pageUrl = ""): { k: string; ms: number; inv: string }[] {
+  const by = new Map<string, { k: string; ms: number; inv: string }>();
+  for (const s of scripts) {
+    if (!s || typeof s.duration !== "number") continue;
+    const k = scriptKey(s, pageUrl);
+    const cur = by.get(k) || { k, ms: 0, inv: "" };
+    cur.ms += s.duration;
+    const inv = sanitizeInvoker(s.invoker);
+    if (inv) cur.inv = inv;
+    by.set(k, cur);
+  }
+  return [...by.values()].sort((a, b) => b.ms - a.ms).map((r) => ({ k: r.k, ms: round1(r.ms), inv: r.inv }));
+}
+
+// ── the collector ───────────────────────────────────────────────────────────────────────────────────
+
+interface TypeStat { n: number; ms_sum: number; ms_max: number; n16: number; n100: number; hist: number[] }
+interface TopStat { ms: number; n: number; inv: string }
+interface Bucket {
+  since: number;                       // wallNow() when the minute began
+  active: boolean;                     // a frame arrived or a long frame was observed
+  frames: Map<string, TypeStat>;
+  free: Ring;
+  loaf: { n: number; blocking_ms: number; worst_ms: number; top: Map<string, TopStat> };
+  slowSent: number;                    // slowframe rows sent or held this minute
+  slowSuppressed: number;              // slow frames past the cap: counted, not sent
+  slowSuppressedWorst: number;
+  wireTypes: number;                   // distinct keys in `frames` that are wire types, and fed:<type> keys, for the two caps
+  fedTypes: number;
+}
+interface PendingSlow { type: string; ms: number; dom: number | null; t0: number; t1: number }
+interface Open { t0: number; child: number }   // a bracket in progress: its start, and the time its inner brackets took
+type ObserverKind = "loaf" | "longtask" | "none";
+
+export class PerfTelemetry implements RompPerf {
+  private bucket: Bucket;
+  private open: Open[] = [];           // the brackets in progress, outermost first
+  private freePending = false;
+  private freeFrom = 0;
+  private rafId = 0;
+  private pendingSlow: PendingSlow[] = [];
+  readonly observerKind: ObserverKind = "none";
+
+  constructor(readonly app: string, private readonly d: PerfDeps) {
+    this.bucket = this.newBucket();
+    this.observerKind = this.startObserver();
+    if (d.setInterval) {
+      try {
+        const h: any = d.setInterval(() => { try { this.tick(); } catch (e) { /* never into the pane */ } }, FLUSH_MS);
+        if (h && typeof h.unref === "function") h.unref();   // a node host must not be kept alive by the flush
+      } catch (e) { /* no timer: the minute flushes on the next pagehide only */ }
+    }
+    try {
+      d.windowEvents?.addEventListener("pagehide", () => { try { this.tick(); } catch (e) { /* never into the pane */ } });
+      // the shell hides a pane by display:none, which has no event of its own; the iframe's viewport going to
+      // zero fires resize, and a sample armed before the hide would otherwise measure the hidden interval
+      d.windowEvents?.addEventListener("resize", () => { try { if (d.hiddenPane()) this.cancelFree(); } catch (e) { /* ditto */ } });
+      d.documentEvents?.addEventListener("visibilitychange", () => { try { if (!d.visible()) this.cancelFree(); } catch (e) { /* ditto */ } });
+    } catch (e) { /* no event hooks */ }
+  }
+
+  setPost(post: PerfPost | null): void { this.d.post = post; }
+
+  /** Run fn as the handling of one frame of `type`, timing it. Brackets nest: each level records its OWN
+   *  time (its total minus its inner brackets'), so `fed:feed` and `feed` add up to the frame's cost; the
+   *  slowframe test and the free-thread sample use the outermost bracket's total. The pane's own exceptions
+   *  propagate. */
+  timed<T>(type: string, fn: () => T): T {
+    const fr: Open = { t0: this.d.now(), child: 0 };
+    this.open.push(fr);
+    try {
+      return fn();
+    } finally {
+      this.open.pop();
+      try {
+        const t1 = this.d.now();
+        const total = t1 - fr.t0;
+        const parent = this.open[this.open.length - 1];
+        if (parent) parent.child += total;
+        this.record(type, Math.max(0, total - fr.child), total, fr.t0, t1, !parent);
+      } catch (e) { /* telemetry never throws into the pane */ }
+    }
+  }
+
+  frame<T>(msg: unknown, fn: () => T): T { return this.timed(classifyFrame(msg), fn); }
+
+  wrapFrameHandler(handler: (e: MessageEvent) => void): (e: MessageEvent) => void {
+    return (e: MessageEvent) => this.frame(e ? e.data : null, () => handler(e));
+  }
+
+  /** The minute timer's callback, also run on pagehide: send the minute if anything happened, start the next. */
+  tick(): void {
+    // slowframe rows still waiting for a long-frame report: no report is coming for a frame this old
+    for (const p of this.pendingSlow.splice(0)) this.sendSlow(p, null);
+    if (this.bucket.active) this.send("minute", this.minuteData(this.bucket));
+    this.bucket = this.newBucket();
+  }
+
+  /** The minute in progress, in the row's shape, plus the collector's own state and a derived p90 per type
+   *  (`p90_le`: the upper edge of the histogram bucket the p90 lands in; Infinity for the top bucket). */
+  snapshot(): Record<string, unknown> {
+    const data = this.minuteData(this.bucket);
+    const frames = data.frames as Record<string, any>;
+    for (const k of Object.keys(frames)) {
+      const b = histQuantileBucket(frames[k].hist, 0.9);
+      frames[k].p90_le = b < 0 ? null : (b < HIST_EDGES.length ? HIST_EDGES[b] : Infinity);
+    }
+    return Object.assign(data, {
+      active: this.bucket.active, observer: this.observerKind,
+      pending_slow: this.pendingSlow.length, free_pending: this.freePending,
+    });
+  }
+
+  // ── recording ──
+
+  private record(type: string, own: number, total: number, t0: number, t1: number, outermost: boolean): void {
+    const b = this.bucket;
+    b.active = true;
+    // the key the frame is counted under: its type, or the fold key once the minute has its cap of distinct
+    // types. Wire types and the federation layer's fed:<type> keys are capped separately (on a kernel page every
+    // wire type has both), and the fold changes the key only: a slow frame below still names its wire type.
+    const fed = type.startsWith("fed:");
+    let key = type;
+    let st = b.frames.get(key);
+    if (!st) {
+      const fold = fed ? "fed:other" : "other";
+      if (key !== fold && (fed ? b.fedTypes : b.wireTypes) >= MAX_FRAME_TYPES) { key = fold; st = b.frames.get(key); }
+      if (!st) {
+        st = { n: 0, ms_sum: 0, ms_max: 0, n16: 0, n100: 0, hist: new Array(HIST_BUCKETS).fill(0) };
+        b.frames.set(key, st);
+        if (fed) b.fedTypes++; else b.wireTypes++;
+      }
+    }
+    st.n++;
+    st.ms_sum += own;
+    if (own > st.ms_max) st.ms_max = own;
+    if (own > DROPPED_FRAME_MS) st.n16++;
+    if (own >= SLOW_FRAME_MS) st.n100++;
+    st.hist[histBucket(own)]++;
+    if (!outermost) return;
+    if (total >= SLOW_FRAME_MS) this.slow(fed ? type.slice(4) : type, total, t0, t1);
+    this.scheduleFree(t1);
+  }
+
+  /** Two animation frames after the outermost handler: the gap is how long the main thread stayed busy with
+   *  the work the handler queued (a deferred render, layout, paint). One sample in flight at a time — frames
+   *  landing before it resolves are part of that same busy stretch. Not taken while the document is hidden
+   *  or the pane has no viewport: requestAnimationFrame does not run there, and a sample bridging a hide
+   *  would measure the hide (the visibilitychange and resize listeners cancel one that was already armed). */
+  private scheduleFree(t1: number): void {
+    const d = this.d;
+    const raf = d.raf;
+    if (this.freePending || !raf) return;
+    if (!d.visible() || d.hiddenPane()) return;
+    this.freePending = true;
+    this.freeFrom = t1;
+    this.rafId = raf(() => {
+      this.rafId = raf(() => {
+        this.freePending = false;
+        this.rafId = 0;
+        try {
+          if (d.visible() && !d.hiddenPane()) {
+            this.bucket.free.push(d.now() - this.freeFrom);
+            this.bucket.active = true;
+          }
+        } catch (e) { /* never into the pane */ }
+      });
+    });
+  }
+
+  private cancelFree(): void {
+    if (this.rafId && this.d.caf) { try { this.d.caf(this.rafId); } catch (e) { /* nothing to cancel */ } }
+    this.rafId = 0;
+    this.freePending = false;
+  }
+
+  private slow(type: string, ms: number, t0: number, t1: number): void {
+    const b = this.bucket;
+    if (b.slowSent >= SLOW_ROWS_PER_MINUTE) {
+      // a pane that is slow on every frame would post one row per frame; past the cap the frames are counted
+      // in the minute row with the worst of them, and the rows already sent are the minute's first
+      b.slowSuppressed++;
+      if (ms > b.slowSuppressedWorst) b.slowSuppressedWorst = ms;
+      return;
+    }
+    b.slowSent++;
+    const row: PendingSlow = { type, ms, dom: this.safeDom(), t0, t1 };
+    if (this.observerKind !== "loaf") { this.sendSlow(row, null); return; }
+    // hold it for the long-frame report that covers this handler; the observer callback attaches the
+    // attribution and sends it, a later report that starts after it proves none is coming, and the minute
+    // tick is the last backstop. Bounded by the cap above: at most SLOW_ROWS_PER_MINUTE wait at once.
+    this.pendingSlow.push(row);
+  }
+
+  // ── long frames ──
+
+  private startObserver(): ObserverKind {
+    const d = this.d;
+    if (!d.observer) return "none";
+    let kind: ObserverKind = "none";
+    let entryType = "";
+    try {
+      const types = d.supportedEntryTypes || [];
+      if (types.indexOf("long-animation-frame") >= 0) { kind = "loaf"; entryType = "long-animation-frame"; }
+      else if (types.indexOf("longtask") >= 0) { kind = "longtask"; entryType = "longtask"; }
+      if (kind === "none") return kind;
+      const po = new d.observer((list) => {
+        try { for (const e of list.getEntries()) this.observeEntry(e); } catch (e) { /* never into the pane */ }
+      });
+      po.observe({ type: entryType, buffered: false });
+      return kind;
+    } catch (e) {
+      return "none";
+    }
+  }
+
+  /** One long-animation-frame (or longtask) entry: fold it into the minute, and settle any slowframe row
+   *  waiting on it. */
+  private observeEntry(e: any): void {
+    if (!e || typeof e.duration !== "number" || e.duration < LONG_FRAME_MS) return;
+    const start = typeof e.startTime === "number" ? e.startTime : 0;
+    const blocking = typeof e.blockingDuration === "number" ? e.blockingDuration : Math.max(0, e.duration - LONG_FRAME_MS);
+    const b = this.bucket;
+    b.active = true;
+    b.loaf.n++;
+    b.loaf.blocking_ms += blocking;
+    if (e.duration > b.loaf.worst_ms) b.loaf.worst_ms = e.duration;
+    const attributed = attributeScripts(Array.isArray(e.scripts) ? e.scripts : [], this.d.pageUrl);
+    for (const a of attributed) {
+      let key = a.k;
+      let t = b.loaf.top.get(key);
+      if (!t) {
+        if (b.loaf.top.size >= MAX_TOP_KEYS && key !== "other") { key = "other"; t = b.loaf.top.get(key); }
+        if (!t) { t = { ms: 0, n: 0, inv: "" }; b.loaf.top.set(key, t); }
+      }
+      t.ms += a.ms;
+      t.n += 1;
+      if (a.inv) t.inv = a.inv;
+    }
+    if (!this.pendingSlow.length) return;
+    const end = start + e.duration;
+    const keep: PendingSlow[] = [];
+    for (const p of this.pendingSlow) {
+      if (start <= p.t0 + 1 && end >= p.t1 - 1) {
+        this.sendSlow(p, { ms: round1(e.duration), blocking_ms: round1(blocking), top: attributed.slice(0, 3) });
+      } else if (start > p.t1) {
+        this.sendSlow(p, null);                // a later frame reported first: none is coming for this one
+      } else {
+        keep.push(p);
+      }
+    }
+    this.pendingSlow = keep;
+  }
+
+  /** Test seam: feed synthetic long-frame entries as the observer would. */
+  observeEntries(entries: any[]): void { for (const e of entries) this.observeEntry(e); }
+
+  // ── rows ──
+
+  private newBucket(): Bucket {
+    return { since: this.d.wallNow(), active: false, frames: new Map(), free: new Ring(FREE_RING),
+             loaf: { n: 0, blocking_ms: 0, worst_ms: 0, top: new Map() },
+             slowSent: 0, slowSuppressed: 0, slowSuppressedWorst: 0, wireTypes: 0, fedTypes: 0 };
+  }
+
+  private minuteData(b: Bucket): Record<string, unknown> {
+    const frames: Record<string, { n: number; ms_sum: number; ms_max: number; n16: number; n100: number; hist: number[] }> = {};
+    for (const [k, st] of b.frames) {
+      frames[k] = { n: st.n, ms_sum: round1(st.ms_sum), ms_max: round1(st.ms_max), n16: st.n16, n100: st.n100, hist: st.hist.slice() };
+    }
+    const fv = b.free.values();
+    const free = b.free.n
+      ? { n: b.free.n, p50: round1(percentile(fv, 0.5)), p90: round1(percentile(fv, 0.9)), max: round1(Math.max(...fv)) }
+      : null;
+    const top = [...b.loaf.top.entries()]
+      .sort((x, y) => y[1].ms - x[1].ms)
+      .slice(0, MAX_TOP)
+      .map(([k, t]) => ({ k, ms: round1(t.ms), n: t.n, inv: t.inv }));
+    const data: Record<string, unknown> = {
+      app: this.app, since: b.since, span_ms: Math.max(0, this.d.wallNow() - b.since),
+      frames, free,
+      loaf: { n: b.loaf.n, blocking_ms: round1(b.loaf.blocking_ms), worst_ms: round1(b.loaf.worst_ms), top, src: this.observerKind },
+      slow: { sent: b.slowSent, suppressed: b.slowSuppressed, suppressed_worst_ms: round1(b.slowSuppressedWorst) },
+      dom: this.safeDom(), visible: this.safe(() => this.d.visible(), true), hidden_pane: this.safe(() => this.d.hiddenPane(), false),
+      ua: this.d.ua,
+    };
+    const heap = this.safe(() => this.d.heapBytes(), null);
+    if (typeof heap === "number") data.heap_mb = round1(heap / 1048576);
+    return data;
+  }
+
+  private sendSlow(p: PendingSlow, loaf: Record<string, unknown> | null): void {
+    const data: Record<string, unknown> = { app: this.app, type: p.type, ms: round1(p.ms), dom: p.dom };
+    if (loaf) data.loaf = loaf;
+    this.send("slowframe", data);
+  }
+
+  private send(what: string, data: Record<string, unknown>): void {
+    const post = this.d.post;
+    if (!post) return;
+    try { post({ type: "clientDiag", surface: "perf", what, data }); } catch (e) { /* the transport's problem, not the pane's */ }
+  }
+
+  private safeDom(): number | null { return this.safe(() => this.d.domCount(), null); }
+  private safe<T>(fn: () => T, fallback: T): T { try { return fn(); } catch (e) { return fallback; } }
+}
+
+export function createPerfTelemetry(app: string, deps: PerfDeps): PerfTelemetry { return new PerfTelemetry(app, deps); }
+
+// ── the browser singleton ───────────────────────────────────────────────────────────────────────────
+
+function browserDeps(post: PerfPost | null): PerfDeps | null {
+  const w: any = window;
+  const doc: any = document;
+  const perf: any = w.performance;
+  if (!perf || typeof perf.now !== "function") return null;   // not a browser this module measures
+  const PO: any = typeof w.PerformanceObserver === "function" ? w.PerformanceObserver : null;
+  const nav: any = w.navigator || {};
+  let pageUrl = "";
+  try { pageUrl = stripQuery(String((w.location && w.location.href) || "")); } catch (e) { pageUrl = ""; }
+  return {
+    now: () => perf.now(),
+    wallNow: () => Date.now(),
+    post,
+    raf: typeof w.requestAnimationFrame === "function" ? (cb) => w.requestAnimationFrame(cb) : null,
+    caf: typeof w.cancelAnimationFrame === "function" ? (id) => w.cancelAnimationFrame(id) : null,
+    setInterval: typeof w.setInterval === "function" ? (cb, ms) => w.setInterval(cb, ms) : null,
+    observer: PO,
+    supportedEntryTypes: (PO && Array.isArray(PO.supportedEntryTypes)) ? PO.supportedEntryTypes : [],
+    heapBytes: () => { const m = perf.memory; return m && typeof m.usedJSHeapSize === "number" ? m.usedJSHeapSize : null; },
+    domCount: () => (doc && typeof doc.getElementsByTagName === "function") ? doc.getElementsByTagName("*").length : null,
+    visible: () => !doc || doc.visibilityState !== "hidden",
+    hiddenPane: () => { try { return w.parent !== w && (w.innerWidth === 0 || w.innerHeight === 0); } catch (e) { return false; } },
+    ua: uaClass(String(nav.userAgent || ""), Number(nav.maxTouchPoints) || 0),
+    pageUrl,
+    windowEvents: typeof w.addEventListener === "function" ? w : null,
+    documentEvents: doc && typeof doc.addEventListener === "function" ? doc : null,
+  };
+}
+
+/** The default transport on a kernel page: federation's outbound (which routes a local message to the shim's
+ *  send), else the shim's send itself. A pane passes its own acquireVsCodeApi().postMessage instead, which
+ *  is the same path on a kernel page and the extension host's pipe in VS Code. */
+function defaultPost(): PerfPost {
+  return (m) => {
+    const w: any = window;
+    const f = w.__rompFed;
+    if (f && typeof f.outbound === "function") f.outbound(m);
+    else if (typeof w.__rompLocalSend === "function") w.__rompLocalSend(m);
+  };
+}
+
+/** The page's one collector, created on first call and published as window.__rompPerf; later callers get
+ *  the same object (federation.js and the pane bundle each carry a copy of this module, so identity is by
+ *  the window slot, not the class). A caller's `post` replaces the transport. Null where nothing can be
+ *  measured (no window, no performance.now), and the pane runs exactly as before. */
+export function installPerfTelemetry(app: string, opts: { post?: PerfPost } = {}): RompPerf | null {
+  try {
+    if (typeof window === "undefined" || typeof document === "undefined") return null;
+    const w: any = window;
+    const existing = w.__rompPerf;
+    if (existing && typeof existing.timed === "function") {
+      if (opts.post) existing.setPost(opts.post);
+      return existing as RompPerf;
+    }
+    const deps = browserDeps(opts.post || defaultPost());
+    if (!deps) return null;
+    const p = new PerfTelemetry(app, deps);
+    w.__rompPerf = p;
+    return p;
+  } catch (e) {
+    return null;
+  }
+}
+
+/** The one-line install for a pane: its window "message" handler, timed per frame. */
+export function perfFrameHandler(app: string, post: PerfPost | undefined, handler: (e: MessageEvent) => void): (e: MessageEvent) => void {
+  const p = installPerfTelemetry(app, post ? { post } : {});
+  return p ? p.wrapFrameHandler(handler) : handler;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -58,6 +58,7 @@ import { chatMdExtensions, userMdHtml } from "./chat-md";
 import { setTip, pruneTip } from "./tip";
 import { agentCount, replyOwed, threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 import { dragSlotIndex } from "./dragslot";
+import { perfFrameHandler } from "./perf-telemetry";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -13156,7 +13157,9 @@ function pipeBanner(up: boolean, queued: number): void {
 // hid). An event gets a transient cue; the steady state stays on the surfaces already carrying it; no pixel
 // of transcript is spent. hostDownNote is still the one place that note is worded — see host-prefix.ts.)
 
-window.addEventListener("message", (e: MessageEvent) => {
+// every frame's synchronous handling time is measured (perf-telemetry.ts: one clientDiag row a
+// minute, read by `romp perf client`); the handler itself is unchanged
+window.addEventListener("message", perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
   // the shell's palette: "Fork this session…" → the fork modal for the ACTIVE session, from the tip
@@ -13584,7 +13587,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     document.getElementById("cmt-pop")?.remove();
     renderCommentPopover();
   }
-});
+}));
 
 // Tick the working timer (the chip color-pulse is pure CSS) and keep the model/ctx
 // meta fresh as status updates land.

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -200,7 +200,9 @@ test("dispatchFrame routes tagEditFailed to the panel — the LOUD half of remot
   assert.equal(dispatchFrame({}, { type: "tagEditFailed" }), false, "an older panel is skipped, never thrown at");
   // …and the kernel's inline boot + the editTag outbound hook stay mirrored (the pinned pair)
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\nelse if\(m\.type==="openViewsDialog"&&panel\._openViewsDialog\)panel\._openViewsDialog\(null\);\}\);/);
+  // (the listener body ends there; the boot registers it wrapped through the page's performance collector when one
+  // is published on window.__rompPerf, the way every pane bundle wraps its own — perf-telemetry.ts)
+  assert.match(KERNEL, /else if\(m\.type==="tagEditFailed"&&panel\.tagEditFailed\)panel\.tagEditFailed\(m\);\nelse if\(m\.type==="openViewsDialog"&&panel\._openViewsDialog\)panel\._openViewsDialog\(null\);\};\nwindow\.addEventListener\("message",\(window\.__rompPerf&&window\.__rompPerf\.wrapFrameHandler\)\?window\.__rompPerf\.wrapFrameHandler\(onFrame\):onFrame\);/);
   assert.match(KERNEL, /window\.__rompTimelineEditTag=function\(edit\)\{post\(\{type:"editTag",edit:edit\}\);\};/);
   const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
   assert.match(BOOT, /__rompTimelineEditTag: \(edit: unknown\) => post\(\{ type: "editTag", edit \}\),/);

--- a/ui/webview/timeline-main.ts
+++ b/ui/webview/timeline-main.ts
@@ -6,6 +6,7 @@
 import { installDomHelpers, dispatchFrame, bridgeFunctions } from "./timeline-boot";
 import { installSettingsSync, loadSettings, onExternalSettingsChange } from "./settings";
 import { applyTheme } from "./theme";
+import { perfFrameHandler } from "./perf-telemetry";
 
 // CJS view module — esbuild inlines it into this bundle at build time.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -22,7 +23,9 @@ Object.assign(window, bridgeFunctions(post));
 (window as any).__rompForwardUsage = (usage: unknown) => post({ type: "usageData", usage });
 
 let panel: any = null;
-window.addEventListener("message", (ev: MessageEvent) => { dispatchFrame(panel, ev.data); });
+// wrapped through the pane's performance collector like every pane's listener (ui/webview/perf-telemetry.ts):
+// each frame's handling is timed by type, and the kernel page's inline boot twin does the same
+window.addEventListener("message", perfFrameHandler("timeline", post, (ev: MessageEvent) => { dispatchFrame(panel, ev.data); }));
 
 // the overall theme (2026-08-28): body classes at boot + on settings writes, like every pane
 installSettingsSync();

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -74,11 +74,12 @@ const webview = {
   sourcemap: !production,
   // Whitespace and syntax are minified for a release; identifiers are NOT: the browser's
   // long-animation-frame reports name the callback they ran by its compile-time name, and perf-telemetry.ts
-  // keys its attribution on that, so a mangled build reports `feed.js:Qe` and a different letter after
-  // every rebuild (the ten-minute fold in `romp perf client` then splits one function across keys). Stack
-  // traces and DevTools profiles read better for the same reason. Measured cost (esbuild 0.21.5): +27% raw
-  // over all webview bundles (feed.js 368 KB to 460 KB, render.js 801 KB to 1026 KB) and +13% gzipped,
-  // which is what the kernel serves (feed.js 117 KB to 132 KB, render.js 247 KB to 280 KB).
+  // puts that name in its attribution key, so keeping identifiers keeps the function name readable across
+  // rebuilds (a mangled build reports `feed.js:Qe`, a letter that changes with every rebuild; the key's
+  // character position moves with any edit to the bundle either way). Stack traces and DevTools profiles
+  // read better for the same reason. Measured cost (esbuild 0.21.5): +27% raw over all webview bundles
+  // (feed.js 368 KB to 460 KB, render.js 801 KB to 1026 KB) and +13% gzipped, which is what the kernel
+  // serves (feed.js 117 KB to 132 KB, render.js 247 KB to 280 KB).
   minifyWhitespace: production,
   minifySyntax: production,
   minifyIdentifiers: false,

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -72,7 +72,16 @@ const webview = {
   loader: { ".woff2": "file" },
   assetNames: "fonts/[name]-[hash]",
   sourcemap: !production,
-  minify: production,
+  // Whitespace and syntax are minified for a release; identifiers are NOT: the browser's
+  // long-animation-frame reports name the callback they ran by its compile-time name, and perf-telemetry.ts
+  // keys its attribution on that, so a mangled build reports `feed.js:Qe` and a different letter after
+  // every rebuild (the ten-minute fold in `romp perf client` then splits one function across keys). Stack
+  // traces and DevTools profiles read better for the same reason. Measured cost (esbuild 0.21.5): +27% raw
+  // over all webview bundles (feed.js 368 KB to 460 KB, render.js 801 KB to 1026 KB) and +13% gzipped,
+  // which is what the kernel serves (feed.js 117 KB to 132 KB, render.js 247 KB to 280 KB).
+  minifyWhitespace: production,
+  minifySyntax: production,
+  minifyIdentifiers: false,
   logLevel: "info",
 };
 


### PR DESCRIPTION
Depends on #1003 (the kernel counters PR), which must merge first; GitHub shows its commits in this diff until then.

Stacks on the kernel counters PR (branch perf-counters-offer): review and merge that first; this PR's own diff is f725a219..195265b9.

**What breaks.** A dashboard that feels slow cannot be attributed to a pane, a frame type or a function. The panes are same-origin iframes on one main thread, and the kernel's `/perf` counters (the PR this one stacks on) say only what the kernel spent, not what the browser spent on the frames it received.

**The fix.** The panes measure their own frame handling and post one summary row a minute; the kernel keeps the file those rows land in bounded; a CLI folds the rows into one screen.

- `ui/webview/perf-telemetry.ts` brackets each pane's window `message` handler with `performance.now()` in the feed, Outline, chat and timeline bundles. The kernel-served timeline page has no bundle of its own, so its inline boot (`_TIMELINE_BOOT`) wraps through the `window.__rompPerf` that `federation.js` publishes before it runs (`test_browser_owned_order` pins that load order).
- Per frame type and minute it keeps a count, the summed and maximum handler time, exact counts over 16.7 ms and at or over 100 ms, and a 14-bucket log2 histogram. The histogram is additive across minutes, so the CLI computes window percentiles from it.
- Federation times its own prefixing, delta application and merge as `fed:<type>`, nested outside the pane's handler. Each level records its own time, so `fed:feed` and `feed` add up to the frame's cost.
- Two `requestAnimationFrame` callbacks after the outermost handler, it samples how long the main thread stayed busy with the work the handler queued.
- A `PerformanceObserver` on `long-animation-frame` entries (`longtask` where that is missing, with no attribution) records long frames keyed `<file>:<function>@<position>`.
- Each pane posts one `clientDiag` row per active minute (surface `perf`, what `minute`) on the socket the panes already use for breadcrumbs, plus a `slowframe` row at once for a frame whose whole handling ran 100 ms or more, at most five a minute. `window.__rompPerf.snapshot()` shows the minute in progress in DevTools.
- Kernel: `client-diag.jsonl` rotates to `.1` at 8 MB. The size check, the rename and the append are one critical section under one lock, because every pane's socket is its own handler thread.
- `romp perf client [--minutes N] [--json]` reads both files directly (no kernel round trip) and folds the last N minutes per dashboard id and pane: handler ms/min by type with p50/p90/p99 and max, the worst minute's main-thread-free p90, long frames with their attributed callbacks, the worst minute, heap and DOM, the slowest frames. An absent file, a file without perf rows and perf rows older than the window each get a specific refusal instead of an empty screen.

**Payload contract.** Rows carry numbers and code identifiers only: frame type strings, script basenames, function names and character positions, and invoker names with the element id stripped (`DIV#tab-web.onclick` is recorded as `DIV.onclick`, an element source as `[src]`, a script URL as its basename), never card text, names, file paths or transcript content. docs/reference.md documents both row shapes as the kernel writes them, so the CLI and any other reader can rely on the fields.

**Two costs.**
1. `client-diag.jsonl` changes from append-forever to two files of about 8 MB each. A minute row is about 1 KB, so an open dashboard writes a few MB a day, and nothing pruned the file before. A reader tailing the file sees a rename at 8 MB, and the `.1` replacement discards the run before it.
2. The last commit turns identifier minification off for the webview bundles (whitespace and syntax are still minified). The browser's long-frame attribution names a callback by its compile-time name, so a mangled build reports `feed.js:Qe` and a different letter after every rebuild, and the ten-minute fold splits one function across keys. Measured on these bundles (esbuild 0.21.5, `node esbuild.js --production`, `gzip -9`): all webview bundles together go from 2.04 MB to 2.59 MB raw (+27%) and from 661 kB to 747 kB gzipped (+13%); feed.js 368 kB to 460 kB raw and 117 kB to 132 kB gzipped; render.js 801 kB to 1026 kB raw and 247 kB to 280 kB gzipped. The extension-host bundle keeps `minify: production` and is unchanged. The commit is separable: without it everything else works and the attribution keys are mangled names.

**Known limits.** The hidden-pane bit is the zero-viewport probe (`innerWidth` 0), which is right for a pane hidden since load and under-reports a pane hidden after its first show, since its iframe keeps its size; for the same reason a free-thread sample armed before such a hide can measure the hidden interval, because `requestAnimationFrame` does not run while the pane is hidden and the resize cancellation fires only when the viewport goes to zero. Safari has no `long-animation-frame` or `performance.memory`, so its rows carry `src` `none` or `longtask` and no heap figure. Rows queued during a socket outage fall under the shim's existing 20-row `clientDiag` cap. A page without `performance.now` gets the plain handler. Nothing is Linux-only: the rotation uses `os.replace`, the CLI is bash plus the python3 standard library, and every browser API sits behind a feature check whose degraded path the node tests cover. A live browser check (open the dashboard for a minute, run `romp perf client`) is worth doing if a browser is at hand; the tests do not need one.

**Tests.** Each new test was run red against the tree before its code change, then green.
- `ui/webview/perf-telemetry.test.ts` (fake clock): the classifier, histogram and quantiles, the minute row's shape, idle minutes send nothing, nested brackets, the free-thread sample and its cancellations, the slowframe threshold, cap and suppression counts, long-frame aggregation with and without scripts, the longtask fallback, the feature guards, the identifier-only contract, federation's `fed:` bracket, the window singleton.
- `tests/test_client_diag_rotation.py`: rotation through the real `Handler._dispatch_ws`, a second rotation replacing `.1`, a refused rename that still appends, a six-thread race, and a two-thread interleaving forced with events. Without the lock, the interleaving test and the race test both fail.
- `tests/romp-perf-client.bats`: the fold, `--minutes`, `--json`, the `.1` file, `ROMP_STATE_DIR`, the three refusals, the flag validation, and that `romp perf` usage and the help table name the sub-verb; a curl stub that exits 7 proves no kernel was contacted.
- Pins: `tests/test_kernel_timeline_split.py` pins the wrapped boot registration; `heal-on-hostup.test.ts` and `timeline-boot.test.ts` follow the wrapped listeners; `tests/test_bundle_build_mode.py` pins the webview's three minify options (after the split, the existing `minify: production` assertion held only through the extension-host block, so the webview build mode was unpinned).
- Full runs on this branch: pytest 7634 passed, 46 skipped; bats 454 passed; `npm test` 2868 passed; `npm run typecheck` and `npm run build` clean.

Telemetry goes live for an open dashboard after the bundles rebuild and the page reloads; the rotation takes effect at the next kernel restart. Fixtures are synthetic (placeholder dashboard ids, invented numbers).

**Commits**, in review order; the last is separable.
1. Panes: the telemetry module and its tests, the four pane wraps, federation's `fed:` bracket, the `heal-on-hostup.test.ts` pin.
2. Kernel: the `client-diag.jsonl` rotation with its tests; the timeline page's inline boot wraps through the page collector, with the `timeline-boot.test.ts` pin.
3. CLI and docs: `romp perf client`, the reference section, the bats suite.
4. Build: the webview release bundles keep identifiers.

Tier: feature
🤖 Generated with [Claude Code](https://claude.com/claude-code)
