### PR TITLE
T244: a ✕ on a provisional tab's sending bubble forgets the send everywhere it lives; every missed cancel leaves evidence

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11143,6 +11143,10 @@ def _drive(msg, client):
             err2 = _cancel_backend_queued(be, sid, -1, md)
             if err2 is None:
                 err = None
+        if err:
+            # evidence for the next report (T244): a ✕ whose cancel found nothing in either queue — the send
+            # had already gone through, or never reached this kernel. sid only: the body is the user's text
+            sys.stderr.write("queued-cancel miss: %s (body-only)\n" % sid)
         client["send"](json.dumps({"type": "cancelResult", "ok": not err, "id": sid,
                                    "md": md, "text": err or ""}))
         _push_soon()

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -428,6 +428,13 @@ class QueuedBubble(unittest.TestCase):
         self.assertIn('_cancel_backend_queued(be, sid, int(msg["idx"]), str(msg.get("md") or ""))', src,
                       "the backend-queue cancel goes through the drift guard now")
 
+    def test_a_body_only_cancel_that_finds_nothing_is_logged(self):
+        # T244 (the user 2026-09-07): a ✕ on a "sending…" bubble left no evidence of which way the cancel went.
+        # The body-only arm now logs a miss (sid only — the body is the user's text) so the next report carries it.
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        arm = src.split('elif t == "cancelQueued" and msg.get("md"):')[1].split("\n    elif ")[0]
+        self.assertIn('sys.stderr.write("queued-cancel miss: %s (body-only)\\n" % sid)', arm)
+
     def test_drive_answers_every_cancel_with_an_authoritative_result_frame(self):
         # the user 2026-07-20: a ✕ whose target had already been handed to the CLI silently no-opped
         # while the client showed the message as deleted — and the CLI answered it anyway. EVERY cancel

--- a/ui/webview/provisional-cancel.test.ts
+++ b/ui/webview/provisional-cancel.test.ts
@@ -1,0 +1,53 @@
+// T244 (the user 2026-09-07, ~10:10 AM PT): ✕ on a message still showing "sending…" put the text back in the
+// composer, but the provisional sending bubble did NOT disappear. Reproduced by reading (the served harness
+// showed the parked-send path clean: ✕ → bubble gone, kernel cancelResult ok:true, nothing re-injected). The
+// long-lived "sending…" is the PROVISIONAL tab's: a send into a session still being created goes into
+// provisionalQueue and shows the bare group for the whole creation window (up to 90s). The ✕ dropped only the
+// optimistic entry (pendingSent) and posted a cancel for a sid the kernel has never heard of; adoption then
+// re-sent every queued text — the cut message included — and re-registered its bubble under the real tab,
+// while the ✕'s restore had already put the same text in the composer: a double-send waiting to happen.
+// Fix: a ✕ on a provisional-tab bubble forgets the text from provisionalQueue too and posts no kernel cancel
+// (there is nothing there to cancel); adoption re-sends only what remains. Plus the evidence the report lacked:
+// a client-diag row for every cancelResult ok:false and for a provisional-stage ✕, and a kernel log line for a
+// body-only cancel that found nothing.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("a ✕ on a provisional-tab bubble forgets the send from provisionalQueue and posts no kernel cancel (T244)", () => {
+  const qx = RENDER.split("    qx: (el) => {")[1].split("\n    },\n")[0];
+  assert.match(RENDER, /function forgetProvisionalSend\(text: string\): boolean \{/);
+  assert.match(qx, /const provisional = isProvisionalId\(sidQ\);/);
+  assert.match(qx, /if \(provisional && qmd\) forgetProvisionalSend\(qmd\);/, "the text must not come back through adoption");
+  assert.match(qx, /if \(!provisional\) vscodeApi\.postMessage\(msg\);/, "nothing at the kernel to cancel for a session that does not exist yet");
+  // the restore to the composer stays — the message never left the client
+  assert.match(qx, /restoreToComposer\(qmd\);/);
+  // adoption re-sends only what remains in the queue (unchanged: it reads provisionalQueue via dropProvisional)
+  assert.match(RENDER, /for \(const text of queued\) \{\s*\n\s*vscodeApi\?\.postMessage\(\{ type: "sendMessage", id: realId, text \}\);\s*\n\s*registerOptimistic\(realId, text\);/);
+});
+
+test("forgetProvisionalSend removes exactly one matching text and reports whether it did (executed)", () => {
+  const src = "function forgetProvisionalSend(text) {" + RENDER.split("function forgetProvisionalSend(text: string): boolean {")[1].split("\n}")[0] + "\n}";
+  const run = (queue: string[], text: string) => new Function("provisionalQueue", "text", src + "\nconst ok = forgetProvisionalSend(text); return { ok, queue: provisionalQueue };")(queue, text);
+  assert.deepEqual(run(["a", "b", "a"], "a"), { ok: true, queue: ["b", "a"] }, "one press forgets one send");
+  assert.deepEqual(run(["a", "b"], "zzz"), { ok: false, queue: ["a", "b"] });
+  assert.deepEqual(run([], "a"), { ok: false, queue: [] });
+});
+
+test("every cancel that misses leaves evidence: a client-diag row and a kernel log line (T244)", () => {
+  // client: cancelResult ok:false → a clientDiag breadcrumb (surface chat, what cancel-miss), body length only — never the text
+  const cr = RENDER.split('else if (m.type === "cancelResult" && typeof m.id === "string") {')[1].split("\n  }\n")[0];
+  assert.match(cr, /vscodeApi\?\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "cancel-miss",/);
+  assert.match(cr, /mdLen: typeof m\.md === "string" \? m\.md\.length : -1/);
+  assert.doesNotMatch(cr, /data: \{[^}]*\bmd: m\.md\b/, "the message body never rides a diag row");
+  // client: a provisional-stage ✕ leaves its own breadcrumb, so the next report says which path it was
+  const qx = RENDER.split("    qx: (el) => {")[1].split("\n    },\n")[0];
+  assert.match(qx, /vscodeApi\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "cancel-provisional",/);
+  // kernel: a body-only cancel that found nothing is logged (sid only, never the body)
+  const arm = KERNEL.split('elif t == "cancelQueued" and msg.get("md"):')[1].split("\n    elif ")[0];
+  assert.match(arm, /sys\.stderr\.write\("queued-cancel miss: %s \(body-only\)\\n" % sid\)/);
+});

--- a/ui/webview/provisional-cancel.test.ts
+++ b/ui/webview/provisional-cancel.test.ts
@@ -24,8 +24,9 @@ test("a ✕ on a provisional-tab bubble forgets the send from provisionalQueue a
   assert.match(qx, /const provisional = isProvisionalId\(sidQ\);/);
   assert.match(qx, /if \(provisional && qmd\) forgetProvisionalSend\(qmd\);/, "the text must not come back through adoption");
   assert.match(qx, /if \(!provisional\) vscodeApi\.postMessage\(msg\);/, "nothing at the kernel to cancel for a session that does not exist yet");
-  // the restore to the composer stays — the message never left the client
+  // the restore to the composer stays — the message never left the client; no cancelResult will come, so no stash is kept
   assert.match(qx, /restoreToComposer\(qmd\);/);
+  assert.match(qx, /if \(!provisional\) pendingCancelRestores\.set\(activeId \+ " " \+ qmd,/);
   // adoption re-sends only what remains in the queue (unchanged: it reads provisionalQueue via dropProvisional)
   assert.match(RENDER, /for \(const text of queued\) \{\s*\n\s*vscodeApi\?\.postMessage\(\{ type: "sendMessage", id: realId, text \}\);\s*\n\s*registerOptimistic\(realId, text\);/);
 });
@@ -42,8 +43,9 @@ test("every cancel that misses leaves evidence: a client-diag row and a kernel l
   // client: cancelResult ok:false → a clientDiag breadcrumb (surface chat, what cancel-miss), body length only — never the text
   const cr = RENDER.split('else if (m.type === "cancelResult" && typeof m.id === "string") {')[1].split("\n  }\n")[0];
   assert.match(cr, /vscodeApi\?\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "cancel-miss",/);
-  assert.match(cr, /mdLen: typeof m\.md === "string" \? m\.md\.length : -1/);
-  assert.doesNotMatch(cr, /data: \{[^}]*\bmd: m\.md\b/, "the message body never rides a diag row");
+  assert.match(cr, /data: \{ sid: m\.id, mdLen: typeof m\.md === "string" \? m\.md\.length : -1, hadRestore: !!stash \} \}/,
+    "sid, body LENGTH, restore flag — never the body, and never the kernel's refusal sentence (it quotes a slash-led body's first token)");
+  assert.doesNotMatch(cr, /what: "cancel-miss",[\s\S]{0,300}?\bmd: m\.md\b|what: "cancel-miss",[\s\S]{0,300}?\btext: m\.text/, "no user content on a diag row");
   // client: a provisional-stage ✕ leaves its own breadcrumb, so the next report says which path it was
   const qx = RENDER.split("    qx: (el) => {")[1].split("\n    },\n")[0];
   assert.match(qx, /vscodeApi\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "cancel-provisional",/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5756,6 +5756,16 @@ let pickAllowNew = false;
 let pendingNewSession: string | null = null;
 let provisionalId: string | null = null;
 const provisionalQueue: string[] = [];
+// A ✕ on a provisional tab's "sending…" bubble forgets the send HERE too (T244, the user 2026-09-07): the
+// message has never left the client — adoption re-sends whatever this queue still holds — so dropping only
+// the optimistic entry brought the cut message back as a bubble under the real tab while the ✕'s restore had
+// already put the same text in the composer. One press forgets one send.
+function forgetProvisionalSend(text: string): boolean {
+  const i = provisionalQueue.indexOf(text);
+  if (i < 0) return false;
+  provisionalQueue.splice(i, 1);
+  return true;
+}
 let provisionalTimer: ReturnType<typeof setTimeout> | undefined;
 // Text typed into a provisional tab whose create had to ask something first, waiting for the retry's tab.
 let pendingCarry = "";
@@ -13123,6 +13133,11 @@ window.addEventListener("message", (e: MessageEvent) => {
     const stash = pendingCancelRestores.get(key);
     pendingCancelRestores.delete(key);
     if (!m.ok) {
+      // evidence for the next report (T244): which cancel missed, and whether a composer restore was in play
+      // — body LENGTH only, never the text
+      vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "cancel-miss",
+                               data: { sid: m.id, mdLen: typeof m.md === "string" ? m.md.length : -1,
+                                       hadRestore: !!stash, text: typeof m.text === "string" ? m.text.slice(0, 120) : "" } });
       if (typeof m.text === "string" && m.text) warnToast(m.text);
       if (stash && m.id === activeId) {
         const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -14381,10 +14396,17 @@ setupSettings();
         if (i >= 0) { list.splice(i, 1); if (list.length) pendingSent.set(sidQ, list); else pendingSent.delete(sidQ); }
         echoShownSig.delete(sidQ);
       }
+      // a PROVISIONAL tab's send has never left the client (T244): forget it from the queue adoption would
+      // re-send, and post no kernel cancel — the kernel has no such session yet, and a miss there would
+      // toast "too late" for a message that was never late. A breadcrumb says which path this ✕ took.
+      const provisional = isProvisionalId(sidQ);
+      if (provisional && qmd) forgetProvisionalSend(qmd);
       const msg: Record<string, unknown> = { type: "cancelQueued", id: sidQ, md: qmd };
       if (el.dataset.qidx !== undefined) msg.idx = Number(el.dataset.qidx);
       if (el.dataset.qpark !== undefined) msg.park = Number(el.dataset.qpark);
-      vscodeApi.postMessage(msg);
+      if (!provisional) vscodeApi.postMessage(msg);
+      else vscodeApi.postMessage({ type: "clientDiag", surface: "chat", what: "cancel-provisional",
+                                  data: { mdLen: qmd ? qmd.length : -1, queuedLeft: provisionalQueue.length } });
       if (qmd && el.dataset.qcmd !== "1" && el.dataset.qromp !== "1") {
         // a message returns to the composer; a command just cancels. The restore is optimistic — stash
         // the composer's before/after so the kernel's cancelResult ok:false can undo it (untouched only).

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13134,10 +13134,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     pendingCancelRestores.delete(key);
     if (!m.ok) {
       // evidence for the next report (T244): which cancel missed, and whether a composer restore was in play
-      // — body LENGTH only, never the text
+      // — body LENGTH only, never the text: not even the kernel's refusal sentence, which quotes the body's
+      // leading token when it starts with "/" (a path-first message would land in the log)
       vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "cancel-miss",
-                               data: { sid: m.id, mdLen: typeof m.md === "string" ? m.md.length : -1,
-                                       hadRestore: !!stash, text: typeof m.text === "string" ? m.text.slice(0, 120) : "" } });
+                               data: { sid: m.id, mdLen: typeof m.md === "string" ? m.md.length : -1, hadRestore: !!stash } });
       if (typeof m.text === "string" && m.text) warnToast(m.text);
       if (stash && m.id === activeId) {
         const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
@@ -14413,7 +14413,8 @@ setupSettings();
         const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
         const before = ta ? ta.value : "";
         restoreToComposer(qmd);
-        pendingCancelRestores.set(activeId + " " + qmd, { before, after: ta ? ta.value : "" });
+        // a provisional ✕ gets no cancelResult (nothing was posted) — no stash to consume, none kept
+        if (!provisional) pendingCancelRestores.set(activeId + " " + qmd, { before, after: ta ? ta.value : "" });
       }
       // Optimistic; the next push rebuilds the queue without it. The GROUP is reflowed in the same breath —
       // the bubble alone leaves its "1 queued message" header behind, still counting what just went.


### PR DESCRIPTION
## Summary
The user pressed ✕ on a message still showing "sending…"; the text returned to the composer but the sending bubble stayed.

**Reproduced by reading, after the harness cleared the obvious path.** A served repro (hermetic kernel, kernel frozen with SIGSTOP so nothing acknowledges the send, ✕ on the bare bubble, then thaw) showed the parked-send path clean: bubble gone, `cancelResult ok:true`, nothing re-injected. The long-lived "sending…" is a **provisional tab's**: a send into a session still being created goes into `provisionalQueue` and wears the bare group for the whole creation window (up to 90 s). The ✕ dropped only the optimistic entry and posted a cancel for a sid the kernel never had; adoption then re-sent every queued text, the cut one included, and re-registered its bubble under the real tab, while the ✕'s restore had already put the same text in the composer.

**Fix.** A ✕ on a provisional-tab bubble also forgets the text from `provisionalQueue` (one press, one send) and posts no kernel cancel; the restore stays. Adoption re-sends only what remains.

**Evidence for next time.** A client-diag row for every `cancelResult ok:false` (sid, body length, whether a restore was in play, the refusal text; never the body) and for every provisional-stage ✕; a kernel log line for a body-only cancel that finds nothing in either queue.

## Tests (red first)
`ui/webview/provisional-cancel.test.ts`: the qx handler's provisional branch; the executed `forgetProvisionalSend` helper; the diag breadcrumbs; the kernel log pin. `tests/test_kernel_send_park.py`: the log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
