### PR TITLE
The auto-nudge and retry-suppress ledgers are never rewritten from a fabricated default after a read fault

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -871,7 +871,11 @@ parse: the file is renamed `<name>.corrupt-<UTC stamp>` beside the original
 error center says so, and the ledger reads as a fresh install until you
 restore it from that file. Nothing is deleted. Any other read fault leaves the
 file untouched: the kernel serves the last copy it read, writes nothing to it,
-and says so once, until the file reads again.
+and says so once, until the file reads again. A write that fails (a full or
+read-only disk) is told to the gesture that asked, the gear's toast or the
+stop button's warning, and said once per fault episode in the error center;
+the automatic pass sends nothing whose record could not land, and the file
+keeps what it holds.
 
 ## Switches
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -863,6 +863,16 @@ entry under the same kind says so. A file that cannot be read at all keeps
 showing its last-read values until it can. Nothing here needs a restart; the
 sidecars are yours to inspect or delete.
 
+Two small ledgers there, `auto-nudge.json` (the auto-nudge switch and its
+per-goal records) and `retry-suppressed.json` (the sessions whose auto-retry
+you stopped), are moved aside rather than overwritten when their bytes do not
+parse: the file is renamed `<name>.corrupt-<UTC stamp>` beside the original
+(`-1`, `-2`, ... when a second one lands in the same second), the dashboard's
+error center says so, and the ledger reads as a fresh install until you
+restore it from that file. Nothing is deleted. Any other read fault leaves the
+file untouched: the kernel serves the last copy it read, writes nothing to it,
+and says so once, until the file reads again.
+
 ## Switches
 
 Effective immediately, no restart.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4106,8 +4106,10 @@ def _setting_stale(name, gt, applied_gt):
     alone left the refusing kernel's verdict invisible to the dashboard that made the gesture
     (the open gear kept showing the refused pick, and with the mesh AGREEING on the kept value
     the mixed marks showed nothing). Every check clears the previous verdict first, so a popped
-    notice is always the CURRENT call's."""
+    notice is always the CURRENT call's — the refused-write verdict (_note_refused_gesture) included,
+    so a setter called outside a WS arm (nothing pops there) never leaves one for an unrelated gesture."""
     _stale_seen.last = None
+    _stale_seen.refused = None
     if gt is None or gt > applied_gt:
         return False
     _stale_seen.last = {"setting": name, "storedGt": applied_gt, "gt": gt}
@@ -4138,7 +4140,7 @@ def _pop_stale_notice():
     return d
 
 
-def _note_refused_gesture(name, gt, enabled, snap):
+def _note_refused_gesture(name, gt, enabled, snap, why=None):
     """A gt-gated toggle's write was REFUSED because its ledger read was unproved (the snapshot carries
     UNPROVED — the file could not be read, so the writer would not persist a copy of it). Recorded on this
     thread the way _setting_stale records a stand-down, so the WS branch that delivered the gesture can tell
@@ -4147,9 +4149,13 @@ def _note_refused_gesture(name, gt, enabled, snap):
     the file healed, ON is what ran. A different notice from the stale one on purpose: nothing about
     ordering is claimed, and the frame names the fault. `known` says whether a kept value can be NAMED at
     all: the tagged copy is the last snapshot this process proved (its last read or its own last write)
-    only when one is cached; otherwise it is the default, and the frame must not present that as kept."""
+    only when one is cached; otherwise it is the default, and the frame must not present that as kept.
+    `why` given: the WRITE itself failed (the snapshot was proved; the publish raised) — the same frame, the
+    fault named, and `write` set so the reply files no second error-center row: the writer already filed the
+    episode's one (the maintainer's fold on PR #1019: a refused write is told, once per episode)."""
     _stale_seen.refused = {"setting": name, "gt": gt, "refused": "on" if enabled else "off",
-                           "why": str(snap.get(UNPROVED) or "the ledger could not be read"),
+                           "why": str(why or snap.get(UNPROVED) or "the ledger could not be read"),
+                           "write": why is not None,
                            "known": str(jd.STATE / "auto-nudge.json") in _autonudge_cache}   # kept: None → the
     #                                                                                gear drops "Keeping …"
 
@@ -4204,17 +4210,25 @@ _NUDGE_LOCK = threading.RLock()
 # the cache would not survive the copy, and a per-path "last read failed" bit races a sibling thread's
 # proved read.
 UNPROVED = "_unproved"                 # snapshot tag → the fault text; never a key a ledger stores
+_LEDGER_REPLACED = "replaced meanwhile; the new bytes get their own read"   # _ledger_quarantine's decline when
+#                                        the file is no longer the one whose bytes failed: the reader re-reads
 _ledger_fault_warned = {}              # what -> fault the reader already shouted; cleared by a proved read
 _ledger_refusal_warned = {}            # what -> fault the writer already shouted; cleared by a proved write
+_ledger_write_failed = {}              # what -> the WRITE fault the writer already shouted; cleared only by a
+#                                        landed write (a proved read ends a read episode, not a write one)
 
 
-def _ledger_read(p, cache, default, what, normalize=None, lock=None):
+def _ledger_read(p, cache, default, what, normalize=None, lock=None, _tries=3):
     """FOUR-STATE read of a small JSON ledger. Absent → default() (uncached: the fresh-install arm, byte for
     byte the old behavior); readable and a JSON object → the dict (normalize applied), cached under its
     stat key; bytes that do not parse → moved aside (_ledger_quarantine), then default(); any other stat
     or read fault → a COPY of the last cached snapshot (else default()) tagged UNPROVED, nothing cached.
     `lock` is the ledger's WRITER lock, held across the quarantine only, never across the read (readers run
-    unlocked on several threads by design); see _ledger_quarantine for the window it closes."""
+    unlocked on several threads by design); see _ledger_quarantine for the window it closes.
+    The stat comes BEFORE the read so the quarantine can tell whether the file it is about to move is still
+    the one whose bytes failed; when a peer's atomic publish replaced it meanwhile, the quarantine declines
+    and THEIR bytes get their own read here, bounded by `_tries` — the shape the goal store's reader wears
+    (the maintainer's fold on PR #1019). Only a file that keeps changing under every read ends unproved."""
     try:
         st = p.stat()
     except FileNotFoundError:
@@ -4247,6 +4261,8 @@ def _ledger_read(p, cache, default, what, normalize=None, lock=None):
             why = _ledger_quarantine(p, st, what, reason)
         if why is None:
             return _ledger_proved(what, default())
+        if why == _LEDGER_REPLACED and _tries > 1:   # a peer published since our stat: read what is there now
+            return _ledger_read(p, cache, default, what, normalize, lock=lock, _tries=_tries - 1)
         return _ledger_unproved(p, cache, default, what, "%s (%s)" % (reason, why))
     if normalize is not None:
         normalize(d)
@@ -4285,8 +4301,9 @@ def _ledger_quarantine(p, st, what, reason):
     follows: the sidecar keeps the original name plus `.corrupt-<utc stamp>` (a `-n` suffix for a second in
     the same second): the state dir's one sidecar convention for bytes moved aside (docs/reference.md,
     "Where things live"; a goal-store quarantine proposed alongside in #1019 wears the same shape).
-    Only while the file is still the one whose bytes failed (same inode and generation) — an atomic publish
-    since then already replaced them, and the new file gets its own read. That check and the rename are one
+    Only while the file is still the one whose bytes failed (same inode, mtime and size as `st`, the stat the
+    reader took BEFORE its read) — an atomic publish since then already replaced them, and the new file gets
+    its own read (_LEDGER_REPLACED: _ledger_read re-reads, bounded). That check and the rename are one
     step ONLY under the ledger's writer lock, which _ledger_read holds around this call (review find,
     2026-09-08): readers run unlocked on several threads, and two that read the same corrupt bytes both
     arrive here with the same stat; between the first one's rename and a writer's fresh publish, the
@@ -4300,7 +4317,7 @@ def _ledger_quarantine(p, st, what, reason):
     try:
         cur = p.stat()
         if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
-            return "replaced meanwhile; the new bytes get their own read"
+            return _LEDGER_REPLACED
         stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
         aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
         while aside.exists():                            # a second corrupt file in the same second
@@ -4310,10 +4327,7 @@ def _ledger_quarantine(p, st, what, reason):
     except FileNotFoundError:
         return None
     except OSError as e:
-        # errno + strerror ONLY: str(e) names both paths, and the destination carries the per-second stamp,
-        # so a text with it changed every second and every once-per-fault-text dedupe fired once a second
-        return "could not be moved aside: %s" % ("[Errno %d] %s" % (e.errno, e.strerror) if e.errno is not None
-                                                 else type(e).__name__)
+        return "could not be moved aside: %s" % _errno_text(e)   # stamp-free: _errno_text (#1020's helper, the same shape)
     # Both channels, one line (review find, 2026-09-08): stderr alone left the user with a ledger that read
     # as a fresh install (an explicit auto-nudge OFF back ON, every session's stop-retrying gone) and
     # nothing in the dashboard saying so. Once per corrupt file by construction: the next read finds it
@@ -4334,7 +4348,14 @@ def _ledger_write_proved(p, what, d, cache, normalize=None):
     A write that lands is a PROVED state: it ends the fault episode and refreshes the cache with what the
     file now holds (read back under its stat key), so "the last snapshot this process proved" — what a
     later fault serves, what a refused gesture names as kept — includes this kernel's own last write, not
-    just its last read. Best-effort: a read-back that fails leaves the cache as it was."""
+    just its last read. Best-effort: a read-back that fails leaves the cache as it was.
+    The WRITE step is a fault boundary too (the maintainer's fold on PR #1019, for the goal store's saves):
+    an OSError from the publish itself (ENOSPC, EROFS, EACCES) is said here ONCE per fault episode — one
+    stderr line and one error-center row, keyed on the stamp-free errno text in the writer's OWN registry
+    (_ledger_write_failed: a proved read clears the read registries, but only a landed write proves the disk
+    takes writes again) — and then re-raised, so the caller that owns a gesture answers its socket (the
+    setting toggles through _note_refused_gesture, the interrupt through its warn toast) and a tick's caller
+    is covered by its own wrap. Left silent at the caller, a refused write looked like one that landed."""
     fault = d.get(UNPROVED) if isinstance(d, dict) else None
     if fault:
         if _ledger_refusal_warned.get(what) != fault:
@@ -4342,7 +4363,18 @@ def _ledger_write_proved(p, what, d, cache, normalize=None):
             sys.stderr.write("%s: refusing to write %s from an unproved snapshot (%s) — the file keeps what "
                              "it holds\n" % (what, p.name, fault))
         return False
-    _atomic_write(p, json.dumps(d))
+    try:
+        _atomic_write(p, json.dumps(d))
+    except OSError as e:
+        fault = "write failed: %s" % _errno_text(e)
+        if _ledger_write_failed.get(what) != fault:
+            _ledger_write_failed[what] = fault
+            line = ("%s: write failed for %s (%s) — the change did not land; the file keeps what it holds"
+                    % (what, p.name, _errno_text(e)))
+            sys.stderr.write(line + "\n")
+            _sdk_problem(line)                # the error center: on record once, however many gestures repeat it
+        raise
+    _ledger_write_failed.pop(what, None)     # a landed write ends the write-fault episode
     _ledger_proved(what, None)               # a proved write ends the episode too
     try:
         st = p.stat()
@@ -4476,11 +4508,14 @@ def _write_auto_nudge(d):
 def _set_auto_nudge(enabled, gt=None):
     """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down —
     see the gesture-time ordering block above _NUDGE_LOCK — or the store write failed (OSError:
-    loud on stderr, nothing applied), or the ledger read was unproved (the writer refuses the
-    snapshot, loud once per fault episode; nothing applied). The catch lives HERE, like _set_update_mode's and
-    _set_judge_state's: a raised OSError reaches the WS reader loop, which classifies it as a
-    socket failure and re-raises into a silent pass — a full-disk gear toggle tearing the whole
-    dashboard WebSocket down with zero log output."""
+    said once per fault episode by the writer, nothing applied, and the delivering socket hears
+    the refusal through _note_refused_gesture, exactly as for an unproved read), or the ledger read
+    was unproved (the writer refuses the snapshot, loud once per fault episode; nothing applied). The
+    catch lives HERE, like _set_update_mode's and _set_judge_state's: a raised OSError reaches the WS
+    reader loop, which classifies it as a socket failure and re-raises into a silent pass — a
+    full-disk gear toggle tearing the whole dashboard WebSocket down with zero log output. Catching it
+    and saying nothing was the defect's quieter face (the maintainer's fold on PR #1019: a refused
+    write must be told): the gear kept the flipped box while the kernel held the old value."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
         if _gesture_echo(gt, _gt_int(d.get("gt")), bool(d.get("enabled")) == bool(enabled)):
@@ -4493,9 +4528,9 @@ def _set_auto_nudge(enabled, gt=None):
             if _write_auto_nudge(d) is False:           # unproved snapshot: refused at the writer, nothing
                 _note_refused_gesture("auto-nudge", gt, enabled, d)   # applied — and the socket hears it
                 return None
-        except OSError as e:
-            sys.stderr.write("setting auto-nudge: write failed (%s) — nothing applied\n" % e)
-            return None
+        except OSError as e:                          # said once per episode by the writer; THIS gesture's
+            _note_refused_gesture("auto-nudge", gt, enabled, d, why="write failed: %s" % _errno_text(e))
+            return None                                 # refusal is answered on its socket (_tell_stale_gesture)
         return d["gt"]
 
 
@@ -4509,7 +4544,8 @@ def _compact_suggest_on():
 
 def _set_compact_suggest(enabled, gt=None):
     """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down or the
-    store write failed (OSError: loud on stderr, nothing applied, nothing ticked) —
+    store write failed (OSError: said once per fault episode by the writer, nothing applied, nothing
+    ticked, and the delivering socket hears the refusal) —
     _set_auto_nudge's contract exactly (same blob, same _NUDGE_LOCK), but the
     stamp is PER SETTING (`compactSuggestGt`): the two checkboxes share a file, not a clock, so a
     queued compact-suggest flush can never stand down against a newer auto-nudge gesture or steal
@@ -4526,9 +4562,9 @@ def _set_compact_suggest(enabled, gt=None):
             if _write_auto_nudge(d) is False:           # unproved snapshot: refused at the writer, nothing
                 _note_refused_gesture("compact-suggest", gt, enabled, d)   # applied — and the socket hears it
                 return None
-        except OSError as e:
-            sys.stderr.write("setting compact-suggest: write failed (%s) — nothing applied\n" % e)
-            return None
+        except OSError as e:                          # as _set_auto_nudge: the writer said it once; the
+            _note_refused_gesture("compact-suggest", gt, enabled, d, why="write failed: %s" % _errno_text(e))
+            return None                                 # socket hears this gesture's refusal
         return d["compactSuggestGt"]
 
 
@@ -5887,14 +5923,14 @@ def _suppress_session_retry(sid):
     the ledger read was unproved (the writer refuses the snapshot — persisting it erased every sibling
     session's stop), or the write itself failed (ENOSPC — before this the OSError escaped into the WS reader
     loop, which reads any OSError as a socket failure and tore the dashboard's connection down, with the
-    suppression neither on disk nor anywhere)."""
+    suppression neither on disk nor anywhere; the writer says a failed write once per fault episode, this
+    arm only answers the click)."""
     with _RETRY_SUPPRESS_LOCK:
         d = dict(_retry_suppress_data())
         d[str(sid)] = time.time()
         try:
             written = _write_retry_suppress(d)
-        except OSError as e:
-            sys.stderr.write("retry-suppress: write failed (%s) — the stop for %s is not recorded\n" % (e, sid))
+        except OSError as e:                          # said once per episode by the writer (_ledger_write_proved)
             why = getattr(e, "strerror", None) or str(e)
         else:
             if written:
@@ -5906,13 +5942,18 @@ def _suppress_session_retry(sid):
 
 def _clear_session_retry_suppress(sid):
     """Drop `sid`'s suppression; True when the ledger on disk changed. A refused write (an unproved snapshot)
-    leaves the suppression standing and returns False — suppressed is the safe direction while the ledger
-    cannot be read; the sweep retries on its next tick, and the file's next proved read is the event."""
+    or a FAILED one (an OSError from the publish, said once per fault episode by the writer) leaves the
+    suppression standing and returns False — suppressed is the safe direction while the ledger cannot be
+    read or written; the sweep retries on its next tick, and the file's next proved read or landed write is
+    the event. Left to raise, the OSError reached the pusher's wrap as a traceback every tick."""
     with _RETRY_SUPPRESS_LOCK:
         d = dict(_retry_suppress_data())
         if d.pop(str(sid), None) is None:
             return False
-        return _write_retry_suppress(d)
+        try:
+            return _write_retry_suppress(d)
+        except OSError:
+            return False
 
 
 def _auto_resume_session_retry(now, tmux):
@@ -31550,8 +31591,8 @@ def _tell_stale_gesture(client, msg):
     was one kernel stderr line: the dashboard that made the gesture kept displaying the refused
     pick as applied (the gear fills only on open), and with the mesh AGREEING on the kept value
     the mixed marks showed nothing. The gear toasts the frame and re-fills if open — event-keyed,
-    the frame IS the deciding event; no polling. A refusal for any other cause (invalid value,
-    OSError) records no notice and sends nothing.
+    the frame IS the deciding event; no polling. A refusal for an invalid value records no notice
+    and sends nothing; a refused WRITE (OSError) records one like the unproved-read refusal below.
     The frame echoes `gesture`: the refused message itself, WITHOUT its stamp, so the toast can
     offer to re-issue it as a new gesture (a fresh click is legitimate new information) stamped
     above the stored one. The stamp is dropped on purpose — a re-issue can never reuse the stale
@@ -31563,7 +31604,9 @@ def _tell_stale_gesture(client, msg):
     the same frame plus `why` (the fault): the gear's copy — not applied, keeping the stored value —
     is exactly true of it, and the frame's re-fill snaps the checkbox back to the last snapshot this
     kernel proved (`kept`, named only when there is one); the fault itself, which the copy does not
-    carry, goes to the error center so it is on record."""
+    carry, goes to the error center so it is on record. A write that FAILED (the snapshot proved, the
+    publish raised) rides the same frame with its fault as `why`; its error-center row is the writer's,
+    filed once per fault episode, so this reply files none (the maintainer's fold on PR #1019)."""
     st = _pop_stale_notice()
     if st:
         _reply(client, {"type": "settingStale", "setting": st["setting"],
@@ -31574,9 +31617,10 @@ def _tell_stale_gesture(client, msg):
     if not rf:
         return
     kept = _setting_kept_value(rf["setting"]) if rf.get("known") else None
-    _sdk_problem("setting %s: %s was not applied — %s; the stored value%s stands until the ledger reads again"
-                 % (rf["setting"], rf["refused"], rf["why"],
-                    "" if kept is None else " (%s)" % ("on" if kept else "off")))
+    if not rf.get("write"):                            # a write fault's row is the writer's, once per episode
+        _sdk_problem("setting %s: %s was not applied — %s; the stored value%s stands until the ledger reads again"
+                     % (rf["setting"], rf["refused"], rf["why"],
+                        "" if kept is None else " (%s)" % ("on" if kept else "off")))
     _reply(client, {"type": "settingStale", "setting": rf["setting"],
                     "storedGt": _setting_stored_gt(rf["setting"]), "gt": rf["gt"], "kept": kept,
                     "why": rf["why"], "gesture": {k: v for k, v in msg.items() if k != "gt"}})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2299,12 +2299,14 @@ def _fire_debt_reminder(sid, now, alive_ids):
     """Send the reminder for every not-yet-reminded ask this session owes; True when one went out. The
     per-ask dedup key (asker>debtor:ts) makes this once-per-ask-EVER — escalation past an ignored
     reminder belongs to the sender's card (the nudge-failed ladder), not to repeat reminders.
-    Records AFTER the send, so a failed send retries (_mark_auto_nudged's direction) — and the record
-    write RE-READS the blob fresh under _NUDGE_LOCK and mutates only debtNudged, the key this writer
-    owns. The old shape held a pre-send snapshot across the live send and wrote the whole blob back:
-    last-writer-wins over every key, so it erased whatever a concurrent writer landed in the gap —
-    including _compact_suggest_tick's claim-before-send latch, which re-opened the double send the
-    claim exists to close (2026-09-01)."""
+    Records BEFORE the send and sends only when the record landed (review find, 2026-09-08, the nudge
+    fire site's rule: it recorded after, so a failed send would retry, but a record the writer refused
+    on a full disk let an unrecorded reminder out again every tick), and the record write RE-READS the
+    blob fresh under _NUDGE_LOCK and mutates only debtNudged, the key this writer owns. The old shape
+    held a pre-send snapshot across the live send and wrote the whole blob back: last-writer-wins over
+    every key, so it erased whatever a concurrent writer landed in the gap, including
+    _compact_suggest_tick's claim-before-send latch, which re-opened the double send the claim exists
+    to close (2026-09-01)."""
     asks = _debt_asks(sid, alive_ids)
     if not asks:
         return False
@@ -2317,14 +2319,19 @@ def _fire_debt_reminder(sid, now, alive_ids):
            if ("%s>%s:%d" % (asker, sid, ts)) not in dn0]
     if not due:
         return False
+    try:
+        with _NUDGE_LOCK:
+            d = dict(_auto_nudge_data())
+            dn = dict(d.get("debtNudged") or {})
+            for asker, _n, ts, _k, _h in due:
+                dn["%s>%s:%d" % (asker, sid, ts)] = int(now)
+            d["debtNudged"] = dn
+            landed = _write_auto_nudge(d)
+    except OSError:
+        landed = False                                 # said once per fault episode by the writer
+    if not landed:
+        return False                                   # nothing sent whose record could not land
     Sessions.backend_for(sid).send(sid, _debt_reminder_body([(n, t, k, h) for _a, n, t, k, h in due]))
-    with _NUDGE_LOCK:
-        d = dict(_auto_nudge_data())
-        dn = dict(d.get("debtNudged") or {})
-        for asker, _n, ts, _k, _h in due:
-            dn["%s>%s:%d" % (asker, sid, ts)] = int(now)
-        d["debtNudged"] = dn
-        _write_auto_nudge(d)
     return True
 
 
@@ -4234,7 +4241,7 @@ def _ledger_read(p, cache, default, what, normalize=None, lock=None, _tries=3):
     except FileNotFoundError:
         return _ledger_proved(what, default())
     except OSError as e:
-        return _ledger_unproved(p, cache, default, what, "stat failed: %s" % e)
+        return _ledger_unproved(p, cache, default, what, "stat failed: %s" % _oserror_text(e))
     key = (st.st_mtime_ns, st.st_size)
     hit = cache.get(str(p))
     if hit is not None and hit[0] == key:
@@ -4245,7 +4252,7 @@ def _ledger_read(p, cache, default, what, normalize=None, lock=None, _tries=3):
     except FileNotFoundError:
         return _ledger_proved(what, default())   # removed between the stat and the read: absent
     except OSError as e:
-        return _ledger_unproved(p, cache, default, what, "read failed: %s" % e)
+        return _ledger_unproved(p, cache, default, what, "read failed: %s" % _oserror_text(e))
     except UnicodeError as e:
         reason = "not UTF-8: %s" % e
     if reason is None:
@@ -4294,6 +4301,15 @@ def _ledger_unproved(p, cache, default, what, fault):
     d = dict(hit[1]) if hit is not None else default()
     d[UNPROVED] = fault
     return d
+
+
+def _oserror_text(e):
+    """errno + strerror ONLY — never str(e): that names the path(s), and a quarantine destination or a
+    write's temp file carries a per-second stamp or a per-call sequence, so a text built from it changed
+    on every fault and every once-per-fault-text dedupe fired every time. The reader's stat/read faults
+    wear it too (review find, 2026-09-08): their text rides the settingStale frame's `why` and the error
+    center, and an absolute state path has no business there."""
+    return ("[Errno %d] %s" % (e.errno, e.strerror)) if getattr(e, "errno", None) is not None else type(e).__name__
 
 
 def _ledger_quarantine(p, st, what, reason):
@@ -4354,8 +4370,12 @@ def _ledger_write_proved(p, what, d, cache, normalize=None):
     stderr line and one error-center row, keyed on the stamp-free errno text in the writer's OWN registry
     (_ledger_write_failed: a proved read clears the read registries, but only a landed write proves the disk
     takes writes again) — and then re-raised, so the caller that owns a gesture answers its socket (the
-    setting toggles through _note_refused_gesture, the interrupt through its warn toast) and a tick's caller
-    is covered by its own wrap. Left silent at the caller, a refused write looked like one that landed."""
+    setting toggles through _note_refused_gesture, the interrupt through its warn toast), and a tick's leg
+    that RECORDS what it sends writes the record FIRST and sends only when it landed (_auto_nudge_session,
+    _wake_goal, _fire_debt_reminder; the walk-gate journal, re-derived every tick, just waits for the next
+    one). A wrap around the tick is no boundary (review find, 2026-09-08): it hides the traceback after the
+    unrecorded message has gone out, and the next cycle sends it again. Left silent at the caller, a refused
+    write looked like one that landed."""
     fault = d.get(UNPROVED) if isinstance(d, dict) else None
     if fault:
         if _ledger_refusal_warned.get(what) != fault:
@@ -6005,7 +6025,10 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
     failed-stamp's response-arrival gate compares against it (the 2026-07-19 network g1 race). `at` is the
     fire time — the failed-stamp's parse-lag guard measures its 6h backstop from it (the user 2026-07-24:
     a stamp raced the parse of a second, still-landing nudge turn and blocked two goals whose response
-    resolved them; the guard waits for the response segment to become VISIBLE, bounded by the backstop)."""
+    resolved them; the guard waits for the response segment to become VISIBLE, bounded by the backstop).
+    Returns the writer's verdict (True landed, False refused over an unproved snapshot) and lets a write
+    fault's OSError propagate: the fire site records BEFORE it sends and sends only on True (review find,
+    2026-09-08; see _auto_nudge_session)."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
         nudged = dict(d.get("nudged", {}))
@@ -6019,7 +6042,7 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
         if len(nudged) > 3000:                                  # bounded; drop the oldest
             nudged = dict(list(nudged.items())[-3000:])
         d["nudged"] = nudged
-        _write_auto_nudge(d)
+        return _write_auto_nudge(d)
 
 
 _auto_nudge_drops_pending = set()   # gids whose spent-record drop was refused under a fault; replayed by the first proved pass
@@ -6984,8 +7007,9 @@ def _compact_suggest_tick(sid, tm, now):
 
 # The tick is SINGLE-FLIGHT (PR #943 review): it has two concurrent entry points — the pusher's
 # periodic pass (0.5 s backstop) and the setAutoNudge / setCompactSuggest arms' act-now pass on the
-# WS handler thread — and the nudge send has no claim-before-send (_mark_auto_nudged records AFTER
-# the send so a failed send retries; _compact_suggest_tick's latch covers only its own seam), so two
+# WS handler thread, and the nudge's record is no CLAIM (_mark_auto_nudged writes it before the send
+# since 2026-09-08, but not as a compare-and-set on the arm; _compact_suggest_tick's latch covers only
+# its own seam), so two
 # passes that overlapped each derived the same due goal from the same store and injected the same
 # nudge twice into one session — reproduced from two threads at the 0.5 s cadence. A non-blocking
 # try-acquire, never a wait: the loser stands down whole, and loses nothing. The flag write precedes
@@ -7189,13 +7213,15 @@ AWAITING_BACKSTOP_TEXT = (
 
 def _put_nudged(gid, rec):
     """Persist ONE nudge/wake record into auto-nudge.json's `nudged` ledger — the read-modify-write the
-    failed stamp already does inline, shared so the wake's answered/fired records take the same shape."""
+    failed stamp already does inline, shared so the wake's answered/fired records take the same shape.
+    Returns the writer's verdict and lets a write fault propagate (_mark_auto_nudged's contract): the wake's
+    fire site gates its send on it."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
         nudged = dict(d.get("nudged", {}))
         nudged[gid] = rec
         d["nudged"] = nudged
-        _write_auto_nudge(d)
+        return _write_auto_nudge(d)
 
 
 # The walk→sweep handoff journal (the user 2026-08-24, retiring the 6h ownership window): the walk
@@ -7215,7 +7241,10 @@ WALK_GATES_WEDGE = ("api-error", "parse-failed", "empty-parse", "all-delegated",
 def _put_walk_gate(key, gate, now):
     """Journal the gate the nudge walk returned on for `key` (a sid, or a gid for per-goal skips).
     Write-on-change only, and the FIRST gate's `at` is kept when only the name flaps (the deferral
-    map's precedent), so a flapping compacting bit can't churn the file at the 0.5-3s tick."""
+    map's precedent), so a flapping compacting bit can't churn the file at the 0.5-3s tick.
+    A write fault is the writer's line, once per episode, and nothing more here (review find, 2026-09-08):
+    the entry is re-derived by every walk, so a journal write that did not land is simply written next
+    tick; it used to rise into the pass's per-session wrap as a traceback per tick."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
         gates = dict(d.get("walkGates", {}))
@@ -7224,17 +7253,24 @@ def _put_walk_gate(key, gate, now):
             return
         gates[key] = {"gate": gate, "at": int((cur or {}).get("at") or now)}
         d["walkGates"] = gates
-        _write_auto_nudge(d)
+        try:
+            _write_auto_nudge(d)
+        except OSError:
+            pass                                             # said once per episode by the writer; retried next tick
 
 
 def _pop_walk_gate(key):
-    """The walk got PAST the gate for `key` — the entry's own retirement event."""
+    """The walk got PAST the gate for `key`: the entry's own retirement event. A refused write waits
+    for the next walk past the gate, as _put_walk_gate's does."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
         gates = dict(d.get("walkGates", {}))
         if gates.pop(key, None) is not None:
             d["walkGates"] = gates
-            _write_auto_nudge(d)
+            try:
+                _write_auto_nudge(d)
+            except OSError:
+                pass                                         # said once per episode by the writer; retried next tick
 
 
 def _last_awaiting_is_lift(nd):
@@ -8048,12 +8084,23 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux, wake_only=F
         _mark_views_dirty()
         _drop_auto_nudge_rec(gid)                    # the spent episode's residue goes with the wait
         return True
+    # RECORD BEFORE SEND (review find, 2026-09-08), the nudge fire site's rule (_auto_nudge_session): a
+    # wake whose record the writer refused (a full or read-only disk raising out of _put_nudged) had
+    # already gone out, so the same wake went out again every tick the session read idle, with no record
+    # to judge its response against. Nothing is sent whose record did not land; the writer said the fault
+    # once per episode, and the next tick re-derives the same due wake against the healed disk.
+    wake = {"wake": True, "anchor": at, "count": (rec.get("count") or 0) + 1,
+            "lastTurnId": lt.get("id"), "armAtoms": len(lt.get("atoms") or []), "at": int(now)}
+    try:
+        landed = _put_nudged(gid, wake)
+    except OSError:
+        landed = False                               # said once per fault episode by the writer
+    if not landed:
+        return False
+    nudged[gid] = wake                               # mirror in-memory for the rest of this tick
     Sessions.backend_for(sid).send(sid, _followup_body(gid, None, AWAITING_BACKSTOP_TEXT,
                                                        injected=True, auto=True, wake=True))
     _nudge_deferred_ok(gid, "", now, sid)            # the hold is over — drop any deferral record
-    nudged[gid] = {"wake": True, "anchor": at, "count": (rec.get("count") or 0) + 1,
-                   "lastTurnId": lt.get("id"), "armAtoms": len(lt.get("atoms") or []), "at": int(now)}
-    _put_nudged(gid, nudged[gid])
     _log_nudge_event(sid, gid, now, 0)               # timeline romp-logo dot (count 0 marks a wake, not an escalation)
     return True
 
@@ -9048,6 +9095,26 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
             _bnodes = _fr.get("nodes") or nodes      # the bundle body renders the same fresh world
         except Exception:
             pass
+    if to_fire:
+        # RECORD BEFORE SEND (review find, 2026-09-08). The record used to follow the send so a failed send
+        # would retry, but a record the WRITER refused (a full or read-only disk: _ledger_write_proved
+        # raises) left a nudge already out with no ledger row behind it. The goal then read as never
+        # nudged, so the same stall was nudged again after every response cycle for as long as the disk
+        # refused writes, the redundancy judge's skip (its own _put_nudged refused) fell through to a fire,
+        # and with no record to climb from the escalation ladder never reached needs-you: the every-cycle
+        # re-nudge the read-fault pause exists to prevent, on the write side, hidden under the per-session
+        # wrap's traceback. Now every due record lands FIRST ({count, lastTurnId, armAtoms, at}: re-arm
+        # only on the next GENUINE ended-working turn; a fresh record resets `failed`), and nothing goes
+        # out whose record did not. The writer said the fault once per episode, so this leg says nothing
+        # and the next tick re-derives the same due goal against the healed disk. A send that raises after
+        # its record landed reaches the per-session wrap as before; the record stands, so it is not repeated.
+        try:
+            landed = all([_mark_auto_nudged(gid, arm_id, count, len(arm.get("atoms") or []), at=now)
+                          for gid, count, _stalled in to_fire])
+        except OSError:
+            landed = False                           # said once per fault episode by the writer
+        if not landed:
+            return fired                             # nothing sent whose record could not land
     if len(to_fire) == 1:
         gid, count, stalled = to_fire[0]
         text = _nudge_text(count, stalled)             # variant by escalation count — a repeat re-asks in fresh words
@@ -9060,7 +9127,6 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     for gid, count, stalled in to_fire:
         _nudge_deferred_ok(gid, "", now, sid)        # the hold is over — drop any deferral record so a stale
         #                                              why can never outlive the wait it described
-        _mark_auto_nudged(gid, arm_id, count, len(arm.get("atoms") or []), at=now)   # {count, lastTurnId, armAtoms, at} → re-arm only on the next GENUINE ended-working turn; a fresh record resets `failed`
         _log_nudge_event(sid, gid, now, count,       # timeline romp-logo dot + escalation count; the row
                          verdict=_verdicts.get(gid, ("fired",))[0],   # says HOW it fired and what evidence
                          ev_t=recent_ts)             # it survived (the 2026-08-25 instrumentation)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
+import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
@@ -4208,11 +4208,13 @@ _ledger_fault_warned = {}              # what -> fault the reader already shoute
 _ledger_refusal_warned = {}            # what -> fault the writer already shouted; cleared by a proved write
 
 
-def _ledger_read(p, cache, default, what, normalize=None):
+def _ledger_read(p, cache, default, what, normalize=None, lock=None):
     """FOUR-STATE read of a small JSON ledger. Absent → default() (uncached: the fresh-install arm, byte for
     byte the old behavior); readable and a JSON object → the dict (normalize applied), cached under its
     stat key; bytes that do not parse → moved aside (_ledger_quarantine), then default(); any other stat
-    or read fault → a COPY of the last cached snapshot (else default()) tagged UNPROVED, nothing cached."""
+    or read fault → a COPY of the last cached snapshot (else default()) tagged UNPROVED, nothing cached.
+    `lock` is the ledger's WRITER lock, held across the quarantine only, never across the read (readers run
+    unlocked on several threads by design); see _ledger_quarantine for the window it closes."""
     try:
         st = p.stat()
     except FileNotFoundError:
@@ -4241,7 +4243,8 @@ def _ledger_read(p, cache, default, what, normalize=None):
             if not isinstance(d, dict):
                 reason = "top-level JSON value is %s, not an object" % type(d).__name__
     if reason is not None:                 # the bytes' fault, not the moment's: move them aside
-        why = _ledger_quarantine(p, st, what, reason)
+        with (lock if lock is not None else contextlib.nullcontext()):
+            why = _ledger_quarantine(p, st, what, reason)
         if why is None:
             return _ledger_proved(what, default())
         return _ledger_unproved(p, cache, default, what, "%s (%s)" % (reason, why))
@@ -4280,12 +4283,20 @@ def _ledger_unproved(p, cache, default, what, fault):
 def _ledger_quarantine(p, st, what, reason):
     """Move an unparseable ledger ASIDE (never delete it) so the evidence survives the fresh start that
     follows: the sidecar keeps the original name plus `.corrupt-<utc stamp>` (a `-n` suffix for a second in
-    the same second), the shape the judge's goal-store quarantine wears, so one convention reads across both.
+    the same second): the state dir's one sidecar convention for bytes moved aside (docs/reference.md,
+    "Where things live"; a goal-store quarantine proposed alongside in #1019 wears the same shape).
     Only while the file is still the one whose bytes failed (same inode and generation) — an atomic publish
-    since then already replaced them, and the new file gets its own read. Returns None once the bytes are out
-    of the way (moved, or already gone: a sibling reader moved them), with one stderr line for the move;
-    else the reason they are NOT, for the caller's fault text — which _ledger_unproved dedupes per episode,
-    so a corrupt file that cannot be moved (a read-only state dir) is said once, never once per read."""
+    since then already replaced them, and the new file gets its own read. That check and the rename are one
+    step ONLY under the ledger's writer lock, which _ledger_read holds around this call (review find,
+    2026-09-08): readers run unlocked on several threads, and two that read the same corrupt bytes both
+    arrive here with the same stat; between the first one's rename and a writer's fresh publish, the
+    second's check has already passed, so its rename moved the FRESH ledger aside and served the default.
+    Every writer publishes under that lock (the 2026-09-01 write discipline), so a reader holding it sees
+    either the file it read (and moves it) or a replacement (and yields). Returns None once the bytes are
+    out of the way (moved, or already gone: a sibling reader moved them), said once on stderr AND in the
+    error center; else the reason they are NOT, for the caller's fault text, which _ledger_unproved
+    dedupes per episode, so a corrupt file that cannot be moved (a read-only state dir) is said once, never
+    once per read."""
     try:
         cur = p.stat()
         if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
@@ -4303,8 +4314,14 @@ def _ledger_quarantine(p, st, what, reason):
         # so a text with it changed every second and every once-per-fault-text dedupe fired once a second
         return "could not be moved aside: %s" % ("[Errno %d] %s" % (e.errno, e.strerror) if e.errno is not None
                                                  else type(e).__name__)
-    sys.stderr.write("%s: %s could not be parsed (%s); moved aside to %s, the ledger reads as absent\n"
-                     % (what, p.name, reason, aside.name))
+    # Both channels, one line (review find, 2026-09-08): stderr alone left the user with a ledger that read
+    # as a fresh install (an explicit auto-nudge OFF back ON, every session's stop-retrying gone) and
+    # nothing in the dashboard saying so. Once per corrupt file by construction: the next read finds it
+    # absent, and the unmovable arm above never reaches here (its text rides the deduped fault instead).
+    line = ("%s: %s could not be parsed (%s); moved aside to %s and reads as a fresh install (its settings "
+            "and records are gone) until you restore it from that file" % (what, p.name, reason, aside.name))
+    sys.stderr.write(line + "\n")
+    _sdk_problem(line)
     return None
 
 
@@ -4356,7 +4373,7 @@ def _auto_nudge_data():
     reads as the last proved snapshot tagged UNPROVED (which _write_auto_nudge refuses), bytes that do not
     parse are moved aside. Writers copy it first (`dict(_auto_nudge_data())`); the tag rides the copy."""
     return _ledger_read(jd.STATE / "auto-nudge.json", _autonudge_cache, _auto_nudge_default, "auto-nudge",
-                        _auto_nudge_normalize)
+                        _auto_nudge_normalize, lock=_NUDGE_LOCK)
 
 
 def _auto_nudge_on():
@@ -5801,10 +5818,13 @@ def _auto_resume_retry(now, tmux):
 # STATE/retry-suppressed.json {sid: stop_ts}. A sid present = suppressed; stop_ts is the re-arm floor (only a
 # successful turn AFTER it lifts the suppression). _auto_resume_session_retry clears re-armed sids each tick.
 _retry_suppress_cache = {}   # str(path) -> ((mtime_ns,size), dict)
-_RETRY_SUPPRESS_LOCK = threading.Lock()   # the arm/clear read-modify-write span: the interrupt handler (a WS
+_RETRY_SUPPRESS_LOCK = threading.RLock()  # the arm/clear read-modify-write span: the interrupt handler (a WS
 #                                           thread) and the pusher's re-arm sweep rewrite the same whole blob;
 #                                           unlocked, the loser's snapshot erased the winner's key. Held across
-#                                           the file read + write only — never across a backend call.
+#                                           the file read + write only, never across a backend call. Re-entrant
+#                                           because the reader takes it too, around a quarantine (_ledger_read's
+#                                           `lock`), and the arm and the clear call the reader while holding it
+#                                           (review find, 2026-09-08).
 _retry_floor_warned = set()               # (sid, type name) of a non-numeric floor already shouted
 
 
@@ -5812,7 +5832,8 @@ def _retry_suppress_data():
     """The per-session retry-suppression ledger's snapshot — the ledger block above _auto_nudge_data: absent
     reads as {} (nobody suppressed), a fault reads as the last proved snapshot tagged UNPROVED (which the
     writer refuses), bytes that do not parse are moved aside."""
-    return _ledger_read(jd.STATE / "retry-suppressed.json", _retry_suppress_cache, dict, "retry-suppress")
+    return _ledger_read(jd.STATE / "retry-suppressed.json", _retry_suppress_cache, dict, "retry-suppress",
+                        lock=_RETRY_SUPPRESS_LOCK)
 
 
 def _write_retry_suppress(d):
@@ -5826,6 +5847,36 @@ def _session_retry_suppressed(sid):
     storm and hasn't landed a successful turn since). Cheap membership read — the re-arm/clear lives in
     _auto_resume_session_retry; the apiRetry gate + the chat status flag both read this."""
     return str(sid) in _retry_suppress_data()
+
+
+_retry_gate_held = [None]   # the fault auto-retry is standing down on (see _retry_suppress_unknown); None = the ledger answers
+
+
+def _retry_suppress_unknown():
+    """True while the retry-suppression ledger reads UNPROVED and this process holds NO proved snapshot to
+    serve in its place: the tagged copy is then the fresh-install {} and EVERY stopped session reads as not
+    stopped, the one answer the auto-retry gate must not act on (review find, 2026-09-08: one EIO on a cold
+    kernel and auto-retry walked straight back into the session the user had interrupted to end its storm).
+    With a proved copy behind the fault the membership read is the best answer this process has (its own
+    arms refresh that copy), so the gate takes it. Unknown holds the AUTO path only (a manual Retry-now is
+    the user's explicit call and never reads this) and is said once per fault episode on stderr and in
+    the error center, the way the nudge pass's stand-down is; the first read that proves (or the first
+    proved copy) ends it: an event, not a clock."""
+    d = _retry_suppress_data()
+    fault = d.get(UNPROVED)
+    if fault and str(jd.STATE / "retry-suppressed.json") not in _retry_suppress_cache:
+        if _retry_gate_held[0] != fault:
+            _retry_gate_held[0] = fault
+            line = ("retry-suppress: retry-suppressed.json is unreadable (%s) and no proved copy is held; "
+                    "auto-retry stands down for every session, rather than resume into one you stopped, until "
+                    "it reads again" % fault)
+            sys.stderr.write(line + "\n")
+            _sdk_problem(line)
+        return True
+    if _retry_gate_held[0] is not None:
+        _retry_gate_held[0] = None
+        sys.stderr.write("retry-suppress: retry-suppressed.json answers again; auto-retry resumed\n")
+    return False
 
 
 def _suppress_session_retry(sid):
@@ -5930,6 +5981,9 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
         _write_auto_nudge(d)
 
 
+_auto_nudge_drops_pending = set()   # gids whose spent-record drop was refused under a fault; replayed by the first proved pass
+
+
 def _drop_auto_nudge_rec(gid):
     """Erase `gid`'s SPENT ledger record — called when NEW INFORMATION voids the episode the record
     tracks (today: an awaiting-stamp LIFT in _lift_spent_awaiting — the wait the episode ended on has
@@ -5942,18 +5996,34 @@ def _drop_auto_nudge_rec(gid):
     counter on every stamp↔lift flap, so the same arm turn drew fresh first-nudges minutes apart and
     _mark_nudge_failed never engaged (the 2026-08-19 audit: three count-1 nudges in 21 minutes, each
     answered "the suite is still running"). A live record keeps itself honest without our help: a
-    genuine new turn re-arms it through the arm-key dedup, and answering marks it answered."""
+    genuine new turn re-arms it through the arm-key dedup, and answering marks it answered.
+
+    A drop that CANNOT land (the ledger read was unproved, or the writer refused the snapshot) is PARKED
+    (_auto_nudge_drops_pending) and replayed by the first pass whose read proves (review find, 2026-09-08):
+    every caller runs OUTSIDE the paused nudge pass (the awaiting lift, the follow-up reopen), off an event
+    that fires once, and its goal-store write had already landed, so a refused drop left the record
+    latched with nothing to retry it, and an idle session's card sat in Working with no reviver, the very
+    hole the drop exists to close. Under a fault the tagged copy cannot say what the file holds, so the gid
+    is parked whether or not the copy shows a record; the replay reads the proved file and drops only a
+    spent record, as ever. Returns True once nothing is owed (dropped, or no spent record to drop), False
+    when parked."""
     with _NUDGE_LOCK:
         d = dict(_auto_nudge_data())
+        if d.get(UNPROVED):
+            _auto_nudge_drops_pending.add(gid)
+            return False
         nudged = dict(d.get("nudged", {}))
         rec = nudged.get(gid)
         if not isinstance(rec, dict):
-            return
+            return True
         if not (rec.get("failed") or rec.get("moot") or rec.get("answeredAt")):
-            return                                        # live mid-episode → the ladder's memory, keep it
+            return True                                   # live mid-episode → the ladder's memory, keep it
         if nudged.pop(gid, None) is not None:
             d["nudged"] = nudged
-            _write_auto_nudge(d)
+            if _write_auto_nudge(d) is False:
+                _auto_nudge_drops_pending.add(gid)
+                return False
+        return True
 
 
 def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
@@ -6141,13 +6211,15 @@ def _mark_nudge_failed(gid, ev_t=None, wake=False):
 
 def _interrupt_focus_top(store):
     """The top-level goal the interrupt actually stopped: the session's active-focus top, if it is
-    currently working. None when there's no working focus to block (nothing owed)."""
+    currently working, or blocked SOLELY by our own interrupt row (judge._intr_paused_only: the newest
+    block-family diary state is src 'interrupt' with no later unblock), which is the same stop still
+    standing; a card a judge has blocked since is theirs. None when there's no such focus (nothing owed)."""
     nodes = store.get("nodes", {})
     x = store.get("lastNode")
     seen = set()
     while x in nodes and nodes[x].get("parentId") is not None and x not in seen:
         seen.add(x); x = nodes[x]["parentId"]
-    if x in nodes and store.get("status", {}).get(x, "working") == "working":
+    if x in nodes and (store.get("status", {}).get(x, "working") == "working" or jd._intr_paused_only(nodes[x])):
         return x
     return None
 
@@ -6178,6 +6250,14 @@ def _record_interrupt_block(sid, ev):
     if not gid:
         return None
     nd = store["nodes"][gid]
+    if nd.get("blocked"):
+        # reachable only through _intr_paused_only: OUR block already holds the card, and only its marker
+        # is owed, so the tick re-mints it (review find, 2026-09-08). The marker write can be refused after
+        # the block landed (the ledger faulted between the tick's tag check and that write), and with the
+        # marker absent and the top no longer "working" every healed tick returned None here: no marker was
+        # ever minted, the re-engagement lift (gated on the marker) could never run, and the card sat in
+        # Needs-you until a judge happened to unblock it. Nothing is appended: the diary already says it.
+        return gid
     why = jd.INTERRUPT_BLOCK_WHY      # shared constant, PROCEDURAL (see judge.procedural_block_why)
     ev = int(ev or 0)
     ceil = max((e.get("ev_t") or 0 for e in (nd.get("log") or [])
@@ -6337,7 +6417,9 @@ def _interrupt_block_tick(now, tmux):
                 if g:
                     # the block IS filed — a proved goal-store write, a needs-you flip the feed must hear —
                     # so this pushes whatever the marker write's fate: a fault landing between the tag
-                    # check above and here refuses the marker, and the next tick stands down at the check
+                    # check above and here refuses the marker, the next tick stands down at the check, and
+                    # the first healed tick re-mints the marker (_record_interrupt_block hands back the gid
+                    # of a card our own block already holds, appending nothing)
                     _set_intr_blocked(sid, g); changed = True
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
@@ -6957,6 +7039,16 @@ def _auto_nudge_pass(now, tmux, run_dead_wait):
         _auto_nudge_pause(snap[UNPROVED])
         return
     _auto_nudge_resume()
+    if _auto_nudge_drops_pending:
+        # the first proved read is the event the parked drops wait on (_drop_auto_nudge_rec): a replay that
+        # lands, or finds nothing spent, leaves the set; one refused again stays for the next proved pass
+        for gid in list(_auto_nudge_drops_pending):
+            if _drop_auto_nudge_rec(gid):
+                _auto_nudge_drops_pending.discard(gid)
+        snap = _auto_nudge_data()                         # the walk below reads the ledger the replay left
+        if snap.get(UNPROVED):
+            _auto_nudge_pause(snap[UNPROVED])
+            return
     on = _auto_nudge_on()
     nudged = dict(snap.get("nudged", {}))                 # {gid: {count, lastTurnId}}
     alive = list(_alive_sessions(now, tmux))
@@ -11681,11 +11773,15 @@ def _fire_api_retry(sid, be, manual=False):
     asking itself is the same decision on the same state.
 
     The GATE block is for the AUTO path only: a global pause or a thread the user interrupted must not
-    relapse into the storm. A MANUAL Retry-now is an explicit one-shot override — it ALWAYS fires so the
-    button is never a dead no-op on a suppressed/paused thread (the user 2026-07-06). It fires ONE retry
-    without clearing the suppression, so it doesn't re-arm the auto-loop the user turned off."""
+    relapse into the storm, nor may a thread whose stop the kernel cannot currently READ (the suppression
+    ledger unreadable with no proved copy behind it reads every stop as absent; _retry_suppress_unknown
+    holds the auto path until it reads again). A MANUAL Retry-now is an explicit one-shot override: it
+    ALWAYS fires so the button is never a dead no-op on a suppressed/paused thread (the user 2026-07-06).
+    It fires ONE retry without clearing the suppression, so it doesn't re-arm the auto-loop the user turned off."""
     if not manual and (_retry_paused_on() or _session_retry_suppressed(sid)):
         return
+    if not manual and _retry_suppress_unknown():
+        return                                            # unknown is not "not stopped": fail safe, said once
     # IDEMPOTENCY (the user 2026-07-08): don't stack a fresh auto-"retry" when the one romp already sent is
     # still QUEUED and unconsumed — the session is blocked, so the previous retry hasn't run yet and another
     # only piles up. Without this the auto-loop enqueued N bare "retry"s into the SDK queue during one

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2308,7 +2308,11 @@ def _fire_debt_reminder(sid, now, alive_ids):
     asks = _debt_asks(sid, alive_ids)
     if not asks:
         return False
-    dn0 = _auto_nudge_data().get("debtNudged") or {}
+    snap = _auto_nudge_data()
+    if snap.get(UNPROVED):
+        return False                                   # the record write would be refused → an unrecorded
+        #                                                reminder re-fires every tick; the tick is paused anyway
+    dn0 = snap.get("debtNudged") or {}
     due = [(asker, name, ts, kind, head) for asker, name, ts, kind, head in asks
            if ("%s>%s:%d" % (asker, sid, ts)) not in dn0]
     if not due:
@@ -4134,6 +4138,28 @@ def _pop_stale_notice():
     return d
 
 
+def _note_refused_gesture(name, gt, enabled, snap):
+    """A gt-gated toggle's write was REFUSED because its ledger read was unproved (the snapshot carries
+    UNPROVED — the file could not be read, so the writer would not persist a copy of it). Recorded on this
+    thread the way _setting_stale records a stand-down, so the WS branch that delivered the gesture can tell
+    its own socket (_tell_stale_gesture). Silent, the refusal was the defect's other face: the gear flips
+    its checkbox locally and re-fills only on reopen, so the box read OFF while the kernel held ON — and once
+    the file healed, ON is what ran. A different notice from the stale one on purpose: nothing about
+    ordering is claimed, and the frame names the fault. `known` says whether a kept value can be NAMED at
+    all: the tagged copy is the last snapshot this process proved (its last read or its own last write)
+    only when one is cached; otherwise it is the default, and the frame must not present that as kept."""
+    _stale_seen.refused = {"setting": name, "gt": gt, "refused": "on" if enabled else "off",
+                           "why": str(snap.get(UNPROVED) or "the ledger could not be read"),
+                           "known": str(jd.STATE / "auto-nudge.json") in _autonudge_cache}   # kept: None → the
+    #                                                                                gear drops "Keeping …"
+
+
+def _pop_refused_notice():
+    d = getattr(_stale_seen, "refused", None)
+    _stale_seen.refused = None
+    return d
+
+
 # ONE lock for every gt-gated setting's read-check-write span (2026-08-29): the stores read the
 # stamp, check _setting_stale, then write, on a ThreadingHTTPServer — with no lock, two
 # near-simultaneous flushes of one setting (two dashboards flushing on a host's recovery) could
@@ -4159,27 +4185,178 @@ _SETTINGS_LOCK = threading.RLock()
 _NUDGE_LOCK = threading.RLock()
 
 
-def _auto_nudge_data():
-    p = jd.STATE / "auto-nudge.json"
+# ── the two automatic ledgers: a snapshot is PROVED, or it says it is not (2026-09-07) ───────────
+# auto-nudge.json and retry-suppressed.json are each read by ONE reader and written by ONE writer, with
+# many read-modify-write sites between them (`d = dict(reader()); d[k] = v; writer(d)`). Both readers
+# used to answer ANY fault with the fresh-install default — a stat or read error, bytes that did not
+# parse — and cache that answer under the file's real stat key, so the next writer persisted it: one
+# EIO on a tick and every stalled goal across every session was nudged again (the dedupe map read as
+# empty), a user's auto-nudge OFF was flipped back ON, and every sibling session's "stop retrying" was
+# erased by the next interrupt. Missing is the ONLY fault that means the default: a file that is not
+# there IS the fresh-install state. Every other fault yields a snapshot the reader cannot vouch for, and
+# that snapshot carries the fault under UNPROVED, so the writer — the one choke point every RMW site
+# already funnels through — refuses to persist it, loud once per fault episode. Readers still get their
+# best view (the last snapshot this process proved, else the default) for display and gates; nothing
+# unproved is ever cached, so the file's next successful read is the episode's end — an event, not a
+# clock. Bytes that do not parse are a fault of the bytes, not of the moment: they are moved aside as
+# <file>.corrupt-<utc stamp> (evidence kept, never deleted) and the ledger then reads, truthfully, as
+# absent. The tag travels IN the snapshot because every RMW site copies it with dict(): a flag beside
+# the cache would not survive the copy, and a per-path "last read failed" bit races a sibling thread's
+# proved read.
+UNPROVED = "_unproved"                 # snapshot tag → the fault text; never a key a ledger stores
+_ledger_fault_warned = {}              # what -> fault the reader already shouted; cleared by a proved read
+_ledger_refusal_warned = {}            # what -> fault the writer already shouted; cleared by a proved write
+
+
+def _ledger_read(p, cache, default, what, normalize=None):
+    """FOUR-STATE read of a small JSON ledger. Absent → default() (uncached: the fresh-install arm, byte for
+    byte the old behavior); readable and a JSON object → the dict (normalize applied), cached under its
+    stat key; bytes that do not parse → moved aside (_ledger_quarantine), then default(); any other stat
+    or read fault → a COPY of the last cached snapshot (else default()) tagged UNPROVED, nothing cached."""
     try:
-        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
-    except OSError:
-        return {"enabled": True, "nudged": {}}
-    hit = _autonudge_cache.get(str(p))
+        st = p.stat()
+    except FileNotFoundError:
+        return _ledger_proved(what, default())
+    except OSError as e:
+        return _ledger_unproved(p, cache, default, what, "stat failed: %s" % e)
+    key = (st.st_mtime_ns, st.st_size)
+    hit = cache.get(str(p))
     if hit is not None and hit[0] == key:
-        return hit[1]
+        return _ledger_proved(what, hit[1])
+    reason = None                          # set when the bytes were read whole and are not a ledger
     try:
-        d = json.loads(p.read_text())
-        if not isinstance(d, dict):
-            d = {}
+        raw = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _ledger_proved(what, default())   # removed between the stat and the read: absent
+    except OSError as e:
+        return _ledger_unproved(p, cache, default, what, "read failed: %s" % e)
+    except UnicodeError as e:
+        reason = "not UTF-8: %s" % e
+    if reason is None:
+        try:
+            d = json.loads(raw)
+        except Exception as e:             # json.JSONDecodeError is a ValueError
+            reason = "invalid JSON: %s" % e
+        else:
+            if not isinstance(d, dict):
+                reason = "top-level JSON value is %s, not an object" % type(d).__name__
+    if reason is not None:                 # the bytes' fault, not the moment's: move them aside
+        why = _ledger_quarantine(p, st, what, reason)
+        if why is None:
+            return _ledger_proved(what, default())
+        return _ledger_unproved(p, cache, default, what, "%s (%s)" % (reason, why))
+    if normalize is not None:
+        normalize(d)
+    cache[str(p)] = (key, d)
+    return _ledger_proved(what, d)
+
+
+def _ledger_proved(what, d):
+    """A PROVED state — a readable object, or absence (the fresh-install state) — ends the fault episode
+    for both once-per-episode registries, the reader's and the writer's, so the next fault shouts again
+    even when the episode ended with reads alone (a write-only reset left the writer's registry armed
+    across a read-healed episode: a repeat fault with the same text then refused silently)."""
+    _ledger_fault_warned.pop(what, None)
+    _ledger_refusal_warned.pop(what, None)
+    return d
+
+
+def _ledger_unproved(p, cache, default, what, fault):
+    """The snapshot a fault leaves: a copy of the last one this process proved (else the default), tagged
+    with the fault so the writer refuses it. One stderr line per fault episode — keyed on the fault text,
+    never on the tick — so a disk that stays broken says so once and a different fault says so again."""
+    hit = cache.get(str(p))
+    if _ledger_fault_warned.get(what) != fault:
+        _ledger_fault_warned[what] = fault
+        sys.stderr.write("%s: %s is unreadable (%s) — serving %s; nothing is written to it until it "
+                         "reads again\n" % (what, p.name, fault,
+                                            "the last snapshot this kernel proved" if hit is not None
+                                            else "the default (no proved snapshot yet)"))
+    d = dict(hit[1]) if hit is not None else default()
+    d[UNPROVED] = fault
+    return d
+
+
+def _ledger_quarantine(p, st, what, reason):
+    """Move an unparseable ledger ASIDE (never delete it) so the evidence survives the fresh start that
+    follows: the sidecar keeps the original name plus `.corrupt-<utc stamp>` (a `-n` suffix for a second in
+    the same second), the shape the judge's goal-store quarantine wears, so one convention reads across both.
+    Only while the file is still the one whose bytes failed (same inode and generation) — an atomic publish
+    since then already replaced them, and the new file gets its own read. Returns None once the bytes are out
+    of the way (moved, or already gone: a sibling reader moved them), with one stderr line for the move;
+    else the reason they are NOT, for the caller's fault text — which _ledger_unproved dedupes per episode,
+    so a corrupt file that cannot be moved (a read-only state dir) is said once, never once per read."""
+    try:
+        cur = p.stat()
+        if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
+            return "replaced meanwhile; the new bytes get their own read"
+        stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
+        while aside.exists():                            # a second corrupt file in the same second
+            n += 1
+            aside = p.with_name("%s.corrupt-%s-%d" % (p.name, stamp, n))
+        os.replace(p, aside)
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        # errno + strerror ONLY: str(e) names both paths, and the destination carries the per-second stamp,
+        # so a text with it changed every second and every once-per-fault-text dedupe fired once a second
+        return "could not be moved aside: %s" % ("[Errno %d] %s" % (e.errno, e.strerror) if e.errno is not None
+                                                 else type(e).__name__)
+    sys.stderr.write("%s: %s could not be parsed (%s); moved aside to %s, the ledger reads as absent\n"
+                     % (what, p.name, reason, aside.name))
+    return None
+
+
+def _ledger_write_proved(p, what, d, cache, normalize=None):
+    """The ONE choke point every RMW site of a ledger funnels through: persist `d` — unless it descends from
+    an unproved snapshot (it carries UNPROVED), then refuse, one stderr line per fault episode, and return
+    False; the file keeps whatever it holds. Persisting that snapshot IS the erase-everything bug: the copy
+    a fault leaves is the default or a stale last-known-good, never the file's current contents. An OSError
+    from the write itself propagates as before (callers that own a gesture catch it and say so).
+    A write that lands is a PROVED state: it ends the fault episode and refreshes the cache with what the
+    file now holds (read back under its stat key), so "the last snapshot this process proved" — what a
+    later fault serves, what a refused gesture names as kept — includes this kernel's own last write, not
+    just its last read. Best-effort: a read-back that fails leaves the cache as it was."""
+    fault = d.get(UNPROVED) if isinstance(d, dict) else None
+    if fault:
+        if _ledger_refusal_warned.get(what) != fault:
+            _ledger_refusal_warned[what] = fault
+            sys.stderr.write("%s: refusing to write %s from an unproved snapshot (%s) — the file keeps what "
+                             "it holds\n" % (what, p.name, fault))
+        return False
+    _atomic_write(p, json.dumps(d))
+    _ledger_proved(what, None)               # a proved write ends the episode too
+    try:
+        st = p.stat()
+        back = json.loads(p.read_text(encoding="utf-8"))
+        st2 = p.stat()
+        if isinstance(back, dict) and (st.st_mtime_ns, st.st_size) == (st2.st_mtime_ns, st2.st_size):
+            if normalize is not None:
+                normalize(back)
+            cache[str(p)] = ((st.st_mtime_ns, st.st_size), back)
     except Exception:
-        d = {}
+        pass                                 # the write landed; the next read proves the file on its own
+    return True
+
+
+def _auto_nudge_default():
+    return {"enabled": True, "nudged": {}}
+
+
+def _auto_nudge_normalize(d):
     d.setdefault("enabled", True)
     d.setdefault("nudged", {})         # {gid: {count, lastTurnId}} — re-arm per stall episode (replaces the one-shot "done" list)
     d.pop("done", None)                # drop the vestigial one-shot list (old code wrote it; nothing reads it now) →
     #                                    cleaned from the file on the next write (the user via business 2026-06-22)
-    _autonudge_cache[str(p)] = (key, d)
-    return d
+
+
+def _auto_nudge_data():
+    """The auto-nudge ledger's snapshot — see the ledger block above: absent reads as the default, a fault
+    reads as the last proved snapshot tagged UNPROVED (which _write_auto_nudge refuses), bytes that do not
+    parse are moved aside. Writers copy it first (`dict(_auto_nudge_data())`); the tag rides the copy."""
+    return _ledger_read(jd.STATE / "auto-nudge.json", _autonudge_cache, _auto_nudge_default, "auto-nudge",
+                        _auto_nudge_normalize)
 
 
 def _auto_nudge_on():
@@ -4273,13 +4450,17 @@ def _conserve_tick(now):
 
 
 def _write_auto_nudge(d):
-    _atomic_write(jd.STATE / "auto-nudge.json", json.dumps(d))
+    """Persist the auto-nudge ledger — the ONE writer behind every RMW site. False (loud, once per fault
+    episode) when `d` descends from an unproved snapshot: see _ledger_write_proved."""
+    return _ledger_write_proved(jd.STATE / "auto-nudge.json", "auto-nudge", d, _autonudge_cache,
+                                _auto_nudge_normalize)
 
 
 def _set_auto_nudge(enabled, gt=None):
     """Returns the applied gesture stamp (epoch ms), or None when a stale `gt` stood down —
     see the gesture-time ordering block above _NUDGE_LOCK — or the store write failed (OSError:
-    loud on stderr, nothing applied). The catch lives HERE, like _set_update_mode's and
+    loud on stderr, nothing applied), or the ledger read was unproved (the writer refuses the
+    snapshot, loud once per fault episode; nothing applied). The catch lives HERE, like _set_update_mode's and
     _set_judge_state's: a raised OSError reaches the WS reader loop, which classifies it as a
     socket failure and re-raises into a silent pass — a full-disk gear toggle tearing the whole
     dashboard WebSocket down with zero log output."""
@@ -4292,7 +4473,9 @@ def _set_auto_nudge(enabled, gt=None):
         d["enabled"] = bool(enabled)
         d["gt"] = gt if gt is not None else int(time.time() * 1000)
         try:
-            _write_auto_nudge(d)
+            if _write_auto_nudge(d) is False:           # unproved snapshot: refused at the writer, nothing
+                _note_refused_gesture("auto-nudge", gt, enabled, d)   # applied — and the socket hears it
+                return None
         except OSError as e:
             sys.stderr.write("setting auto-nudge: write failed (%s) — nothing applied\n" % e)
             return None
@@ -4323,7 +4506,9 @@ def _set_compact_suggest(enabled, gt=None):
         d["compactSuggestEnabled"] = bool(enabled)
         d["compactSuggestGt"] = gt if gt is not None else int(time.time() * 1000)
         try:
-            _write_auto_nudge(d)
+            if _write_auto_nudge(d) is False:           # unproved snapshot: refused at the writer, nothing
+                _note_refused_gesture("compact-suggest", gt, enabled, d)   # applied — and the socket hears it
+                return None
         except OSError as e:
             sys.stderr.write("setting compact-suggest: write failed (%s) — nothing applied\n" % e)
             return None
@@ -5616,26 +5801,24 @@ def _auto_resume_retry(now, tmux):
 # STATE/retry-suppressed.json {sid: stop_ts}. A sid present = suppressed; stop_ts is the re-arm floor (only a
 # successful turn AFTER it lifts the suppression). _auto_resume_session_retry clears re-armed sids each tick.
 _retry_suppress_cache = {}   # str(path) -> ((mtime_ns,size), dict)
+_RETRY_SUPPRESS_LOCK = threading.Lock()   # the arm/clear read-modify-write span: the interrupt handler (a WS
+#                                           thread) and the pusher's re-arm sweep rewrite the same whole blob;
+#                                           unlocked, the loser's snapshot erased the winner's key. Held across
+#                                           the file read + write only — never across a backend call.
+_retry_floor_warned = set()               # (sid, type name) of a non-numeric floor already shouted
 
 
 def _retry_suppress_data():
-    p = jd.STATE / "retry-suppressed.json"
-    try:
-        stt = p.stat()
-        key = (stt.st_mtime_ns, stt.st_size)
-    except OSError:
-        return {}
-    hit = _retry_suppress_cache.get(str(p))
-    if hit and hit[0] == key:
-        return hit[1]
-    try:
-        d = json.loads(p.read_text())
-        if not isinstance(d, dict):
-            d = {}
-    except Exception:
-        d = {}
-    _retry_suppress_cache[str(p)] = (key, d)
-    return d
+    """The per-session retry-suppression ledger's snapshot — the ledger block above _auto_nudge_data: absent
+    reads as {} (nobody suppressed), a fault reads as the last proved snapshot tagged UNPROVED (which the
+    writer refuses), bytes that do not parse are moved aside."""
+    return _ledger_read(jd.STATE / "retry-suppressed.json", _retry_suppress_cache, dict, "retry-suppress")
+
+
+def _write_retry_suppress(d):
+    """The ONE writer behind the arm and the clear: False (loud, once per fault episode) when `d` descends
+    from an unproved snapshot — see _ledger_write_proved."""
+    return _ledger_write_proved(jd.STATE / "retry-suppressed.json", "retry-suppress", d, _retry_suppress_cache)
 
 
 def _session_retry_suppressed(sid):
@@ -5647,18 +5830,38 @@ def _session_retry_suppressed(sid):
 
 def _suppress_session_retry(sid):
     """Arm per-session retry-suppression at NOW (the re-arm floor). Every interrupt refreshes the floor, so
-    "suppressed since your most recent interrupt" is the invariant."""
-    d = dict(_retry_suppress_data())
-    d[str(sid)] = time.time()
-    _atomic_write(jd.STATE / "retry-suppressed.json", json.dumps(d))
+    "suppressed since your most recent interrupt" is the invariant. Returns None once the suppression is on
+    disk, else ONE sentence saying why it is not — the caller is the user's stop click (the interrupt
+    handler), which toasts it: a stop that did not land must never look like one. Two ways it does not land:
+    the ledger read was unproved (the writer refuses the snapshot — persisting it erased every sibling
+    session's stop), or the write itself failed (ENOSPC — before this the OSError escaped into the WS reader
+    loop, which reads any OSError as a socket failure and tore the dashboard's connection down, with the
+    suppression neither on disk nor anywhere)."""
+    with _RETRY_SUPPRESS_LOCK:
+        d = dict(_retry_suppress_data())
+        d[str(sid)] = time.time()
+        try:
+            written = _write_retry_suppress(d)
+        except OSError as e:
+            sys.stderr.write("retry-suppress: write failed (%s) — the stop for %s is not recorded\n" % (e, sid))
+            why = getattr(e, "strerror", None) or str(e)
+        else:
+            if written:
+                return None
+            why = d.get(UNPROVED)
+    return ("Interrupted, but the stop could not be recorded (retry-suppressed.json: %s) — romp may retry "
+            "into this session again" % why)
 
 
 def _clear_session_retry_suppress(sid):
-    d = dict(_retry_suppress_data())
-    if d.pop(str(sid), None) is not None:
-        _atomic_write(jd.STATE / "retry-suppressed.json", json.dumps(d))
-        return True
-    return False
+    """Drop `sid`'s suppression; True when the ledger on disk changed. A refused write (an unproved snapshot)
+    leaves the suppression standing and returns False — suppressed is the safe direction while the ledger
+    cannot be read; the sweep retries on its next tick, and the file's next proved read is the event."""
+    with _RETRY_SUPPRESS_LOCK:
+        d = dict(_retry_suppress_data())
+        if d.pop(str(sid), None) is None:
+            return False
+        return _write_retry_suppress(d)
 
 
 def _auto_resume_session_retry(now, tmux):
@@ -5675,6 +5878,14 @@ def _auto_resume_session_retry(now, tmux):
     for s in _alive_sessions(now, tmux):
         sid = str(s.get("sid"))
         floor = d.get(sid)
+        if floor is not None and (isinstance(floor, bool) or not isinstance(floor, (int, float))):
+            # a hand-edited or foreign file: never a compare operand (the `<= floor` below raised TypeError
+            # into the pusher tick and the whole sweep died) — read as no floor, said once per session
+            if (sid, type(floor).__name__) not in _retry_floor_warned:
+                _retry_floor_warned.add((sid, type(floor).__name__))
+                sys.stderr.write("retry-suppress: session %s has a non-numeric floor (%r) — read as no floor; "
+                                 "nothing re-arms it until the entry is a number\n" % (sid, floor))
+            continue
         if not floor:
             continue
         path = s.get("path")
@@ -6041,7 +6252,7 @@ def _set_intr_blocked(sid, gid):
         else:
             m.pop(str(sid), None)
         d["intrBlocked"] = m
-        _write_auto_nudge(d)
+        return _write_auto_nudge(d)      # False when refused (an unproved snapshot): the caller gates on it
 
 
 def _intr_block_stands(sid, gid):
@@ -6099,6 +6310,16 @@ def _interrupt_block_tick(now, tmux):
         #                                                  evidence times both writes are stamped with
         block_it = bool(turns) and not _session_working(turns) and stop_t > human_t
         if block_it:                                     # a GENUINE user stop → block the focus goal on them,
+            snap = _auto_nudge_data()
+            if snap.get(UNPROVED):
+                # the ledger cannot be read: file NO block now — its once-per-episode marker could not be
+                # minted (the writer refuses an unproved snapshot), and the lift on re-engagement is gated
+                # on that marker, so an unmarked block would stand until a judge happened to unblock it.
+                # The stop is re-evaluated from the transcript every push, so the block lands on the first
+                # tick after the file reads again. Loud once per fault episode, on the pass's latch.
+                _auto_nudge_pause(snap[UNPROVED])
+                continue
+            _auto_nudge_resume()
             ib = _intr_blocked(sid)                      # once per interrupt episode (the intrBlocked marker) —
             if ib and not _intr_block_stands(sid, ib):   # but VERIFY the marked block still holds its card (see
                 _set_intr_blocked(sid, None)             # _intr_block_stands): a stale marker is the 'already
@@ -6114,15 +6335,23 @@ def _interrupt_block_tick(now, tmux):
                                      for a in (turn.get("atoms") or [])])
                 g = _record_interrupt_block(sid, ev)
                 if g:
+                    # the block IS filed — a proved goal-store write, a needs-you flip the feed must hear —
+                    # so this pushes whatever the marker write's fate: a fault landing between the tag
+                    # check above and here refuses the marker, and the next tick stands down at the check
                     _set_intr_blocked(sid, g); changed = True
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
             if ib:
                 # the re-engagement IS the newest turn's trigger — the same stamp the judges will put on
-                # every verdict about that turn, so their ruling outranks this lift on arrival order
+                # every verdict about that turn, so their ruling outranks this lift on arrival order.
+                # The lift runs whatever the ledger's state — it is the user's own re-engagement — but
+                # `changed` follows the MARKER write: refused under a fault, the marker stays in the last
+                # proved snapshot, the lift re-runs as a no-op next tick, and nothing pushes every cycle.
+                # A lift that could not READ the goals store (False: its row is filed) keeps the marker
+                # too, so the next tick retries the lift rather than erasing it (the #1019 boundary)
                 if _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0):
-                    _set_intr_blocked(sid, None); changed = True   # spent; on a store fault the marker
-                #                                                    stays so the next tick retries the lift
+                    if _set_intr_blocked(sid, None):     # spent → the marker goes; `changed` follows the write
+                        changed = True
     if changed:                                          # a needs-you flip should reach the feed at once
         _push_all()
 
@@ -6600,7 +6829,8 @@ def _compact_suggest_tick(sid, tm, now):
         #                                                BOTH thresholds latch when found past both —
         #                                                one message, never two in a tick
         d["compactSuggested"] = cs
-        _write_auto_nudge(d)
+        if _write_auto_nudge(d) is False:
+            return False                               # the claim did not latch (unproved ledger): no send
     try:
         # the marker tail its sibling injectors carry (T207, the user 2026-08-31, who saw the
         # bare send render as their own blue bubble and ruled it must read system-injected):
@@ -6690,12 +6920,45 @@ def _ws_act_now_tick():
         sys.stderr.write("auto-nudge (ws act-now): %s\n" % traceback.format_exc())
 
 
+_auto_nudge_paused = [None]   # the fault the tick is standing down on; None = the ledger reads, nudging runs
+
+
+def _auto_nudge_pause(fault):
+    """A tick found the ledger unreadable: the nudge pass stands down WHOLE — the nudge, the wake, the
+    compaction suggestion, the debt ladder, the sweeps — and the interrupt→blocked tick files no block;
+    loudly, once per fault episode (stderr + the dashboard's bell), and never defaulted on. Every leg
+    records what it fired in this ledger, and a record the writer refuses re-fires the same message every
+    tick (the every-tick re-nudge of every stalled goal, reproduced with one EIO); the fabricated default
+    also read an explicit OFF as ON. One latch for both ticks, so a fault says so once. Resumes on the
+    first tick whose read proves (_auto_nudge_resume) — the file's next successful read is the event; there
+    is no timer."""
+    if _auto_nudge_paused[0] == fault:
+        return
+    _auto_nudge_paused[0] = fault
+    line = ("auto-nudge: auto-nudge.json is unreadable (%s) — nudging and the interrupt→blocked flip are "
+            "paused, not defaulted on, until it reads again" % fault)
+    sys.stderr.write(line + "\n")
+    _sdk_problem(line)                                    # the error center: a kernel-side fault the user can act on
+
+
+def _auto_nudge_resume():
+    if _auto_nudge_paused[0] is not None:
+        _auto_nudge_paused[0] = None
+        sys.stderr.write("auto-nudge: auto-nudge.json reads again — nudging resumed\n")
+
+
 def _auto_nudge_pass(now, tmux, run_dead_wait):
     """The body of one pass — the walk, the sweeps, the push. Only _auto_nudge_tick calls it, under
     the single-flight guard (split out the way _pusher_cycle_jobs is from _pusher_cycle). `on` is the auto-nudge toggle:
-    off, the walk runs WAKE-ONLY — the awaiting dead-man still fires (see _auto_nudge_tick)."""
+    off, the walk runs WAKE-ONLY — the awaiting dead-man still fires (see _auto_nudge_tick). An UNPROVED
+    ledger snapshot (a read fault) stands the whole pass down — see _auto_nudge_pause."""
+    snap = _auto_nudge_data()
+    if snap.get(UNPROVED):
+        _auto_nudge_pause(snap[UNPROVED])
+        return
+    _auto_nudge_resume()
     on = _auto_nudge_on()
-    nudged = dict(_auto_nudge_data().get("nudged", {}))   # {gid: {count, lastTurnId}}
+    nudged = dict(snap.get("nudged", {}))                 # {gid: {count, lastTurnId}}
     alive = list(_alive_sessions(now, tmux))
     alive_ids = {s["sid"] for s in alive}
     waitfor = _wait_for_graph(now, alive_ids)             # {sid:{peerSid,name,inCycle}} — the peer-wait gate
@@ -11786,9 +12049,11 @@ def _drive(msg, client):
     elif t == "interrupt":
         be.interrupt(sid)                                 # Esc/stop AND settle idle (in the backend)
         _interrupt_clicked[str(sid)] = time.time()        # chip → "interrupting" NOW (event-cleared on settle)
-        _suppress_session_retry(sid)                      # interrupting a thread STOPS romp's auto-retry into it until a
+        err = _suppress_session_retry(sid)                # interrupting a thread STOPS romp's auto-retry into it until a
                                                           # successful turn re-arms (the user 2026-07-06) — the interrupt
                                                           # already aborted any in-flight CLI retry; this stops the relapse
+        if err:                                           # …and a stop that did NOT land is said, the rewind ops' warn-toast
+            client["send"](json.dumps({"type": "warn", "text": err}))   # idiom (fail loudly; the interrupt itself happened)
         _mark_views_dirty()                               # the stamp lives in memory — no sig sees it
     elif t in ("compact", "compactSession"):
         # Mid-turn (or behind an existing queue) the click PARKS as a queued /compact chip and fires when
@@ -31197,13 +31462,28 @@ def _tell_stale_gesture(client, msg):
     one — and the gear only re-issues a type that matches the setting the frame names.
     It also carries `gt`, the refused gesture's OWN stamp: a dashboard's broadcast reaches every
     linked kernel, so one stale flush draws one refusal per kernel — all sharing this stamp — and
-    the gear folds them into one toast naming the refusing hosts (setting + gt is the fold key)."""
+    the gear folds them into one toast naming the refusing hosts (setting + gt is the fold key).
+    A write REFUSED over an unproved ledger read (_note_refused_gesture) answers the same socket with
+    the same frame plus `why` (the fault): the gear's copy — not applied, keeping the stored value —
+    is exactly true of it, and the frame's re-fill snaps the checkbox back to the last snapshot this
+    kernel proved (`kept`, named only when there is one); the fault itself, which the copy does not
+    carry, goes to the error center so it is on record."""
     st = _pop_stale_notice()
-    if not st:
+    if st:
+        _reply(client, {"type": "settingStale", "setting": st["setting"],
+                        "storedGt": st["storedGt"], "gt": st["gt"], "kept": _setting_kept_value(st["setting"]),
+                        "gesture": {k: v for k, v in msg.items() if k != "gt"}})
         return
-    _reply(client, {"type": "settingStale", "setting": st["setting"],
-                    "storedGt": st["storedGt"], "gt": st["gt"], "kept": _setting_kept_value(st["setting"]),
-                    "gesture": {k: v for k, v in msg.items() if k != "gt"}})
+    rf = _pop_refused_notice()
+    if not rf:
+        return
+    kept = _setting_kept_value(rf["setting"]) if rf.get("known") else None
+    _sdk_problem("setting %s: %s was not applied — %s; the stored value%s stands until the ledger reads again"
+                 % (rf["setting"], rf["refused"], rf["why"],
+                    "" if kept is None else " (%s)" % ("on" if kept else "off")))
+    _reply(client, {"type": "settingStale", "setting": rf["setting"],
+                    "storedGt": _setting_stored_gt(rf["setting"]), "gt": rf["gt"], "kept": kept,
+                    "why": rf["why"], "gesture": {k: v for k, v in msg.items() if k != "gt"}})
 
 
 # ---- pasted-image hydration + dropped-file handling (ported from the old TS kernel chat-view/src/

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -42,7 +42,8 @@ class DebtBase(unittest.TestCase):
                        km._write_auto_nudge, km.Sessions.backend_for)
         self._d = {"nudged": {}}
         km._auto_nudge_data = lambda: self._d
-        km._write_auto_nudge = lambda d: self._d.update(d)
+        km._write_auto_nudge = lambda d: self._d.update(d) or True   # the writer's verdict: the reminder
+        #                                            sends only when its record landed (a None here reads as refused)
         km._name_of = lambda sid: {ASKER: "web", ASKER2: "api", DEBTOR: "tests"}.get(sid)
         self.rec = _Recorder()
         km.Sessions.backend_for = lambda sid: self.rec

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""The auto-nudge ledger is never rewritten from a fabricated default after a read fault (2026-09-07).
+
+auto-nudge.json has one reader (_auto_nudge_data) and one writer (_write_auto_nudge) with some twenty
+read-modify-write sites between them — `d = dict(_auto_nudge_data()); d[k] = v; _write_auto_nudge(d)`.
+The reader used to answer ANY fault — a stat or read error, bytes that did not parse — with the
+fresh-install default {"enabled": True, "nudged": {}} and cache it under the file's real stat key, so the
+next writer persisted it: after one EIO every stalled goal in every session was nudged again (the dedupe
+map read as empty) and an explicit auto-nudge OFF came back ON.
+
+Now only a MISSING file reads as the default — that IS the fresh-install state. Every other fault yields a
+snapshot tagged "_unproved" (a copy of the last one this process proved, else the default) that the writer
+refuses, loud once per fault episode; nothing unproved is cached, so the file's next successful read ends
+the episode. Bytes that do not parse are moved aside as auto-nudge.json.corrupt-<utc stamp> (evidence
+kept) and the ledger then reads as absent. The nudge pass's stand-down rides the same tag and is pinned
+where the firing fixture lives (tests/test_wake_deadman_toggle.py); the interrupt→blocked tick, which runs
+outside that pass, is pinned here; the retry-suppress ledger takes the same shape in
+tests/test_session_retry_suppress.py.
+
+Synthetic fixtures only: a placeholder sid, invented goal ids, a temp state root."""
+import contextlib
+import errno
+import io
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_ledger_unproved", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+GID = SID + ":g1"
+DEFAULT = {"enabled": True, "nudged": {}}
+SEEDED = {"enabled": False, "nudged": {GID: {"count": 2, "lastTurnId": "t7"}}}   # an explicit OFF + a dedupe record
+EIO = OSError(errno.EIO, "Input/output error")
+# Spelled out, not km.UNPROVED: a kernel without the fix has no such name, and these tests must fail
+# there on the DEFECT (a rewritten file, a fired message), never on an AttributeError in the fixture.
+UNPROVED = "_unproved"
+REGISTRIES = ("_ledger_fault_warned", "_ledger_refusal_warned")   # the once-per-episode registries
+
+
+def _reset_ledger_state():
+    km._autonudge_cache.clear()
+    for reg in REGISTRIES:                       # absent on a kernel before the fix (see UNPROVED above)
+        vars(km).get(reg, {}).clear()
+    vars(km).get("_auto_nudge_paused", [None])[0] = None
+
+
+def _fail_path(target, method, exc):
+    """Path.<method> raises `exc` for `target` only; every other path behaves as before. Returns the undo."""
+    real = getattr(Path, method)
+
+    def failing(p, *a, **k):
+        if str(p) == str(target):
+            raise exc
+        return real(p, *a, **k)
+    setattr(Path, method, failing)
+    return lambda: setattr(Path, method, real)
+
+
+class _Ledger(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        self.p = jd.STATE / "auto-nudge.json"
+        self._undo = []
+        _reset_ledger_state()
+
+    def tearDown(self):
+        self._heal()
+        _reset_ledger_state()
+        jd.STATE = self.saved_state
+        self.td.cleanup()
+
+    def _seed(self, d=SEEDED):
+        self.p.write_text(json.dumps(d))
+        km._autonudge_cache.clear()
+        return self.p.read_bytes()
+
+    def _fail(self, method, exc=EIO):
+        self._undo.append(_fail_path(self.p, method, exc))
+
+    def _heal(self):
+        for undo in reversed(self._undo):
+            undo()
+        self._undo = []
+
+    def _aside(self):
+        return sorted(n for n in os.listdir(jd.STATE) if n.startswith("auto-nudge.json.corrupt-"))
+
+
+class FreshInstall(_Ledger):
+    def test_a_missing_file_reads_as_the_default_with_no_log_and_no_quarantine(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._auto_nudge_data()
+        self.assertEqual(d, DEFAULT)
+        self.assertNotIn(UNPROVED, d, "absent is the one fault that IS the default — a proved read")
+        self.assertEqual(err.getvalue(), "", "a fresh install is not an incident")
+        self.assertEqual(os.listdir(jd.STATE), [], "nothing moved aside, nothing created")
+        self.assertEqual(km._autonudge_cache, {}, "absent is not cached — the old arm, byte for byte")
+        km._mark_auto_nudged(GID, "t1", 1)
+        self.assertEqual(json.loads(self.p.read_text())["nudged"][GID]["count"], 1,
+                         "…and the first RMW writes the ledger, as it always did")
+
+
+class ReadFault(_Ledger):
+    def test_an_ordinary_rmw_after_a_read_fault_leaves_the_file_unchanged(self):
+        # THE defect: the reader fabricated the default on EIO, cached it under the file's real stat key,
+        # and the next writer persisted it — flipping the OFF to ON and erasing the dedupe record.
+        before = self._seed()
+        self._fail("read_text")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            applied = km._set_auto_nudge(True, gt=1_700_000_000_000)
+            applied2 = km._set_compact_suggest(True, gt=1_700_000_000_000)
+            km._mark_auto_nudged(GID + "x", "t9", 1)
+        self._heal()
+        self.assertEqual(self.p.read_bytes(), before, "the file on disk is byte for byte what it was")
+        self.assertIsNone(applied, "a refused write reports not-applied, like a failed write")
+        self.assertIsNone(applied2, "…the compaction-suggestion toggle too (the same blob, the same writer)")
+        self.assertEqual(err.getvalue().count("refusing to write auto-nudge.json"), 1,
+                         "one refusal line per fault episode — not one per write, not one per tick")
+        self.assertIn("Input/output error", err.getvalue(), "the line names the fault")
+        self.assertEqual(km._autonudge_cache, {}, "nothing unproved is cached")
+
+    def test_a_stat_fault_is_unproved_too(self):
+        # the old stat arm returned the default for ANY OSError; only ENOENT means absent
+        before = self._seed()
+        self._fail("stat")
+        with contextlib.redirect_stderr(io.StringIO()):
+            d = km._auto_nudge_data()
+            km._mark_auto_nudged(GID + "x", "t9", 1)
+        self._heal()
+        self.assertEqual(self.p.read_bytes(), before)
+        self.assertTrue(str(d.get(UNPROVED, "")).startswith("stat failed"))
+
+    def test_the_snapshot_is_a_copy_of_the_last_proved_one_tagged_with_the_fault(self):
+        self._seed()
+        proved = km._auto_nudge_data()                     # a proved read fills the cache
+        self.assertFalse(proved["enabled"])
+        self.p.write_text(json.dumps(DEFAULT))             # the file moves on (a different size → a new key)…
+        self._fail("read_text")                            # …and the new bytes cannot be read
+        with contextlib.redirect_stderr(io.StringIO()):
+            d = km._auto_nudge_data()
+        self.assertFalse(d["enabled"], "the last snapshot this process proved — not the fabricated default")
+        self.assertIn(GID, d["nudged"])
+        self.assertTrue(str(d.get(UNPROVED, "")).startswith("read failed"))
+        d["scratch"] = 1
+        self.assertNotIn("scratch", proved, "a copy: no site can poison the proved snapshot through it")
+        self.assertIs(km._autonudge_cache[str(self.p)][1], proved, "the cache still holds the proved one")
+        self.assertFalse(km._write_auto_nudge(dict(d)), "the writer refuses a snapshot wearing the tag")
+        km._autonudge_cache.clear()                        # no proved snapshot at all (a fault at boot):
+        with contextlib.redirect_stderr(io.StringIO()):
+            d2 = km._auto_nudge_data()
+        self.assertEqual({k: v for k, v in d2.items() if k != UNPROVED}, DEFAULT,
+                         "readers get the default to display — tagged, so no writer may persist it")
+        self.assertIn(UNPROVED, d2)
+
+    def test_the_reader_and_the_writer_shout_once_per_fault_episode(self):
+        # keyed on the fault TEXT, reset by EVERY proved state — a write, a read, a cache hit, absence —
+        # so a disk that stays broken says so once, and the SAME fault returning after a heal says so again
+        self._seed()
+        err = io.StringIO()
+
+        def episode(n, method="read_text"):
+            if method == "read_text":
+                km._autonudge_cache.clear()                # the file must actually be read (no cache hit)
+            self._fail(method)
+            with contextlib.redirect_stderr(err):
+                for _ in range(3):
+                    km._auto_nudge_data()
+                    km._mark_auto_nudged(GID + "y", "t1", 1)
+            self._heal()
+            self.assertEqual(err.getvalue().count("auto-nudge.json is unreadable"), n, "the reader: once per episode")
+            self.assertEqual(err.getvalue().count("refusing to write"), n, "the writer: once per episode")
+        episode(1)
+        with contextlib.redirect_stderr(err):
+            km._mark_auto_nudged(GID + "y", "t1", 1)       # healed: a proved RMW lands, quietly…
+        self.assertIn(GID + "y", json.loads(self.p.read_text())["nudged"])
+        episode(2)                                         # …and ended the episode: the same text shouts again
+        with contextlib.redirect_stderr(err):
+            km._auto_nudge_data()                          # healed: a proved READ alone, no write…
+        episode(3)                                         # …ends the episode too (both registries, not just the reader's)
+        with contextlib.redirect_stderr(err):
+            km._auto_nudge_data()                          # a proved read: the cache now holds the file's key
+        episode(4, "stat")                                 # a STAT fault: the cache is never consulted…
+        with contextlib.redirect_stderr(err):
+            self.assertNotIn(UNPROVED, km._auto_nudge_data(), "healed: stat OK, same key — a cache HIT")
+        episode(5, "stat")                                 # …and the cache hit ended the episode (same text, shouts again)
+        self.p.unlink()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._auto_nudge_data(), DEFAULT, "healed by absence: ENOENT is a proved state")
+        self._seed()                                       # recreated…
+        episode(6, "stat")                                 # …and faulting again with the same text: shouts again
+        km._autonudge_cache.clear()
+        self._fail("read_text", OSError(errno.EACCES, "Permission denied"))
+        with contextlib.redirect_stderr(err):
+            km._mark_auto_nudged(GID + "z", "t1", 1)
+        self.assertEqual(err.getvalue().count("refusing to write"), 7, "a different fault text is its own episode")
+        self.assertIn("Permission denied", err.getvalue())
+
+
+class CorruptBytes(_Ledger):
+    def _corrupt(self, text):
+        self.p.write_text(text)
+        km._autonudge_cache.clear()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._auto_nudge_data()
+        return d, err.getvalue()
+
+    def test_bytes_that_do_not_parse_are_moved_aside_then_read_as_the_default(self):
+        d, err = self._corrupt('{"enabled": fals')        # a torn or hand-edited file
+        self.assertEqual(d, DEFAULT)
+        self.assertNotIn(UNPROVED, d, "absent after the move: a proved default, so writes proceed")
+        self.assertFalse(self.p.exists(), "the corrupt file is out of the way")
+        aside = self._aside()
+        self.assertEqual(len(aside), 1, "evidence kept, never deleted")
+        self.assertRegex(aside[0], r"^auto-nudge\.json\.corrupt-\d{8}T\d{6}Z$",
+                         "the judge's goal-store quarantine shape: <name>.corrupt-<utc stamp>")
+        self.assertEqual((jd.STATE / aside[0]).read_text(), '{"enabled": fals')
+        self.assertEqual(err.count("moved aside"), 1, "one stderr line naming the move")
+        self.assertIn("invalid JSON", err)
+        km._mark_auto_nudged(GID, "t1", 1)
+        self.assertEqual(json.loads(self.p.read_text())["nudged"][GID]["count"], 1,
+                         "the next RMW writes a fresh ledger: absent is the fresh-install state")
+
+    def test_a_json_value_that_is_not_an_object_is_corrupt_too(self):
+        d, err = self._corrupt("[1, 2, 3]")
+        self.assertEqual(d, DEFAULT)
+        self.assertFalse(self.p.exists())
+        self.assertEqual(len(self._aside()), 1)
+        self.assertIn("top-level JSON value is list, not an object", err)
+
+    def test_a_second_corrupt_file_in_the_same_second_takes_a_suffix(self):
+        real = time.gmtime
+        time.gmtime = lambda *a: real(0)                   # pin the stamp: both moves land in one second
+        self.addCleanup(setattr, time, "gmtime", real)
+        self._corrupt("{")
+        self._corrupt("}")
+        self.assertEqual(self._aside(), ["auto-nudge.json.corrupt-19700101T000000Z",
+                                         "auto-nudge.json.corrupt-19700101T000000Z-1"],
+                         "the second never overwrites the first: a -n suffix, the judge's convention")
+
+    def test_a_file_replaced_under_a_corrupt_read_is_not_moved_aside(self):
+        # the inode guard: the bytes that failed are the ones to move; a concurrent atomic publish between
+        # our read and our rename has already replaced them, and the NEW file must not be quarantined
+        self.p.write_text("{")
+        km._autonudge_cache.clear()
+        real, target = Path.read_text, str(self.p)
+
+        def read_then_publish(p, *a, **k):
+            raw = real(p, *a, **k)
+            if str(p) == target:                           # a peer publishes a valid ledger under us
+                tmp = p.with_name("auto-nudge.json.tmp.peer")
+                tmp.write_text(json.dumps(SEEDED))
+                os.replace(tmp, p)
+            return raw
+        Path.read_text = read_then_publish
+        self._undo.append(lambda: setattr(Path, "read_text", real))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._auto_nudge_data()
+        self._heal()
+        self.assertEqual(self._aside(), [], "the replacement is not the file whose bytes failed")
+        self.assertEqual(json.loads(self.p.read_text()), SEEDED, "…and it stands, untouched")
+        self.assertIn("replaced meanwhile", str(d.get(UNPROVED, "")), "this read is unproved; the next one reads the new bytes")
+        km._autonudge_cache.clear()
+        self.assertEqual(km._auto_nudge_data()["nudged"], SEEDED["nudged"])
+
+    def test_a_corrupt_file_that_cannot_be_moved_aside_is_said_once_not_once_per_read(self):
+        # a read-only state dir: every read re-fails the parse and the move; build_feed reads this ledger
+        # once per node per push, so a line per read floods the log — the move failure rides the fault
+        # text, which the reader dedupes per episode. The text must be STAMP-FREE: str(OSError) from
+        # os.replace names the destination, whose per-second stamp made the text — and so every dedupe:
+        # the reader's line, the writer's, the pause latch, the error-center row — fire once a second.
+        self.p.write_text("{")
+        km._autonudge_cache.clear()
+        real_replace, real_gmtime, clock = os.replace, time.gmtime, [1_000_000]
+
+        def refuse_aside(src, dst, *a, **k):
+            if ".corrupt-" in str(dst):
+                raise OSError(errno.EROFS, "Read-only file system", str(src), None, str(dst))
+            return real_replace(src, dst, *a, **k)
+
+        def ticking(*a):                                   # every read lands in a NEW second
+            clock[0] += 1
+            return real_gmtime(clock[0])
+        os.replace, time.gmtime = refuse_aside, ticking
+        self._undo.append(lambda: setattr(os, "replace", real_replace))
+        self._undo.append(lambda: setattr(time, "gmtime", real_gmtime))
+        err, snaps, rows = io.StringIO(), [], len(km._SDK_BOOT_PROBLEMS)
+        pause = vars(km).get("_auto_nudge_pause", lambda fault: None)   # absent before the fix (see UNPROVED)
+        with contextlib.redirect_stderr(err):
+            for _ in range(3):
+                snaps.append(km._auto_nudge_data())
+                pause(snaps[-1].get(UNPROVED, ""))         # what the ticks do with the text: latch on it
+        self._heal()
+        self.assertTrue(self.p.exists(), "nothing moved: the bytes stand for repair")
+        texts = {str(d.get(UNPROVED, "")) for d in snaps}
+        self.assertEqual(len(texts), 1, "ONE fault text across three seconds — no destination, no stamp")
+        text = texts.pop()
+        self.assertNotRegex(text, r"\d{8}T\d{6}Z", "the stamp never rides the fault text")
+        self.assertIn("[Errno %d] Read-only file system" % errno.EROFS, text, "errno + strerror name the failure")
+        lines = [l for l in err.getvalue().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2, "two channels, one line each: the reader's, and the pause latch's:\n" + err.getvalue())
+        self.assertEqual(sum("serving the default" in l for l in lines), 1, "the reader: once per fault episode, not per second")
+        self.assertEqual(sum("paused, not defaulted on" in l for l in lines), 1, "the pause latch: once")
+        self.assertTrue(all("could not be moved aside" in l for l in lines), "both carry the stamp-free reason")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), rows + 1, "one error-center row")
+        self.assertFalse(km._write_auto_nudge(dict(snaps[-1])), "and nothing is written over the corrupt file")
+
+    def test_bytes_that_are_not_utf8_are_corrupt_too(self):
+        self.p.write_bytes(b"\xff\xfe{")
+        km._autonudge_cache.clear()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._auto_nudge_data()
+        self.assertEqual(d, DEFAULT)
+        self.assertFalse(self.p.exists())
+        self.assertEqual(len(self._aside()), 1, "moved aside like any other unparseable bytes")
+        self.assertEqual((jd.STATE / self._aside()[0]).read_bytes(), b"\xff\xfe{")
+        self.assertIn("not UTF-8", err.getvalue())
+
+
+class InterruptBlockTickUnderAFault(unittest.TestCase):
+    """_interrupt_block_tick runs every push OUTSIDE the paused nudge pass. Under an unproved snapshot its
+    block arm used to file the block in the goal store (a proved write) and then have the marker write
+    refused — and the lift on re-engagement is gated on that marker, so a block placed during a fault
+    episode stood until a judge happened to unblock it; and its lift arm, with the marker clear refused,
+    set `changed` every cycle and pushed every cycle. Now the block arm files nothing under a fault (the
+    stop is re-evaluated from the transcript every push, so the block lands on the first tick after the
+    file reads again), the lift still runs (it is the user's own re-engagement), and `changed` follows the
+    marker write. Control flow only: every collaborator is a recording stub."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        self.p = jd.STATE / "auto-nudge.json"
+        names = ("_alive_sessions", "_session_flag", "_compacting_now", "_api_error", "_interrupt_marks",
+                 "_session_working", "_record_interrupt_block", "_lift_interrupt_block", "_intr_block_stands",
+                 "_push_all")
+        self.saved = {n: getattr(km, n) for n in names}
+        self.saved_parsed = jd.parsed_session
+        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": "/nonexistent.jsonl"}]
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "t": 1000, "atoms": []}]}
+        km._session_working = lambda turns: False
+        self.marks = (1200, 900)                           # the stop is newer than the last human message: a user stop
+        km._interrupt_marks = lambda turns, sid="": self.marks
+        self.recorded, self.lifted, self.pushes = [], [], []
+        km._record_interrupt_block = lambda sid, ev: self.recorded.append((sid, ev)) or GID
+        km._lift_interrupt_block = lambda sid, gid, ev: self.lifted.append((sid, gid, ev)) or True   # True: spent (the
+        #                                                  #1019 contract; False keeps the marker for a goals-store fault)
+        km._intr_block_stands = lambda sid, gid: True
+        km._push_all = lambda *a, **k: self.pushes.append(1)
+        self._undo = []
+        _reset_ledger_state()
+
+    def tearDown(self):
+        for undo in reversed(self._undo):
+            undo()
+        for n, v in self.saved.items():
+            setattr(km, n, v)
+        jd.parsed_session = self.saved_parsed
+        _reset_ledger_state()
+        jd.STATE = self.saved_state
+        self.td.cleanup()
+
+    def _fail_read(self):
+        self._undo.append(_fail_path(self.p, "read_text", EIO))
+
+    def _heal(self):
+        for undo in reversed(self._undo):
+            undo()
+        self._undo = []
+
+    def _tick(self, n=1):
+        for _ in range(n):
+            km._interrupt_block_tick(2000, {SID: {"state": ""}})
+
+    def test_a_stop_during_a_fault_files_no_block_until_the_ledger_reads_again(self):
+        self.p.write_text(json.dumps(DEFAULT))
+        km._autonudge_cache.clear()
+        before = self.p.read_bytes()
+        self._fail_read()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self._tick(5)
+        self.assertEqual(self.recorded, [], "no block whose marker cannot be minted: unmarked, it could never be lifted")
+        self.assertEqual(self.pushes, [], "…and nothing pushes")
+        self.assertEqual(self.p.read_bytes(), before)
+        self.assertEqual(err.getvalue().count("paused"), 1, "loud once per fault episode, on the pass's latch")
+        self._heal()
+        with contextlib.redirect_stderr(err):
+            self._tick()
+        self.assertEqual(len(self.recorded), 1, "the stop is re-evaluated every push: the block lands on the first tick after the file reads")
+        self.assertEqual(json.loads(self.p.read_text())["intrBlocked"], {SID: GID}, "…with its once-per-episode marker")
+        self.assertEqual(len(self.pushes), 1)
+
+    def test_a_fault_landing_mid_tick_still_pushes_the_block_it_filed_and_then_stands_down(self):
+        # the tag check at the arm's top proves; the fault lands before the marker write. The block IS in
+        # the goal store — a proved write, a needs-you flip the feed must hear — so this tick pushes once
+        # whatever the marker's fate; every later faulted tick stands down at the check: no storm
+        self.p.write_text(json.dumps(DEFAULT))
+        km._autonudge_cache.clear()
+        real, calls, ledger, test = km._auto_nudge_data, [0], self.p, self
+
+        def flaky():
+            calls[0] += 1
+            if calls[0] == 2:                              # the file moves on (a new key) and cannot be read
+                ledger.write_text(json.dumps(DEFAULT, indent=1))
+                test._fail_read()
+            return real()
+        km._auto_nudge_data = flaky
+        self._undo.append(lambda: setattr(km, "_auto_nudge_data", real))
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick(5)
+        self.assertEqual(len(self.recorded), 1, "the block was filed once")
+        self.assertEqual(self.pushes, [1], "…and pushed exactly once, marker or no marker")
+        self.assertNotIn("intrBlocked", json.loads(self.p.read_bytes()), "the marker write was refused")
+
+    def test_a_re_engagement_during_a_fault_lifts_our_block_and_pushes_once_the_marker_clears(self):
+        marked = dict(DEFAULT, intrBlocked={SID: GID})
+        self.p.write_text(json.dumps(marked))
+        km._autonudge_cache.clear()
+        km._auto_nudge_data()                              # a proved read: the marker is in the last proved snapshot
+        self.p.write_text(json.dumps(marked, indent=1))    # the file moves on (a new stat key)…
+        before = self.p.read_bytes()
+        self._fail_read()                                  # …and cannot be read
+        self.marks = (900, 1200)                           # the user spoke after the stop: re-engaged
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick(5)
+        self.assertGreaterEqual(len(self.lifted), 1, "the lift is the user's own re-engagement: it runs whatever the ledger's state")
+        self.assertEqual(self.pushes, [], "the marker clear was refused: no push storm (one per cycle before)")
+        self.assertEqual(self.p.read_bytes(), before)
+        self._heal()
+        self._tick()
+        self.assertNotIn(SID, json.loads(self.p.read_text()).get("intrBlocked", {}), "the marker clears on the first tick after the file reads")
+        self.assertEqual(len(self.pushes), 1, "…and that is the one push")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -24,6 +24,7 @@ import io
 import json
 import os
 import tempfile
+import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -56,6 +57,7 @@ def _reset_ledger_state():
     for reg in REGISTRIES:                       # absent on a kernel before the fix (see UNPROVED above)
         vars(km).get(reg, {}).clear()
     vars(km).get("_auto_nudge_paused", [None])[0] = None
+    vars(km).get("_auto_nudge_drops_pending", set()).clear()   # drops parked under a fault (review find, 2026-09-08)
 
 
 def _fail_path(target, method, exc):
@@ -336,16 +338,73 @@ class CorruptBytes(_Ledger):
         self.assertEqual((jd.STATE / self._aside()[0]).read_bytes(), b"\xff\xfe{")
         self.assertIn("not UTF-8", err.getvalue())
 
+    def test_the_move_is_said_in_the_error_center_once(self):
+        # stderr alone left the user with a ledger that read as a fresh install (an explicit OFF back ON,
+        # every session's stop-retrying gone) and nothing in the dashboard saying so (review find,
+        # 2026-09-08). One line, both channels; once per corrupt file, because the next read finds it absent
+        rows = len(km._SDK_BOOT_PROBLEMS)
+        d, err = self._corrupt('{"enabled": fals')
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), rows + 1, "the dashboard's error center hears the move")
+        row = km._SDK_BOOT_PROBLEMS[-1]["text"]
+        self.assertIn("reads as a fresh install", row, "…worded as what it costs")
+        self.assertIn(self._aside()[0], row, "…and naming the file to restore from")
+        self.assertEqual(err.strip(), row, "the stderr line is the same line")
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._auto_nudge_data()                          # absent now: a proved default, nothing more to say
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), rows + 1, "once per corrupt file")
 
-class InterruptBlockTickUnderAFault(unittest.TestCase):
-    """_interrupt_block_tick runs every push OUTSIDE the paused nudge pass. Under an unproved snapshot its
-    block arm used to file the block in the goal store (a proved write) and then have the marker write
-    refused — and the lift on re-engagement is gated on that marker, so a block placed during a fault
-    episode stood until a judge happened to unblock it; and its lift arm, with the marker clear refused,
-    set `changed` every cycle and pushed every cycle. Now the block arm files nothing under a fault (the
-    stop is re-evaluated from the transcript every push, so the block lands on the first tick after the
-    file reads again), the lift still runs (it is the user's own re-engagement), and `changed` follows the
-    marker write. Control flow only: every collaborator is a recording stub."""
+    def test_a_second_reader_of_the_same_corrupt_bytes_cannot_move_a_fresh_ledger_aside(self):
+        # the inode guard alone is check-then-act: readers run unlocked on several threads, and two that
+        # read the same corrupt bytes both reach the quarantine with the same stat. Between the first one's
+        # rename and a writer's fresh publish, the second's check has already passed, so its rename moved
+        # the FRESH ledger aside and served the untagged default (review find, 2026-09-08). The check and
+        # the rename are one step under the ledger's writer lock, which every writer publishes under.
+        # Deterministic: at the moment of our rename a peer PROBES that lock without blocking: if it gets
+        # it, the window is open and the peer does exactly what the first reader and the writer would
+        # (moves the bytes, publishes a valid ledger) before our rename runs; if not, it waits like any
+        # writer, and acts once we are done. Either way, the fresh ledger must stand.
+        self.p.write_text("{")
+        km._autonudge_cache.clear()
+        real_replace, ledger, lock, probed, peer = os.replace, self.p, km._NUDGE_LOCK, threading.Event(), []
+
+        def peer_moves_and_publishes():
+            got = lock.acquire(blocking=False)
+            if not got:
+                probed.set()
+                lock.acquire()                             # a peer that respects the lock waits for us
+            try:
+                if ledger.exists():                        # the first reader's rename of the bytes that failed
+                    real_replace(ledger, ledger.with_name("auto-nudge.json.corrupt-peer"))
+                tmp = ledger.with_name("auto-nudge.json.tmp.peer")
+                tmp.write_text(json.dumps(SEEDED))         # the writer's publish
+                real_replace(tmp, ledger)
+            finally:
+                lock.release()
+                probed.set()
+
+        def replace_racing(src, dst, *a, **k):
+            if ".corrupt-" in str(dst) and not peer:
+                peer.append(threading.Thread(target=peer_moves_and_publishes))
+                peer[0].start()
+                self.assertTrue(probed.wait(5), "the peer probed the lock")
+            return real_replace(src, dst, *a, **k)
+        os.replace = replace_racing
+        self._undo.append(lambda: setattr(os, "replace", real_replace))
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._auto_nudge_data()
+        peer[0].join(5)
+        self._heal()
+        self.assertTrue(self.p.exists(), "the fresh ledger was not moved aside")
+        self.assertEqual(json.loads(self.p.read_text()), SEEDED, "…and it stands, untouched")
+        for name in self._aside():
+            self.assertEqual((jd.STATE / name).read_text(), "{", "only the bytes that failed were moved aside: " + name)
+        km._autonudge_cache.clear()
+        self.assertEqual(km._auto_nudge_data()["nudged"], SEEDED["nudged"], "the next read serves the fresh ledger")
+
+
+class _InterruptTickRig(unittest.TestCase):
+    """The interrupt tick's collaborators as recording stubs, the rig the two classes below share
+    (unittest collects inherited test_ names, so the fixture lives apart from either's tests)."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -395,6 +454,17 @@ class InterruptBlockTickUnderAFault(unittest.TestCase):
     def _tick(self, n=1):
         for _ in range(n):
             km._interrupt_block_tick(2000, {SID: {"state": ""}})
+
+
+class InterruptBlockTickUnderAFault(_InterruptTickRig):
+    """_interrupt_block_tick runs every push OUTSIDE the paused nudge pass. Under an unproved snapshot its
+    block arm used to file the block in the goal store (a proved write) and then have the marker write
+    refused — and the lift on re-engagement is gated on that marker, so a block placed during a fault
+    episode stood until a judge happened to unblock it; and its lift arm, with the marker clear refused,
+    set `changed` every cycle and pushed every cycle. Now the block arm files nothing under a fault (the
+    stop is re-evaluated from the transcript every push, so the block lands on the first tick after the
+    file reads again), the lift still runs (it is the user's own re-engagement), and `changed` follows the
+    marker write. Control flow only: every collaborator is a recording stub."""
 
     def test_a_stop_during_a_fault_files_no_block_until_the_ledger_reads_again(self):
         self.p.write_text(json.dumps(DEFAULT))
@@ -455,6 +525,111 @@ class InterruptBlockTickUnderAFault(unittest.TestCase):
         self._tick()
         self.assertNotIn(SID, json.loads(self.p.read_text()).get("intrBlocked", {}), "the marker clears on the first tick after the file reads")
         self.assertEqual(len(self.pushes), 1, "…and that is the one push")
+
+
+B = 1_700_000_000   # an epoch base for the store class below: the diary is an evidence-time ledger
+
+
+class MidTickFaultThenHeal(_InterruptTickRig):
+    """The window the arm above cannot close: the tag check proved, the block was FILED in the goal store,
+    and the fault landed on the marker write's own read. The card is blocked, the marker is absent, and
+    every healed tick used to return None from _record_interrupt_block (its focus-top rule accepted only a
+    "working" top), so no marker was ever minted, the re-engagement lift (gated on the marker) could never
+    run, and the card sat in Needs-you until a judge happened to unblock it (review find, 2026-09-08). Now a
+    top blocked SOLELY by our own interrupt row (judge._intr_paused_only) is the same stop still standing:
+    the first healed tick re-mints the marker without appending, and the lift runs on re-engagement. A
+    judge's block filed since is theirs and is left alone. The real store and the real record/lift/stands
+    functions; only the transcript and the session list are stubs."""
+
+    def setUp(self):
+        super().setUp()
+        for n in ("_record_interrupt_block", "_lift_interrupt_block", "_intr_block_stands"):
+            setattr(km, n, self.saved[n])                  # the real ones: this class is about the store
+        self.saved_goaldir = jd.GOALDIR
+        jd.GOALDIR = jd.STATE / "goals"
+        jd.GOALDIR.mkdir(parents=True)                     # (the overrides journal follows GOALDIR: private too)
+        store = {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "lastNode": GID,
+                 "nodes": {GID: {"id": GID, "text": "Ship the widget", "parentId": None, "nodeComplete": False,
+                                 "blocked": False, "cleared": False, "trail": [], "t": B + 500, "mt": B + 800}}}
+        jd.rollup_status(store, False)
+        jd.save_goals(SID, store)
+        self.marks = (B + 1200, B + 900)                   # a user stop, newer than the last human message
+        jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "t": B + 1000, "atoms": []}]}
+        self.p.write_text(json.dumps(DEFAULT))
+        km._autonudge_cache.clear()
+
+    def tearDown(self):
+        jd.GOALDIR = self.saved_goaldir
+        super().tearDown()
+
+    def _tick(self, n=1):
+        for _ in range(n):
+            km._interrupt_block_tick(B + 2000, {SID: {"state": ""}})
+
+    def _store(self):
+        return jd.load_goals(SID)
+
+    def _block_rows(self):
+        return [e.get("src") for e in self._store()["nodes"][GID].get("log") or [] if e.get("kind") == "block"]
+
+    def _fault_on_the_marker_write(self):
+        """Reads 1 (the tag check) and 2 (the marker lookup) prove; the block is filed; read 3, the marker
+        write's own, finds the file moved on and unreadable. Leaves the file healed."""
+        real, calls, ledger, test = km._auto_nudge_data, [0], self.p, self
+
+        def flaky():
+            calls[0] += 1
+            if calls[0] == 3:
+                ledger.write_text(json.dumps(DEFAULT, indent=1))
+                test._fail_read()
+            return real()
+        km._auto_nudge_data = flaky
+        self._undo.append(lambda: setattr(km, "_auto_nudge_data", real))
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(self._store()["status"][GID], "blocked", "the block was filed in the goal store")
+        self.assertEqual(self._block_rows(), ["interrupt"])
+        self.assertNotIn("intrBlocked", json.loads(self.p.read_bytes()), "…and the marker write was refused")
+        self.assertEqual(self.pushes, [1], "the block's push")
+        self._heal()
+
+    def _re_engage(self):
+        self.marks = (B + 1200, B + 1300)                  # the user spoke after the stop…
+        jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "t": B + 1000, "atoms": []},
+                                                               {"id": "t2", "t": B + 1300, "atoms": []}]}   # …opening a turn
+
+    def test_the_first_healed_tick_mints_the_marker_and_the_re_engagement_lift_runs(self):
+        self._fault_on_the_marker_write()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(json.loads(self.p.read_text()).get("intrBlocked"), {SID: GID},
+                         "the marker our own block is owed is minted on the first tick after the file reads")
+        self.assertEqual(self._block_rows(), ["interrupt"], "…without a second block row: the diary already says it")
+        self.assertEqual(self.pushes, [1, 1], "the block's push, and the marker's")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick(3)
+        self.assertEqual(self.pushes, [1, 1], "settled: the marker stands and the block holds, nothing more to push")
+        self._re_engage()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(self._store()["status"][GID], "working", "the re-engagement lifts our block: the card leaves Needs-you")
+        self.assertNotIn(SID, json.loads(self.p.read_text()).get("intrBlocked", {}), "…and the marker clears")
+
+    def test_a_judge_block_filed_since_is_left_alone(self):
+        self._fault_on_the_marker_write()
+        st = self._store()
+        jd.record_verdict(st, st["nodes"][GID], "closer", "block", B + 1250, why="pick a name for the widget")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick(3)
+        self.assertNotIn("intrBlocked", json.loads(self.p.read_text()), "a card a judge has blocked is theirs: no marker")
+        self.assertEqual(self._block_rows(), ["interrupt", "closer"], "…and nothing appended")
+        self.assertEqual(self.pushes, [1], "…and nothing pushed")
+        self._re_engage()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(self._store()["status"][GID], "blocked", "the judge's block stands through the re-engagement")
 
 
 if __name__ == "__main__":

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -150,6 +150,17 @@ class ReadFault(_Ledger):
         self.assertEqual(self.p.read_bytes(), before)
         self.assertTrue(str(d.get(UNPROVED, "")).startswith("stat failed"))
 
+    def test_the_fault_text_carries_the_errno_never_the_path(self):
+        # the tag rides the settingStale frame's `why` and the error-center row: errno + strerror only, the
+        # writer's shaping (_oserror_text), so no absolute path leaves the kernel (review find, 2026-09-08)
+        self._seed()
+        for method, arm in (("stat", "stat failed"), ("read_text", "read failed")):
+            self._fail(method, OSError(errno.EIO, "Input/output error", str(self.p)))
+            with contextlib.redirect_stderr(io.StringIO()):
+                d = km._auto_nudge_data()
+            self._heal()
+            self.assertEqual(d.get(UNPROVED), "%s: [Errno 5] Input/output error" % arm, method)
+
     def test_the_snapshot_is_a_copy_of_the_last_proved_one_tagged_with_the_fault(self):
         self._seed()
         proved = km._auto_nudge_data()                     # a proved read fills the cache
@@ -456,8 +467,8 @@ class _InterruptTickRig(unittest.TestCase):
         km._interrupt_marks = lambda turns, sid="": self.marks
         self.recorded, self.lifted, self.pushes = [], [], []
         km._record_interrupt_block = lambda sid, ev: self.recorded.append((sid, ev)) or GID
-        km._lift_interrupt_block = lambda sid, gid, ev: self.lifted.append((sid, gid, ev)) or True   # True: spent (the
-        #                                                  #1019 contract; False keeps the marker for a goals-store fault)
+        km._lift_interrupt_block = lambda sid, gid, ev: self.lifted.append((sid, gid, ev)) or True   # spent; the real
+        #                                            one returns False only on a goal-store read fault, keeping the marker (PR #1019)
         km._intr_block_stands = lambda sid, gid: True
         km._push_all = lambda *a, **k: self.pushes.append(1)
         self._undo = []

--- a/tests/test_ledger_unproved_reads.py
+++ b/tests/test_ledger_unproved_reads.py
@@ -49,7 +49,7 @@ EIO = OSError(errno.EIO, "Input/output error")
 # Spelled out, not km.UNPROVED: a kernel without the fix has no such name, and these tests must fail
 # there on the DEFECT (a rewritten file, a fired message), never on an AttributeError in the fixture.
 UNPROVED = "_unproved"
-REGISTRIES = ("_ledger_fault_warned", "_ledger_refusal_warned")   # the once-per-episode registries
+REGISTRIES = ("_ledger_fault_warned", "_ledger_refusal_warned", "_ledger_write_failed")   # the once-per-episode registries
 
 
 def _reset_ledger_state():
@@ -260,7 +260,9 @@ class CorruptBytes(_Ledger):
 
     def test_a_file_replaced_under_a_corrupt_read_is_not_moved_aside(self):
         # the inode guard: the bytes that failed are the ones to move; a concurrent atomic publish between
-        # our read and our rename has already replaced them, and the NEW file must not be quarantined
+        # our read and our rename has already replaced them, and the NEW file must not be quarantined —
+        # and (the maintainer's fold on PR #1019) the peer's bytes get their own read IN THIS CALL, so the
+        # reader returns what is there now, proved, rather than an unproved copy of the old snapshot
         self.p.write_text("{")
         km._autonudge_cache.clear()
         real, target = Path.read_text, str(self.p)
@@ -280,9 +282,37 @@ class CorruptBytes(_Ledger):
         self._heal()
         self.assertEqual(self._aside(), [], "the replacement is not the file whose bytes failed")
         self.assertEqual(json.loads(self.p.read_text()), SEEDED, "…and it stands, untouched")
-        self.assertIn("replaced meanwhile", str(d.get(UNPROVED, "")), "this read is unproved; the next one reads the new bytes")
+        self.assertNotIn(UNPROVED, d, "the peer's bytes were read in this call: a PROVED snapshot, not the old one tagged")
+        self.assertEqual(d["nudged"], SEEDED["nudged"], "…and it is what the peer published")
+        self.assertEqual(err.getvalue(), "", "a peer's publish is not an incident: no line")
         km._autonudge_cache.clear()
         self.assertEqual(km._auto_nudge_data()["nudged"], SEEDED["nudged"])
+
+    def test_a_file_that_keeps_changing_under_the_read_ends_unproved_after_the_bound(self):
+        # the re-read is BOUNDED: a peer that republishes corrupt bytes under every read is chased three
+        # times, then the reader stops and reports the last try unproved (never a spin, never a move aside)
+        self.p.write_text("{")
+        km._autonudge_cache.clear()
+        real, target, reads = Path.read_text, str(self.p), []
+
+        def read_then_republish_corrupt(p, *a, **k):
+            raw = real(p, *a, **k)
+            if str(p) == target:                           # a peer publishes again — corrupt again, a new size
+                reads.append(1)
+                tmp = p.with_name("auto-nudge.json.tmp.peer")
+                tmp.write_text("{" * (len(reads) + 1))
+                os.replace(tmp, p)
+            return raw
+        Path.read_text = read_then_republish_corrupt
+        self._undo.append(lambda: setattr(Path, "read_text", real))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._auto_nudge_data()
+        self._heal()
+        self.assertEqual(len(reads), 3, "three tries, then the reader stops chasing the file")
+        self.assertIn("replaced meanwhile", str(d.get(UNPROVED, "")), "…and reports the last try unproved")
+        self.assertEqual(self._aside(), [], "nothing of a peer's was moved aside")
+        self.assertEqual(err.getvalue().count("unreadable"), 1, "said once")
 
     def test_a_corrupt_file_that_cannot_be_moved_aside_is_said_once_not_once_per_read(self):
         # a read-only state dir: every read re-fails the parse and the move; build_feed reads this ledger

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -6,10 +6,14 @@ interrupt aborts the in-flight CLI retry, and this suppression keeps romp from r
 thread until a SUCCESSFUL turn lands, then it re-arms. Mirrors how an interrupt already suppresses
 auto-NUDGE (_interrupt_suppresses_nudge). Functional tests on the state machine + source-pins on the wiring.
 """
+import contextlib
+import errno
+import io
 import json
 import os
 import tempfile
 import time
+import types
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -124,6 +128,187 @@ class SessionRetrySuppressWiring(unittest.TestCase):
         # (now, tmux) — the cycle's ONE liveness snapshot, not a per-job fresh read (2026-08-10 CPU fix)
         self.assertIn("_auto_resume_session_retry(now, tmux)", SRC,
                       "the pusher tick re-arms suppressed threads that land a clean turn")
+
+    def test_the_interrupt_handler_toasts_a_stop_that_did_not_land(self):
+        blk = SRC.split('elif t == "interrupt":', 1)[1].split("elif t ==", 1)[0]
+        self.assertIn("err = _suppress_session_retry(sid)", blk, "the arm's verdict is read, not dropped")
+        self.assertIn('"warn"', blk, "…and a refusal takes the rewind ops' warn-toast idiom")
+
+    def test_arm_and_clear_hold_the_ledger_lock_across_their_read_modify_write(self):
+        # the interrupt handler (a WS thread) and the pusher's re-arm sweep rewrite the same whole blob;
+        # unlocked, the loser's snapshot erased the winner's key
+        for fn in ("_suppress_session_retry", "_clear_session_retry_suppress"):
+            body = SRC.split("def %s(" % fn, 1)[1].split("\ndef ", 1)[0]
+            self.assertIn("with _RETRY_SUPPRESS_LOCK:", body, fn)
+
+
+SID = "11111111-2222-3333-4444-555555555555"
+EIO = OSError(errno.EIO, "Input/output error")
+
+
+class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
+    """The ledger is never rewritten from a fabricated default after a read fault (2026-09-07). The reader
+    answered ANY fault with {} and cached it under the file's real stat key; the next interrupt then wrote
+    {that sid} over every sibling session's stop — a retry storm the user had explicitly halted, resumed.
+    And the write itself had no OSError handling: an ENOSPC out of the interrupt handler reached the WS
+    reader loop, which reads any OSError as a socket failure and tore the dashboard's connection down.
+    Now only a MISSING file reads as {}; every other fault yields a snapshot tagged UNPROVED that the
+    writer refuses (loud once per fault episode), a failed write is reported to the click that asked, and
+    a non-numeric floor is read as no floor instead of a TypeError that killed the re-arm sweep. The
+    shared reader contract is pinned in tests/test_ledger_unproved_reads.py."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.dir = Path(self.td.name)
+        self._saved_state = km.jd.STATE
+        km.jd.STATE = self.dir
+        self.p = self.dir / "retry-suppressed.json"
+        self._orig = {k: getattr(km, k) for k in
+                      ("_alive_sessions", "_parse_cached", "_session_chip", "_mark_views_dirty",
+                       "_kernel_knows", "_atomic_write")}
+        self._orig_backend = km.Sessions.backend_for
+        km._mark_views_dirty = lambda *a, **k: None
+        self._undo = []
+        self._reset()
+
+    def tearDown(self):
+        for undo in reversed(self._undo):
+            undo()
+        for k, v in self._orig.items():
+            setattr(km, k, v)
+        km.Sessions.backend_for = self._orig_backend
+        self._reset()
+        km.jd.STATE = self._saved_state
+        self.td.cleanup()
+
+    @staticmethod
+    def _reset():
+        km._retry_suppress_cache.clear()
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_retry_floor_warned"):
+            vars(km).get(reg, set()).clear()       # the once-only registries — absent on a kernel before the
+            #                                        fix, so these tests fail there on the DEFECT, not in setUp
+
+    def _seed(self, d=None):
+        self.p.write_text(json.dumps(d if d is not None else {"s1": 100.0, "s2": 200.0}))
+        km._retry_suppress_cache.clear()
+        return self.p.read_bytes()
+
+    def _fail_read(self, exc=EIO):
+        real, target = Path.read_text, str(self.p)
+
+        def failing(p, *a, **k):
+            if str(p) == target:
+                raise exc
+            return real(p, *a, **k)
+        Path.read_text = failing
+        self._undo.append(lambda: setattr(Path, "read_text", real))
+
+    def _aside(self):
+        return sorted(n for n in os.listdir(self.dir) if n.startswith("retry-suppressed.json.corrupt-"))
+
+    def test_a_missing_file_reads_as_nobody_suppressed_with_no_log(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km._retry_suppress_data()
+        self.assertEqual(d, {})
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(os.listdir(self.dir), [], "absent: nothing moved aside, nothing created")
+        self.assertEqual(km._retry_suppress_cache, {}, "absent is not cached — the old arm, byte for byte")
+
+    def test_a_read_fault_never_rewrites_the_file_and_the_click_is_told(self):
+        self._seed()
+        self.assertTrue(km._session_retry_suppressed("s1"))      # a proved read: s1 and s2 are the last proved snapshot
+        self.p.write_text(json.dumps({"s1": 100.0, "s2": 200.0}, indent=1))   # the file moves on (a new stat key)…
+        before = self.p.read_bytes()
+        self._fail_read()                                         # …and the new bytes cannot be read
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            cleared = km._clear_session_retry_suppress("s1")      # the sweep's clear: s1 IS in the tagged copy…
+        self.assertEqual(self.p.read_bytes(), before, "suppressed is the safe direction while the ledger cannot be read")
+        self.assertFalse(cleared, "…so the clear reaches the writer, and the writer refuses")
+        self.assertEqual(err.getvalue().count("refusing to write retry-suppressed.json"), 1,
+                         "the refusal count rose: refused at the writer, not short-circuited before it")
+        with contextlib.redirect_stderr(err):
+            told = km._suppress_session_retry("s3")
+        self.assertEqual(self.p.read_bytes(), before, "s1 and s2 keep their stops: the file is byte for byte what it was")
+        self.assertIsInstance(told, str, "the arm reports a stop that did not land")
+        self.assertIn("could not be recorded", told)
+        self.assertIn("Input/output error", told, "…and names the fault")
+        self.assertEqual(err.getvalue().count("refusing to write"), 1, "once per fault episode, not per write")
+        st = os.stat(self.p)
+        self.assertNotEqual(km._retry_suppress_cache[str(self.p)][0], (st.st_mtime_ns, st.st_size),
+                            "nothing unproved is cached: the cache still holds the proved snapshot's key, not the file's")
+        self.assertEqual(set(km._retry_suppress_cache[str(self.p)][1]), {"s1", "s2"})
+
+    def test_the_snapshot_a_fault_leaves_is_the_last_proved_one(self):
+        self._seed()
+        self.assertTrue(km._session_retry_suppressed("s1"))      # a proved read fills the cache
+        self.p.write_text(json.dumps({"s1": 100.0}))              # the file moves on (a different size)…
+        self._fail_read()                                         # …and the new bytes cannot be read
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertTrue(km._session_retry_suppressed("s2"), "membership reads the last proved snapshot, never a fabricated {}")
+
+    def test_enospc_on_the_write_is_reported_to_the_click_not_raised(self):
+        before = self._seed()
+
+        def full(*a, **k):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        km._atomic_write = full
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            told = km._suppress_session_retry("s3")               # raised straight into the WS reader loop before
+        self.assertIsInstance(told, str)
+        self.assertIn("No space left on device", told)
+        self.assertIn("write failed", err.getvalue())
+        self.assertEqual(self.p.read_bytes(), before)
+
+    def test_the_interrupt_handler_toasts_a_stop_that_did_not_land(self):
+        # through the real dispatcher (_drive → the interrupt branch): the interrupt itself happens, the
+        # stop's failure is a warn toast on the delivering socket, and a healthy ledger toasts nothing
+        self._seed()
+        cuts = []
+        km._kernel_knows = lambda sid: True
+        km.Sessions.backend_for = lambda sid: types.SimpleNamespace(interrupt=lambda sid: cuts.append(sid))
+        sent = []
+        client = {"app": "chat", "alive": True, "send": lambda s: sent.append(json.loads(s))}
+        self._fail_read()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "interrupt", "id": SID}, client)
+        self.assertEqual(cuts, [SID], "the interrupt itself happened")
+        self.assertEqual([m["type"] for m in sent], ["warn"], "the stop that did not land is said, not swallowed")
+        self.assertIn("could not be recorded", sent[0]["text"])
+        for undo in self._undo:
+            undo()
+        self._undo = []
+        sent.clear()
+        km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "interrupt", "id": SID}, client)
+        self.assertEqual(sent, [], "a stop that landed says nothing — the chip's 'interrupting' is the acknowledgement")
+        self.assertIn(SID, json.loads(self.p.read_text()))
+
+    def test_a_non_numeric_floor_is_read_as_no_floor_and_said_once(self):
+        self._seed({"s1": "yesterday", "s2": 200.0})
+        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "x"}, {"sid": "s2", "path": "y"}]
+        km._parse_cached = lambda p: {"turns": [_human_turn(500)]}      # both spoke after any numeric floor
+        km._session_chip = lambda *a, **k: "ready"
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._auto_resume_session_retry(1000, {})                    # a TypeError killed the whole sweep before
+            km._auto_resume_session_retry(1001, {})
+        self.assertEqual(json.loads(self.p.read_text()), {"s1": "yesterday"},
+                         "s2 re-armed as ever; s1's entry is not a floor, so nothing re-arms it — and nothing invents one")
+        self.assertEqual(err.getvalue().count("non-numeric floor"), 1, "said once per session, not per tick")
+
+    def test_corrupt_bytes_are_moved_aside_and_the_next_stop_lands_on_a_fresh_ledger(self):
+        self.p.write_text('{"s1": 100.0,')
+        km._retry_suppress_cache.clear()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsNone(km._suppress_session_retry("s3"), "absent after the move is the fresh-install state")
+        self.assertEqual(set(json.loads(self.p.read_text())), {"s3"})
+        aside = self._aside()
+        self.assertEqual(len(aside), 1, "evidence kept, never deleted")
+        self.assertEqual((self.dir / aside[0]).read_text(), '{"s1": 100.0,')
+        self.assertEqual(err.getvalue().count("moved aside"), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -12,6 +12,7 @@ import io
 import json
 import os
 import tempfile
+import threading
 import time
 import types
 import unittest
@@ -201,7 +202,9 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
                 raise exc
             return real(p, *a, **k)
         Path.read_text = failing
-        self._undo.append(lambda: setattr(Path, "read_text", real))
+        heal = lambda: setattr(Path, "read_text", real)
+        self._undo.append(heal)
+        return heal
 
     def _aside(self):
         return sorted(n for n in os.listdir(self.dir) if n.startswith("retry-suppressed.json.corrupt-"))
@@ -309,6 +312,91 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
         self.assertEqual(len(aside), 1, "evidence kept, never deleted")
         self.assertEqual((self.dir / aside[0]).read_text(), '{"s1": 100.0,')
         self.assertEqual(err.getvalue().count("moved aside"), 1)
+
+    # ── the auto-retry gate reads this ledger: unknown is not "not stopped" ─────────────────────
+    def _retry_rig(self):
+        """_fire_api_retry's collaborators, stubbed down to the gate under test: an api-errored live session,
+        no backoff due, no queued retry, and a backend that records what it was asked to send."""
+        sent = []
+        be = types.SimpleNamespace(pending_queued=lambda sid: [], send=lambda sid, body: sent.append(sid))
+        for n, v in (("_retry_paused_on", lambda: False), ("_api_error", lambda p: {"uuid": "e1"}),
+                     ("_path_of", lambda sid: "x"), ("_retry_gate_state", lambda sid: (0, 0)),
+                     ("_note_retry_sent", lambda *a, **k: None)):
+            orig = getattr(km, n)
+            setattr(km, n, v)
+            self._undo.append(lambda n=n, orig=orig: setattr(km, n, orig))
+        km._auto_retried.clear()
+        self.addCleanup(km._auto_retried.clear)
+        vars(km).get("_retry_gate_held", [None])[0] = None    # the gate's once-per-episode latch (absent before the fix)
+        return be, sent
+
+    def _fire(self, be, *sids, manual=False):
+        for sid in sids:
+            km._fire_api_retry(sid, be, manual=manual)
+            km._auto_retried.clear()                          # each ask is its own error episode here
+
+    def test_an_unreadable_ledger_with_no_proved_copy_retries_nobody_until_it_reads_again(self):
+        # the membership read answered `sid in {}` (every stopped session read as NOT stopped) and the
+        # auto-retry walked back into the session the user had interrupted to end its storm (review find,
+        # 2026-09-08). Unknown is not "not stopped": with no proved copy to fall back on, the auto path
+        # stands down for every session, said once, until the file reads again; a manual Retry-now still fires.
+        self._seed({"s1": 100.0})                             # s1 stopped; this process has proved nothing yet
+        be, sent = self._retry_rig()
+        heal = self._fail_read()
+        err, rows = io.StringIO(), len(km._SDK_BOOT_PROBLEMS)
+        with contextlib.redirect_stderr(err):
+            self._fire(be, "s1", "s2")
+            self._fire(be, "s1")
+        self.assertEqual(sent, [], "no auto-retry into s1 (stopped), nor s2: the ledger cannot say who is stopped")
+        self.assertEqual(err.getvalue().count("auto-retry stands down"), 1, "said once per fault episode, not per ask")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), rows + 1, "…and once in the error center")
+        with contextlib.redirect_stderr(err):
+            self._fire(be, "s1", manual=True)
+        self.assertEqual(sent, ["s1"], "a manual Retry-now is the user's explicit call: it fires")
+        heal()
+        del sent[:]
+        with contextlib.redirect_stderr(err):
+            self._fire(be, "s1", "s2")
+        self.assertEqual(sent, ["s2"], "healed: the real answer applies; s1 stays stopped, s2 retries")
+        self.assertIn("auto-retry resumed", err.getvalue())
+
+    def test_with_a_proved_copy_behind_the_fault_the_copy_answers(self):
+        self._seed({"s1": 100.0})
+        self.assertTrue(km._session_retry_suppressed("s1"))   # a proved read: the copy this process holds
+        self.p.write_text(json.dumps({"s1": 100.0}, indent=1))   # the file moves on…
+        be, sent = self._retry_rig()
+        self._fail_read()                                     # …and cannot be read
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._fire(be, "s1", "s2")
+        self.assertEqual(sent, ["s2"], "the last proved snapshot is the best answer this process has: s1 stays stopped, s2 retries")
+
+    def test_the_arm_and_the_sweep_s_clear_cannot_erase_each_other_s_key(self):
+        # the interrupt handler's arm (a WS thread) and the pusher's re-arm clear rewrite the same whole
+        # blob. Interleaved deterministically: the arm's read returns and then STALLS until the clear has
+        # run, a window that opens only if nothing holds the clear out (the wait has a timeout because,
+        # with the lock held, it is a deadlock by design: the clear cannot run until the arm is done).
+        self._seed({"s1": 100.0, "s2": 200.0})
+        real, main = km._retry_suppress_data, threading.current_thread()
+        arm_read, clear_done = threading.Event(), threading.Event()
+
+        def stalling():
+            d = real()
+            if threading.current_thread() is not main:        # the arm's thread only
+                arm_read.set()
+                clear_done.wait(0.5)
+            return d
+        km._retry_suppress_data = stalling
+        self._undo.append(lambda: setattr(km, "_retry_suppress_data", real))
+        arm = threading.Thread(target=km._suppress_session_retry, args=("s3",))
+        arm.start()
+        self.assertTrue(arm_read.wait(5), "the arm read the ledger")
+        cleared = km._clear_session_retry_suppress("s1")      # the sweep's clear, racing the arm's write
+        clear_done.set()
+        arm.join(5)
+        km._retry_suppress_cache.clear()
+        self.assertEqual(set(json.loads(self.p.read_text())), {"s2", "s3"},
+                         "both land, s1's clear and s3's stop: neither snapshot erased the other's key")
+        self.assertTrue(cleared)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -185,7 +185,7 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
     @staticmethod
     def _reset():
         km._retry_suppress_cache.clear()
-        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_retry_floor_warned"):
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_ledger_write_failed", "_retry_floor_warned"):
             vars(km).get(reg, set()).clear()       # the once-only registries — absent on a kernel before the
             #                                        fix, so these tests fail there on the DEFECT, not in setUp
 
@@ -260,10 +260,65 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             told = km._suppress_session_retry("s3")               # raised straight into the WS reader loop before
+            told2 = km._suppress_session_retry("s3")              # the user presses stop again on the same full disk
         self.assertIsInstance(told, str)
         self.assertIn("No space left on device", told)
-        self.assertIn("write failed", err.getvalue())
+        self.assertEqual(told2, told, "every click is answered")
+        self.assertEqual(err.getvalue().count("write failed"), 1,
+                         "…but the fault is said ONCE per episode, at the writer (the maintainer's fold on PR #1019)")
         self.assertEqual(self.p.read_bytes(), before)
+
+    def test_a_full_disk_stop_toasts_every_click_and_the_client_survives_said_once_per_episode(self):
+        # the incident shape through the real dispatcher, with the publish itself failing: the interrupt
+        # happens, each click hears its own warn toast, the client is never dropped, and the fault is on
+        # record once per episode; a landed write ends the episode and a fresh fault speaks again
+        before = self._seed()
+        cuts = []
+        km._kernel_knows = lambda sid: True
+        km.Sessions.backend_for = lambda sid: types.SimpleNamespace(interrupt=lambda sid: cuts.append(sid))
+        real_write = km._atomic_write
+
+        def full(*a, **k):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        km._atomic_write = full
+        sent, err = [], io.StringIO()
+        client = {"app": "chat", "alive": True, "send": lambda s: sent.append(json.loads(s))}
+        with contextlib.redirect_stderr(err):
+            for _ in range(2):
+                km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "interrupt", "id": SID}, client)
+        self.assertEqual(cuts, [SID, SID], "both interrupts happened")
+        self.assertTrue(client["alive"])
+        self.assertEqual([m["type"] for m in sent], ["warn", "warn"], "each stop that did not land is said to the click")
+        self.assertIn("No space left on device", sent[1]["text"])
+        self.assertEqual(err.getvalue().count("write failed"), 1, "the fault is said once per episode")
+        self.assertEqual(self.p.read_bytes(), before, "the ledger is untouched")
+        km._atomic_write = real_write
+        sent.clear()
+        km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "interrupt", "id": SID}, client)
+        self.assertEqual(sent, [], "the disk heals: the stop lands and nothing is said")
+        self.assertIn(SID, json.loads(self.p.read_text()))
+        km._atomic_write = full
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertIsInstance(km._suppress_session_retry("s4"), str)
+        self.assertEqual(err.getvalue().count("write failed"), 1, "a landed write ended the episode: said again")
+
+    def test_the_sweep_s_clear_under_a_full_disk_returns_false_and_does_not_raise(self):
+        # the clear-suppress path is the pusher's, not a gesture: a failed publish leaves the suppression
+        # standing (the safe direction) and returns False instead of a traceback into the pusher's wrap
+        # every tick; the writer says it once per episode
+        before = self._seed()
+        self.assertTrue(km._session_retry_suppressed("s1"))
+
+        def full(*a, **k):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        km._atomic_write = full
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertFalse(km._clear_session_retry_suppress("s1"))       # raised OSError before
+            self.assertFalse(km._clear_session_retry_suppress("s1"))
+        self.assertEqual(self.p.read_bytes(), before, "s1 stays suppressed on disk")
+        self.assertEqual(err.getvalue().count("write failed"), 1)
 
     def test_the_interrupt_handler_toasts_a_stop_that_did_not_land(self):
         # through the real dispatcher (_drive → the interrupt branch): the interrupt itself happens, the

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -209,6 +209,18 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
     def _aside(self):
         return sorted(n for n in os.listdir(self.dir) if n.startswith("retry-suppressed.json.corrupt-"))
 
+    @staticmethod
+    def _full_disk():
+        """A stand-in for km._atomic_write on a full disk: ENOSPC naming the TEMP path with a per-call
+        sequence, the shape the real publish raises: a fault text built from str(e) would then differ on
+        every call, and the once-per-episode assertions below would catch it (review find, 2026-09-08)."""
+        calls = [0]
+
+        def full(path, text, mode=None):
+            calls[0] += 1
+            raise OSError(errno.ENOSPC, "No space left on device", "%s.tmp.1.2.%d" % (path, calls[0]))
+        return full
+
     def test_a_missing_file_reads_as_nobody_suppressed_with_no_log(self):
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
@@ -254,8 +266,7 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
     def test_enospc_on_the_write_is_reported_to_the_click_not_raised(self):
         before = self._seed()
 
-        def full(*a, **k):
-            raise OSError(errno.ENOSPC, "No space left on device")
+        full = self._full_disk()
         km._atomic_write = full
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
@@ -278,8 +289,7 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
         km.Sessions.backend_for = lambda sid: types.SimpleNamespace(interrupt=lambda sid: cuts.append(sid))
         real_write = km._atomic_write
 
-        def full(*a, **k):
-            raise OSError(errno.ENOSPC, "No space left on device")
+        full = self._full_disk()
         km._atomic_write = full
         sent, err = [], io.StringIO()
         client = {"app": "chat", "alive": True, "send": lambda s: sent.append(json.loads(s))}
@@ -310,8 +320,7 @@ class LedgerFaultsNeverEraseSiblings(unittest.TestCase):
         before = self._seed()
         self.assertTrue(km._session_retry_suppressed("s1"))
 
-        def full(*a, **k):
-            raise OSError(errno.ENOSPC, "No space left on device")
+        full = self._full_disk()
         km._atomic_write = full
         err = io.StringIO()
         with contextlib.redirect_stderr(err):

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -83,6 +83,8 @@ class _Base(unittest.TestCase):
         km.jd.STATE = Path(self._td)
         km.jd._state_cache.clear()
         km._autonudge_cache.clear()
+        vars(km).get("_ledger_write_failed", {}).clear()   # the writer's per-episode registry: no episode leaks in
+        km._stale_seen.refused = None                      # a direct setter call's verdict never rides a later dispatch
         self._saved = {n: getattr(km, n) for n in
                        ("_propagate_judge_settings", "_auto_nudge_tick", "_tmux_sessions", "threading")}
         self.propagated = []
@@ -537,14 +539,14 @@ class StoreWriteFailureIsLoudAndContained(_Base):
     _set_judge_state and _set_update_mode already hold this contract; these tests pin
     _set_auto_nudge and _set_file_editing onto the same one."""
 
-    def _fail_writes(self):
+    def _fail_writes(self, exc=None):
         """Patch Path.write_text to raise OSError on every call from now (both stores publish
         via _atomic_write, whose temp-file write funnels through it)."""
         import pathlib
         orig = pathlib.Path.write_text
 
         def failing(p, *a, **k):
-            raise OSError("simulated full disk")
+            raise exc or OSError("simulated full disk")
 
         pathlib.Path.write_text = failing
         return lambda: setattr(pathlib.Path, "write_text", orig)
@@ -602,8 +604,62 @@ class StoreWriteFailureIsLoudAndContained(_Base):
             restore()
         self.assertTrue(client["alive"], "the delivering client survives the failed write")
         self.assertEqual(ticks, [], "a stood-down toggle fires no nudge tick — no new information")
-        self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [],
-                         "a write failure is not a stale gesture — no settingStale frame")
+        # This used to pin "no settingStale frame" for both toggles: a write failure sent nothing. The
+        # maintainer's fold on PR #1019 draws the line the other way — a user gesture's WRITE step is a
+        # fault boundary too, and a refused write must be TOLD — so the ledger toggle now answers its socket
+        # with the same settingStale+why frame an unproved-read refusal sends (the gear snaps the box back to
+        # the stored value and says why). setFileEditing's store is not one of this PR's two ledgers and keeps
+        # its silent arm for now: nothing escapes there, and nothing is told.
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual([(f["setting"], f["why"].split(":")[0]) for f in frames], [("auto-nudge", "write failed")],
+                         "the ledger toggle's refused write is answered on the delivering socket, once")
+        self.assertIsNone(frames[0]["kept"], "no write ever landed here: the frame does not present the default as kept")
+
+    def test_a_refused_ledger_write_is_told_per_gesture_and_said_once_per_episode(self):
+        """The maintainer's fold on PR #1019 (a user gesture's WRITE step is a fault boundary too), on the two
+        ledger toggles through the REAL dispatch: every gesture whose publish raises is answered on the
+        delivering socket — the settingStale+why frame, `kept` naming the value the gear re-fills to — while
+        the fault itself is said ONCE per episode (one stderr line, one error-center row) however many gestures
+        repeat it; a landed write ends the episode, and a fresh fault speaks again. Before: the OSError arm
+        logged per call and sent nothing, so the gear kept the flipped box while the kernel held the old value."""
+        self.assertEqual(km._set_auto_nudge(True, gt=T_OLD), T_OLD)
+        del km._SDK_BOOT_PROBLEMS[:]
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        full = OSError(errno.ENOSPC, "No space left on device")
+        restore, err = self._fail_writes(full), io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                for msg in ({"type": "setAutoNudge", "enabled": False, "gt": T_NEW},
+                            {"type": "setAutoNudge", "enabled": False, "gt": T_NEW + 1},
+                            {"type": "setCompactSuggest", "enabled": True, "gt": T_NEW}):
+                    km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        finally:
+            restore()
+        self.assertTrue(client["alive"], "nothing escaped to the reader loop")
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual([(f["setting"], f["gt"]) for f in frames],
+                         [("auto-nudge", T_NEW), ("auto-nudge", T_NEW + 1), ("compact-suggest", T_NEW)],
+                         "every refused gesture is answered on its own socket")
+        for f in frames:
+            self.assertIn("No space left on device", f["why"], "the frame names the fault")
+            self.assertNotIn(".tmp.", f["why"], "errno + strerror only: never the temp path")
+        self.assertIs(frames[0]["kept"], True, "the stored value stands: the gear snaps the box back to it")
+        self.assertEqual(err.getvalue().count("write failed"), 1, "said once per fault episode, not per gesture")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), 1, "one error-center row per episode")
+        self.assertIn("auto-nudge.json", km._SDK_BOOT_PROBLEMS[0]["text"])
+        km._autonudge_cache.clear()
+        self.assertTrue(km._auto_nudge_on(), "nothing applied — the store keeps the old value")
+        self.assertFalse(km._compact_suggest_on())
+        self.assertEqual(km._set_auto_nudge(False, gt=T_NEW + 2), T_NEW + 2, "the disk heals: the next gesture lands")
+        restore, err = self._fail_writes(full), io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._set_auto_nudge(True, gt=T_NEW + 3))
+        finally:
+            restore()
+        self.assertEqual(err.getvalue().count("write failed"), 1, "a landed write ended the episode: a new fault speaks again")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), 2)
 
 
 class StaleGestureAnswersTheDeliveringSocket(_Base):
@@ -1143,7 +1199,7 @@ class RefusedToggleTellsTheDeliveringSocket(_Base):
 
     def setUp(self):
         super().setUp()
-        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned"):
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_ledger_write_failed"):
             vars(km).get(reg, {}).clear()                  # absent on a kernel before the fix: fail on the defect
         self.ledger = km.jd.STATE / "auto-nudge.json"
         self.problems = len(km._SDK_BOOT_PROBLEMS)

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -541,12 +541,17 @@ class StoreWriteFailureIsLoudAndContained(_Base):
 
     def _fail_writes(self, exc=None):
         """Patch Path.write_text to raise OSError on every call from now (both stores publish
-        via _atomic_write, whose temp-file write funnels through it)."""
+        via _atomic_write, whose temp-file write funnels through it). The raise carries the REAL
+        shape (errno, strerror and the path being written, which for a publish is the temp file
+        with its per-call sequence), so a fault text built from str(e) would differ on every call
+        and the once-per-episode and never-the-temp-path assertions below would catch it (review
+        find, 2026-09-08). Default: a read-only STATE dir."""
         import pathlib
         orig = pathlib.Path.write_text
+        e = exc or OSError(errno.EROFS, "Read-only file system")
 
         def failing(p, *a, **k):
-            raise exc or OSError("simulated full disk")
+            raise OSError(e.errno, e.strerror, str(p))
 
         pathlib.Path.write_text = failing
         return lambda: setattr(pathlib.Path, "write_text", orig)
@@ -660,6 +665,38 @@ class StoreWriteFailureIsLoudAndContained(_Base):
             restore()
         self.assertEqual(err.getvalue().count("write failed"), 1, "a landed write ended the episode: a new fault speaks again")
         self.assertEqual(len(km._SDK_BOOT_PROBLEMS), 2)
+
+    def test_a_direct_setter_refusal_never_rides_an_unrelated_gesture(self):
+        """A setter called OUTSIDE a WS arm (a direct call: nothing pops its verdict) leaves the refused-write
+        verdict on the thread. The next gt-gated gesture on that thread clears it at its own stand-down check
+        (_setting_stale clears `refused` alongside `last`), so an unrelated gesture that then reaches
+        _tell_stale_gesture (its own write refused under the same fault, or applied) never answers its
+        socket with a frame naming a setting it did not touch (review find, 2026-09-08)."""
+        self.assertEqual(km._set_auto_nudge(True, gt=T_OLD), T_OLD)
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        restore = self._fail_writes()
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertIsNone(km._set_auto_nudge(False, gt=T_NEW), "refused: the write failed")
+                self.assertEqual((km._stale_seen.refused or {}).get("setting"), "auto-nudge",
+                                 "a direct call leaves its verdict on the thread: nothing popped it")
+                # an UNRELATED gesture, its own write refused under the same fault: the frame it answers, if
+                # any, must be about update-mode; a leaked auto-nudge verdict would ride out here
+                km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "setUpdateMode", "mode": "auto", "gt": T_NEW}, client)
+                self.assertEqual([m.get("setting") for m in sent if m.get("type") == "settingStale"], [],
+                                 "update-mode's refused write records no notice of its own, and auto-nudge's never rides it")
+                self.assertIsNone(km._stale_seen.refused, "the unrelated gesture's check cleared the stale verdict")
+                self.assertIsNone(km._set_auto_nudge(False, gt=T_NEW + 1), "refused again: a fresh verdict on the thread")
+                self.assertEqual((km._stale_seen.refused or {}).get("setting"), "auto-nudge")
+        finally:
+            restore()
+        # the disk healed: an unrelated APPLYING gesture pops nothing (the setter returned a stamp), and the
+        # stale verdict must not be waiting there for whichever refusal comes next
+        km.Handler._dispatch_ws(types.SimpleNamespace(), {"type": "setUpdateMode", "mode": "off", "gt": T_NEW + 2}, client)
+        self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [], "an APPLYING gesture answers no frame")
+        self.assertIsNone(km._stale_seen.refused, "…and its check cleared the verdict left by the direct call")
+        self.assertEqual(km._update_mode(), "off", "…and applied")
 
 
 class StaleGestureAnswersTheDeliveringSocket(_Base):

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -27,6 +27,7 @@ binding for a delegating namespace whose Thread runs inline, so every fan-out is
 synchronously and nothing sleeps.
 """
 import contextlib
+import errno
 import io
 import json
 import os
@@ -1128,6 +1129,111 @@ class ThinkingSummariesSetting(_Base):
                          "per-install: NOT a KERNEL_SETTING — it must never queue for or reach another kernel")
         km._set_thinking_summaries(True, gt=T_NEW)
         self.assertIs(km._version_info()["thinkingSummaries"], True, "/version reports it so the gear fills")
+
+
+class RefusedToggleTellsTheDeliveringSocket(_Base):
+    """A toggle whose ledger read was UNPROVED (auto-nudge.json unreadable; 2026-09-07) is refused at the
+    writer rather than persisting a copy the reader could not vouch for — and the refusal must reach the
+    socket that made the gesture. Silent, it was the defect's other face: gear.js flips the checkbox
+    locally and re-fills only on reopen, so the box read OFF while the kernel kept ON, and when the file
+    healed ON is what ran. The setter records a `refused` notice (a sibling of _setting_stale's stand-down,
+    claiming nothing about ordering) and the WS branch answers with the settingStale frame plus `why`: the
+    gear's copy — not applied, keeping the stored value — is exactly true, and its re-fill snaps the box
+    back; the fault itself goes to the error center."""
+
+    def setUp(self):
+        super().setUp()
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned"):
+            vars(km).get(reg, {}).clear()                  # absent on a kernel before the fix: fail on the defect
+        self.ledger = km.jd.STATE / "auto-nudge.json"
+        self.problems = len(km._SDK_BOOT_PROBLEMS)
+        self.ticks = []
+        km._auto_nudge_tick = lambda *a, **k: self.ticks.append(a)
+        self._real_read = Path.read_text
+
+    def tearDown(self):
+        Path.read_text = self._real_read
+        super().tearDown()
+
+    def _fault(self):
+        real, target = Path.read_text, str(self.ledger)
+
+        def failing(p, *a, **k):
+            if str(p) == target:
+                raise OSError(errno.EIO, "Input/output error")
+            return real(p, *a, **k)
+        Path.read_text = failing
+
+    def _dispatch(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        return sent, client
+
+    def test_a_toggle_under_a_read_fault_is_refused_and_the_socket_hears_it(self):
+        self.assertEqual(km._set_auto_nudge(False, gt=T_OLD), T_OLD)   # OFF on disk
+        km._autonudge_cache.clear()
+        km._auto_nudge_data()                                          # a proved read: OFF is the last proved snapshot
+        self.ledger.write_text(json.dumps(json.loads(self.ledger.read_bytes()), indent=1))   # the file moves on…
+        before = self.ledger.read_bytes()
+        self._fault()                                                  # …and the new bytes cannot be read
+        sent, client = self._dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})
+        Path.read_text = self._real_read
+        self.assertEqual(self.ledger.read_bytes(), before, "the file keeps its bytes: nothing rewritten from a copy the reader could not vouch for")
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(len(frames), 1, "the delivering socket hears the refusal: the gear re-fills and says not applied")
+        f = frames[0]
+        self.assertEqual(f["setting"], "auto-nudge")
+        self.assertIs(f["kept"], False, "the kept value is the last snapshot this process proved — OFF — never the fabricated ON")
+        self.assertIn("Input/output error", f["why"], "…and the frame names the fault")
+        self.assertEqual(f["gt"], T_NEW)
+        self.assertEqual(f["storedGt"], T_OLD)
+        self.assertEqual(f["gesture"], {"type": "setAutoNudge", "enabled": True})
+        self.assertEqual(self.ticks, [], "a refused toggle fires no act-now tick")
+        self.assertTrue(client["alive"])
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), self.problems + 1, "the fault is on record in the error center")
+        self.assertIn("on was not applied", km._SDK_BOOT_PROBLEMS[-1]["text"])
+        # healed, the same gesture applies and the socket hears nothing
+        sent, _c = self._dispatch({"type": "setAutoNudge", "enabled": True, "gt": T_NEW})
+        self.assertEqual([m for m in sent if m.get("type") == "settingStale"], [])
+        km._autonudge_cache.clear()
+        self.assertTrue(km._auto_nudge_on())
+        self.assertEqual(len(self.ticks), 1, "…and the turn-on acts at once, as ever")
+
+    def test_the_kept_value_includes_this_kernel_s_own_last_write(self):
+        # a proved WRITE is a proved state too: after it, and before any read, a refusal must name the
+        # written value — not the value of the last proved read (the writer publishes and refreshes the
+        # cache with what it read back under the file's stat key)
+        self.assertEqual(km._set_auto_nudge(False, gt=T_OLD), T_OLD)
+        km._autonudge_cache.clear()
+        self.assertFalse(km._auto_nudge_data()["enabled"])            # the last proved READ says OFF
+        self.assertEqual(km._set_auto_nudge(True, gt=T_OLD + 1), T_OLD + 1)   # this kernel writes ON; no read since
+        self.ledger.write_text(json.dumps(json.loads(self.ledger.read_bytes()), indent=1))   # the file moves on…
+        self._fault()                                                  # …and the new bytes cannot be read
+        sent, _c = self._dispatch({"type": "setAutoNudge", "enabled": False, "gt": T_NEW})
+        Path.read_text = self._real_read
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0]["kept"], True, "the kept value is what this kernel last proved — its own write, ON")
+        self.assertIn("off was not applied", km._SDK_BOOT_PROBLEMS[-1]["text"])
+
+    def test_with_no_proved_snapshot_the_frame_names_no_kept_value(self):
+        # a fault before this kernel ever proved a read (boot): the copy readers get is the DEFAULT, so
+        # the frame must not present it as the kept value — the gear then drops its "Keeping …" clause
+        self.assertEqual(km._set_compact_suggest(True, gt=T_OLD), T_OLD)
+        km._autonudge_cache.clear()
+        before = self.ledger.read_bytes()
+        self._fault()
+        sent, _c = self._dispatch({"type": "setCompactSuggest", "enabled": False, "gt": T_NEW})
+        Path.read_text = self._real_read
+        self.assertEqual(self.ledger.read_bytes(), before)
+        frames = [m for m in sent if m.get("type") == "settingStale"]
+        self.assertEqual(len(frames), 1)
+        self.assertEqual(frames[0]["setting"], "compact-suggest")
+        self.assertIsNone(frames[0]["kept"], "unknown is unknown: no fabricated kept value")
+        self.assertIn("Input/output error", frames[0]["why"])
+        self.assertEqual(self.ticks, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -16,6 +16,9 @@ unprompted messages): it files the stamp's lift, the exact row the orphan lift f
 returns to plain Working and the closer is re-nominated. With nudges ON the injected check-in is
 unchanged. Either way it acts once per stamp episode (the wake record / the lifted stamp), never
 again per tick. SYNTHETIC fixtures only; a PRIVATE sid (goal-store fixture rule)."""
+import contextlib
+import errno
+import io
 import json
 import os
 import tempfile
@@ -229,6 +232,140 @@ class OwnWaitOutranksTheDelegatedGate(_Base):
         self._seed(kind=None, age=7 * H)
         self._tick()
         self.assertEqual(self.fb.sent, [], "a kindless stamp may be a peer wait — conservative, as before")
+
+
+class UnreadableLedgerPausesThePass(_Base):
+    """…but never from a ledger the reader cannot vouch for (2026-09-07). A read fault on auto-nudge.json
+    used to fabricate the default — enabled:True, nudged:{} — so the walk fired every due wake and nudge
+    AGAIN each tick (the dedupe map read as empty; the record write then persisted the fabrication) and
+    read an explicit OFF as ON. The pass now stands down whole on an UNPROVED snapshot, says so once per
+    fault episode (stderr + the dashboard's bell), and resumes on the first pass whose read proves — the
+    file reading again is the event; there is no timer. Pinned here because this is where the firing
+    fixture lives; the ledger's own read/write contract is tests/test_ledger_unproved_reads.py."""
+
+    def setUp(self):
+        super().setUp()
+        # the pause latch + the once-per-episode registries (absent on a kernel before the fix, so these
+        # tests fail there on the DEFECT — a fired wake — not in setUp)
+        vars(km).get("_auto_nudge_paused", [None])[0] = None
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned"):
+            vars(km).get(reg, {}).clear()
+        self.problems = len(km._SDK_BOOT_PROBLEMS)
+        self.ledger = jd.STATE / "auto-nudge.json"
+
+    def _fault(self):
+        real, target = Path.read_text, str(self.ledger)
+
+        def failing(p, *a, **k):
+            if str(p) == target:
+                raise OSError(errno.EIO, "Input/output error")
+            return real(p, *a, **k)
+        Path.read_text = failing
+        self.addCleanup(setattr, Path, "read_text", real)
+        return lambda: setattr(Path, "read_text", real)
+
+    def test_no_wake_fires_from_an_unproved_snapshot_and_the_first_proved_read_resumes(self):
+        self._toggle(True)
+        self._seed(kind="job", age=7 * H)                # the shape NudgesOnKeepTheCheckIn fires one wake for
+        before = self.ledger.read_bytes()
+        heal = self._fault()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self._tick(); self._tick(NOW + 5); self._tick(NOW + 10)
+        self.assertEqual(self.fb.sent, [], "nothing injected from a snapshot the reader cannot vouch for")
+        self.assertEqual(self.ledger.read_bytes(), before, "and nothing written over the file")
+        self.assertEqual(err.getvalue().count("paused, not defaulted on"), 1, "loud once per fault episode, not per tick")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), self.problems + 1, "…and once in the dashboard's bell")
+        self.assertIn("Input/output error", km._SDK_BOOT_PROBLEMS[-1]["text"])
+        heal()
+        with contextlib.redirect_stderr(err):
+            self._tick(NOW + 60)
+        self.assertEqual(len(self._wakes()), 1, "the first pass whose read proves fires — the event, no timer")
+        self.assertIn("nudging resumed", err.getvalue())
+        self.assertTrue(km._auto_nudge_data()["nudged"][self.gid].get("wake"), "recorded, so the next tick dedupes")
+
+    def test_an_explicit_off_is_never_read_as_on(self):
+        self._toggle(False)
+        self._seed(stamped=False, delegated=False)       # an unstamped working top: the plain nudge's shape
+        self._fault()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(self.fb.sent, [], "OFF on disk, unreadable now: no fabricated ON fires a status check")
+
+    # ── a fault that lands MID-pass: the head read proved, a leg's read did not ──────────────────
+    # The pass gate covers a fault at the head. Two legs record what they fired only AFTER deciding to
+    # send (the debt reminder) or send only after a durable claim (the compaction suggestion); each
+    # checks the tag itself, because a fault between the head and its own read hands it a tagged copy —
+    # and a send whose record or claim the writer refuses is a send repeated every tick.
+
+    def _fault_after_the_first_read(self):
+        """The pass's head read proves; from the reader's second call on, the file has moved on (a peer
+        wrote it — a new stat key) and the new bytes cannot be read, so every leg sees a tagged copy of
+        the last proved snapshot. Deterministic: the wrapper counts the reader's calls."""
+        real, calls, ledger, test = km._auto_nudge_data, [0], self.ledger, self
+
+        def flaky():
+            calls[0] += 1
+            if calls[0] == 2:
+                ledger.write_text(json.dumps(json.loads(ledger.read_bytes()), indent=1))
+                test.moved_on = ledger.read_bytes()
+                test._fault()
+            return real()
+        km._auto_nudge_data = flaky
+        self.addCleanup(setattr, km, "_auto_nudge_data", real)
+
+    def _owes_a_reply(self):
+        orig = km._debt_asks
+        km._debt_asks = lambda sid, alive: [("66666666-7777-8888-9999-000000000000", "web", NOW - 1800,
+                                              "question", "Which port should the staging server use?")]
+        self.addCleanup(setattr, km, "_debt_asks", orig)
+
+    def test_control_an_owed_reply_draws_the_reminder_when_the_ledger_reads(self):
+        self._toggle(True)
+        self._owes_a_reply()
+        self._tick()
+        self.assertEqual(len(self.fb.sent), 1, "the path is reached: one reminder goes out")
+        self.assertIn("web", self.fb.sent[0][1])
+
+    def test_no_debt_reminder_when_the_ledger_faults_mid_pass(self):
+        self._toggle(True)
+        self._owes_a_reply()
+        self._fault_after_the_first_read()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(self.fb.sent, [], "an unrecorded reminder re-fires every tick: no send whose record would be refused")
+        self.assertEqual(self.ledger.read_bytes(), self.moved_on, "and the file is untouched")
+        self.assertIsNone(vars(km).get("_auto_nudge_paused", [None])[0],
+                          "the head gate proved: the leg refused on its own, not the pause")
+
+    def _settled_past_a_crossing(self):
+        d = json.loads(self.ledger.read_bytes())
+        d["compactSuggestEnabled"] = True                # the per-install opt-in (default OFF)
+        self.ledger.write_text(json.dumps(d))
+        km._autonudge_cache.clear()
+        for n, v in (("_settle_event_key", lambda sid: NOW - 7200), ("_thread_reg", lambda sid: {})):
+            orig = getattr(km, n)
+            setattr(km, n, v)
+            self.addCleanup(setattr, km, n, orig)
+        return {SID: {"state": "", "ctxTokens": 450_000}}   # idle, an hour settled, past the first threshold
+
+    def test_control_a_settled_crossing_draws_the_suggestion_when_the_ledger_reads(self):
+        self._toggle(True)
+        tm = self._settled_past_a_crossing()
+        km._auto_nudge_tick(NOW, tm)
+        self.assertEqual(len(self.fb.sent), 1, "the path is reached: one suggestion goes out")
+        self.assertIn("compact", self.fb.sent[0][1])
+
+    def test_no_compaction_suggestion_when_the_ledger_faults_mid_pass(self):
+        self._toggle(True)
+        tm = self._settled_past_a_crossing()
+        self._fault_after_the_first_read()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._auto_nudge_tick(NOW, tm)
+        self.assertEqual(self.fb.sent, [], "the claim did not latch: a suggestion whose claim is refused is sent again every tick")
+        self.assertEqual(self.ledger.read_bytes(), self.moved_on, "and the file is untouched")
+        self.assertIsNone(vars(km).get("_auto_nudge_paused", [None])[0],
+                          "the head gate proved: the leg refused on its own, not the pause")
 
 
 if __name__ == "__main__":

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -292,6 +292,36 @@ class UnreadableLedgerPausesThePass(_Base):
             self._tick()
         self.assertEqual(self.fb.sent, [], "OFF on disk, unreadable now: no fabricated ON fires a status check")
 
+    def test_a_drop_refused_during_a_fault_replays_on_the_first_proved_pass(self):
+        # the awaiting lift and the follow-up reopen drop a SPENT record from OUTSIDE the paused pass, off an
+        # event that fires once; their goal-store write lands, the ledger drop is refused under the fault,
+        # and nothing retried it: the record stayed latched and an idle session's card sat in Working with
+        # no reviver (review find, 2026-09-08). Now a refused drop is parked and the first proved pass
+        # replays it; a LIVE record parked alongside is kept, as the drop always keeps live records.
+        self._toggle(False)                              # wake-only, no store: the walk writes nothing itself
+        spent, live = self.gid, SID + ":g2"
+        d = json.loads(self.ledger.read_bytes())
+        d["nudged"] = {spent: {"count": 3, "lastTurnId": "t1", "failed": True, "failedAt": NOW - H},
+                       live: {"count": 1, "lastTurnId": "t1"}}
+        self.ledger.write_text(json.dumps(d))
+        km._autonudge_cache.clear()
+        before = self.ledger.read_bytes()
+        vars(km).get("_auto_nudge_drops_pending", set()).clear()          # absent before the fix (see setUp)
+        self.addCleanup(lambda: vars(km).get("_auto_nudge_drops_pending", set()).clear())
+        heal = self._fault()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            verdicts = [km._drop_auto_nudge_rec(spent), km._drop_auto_nudge_rec(live)]
+        self.assertEqual(self.ledger.read_bytes(), before, "under the fault the drops are refused: the file keeps its bytes")
+        heal()
+        with contextlib.redirect_stderr(err):
+            self._tick()
+        nudged = json.loads(self.ledger.read_text())["nudged"]
+        self.assertNotIn(spent, nudged, "the first proved pass replays the drop: the spent record is gone")
+        self.assertIn(live, nudged, "…and the live record (the ladder's memory) is kept, as ever")
+        self.assertEqual(verdicts, [False, False], "the callers were told the drop did not land")
+        self.assertEqual(self.fb.sent, [], "nothing injected: the replay is bookkeeping")
+
     # ── a fault that lands MID-pass: the head read proved, a leg's read did not ──────────────────
     # The pass gate covers a fault at the head. Two legs record what they fired only AFTER deciding to
     # send (the debt reminder) or send only after a durable claim (the compaction suggestion); each

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -398,5 +398,135 @@ class UnreadableLedgerPausesThePass(_Base):
                           "the head gate proved: the leg refused on its own, not the pause")
 
 
+class UnwritableLedgerSendsNothing(_Base):
+    """…and nothing goes out whose record cannot LAND (review find, 2026-09-08). The pass gates on the READ
+    tag, but a WRITE fault (a full or read-only disk) refused the record only AFTER the nudge had gone out:
+    the OSError rose into the per-session wrap as a traceback every tick, the unrecorded goal read as never
+    nudged, and the same stall was nudged again after every response cycle for as long as the disk refused
+    writes, with the redundancy judge's skip falling through to a fire and the escalation ladder never
+    climbing. Now the nudge and the wake record BEFORE they send and send only when the record landed; the
+    walk-gate journal, re-derived every tick, waits quietly for the next one. The writer says the fault once
+    per episode (stderr + the error center); the first pass after the disk heals sends once and records it."""
+
+    def setUp(self):
+        super().setUp()
+        vars(km).get("_auto_nudge_paused", [None])[0] = None
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_ledger_write_failed"):
+            vars(km).get(reg, {}).clear()
+        self.problems = len(km._SDK_BOOT_PROBLEMS)
+        self.ledger = jd.STATE / "auto-nudge.json"
+
+    def _write_fault(self, exc):
+        """km._atomic_write raises `exc`'s errno for the ledger only, naming a temp path with a per-call
+        sequence the way the real publish does: a fault text built from str(e) would then differ on every
+        call, and the once-per-episode assertions below would catch it."""
+        real, target, calls = km._atomic_write, str(self.ledger), [0]
+
+        def failing(path, text, mode=None):
+            if str(path) == target:
+                calls[0] += 1
+                raise OSError(exc.errno, exc.strerror, "%s.tmp.1.2.%d" % (target, calls[0]))
+            return real(path, text, mode)
+        km._atomic_write = failing
+        self.addCleanup(setattr, km, "_atomic_write", real)
+        return lambda: setattr(km, "_atomic_write", real)
+
+    ENOSPC = OSError(errno.ENOSPC, "No space left on device")
+    EACCES = OSError(errno.EACCES, "Permission denied")
+
+    def _nothing_until_the_heal(self, exc, what):
+        """Three faulted passes send nothing and say the fault once; the first pass after the heal sends
+        once. Returns the goal's landed record."""
+        before = self.ledger.read_bytes()
+        heal = self._write_fault(exc)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self._tick(); self._tick(NOW + 5); self._tick(NOW + 10)
+        self.assertEqual(self.fb.sent, [], "a %s whose record cannot land is not sent" % what)
+        self.assertEqual(self.ledger.read_bytes(), before, "the file keeps what it holds")
+        self.assertEqual(err.getvalue().count("write failed"), 1, "said once per fault episode, not per tick")
+        self.assertNotIn("Traceback", err.getvalue(), "no per-session traceback per tick: the leg stood down itself")
+        self.assertEqual(len(km._SDK_BOOT_PROBLEMS), self.problems + 1, "one error-center row per episode")
+        self.assertIn(exc.strerror, km._SDK_BOOT_PROBLEMS[-1]["text"])
+        self.assertNotIn(".tmp.", km._SDK_BOOT_PROBLEMS[-1]["text"], "errno + strerror only: never the temp path")
+        heal()
+        with contextlib.redirect_stderr(err):
+            self._tick(NOW + 60)
+        self.assertEqual(len(self.fb.sent), 1, "the first pass after the heal sends once: the landed write is the event")
+        self.assertEqual(err.getvalue().count("write failed"), 1, "…and says nothing more")
+        return km._auto_nudge_data()["nudged"][self.gid]
+
+    def test_control_a_stalled_goal_draws_one_nudge_when_the_ledger_writes(self):
+        self._toggle(True)
+        self._seed(stamped=False, delegated=False)       # an unstamped working top: the plain nudge's shape
+        self._tick(); self._tick(NOW + 5)
+        self.assertEqual(len(self.fb.sent), 1, "the path is reached: one status check goes out, once")
+        self.assertEqual(km._auto_nudge_data()["nudged"][self.gid].get("lastTurnId"), "t1", "…and is recorded")
+
+    def test_enospc_a_nudge_is_not_sent_until_its_record_lands(self):
+        self._toggle(True)
+        self._seed(stamped=False, delegated=False)
+        rec = self._nothing_until_the_heal(self.ENOSPC, "nudge")
+        self.assertEqual((rec.get("count"), rec.get("lastTurnId")), (1, "t1"), "the healed pass's record")
+        self.assertNotIn(km.AWAITING_BACKSTOP_TEXT, self.fb.sent[0][1], "…for the plain nudge it sent")
+
+    def test_eacces_a_nudge_is_not_sent_until_its_record_lands(self):
+        self._toggle(True)
+        self._seed(stamped=False, delegated=False)
+        rec = self._nothing_until_the_heal(self.EACCES, "nudge")
+        self.assertEqual(rec.get("count"), 1)
+
+    def test_a_wake_is_not_sent_until_its_record_lands(self):
+        self._toggle(True)
+        self._seed(kind="job", age=7 * H)                # the shape NudgesOnKeepTheCheckIn fires one wake for
+        rec = self._nothing_until_the_heal(self.ENOSPC, "wake")
+        self.assertTrue(rec.get("wake"), "the healed pass's wake record")
+        self.assertEqual(len(self._wakes()), 1)
+
+    def test_a_debt_reminder_is_not_sent_until_its_record_lands(self):
+        # the same shape on the debt leg: it recorded after the send, and a refused record let the reminder
+        # out again every tick (the read-tag check above it covers only a fault the READER saw)
+        self._toggle(True)
+        orig = km._debt_asks
+        km._debt_asks = lambda sid, alive: [("66666666-7777-8888-9999-000000000000", "web", NOW - 1800,
+                                              "question", "Which port should the staging server use?")]
+        self.addCleanup(setattr, km, "_debt_asks", orig)
+        before = self.ledger.read_bytes()
+        heal = self._write_fault(self.ENOSPC)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self._tick(); self._tick(NOW + 5)
+        self.assertEqual(self.fb.sent, [], "a reminder whose record cannot land is not sent")
+        self.assertEqual(self.ledger.read_bytes(), before)
+        self.assertEqual(err.getvalue().count("write failed"), 1)
+        self.assertNotIn("Traceback", err.getvalue())
+        heal()
+        with contextlib.redirect_stderr(err):
+            self._tick(NOW + 60); self._tick(NOW + 65)
+        self.assertEqual(len(self.fb.sent), 1, "the first pass after the heal sends once, and the record dedupes the next")
+        self.assertIn("web", self.fb.sent[0][1])
+        self.assertEqual(len(km._auto_nudge_data().get("debtNudged") or {}), 1)
+
+    def test_the_walk_gate_journal_waits_for_the_next_tick_without_a_traceback(self):
+        # a gated session journals its gate (walkGates) on the way out of the walk; that entry is
+        # re-derived every tick, so a refused write is simply written next time, never a traceback per tick
+        self._toggle(True)
+        self._seed(stamped=False, delegated=False)
+        km._compacting_now = lambda sid: True             # the session is gated: no nudge, a journal entry
+        heal = self._write_fault(self.ENOSPC)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self._tick(); self._tick(NOW + 5)
+        self.assertEqual(self.fb.sent, [])
+        self.assertEqual(err.getvalue().count("write failed"), 1)
+        self.assertNotIn("Traceback", err.getvalue(), "the journal write's fault is the writer's line, nothing more")
+        self.assertNotIn(SID, km._auto_nudge_data().get("walkGates", {}), "nothing landed while the disk refused")
+        heal()
+        with contextlib.redirect_stderr(err):
+            self._tick(NOW + 60)
+        self.assertEqual(km._auto_nudge_data()["walkGates"][SID]["gate"], "needs-input", "the next tick journals it")
+        self.assertEqual(self.fb.sent, [], "still gated: nothing sent")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -248,7 +248,7 @@ class UnreadableLedgerPausesThePass(_Base):
         # the pause latch + the once-per-episode registries (absent on a kernel before the fix, so these
         # tests fail there on the DEFECT — a fired wake — not in setUp)
         vars(km).get("_auto_nudge_paused", [None])[0] = None
-        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned"):
+        for reg in ("_ledger_fault_warned", "_ledger_refusal_warned", "_ledger_write_failed"):
             vars(km).get(reg, {}).clear()
         self.problems = len(km._SDK_BOOT_PROBLEMS)
         self.ledger = jd.STATE / "auto-nudge.json"

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -887,9 +887,9 @@ function initGear(post) {
   // machine, the name the gear already uses for it.
   var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...], refused: the value in words } while the toast is up
   function staleHost(m) { return (typeof m.host === 'string' && m.host) ? m.host : 'this machine'; }
-  // The kernel's reason a write was refused OUTRIGHT (it could not read the setting's file) as a clause
-  // for the copy; absent on an ordering stand-down, and from an older kernel (review find on #1018, 2026-09-08)
-  function staleWhy(m) { return (typeof m.why === 'string' && m.why) ? ' Its settings file could not be read (' + m.why + ').' : ''; }
+  // The kernel's reason a write was refused OUTRIGHT as a clause for the copy: its file could not be READ, or
+  // (a `why` starting "write failed:", the fold on PR #1019) WRITTEN — one clause per cause; absent on a stand-down
+  function staleWhy(m) { return (typeof m.why === 'string' && m.why) ? ' Its settings file could not be ' + (m.why.indexOf('write failed:') === 0 ? 'written' : 'read') + ' (' + m.why + ').' : ''; }
   function staleLive(t) { return !!t.parentNode && !(t.classList && t.classList.contains('fade')); }
   // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
   // page has seen (the frame's storedGt included, learned just before): a fresh click is legitimate

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -887,6 +887,9 @@ function initGear(post) {
   // machine, the name the gear already uses for it.
   var staleOpen = {};   // 'setting:gt' → { t: the toast node, hosts: [...], refused: the value in words } while the toast is up
   function staleHost(m) { return (typeof m.host === 'string' && m.host) ? m.host : 'this machine'; }
+  // The kernel's reason a write was refused OUTRIGHT (it could not read the setting's file) as a clause
+  // for the copy; absent on an ordering stand-down, and from an older kernel (review find on #1018, 2026-09-08)
+  function staleWhy(m) { return (typeof m.why === 'string' && m.why) ? ' Its settings file could not be read (' + m.why + ').' : ''; }
   function staleLive(t) { return !!t.parentNode && !(t.classList && t.classList.contains('fade')); }
   // Apply anyway re-issues the frame's echoed gesture as a NEW one, stamped above everything this
   // page has seen (the frame's storedGt included, learned just before): a fresh click is legitimate
@@ -911,11 +914,15 @@ function initGear(post) {
     var key = typeof m.gt === 'number' ? m.setting + ':' + m.gt : '';
     var live = key && staleOpen[key] && staleLive(staleOpen[key].t) ? staleOpen[key] : null;
     var where = staleHost(m);
+    // A write the kernel refused because it could not READ the setting's file (the frame carries `why`) is
+    // not an ordering race: re-issuing the gesture cannot succeed while the file is unreadable, so that
+    // toast offers no Apply anyway and says why instead (review find on #1018, 2026-09-08)
+    var why = staleWhy(m);
     if (live) {   // the same gesture, refused by one more kernel: add the host to the toast on screen
       if (live.hosts.indexOf(where) < 0) live.hosts.push(where);
-      live.t.querySelector('.rs-stale-toast-msg').textContent = staleText(label, live.refused || refused, kept, live.hosts);
+      live.t.querySelector('.rs-stale-toast-msg').textContent = staleText(label, live.refused || refused, kept, live.hosts) + why;
     } else {
-      var t = staleToast(staleText(label, refused, kept, [where]), staleAction(m, refused));
+      var t = staleToast(staleText(label, refused, kept, [where]) + why, why ? null : staleAction(m, refused));
       if (key) staleOpen[key] = { t: t, hosts: [where], refused: refused };
     }
     if (!p.hidden) fill();   // the open modal re-reads the kernel's values so it stops showing the refused pick

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -212,3 +212,23 @@ test("the open modal re-fills once per frame; a closed one never does", () => {
   g.frame({ ...REFUSED, gt: 5, host: "gpu1" });
   assert.equal(g.fills(), 2, "open: the frame IS the event — one re-read per frame, folded or not");
 });
+
+test("a write refused because the kernel could not read the setting's file offers no Apply anyway and says why", () => {
+  // the kernel answers a refused ledger write with the same frame plus `why` (kernel/kernel.py
+  // _tell_stale_gesture); re-issuing the gesture cannot succeed while the file is unreadable, so the
+  // toast drops the button (offered, it was a click that could only draw the same refusal) and names
+  // the reason beside the kept value (review find on #1018, 2026-09-08)
+  const g = lift();
+  g.frame({ type: "settingStale", setting: "auto-nudge", storedGt: 2000, gt: 1000, kept: false,
+            why: "read failed: [Errno 5] Input/output error", gesture: { type: "setAutoNudge", enabled: true } });
+  assert.equal(g.box().children.length, 1);
+  const t = g.box().children[0];
+  assert.equal(t.children.filter((c) => c.className === "rs-stale-toast-act").length, 0, "no Apply anyway: it could not succeed");
+  assert.match(g.texts()[0], /on was not applied on this machine\. Keeping off\./, "the stand-down copy is exactly true of it");
+  assert.match(g.texts()[0], /could not be read \(read failed: \[Errno 5\] Input\/output error\)/, "…and the reason is on the toast");
+  // an ordering stand-down (no why) keeps its button, the frozen-tab case the button exists for
+  g.frame({ ...REFUSED });
+  const t2 = g.box().children[1];
+  assert.equal(t2.children.filter((c) => c.className === "rs-stale-toast-act").length, 1);
+  assert.doesNotMatch(g.texts()[1], /could not be read/);
+});

--- a/ui/webview/setting-stale-fold.test.ts
+++ b/ui/webview/setting-stale-fold.test.ts
@@ -232,3 +232,25 @@ test("a write refused because the kernel could not read the setting's file offer
   assert.equal(t2.children.filter((c) => c.className === "rs-stale-toast-act").length, 1);
   assert.doesNotMatch(g.texts()[1], /could not be read/);
 });
+
+test("a write refused because the publish itself failed names THAT cause: could not be written, not read", () => {
+  // the kernel answers a ledger write that FAILED (ENOSPC, EROFS, EACCES out of the publish) with the same
+  // frame, its `why` starting "write failed:" (kernel/kernel.py _set_auto_nudge / _set_compact_suggest,
+  // the maintainer's fold on PR #1019: the write step is a fault boundary too). The clause hardcoded
+  // "could not be read", so a full disk read as an unreadable file; the toast names the cause it carries
+  // (review find, 2026-09-08). No Apply anyway either: a re-issue cannot land while the disk refuses.
+  const g = lift();
+  g.frame({ type: "settingStale", setting: "auto-nudge", storedGt: 2000, gt: 1000, kept: true,
+            why: "write failed: [Errno 28] No space left on device", gesture: { type: "setAutoNudge", enabled: false } });
+  assert.equal(g.box().children.length, 1);
+  const t = g.box().children[0];
+  assert.equal(t.children.filter((c) => c.className === "rs-stale-toast-act").length, 0, "no Apply anyway: it could not succeed");
+  assert.match(g.texts()[0], /off was not applied on this machine\. Keeping on\./);
+  assert.match(g.texts()[0], /could not be written \(write failed: \[Errno 28\] No space left on device\)/, "the cause the frame carries");
+  assert.doesNotMatch(g.texts()[0], /could not be read/, "a full disk is not an unreadable file");
+  // the read-fault clause is unchanged beside it
+  g.frame({ type: "settingStale", setting: "compact-suggest", storedGt: 2000, gt: 1001, kept: false,
+            why: "read failed: [Errno 5] Input/output error", gesture: { type: "setCompactSuggest", enabled: true } });
+  assert.match(g.texts()[1], /could not be read \(read failed: \[Errno 5\] Input\/output error\)/);
+  assert.doesNotMatch(g.texts()[1], /could not be written/);
+});


### PR DESCRIPTION
The auto-nudge and retry-suppress ledgers are never rewritten from a fabricated default after a read fault

Two automatic ledgers under STATE — auto-nudge.json and retry-suppressed.json —
are each read by one reader and written by one writer, with many
read-modify-write sites between them (`d = dict(reader()); d[k] = v; writer(d)`).
Both readers answered ANY fault with the fresh-install default and cached it
under the file's real stat key, so the next writer persisted the fabrication.

auto-nudge.json: `_auto_nudge_data` returned {"enabled": True, "nudged": {}} on
any stat OSError (not just ENOENT) and on any read or decode fault, then cached
it. After one EIO on a tick the dedupe map read as empty, so every stalled goal
across every session was nudged again, every tick; and a user's explicit
auto-nudge OFF came back ON.

retry-suppressed.json: `_retry_suppress_data` did the same with {}; the arm in
`_suppress_session_retry` then wrote {this sid} over every sibling session's
"stop retrying" — a retry storm the user had explicitly halted, resumed. The
arm's write also had no OSError handling: an ENOSPC out of the interrupt handler
reached the WS reader loop, which reads any OSError as a socket failure and tore
the dashboard's connection down with the suppression neither on disk nor
anywhere. The arm and the pusher's re-arm sweep rewrote the whole blob unlocked,
and a non-numeric floor raised TypeError into the sweep and killed it.

The fix, shared by both ledgers (`_ledger_read` / `_ledger_write_proved`):

- Missing is the ONLY fault that reads as the default — a file that is not
  there IS the fresh-install state (ENOENT behavior unchanged byte for byte:
  uncached, no log). Any other stat/read fault yields a COPY of the last
  snapshot this process proved (else the default) tagged "_unproved" with the
  fault text; nothing unproved is cached, so the file's next successful read
  ends the episode — an event, not a clock. Every proved state — a read, a
  cache hit, absence, a write — resets BOTH once-per-episode registries, so the
  same fault returning after a heal is said again. Fault texts carry no
  destination path and no stamp, so a fault that persists has one text.
- The writer is the one choke point: it refuses any snapshot carrying the tag
  (one stderr line per fault episode, keyed on the fault text) and returns
  False; the file keeps what it holds. A write that lands refreshes the cache
  with what it read back under the file's stat key, so "the last snapshot this
  process proved" includes this kernel's own last write. The tag travels IN the
  snapshot because every RMW site copies it with dict(): a flag beside the
  cache would not survive the copy, and a per-path "last read failed" bit races
  a sibling thread's proved read. The ~20 auto-nudge RMW sites are covered
  unchanged.
- Bytes that do not parse (invalid JSON, a non-object value, not UTF-8 — the
  ledgers are read as UTF-8, never the locale's encoding) are moved aside as
  <file>.corrupt-<utc stamp> (a -n suffix within one second) — the judge's
  goal-store quarantine shape — evidence kept, never deleted, one stderr line,
  and the ledger then reads as absent. The move is guarded on the file still
  being the one read (same inode and generation); a file that cannot be moved
  (a read-only state dir) rides the deduped fault text as errno + strerror,
  never a line per read and never a text per second.
- The auto-nudge pass stands down whole on an unproved snapshot (nudge, wake,
  compaction suggestion, debt ladder, sweeps — each records what it fired in
  this ledger, and a refused record re-fires every tick), once-loud on stderr
  and in the dashboard's error center, and resumes on the first tick whose read
  proves. The debt reminder and the compaction-suggestion claim check the tag
  themselves for a fault that lands mid-pass. The interrupt→blocked tick, which
  runs outside that pass, files no block under a fault (its once-per-episode
  marker could not be minted, and the lift is gated on the marker); a block it
  did file — a proved goal-store write the feed must hear — pushes whatever the
  marker write's fate; the lift on re-engagement runs whatever the ledger's
  state, and pushes only when its marker clear lands (a refused clear with an
  idempotent lift is not a push per cycle).
- `_set_auto_nudge` / `_set_compact_suggest` report a refused write as
  not-applied (None) and record a `refused` notice on the thread, a sibling of
  `_setting_stale`'s stand-down; the WS branch answers the delivering socket
  with the settingStale frame plus `why` (the gear re-fills the checkbox and
  says not applied, keeping the stored value — `kept` is the last snapshot this
  process proved, named only when there is one) and files the fault in the
  error center.
- retry-suppress: `_suppress_session_retry` returns None when the stop is on
  disk, else one sentence naming why (an unproved read, or the write's
  OSError, now caught); the interrupt handler warn-toasts it while the
  interrupt itself still happens. Arm and clear hold a new
  `_RETRY_SUPPRESS_LOCK` across their read-modify-write only. A non-numeric
  floor is read as no floor, said once per session.

Unchanged: `_auto_nudge_on` (display); the fresh-install path; every RMW
site's code; the OSError arm of the setting toggles.

Tests: 32 new, run against a `git archive` copy of origin/main f06e6678. 27
fail there, each on its defect's assertion (a rewritten file, a fired message,
a raised OSError or TypeError, a silent socket) — never on a missing name.
Five pass on main, by construction or by design: the two ENOENT pins
(FreshInstall and retry-suppress: that arm is unchanged), the two mid-pass
controls (they prove the path is reached on a healthy ledger), and
test_no_compaction_suggestion_when_the_ledger_faults_mid_pass — which passes
on main for an unrelated reason (main's fabricated default lacks
compactSuggestEnabled, so `_compact_suggest_tick` returns at its own gate) and
earns its place as the sole killer of the claim-latch mutant.
- tests/test_ledger_unproved_reads.py (new): the seeded OFF + dedupe record,
  Path.read_text raising EIO; `_set_auto_nudge`, `_set_compact_suggest` and
  `_mark_auto_nudged` leave the bytes unchanged and log one refusal; a stat
  fault; the tagged copy of the last proved snapshot; once per episode across
  six same-text episodes ended by a write, a read, a cache hit and ENOENT;
  corrupt bytes / a JSON array / non-UTF-8 quarantined in the judge's shape
  with the -n suffix; a file replaced under a corrupt read is not moved aside;
  an unmovable corrupt file has one fault text across three seconds; ENOENT;
  the interrupt→blocked tick under a fault (no block filed, no push storm, the
  lift honored, a mid-tick fault pushes the block it filed exactly once).
- tests/test_wake_deadman_toggle.py: the pass fires nothing under EIO, logs
  once, posts one error-center row, resumes on the first proved read; an
  explicit OFF is never read as ON; the debt reminder and the compaction
  suggestion send nothing when the fault lands mid-pass and the head gate
  stayed open (with controls).
- tests/test_session_retry_suppress.py: a read fault leaves {s1, s2} byte for
  byte, the clear reaches the writer's refusal, the click is told; ENOSPC is
  reported, not raised; the interrupt handler toasts through the real
  dispatcher; a non-numeric floor; corrupt bytes; ENOENT; lock and toast pins.
- tests/test_setting_gesture_order.py: a toggle under EIO through the real
  dispatcher — file unchanged, the socket hears the frame with the kept value
  and the fault, no act-now tick, one error-center row; the kept value includes
  this kernel's own last write; with no proved snapshot the frame names none.

Measured on this commit: the four touched modules (118 passed) and the 34
ledger-touching modules in one sequential run (1156 passed, 25 subtests). The
full suite is left to CI (not run on the development machine).



## Tier

**fix** — a bug fix with tests that fail before it. A fork author cannot apply labels here; asking a maintainer to apply `fix`.

## Notes for review

- Tests were run per module on the development machine (the four touched modules and the 34 ledger-touching modules, one process at a time); the full suite is left to this PR's CI.
- **#994** (user todos) reads `_auto_nudge_data` at two new sites; it does not touch the reader or writer this changes, so whichever lands second should rebase cleanly.
- The quarantine sidecar shape (`<file>.corrupt-<UTC stamp>[-n]`, `os.replace`, an inode re-check) matches the goal-store PR opened alongside this one, so the two stores wear one convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
