### PR TITLE
No romp key source means Claude Code's own credential, for every billing pick

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -368,6 +368,16 @@ selected configuration. An empty or invalid reference is an error, not a
 request to use the legacy key. Remove competing plaintext assignments when
 migrating; `romp keyswap` does this automatically when selecting a profile.
 
+With no key source selected — the env file has no `ROMP_API_KEY_REF=` line
+and no `ANTHROPIC_API_KEY=` line with a value, and no reference was selected
+earlier (a removed reference stays an error until another source is
+configured; see below) — Romp injects nothing, and Claude Code's own
+credential resolution applies: its `apiKeyHelper`, which can fetch a key from
+any secrets manager, or its login. A session's API-key Billing pick then only
+takes effect once a source exists; until one does, the kernel says so once in
+its log. A reference or key line in `service.env` is for boxes where Romp
+should manage the key — swap it, fingerprint it, cycle sessions onto it.
+
 Romp runs [`op read --no-newline`](https://www.1password.dev/cli/reference/commands/read)
 for each Claude SDK session launch or reconnect, each API-key-billed judge
 call, and each direct model-catalog refresh. A paginated catalog refresh uses

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -490,9 +490,10 @@ key inherited when the kernel started. After removing a selected provider,
 API-key operations fail until a valid source is selected; choose **Login**
 explicitly to use that mode. Removing a static `ANTHROPIC_API_KEY=` line
 while the kernel runs is different: the file stays authoritative and
-sessions without an explicit Billing pick launch on the login, and the
-kernel log says so once, with the removed key's fingerprint and the file's
-path. Removing a source does not revoke a credential already held by a
+sessions launch with nothing of Romp's injected, whatever their Billing
+pick, so Claude Code's own credential (its `apiKeyHelper` or login) applies;
+the kernel log says so once, with the removed key's fingerprint and the
+file's path. Removing a source does not revoke a credential already held by a
 running Claude process; reconnect or end those sessions too. Rotate a
 previously exposed key with its issuer as appropriate.
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1046,6 +1046,21 @@ def _work_key_configured():
     return _keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "").configured
 
 
+def _key_source_unconfigured():
+    """True only when the selected key source is KNOWN to be unconfigured without retrieving anything: the
+    kernel's configured wire when it is up; a standalone caller wiring the key callback alone leaves the
+    verdict to the retrieval (as before); no wire at all reads the source descriptor. Never _work_key():
+    a resolve here would run outside the per-pass gate."""
+    if _WORK_KEY_CONFIGURED_FN is not None:
+        return not _WORK_KEY_CONFIGURED_FN()
+    if _WORK_KEY_FN is not None:
+        return False
+    return not _keysrc.select_source(os.environ.get("ANTHROPIC_API_KEY", "") or "").configured
+
+
+_UNKEYED_SAID = set()   # the key-billed-calls-run-on-the-CLI's-own-credential line: said once per process
+
+
 def _login_auth_env():
     if _LOGIN_AUTH_ENV_FN is not None:
         return _LOGIN_AUTH_ENV_FN()
@@ -1327,6 +1342,22 @@ def _judge_env(tier, auth="login", model=None):
         # _judge_run is the lever that lands. Both ride together; neither can hurt the other.
         env["MAX_THINKING_TOKENS"] = "0"
     if auth == "key":
+        # No source configured at all (a supervised box whose env file carries no key line: the session's
+        # `key` pick outlived the line) is decided BEFORE any retrieval, so a retrieval FAILURE keeps its own
+        # gated path below. The child then runs on Claude Code's own credential — its apiKeyHelper or its
+        # login — the shape every judge had before #932's hard error, which logged err=auth on every pass
+        # and took a board down (the maintainer's direction, 2026-09-07: given no key, romp defers to
+        # Claude Code's default); said once per process. The login tokens ride along exactly as for a
+        # login call (the session half restores them the same way): before #932 the child simply
+        # inherited the manager's, and a box whose login lives in those tokens would otherwise hand the
+        # judge no credential at all and floor its cards with an auth-down mark.
+        if _key_source_unconfigured():
+            env.update(_login_auth_env())
+            if not _UNKEYED_SAID:
+                _UNKEYED_SAID.add(True)
+                sys.stderr.write("romp-judge: key-billed judge calls run on Claude Code's own credential — "
+                                 "romp holds no key source\n")
+            return env
         wk = _resolve_work_key_gated()               # resolve only at the call boundary — once per pass on failure
         if not wk:
             raise _keysrc.KeySourceError("No API key source is configured for this judge call")

--- a/kernel/keysource.py
+++ b/kernel/keysource.py
@@ -8,10 +8,14 @@ The design, in four rules:
   identity checks — reads the source. Only resolve() ever runs ``op read``, at the moment a Claude
   session launches, an API-key-billed judge call is made, or the model catalog refreshes; the value
   is handed to that one operation and never written to disk or cached for a later one.
-* A selected source is AUTHORITATIVE. A file that once carried a key line or a reference keeps
-  governing this process: emptying it, removing the line, or making it unreadable is an error the
-  operation reports, never permission to fall back to the key the manager started with or to a
-  login. That is what makes ``romp keyswap`` a swap — nothing an operator removed can come back.
+* A selected source is AUTHORITATIVE over the key the manager started with. A file that once
+  carried a key line or a reference keeps governing this process: nothing an operator removed can
+  come back, which is what makes ``romp keyswap`` a swap. An unreadable file, or a removed
+  1Password reference (remembered by the marker), is an error the operation reports. A file whose
+  static key line was emptied or removed is an UNCONFIGURED source: romp injects nothing and Claude
+  Code's own credential resolution (its apiKeyHelper or its login) decides for every session,
+  whatever its Billing pick, said once as a problem row (2026-09-07; until then an explicit API-key
+  pick was refused at launch, which took every session of an apiKeyHelper box down).
 * Supervised managers (``ROMP_SUPERVISED=1``: the systemd/launchd service) read the FILE only. The
   manager process keeps the environment it started with across every kernel restart, so a key it
   inherited would otherwise resurrect after the operator removed it from the file. A startup key

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2033,10 +2033,11 @@ def work_api_key_source():
                        if source.kind == "file" and os.environ.get("ROMP_SUPERVISED") == "1"
                        else "%s selects the 1Password source" % _keysrc.REF_VAR if source.kind == "op"
                        else "the env file's key line is empty")
-                sys.stderr.write("work key: the startup key (sha256:%s) is IGNORED — %s. Sessions without an "
-                                 "explicit Billing pick %s.\n"
-                                 % (_keysrc.fingerprint(startup), why,
-                                    "launch on the login" if not source.configured else "use that source"))
+                tail = ("Sessions launch with nothing of romp's injected, whatever their Billing pick (Claude "
+                        "Code's own credential pays)." if not source.configured
+                        else "Sessions without an explicit Billing pick use that source.")
+                sys.stderr.write("work key: the startup key (sha256:%s) is IGNORED — %s. %s\n"
+                                 % (_keysrc.fingerprint(startup), why, tail))
             _WORK_KEY = ""
         # "error" (an unreadable or undecodable file) is not a selection: it fails the operation that asked
         # while it lasts, and the startup key stays claimed so a transient permission blemish cannot
@@ -2056,8 +2057,9 @@ def work_api_key() -> str:
 def _note_key_file_gone(live: str) -> None:
     """Say ONCE, on stderr, when the env file's static key line is REMOVED while this process runs. The
     file stays authoritative (select_source returns an empty file source, never the startup key), so
-    every session without an explicit Billing pick quietly starts launching on the login — a change of
-    who pays with nothing in the log to find it by (review find, 2026-09-06). Fingerprint and path only.
+    every session — whatever its Billing pick (2026-09-07) — quietly starts launching with nothing of
+    romp's injected, and Claude Code's own credential pays: a change of who pays with nothing in the
+    log to find it by (review find, 2026-09-06). Fingerprint and path only.
     A line that comes back re-arms the notice, so a second removal is said too."""
     global _FILE_KEY_SEEN_FP
     if live:
@@ -2066,8 +2068,8 @@ def _note_key_file_gone(live: str) -> None:
     if not _FILE_KEY_SEEN_FP:
         return
     sys.stderr.write("work key: the %s line (sha256:%s) is GONE from %s — the file stays authoritative, so "
-                     "sessions without an explicit Billing pick now launch on the login. Restore the line or "
-                     "select a source with `romp keyswap`.\n"
+                     "sessions now launch with nothing of romp's injected, whatever their Billing pick (Claude "
+                     "Code's own credential pays). Restore the line or select a source with `romp keyswap`.\n"
                      % (_keysrc.KEY_VAR, _FILE_KEY_SEEN_FP, _keysrc.service_env_path()))
     _FILE_KEY_SEEN_FP = ""
 
@@ -5054,6 +5056,7 @@ class SdkBackend:
         #   so a keyswap needs no kernel restart (the user 2026-09-04).
         self._key_fp_said = None                  # last key fingerprint written to the log (change-only)
         self._unkeyed_pick_said = False           # the "launching on Claude Code's own credential" row: once per process
+        self._seed_skip_said = False              # the "remembered key pick set aside, no key source" row: once per process
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -5191,6 +5194,19 @@ class SdkBackend:
                   "ANTHROPIC_API_KEY to %s if romp should manage the key" % _keysrc.service_env_path(),
                   problem=True)
 
+    def _note_seed_skipped(self) -> None:
+        """Said ONCE per process, as a problem row: the remembered Billing default is the API key, but romp holds
+        no key source, so new sessions are left unpicked (spawn) — they launch the same way either pick would
+        here (nothing of romp's injected; Claude Code's own credential pays), but their badge, judge billing and
+        cycling read an unpicked session, and a pick the user made is being set aside without a word otherwise."""
+        if self._seed_skip_said:
+            return
+        self._seed_skip_said = True
+        self._log("the remembered Billing pick is the API key but romp holds no key source, so new sessions start "
+                  "unpicked and launch on Claude Code's own credential (its apiKeyHelper or login) — add "
+                  "ROMP_API_KEY_REF=op://vault/item/field or ANTHROPIC_API_KEY to %s to apply the pick"
+                  % _keysrc.service_env_path(), problem=True)
+
     def cycle_key(self, sid: str, expected_source_fp: str | None = None, current_key_fp: str | None = None,
                   probe: bool = False, resolve_error: str | None = None) -> str:
         """Re-present the CURRENT work key to one LIVE session by reconnecting it — the apply half of
@@ -5238,6 +5254,12 @@ class SdkBackend:
         if s is None:
             return "dormant"
         source = self._work_key_source()
+        if not source.configured:
+            # romp holds no key source: every session launched with nothing of romp's injected, whatever its
+            # pick (Claude Code's own credential pays), so there is no key to re-present — the row reads
+            # `login`, as for a login pick, not the refusal it answered until 2026-09-07 (review find; the
+            # PR that made the launch un-injected had left --cycle on the old error)
+            return "login"
         if s.effective_auth(source.configured) != "key":
             return "login"
         with s._sub_lock:
@@ -6029,10 +6051,15 @@ class SdkBackend:
                           "session is billing the %s. Check the helper and service.env."
                           % (sess.name, what, source, "API key" if keyed else "login"), problem=True)
             else:
+                # an explicit key pick that launched with nothing injected landed on the login: the key it
+                # meant was Claude Code's own (apiKeyHelper), so that is what to check — not romp's login
+                remedy = ("Check Claude Code's apiKeyHelper (romp injected nothing) and service.env."
+                          if getattr(sess, "_launched_unkeyed_pick", False) and not keyed
+                          else "Check the login (claude /login) and service.env.")
                 self._log("auth (%s): launched for %s but the CLI reports apiKeySource=%r — this session "
-                          "is billing the %s. Check the login (claude /login) and service.env."
+                          "is billing the %s. %s"
                           % (sess.name, "the API key" if meant_key else "the login", source,
-                             "API key" if keyed else "login"), problem=True)
+                             "API key" if keyed else "login", remedy), problem=True)
         sess.auth_live = "key" if keyed else "login"   # the CLI's own report, for the Billing row
         if keyed == sess.api_key_auth:
             return
@@ -6535,12 +6562,16 @@ class SdkBackend:
         # session); unset stays unset — effective_auth's fallback IS the pre-selector behavior.
         a = auth if auth in ("login", "key") else (d.get("auth") if d.get("auth") in ("login", "key") else "")
         if a == "key" and not auth and not self.work_key_configured:
-            # A REMEMBERED key default on a box with no key source seeds nothing: _auth_avail already
-            # shows the picker "login" there, and a seeded pick would launch unkeyed with the once-row
-            # plus a per-init "launched for the API key" alarm for every new session (review find,
-            # 2026-09-07). A re-seed is never an explicit pick (_declared_auth); an EXPLICIT `auth` from
-            # the picker still lands as asked.
+            # A REMEMBERED key default on a box with no key source seeds nothing. Not because of the launch
+            # or the per-init check: both come out the same either way (nothing of romp's injected, and a
+            # login landing rings through the remembered pick in _declared_auth just as it would through a
+            # seeded one). Because the picker offers no key choice on this box (_auth_avail shows login), so
+            # a re-seed would apply a pick the user cannot make here, and because what the session SAYS
+            # about itself — Billing badge, judge billing, cycling — should read what it is: unpicked. A
+            # remembered pick set aside is said once, as a problem row (review find, 2026-09-07). A re-seed
+            # is never an explicit pick (_declared_auth); an EXPLICIT `auth` from the picker still lands.
             a = ""
+            self._note_seed_skipped()
         if a:
             reg["auth"] = a
         # Per-session env is a per-spawn ask, never a remembered default (a var one session needed is

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2424,6 +2424,9 @@ class SdkSession:
         #   _note_auth_source compares the init's apiKeySource against THIS, so a CLI that lands on
         #   the other auth (a stale login, a key found via apiKeyHelper) is flagged loudly instead
         #   of silently billing the wrong account
+        self._launched_unkeyed_pick = False  # an explicit API-key pick that launched with NOTHING injected
+        #   because romp holds no key source (_options): Claude Code's own credential — its apiKeyHelper
+        #   or its login — is what pays, said once per process in the log
         self._last_cost_total = 0.0   # the CLI's totalCostUSD is CUMULATIVE per process (verified in
         #   the bundle: the result event's total_cost_usd sits beside total_duration/lines counters),
         #   so spend folds the DELTA between results — folding the raw value re-added the whole
@@ -3100,9 +3103,12 @@ class SdkSession:
     def effective_auth(self, key=None) -> str:
         """Billing intent, without retrieving credentials for repeated UI snapshots.
 
-        An explicit key pick stays keyed even when retrieval fails: launch must report
-        the missing credential instead of billing the login. `key` permits callers
-        holding an already-resolved credential to avoid a second source read.
+        An explicit key pick stays keyed while a source is CONFIGURED, even when its
+        retrieval fails: the launch must then report the missing credential instead of
+        billing the login. With no source selected romp injects nothing for any pick and
+        Claude Code's own credential decides (the maintainer 2026-09-07); _options owns
+        that rule. `key` permits callers holding an already-resolved credential to avoid a
+        second source read.
         """
         if self.auth == "login":
             return "login"
@@ -5047,6 +5053,7 @@ class SdkBackend:
         #   EVERY session whatever its pick. The VALUE is read per launch off `work_key` below, live,
         #   so a keyswap needs no kernel restart (the user 2026-09-04).
         self._key_fp_said = None                  # last key fingerprint written to the log (change-only)
+        self._unkeyed_pick_said = False           # the "launching on Claude Code's own credential" row: once per process
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -5170,6 +5177,19 @@ class SdkBackend:
             else:
                 src = "read from %s" % _keysrc.service_env_path()
             self._log("work key: sessions now launch on the key sha256:%s (%s)" % (fp, src))
+
+    def _note_unkeyed_pick(self) -> None:
+        """Said ONCE per process, as a problem row: a session picked for API-key billing is launching with
+        nothing of romp's injected, because romp holds no key source — Claude Code's own credential (its
+        apiKeyHelper or its login) is what pays. That is how these boxes ran before #932 and it works; but
+        it is a key romp cannot see, swap or fingerprint, so the row names what puts romp in charge of it."""
+        if self._unkeyed_pick_said:
+            return
+        self._unkeyed_pick_said = True
+        self._log("sessions picked for API-key billing launch on Claude Code's own credential (its apiKeyHelper "
+                  "or login) because romp holds no key source — add ROMP_API_KEY_REF=op://vault/item/field or "
+                  "ANTHROPIC_API_KEY to %s if romp should manage the key" % _keysrc.service_env_path(),
+                  problem=True)
 
     def cycle_key(self, sid: str, expected_source_fp: str | None = None, current_key_fp: str | None = None,
                   probe: bool = False, resolve_error: str | None = None) -> str:
@@ -5994,8 +6014,14 @@ class SdkBackend:
         # the box's UNPICKED design, while set_auth's contract is that the next init confirms the
         # PICK — judged (and worded) against what the pick launched, so a landing honoring the pick
         # stays quiet whatever the box declares, and one contradicting it still rings.
+        # An explicit API-key pick that launched with NOTHING injected (romp holds no key source, so
+        # Claude Code's own resolution decides — the maintainer's direction, 2026-09-07) MEANT the key:
+        # a keyed landing (the CLI's apiKeyHelper) is what the pick wanted and stays quiet, a login
+        # landing is the pick contradicted and rings. Before this the row rang on every init of such a
+        # session — the same false alarm ROMP_EXPECTED_AUTH was introduced to end for unpicked ones.
+        meant_key = sess._launched_keyed or sess._launched_unkeyed_pick
         exp, exp_src = ("", "") if sess.auth in ("login", "key") else _declared_auth(self.state_dir)
-        if keyed != ((exp == "key") if exp else sess._launched_keyed):
+        if keyed != ((exp == "key") if exp else meant_key):
             if exp:
                 what = ("ROMP_EXPECTED_AUTH=%s" % exp) if exp_src == "env" \
                     else ("the remembered Billing pick is %s" % exp)
@@ -6005,7 +6031,7 @@ class SdkBackend:
             else:
                 self._log("auth (%s): launched for %s but the CLI reports apiKeySource=%r — this session "
                           "is billing the %s. Check the login (claude /login) and service.env."
-                          % (sess.name, "the API key" if sess._launched_keyed else "the login", source,
+                          % (sess.name, "the API key" if meant_key else "the login", source,
                              "API key" if keyed else "login"), problem=True)
         sess.auth_live = "key" if keyed else "login"   # the CLI's own report, for the Billing row
         if keyed == sess.api_key_auth:
@@ -6448,9 +6474,17 @@ class SdkBackend:
                                 env=env_vars, log=self._log)
         if fs:
             kw["settings"] = fs
-        # Authentication is resolved only for a launch that selects API-key billing.
-        # Source presence is metadata; a provider failure cannot turn it into login.
-        launch_keyed = sess.auth == "key" or (sess.auth != "login" and key_source.configured)
+        # Authentication is resolved only for a launch that selects API-key billing AND has a source to
+        # bill. An explicit API-key pick with NO key source configured (an empty supervised service.env,
+        # nothing anywhere) launches like an unpicked session: romp injects nothing, and Claude Code's
+        # own credential resolution applies — its apiKeyHelper if one is configured, else its login.
+        # That is how such boxes ran before #932; the hard refusal #932 put here took every one of their
+        # sessions down, with no way back until an operator rewrote service.env and restarted the
+        # service (the maintainer's direction, 2026-09-07: given no key, romp defers to Claude Code's
+        # default). Said once per process, as a problem row, when an explicit pick launched this way.
+        # A CONFIGURED source that fails to resolve stays the hard failure below: source presence is
+        # metadata, and a provider failure cannot turn it into login.
+        launch_keyed = key_source.configured and sess.auth != "login"
         work_key = ""
         if launch_keyed:
             work_key, key_src = self._work_key_and_source(key_source)
@@ -6461,7 +6495,10 @@ class SdkBackend:
                              **key_fast_org_env(work_key, self._log))
         else:
             kw["env"] = dict(kw["env"], **startup_auth_env())
+            if sess.auth == "key":
+                self._note_unkeyed_pick()
         sess._launched_keyed = launch_keyed
+        sess._launched_unkeyed_pick = sess.auth == "key" and not launch_keyed
         sess._launched_key_fp = _keysrc.fingerprint(work_key) if launch_keyed else ""
         return ClaudeAgentOptions(**kw)
 
@@ -6497,6 +6534,13 @@ class SdkBackend:
         # Auth: the picker's explicit pick wins; else the remembered default (a gear /auth pick on any
         # session); unset stays unset — effective_auth's fallback IS the pre-selector behavior.
         a = auth if auth in ("login", "key") else (d.get("auth") if d.get("auth") in ("login", "key") else "")
+        if a == "key" and not auth and not self.work_key_configured:
+            # A REMEMBERED key default on a box with no key source seeds nothing: _auth_avail already
+            # shows the picker "login" there, and a seeded pick would launch unkeyed with the once-row
+            # plus a per-init "launched for the API key" alarm for every new session (review find,
+            # 2026-09-07). A re-seed is never an explicit pick (_declared_auth); an EXPLICIT `auth` from
+            # the picker still lands as asked.
+            a = ""
         if a:
             reg["auth"] = a
         # Per-session env is a per-spawn ask, never a remembered default (a var one session needed is

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -70,6 +70,7 @@ class _JudgeAuthBase(unittest.TestCase):
         jd._WORK_KEY_CONFIGURED_FN = None
         jd._LOGIN_AUTH_ENV_FN = None
         jd._auth_cache[:] = [None, {}]
+        jd._UNKEYED_SAID.clear()          # the once-per-process line is asserted per test
         jd.SDKDIR.mkdir(parents=True, exist_ok=True)
         for p in (jd.JUDGE_AUTH, jd.SDKDIR / (SID + ".json"),
                   jd.STATE / "retry-paused.json", jd.STATE / "usage.json"):
@@ -141,8 +142,12 @@ class JudgeBillingResolution(_JudgeAuthBase):
     def test_a_key_pick_with_no_key_keeps_its_billing_intent(self):
         self._reg("key")
         self.assertEqual(jd._judge_auth(SID), "key")
-        with self.assertRaises(jd._keysrc.KeySourceError):
-            jd._judge_env("triage", "key")
+        # …and with no romp key source the call runs keyless on the CLI's own credential (2026-09-07;
+        # UnkeyedJudgeCalls below) — until then it raised, and every pass logged err=auth
+        import io
+        from contextlib import redirect_stderr
+        with redirect_stderr(io.StringIO()):
+            self.assertNotIn("ANTHROPIC_API_KEY", jd._judge_env("triage", "key"))
 
 
 class JudgeEnvBilling(_JudgeAuthBase):
@@ -519,6 +524,87 @@ class OpCredentialAndRetrievalGate(_JudgeAuthBase):
             self.assertEqual(len(calls), 2)
         finally:
             jd._KEY_GATE.update(saved); jd._PASS_GEN[0] = saved_gen
+
+
+class UnkeyedJudgeCalls(_JudgeAuthBase):
+    """2026-09-07: a session whose pick said `key` on a box whose env file carries NO key line. Before
+    runtime retrieval (#932) its judge children launched without an injected key and Claude Code's own
+    credential — an apiKeyHelper, or the login — authenticated them; the hard error that replaced that
+    logged err=auth on every pass while the board was down. The maintainer's direction since: given no
+    key, romp defers to Claude Code's default. So an UNCONFIGURED source (decided before any retrieval)
+    launches the child keyless, said once per process; a configured source — resolving or failing —
+    keeps its own path."""
+
+    def _stderr(self, fn):
+        import io
+        from contextlib import redirect_stderr
+        out = io.StringIO()
+        with redirect_stderr(out):
+            r = fn()
+        return r, out.getvalue()
+
+    def test_an_unconfigured_source_launches_the_child_keyless_and_says_so_once(self):
+        self._reg("key")
+        self.assertTrue(jd._key_source_unconfigured())
+        prev_login = jd._LOGIN_AUTH_ENV_FN
+        jd._LOGIN_AUTH_ENV_FN = lambda: {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-login-token"}
+        self.addCleanup(setattr, jd, "_LOGIN_AUTH_ENV_FN", prev_login)
+        env, err = self._stderr(lambda: jd._judge_env("triage", "key"))
+        self.assertNotIn("ANTHROPIC_API_KEY", env, "the CLI's own credential authenticates it — removal, not blanking")
+        self.assertEqual(env.get("CLAUDE_CODE_OAUTH_TOKEN"), "synthetic-login-token",
+                         "the unkeyed child gets the login tokens a login call gets (before #932 it inherited them)")
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env, "…and only those: the ambient bearer stays stripped")
+        self.assertEqual(env.get("ROMP_SUMMARIZING"), "1", "the rest of the env contract is untouched")
+        self.assertIn("romp-judge: key-billed judge calls run on Claude Code's own credential", err)
+        self.assertIn("romp holds no key source", err)
+        _, err2 = self._stderr(lambda: jd._judge_env("index", "key"))
+        self.assertEqual(err2, "", "said once per process")
+
+    def test_the_kernel_wire_decides_configuredness_without_a_retrieval(self):
+        jd._WORK_KEY_CONFIGURED_FN = lambda: False
+        jd._WORK_KEY_FN = Mock(side_effect=AssertionError("an unconfigured source is never resolved"))
+        env, _ = self._stderr(lambda: jd._judge_env("triage", "key"))
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        jd._WORK_KEY_FN.assert_not_called()
+
+    def test_a_retrieval_failure_keeps_its_own_path(self):
+        def failing():
+            raise jd._keysrc.KeySourceError("1Password credential retrieval timed out; check op authentication")
+        jd._WORK_KEY_FN = failing
+        jd._WORK_KEY_CONFIGURED_FN = lambda: True
+        with self.assertRaisesRegex(jd._keysrc.KeySourceError, "timed out"):
+            jd._judge_env("triage", "key")
+
+    def test_a_wired_key_callback_alone_is_a_configured_source_and_the_retrieval_decides(self):
+        # standalone wiring of the key callback alone (no configured wire): the retrieval is the verdict, as before
+        jd._WORK_KEY_FN = lambda: ""
+        self.assertFalse(jd._key_source_unconfigured())
+        with self.assertRaisesRegex(jd._keysrc.KeySourceError, "No API key source is configured for this judge call"):
+            jd._judge_env("triage", "key")
+
+    def test_a_configured_source_still_injects_the_key_and_says_nothing(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        jd._WORK_KEY_CONFIGURED_FN = lambda: True
+        env, err = self._stderr(lambda: jd._judge_env("triage", "key"))
+        self.assertEqual(env.get("ANTHROPIC_API_KEY"), FAKE_KEY)
+        self.assertEqual(err, "")
+
+    def test_a_keyless_call_runs_end_to_end_and_latches_nothing(self):
+        self._reg("key")
+        jd._judge_ctx.fsid = SID
+        seen = {}
+
+        def fake_run(cmd, input=None, env=None, **kw):
+            seen["env"] = env
+            return SimpleNamespace(stdout=json.dumps({"result": "ok", "usage": {}, "duration_ms": 3}),
+                                   stderr="", returncode=0)
+        with patch.object(jd, "_judge_engine", return_value="claude"), \
+                patch.object(jd.subprocess, "run", side_effect=fake_run):
+            out, _ = self._stderr(lambda: jd._judge_run("sonnet", "SYS", "u", judge="planner", tier="triage"))
+        self.assertEqual(out, "ok")
+        self.assertNotIn("ANTHROPIC_API_KEY", seen["env"])
+        self.assertEqual(jd._auth_down_map(), {}, "a call that ran is not an auth failure")
+        self.assertFalse(jd._judge_ctx.paused)
 
 
 if __name__ == "__main__":

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -305,10 +305,19 @@ class LiveSpawnEnv(_Backend):
             ks.read_source = orig
         self.assertEqual(len(reads), 1, "two reads could return two different keys")
 
-    def test_an_empty_key_line_refuses_an_explicit_key_launch(self):
+    def test_an_empty_key_line_launches_an_explicit_key_pick_with_nothing_injected(self):
+        """Until 2026-09-07 this refused the launch (#932). The maintainer's direction since: given no
+        key, romp injects nothing and Claude Code's own credential resolution applies — its apiKeyHelper
+        or its login — so a box that never handed romp a key keeps launching, said once as a problem
+        row. A source that cannot be READ (the op marker, a garbled line) still refuses."""
         self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
-        with self.assertRaisesRegex(ks.KeySourceError, "no API key source"):
-            self._launch_env(4)
+        env = self._launch_env(4)
+        self.assertNotIn("ANTHROPIC_API_KEY", env, "nothing injected: the CLI's own credential pays")
+        self._launch_env(5)
+        rows = [l for l in self.logged if "Claude Code's own credential" in l]
+        self.assertEqual(len(rows), 1, "one row per process")
+        self.assertIn(self.path, rows[0])
+        self.assertNotIn(OLD_KEY, "\n".join(self.logged))
 
     def test_the_live_key_reaches_the_has_a_key_bool_and_the_auth_default(self):
         self.assertEqual(self.be.default_auth({}), "key")
@@ -329,12 +338,18 @@ class StartupFallback(_Backend):
     BOOT = BOOT_KEY
 
     def test_removing_a_previously_selected_file_key_does_not_restore_the_startup_key(self):
+        """The file once carried the key, so it stays authoritative: with the line gone, an explicit key
+        pick launches with NOTHING injected (the maintainer's direction, 2026-09-07: given no key, romp
+        defers to Claude Code's default) — never the key the manager started with, the fallback this
+        rule exists to end. Until 2026-09-07 the launch refused instead (#932)."""
         with open(self.path, "w") as fh:                # genuinely no assignment, not an empty one
             fh.write("ROMP_PERF=1\n")
         ks._CACHE = ((), "")
         self.assertEqual(self.be.work_key, "")
-        with self.assertRaises(ks.KeySourceError):
-            self._launch_env(1)
+        env = self._launch_env(1)
+        self.assertNotIn("ANTHROPIC_API_KEY", env, "not the startup key — not anything")
+        self.assertNotIn(BOOT_KEY, repr(env))
+        self.assertTrue([l for l in self.logged if "Claude Code's own credential" in l])
 
     def test_an_empty_key_line_does_not_restore_the_startup_key(self):
         self.write_env("", lines=["ROMP_PERF=1"])       # `ANTHROPIC_API_KEY=` with nothing after it
@@ -1286,12 +1301,13 @@ class NothingLeaksTheKey(_Backend):
                          "the one-claimer property: an ambient key bills every session")
 
     def test_the_problem_ring_the_dashboard_reads_never_carries_a_key(self):
-        self.write_env("", lines=["ROMP_PERF=1"])       # a key pick with no key: the loudest path
-        with self.assertRaises(ks.KeySourceError):
-            self._launch_env(1)
+        self.write_env("", lines=["ROMP_PERF=1"])       # a key pick with no key: the loudest path — since
+        self._launch_env(1)                             # 2026-09-07 a problem row, not a refusal
         self.write_env(NEW_KEY)
         self._launch_env(2)
-        for p in self.be.problems(50):
+        rows = self.be.problems(50)
+        self.assertTrue([p for p in rows if "Claude Code's own credential" in p["text"]], "the path was walked")
+        for p in rows:
             self.assertNotIn(NEW_KEY, p["text"])
             self.assertNotIn(OLD_KEY, p["text"])
 

--- a/tests/test_keyswap.py
+++ b/tests/test_keyswap.py
@@ -446,7 +446,7 @@ class KeyLineGone(_Backend):
         self.assertEqual(said.count("is GONE"), 1, said)
         self.assertIn("sha256:" + ks.fingerprint(OLD_KEY), said)
         self.assertIn(self.path, said)
-        self.assertIn("launch on the login", said)
+        self.assertIn("nothing of romp's injected, whatever their Billing pick", said)
         self.assertNotIn(OLD_KEY, said, "fingerprints only")
         # the line coming back re-arms the notice: a second removal is a second event
         self.write_env(NEW_KEY)

--- a/tests/test_runtime_key_auth.py
+++ b/tests/test_runtime_key_auth.py
@@ -116,13 +116,21 @@ class RuntimeSdkAuth(unittest.TestCase):
         self.assertEqual(sess.effective_auth(), "key")
         self.assertNotIn("provider-output", str(record.call_args))
 
-    def test_empty_explicit_key_refuses_login_fallback(self):
+    def test_an_explicit_key_pick_with_no_key_launches_on_claude_codes_own_credential(self):
+        """Until 2026-09-07 this refused the launch (#932). The maintainer's direction since: given no
+        key, romp injects nothing and defers to Claude Code's own credential resolution (its apiKeyHelper
+        or its login) — the pre-#932 launch — said once per process as a problem row."""
         self.be.work_key = ""
         sess = self.session("key")
-        self.assertEqual(sess.effective_auth(), "key")
-        with self.assertRaisesRegex(ks.KeySourceError, "no API key source"):
-            self.be._options(sess, dict)
+        self.assertEqual(sess.effective_auth(), "key", "the pick itself stands")
+        opts = self.be._options(sess, dict)
+        self.assertNotIn("ANTHROPIC_API_KEY", opts["env"], "nothing injected — not an empty var either")
+        self.assertEqual(opts["env"].get("CLAUDE_CODE_OAUTH_TOKEN"), "synthetic-oauth", "as a login launch")
+        self.assertFalse(sess._launched_keyed)
+        self.assertTrue(sess._launched_unkeyed_pick)
         self.provider.assert_not_called()
+        self.be._options(sess, dict)
+        self.assertEqual(sum("Claude Code's own credential" in l for l in self.logs), 1, "said once")
 
     def test_provider_failure_record_does_not_reuse_a_previous_clis_stderr(self):
         sess = self.session("key")
@@ -361,3 +369,166 @@ class OpCredentialAndDiscardNotice(unittest.TestCase):
             self.be.cycle_key(keyed.sid, resolve_error="1Password credential retrieval failed")
         self.provider.assert_not_called()
 
+
+class UnkeyedPickLaunch(unittest.TestCase):
+    """An explicit API-key pick on a box that holds NO key source — the shape the 2026-09-07 outage had:
+    a supervised service.env with no key line, the sessions billing through Claude Code's own
+    apiKeyHelper. #932 made that launch raise, so every such session died at its next connect and
+    stayed dead until an operator rewrote the file and restarted the service. The maintainer's
+    direction since: given no key, romp injects nothing and defers to Claude Code's own credential
+    resolution (its apiKeyHelper or its login), said once per process as a problem row. A CONFIGURED
+    source — resolving, failing, or a reference removed behind its marker — is untouched."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "service.env"
+        self.path.write_text("ROMP_PERF=1\n")          # a supervised box whose env file carries NO key line
+        self.env = patch.dict(os.environ, {
+            "ROMP_SERVICE_ENV_FILE": str(self.path), "ROMP_SERVICE_ENV": str(self.path),
+            "ROMP_SUPERVISED": "1", "ANTHROPIC_API_KEY": "synthetic-old-startup-key",
+            "ANTHROPIC_AUTH_TOKEN": "synthetic-bearer", "CLAUDE_CODE_OAUTH_TOKEN": "synthetic-oauth",
+        })
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.addCleanup(patch.stopall)
+        os.environ.pop("ROMP_API_KEY_REF", None)      # an (even empty) reference in the env is a selection
+        os.environ.pop("ROMP_EXPECTED_AUTH", None)
+        patch.object(sb, "_WORK_KEY", None).start()
+        patch.object(sb, "_STARTUP_AUTH_ENV", None).start()
+        patch.object(sb, "_STARTUP_KEY_DISCARD_SAID", False).start()
+        patch.object(sb, "_KEY_FILE_CHECKED", True).start()
+        patch.object(ks, "_CACHE", ((), ks.KeySource("none"))).start()
+        patch.object(ks, "_AUTHORITATIVE_PATHS", {}).start()
+        patch.object(sb, "_FAST_ORG_VERDICTS", {}).start()
+        patch.object(sb, "_fetch_key_fast_org", return_value=True).start()
+        self.provider = patch.object(ks.subprocess, "run", return_value=SimpleNamespace(
+            returncode=0, stdout=KEY.encode())).start()
+        fake_sdk = ModuleType("claude_agent_sdk")
+        fake_sdk.HookMatcher = lambda **kw: kw
+        fake_sdk.ClaudeAgentOptions = dict
+        fake_sdk.ClaudeSDKClient = unittest.mock.Mock()
+        for name in ("AssistantMessage", "ResultMessage", "SystemMessage"):
+            setattr(fake_sdk, name, type(name, (), {}))
+        patch.dict(sys.modules, {"claude_agent_sdk": fake_sdk}).start()
+        patch("sys.stderr", new_callable=lambda: __import__("io").StringIO()).start()
+        self.logs = []
+        self.be = sb.SdkBackend(str(Path(self.tmp.name) / "state"), "/bin/true",
+                                lambda *a, **k: None, log=self.logs.append)
+
+    def session(self, auth="key", name="synthetic"):
+        sid = self.be.spawn(name, "/tmp", auth=auth)
+        return sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+
+    def configure_source(self):
+        """The operator writes the reference line."""
+        self.path.write_text("ROMP_API_KEY_REF=" + REF + "\n")
+        ks._CACHE = ((), ks.KeySource("none"))
+
+    def rows(self):
+        return [l for l in self.logs if "Claude Code's own credential" in l]
+
+    def problems(self):
+        return [p["text"] for p in self.be._problems]
+
+    def test_the_box_is_unconfigured_the_way_the_incident_left_it(self):
+        src = self.be._work_key_source()
+        self.assertEqual((src.kind, src.configured), ("file", False))
+        self.assertFalse(self.be.work_key_configured)
+        self.assertEqual(self.be.default_auth({}), "login", "an unpicked session launches login-side, as before")
+
+    def test_an_explicit_key_pick_launches_with_nothing_injected_and_says_so_once(self):
+        sess = self.session("key")
+        self.assertEqual(sess.effective_auth(), "key", "the pick itself stands")
+        opts = self.be._options(sess, dict)
+        self.assertNotIn("ANTHROPIC_API_KEY", opts["env"], "nothing injected — not an empty var either")
+        self.assertEqual(opts["env"].get("CLAUDE_CODE_OAUTH_TOKEN"), "synthetic-oauth",
+                         "the login tokens ride exactly as they do for a login launch")
+        self.assertEqual(opts["env"].get("ANTHROPIC_AUTH_TOKEN"), "synthetic-bearer")
+        self.assertFalse(sess._launched_keyed)
+        self.assertTrue(sess._launched_unkeyed_pick)
+        self.assertEqual(sess._launched_key_fp, "")
+        self.provider.assert_not_called()
+        self.assertEqual(len(self.rows()), 1)
+        self.assertIn("picked for API-key billing", self.rows()[0])
+        self.assertIn("ROMP_API_KEY_REF=op://vault/item/field", self.rows()[0])
+        self.assertIn(str(self.path), self.rows()[0], "the row names the file to write")
+        self.assertIn(self.rows()[0], self.problems(), "a key romp cannot see is a problem row")
+        self.be._options(sess, dict)
+        self.be._options(self.session("key", name="second"), dict)
+        self.assertEqual(len(self.rows()), 1, "one row per process")
+
+    def test_an_unpicked_session_launches_the_same_way_and_says_nothing(self):
+        sess = self.session("")
+        opts = self.be._options(sess, dict)
+        self.assertNotIn("ANTHROPIC_API_KEY", opts["env"])
+        self.assertFalse(sess._launched_keyed)
+        self.assertFalse(sess._launched_unkeyed_pick)
+        self.assertEqual(self.rows(), [], "the row is for an explicit pick romp cannot honour")
+
+    def test_a_remembered_key_default_is_not_seeded_onto_a_box_with_no_source(self):
+        """_auth_avail already tells the picker the default is login on such a box; seeding `key`
+        anyway would launch every NEW session unkeyed with the once-row and, on a login landing, a
+        per-init alarm — a standing false alarm the rule would otherwise create. A re-seed is never an
+        explicit pick; an explicit `auth` from the picker still lands as asked."""
+        d = Path(self.be.state_dir)
+        d.mkdir(parents=True, exist_ok=True)              # nothing has written the state dir yet in this test
+        sb._defaults_path(d).write_text(json.dumps({"auth": "key"}))
+        sid = self.be.spawn("seeded", "/tmp")
+        self.assertNotIn("auth", sb.read_reg(self.be.state_dir, sid), "the remembered key default seeds nothing here")
+        sid2 = self.be.spawn("asked", "/tmp", auth="key")
+        self.assertEqual(sb.read_reg(self.be.state_dir, sid2).get("auth"), "key", "an explicit ask still lands")
+        self.configure_source()
+        sid3 = self.be.spawn("seeded-later", "/tmp")
+        self.assertEqual(sb.read_reg(self.be.state_dir, sid3).get("auth"), "key", "with a source the default seeds as before")
+
+    def test_the_init_check_judges_an_unkeyed_pick_by_what_it_meant(self):
+        """An explicit API-key pick that launched with nothing injected MEANT the key: the CLI landing
+        on its own apiKeyHelper is the intended outcome and stays quiet (before this, every init of
+        such a session rang the launched-for-the-login row — the false alarm ROMP_EXPECTED_AUTH was
+        introduced to end for unpicked sessions), while a login landing is the pick contradicted and
+        rings, worded as a launch for the API key."""
+        sess = self.session("key")
+        self.be._options(sess, dict)
+        self.be._note_auth_source(sess, "apiKeyHelper")
+        self.assertEqual([l for l in self.logs if "is billing the" in l], [], "a keyed landing honours the pick")
+        self.assertEqual(sess.auth_live, "key")
+        self.be._note_auth_source(sess, "none")
+        ring = [l for l in self.logs if "is billing the login" in l]
+        self.assertEqual(len(ring), 1, "a login landing contradicts the pick and rings")
+        self.assertIn("launched for the API key", ring[0])
+        self.assertIn(ring[0], [p["text"] for p in self.be._problems])
+
+    def test_a_configured_source_is_untouched(self):
+        self.configure_source()
+        self.assertTrue(self.be.work_key_configured)
+        sess = self.session("key")
+        opts = self.be._options(sess, dict)
+        self.assertEqual(opts["env"]["ANTHROPIC_API_KEY"], KEY, "a configured source is what launches")
+        self.assertTrue(sess._launched_keyed)
+        self.assertFalse(sess._launched_unkeyed_pick)
+        self.assertEqual(sess._launched_key_fp, ks.fingerprint(KEY))
+        self.assertEqual(self.provider.call_count, 1)
+        self.assertEqual(self.rows(), [])
+        # …and one that FAILS to resolve keeps today's hard failure: a selected source is authoritative
+        self.provider.return_value = SimpleNamespace(returncode=1, stdout=b"provider-output-must-not-leak")
+        with self.assertRaisesRegex(ks.KeySourceError, "1Password credential retrieval failed"):
+            self.be._options(self.session("key", name="second"), dict)
+        self.assertNotIn("provider-output", "\n".join(self.logs))
+        self.assertEqual(self.rows(), [])
+
+    def test_a_reference_removed_behind_its_marker_still_refuses(self):
+        """Only the GENUINELY unconfigured box changed. A file that once selected a 1Password reference
+        keeps governing (the durable `op` marker): emptying it is an error the launch reports, never a
+        slide onto the CLI's credential — the silent fallback keysource exists to end."""
+        self.configure_source()
+        self.be._options(self.session("key"), dict)                 # selects the reference; writes the marker
+        self.assertEqual(ks.read_marker(str(self.path)), "op")
+        self.path.write_text("ROMP_PERF=1\n")
+        ks._CACHE = ((), ks.KeySource("none"))
+        ks._AUTHORITATIVE_PATHS.clear()                            # a restarted kernel: the marker alone decides
+        src = self.be._work_key_source()
+        self.assertEqual((src.kind, src.configured), ("error", True))
+        with self.assertRaisesRegex(ks.KeySourceError, "1Password reference was removed"):
+            self.be._options(self.session("key", name="second"), dict)
+        self.assertEqual(self.rows(), [])

--- a/tests/test_runtime_key_auth.py
+++ b/tests/test_runtime_key_auth.py
@@ -286,7 +286,7 @@ class OpCredentialAndDiscardNotice(unittest.TestCase):
         src = sb.work_api_key_source()
         self.assertEqual((src.kind, src.value, src.configured), ("file", "", False), "no file line: no key")
         out = self.err.getvalue()
-        self.assertIn("supervised managers read", out); self.assertIn("launch on the login", out)
+        self.assertIn("supervised managers read", out); self.assertIn("nothing of romp's injected", out)
         self.assertIn(ks.fingerprint("synthetic-old-startup-key"), out)
 
     def test_an_unreadable_file_fails_loudly_but_discards_nothing(self):
@@ -476,6 +476,12 @@ class UnkeyedPickLaunch(unittest.TestCase):
         sb._defaults_path(d).write_text(json.dumps({"auth": "key"}))
         sid = self.be.spawn("seeded", "/tmp")
         self.assertNotIn("auth", sb.read_reg(self.be.state_dir, sid), "the remembered key default seeds nothing here")
+        skipped = [l for l in self.logs if "remembered Billing pick is the API key but romp holds no key source" in l]
+        self.assertEqual(len(skipped), 1, "a pick set aside is said, once, as a problem row")
+        self.assertIn(str(self.path), skipped[0])
+        self.assertIn(skipped[0], self.problems())
+        self.be.spawn("seeded-again", "/tmp")
+        self.assertEqual(len([l for l in self.logs if "remembered Billing pick is the API key" in l]), 1, "once per process")
         sid2 = self.be.spawn("asked", "/tmp", auth="key")
         self.assertEqual(sb.read_reg(self.be.state_dir, sid2).get("auth"), "key", "an explicit ask still lands")
         self.configure_source()
@@ -497,7 +503,22 @@ class UnkeyedPickLaunch(unittest.TestCase):
         ring = [l for l in self.logs if "is billing the login" in l]
         self.assertEqual(len(ring), 1, "a login landing contradicts the pick and rings")
         self.assertIn("launched for the API key", ring[0])
+        self.assertIn("apiKeyHelper", ring[0], "the remedy names the credential the un-injected pick meant")
+        self.assertNotIn("claude /login", ring[0])
         self.assertIn(ring[0], [p["text"] for p in self.be._problems])
+
+    def test_cycling_a_key_picked_session_on_a_box_with_no_source_reads_login_instead_of_refusing(self):
+        """`romp keyswap --cycle` walks every live session through cycle_key. With no key source, a key-picked
+        session launched with nothing of romp's injected, so there is no key to re-present: its row reads
+        `login`, like a login pick's, rather than the "no API key source is configured" refusal the route
+        answered until 2026-09-07 (review find; the launch rule had moved and --cycle had not)."""
+        sess = self.session("key")
+        self.be._options(sess, dict)
+        self.be.sessions[sess.sid] = sess
+        self.assertEqual(self.be.cycle_key(sess.sid), "login")
+        self.assertEqual(self.be.cycle_key(sess.sid, probe=True), "login")
+        self.configure_source()                                    # with a source the pick is cycled as before
+        self.assertEqual(self.be.cycle_key(sess.sid, probe=True), "cycle")
 
     def test_a_configured_source_is_untouched(self):
         self.configure_source()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -168,10 +168,21 @@ class OptionsInjection(_OptionsHarness):
         self._options_kw(s2)
         self.assertFalse(s2._launched_keyed)
 
-    def test_a_key_pick_with_no_key_refuses_to_launch_on_the_login(self):
+    def test_a_key_pick_with_no_key_launches_on_claude_codes_own_credential(self):
+        """Until 2026-09-07 this refused the launch (#932: an explicit key pick must never silently bill
+        the login). The maintainer's direction since: given no key, romp injects nothing and defers to
+        Claude Code's own credential resolution (its apiKeyHelper or its login) — the pre-#932 launch, so
+        a box that never handed romp a key keeps working — and says so once, as a problem row."""
         self.be.work_key = ""
-        with self.assertRaisesRegex(sb._keysrc.KeySourceError, "no API key source"):
-            self._options_kw(self._sess(3, auth="key"))
+        s = self._sess(3, auth="key")
+        kw = self._options_kw(s)
+        self.assertNotIn("ANTHROPIC_API_KEY", kw["env"], "nothing injected — not an empty var either")
+        self.assertFalse(s._launched_keyed)
+        self.assertTrue(s._launched_unkeyed_pick)
+        self._options_kw(self._sess(4, auth="key"))
+        rows = [p["text"] for p in self.be.problems(20) if "Claude Code's own credential" in p["text"]]
+        self.assertEqual(len(rows), 1, "said once per process")
+        self.assertIn(sb._keysrc.service_env_path(), rows[0])
 
 
 class FastOrgPermissionFollowsBilling(_OptionsHarness):


### PR DESCRIPTION
## What

After #932/#962, a session whose Billing pick is the API key crashes at launch when romp holds no key source: `_options` raises `KeySourceError("API key billing selected but no API key source is configured")`, the thread dies, and every key-billed judge call fails for the rest of its pass. Before #932 the same launch started the CLI without an injected key and Claude Code's own credential resolution applied, on many boxes its `apiKeyHelper`. That is how an install that had always billed a key through the helper looked when it took the update: `service.env` with `ROMP_EXPECTED_AUTH=key` and no key or reference line. The board was down until the operator wrote a reference and token into the file and restarted the service by hand.

This restores the rule from before #932 for that one case: **when no key source is configured, romp injects nothing and Claude Code decides**, whatever the session's pick. A configured source that fails to resolve still refuses the launch as #932 intended.

- **`kernel/sdk_backend.py` `_options`**: an unconfigured source means `launch_keyed` is false for every pick; the CLI launches with no `ANTHROPIC_API_KEY` and the login tokens restored, exactly like an unpicked launch today. When the pick was the API key, one problem row per process says the sessions are running on Claude Code's own credential and names the two lines that would put romp in charge. The existing per-init `apiKeySource` row behaves as before #932.
- **`kernel/judge.py` `_judge_env`**: the same for key-billed judge calls, the pre-#932 keyless child, said once per process on stderr; a configured source keeps the gated retrieval path.
- **`docs/reference.md`**: one paragraph. With no source, Claude Code's `apiKeyHelper` (which can fetch from any secrets manager) or its login applies; a reference or key line is for boxes where romp should manage the key. romp reads no Claude Code settings; it simply stays out of the way.

Deliberately reversed from #932: "explicit API-key billing with no key now fails instead of switching to login." The maintainer's direction (2026-09-07) is that not providing romp a key should mean Claude Code's default, and that romp should stay agnostic to any particular key system.

Two small companions of the rule: a remembered API-key default is not seeded onto a new session on a box with no source (the picker already shows login there; a seeded pick would ring the per-init row for every new session), and the judge's keyless child gets the login tokens a login call gets, as it inherited them before #932.

Known follow-up, not changed here: `romp keyswap --cycle` on a box with no source still answers the old "no API key source is configured" error for key-picked sessions instead of moving them onto the new rule; it did so before this change too.

Not in this PR: hold/self-heal machinery, a preflight, a setup command, or changes to how `op read` runs (those live on a separate branch and are discussed against #1012 instead).

## Tier

- [ ] tests-only
- [x] fix — `tests/test_runtime_key_auth.py`'s unconfigured-source launch tests fail before this change (the launch raises).
- [ ] feature
- [ ] major-feature

## Tests

`tests/test_runtime_key_auth.py` 27 (new `UnkeyedPickLaunch`: the incident's box shape, an explicit pick launches un-injected with a login launch's tokens, one row across launches, the init check quiet on a keyed landing and ringing on a login one, a configured source unchanged, a removed reference still refused, the remembered default not seeded), `tests/test_judge_auth_billing.py` 45 (new `UnkeyedJudgeCalls`), `tests/test_session_auth.py` 40, `tests/test_keyswap.py` 91 (three refusal tests flipped to the rule; marker and error cases still refuse), `tests/test_runtime_keysource.py` 74, `tests/test_sdk_backend.py` 230, `tests/test_expected_auth.py` 32, `tests/test_sdk_launch_error.py` 34, `tests/test_op_credential_boundary.py` 5, `tests/test_supervised_floor.py` 3. Run one module at a time on a shared machine; the full suites are CI's. A read-only adversarial review found five issues, all folded (the judge child's login tokens, the seeded default, the docs criterion, a stale docstring) or noted above (`--cycle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
