### PR TITLE
A goals file that cannot be read is never republished as an empty store: read faults raise and unparseable bytes are quarantined aside

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -463,7 +463,15 @@ permission/API-error floors: one interrupt at a time, the present event first.
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
   call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,
   task-key-collision — a duplicated to-do mirror key, reconciled per node
-  and surfaced loudly),
+  and surfaced loudly, store-unreadable: a goals file that cannot be read,
+  filed once per fault episode and ended by the next successful read,
+  store-unwritable: a goals file whose publish failed under a user gesture,
+  and store-quarantined: a goals file whose bytes did not parse, moved aside).
+  A file that does not parse is never deleted: it is moved beside its path as
+  `<file>.corrupt-<utc stamp>` (a `-n` suffix when two land in the same second)
+  before a fresh one is written, so the bytes survive for inspection, and the
+  `*.json` globs that enumerate stores skip it; the same sidecar convention
+  applies to any other state file romp moves aside as unparseable.
   `STATE/judge-auth.json` (the per-session judge-auth-down latch — see
   "Billing" above).
 - Debugging: run the judge's own code against the live store

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -124,6 +124,7 @@ def _rebind_state(path):
     CODEXDIR = STATE / "codex"
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
+    _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
@@ -839,7 +840,11 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              "scratch" (the judge scratch cwd can't be made private — call skipped, never rerouted
              to a world-writable directory; see _ensure_judge_scratch), "sweep-cut" (the closer ended a
              session's walk for the pass at a FAILED call — _close_session; the note names the turns left
-             behind and the shape of the menu that died)
+             behind and the shape of the menu that died), "store-quarantined" (a goals store that
+             could not be parsed was moved aside to <file>.corrupt-<stamp> and the session started fresh),
+             "store-unreadable" (a goals store that cannot be READ — EACCES, EIO — filed once per fault
+             episode by load_goals_or_fault; inside a judge pass the raise instead reaches the pass
+             wrapper's "pass-crash" row)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -2350,8 +2355,11 @@ def tasks_for(fsid, leaf, files, now):
     except Exception:
         pass
     session = parsed_session(fsid, files, now)
-    tasks = []
-    for t in _ready_tasks(session, load_goals(fsid)):
+    store, fault = load_goals_or_fault(fsid)
+    if fault is not None:
+        return []                                      # its row is filed; this session captions nothing this
+    tasks = []                                         # pass and the other sessions' captions proceed
+    for t in _ready_tasks(session, store):
         kind = t.get("kind", "work")
         text = _prompt_text(t["atoms"]) if kind == "prompt" else _unit_text(t["atoms"])
         task = {"kind": kind, "text": text, "writes": t["writes"]}
@@ -2963,16 +2971,83 @@ def _guard_nodes(store):
     return store
 
 
-def load_goals(fsid):
+def _quarantine_store(path, reason):
+    """Move an unparseable store file ASIDE (never delete it) so the evidence survives the fresh start
+    that follows. The sidecar keeps the original name plus `.corrupt-<utc stamp>`, so the `*.json` globs
+    that enumerate live stores (the kernel's compaction sweep and pre-pass feed snapshot, the propagate
+    sweep's sender walk) never pick it up; the kernel's store fingerprint scandirs the whole directory and
+    does see it, which is harmless (the store did change). Loud on both channels the repo uses: one stderr
+    line for the kernel log, one judge-errors row for `romp judges` and the feed's debug join. Bounded by
+    construction: the next read of the path is a plain ENOENT, so a quarantine fires once per corrupt
+    file, never once per pass.
+
+    No file lock (this codebase takes none), so the rename shares save_goals' vanishingly small window
+    with a concurrent writer that republishes the path between our read and our rename. A source that
+    vanished in that window was already handled by a peer: nothing left to move."""
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    aside, n = path.with_name("%s.corrupt-%s" % (path.name, stamp)), 0
+    while aside.exists():                            # a second corrupt file in the same second
+        n += 1
+        aside = path.with_name("%s.corrupt-%s-%d" % (path.name, stamp, n))
     try:
-        store = _guard_nodes(json.loads((GOALDIR / (fsid + ".json")).read_text()))
-    except Exception:
+        os.replace(path, aside)
+    except FileNotFoundError:
+        return None
+    note = "goals store %s could not be parsed (%s); moved aside to %s, the session starts fresh" % (
+        path, reason, aside.name)
+    sys.stderr.write("romp-judge: %s\n" % note)
+    _log_judge_error("romp", path.stem, "store-quarantined", note=note)
+    return aside
+
+
+def _read_store_json(path, *, quarantine=False):
+    """The parsed JSON object at `path`, or None when the file is ABSENT (a session with no store yet).
+
+    Every other failure is a fact about the file the caller must not paper over: a read FAULT (EIO,
+    EACCES, a directory where the file should be) RAISES, always. Unparseable content (a torn write,
+    bytes that are not UTF-8, JSON whose top level is not an object) is quarantined aside and read as
+    None when `quarantine` is set (load_goals: a fresh store is legitimate ONLY once the bad bytes are
+    preserved), and raises otherwise (the save path: a writer that cannot read the file it is about to
+    replace publishes nothing). Before this, all of those read as "no file" and the CAS in save_goals
+    then found base 0 == disk 0 and published an EMPTY store over the user's goals.
+
+    A raised fault is surfaced by whoever owns the pass: every judge pass wrapper files a `pass-crash`
+    judge-errors row for that session and moves on to the next, so the fault is logged once per pass
+    rather than once here AND once there."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except UnicodeError as e:
+        if not quarantine:
+            raise
+        _quarantine_store(path, "not UTF-8: %s" % e)
+        return None
+    try:
+        value = json.loads(raw)
+    except ValueError as e:                          # json.JSONDecodeError is a ValueError
+        if not quarantine:
+            raise
+        _quarantine_store(path, "invalid JSON: %s" % e)
+        return None
+    if not isinstance(value, dict):
+        if not quarantine:
+            raise ValueError("%s: top-level JSON value is %s, not an object" % (path, type(value).__name__))
+        _quarantine_store(path, "top-level JSON value is %s, not an object" % type(value).__name__)
+        return None
+    return value
+
+
+def load_goals(fsid):
+    raw = _read_store_json(GOALDIR / (fsid + ".json"), quarantine=True)
+    if raw is None:
         # a FRESH store is born at the current identity version — only stores with history recorded
         # under an OLDER derivation are ever sealed (see _migrate_placements)
         store = {"rompUuid": fsid, "seq": 0, "nodes": {}, "placements": {}, "status": {},
                  "placementsV": PLACEMENTS_V}
         store["_baseRev"] = 0            # no file yet; a writer that CREATES one still trips the CAS
         return store
+    store = _guard_nodes(raw)
     if _replay_overrides(fsid, store):
         # the replay WROTE (a clobbered user resolve/clear re-flagged): the published status/confirming
         # predate it, and every reader now trusts those exports as the one truth (no raw-flag second
@@ -2985,12 +3060,50 @@ def load_goals(fsid):
     return store
 
 
-def _disk_rev(fsid):
-    """The revision currently published on disk (0 when absent/unreadable)."""
+_STORE_FAULTS = {}                       # fsid -> the fault text of its CURRENT unreadable episode (load_goals_or_fault)
+_STORE_FAULTS_LOCK = threading.Lock()
+
+
+def load_goals_or_fault(fsid):
+    """The per-session BOUNDARY for every hot path that reads a goal store: `(store, None)` on a read,
+    `(None, exc)` when the file cannot be read. load_goals itself stays strict (a read fault RAISES, never an
+    empty store); this is where that raise is caught, filed, and CONTAINED to the one session it is about.
+    Before it, the feed and timeline builders, the chat ledger, the kernel's ticks and sweeps and the index
+    tier all reached load_goals with no per-session catch, so one session's EACCES/EIO/directory-at-the-path
+    aborted the whole build or pass for EVERY session: the pusher logged one line and sent nothing to any
+    client, every cycle, for as long as the fault lasted. One session's fault must be loud for that session
+    and invisible to the others.
+
+    Loud ONCE PER FAULT EPISODE, on the surface every per-session failure already reaches (`romp judges`,
+    the feed's debug join): the first fault files a `store-unreadable` judge-errors row for the sid; an
+    identical repeat files nothing (a persistent fault would otherwise add a row per build); a fault with
+    DIFFERENT text is a new episode and files again; a successful read of that sid ENDS the episode (the
+    event, not a timer), so a later fault files afresh.
+
+    NEVER hands back an empty store: a caller that gets `(None, exc)` skips that session's goal-derived
+    work for this build or pass, and writes nothing."""
     try:
-        return int((json.loads((GOALDIR / (fsid + ".json")).read_text()) or {}).get("rev") or 0)
-    except Exception:
-        return 0
+        store = load_goals(fsid)
+    except OSError as e:
+        text = "%s: %s" % (type(e).__name__, e)
+        with _STORE_FAULTS_LOCK:
+            repeat = _STORE_FAULTS.get(fsid) == text
+            _STORE_FAULTS[fsid] = text
+        if not repeat:
+            _log_judge_error("romp", fsid, "store-unreadable",
+                             note="goals store cannot be read; this session's goal-derived work is skipped "
+                                  "until it reads again: %s" % text)
+        return None, e
+    with _STORE_FAULTS_LOCK:
+        _STORE_FAULTS.pop(fsid, None)                # a successful read ends the episode
+    return store, None
+
+
+def _disk_rev(fsid):
+    """The revision currently published on disk (0 only when ABSENT). A read fault or unparseable file
+    raises: read as 0 it matched a fresh store's base of 0, and save_goals then published that empty
+    store over a file it never managed to read."""
+    return int((_read_store_json(GOALDIR / (fsid + ".json")) or {}).get("rev") or 0)
 
 
 def _rebase_onto_disk(fsid, store):
@@ -3005,11 +3118,11 @@ def _rebase_onto_disk(fsid, store):
 
     Verdict identity is (ev_t, src, kind) — the same triple _replay_overrides dedups a re-recorded block
     on — so a replayed/duplicated event folds instead of doubling."""
-    try:
-        disk = _guard_nodes(json.loads((GOALDIR / (fsid + ".json")).read_text()))
-    except Exception:
-        return                                       # nothing readable to rebase onto → publish as-is
-    d_nodes, m_nodes = disk.get("nodes") or {}, store.get("nodes") or {}
+    raw = _read_store_json(GOALDIR / (fsid + ".json"))
+    if raw is None:
+        return                                       # no published store to rebase onto → publish as-is
+    disk = _guard_nodes(raw)                         # (a fault or unparseable file raises: never rebase
+    d_nodes, m_nodes = disk.get("nodes") or {}, store.get("nodes") or {}    #  past what we could not read)
     # MERGE TOMBSTONES (2026-08-13): presence-in-a-snapshot is not truth — a stale pre-merge writer
     # publishing across a grouper merge used to RESURRECT the merged-away node (its id absent from the
     # newer side, so the adopt-wholesale branch below re-minted it), and the twin then held a duplicate
@@ -3384,12 +3497,13 @@ def _store_content(store):
 
 def _matches_disk(fsid, store):
     """True when publishing `store` would write back exactly what the file already holds (see save_goals).
-    Anything unreadable, absent or unserializable answers False, so the real write still happens and still
-    raises on its own terms — a no-op check must never swallow a publish it merely failed to understand."""
-    try:
-        disk = json.loads((GOALDIR / (fsid + ".json")).read_text())
-    except Exception:
-        return False                                 # no file yet (a create), or unreadable → publish
+    An absent file answers False (a create), and an unserializable `store` answers False so the real write
+    still raises on its own terms — a no-op check must never swallow a publish it merely failed to
+    understand. A file that cannot be READ raises instead: answering False there let the publish go ahead
+    over the very bytes it failed to compare against."""
+    disk = _read_store_json(GOALDIR / (fsid + ".json"))
+    if disk is None:
+        return False                                 # no file yet (a create) → publish
     try:
         return _store_content(disk) == _store_content(store)
     except (TypeError, ValueError):
@@ -13236,7 +13350,11 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
         # specimen sat open seven hours with its completion event already fired and recorded.
         # Read-only on this side: propagate writes SENDER stores only.
         rnodes = dict(load_goal_archive(fsid).get("nodes") or {})
-        rnodes.update(load_goals(fsid).get("nodes") or {})
+        try:
+            rnodes.update(load_goals(fsid).get("nodes") or {})
+        except Exception as e:                         # an unreadable store: this session's row, the next session's turn
+            _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
+            continue
         for nid, nd in list(rnodes.items()):
             if not nd.get("nodeComplete"):
                 continue                                # B hasn't finished it yet
@@ -13246,7 +13364,11 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                      if isinstance(l, dict) and l.get("peer") and l.get("goalId")]
             for ref in refs:
                 a_sid, a_gid = ref["peer"], ref["goalId"]
-                a_store = load_goals(a_sid)
+                try:
+                    a_store = load_goals(a_sid)
+                except Exception as e:                 # the sender's store faulted: its tracker waits for the next pass
+                    _log_judge_error("propagate", fsid, "pass-crash", note="sender %s store: %r" % (a_sid[:8], e))
+                    continue
                 a_node = a_store.get("nodes", {}).get(a_gid)
                 if not a_node or a_node.get("nodeComplete"):
                     continue                            # sender's tracking node gone or already done → idempotent
@@ -13289,7 +13411,8 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
         """The recipient goal a tracker's msgId joins to (origin or links), live+archive merged."""
         if peer_sid not in _rmemo:
             m = dict(load_goal_archive(peer_sid).get("nodes") or {})
-            m.update(load_goals(peer_sid).get("nodes") or {})
+            live, fault = load_goals_or_fault(peer_sid)   # a faulting recipient joins to nothing this pass
+            m.update((live or {}).get("nodes") or {})     # (forward-only: the tracker simply stays open)
             _rmemo[peer_sid] = m
         for rd in _rmemo[peer_sid].values():
             if not isinstance(rd, dict):
@@ -13323,7 +13446,11 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                for v in (_st0.get("nodes") or {}).values()):
             _sw_senders.append(_f.stem)
     for fsid in _sw_senders:
-        store = load_goals(fsid)
+        try:
+            store = load_goals(fsid)
+        except Exception as e:
+            _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
+            continue
         changed = False
         for nid, nd in list(store.get("nodes", {}).items()):
             h = nd.get("handoff")
@@ -13391,7 +13518,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         except Exception as e:                         # a poisoned transcript must not skip silently (T111)
             _log_judge_error("courier", fsid, "pass-crash", note="parse: %r" % e)
             continue
-        cstore = load_goals(fsid)
+        try:
+            cstore = load_goals(fsid)
+        except Exception as e:                         # an unreadable store: this session's row, the next session's turn
+            _log_judge_error("courier", fsid, "pass-crash", note="store: %r" % e)
+            continue
         closed[fsid] = _session_settled(fsid, str(path), session, cstore)
         placed_ids = cstore["placements"]
         floor = episode_floor(fsid)
@@ -13460,7 +13591,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     except OSError:
         xrows = []
     for o in xrows:
-        sstore = load_goals(o["from_id"])
+        try:
+            sstore = load_goals(o["from_id"])
+        except Exception as e:
+            _log_judge_error("courier", o["from_id"], "pass-crash", note="sender store: %r" % e)
+            continue
         if any(isinstance(nd.get("handoff"), dict) and nd["handoff"].get("msgId") == o["id"]
                for nd in sstore["nodes"].values()):
             continue
@@ -13471,7 +13606,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         placed += 1
     pending.sort(key=lambda x: x[0])                  # global cross-session oldest-first
     for seg_t, fsid, seg_id, text, mid, sender, declared, anchor_uuid, path in pending:
-        store = load_goals(fsid)
+        try:
+            store = load_goals(fsid)
+        except Exception as e:
+            _log_judge_error("courier", fsid, "pass-crash", note="store: %r" % e)
+            continue
         if _placed_key(store["placements"], seg_id):  # drift-safe: never re-plant a t-shifted duplicate
             continue
         if now - seg_t > COURIER_RETRY_HORIZON:
@@ -13507,7 +13646,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             save_goals(fsid, store)
             placed += 1
             continue
-        sender_store = load_goals(sender)
+        try:
+            sender_store = load_goals(sender)
+        except Exception as e:                         # the message stays pending; retried next pass
+            _log_judge_error("courier", fsid, "pass-crash", note="sender %s store: %r" % (sender[:8], e))
+            continue
         # cap 40 for the LINK menu (the user 2026-08-24, the resurfaced-ask specimen): open_menu is
         # oldest-first, and a busy sender holds >20 open nodes — the default cap starved exactly the
         # candidates a dispatch usually serves (the fresh ask AND its older original), so the courier
@@ -13586,7 +13729,11 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             # top — its work lives in that session's own view and transcript, and any needs-you
             # state still reaches the board through the hard-block floor/placeholder, which need no
             # goal node. Uncertainty quiets by design (the trace's docstring names the surface).
-            rooted = _delegate_user_rooted(sender, link_id, paths_map, now)
+            try:
+                rooted = _delegate_user_rooted(sender, link_id, paths_map, now)
+            except Exception as e:                     # a peer store on the root walk faulted: skip THIS message this
+                _log_judge_error("courier", fsid, "pass-crash", note="root walk: %r" % e)   # pass, never
+                continue                               # "unrooted" (that would mint a top the ask may already own)
             # WALKED-AT-RELAY ROOT (the user 2026-08-27, T126): a cross-host dispatch carries the
             # record the ORIGIN kernel walked at send time — the evidence (stores + transcripts)
             # lives on that machine's disk, so the local walk rightly refuses the hop, but at the

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -844,7 +844,9 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              could not be parsed was moved aside to <file>.corrupt-<stamp> and the session started fresh),
              "store-unreadable" (a goals store that cannot be READ — EACCES, EIO — filed once per fault
              episode by load_goals_or_fault; inside a judge pass the raise instead reaches the pass
-             wrapper's "pass-crash" row)
+             wrapper's "pass-crash" row), "store-unwritable" (a goals store that read but whose publish
+             then failed under a user gesture, the save path's own strict read or the write itself; filed
+             once per fault episode by save_goals_or_fault, and the gesture is answered on its socket)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -2971,7 +2973,7 @@ def _guard_nodes(store):
     return store
 
 
-def _quarantine_store(path, reason):
+def _quarantine_store(path, reason, st):
     """Move an unparseable store file ASIDE (never delete it) so the evidence survives the fresh start
     that follows. The sidecar keeps the original name plus `.corrupt-<utc stamp>`, so the `*.json` globs
     that enumerate live stores (the kernel's compaction sweep and pre-pass feed snapshot, the propagate
@@ -2982,8 +2984,19 @@ def _quarantine_store(path, reason):
     file, never once per pass.
 
     No file lock (this codebase takes none), so the rename shares save_goals' vanishingly small window
-    with a concurrent writer that republishes the path between our read and our rename. A source that
-    vanished in that window was already handled by a peer: nothing left to move."""
+    with a concurrent writer that republishes the path between our read and our rename. `st` is the stat
+    the caller took BEFORE the read whose bytes failed: the file is re-stat'ed here and moved only while
+    it is still that very file (same inode, mtime and size). A different file at the path is a peer's
+    atomic publish since our read, and moving it would quarantine their VALID store and start the session
+    fresh over it; a path that vanished was already handled by a peer. Either way nothing of ours is left
+    to move: None, no row, and the caller reads what is there now (review find, 2026-09-08; the same
+    identity check the ledger quarantine wears)."""
+    try:
+        cur = path.stat()
+    except FileNotFoundError:
+        return None
+    if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
+        return None
     stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     aside, n = path.with_name("%s.corrupt-%s" % (path.name, stamp)), 0
     while aside.exists():                            # a second corrupt file in the same second
@@ -3000,7 +3013,7 @@ def _quarantine_store(path, reason):
     return aside
 
 
-def _read_store_json(path, *, quarantine=False):
+def _read_store_json(path, *, quarantine=False, _tries=3):
     """The parsed JSON object at `path`, or None when the file is ABSENT (a session with no store yet).
 
     Every other failure is a fact about the file the caller must not paper over: a read FAULT (EIO,
@@ -3013,29 +3026,33 @@ def _read_store_json(path, *, quarantine=False):
 
     A raised fault is surfaced by whoever owns the pass: every judge pass wrapper files a `pass-crash`
     judge-errors row for that session and moves on to the next, so the fault is logged once per pass
-    rather than once here AND once there."""
+    rather than once here AND once there.
+
+    The stat comes BEFORE the read, so the quarantine can tell whether the file it is about to move is
+    still the one whose bytes failed (see _quarantine_store); when it is not, a peer published meanwhile
+    and THEIR bytes get their own read, bounded by `_tries` (review find, 2026-09-08)."""
     try:
+        st = path.stat()
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
     except UnicodeError as e:
-        if not quarantine:
-            raise
-        _quarantine_store(path, "not UTF-8: %s" % e)
-        return None
-    try:
-        value = json.loads(raw)
-    except ValueError as e:                          # json.JSONDecodeError is a ValueError
-        if not quarantine:
-            raise
-        _quarantine_store(path, "invalid JSON: %s" % e)
-        return None
-    if not isinstance(value, dict):
-        if not quarantine:
-            raise ValueError("%s: top-level JSON value is %s, not an object" % (path, type(value).__name__))
-        _quarantine_store(path, "top-level JSON value is %s, not an object" % type(value).__name__)
-        return None
-    return value
+        bad, reason = e, "not UTF-8: %s" % e
+    else:
+        try:
+            value = json.loads(raw)
+        except ValueError as e:                      # json.JSONDecodeError is a ValueError
+            bad, reason = e, "invalid JSON: %s" % e
+        else:
+            if isinstance(value, dict):
+                return value
+            reason = "top-level JSON value is %s, not an object" % type(value).__name__
+            bad = ValueError("%s: %s" % (path, reason))
+    if not quarantine:
+        raise bad
+    if _quarantine_store(path, reason, st) is not None or _tries <= 1:
+        return None                                  # the bad bytes are preserved aside: a fresh store is legitimate
+    return _read_store_json(path, quarantine=True, _tries=_tries - 1)   # declined: the file changed under us
 
 
 def load_goals(fsid):
@@ -3085,18 +3102,50 @@ def load_goals_or_fault(fsid):
     try:
         store = load_goals(fsid)
     except OSError as e:
-        text = "%s: %s" % (type(e).__name__, e)
-        with _STORE_FAULTS_LOCK:
-            repeat = _STORE_FAULTS.get(fsid) == text
-            _STORE_FAULTS[fsid] = text
-        if not repeat:
-            _log_judge_error("romp", fsid, "store-unreadable",
-                             note="goals store cannot be read; this session's goal-derived work is skipped "
-                                  "until it reads again: %s" % text)
+        _file_store_fault(fsid, e, "store-unreadable",
+                          "goals store cannot be read; this session's goal-derived work is skipped until it "
+                          "reads again")
         return None, e
-    with _STORE_FAULTS_LOCK:
-        _STORE_FAULTS.pop(fsid, None)                # a successful read ends the episode
+    _end_store_fault(fsid)                           # a successful read ends the episode
     return store, None
+
+
+def save_goals_or_fault(fsid, store):
+    """save_goals behind the same per-session boundary, for a USER GESTURE's write: None when the publish
+    landed (or was a no-op), the exception when it did not. The save path reads the file strictly
+    (_matches_disk, _disk_rev, _rebase_onto_disk: a fault or a corrupt file raises so nothing is published
+    over bytes we could not read), and the write itself can fail (a full disk, a directory gone read-only).
+    Either way the gesture's flag did not land and the caller answers the user; left to raise, an OSError
+    out of a WS gesture handler reached the receive loop's catch, which re-raises it to the outer handler,
+    where it is swallowed and the CLIENT DROPPED (`finally: client["alive"] = False`), so the dashboard
+    disconnected without a word (review find, 2026-09-08). Filed once per fault episode as
+    `store-unwritable`, on the same per-sid episode table as the load boundary (the same EACCES met at the
+    load and then at the save is one episode, not two rows); a successful publish ends the episode."""
+    try:
+        save_goals(fsid, store)
+    except (OSError, ValueError) as e:               # UnicodeError is a ValueError; a corrupt file at the save raises one
+        _file_store_fault(fsid, e, "store-unwritable",
+                          "goals store could not be published (the save's own read of the file, or the write "
+                          "itself, failed); the gesture that asked for it was refused and answered")
+        return e
+    _end_store_fault(fsid)
+    return None
+
+
+def _file_store_fault(fsid, e, kind, what):
+    """One judge-errors row per fault EPISODE for `fsid` (see load_goals_or_fault): the first fault with this
+    text files, an identical repeat files nothing, a different text is a new episode."""
+    text = "%s: %s" % (type(e).__name__, e)
+    with _STORE_FAULTS_LOCK:
+        repeat = _STORE_FAULTS.get(fsid) == text
+        _STORE_FAULTS[fsid] = text
+    if not repeat:
+        _log_judge_error("romp", fsid, kind, note="%s: %s" % (what, text))
+
+
+def _end_store_fault(fsid):
+    with _STORE_FAULTS_LOCK:
+        _STORE_FAULTS.pop(fsid, None)
 
 
 def _disk_rev(fsid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24578,7 +24578,14 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
         except Exception:
             closed = False
         jd.rollup_status(store, closed)
-        jd.save_goals(sid, store)
+        fault = jd.save_goals_or_fault(sid, store)
+        if fault is not None:
+            skipped[sid] = str(fault)                  # the store read a moment ago and faults at its SAVE (the
+            continue                                   # save path's own strict reads, or the publish itself): the
+        #                                                flag did not land, and the caller answers the user exactly
+        #                                                as for a load fault. Left to raise, an OSError out of a WS
+        #                                                gesture reached the receive loop, which re-raises it and
+        #                                                DROPS the client (review find, 2026-09-08)
         if not value:
             # A restore is a USER GESTURE and must never wait out a judge pass (the same rule as a card
             # reply, the user 2026-07-21/23): punch it through the pre-pass snapshot and push now. The
@@ -24750,23 +24757,27 @@ def _gesture_store_refusal(client, gesture, skipped):
     next Undo retries it (_undo_clear keeps those ids the newest batch). `text` carries the whole
     account; there is no `copy` key, which by contract is the USER'S undelivered text (the feed renders
     it as a "Copy my text" button and folds it into the bell entry). The skip itself is already a
-    `store-unreadable` judge-errors row (jd.load_goals_or_fault); this is the user's copy."""
+    judge-errors row: `store-unreadable` when the load faulted (jd.load_goals_or_fault), `store-unwritable`
+    when the store read and its publish then faulted (jd.save_goals_or_fault: the save path's strict reads,
+    or the write itself), so the prose says "read or write" and lets the fault text name which; this is
+    the user's copy (the save shape added on a review find, 2026-09-08: left to raise, it dropped the
+    dashboard's socket without a word)."""
     for sid, fault in (skipped or {}).items():
         who = _name_of(sid) or sid[:8]
         if gesture == "undo":
             title = "That undo did not land for %s" % who
-            text = ("Its cards were not restored: romp could not read that session's goals file (%s). "
-                    "They are still held for you; press Undo again once the file reads. The other sessions "
+            text = ("Its cards were not restored: romp could not read or write that session's goals file (%s). "
+                    "They are still held for you; press Undo again once it can. The other sessions "
                     "were not affected." % fault)
         elif gesture == "drop":
             title = "That sub-goal was not cleared for %s" % who
-            text = ("romp could not read that session's goals file (%s), so nothing changed there and the "
-                    "row is as it was. Try it again once the file reads." % fault)
+            text = ("romp could not read or write that session's goals file (%s), so nothing changed there and "
+                    "the row is as it was. Try it again once it can." % fault)
         else:                                          # "clear": one card, or every card of one session
             title = "That clear did not fully land for %s" % who
             text = ("What you cleared there is off the board, but the clear was not written into that "
-                    "session's goals file, which romp could not read (%s); nothing else changed there, and "
-                    "the other sessions were not affected." % fault)
+                    "session's goals file, which romp could not read or write (%s); nothing else changed there, "
+                    "and the other sessions were not affected." % fault)
         try:
             client["send"](json.dumps({"type": "err", "sid": sid, "title": title, "text": text}))
         except Exception:
@@ -24830,13 +24841,18 @@ def _undo_clear():
     late = _mark_nodes_cleared(restored, False)       # so this finds the nodes → un-set the durable flag → real status
     if late:
         # The store read fine (or held nothing archived) a moment ago and faults NOW, after the undo row
-        # landed: the node is restored flag-cleared, which build_feed hides exactly like the clear did, and
-        # the modal has no op that could reach it (resolve and clear only). Re-journal the clear for those
-        # ids so the batch stays owed — the very next Undo restores them once the file reads again.
+        # landed (at the flag step's read, or at its publish): the node is restored flag-cleared, which
+        # build_feed hides exactly like the clear did, and the modal has no op that could reach it (resolve
+        # and clear only). Re-journal the clear for those ids so the batch stays owed: the very next Undo
+        # restores them once the file reads again. ONE stamp for the whole re-journal, as _clear_all takes
+        # one before its loop: a batch IS its exact timestamp (_cleared_ids keys on equality), so a stamp
+        # per row split a two-card batch into two one-card batches and each further Undo brought back one
+        # card, against the promise that the next Undo restores exactly them (review find, 2026-09-08).
+        t = time.time()
         with (jd.STATE / "cleared.jsonl").open("a") as f:
             for iid in restored:
                 if iid.rsplit(":", 1)[0] in late:
-                    f.write(json.dumps({"id": iid, "t": time.time(), "op": "clear"}) + "\n")
+                    f.write(json.dumps({"id": iid, "t": t, "op": "clear"}) + "\n")
         skipped.update(late)
     return skipped                                    # {sid: fault} for sessions whose store could not be read
 
@@ -24991,7 +25007,13 @@ def _restore_goal_archive(item_ids):
                     store.setdefault("rewindRestored", {})[nid] = max(rt, int(sv))
             # (Sticky completion restore lives in _mark_nodes_cleared now — 2026-07-07: the settle event must
             # land AFTER the undo reopen it records, or the fold consumes it and the card returns to Working.)
-            jd.save_goals(sid, store)
+            fault = jd.save_goals_or_fault(sid, store)
+            if fault is not None:
+                skipped[sid] = str(fault)              # the publish did not land (a save-path read fault, or the
+                continue                               # write itself), so the archive is NOT saved: it keeps these
+            #                                            nodes for the next Undo, whose restore journal row replays
+            #                                            idempotently; the caller answers the user (review find,
+            #                                            2026-09-08: left to raise, this dropped the WS client)
             jd.save_goal_archive(sid, arch)
             _compact_seen.pop(sid, None)               # force a re-stat next sweep (we just changed the live file)
     return skipped

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1769,7 +1769,9 @@ def _followup_body(iid, title, text, injected=False, auto=False, stalled=False, 
     sid = str(iid).rsplit(":", 1)[0]
     nodes = {}
     try:
-        nodes = jd.load_goals(sid).get("nodes", {})
+        store, fault = jd.load_goals_or_fault(sid)  # a faulting store files its row; the message still goes
+        if fault is None:                            # out in the single-line form (no goal-derived enumeration)
+            nodes = store.get("nodes", {})
     except Exception:
         pass
     title = (title or "").strip()
@@ -5132,7 +5134,9 @@ def _record_interrupt_block(sid, ev):
     fold would bury the row anyway. The tick retries every push, so a refused APPEND would grow the
     diary at push cadence; refusing without one keeps it clean until newer evidence (the next settled
     turn) makes the block land."""
-    store = jd.load_goals(sid)
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return None                                  # its row is filed; no block is recorded on a store we cannot read
     gid = _interrupt_focus_top(store)
     if not gid:
         return None
@@ -5173,11 +5177,18 @@ def _lift_interrupt_block(sid, gid, ev):
     read as "evidence newer than the last turn romp saw end", so _nudge_fire_list held the nudge under
     a why the stall surface screens), until a peer's message opened a fresh turn whose verdict finally
     outranked it. Floored at the block's own stamp so the lift can never sort BEFORE what it lifts —
-    the same guard rollup_status's moot-unblock uses."""
-    store = jd.load_goals(sid)
+    the same guard rollup_status's moot-unblock uses.
+
+    Returns True when the marker is SPENT (the block lifted, or there was nothing of ours left to lift)
+    and False when the store could not be read: the tick keeps the intrBlocked marker on False so the
+    lift is retried next tick, instead of erasing it and leaving romp's own block on the card with no
+    tick ever looking again."""
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return False                                 # its row is filed; the caller keeps the marker → retried next tick
     nd = store.get("nodes", {}).get(gid)
     if nd is None:
-        return
+        return True
     log = nd.get("log") or []
     lastblk = next((e.get("src") for e in reversed(log) if e.get("kind") == "block"), None)
     if lastblk == "interrupt" and nd.get("blocked"):
@@ -5187,6 +5198,7 @@ def _lift_interrupt_block(sid, gid, ev):
         jd.rollup_status(store, False)
         jd.save_goals(sid, store)
         _mark_views_dirty()
+    return True
 
 
 def _intr_blocked(sid=None):
@@ -5214,13 +5226,17 @@ def _intr_block_stands(sid, gid):
     compaction archives it — and a tick that trusts the bare marker skips the re-block forever while
     the session's live focus goal sits in Working wearing only the 'interrupted' badge, auto-nudge
     suppressed: invisible-blocked (the user 2026-08-08, whose stopped session's marker pointed at a
-    goal since ruled done, cleared, and archived)."""
+    goal since ruled done, cleared, and archived). An UNREADABLE store is not evidence the block fell:
+    it reads as standing, so the marker is KEPT (its row is filed) exactly as the lift keeps it — a
+    second stop during a persisting fault used to read "no longer stands", pop the marker, fail to
+    re-block through the same fault, and leave romp's own block on the card with nothing to lift it
+    once the file read again."""
     if not gid:
         return False
-    try:
-        nd = jd.load_goals(sid).get("nodes", {}).get(gid)
-    except Exception:
-        return False
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return True
+    nd = store.get("nodes", {}).get(gid)
     return bool(nd and nd.get("blocked"))
 
 
@@ -5278,8 +5294,9 @@ def _interrupt_block_tick(now, tmux):
             if ib:
                 # the re-engagement IS the newest turn's trigger — the same stamp the judges will put on
                 # every verdict about that turn, so their ruling outranks this lift on arrival order
-                _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0)
-                _set_intr_blocked(sid, None); changed = True
+                if _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0):
+                    _set_intr_blocked(sid, None); changed = True   # spent; on a store fault the marker
+                #                                                    stays so the next tick retries the lift
     if changed:                                          # a needs-you flip should reach the feed at once
         _push_all()
 
@@ -6142,7 +6159,10 @@ def _lift_spent_awaiting(now, tmux):
             if gate is not None and _lift_seen.get(sid) == gate:
                 continue
             _lift_seen[sid] = gate                    # recorded now; a ruling that RAISES forgets it below,
-            store = jd.load_goals(sid)                # so the next cycle retries instead of skipping
+            store, fault = jd.load_goals_or_fault(sid)   # so the next cycle retries instead of skipping
+            if fault is not None:                     # its row is filed; forget the gate so the next cycle
+                _lift_seen.pop(sid, None)             # retries this session, and go on to the others
+                continue
             nodes = store.get("nodes") or {}
             stamped = [nd for nd in nodes.values()
                        if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]
@@ -7449,7 +7469,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None, wake_only
     # deliberately NOT the arm: a romp-injected turn can never become the arm, so a verdict about one is
     # newer than the arm FOREVER (see _nudge_fire_list's deadlock note).
     seen = next((tn for tn in reversed(turns) if tn.get("ended")), None)
-    store = jd.load_goals(sid)
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return None                                  # its row is filed; nothing fires or stamps on a store we cannot read
     # Don't nudge until the CLOSER has classified this turn AT ITS CURRENT SIZE (session-level gate). A turn
     # that ENDS by asking you a question is "working" only in the window before the closer marks its goal
     # blocked; nudging there is pointless (it's waiting on YOU) and churns. _closer_settled mirrors the
@@ -19998,7 +20020,12 @@ def _feed_goals(sid):
                     sys.stderr.write("feed-goals: user-override replay: %s\n" % traceback.format_exc())
             return _apply_rewind_hold(sid, store)      # a pending rewind's cards are hidden NOW (latched
             #                                            at the gesture; archive lands at the branch-take)
-    return _apply_rewind_hold(sid, jd.load_goals(sid))   # no pass in flight → live read, outside the lock
+    store, fault = jd.load_goals_or_fault(sid)     # no pass in flight → live read, outside the lock
+    if fault is not None:
+        return None                                    # the read FAULTED (the pre-pass snapshot skips such a file
+    #                                                    too): the row is filed once per episode, and build_feed
+    #                                                    renders this one session without goal-derived content
+    return _apply_rewind_hold(sid, store)
 
 # Delta-send (the user 2026-06-25, who wanted to stop re-sending what didn't change): the chat pusher used to send the
 # FULL events array (~8MB for a 34MB transcript) on every change, even when one event was appended. Keep the
@@ -23224,7 +23251,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     events, by_tool = [], {}                  # by_tool: tool_use_id → its tool event (fill output later)
     uuid2seg, seg_anchors = {}, {}            # atom uuid → seg id; seg id → (promptId, workId) for the dot/bar split
     seg_trig, seg_work = {}, {}               # goal-node DEEP-LINK anchors: prompt = the segment's trigger
-    _bs_store = jd.load_goals(sid)            # seam-aware seg ids (mirror the judge's split)
+    _bs_store, _bs_fault = jd.load_goals_or_fault(sid)   # seam-aware seg ids (mirror the judge's split); a
+    #                                                      FAULT (row filed) → None → seams off, the tab still builds
     #                                          (the per-turn seg loop runs below, after the fold decision)
     last_t = None
     last_model = ""                           # the model on the most recent assistant message (system-card meta)
@@ -24045,18 +24073,22 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # LEAF: its descendants are hidden even if open. Skip cleared nodes. `current` marks the focus node
     # being worked on (the graph's lastNode) so render can point a line at it; done nodes carry their
     # time for a recency-coloured "(Xm ago)" on the right.
-    gstore = _apply_rewind_hold(sid, jd.load_goals(sid))   # a pending rewind's cards hide on EVERY
+    gstore, gfault = jd.load_goals_or_fault(sid)   # a FAULT (row filed) → None: this tab's ledger tree
+    if gfault is None:                             # renders EMPTY instead of every tab's build failing
+        gstore = _apply_rewind_hold(sid, gstore)   # a pending rewind's cards hide on EVERY
     #                                            surface — this ledger tree (and the tab-hover
     #                                            recents derived from it) used to keep showing the
     #                                            doomed asks for the whole armed window while the
     #                                            feed hid them (the "one chokepoint" premise was
     #                                            false; the window is unbounded on a bare delete)
-    gnodes, gstatus, gcleared = gstore.get("nodes", {}), gstore.get("status", {}), _cleared_ids()
+    gnodes = gstore.get("nodes", {}) if gstore is not None else {}
+    gstatus = gstore.get("status", {}) if gstore is not None else {}
+    gcleared = _cleared_ids()
     gkids = {}
     for _gid, _gn in gnodes.items():
         gkids.setdefault(_gn.get("parentId"), []).append(_gid)
     g_agent_open = _agent_open_set(gnodes, gkids)   # authoritative-open subtree → never 'done' (mirrors build_feed / the judge)
-    focus = gstore.get("lastNode")
+    focus = gstore.get("lastNode") if gstore is not None else None
     tree = []
 
     def _cleared(cid):
@@ -24502,10 +24534,14 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
     # a full jd.discover() filesystem enumeration — INSIDE the loop, so a Clear-all → Undo-clear across N
     # sessions did N back-to-back discoveries, blocking the single-threaded kernel (the "really slow" undo).
     sess_paths = {s["sid"]: s["path"] for s in _sessions(now)}
+    skipped = {}                                       # sid -> fault text: sessions this gesture could NOT reach
     for sid, ids in by_sid.items():
-        store = jd.load_goals(sid)
-        nodes = store.get("nodes", {})
-        touched = False
+        store, fault = jd.load_goals_or_fault(sid)
+        if fault is not None:
+            skipped[sid] = str(fault)                  # its row is filed; the flag cannot be written on a store we
+            continue                                   # cannot read (the view-level clear still holds), the other
+        nodes = store.get("nodes", {})                 # sessions' clears proceed, and the CALLER answers the user
+        touched = False                                # (a WS gesture reports the refusal to its own socket)
         for iid in ids:
             nd = nodes.get(iid)
             if nd is not None and bool(nd.get("cleared")) != value:
@@ -24550,6 +24586,7 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
             _note_user_goal_write(sid)
     if not value:
         _mark_views_dirty()
+    return skipped
 
 
 # ── /clear is an episode boundary, not a deletion (the user 2026-07-26) ──────────────────────────
@@ -24634,8 +24671,9 @@ def _episode_boundary_check(sid, path, now):
 
 
 def _clear_ask(item_id):
-    """Clear one feed card (inbox-zero) — a batch of one (see _clear_all)."""
-    _clear_all([item_id])
+    """Clear one feed card (inbox-zero) — a batch of one (see _clear_all). Returns _clear_all's
+    {sid: fault} so the WS op answers the socket when the card's session could not be read."""
+    return _clear_all([item_id])
 
 
 def _subtree_item_ids(iid):
@@ -24699,6 +24737,42 @@ def _delegation_linked_ids(item_ids):
     return out
 
 
+def _gesture_store_refusal(client, gesture, skipped):
+    """A user gesture (a clear, a sub-goal drop, an undo) that a session's UNREADABLE goal store made us
+    skip must say so on the socket that made it (the standing rule: a refusal of a user gesture reaches
+    the user). The feed's `err` dialog is the existing "that action did not land" surface, bell included;
+    one per session skipped, naming the session and the fault, and saying exactly what did and did not
+    happen, never a promise. Three accounts, because three different things happened: a whole-card clear
+    (askClear, Clear-all) DID hide the card(s) — cleared.jsonl hides top cards on its own — but the
+    durable flag was not written; a sub-goal drop (the modal's Drop, sub-task-only) changed NOTHING,
+    since a sub row renders from the node flag alone, the very write the fault refused, so the user is
+    told to try again (a retry appends a fresh row and sets the flag); an undo restored nothing and the
+    next Undo retries it (_undo_clear keeps those ids the newest batch). `text` carries the whole
+    account; there is no `copy` key, which by contract is the USER'S undelivered text (the feed renders
+    it as a "Copy my text" button and folds it into the bell entry). The skip itself is already a
+    `store-unreadable` judge-errors row (jd.load_goals_or_fault); this is the user's copy."""
+    for sid, fault in (skipped or {}).items():
+        who = _name_of(sid) or sid[:8]
+        if gesture == "undo":
+            title = "That undo did not land for %s" % who
+            text = ("Its cards were not restored: romp could not read that session's goals file (%s). "
+                    "They are still held for you; press Undo again once the file reads. The other sessions "
+                    "were not affected." % fault)
+        elif gesture == "drop":
+            title = "That sub-goal was not cleared for %s" % who
+            text = ("romp could not read that session's goals file (%s), so nothing changed there and the "
+                    "row is as it was. Try it again once the file reads." % fault)
+        else:                                          # "clear": one card, or every card of one session
+            title = "That clear did not fully land for %s" % who
+            text = ("What you cleared there is off the board, but the clear was not written into that "
+                    "session's goals file, which romp could not read (%s); nothing else changed there, and "
+                    "the other sessions were not affected." % fault)
+        try:
+            client["send"](json.dumps({"type": "err", "sid": sid, "title": title, "text": text}))
+        except Exception:
+            sys.stderr.write("gesture refusal (%s %s): %s\n" % (gesture, sid[:8], traceback.format_exc()))
+
+
 def _clear_all(item_ids):
     """Clear every given card in ONE batch (shared float timestamp = the batch key) so a single
     UndoClear restores the whole batch. Append-only + single-writer (the kernel) → crash-safe; an
@@ -24707,7 +24781,7 @@ def _clear_all(item_ids):
     sides at once and one UndoClear restores it on both (the user 2026-06-23)."""
     item_ids = [i for i in item_ids if i]
     if not item_ids:
-        return
+        return {}
     seen = set(item_ids)
     item_ids = item_ids + [i for i in _delegation_linked_ids(item_ids) if i not in seen]   # + the delegation's peer copy
     p = jd.STATE / "cleared.jsonl"
@@ -24716,12 +24790,13 @@ def _clear_all(item_ids):
     with p.open("a") as f:
         for iid in item_ids:
             f.write(json.dumps({"id": iid, "t": t, "op": "clear"}) + "\n")
-    _mark_nodes_cleared(item_ids, True)               # durable node flag → no grouper re-wrap, no column bounce
+    skipped = _mark_nodes_cleared(item_ids, True)     # durable node flag → no grouper re-wrap, no column bounce
     # CLEAR IS SILENT (the user 2026-08-23, reversing the 2026-07-24 wrap-up): the session hears
     # NOTHING. The wrap's response turn routinely re-minted the very card the user had just cleared —
     # a discard that answered back — so the gesture now only discards; if anything real remains, the
     # user asks a follow-up or tells the session themselves. The judge keeps recognizing HISTORICAL
     # wrap markers in old transcripts; no new ones are ever sent.
+    return skipped                                    # {sid: fault} for sessions whose store could not be read
 
 
 # (_clear_wrap_targets / _clear_wrap_body / _clear_wrap_notify lived here 2026-07-24..2026-08-23:
@@ -24733,17 +24808,37 @@ def _clear_all(item_ids):
 
 def _undo_clear():
     """Restore the most-recent clear BATCH — every id cleared at the latest timestamp. So one
-    UndoClear undoes a Clear-all as a unit, and a single-card clear restores just that card."""
+    UndoClear undoes a Clear-all as a unit, and a single-card clear restores just that card.
+    A session whose goals file cannot be read is left OWED, never consumed: its ids are journaled as
+    undone only if the archive restore reached its store, and any id journaled whose flag step then
+    could not run is re-journaled as cleared, so in every fault shape those ids stay the newest batch
+    and the user's next Undo retries exactly them. Journaling every id first consumed the batch on a
+    fault (the ids read as undone, the nodes stayed in the archive, and no later Undo could reach
+    them); journaling last is not an option either, since the reopen verdict's gate needs the undo
+    row on disk before the flag step runs (its comment says why). Returns {sid: fault} for the
+    sessions skipped."""
     cur = _cleared_ids()
     if not cur:
-        return
+        return {}
     newest = max(cur.values())
     restored = [i for i, ct in cur.items() if ct == newest]
-    with (jd.STATE / "cleared.jsonl").open("a") as f:
+    skipped = dict(_restore_goal_archive(restored))   # pull the restored tops back OUT of the archive FIRST,
+    restored = [i for i in restored if i.rsplit(":", 1)[0] not in skipped]   # (a session it could not read
+    with (jd.STATE / "cleared.jsonl").open("a") as f:   # keeps its clear rows: still the newest batch)
         for iid in restored:
             f.write(json.dumps({"id": iid, "t": time.time(), "op": "undo"}) + "\n")
-    _restore_goal_archive(restored)                   # pull the restored tops back OUT of the archive FIRST,
-    _mark_nodes_cleared(restored, False)              # so this finds the nodes → un-set the durable flag → real status
+    late = _mark_nodes_cleared(restored, False)       # so this finds the nodes → un-set the durable flag → real status
+    if late:
+        # The store read fine (or held nothing archived) a moment ago and faults NOW, after the undo row
+        # landed: the node is restored flag-cleared, which build_feed hides exactly like the clear did, and
+        # the modal has no op that could reach it (resolve and clear only). Re-journal the clear for those
+        # ids so the batch stays owed — the very next Undo restores them once the file reads again.
+        with (jd.STATE / "cleared.jsonl").open("a") as f:
+            for iid in restored:
+                if iid.rsplit(":", 1)[0] in late:
+                    f.write(json.dumps({"id": iid, "t": time.time(), "op": "clear"}) + "\n")
+        skipped.update(late)
+    return skipped                                    # {sid: fault} for sessions whose store could not be read
 
 
 # ── goal-store compaction: archive dismissed (cleared) cards out of the live tree ──────────────────────────
@@ -24764,7 +24859,9 @@ def _compact_goal_store(fsid):
     Returns the count of nodes moved. Whole-subtree only (a cleared top rolls cleared/done DOWN its tree, so the
     subtree is terminal) and roots only (parentId is null), so an active card never loses children."""
     cleared = _cleared_ids()
-    store = jd.load_goals(fsid)
+    store, fault = jd.load_goals_or_fault(fsid)
+    if fault is not None:
+        return None                                    # its row is filed; nothing moves out of a store we cannot read
     nodes = store.get("nodes", {})
     if not nodes:
         return 0
@@ -24821,7 +24918,10 @@ def _compact_goal_stores():
             continue
         if _compact_seen.get(fsid) == mt:
             continue                                   # unchanged → nothing new to archive
-        moved += _compact_goal_store(fsid)
+        n = _compact_goal_store(fsid)
+        if n is None:
+            continue                                   # unreadable this sweep: NOT recorded as seen (its mtime did
+        moved += n                                     # not move), so the next sweep retries it
         try:                                           # record OUR write's mtime so we don't re-sweep it next pass
             _compact_seen[fsid] = os.path.getmtime(jd.GOALDIR / (fsid + ".json"))
         except OSError:
@@ -24836,6 +24936,7 @@ def _restore_goal_archive(item_ids):
     by_sid = {}
     for iid in item_ids:
         by_sid.setdefault(iid.rsplit(":", 1)[0], []).append(iid)
+    skipped = {}                                       # sid -> fault text: sessions the restore could NOT reach
     for sid, ids in by_sid.items():
         with jd._GOAL_ARCH_LOCK:                       # the archive is a blind RMW — see the lock's note
             arch = jd.load_goal_archive(sid)
@@ -24857,8 +24958,11 @@ def _restore_goal_archive(item_ids):
                             stack.extend(a_children.get(x, []))
             if not move:
                 continue
-            store = jd.load_goals(sid)
-            nodes = store.setdefault("nodes", {})
+            store, fault = jd.load_goals_or_fault(sid)
+            if fault is not None:
+                skipped[sid] = str(fault)              # its row is filed; the archive keeps these nodes (nothing is
+                continue                               # restored INTO a store we cannot read), the other sessions'
+            nodes = store.setdefault("nodes", {})      # restores proceed, and the caller answers the user
             status = store.setdefault("status", {})
             # Journal the payload FIRST (the user 2026-07-10): once the archive save below lands, these nodes
             # exist only in the live store's save — a stale triage-pass save racing it would drop them from
@@ -24890,6 +24994,7 @@ def _restore_goal_archive(item_ids):
             jd.save_goals(sid, store)
             jd.save_goal_archive(sid, arch)
             _compact_seen.pop(sid, None)               # force a re-stat next sweep (we just changed the live file)
+    return skipped
 
 
 def _resolve_node(sid, node_id):
@@ -25544,6 +25649,14 @@ def build_feed(now, tmux=None):
         sess_retrying = _session_retrying(fsid, tm)
         store = _feed_goals(fsid)                # pre-pass snapshot while a judge pass is mid-flight → the card's
                                                  # status never shows a half-applied intermediate (atomic visibility)
+        store_faulted = store is None            # this session's store could not be READ (EACCES, EIO, a directory
+        if store_faulted:                        # at the path): its row is filed (jd.load_goals_or_fault) and THIS
+            store = {"nodes": {}, "status": {}}  # session renders with no goal-derived content — no cards (so no
+            #                                      floors and no swirl, which land only on cards) and nothing
+            #                                      inferred from the absence (the provisional card is gated on the
+            #                                      flag below). A render-only stand-in, never saved. Every other
+            #                                      session is untouched; before this, one such file aborted the
+            #                                      whole build.
         # ANALYZING (the user 2026-07-13; broadened 2026-08-12): the card must say when romp is working
         # on it. Two prongs, either lights the swirl:
         #   * the SETTLE GAP — the turn just settled but the closer hasn't delivered its verdict yet
@@ -25957,9 +26070,11 @@ def build_feed(now, tmux=None):
                 # offered Continue. Badges persist for the card's life, so one absorbed badge
                 # poisoned the session's whole card tail.
                 psid, gid = o["peer"], o.get("goalId")
-                sgoal = jd.load_goals(psid).get("nodes", {}).get(gid) if gid else None
+                pstore, pfault = jd.load_goals_or_fault(psid) if gid else (None, None)
+                sgoal = pstore.get("nodes", {}).get(gid) if pstore is not None else None
                 origin_live = bool(sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared")
-                                   and gid not in cleared)
+                                   and gid not in cleared)   # a sender whose store faults reads absorbed (dimmed,
+                #                                              no affordance) rather than aborting the build
                 # Name resolution: the live names registry first (a local sender may have been
                 # renamed), then the courier's plant-time snapshot (the only source for a
                 # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
@@ -26400,7 +26515,9 @@ def build_feed(now, tmux=None):
             # perm_top excluded: a live-blocked focus card no longer counts as "working" (it reports needs_input
             # now), so without this guard a session whose ONLY card is the picker-blocked one would ALSO get a
             # provisional working placeholder — a duplicate. A floored perm_top already covers the live prompt.
-            pc = _provisional_card(s, name, color, fsid, live, now, store)
+            # store_faulted excluded: "the planner has not placed this yet" is an inference from placements we
+            # could not read, so a session whose store faulted gets no provisional card (its row says why).
+            pc = _provisional_card(s, name, color, fsid, live, now, store) if not store_faulted else None
             if pc:
                 asks.append(pc)
             elif perm_state in _NEEDS_INPUT_STATES:      # perm_top is None here (outer guard) → no goal to floor
@@ -28453,7 +28570,9 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         tm = tmux.get(sid)
         live = tm is not None
         hexcol = (tm and tm["color"]) or (_name_color(sid) or {}).get("bg", "#888888")
-        goals = jd.load_goals(sid)
+        goals, gfault = jd.load_goals_or_fault(sid)  # a FAULT (row filed) → None: this lane renders without
+        if gfault is not None:                       # goal-derived data (blocked state, seams, judging marks)
+            _bars_complain(sid, "goals", gfault)     # and the frame ships for every other lane
         if with_bars:
             try:
                 session = _parse(s["path"], sid, now)
@@ -28520,7 +28639,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         else:                             # dead lane: NEVER "working" — a turn left open at death (e.g. a stalled API
                                           # turn that never returned a ResultMessage, then ended) must not read as
                                           # active (the user 2026-06-23); badgeFor dims a dead lane anyway.
-            blocked = "blocked" in goals.get("status", {}).values() and not _session_flag(sid, "hideFromFeed")
+            blocked = (goals is not None and "blocked" in goals.get("status", {}).values()
+                       and not _session_flag(sid, "hideFromFeed"))
             state = "needsInput" if blocked else "idle"   # muted → no awaiting/background-task badge on the lane
             aw_open = open_now                          # unused (awaitingBg is None for a dead lane) — kept defined
         bars, last_t, seg_ends = [], None, {}            # seg_ends: seg-start t → work-END t (for completion marks)
@@ -28586,7 +28706,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         if with_bars:
             turns[sid] = bars
             try:
-                _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+                if goals is not None:
+                    _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
             except Exception as e:
                 _bars_complain(sid, "judging-marks", e)   # this lane loses its marks, the frame ships
         _bft = (branch_of.get(sid) or {}).get("t")
@@ -29196,7 +29317,10 @@ def _goal_segments(item_id):
     `id` IS the segment id, so `hit(segId)` lights both its dot and bar). item_id is the goal node id;
     its prefix (before ':gN') is the owning session's rompUuid. Empty list if unknown."""
     sid = item_id.rsplit(":", 1)[0]
-    nodes = jd.load_goals(sid).get("nodes", {})
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return []                                      # its row is filed; nothing lights for a store we cannot read
+    nodes = store.get("nodes", {})
     if item_id not in nodes:
         return []
     children = {}
@@ -29222,7 +29346,10 @@ def _cards_for_segments(sid, seg_ids):
     seg_set = set(seg_ids or [])
     if not seg_set:
         return []
-    nodes = jd.load_goals(sid).get("nodes", {})
+    store, fault = jd.load_goals_or_fault(sid)
+    if fault is not None:
+        return []                                      # its row is filed; nothing lights for a store we cannot read
+    nodes = store.get("nodes", {})
 
     def top(nid):
         while nodes.get(nid, {}).get("parentId") is not None:
@@ -38798,7 +38925,7 @@ class Handler(BaseHTTPRequestHandler):
             # (wireNodeZones sends the clicked node's own id), so collect the card's whole subtree BEFORE
             # the clear archives it out of the live store, and drop a chip citing ANY of those nodes.
             _gone = _subtree_item_ids(str(msg["itemId"]))
-            _clear_ask(msg["itemId"])
+            _gesture_store_refusal(client, "clear", _clear_ask(msg["itemId"]))
             _send_to_app("chat", {"type": "dropCitation", "itemId": str(msg["itemId"]), "itemIds": _gone})
             _mark_views_dirty()                # cleared.jsonl is invisible to the fleet sig → dirty-rebuild now
         elif msg and msg.get("type") == "quarantineDecision" and msg.get("mid"):
@@ -38846,7 +38973,7 @@ class Handler(BaseHTTPRequestHandler):
                                       "op": "resolve", "ok": _rok, "error": _rerr})
             elif msg.get("op") == "clear":
                 _gone = _subtree_item_ids(str(msg["nodeId"]))
-                _clear_all([str(msg["nodeId"])])
+                _gesture_store_refusal(client, "drop", _clear_all([str(msg["nodeId"])]))   # a SUB-goal: its own account
                 _send_to_app("chat", {"type": "dropCitation", "itemId": str(msg["nodeId"]), "itemIds": _gone})
                 _mark_views_dirty()
         elif msg and msg.get("type") == "redistill" and msg.get("sid") and msg.get("itemId"):
@@ -38884,11 +39011,15 @@ class Handler(BaseHTTPRequestHandler):
                 pass
         elif msg and msg.get("type") == "clearAll":
             d = build_feed(int(time.time()))
-            _clear_all([a["itemId"] for a in d["asks"]] + [c["itemId"] for c in d["items"]])
+            # `items` (the old stream deliverables) is no longer a payload key; indexing it raised before
+            # _clear_all ever ran, so Clear-all cleared nothing and only the receive loop's stderr line knew
+            _gesture_store_refusal(client, "clear",
+                                   _clear_all([a["itemId"] for a in d["asks"]]
+                                              + [c["itemId"] for c in (d.get("items") or [])]))
             _send_to_app("chat", {"type": "dropCitationsAll"})   # every card cleared → drop every composer chip
             _mark_views_dirty()
         elif msg and msg.get("type") == "undoClear":
-            _undo_clear()
+            _gesture_store_refusal(client, "undo", _undo_clear())
             _mark_views_dirty()
         elif msg and msg.get("type") == "dismissLane" and msg.get("id"):
             # timeline: clear a DEAD lane's leftover row (the user 2026-07-02). DURABLE since 2026-08-14

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -15,6 +15,7 @@ made it.
 SYNTHETIC fixtures only: private synthetic sids, the notes-api demo world (`web` / `api` / `tests`),
 message ids stamped TESTHOST; the per-sid override journals are cleaned in tearDown."""
 import errno
+import itertools
 import json
 import os
 import tempfile
@@ -289,6 +290,23 @@ class InterruptLiftBoundary(_World):
         self.assertEqual(jd.load_goals(A)["status"][gid], "working", "the next healthy tick lifts the block")
         self.assertIsNone(km._intr_blocked(A), "and spends the marker")
 
+    def test_a_fault_at_the_stop_tick_records_no_block_and_the_next_healthy_tick_does(self):
+        """The BLOCK half of the tick meets the fault too: a genuine stop whose store cannot be read records
+        nothing, writes nothing and marks nothing (a marker with no block behind it would be a claim with no
+        evidence), files the session's one `store-unreadable` row, and the next healthy tick blocks the focus
+        goal as if the fault had never been. A bare load_goals here raised out of the whole tick, which has
+        no per-session catch around this write (review find, 2026-09-08)."""
+        gid = A + ":g1"
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            km._interrupt_block_tick(NOW, self.tmux)
+        self.assertIsNone(km._intr_blocked(A), "no marker: nothing was blocked")
+        self.assertEqual(self.a_file.read_bytes(), before, "nothing was written to a store we could not read")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [A], "and the fault is filed once")
+        km._interrupt_block_tick(NOW, self.tmux)          # the fault cleared
+        self.assertEqual(km._intr_blocked(A), gid, "the next healthy tick blocks the focus goal and marks it")
+        self.assertEqual(jd.load_goals(A)["status"][gid], "blocked")
+
     def _append(self, recs):
         with open(self.tpath, "a") as f:
             for r in recs:
@@ -323,6 +341,56 @@ class InterruptLiftBoundary(_World):
         km._interrupt_block_tick(NOW, self.tmux)              # re-engaged, readable: the lift lands
         self.assertEqual(jd.load_goals(A)["status"][gid], "working", "romp's own block is lifted")
         self.assertIsNone(km._intr_blocked(A), "and the marker is spent")
+
+
+class NudgeTickBoundary(_World):
+    """The auto-nudge tick's per-session slice reads the store once every session-level gate has passed:
+    a fault there fires nothing, stamps nothing and files the session's one row. A bare load_goals raised
+    out of the slice into the tick's per-session catch: one stderr line per tick, no row, and every nudge
+    module still passed (review find, 2026-09-08)."""
+
+    def setUp(self):
+        super().setUp()
+        uid = "11111111-2222-3333-4444-555555555555"
+        turns = [{"id": "t1", "t": NOW - 600, "end": NOW - 540, "ended": True, "trigger": {"uuid": uid},
+                  "atoms": [{"uuid": uid, "type": "user", "author": "human", "t": NOW - 600}]}]
+        self.sent = []
+        test = self
+
+        class FakeBackend:
+            def send(self, sid, body):
+                test.sent.append((sid, body))
+        for p in (mock.patch.object(km, "_session_flag", lambda sid, flag: False),
+                  mock.patch.object(km, "_compacting_now", lambda sid: False),
+                  mock.patch.object(km, "_api_error", lambda path: None),
+                  mock.patch.object(km, "_session_working", lambda turns: False),
+                  mock.patch.object(km, "_interrupt_suppresses_nudge", lambda turns, sid="": False),
+                  mock.patch.object(km, "_backend_queued", lambda sid: False),
+                  mock.patch.object(km, "_backend_rewind_pending", lambda sid: False),
+                  mock.patch.object(km, "_last_state", lambda sid: ("", 0)),
+                  mock.patch.object(km, "_session_awaiting", lambda *a, **k: False),
+                  # the first gate AFTER the read, held shut: a healthy slice stops right there, so the one
+                  # question here (does the read stay inside the boundary?) has one answer either way
+                  mock.patch.object(km, "_closer_settled", lambda *a: False),
+                  mock.patch.object(km, "_pending_ops", {}),
+                  mock.patch.object(jd, "parsed_session", lambda sid, paths, now: {"turns": turns}),
+                  mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: FakeBackend()))):
+            p.start()
+            self.addCleanup(p.stop)
+        km._autonudge_cache.clear()
+
+    def _slice(self):
+        return km._auto_nudge_session({"sid": A, "path": "/nonexistent/%s.jsonl" % A}, NOW, {}, {}, {})
+
+    def test_a_faulting_store_fires_nothing_and_files_one_row(self):
+        self.assertEqual(self._slice(), "closer-unsettled", "premise: every gate before the read passes; the read runs")
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            self.assertIsNone(self._slice(), "the fault stands the slice down")
+        self.assertEqual(self.sent, [], "nothing was sent to the session")
+        self.assertEqual(self.a_file.read_bytes(), before, "nothing was written to a store we could not read")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [A], "and the fault is filed once")
+        self.assertEqual(self._slice(), "closer-unsettled", "the next tick reads again")
 
 
 class TriagePassBoundary(_World):
@@ -692,6 +760,86 @@ class GestureRefusal(_World):
         self.assertFalse(jd.load_goals(A)["nodes"][A + ":g1"]["cleared"], "the next Undo un-clears it")
         self.assertEqual(km._cleared_ids(), {})
         self.assertIn(A + ":g1", self._feed_rows(A))
+
+    def test_a_re_journaled_batch_shares_one_timestamp_so_the_next_undo_restores_all_of_it(self):
+        """Two cards of one session cleared in ONE batch, undone while the store faults at the flag step: the
+        re-journaled clear rows must carry one shared `t`, because a batch IS its exact timestamp (_cleared_ids
+        and _undo_clear key on equality; _clear_all stamps one `t` before its loop for that reason). Stamped
+        per row, the two cards split into two one-card batches and each further Undo brought back one card,
+        against the promise that the next Undo restores exactly them (review find, 2026-09-08). time.time is
+        a counter for the faulting undo, so two stamps taken in one loop can never happen to coincide."""
+        gid, g3 = A + ":g1", A + ":g3"
+        st = _store(A, "the first card", cleared=True)
+        st["nodes"][g3] = dict(st["nodes"][gid], id=g3, text="the second card")
+        st["status"] = {gid: "cleared", g3: "cleared"}
+        self._write(A, st)
+        with (jd.STATE / "cleared.jsonl").open("a") as f:
+            for iid in (gid, g3):
+                f.write(json.dumps({"id": iid, "t": NOW - 10, "op": "clear"}) + "\n")
+        self.assertEqual(set(km._cleared_ids()), {gid, g3}, "premise: one two-card batch")
+        with _fault_on(self.a_file), mock.patch.object(km.time, "time", side_effect=itertools.count(NOW)):
+            sent = self._dispatch({"type": "undoClear"})
+        self.assertEqual([m.get("sid") for m in sent if m.get("type") == "err"], [A])
+        cur = km._cleared_ids()
+        self.assertEqual(set(cur), {gid, g3}, "both ids are re-journaled as cleared: owed")
+        self.assertEqual(len(set(cur.values())), 1, "and they share ONE timestamp: still one batch")
+        sent = self._dispatch({"type": "undoClear"})     # the fault cleared; Undo ONCE
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [])
+        self.assertEqual(km._cleared_ids(), {}, "one Undo restores the whole batch")
+        a = jd.load_goals(A)
+        self.assertFalse(a["nodes"][gid]["cleared"])
+        self.assertFalse(a["nodes"][g3]["cleared"])
+        self.assertEqual(set(self._feed_rows(A)), {gid, g3}, "both cards are back on the board")
+
+    def test_a_fault_at_the_save_step_of_a_clear_answers_the_socket_instead_of_dropping_it(self):
+        """The store reads at the flag step and faults at its SAVE (save_goals' own strict reads: the file
+        went unreadable between the load and the publish). That raise left _clear_all and the dispatcher
+        unhandled, and the receive loop re-raises any OSError to the outer handler, which swallows it and
+        marks the client dead: the dashboard disconnected without a word. The save now sits behind the
+        same boundary as the load: the dispatch RETURNS (so the loop goes on reading this socket), the
+        socket hears the same account, and the fault is filed once (review find, 2026-09-08)."""
+        before, orig = self.a_file.read_bytes(), jd.save_goals
+
+        def save_under_fault(fsid, store):
+            with _fault_on(self.a_file):
+                return orig(fsid, store)
+        with mock.patch.object(jd, "save_goals", save_under_fault):
+            sent = self._dispatch({"type": "askClear", "itemId": A + ":g1"})   # raised OSError before
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A], "one refusal, for the card's session")
+        self.assertIn("clear", errs[0]["title"])
+        self._assert_clear_refusal(errs[0], before)
+        self.assertEqual([r["fsid"] for r in self._rows("store-unwritable")], [A], "filed once, like a load fault")
+
+    def test_a_publish_that_fails_at_the_undo_answers_and_leaves_the_ids_owed(self):
+        """The other save-step shape: the file reads fine and the PUBLISH itself fails (the temp cannot be
+        written: a full disk, a directory gone read-only). The undo's restore reached the store and could not
+        publish it, so nothing is journaled as undone, the archive keeps the card, the socket hears why, and
+        the next Undo, once the publish lands, restores it."""
+        for sid in (A, B):
+            self._compacted(sid, NOW - 10)
+        before, orig = self.a_file.read_bytes(), jd._publish_tmp
+
+        def unwritable_for_a(dirpath, fsid):
+            p = orig(dirpath, fsid)
+            return Path(self.td.name) / "gone" / p.name if fsid == A and dirpath == jd.GOALDIR else p
+        with mock.patch.object(jd, "_publish_tmp", unwritable_for_a):
+            sent = self._dispatch({"type": "undoClear"})   # raised FileNotFoundError before
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A])
+        self.assertIn("undo", errs[0]["title"])
+        self.assertIn("No such file or directory", errs[0]["text"], "it says why: the publish that failed")
+        self.assertIn("not restored", errs[0]["text"])
+        self.assertEqual(self._undo_rows(), [B + ":g1"], "only the id whose publish LANDED is journaled as undone")
+        self.assertEqual(km._cleared_ids(), {A + ":g1": NOW - 10}, "A's ids remain the newest cleared batch")
+        self.assertEqual(self.a_file.read_bytes(), before, "A's store was not written")
+        self.assertIn(A + ":g1", json.loads((jd.GOALARCHDIR / (A + ".json")).read_text())["nodes"],
+                      "A's archive still holds the card")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unwritable")], [A])
+        sent = self._dispatch({"type": "undoClear"})     # the publish lands again; Undo
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [])
+        self.assertIn(A + ":g1", jd.load_goals(A)["nodes"], "A's card is restored")
+        self.assertEqual(km._cleared_ids(), {})
 
     def test_a_gesture_that_reaches_every_session_says_nothing(self):
         (jd.STATE / "cleared.jsonl").write_text(json.dumps({"id": B + ":g1", "t": NOW - 10, "op": "clear"}) + "\n")

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""One session's UNREADABLE goals file is loud for that session and invisible to the others.
+
+load_goals raises on a read fault (EACCES, EIO, a directory at the path) instead of fabricating an
+empty store. Inside the judge passes that raise reaches the per-session pass wrapper; everywhere else
+it used to reach nothing: the feed builder's session loop, the timeline, the chat ledger, the kernel's
+ticks and the index tier read every store with no per-session catch, all under the pusher's single
+outer try. One faulting file made the pusher log a line and send NOTHING to ANY client, every cycle,
+for as long as the fault lasted. jd.load_goals_or_fault is the boundary: `(store, None)` or
+`(None, exc)`, one `store-unreadable` judge-errors row per fault EPISODE (a successful read ends the
+episode), and never an empty store. run_courier and run_propagate get the per-session `pass-crash`
+catch the other passes already have, and a user gesture a fault made us skip answers the socket that
+made it.
+
+SYNTHETIC fixtures only: private synthetic sids, the notes-api demo world (`web` / `api` / `tests`),
+message ids stamped TESTHOST; the per-sid override journals are cleaned in tearDown."""
+import errno
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_storefault", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+A = "9c0d1e2f-3a4b-4c5d-8e6f-0a1b2c3d4e5f"      # the session whose store FAULTS
+B = "9c0d1e2f-3a4b-4c5d-8e6f-0a1b2c3d4e60"      # a healthy peer
+P = "9c0d1e2f-3a4b-4c5d-8e6f-0a1b2c3d4e61"      # a third session, the peer a walk or a link reaches
+NOW = 1781300000
+T0 = NOW - 3600
+MID1 = "1781296400.000001_1.TESTHOST"
+MID2 = "1781296400.000002_1.TESTHOST"
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def _aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def _peer_body(mid, text):
+    return "DELEGATE: %s\n<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % (text, mid)
+
+
+def _TM():
+    """One live tmux entry, every key the feed and timeline builders read."""
+    return {"state": "ready", "color": "#888888", "since": NOW - 60, "model": "", "effort": "",
+            "context": None, "backend": "tmux"}
+
+
+def _store(sid, text, **node):
+    """A one-goal store in the judge's own shape; `node` overrides the goal's fields."""
+    gid = sid + ":g1"
+    nd = {"id": gid, "parentId": None, "t": T0, "mt": T0, "text": text, "nodeComplete": False,
+          "blocked": False, "cleared": False, "trail": [], "log": []}
+    nd.update(node)
+    return {"rompUuid": sid, "seq": 1, "rev": 1, "placementsV": jd.PLACEMENTS_V, "placements": {},
+            "nodes": {gid: nd}, "status": {gid: "completed" if nd.get("nodeComplete") else "working"},
+            "lastNode": gid}
+
+
+def _fault_on(path):
+    """Path.read_text raises EIO for `path` alone; every other read is untouched."""
+    orig = Path.read_text
+
+    def faulting(p, *a, **kw):
+        if p == path:
+            raise OSError(errno.EIO, "Input/output error", str(p))
+        return orig(p, *a, **kw)
+    return mock.patch.object(Path, "read_text", faulting)
+
+
+class _World(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+        jd.GOALDIR.mkdir(parents=True)
+        jd.NAMES.mkdir(parents=True)
+        self.a_file = jd.GOALDIR / (A + ".json")
+        self.b_file = jd.GOALDIR / (B + ".json")
+        self._write(A, _store(A, "the faulting session's goal"))
+        self._write(B, _store(B, "the healthy session's goal"))
+        km._parse_cache.clear()
+        jd._PARSE_CACHE.clear()
+
+    def tearDown(self):
+        for sid in (A, B, P):
+            (jd._overrides_dir() / (sid + ".jsonl")).unlink(missing_ok=True)
+        jd._rebind_state(self._saved)
+        for sid in (A, B, P):
+            (jd._overrides_dir() / (sid + ".jsonl")).unlink(missing_ok=True)
+        self.td.cleanup()
+
+    def _write(self, sid, store):
+        (jd.GOALDIR / (sid + ".json")).write_text(json.dumps(store))
+
+    def _transcript(self, sid, recs):
+        p = Path(self.td.name) / (sid + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        km._parse_cache.clear()
+        jd._PARSE_CACHE.clear()
+        return str(p)
+
+    def _rows(self, err=None):
+        if not jd.ERRORS.exists():
+            return []
+        rows = [json.loads(l) for l in jd.ERRORS.read_text().splitlines()]
+        return [r for r in rows if err is None or r["err"] == err]
+
+
+class FeedBoundary(_World):
+    def setUp(self):
+        super().setUp()
+        # B's card wears a delegation-origin badge pointing at A's goal: the badge's liveness is read
+        # from A's store, so the PEER read in build_feed's card loop is exercised too
+        self._write(B, _store(B, "the healthy session's goal", origin={"peer": A, "goalId": A + ":g1"}))
+        self.sessions = [{"sid": A, "name": "web", "path": "/nonexistent/%s.jsonl" % A, "anchor": 0, "mtime": 0},
+                         {"sid": B, "name": "api", "path": "/nonexistent/%s.jsonl" % B, "anchor": 0, "mtime": 0}]
+        for p in (mock.patch.object(km, "_alive_sessions", lambda now, tmux: list(self.sessions)),
+                  mock.patch.object(km, "_warm_fleet_bg", lambda now: None)):
+            p.start()
+            self.addCleanup(p.stop)
+        self.tmux = {A: _TM(), B: _TM()}
+
+    def _asks(self):
+        return {a["itemId"]: a for a in km.build_feed(NOW, self.tmux)["asks"]}
+
+    def test_one_faulting_store_costs_that_session_only_and_files_one_row_per_episode(self):
+        with _fault_on(self.a_file):
+            cards = self._asks()
+            self.assertIn(B + ":g1", cards, "the healthy session's card is on the board")
+            self.assertNotIn(A + ":g1", cards, "nothing goal-derived is shown for the session that faulted")
+            self.assertFalse(cards[B + ":g1"]["origin"]["live"],
+                             "a badge whose sender's store faults reads absorbed, and the build goes on")
+            rows = self._rows("store-unreadable")
+            self.assertEqual([(r["fsid"], r["judge"]) for r in rows], [(A, "romp")],
+                             "exactly one row, for the faulting session, on the judge-errors surface")
+            self.assertIn("Input/output error", rows[0]["note"], "the note carries the fault itself")
+            self._asks()
+            self.assertEqual(len(self._rows("store-unreadable")), 1, "a repeat of the same fault files nothing new")
+        cards = self._asks()                         # the fault cleared: A reads again → its episode ends
+        self.assertIn(A + ":g1", cards)
+        self.assertTrue(cards[B + ":g1"]["origin"]["live"], "the badge reads the sender's open goal again")
+        self.assertEqual(len(self._rows("store-unreadable")), 1, "a healthy build files nothing")
+        with _fault_on(self.a_file):
+            self._asks()
+        self.assertEqual(len(self._rows("store-unreadable")), 2,
+                         "a fault after a successful read is a NEW episode and files again")
+
+    def test_the_faulting_stores_file_is_never_written(self):
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            self._asks()
+        self.assertEqual(self.a_file.read_bytes(), before, "the build never publishes over a store it could not read")
+
+    def test_the_provisional_card_is_not_inferred_from_a_store_that_faulted(self):
+        """'The planner has not placed this prompt yet' is read off PLACEMENTS. With the store unreadable
+        that is not knowledge, so the placeholder that would surface on a healthy store must not."""
+        self._write(A, _store(A, "the faulting session's goal", nodeComplete=True))   # no working card fronts it
+        tpath = self._transcript(A, [_uline(NOW - 500, "start the next piece", "u1"),
+                                     _aline(NOW - 480, "Done.", "a1", "u1")])
+        self.sessions[0]["path"] = tpath
+        km._parse(tpath, A, NOW)                     # warm: build_feed reads the parse cache only
+        self.assertIn("provisional:" + A, self._asks(),
+                      "premise: on a healthy store the unplaced prompt surfaces a provisional card")
+        with _fault_on(self.a_file):
+            ids = set(self._asks())
+        self.assertNotIn("provisional:" + A, ids, "not inferred from placements we could not read")
+        self.assertEqual([i for i in ids if A in i], [], "nothing at all is shown for the faulting session")
+        self.assertIn("provisional:" + A, self._asks(), "and it is back once the store reads again")
+
+    def test_the_timeline_frame_ships_with_one_lane_faulting(self):
+        km._BARS_COMPLAINED.clear()
+        with _fault_on(self.a_file):
+            tl = km.build_timeline(NOW, self.tmux, with_bars=False)
+            self.assertIsNotNone(tl, "the frame ships")
+            lanes = {s["id"] for s in tl.get("sessions") or []} if isinstance(tl, dict) else set()
+            self.assertIn(B, lanes, "the healthy lane is there")
+            self.assertEqual(len(self._rows("store-unreadable")), 1, "one row for the faulting lane")
+        self.assertTrue(str(km._BARS_COMPLAINED.get((A, "goals"), "")).startswith("OSError"),
+                        "and the lane says why it renders without goal data, like every other bars stage")
+
+    def test_the_chat_tab_builds_with_its_store_faulting(self):
+        tpath = self._transcript(A, [_uline(NOW - 500, "start the next piece", "u1"),
+                                     _aline(NOW - 480, "Done.", "a1", "u1")])
+        sess = [{"sid": A, "name": "web", "anchor": None, "path": tpath, "mtime": NOW}]
+        with mock.patch.object(km, "_sessions", lambda now, window=None, forks=True: list(sess)):
+            healthy = km.build_session(A, NOW, self.tmux)
+            self.assertTrue(healthy and healthy["ledger"]["tree"], "premise: the tab's ledger tree shows the goal")
+            with _fault_on(self.a_file):
+                m = km.build_session(A, NOW, self.tmux)
+        self.assertIsNotNone(m, "the tab builds")
+        self.assertEqual(m["id"], A)
+        self.assertEqual(m["ledger"]["tree"], [], "with no goal-derived content")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [A])
+
+
+class PushBoundary(_World):
+    def test_one_faulting_store_does_not_stop_the_push(self):
+        """The pusher's outer try used to catch the raise and return before sending to ANY client."""
+        sessions = [{"sid": A, "name": "web", "path": "/nonexistent/%s.jsonl" % A, "anchor": 0, "mtime": 0},
+                    {"sid": B, "name": "api", "path": "/nonexistent/%s.jsonl" % B, "anchor": 0, "mtime": 0}]
+        tmux = {A: _TM(), B: _TM()}
+        sent = []
+        with mock.patch.object(km, "_alive_sessions", lambda now, tm: list(sessions)), \
+                mock.patch.object(km, "_warm_fleet_bg", lambda now: None), \
+                mock.patch.object(km, "_tmux_sessions", lambda: dict(tmux)), \
+                mock.patch.object(km, "_chat_tab_sessions", lambda now, tm: []), \
+                mock.patch.object(km, "_send_client", lambda c, key, msg, pre=None, sig=None: sent.append((key, msg))), \
+                _fault_on(self.a_file):
+            km._push([{"app": "feed", "alive": True}], tmux=tmux)
+        keys = [k[0] for k, _ in sent]
+        self.assertIn("feed", keys, "a feed payload reached the client despite one session's fault: %r" % keys)
+        payload = next(m for k, m in sent if k[0] == "feed")
+        body = payload if isinstance(payload, dict) else json.loads(payload)
+        data = body.get("data") or body.get("feed") or body
+        cards = {a["itemId"] for a in (data.get("asks") or [])}
+        self.assertIn(B + ":g1", cards, "and it carries the healthy session's card")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [A])
+
+
+class InterruptLiftBoundary(_World):
+    """The interrupt tick's LIFT: on a store fault the intrBlocked marker must be KEPT, so the next
+    healthy tick lifts romp's own block; erasing it would leave the card in Needs-you wearing a block
+    no tick ever looks at again."""
+    CUT_T = NOW - 1800
+    RESUME_T = NOW - 600
+
+    def setUp(self):
+        super().setUp()
+        self.tpath = self._transcript(A, [_uline(NOW - 3600, "wire up the reconnect banner", "u1"),
+                                          _aline(NOW - 3580, "on it", "a1", "u1", "tool_use"),
+                                          _uline(self.CUT_T, "[Request interrupted by user]", "u2", "a1")])
+        st = _store(A, "Ship the reconnect banner")
+        st["closedTurns"] = []
+        self._write(A, st)
+        km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
+        for p in (mock.patch.object(km, "_alive_sessions", lambda now, tmux: [{"sid": A, "path": self.tpath}]),
+                  mock.patch.object(km, "_push_all", lambda *a, **k: None),
+                  mock.patch.object(jd, "CLOSER_ON", False)):
+            p.start()
+            self.addCleanup(p.stop)
+        km._downtime[:] = []
+        km._autonudge_cache.clear()
+        km._pending_ops.clear()
+        self.tmux = {A: dict(_TM(), state="idle")}
+
+    def _reengage(self):
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(_uline(self.RESUME_T, "use the staging host for now", "u3", "u2")) + "\n")
+            f.write(json.dumps(_aline(self.RESUME_T + 40, "done", "a2", "u3")) + "\n")
+        km._parse_cache.clear()
+        jd._PARSE_CACHE.clear()
+
+    def test_a_fault_at_the_reengage_tick_keeps_the_marker_so_the_next_tick_lifts(self):
+        gid = A + ":g1"
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(km._intr_blocked(A), gid, "premise: the stop blocked the focus goal and marked it")
+        self.assertEqual(jd.load_goals(A)["status"][gid], "blocked")
+        self._reengage()
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(self.a_file.read_bytes(), before, "nothing was written to a store we could not read")
+        self.assertEqual(km._intr_blocked(A), gid, "the marker is KEPT: the lift is owed, not spent")
+        km._interrupt_block_tick(NOW, self.tmux)  # the fault cleared
+        self.assertEqual(jd.load_goals(A)["status"][gid], "working", "the next healthy tick lifts the block")
+        self.assertIsNone(km._intr_blocked(A), "and spends the marker")
+
+    def _append(self, recs):
+        with open(self.tpath, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        km._parse_cache.clear()
+        jd._PARSE_CACHE.clear()
+
+    def test_a_second_stop_during_the_fault_keeps_the_marker_so_the_block_is_still_lifted_after(self):
+        """The kept-marker promise has to survive the block branch too: a SECOND genuine stop while the
+        fault persists asks _intr_block_stands whether the marked block still holds its card, and a store
+        it cannot read is not evidence that it fell. Reading a fault as 'no longer stands' popped the
+        marker, the re-block failed through the same fault, and romp's own block outlived every tick."""
+        gid = A + ":g1"
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(km._intr_blocked(A), gid, "premise: the stop blocked the focus goal and marked it")
+        self._reengage()
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            km._interrupt_block_tick(NOW, self.tmux)          # re-engaged under the fault: the lift is owed
+            self.assertEqual(km._intr_blocked(A), gid, "kept (the lift's half of the promise)")
+            self._append([_uline(self.RESUME_T + 100, "and the prod host after", "u4", "a2"),
+                          _aline(self.RESUME_T + 120, "on it", "a3", "u4", "tool_use"),
+                          _uline(self.RESUME_T + 200, "[Request interrupted by user]", "u5", "a3")])
+            km._interrupt_block_tick(NOW, self.tmux)          # a second stop, still under the fault
+            self.assertEqual(km._intr_blocked(A), gid, "still kept: an unreadable store is not evidence the block fell")
+        self.assertEqual(self.a_file.read_bytes(), before, "nothing was written through the fault")
+        km._interrupt_block_tick(NOW, self.tmux)              # the fault cleared, the stop still stands
+        self.assertEqual(km._intr_blocked(A), gid, "the marked block holds its card, so the marker holds")
+        self.assertEqual(jd.load_goals(A)["status"][gid], "blocked")
+        self._append([_uline(self.RESUME_T + 300, "keep going with staging", "u6", "u5"),
+                      _aline(self.RESUME_T + 340, "done", "a4", "u6")])
+        km._interrupt_block_tick(NOW, self.tmux)              # re-engaged, readable: the lift lands
+        self.assertEqual(jd.load_goals(A)["status"][gid], "working", "romp's own block is lifted")
+        self.assertIsNone(km._intr_blocked(A), "and the marker is spent")
+
+
+class TriagePassBoundary(_World):
+    """run_courier and run_propagate walk every session with the same per-session catch the other passes
+    have: the faulting session files a `pass-crash` row and the pass goes on to the next session."""
+
+    def setUp(self):
+        super().setUp()
+        self.paths = {}
+        for sid, text in ((A, "start the faulting session's work"), (B, "start the healthy session's work"),
+                          (P, "start the peer's work")):
+            self.paths[sid] = self._transcript(sid, [_uline(T0, text, "u-" + sid[-2:])])
+        self._discover([A, B])
+        self.msgs = Path(self.td.name) / "messages.jsonl"
+        p = mock.patch.object(jd, "MESSAGES", self.msgs)
+        p.start()
+        self.addCleanup(p.stop)
+        self.seen = []
+        orig = jd.load_goals
+
+        def recording(fsid):
+            self.seen.append(fsid)
+            return orig(fsid)
+        p = mock.patch.object(jd, "load_goals", recording)
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _discover(self, sids):
+        names = {A: "web", B: "api", P: "tests"}
+        discovered = [(sid, self.paths[sid], None, names[sid]) for sid in sids]
+        p = mock.patch.object(jd, "discover", lambda now, window=None, forks=True: list(discovered))
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _messages(self, rows):
+        self.msgs.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    def _sent(self, mid, sender, to, body):
+        return {"t": T0, "ev": "sent", "id": mid, "from": "web", "from_id": sender, "to_id": to,
+                "kind": "delegate", "body": body}
+
+    def _crashes(self, judge):
+        return sorted((r["fsid"], r["note"].split(":")[0]) for r in self._rows("pass-crash") if r["judge"] == judge)
+
+    def test_run_courier_continues_past_a_faulting_session(self):
+        with _fault_on(self.a_file):
+            jd.run_courier(now=NOW)
+        self.assertIn(B, self.seen, "the pass reached the healthy session after the fault")
+        rows = self._rows("pass-crash")
+        self.assertEqual([(r["judge"], r["fsid"]) for r in rows], [("courier", A)],
+                         "one pass-crash row, for the faulting session, from the courier")
+        self.assertIn("Input/output error", rows[0]["note"])
+
+    def test_run_courier_files_a_faulting_sender_and_moves_on_to_the_next_message(self):
+        """Three of the courier's reads name another session: a relayed message's sender, a pending
+        message's recipient (read again when its turn comes), and a pending message's sender. Each
+        faults here — P outright, A only from its second read — and each files its own row."""
+        body_a, body_b = _peer_body(MID1, "the first piece"), _peer_body(MID2, "the second piece")
+        self.paths[A] = self._transcript(A, [_uline(T0, body_a, "m1", ps="sdk"), _aline(T0 + 60, "On it.", "a1", "m1")])
+        self.paths[B] = self._transcript(B, [_uline(T0 + 5, body_b, "m2", ps="sdk"), _aline(T0 + 65, "On it.", "a2", "m2")])
+        self._discover([A, B, P])
+        self._messages([self._sent(MID1, P, A, body_a), self._sent(MID2, P, B, body_b),
+                        dict(self._sent("1781296400.000003_1.TESTHOST", P, "peer:remote-api", "DELEGATE: relayed"),
+                             toName="remote-api", t=T0 + 1)])
+        calls, orig = {}, jd.load_goals
+
+        def faulting(fsid):
+            calls[fsid] = calls.get(fsid, 0) + 1
+            if fsid == P or (fsid == A and calls[fsid] >= 2):
+                raise OSError(errno.EIO, "Input/output error", str(jd.GOALDIR / (fsid + ".json")))
+            return orig(fsid)
+        with mock.patch.object(jd, "load_goals", faulting):
+            jd.run_courier(now=NOW)
+        self.assertEqual(self._crashes("courier"),
+                         sorted([(P, "store"), (P, "sender store"), (A, "store"), (B, "sender %s store" % P[:8])]),
+                         "P's own walk, the relayed sender, the re-read recipient and the pending sender each file a row")
+        self.assertGreaterEqual(calls.get(B, 0), 2, "the healthy recipient was read in both arms: the pass went on")
+        self.assertNotIn(A + ":g2", jd.load_goals(A).get("nodes", {}), "nothing was planted off a faulting sender")
+
+    def test_run_courier_skips_a_message_whose_root_walk_hits_a_faulting_peer(self):
+        """The sender is healthy; the link's chain hops to a PEER whose store faults. The message is
+        skipped this pass (retried next), never treated as 'unrooted', which would mint a recipient top."""
+        body = _peer_body(MID1, "the first piece")
+        self.paths[B] = self._transcript(B, [_uline(T0, body, "m1", ps="sdk"), _aline(T0 + 60, "On it.", "a1", "m1")])
+        self._discover([A, B, P])
+        self._messages([self._sent(MID1, A, B, body)])
+        self._write(A, _store(A, "the sender's open ask", origin={"peer": P, "goalId": P + ":g1"}))
+        self._write(P, _store(P, "the peer's goal"))
+        calls, orig = {}, jd.load_goals
+
+        def faulting(fsid):                          # P reads fine in the session loop; its store faults when the
+            calls[fsid] = calls.get(fsid, 0) + 1     # root walk hops to it
+            if fsid == P and calls[fsid] >= 2:
+                raise OSError(errno.EIO, "Input/output error", str(jd.GOALDIR / (fsid + ".json")))
+            return orig(fsid)
+        with mock.patch.object(jd, "courier_llm",
+                               lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 1, "text": "the first piece"}'), \
+                mock.patch.object(jd, "load_goals", faulting):
+            jd.run_courier(now=NOW)
+        self.assertEqual(self._crashes("courier"), [(B, "root walk")], "the one arm that tripped, attributed to the recipient")
+        self.assertGreaterEqual(calls.get(P, 0), 2, "premise: the walk did hop to the peer")
+        b = jd.load_goals(B)
+        self.assertEqual(list(b["nodes"]), [B + ":g1"], "no recipient top was minted off an unresolved walk")
+        self.assertEqual(b["placements"], {}, "the message stays pending for the next pass")
+
+    def test_run_propagate_continues_past_a_faulting_session(self):
+        with _fault_on(self.a_file):
+            jd.run_propagate(now=NOW)
+        self.assertGreaterEqual(self.seen.count(B), 2, "both arms of the pass reached the healthy session")
+        rows = self._rows("pass-crash")
+        self.assertTrue(rows, "the faulting session's rows are filed")
+        self.assertEqual({(r["judge"], r["fsid"]) for r in rows}, {("propagate", A)},
+                         "every row is the faulting session's, from the propagate pass")
+
+    def test_run_propagate_leaves_a_faulting_senders_tracker_for_the_next_pass(self):
+        # B finished a goal it was handed by A; checking A's tracker off needs A's store, which faults
+        self._write(B, _store(B, "the delegated piece", nodeComplete=True, origin={"peer": A, "goalId": A + ":g1"}))
+        with _fault_on(self.a_file):
+            jd.run_propagate(now=NOW)
+        crashes = self._crashes("propagate")
+        self.assertIn((B, "sender %s store" % A[:8]), crashes, "the recipient's row names the sender it could not read")
+        self.assertIn(B, self.seen)
+
+    def test_run_propagate_joins_a_faulting_recipient_to_nothing_and_writes_no_tracker(self):
+        # A's tracker waits on B; the reply sweep asks B's store whether the card was dismissed
+        self._write(A, _store(A, "the handed-off piece", handoff={"peer": B, "msgId": MID1, "t": T0}))
+        before = self.a_file.read_bytes()
+        with _fault_on(self.b_file):
+            jd.run_propagate(now=NOW)
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [B],
+                         "the recipient lookup goes through the boundary: one row for B")
+        self.assertEqual(self.a_file.read_bytes(), before, "A's tracker stays open, unwritten")
+
+    def test_the_index_tier_captions_the_healthy_session_when_one_store_faults(self):
+        with _fault_on(self.a_file):
+            self.assertEqual(jd.tasks_for(A, self.paths[A], [self.paths[A]], NOW), [],
+                             "no caption tasks are derived from a store that could not be read")
+            self.assertTrue(jd.tasks_for(B, self.paths[B], [self.paths[B]], NOW),
+                            "the healthy session's tasks are unaffected")
+        self.assertEqual([r["fsid"] for r in self._rows("store-unreadable")], [A])
+
+
+class GestureRefusal(_World):
+    """A user gesture a fault made us skip must reach the socket that made it: an undo whose session
+    cannot be read appends its journal row, but the card does not come back, and before this nothing on
+    screen said why."""
+
+    def setUp(self):
+        super().setUp()
+        sessions = [{"sid": A, "name": "web", "path": "/nonexistent/%s.jsonl" % A, "anchor": 0, "mtime": 0},
+                    {"sid": B, "name": "api", "path": "/nonexistent/%s.jsonl" % B, "anchor": 0, "mtime": 0}]
+        self.tmux = {A: _TM(), B: _TM()}
+        for p in (mock.patch.object(km, "_alive_sessions", lambda now, tmux: list(sessions)),
+                  mock.patch.object(km, "_warm_fleet_bg", lambda now: None),
+                  mock.patch.object(km, "_tmux_sessions", lambda: dict(self.tmux))):   # the handler's own build
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _dispatch(self, msg):
+        sent = []
+        client = {"app": "feed", "alive": True, "send": lambda s: sent.append(json.loads(s))}
+        km.Handler._dispatch_ws(object.__new__(km.Handler), msg, client)
+        return sent
+
+    def _feed_rows(self, sid):
+        """What the board shows for `sid` right now: {card itemId: card}."""
+        return {a["itemId"]: a for a in km.build_feed(NOW, self.tmux)["asks"] if a["itemId"].startswith(sid)}
+
+    def test_an_undo_clear_the_fault_skipped_answers_the_socket_that_asked(self):
+        gid = A + ":g1"
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)   # the cleared card was compacted to the archive
+        arch = _store(A, "the cleared card", cleared=True)
+        (jd.GOALARCHDIR / (A + ".json")).write_text(json.dumps({"rompUuid": A, "nodes": arch["nodes"],
+                                                                 "status": {gid: "cleared"}}))
+        (jd.STATE / "cleared.jsonl").write_text(json.dumps({"id": gid, "t": NOW - 10, "op": "clear"}) + "\n")
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "undoClear"})
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A], "one refusal, for the session the undo could not reach")
+        self.assertIn("undo", errs[0]["title"])
+        self.assertIn("Input/output error", errs[0]["text"], "and it says why")
+        self.assertIn("not restored", errs[0]["text"], "and what did not happen")
+        self.assertIn("press Undo again", errs[0]["text"], "and the one true remedy: the next Undo retries these ids")
+        self.assertNotIn("copy", errs[0], "`copy` is the USER'S undelivered text by contract; romp's prose never rides it")
+        self.assertEqual(self.a_file.read_bytes(), before, "nothing was written to the store")
+        self.assertIn(gid, json.loads((jd.GOALARCHDIR / (A + ".json")).read_text())["nodes"],
+                      "the archive still holds the card for a later undo")
+
+    def test_a_sub_goal_drop_the_fault_skipped_answers_with_its_own_account(self):
+        """The modal's Drop is sub-task-only, and a sub-goal row renders from the node FLAG alone
+        (cleared.jsonl hides TOP cards only) — the very write the fault refused. So the whole-card
+        account ("off the board") would be false here: nothing changed, the row is as it was, try again."""
+        gid, sub = A + ":g1", A + ":g2"
+        st = _store(A, "the parent goal")
+        st["nodes"][sub] = dict(st["nodes"][gid], id=sub, parentId=gid, text="the sub-goal to drop")
+        st["status"][sub] = "working"
+        self._write(A, st)
+        row = lambda: next(r for r in self._feed_rows(A)[gid]["tree"] if r["id"] == sub)
+        self.assertFalse(row()["cleared"], "premise: the sub row renders un-cleared")
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "nodeOverride", "sid": A, "nodeId": sub, "op": "clear"})
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A])
+        self.assertIn("sub-goal was not cleared", errs[0]["title"])
+        self.assertIn("Input/output error", errs[0]["text"], "it says why")
+        self.assertIn("nothing changed there", errs[0]["text"], "what happened: nothing")
+        self.assertIn("Try it again", errs[0]["text"], "the true remedy: a retry appends a fresh row and sets the flag")
+        self.assertNotIn("copy", errs[0])
+        self.assertEqual(self.a_file.read_bytes(), before, "the flag was not written")
+        self.assertIn(gid, self._feed_rows(A), "the card stays on the board")
+        self.assertFalse(row()["cleared"], "and the sub row still renders un-cleared, as the dialog says")
+        sent = self._dispatch({"type": "nodeOverride", "sid": A, "nodeId": sub, "op": "clear"})   # the retry, readable
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [], "nothing to refuse")
+        self.assertTrue(row()["cleared"], "the retry sets the flag: the row renders cleared")
+        self.assertIn(gid, self._feed_rows(A), "the card itself was never cleared")
+
+    def test_a_clear_all_answers_once_per_session_and_reads_true_for_several_cards(self):
+        """Clear-all across two cards of one session whose store faults at the flag step (a fault before
+        the build would keep A's cards out of the batch itself): ONE refusal for the session, worded for
+        any number of cards, and true — the cards are off the board (their cleared.jsonl rows landed), the
+        durable flag is not. Through the real dispatcher, which also pins that Clear-all clears at all:
+        the handler indexed `items`, a payload key build_feed no longer emits, and raised before
+        _clear_all ran — so Clear-all cleared nothing and only a stderr line knew."""
+        gid, g3 = A + ":g1", A + ":g3"
+        st = _store(A, "the first card")
+        st["nodes"][g3] = dict(st["nodes"][gid], id=g3, text="the second card")
+        st["status"][g3] = "working"
+        self._write(A, st)
+        self.assertEqual(set(self._feed_rows(A)), {gid, g3}, "premise: two cards of one session")
+        before, orig = self.a_file.read_bytes(), km._mark_nodes_cleared
+
+        def flag_step_under_fault(ids, value, **kw):
+            with _fault_on(self.a_file):
+                return orig(ids, value, **kw)
+        with mock.patch.object(km, "_mark_nodes_cleared", flag_step_under_fault):
+            sent = self._dispatch({"type": "clearAll"})
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A], "one refusal per session, not per card")
+        self.assertIn("What you cleared there is off the board", errs[0]["text"], "plural-safe: any number of cards")
+        self._assert_clear_refusal(errs[0], before)
+        self.assertIn(g3, km._cleared_ids())
+        self.assertEqual(self._feed_rows(A), {}, "both cards are off the board, as it says")
+        self.assertTrue(jd.load_goals(B)["nodes"][B + ":g1"]["cleared"], "the other session's clear landed in full")
+
+    def _assert_clear_refusal(self, err, before):
+        """The whole-card clear dialog says exactly what happened: the card is off the board (its
+        cleared.jsonl row landed) but the durable flag was not written into a goals file romp could not read."""
+        self.assertIn("Input/output error", err["text"], "it says why")
+        self.assertIn("off the board", err["text"], "what did happen")
+        self.assertIn("not written", err["text"], "what did not")
+        self.assertNotIn("copy", err, "`copy` is the USER'S undelivered text by contract; romp's prose never rides it")
+        self.assertIn(A + ":g1", km._cleared_ids(), "the view-level clear holds, as the dialog says")
+        self.assertEqual(self.a_file.read_bytes(), before, "and nothing was written to the store, as it says")
+
+    def test_a_card_clear_the_fault_skipped_answers_the_socket_that_asked(self):
+        """The per-card Clear (askClear) is the same gesture as Clear-all; it answers the socket on the
+        same condition, with the same account."""
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "askClear", "itemId": A + ":g1"})
+        errs = [m for m in sent if m.get("type") == "err"]
+        self.assertEqual([m.get("sid") for m in errs], [A], "one refusal, for the card's session")
+        self.assertIn("clear", errs[0]["title"])
+        self._assert_clear_refusal(errs[0], before)
+
+    def _compacted(self, sid, t):
+        """`sid`'s only card, cleared at `t` and already swept into the archive (the live store holds
+        no node for it), the shape a later Undo must reach into."""
+        gid = sid + ":g1"
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        arch = _store(sid, "the cleared card", cleared=True)
+        (jd.GOALARCHDIR / (sid + ".json")).write_text(json.dumps({"rompUuid": sid, "nodes": arch["nodes"],
+                                                                   "status": {gid: "cleared"}}))
+        live = _store(sid, "unused")
+        live["nodes"], live["status"], live["lastNode"] = {}, {}, None
+        self._write(sid, live)
+        with (jd.STATE / "cleared.jsonl").open("a") as f:
+            f.write(json.dumps({"id": gid, "t": t, "op": "clear"}) + "\n")
+
+    def _undo_rows(self):
+        return [json.loads(l)["id"] for l in (jd.STATE / "cleared.jsonl").read_text().splitlines()
+                if json.loads(l).get("op") == "undo"]
+
+    def test_an_undo_the_fault_skipped_is_retried_by_the_next_undo(self):
+        """One Clear-all batch across two sessions; A's store faults at Undo. B's card comes back and
+        its undo row is journaled; A's ids are NOT journaled as undone, so they stay the newest batch —
+        the next Undo, once the file reads, restores exactly them. (Journaling every id first consumed
+        the batch: a second Undo found nothing and A's card stayed in the archive for good.)"""
+        for sid in (A, B):
+            self._compacted(sid, NOW - 10)
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "undoClear"})
+        self.assertEqual([m.get("sid") for m in sent if m.get("type") == "err"], [A])
+        self.assertEqual(self._undo_rows(), [B + ":g1"], "only the ids whose restore RAN are journaled as undone")
+        self.assertEqual(km._cleared_ids(), {A + ":g1": NOW - 10}, "A's ids remain the newest cleared batch")
+        b = jd.load_goals(B)
+        self.assertFalse(b["nodes"][B + ":g1"]["cleared"], "B's card is back and un-cleared")
+        self.assertEqual(json.loads((jd.GOALARCHDIR / (B + ".json")).read_text())["nodes"], {})
+        self.assertEqual(self.a_file.read_bytes(), before, "A's store was not written")
+        self.assertIn(A + ":g1", json.loads((jd.GOALARCHDIR / (A + ".json")).read_text())["nodes"],
+                      "A's archive still holds the card")
+        sent = self._dispatch({"type": "undoClear"})     # the fault cleared; the user presses Undo again
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [], "nothing to refuse this time")
+        a = jd.load_goals(A)
+        self.assertIn(A + ":g1", a["nodes"], "A's card is restored into the live store")
+        self.assertFalse(a["nodes"][A + ":g1"]["cleared"])
+        self.assertEqual(json.loads((jd.GOALARCHDIR / (A + ".json")).read_text())["nodes"], {})
+        self.assertEqual(self._undo_rows(), [B + ":g1", A + ":g1"], "and now A's undo row is journaled")
+        self.assertEqual(km._cleared_ids(), {}, "the batch is fully undone")
+
+    def _uncompacted(self, sid, t):
+        """`sid`'s only card, cleared at `t` but not yet swept: the node sits flag-cleared in the LIVE
+        store and the archive holds nothing, so the restore step has no store read to fault on."""
+        st = _store(sid, "the cleared card", cleared=True)
+        st["status"][sid + ":g1"] = "cleared"
+        self._write(sid, st)
+        with (jd.STATE / "cleared.jsonl").open("a") as f:
+            f.write(json.dumps({"id": sid + ":g1", "t": t, "op": "clear"}) + "\n")
+
+    def test_an_undo_of_an_uncompacted_card_whose_store_faults_stays_owed(self):
+        """Nothing archived means the restore step cannot skip the session; the flag step is the first
+        read to meet the fault, AFTER the undo row landed. Those ids are re-journaled as cleared, so the
+        batch stays owed and the next Undo restores exactly them (journaled-and-consumed before)."""
+        for sid in (A, B):
+            self._uncompacted(sid, NOW - 10)
+        before = self.a_file.read_bytes()
+        with _fault_on(self.a_file):
+            sent = self._dispatch({"type": "undoClear"})
+        self.assertEqual([m.get("sid") for m in sent if m.get("type") == "err"], [A])
+        self.assertIn(A + ":g1", km._cleared_ids(), "A's card is still owed its undo")
+        self.assertNotIn(B + ":g1", km._cleared_ids())
+        self.assertFalse(jd.load_goals(B)["nodes"][B + ":g1"]["cleared"], "B's card is back")
+        self.assertEqual(self.a_file.read_bytes(), before, "A's store was not written")
+        self.assertEqual(self._feed_rows(A), {}, "A's card stays hidden, as the dialog says")
+        sent = self._dispatch({"type": "undoClear"})     # the fault cleared; Undo again
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [])
+        self.assertFalse(jd.load_goals(A)["nodes"][A + ":g1"]["cleared"], "the next Undo un-clears A's card")
+        self.assertEqual(km._cleared_ids(), {})
+        self.assertIn(A + ":g1", self._feed_rows(A), "and it is back on the board")
+
+    def test_a_fault_that_first_appears_at_the_flag_step_leaves_the_undo_owed(self):
+        """The store read fine for the restore and faults at the flag step: the node is back in the
+        live store but flag-cleared, which the board hides exactly like the clear did, and no modal op
+        can reach a hidden card. With its undo row already journaled the batch would be consumed; the
+        re-journaled clear keeps it owed, and the next Undo un-clears it."""
+        for sid in (A, B):
+            self._compacted(sid, NOW - 10)
+        orig = km._mark_nodes_cleared
+
+        def flag_step_under_fault(ids, value, **kw):
+            with _fault_on(self.a_file):
+                return orig(ids, value, **kw)
+        with mock.patch.object(km, "_mark_nodes_cleared", flag_step_under_fault):
+            sent = self._dispatch({"type": "undoClear"})
+        self.assertEqual([m.get("sid") for m in sent if m.get("type") == "err"], [A])
+        a = jd.load_goals(A)
+        self.assertIn(A + ":g1", a["nodes"], "the restore ran: the node is back in the live store...")
+        self.assertTrue(a["nodes"][A + ":g1"]["cleared"], "...still flag-cleared (the flag step could not run)")
+        self.assertIn(A + ":g1", km._cleared_ids(), "so the id is re-journaled as cleared: the batch stays owed")
+        self.assertEqual(self._feed_rows(A), {}, "the card is hidden, as the dialog says")
+        self.assertFalse(jd.load_goals(B)["nodes"][B + ":g1"]["cleared"], "B's undo landed in full")
+        sent = self._dispatch({"type": "undoClear"})     # readable again
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [])
+        self.assertFalse(jd.load_goals(A)["nodes"][A + ":g1"]["cleared"], "the next Undo un-clears it")
+        self.assertEqual(km._cleared_ids(), {})
+        self.assertIn(A + ":g1", self._feed_rows(A))
+
+    def test_a_gesture_that_reaches_every_session_says_nothing(self):
+        (jd.STATE / "cleared.jsonl").write_text(json.dumps({"id": B + ":g1", "t": NOW - 10, "op": "clear"}) + "\n")
+        sent = self._dispatch({"type": "undoClear"})
+        self.assertEqual([m for m in sent if m.get("type") == "err"], [], "no refusal without a skipped session")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -10,10 +10,12 @@ save_goals now compares the revision it loaded at against the one on disk and RE
 logs) instead of clobbering. The store is an append-only event log, so two writers appending different
 events never really conflicted: the right answer is both sets. All fixtures SYNTHETIC.
 """
+import errno
 import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -185,6 +187,118 @@ class StoreCas(unittest.TestCase):
         jd.record_verdict(s, s["nodes"][gid], "planner", "done", T0 + 30, why="shipped")
         jd.save_goals(SID, s)                        # nobody else wrote → straight publish
         self.assertTrue(jd.load_goals(SID)["nodes"][gid].get("nodeComplete"))
+
+
+class ReadFaultCas(unittest.TestCase):
+    """The CAS can never publish over a file it could not READ.
+
+    Before this, every reader in the save path answered a read failure with the ABSENT-file value:
+    load_goals returned a fresh store at base 0, _disk_rev read 0, _matches_disk read "no match" and
+    _rebase_onto_disk had "nothing to rebase onto". So on an EIO, an EACCES or a corrupt file, save_goals
+    found base 0 == disk 0 and published the empty store over the user's goals. Now a read fault raises
+    from every one of those readers and the file on disk is left byte for byte as it was.
+
+    Mints goals, so it uses a PRIVATE synthetic sid (CLAUDE.md, 2026-08-24) and cleans that sid's override
+    journal in tearDown."""
+    FSID = "7b2c3d4e-5f60-4182-93a4-b5c6d7e8f901"
+
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+
+    def tearDown(self):
+        (jd._overrides_dir() / (self.FSID + ".jsonl")).unlink(missing_ok=True)
+        jd._rebind_state(self._saved)
+        (jd._overrides_dir() / (self.FSID + ".jsonl")).unlink(missing_ok=True)
+        self.td.cleanup()
+
+    def _file(self):
+        return jd.GOALDIR / (self.FSID + ".json")
+
+    def _gid(self):
+        return "%s:g1" % self.FSID
+
+    def _seed(self):
+        s = {"rompUuid": self.FSID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+             "placements": {}, "status": {}}
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "A goal"}], [])
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(self.FSID, s)
+
+    def _eio_on_the_store(self):
+        """Path.read_text raises EIO for THIS store's path only; every other read is untouched."""
+        target, orig = self._file(), Path.read_text
+
+        def faulting(path, *a, **kw):
+            if path == target:
+                raise OSError(errno.EIO, "Input/output error", str(path))
+            return orig(path, *a, **kw)
+        return mock.patch.object(Path, "read_text", faulting)
+
+    def test_a_read_fault_raises_from_load_instead_of_reading_as_an_empty_store(self):
+        self._seed()
+        with self._eio_on_the_store():
+            with self.assertRaises(OSError) as cm:
+                jd.load_goals(self.FSID)
+        self.assertEqual(cm.exception.errno, errno.EIO, "the fault itself, not a fresh store")
+        self.assertEqual(len(self._sidecars()), 0, "a FAULT is not corruption: nothing is moved aside")
+
+    def test_a_read_fault_at_save_publishes_nothing_and_the_file_is_untouched(self):
+        self._seed()
+        before = self._file().read_bytes()
+        s = jd.load_goals(self.FSID)                 # a snapshot taken while the disk was healthy...
+        jd.record_verdict(s, s["nodes"][self._gid()], "planner", "done", T0 + 30, why="shipped")
+        with self._eio_on_the_store():               # ...then the store becomes unreadable
+            with self.assertRaises(OSError):
+                jd.save_goals(self.FSID, s)
+        self.assertEqual(self._file().read_bytes(), before,
+                         "the publish did not go ahead over bytes it failed to compare against")
+
+    def test_a_file_corrupted_after_load_is_not_overwritten_by_the_save(self):
+        """The save path never quarantines (that is load's job, after the evidence is preserved): a store
+        that turned unparseable underneath a held snapshot makes the save raise, and the bytes stay put for
+        the next load to move aside."""
+        self._seed()
+        s = jd.load_goals(self.FSID)
+        jd.record_verdict(s, s["nodes"][self._gid()], "planner", "done", T0 + 30, why="shipped")
+        self._file().write_text("{not json")
+        with self.assertRaises(ValueError):
+            jd.save_goals(self.FSID, s)
+        self.assertEqual(self._file().read_text(), "{not json", "the save wrote nothing")
+        self.assertEqual(len(self._sidecars()), 0, "and moved nothing: the save path only reads")
+        fresh = jd.load_goals(self.FSID)             # the next load is the one that quarantines
+        self.assertEqual(len(self._sidecars()), 1)
+        jd.save_goals(self.FSID, fresh)
+        self.assertEqual(json.loads(self._file().read_text())["rompUuid"], self.FSID)
+
+    def test_disk_rev_reads_zero_only_for_an_absent_file(self):
+        self.assertEqual(jd._disk_rev(self.FSID), 0, "absent → 0, a create")
+        self._seed()
+        self.assertGreater(jd._disk_rev(self.FSID), 0)
+        with self._eio_on_the_store():
+            with self.assertRaises(OSError):
+                jd._disk_rev(self.FSID)
+        self._file().write_text("{not json")
+        with self.assertRaises(ValueError):
+            jd._disk_rev(self.FSID)
+
+    def test_matches_disk_and_rebase_raise_on_a_fault_or_a_corrupt_file(self):
+        """Each reader in the save path on its own: a version of either that swallowed the read and answered
+        'no match' / 'nothing to rebase onto' would let save_goals go ahead and passed every other test."""
+        self._seed()
+        s = jd.load_goals(self.FSID)
+        self.assertTrue(jd._matches_disk(self.FSID, s), "premise: a healthy read matches")
+        with self._eio_on_the_store():
+            self.assertRaises(OSError, jd._matches_disk, self.FSID, s)
+            self.assertRaises(OSError, jd._rebase_onto_disk, self.FSID, s)
+        self._file().write_text("{not json")
+        self.assertRaises(ValueError, jd._matches_disk, self.FSID, s)
+        self.assertRaises(ValueError, jd._rebase_onto_disk, self.FSID, s)
+        self.assertEqual(self._file().read_text(), "{not json", "neither reader touched the file")
+
+    def _sidecars(self):
+        return sorted(jd.GOALDIR.glob(self.FSID + ".json.corrupt-*"))
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_store_noop_publish.py
+++ b/tests/test_judge_store_noop_publish.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
@@ -207,6 +208,34 @@ class UnparseableStore(unittest.TestCase):
                 self.assertEqual(len(held), 1, "the bytes survive verbatim in exactly one sidecar")
                 self.assertIn(reason, err.getvalue())
         self.assertEqual([r["err"] for r in self._error_rows()], ["store-quarantined"] * 3)
+
+    def test_a_store_republished_between_the_read_and_the_rename_is_left_alone(self):
+        """No lock guards the rename, so a peer can publish a VALID store to the path between the read that
+        failed to parse and the move aside; moving what is there now would quarantine the peer's good store
+        and start the session fresh over it. The quarantine re-checks the file's identity (inode, mtime,
+        size) against the stat taken before the read and declines when it changed; the reader then reads
+        what is there now (review find, 2026-09-08)."""
+        self._seed()
+        good = self._file().read_bytes()
+        self._file().write_text("{not json")
+        orig, fired, test = Path.read_text, [], self
+
+        def read_then_a_peer_publishes(p, *a, **kw):
+            raw = orig(p, *a, **kw)
+            if p == test._file() and not fired:          # the first read sees the bad bytes; a peer's atomic
+                fired.append(1)                          # publish then replaces the file before our rename
+                tmp = p.with_name(p.name + ".peer")
+                tmp.write_bytes(good)
+                os.replace(tmp, p)
+            return raw
+        err = io.StringIO()
+        with mock.patch.object(Path, "read_text", read_then_a_peer_publishes), contextlib.redirect_stderr(err):
+            s = jd.load_goals(self.QSID)
+        self.assertEqual(self._sidecars(), [], "the peer's valid store was not moved aside")
+        self.assertEqual(self._file().read_bytes(), good, "and sits untouched at the path")
+        self.assertEqual(self._error_rows(), [], "no row: nothing was quarantined")
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(len(s["nodes"]), 1, "the reader returns what is there now, not a fresh store")
 
     def test_an_absent_file_is_a_fresh_store_with_no_quarantine_and_no_error(self):
         self.assertFalse(self._file().exists())

--- a/tests/test_judge_store_noop_publish.py
+++ b/tests/test_judge_store_noop_publish.py
@@ -12,6 +12,8 @@ with no events to contribute can neither lose its own work nor clobber a concurr
 
 All fixtures SYNTHETIC: placeholder UUID, invented goal text.
 """
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -120,13 +122,104 @@ class NoOpPublish(unittest.TestCase):
         self.assertEqual(jd._store_content(s), jd._store_content(t),
                          "same content, different revision + key order → the same publish")
 
-    def test_an_unreadable_file_falls_through_to_a_real_write(self):
+
+
+class UnparseableStore(unittest.TestCase):
+    """An UNPARSEABLE goals file is quarantined aside, and only then does the session start fresh.
+
+    The old test here (`test_an_unreadable_file_falls_through_to_a_real_write`) asserted the defect: it
+    wrote "{not json" over a published store and expected load_goals + save_goals to REPLACE the file with
+    a fresh one. That replacement destroyed the only copy of whatever the file held, and the same branch
+    fired for a torn write, a permission fault and an I/O error alike (see test_judge_store_cas.py for the
+    fault half). Now the bad bytes are moved to <file>.corrupt-<stamp> first, the event is logged on both
+    channels the repo uses, and the fresh store is published to the empty path.
+
+    Mints goals, so it uses a PRIVATE synthetic sid (CLAUDE.md, 2026-08-24) and cleans that sid's override
+    journal in tearDown."""
+    QSID = "6a1b2c3d-4e5f-4071-8293-a4b5c6d7e8f9"
+
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+
+    def tearDown(self):
+        (jd._overrides_dir() / (self.QSID + ".jsonl")).unlink(missing_ok=True)
+        jd._rebind_state(self._saved)
+        (jd._overrides_dir() / (self.QSID + ".jsonl")).unlink(missing_ok=True)
+        self.td.cleanup()
+
+    def _file(self):
+        return jd.GOALDIR / (self.QSID + ".json")
+
+    def _sidecars(self):
+        return sorted(jd.GOALDIR.glob(self.QSID + ".json.corrupt-*"))
+
+    def _error_rows(self):
+        if not jd.ERRORS.exists():
+            return []
+        return [json.loads(l) for l in jd.ERRORS.read_text().splitlines()]
+
+    def _seed(self):
+        s = {"rompUuid": self.QSID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+             "placements": {}, "status": {}}
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "A goal"}], [])
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(self.QSID, s)
+
+    def test_an_unparseable_file_is_quarantined_aside_then_a_fresh_store_is_written(self):
         self._seed()
         self._file().write_text("{not json")
-        s = jd.load_goals(SID)                          # load recovers a fresh store
-        jd.save_goals(SID, s)
-        self.assertEqual(json.loads(self._file().read_text())["rompUuid"], SID,
-                         "an unparseable file is republished, never mistaken for a match")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            s = jd.load_goals(self.QSID)
+        self.assertEqual(s["nodes"], {}, "the session starts fresh...")
+        self.assertEqual(s["_baseRev"], 0)
+        aside = self._sidecars()
+        self.assertEqual(len(aside), 1, "...but ONLY after the bad bytes were moved aside")
+        self.assertEqual(aside[0].read_text(), "{not json", "the sidecar holds the original bytes")
+        self.assertFalse(self._file().exists(), "the live path is empty until the next publish")
+        self.assertIn(str(self._file()), err.getvalue(), "one stderr line names the file...")
+        self.assertIn("invalid JSON", err.getvalue(), "...and the reason")
+        self.assertEqual([(r["err"], r["fsid"]) for r in self._error_rows()],
+                         [("store-quarantined", self.QSID)], "and one judge-errors row carries it")
+        jd.save_goals(self.QSID, s)
+        self.assertEqual(json.loads(self._file().read_text())["rompUuid"], self.QSID,
+                         "the fresh store is then published to the empty path")
+        self.assertEqual(aside[0].read_text(), "{not json", "...without touching the sidecar")
+        self.assertEqual(self._sidecars(), aside, "and quarantines nothing further")
+
+    def test_every_unparseable_shape_is_quarantined_not_replaced(self):
+        """A torn write, bytes that are not UTF-8, and valid JSON whose top level is not an object all
+        used to read as 'no file'. Each is moved aside; same-second quarantines get distinct names."""
+        self._seed()
+        for i, (payload, reason) in enumerate([(b"{\"rompUuid\": \"", "invalid JSON"),
+                                                (b"\xff\xfe{}", "not UTF-8"),
+                                                (b"[1, 2]", "not an object")], start=1):
+            with self.subTest(payload=payload):
+                self._file().write_bytes(payload)
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    s = jd.load_goals(self.QSID)
+                self.assertEqual(s["nodes"], {})
+                self.assertEqual(len(self._sidecars()), i, "one more sidecar per quarantine")
+                held = [p for p in self._sidecars() if p.read_bytes() == payload]
+                self.assertEqual(len(held), 1, "the bytes survive verbatim in exactly one sidecar")
+                self.assertIn(reason, err.getvalue())
+        self.assertEqual([r["err"] for r in self._error_rows()], ["store-quarantined"] * 3)
+
+    def test_an_absent_file_is_a_fresh_store_with_no_quarantine_and_no_error(self):
+        self.assertFalse(self._file().exists())
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            s = jd.load_goals(self.QSID)
+        self.assertEqual(s["nodes"], {})
+        self.assertEqual(s["_baseRev"], 0, "a writer that CREATES the file still trips the CAS")
+        self.assertEqual(self._sidecars(), [], "nothing to move aside")
+        self.assertEqual(err.getvalue(), "", "nothing to complain about")
+        self.assertEqual(self._error_rows(), [])
+        jd.save_goals(self.QSID, s)
+        self.assertTrue(self._file().exists(), "an absent file is a create, exactly as before")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -16,11 +16,13 @@ stamp (those remain the 6h backstop's job, the one case a timer is the only tool
 
 SYNTHETIC fixtures only: placeholder UUIDs, invented task descriptions.
 """
+import errno
 import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -126,6 +128,28 @@ class AwaitingLift(unittest.TestCase):
         self.assertIsNotNone(self._stamp(), "precondition: the goal starts stamped")
         self._tick()
         self.assertIsNone(self._stamp(), "every dispatch came back → the wait is over")
+
+    def test_a_faulting_store_forgets_the_gate_so_the_next_tick_retries(self):
+        """The inputs gate (_lift_seen) is recorded before the store read; a read FAULT must forget it,
+        exactly as a raised ruling does, or the next tick over the same inputs would skip the session
+        and the lift would wait for the transcript to change."""
+        self._transcript([_launch("t1", LAUNCH), _launch("t2", LAUNCH + 5),
+                          _notification("t1", BACK), _notification("t2", BACK + 5)])
+        self._seed()
+        km._lift_seen.pop(SID, None)
+        km.jd._STORE_FAULTS.pop(SID, None)
+        target, orig = km.jd.GOALDIR / (SID + ".json"), Path.read_text
+
+        def faulting(path, *a, **kw):
+            if path == target:
+                raise OSError(errno.EIO, "Input/output error", str(path))
+            return orig(path, *a, **kw)
+        with mock.patch.object(Path, "read_text", faulting):
+            self._tick()
+        self.assertIsNotNone(self._stamp(), "nothing is written to a store that could not be read")
+        self.assertNotIn(SID, km._lift_seen, "the gate is forgotten on a fault, not spent...")
+        self._tick()
+        self.assertIsNone(self._stamp(), "...so the very next tick, same inputs, retries and lifts")
 
     def test_one_still_running_keeps_the_stamp(self):
         self._transcript([_launch("t1", LAUNCH), _launch("t2", LAUNCH + 5),

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -7,6 +7,7 @@ cleared (exactly the cards the feed already hides), so the live store stays ≈ 
 (segment-id, phase) dedup lives in store["placements"], which compaction LEAVES in the live store, so the judge
 never re-mints an archived node. Undo-clear restores from the archive. Synthetic stores only (no live data).
 """
+import errno
 import json
 import os
 import shutil
@@ -14,6 +15,7 @@ import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -116,6 +118,31 @@ class GoalCompactionTest(unittest.TestCase):
             self.assertNotIn(SID, calls, "an unchanged store is not re-swept (steady state is just stats)")
         finally:
             km._compact_goal_store = orig
+
+    def test_g_an_unreadable_store_is_not_marked_seen_so_the_next_sweep_retries_it(self):
+        """A store the sweep could not READ (EIO, EACCES) is skipped for that sweep only: recording it as
+        swept would gate on an mtime that never moves (a permission fix changes no mtime), so it would
+        never be looked at again. Private synthetic sid; its journal lives in this test's temp root."""
+        other = "5d4c3b2a-1f0e-4d9c-8b7a-6f5e4d3c2b1a"
+        g = lambda n: "%s:%s" % (other, n)
+        jd.save_goals(other, {"rompUuid": other, "seq": 1, "lastNode": g("g1"), "placements": {},
+                              "nodes": {g("g1"): _node(g("g1"), None, cleared=True)},
+                              "status": {g("g1"): "cleared"}})
+        target, orig = jd.GOALDIR / (other + ".json"), Path.read_text
+
+        def faulting(path, *a, **kw):
+            if path == target:
+                raise OSError(errno.EIO, "Input/output error", str(path))
+            return orig(path, *a, **kw)
+        with mock.patch.object(Path, "read_text", faulting):
+            km._compact_goal_stores()
+        self.assertNotIn(other, km._compact_seen, "an unreadable store is not recorded as swept...")
+        self.assertFalse((jd.GOALARCHDIR / (other + ".json")).exists(), "...and nothing moved out of it")
+        self.assertIn(SID, km._compact_seen, "the other store was swept as usual")
+        km._compact_goal_stores()                     # the fault cleared; the file's mtime never moved
+        self.assertIn(other, km._compact_seen, "...so the next sweep retries it")
+        self.assertIn(g("g1"), json.loads((jd.GOALARCHDIR / (other + ".json")).read_text())["nodes"],
+                      "and archives its cleared top")
 
     def test_f_undo_clear_wires_in_the_archive_restore_before_unsetting_the_flag(self):
         import inspect

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -534,7 +534,10 @@ class TwoPhaseRewindTiming(unittest.TestCase):
         # tab-hover recents derived from it) read jd.load_goals raw and kept showing the doomed
         # asks for the whole armed window — unbounded on a bare delete
         src = inspect.getsource(km.build_session)
-        self.assertIn("gstore = _apply_rewind_hold(sid, jd.load_goals(sid))", src)
+        # the read goes through the per-session boundary (a faulting store renders an EMPTY tree
+        # instead of failing every tab's build), and the hold filter is applied to what it read
+        self.assertIn("gstore, gfault = jd.load_goals_or_fault(sid)", src)
+        self.assertIn("gstore = _apply_rewind_hold(sid, gstore)", src)
 
     def test_the_boot_pass_resolves_a_hold_the_transcript_moved_past_out_of_band(self):
         # bare rollback armed, kernel dies, the user continues the session CLI-natively: the OLD

--- a/tests/test_timeline_bars_resilience.py
+++ b/tests/test_timeline_bars_resilience.py
@@ -79,6 +79,7 @@ class FrameNeverSilentlyDies(unittest.TestCase):
         self.assertIn('_bars_complain(sid, "live-merge", e)', src)
         # seam refinement failing costs the seams, never the lane's bars
         self.assertIn('_bars_complain(sid, "seams", e)', src)
+        self.assertIn('_bars_complain(sid, "goals", gfault)', src)   # an unreadable goal store: lane without goal data
         self.assertIn('_bars_complain(sid, "judging-marks", e)', src)
         # the global stages are guarded ALONE — one malformed row costs that band, never the frame
         self.assertIn('_bars_complain("*", "messages", e)', src)


### PR DESCRIPTION
A goals file that cannot be read is never republished as an empty store: read faults raise and unparseable bytes are quarantined aside

One session's goals file that cannot be read or parsed is preserved and reported,
never replaced by an empty store, and never lets one session's fault take the board
down for every other session.

## Tier

- [x] `fix`: a bug fix, with a test that fails before it.

## The defect

Every reader in the goal store's save path answered a read failure with the
ABSENT-file value: load_goals swallowed any exception into a fresh store at
_baseRev 0, _disk_rev read 0, _matches_disk read "no match", _rebase_onto_disk
had "nothing to rebase onto". So on an I/O error, a permission fault, or a
torn/half-written file, save_goals found base 0 == disk 0 and published the
empty store over the user's goals file, destroying the only copy of everything
it held. ENOENT, EIO, EACCES and corrupt content all took the same branch.

## The fix

1. One strict reader, `_read_store_json(path, *, quarantine=False)`: an absent
   file reads as None (a session with no store yet); a read FAULT (EIO, EACCES,
   a directory at the path) RAISES, always; UNPARSEABLE content (invalid JSON,
   bytes that are not UTF-8, a top-level value that is not an object) is moved
   aside to `<file>.corrupt-<utc stamp>` when `quarantine` is set and read as
   None, and raises otherwise. load_goals reads with quarantine on, so a session
   starts fresh only after the bad bytes are preserved, with one stderr line and
   one `store-quarantined` judge-errors row recording the move. _disk_rev,
   _matches_disk and _rebase_onto_disk read strictly, so a fault or a corrupt
   file at save time raises out of save_goals and the file is left byte for byte
   as it was.

2. A per-session boundary, `jd.load_goals_or_fault(fsid)` -> `(store, None)` or
   `(None, exc)`. load_goals stays strict; this is where its raise is caught,
   filed and CONTAINED to the one session it is about. The first fault files one
   `store-unreadable` judge-errors row for that sid (the surface every
   per-session failure already reaches: `romp judges`, the feed's debug join); an
   identical repeat files nothing; a fault with different text is a new episode;
   a successful read of that sid ends the episode (the event, not a timer), so a
   later fault files again. It never hands back an empty store: a caller that
   gets `(None, exc)` skips that session's goal-derived work and writes nothing.

   Without it the strict raise reached nothing outside the judge passes: the
   feed builder's session loop (`_feed_goals`, its live fallback for any sid the
   pre-pass snapshot skipped), build_timeline, build_session's two reads, and the
   kernel's ticks all ran under the pusher's single outer try, so ONE faulting
   file made the pusher log a line and send nothing to any client, every cycle,
   for as long as the fault lasted; run_courier and run_propagate had no
   per-session catch, so a raise there skipped the grouper, consolidator and
   distiller for every session that pass; and a raise inside a WS gesture
   handler would have reached the receive loop's catch, which re-raises an
   OSError to the outer handler, where it is SWALLOWED and the client dropped
   (`except (BrokenPipeError, ConnectionResetError, OSError): pass` +
   `finally: client["alive"] = False`) - the dashboard disconnected without a
   word. A raise from load_goals is now contained per session at every kernel
   and judge site, not only in the pass wrappers:
   - routed through the boundary: `_feed_goals` + build_feed's loop (the
     faulting session renders with no goal-derived content: no cards, so no
     floors and no Analyzing swirl, which land only on cards; the provisional
     card is gated off, since "the planner has not placed this yet" is an
     inference from placements we could not read; a render-only stand-in that is
     never saved), build_feed's peer-store read for the origin badge (a sender
     whose store faults reads absorbed), build_timeline (the lane renders without
     goal-derived data and `_bars_complain(sid, "goals", ...)` names it), both
     build_session reads (seams off, an empty ledger tree, the tab still builds),
     `_followup_body`, `_record_interrupt_block`, `_lift_interrupt_block` (which
     returns False on a fault so `_interrupt_block_tick` KEEPS the intrBlocked
     marker and retries the lift next tick - erasing it would have left romp's
     own block on the card with no tick ever looking again) and `_intr_block_stands`
     (an unreadable store reads as "the block still stands", so a SECOND stop
     during the fault keeps the marker too instead of popping it and failing to
     re-block through the same fault), `_lift_spent_awaiting`
     (the gate is forgotten so the next cycle retries), `_auto_nudge_session`,
     `_compact_goal_store` (+ the sweep does not mark an unreadable store as seen,
     since its mtime never moves), `_mark_nodes_cleared` and `_restore_goal_archive`
     (the faulting session is skipped and RETURNED as `{sid: fault}`; `_clear_all`,
     `_clear_ask` and `_undo_clear` pass that up, and the WS `askClear`, `clear`,
     `clearAll` and `undoClear` ops answer the socket that made the gesture with
     the feed's `err` dialog - `_gesture_store_refusal` - because a refusal of a
     user gesture must reach the user, not only the judge-errors log. The dialog
     says what happened, in `text`, with no promise, and three different things
     can have happened: a whole-card clear (askClear, Clear-all; one dialog per
     session, worded for any number of cards) DID take the cards off the board -
     cleared.jsonl hides top cards on its own - but the durable flag was not
     written into a goals file romp could not read; a sub-goal drop (the modal's
     Drop, sub-task-only) changed NOTHING, because a sub row renders from the node
     flag alone, the very write the fault refused, so the user is told to try
     again (a retry appends a fresh row and sets the flag); an undo restored
     nothing and the next Undo retries it. It sends no `copy`, which by contract
     is the USER'S undelivered text - the feed renders it as a "Copy my text"
     button and folds it into the bell entry. `_undo_clear` keeps a faulting
     session's ids OWED in every fault shape: a compacted card's restore read
     faults, so its ids are never journaled as undone; an id that was journaled
     (an uncompacted card, whose restore step has nothing to read; or a store that
     faults between the restore and the flag step) whose flag step then could not
     run is re-journaled as cleared. Either way those ids stay the newest cleared
     batch and the next Undo restores exactly them. Journaling every id first
     consumed the batch and the nodes stayed in the archive for good; journaling
     last is not an option, since the reopen verdict's gate needs the undo row on
     disk before the flag step; and a node left restored-but-flag-cleared would be
     hidden exactly like the clear, with its undo spent and no modal op able to
     reach it (resolve and clear are the only two). Found by the Clear-all test:
     the WS clearAll handler indexed `d["items"]`, a payload key build_feed no
     longer emits, and raised before _clear_all ran - Clear-all cleared nothing and
     only a stderr line knew; it now reads `d.get("items") or []`), `_goal_segments`, `_cards_for_segments`, propagate's `_ref_goal` (a
     faulting recipient joins to nothing this pass, the tracker stays open; it
     files a `store-unreadable` row through the boundary, not `pass-crash`), and
     the index tier's `tasks_for` (no caption tasks for that session this pass);
   - run_courier and run_propagate: a per-session try around every store read
     files the same `pass-crash` row the other passes file and continues - the
     courier's own-session read, a relayed message's sender, a pending message's
     recipient and its sender, and the root walk (a faulting peer on the walk
     skips that message this pass rather than minting an "unrooted" top);
     propagate's recipient scan and the sender's store;
   - every remaining direct load_goals call sits inside an existing per-session
     catch: the planner/grouper/consolidator/closer/unblocker/distiller pass
     wrappers and the rewound-reconcile loop (`pass-crash` / `rewound-reconcile`
     rows), the courier's link-repair try, the kernel's per-session tick and
     sweep catches (dead-wait sweep, awaiting-wake outcomes, deferral sweep, debt
     escalation, episode boundary, message-summary scan, nudge-failed, interrupt
     marker check, wake, fork seeding, stamp read, background-task tops), the WS
     gesture handlers that answer the client with an error (resolve, decision),
     `_drop_goals_after` (a `revert-failed` row), the follow-up reopen (stderr),
     best-effort decorations that return None/{}/[] on any failure, and CLI-only
     entry points (--ab-close, --ab-classify, the echo backfill).

## The old test asserted the defect

tests/test_judge_store_noop_publish.py's
test_an_unreadable_file_falls_through_to_a_real_write wrote "{not json" over a
published store and expected the file to be REPLACED by a fresh one. It is
rewritten as UnparseableStore: the bad bytes must be in a .corrupt-* sidecar,
verbatim, before the fresh store is published to the emptied path.

Unchanged: an absent file is still a fresh store and a create, with no
quarantine and no error; no file lock is taken (this codebase takes none), so
the quarantine rename shares save_goals' documented window with a concurrent
republish; the kernel's pre-pass feed snapshot (which reads the files itself) is
not touched here. The cleared-goal ARCHIVE keeps its swallow-then-blind-write
shape (load_goal_archive reads any fault as an empty archive; save_goal_archive
republishes), so the same fault class can still empty an archive - a follow-up,
not touched here.

## Tests

Fail on main unless marked; the boundary module also fails with the strict
reader alone (the raise escapes build_feed, _push, run_courier, run_propagate
and tasks_for).

  tests/test_judge_store_noop_publish.py::UnparseableStore
    test_an_unparseable_file_is_quarantined_aside_then_a_fresh_store_is_written
    test_every_unparseable_shape_is_quarantined_not_replaced
    test_an_absent_file_is_a_fresh_store_with_no_quarantine_and_no_error (passes
      on main: pins that ENOENT is unchanged)
  tests/test_judge_store_cas.py::ReadFaultCas
    test_a_read_fault_raises_from_load_instead_of_reading_as_an_empty_store
    test_a_read_fault_at_save_publishes_nothing_and_the_file_is_untouched
    test_a_file_corrupted_after_load_is_not_overwritten_by_the_save
    test_disk_rev_reads_zero_only_for_an_absent_file
    test_matches_disk_and_rebase_raise_on_a_fault_or_a_corrupt_file
  tests/test_goal_store_fault_boundary.py
    FeedBoundary: one faulting store costs that session only and files one row
      per episode (repeat files nothing, a successful read re-arms; the origin
      badge whose sender faults reads absorbed and comes back live); the
      faulting file is never written (passes on main: pins containment/no-write);
      the provisional card is not inferred from a store that faulted (and is back
      once it reads); the timeline frame ships with one lane faulting and
      `_bars_complain` names it; the chat tab builds with its store faulting
      (seams off, empty ledger tree, one row)
    PushBoundary: one faulting store does not stop the push (a feed payload with
      the healthy session's card reaches the client)
    InterruptLiftBoundary: a fault at the re-engage tick keeps the intrBlocked
      marker and writes nothing; the next healthy tick lifts the block and
      spends the marker; a second stop during the fault keeps it too, and once
      the file reads the re-engage lifts romp's own block
    TriagePassBoundary: run_courier and run_propagate continue past a faulting
      session and file its pass-crash row; the courier files a faulting relayed
      sender, a faulting re-read recipient and a faulting pending sender each
      as its own row and moves on; a root walk that hits a faulting peer skips
      the message (no recipient top minted, the message stays pending); propagate
      leaves a faulting sender's tracker for the next pass and joins a faulting
      recipient to nothing (one store-unreadable row, the tracker unwritten); the
      index tier captions the healthy session when one store faults
    GestureRefusal (through the real WS dispatcher): an undo whose session faults
      answers the socket with an `err` whose text names the fault, says the cards
      were not restored and that the next Undo retries them, and carries no
      `copy`; it writes nothing and keeps the archive; the per-card clear
      (askClear) answers with what happened (card off the board, flag not written,
      no `copy`); Clear-all across two cards of one session answers once, plural-
      safe and true, and clears (the `items` crash); a sub-goal drop on a REAL child
      node gets its own account, the row still renders un-cleared afterwards, and
      a healthy retry clears it; a compacted card's undo skipped for one session
      journals only the other session's undo rows and the next Undo restores
      exactly the skipped ids; an uncompacted card's undo, and an undo whose fault
      first appears at the flag step, both stay owed and are restored by the next
      Undo; a gesture that reaches every session says nothing (passes on main: a
      pin)
  tests/test_kernel_goal_compaction.py: an unreadable store is not marked seen,
    so the next sweep retries it and archives its cleared top
  tests/test_kernel_awaiting_lift.py: a faulting store forgets the inputs gate
    (_lift_seen) so the very next tick retries and lifts
  tests/test_timeline_bars_resilience.py: pins `_bars_complain(sid, "goals", gfault)`
    among the per-lane stages

Each per-session catch was checked against the mutant that restores the bare
read (every courier and propagate site, the provisional gate, the compaction
seen-mark, the _lift_seen forget, the timeline complain, both build_session
reads, the origin-badge peer read): each mutant is killed by the test named for
it above.

tests/test_kernel_rewind.py's source pin on build_session's ledger read is
updated to the boundary-routed shape (the hold filter still applies).

Ran, one module at a time (the full suite is not run on the maintainer's devbox
per the 2026-09-07 ruling; CI runs it): against the final tree,
tests/test_goal_store_fault_boundary.py (23 passed) and tests/test_kernel.py (464
passed); the wider sweep of the seven test modules the commit touches plus the 25
modules that pin or exercise the changed functions (32 single-module runs, 1643
passed, 0 failed) ran one revision earlier, before the final _undo_clear and
dialog-text shape. No .bats exercises this change (the only one naming judge.py
does so in comments). The five webview tests that read judge.py were re-checked
against the new source with their own JUDGE/JUDGE_FLAT transforms (21
match/includes targets, all hit; node_modules is absent on that machine, so they
were not executed via npm; judge.py is unchanged since). Against an origin/main
copy, the boundary module fails 21 of 23 (the two marked above pass), and the
compaction, awaiting-lift and timeline-bars additions each fail. Deleting the
re-journaled clear for a flag step that could not run fails exactly the
uncompacted-undo and flag-step-fault tests.

Every new test uses a private synthetic sid and cleans its override journal in
tearDown.



## Tier

**fix** — a bug fix with tests that fail before it. A fork author cannot apply labels here; asking a maintainer to apply `fix`.

## Notes for review

- Tests were run per module on the development machine (the boundary module, the judge-store modules and the modules that pin the changed functions, one process at a time); the full suite is left to this PR's CI.
- This also fixes a pre-existing bug the new dispatcher test exposed: the WS `clearAll` handler indexed a payload key the feed no longer sends, so Clear-all had silently done nothing. It is a one-token change with its own test; say if you would rather have it as a separate PR.
- **#1003** and **#1009** (perf counters, pane telemetry) add `load_goals` call sites; they do not touch the store readers this changes, so a rebase should be clean either way.
- The cleared-goal ARCHIVE readers keep their old swallow-then-write shape (named in the body); a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
