### PR TITLE
Returning to the dashboard's tab no longer redials every pane and replays the world

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -56,7 +56,13 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   contract.
 - **Liveness is a keepalive, and staleness is event-keyed.** The kernel sends a
   `ka` frame to every socket every 10 s; the pane shim abandons a socket that has
-  gone 30 s without any frame and redials at once. After a reconnect the shim
+  gone 30 s without any frame and redials at once, the silence measured from the
+  later of the last frame and a Chromium `resume` (the thaw of a frozen tab) on a
+  still-open socket. A socket kept on the strength of that stamp is provisional:
+  if no frame confirms it within 15 s (1.5 keepalive periods) the watchdog puts
+  it down there instead, a socket already 30 s overdue when the tab froze is not
+  stamped and is redialed at the return, and a browser without `resume` behaves
+  as before. After a reconnect the shim
   raises the "what you see may be stale" prompt only on the SECOND `ka` arriving
   before the resync frame — one full heartbeat period, bracketed by two kernel
   heartbeats on that socket with no resync between them (a single `ka` can be a
@@ -73,11 +79,17 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   browser reports for a socket that opened leaves a `wsclose` breadcrumb (code,
   reason, socket age) in `client-diag.jsonl`; a socket the shim abandons leaves
   none — the watchdog's own `watchdog-close` row went down the quiet socket
-  before the abandon (the foreground path's abandon sends none), so an armed
-  socket's raise, `reconnect-quiet` or `foreground-quiet`, queued for the redial,
-  is the record that survives; the redials an outage refuses are counted and
-  reported as one `wsconnfail` row on the next open, and at most 20 breadcrumbs
-  wait in the shim's queue for it.
+  before the abandon (the foreground path's abandon sends none, but its `return`
+  row queues for the redial), so an armed socket's raise, `reconnect-quiet` or
+  `foreground-quiet`, queued for the redial, is the record that survives; the
+  redials an outage refuses are counted and reported as one `wsconnfail` row on
+  the next open, and at most 20 breadcrumbs wait in the shim's queue for it.
+  Every return to the tab leaves its own rows: `return` with the decision
+  (`keep`, `redial-closed` or `redial-stale`) and the hidden, frozen and quiet
+  gaps, `return-fresh` with the wait for the first fresh frame, and `page-load`
+  for a reload or a tab the browser discarded; a `resent: true` copy of the
+  `return` row means the kept socket proved dead and the row was re-filed onto
+  the redial.
 - **The Outline pane's ages run on the kernel's clock.** Its timestamps are the
   kernel's, so the pane never reads the browser's clock against them: it anchors
   on the frame's `now` paired with the moment that frame arrived from the wire

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32682,7 +32682,7 @@ def _shim(app, v=0):
     # "newer build" prompt, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone
     # pane sat silent through rebuilds).
     return """
-(function(){var queue=[],ws=null,everConnected=false;
+(function(){/*shim-core*/var queue=[],ws=null,everConnected=false;
 var queuedDiag=0,DIAG_QUEUE_MAX=20;   // clientDiag rows waiting in `queue` for a reconnect, capped (an outage must not pile up breadcrumbs); other queued messages are untouched
 var failedConnects=0,firstFailT=0;   // handshakes that never OPENED since the last open: reported as ONE wsconnfail row on the next open, never one wsclose per redial
 // This pane's DASHBOARD id. ?wid= when the host supplies one (the VS Code extension builds its own pane
@@ -32723,7 +32723,8 @@ function selfStale(){selfBar("romp lost the live connection, so what you see may
 // new code is not delivered by a resync, so only a reload can answer that one.
 function clearStale(){stalePending="";   // armed but never shown → nothing to see
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
-else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}}
+else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}
+try{window.dispatchEvent(new Event("romp:wsfresh"));}catch(e){}}   // the pane's own reconnecting cue (_pane_spin's corner badge) ends on FRESH DATA, not on the socket opening (the user 2026-09-07: over a slow link the resync ran for seconds with no cue, so the dashboard looked frozen)
 // A pane the user cannot SEE never interrupts them about ITS OWN staleness (the user 2026-08-15: the
 // phone shell shows one pane at a time via display:none, iOS throttles the hidden iframes' JS, and each
 // hidden pane's watchdog force-closed its own healthy socket and re-raised the banner every ~45s over a
@@ -32739,6 +32740,29 @@ function paneHidden(){try{return window.parent!==window&&(window.innerWidth===0|
 // socket is down and delivers on reconnect, so the breadcrumb survives the very drop it describes.
 function staleDiag(what,why){try{send({type:"clientDiag",surface:"pane-shim",what:what,
 data:{app:APP,why:why||"",ready:ws?ws.readyState:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,hidden:paneHidden()}});}catch(e){}}
+// RETURN breadcrumbs (the user 2026-09-07, whose dashboard froze after its tab sat in the background): which
+// browser regime a return lands in — hidden-but-running, FROZEN (Page Lifecycle freeze/resume) or DISCARDED (a
+// cold reload; document.wasDiscarded) — decides what can help, and no emulation can tell them apart. So the
+// shim records, on the user's own machine: the page load (discarded? navigation type), every return (was a
+// resume seen; how long frozen/hidden/quiet; the socket state; what the fast-path below DECIDED), and how long
+// the first fresh frame then took (and whether a redial got in the way). Same clientDiag path as staleDiag:
+// send() queues while the socket is down, so a row survives the very redial it describes.
+var frozeAt=0,resumedAt=0,resumeQuiet=-1,hiddenAt=0,foregroundedAt=0,returnAt=0,returnBytes=0,returnRedialed=false,returnRow=null,eagerDial=false;   // eagerDial: the one immediate redial each return window gets   // returnRow: a keep-decision row held until a close inside the return window proves its socket was already dead
+function returnDiag(what,data){try{data.app=APP;send({type:"clientDiag",surface:"pane-shim",what:what,data:data});}catch(e){}}
+var nav="";try{var ne=performance.getEntriesByType("navigation");nav=(ne&&ne[0]&&ne[0].type)||"";}catch(e){}
+// the page-load row exists to catch a tab the browser DISCARDED and reloaded on return (Memory Saver: the return is a
+// cold load, no visibilitychange, so no `return` row) or a reload/back-forward arrival — a plain navigation says
+// nothing, so it files nothing (four rows per dashboard open would be noise, and they would eat the queued-breadcrumb
+// cap other rows share) (2026-09-07)
+if(document.wasDiscarded||(nav&&nav!=="navigate"))returnDiag("page-load",{wasDiscarded:!!document.wasDiscarded,nav:nav});
+document.addEventListener("freeze",function(){frozeAt=Date.now();});
+// `resume` (Chromium's thaw, dispatched before visibilitychange and before any task the freeze queued) is the
+// event that "lastRecv is stale" was approximating: lastRecv measures how long JS did not RUN, not how long
+// the socket was silent, so a thawed tab read its healthy OPEN socket as dead and redialed — a full resync per
+// pane on every return. Stamping here makes the clock honest; the foreground test and the watchdog tick the
+// freeze queued then KEEP the socket. No `resume` (Firefox, Safari, hidden-but-running, a genuinely silent
+// socket) reads stale exactly as before and redials at once. The pre-stamp gap is kept for the return row.
+document.addEventListener("resume",function(){resumedAt=Date.now();resumeQuiet=lastRecv?resumedAt-lastRecv:-1;if(ws&&ws.readyState===1)lastRecv=Date.now();});
 function raiseStale(why){if(paneHidden()){staleDiag("stale-suppressed-hidden",why);return;}
 staleDiag("stale-raise",why);
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
@@ -32775,6 +32799,7 @@ function raiseBuild(){if(buildRaised)return;buildRaised=true;
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale",build:1},"*");}catch(e){}}
 else selfBar("A newer romp build is available.","build");}
 function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // one live attempt at a time — a lost timer + the watchdog can both call in
+if(returnAt)returnRedialed=true;   // a dial inside a return window (whatever path led here) → the return-fresh row says so
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
 ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):""));
@@ -32790,7 +32815,7 @@ if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail"
 if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
 if(!ann)armStale(pendingWhy||"reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; a restart that never comes back stays loud through the disconnected state itself, and a SECOND reconnect arms as always
 pendingWhy="";freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
-ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
+ws.onmessage=function(ev){lastRecv=Date.now();if(returnAt)returnBytes+=(ev.data&&ev.data.length)||0;var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();
 if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}   // the SECOND keepalive since the arm, no resync between: a full heartbeat period on THIS socket with the kernel alive, talking to it, and not resyncing it — the view IS stale. (One keepalive alone can be a beat queued at accept, ahead of the resync frame.)
 return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
@@ -32804,12 +32829,13 @@ if(msg&&msg.type==="restarting"){restartAnnounced=Date.now();staleDiag("restart-
 // the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
 // "what you see may be stale" prompt is answered and retires (see clearStale). Keepalives return above.
 if(freshPending){freshPending=false;clearStale();}
+if(returnAt){returnDiag("return-fresh",{ms:Date.now()-returnAt,bytesSince:returnBytes,redialed:returnRedialed});returnAt=0;}   // the first real frame after a return: how long the user waited for current content
 // VIEW DELTAS (2026-09-03): the bars/feed slots arrive as {type:"delta"} frames carrying only the changed
 // entries; reassemble the full message from what this pane holds and hand the bundle exactly what it
 // used to receive. A delta whose base is not the revision held here cannot be applied → ask for a full.
 if(msg&&msg.type==="delta"){var full=applyDelta(msg);if(!full){send({type:"needSlot",slot:msg.slot});return;}msg=full;}
 else if(msg&&DELTA_KINDS[msg.type]){var keys=msg._keys;delete msg._keys;LAST[msg.type]=keys?{rev:0,msg:msg,maps:buildMaps(msg,keys)}:null;}
-if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
+enqueue(msg);};   // the handoff to the bundle is the ONE deferred step (see the FIFO below); everything above reacted to the wire, in wire order
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
 // Every close the BROWSER reports for a socket that OPENED leaves a breadcrumb with the CLOSE CODE and
@@ -32827,11 +32853,45 @@ if(openSock===this){try{send({type:"clientDiag",surface:"pane-shim",what:"wsclos
 else{if(!failedConnects)firstFailT=Date.now();failedConnects++;}
 if(stalePending&&openSock===this){var cw=stalePending;stalePending="";raiseStale(cw+"-closed");}   // the reconnected socket died before its resync: nothing is coming on it, and the view IS stale
 try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}
-setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);};   // announced death → tight redial (the frame is the event; the blind 1.5s stays for unannounced drops)
+// a close landing inside the return window: the socket the keep-decision row (and maybe its return-fresh) was written
+// into was already dead when the tab thawed — re-file the row marked resent and re-open the return-fresh window, so
+// both ride the redial (review find 2026-09-07: the frozen-then-dropped regime otherwise left no trace)
+if(returnRow&&Date.now()-foregroundedAt<STALE_MS){var rr=returnRow;returnRow=null;rr.resent=true;returnDiag("return",rr);returnAt=returnAt||foregroundedAt;returnBytes=0;}
+var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;   // a close landing within STALE_MS of a foreground (the FIN a frozen tab thawed into; an iOS return): the close IS the event
+if(inWin){d=eagerDial?0:250;eagerDial=false;}   // …so the FIRST such close redials NOW; a second one in the same window waits 250 ms (a kernel that is down must not be hammered) (2026-09-07)
+if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);   // an announced death keeps its tight redial
+setTimeout(connect,d);};   // the blind 1.5 s stays for unannounced drops outside any return window
 ws.onerror=function(){try{ws.close();}catch(e){}};}
 function send(m){var s=JSON.stringify(m);if(ws&&ws.readyState===1){ws.send(s);return;}
 if(m&&m.type==="clientDiag"){if(queuedDiag>=DIAG_QUEUE_MAX)return;queuedDiag++;}   // breadcrumbs waiting for a reconnect are capped; everything else queues as before
 queue.push(s);}
+// ONE ordered dispatch FIFO per socket (the user 2026-09-07, whose dashboard froze on return to its tab): a tab
+// that sat hidden or frozen thaws into EVERY frame the browser queued for it, and each used to be parsed AND
+// fully rendered in its own task — eight feed renders and sixteen timeline draws for a board that only needs
+// its newest state. Frames are still parsed, delta-applied and LAST-stamped synchronously in wire order above
+// (reactions to the wire, like ka/restarting/needSlot/clearStale); only the HANDOFF to the bundle rides this
+// queue, flushed in one MessageChannel task — never rAF (held while hidden and in a display:none frame, and
+// state must still land) and never a timer (throttled in the background). A newer WHOLE-STATE frame (a full
+// feed/bars/skeleton/tabOrder/working/globalRetryPaused) replaces the older entry of its type and takes the
+// END position, so it never overtakes a frame that arrived between them (a `closed` between two tabOrders must
+// still land before the second, or the closed tab ghosts back). Chained kinds (session, chatTail, closed,
+// focus, status, …) are never removed. abandon()/onclose leave the queue alone: its frames are the newest
+// state the pane should hold; the next socket's frames enter behind them. Steady state: one sub-ms task hop.
+var FIFO=[],flushArmed=false,WHOLE={feed:1,bars:1,data:1,tabOrder:1,working:1,globalRetryPaused:1};
+var ch=new MessageChannel();ch.port1.onmessage=flush;
+function enqueue(m){if(m&&WHOLE[m.type]){for(var i=0;i<FIFO.length;i++){if(FIFO[i]&&FIFO[i].type===m.type){FIFO.splice(i,1);break;}}}
+FIFO.push(m);if(!flushArmed){flushArmed=true;ch.port2.postMessage(0);}}
+// The flush is TIME-SLICED (2026-09-07, measured on the thaw of a 45 s freeze: one task delivering 25 chat tails
+// ran 796 ms — every tail an incremental repaint with a forced layout). Frames are delivered in wire order until
+// the slice budget is spent, then the port is re-armed and the rest follows in the next task, so a click or a
+// keystroke can land between slices and a frame can paint. Nothing is lost or reordered: the queue is drained
+// from its head, and a newer whole-state frame arriving mid-burst still replaces its older still-queued twin.
+var FLUSH_MS=8;
+function flush(){flushArmed=false;var t0=Date.now(),err=null;
+while(FIFO.length){var m=FIFO.shift();try{deliver(m);}catch(e){if(!err)err=e;}   // one bad frame never eats the rest of the burst; its error still surfaces
+if(FIFO.length&&Date.now()-t0>=FLUSH_MS){flushArmed=true;ch.port2.postMessage(0);break;}}   // budget spent → the rest rides the next task
+if(err)throw err;}
+function deliver(m){if(window.__rompFed){window.__rompFed.inbound("",m);}else{window.dispatchEvent(new MessageEvent("message",{data:m}));}}
 // The delta reassembler. DELTA_KINDS mirrors the kernel's _DELTA_SLOTS: which top-level collections of each
 // slot are keyed, and how — "dict" (an object keyed by its own keys), "byid" (a list keyed by item id),
 // "bykeys:a,b" (a list keyed by a composite of item fields), "dictlist:id" (an object of lists, each item keyed by its
@@ -32888,13 +32948,36 @@ if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // visibility fast-path (the user 2026-07-05): a BACKGROUNDED tab has its timers throttled, so the 5s watchdog
 // above can lag and the browser may have quietly dropped the socket while it slept. The instant the tab is
 // foregrounded, if the socket isn't open or has gone quiet past the watchdog window, treat the view as stale:
-// force a reconnect (which resyncs live) and hand the reconnect its reason, so ITS arm reads "foreground" —
-// the prompt then follows the same two events as any reconnect, rather than leaving the user on a frozen frame.
-document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"||!everConnected)return;
-if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;
+// force a reconnect (which resyncs live) and hand the reconnect its reason, so ITS arm reads "foreground".
+// 2026-09-07: it latches hiddenAt/foregroundedAt first (onclose's eager redial and the return rows key on them),
+// names its DECISION, files the `return` row, and only then acts — the test itself is unchanged.
+document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"){hiddenAt=Date.now();return;}
+foregroundedAt=Date.now();eagerDial=true;if(!everConnected)return;
+var stale=!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS;var res=resumedAt>hiddenAt;
+var row={decision:stale?((!ws||ws.readyState!==1)?"redial-closed":"redial-stale"):"keep",resumed:res,hiddenMs:hiddenAt?Date.now()-hiddenAt:-1,
+frozenMs:(res&&frozeAt>=hiddenAt&&resumedAt>frozeAt)?resumedAt-frozeAt:0,quietMs:lastRecv?Date.now()-lastRecv:-1,quietAtResumeMs:res?resumeQuiet:-1,ready:ws?ws.readyState:-1};
+returnAt=Date.now();returnBytes=0;returnRedialed=false;
+if(!stale){returnRow=row;returnDiag("return",row);return;}   // the socket stands: the row rides it now — and is HELD, because a FIN queued in the same thaw burst would swallow it (review find 2026-09-07; onclose re-files)
+pendingWhy="foreground";freshPending=true;   // the reconnect's arm reads "foreground" (upstream's two-event prompt)
 if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries
-if(!ws||ws.readyState===3)connect();}});})();
+if(!ws||ws.readyState===3)connect();
+returnDiag("return",row);});/*end-shim-core*/})();   // filed AFTER the redial so it queues for the new socket instead of vanishing into the dead one
 """ % (app, int(v), app, app)
+
+
+def _shim_core_js(app="test", v=0):
+    """The shim's decision code alone — the IIFE body between its /*shim-core*/ anchors, formatted for `app` —
+    so a node test can run the REAL code (connect/onmessage/onclose, the watchdog, the visibility fast-path,
+    the resume stamp, the dispatch FIFO, the return breadcrumbs) at module scope with fakes for Date.now,
+    document, WebSocket, MessageChannel and the timers, and read its state back by name. A helper rather than
+    a regex in the tests (2026-09-07): test_view_deltas' regex lift of the delta functions is one reflow of its
+    anchor line away from silently matching nothing. Fails loudly if the anchors ever go missing."""
+    js = _shim(app, v)
+    a, b = "/*shim-core*/", "/*end-shim-core*/"
+    i, j = js.find(a), js.find(b)
+    if i < 0 or j < i:
+        raise RuntimeError("the shim-core anchors are missing from _shim")
+    return js[i + len(a):j]
 
 
 # On a narrow / touch viewport the chat's session tabs wrap into several rows and eat vertical space.
@@ -33180,13 +33263,21 @@ def _pane_spin(cid, ignore_id=""):
             "arm();"
             "if(c){try{new MutationObserver(function(){if(ready())hide();}).observe(c,{childList:true});}catch(e){}"
             "if(ready())hide();}"
-            "var rb=document.getElementById('pane-reconn');"
-            "function badge(on){if(rb)rb.classList.toggle('on',!!on);}"
+            "var rb=document.getElementById('pane-reconn'),bfail=0;"
+            # the badge's own failsafe, armed per SHOW like the sheet's (2026-09-07): it now waits for
+            # fresh DATA (below), which over a dead tunnel may never come — 30s only ever fires then.
+            "function badge(on){if(rb)rb.classList.toggle('on',!!on);clearTimeout(bfail);if(on)bfail=setTimeout(function(){badge(false);},30000);}"
             # T217: a drop over EXISTING content keeps the content — translucent corner badge, not
             # the opaque sheet; the sheet stays for a genuinely empty pane (cold load / never
-            # painted), per the loading-states rule. wsup ends both, exactly as before.
+            # painted), per the loading-states rule.
             "window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});"
-            "window.addEventListener('romp:wsup',function(){badge(false);hide();});})();</script>")
+            # wsup still ends the empty-pane sheet (content arrival hides it too, via the observer). The
+            # BADGE no longer comes down on wsup (2026-09-07, the user, whose dashboard looked frozen while
+            # a slow resync ran with no cue): the socket OPENING is not the end of "reconnecting" for a
+            # pane that has content — the kernel's connect-time push landing is. So it waits for
+            # romp:wsfresh, the shim's first real frame after the reconnect.
+            "window.addEventListener('romp:wsup',function(){hide();});"
+            "window.addEventListener('romp:wsfresh',function(){badge(false);});})();</script>")
 
 
 def _chat_page():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -32697,6 +32697,7 @@ try{if(!wid)wid=window.sessionStorage.getItem("romp:wid")||"";}catch(e){}
 // sessionStorage, and with it wid; it must not copy this).
 var IID="";try{IID=(window.crypto&&crypto.randomUUID)?crypto.randomUUID():"";}catch(e){}if(!IID)IID=String(Math.random()).slice(2)+"-"+Date.now();
 var APP="%s";var LOADEDV=%d;var lastRecv=0;var STALE_MS=30000;   // watchdog: no frame (incl. keepalive) for this long → the socket is dead → reconnect
+var PROVISIONAL_MS=15000,resumeProvisional=0;   // a resumed keep is PROVISIONAL (review find, 2026-09-08): the `resume` stamp below re-bases the watchdog on a socket the browser still holds OPEN, but the far end can have died without a FIN reaching the browser, and only the kernel's next frame can tell. Until one lands the watchdog runs at 1.5 keepalive periods (KEEPALIVE_S is 10 s, so 15 s: one beat may be in flight, two missing is silence) instead of STALE_MS. resumeProvisional holds the stamp a kept socket rests on; 0 once a frame confirmed it (or the socket is a fresh one)
 var connT=0;   // when the current socket's connect() attempt started — the progress watchdog's reference point
 // Tell the shell this pane's WS state so it can show ONE "disconnected" banner (the user 2026-06-27): a real
 // network drop used to blind-reload into a dead page, leaving the pane silently frozen with no explanation.
@@ -32747,7 +32748,7 @@ data:{app:APP,why:why||"",ready:ws?ws.readyState:-1,quietMs:lastRecv?Date.now()-
 // resume seen; how long frozen/hidden/quiet; the socket state; what the fast-path below DECIDED), and how long
 // the first fresh frame then took (and whether a redial got in the way). Same clientDiag path as staleDiag:
 // send() queues while the socket is down, so a row survives the very redial it describes.
-var frozeAt=0,resumedAt=0,resumeQuiet=-1,hiddenAt=0,foregroundedAt=0,returnAt=0,returnBytes=0,returnRedialed=false,returnRow=null,eagerDial=false;   // eagerDial: the one immediate redial each return window gets   // returnRow: a keep-decision row held until a close inside the return window proves its socket was already dead
+var frozeAt=0,resumedAt=0,resumeQuiet=-1,hiddenAt=0,foregroundedAt=0,returnAt=0,returnBytes=0,returnRedialed=false,returnRow=null,eagerDial=false;   // eagerDial: the one immediate redial each return window gets   // returnRow: a keep-decision row held until a close inside the return window (or the watchdog, at the provisional bound) proves its socket was already dead; retired by the flush once its return-fresh has filed
 function returnDiag(what,data){try{data.app=APP;send({type:"clientDiag",surface:"pane-shim",what:what,data:data});}catch(e){}}
 var nav="";try{var ne=performance.getEntriesByType("navigation");nav=(ne&&ne[0]&&ne[0].type)||"";}catch(e){}
 // the page-load row exists to catch a tab the browser DISCARDED and reloaded on return (Memory Saver: the return is a
@@ -32762,7 +32763,15 @@ document.addEventListener("freeze",function(){frozeAt=Date.now();});
 // pane on every return. Stamping here makes the clock honest; the foreground test and the watchdog tick the
 // freeze queued then KEEP the socket. No `resume` (Firefox, Safari, hidden-but-running, a genuinely silent
 // socket) reads stale exactly as before and redials at once. The pre-stamp gap is kept for the return row.
-document.addEventListener("resume",function(){resumedAt=Date.now();resumeQuiet=lastRecv?resumedAt-lastRecv:-1;if(ws&&ws.readyState===1)lastRecv=Date.now();});
+// The stamp RE-BASES the watchdog, it does not disarm it (review find, 2026-09-08): an OPEN readyState says only
+// that the browser has seen no FIN, and a peer that died while the tab was frozen (a laptop sleep across a network
+// change, a tunnel whose local end stays open) leaves the socket looking exactly like a healthy one. So the stamp
+// is PROVISIONAL (resumeProvisional: the watchdog runs at PROVISIONAL_MS until a frame confirms it, and abandon()
+// re-files the held keep row onto the redial when none does), and a socket already overdue BEFORE the freeze is
+// not stamped at all: its silence began while JS was running, so that gap is real and the return redials it at
+// once, as it did before the stamp existed.
+document.addEventListener("resume",function(){resumedAt=Date.now();resumeQuiet=lastRecv?resumedAt-lastRecv:-1;
+if(ws&&ws.readyState===1&&!(frozeAt&&frozeAt-lastRecv>STALE_MS)){lastRecv=Date.now();resumeProvisional=lastRecv;}});   // only an OPEN socket that was in time at the freeze earns the stamp, and only provisionally
 function raiseStale(why){if(paneHidden()){staleDiag("stale-suppressed-hidden",why);return;}
 staleDiag("stale-raise",why);
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
@@ -32810,15 +32819,15 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];queuedDiag=0;
+ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");resumeProvisional=0;var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];queuedDiag=0;
 if(failedConnects){send({type:"clientDiag",surface:"pane-shim",what:"wsconnfail",data:{app:APP,attempts:failedConnects,firstFailMs:Date.now()-firstFailT}});failedConnects=0;firstFailT=0;}   // the redials that never opened since the last open, as ONE row: how many, and how long ago the first failed
 if(wasReconn){var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;   // one-shot: spent here
 if(!ann)armStale(pendingWhy||"reconnect");   // T217: an ANNOUNCED restart's reconnect skips the arm — the resync lands in a beat and the flash was pure noise; a restart that never comes back stays loud through the disconnected state itself, and a SECOND reconnect arms as always
 pendingWhy="";freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
-ws.onmessage=function(ev){lastRecv=Date.now();if(returnAt)returnBytes+=(ev.data&&ev.data.length)||0;var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
+ws.onmessage=function(ev){lastRecv=Date.now();resumeProvisional=0;if(returnAt)returnBytes+=(ev.data&&ev.data.length)||0;var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();
 if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}   // the SECOND keepalive since the arm, no resync between: a full heartbeat period on THIS socket with the kernel alive, talking to it, and not resyncing it — the view IS stale. (One keepalive alone can be a beat queued at accept, ahead of the resync frame.)
-return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
+return;}   // keepalive: stamped lastRecv above and confirmed a resumed keep (resumeProvisional=0: any frame does); carries the build token (drift → reload banner); nothing for the bundle to render
 // T217: the kernel announces its own death (one final frame from the dying process). Latch it: the
 // imminent close is EXPECTED — onclose redials eagerly instead of on the blind cadence, and the
 // reconnect skips the stale-banner arm once (the resync is seconds away; a restart that never
@@ -32858,7 +32867,7 @@ try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}
 // both ride the redial (review find 2026-09-07: the frozen-then-dropped regime otherwise left no trace)
 if(returnRow&&Date.now()-foregroundedAt<STALE_MS){var rr=returnRow;returnRow=null;rr.resent=true;returnDiag("return",rr);returnAt=returnAt||foregroundedAt;returnBytes=0;}
 var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;   // a close landing within STALE_MS of a foreground (the FIN a frozen tab thawed into; an iOS return): the close IS the event
-if(inWin){d=eagerDial?0:250;eagerDial=false;}   // …so the FIRST such close redials NOW; a second one in the same window waits 250 ms (a kernel that is down must not be hammered) (2026-09-07)
+if(inWin){d=eagerDial?0:250;eagerDial=false;}   // …so the FIRST such close redials NOW; every further close in the same window waits 250 ms (a kernel that is down must not be hammered) (2026-09-07)
 if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);   // an announced death keeps its tight redial
 setTimeout(connect,d);};   // the blind 1.5 s stays for unannounced drops outside any return window
 ws.onerror=function(){try{ws.close();}catch(e){}};}
@@ -32888,6 +32897,7 @@ FIFO.push(m);if(!flushArmed){flushArmed=true;ch.port2.postMessage(0);}}
 // from its head, and a newer whole-state frame arriving mid-burst still replaces its older still-queued twin.
 var FLUSH_MS=8;
 function flush(){flushArmed=false;var t0=Date.now(),err=null;
+if(returnRow&&!returnAt)returnRow=null;   // the held keep row is spent once its return-fresh has filed AND the burst that carried the frame has drained: this hop runs after every task the thaw queued, a same-burst FIN included, so that FIN still finds the row (onclose re-files it) and an ordinary close later does not (review find, 2026-09-08: a kernel restart 5 s after a healthy return re-filed the row `resent` and a second return-fresh followed)
 while(FIFO.length){var m=FIFO.shift();try{deliver(m);}catch(e){if(!err)err=e;}   // one bad frame never eats the rest of the burst; its error still surfaces
 if(FIFO.length&&Date.now()-t0>=FLUSH_MS){flushArmed=true;ch.port2.postMessage(0);break;}}   // budget spent → the rest rides the next task
 if(err)throw err;}
@@ -32934,6 +32944,7 @@ setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}
 // socket still carries writes; the raise's row does not depend on that.)
 function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;
 if(stalePending&&openSock===d){var qw=stalePending;stalePending="";raiseStale(qw+"-quiet");}   // the reconnected socket armed and then said nothing before its resync: nothing is coming on it, and the view IS stale — the disowned onclose cannot rule on it, and the redial's open would otherwise re-arm from zero
+if(returnRow&&returnAt){var rr=returnRow;returnRow=null;rr.resent=true;returnDiag("return",rr);returnBytes=0;}   // a KEPT socket put down before any fresh frame reached this return (the watchdog at the provisional bound): the keep row went into a socket that proved dead, so re-file it onto the redial as onclose does for a same-burst FIN, keyed on the return still being open, never on the clock (review find, 2026-09-08)
 netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}
 // progress watchdog (state-keyed, one per socket state): OPEN but silent past STALE_MS = half-open, no
 // onclose will ever fire — force-close (the user 2026-06-29). CONNECTING past its deadline = the browser is
@@ -32942,7 +32953,7 @@ netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}
 // "Disconnected — reconnecting…" banner sat until a manual refresh). CLOSED with no fresh attempt = the 1.5s
 // retry timer was lost (throttled/killed) — re-dial directly; connect()'s own guard makes this idempotent.
 setInterval(function(){if(!ws)return;
-if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");abandon();connect();}return;}
+if(ws.readyState===1){var bound=resumeProvisional?PROVISIONAL_MS:STALE_MS;if(everConnected&&Date.now()-lastRecv>bound){staleDiag("watchdog-close","quiet");abandon();connect();}return;}   // a resumed keep no frame has confirmed runs at the shorter bound (PROVISIONAL_MS, above)
 if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}
 if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // visibility fast-path (the user 2026-07-05): a BACKGROUNDED tab has its timers throttled, so the 5s watchdog
@@ -32956,7 +32967,7 @@ foregroundedAt=Date.now();eagerDial=true;if(!everConnected)return;
 var stale=!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS;var res=resumedAt>hiddenAt;
 var row={decision:stale?((!ws||ws.readyState!==1)?"redial-closed":"redial-stale"):"keep",resumed:res,hiddenMs:hiddenAt?Date.now()-hiddenAt:-1,
 frozenMs:(res&&frozeAt>=hiddenAt&&resumedAt>frozeAt)?resumedAt-frozeAt:0,quietMs:lastRecv?Date.now()-lastRecv:-1,quietAtResumeMs:res?resumeQuiet:-1,ready:ws?ws.readyState:-1};
-returnAt=Date.now();returnBytes=0;returnRedialed=false;
+returnAt=Date.now();returnBytes=0;returnRedialed=false;returnRow=null;   // every return starts with no held row (review find, 2026-09-08): a keep row left over from an earlier return must not ride this one's close or abandon
 if(!stale){returnRow=row;returnDiag("return",row);return;}   // the socket stands: the row rides it now — and is HELD, because a FIN queued in the same thaw burst would swallow it (review find 2026-09-07; onclose re-files)
 pendingWhy="foreground";freshPending=true;   // the reconnect's arm reads "foreground" (upstream's two-event prompt)
 if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -34,7 +34,7 @@ class DisconnectBanner(unittest.TestCase):
         # T217: an ANNOUNCED death redials tight; since 2026-09-07 so does a close landing within STALE_MS
         # of a foreground (the FIN a frozen tab thawed into); the blind 1.5s stays for unannounced drops
         self.assertIn("var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;", js)
-        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", js)   # the FIRST close after a foreground redials now; a second waits 250 ms
+        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", js)   # the FIRST close after a foreground redials now; every further one in the window waits 250 ms
         self.assertIn("if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);", js)
         self.assertIn("setTimeout(connect,d);", js)
         self.assertIn("ws.onerror=function(){try{ws.close();}catch(e){}};", js)
@@ -122,8 +122,9 @@ class DisconnectBanner(unittest.TestCase):
         # the watchdog handles EVERY socket state: half-open OPEN, stuck CONNECTING, and lost-timer CLOSED.
         # A quiet OPEN socket is ABANDONED and redialed in the same tick (2026-09-02): close() alone
         # starts a closing handshake a dead far side never answers, and the browser holds CLOSING ~60s
-        # before onclose — the audited phone panes came back 64s after their own watchdog-close.
-        self.assertIn('if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");abandon();connect();}return;}', js)
+        # before onclose — the audited phone panes came back 64s after their own watchdog-close. The bound is
+        # PROVISIONAL_MS while a resumed keep awaits its confirming frame, STALE_MS otherwise (review find, 2026-09-08).
+        self.assertIn('if(ws.readyState===1){var bound=resumeProvisional?PROVISIONAL_MS:STALE_MS;if(everConnected&&Date.now()-lastRecv>bound){staleDiag("watchdog-close","quiet");abandon();connect();}return;}', js)
         self.assertIn("function abandon(){var d=ws;if(!d)return;d.onopen=d.onmessage=d.onclose=d.onerror=null;try{d.close();}catch(e){}ws=null;", js)
         self.assertIn('netState("down");try{window.dispatchEvent(new Event("romp:wsdown"));}catch(e){}}', js,
                       "the abandoned socket's onclose is disowned, so abandon() itself does what onclose did (banner + close rule + loader)")

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -29,10 +29,14 @@ class DisconnectBanner(unittest.TestCase):
         js = km._shim("chat")
         # reports up/down to the shell
         self.assertIn('postMessage({romp:"wsState",app:APP,state:s}', js)
-        self.assertIn('ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");', js)   # lastRecv stamp → heartbeat watchdog; openT/openSock → the close rule + wsclose breadcrumb
+        self.assertIn('ws.onopen=function(){lastRecv=Date.now();openT=lastRecv;openSock=this;netState("up");', js)   # lastRecv stamp → heartbeat watchdog; openT/openSock → the close rule + ws
         self.assertIn('ws.onclose=function(ev){netState("down");', js)   # reconnects on close (wsdown loader + retry follow)
-        self.assertIn("setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);",
-                      js, "T217: an ANNOUNCED death redials tight; the blind 1.5s stays for real drops")
+        # T217: an ANNOUNCED death redials tight; since 2026-09-07 so does a close landing within STALE_MS
+        # of a foreground (the FIN a frozen tab thawed into); the blind 1.5s stays for unannounced drops
+        self.assertIn("var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;", js)
+        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", js)   # the FIRST close after a foreground redials now; a second waits 250 ms
+        self.assertIn("if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);", js)
+        self.assertIn("setTimeout(connect,d);", js)
         self.assertIn("ws.onerror=function(){try{ws.close();}catch(e){}};", js)
         # a RECONNECT no longer silently reloads (the user 2026-07-05): it PROMPTS via raiseStale, and the fresh
         # socket resyncs live. The old auto-reload-on-reopen is gone.
@@ -59,7 +63,11 @@ class DisconnectBanner(unittest.TestCase):
         # hands that reconnect its reason; the reconnect's arm then follows the same two events as any other
         # (a keepalive or a close before the resync), and the resync frame disarms it (the user 2026-08-01).
         self.assertIn('document.addEventListener("visibilitychange"', js)
-        self.assertIn('Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;', js)
+        # 2026-09-07: the handler latches foregroundedAt, names its verdict (`stale`, filed as the return
+        # breadcrumb's decision) and only then hands the reconnect its reason — the test itself is unchanged
+        self.assertIn("var stale=!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS;", js)
+        self.assertIn('if(!stale){returnRow=row;returnDiag("return",row);return;}', js)   # held: a FIN queued in the thaw burst re-files it
+        self.assertIn('pendingWhy="foreground";freshPending=true;', js)
 
     def test_a_hidden_pane_never_raises_the_stale_banner(self):
         # the user 2026-08-15, on the phone: the mobile shell shows ONE pane, hiding the rest with
@@ -201,7 +209,11 @@ class DisconnectBanner(unittest.TestCase):
         # a tab foregrounded onto a dead socket forces a reconnect and used to prompt immediately; that
         # reconnect resyncs like any other, so it arms the same window and disarms on the same frame
         js = km._shim("chat", 7777)
-        self.assertIn('Date.now()-lastRecv>STALE_MS){pendingWhy="foreground";freshPending=true;', js)
+        # 2026-09-07: the handler latches foregroundedAt, names its verdict (`stale`, filed as the return
+        # breadcrumb's decision) and only then hands the reconnect its reason — the test itself is unchanged
+        self.assertIn("var stale=!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS;", js)
+        self.assertIn('if(!stale){returnRow=row;returnDiag("return",row);return;}', js)   # held: a FIN queued in the thaw burst re-files it
+        self.assertIn('pendingWhy="foreground";freshPending=true;', js)
         self.assertNotIn("STALE_MS){raiseStale();", js)
 
     def test_a_standalone_page_retires_only_its_connection_bar(self):

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -78,12 +78,17 @@ class ShimWatchdogSourcePins(unittest.TestCase):
         # said "JS did not run", so a healthy OPEN socket read as dead and was redialed on every return
         self.assertGreaterEqual(KSRC.count("lastRecv=Date.now()"), 3)
         self.assertIn('document.addEventListener("resume",function(){resumedAt=Date.now();', KSRC)
-        self.assertIn("if(ws&&ws.readyState===1)lastRecv=Date.now();});", KSRC, "only an OPEN socket earns the stamp")
+        self.assertIn("if(ws&&ws.readyState===1&&!(frozeAt&&frozeAt-lastRecv>STALE_MS)){lastRecv=Date.now();resumeProvisional=lastRecv;}});", KSRC,
+                      "only an OPEN socket that was in time at the freeze earns the stamp, and only provisionally (review find, 2026-09-08)")
         # the staleness threshold is used TWICE within the one shim: the 5s interval watchdog AND the
         # visibilitychange fast-path (a foregrounded tab checks freshness at once — since 2026-09-07 it
         # names that verdict `stale` and files it as the return row's decision, still one test). Both live
-        # in _shim, so the single-shim guard above still holds.
-        self.assertEqual(KSRC.count("Date.now()-lastRecv>STALE_MS"), 2)
+        # in _shim, so the single-shim guard above still holds. Since 2026-09-08 the watchdog reads its bound
+        # through `bound`: PROVISIONAL_MS (1.5 keepalive periods) while a resumed keep awaits a confirming frame,
+        # STALE_MS otherwise, so the literal appears once and the watchdog's line once.
+        self.assertEqual(KSRC.count("Date.now()-lastRecv>STALE_MS"), 1)
+        self.assertEqual(KSRC.count("var bound=resumeProvisional?PROVISIONAL_MS:STALE_MS;if(everConnected&&Date.now()-lastRecv>bound)"), 1)
+        self.assertEqual(KSRC.count("var PROVISIONAL_MS=15000,resumeProvisional=0;"), 1)
         self.assertNotIn("new WebSocket", km._TIMELINE_BOOT, "the timeline boot owns no socket of its own")
 
     def test_shim_ignores_the_keepalive_frame(self):

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -74,10 +74,15 @@ class ShimWatchdogSourcePins(unittest.TestCase):
         # watchdog wiring in the shared shim AND that no second copy has crept back in.
         self.assertEqual(KSRC.count("var lastRecv=0;var STALE_MS=30000;"), 1,
                          "still ONE shim — the anti-duplicate guard (no second hand-rolled copy)")
-        self.assertGreaterEqual(KSRC.count("lastRecv=Date.now()"), 2)   # onopen + onmessage
+        # onopen + onmessage + the Page Lifecycle `resume` stamp (2026-09-07): a thawed tab's lastRecv only
+        # said "JS did not run", so a healthy OPEN socket read as dead and was redialed on every return
+        self.assertGreaterEqual(KSRC.count("lastRecv=Date.now()"), 3)
+        self.assertIn('document.addEventListener("resume",function(){resumedAt=Date.now();', KSRC)
+        self.assertIn("if(ws&&ws.readyState===1)lastRecv=Date.now();});", KSRC, "only an OPEN socket earns the stamp")
         # the staleness threshold is used TWICE within the one shim: the 5s interval watchdog AND the
-        # visibilitychange fast-path (a foregrounded tab checks freshness at once). Both live in _shim, so the
-        # single-shim guard above still holds.
+        # visibilitychange fast-path (a foregrounded tab checks freshness at once — since 2026-09-07 it
+        # names that verdict `stale` and files it as the return row's decision, still one test). Both live
+        # in _shim, so the single-shim guard above still holds.
         self.assertEqual(KSRC.count("Date.now()-lastRecv>STALE_MS"), 2)
         self.assertNotIn("new WebSocket", km._TIMELINE_BOOT, "the timeline boot owns no socket of its own")
 

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -61,7 +61,10 @@ class PaneLoaderReconnect(unittest.TestCase):
     def test_the_loader_comes_down_when_the_socket_comes_back(self):
         """The event-based exit for the re-show path. Without it the only way down is the failsafe, i.e.
         30 seconds of romp logo over a pane whose socket reconnected in under two."""
-        self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", self.js)
+        self.assertIn("window.addEventListener('romp:wsup',function(){hide();});", self.js)
+        # …while the corner BADGE (a pane that has content) waits for the first fresh frame instead
+        # (2026-09-07; test_pane_shim_return.py owns that half)
+        self.assertIn("window.addEventListener('romp:wsfresh',function(){badge(false);});", self.js)
         self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});", self.js,
                       "the drop still raises SOMETHING — a matched pair; since T217 a pane with "
                       "content gets the translucent badge and only an empty pane the opaque sheet")
@@ -84,10 +87,11 @@ class PaneLoaderReconnect(unittest.TestCase):
         bars-area loader instead, the user 2026-06-26) — it still carries the shim, so it gets the event
         whether or not anything listens today."""
         for page in (km._chat_page(), km._feed_page(), km._fleet_page()):
-            self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", page)
+            self.assertIn("window.addEventListener('romp:wsup',function(){hide();});", page)
+            self.assertIn("window.addEventListener('romp:wsfresh',function(){badge(false);});", page)
             self.assertIn('new Event("romp:wsup")', page)
         self.assertIn('new Event("romp:wsup")', km._timeline_page())
-        self.assertNotIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", km._timeline_page(),
+        self.assertNotIn("window.addEventListener('romp:wsup',function(){hide();});", km._timeline_page(),
                          "the timeline still owns no _pane_spin overlay")
 
 

--- a/tests/test_pane_shim_return.py
+++ b/tests/test_pane_shim_return.py
@@ -160,6 +160,65 @@ out({ret:rows(sock(),"return")});""")
         self.assertEqual(r["ret"][0]["data"]["decision"], "redial-closed")
         self.assertEqual(r["ret"][0]["data"]["ready"], 3)
 
+    # A resumed keep is PROVISIONAL (review find, 2026-09-08): the stamp re-bases the watchdog, it does not vouch
+    # for the far end. A peer that died without a FIN reaching the browser (a laptop sleep across a network change,
+    # a tunnel whose local end stays open) leaves the socket OPEN at the thaw, so the stamp made the return say
+    # `keep` and the old content sat with no badge until the 5 s watchdog crossed STALE_MS, 30 to 35 s later,
+    # where the pre-stamp shim redialed at once. Now the kernel's next frame confirms the keep, and until one
+    # lands the watchdog runs at PROVISIONAL_MS (1.5 keepalive periods) instead of STALE_MS.
+    def test_a_resumed_keep_that_no_frame_confirms_is_put_down_at_the_provisional_bound_and_the_row_re_filed(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=1000;fire("freeze");NOW+=45000;fire("resume");show();
+var kept=sockets.length;NOW+=10000;tick();var at10=sockets.length;   // 10 s of silence since the stamp: inside the bound
+NOW+=5001;tick();   // past PROVISIONAL_MS with no beat from the kernel: the kept socket was dead all along
+var at15={sockets:sockets.length,oldReady:sockets[0].readyState,wsdown:count(winEvents,"romp:wsdown")};
+open();NOW+=200;recv({type:"feed",asks:[]});
+out({kept:kept,at10:at10,at15:at15,bound:PROVISIONAL_MS,wdOld:rows(sockets[0],"watchdog-close").length,wdNew:rows(sock(),"watchdog-close").length,
+retOld:rows(sockets[0],"return").map(function(x){return x.data;}),retNew:rows(sock(),"return").map(function(x){return x.data;}),
+rf:rows(sock(),"return-fresh").map(function(x){return x.data;}),held:returnRow,prov:resumeProvisional});""")
+        self.assertEqual(r["kept"], 1, "the thaw itself still keeps the socket: the healthy case pays nothing")
+        self.assertEqual(r["at10"], 1, "inside the provisional bound the socket stands")
+        self.assertEqual(r["bound"], 15000, "1.5 kernel keepalive periods (KEEPALIVE_S is 10 s): one beat may be in flight, two missing is silence")
+        self.assertEqual(r["at15"]["sockets"], 2, "past the bound the watchdog puts it down and redials, not at 30 to 35 s")
+        self.assertEqual(r["at15"]["oldReady"], 3)
+        self.assertEqual(r["at15"]["wsdown"], 1)
+        self.assertEqual((r["wdOld"], r["wdNew"]), (1, 0), "one watchdog-close row, sent down the quiet socket before the abandon")
+        self.assertEqual(len(r["retOld"]), 1)
+        self.assertEqual(r["retOld"][0]["decision"], "keep")
+        self.assertEqual(len(r["retNew"]), 1, "the keep row is re-filed onto the redial: the kept socket proved dead")
+        self.assertEqual((r["retNew"][0]["decision"], r["retNew"][0]["resent"]), ("keep", True))
+        self.assertIsNone(r["held"], "the held row is spent")
+        self.assertEqual(len(r["rf"]), 1)
+        self.assertTrue(r["rf"][0]["redialed"], "the return-fresh row on the redial says a dial got in the way")
+        self.assertEqual(r["rf"][0]["ms"], 15201, "measured from the foreground, as on any return")
+        self.assertEqual(r["prov"], 0, "the redial's frame confirmed the new socket")
+
+    def test_a_resumed_keep_that_a_frame_confirms_lives_to_stale_ms(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=1000;fire("freeze");NOW+=45000;fire("resume");show();var provAtKeep=resumeProvisional;
+NOW+=2000;recv({type:"ka"});var provAfterKa=resumeProvisional;   // the kernel's beat confirms the keep: a keepalive is enough
+NOW+=20000;tick();var at22=sockets.length;   // 20 s since that frame: past the provisional bound, inside STALE_MS
+NOW+=10001;tick();var at32=sockets.length;   // 30 s since the frame: the ordinary watchdog, as before
+out({provAtKeep:provAtKeep,provAfterKa:provAfterKa,at22:at22,at32:at32,wd:rows(sockets[0],"watchdog-close").length});""")
+        self.assertEqual(r["provAtKeep"], 1000000 + 46000, "the keep records the stamp it rests on")
+        self.assertEqual(r["provAfterKa"], 0, "any frame confirms, the keepalive included")
+        self.assertEqual(r["at22"], 1, "confirmed: the shorter bound no longer applies")
+        self.assertEqual(r["at32"], 2, "real silence after the confirmation is still put down at STALE_MS")
+        self.assertEqual(r["wd"], 1)
+
+    def test_a_socket_already_overdue_before_the_freeze_is_not_stamped_and_redials_at_the_return(self):
+        r = _run(r"""
+open();recv({type:"ka"});var stamped=lastRecv;hide();NOW+=31000;fire("freeze");NOW+=45000;fire("resume");show();
+var afterShow={sockets:sockets.length,lastRecvUnchanged:lastRecv===stamped,prov:resumeProvisional};NOW+=300;open();
+out({afterShow:afterShow,ret:rows(sock(),"return").map(function(x){return x.data;})});""")
+        a = r["afterShow"]
+        self.assertTrue(a["lastRecvUnchanged"], "31 s of silence before the freeze: the far end was gone while JS still ran, the resume vouches for nothing")
+        self.assertEqual(a["prov"], 0)
+        self.assertEqual(a["sockets"], 2, "the return redials at once, as before the stamp existed")
+        self.assertEqual(len(r["ret"]), 1)
+        self.assertEqual((r["ret"][0]["decision"], r["ret"][0]["resumed"]), ("redial-stale", True))
+        self.assertEqual(r["ret"][0]["quietAtResumeMs"], 76000)
+
 
 class EagerRedialAfterForeground(unittest.TestCase):
     """§1.1: a close landing within STALE_MS of a foreground is the FIN a frozen tab thawed into — redial now."""
@@ -333,6 +392,51 @@ out({fresh:rows(sock(),"return").length,delay:liveTimers()});""")
         self.assertNotIn("romp:wsfresh',function(){badge(false);", km._timeline_page(), "the timeline owns no _pane_spin")
 
 
+class HeldReturnRow(unittest.TestCase):
+    """The keep-decision row is held for ONE reason: a FIN queued in the same thaw burst proves the kept socket was
+    already dead, and the close re-files the row onto the redial. Held past that it is a liability (review find,
+    2026-09-08): a fresh frame filed return-fresh and zeroed returnAt but left the row, so an ordinary close within
+    STALE_MS of the foreground (a kernel restart 5 s after a healthy return) re-filed it `resent` and a second,
+    contradictory return-fresh followed. Every return now starts with no held row, and the flush retires a row
+    whose return-fresh has filed, once the burst that carried the frame has drained."""
+
+    def test_keep_then_frame_then_an_ordinary_close_files_no_resent_row_and_no_second_return_fresh(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=1000;fire("freeze");NOW+=45000;fire("resume");show();NOW+=40;recv({type:"feed",asks:[]});runFlushes();
+var afterFresh={held:returnRow,rf:rows(sock(),"return-fresh").length,returnAt:returnAt};
+NOW+=5000;sock().readyState=3;sock().onclose();var d=liveTimers().slice(-1);timers[timers.length-1].fn();open();NOW+=100;recv({type:"feed",asks:[]});
+out({afterFresh:afterFresh,d:d,retNew:rows(sock(),"return").length,rfOld:rows(sockets[0],"return-fresh").length,rfNew:rows(sock(),"return-fresh").length});""")
+        self.assertEqual(r["afterFresh"]["rf"], 1)
+        self.assertEqual(r["afterFresh"]["returnAt"], 0)
+        self.assertIsNone(r["afterFresh"]["held"], "the frame answered the return; once its burst drained, nothing is held")
+        self.assertEqual(r["d"], [{"ms": 0, "fn": "connect"}], "the close still redials at once: that rule is the foreground's, not the row's")
+        self.assertEqual(r["retNew"], 0, "no resent copy: the kept socket delivered, it did not prove dead")
+        self.assertEqual((r["rfOld"], r["rfNew"]), (1, 0), "one return-fresh per return")
+
+    def test_a_row_is_retired_only_once_its_burst_drained_so_a_same_burst_fin_still_re_files(self):
+        # the frames-then-FIN thaw (FreshCue above) needs the row to survive the frame that files return-fresh: the
+        # hop to the flush runs AFTER every task the thaw queued, a FIN included, so the close still finds the row
+        # and it is gone right after
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=45000;fire("resume");show();recv({type:"feed",asks:[]});
+var heldAfterFrame=!!returnRow;runFlushes();var heldAfterFlush=returnRow;
+out({heldAfterFrame:heldAfterFrame,heldAfterFlush:heldAfterFlush,fifo:FIFO.length});""")
+        self.assertTrue(r["heldAfterFrame"], "the frame alone does not retire the row (a FIN may still be queued behind it)")
+        self.assertIsNone(r["heldAfterFlush"])
+        self.assertEqual(r["fifo"], 0)
+
+    def test_a_later_return_that_decides_stale_holds_nothing(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=2000;show();var firstHeld=!!returnRow;   // a keep no frame ever answered
+hide();NOW+=46000;show();var held=returnRow;NOW+=300;open();
+out({firstHeld:firstHeld,held:held,ret:rows(sock(),"return").map(function(x){return x.data;})});""")
+        self.assertTrue(r["firstHeld"])
+        self.assertIsNone(r["held"], "every return starts with no held row")
+        self.assertEqual(len(r["ret"]), 1, "the stale return files its own row, and nothing older rides the redial")
+        self.assertEqual(r["ret"][0]["decision"], "redial-stale")
+        self.assertNotIn("resent", r["ret"][0])
+
+
 class ReturnBreadcrumbs(unittest.TestCase):
     """§1.0: the rows that name the regime on the user's own machine."""
 
@@ -429,6 +533,21 @@ for(var i=1;i<=5;i++)recv({type:"chatTail",id:"s"+i,from:0,events:[]});
 var armed=flushes.length;runFlushes();
 out({armed:armed,n:delivered.length,armedAfter:flushes.length});""")
         self.assertEqual((r["armed"], r["n"], r["armedAfter"]), (1, 5, 0), "no clock spent → one slice, no re-arm")
+
+    def test_a_frame_whose_handler_throws_does_not_eat_the_rest_of_the_burst_and_its_error_still_surfaces(self):
+        # the isolation branch, run (review find, 2026-09-08: it had no test): the bundle throws on the second of
+        # three frames; the first and third still land in order, the queue is drained, the port is not left armed,
+        # and the error reaches the task's caller (the console, in a browser) instead of vanishing
+        r = _run(r"""
+open();var n=0;window.__rompFed={inbound:function(h,m){n++;if(n===2)throw new Error("bad frame");delivered.push(m);}};
+recv({type:"chatTail",id:"a",from:0,events:[]});recv({type:"chatTail",id:"b",from:0,events:[]});recv({type:"chatTail",id:"c",from:0,events:[]});
+var err="";try{runFlushes();}catch(e){err=String(e&&e.message);}
+out({got:delivered.map(function(m){return m.id;}),fifo:FIFO.length,armed:flushArmed,rearmed:flushes.length,err:err});""")
+        self.assertEqual(r["got"], ["a", "c"], "the bad frame alone is lost; its neighbours are delivered in order")
+        self.assertEqual(r["fifo"], 0)
+        self.assertFalse(r["armed"])
+        self.assertEqual(r["rearmed"], 0, "nothing left to flush, so no re-arm")
+        self.assertEqual(r["err"], "bad frame", "the first error is rethrown after the drain")
 
     def test_source_pin_the_budget_and_the_re_arm(self):
         js = km._shim_core_js()

--- a/tests/test_pane_shim_return.py
+++ b/tests/test_pane_shim_return.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Returning to the dashboard's browser tab must not freeze it (the user 2026-09-07, whose dashboard locked up
+after its tab sat in the background).
+
+Each pane iframe rides the kernel's inline WS shim (kernel.py _shim). Before this change a return did three
+expensive things at once: the visibility fast-path read `lastRecv` — which only measures how long JS did not
+RUN — as "the socket is dead" and redialed a healthy socket (a full resync per pane); every frame the browser
+had queued while the tab was hidden or frozen was parsed AND fully rendered in its own task (eight feed
+renders, sixteen timeline draws for one newest state); and a redial waited out the blind 1.5s cadence. Now the
+Page Lifecycle `resume` event stamps `lastRecv` when the socket is OPEN, the handoff to the bundle rides ONE
+ordered FIFO per socket flushed in a single MessageChannel task (a newer whole-state frame replaces the older
+one of its type at the END position), a close within STALE_MS of a foreground redials in 250 ms, and every
+return leaves a clientDiag breadcrumb naming the regime it landed in. The pane's corner "reconnecting" badge
+comes down on the first FRESH frame (romp:wsfresh), not on the socket opening.
+
+The shim's decision code runs here for REAL: km._shim_core_js() returns the IIFE body between its
+/*shim-core*/ anchors, and node executes it at module scope with fakes for Date.now, document, WebSocket,
+MessageChannel and the timers — the same pattern test_view_deltas.py uses for the delta reassembler, minus the
+regex. Synthetic data only: no real session content, TESTHOST as the host.
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_shimreturn", os.path.join(BIN, "romp-kernel")).load_module()
+
+# The browser the shim thinks it runs in. `var` at module scope shadows node's own WebSocket / MessageChannel /
+# setTimeout for the core that follows in the same file, so nothing here touches a real socket or clock.
+HARNESS = r"""
+var NOW=1000000;Date.now=function(){return NOW;};
+var timers=[];var setTimeout=function(fn,ms){timers.push({fn:fn,ms:ms,live:true});return timers.length;};
+var clearTimeout=function(id){if(id&&timers[id-1])timers[id-1].live=false;};
+var intervals=[];var setInterval=function(fn,ms){intervals.push({fn:fn,ms:ms});return intervals.length;};
+var docL={};var document={visibilityState:"visible",wasDiscarded:false,
+addEventListener:function(t,f){(docL[t]=docL[t]||[]).push(f);},getElementById:function(){return null;}};
+function fire(t){(docL[t]||[]).forEach(function(f){f({type:t});});}
+var parentPosts=[],winEvents=[],delivered=[];
+var window={innerWidth:800,innerHeight:600,parent:{postMessage:function(m){parentPosts.push(m);}},
+dispatchEvent:function(e){winEvents.push(e.type);return true;},sessionStorage:{getItem:function(){return "";}},
+__rompFed:{inbound:function(h,m){delivered.push(m);}}};
+var location={protocol:"http:",host:"TESTHOST",search:""};
+var localStorage={getItem:function(){return null;},setItem:function(){}};
+var sockets=[];function WebSocket(url){this.url=url;this.readyState=0;this.sent=[];sockets.push(this);}
+WebSocket.prototype.send=function(s){this.sent.push(s);};WebSocket.prototype.close=function(){this.readyState=3;};
+var flushes=[];function MessageChannel(){var self=this;this.port1={onmessage:null};
+this.port2={postMessage:function(d){flushes.push(function(){self.port1.onmessage({data:d});});}};}
+function runFlushes(){var f=flushes;flushes=[];for(var i=0;i<f.length;i++)f[i]();}
+function sock(){return sockets[sockets.length-1];}
+function open(){var s=sock();s.readyState=1;s.onopen();return s;}
+function recv(m){sock().onmessage({data:JSON.stringify(m)});}
+function tick(){for(var i=0;i<intervals.length;i++)intervals[i].fn();}
+function rows(s,what){return s.sent.map(function(x){return JSON.parse(x);}).filter(function(m){return m.type==="clientDiag"&&(!what||m.what===what);});}
+function hide(){document.visibilityState="hidden";fire("visibilitychange");}
+function show(){document.visibilityState="visible";fire("visibilitychange");}
+function liveTimers(){return timers.filter(function(t){return t.live;}).map(function(t){return {ms:t.ms,fn:t.fn.name};});}
+function redials(){return liveTimers().filter(function(t){return t.fn==="connect";});}
+function count(list,x){return list.filter(function(e){return e===x;}).length;}
+function out(o){process.stdout.write(JSON.stringify(o));}
+"""
+
+
+def _run(scenario, pre=""):
+    node = shutil.which("node")
+    if not node:
+        raise unittest.SkipTest("node not installed")
+    fx = tempfile.mkdtemp()
+    path = os.path.join(fx, "run.js")
+    with open(path, "w") as f:
+        f.write(pre + HARNESS + km._shim_core_js() + "\n" + scenario)
+    r = subprocess.run([node, path], capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        raise AssertionError("node failed:\n" + r.stderr)
+    return json.loads(r.stdout)
+
+
+class TheSeam(unittest.TestCase):
+    def test_the_core_is_the_iife_body_and_fails_loudly_without_anchors(self):
+        core = km._shim_core_js()
+        self.assertIn("function connect()", core)
+        self.assertIn("function enqueue(m)", core)
+        self.assertIn('document.addEventListener("visibilitychange"', core)
+        self.assertNotIn("/*shim-core*/", core)
+        full = km._shim("feed", 3)
+        self.assertTrue(full.count("/*shim-core*/") == 1 and full.count("/*end-shim-core*/") == 1)
+        self.assertLess(full.index("/*shim-core*/"), full.index("/*end-shim-core*/"))
+        # formatted: no python placeholder survives into the runnable core
+        self.assertIn('var APP="test";', core)
+        self.assertNotIn("%s", core)
+
+
+class ResumeAwareLiveness(unittest.TestCase):
+    """§1.1: `resume` is the event 'lastRecv is stale' was approximating."""
+
+    def test_a_45s_gap_with_a_resume_keeps_the_socket_and_the_watchdog_tick_does_not_abandon(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=1000;fire("freeze");NOW+=45000;fire("resume");show();tick();
+out({sockets:sockets.length,ready:sock().readyState,wsdown:count(winEvents,"romp:wsdown"),
+ret:rows(sockets[0],"return"),timers:liveTimers(),lastRecv:lastRecv,now:NOW});""")
+        self.assertEqual(r["sockets"], 1, "no redial: the thawed socket is kept")
+        self.assertEqual(r["ready"], 1)
+        self.assertEqual(r["wsdown"], 0, "the queued watchdog tick saw a fresh lastRecv and did not abandon")
+        self.assertEqual(r["lastRecv"], r["now"], "resume stamped the clock")
+        self.assertEqual([t for t in r["timers"] if t["ms"] == 1000], [], "no stale prompt armed")
+        self.assertEqual(len(r["ret"]), 1)
+        d = r["ret"][0]["data"]
+        self.assertEqual(d["decision"], "keep")
+        self.assertTrue(d["resumed"])
+        self.assertEqual(d["frozenMs"], 45000)
+        self.assertEqual(d["hiddenMs"], 46000)
+        self.assertEqual(d["quietAtResumeMs"], 46000, "the pre-stamp silence is kept for the diagnosis")
+        self.assertEqual(d["quietMs"], 0)
+        self.assertEqual(d["ready"], 1)
+
+    def test_the_same_gap_without_a_resume_abandons_and_redials_at_once(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=46000;show();
+var afterShow={sockets:sockets.length,oldReady:sockets[0].readyState,oldOnclose:sockets[0].onclose,wsdown:count(winEvents,"romp:wsdown"),timers:liveTimers(),why:pendingWhy};
+tick();NOW+=300;open();
+out({afterShow:afterShow,afterTick:sockets.length,ret:rows(sock(),"return"),retOnOld:rows(sockets[0],"return").length,newReady:sock().readyState});""")
+        a = r["afterShow"]
+        self.assertEqual(a["sockets"], 2, "abandon + connect in the same handler — today's behaviour, unchanged")
+        self.assertEqual(a["oldReady"], 3)
+        self.assertIsNone(a["oldOnclose"], "the abandoned socket's handlers are disowned")
+        self.assertEqual(a["wsdown"], 1)
+        self.assertEqual(a["why"], "foreground", "the redial is handed its reason: its onopen arms the stale prompt as 'foreground'")
+        self.assertEqual(a["timers"], [], "no timer stands in for that event")
+        self.assertEqual(r["afterTick"], 2, "the watchdog tick does not dial a third socket over a fresh CONNECTING one")
+        # the row is filed AFTER the redial, so it queued for the NEW socket instead of vanishing into the dead one
+        self.assertEqual(r["retOnOld"], 0)
+        self.assertEqual(len(r["ret"]), 1)
+        d = r["ret"][0]["data"]
+        self.assertEqual(d["decision"], "redial-stale")
+        self.assertFalse(d["resumed"])
+        self.assertEqual(d["frozenMs"], 0)
+        self.assertEqual(d["quietMs"], 46000)
+        self.assertEqual(d["quietAtResumeMs"], -1)
+
+    def test_a_resume_on_a_closed_socket_does_not_stamp_and_the_return_redials_closed(self):
+        r = _run(r"""
+open();recv({type:"ka"});var stamped=lastRecv;hide();sock().readyState=3;NOW+=45000;fire("resume");show();
+out({lastRecvUnchanged:lastRecv===stamped,sockets:sockets.length,decision:null});
+""")
+        self.assertTrue(r["lastRecvUnchanged"], "only an OPEN socket earns the stamp")
+        self.assertEqual(r["sockets"], 2, "a CLOSED socket at return is redialed")
+
+    def test_a_return_that_redials_closed_names_it(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();sock().readyState=3;NOW+=45000;show();NOW+=100;open();
+out({ret:rows(sock(),"return")});""")
+        self.assertEqual(r["ret"][0]["data"]["decision"], "redial-closed")
+        self.assertEqual(r["ret"][0]["data"]["ready"], 3)
+
+
+class EagerRedialAfterForeground(unittest.TestCase):
+    """§1.1: a close landing within STALE_MS of a foreground is the FIN a frozen tab thawed into — redial now."""
+
+    def test_onclose_within_stale_ms_of_a_foreground_redials_now_else_1500_and_announced_stays_250(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=5000;show();
+sock().readyState=3;sock().onclose();var afterForeground=redials();
+timers.length=0;NOW+=60000;connect();open();sock().readyState=3;sock().onclose();var late=redials();
+timers.length=0;connect();open();recv({type:"restarting"});sock().readyState=3;sock().onclose();var announced=redials();
+out({afterForeground:afterForeground,late:late,announced:announced});""")
+        self.assertEqual(r["afterForeground"], [{"ms": 0, "fn": "connect"}], "the first close after a foreground: the close IS the event, redial now")
+        self.assertEqual(r["late"], [{"ms": 1500, "fn": "connect"}], "the blind cadence stays for a close nobody foregrounded into")
+        self.assertEqual(r["announced"], [{"ms": 250, "fn": "connect"}], "T217's announced-death branch is unchanged")
+
+
+class OrderedDispatchFifo(unittest.TestCase):
+    """§1.2: one FIFO per socket; whole-state frames coalesce at the END position; chained kinds never drop."""
+
+    KEY = 'function k(m){return m.type+(m.n||"")+(m.id?":"+m.id:"");}'
+
+    def test_a_closed_between_two_taborders_lands_before_the_second(self):
+        r = _run(self.KEY + r"""
+open();recv({type:"tabOrder",order:["a","x"],n:1});recv({type:"closed",id:"x"});recv({type:"tabOrder",order:["a"],n:2});
+var before=delivered.length,armed=flushes.length;runFlushes();
+out({before:before,armed:armed,got:delivered.map(k),armedAfter:flushes.length});""")
+        self.assertEqual(r["before"], 0, "nothing is handed to the bundle synchronously")
+        self.assertEqual(r["armed"], 1, "one flush per burst")
+        self.assertEqual(r["got"], ["closed:x", "tabOrder2"])
+        self.assertEqual(r["armedAfter"], 0)
+
+    def test_three_feeds_collapse_to_the_last(self):
+        r = _run(self.KEY + r"""
+open();recv({type:"feed",n:1});recv({type:"feed",n:2});recv({type:"feed",n:3});runFlushes();out({got:delivered.map(k)});""")
+        self.assertEqual(r["got"], ["feed3"])
+
+    def test_chained_chat_frames_keep_their_places_around_a_coalesced_feed(self):
+        r = _run(self.KEY + r"""
+open();recv({type:"session",n:1});recv({type:"feed",n:1});recv({type:"chatTail",n:1});recv({type:"feed",n:2});runFlushes();out({got:delivered.map(k)});""")
+        self.assertEqual(r["got"], ["session1", "chatTail1", "feed2"])
+
+    def test_skeleton_and_bars_pairs_collapse_to_the_last_of_each_in_order(self):
+        r = _run(self.KEY + r"""
+open();recv({type:"data",n:1});recv({type:"bars",n:1});recv({type:"data",n:2});recv({type:"bars",n:2});runFlushes();out({got:delivered.map(k)});""")
+        self.assertEqual(r["got"], ["data2", "bars2"])
+
+    def test_a_failed_delta_sends_needslot_synchronously_and_enqueues_nothing(self):
+        r = _run(r"""
+open();recv({type:"delta",slot:"bars",base:7,rev:8,coll:{}});
+out({sent:sock().sent.map(function(x){return JSON.parse(x);}).filter(function(m){return m.type==="needSlot";}),fifo:FIFO.length,armed:flushes.length,delivered:delivered.length});""")
+        self.assertEqual(r["sent"], [{"type": "needSlot", "slot": "bars"}])
+        self.assertEqual(r["fifo"], 0)
+        self.assertEqual(r["armed"], 0)
+        self.assertEqual(r["delivered"], 0)
+
+    def test_ka_and_restarting_never_enter_the_fifo(self):
+        r = _run(r"""
+open();recv({type:"ka"});recv({type:"restarting"});out({fifo:FIFO.length,armed:flushes.length,announced:restartAnnounced>0});""")
+        self.assertEqual(r["fifo"], 0)
+        self.assertEqual(r["armed"], 0)
+        self.assertTrue(r["announced"], "restarting is still latched synchronously at receipt")
+
+    def test_abandon_does_not_clear_the_fifo(self):
+        r = _run(self.KEY + r"""
+open();recv({type:"feed",n:1});recv({type:"session",n:1});abandon();connect();open();recv({type:"chatTail",n:2});runFlushes();out({got:delivered.map(k)});""")
+        self.assertEqual(r["got"], ["feed1", "session1", "chatTail2"], "the old socket's frames are the newest state; the new socket's enter behind")
+
+    def test_the_hop_is_a_message_channel_and_the_shim_has_no_raf(self):
+        js = km._shim("chat", 1)
+        self.assertIn("var ch=new MessageChannel();ch.port1.onmessage=flush;", js)
+        self.assertIn("ch.port2.postMessage(0);", js)
+        self.assertNotIn("requestAnimationFrame", js, "rAF is held while hidden and in display:none frames — state would be withheld")
+        self.assertIn("enqueue(msg);};", js, "the handoff line is the one deferred step")
+        self.assertIn("WHOLE={feed:1,bars:1,data:1,tabOrder:1,working:1,globalRetryPaused:1}", js)
+
+
+class FreshCue(unittest.TestCase):
+    """§1.4: the pane's reconnecting badge ends on the first FRESH frame, not on the socket opening."""
+
+    def test_wsfresh_fires_at_clearstale_and_the_return_fresh_row_follows_the_first_real_frame(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=46000;show();NOW+=300;open();
+var atOpen={wsup:count(winEvents,"romp:wsup"),wsfresh:count(winEvents,"romp:wsfresh")};
+NOW+=700;recv({type:"ka"});
+var afterKa={wsfresh:count(winEvents,"romp:wsfresh"),rf:rows(sock(),"return-fresh").length};
+NOW+=500;recv({type:"feed",asks:[]});
+out({atOpen:atOpen,afterKa:afterKa,wsfresh:count(winEvents,"romp:wsfresh"),parentFresh:parentPosts.filter(function(p){return p.romp==="wsFresh";}).length,
+rf:rows(sock(),"return-fresh"),bytes:JSON.stringify({type:"ka"}).length+JSON.stringify({type:"feed",asks:[]}).length,staleLive:liveTimers().filter(function(t){return t.ms===1000;}).length});""")
+        self.assertEqual(r["atOpen"], {"wsup": 1, "wsfresh": 0}, "the socket opening is not fresh data")
+        self.assertEqual(r["afterKa"], {"wsfresh": 0, "rf": 0}, "a keepalive is not fresh data either")
+        self.assertEqual(r["wsfresh"], 1)
+        self.assertEqual(r["parentFresh"], 1, "the shell's wsFresh still rides along")
+        self.assertEqual(r["staleLive"], 0, "the armed stale prompt was disarmed by the resync")
+        self.assertEqual(len(r["rf"]), 1)
+        d = r["rf"][0]["data"]
+        self.assertEqual(d["ms"], 1500)
+        self.assertEqual(d["bytesSince"], r["bytes"])
+        self.assertTrue(d["redialed"])
+
+    def test_a_kept_socket_reports_return_fresh_without_a_redial(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=1000;fire("freeze");NOW+=45000;fire("resume");show();NOW+=40;recv({type:"bars",turns:{}});
+out({rf:rows(sock(),"return-fresh"),sockets:sockets.length});""")
+        self.assertEqual(r["sockets"], 1)
+        self.assertEqual(r["rf"][0]["data"]["ms"], 40)
+        self.assertFalse(r["rf"][0]["data"]["redialed"])
+
+    def test_a_kept_socket_whose_fin_thaws_in_the_burst_reports_the_redial(self):
+        # the FIN a frozen tab thawed into: decision keep, then onclose in the same burst → 250ms redial. The keep
+        # row was written into a socket that was already dead (readyState still 1 until the queued close runs), so
+        # the close RE-FILES it marked resent onto the redial, and the return-fresh row on the new socket says
+        # redialed:true (review find 2026-09-07: the frozen-then-dropped regime otherwise left no trace)
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=45000;fire("resume");show();sock().readyState=3;sock().onclose();
+var t=liveTimers();NOW+=0;timers[timers.length-1].fn();open();recv({type:"feed",asks:[]});
+out({t:t,dead:rows(sockets[0],"return").map(function(x){return x.data;}),fresh:rows(sock(),"return").map(function(x){return x.data;}),
+rf:rows(sock(),"return-fresh").map(function(x){return x.data;})});""")
+        self.assertEqual(r["t"], [{"ms": 0, "fn": "connect"}], "the first close after a foreground redials NOW")
+        self.assertEqual(len(r["dead"]), 1, "the first copy went into the dead socket (nothing can know that yet)")
+        self.assertEqual(r["dead"][0]["decision"], "keep")
+        self.assertEqual(len(r["fresh"]), 1, "…and the close re-filed it onto the redial")
+        self.assertEqual((r["fresh"][0]["decision"], r["fresh"][0]["resent"]), ("keep", True))
+        self.assertEqual(len(r["rf"]), 1)
+        self.assertTrue(r["rf"][0]["redialed"])
+        self.assertEqual(r["rf"][0]["ms"], 0, "the redial was immediate, the first frame followed in the same instant here")
+
+    def test_frames_then_fin_in_the_burst_re_file_both_rows_on_the_redial(self):
+        # the common shape: the kernel pushed frames before it gave up, so the thaw burst is [frames…, FIN]. The
+        # stale frames land on the dead socket first (readyState still 1) and would file return-fresh there; the
+        # close then re-files the return row AND re-opens the return-fresh window, so the new socket carries both
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=45000;fire("resume");show();recv({type:"feed",asks:[]});recv({type:"bars",turns:{}});
+sock().readyState=3;sock().onclose();timers[timers.length-1].fn();open();NOW+=30;recv({type:"feed",asks:[]});
+out({fresh:rows(sock(),"return").map(function(x){return x.data;}),rf:rows(sock(),"return-fresh").map(function(x){return x.data;}),held:returnRow});""")
+        self.assertEqual(len(r["fresh"]), 1)
+        self.assertTrue(r["fresh"][0]["resent"])
+        self.assertEqual(len(r["rf"]), 1, "return-fresh re-measured on the socket that delivers")
+        self.assertTrue(r["rf"][0]["redialed"])
+        self.assertEqual(r["rf"][0]["ms"], 30, "measured from the foreground, not from the dead socket's stale frame")
+        self.assertIsNone(r["held"], "the held row is spent")
+
+    def test_a_second_close_inside_the_same_return_window_waits_250ms(self):
+        # the immediate redial is spent once per foreground; a kernel that is down answers the redial with another
+        # close, and that one waits 250 ms — no tight loop
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=45000;fire("resume");show();sock().readyState=3;sock().onclose();
+var first=liveTimers();timers[timers.length-1].fn();sock().readyState=3;sock().onclose();var second=liveTimers().slice(-1);
+out({first:first,second:second});""")
+        self.assertEqual(r["first"], [{"ms": 0, "fn": "connect"}])
+        self.assertEqual(r["second"], [{"ms": 250, "fn": "connect"}])
+
+    def test_a_close_long_after_the_return_does_not_re_file(self):
+        r = _run(r"""
+open();recv({type:"ka"});hide();NOW+=45000;fire("resume");show();recv({type:"feed",asks:[]});NOW+=60000;
+sock().readyState=3;sock().onclose();NOW+=1500;timers[timers.length-1].fn();open();
+out({fresh:rows(sock(),"return").length,delay:liveTimers()});""")
+        self.assertEqual(r["fresh"], 0, "a close outside the return window is an ordinary drop: no resend")
+
+    def test_pane_spin_drops_the_badge_on_wsfresh_with_its_own_failsafe_and_no_longer_on_wsup(self):
+        for spin in (km._pane_spin("content", "live-ask"), km._pane_spin("feed-list"), km._pane_spin("fleet-list")):
+            self.assertIn("window.addEventListener('romp:wsfresh',function(){badge(false);});", spin)
+            self.assertIn("window.addEventListener('romp:wsup',function(){hide();});", spin, "wsup still ends the empty-pane sheet")
+            self.assertNotIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", spin,
+                             "the socket opening no longer ends 'reconnecting' for a pane with content")
+            self.assertIn("function badge(on){if(rb)rb.classList.toggle('on',!!on);clearTimeout(bfail);"
+                          "if(on)bfail=setTimeout(function(){badge(false);},30000);}", spin,
+                          "the badge's failsafe is armed per show (loader rule) and cleared on hide")
+            self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});", spin)
+        for page in (km._chat_page(), km._feed_page(), km._fleet_page(), km._timeline_page()):
+            self.assertIn('new Event("romp:wsfresh")', page, "every pane's shim can fire it")
+        self.assertNotIn("romp:wsfresh',function(){badge(false);", km._timeline_page(), "the timeline owns no _pane_spin")
+
+
+class ReturnBreadcrumbs(unittest.TestCase):
+    """§1.0: the rows that name the regime on the user's own machine."""
+
+    def test_a_plain_navigation_files_no_page_load_row(self):
+        # the row exists for a DISCARDED-and-reloaded tab (the return is a cold load: no visibilitychange, so no
+        # `return` row) or a reload/back-forward arrival; a plain navigation has nothing to say and files nothing
+        # (four rows per dashboard open would be noise, and they share the queued-breadcrumb cap with real rows)
+        r = _run(r"""open();out({sent:sockets[0].sent.map(function(x){return JSON.parse(x).what||JSON.parse(x).type;})});""")
+        self.assertNotIn("page-load", r["sent"])
+
+    def test_a_reload_arrival_files_the_page_load_row(self):
+        r = _run(r"""open();out({first:JSON.parse(sockets[0].sent[0])});""",
+                 pre='var performance={getEntriesByType:function(){return [{type:"reload"}];}};\n')
+        self.assertEqual(r["first"], {"type": "clientDiag", "surface": "pane-shim", "what": "page-load",
+                                      "data": {"wasDiscarded": False, "nav": "reload", "app": "test"}})
+
+    def test_a_discarded_load_is_flagged(self):
+        # the flag is read at load, so the fake document must carry it before the core runs
+        script = HARNESS.replace("wasDiscarded:false", "wasDiscarded:true")
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not installed")
+        fx = tempfile.mkdtemp()
+        with open(os.path.join(fx, "run.js"), "w") as f:
+            f.write(script + km._shim_core_js() + "\nopen();out({first:JSON.parse(sockets[0].sent[0])});")
+        res = subprocess.run([node, os.path.join(fx, "run.js")], capture_output=True, text=True, timeout=60)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertTrue(json.loads(res.stdout)["first"]["data"]["wasDiscarded"])
+
+    def test_return_row_shape(self):
+        r = _run(r"""open();recv({type:"ka"});hide();NOW+=2000;show();out({row:rows(sock(),"return")[0]});""")
+        row = r["row"]
+        self.assertEqual(row["type"], "clientDiag")
+        self.assertEqual(row["surface"], "pane-shim")
+        self.assertEqual(row["what"], "return")
+        self.assertEqual(sorted(row["data"].keys()),
+                         sorted(["decision", "resumed", "hiddenMs", "frozenMs", "quietMs", "quietAtResumeMs", "ready", "app"]))
+        self.assertEqual(row["data"]["decision"], "keep")
+        self.assertEqual(row["data"]["hiddenMs"], 2000)
+
+    def test_return_fresh_row_shape(self):
+        r = _run(r"""open();recv({type:"ka"});hide();NOW+=2000;show();NOW+=10;recv({type:"feed",asks:[]});out({row:rows(sock(),"return-fresh")[0]});""")
+        self.assertEqual(r["row"]["what"], "return-fresh")
+        self.assertEqual(sorted(r["row"]["data"].keys()), sorted(["ms", "bytesSince", "redialed", "app"]))
+
+    def test_no_return_row_before_the_first_connect_and_none_while_going_hidden(self):
+        r = _run(r"""hide();show();var pre=sockets[0].sent.length;open();
+out({pre:pre,ret:rows(sock(),"return").length,kinds:rows(sock()).map(function(m){return m.what;})});""")
+        self.assertEqual(r["pre"], 0, "nothing is sent on a socket that has not opened")
+        self.assertEqual(r["ret"], 0, "a return before everConnected has nothing to say")
+        self.assertEqual(r["kinds"], [], "…and a plain load files no page-load row either")
+
+    def test_the_kernel_writes_the_rows_to_client_diag(self):
+        # the receiving half: the existing clientDiag branch records `data` as-is, so the shape above is what lands
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        self.assertIn('elif msg and msg.get("type") == "clientDiag":', src)
+        self.assertIn('"data": msg.get("data")}', src)
+        self.assertIn('with open(jd.STATE / "client-diag.jsonl", "a", encoding="utf-8") as f:', src)
+
+
+class TimeSlicedFlush(unittest.TestCase):
+    """The burst after a thaw is delivered in SLICES (2026-09-07): a flush that has spent its budget re-arms the
+    port and the rest of the queue follows in the next task, in order, with the whole-state dedup still in force."""
+
+    def test_a_slow_burst_is_split_across_tasks_in_order_and_nothing_is_lost(self):
+        r = _run("""
+open();
+// every deliver costs 5 ms of fake clock: two frames spend the 8 ms budget, so a 6-frame burst takes 3 tasks
+window.__rompFed={inbound:function(h,m){delivered.push(m);NOW+=5;}};
+for(var i=1;i<=6;i++)recv({type:"chatTail",id:"s"+i,from:0,events:[]});
+var firstArmed=flushes.length;var seen=[];
+while(flushes.length){var f=flushes.shift();f();seen.push(delivered.length);}
+out({firstArmed:firstArmed,seen:seen,got:delivered.map(function(m){return m.id;}),fifo:FIFO.length});""")
+        self.assertEqual(r["firstArmed"], 1, "one flush armed for the burst")
+        self.assertEqual(r["got"], ["s1", "s2", "s3", "s4", "s5", "s6"], "wire order, nothing dropped or duplicated")
+        self.assertEqual(r["seen"], [2, 4, 6], "two frames per slice at 5 ms each against an 8 ms budget")
+        self.assertEqual(r["fifo"], 0)
+
+    def test_a_newer_whole_state_frame_arriving_mid_burst_replaces_its_queued_twin(self):
+        r = _run("""
+open();
+window.__rompFed={inbound:function(h,m){delivered.push(m);NOW+=9;}};   // one frame per slice
+recv({type:"chatTail",id:"a",from:0,events:[]});recv({type:"feed",asks:[],v:1});recv({type:"chatTail",id:"b",from:0,events:[]});
+flushes.shift()();                                   // slice 1: delivers the first tail, re-arms
+recv({type:"feed",asks:[],v:2});                     // arrives between slices: the queued v1 feed is superseded
+while(flushes.length){flushes.shift()();}
+out({got:delivered.map(function(m){return m.type+":"+(m.id||m.v);})});""")
+        self.assertEqual(r["got"], ["chatTail:a", "chatTail:b", "feed:2"], "the older feed left the queue; the newer took the end")
+
+    def test_a_fast_burst_is_one_task_as_before(self):
+        r = _run("""
+open();
+for(var i=1;i<=5;i++)recv({type:"chatTail",id:"s"+i,from:0,events:[]});
+var armed=flushes.length;runFlushes();
+out({armed:armed,n:delivered.length,armedAfter:flushes.length});""")
+        self.assertEqual((r["armed"], r["n"], r["armedAfter"]), (1, 5, 0), "no clock spent → one slice, no re-arm")
+
+    def test_source_pin_the_budget_and_the_re_arm(self):
+        js = km._shim_core_js()
+        self.assertIn("var FLUSH_MS=8;", js)
+        self.assertIn("if(FIFO.length&&Date.now()-t0>=FLUSH_MS){flushArmed=true;ch.port2.postMessage(0);break;}", js)
+        self.assertIn("while(FIFO.length){var m=FIFO.shift();", js, "drained from the head, in order")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_seam.py
+++ b/tests/test_restart_seam.py
@@ -168,7 +168,7 @@ class ShimSeam(unittest.TestCase):
     def test_an_announced_death_redials_tight_and_a_blind_drop_keeps_the_cadence(self):
         # 2026-09-07 added a second tight-redial event (a close within STALE_MS of a foreground) beside T217's
         self.assertIn("var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;", self.js)
-        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", self.js)   # the FIRST close after a foreground redials now; a second waits 250 ms
+        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", self.js)   # the FIRST close after a foreground redials now; every further one in the window waits 250 ms
         self.assertIn("if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);", self.js)
         self.assertIn("setTimeout(connect,d);", self.js)
 

--- a/tests/test_restart_seam.py
+++ b/tests/test_restart_seam.py
@@ -166,8 +166,11 @@ class ShimSeam(unittest.TestCase):
         self.assertIn('if(msg&&msg.type==="restarting"){restartAnnounced=Date.now();', self.js)
 
     def test_an_announced_death_redials_tight_and_a_blind_drop_keeps_the_cadence(self):
-        self.assertIn('setTimeout(connect,(restartAnnounced&&Date.now()-restartAnnounced<30000)?250:1500);',
-                      self.js)
+        # 2026-09-07 added a second tight-redial event (a close within STALE_MS of a foreground) beside T217's
+        self.assertIn("var inWin=Date.now()-foregroundedAt<STALE_MS,d=1500;", self.js)
+        self.assertIn("if(inWin){d=eagerDial?0:250;eagerDial=false;}", self.js)   # the FIRST close after a foreground redials now; a second waits 250 ms
+        self.assertIn("if(restartAnnounced&&Date.now()-restartAnnounced<30000)d=Math.min(d,250);", self.js)
+        self.assertIn("setTimeout(connect,d);", self.js)
 
     def test_the_announced_reconnect_skips_the_stale_arm_once(self):
         self.assertIn("var ann=restartAnnounced&&Date.now()-restartAnnounced<30000;restartAnnounced=0;",
@@ -187,7 +190,10 @@ class ShimSeam(unittest.TestCase):
         self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});",
                       self.spin, "content stays legible under a translucent corner affordance; the "
                                  "opaque loader is only for a genuinely empty pane")
-        self.assertIn("window.addEventListener('romp:wsup',function(){badge(false);hide();});", self.spin)
+        # 2026-09-07: the badge ends on the first FRESH frame (romp:wsfresh), not on the socket opening —
+        # over a slow link the resync ran for seconds with no cue; wsup still ends the empty-pane sheet
+        self.assertIn("window.addEventListener('romp:wsup',function(){hide();});", self.spin)
+        self.assertIn("window.addEventListener('romp:wsfresh',function(){badge(false);});", self.spin)
         self.assertIn("id=pane-reconn", self.spin)
         self.assertIn("pointer-events:none", self.spin,
                       "clicks pass through to the content and queue in the shim, by design")

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -831,6 +831,11 @@ class TimelinePanel {
     // so draw() paints the romp swirl loader there. Set true the instant applyBars runs (or a full one-shot
     // data object arrives through update()), and the loader is gone on the next draw. CLAUDE.md loader rule.
     this._barsLoaded = false;
+    // A bars frame that arrived BEFORE any lanes skeleton (the user 2026-09-07, who came back to a frozen
+    // dashboard tab): the pane shim now coalesces same-type frames, so on a first connect [data1, bars1,
+    // data2] can reach the pane as [bars1, data2] — and applyBars used to drop bars1 on `!this.data`. It is
+    // parked here instead and lands with the next skeleton (update()). Newest parked frame wins.
+    this._pendingBars = null;
     // per-LANE bars evidence (the user 2026-08-15: after a restart, a live WORKING lane vanished from
     // the active-only view, then reappeared bar-less): every with_bars build writes a turns entry for
     // EVERY lane it covered (empty for a quiet one), so a lane's key appearing is the exact "its
@@ -1064,6 +1069,25 @@ class TimelinePanel {
       if (this.tip && this.tip.classList && this.tip.classList.contains('show')) this.hideTip();
       _release();
     });
+    // Paint only when the pane can be seen (the user 2026-09-07, who came back to the dashboard's browser tab
+    // after it sat in the background and found the page frozen): every frame the kernel pushed while the tab
+    // was hidden was parsed AND fully drawn — N frames, N whole-SVG rebuilds — so the return paid for all of
+    // them at once. update()/applyBars() now apply their STATE unconditionally (this.data, the live edge's
+    // clock, the loader latch) but hold the draw while hidden, on the same _dirtyWhileTip path the tooltip
+    // and click holds use, and this is that hold's RELEASE: the tab coming back (visibilitychange → visible)
+    // or the pane itself coming into view (IntersectionObserver on the wrap — a display:none pane, a hidden
+    // Obsidian leaf, where the tab never changed state). One catch-up draw per return, never one per frame.
+    // Both are events; no timer polls for visibility. The observer is optional (Obsidian / a bare host may
+    // lack it) — see _hiddenForPaint for what the hold keys on without it.
+    this._onVis = () => this._releasePaintHold();
+    if (typeof document !== 'undefined' && document.addEventListener) document.addEventListener('visibilitychange', this._onVis);
+    this._io = null;
+    if (typeof IntersectionObserver !== 'undefined') {
+      try {
+        this._io = new IntersectionObserver((entries) => { if (entries.some((e) => e.isIntersecting)) this._releasePaintHold(); });
+        this._io.observe(this.wrap);
+      } catch (e) { this._io = null; }
+    }
 
     // controls row BELOW the time axis. Layout (the user 2026-06-11): usage bars LEFT-justified,
     // then a flexible spacer, then RIGHT-justified "collapse idle gaps" with the 🔒 lock-to-now
@@ -1236,7 +1260,7 @@ class TimelinePanel {
     this._hover = null; // feed→timeline hover highlight {ids,...} (set by update from data.hover OR setHover; null = none)
     this._hoverNonce = null;  // highest hover nonce applied — gates the direct push vs the file poll so neither clobbers the other (the same monotonic nonce rides both; see setHover)
     this._frozeFromPin = false;  // freeze-on-hover: true while a tooltip has paused live-follow that WAS pinned (so hideTip knows to resume)
-    this._dirtyWhileTip = false; // a data poll arrived while a tooltip was up (draw was skipped) → hideTip repaints the catch-up
+    this._dirtyWhileTip = false; // a data poll arrived while a tooltip was up (draw was skipped) → hideTip repaints the catch-up; also set under a pressed pointer (_release repaints) and while the pane is out of sight (_releasePaintHold repaints, 2026-09-07)
     this._unfreezeTimer = null;  // deferred hideTip resume — cancelled by a quick glyph→glyph hover handoff
     this.wrap.tabIndex = 0; this.wrap.style.outline = 'none';
     this._onKey = (e) => this.onKey(e);
@@ -1302,6 +1326,8 @@ class TimelinePanel {
       this.wrap.removeEventListener('touchstart', this._onTouchStart); this.wrap.removeEventListener('touchmove', this._onTouchMove); this.wrap.removeEventListener('touchend', this._onTouchEnd); this.wrap.removeEventListener('touchcancel', this._onTouchEnd); }
     if (this._drawRAF) cancelAnimationFrame(this._drawRAF);
     this._stopLiveTick();
+    if (this._onVis && typeof document !== 'undefined' && document.removeEventListener) document.removeEventListener('visibilitychange', this._onVis);
+    if (this._io) { try { this._io.disconnect(); } catch (e) {} this._io = null; }
     if (this._autoOpenT) clearTimeout(this._autoOpenT);
     if (this._unfreezeTimer) clearTimeout(this._unfreezeTimer);
     if (this._onDragMove) window.removeEventListener('mousemove', this._onDragMove, true);
@@ -1607,6 +1633,27 @@ class TimelinePanel {
     const w = this.wrap;
     return !!(w && w.offsetParent !== null);
   }
+  // Out of sight, for the PAINT hold in update()/applyBars() (2026-09-07)? Says "hidden" only for a reason
+  // whose RELEASE event is wired: the tab's visibilityState always (visibilitychange); the pane's own layout
+  // (offsetParent null — a display:none iframe, a hidden Obsidian leaf) only where the IntersectionObserver
+  // could be installed to notice it coming back. Without the observer an offsetParent-null pane keeps
+  // painting as it always did, rather than freezing on a stale frame with nothing to wake it — the
+  // 2026-06-25 stuck-hold bug in a new coat (a held pane must always have a release).
+  _hiddenForPaint() {
+    if (this._io) return !this._isVisible();
+    return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+  }
+  // The paint hold's release (2026-09-07): the tab came back or the pane came into view. Repaint the held
+  // frames as ONE catch-up — exactly what hideTip / _release do for their holds — and re-arm the live tick,
+  // which _tickLive stopped while hidden. Still hidden by the OTHER criterion (tab visible, pane display:none,
+  // or the reverse) → that criterion's own event releases later. A shown tip or a pressed pointer keeps its
+  // own hold and its own release repaints; the tick re-arm is safe under both (it self-gates).
+  _releasePaintHold() {
+    if (this._hiddenForPaint()) return;
+    const tipUp = this.tip && this.tip.classList && this.tip.classList.contains('show');
+    if (this._dirtyWhileTip && !tipUp && !this._pointerHeld) { this._dirtyWhileTip = false; this.draw(); }
+    this._startLiveTick();
+  }
   // The effective `now` draw() renders the right edge at: data.now plus wall-clock since that poll while
   // live-following, else the raw data.now (a held/frozen view must NOT creep as time passes).
   _liveNow() {
@@ -1623,8 +1670,10 @@ class TimelinePanel {
   // The live-follow loop: a look (draw if the edge moved LIVE_MIN_PX; see _tickLive), then a sleep sized to
   // the edge's speed, then the next look on an animation frame. Restarted by update()/applyBars() (each frame
   // re-paces it: a pending sleep computed for the old zoom or data is dropped), by gestures, and by the
-  // pointer release when a look was skipped under a held pointer. Hidden pane: it keeps sleeping (long) so it
-  // resumes by itself when shown; not live-following: it stops until a gesture pins the edge again.
+  // pointer release when a look was skipped under a held pointer. Hidden pane: the loop STOPS (its old 2 s
+  // sleep re-entered _isVisible()'s forced offsetParent layout every wake, for a pane nobody could see —
+  // 2026-09-07) and the paint hold's release (_releasePaintHold) re-arms it; not live-following: it stops
+  // until a gesture pins the edge again.
   _startLiveTick() {
     if (!this._liveFollowing() || !this._isVisible()) return;
     if (this._liveRAF != null) return;                                        // a look is already imminent
@@ -1648,7 +1697,7 @@ class TimelinePanel {
   _tickLive() {
     this._liveRAF = null; this._liveTO = null;
     if (!this._liveFollowing() || !this.data) return;          // gate closed → stop; a gesture or a frame re-arms
-    if (!this._isVisible()) { this._sleep(2000); return; }      // hidden pane: stay alive cheaply, resume when shown
+    if (!this._isVisible()) return;                             // hidden pane: stop; _releasePaintHold re-arms when it shows (no 2 s layout poll)
     // Click-safe: don't rebuild the SVG under a pressed pointer (a click in progress). The release event
     // (_release) restarts the loop — no polling for it. See the constructor.
     if (this._pointerHeld) { this._liveResume = true; return; }
@@ -1799,7 +1848,8 @@ class TimelinePanel {
     // A FULL data object (the test harness / an older one-shot) carries its own turns, so the bars are
     // already present → no loader. The two-message path leaves turns empty here; the loader shows until
     // applyBars lands. Read the RAW turns BEFORE the prev-carry below back-fills them.
-    if (data.turns && Object.keys(data.turns).length) this._barsLoaded = true;
+    const ownBars = !!(data.turns && Object.keys(data.turns).length);
+    if (ownBars) this._barsLoaded = true;
     if (data.turns) for (const k of Object.keys(data.turns)) this._barsSeen.add(k);
     const prev = this.data;
     if (prev && (!data.turns || !Object.keys(data.turns).length)) {
@@ -1831,6 +1881,11 @@ class TimelinePanel {
       this._nowBaseSec = data.now; this._nowBaseMs = _tMs;
     }
     this._wasLive = _live;
+    // A bars frame parked ahead of its skeleton (see applyBars) lands now that lanes exist — the skeleton
+    // arriving IS the event. Merged AFTER this frame's clock so the newer skeleton's `now` wins the edge, and
+    // BEFORE the fit + draw below so the first paint carries the bars. A skeleton that brought its own turns
+    // (a full one-shot) is newer than anything parked before it, so the parked frame is dropped (2026-09-07).
+    if (this._pendingBars) { const pb = this._pendingBars; this._pendingBars = null; if (!ownBars) this._mergeBars(pb); }
     if (!this.fitted && Object.keys(this.data.turns || {}).length && this.fitWindow()) this.fitted = true;   // fit once bars exist (a skeleton-only first paint waits for applyBars); no latch without a clock sample
     // first paint with a chat already open → seed the highlight from it (don't override a later local pick)
     if (this.selectedSid == null) { const sid = this._sidForActiveChat(data.activeChat); if (sid) this.selectedSid = sid; }
@@ -1859,9 +1914,11 @@ class TimelinePanel {
     // every x-position = the jump the user saw under the held edge. Keep the last frame; hideTip repaints
     // the buffered data as ONE catch-up. (Also skips the focus-jump + live-tick below — both move the view.)
     // Hold the SVG layout while it's deliberately frozen: a tooltip is up (freeze-on-hover) OR a pointer is
-    // pressed (a click in progress — click-safe, see the constructor). Buffer the data; repaint the catch-up
-    // when the hold ends (hideTip / pointer release). Skips the focus-jump + live-tick below — both move the view.
-    if ((this.tip && this.tip.classList && this.tip.classList.contains('show')) || this._pointerHeld) { this._dirtyWhileTip = true; return; }
+    // pressed (a click in progress — click-safe, see the constructor) OR the pane is out of sight (a hidden tab,
+    // a display:none pane — 2026-09-07; nobody sees a paint there, and the return used to pay for every held
+    // frame's rebuild at once). Buffer the data; repaint the catch-up when the hold ends (hideTip / pointer
+    // release / _releasePaintHold). Skips the focus-jump + live-tick below — both move the view.
+    if ((this.tip && this.tip.classList && this.tip.classList.contains('show')) || this._hiddenForPaint() || this._pointerHeld) { this._dirtyWhileTip = true; return; }
     this.draw();
     // feed→timeline locate: a NEW focus nonce (update_feed wrote timeline-focus.json on a card click)
     // → pan/scroll/pulse to that event. Adopt the nonce silently on first load (don't jump to a stale
@@ -1890,7 +1947,23 @@ class TimelinePanel {
     this._wasLive = live;
   }
   applyBars(m) {
-    if (!m || !this.data || !this.data.sessions) return;
+    if (!m) return;
+    // No skeleton yet → PARK the frame, don't drop it (2026-09-07): the pane shim coalesces same-type frames,
+    // so a first connect's [data1, bars1, data2] can arrive here as [bars1, data2]; dropping bars1 left the
+    // loader up until the next bars push. update() merges the parked frame when the skeleton lands.
+    if (!this.data || !this.data.sessions) { this._pendingBars = m; return; }
+    this._pendingBars = null;   // anything parked is older than this frame
+    this._mergeBars(m);
+    // honor the same freeze-on-hover / click-hold / out-of-sight guard update() uses (don't relayout under a
+    // held pointer or tip, nor for a pane nobody can see — _releasePaintHold repaints the catch-up)
+    if ((this.tip && this.tip.classList && this.tip.classList.contains('show')) || this._hiddenForPaint() || this._pointerHeld) { this._dirtyWhileTip = true; return; }
+    this.draw();
+    this._startLiveTick();   // bars are up now → resume the smooth-advance loop (gated off while the loader showed)
+  }
+  // The STATE half of a bars frame — everything that must land whether or not the pane can be seen: the
+  // turns/judging/messages, the loader latch, the live edge's clock (2026-09-07). applyBars() paints after
+  // it; update() runs it for a frame that was parked ahead of its skeleton.
+  _mergeBars(m) {
     this.data.turns = m.turns || {};
     for (const k of Object.keys(this.data.turns)) this._barsSeen.add(k);
     this.data.judging = m.judging || [];
@@ -1919,10 +1992,6 @@ class TimelinePanel {
       this._anchorNow(this.data.now);
     }
     if (!this.fitted && Object.keys(this.data.turns).length && this.fitWindow()) this.fitted = true;   // no latch without a clock sample (see fitWindow)
-    // honor the same freeze-on-hover / click-hold guard update() uses (don't relayout under a held pointer/tip)
-    if ((this.tip && this.tip.classList && this.tip.classList.contains('show')) || this._pointerHeld) { this._dirtyWhileTip = true; return; }
-    this.draw();
-    this._startLiveTick();   // bars are up now → resume the smooth-advance loop (gated off while the loader showed)
   }
 
   // Direct hover push from the kernel (server.ts pushHover) — the FAST path that skips the

--- a/ui/timeline-hidden-hold.test.ts
+++ b/ui/timeline-hidden-hold.test.ts
@@ -1,0 +1,283 @@
+// Paint only when the pane can be seen (the user 2026-09-07, who came back to the dashboard's browser tab
+// after it sat in the background and found the page frozen). The timeline parsed AND fully drew every frame
+// the kernel pushed while the tab was hidden — N frames, N whole-SVG rebuilds — so the return paid for all of
+// them at once. Now update()/applyBars() still apply their STATE unconditionally (this.data, the loader
+// latch, the live edge's clock) but hold the draw while the pane is out of sight, on the same _dirtyWhileTip
+// path the tooltip and click holds use; the tab coming back (visibilitychange) or the pane coming into view
+// (IntersectionObserver) paints ONE catch-up and re-arms the live tick, which stops while hidden instead of
+// waking every 2 s into a forced layout. A bars frame that outruns its skeleton is parked, not dropped.
+// Headless over the render test's DOM shim, with a recording document and a fake IntersectionObserver.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+// ---- minimal DOM shim (the timeline-render.test.ts shim: only what the view touches) ----
+function makeNode(tag: string): any {
+  const n: any = {
+    tag, _attrs: {}, children: [] as any[], style: {}, dataset: {}, textContent: "", parentNode: null,
+    classList: { _s: new Set<string>(), add(...a: string[]) { a.forEach((c) => this._s.add(c)); },
+      remove(...a: string[]) { a.forEach((c) => this._s.delete(c)); },
+      toggle(c: string, f?: boolean) { f ? this._s.add(c) : this._s.delete(c); }, contains(c: string) { return this._s.has(c); } },
+    setAttribute(k: string, v: any) { this._attrs[k] = v; }, getAttribute(k: string) { return this._attrs[k]; },
+    setAttributeNS(_n: any, k: string, v: any) { this._attrs[k] = v; }, removeAttribute(k: string) { delete this._attrs[k]; },
+    appendChild(c: any) { c.parentNode = n; this.children.push(c); return c; },
+    insertBefore(c: any, ref: any) { c.parentNode = n; const i = this.children.indexOf(ref); i < 0 ? this.children.push(c) : this.children.splice(i, 0, c); return c; },
+    removeChild(c: any) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); return c; },
+    remove() { if (this.parentNode) this.parentNode.removeChild(this); },
+    get firstChild() { return this.children[0] || null; },
+    addEventListener() {}, removeEventListener() {}, querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { width: 1400, height: 420, left: 0, top: 0, right: 1400, bottom: 420 }; },
+    closest() { return null; }, focus() {},
+    createEl(t: string, o: any) { const e = makeNode(t); if (o && o.cls) e.classList.add(o.cls); if (o && o.text) e.textContent = o.text; this.appendChild(e); return e; },
+    createDiv(o: any) { return this.createEl("div", o); }, createSpan(o: any) { return this.createEl("span", o); },
+  };
+  return n;
+}
+// The document RECORDS its listeners so a test can raise visibilitychange the way the browser does — every
+// panel's handler runs, in order — and its visibilityState is a plain settable field.
+const docListeners: Record<string, Array<(e: any) => void>> = {};
+const g: any = global;
+g.document = {
+  visibilityState: "visible",
+  createElement(t: string) { return t === "canvas" ? { getContext() { return { font: "", measureText(s: string) { return { width: (s ? s.length : 0) * 6 }; } }; } } : makeNode(t); },
+  createElementNS(_n: any, t: string) { return makeNode(t); },
+  body: makeNode("body"), documentElement: makeNode("html"), head: makeNode("head"),
+  getElementById() { return null; },
+  addEventListener(t: string, fn: (e: any) => void) { (docListeners[t] ||= []).push(fn); },
+  removeEventListener(t: string, fn: (e: any) => void) { const a = docListeners[t] || []; const i = a.indexOf(fn); if (i >= 0) a.splice(i, 1); },
+};
+// A fake IntersectionObserver: remembers its callback + targets so a test can report the pane coming into view.
+const ios: FakeIO[] = [];
+class FakeIO {
+  cb: (entries: any[], io: any) => void; targets: any[] = []; disconnected = false;
+  constructor(cb: (entries: any[], io: any) => void) { this.cb = cb; ios.push(this); }
+  observe(t: any) { this.targets.push(t); }
+  disconnect() { this.disconnected = true; }
+  fire(isIntersecting: boolean) { this.cb([{ isIntersecting, target: this.targets[0] }], this); }
+}
+g.IntersectionObserver = FakeIO;
+g.localStorage = { getItem() { return null; }, setItem() {}, removeItem() {} };
+g.getComputedStyle = () => ({ backgroundColor: "rgb(30,30,30)" });
+const rafs: Array<() => void> = [];
+g.requestAnimationFrame = (cb: () => void) => { rafs.push(cb); return rafs.length; };   // a real handle, never run: the tests read the arming, not the tick
+g.cancelAnimationFrame = () => {};
+g.addEventListener = () => {}; g.removeEventListener = () => {};
+g.matchMedia = () => ({ matches: false, addEventListener() {}, addListener() {} });
+g.window = g;
+g.innerWidth = 1400; g.innerHeight = 800;
+
+const viewPath = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const SRC = fs.readFileSync(viewPath, "utf8");
+const { TimelinePanel } = createRequire(__filename)(viewPath);
+
+// The render test's two-lane payload: live lanes with in-window turns, so a real draw() emits a populated SVG.
+function synthData() {
+  const now = 1_781_000_000;
+  const turn = (id: string, dt0: number, dt1: number) => ({
+    id, promptId: id + "#p", workId: id + "#w",
+    start: now - dt0, end: now - dt1, prompt: "do the thing", src: "typed", mids: [],
+    pending: false, summary: "did the thing", reply: "did it", tid: "fork-" + id, uuid: "u-" + id,
+    workUuid: "w-" + id, replyUuid: "r-" + id,
+  });
+  const sess = (id: string, name: string) => ({
+    id, name, color: "#7aa2f7", state: "working", live: true, model: "Opus 4.8", effort: "xhigh",
+    context: 40, since: now - 60, awaiting: [], compacting: [], pendingMail: 0, compactions: [], faded: false, stale: false,
+  });
+  return {
+    now,
+    sessions: [sess("S1", "alpha"), sess("S2", "beta")],
+    turns: { S1: [turn("S1:1:aa", 300, 60), turn("S1:2:bb", 50, 5)], S2: [turn("S2:1:cc", 200, 30)] },
+    messages: [], activeChat: null, focus: null, hover: null, usage: null,
+  };
+}
+// The wire shape: a {type:"data"} lanes skeleton (no turns) and the {type:"bars"} detail that follows it.
+function skeletonOf(full: any, dNow = 0) {
+  return { now: full.now + dNow, sessions: full.sessions, turns: {}, judging: [], messages: [], nudges: [],
+           activeChat: null, focus: null, hover: null, usage: null };
+}
+function barsOf(full: any, dNow = 0) {
+  return { type: "bars", turns: full.turns, judging: [], messages: [], nudges: [], now: full.now + dNow };
+}
+
+function mk() {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  if (panel._loaderBackstop != null) { clearTimeout(panel._loaderBackstop); panel._loaderBackstop = null; }   // keep node from waiting 12 s on it
+  const c = { draws: 0 };
+  const real = panel.draw.bind(panel);
+  panel.draw = () => { c.draws++; real(); };
+  return { panel, c, io: ios[ios.length - 1] };
+}
+function setVisibility(state: "hidden" | "visible") {
+  g.document.visibilityState = state;
+  for (const fn of [...(docListeners.visibilitychange || [])]) fn({ type: "visibilitychange" });
+}
+// Unhook a finished test's panel so a later test's visibilitychange doesn't reach it.
+function done(panel: any) { g.document.removeEventListener("visibilitychange", panel._onVis); g.document.visibilityState = "visible"; }
+
+test("while the tab is hidden, update() and applyBars() apply their state but never draw", () => {
+  const { panel, c } = mk();
+  const full = synthData();
+  setVisibility("hidden");
+  panel.update(skeletonOf(full));
+  assert.equal(c.draws, 0, "a skeleton landing on a hidden tab is not drawn");
+  assert.equal(panel._dirtyWhileTip, true, "…it is buffered on the hold path the tooltip/click holds use");
+  assert.equal(panel.data.sessions.length, 2, "…but the lanes ARE applied (state, not paint)");
+  panel.applyBars(barsOf(full));
+  assert.equal(c.draws, 0, "the bars frame is not drawn either");
+  assert.deepEqual(panel.data.turns, full.turns, "…yet the bars are merged into the live data");
+  assert.equal(panel._barsLoaded, true, "…and the loader latch flipped (a return must not show the loader)");
+  assert.equal(panel._newestNow, full.now, "…and the live edge's clock adopted the frame's now");
+  for (let i = 1; i <= 10; i++) { panel.update(skeletonOf(full, i)); panel.applyBars(barsOf(full, i)); }
+  assert.equal(c.draws, 0, "twenty more frames while hidden: still not one rebuild");
+  assert.equal(panel.data.now, full.now + 10, "the state kept moving with every frame");
+  done(panel);
+});
+
+test("coming back to the tab paints ONE catch-up and re-arms the live tick; a second return with nothing new paints nothing", () => {
+  const { panel, c } = mk();
+  const full = synthData();
+  setVisibility("hidden");
+  for (let i = 0; i < 6; i++) { panel.update(skeletonOf(full, i)); panel.applyBars(barsOf(full, i)); }
+  assert.equal(c.draws, 0);
+  assert.equal(panel._liveRAF, null, "the live tick was never armed for a hidden pane");
+  setVisibility("visible");
+  assert.equal(c.draws, 1, "exactly one draw for six held frames");
+  assert.equal(panel._dirtyWhileTip, false, "the hold is released");
+  assert.ok(panel.svg.children.length > 10, "the catch-up painted the bars (loader down, lanes + bars up)");
+  assert.notEqual(panel._liveRAF, null, "the live tick is re-armed by the release, not left for the next frame");
+  setVisibility("visible");
+  assert.equal(c.draws, 1, "nothing new arrived → nothing to paint");
+  panel.update(skeletonOf(full, 7));
+  assert.equal(c.draws, 2, "visible again: a frame draws synchronously, as it always did");
+  done(panel);
+});
+
+test("a bars frame that outruns its skeleton is parked, not dropped, and lands with the skeleton (the coalesced [bars1, data2] order)", () => {
+  const { panel, c } = mk();
+  const full = synthData();
+  const early = barsOf(full);
+  panel.applyBars(early);
+  assert.equal(panel.data, null, "no skeleton yet: nothing to draw onto");
+  assert.equal(panel._pendingBars, early, "…so the frame is parked");
+  assert.equal(c.draws, 0);
+  const newer = barsOf(full, 1);
+  panel.applyBars(newer);
+  assert.equal(panel._pendingBars, newer, "a second early frame supersedes the first (newest wins)");
+  panel.update(skeletonOf(full, 2));
+  assert.equal(panel._pendingBars, null, "the skeleton arriving is the event that lands the parked frame");
+  assert.deepEqual(panel.data.turns, full.turns, "the parked bars are merged into the skeleton's data");
+  assert.equal(panel._barsLoaded, true, "the loader latch flipped with them");
+  assert.equal(c.draws, 1, "one paint carries lanes AND bars — not a loader paint then a bars paint");
+  assert.ok(panel.svg.children.length > 10, "…and it is a populated SVG, not the loader");
+  assert.equal(panel.data.now, full.now + 2, "the newer skeleton's clock wins over the parked frame's");
+  done(panel);
+});
+
+test("a full one-shot payload carrying its own turns outranks a frame parked before it", () => {
+  const { panel } = mk();
+  const full = synthData();
+  const stale: any = barsOf(full); stale.turns = { S1: [] };
+  panel.applyBars(stale);
+  panel.update(full);
+  assert.deepEqual(panel.data.turns, full.turns, "the later, complete payload's bars stand");
+  assert.equal(panel._pendingBars, null, "the parked frame is dropped, not kept for a later skeleton");
+  done(panel);
+});
+
+test("a pane out of view on a visible tab (display:none → offsetParent null) holds too; the IntersectionObserver releases it", () => {
+  const { panel, c, io } = mk();
+  const full = synthData();
+  assert.equal(io.targets[0], panel.wrap, "the constructor observes the wrap");
+  panel.wrap.offsetParent = null;   // what a display:none iframe / hidden Obsidian leaf reports
+  panel.update(skeletonOf(full)); panel.applyBars(barsOf(full));
+  assert.equal(c.draws, 0, "nobody can see the pane: held");
+  assert.equal(panel._dirtyWhileTip, true);
+  setVisibility("visible");
+  assert.equal(c.draws, 0, "the tab was visible all along — its event does not release a pane hidden by layout");
+  panel.wrap.offsetParent = makeNode("div");
+  io.fire(true);
+  assert.equal(c.draws, 1, "the pane coming into view paints the one catch-up");
+  assert.equal(panel._dirtyWhileTip, false);
+  io.fire(true);
+  assert.equal(c.draws, 1, "an observer callback with nothing held paints nothing");
+  done(panel);
+});
+
+test("the release yields to a shown tooltip or a pressed pointer — their own releases repaint", () => {
+  const { panel, c } = mk();
+  const full = synthData();
+  setVisibility("hidden");
+  panel.update(skeletonOf(full)); panel.applyBars(barsOf(full));
+  panel.tip.classList.add("show");
+  setVisibility("visible");
+  assert.equal(c.draws, 0, "a tooltip is up: its still-snapshot hold stands (hideTip paints the catch-up)");
+  assert.equal(panel._dirtyWhileTip, true, "…and the frames stay buffered for it");
+  panel.tip.classList.remove("show");
+  panel._pointerHeld = true;
+  setVisibility("visible");
+  assert.equal(c.draws, 0, "a click in progress: click-safe hold stands (_release paints after the click)");
+  panel._pointerHeld = false;
+  setVisibility("visible");
+  assert.equal(c.draws, 1, "no other hold left: the return paints");
+  done(panel);
+});
+
+test("_tickLive stops while hidden instead of sleeping into a forced layout; the release re-arms it", () => {
+  const { panel } = mk();
+  panel.update(synthData());   // a full payload: bars present → the live tick is armed
+  assert.notEqual(panel._liveRAF, null, "live-following and visible: armed");
+  panel._liveRAF = null; panel._liveTO = null;   // the loop's own wake clears its handles before the look
+  setVisibility("hidden");
+  panel._tickLive();
+  assert.equal(panel._liveTO, null, "hidden: no 2 s sleep is scheduled");
+  assert.equal(panel._liveRAF, null, "…and no animation frame either — the loop is stopped");
+  setVisibility("visible");
+  assert.notEqual(panel._liveRAF, null, "the return re-arms it");
+  done(panel);
+});
+
+test("without an IntersectionObserver (a bare host), a layout-hidden pane is not held — nothing could release it", () => {
+  const saved = g.IntersectionObserver;
+  g.IntersectionObserver = undefined;
+  try {
+    const { panel, c } = mk();
+    assert.equal(panel._io, null);
+    panel.wrap.offsetParent = null;
+    panel.update(skeletonOf(synthData()));
+    assert.equal(c.draws, 1, "paints as it always did: a hold with no release event would freeze the lanes on a stale frame");
+    setVisibility("hidden");
+    panel.update(skeletonOf(synthData(), 1));
+    assert.equal(c.draws, 1, "the tab's own visibility still holds — visibilitychange releases that");
+    done(panel);
+  } finally { g.IntersectionObserver = saved; }
+});
+
+test("destroy() unhooks the visibility listener and the observer", () => {
+  const { panel, io } = mk();
+  assert.ok((docListeners.visibilitychange || []).includes(panel._onVis), "installed by the constructor");
+  panel.destroy();
+  assert.ok(!(docListeners.visibilitychange || []).includes(panel._onVis), "gone after destroy");
+  assert.equal(io.disconnected, true);
+  assert.equal(panel._io, null);
+});
+
+test("source pins: the hidden branch of _tickLive returns; both hold sites key on _hiddenForPaint; the release is synchronous", () => {
+  const tick = /  _tickLive\(\) \{([\s\S]*?)\n  \}/.exec(SRC)![1];
+  assert.match(tick, /if \(!this\._isVisible\(\)\) return;/, "hidden: stop the loop");
+  assert.doesNotMatch(tick, /_sleep\(2000\)/, "no long sleep re-entering _isVisible()'s forced offsetParent layout every 2 s");
+  const hold = "|| this._hiddenForPaint() || this._pointerHeld) { this._dirtyWhileTip = true; return; }";
+  assert.equal(SRC.split(hold).length - 1, 2, "update() and applyBars() share the one hold condition, pointer-held last (click-safe.test.ts pins that tail)");
+  assert.match(SRC, /document\.addEventListener\('visibilitychange', this\._onVis\);/);
+  assert.match(SRC, /if \(typeof IntersectionObserver !== 'undefined'\) \{[\s\S]*?this\._io\.observe\(this\.wrap\);/, "the observer is guarded — Obsidian / a bare host may lack it");
+  assert.match(SRC, /document\.removeEventListener\('visibilitychange', this\._onVis\);/);
+  assert.match(SRC, /this\._io\.disconnect\(\);/);
+  assert.match(SRC, /_hiddenForPaint\(\) \{\s*\n\s*if \(this\._io\) return !this\._isVisible\(\);\s*\n\s*return typeof document !== 'undefined' && document\.visibilityState === 'hidden';/,
+    "layout-hidden counts only when the observer exists to release it");
+  const rel = /  _releasePaintHold\(\) \{([\s\S]*?)\n  \}/.exec(SRC)![1];
+  assert.doesNotMatch(rel, /setTimeout|requestAnimationFrame/, "the catch-up paints synchronously in the release event — the compositor shows the cached frame on a tab switch, so this is the earliest fresh one");
+  assert.match(rel, /this\._startLiveTick\(\);/);
+  assert.match(SRC, /if \(!this\.data \|\| !this\.data\.sessions\) \{ this\._pendingBars = m; return; \}/, "bars ahead of the skeleton are parked");
+  assert.match(SRC, /if \(this\._pendingBars\) \{ const pb = this\._pendingBars; this\._pendingBars = null; if \(!ownBars\) this\._mergeBars\(pb\); \}/, "…and update() lands them");
+});

--- a/ui/timeline-live-tick.test.ts
+++ b/ui/timeline-live-tick.test.ts
@@ -33,9 +33,10 @@ test("the live wait is bounded and scales with the zoom", () => {
   assert.equal(fn.call({ _geom: null }), 1000, "no geometry yet: a plain second");
 });
 
-// (The skeleton and bars frames of one cycle are NOT coalesced client-side: update()/applyBars() draw
-// synchronously, which the view's tests rely on. The kernel stops re-sending an unchanged skeleton instead —
-// tests/test_timeline_skeleton_dedup.py — so in steady state only the bars frame lands, and only when it changed.)
+// (A skeleton and its bars frame are two draws: update()/applyBars() draw synchronously while the pane can be
+// seen, which the view's tests rely on — out of sight they hold to one catch-up, timeline-hidden-hold.test.ts.
+// The kernel stops re-sending an unchanged skeleton instead — tests/test_timeline_skeleton_dedup.py — so in
+// steady state only the bars frame lands, and only when it changed.)
 
 test("the prompt-dot pass indexes processed messages by recipient instead of scanning them per turn", () => {
   assert.doesNotMatch(SRC, /data\.messages\.some\(\(mm\) => mm\.toId === s\.id && !mm\.pending/);
@@ -61,16 +62,19 @@ test("sortedHasWithin answers the ±1 s question exactly", () => {
   for (let t = -2; t < 40; t += 0.37) assert.equal(f(xs, t, 1), xs.some((v) => Math.abs(v - t) <= 1), "t=" + t);
 });
 
-test("a hidden pane keeps the loop alive on a long sleep; a held pointer yields to the release event", () => {
+test("a hidden pane stops the loop (the paint hold's release re-arms it); a held pointer yields to the release event", () => {
   const tick = /  _tickLive\(\) \{([\s\S]*?)\n  \}/.exec(SRC)![1];
-  assert.match(tick, /if \(!this\._isVisible\(\)\) \{ this\._sleep\(2000\); return; \}/);
+  // 2026-09-07: the old 2 s sleep re-entered _isVisible()'s forced layout every wake for a pane nobody could
+  // see; the loop now stops and _releasePaintHold re-arms it on visibilitychange / the pane's observer.
+  assert.match(tick, /if \(!this\._isVisible\(\)\) return;/);
+  assert.doesNotMatch(tick, /_sleep\(2000\)/);
   assert.match(tick, /if \(this\._pointerHeld\) \{ this\._liveResume = true; return; \}/);
   assert.match(SRC, /if \(this\._liveResume\) \{ this\._liveResume = false; this\._startLiveTick\(\); \}/, "_release restarts it");
   assert.match(SRC, /this\._liveRAF = null; this\._liveTO = null; this\._liveResume = false;/, "the constructor knows every handle");
 });
 
 test("a bars frame re-anchors the live edge, and the glide cap outlasts the kernel's 60 s repost", () => {
-  const bars = /  applyBars\(m\) \{([\s\S]*?)\n  \}/.exec(SRC)![1];
+  const bars = /  _mergeBars\(m\) \{([\s\S]*?)\n  \}/.exec(SRC)![1];   // the state half of applyBars (2026-09-07)
   assert.match(bars, /this\._anchorNow\(this\.data\.now\);/);
   assert.match(SRC, /_anchorNow\(sample\) \{[\s\S]*?reanchorEdge\(this\._nowBaseSec, this\._nowBaseMs, tMs, sample, this\._wasLive\)/);
   const cap = Number(/const MAX_INTERP_AHEAD = (\d+);/.exec(SRC)![1]);

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -33,7 +33,9 @@ test("a status-only frame re-renders the awaiting box when its fields change —
   // the chatTail delta is the frame a status-only change actually rides (kernel _send_chat)
   const tail = RENDER.split("function chatTail(msg: any) {")[1].split("\n}")[0];
   assert.match(tail, /const before = awaitKey\(s\.status\);\s*\n\s*if \(msg\.status\) s\.status = msg\.status;/);
-  assert.match(tail, /appendActive\(\);\s*\n\s*renderLedger\(\);[\s\S]{0,900}?if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/,
+  // (2026-09-07: the active tab's repaint is scheduled per animation frame — scheduleAppendActive carries
+  // appendActive + renderLedger — while the awaited-agents box still keys on THIS frame's status change)
+  assert.match(tail, /scheduleAppendActive\(\);[\s\S]{0,900}?if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/,
     "the box renders from the SAME chatTail frame that flipped the chip");
   // the `update` delta and the host-side status frame render it the same way
   const upd = RENDER.split("function update(msg: any) {")[1].split("\n}")[0];

--- a/ui/webview/chat-tail-repaint.test.ts
+++ b/ui/webview/chat-tail-repaint.test.ts
@@ -1,0 +1,45 @@
+// The chat's ACTIVE-tab repaint after a tail is coalesced per animation frame (2026-09-07). On the thaw of a
+// frozen tab the queued tails replay as a burst; before this, each tail ran appendActive() — a forced layout
+// and a repaint of the same suffix — inside one long task (796 ms measured on a 45 s freeze). Now every tail
+// still APPLIES at once and the paint happens once per frame from the earliest changed point. Source pins
+// (render.ts has import-time DOM side effects, so no test imports it — the repo's standing pattern).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("function chatHead("));
+
+test("a tail for the active tab schedules ONE repaint per frame instead of painting inline", () => {
+  assert.match(tail, /v\.rendered = Math\.min\(v\.rendered, from\);/, "the state still lowers the repaint point at once");
+  assert.match(tail, /if \(shrank\) v\.stale = true;/);
+  const active = tail.slice(tail.indexOf("if (msg.id === activeId) {"), tail.indexOf("} else {"));
+  assert.match(active, /scheduleAppendActive\(\);/);
+  assert.doesNotMatch(active, /\bappendActive\(\);/, "no inline appendActive on the tail path any more");
+  assert.doesNotMatch(active, /\brenderLedger\(\);/, "the ledger paint rides the scheduled frame");
+  assert.match(active, /if \(awaitKey\(s\.status\) !== before\) renderBgTasks\(\);/, "the awaited-agents box still keys on the SAME frame's status change");
+});
+
+test("the scheduler mirrors scheduleRenderTabs: one pending frame, then appendActive + renderLedger", () => {
+  assert.match(RENDER, /let appendRaf: number \| null = null;\nfunction scheduleAppendActive\(\): void \{\n  if \(appendRaf != null\) return;\n  appendRaf = requestAnimationFrame\(\(\) => \{ appendRaf = null; appendActive\(\); renderLedger\(\); \}\);\n\}/);
+});
+
+test("the full-session paths keep their synchronous paint (one frame each)", () => {
+  const upsert = RENDER.slice(RENDER.indexOf("function upsert("), RENDER.indexOf("function chatTail(msg: any) {"));
+  assert.match(upsert, /appendActive\(\);/, "a full frame paints at once as before");
+});
+
+// Executed replica of the coalescing: N tails in one task → one paint, from the LOWEST changed point.
+test("replica: five tails in one task paint once, from the earliest changed index", () => {
+  let rafCb: (() => void) | null = null;
+  const raf = (cb: () => void) => { rafCb = cb; return 1; };
+  let appendRaf: number | null = null; let paints: number[] = []; const v = { rendered: 100 };
+  const appendActive = () => { paints.push(v.rendered); v.rendered = 120; };
+  const schedule = () => { if (appendRaf != null) return; appendRaf = raf(() => { appendRaf = null; appendActive(); }); };
+  for (const from of [90, 95, 70, 110, 80]) { v.rendered = Math.min(v.rendered, from); schedule(); }
+  assert.equal(paints.length, 0, "nothing painted inside the task");
+  rafCb!();
+  assert.deepEqual(paints, [70], "one paint, from the lowest point any tail touched");
+  assert.equal(appendRaf, null, "the frame is spent; the next tail schedules a new one");
+});

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -9,6 +9,8 @@
 // only (host TESTHOST, placeholder uuids).
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { FederationManager, mergeHostTimelines, socketVerdict,
          REMOTE_STALE_MS, REMOTE_CONNECT_MS, REMOTE_REDIAL_MS } from "./federation";
 
@@ -163,6 +165,128 @@ test("a detached host is never touched by the watchdog, and a DOWN tunnel is nev
     fm.watchdog(clock);
     assert.equal(FakeWS.made.length, n, "a detached conn is skipped, never redialed");
   });
+});
+
+// ── the Page Lifecycle `resume` stamp (the user 2026-09-07, whose dashboard froze on return) ─────
+// A Chromium tab left in the background is FROZEN: no JS runs, so no frame can stamp lastRecv even
+// while the socket underneath stays open and the kernel keeps heartbeating. lastRecv then measures
+// "JS did not run", not "the socket went silent" — and the foreground fast-path above read that as
+// 30s+ of silence and abandoned+redialed EVERY attached host on every thaw, each redial a full resend.
+// The thaw fires `resume` before `visibilitychange`; stamping every OPEN socket there makes the
+// foreground pass see fresh sockets and keep them. socketVerdict itself is unchanged.
+test("`resume` stamps every OPEN relay socket's lastRecv — and only the open ones", async () => {
+  await withManager((fm) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("HOSTB", "tok", true);
+    fm.openRemote("HOSTC", "tok", true);
+    const [a, b, c] = FakeWS.made;
+    a.open(); b.open();                                   // c never finishes its handshake (CONNECTING)
+    clock += 45_000;                                      // frozen: no JS ran, so no frame was stamped
+    fm.resumed(clock);
+    assert.equal(fm.conns.get("TESTHOST").lastRecv, clock, "an open socket is stamped at the thaw");
+    assert.equal(fm.conns.get("HOSTB").lastRecv, clock, "…every open socket, not just the first");
+    assert.equal(fm.conns.get("HOSTC").lastRecv, 0, "a CONNECTING socket is NOT stamped — the foreground pass must still kill it");
+    assert.equal(c.readyState, 0);
+    for (const h of ["TESTHOST", "HOSTB", "HOSTC"]) fm.conns.get(h).closed = true;
+  });
+});
+
+test("thaw: `resume` then the foreground watchdog pass closes NOTHING — and silence AFTER the resume still counts", async () => {
+  await withManager((fm, _e, diag) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("HOSTB", "tok", true);
+    const [a, b] = FakeWS.made;
+    a.open(); b.open();
+    clock += 45_000;                                      // well past REMOTE_STALE_MS with no frame
+    fm.resumed(clock);
+    fm.watchdog(clock, true);                             // the visibilitychange fast-path, as on every thaw
+    assert.equal(a.closed, 0, "the open socket is kept: the resume re-based its silence to now");
+    assert.equal(b.closed, 0, "…for every attached host");
+    assert.equal(FakeWS.made.length, 2, "no redial → no full resend from either kernel");
+    assert.equal(diag.filter((d) => d.data && d.data.ev === "watchdog-close").length, 0, "nothing was put down, so no crumb");
+    clock += 5000;
+    fm.watchdog(clock);
+    assert.equal(a.closed, 0, "the next plain tick keeps it too");
+    // the stamp re-BASES the watchdog, it does not disarm it: a socket that stays silent after the
+    // thaw (dead on arrival, FIN never delivered) is still abandoned at the same bound as before
+    clock += REMOTE_STALE_MS;
+    fm.watchdog(clock);
+    assert.equal(a.closed, 1, "30s+ of real silence after the resume → abandoned as before");
+    assert.equal(b.closed, 1);
+    assert.equal(FakeWS.made.length, 4, "…and redialed");
+    for (const h of ["TESTHOST", "HOSTB"]) fm.conns.get(h).closed = true;
+  });
+});
+
+test("no `resume` (a browser without Page Lifecycle, or a tab that was hidden but running): the stale verdict still closes on foreground", async () => {
+  await withManager((fm, _e, diag) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    const ws = FakeWS.made[0];
+    ws.open();
+    clock += 45_000;                                      // 45s with no frame and no resume = real silence
+    fm.watchdog(clock, true);
+    assert.equal(ws.closed, 1, "abandoned exactly as before the resume stamp existed");
+    assert.equal(FakeWS.made.length, 2, "…and a fresh socket dialed in the same pass");
+    const crumb = diag.find((d) => d.data && d.data.ev === "watchdog-close");
+    assert.equal(crumb.data.why, "quiet");
+    assert.equal(crumb.data.foreground, true);
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("a CONNECTING socket is still killed on foreground after a `resume` — the stamp never reaches an unfinished handshake", async () => {
+  await withManager((fm, _e, diag) => {
+    fm.openRemote("TESTHOST", "tok", true);
+    const ws = FakeWS.made[0];                            // never opens
+    clock += 1000;
+    fm.resumed(clock);
+    assert.equal(fm.conns.get("TESTHOST").lastRecv, 0, "not stamped");
+    fm.watchdog(clock, true);
+    assert.equal(ws.closed, 1, "the foreground pass closes it now, resume or not");
+    assert.equal(FakeWS.made.length, 2, "…and dials a fresh one");
+    assert.equal(diag.filter((d) => d.data && d.data.ev === "watchdog-close" && d.data.why === "connecting" && d.data.foreground).length, 1);
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("the document wiring: `resume` then `visibilitychange`→visible keeps an open socket; `visibilitychange` alone abandons a quiet one; hidden fires nothing", async () => {
+  await withManager((fm) => {
+    // a fake document that records the listeners and lets the test fire them in the browser's order
+    const listeners: Record<string, Array<() => void>> = {};
+    const doc = {
+      visibilityState: "visible",
+      addEventListener(t: string, fn: () => void) { (listeners[t] ||= []).push(fn); },
+      fire(t: string) { for (const fn of listeners[t] || []) fn(); },
+    };
+    fm.watchLifecycle(doc);
+    assert.equal((listeners.resume || []).length, 1, "one resume listener");
+    assert.equal((listeners.visibilitychange || []).length, 1, "one visibilitychange listener");
+    fm.openRemote("TESTHOST", "tok", true);
+    const ws = FakeWS.made[0];
+    ws.open();
+    clock += 45_000;
+    doc.fire("resume");                                   // Chromium's thaw order: resume, then visibilitychange
+    doc.fire("visibilitychange");
+    assert.equal(ws.closed, 0, "kept: the resume stamped it before the foreground pass ran");
+    assert.equal(FakeWS.made.length, 1);
+    clock += 45_000;
+    doc.visibilityState = "hidden";
+    doc.fire("visibilitychange");
+    assert.equal(ws.closed, 0, "going HIDDEN is not a foreground pass");
+    doc.visibilityState = "visible";
+    doc.fire("visibilitychange");                         // no resume this time: real silence
+    assert.equal(ws.closed, 1, "abandoned on foreground, exactly today's behaviour");
+    assert.equal(FakeWS.made.length, 2);
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+test("source pin: start() installs the lifecycle listeners through watchLifecycle(document), guarded for a document-less host", () => {
+  const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  const start = src.slice(src.indexOf("  start(): void {"), src.indexOf("  watchLifecycle("));
+  assert.ok(start.length > 0, "start() precedes watchLifecycle()");
+  assert.match(start, /try \{\s*this\.watchLifecycle\(document\);\s*\} catch/, "installed once, inside the no-document guard");
+  assert.ok(!/document\.addEventListener/.test(start), "no second, un-testable listener install in start()");
 });
 
 // ── the pending-host signal: what the panes and the shell read while a host is still coming ────

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -12,7 +12,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { FederationManager, mergeHostTimelines, socketVerdict,
-         REMOTE_STALE_MS, REMOTE_CONNECT_MS, REMOTE_REDIAL_MS } from "./federation";
+         REMOTE_STALE_MS, REMOTE_CONNECT_MS, REMOTE_REDIAL_MS, REMOTE_PROVISIONAL_MS } from "./federation";
 
 const U = "11111111-2222-3333-4444-555555555555";
 
@@ -39,6 +39,7 @@ test("the bounds are the pane shim's, byte for byte (kernel keepalive 10s → st
   assert.equal(REMOTE_STALE_MS, 30000);
   assert.equal(REMOTE_CONNECT_MS, 15000);
   assert.equal(REMOTE_REDIAL_MS, 8000);
+  assert.equal(REMOTE_PROVISIONAL_MS, 15000, "a resumed keep no frame has confirmed: 1.5 keepalive periods");
 });
 
 // ── the manager, end to end, with a fake WebSocket ──────────────────────────────────────────────
@@ -208,7 +209,8 @@ test("thaw: `resume` then the foreground watchdog pass closes NOTHING — and si
     fm.watchdog(clock);
     assert.equal(a.closed, 0, "the next plain tick keeps it too");
     // the stamp re-BASES the watchdog, it does not disarm it: a socket that stays silent after the
-    // thaw (dead on arrival, FIN never delivered) is still abandoned at the same bound as before
+    // thaw (dead on arrival, FIN never delivered) is still abandoned (at the provisional bound since
+    // 2026-09-08, see below; this tick is past either)
     clock += REMOTE_STALE_MS;
     fm.watchdog(clock);
     assert.equal(a.closed, 1, "30s+ of real silence after the resume → abandoned as before");
@@ -277,6 +279,89 @@ test("the document wiring: `resume` then `visibilitychange`→visible keeps an o
     doc.fire("visibilitychange");                         // no resume this time: real silence
     assert.equal(ws.closed, 1, "abandoned on foreground, exactly today's behaviour");
     assert.equal(FakeWS.made.length, 2);
+    fm.conns.get("TESTHOST").closed = true;
+  });
+});
+
+// A resumed keep is PROVISIONAL (review find, 2026-09-08): the stamp re-bases the watchdog, it does not vouch
+// for the far end. A peer that died without a FIN reaching the browser (a laptop sleep across a network change,
+// a tunnel whose local end stays open) leaves the relay socket OPEN at the thaw, so the stamp kept it and the
+// host sat absent until the tick crossed REMOTE_STALE_MS, 30 s later. Now the kernel's next frame confirms the
+// keep, and until one lands the watchdog runs at REMOTE_PROVISIONAL_MS; a socket already overdue BEFORE the
+// freeze is not stamped at all, its gap is real and the foreground pass redials it as it did before the stamp.
+test("a resumed keep is provisional: silence after the thaw is put down at REMOTE_PROVISIONAL_MS, a frame confirms it to the full bound", async () => {
+  await withManager((fm, _e, diag) => {
+    const listeners: Record<string, Array<() => void>> = {};
+    const doc = {
+      visibilityState: "visible",
+      addEventListener(t: string, fn: () => void) { (listeners[t] ||= []).push(fn); },
+      fire(t: string) { for (const fn of listeners[t] || []) fn(); },
+    };
+    fm.watchLifecycle(doc);
+    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("HOSTB", "tok", true);
+    const [a, b] = FakeWS.made;
+    a.open(); b.open();
+    clock += 1000;
+    doc.fire("freeze");
+    clock += 45_000;
+    doc.fire("resume");                                   // Chromium's thaw order: resume, then visibilitychange
+    doc.fire("visibilitychange");
+    const stamp = clock;
+    assert.equal(a.closed, 0, "the thaw itself keeps both sockets: the healthy case pays nothing");
+    assert.equal(b.closed, 0);
+    assert.equal(fm.conns.get("TESTHOST").resumeProvisional, stamp, "the keep records the stamp it rests on");
+    clock += 2000;
+    b.frame({ type: "ka", dv: 1 });                       // HOSTB's kernel speaks: its keep is confirmed, a keepalive is enough
+    assert.equal(fm.conns.get("HOSTB").resumeProvisional, 0);
+    assert.equal(fm.conns.get("TESTHOST").resumeProvisional, stamp, "TESTHOST's is still waiting on a frame");
+    clock += 10_000;                                      // 12 s since the stamp
+    fm.watchdog(clock);
+    assert.equal(a.closed, 0, "inside the provisional bound the socket stands");
+    clock += 3001;                                        // 15.001 s since the stamp, no beat from that kernel
+    fm.watchdog(clock);
+    assert.equal(a.closed, 1, "put down at the provisional bound, not at 30 s: the kept socket was dead all along");
+    assert.equal(b.closed, 0, "the confirmed socket stands");
+    assert.equal(FakeWS.made.length, 3, "…and TESTHOST is redialed at once");
+    const crumb = diag.find((d) => d.what === "hostconn" && d.data && d.data.ev === "watchdog-close");
+    assert.equal(crumb.data.host, "TESTHOST");
+    assert.equal(crumb.data.why, "quiet");
+    assert.equal(crumb.data.quietMs, 15_001, "silence measured from the stamp");
+    assert.equal(fm.conns.get("TESTHOST").resumeProvisional, 0, "the fresh socket starts unmarked: the rule was the resumed socket's");
+    clock += 15_999;                                      // 29 s since HOSTB's confirming frame
+    fm.watchdog(clock);
+    assert.equal(b.closed, 0, "confirmed: the shorter bound no longer applies");
+    clock += 1001;                                        // 30.001 s since that frame
+    fm.watchdog(clock);
+    assert.equal(b.closed, 1, "real silence after the confirmation is still put down at REMOTE_STALE_MS");
+    for (const h of ["TESTHOST", "HOSTB"]) fm.conns.get(h).closed = true;
+  });
+});
+
+test("a socket already overdue before the freeze is not stamped by `resume`: the foreground pass redials it at once", async () => {
+  await withManager((fm, _e, diag) => {
+    const listeners: Record<string, Array<() => void>> = {};
+    const doc = {
+      visibilityState: "visible",
+      addEventListener(t: string, fn: () => void) { (listeners[t] ||= []).push(fn); },
+      fire(t: string) { for (const fn of listeners[t] || []) fn(); },
+    };
+    fm.watchLifecycle(doc);
+    fm.openRemote("TESTHOST", "tok", true);
+    const ws = FakeWS.made[0];
+    ws.open();
+    const opened = clock;
+    clock += 31_000;                                      // silent past REMOTE_STALE_MS while JS still ran: that gap is real
+    doc.fire("freeze");
+    clock += 45_000;
+    doc.fire("resume");
+    assert.equal(fm.conns.get("TESTHOST").lastRecv, opened, "not stamped: the resume vouches for nothing here");
+    assert.equal(fm.conns.get("TESTHOST").resumeProvisional, 0);
+    doc.fire("visibilitychange");
+    assert.equal(ws.closed, 1, "abandoned on foreground, exactly as before the stamp existed");
+    assert.equal(FakeWS.made.length, 2, "…and a fresh socket dialed in the same pass");
+    const crumb = diag.find((d) => d.data && d.data.ev === "watchdog-close");
+    assert.equal(crumb.data.quietMs, 76_000);
     fm.conns.get("TESTHOST").closed = true;
   });
 });

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -685,8 +685,34 @@ export class FederationManager {
     // remote socket that is not open, or has gone quiet past the bound, is closed and redialed now
     // rather than waited out — the phone's re-foreground is exactly the audited case.
     try {
-      document.addEventListener("visibilitychange", () => { if (document.visibilityState === "visible") this.watchdog(Date.now(), true); });
+      this.watchLifecycle(document);
     } catch (e) { /* no document — the node tests construct the manager bare */ }
+  }
+
+  /** The Page Lifecycle listeners on the document (public and parameterised so the tests install them
+   *  on a fake and fire the events in the browser's order). `resume` → resumed(); `visibilitychange`
+   *  to visible → the foreground watchdog pass, exactly as before. */
+  watchLifecycle(doc: { addEventListener(type: string, listener: () => void): void; readonly visibilityState: string }): void {
+    doc.addEventListener("resume", () => this.resumed(Date.now()));
+    doc.addEventListener("visibilitychange", () => { if (doc.visibilityState === "visible") this.watchdog(Date.now(), true); });
+  }
+
+  /** The Page Lifecycle `resume` event (the user 2026-09-07, whose dashboard froze every time they came
+   *  back to its tab): stamp every OPEN relay socket's lastRecv to now. A Chromium tab left in the
+   *  background is FROZEN — no JS runs at all — so no frame could stamp lastRecv even though the socket
+   *  stayed open and the kernel kept heartbeating. lastRecv therefore measured "JS did not run", not
+   *  "the socket went silent", and the foreground pass (watchdog(now, true), fired by visibilitychange
+   *  right after the thaw) read the frozen stretch as 30s+ of silence and abandoned+redialed EVERY
+   *  attached host on EVERY return — each redial a full resend from that kernel. Chromium fires
+   *  `resume` before `visibilitychange`, so the stamp lands first and socketVerdict (unchanged) sees a
+   *  fresh socket and keeps it; the frames queued during the freeze then dispatch on the same socket.
+   *  This re-BASES the measurement, it does not disarm it: a socket that stays silent after the thaw is
+   *  still put down at REMOTE_STALE_MS by the regular tick. Only readyState 1 is stamped — a socket
+   *  still CONNECTING is a handshake the frozen tab never finished, and the foreground pass still kills
+   *  it. Where no `resume` fires (Firefox, Safari, a hidden-but-running tab) stale lastRecv IS real
+   *  silence, and today's instant abandon on foreground is unchanged. */
+  resumed(now: number): void {
+    for (const c of this.conns.values()) if (c.ws && c.ws.readyState === 1) c.lastRecv = now;
   }
 
   /** One pass of the remote-socket watchdog (public so the tests can tick it with their own clock):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -593,14 +593,22 @@ export function mergeHostBars(perHost: Record<string, any>, hostSeq: readonly st
 export const REMOTE_STALE_MS = 30000;
 export const REMOTE_CONNECT_MS = 15000;
 export const REMOTE_REDIAL_MS = 8000;
+// A resumed keep is PROVISIONAL (review find, 2026-09-08), the pane shim's PROVISIONAL_MS byte for byte: 1.5
+// kernel keepalive periods (KEEPALIVE_S is 10 s, so 15 s: one beat may be in flight, two missing is silence).
+// The `resume` stamp (resumed() below) re-bases a socket the browser still holds OPEN, but the far end can
+// have died without a FIN reaching the browser (a laptop sleep across a network change, a tunnel whose local
+// end stays open), and only the kernel's next frame can tell; until one lands the watchdog runs at this bound
+// instead of REMOTE_STALE_MS.
+export const REMOTE_PROVISIONAL_MS = 15000;
 
 /** What the watchdog should do about ONE remote socket, from its state alone (pure, unit-tested):
  *  "close" — force-close so the onclose→redial chain runs (open but silent past the keepalive bound,
  *  or a hung handshake); "redial" — CLOSED with no fresh attempt: dial directly; "" — leave it be.
  *  `lastRecv` is stamped at open and on every frame, so an open socket's silence is measured from
- *  its own open, never from an earlier socket's traffic. */
-export function socketVerdict(readyState: number, lastRecv: number, connT: number, now: number): "close" | "redial" | "" {
-  if (readyState === 1) return now - (lastRecv || connT) > REMOTE_STALE_MS ? "close" : "";
+ *  its own open, never from an earlier socket's traffic. `staleMs` is the silence bound for an OPEN
+ *  socket: REMOTE_STALE_MS, or REMOTE_PROVISIONAL_MS while a resumed keep awaits its confirming frame. */
+export function socketVerdict(readyState: number, lastRecv: number, connT: number, now: number, staleMs = REMOTE_STALE_MS): "close" | "redial" | "" {
+  if (readyState === 1) return now - (lastRecv || connT) > staleMs ? "close" : "";
   if (readyState === 0) return now - connT > REMOTE_CONNECT_MS ? "close" : "";
   if (readyState === 3) return now - connT > REMOTE_REDIAL_MS ? "redial" : "";
   return "";
@@ -620,6 +628,7 @@ interface Conn {
   closed: boolean;
   live: boolean; // kernel reports this tunnel "up" — the only state in which its port is dialed
   lastRecv: number; // epoch ms of the last frame on the CURRENT socket (keepalives count); 0 = none yet
+  resumeProvisional: number; // the `resume` stamp lastRecv rests on until a frame confirms it (the watchdog runs at REMOTE_PROVISIONAL_MS meanwhile); 0 = confirmed, or no stamp
   connT: number;    // when the current socket's connect() attempt started — the watchdog's reference point
   // KERNEL_SETTING messages that arrived while this host's socket was down, newest per type only —
   // flushed on the socket's open event (sendRemote/flushPending). Bounded by construction: at most
@@ -631,6 +640,7 @@ interface Conn {
 export class FederationManager {
   app = "chat";
   private conns = new Map<string, Conn>();
+  private frozeAt = 0;   // the Page Lifecycle `freeze` before the current thaw: a socket already overdue at that moment is not stamped by resumed()
   private perHostOrder: Record<string, string[]> = {};
   private perHostTabs: Record<string, any[]> = {};
   private localViews: any = null;   // the LOCAL kernel's session-views blob, carried on merged tabOrder re-emits
@@ -690,9 +700,10 @@ export class FederationManager {
   }
 
   /** The Page Lifecycle listeners on the document (public and parameterised so the tests install them
-   *  on a fake and fire the events in the browser's order). `resume` → resumed(); `visibilitychange`
+   *  on a fake and fire the events in the browser's order). `freeze` → frozeAt; `resume` → resumed(); `visibilitychange`
    *  to visible → the foreground watchdog pass, exactly as before. */
   watchLifecycle(doc: { addEventListener(type: string, listener: () => void): void; readonly visibilityState: string }): void {
+    doc.addEventListener("freeze", () => { this.frozeAt = Date.now(); });
     doc.addEventListener("resume", () => this.resumed(Date.now()));
     doc.addEventListener("visibilitychange", () => { if (doc.visibilityState === "visible") this.watchdog(Date.now(), true); });
   }
@@ -707,12 +718,23 @@ export class FederationManager {
    *  `resume` before `visibilitychange`, so the stamp lands first and socketVerdict (unchanged) sees a
    *  fresh socket and keeps it; the frames queued during the freeze then dispatch on the same socket.
    *  This re-BASES the measurement, it does not disarm it: a socket that stays silent after the thaw is
-   *  still put down at REMOTE_STALE_MS by the regular tick. Only readyState 1 is stamped — a socket
+   *  still put down by the regular tick, and sooner than REMOTE_STALE_MS (review find, 2026-09-08): an
+   *  OPEN readyState says only that the browser has seen no FIN, and a peer that died while the tab was
+   *  frozen leaves the socket looking exactly like a healthy one, so the stamp is PROVISIONAL
+   *  (resumeProvisional: the watchdog runs at REMOTE_PROVISIONAL_MS until a frame confirms it), and a
+   *  socket already overdue BEFORE the freeze is not stamped at all: its silence began while JS was
+   *  running, so that gap is real and the foreground pass redials it as it did before the stamp
+   *  existed. Only readyState 1 is stamped — a socket
    *  still CONNECTING is a handshake the frozen tab never finished, and the foreground pass still kills
    *  it. Where no `resume` fires (Firefox, Safari, a hidden-but-running tab) stale lastRecv IS real
    *  silence, and today's instant abandon on foreground is unchanged. */
   resumed(now: number): void {
-    for (const c of this.conns.values()) if (c.ws && c.ws.readyState === 1) c.lastRecv = now;
+    for (const c of this.conns.values()) {
+      if (!c.ws || c.ws.readyState !== 1) continue;
+      if (this.frozeAt && this.frozeAt - (c.lastRecv || c.connT) > REMOTE_STALE_MS) continue;   // overdue before the freeze: real silence, no stamp
+      c.lastRecv = now;
+      c.resumeProvisional = now;
+    }
   }
 
   /** One pass of the remote-socket watchdog (public so the tests can tick it with their own clock):
@@ -722,7 +744,7 @@ export class FederationManager {
     for (const c of this.conns.values()) {
       if (c.closed || !c.ws) continue;
       const rs = c.ws.readyState;
-      let v = socketVerdict(rs, c.lastRecv, c.connT, now);
+      let v = socketVerdict(rs, c.lastRecv, c.connT, now, c.resumeProvisional ? REMOTE_PROVISIONAL_MS : REMOTE_STALE_MS);
       if (foreground && rs === 0) v = "close";
       if (v === "close") {
         // the same breadcrumb family as open/close/detach, so a "cards came back late" report reads
@@ -1115,7 +1137,7 @@ export class FederationManager {
     const w = dashboardWid();
     const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`
       + (w ? `&wid=${encodeURIComponent(w)}` : "");
-    const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, connT: 0, pending: new Map() };
+    const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, resumeProvisional: 0, connT: 0, pending: new Map() };
     this.conns.set(host, conn);
     this.ensureHost(host);
     this.connect(conn);
@@ -1136,6 +1158,7 @@ export class FederationManager {
     let ws: WebSocket;
     conn.connT = Date.now();
     conn.lastRecv = 0;
+    conn.resumeProvisional = 0;   // a fresh socket starts unmarked: the provisional rule was the resumed socket's
     try {
       ws = new WebSocket(conn.url);
     } catch (e) {
@@ -1163,6 +1186,7 @@ export class FederationManager {
     };
     ws.onmessage = (ev: MessageEvent) => {
       conn.lastRecv = Date.now();   // every frame counts, the keepalive included — that is the heartbeat
+      conn.resumeProvisional = 0;   // and any frame, the keepalive included, confirms a resumed keep
       let msg: any;
       try {
         msg = JSON.parse(ev.data);

--- a/ui/webview/feed-flip.test.ts
+++ b/ui/webview/feed-flip.test.ts
@@ -27,7 +27,9 @@ test("the first paint never flies", () => {
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 test("render() gates both forced layouts on the flip decision, and remembers the columns it painted", () => {
-  assert.match(SRC, /const nextCols = columnsOf\(buckets\);\n\s*const needFlip = flipNeeded\(prevCols, nextCols\);\n\s*prevCols = nextCols;\n\s*const flipFirst = needFlip \? captureCardRects\(cols\) : new Map<string, FlipState>\(\);/);
+  // 2026-09-07: the release paint after a hidden stretch skips the pass once (skipFlipOnce, pinned with its
+  // release path in feed-hidden-paint.test.ts); prevCols still records every painted render
+  assert.match(SRC, /const nextCols = columnsOf\(buckets\);\n(\s*\/\/[^\n]*\n)*\s*const needFlip = !skipFlipOnce && flipNeeded\(prevCols, nextCols\);\n\s*skipFlipOnce = false;\n\s*prevCols = nextCols;\n\s*const flipFirst = needFlip \? captureCardRects\(cols\) : new Map<string, FlipState>\(\);/);
   assert.match(SRC, /if \(needFlip\) flyColumnChanges\(flipFirst, cols\);/);
   // columnsOf keys every entry kind (a header per column, so one that changes column counts as moved) and
   // records column AND position, so the gate sees reorders; the keys only need to be consistent with

--- a/ui/webview/feed-followup-move.test.ts
+++ b/ui/webview/feed-followup-move.test.ts
@@ -29,8 +29,16 @@ test("a predicted card is kept in Working at render, styled like the kernel's re
   assert.match(FEED, /if \(\(pendingMoveKind\.get\(a\.itemId\) \?\? "followup"\) === "followup"\) \{ c\.recheck = true; c\.followupPending = true; \}/);
   // applied at the top of render so EVERY render (push, modal close) reflects the prediction
   // (2026-07-27: render() prunes the age-provenance popover first — hiding it only when the hovered
-  // stamp was torn out of the DOM — so the pin allows that line between the two.)
-  assert.match(FEED, /const list = document\.getElementById\("feed-list"\)!;\s*\n(\s*pruneTip\(\);.*\n)?\s*applyFollowMove\(asks\);/);
+  // stamp was torn out of the DOM — so the pin allows that line between the two. 2026-09-07: the
+  // paint gate sits between them too — a hidden pane applies state and skips the paint, and this
+  // styling is paint-side (a copy for the cards), so it rightly waits with the paint; see paint-gate.ts.)
+  const head = FEED.slice(FEED.indexOf("function render() {"));
+  const gateEnd = head.indexOf("applyFollowMove(asks);");
+  assert.ok(gateEnd > 0, "applyFollowMove(asks) follows the list lookup");
+  const between = head.slice(0, gateEnd);
+  assert.ok(between.split("\n").length <= 16, "only the paint gate, its observer install and pruneTip may sit before it");
+  assert.match(between, /paintHeld\(document\.hidden, feedIntersecting, list\.childElementCount > 0\)/, "the gate");
+  assert.match(between, /pruneTip\(\);[^\n]*\n\s*$/, "pruneTip immediately precedes it");
   // the removed drag machinery must not creep back in front of it
   assert.doesNotMatch(FEED, /dragAskId|DRAG_CARDS_ENABLED|fdrop-slot/);
   assert.doesNotMatch(FEED, /"cardMove"/, "the messageless move op is gone from the feed");

--- a/ui/webview/feed-hidden-paint.test.ts
+++ b/ui/webview/feed-hidden-paint.test.ts
@@ -1,0 +1,177 @@
+// The feed applies every payload while the tab is hidden but paints none of them (the user 2026-09-07,
+// whose dashboard froze on the return to its browser tab): each hidden render was a full paint — the FLIP
+// pass's two forced layouts and a double rAF per moved card all piled onto the return frame. Now render()
+// is owed while nobody can see the pane and settled ONCE, synchronously, on the event that shows it, with
+// the flip skipped (cards that moved while away snap into place: motion without new information, the
+// 2026-07-29 rule). State keeps flowing: the follow-move backstop must find its prediction already
+// confirmed by a payload applied hidden, or it would revert a move the kernel had confirmed.
+//
+// feed.ts has import-time DOM side effects (the repo convention: no test imports it), so this has two
+// halves — the harness below runs the PINNED lines against the pure modules they call (paint-gate.ts,
+// feed-flip.ts), and the source pins hold feed.ts to exactly that wiring.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { paintHeld, paintReleased } from "./paint-gate";
+import { flipNeeded } from "./feed-flip";
+
+type Ask = { itemId: string; column: string };
+type Payload = { asks: Ask[] };
+
+// The harness: feed.ts's render() gate, flip decision, release path and the follow-move backstop, line for
+// line (the pins below are what keep this honest), over a list whose "content" is its painted cards.
+function feedHarness() {
+  const st = {
+    hidden: false, intersecting: true,
+    asks: [] as Ask[], painted: 0,                     // painted = list.childElementCount after the last paint
+    pendingFollowMove: new Map<string, true>(),
+    paintDirty: false, skipFlipOnce: false,
+    prevCols: new Map<string, string>(),
+    paints: 0, flipChecks: 0, lastNeedFlip: null as boolean | null,
+  };
+  const columnsOf = (asks: Ask[]) => new Map(asks.map((a, i) => ["a:" + a.itemId, a.column + ":" + i] as const));
+  const flipNeededSpy = (a: Map<string, string>, b: Map<string, string>) => { st.flipChecks++; return flipNeeded(a, b); };
+  function render() {
+    if (paintHeld(st.hidden, st.intersecting, st.painted > 0)) { st.paintDirty = true; return; }
+    const nextCols = columnsOf(st.asks);
+    const needFlip = !st.skipFlipOnce && flipNeededSpy(st.prevCols, nextCols);
+    st.skipFlipOnce = false;
+    st.prevCols = nextCols;
+    st.lastNeedFlip = needFlip;
+    st.paints++; st.painted = st.asks.length;
+  }
+  // applyFeedPayload: model swap + reconcileFollowMove (a prediction the kernel now lists as working is
+  // confirmed → dropped) + render(); nothing here looks at the visibility
+  function applyFeedPayload(m: Payload) {
+    st.asks = m.asks;
+    for (const id of Array.from(st.pendingFollowMove.keys())) {
+      const a = m.asks.find((x) => x.itemId === id);
+      if (!a || a.column === "working") st.pendingFollowMove.delete(id);
+    }
+    render();
+  }
+  // ackFollowMove's backstop timer body
+  function backstop(itemId: string): "kept" | "reverted" {
+    if (!st.pendingFollowMove.has(itemId)) return "kept";
+    st.pendingFollowMove.delete(itemId); render(); return "reverted";
+  }
+  function releasePaint() {
+    if (!paintReleased(st.paintDirty, st.hidden, st.intersecting)) return;
+    st.paintDirty = false;
+    st.skipFlipOnce = true;
+    render();
+  }
+  return { st, render, applyFeedPayload, backstop, releasePaint, columnsOf };
+}
+
+test("hidden → ten payloads → zero paints, while the asks model and the follow-move bookkeeping keep updating", () => {
+  const f = feedHarness();
+  f.applyFeedPayload({ asks: [{ itemId: "g1", column: "asks" }, { itemId: "g2", column: "needsInput" }] });   // first content, visible
+  assert.equal(f.st.paints, 1);
+  f.st.pendingFollowMove.set("g2", true);          // the user replied to g2: predicted into Working
+  f.st.hidden = true;                              // the tab goes to the background
+  for (let i = 0; i < 10; i++) {
+    f.applyFeedPayload({ asks: [{ itemId: "g1", column: "asks" }, { itemId: "g2", column: i >= 3 ? "working" : "needsInput" }, { itemId: "g" + (10 + i), column: "asks" }] });
+  }
+  assert.equal(f.st.paints, 1, "no paint while hidden");
+  assert.equal(f.st.paintDirty, true, "a paint is owed");
+  assert.equal(f.st.asks.length, 3, "the model is the newest payload's");
+  assert.equal(f.st.asks[2].itemId, "g19");
+  assert.equal(f.st.pendingFollowMove.size, 0, "the confirming payload (g2 working) retired the prediction while hidden");
+});
+
+test("the follow-move backstop that fires after a confirming payload was applied hidden does not revert", () => {
+  const f = feedHarness();
+  f.applyFeedPayload({ asks: [{ itemId: "g2", column: "needsInput" }] });
+  f.st.pendingFollowMove.set("g2", true);
+  f.st.hidden = true;
+  f.applyFeedPayload({ asks: [{ itemId: "g2", column: "working" }] });   // the kernel confirms while the tab is hidden
+  assert.equal(f.backstop("g2"), "kept", "MOVE_ACK_MS elapses: the prediction is already confirmed, nothing to revert");
+  assert.equal(f.st.paints, 1, "and the backstop's render() is held like any other");
+});
+
+test("release → exactly one synchronous paint, the flip decision skipped, prevCols = the painted columns", () => {
+  const f = feedHarness();
+  f.applyFeedPayload({ asks: [{ itemId: "g1", column: "asks" }, { itemId: "g2", column: "needsInput" }] });
+  f.st.hidden = true;
+  f.applyFeedPayload({ asks: [{ itemId: "g2", column: "completed" }, { itemId: "g1", column: "working" }] });   // both moved while away
+  f.applyFeedPayload({ asks: [{ itemId: "g2", column: "completed" }, { itemId: "g1", column: "working" }, { itemId: "g3", column: "asks" }] });
+  const checksBefore = f.st.flipChecks;
+  f.st.hidden = false; f.releasePaint();           // visibilitychange → visible
+  assert.equal(f.st.paints, 2, "one paint for the whole hidden stretch");
+  assert.equal(f.st.lastNeedFlip, false, "cards snap into place");
+  assert.equal(f.st.flipChecks, checksBefore, "flipNeeded was not even consulted");
+  assert.deepEqual(f.st.prevCols, f.columnsOf(f.st.asks), "the flip baseline is what was painted");
+  assert.equal(f.st.paintDirty, false);
+  f.releasePaint();                                // a second release event (the observer's callback) owes nothing
+  assert.equal(f.st.paints, 2);
+  // the NEXT move, seen live, glides again: the skip was one-shot
+  f.applyFeedPayload({ asks: [{ itemId: "g1", column: "working" }, { itemId: "g2", column: "completed" }, { itemId: "g3", column: "completed" }] });
+  assert.equal(f.st.paints, 3);
+  assert.equal(f.st.lastNeedFlip, true);
+});
+
+test("a display:none pane holds too, and the tab's return alone does not release it — the observer does", () => {
+  const f = feedHarness();
+  f.applyFeedPayload({ asks: [{ itemId: "g1", column: "asks" }] });
+  f.st.intersecting = false; f.st.hidden = true;
+  f.applyFeedPayload({ asks: [{ itemId: "g1", column: "working" }] });
+  f.st.hidden = false; f.releasePaint();
+  assert.equal(f.st.paints, 1, "tab back, pane still display:none");
+  f.st.intersecting = true; f.releasePaint();
+  assert.equal(f.st.paints, 2);
+});
+
+// ── source pins: feed.ts wires exactly the lines the harness ran ──
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const body = (name: string) => new RegExp("^function " + name + "\\([\\s\\S]*?\\n\\}", "m").exec(SRC)![0];
+
+test("render() is gated first, on the shared pure decision, and nothing else in feed.ts is", () => {
+  assert.match(SRC, /import \{ paintHeld, paintReleased \} from "\.\/paint-gate";/);
+  assert.match(SRC, /function render\(\) \{\n  const list = document\.getElementById\("feed-list"\)!;\n  if \(!feedWatching\) \{ feedWatching = true; watchFeedVisibility\(list\); \}\n  if \(paintHeld\(document\.hidden, feedIntersecting, list\.childElementCount > 0\)\) \{ paintDirty = true; return; \}\n  pruneTip\(\);/,
+    "the gate precedes every paint-side step (pruneTip, applyFollowMove, the footer, the columns)");
+  assert.equal(SRC.split("paintHeld(").length - 1, 1, "one gate, in render(): no other path is withheld");
+  assert.match(SRC, /let feedIntersecting = true;/, "visible until the observer says otherwise: no observer → the tab alone gates");
+});
+
+test("the flip is skipped exactly once after a release, and prevCols still records what was painted", () => {
+  assert.match(SRC, /const needFlip = !skipFlipOnce && flipNeeded\(prevCols, nextCols\);\n\s*skipFlipOnce = false;\n\s*prevCols = nextCols;/);
+  assert.match(SRC, /askEls\.clear\(\); groupEls\.clear\(\);\n\s*skipFlipOnce = false;/, "the empty-board paint spends the snap too");
+  const rel = body("releasePaint");
+  assert.match(rel, /if \(!paintReleased\(paintDirty, document\.hidden, feedIntersecting\)\) return;\n\s*paintDirty = false;\n\s*skipFlipOnce = true;\n\s*render\(\);/);
+  assert.doesNotMatch(rel, /requestAnimationFrame|setTimeout|queueMicrotask/, "the release paints synchronously: the earliest fresh frame after the compositor's cached one");
+});
+
+test("BOTH release events run the same release: visibilitychange→visible and the observer's callback", () => {
+  assert.match(SRC, /document\.addEventListener\("visibilitychange", \(\) => \{ if \(!document\.hidden\) releasePaint\(\); \}\);/);
+  const watch = body("watchFeedVisibility");
+  assert.match(watch, /new IntersectionObserver\(\(entries\) => \{\n\s*feedIntersecting = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*releasePaint\(\);\n\s*\}\)\.observe\(list\);/);
+  assert.match(watch, /if \(typeof IntersectionObserver === "undefined"\) return;/);
+});
+
+test("state is applied whatever the visibility: the payload path and its bookkeeping never look at the gate", () => {
+  const apply = body("applyFeedPayload");
+  assert.doesNotMatch(apply, /document\.hidden|paintDirty|feedIntersecting|paintHeld/);
+  for (const must of ["reconcileFollowMove(", "mirrorBadges(", "clearUndoBusy();", "pendingCleared", "pendingRestored", "reconcilePendingDone("]) {
+    assert.ok(apply.includes(must), "applyFeedPayload still runs " + must);
+  }
+  assert.equal((apply.match(/\brender\(\);/g) || []).length, 1, "ONE gated render");
+  assert.match(apply, /\n  render\(\);\n  if \(!feedAnnounced\) \{/, "…followed only by the shell's first-content announcement");
+  // the message handler applies live unless a card is hovered/keyed — the hover-freeze holder is not
+  // widened into a hidden holder (it withholds the payload itself, which the backstop test above forbids)
+  assert.match(SRC, /if \(m\.type === "feed"\) \{[\s\S]*?if \(freezeKey \|\| tabScopeKey\) \{ pendingFeedPayload = m; paintFreezeBadges\(\); return; \}\n\s*applyFeedPayload\(m\);/);
+  assert.doesNotMatch(SRC, /freezeKey \|\| tabScopeKey \|\| document\.hidden|document\.hidden \|\| freezeKey/);
+});
+
+test("the follow-move backstop yields to a prediction a payload already retired; the payload retires it on `working`", () => {
+  const ack = body("ackFollowMove");
+  const guard = ack.indexOf('if (!pendingFollowMove.has(itemId)) return;\n    clearFollowMove(itemId, "backstop-noconfirm"); render();');
+  assert.ok(guard > 0, "the backstop checks the prediction still stands before it reverts");
+  assert.match(body("reconcileFollowMove"), /if \(!a \|\| a\.column === "working" \|\| pendingMoveKind\.get\(id\) === "answer"\) \{\n\s*clearFollowMove\(/);
+});
+
+test("a bell jump settles the owed paint on the shell's word before it looks for the card", () => {
+  // the shell shows the pane and posts revealCard in the same task, before the observer re-measures
+  assert.match(SRC, /if \(m\.romp === "revealCard"\) \{[\s\S]*?if \(paintDirty\) \{ feedIntersecting = true; releasePaint\(\); \}\n\s*const key = "a:" \+ String\(m\.itemId \|\| ""\);/);
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -8,6 +8,7 @@
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending, distillStaleNote } from "./distiller-line";
 import { flipNeeded } from "./feed-flip";
+import { paintHeld, paintReleased } from "./paint-gate";
 import { spinFor, waitedSuffix, awaitWord, groupRows, GROUP_TITLE, ROW_KIND_OF_LEGACY, type AwaitRow } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
@@ -4512,8 +4513,42 @@ function ensureHostLoad(list: HTMLElement): void {
   }));
 }
 
+// ── HIDDEN-PAINT HOLD (the user 2026-09-07, whose dashboard froze on the return to its browser tab) ──
+// Every payload is APPLIED the moment it arrives — applyFeedPayload's bookkeeping (mirrorBadges feeds the
+// shell's bell, clearUndoBusy, pendingCleared/pendingRestored, reconcileFollowMove and the follow-move
+// backstops it retires) never waits — but the PAINT is owed while nobody can see it, and settled once,
+// synchronously, on the event that makes the pane visible again: the tab's visibilitychange, or the
+// observer's callback for a display:none pane (each is blind to the other's case; paint-gate.ts). Before
+// this, a hidden tab rendered every payload in full — the FLIP pass pinned two forced layouts and a
+// double rAF per moved card onto the return frame — and the hidden-tab pile-up was the freeze. NOT the
+// hover-freeze queue below: that holder withholds the payload itself, and a confirming payload held back
+// lets the follow-move backstop revert a move the kernel had already confirmed.
+let feedIntersecting = true;   // #feed-list on screen by the observer's measure; true where there is no observer
+let paintDirty = false;        // a render was withheld while the pane could not be seen
+let skipFlipOnce = false;      // the release paint snaps: cards that moved while away have no old spot to glide from
+let feedWatching = false;
+function watchFeedVisibility(list: HTMLElement): void {
+  if (typeof IntersectionObserver === "undefined") return;   // no observer → the tab's visibility alone gates
+  new IntersectionObserver((entries) => {
+    feedIntersecting = entries.some((e) => e.isIntersecting);
+    releasePaint();
+  }).observe(list);
+}
+// The owed paint, settled the moment both measures say the pane can be seen. Synchronous on purpose (no
+// requestAnimationFrame hop): on a tab switch the compositor shows the cached frame until the page paints,
+// so a paint inside the event handler is the earliest fresh frame.
+function releasePaint(): void {
+  if (!paintReleased(paintDirty, document.hidden, feedIntersecting)) return;
+  paintDirty = false;
+  skipFlipOnce = true;
+  render();
+}
+document.addEventListener("visibilitychange", () => { if (!document.hidden) releasePaint(); });
+
 function render() {
   const list = document.getElementById("feed-list")!;
+  if (!feedWatching) { feedWatching = true; watchFeedVisibility(list); }
+  if (paintHeld(document.hidden, feedIntersecting, list.childElementCount > 0)) { paintDirty = true; return; }
   pruneTip();   // drop the styled tip only if the render tore its hovered anchor out (tip.ts pruneTip)
   applyFollowMove(asks);   // keep optimistically-moved follow-up cards in Working until the kernel confirms (or reverts)
   paintJudgeLimit();   // the usage-limit banner above the columns (build-once; hidden when unlatched)
@@ -4535,6 +4570,7 @@ function render() {
     //                     wordmark never rendered (the user 2026-07-08; payload-audit fallout). Goal cards are
     //                     the only feed unit now, so an empty asks list IS an empty feed.
     askEls.clear(); groupEls.clear();
+    skipFlipOnce = false;   // this IS the release paint when the board emptied while away — the snap is spent
     // inbox zero → the romp wordmark (a CSS background). role/aria-label + title keep the meaning for hover /
     // screen readers, since a background image carries no accessible text. Created ONCE (idempotent): on the
     // transition from cards→empty we mint it (its CSS fade-in plays once, the user 2026-06-25), and every
@@ -4625,7 +4661,12 @@ function render() {
   // something CAN move: the capture and the fly each force a layout of the whole document, and most frames
   // change a card in place (text, tint, status chip) with every card staying where it was (2026-09-04).
   const nextCols = columnsOf(buckets);
-  const needFlip = flipNeeded(prevCols, nextCols);
+  // The release paint after a hidden stretch SNAPS (skipFlipOnce, 2026-09-07): a card that moved while nobody
+  // watched has no old spot in the user's eye to glide from — motion on return is motion without new
+  // information (the 2026-07-29 rule) — and the two forced layouts plus a double rAF per moved card are what
+  // the return frame cannot afford. prevCols still records the painted columns, so the NEXT move glides.
+  const needFlip = !skipFlipOnce && flipNeeded(prevCols, nextCols);
+  skipFlipOnce = false;
   prevCols = nextCols;
   const flipFirst = needFlip ? captureCardRects(cols) : new Map<string, FlipState>();
 
@@ -5229,6 +5270,11 @@ window.addEventListener("message", (e: MessageEvent) => {
     // FOLDED thread has no element yet — unfold first (the same rule revealCards follows: the navigation wins
     // over the disclosure). A card that no longer exists under its own key (cleared, or folded into a group)
     // falls back to opening the session.
+    // The shell shows this pane and posts the jump in the SAME task, before the observer has re-measured
+    // the list (its callback waits for a rendering step): a paint owed from a hidden stretch is settled
+    // here on the shell's word, or a card added while away is not there to find (2026-09-07). The
+    // observer's next callback re-measures, so a wrong word costs one unseen paint, never a stale pane.
+    if (paintDirty) { feedIntersecting = true; releasePaint(); }
     const key = "a:" + String(m.itemId || "");
     unfoldThreadsFor(new Set([key]));
     // Match the key STRUCTURALLY, never an interpolated attribute selector: a crafted push-card value

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -5,6 +5,7 @@
 // bottom "Show completed" checkbox (default off). The recency colour helpers are copied verbatim from render.ts
 // so the colours are IDENTICAL to the ledger box.
 import { delegate, flash } from "./actions";
+import { paintHeld, paintReleased } from "./paint-gate";
 import { applyTheme } from "./theme";
 import { loadSettings, installSettingsSync, onExternalSettingsChange } from "./settings";
 import { SessionViews, viewTagUnion } from "./session-views";
@@ -390,15 +391,28 @@ function hostLoadStrip(): HTMLElement {
 // The pane is hidden by default in the dashboard shell (a display:none iframe) yet it received every feed
 // push and rebuilt its whole list for nobody, on the main thread every pane shares (2026-09-04). While the
 // list is not on screen the payload is kept and the rebuild deferred to the moment it comes into view.
+// TWO measures of "not on screen" (the user 2026-09-07, whose dashboard froze on the return to its tab):
+// the observer sees a display:none pane but never fires while the TAB is hidden — so an on-screen pane in
+// a background tab kept rebuilding on every push, and nothing fired on the return — and document.hidden
+// sees the tab but never a display:none pane. Both gate, both events release, and the payload (sessions,
+// asksById, the pending hosts) is applied either way; only the rebuild waits (paint-gate.ts).
 let paneVisible = true;
 let paneDirty = false;
 function watchPaneVisibility(list: HTMLElement): void {
-  if (typeof IntersectionObserver === "undefined") return;   // no observer → always render, as before
+  if (typeof IntersectionObserver === "undefined") return;   // no observer → the tab's visibility alone gates
   new IntersectionObserver((entries) => {
     paneVisible = entries.some((e) => e.isIntersecting);
-    if (paneVisible && paneDirty) { paneDirty = false; render(); }
+    releasePaint();
   }).observe(list);
 }
+// Synchronous on purpose: a paint inside the event handler is the earliest fresh frame after the
+// compositor's cached one; a requestAnimationFrame hop is later at best and never fires in a hidden frame.
+function releasePaint(): void {
+  if (!paintReleased(paneDirty, document.hidden, paneVisible)) return;
+  paneDirty = false;
+  render();
+}
+document.addEventListener("visibilitychange", () => { if (!document.hidden) releasePaint(); });
 let paneWatching = false;
 function render() {
   syncFleetTagBtn?.();
@@ -408,7 +422,7 @@ function render() {
   // Nobody can see it: paint when it is shown — except the FIRST content, which paints through so the reveal
   // shows the list at once rather than the pane loader fading out over an empty pane (an empty list IS the
   // loader-up state; one hidden render buys an instant reveal).
-  if (!paneVisible && list.childElementCount > 0) { paneDirty = true; return; }
+  if (paintHeld(document.hidden, paneVisible, list.childElementCount > 0)) { paneDirty = true; return; }
   list.replaceChildren();
   // BEFORE the first payload: leave the list EMPTY so the page's romp loader (_pane_spin over #fleet-list)
   // stays up — no child means it never hides — instead of flashing a false "no work" message (the user

--- a/ui/webview/outline-visibility.test.ts
+++ b/ui/webview/outline-visibility.test.ts
@@ -3,17 +3,48 @@
 // pane's clicks share. The first content still paints through while hidden, so revealing the pane shows
 // the list at once instead of the pane loader fading over nothing. Pinned at the source, like the other
 // pane-wiring tests.
+//
+// 2026-09-07 (the user, whose dashboard froze on the return to its browser tab): the observer-only gate
+// kept rebuilding an ON-SCREEN pane in a HIDDEN tab — the observer sees the pane, not the tab — and its
+// callback never fires on the return (nothing intersected differently), so nothing released. The gate
+// now reads both measures through the shared pure decision (paint-gate.ts), and visibilitychange releases
+// alongside the observer.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { paintHeld } from "./paint-gate";
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "fleet.ts"), "utf8");
+const body = (name: string) => new RegExp("^function " + name + "\\([\\s\\S]*?\\n\\}", "m").exec(SRC)![0];
 
 test("render() defers while the list is off screen, lets the first content through, and paints once when shown", () => {
+  assert.match(SRC, /import \{ paintHeld, paintReleased \} from "\.\/paint-gate";/);
   assert.match(SRC, /function render\(\) \{[\s\S]*?if \(!paneWatching\) \{ paneWatching = true; watchPaneVisibility\(list\); \}/);
-  assert.match(SRC, /if \(!paneVisible && list\.childElementCount > 0\) \{ paneDirty = true; return; \}/);
-  assert.match(SRC, /new IntersectionObserver\(\(entries\) => \{\n\s*paneVisible = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*if \(paneVisible && paneDirty\) \{ paneDirty = false; render\(\); \}/);
-  assert.match(SRC, /if \(typeof IntersectionObserver === "undefined"\) return;/, "no observer → always render, as before");
+  assert.match(SRC, /if \(paintHeld\(document\.hidden, paneVisible, list\.childElementCount > 0\)\) \{ paneDirty = true; return; \}/);
+  assert.match(SRC, /if \(typeof IntersectionObserver === "undefined"\) return;/, "no observer → the tab's visibility alone gates");
   assert.match(SRC, /let paneVisible = true;/, "visible until told otherwise: the first paint is never withheld");
+});
+
+test("the gate includes the TAB's visibility: an on-screen pane in a hidden tab holds (the observer-only gate did not)", () => {
+  // the pure decision fleet.ts now calls, with the pane on screen by the observer's measure
+  assert.equal(paintHeld(true, true, true), true, "hidden tab → held");
+  assert.equal(!true && true, false, "the old gate (`!paneVisible && content`) let this case through");
+  assert.equal(paintHeld(true, true, false), false, "…but the first content still paints through");
+  assert.equal(paintHeld(false, true, true), false);
+});
+
+test("BOTH release events run the same synchronous release: the observer's callback and visibilitychange→visible", () => {
+  assert.match(body("watchPaneVisibility"), /new IntersectionObserver\(\(entries\) => \{\n\s*paneVisible = entries\.some\(\(e\) => e\.isIntersecting\);\n\s*releasePaint\(\);\n\s*\}\)\.observe\(list\);/);
+  const rel = body("releasePaint");
+  assert.match(rel, /if \(!paintReleased\(paneDirty, document\.hidden, paneVisible\)\) return;\n\s*paneDirty = false;\n\s*render\(\);/);
+  assert.doesNotMatch(rel, /requestAnimationFrame|setTimeout|queueMicrotask/, "synchronous: the earliest fresh frame after the compositor's cached one");
+  assert.match(SRC, /document\.addEventListener\("visibilitychange", \(\) => \{ if \(!document\.hidden\) releasePaint\(\); \}\);/);
+});
+
+test("the payload is applied whatever the visibility — only the rebuild waits", () => {
+  // the message handler swaps the model before render() decides whether to paint; no visibility check on the way
+  const handler = /window\.addEventListener\("message", \(e: MessageEvent\) => \{[\s\S]*?\n\}\);/.exec(SRC)![0];
+  assert.match(handler, /loaded = true;\n\s*sessions = m\.ledgers as FleetSession\[\];/);
+  assert.doesNotMatch(handler, /document\.hidden|paneVisible|paneDirty|paintHeld/);
 });

--- a/ui/webview/paint-gate.test.ts
+++ b/ui/webview/paint-gate.test.ts
@@ -1,0 +1,48 @@
+// The shared paint gate (the user 2026-09-07, whose dashboard froze on the return to its browser tab):
+// a pane applies every frame but paints only when it can be seen. Pure, so the truth table and the release
+// ordering run executably; feed-hidden-paint.test.ts and outline-visibility.test.ts pin the wiring.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { paintHeld, paintReleased } from "./paint-gate";
+
+test("the first content always paints through, whatever the visibility (the pane loader retires on it)", () => {
+  assert.equal(paintHeld(true, true, false), false, "hidden tab, empty list");
+  assert.equal(paintHeld(false, false, false), false, "display:none pane, empty list");
+  assert.equal(paintHeld(true, false, false), false, "both");
+});
+
+test("with content on screen, EITHER measure holds the paint: a hidden tab, or a pane the observer cannot see", () => {
+  assert.equal(paintHeld(false, true, true), false, "visible tab, intersecting pane → paint");
+  assert.equal(paintHeld(true, true, true), true, "hidden tab with an on-screen pane — the case the observer-only gate missed");
+  assert.equal(paintHeld(false, false, true), true, "display:none pane in a visible tab — the case document.hidden misses");
+  assert.equal(paintHeld(true, false, true), true);
+});
+
+test("a release settles a paint only when one is owed AND both measures agree the pane can be seen", () => {
+  assert.equal(paintReleased(false, false, true), false, "nothing owed → no paint (a visibilitychange with nothing pending)");
+  assert.equal(paintReleased(true, false, true), true);
+  assert.equal(paintReleased(true, true, true), false, "still hidden (an observer callback inside a hidden tab)");
+  assert.equal(paintReleased(true, false, false), false, "tab back, pane still display:none → the observer's callback releases later");
+});
+
+test("release ordering: whichever measure clears LAST releases exactly once, in either order", () => {
+  // tab hidden AND the pane display:none, a paint owed; the tab returns first, then the pane is shown
+  let dirty = true;
+  let paints = 0;
+  const release = (docHidden: boolean, intersecting: boolean) => {
+    if (!paintReleased(dirty, docHidden, intersecting)) return;
+    dirty = false; paints++;
+  };
+  release(false, false);   // visibilitychange → visible, pane still hidden
+  assert.equal(paints, 0);
+  release(false, true);    // the observer: intersecting
+  assert.equal(paints, 1);
+  release(false, true);    // a second observer callback (a resize) — nothing owed any more
+  assert.equal(paints, 1);
+  // the other order: pane shown while the tab is hidden (a shell toggle from another script), then the tab returns
+  dirty = true; paints = 0;
+  release(true, true);
+  assert.equal(paints, 0);
+  release(false, true);
+  assert.equal(paints, 1);
+});

--- a/ui/webview/paint-gate.ts
+++ b/ui/webview/paint-gate.ts
@@ -1,0 +1,27 @@
+// Paint only when the pane can be seen (the user 2026-09-07, whose dashboard froze for seconds on the
+// return to its browser tab). Every pane APPLIES every frame it receives the moment it arrives — the model,
+// the badge mirror, the follow-move reconciliation — but the PAINT (the feed's render(), the board pane's
+// rebuild) is owed, not done, while nobody can see it: the tab is hidden, or the pane sits in a
+// display:none iframe. Two measures, because each is blind to the other's case: `document.hidden` is per
+// TAB and never reports a display:none pane; an IntersectionObserver reports the pane but never fires
+// while the tab is hidden, and not on the return either (nothing intersected differently). So both events
+// release — visibilitychange→visible and the observer's callback — and this is the decision they share.
+// Pure and DOM-free so node --test executes it; feed.ts and fleet.ts pass their own measures in.
+//
+// The FIRST content always paints through: an empty list is the pane loader's "still loading" state (the
+// loader retires on the list's first child — kernel _pane_spin's MutationObserver), so withholding it would
+// reveal a pane with the loader fading over nothing (the 2026-09-04 board-pane bug, now the shared rule).
+export function paintHeld(docHidden: boolean, intersecting: boolean, hasContent: boolean): boolean {
+  if (!hasContent) return false;
+  return docHidden || !intersecting;
+}
+
+// The release events' shared decision: a paint is owed (dirty) AND both measures now say the pane can be
+// seen. visibilitychange→visible on a pane that is still display:none waits for the observer; an observer
+// callback inside a hidden tab (a resize while away) waits for the tab. The caller paints SYNCHRONOUSLY on
+// a true: on a tab switch the compositor shows the cached frame until the page paints, so a paint inside
+// the event handler is the earliest fresh frame — a requestAnimationFrame hop would be one frame later at
+// best, and held indefinitely in a display:none frame.
+export function paintReleased(dirty: boolean, docHidden: boolean, intersecting: boolean): boolean {
+  return dirty && !paintHeld(docHidden, intersecting, true);
+}

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -76,6 +76,11 @@ class Harness {
       MessageEvent: class { type: string; data: any; constructor(t: string, o: any) { this.type = t; this.data = o.data; } },
       setTimeout: (f: () => void) => { h.timers.push(f); return h.timers.length; },
       clearTimeout: () => {}, setInterval: (f: () => void) => { h.interval = f; return 1; },
+      // 2026-09-07: the shim hands frames to the bundle through a MessageChannel-flushed queue. Delivered
+      // synchronously here, so `toBundle` reads in wire order exactly as before; the slicing has its own tests
+      // (tests/test_pane_shim_return.py). `performance` backs the page-load breadcrumb's navigation type.
+      MessageChannel: class { port1: any = { onmessage: null }; port2: any; constructor() { const p1 = this.port1; this.port2 = { postMessage: (d: any) => { p1.onmessage?.({ data: d }); } }; } },
+      performance: { getEntriesByType: () => [] },
     };
     sandbox.window.window = sandbox.window;
     this.win = sandbox.window;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4604,6 +4604,19 @@ function scheduleRenderTabs(): void {
   tabsRaf = requestAnimationFrame(() => { tabsRaf = null; renderTabs(); });
 }
 
+// The same coalescing for the ACTIVE tab's incremental repaint (2026-09-07, measured on the thaw of a 45 s
+// freeze: the queued tails for the watched session replayed as one task of 796 ms — each tail an appendActive
+// with a forced layout, repainting the same suffix again and again). Tails still APPLY at once (events pushed,
+// `rendered` lowered to the earliest changed point, the ledger stored); the paint runs once per animation
+// frame from that lowest point, and carries the ledger with it. A frame is also the right clock for a hidden
+// tab: the browser holds it, so a background tab applies state and paints once on return. The full-session
+// paths (upsert, chatHead, the rewind overlay) keep their synchronous appendActive — they are one frame each.
+let appendRaf: number | null = null;
+function scheduleAppendActive(): void {
+  if (appendRaf != null) return;
+  appendRaf = requestAnimationFrame(() => { appendRaf = null; appendActive(); renderLedger(); });
+}
+
 function renderTabs() {
   if (renameActive) { renderPendingAfterRename = true; return; }
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
@@ -12546,8 +12559,7 @@ function chatTail(msg: any) {
       v.rendered = Math.min(v.rendered, from);        // repaint from the exact changed point (catches a tool fill)
       if (shrank) v.stale = true;                     // …but a pure truncation needs the window rebuilt, see above
     }
-    appendActive();
-    renderLedger();
+    scheduleAppendActive();   // one paint per animation frame however many tails land (2026-09-07); the ledger rides it
     // THIS is the frame that flips the chip (T225): a status-only change reaches a caught-up client as a
     // chatTail with an empty suffix and the full status — awaitingWhy/Kind/Count/Tasks included. The box
     // rendered only from the full-session path, so the chip read "Awaiting agents" with no box until a

--- a/vscode-extension/src/timeline-barsloader.test.ts
+++ b/vscode-extension/src/timeline-barsloader.test.ts
@@ -17,7 +17,9 @@ test("the bars-loaded gate starts false and flips true when applyBars lands real
 });
 
 test("a full one-shot data object through update() also marks the bars loaded (test harness / older clients)", () => {
-  assert.match(SRC, /if \(data\.turns && Object\.keys\(data\.turns\)\.length\) this\._barsLoaded = true;/);
+  // 2026-09-07: the verdict is named (`ownBars`) because update() also uses it to decide whether a bars frame
+  // parked ahead of its skeleton is older than this full object (timeline-hidden-hold.test.ts)
+  assert.match(SRC, /const ownBars = !!\(data\.turns && Object\.keys\(data\.turns\)\.length\);\s*\n\s*if \(ownBars\) this\._barsLoaded = true;/);
 });
 
 test("draw() shows ONLY the loader and returns early until bars are ready (no lanes, no gridlines)", () => {


### PR DESCRIPTION
Follows #934 (the chat tab-click lag fixes, merged 2026-09-07), which this change was developed on top of and rebased onto current main; the same render paths are involved.

## What

Switching back to the dashboard's browser tab after it sat in the background froze the page. Each pane iframe holds its own socket to the kernel, and the pane shim judged that socket by the age of its last received frame. A tab Chrome had frozen ran no script, so on return every pane found a "stale" socket, abandoned it, redialed, and the kernel re-sent the whole state to all four panes at once: about 15 MB on a seventeen-session board, each frame parsed and painted on the one main thread the same-origin panes share. A shorter absence replayed its queued frames instead, one full paint per frame.

- **Honest silence (kernel.py `_shim`).** The Page Lifecycle `resume` event, which Chromium fires before `visibilitychange` on a thaw, stamps the last-received clock on an OPEN socket, so a paused renderer is no longer read as a dead link. A socket the kernel really dropped closes in the same burst; the first close after a foreground redials **now** (a second one inside the window waits 250 ms so a kernel that is down is not hammered), instead of the blind 1.5 s. `federation.ts` stamps its remote sockets the same way. Browsers without `resume` keep today's behaviour.
- **One ordered queue per socket, sliced.** Frames are handed to the bundle through a FIFO flushed from a `MessageChannel` task in ~8 ms slices: a newer whole-state frame (`feed`/`bars`/`data`/`tabOrder`/`working`/`globalRetryPaused`) replaces its older queued twin, chained frames keep wire order, `applyDelta`/`needSlot` stay synchronous, and a click can land between slices. Measured: the first cut delivered 25 queued chat tails in one 796 ms task; sliced, the longest task is 96 ms.
- **Apply state always, paint when visible.** New pure `ui/webview/paint-gate.ts`. The feed and board panes apply every payload while hidden and paint once on `visibilitychange`/intersection, with cards that moved while away snapping (no FLIP replay: 788 held frames in 45 s, 31,044 in ten minutes, are gone). The timeline parks bars that outrun their skeleton, holds its draw while hidden, and its live tick stops instead of polling a layout every 2 s. The chat's active tab paints once per animation frame however many tails a burst lands.
- **An honest cue and a breadcrumb.** The pane's corner badge now waits for the first fresh frame (`romp:wsfresh`), not the socket opening, so a real resync over a tunnel never looks like a frozen dashboard. Each return files a `clientDiag` row naming the browser state it found (`page-load` with `wasDiscarded`, `return` with `decision keep|redial-closed|redial-stale`, `frozenMs`, `quietAtResumeMs`, and `return-fresh` with the wait), re-filed onto the redial when the kept socket turns out to have been dead, so the regime a user actually hits can be read from `client-diag.jsonl`.

## Measured

Offline replay of a seventeen-session board in headless Chromium, hidden/frozen tabs emulated in-page (Chrome's own freeze cannot be driven headless), medians of three runs per row, same harness before and after:

| regime | redials | MB after the switch | busy ms, first 2 s | longest task ms | time to current state |
|---|---|---|---|---|---|
| frozen 45 s, socket alive | 4 → 0 | 17 → 2 | 532 → 354 | 135 → 96 | 1231 → 475 ms |
| frozen 45 s at 6× cadence | 4 → 0 | 28 → 13 | 427 → 452 | 214 → 300 | 2195 → 585 ms |
| hidden 45 s | 0 → 0 | 0 | 58 → 51 | 83 → 74 | paints while hidden 14–15 → 0 |
| hidden 10 min | 0 → 0 | 5 → 5 | 168 → 124 | 123 → 105 | paints while hidden 127–192 → 0 |
| socket already dropped by the kernel | 4 → 4 | 15 → 15 | 483 → 424 | 118 → 135 | new socket in 72–98 ms (was 114–215); current state 1.3–1.4 s (was 1.1–1.2 s: the panes' deferred paints now land ahead of the resync) |

The dropped-socket row is the next change's subject (an active-tab-only reconnect push with skeleton tabs); this PR makes it no worse and instruments it.

## Review

A design critique (three critics, a defender, a synthesizer) reshaped the first proposal before any code: the `hello` probe was dropped for the `resume` stamp, per-slot deferral became one ordered FIFO, coalescing moved off `requestAnimationFrame` (held while hidden) onto `MessageChannel`, and the harness was rebuilt after its chat numbers were shown to be a refusal loop of its own making. Two adversarial passes with a refuter per finding on the implementation, plus a skeptic pass on the two late refinements: one finding survived (the keep-decision breadcrumb written into an already-dead socket), fixed and pinned.

## Tier

- [ ] tests-only
- [x] fix — a bug fix with tests that fail before it (the shim's return-to-tab and reconnect behaviour).
- [ ] feature
- [ ] major-feature

## Tests

`tests/test_pane_shim_return.py` (36 tests) runs the real shim under node with a faked browser: the resume stamp and the watchdog, the immediate redial on the first close after a foreground and the 250 ms wait on the next, the ordered queue with its whole-state replacement and time slicing, the held return row re-filed onto a redial, the breadcrumb rows and the badge cue. `ui/webview/paint-gate.test.ts` and `feed-hidden-paint.test.ts` pin the pure gate and the feed's hold, release and snap; `ui/timeline-hidden-hold.test.ts` the parked bars and the held draw; `ui/webview/chat-tail-repaint.test.ts` the coalesced repaint; `ui/webview/federation-reconnect.test.ts` the remote sockets' resume stamp; the heartbeat, banner, restart-seam, loader, outline-visibility, feed-flip, follow-move, awaiting-box, live-tick and bars-loader pins follow the new lines deliberately. Full suites on this tree: Python 7368 passed / 40 skipped; node 2836; bats 402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
