### PR TITLE
Flag, order and bell writes are refused when their state file can't be read, never written over an empty

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -633,6 +633,19 @@ State is written under `${XDG_STATE_HOME:-~/.local/state}/romp/`. Transcripts
 are read in place from where Claude Code writes them (`~/.claude/projects/`)
 and never copied.
 
+Three small files there hold settings you set by hand: `session-flags.json`
+(per-session flags, the postal isolation switch among them), `session-order.json`
+(the saved tab and lane order) and `notify-cards.json` (the bell overrides). A
+change to one of them is refused, never written over an empty, when the file
+exists but cannot be read; the refusal reaches the dashboard's error center
+under the `not saved` kind, with the reason, and the same change can be tried
+again. A file whose bytes cannot be parsed (a torn write) is moved aside, never
+deleted, to `<file>.corrupt-<UTC stamp>` in the same directory (a `-1`, `-2`
+suffix when two land in the same second), the store starts over empty, and an
+entry under the same kind says so. A file that cannot be read at all keeps
+showing its last-read values until it can. Nothing here needs a restart; the
+sidecars are yours to inspect or delete.
+
 ## Switches
 
 Effective immediately, no restart.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2278,10 +2278,22 @@ def _state_quarantine(p, st, reason):
         return "could not be moved aside: %s" % _errno_text(e)
     sys.stderr.write("romp-kernel: %s could not be parsed (%s); moved aside to %s, the store reads as empty\n"
                      % (p.name, reason, aside.name))
+    # The dashboard hears it too (review find, 2026-09-08): a quarantine resets the store to EMPTY, so
+    # every bell override, lane flag (postal isolation included) or saved lane order it held reads as
+    # a default from here on, and the stderr line alone left that looking like settings resetting
+    # themselves. One notice, under the bell's `refused` kind (a setting that did not hold, not a
+    # machine sync); no dedupe registry: the next read of this path is an ENOENT, so a corrupt file
+    # speaks exactly once. Guarded like _note_state_fault: a notice never turns a successful move
+    # into a raise.
+    try:
+        _sync_notice("%s could not be parsed and was moved aside to %s; the settings it held start over "
+                     "empty until you set them again" % (p.name, aside.name), ok=False, kind="refused")
+    except Exception:
+        pass
     return None
 
 
-def _read_state_json(path, st=None, _tries=3):
+def _read_state_json(path, st=None, expect=None, _tries=3):
     """The ONE strict reader for a small JSON state file (session-flags, session-order, notify-cards;
     timeline-views follows in its own change). Distinguishes the outcomes the old `except Exception: {}` conflated:
       - a MISSING file is legitimately empty            -> returns None (a fresh install has no files)
@@ -2293,6 +2305,11 @@ def _read_state_json(path, st=None, _tries=3):
         rename is left alone and read afresh here, bounded by `_tries` (the maintainer's fold on
         PR #1019), so the caller gets what is there now -- only a file that keeps changing under
         every read ends _StateUnreadable.
+      - valid JSON of the WRONG top-level type           -> quarantined the same way, when the caller
+        names the store's shape in `expect` (dict for the flags and bells, list for the order). Read
+        as empty instead, a list where a dict belongs was overwritten by the next writer, and a file
+        none of our writers produce is exactly the evidence worth keeping (review find, 2026-09-08).
+        None skips the check.
     `st` is the stat the caller already took (the display readers key their cache on it); without
     one the reader stats first, so the quarantine can tell the file it read from one published
     since. Reads bytes (json.loads accepts them and auto-detects the encoding), so a non-UTF-8 torn
@@ -2313,14 +2330,23 @@ def _read_state_json(path, st=None, _tries=3):
     except OSError as e:
         raise _StateUnreadable(path, "read failed: %s" % _errno_text(e))
     try:
-        return json.loads(raw)
+        data = json.loads(raw)
     except (ValueError, UnicodeDecodeError) as e:
         why = _state_quarantine(path, st, "invalid JSON: %s" % e)
         if why is None:
             return None                              # the bytes are preserved; the store starts empty
         if why == _STATE_REPLACED and _tries > 1:    # a peer published since our stat: read what is there now
-            return _read_state_json(path, None, _tries=_tries - 1)
+            return _read_state_json(path, None, expect=expect, _tries=_tries - 1)
         raise _StateUnreadable(path, "invalid JSON; %s" % why)
+    if expect is not None and not isinstance(data, expect):
+        why = _state_quarantine(path, st, "wrong shape: %s where %s was expected"
+                                % (type(data).__name__, expect.__name__))
+        if why is None:
+            return None
+        if why == _STATE_REPLACED and _tries > 1:
+            return _read_state_json(path, None, expect=expect, _tries=_tries - 1)
+        raise _StateUnreadable(path, "wrong shape; %s" % why)
+    return data
 
 
 # Last-known-good session order (session-order.json has no mtime cache): served over a transient
@@ -2346,8 +2372,9 @@ def _note_state_fault(exc):
     quiet until a clean read clears it. The value the reader returns is UNPROVED (last-known or the
     empty default) and no writer will persist it -- the mutation path reads the proved snapshot,
     which raises and refuses. Never raises itself. The sync-notice ring is the surface the views
-    store's stale-writer guard already uses (the shell's bell files it under its sync label); a
-    dedicated kernel-fault surface is a follow-up. A WRITE fault (_StateUnwritable, from
+    store's stale-writer guard already uses; the row carries the bell's `refused` kind (review find,
+    2026-09-08: filed under the ring's default sync kind, a user who muted the machine-sync log muted
+    every disk-fault notice with it, and the chip named a sync that moved no commits). A WRITE fault (_StateUnwritable, from
     _write_state_json) files once per episode too, keyed on the same path but in its own table
     (_state_write_fault_seen): only a landed write ends a write episode, where a clean read ends a
     read one."""
@@ -2364,7 +2391,7 @@ def _note_state_fault(exc):
     table[key] = text
     sys.stderr.write("romp-kernel: %s\n" % text)
     try:
-        _sync_notice(text, ok=False)                 # the shell bell / feed sync-notice row (resolved at call time)
+        _sync_notice(text, ok=False, kind="refused")   # the shell bell / feed sync-notice row (resolved at call time)
     except Exception:
         pass
 
@@ -2421,7 +2448,7 @@ def _session_order():
     refuses); the fault is loud once per episode (a sync-notice), never a raise into the build path."""
     p = jd.STATE / "session-order.json"
     try:
-        raw = _read_state_json(p)
+        raw = _read_state_json(p, expect=list)
     except _StateUnreadable as e:
         # DISPLAY path: never raise into the push (one outer try would abort every client's build).
         _note_state_fault(e)
@@ -2438,7 +2465,7 @@ def _session_order_proved():
     reorder every tab/lane on a transient EIO, under no gesture). Only a missing (or
     freshly-quarantined) file reads as empty; no last-known-good -- a writer acts on the real store
     or not at all."""
-    raw = _read_state_json(jd.STATE / "session-order.json")
+    raw = _read_state_json(jd.STATE / "session-order.json", expect=list)
     return [x for x in raw if isinstance(x, str)] if isinstance(raw, list) else []
 
 
@@ -2633,7 +2660,10 @@ def _ordered(sessions):
         lkg = _session_order_lkg[0] or []
         idx0 = {sid: i for i, sid in enumerate(lkg)}
         return sorted(sessions, key=lambda s: idx0.get(s["sid"], len(idx0)))
-    _session_order_lkg[0] = order
+    _session_order_lkg[0] = list(order)   # a COPY of the clean read: `order` is spliced below and only
+    #                                       _write_session_order latches the spliced list, AFTER it lands
+    #                                       (review find, 2026-09-08: latched by reference, a publish that
+    #                                       failed left an unpersisted order as the known-good)
     known = set(order)
     # Slot inheritance keys on the STABLE session NAME (customTitle), NOT the fsid or discover's anchor: a
     # /clear, relaunch, or revive mints a NEW transcript fsid for the SAME logical session, and it must
@@ -3362,7 +3392,7 @@ def _session_flags_proved():
     _set_session_flag / _set_notify_session refuse rather than writing a fabricated {} back over
     every session's flags -- including the postalServiceOff isolation boundaries -- under a success
     ack (the state-readers audit). Only a missing (or freshly-quarantined) file reads as empty."""
-    raw = _read_state_json(jd.STATE / "session-flags.json")
+    raw = _read_state_json(jd.STATE / "session-flags.json", expect=dict)
     return raw if isinstance(raw, dict) else {}
 
 
@@ -3384,7 +3414,7 @@ def _session_flags():
         _clear_state_fault(p)
         return hit[1]
     try:
-        raw = _read_state_json(p, st)
+        raw = _read_state_json(p, st, expect=dict)
     except _StateUnreadable as e:
         _note_state_fault(e)
         return hit[1] if hit is not None else {}
@@ -3485,7 +3515,7 @@ def _notify_cards_proved():
     refuse rather than writing a fabricated {} back over every per-card, session and master bell
     override under a success ack (the state-readers audit). Only a missing (or freshly-quarantined)
     file reads as empty."""
-    raw = _read_state_json(jd.STATE / "notify-cards.json")
+    raw = _read_state_json(jd.STATE / "notify-cards.json", expect=dict)
     return raw if isinstance(raw, dict) else {}
 
 
@@ -3507,7 +3537,7 @@ def _notify_cards():
         _clear_state_fault(p)
         return hit[1]
     try:
-        raw = _read_state_json(p, st)
+        raw = _read_state_json(p, st, expect=dict)
     except _StateUnreadable as e:
         _note_state_fault(e)
         return hit[1] if hit is not None else {}
@@ -15238,11 +15268,16 @@ _SYNC_SEQ = 0
 SYNC_RING = 40
 
 
-def _sync_notice(text, ok=True):
+def _sync_notice(text, ok=True, kind="sync"):
+    """One row on the ring the shell's bell mirrors. `kind` is the bell kind the row is filed under:
+    "sync" (the default, the ring's original tenant: a machine sync) or "refused" (a state file that
+    could not be read or written, or was moved aside), so a mute on one never hides the other (review
+    find, 2026-09-08). The shell allowlists the value; anything it does not know reads as sync."""
     global _SYNC_SEQ
     with _SYNC_LOCK:
         _SYNC_SEQ += 1
-        _SYNC_NOTICES.append({"seq": _SYNC_SEQ, "t": time.time(), "text": str(text), "ok": bool(ok)})
+        _SYNC_NOTICES.append({"seq": _SYNC_SEQ, "t": time.time(), "text": str(text), "ok": bool(ok),
+                              "kind": str(kind or "sync")})
         del _SYNC_NOTICES[:-SYNC_RING]
 
 
@@ -15257,7 +15292,7 @@ def _sync_notice_rows(limit=20, cap=300):
     with _SYNC_LOCK:
         rows = list(_SYNC_NOTICES[-limit:])
     return [{"sig": "sync|%d|%d" % (int(_STARTED), r["seq"]), "t": float(r["t"]),
-             "text": r["text"][:cap], "ok": bool(r["ok"])} for r in rows]
+             "text": r["text"][:cap], "ok": bool(r["ok"]), "kind": str(r.get("kind") or "sync")} for r in rows]
 
 
 def _auto_push_remote(host):
@@ -33982,7 +34017,7 @@ sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an 
 sync:"romp moved commits between your machines by itself \u2014 a push to a remote, a pull from one, or an ask that a peer fast-forward itself. Successes are logged as well as failures, so this is the record of what romp did to your machines; the network panel shows a sync while it is still running",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
 cleared:"a /clear in a session dropped still-open cards at the boundary; Undo on the feed restores them",
-refused:"a change you made \u2014 a lane or tab setting, a card bell, a tag or view, a lane order \u2014 was not saved because the file that holds it could not be read or written; nothing changed, the entry carries the reason, and the same change can be tried again",
+refused:"a setting that could not be saved, or a state file that could not be read. A change you made \u2014 a lane or tab setting, a card bell, a lane order \u2014 was not saved because romp could not read or write the file that holds it; nothing changed, the entry carries the reason, and the same change can be tried again. Or one of those files could not be read (the last values are shown until it can), or held bytes romp could not parse and was moved aside, so what it held starts over as defaults",
 undelivered:"something you sent never reached a session — the kernel it was addressed to has no session by that id, which on a board showing more than one machine means the pane addressed the wrong one. Nothing was delivered. Your text is kept verbatim in undelivered.jsonl under ~/.local/state/romp"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
@@ -35379,7 +35414,7 @@ function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Notificat
 function post(path,obj){return fetch(path,{method:'POST',body:JSON.stringify(obj)}).then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});
 return r.json().catch(function(){return {};});}).then(function(d){
-if(d&&d.ok===false)throw new Error(d.error||'the kernel refused it');   // a refusal in the route's own shape: the switch stays put and the reason toasts
+if(d&&d.ok===false&&d.error)throw new Error(d.error);   // a refusal in the route's own shape ({ok:false, error}): the switch stays put and the reason toasts. Only bodies carrying `error`: /push/test answers 200 {ok:false, status, detail} for a refused or unsubscribed test push, and its caller reads those itself (review find, 2026-09-08)
 return d;});}
 function b64u(s){var raw=atob((s+'==='.slice((s.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/'));
 var a=new Uint8Array(raw.length);for(var i=0;i<raw.length;i++)a[i]=raw.charCodeAt(i);return a;}
@@ -37720,12 +37755,14 @@ class Handler(BaseHTTPRequestHandler):
                 try:
                     _set_notify_all(_on)
                 except (_StateUnreadable, _StateUnwritable) as e:
-                    # the bells store could not be read, or its publish failed: refuse in the route's OWN
-                    # shape -- 200 with ok:false -- never a 5xx (a failed publish used to reach do_POST's
-                    # catch-all as a 500 traceback). The shell's post() reads ok:false as the refusal it is
-                    # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
-                    # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
-                    return self._send(200, json.dumps({"ok": False, "retryable": True,
+                    # the bells store could not be read, or its publish failed: refuse in the shape every
+                    # kernel refusal wears -- 200 with {ok:false, error}, as /send and /new answer theirs --
+                    # never a 5xx (a failed publish used to reach do_POST's catch-all as a 500 traceback).
+                    # The shell's post() consumes that shape; a non-2xx would reach it as raw JSON inside
+                    # an HTTP error, the toast showing a body instead of the reason. (An earlier comment
+                    # here credited `romp tag`'s curl -sf and the federation forward; neither calls this
+                    # route -- review find, 2026-09-08. No `retryable` key: nothing reads one.)
+                    return self._send(200, json.dumps({"ok": False,
                         "error": "%s \u2014 the change did not land; try again" % e}), "application/json")
                 _mark_views_dirty()
                 _send_to_app("shell", {"type": "notifyAll", "on": _on})
@@ -37741,12 +37778,14 @@ class Handler(BaseHTTPRequestHandler):
                 try:
                     _set_notify_turns(_on)
                 except (_StateUnreadable, _StateUnwritable) as e:
-                    # the bells store could not be read, or its publish failed: refuse in the route's OWN
-                    # shape -- 200 with ok:false -- never a 5xx (a failed publish used to reach do_POST's
-                    # catch-all as a 500 traceback). The shell's post() reads ok:false as the refusal it is
-                    # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
-                    # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
-                    return self._send(200, json.dumps({"ok": False, "retryable": True,
+                    # the bells store could not be read, or its publish failed: refuse in the shape every
+                    # kernel refusal wears -- 200 with {ok:false, error}, as /send and /new answer theirs --
+                    # never a 5xx (a failed publish used to reach do_POST's catch-all as a 500 traceback).
+                    # The shell's post() consumes that shape; a non-2xx would reach it as raw JSON inside
+                    # an HTTP error, the toast showing a body instead of the reason. (An earlier comment
+                    # here credited `romp tag`'s curl -sf and the federation forward; neither calls this
+                    # route -- review find, 2026-09-08. No `retryable` key: nothing reads one.)
+                    return self._send(200, json.dumps({"ok": False,
                         "error": "%s \u2014 the change did not land; try again" % e}), "application/json")
                 _send_to_app("shell", {"type": "notifyTurns", "on": _on})
                 return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2222,11 +2222,33 @@ class _StateUnreadable(Exception):
         super().__init__("%s could not be read (%s)" % (self.path.name, self.fault))
 
 
+class _StateUnwritable(Exception):
+    """A small JSON state file could not be WRITTEN -- ENOSPC, EROFS, EACCES out of the publish itself,
+    after the store read proved. The sibling of _StateUnreadable for the gesture's other step (the
+    maintainer's fold on PR #1019: a user gesture's WRITE step is a fault boundary too). Raised by
+    _write_state_json in place of the OSError, which the WS receive loop re-raised as a socket failure
+    and turned into a DROPPED client (`finally: client["alive"] = False`): the dashboard disconnected
+    without a word, and the HTTP routes answered a 500 traceback where their callers read only their
+    own ok:false shape. As a plain Exception the same escape costs one logged line, and the gesture
+    arms catch it beside _StateUnreadable and answer the socket. `path` and `fault` as its sibling's:
+    errno + strerror only, never the temp path (which carries a per-call sequence), so the per-path
+    fault registry dedupes a disk that stays full."""
+
+    def __init__(self, path, fault):
+        self.path = Path(path)
+        self.fault = str(fault)
+        super().__init__("%s could not be written (%s)" % (self.path.name, self.fault))
+
+
 def _errno_text(e):
     """errno + strerror ONLY: str(e) names the path(s), and a quarantine destination carries a
     per-second stamp, so a text built from it changed every second and every once-per-fault-text
     dedupe fired once a second (the ledgers' lesson)."""
     return ("[Errno %d] %s" % (e.errno, e.strerror)) if getattr(e, "errno", None) is not None else type(e).__name__
+
+
+_STATE_REPLACED = "replaced meanwhile; the new bytes get their own read"   # _state_quarantine's decline when the
+#                                        file is no longer the one whose bytes failed: the reader re-reads (bounded)
 
 
 def _state_quarantine(p, st, reason):
@@ -2235,14 +2257,15 @@ def _state_quarantine(p, st, reason):
     suffix for a second in the same second) -- the shape the goal-store and ledger quarantines wear,
     so one convention reads across all three. Only while the file is still the one whose bytes
     failed (same inode, mtime and size as `st`, the stat taken before the read): an atomic publish
-    that landed before the re-check already replaced them, and the new file gets its own read (the
-    window left is between the re-check and the os.replace). Returns None once the
-    bytes are out of the way (moved, or already gone: a sibling reader moved them), with one stderr
-    line for the move; else the reason they are NOT, for the caller's fault text."""
+    that landed before the re-check already replaced them, and the new file gets its own read
+    (_STATE_REPLACED: _read_state_json re-reads, bounded -- the maintainer's fold on PR #1019; the
+    window left is between the re-check and the os.replace). Returns None once the bytes are out of
+    the way (moved, or already gone: a sibling reader moved them), with one stderr line for the move;
+    else the reason they are NOT, for the caller's fault text."""
     try:
         cur = p.stat()
         if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
-            return "replaced meanwhile; the new bytes get their own read"
+            return _STATE_REPLACED
         stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
         aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
         while aside.exists():                            # a second corrupt file in the same second
@@ -2258,16 +2281,18 @@ def _state_quarantine(p, st, reason):
     return None
 
 
-def _read_state_json(path, st=None):
+def _read_state_json(path, st=None, _tries=3):
     """The ONE strict reader for a small JSON state file (session-flags, session-order, notify-cards;
     timeline-views follows in its own change). Distinguishes the outcomes the old `except Exception: {}` conflated:
       - a MISSING file is legitimately empty            -> returns None (a fresh install has no files)
       - an UNREADABLE existing file (EIO/EACCES/...)     -> raises _StateUnreadable (never reads empty)
       - TORN or non-JSON bytes                           -> QUARANTINED aside (_state_quarantine: a move,
         never a delete -- the evidence survives for forensics), then None, so the store starts empty
-        ONLY after the bad bytes are preserved; bytes that could not be moved aside, or a file
-        replaced between the stat and the rename, raise _StateUnreadable instead (the next read is
-        a fresh one).
+        ONLY after the bad bytes are preserved; bytes that could not be moved aside raise
+        _StateUnreadable instead; a file a peer's atomic publish REPLACED between the stat and the
+        rename is left alone and read afresh here, bounded by `_tries` (the maintainer's fold on
+        PR #1019), so the caller gets what is there now -- only a file that keeps changing under
+        every read ends _StateUnreadable.
     `st` is the stat the caller already took (the display readers key their cache on it); without
     one the reader stats first, so the quarantine can tell the file it read from one published
     since. Reads bytes (json.loads accepts them and auto-detects the encoding), so a non-UTF-8 torn
@@ -2293,6 +2318,8 @@ def _read_state_json(path, st=None):
         why = _state_quarantine(path, st, "invalid JSON: %s" % e)
         if why is None:
             return None                              # the bytes are preserved; the store starts empty
+        if why == _STATE_REPLACED and _tries > 1:    # a peer published since our stat: read what is there now
+            return _read_state_json(path, None, _tries=_tries - 1)
         raise _StateUnreadable(path, "invalid JSON; %s" % why)
 
 
@@ -2306,6 +2333,11 @@ _session_order_lkg = [None]
 # stderr line + one dashboard notice; a repeat of the SAME text files nothing; a clean read clears
 # the entry (the event, no timer) so a recovered-then-refaulted file speaks again.
 _state_fault_seen = {}
+# The WRITE faults' own table, same key (str(path)): a clean READ ends a read episode, not a write one --
+# the display readers clear _state_fault_seen on every clean read, and a gesture's refusal reads the store
+# to name the value it still paints, so a write fault filed there was cleared before the next click and
+# said again per click. Only a landed write (_write_state_json) clears an entry here.
+_state_write_fault_seen = {}
 
 
 def _note_state_fault(exc):
@@ -2315,13 +2347,21 @@ def _note_state_fault(exc):
     empty default) and no writer will persist it -- the mutation path reads the proved snapshot,
     which raises and refuses. Never raises itself. The sync-notice ring is the surface the views
     store's stale-writer guard already uses (the shell's bell files it under its sync label); a
-    dedicated kernel-fault surface is a follow-up."""
+    dedicated kernel-fault surface is a follow-up. A WRITE fault (_StateUnwritable, from
+    _write_state_json) files once per episode too, keyed on the same path but in its own table
+    (_state_write_fault_seen): only a landed write ends a write episode, where a clean read ends a
+    read one."""
     key = str(exc.path)
-    text = ("%s — showing the last-known value; changes to it are refused until the file can be "
-            "read again" % exc)
-    if _state_fault_seen.get(key) == text:
+    if isinstance(exc, _StateUnwritable):
+        table = _state_write_fault_seen
+        text = "%s — the change was not saved; changes to it are refused until the file can be written again" % exc
+    else:
+        table = _state_fault_seen
+        text = ("%s — showing the last-known value; changes to it are refused until the file can be "
+                "read again" % exc)
+    if table.get(key) == text:
         return
-    _state_fault_seen[key] = text
+    table[key] = text
     sys.stderr.write("romp-kernel: %s\n" % text)
     try:
         _sync_notice(text, ok=False)                 # the shell bell / feed sync-notice row (resolved at call time)
@@ -2336,7 +2376,8 @@ def _clear_state_fault(path):
 
 def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", value=None):
     """A dashboard gesture (a lane/tab flag, a card bell, a drag, a view change) that this kernel
-    REFUSED because the store it edits could not be read: one stderr line, and the refusal answered
+    REFUSED because the store it edits could not be read -- or, since the maintainer's fold on PR
+    #1019, WRITTEN (_StateUnwritable: the publish itself failed): one stderr line, and the refusal answered
     on the DELIVERING socket as a `settingRefused` frame -- the same targeted _reply idiom the
     settingStale stand-down and the saveFile acks use, never a broadcast. The frame names the
     `gesture` ("flag" / "bell" / "order"; "views" follows with its store, so a pane never infers it from which fields are
@@ -2403,6 +2444,25 @@ def _session_order_proved():
 
 _atomic_lock = threading.Lock()
 _atomic_seq = [0]
+
+
+def _write_state_json(path, text):
+    """The ONE write door for the small JSON state files (session-flags, session-order, notify-cards,
+    and the views store once its path folds in): _atomic_write, with the publish's OSError turned into
+    _StateUnwritable and the fault filed ONCE per episode on the path's registry (_note_state_fault, the
+    write faults' own table beside the read faults'); a landed write ends the episode. Left as an OSError, a publish that
+    failed under a WS gesture escaped the arm's `except _StateUnreadable` to the receive loop, which
+    re-raised it as a socket failure and dropped the client, and under an HTTP route reached do_POST's
+    catch-all as a 500 traceback (the maintainer's fold on PR #1019: the write step is a fault boundary
+    too). Defined here, beside _atomic_write, because _write_session_order below is its first caller."""
+    path = Path(path)
+    try:
+        _atomic_write(path, text)
+    except OSError as e:
+        exc = _StateUnwritable(path, "write failed: %s" % _errno_text(e))
+        _note_state_fault(exc)
+        raise exc from e
+    _state_write_fault_seen.pop(str(path), None)     # a landed write ends the write-fault episode
 
 
 def _atomic_write(path, text, mode=None):
@@ -2496,8 +2556,8 @@ def _write_session_order(order):
     # for the audit only: the DISPLAY read never raises (a fault serves the last-known order), so a
     # fault here cannot block the write -- the caller already read the store PROVED to build `order`
     _order_audit("persist", _session_order(), new)   # every mutation of the authoritative order, with its stack
-    _atomic_write(jd.STATE / "session-order.json", json.dumps(new))
-    _session_order_lkg[0] = new                      # what we just published IS the new known-good
+    _write_state_json(jd.STATE / "session-order.json", json.dumps(new))   # a failed publish raises _StateUnwritable:
+    _session_order_lkg[0] = new                      # what we just published IS the new known-good; nothing latched otherwise
 
 
 def _gc_session_order(known):
@@ -2514,7 +2574,10 @@ def _gc_session_order(known):
         return
     kept = [sid for sid in order if sid in known]
     if kept != order:
-        _write_session_order(kept)
+        try:
+            _write_session_order(kept)
+        except _StateUnwritable:
+            pass                                     # filed once per episode by the write door; the next pass retries
 
 
 def _merge_session_order(incoming):
@@ -2596,7 +2659,11 @@ def _ordered(sessions):
             else:
                 order.append(sid)                        # a genuinely new session appends, then is frozen
                 name_at.append(a)
-        _write_session_order(order)
+        try:
+            _write_session_order(order)
+        except _StateUnwritable:
+            pass                                         # this build still sorts by the in-memory order; the publish
+            #                                              is filed once per episode and the next pass retries it
     idx = {sid: i for i, sid in enumerate(order)}
     return sorted(sessions, key=lambda s: idx.get(s["sid"], len(idx)))   # stable sort: ties keep input order
 
@@ -3353,7 +3420,7 @@ def _set_session_flag(sid, flag, value):
         cur[sid] = f
     else:
         cur.pop(sid, None)
-    _atomic_write(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
+    _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
     if flag == "hideFromFeed" and value:
         # Muting takes the session OUT of task tracking → VIEW-CLEAR its current goals: seal them exactly like
         # crossing each card off the feed (cleared.jsonl + the durable node flag), NOT delete — they stay on
@@ -3461,7 +3528,7 @@ def _set_notify_all(value):
         cur[NOTIFY_ALL_KEY] = True
     else:
         cur.pop(NOTIFY_ALL_KEY, None)
-    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+    _write_state_json(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
 
 
 def _notify_turns_on():
@@ -3477,7 +3544,7 @@ def _set_notify_turns(value):
         cur[NOTIFY_TURNS_KEY] = True
     else:
         cur.pop(NOTIFY_TURNS_KEY, None)
-    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+    _write_state_json(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
 
 
 def _notify_session_effective(sid):
@@ -3515,7 +3582,7 @@ def _set_notify_card(item_id, value, sid=""):
         cur.pop(item_id, None)
     else:
         cur[item_id] = bool(value)
-    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+    _write_state_json(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
 
 
 def _set_notify_session(sid, value):
@@ -3538,7 +3605,7 @@ def _set_notify_session(sid, value):
         cur[sid] = f
     else:
         cur.pop(sid, None)
-    _atomic_write(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
+    _write_state_json(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
 
 
 def _prune_notify_cards(live_ids):
@@ -3555,7 +3622,10 @@ def _prune_notify_cards(live_ids):
     gone = [i for i in cur if i not in live_ids and i not in _NOTIFY_RESERVED]
     if gone:
         kept = {i: cur[i] for i in cur if i in live_ids or i in _NOTIFY_RESERVED}
-        _atomic_write(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
+        try:
+            _write_state_json(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
+        except _StateUnwritable:
+            pass                                     # filed once per episode by the write door; the next leaving card retries
 
 
 # ── Auto Nudge (the user 2026-06-19) ──────────────────────────────────────────────────────────────
@@ -33912,7 +33982,7 @@ sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an 
 sync:"romp moved commits between your machines by itself \u2014 a push to a remote, a pull from one, or an ask that a peer fast-forward itself. Successes are logged as well as failures, so this is the record of what romp did to your machines; the network panel shows a sync while it is still running",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
 cleared:"a /clear in a session dropped still-open cards at the boundary; Undo on the feed restores them",
-refused:"a change you made \u2014 a lane or tab setting, a card bell, a tag or view, a lane order \u2014 was not saved because romp could not read the file that holds it; nothing changed, the entry carries the reason, and the same change can be tried again",
+refused:"a change you made \u2014 a lane or tab setting, a card bell, a tag or view, a lane order \u2014 was not saved because the file that holds it could not be read or written; nothing changed, the entry carries the reason, and the same change can be tried again",
 undelivered:"something you sent never reached a session — the kernel it was addressed to has no session by that id, which on a board showing more than one machine means the pane addressed the wrong one. Nothing was delivered. Your text is kept verbatim in undelivered.jsonl under ~/.local/state/romp"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
@@ -37649,9 +37719,10 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(400, "bad json", "text/plain")
                 try:
                     _set_notify_all(_on)
-                except _StateUnreadable as e:
-                    # the bells store could not be read: refuse in the route's OWN shape -- 200 with
-                    # ok:false -- never a 5xx. The shell's post() reads ok:false as the refusal it is
+                except (_StateUnreadable, _StateUnwritable) as e:
+                    # the bells store could not be read, or its publish failed: refuse in the route's OWN
+                    # shape -- 200 with ok:false -- never a 5xx (a failed publish used to reach do_POST's
+                    # catch-all as a 500 traceback). The shell's post() reads ok:false as the refusal it is
                     # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
                     # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
                     return self._send(200, json.dumps({"ok": False, "retryable": True,
@@ -37669,9 +37740,10 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(400, "bad json", "text/plain")
                 try:
                     _set_notify_turns(_on)
-                except _StateUnreadable as e:
-                    # the bells store could not be read: refuse in the route's OWN shape -- 200 with
-                    # ok:false -- never a 5xx. The shell's post() reads ok:false as the refusal it is
+                except (_StateUnreadable, _StateUnwritable) as e:
+                    # the bells store could not be read, or its publish failed: refuse in the route's OWN
+                    # shape -- 200 with ok:false -- never a 5xx (a failed publish used to reach do_POST's
+                    # catch-all as a 500 traceback). The shell's post() reads ok:false as the refusal it is
                     # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
                     # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
                     return self._send(200, json.dumps({"ok": False, "retryable": True,
@@ -38963,9 +39035,11 @@ class Handler(BaseHTTPRequestHandler):
                     _set_notify_session(str(msg["id"]), bool(msg.get("value")))
                 else:
                     _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
-            except _StateUnreadable as e:
-                # the flags store could not be read: refuse on the DELIVERING socket, addressed to the
-                # toggle (sid + flag) so the lane gear / tab menu ends its optimistic state and says why
+            except (_StateUnreadable, _StateUnwritable) as e:
+                # the flags store could not be read, or its publish failed: refuse on the DELIVERING socket,
+                # addressed to the toggle (sid + flag) so the lane gear / tab menu ends its optimistic state
+                # and says why. Left as an OSError, the failed publish reached the receive loop and DROPPED
+                # this client (the maintainer's fold on PR #1019)
                 _refuse_setting(client, e, "that setting", "flag", sid=msg["id"], flag=msg["flag"],
                                 value=_painted_flag_value(str(msg["id"]), str(msg["flag"])))
             else:
@@ -39024,9 +39098,9 @@ class Handler(BaseHTTPRequestHandler):
             # the master) and deleted when it merely restates it.
             try:
                 _set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))
-            except _StateUnreadable as e:
-                # the bells store could not be read: refuse on the DELIVERING socket, addressed to the
-                # card (itemId) so the feed drops that bell's optimistic latch and says why
+            except (_StateUnreadable, _StateUnwritable) as e:
+                # the bells store could not be read, or its publish failed: refuse on the DELIVERING socket,
+                # addressed to the card (itemId) so the feed drops that bell's optimistic latch and says why
                 _refuse_setting(client, e, "that bell", "bell", sid=msg.get("sid") or "", item_id=msg["itemId"],
                                 value=bool(_notify_card_effective(_notify_cards(), str(msg["itemId"]), str(msg.get("sid") or ""))))
             else:
@@ -39243,15 +39317,15 @@ class Handler(BaseHTTPRequestHandler):
             # persisted one (don't overwrite): a chat-tab drag must not drop/reshuffle timeline-only lanes.
             try:
                 _merged = _merge_session_order(msg["order"])
-            except _StateUnreadable as e:
-                # the order file could not be read; the drag must not splice against a fabricated []
-                # and persist discovery order over the user's saved order. Refused on the delivering
-                # socket. (No shipped pane posts this op today -- the strip and the lanes write the
-                # viewer's own arrangement -- so the frame has no latch to release; the contract holds
+                _write_session_order(_merged)            # the publish too: a failed one is refused, never a
+            except (_StateUnreadable, _StateUnwritable) as e:   # dropped socket (the fold on PR #1019)
+                # the order file could not be read, or its publish failed; the drag must not splice against
+                # a fabricated [] and persist discovery order over the user's saved order. Refused on the
+                # delivering socket. (No shipped pane posts this op today -- the strip and the lanes write
+                # the viewer's own arrangement -- so the frame has no latch to release; the contract holds
                 # for the op all the same.)
                 _refuse_setting(client, e, "the new order", "order")
             else:
-                _write_session_order(_merged)
                 # _mark_views_dirty, NOT _push_all: the feed/timeline order the grouped cards CLIENT-side by this
                 # list, but a plain push serves the CACHED feed — reused for REBUILD_MIN_S (2s) even though the sig
                 # changed — so the reordered cards lagged up to ~2s before the dirty mark. The dirty mark bypasses

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2198,15 +2198,207 @@ def _alive_sessions(now, tmux):
     return _sessions(now)
 
 
+class _StateUnreadable(Exception):
+    """A small JSON state file EXISTS but could not be read -- a transient EIO, an EACCES, torn bytes
+    that could not be moved aside -- as opposed to a missing file. Raised by _read_state_json so a
+    read-modify-write writer REFUSES the write rather than folding the fault to an empty store and
+    publishing that emptiness back over the user's real state under a success ack (one such fold
+    erased a whole tag set, every session flag, the saved lane order, or every bell override,
+    silently). Callers on the MUTATION path let it propagate to a loud refusal; DISPLAY readers
+    serve their last-known-good cache if they hold one, else the empty default, UNPROVED and
+    uncached, so no writer persists it.
+
+    A plain Exception, deliberately NOT an OSError: the WS receive loop re-raises
+    `(BrokenPipeError, ConnectionResetError, OSError)` as a genuine socket failure and tears the
+    connection down, while any other exception falls to its logging arm and the next message still
+    processes. Were this an OSError, one handler branch that forgot to catch it would drop the
+    dashboard's socket on a read fault; as an Exception the same escape costs one logged line.
+    `path` is the file, `fault` the errno-and-strerror text (never the per-second quarantine stamp,
+    never a second path), so the once-per-fault-text registries dedupe a disk that stays broken."""
+
+    def __init__(self, path, fault):
+        self.path = Path(path)
+        self.fault = str(fault)
+        super().__init__("%s could not be read (%s)" % (self.path.name, self.fault))
+
+
+def _errno_text(e):
+    """errno + strerror ONLY: str(e) names the path(s), and a quarantine destination carries a
+    per-second stamp, so a text built from it changed every second and every once-per-fault-text
+    dedupe fired once a second (the ledgers' lesson)."""
+    return ("[Errno %d] %s" % (e.errno, e.strerror)) if getattr(e, "errno", None) is not None else type(e).__name__
+
+
+def _state_quarantine(p, st, reason):
+    """Move an unparseable state file ASIDE (never delete it) so the evidence survives the fresh
+    start that follows: the sidecar keeps the original name plus `.corrupt-<utc stamp>` (a `-n`
+    suffix for a second in the same second) -- the shape the goal-store and ledger quarantines wear,
+    so one convention reads across all three. Only while the file is still the one whose bytes
+    failed (same inode, mtime and size as `st`, the stat taken before the read): an atomic publish
+    that landed before the re-check already replaced them, and the new file gets its own read (the
+    window left is between the re-check and the os.replace). Returns None once the
+    bytes are out of the way (moved, or already gone: a sibling reader moved them), with one stderr
+    line for the move; else the reason they are NOT, for the caller's fault text."""
+    try:
+        cur = p.stat()
+        if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
+            return "replaced meanwhile; the new bytes get their own read"
+        stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
+        while aside.exists():                            # a second corrupt file in the same second
+            n += 1
+            aside = p.with_name("%s.corrupt-%s-%d" % (p.name, stamp, n))
+        os.replace(p, aside)
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        return "could not be moved aside: %s" % _errno_text(e)
+    sys.stderr.write("romp-kernel: %s could not be parsed (%s); moved aside to %s, the store reads as empty\n"
+                     % (p.name, reason, aside.name))
+    return None
+
+
+def _read_state_json(path, st=None):
+    """The ONE strict reader for a small JSON state file (session-flags, session-order, notify-cards;
+    timeline-views follows in its own change). Distinguishes the outcomes the old `except Exception: {}` conflated:
+      - a MISSING file is legitimately empty            -> returns None (a fresh install has no files)
+      - an UNREADABLE existing file (EIO/EACCES/...)     -> raises _StateUnreadable (never reads empty)
+      - TORN or non-JSON bytes                           -> QUARANTINED aside (_state_quarantine: a move,
+        never a delete -- the evidence survives for forensics), then None, so the store starts empty
+        ONLY after the bad bytes are preserved; bytes that could not be moved aside, or a file
+        replaced between the stat and the rename, raise _StateUnreadable instead (the next read is
+        a fresh one).
+    `st` is the stat the caller already took (the display readers key their cache on it); without
+    one the reader stats first, so the quarantine can tell the file it read from one published
+    since. Reads bytes (json.loads accepts them and auto-detects the encoding), so a non-UTF-8 torn
+    file lands in the quarantine arm rather than escaping as an uncaught UnicodeDecodeError. Never
+    caches: the caller stores only a value that came from a clean read."""
+    path = Path(path)
+    if st is None:
+        try:
+            st = path.stat()
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            raise _StateUnreadable(path, "stat failed: %s" % _errno_text(e))
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as e:
+        raise _StateUnreadable(path, "read failed: %s" % _errno_text(e))
+    try:
+        return json.loads(raw)
+    except (ValueError, UnicodeDecodeError) as e:
+        why = _state_quarantine(path, st, "invalid JSON: %s" % e)
+        if why is None:
+            return None                              # the bytes are preserved; the store starts empty
+        raise _StateUnreadable(path, "invalid JSON; %s" % why)
+
+
+# Last-known-good session order (session-order.json has no mtime cache): served over a transient
+# fault instead of a fabricated [], and the order to render when the store cannot be re-read.
+_session_order_lkg = [None]
+
+# One VISIBLE error per fault EPISODE, per state file (never a raise into the push/build path -- one
+# unreadable state file must not abort the whole push and wedge the board). str(path) -> the fault
+# text last filed. The first time a given fault text is seen for a path, _note_state_fault files one
+# stderr line + one dashboard notice; a repeat of the SAME text files nothing; a clean read clears
+# the entry (the event, no timer) so a recovered-then-refaulted file speaks again.
+_state_fault_seen = {}
+
+
+def _note_state_fault(exc):
+    """A DISPLAY-time state read fault is loud ONCE per episode, not on every build: file one stderr
+    line + one dashboard sync-notice the first time this fault text is seen for this path, then stay
+    quiet until a clean read clears it. The value the reader returns is UNPROVED (last-known or the
+    empty default) and no writer will persist it -- the mutation path reads the proved snapshot,
+    which raises and refuses. Never raises itself. The sync-notice ring is the surface the views
+    store's stale-writer guard already uses (the shell's bell files it under its sync label); a
+    dedicated kernel-fault surface is a follow-up."""
+    key = str(exc.path)
+    text = ("%s — showing the last-known value; changes to it are refused until the file can be "
+            "read again" % exc)
+    if _state_fault_seen.get(key) == text:
+        return
+    _state_fault_seen[key] = text
+    sys.stderr.write("romp-kernel: %s\n" % text)
+    try:
+        _sync_notice(text, ok=False)                 # the shell bell / feed sync-notice row (resolved at call time)
+    except Exception:
+        pass
+
+
+def _clear_state_fault(path):
+    """A clean read of `path` ends its fault episode, so the next fault on it files a fresh notice."""
+    _state_fault_seen.pop(str(path), None)
+
+
+def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", value=None):
+    """A dashboard gesture (a lane/tab flag, a card bell, a drag, a view change) that this kernel
+    REFUSED because the store it edits could not be read: one stderr line, and the refusal answered
+    on the DELIVERING socket as a `settingRefused` frame -- the same targeted _reply idiom the
+    settingStale stand-down and the saveFile acks use, never a broadcast. The frame names the
+    `gesture` ("flag" / "bell" / "order"; "views" follows with its store, so a pane never infers it from which fields are
+    empty), the gesture's own address (sid / itemId / flag), and `value`: what the kernel's display
+    path still paints for that flag or bell -- the value the next push carries -- so the pane
+    repaints the refused toggle to it on THIS event rather than to a value it recorded at the click
+    (two clicks before the first refusal made such a record wrong until the next push). None for a
+    gesture with no single value (an order, a whole-blob view write). A `warn` frame did none of
+    this: only the chat page renders `warn`, so a refused bell on the feed page and a refused lane
+    flag on the timeline page stayed painted as if they had landed until a reload. A dead socket is
+    the client's problem: the refusal already stands."""
+    text = "couldn't save %s \u2014 %s; try again" % (what, exc)
+    sys.stderr.write("romp-kernel: %s\n" % text)
+    if not client or not callable(client.get("send")):
+        return
+    _reply(client, {"type": "settingRefused", "gesture": str(gesture), "sid": str(sid or ""),
+                    "itemId": str(item_id or ""), "flag": str(flag or ""),
+                    "value": value if isinstance(value, bool) else None, "text": text})
+
+
+def _painted_flag_value(sid, flag):
+    """What the DISPLAY path paints for one lane/tab flag right now -- the derivation build_timeline
+    and build_session use for the lane and the tab (the bell EFFECTIVE: override, else the master).
+    Rides a settingRefused frame as `value`, so the pane repaints a refused toggle to exactly what
+    the next push will show. Never raises: the display readers serve their last read (or the empty
+    default) over a fault."""
+    if flag == "notify":
+        return bool(_notify_session_effective(sid))
+    if flag == "postalServiceOff":
+        return bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))
+    return bool(_session_flag(sid, flag))
+
+
 def _session_order():
     """The shared session order (SID list), persisted by a tab-drag (reorderTabs) or a lane-drag
     (writeOrder). Chat tabs AND timeline lanes both order by it, so dragging either reorders both
-    (parity with the old UI's session-order.json). [] when unset."""
+    (parity with the old UI's session-order.json). [] when unset. This is the DISPLAY read: a
+    transient fault serves the last-known-good order this kernel read or wrote, else the empty
+    default (a cold start with no known-good yet) -- UNPROVED either way, never latched as the new
+    known-good, and no writer persists it (the mutation path reads _session_order_proved, which
+    refuses); the fault is loud once per episode (a sync-notice), never a raise into the build path."""
+    p = jd.STATE / "session-order.json"
     try:
-        a = json.loads((jd.STATE / "session-order.json").read_text())
-        return [x for x in a if isinstance(x, str)] if isinstance(a, list) else []
-    except Exception:
-        return []
+        raw = _read_state_json(p)
+    except _StateUnreadable as e:
+        # DISPLAY path: never raise into the push (one outer try would abort every client's build).
+        _note_state_fault(e)
+        return list(_session_order_lkg[0]) if _session_order_lkg[0] is not None else []
+    _clear_state_fault(p)
+    order = [x for x in raw if isinstance(x, str)] if isinstance(raw, list) else []
+    _session_order_lkg[0] = list(order)              # a COPY: callers reorder the list they get
+    return order
+
+
+def _session_order_proved():
+    """The MUTATION snapshot of the lane order: a read fault RAISES (_StateUnreadable) so a writer
+    refuses rather than persisting a fabricated [] over the user's saved order (the drag that would
+    reorder every tab/lane on a transient EIO, under no gesture). Only a missing (or
+    freshly-quarantined) file reads as empty; no last-known-good -- a writer acts on the real store
+    or not at all."""
+    raw = _read_state_json(jd.STATE / "session-order.json")
+    return [x for x in raw if isinstance(x, str)] if isinstance(raw, list) else []
 
 
 _atomic_lock = threading.Lock()
@@ -2301,8 +2493,11 @@ def _write_session_order(order):
     if not isinstance(order, list):
         return
     new = [x for x in order if isinstance(x, str)]
+    # for the audit only: the DISPLAY read never raises (a fault serves the last-known order), so a
+    # fault here cannot block the write -- the caller already read the store PROVED to build `order`
     _order_audit("persist", _session_order(), new)   # every mutation of the authoritative order, with its stack
     _atomic_write(jd.STATE / "session-order.json", json.dumps(new))
+    _session_order_lkg[0] = new                      # what we just published IS the new known-good
 
 
 def _gc_session_order(known):
@@ -2312,7 +2507,11 @@ def _gc_session_order(known):
     it so a closed / aged-out session falls out on its own). Everything still around keeps its EXACT slot —
     only truly-absent sids are removed, and since the discover window only slides FORWARD a pruned sid never
     flickers back to reclaim a slot. Writes only when something actually changed (no churn on the hot path)."""
-    order = _session_order()
+    try:
+        order = _session_order_proved()
+    except _StateUnreadable as e:
+        _note_state_fault(e)                         # loud once per episode, not per pass
+        return
     kept = [sid for sid in order if sid in known]
     if kept != order:
         _write_session_order(kept)
@@ -2328,7 +2527,9 @@ def _merge_session_order(incoming):
     sid's slot, so those lanes jumped — a drag that auto-reordered untouched lanes.) Returns the merged full
     SID order (deduped, strings only)."""
     incoming = [x for x in incoming if isinstance(x, str)]
-    existing = _session_order()
+    existing = _session_order_proved()   # a read fault RAISES -> the drag is refused loudly by the caller,
+    #                                      never spliced into a fabricated [] and persisted (the WS branch
+    #                                      catches _StateUnreadable and warns; it does not overwrite the order)
     inset = set(incoming)
     queue = list(incoming)
     merged = []
@@ -2358,7 +2559,18 @@ def _ordered(sessions):
     sibling already in the order. A genuinely-new session still appends at the end. Keyed off the anchor the
     sessions carry (default: the sid itself), so session-order.json + the client stay fsid-based — no
     migration (the user 2026-06-24: keep ONE slot across /clear / revive)."""
-    order = _session_order()
+    try:
+        order = _session_order_proved()   # a PROVED read: a transient fault must not fold to [] and then
+        #                                   mark every session "new", persisting discovery order over the
+        #                                   user's saved order under no gesture (the state-readers audit).
+    except _StateUnreadable as e:
+        # render the last-known order (or plain input order if we never read one) and persist NOTHING
+        # this pass; the next clean read re-appends any true newcomers. Loud once per episode.
+        _note_state_fault(e)
+        lkg = _session_order_lkg[0] or []
+        idx0 = {sid: i for i, sid in enumerate(lkg)}
+        return sorted(sessions, key=lambda s: idx0.get(s["sid"], len(idx0)))
+    _session_order_lkg[0] = order
     known = set(order)
     # Slot inheritance keys on the STABLE session NAME (customTitle), NOT the fsid or discover's anchor: a
     # /clear, relaunch, or revive mints a NEW transcript fsid for the SAME logical session, and it must
@@ -3078,21 +3290,39 @@ def _edit_tag(name, add=(), remove=(), color=None, delete=False, rename=None):
 _flags_cache = {}   # str(path) -> ((mtime,size), dict)
 
 
+def _session_flags_proved():
+    """The MUTATION snapshot of the per-session flags: a read fault RAISES (_StateUnreadable) so
+    _set_session_flag / _set_notify_session refuse rather than writing a fabricated {} back over
+    every session's flags -- including the postalServiceOff isolation boundaries -- under a success
+    ack (the state-readers audit). Only a missing (or freshly-quarantined) file reads as empty."""
+    raw = _read_state_json(jd.STATE / "session-flags.json")
+    return raw if isinstance(raw, dict) else {}
+
+
 def _session_flags():
     p = jd.STATE / "session-flags.json"
+    hit = _flags_cache.get(str(p))
     try:
         st = p.stat(); key = (st.st_mtime_ns, st.st_size)   # ns + size → no stale hit on rapid toggles
-    except OSError:
+    except FileNotFoundError:
+        _clear_state_fault(p)
         return {}
-    hit = _flags_cache.get(str(p))
+    except OSError as e:
+        # DISPLAY path: never raise into the push. The last cached value if there is one, else {} (a
+        # cold start) -- UNPROVED either way, not cached; one loud notice per episode. Writers refuse
+        # via _session_flags_proved.
+        _note_state_fault(_StateUnreadable(p, "stat failed: %s" % _errno_text(e)))
+        return hit[1] if hit is not None else {}
     if hit is not None and hit[0] == key:
+        _clear_state_fault(p)
         return hit[1]
     try:
-        d = json.loads(p.read_text())
-        if not isinstance(d, dict):
-            d = {}
-    except Exception:
-        d = {}
+        raw = _read_state_json(p, st)
+    except _StateUnreadable as e:
+        _note_state_fault(e)
+        return hit[1] if hit is not None else {}
+    _clear_state_fault(p)
+    d = raw if isinstance(raw, dict) else {}
     _flags_cache[str(p)] = (key, d)
     return d
 
@@ -3112,7 +3342,8 @@ def _session_flag_raw(sid, flag):
 
 
 def _set_session_flag(sid, flag, value):
-    cur = dict(_session_flags())                     # copy: never mutate the cached dict in place
+    cur = dict(_session_flags_proved())              # PROVED: a read fault refuses (raises) rather than
+    #                                                  overwriting every session's flags with a fabricated {}
     f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
     if value:
         f[flag] = True
@@ -3181,21 +3412,40 @@ _NOTIFY_RESERVED = frozenset((NOTIFY_ALL_KEY, NOTIFY_TURNS_KEY))
 _notify_cards_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
+def _notify_cards_proved():
+    """The MUTATION snapshot of the notification subscriptions: a read fault RAISES
+    (_StateUnreadable) so the bell setters (_set_notify_all/_turns/_card) and _prune_notify_cards
+    refuse rather than writing a fabricated {} back over every per-card, session and master bell
+    override under a success ack (the state-readers audit). Only a missing (or freshly-quarantined)
+    file reads as empty."""
+    raw = _read_state_json(jd.STATE / "notify-cards.json")
+    return raw if isinstance(raw, dict) else {}
+
+
 def _notify_cards():
     p = jd.STATE / "notify-cards.json"
+    hit = _notify_cards_cache.get(str(p))
     try:
         st = p.stat(); key = (st.st_mtime_ns, st.st_size)
-    except OSError:
+    except FileNotFoundError:
+        _clear_state_fault(p)
         return {}
-    hit = _notify_cards_cache.get(str(p))
+    except OSError as e:
+        # DISPLAY path: never raise into the push. The last cached value if there is one, else {} (a
+        # cold start) -- UNPROVED either way, not cached; one loud notice per episode. Writers refuse
+        # via _notify_cards_proved.
+        _note_state_fault(_StateUnreadable(p, "stat failed: %s" % _errno_text(e)))
+        return hit[1] if hit is not None else {}
     if hit is not None and hit[0] == key:
+        _clear_state_fault(p)
         return hit[1]
     try:
-        d = json.loads(p.read_text())
-        if not isinstance(d, dict):
-            d = {}
-    except Exception:
-        d = {}
+        raw = _read_state_json(p, st)
+    except _StateUnreadable as e:
+        _note_state_fault(e)
+        return hit[1] if hit is not None else {}
+    _clear_state_fault(p)
+    d = raw if isinstance(raw, dict) else {}
     _notify_cards_cache[str(p)] = (key, d)
     return d
 
@@ -3206,7 +3456,7 @@ def _notify_all_on():
 
 
 def _set_notify_all(value):
-    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
+    cur = dict(_notify_cards_proved())               # PROVED: a read fault refuses rather than erasing bells
     if value:
         cur[NOTIFY_ALL_KEY] = True
     else:
@@ -3222,7 +3472,7 @@ def _notify_turns_on():
 
 
 def _set_notify_turns(value):
-    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
+    cur = dict(_notify_cards_proved())               # PROVED: a read fault refuses rather than erasing bells
     if value:
         cur[NOTIFY_TURNS_KEY] = True
     else:
@@ -3251,8 +3501,14 @@ def _set_notify_card(item_id, value, sid=""):
     matches what the card would inherit anyway (session override, else master), in which case the
     override is deleted: clicking a bell back to its default returns it to FOLLOWING the default,
     rather than pinning today's default against tomorrow's master flip."""
-    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
-    default = _session_flag_raw(sid, "notify")
+    cur = dict(_notify_cards_proved())               # PROVED: a read fault refuses rather than erasing bells
+    # the default this click is judged against comes from the OTHER store, and it must be PROVED too:
+    # read through the display reader, a fault on session-flags.json folded the session's bell to
+    # "unset" and the click was judged against the master instead -- a mute that matched the
+    # fabricated default was DELETED under the success path (the user's override, erased). A fault
+    # there refuses this write exactly like a fault on the bells file.
+    f = _session_flags_proved().get(sid)
+    default = None if not isinstance(f, dict) or f.get("notify") is None else bool(f.get("notify"))
     if default is None:
         default = bool(cur.get(NOTIFY_ALL_KEY))
     if bool(value) == default:
@@ -3267,9 +3523,14 @@ def _set_notify_session(sid, value):
     discipline as _set_notify_card, against the master. Not _set_session_flag: that setter's
     pop-on-false is right for the on/off view flags, but here False is a real value (muted while
     the master is on)."""
-    cur = dict(_session_flags())                     # copy: never mutate the cached dict in place
+    cur = dict(_session_flags_proved())              # PROVED: a read fault refuses rather than erasing flags
     f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
-    if bool(value) == _notify_all_on():
+    # the master this click is judged against lives in the OTHER store and must be PROVED too: read
+    # through the display reader, a fault on notify-cards.json folded it to off, so a click matching
+    # that fabricated master popped the session's stored override -- a mute erased under the success
+    # path. A fault there refuses this write exactly like a fault on the flags file.
+    master = bool(_notify_cards_proved().get(NOTIFY_ALL_KEY))
+    if bool(value) == master:
         f.pop("notify", None)
     else:
         f["notify"] = bool(value)
@@ -3285,7 +3546,12 @@ def _prune_notify_cards(live_ids):
     Called from the feed-diff detector, so the write happens only on the event of a card leaving.
     The reserved keys (the master, the turn-finished switch) are not cards and never prune; values
     are kept as stored (False = a mute)."""
-    cur = _notify_cards()
+    try:
+        cur = _notify_cards_proved()   # PROVED: a fault must not prune against a fabricated {} and then
+        #                                write the truncation over the user's real bell overrides
+    except _StateUnreadable as e:
+        _note_state_fault(e)                         # loud once per episode, not per pass
+        return
     gone = [i for i in cur if i not in live_ids and i not in _NOTIFY_RESERVED]
     if gone:
         kept = {i: cur[i] for i in cur if i in live_ids or i in _NOTIFY_RESERVED}
@@ -33351,6 +33617,7 @@ else if(m.type==="hover"&&panel.setHover)panel.setHover(m);
 // timeline-boot.test.ts pins the pair.
 else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.id);
 else if(m.type==="models"&&panel.refreshModels)panel.refreshModels();
+else if(m.type==="settingRefused"&&panel.settingRefused)panel.settingRefused(m);
 else if(m.type==="tagEditFailed"&&panel.tagEditFailed)panel.tagEditFailed(m);
 else if(m.type==="openViewsDialog"&&panel._openViewsDialog)panel._openViewsDialog(null);});
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
@@ -33627,10 +33894,10 @@ el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
-var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','sync','locate','cleared','undelivered'];
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','sync','locate','cleared','refused','undelivered'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
 nudge:'follow-up failed',retry:'retrying',apierror:'api error',sdk:'sdk',sync:'fleet sync',
-locate:'jump failed',cleared:'cleared',undelivered:'not sent'};
+locate:'jump failed',cleared:'cleared',refused:'not saved',undelivered:'not sent'};
 // what each kind MEANS (the user 2026-07-28: the tooltip should explain the badge, not just say
 // show/hide) — worn by the filter toggles AND every entry's chip
 var DESC={conn:"the dashboard lost its live connection to the kernel for a visible pane; it reconnects on its own",
@@ -33645,6 +33912,7 @@ sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an 
 sync:"romp moved commits between your machines by itself \u2014 a push to a remote, a pull from one, or an ask that a peer fast-forward itself. Successes are logged as well as failures, so this is the record of what romp did to your machines; the network panel shows a sync while it is still running",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
 cleared:"a /clear in a session dropped still-open cards at the boundary; Undo on the feed restores them",
+refused:"a change you made \u2014 a lane or tab setting, a card bell, a tag or view, a lane order \u2014 was not saved because romp could not read the file that holds it; nothing changed, the entry carries the reason, and the same change can be tried again",
 undelivered:"something you sent never reached a session — the kernel it was addressed to has no session by that id, which on a board showing more than one machine means the pane addressed the wrong one. Nothing was delivered. Your text is kept verbatim in undelivered.jsonl under ~/.local/state/romp"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
@@ -35040,7 +35308,9 @@ sub().then(function(s){devOn=!!s;paint();});
 function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Notifications: '+((e&&e.message)||e));}catch(err){}}
 function post(path,obj){return fetch(path,{method:'POST',body:JSON.stringify(obj)}).then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});
-return r.json().catch(function(){return {};});});}
+return r.json().catch(function(){return {};});}).then(function(d){
+if(d&&d.ok===false)throw new Error(d.error||'the kernel refused it');   // a refusal in the route's own shape: the switch stays put and the reason toasts
+return d;});}
 function b64u(s){var raw=atob((s+'==='.slice((s.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/'));
 var a=new Uint8Array(raw.length);for(var i=0;i<raw.length;i++)a[i]=raw.charCodeAt(i);return a;}
 function devSubscribe(permP){return permP.then(function(p){
@@ -36148,6 +36418,7 @@ def _landing():
             ".rerr-chip{flex:0 0 auto;font-size:9px;font-weight:700;letter-spacing:.04em;padding:1px 6px;"
             "border-radius:999px;line-height:1.4;white-space:nowrap;border:1px solid transparent}"
             ".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166;border-color:rgba(255,209,102,0.6)}"
+            ".rerr-chip.k-refused{color:#ffd166;border-color:rgba(255,209,102,0.6)}"   # a change that did not land: the warning yellow, its own kind
             # "not sent" rides with the follow-up-failed red: both mean a message of yours didn't land, and
             # this one is the harder loss of the two — nothing was delivered at all (the user 2026-07-29)
             ".rerr-chip.k-nudge,.rerr-chip.k-undelivered{color:#ff6a6a;border-color:rgba(255,106,106,0.6)}"
@@ -37376,7 +37647,15 @@ class Handler(BaseHTTPRequestHandler):
                     _on = bool(json.loads(raw_body or b"{}").get("on"))
                 except (ValueError, AttributeError):
                     return self._send(400, "bad json", "text/plain")
-                _set_notify_all(_on)
+                try:
+                    _set_notify_all(_on)
+                except _StateUnreadable as e:
+                    # the bells store could not be read: refuse in the route's OWN shape -- 200 with
+                    # ok:false -- never a 5xx. The shell's post() reads ok:false as the refusal it is
+                    # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
+                    # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
+                    return self._send(200, json.dumps({"ok": False, "retryable": True,
+                        "error": "%s \u2014 the change did not land; try again" % e}), "application/json")
                 _mark_views_dirty()
                 _send_to_app("shell", {"type": "notifyAll", "on": _on})
                 return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")
@@ -37388,7 +37667,15 @@ class Handler(BaseHTTPRequestHandler):
                     _on = bool(json.loads(raw_body or b"{}").get("on"))
                 except (ValueError, AttributeError):
                     return self._send(400, "bad json", "text/plain")
-                _set_notify_turns(_on)
+                try:
+                    _set_notify_turns(_on)
+                except _StateUnreadable as e:
+                    # the bells store could not be read: refuse in the route's OWN shape -- 200 with
+                    # ok:false -- never a 5xx. The shell's post() reads ok:false as the refusal it is
+                    # (a non-2xx would reach it as raw JSON in an HTTP error), and the same body
+                    # crosses a federation forward, which treats any non-200 as a tunnel hiccup.
+                    return self._send(200, json.dumps({"ok": False, "retryable": True,
+                        "error": "%s \u2014 the change did not land; try again" % e}), "application/json")
                 _send_to_app("shell", {"type": "notifyTurns", "on": _on})
                 return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")
             if u.path == "/push/test":
@@ -38671,11 +38958,18 @@ class Handler(BaseHTTPRequestHandler):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
             # re-broadcast so the feed drops/restores that session's cards immediately. The notify
             # bell is tri-state (an override on the master default) → its own setter.
-            if str(msg["flag"]) == "notify":
-                _set_notify_session(str(msg["id"]), bool(msg.get("value")))
+            try:
+                if str(msg["flag"]) == "notify":
+                    _set_notify_session(str(msg["id"]), bool(msg.get("value")))
+                else:
+                    _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
+            except _StateUnreadable as e:
+                # the flags store could not be read: refuse on the DELIVERING socket, addressed to the
+                # toggle (sid + flag) so the lane gear / tab menu ends its optimistic state and says why
+                _refuse_setting(client, e, "that setting", "flag", sid=msg["id"], flag=msg["flag"],
+                                value=_painted_flag_value(str(msg["id"]), str(msg["flag"])))
             else:
-                _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
-            _mark_views_dirty()
+                _mark_views_dirty()
         elif msg and msg.get("type") == "setTimelineViews" and isinstance(msg.get("views"), dict):
             # timeline corner panel → replace the whole views blob (tiny; last-write-wins across
             # dashboards, like colormap). Validation/normalization happens in the setter.
@@ -38728,8 +39022,15 @@ class Handler(BaseHTTPRequestHandler):
             # completes). Persisted to notify-cards.json; build_feed echoes it back as ask.notify.
             # sid rides so the override can be resolved against the card's own default (session, else
             # the master) and deleted when it merely restates it.
-            _set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))
-            _mark_views_dirty()
+            try:
+                _set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))
+            except _StateUnreadable as e:
+                # the bells store could not be read: refuse on the DELIVERING socket, addressed to the
+                # card (itemId) so the feed drops that bell's optimistic latch and says why
+                _refuse_setting(client, e, "that bell", "bell", sid=msg.get("sid") or "", item_id=msg["itemId"],
+                                value=bool(_notify_card_effective(_notify_cards(), str(msg["itemId"]), str(msg.get("sid") or ""))))
+            else:
+                _mark_views_dirty()
         elif msg and msg.get("type") == "setSessionColor" and msg.get("id") and msg.get("bg"):
             # tab right-click color picker → override the session's identity color (persisted to the names
             # registry); re-broadcast so every tab/lane/card repaints in the new color at once.
@@ -38940,12 +39241,22 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") in ("reorderTabs", "writeOrder") and isinstance(msg.get("order"), list):
             # tab-drag or lane-drag → reorder BOTH surfaces. MERGE the dragged surface's order into the
             # persisted one (don't overwrite): a chat-tab drag must not drop/reshuffle timeline-only lanes.
-            _write_session_order(_merge_session_order(msg["order"]))
-            # _mark_views_dirty, NOT _push_all: the feed/timeline order the grouped cards CLIENT-side by this
-            # list, but a plain push serves the CACHED feed — reused for REBUILD_MIN_S (2s) even though the sig
-            # changed — so the reordered cards lagged up to ~2s (the user 2026-07-15). The dirty mark bypasses
-            # the throttle AND wakes the pusher, so the rebuilt payload (fresh order) ships right away.
-            _mark_views_dirty()
+            try:
+                _merged = _merge_session_order(msg["order"])
+            except _StateUnreadable as e:
+                # the order file could not be read; the drag must not splice against a fabricated []
+                # and persist discovery order over the user's saved order. Refused on the delivering
+                # socket. (No shipped pane posts this op today -- the strip and the lanes write the
+                # viewer's own arrangement -- so the frame has no latch to release; the contract holds
+                # for the op all the same.)
+                _refuse_setting(client, e, "the new order", "order")
+            else:
+                _write_session_order(_merged)
+                # _mark_views_dirty, NOT _push_all: the feed/timeline order the grouped cards CLIENT-side by this
+                # list, but a plain push serves the CACHED feed — reused for REBUILD_MIN_S (2s) even though the sig
+                # changed — so the reordered cards lagged up to ~2s before the dirty mark. The dirty mark bypasses
+                # the throttle AND wakes the pusher, so the rebuilt payload (fresh order) ships right away.
+                _mark_views_dirty()
         elif msg and msg.get("type") == "createSession" and msg.get("name"):
             nm = str(msg["name"]).strip()
             if not NAME_RE.match(nm):

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -227,12 +227,15 @@ class ErrorCenterExecutes(unittest.TestCase):
         # 'fleet sync' joined on 2026-07-30: romp moves commits between machines on its own, and the
         # network panel's phase line is live-only — so an unwatched push left no record either way,
         # the success least of all. It is the one kind here that logs wins as well as failures.
+        # 'not saved' joined with the state-readers change: a setting, bell, tag or order the kernel REFUSED
+        # because it could not read the file that holds it files an entry of its own kind, so muting the
+        # judge's 'warning' never mutes a change of yours that did not land.
         a = self.out["filterBar"]
-        self.assertEqual(a["n"], 13)
+        self.assertEqual(a["n"], 14)
         self.assertEqual(a["first"], "offline")
         self.assertEqual(a["labels"],
                          "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|"
-                         "sdk|fleet sync|jump failed|cleared|not sent")
+                         "sdk|fleet sync|jump failed|cleared|not saved|not sent")
 
     def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
         a = self.out["afterMute"]

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7449,11 +7449,11 @@ class SessionOrderStable(unittest.TestCase):
     pulled into a separate mtime-sorted block, so a session jumped slots the moment it died."""
     def setUp(self):
         self._saved = (km._ordered_alive, km._alive_sessions, km._sessions, km._session_order,
-                       set(km._kept_open))
+                       km._session_order_proved, set(km._kept_open))
 
     def tearDown(self):
         (km._ordered_alive, km._alive_sessions, km._sessions, km._session_order,
-         kept) = self._saved
+         km._session_order_proved, kept) = self._saved
         km._kept_open.clear(); km._kept_open.update(kept)
 
     def _fleet(self):
@@ -7462,7 +7462,10 @@ class SessionOrderStable(unittest.TestCase):
         A = {"sid": "A", "name": "a", "path": "/a", "mtime": NOW - 200}
         B = {"sid": "B", "name": "b", "path": "/b", "mtime": NOW - 5}
         C = {"sid": "C", "name": "c", "path": "/c", "mtime": NOW - 400}
-        km._session_order = lambda: ["A", "B", "C"]      # the persisted (drag) order
+        # the persisted (drag) order — injected at BOTH seams: _session_order_proved is the mutation
+        # snapshot _ordered reads (the state-readers audit split the proved read from the display one)
+        km._session_order = lambda: ["A", "B", "C"]
+        km._session_order_proved = lambda: ["A", "B", "C"]
         km._sessions = lambda now: [B, A, C]             # _sessions is mtime-DESC → B first
         # _chat_tab_sessions/_timeline_sessions now read _alive_sessions directly and order via _ordered
         # (the session-order refactor, 15f5037) — stub THAT for the live list; _ordered_alive is no longer

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -296,6 +296,25 @@ from unittest import mock
 
 
 @contextlib.contextmanager
+def _stat_fault(target):
+    """Fail every stat of ONE path with an EACCES for the duration of the block -- the arm the read-fault
+    injector never reaches (review find, 2026-09-08): every reader stats BEFORE it reads (the display
+    readers key their cache on it), and a state dir that cannot be searched faults exactly there.
+    Everything else stats normally."""
+    real_stat = Path.stat
+    tgt = str(target)
+    def st(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EACCES, "injected EACCES")
+        return real_stat(self, *a, **k)
+    Path.stat = st
+    try:
+        yield
+    finally:
+        Path.stat = real_stat
+
+
+@contextlib.contextmanager
 def _reads_fault(target):
     """Fail every byte read of ONE path with an EIO for the duration of the block."""
     real_rb, real_rt = Path.read_bytes, Path.read_text
@@ -346,8 +365,12 @@ class OrderDisplayReaderServesUnproved(unittest.TestCase):
         km.jd.STATE = Path(self.td.name)
         km._session_order_lkg[0] = None
         km._state_fault_seen.clear()
+        self.notices = []
+        self._notice = km._sync_notice
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok, kind))
 
     def tearDown(self):
+        km._sync_notice = self._notice
         km.jd.STATE = self._saved_state
         km._session_order_lkg[0] = self._lkg
         km._state_fault_seen.clear()
@@ -355,6 +378,105 @@ class OrderDisplayReaderServesUnproved(unittest.TestCase):
 
     def _path(self):
         return km.jd.STATE / "session-order.json"
+
+    def test_a_stat_fault_serves_the_known_good_and_refuses_a_drag(self):
+        km._write_session_order([A, B, C])
+        self.assertEqual(km._session_order(), [A, B, C])                # primes the known-good
+        before = self._path().read_bytes()
+        with _stat_fault(self._path()):
+            self.assertEqual(km._session_order(), [A, B, C], "the stat arm serves the last-known order")
+            with self.assertRaises(km._StateUnreadable) as cm:
+                km._session_order_proved()
+            self.assertIn("stat failed: [Errno 13]", str(cm.exception))
+            with self.assertRaises(km._StateUnreadable):
+                km._merge_session_order([C, B])                          # a drag refuses on the stat fault too
+        self.assertEqual(self._path().read_bytes(), before)
+        bad = [t for t, ok, _k in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "one notice for the episode")
+        self.assertIn("session-order.json could not be read (stat failed: [Errno 13]", bad[0])
+        km._session_order_lkg[0] = None
+        with _stat_fault(self._path()):
+            self.assertEqual(km._session_order(), [], "no known-good: the empty default")
+            self.assertIsNone(km._session_order_lkg[0], "…not latched")
+
+    def test_the_push_path_gc_skips_the_pass_on_a_fault_loud_once(self):
+        # the body's claim, unpinned until now (review find, 2026-09-08: deleting the GC's try/except
+        # passed the suite): the self-clean on every push skips its pass on a fault instead of pruning
+        # against a fabricated [] and writing the truncation, loud once per episode
+        km._write_session_order([A, B, C])
+        before = self._path().read_bytes()
+        with _reads_fault(self._path()):
+            km._gc_session_order({A})                                  # B and C are gone: a clean pass prunes them
+            km._gc_session_order({A})
+        self.assertEqual(self._path().read_bytes(), before, "a fault must not prune against a fabricated [] and write it")
+        bad = [t for t, ok, _k in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "loud once per episode, not once per pass")
+        self.assertIn("session-order.json could not be read", bad[0])
+        # through the push path itself: _chat_tab_sessions orders, then runs the GC -- neither raises
+        saved = (km._alive_sessions, km._sessions)
+        km._alive_sessions = lambda now, tmux: [sess(A, 1)]
+        km._sessions = lambda now: [sess(A, 1)]
+        try:
+            with _reads_fault(self._path()):
+                got = [s["sid"] for s in km._chat_tab_sessions(0, {})]
+        finally:
+            km._alive_sessions, km._sessions = saved
+        self.assertEqual(got, [A])
+        self.assertEqual(self._path().read_bytes(), before)
+        self.assertEqual(len([t for t, ok, _k in self.notices if not ok]), 1, "the same episode: nothing new filed")
+        km._gc_session_order({A})                                      # the disk recovers: the pass prunes as before
+        self.assertEqual(km._session_order_proved(), [A])
+
+    def test_a_failed_write_leaves_the_known_good_at_the_order_that_was_read(self):
+        # review find, 2026-09-08: _ordered latched the list it was about to SPLICE, by reference, so
+        # until the publish landed the known-good WAS the unpersisted order (served to a concurrent
+        # display read, or kept if the publish failed). The clean read latches a copy; only a write that
+        # lands latches the spliced list. Pinned at the write moment: _write_session_order's own audit
+        # read re-latches from the file when it is clean, which would hide the alias from a test that
+        # only looked after a failed publish
+        km._write_session_order([A, B])
+        km._session_order_lkg[0] = None
+        self.assertEqual(km._session_order(), [A, B])
+        at_write = []
+        def failing_write(order):
+            at_write.append(list(km._session_order_lkg[0]))          # the known-good as the publish is attempted
+            raise km._StateUnwritable(self._path(), "write failed: [Errno 28] No space left on device")
+        with mock.patch.object(km, "_write_session_order", failing_write):
+            out = [s["sid"] for s in km._ordered([sess(A, 1), sess(B, 2), sess(C, 3)])]   # C is new: spliced, then the publish fails
+        self.assertEqual(out, [A, B, C], "this build still sorts by the in-memory order")
+        self.assertEqual(at_write, [[A, B]], "at the write, the known-good is still what was READ, not the spliced list")
+        self.assertEqual(km._session_order_lkg[0], [A, B],
+                         "and after the failed write it stays so: never an order nobody persisted")
+        self.assertEqual(json.loads(self._path().read_text()), [A, B])
+        out = [s["sid"] for s in km._ordered([sess(A, 1), sess(B, 2), sess(C, 3)])]   # the disk recovers
+        self.assertEqual(out, [A, B, C])
+        self.assertEqual(km._session_order_lkg[0], [A, B, C], "the write that landed is the new known-good")
+
+    def test_a_quarantine_tells_the_dashboard_once_under_the_refused_kind(self):
+        # review find, 2026-09-08: a quarantine reset the saved order with only a stderr line, so from
+        # the dashboard the lanes simply reshuffled themselves into discovery order
+        torn = b'["' + A.encode() + b'", "' + B.encode()
+        self._path().write_bytes(torn)
+        self.assertEqual(km._session_order_proved(), [])
+        self.assertEqual(len(self.notices), 1)
+        text, ok, kind = self.notices[0]
+        self.assertEqual((ok, kind), (False, "refused"))
+        self.assertIn("session-order.json could not be parsed and was moved aside to session-order.json.corrupt-", text)
+        self.assertIn("start over empty", text)
+        self.assertEqual(km._session_order_proved(), [])                # the next read is an ENOENT …
+        self.assertEqual(len(self.notices), 1, "… and files nothing more")
+
+    def test_valid_json_of_the_wrong_shape_is_quarantined_not_read_as_empty(self):
+        # review find, 2026-09-08: a DICT where the order list belongs read as a proved empty order and
+        # the next push overwrote it with discovery order -- a file none of our writers produce, gone
+        wrong = b'{"' + A.encode() + b'": 1}'
+        self._path().write_bytes(wrong)
+        self.assertEqual(km._session_order_proved(), [], "empty only AFTER the bytes are moved aside")
+        aside = list(km.jd.STATE.glob("session-order.json.corrupt-*"))
+        self.assertEqual(len(aside), 1, "quarantined like torn bytes")
+        self.assertEqual(aside[0].read_bytes(), wrong)
+        self.assertFalse(self._path().exists())
+        self.assertEqual([k for _t, _ok, k in self.notices], ["refused"])
 
     def test_a_fault_serves_the_last_known_order_on_every_faulted_read(self):
         km._write_session_order([A, B, C])
@@ -540,6 +662,19 @@ class StateQuarantineShape(unittest.TestCase):
             with self.assertRaises(km._StateUnreadable):
                 km._session_order_proved()                             # so a writer refuses, exactly as for an EIO
         self.assertEqual(p.read_bytes(), torn)
+
+    def test_non_utf8_torn_bytes_are_quarantined_not_escaped_as_a_decode_error(self):
+        # the body's claim, unexercised until now (review find, 2026-09-08: every torn fixture was pure
+        # ASCII): the reader takes BYTES, so a torn file that is not valid UTF-8 lands in the quarantine
+        # arm rather than escaping a text read as an uncaught UnicodeDecodeError
+        torn = b'["' + A.encode() + b'", "\xff\xfe'
+        self._path().write_bytes(torn)
+        self.assertIsNone(km._read_state_json(self._path()))
+        q = list(km.jd.STATE.glob("session-order.json.corrupt-*"))
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q[0].read_bytes(), torn, "the quarantine holds the ORIGINAL bytes")
+        self.assertFalse(self._path().exists())
+        self.assertEqual(km._session_order_proved(), [], "the store starts empty only after the bytes are saved")
 
     def test_the_move_is_an_os_replace_and_the_fault_text_carries_no_stamp_or_path(self):
         # the fault text feeds the once-per-fault-text registries: a path or a per-second stamp in it

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -196,5 +196,292 @@ class SessionOrder(unittest.TestCase):
         self.assertEqual(out, [OBS2, B, C], "the fork renders in obsidian's slot (first), not at the end")
 
 
+class OrderStoreUnreadableRefuses(unittest.TestCase):
+    """The state-readers audit (rank 8): _session_order used to fold ANY read fault to [], and both
+    _merge_session_order (a drag) and _ordered (per push) persisted the result — so a transient EIO
+    turned every session "new", overwriting the user's saved lane order with plain discovery order
+    under no gesture. The mutation paths now read PROVED: a drag is refused loudly and _ordered
+    renders last-known and persists nothing on a fault. Synthetic sids only."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        # _session_order_lkg is new on the fix; guard so this module still IMPORTS + runs on origin/main
+        # (where the primary test must fail by SHOWING the erasure, not erroring in setUp)
+        self._lkg = km._session_order_lkg[0] if hasattr(km, "_session_order_lkg") else None
+        self._saved_state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        if hasattr(km, "_session_order_lkg"):
+            km._session_order_lkg[0] = None
+
+    def tearDown(self):
+        km.jd.STATE = self._saved_state
+        if hasattr(km, "_session_order_lkg"):
+            km._session_order_lkg[0] = self._lkg
+        self.td.cleanup()
+
+    def _path(self):
+        return km.jd.STATE / "session-order.json"
+
+    def _fault_reads_of(self, target):
+        """Fail BOTH read_bytes (the fix's proved reader) and read_text (origin/main's reader) for one
+        path — green on the fix, RED on main where the fold-to-[] overwrites the order with a drag's
+        subset (or discovery order)."""
+        import errno
+        real_rb, real_rt = Path.read_bytes, Path.read_text
+        tgt = str(target)
+        def rb(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rb(self, *a, **k)
+        def rt(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rt(self, *a, **k)
+        Path.read_bytes, Path.read_text = rb, rt
+        return (real_rb, real_rt)
+
+    def test_a_drag_is_refused_and_the_order_untouched_when_the_store_cannot_be_read(self):
+        km._write_session_order([A, B, C])                 # the user's saved lane order
+        before = self._path().read_bytes()
+        saved = self._fault_reads_of(self._path())
+        raised = None
+        try:
+            # a chat-tab drag publishing only [C, B]: on origin/main _merge_session_order reads a
+            # fabricated [] and returns [C, B], which _write_session_order then persists — DROPPING A's
+            # slot. Here we persist the merge result exactly as the WS branch does, so the erasure shows.
+            merged = km._merge_session_order([C, B])
+            km._write_session_order(merged)
+        except Exception as e:                             # noqa: BLE001 — on main it never raises
+            raised = e
+        finally:
+            Path.read_bytes, Path.read_text = saved
+        # THE erasure: on main the file is now [C, B] (A gone); the fix refuses before any write.
+        self.assertEqual(self._path().read_bytes(), before,
+                         "the order file must be unchanged when its file can't be read (main drops A here)")
+        self.assertEqual(type(raised).__name__, "_StateUnreadable",
+                         "the drag is refused LOUDLY, not spliced into a fabricated [] (got %r)" % raised)
+
+    def test_ordered_renders_last_known_and_persists_nothing_on_a_fault(self):
+        km._write_session_order([A, B, C])
+        _ = km._session_order()                            # prime the last-known-good
+        before = self._path().read_bytes()
+        saved = self._fault_reads_of(self._path())
+        try:
+            out = [s["sid"] for s in km._ordered([sess(C, 300), sess(A, 100), sess(B, 200)])]
+        finally:
+            Path.read_bytes, Path.read_text = saved
+        self.assertEqual(out, [A, B, C], "renders the last-known order, not discovery order")
+        self.assertEqual(self._path().read_bytes(), before,
+                         "a display fault persists NOTHING — the saved order is not overwritten")
+
+    def test_a_torn_order_file_is_quarantined_aside_not_overwritten(self):
+        torn = b'["aaaa", THIS IS NOT JSON'
+        self._path().write_bytes(torn)
+        self.assertEqual(km._session_order_proved(), [], "the store starts empty only after the bytes are saved")
+        q = list(km.jd.STATE.glob("session-order.json.corrupt-*"))
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q[0].read_bytes(), torn, "the quarantine holds the ORIGINAL bytes")
+        self.assertFalse(self._path().exists())
+
+    def test_enoent_order_still_reads_empty_with_no_quarantine(self):
+        self.assertEqual(km._session_order(), [], "a missing store is legitimately empty")
+        self.assertEqual(km._session_order_proved(), [])
+        self.assertEqual(list(km.jd.STATE.glob("session-order.json.corrupt-*")), [])
+
+
+import contextlib
+import errno
+import time
+from unittest import mock
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO for the duration of the block."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
+class OrderDisplayReaderServesUnproved(unittest.TestCase):
+    """The DISPLAY reader of the lane order under a fault serves the last order this kernel read or
+    wrote -- and never latches what the fault produced as the new known-good. A reader that latched
+    [] would render discovery order on the second faulted build and hand the mutation path a
+    fabricated 'last known' to fall back on."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved_state, self._lkg = km.jd.STATE, km._session_order_lkg[0]
+        km.jd.STATE = Path(self.td.name)
+        km._session_order_lkg[0] = None
+        km._state_fault_seen.clear()
+
+    def tearDown(self):
+        km.jd.STATE = self._saved_state
+        km._session_order_lkg[0] = self._lkg
+        km._state_fault_seen.clear()
+        self.td.cleanup()
+
+    def _path(self):
+        return km.jd.STATE / "session-order.json"
+
+    def test_a_fault_serves_the_last_known_order_on_every_faulted_read(self):
+        km._write_session_order([A, B, C])
+        self.assertEqual(km._session_order(), [A, B, C])                # primes the known-good
+        with _reads_fault(self._path()):
+            self.assertEqual(km._session_order(), [A, B, C])
+            self.assertEqual(km._session_order(), [A, B, C], "the second faulted read serves the same -- nothing was latched")
+            self.assertEqual(km._session_order_lkg[0], [A, B, C])
+        self.assertEqual(km._session_order(), [A, B, C])
+
+    def test_a_fault_with_no_known_good_serves_empty_and_latches_nothing(self):
+        km._write_session_order([A, B, C])
+        km._session_order_lkg[0] = None                                # a cold start: nothing read yet
+        with _reads_fault(self._path()):
+            self.assertEqual(km._session_order(), [], "no known-good: the empty default, unproved")
+            self.assertIsNone(km._session_order_lkg[0], "the fault's [] is NOT latched as the known-good")
+        self.assertEqual(km._session_order(), [A, B, C], "the real order reads once the fault clears")
+
+    def test_the_display_read_returns_a_copy_so_a_caller_cannot_mutate_the_known_good(self):
+        km._write_session_order([A, B])
+        got = km._session_order(); got.append(C)
+        self.assertEqual(km._session_order_lkg[0], [A, B])
+
+
+class OrderWsRefusal(unittest.TestCase):
+    """The reorderTabs / writeOrder WS arm under a store fault: the order file is untouched, the
+    poster gets a `settingRefused` frame on its own socket, nothing escapes _dispatch_ws."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.jd.STATE, km._mark_views_dirty, km._session_order_lkg[0])
+        km.jd.STATE = Path(self.td.name)
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        km.jd.STATE, km._mark_views_dirty, km._session_order_lkg[0] = self._saved
+        self.td.cleanup()
+
+    def test_a_refused_drag_answers_the_poster_and_leaves_the_order_alone(self):
+        km._write_session_order([A, B, C])
+        p = km.jd.STATE / "session-order.json"
+        before = p.read_bytes()
+        sent = []
+        client = {"app": "chat", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _reads_fault(p):
+            km.Handler._dispatch_ws(None, {"type": "reorderTabs", "order": [C, B]}, client)
+        self.assertEqual(p.read_bytes(), before, "the order file is byte-for-byte unchanged (a fold-to-[] would have dropped A)")
+        self.assertEqual(len(sent), 1)
+        self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["value"]), ("settingRefused", "order", None))
+        self.assertIn("couldn't save the new order", sent[0]["text"])
+        self.assertIn("session-order.json could not be read", sent[0]["text"])
+        self.assertEqual(self.dirty, [])
+
+    def test_a_clean_drag_still_lands(self):
+        km._write_session_order([A, B, C])
+        sent = []
+        client = {"app": "chat", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        km.Handler._dispatch_ws(None, {"type": "reorderTabs", "order": [C, B]}, client)
+        self.assertEqual(sent, [])
+        self.assertEqual(km._session_order_proved(), [A, C, B], "the drag merged: the untouched lane keeps its slot, the dragged pair reorders in place")
+        self.assertEqual(self.dirty, [1])
+
+
+class StateQuarantineShape(unittest.TestCase):
+    """The quarantine wears the shape the goal-store and ledger quarantines wear: `<file>.corrupt-<utc
+    stamp>` with a `-n` suffix for a second collision, an os.replace, and a same-file re-check
+    (inode, mtime, size) before the move -- so an atomic publish that landed between the read and
+    the rename is never moved aside, and bytes that cannot be moved leave the store UNREADABLE (a
+    writer refuses) rather than read as empty over evidence that was not preserved."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved_state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+
+    def tearDown(self):
+        km.jd.STATE = self._saved_state
+        self.td.cleanup()
+
+    def _path(self):
+        return km.jd.STATE / "session-order.json"
+
+    def test_a_second_corrupt_file_in_the_same_second_gets_a_numbered_suffix(self):
+        fixed = time.gmtime(1_800_000_000)
+        with mock.patch.object(km.time, "gmtime", return_value=fixed):
+            stamp = time.strftime("%Y%m%dT%H%M%SZ", fixed)
+            first = self._path().with_name("session-order.json.corrupt-" + stamp)
+            first.write_bytes(b"earlier corrupt bytes")
+            torn = b'["aaaa", NOT JSON'
+            self._path().write_bytes(torn)
+            self.assertIsNone(km._read_state_json(self._path()))
+        self.assertEqual(first.read_bytes(), b"earlier corrupt bytes", "the earlier quarantine is never overwritten")
+        second = self._path().with_name("session-order.json.corrupt-" + stamp + "-1")
+        self.assertEqual(second.read_bytes(), torn, "the collision takes the -1 suffix")
+        self.assertFalse(self._path().exists())
+
+    def test_a_file_republished_between_the_read_and_the_rename_is_not_moved_aside(self):
+        # the torn bytes are read, and BEFORE the quarantine's rename an atomic publish replaces the
+        # file with a good one (a writer on another thread): the re-check sees a different inode /
+        # mtime / size and leaves the new file exactly where it is -- the caller gets a transient
+        # UNREADABLE (its next read is a fresh one), never a good file quarantined
+        good = json.dumps([A, B]).encode()
+        p = self._path()
+        p.write_bytes(b'["aaaa", NOT JSON')
+        real_rb = Path.read_bytes
+        def rb(self_, *a, **k):
+            raw = real_rb(self_, *a, **k)
+            if str(self_) == str(p):
+                km._atomic_write(p, good.decode())                 # the publish lands after our read
+            return raw
+        Path.read_bytes = rb
+        try:
+            with self.assertRaises(km._StateUnreadable) as cm:
+                km._read_state_json(p)
+        finally:
+            Path.read_bytes = real_rb
+        self.assertIn("replaced meanwhile", str(cm.exception))
+        self.assertEqual(p.read_bytes(), good, "the republished good file is untouched")
+        self.assertEqual(list(km.jd.STATE.glob("session-order.json.corrupt-*")), [], "nothing was moved aside")
+        self.assertEqual(km._read_state_json(p), [A, B], "the next read is a fresh, clean one")
+
+    def test_bytes_that_cannot_be_moved_aside_leave_the_store_unreadable_not_empty(self):
+        p = self._path()
+        torn = b'["aaaa", NOT JSON'
+        p.write_bytes(torn)
+        with mock.patch.object(km.os, "replace", side_effect=PermissionError(errno.EACCES, "Permission denied")):
+            with self.assertRaises(km._StateUnreadable) as cm:
+                km._read_state_json(p)
+            self.assertIn("could not be moved aside: [Errno 13] Permission denied", str(cm.exception))
+            self.assertEqual(p.read_bytes(), torn, "the evidence stays in place; the store is not read as empty over it")
+            with self.assertRaises(km._StateUnreadable):
+                km._session_order_proved()                             # so a writer refuses, exactly as for an EIO
+        self.assertEqual(p.read_bytes(), torn)
+
+    def test_the_move_is_an_os_replace_and_the_fault_text_carries_no_stamp_or_path(self):
+        # the fault text feeds the once-per-fault-text registries: a path or a per-second stamp in it
+        # would defeat the dedupe (the ledgers' lesson), so it is errno + strerror only
+        e = km._StateUnreadable(self._path(), "read failed: %s" % km._errno_text(OSError(errno.EIO, "Input/output error", "/some/where")))
+        self.assertEqual(e.fault, "read failed: [Errno 5] Input/output error")
+        self.assertNotIn("/some/where", str(e))
+        with mock.patch.object(km.os, "replace", wraps=os.replace) as rep:
+            self._path().write_bytes(b"{ not json")
+            self.assertIsNone(km._read_state_json(self._path()))
+        self.assertEqual(rep.call_count, 1, "the quarantine moves with os.replace, like its siblings")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -315,6 +315,25 @@ def _reads_fault(target):
         Path.read_bytes, Path.read_text = real_rb, real_rt
 
 
+@contextlib.contextmanager
+def _writes_fault(target):
+    """Fail the PUBLISH of ONE state file with an ENOSPC for the duration of the block: _atomic_write
+    writes `<name>.tmp.<pid>.<tid>.<n>` beside the file and renames it over, so failing every write_text
+    of that shape is the disk refusing this file's publish while every other path, and every read, behaves."""
+    real = Path.write_text
+    prefix = Path(target).name + ".tmp."
+
+    def wt(self, *a, **k):
+        if self.name.startswith(prefix):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real(self, *a, **k)
+    Path.write_text = wt
+    try:
+        yield
+    finally:
+        Path.write_text = real
+
+
 class OrderDisplayReaderServesUnproved(unittest.TestCase):
     """The DISPLAY reader of the lane order under a fault serves the last order this kernel read or
     wrote -- and never latches what the fault produced as the new known-good. A reader that latched
@@ -399,6 +418,35 @@ class OrderWsRefusal(unittest.TestCase):
         self.assertEqual(km._session_order_proved(), [A, C, B], "the drag merged: the untouched lane keeps its slot, the dragged pair reorders in place")
         self.assertEqual(self.dirty, [1])
 
+    def test_a_drag_whose_publish_fails_is_refused_not_a_dropped_socket(self):
+        # the order READS and the merge is right, but the PUBLISH fails (ENOSPC): the maintainer's fold on PR
+        # #1019 -- the write step is a fault boundary too. Before, the write sat in the arm's `else:` outside
+        # its catch, and the OSError escaped _dispatch_ws to the receive loop, which dropped the client.
+        km._write_session_order([A, B, C])
+        km._state_fault_seen.clear()
+        p = km.jd.STATE / "session-order.json"
+        before = p.read_bytes()
+        sent = []
+        client = {"app": "chat", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _writes_fault(p):
+            try:
+                km.Handler._dispatch_ws(None, {"type": "reorderTabs", "order": [C, B]}, client)
+            except OSError:
+                self.fail("the OSError escaped _dispatch_ws -- the receive loop re-raises it and drops the client")
+        self.assertTrue(client["alive"])
+        self.assertEqual(p.read_bytes(), before, "the order file is byte-for-byte unchanged")
+        self.assertEqual(km._session_order_lkg[0], [A, B, C], "nothing is latched as known-good off a publish that failed")
+        self.assertEqual(len(sent), 1)
+        self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["value"]), ("settingRefused", "order", None))
+        self.assertIn("couldn't save the new order", sent[0]["text"])
+        self.assertIn("session-order.json could not be written", sent[0]["text"])
+        self.assertEqual(self.dirty, [])
+        self.assertIn(str(p), km._state_write_fault_seen, "the fault is on the path's write registry")
+        km.Handler._dispatch_ws(None, {"type": "reorderTabs", "order": [C, B]}, client)
+        self.assertEqual(len(sent), 1, "the disk heals: the drag lands and nothing more is said")
+        self.assertEqual(km._session_order_proved(), [A, C, B])
+        self.assertNotIn(str(p), km._state_write_fault_seen, "a landed write ends the episode")
+
 
 class StateQuarantineShape(unittest.TestCase):
     """The quarantine wears the shape the goal-store and ledger quarantines wear: `<file>.corrupt-<utc
@@ -436,8 +484,9 @@ class StateQuarantineShape(unittest.TestCase):
     def test_a_file_republished_between_the_read_and_the_rename_is_not_moved_aside(self):
         # the torn bytes are read, and BEFORE the quarantine's rename an atomic publish replaces the
         # file with a good one (a writer on another thread): the re-check sees a different inode /
-        # mtime / size and leaves the new file exactly where it is -- the caller gets a transient
-        # UNREADABLE (its next read is a fresh one), never a good file quarantined
+        # mtime / size and leaves the new file exactly where it is -- and the peer's bytes get their own
+        # read IN THIS CALL (the maintainer's fold on PR #1019, bounded), so the caller gets what is there
+        # now rather than a transient UNREADABLE; never a good file quarantined
         good = json.dumps([A, B]).encode()
         p = self._path()
         p.write_bytes(b'["aaaa", NOT JSON')
@@ -449,14 +498,35 @@ class StateQuarantineShape(unittest.TestCase):
             return raw
         Path.read_bytes = rb
         try:
+            got = km._read_state_json(p)                           # raised a transient _StateUnreadable before the fold
+        finally:
+            Path.read_bytes = real_rb
+        self.assertEqual(got, [A, B], "the reader returns what is there now: the peer's valid store")
+        self.assertEqual(p.read_bytes(), good, "the republished good file is untouched")
+        self.assertEqual(list(km.jd.STATE.glob("session-order.json.corrupt-*")), [], "nothing was moved aside")
+
+    def test_a_file_that_keeps_changing_under_the_read_is_unreadable_after_the_bound(self):
+        # the re-read is BOUNDED: a peer republishing torn bytes under every read is chased three times,
+        # then the reader stops and raises the transient _StateUnreadable (never a spin, never a move aside)
+        p = self._path()
+        p.write_bytes(b'["aaaa", NOT JSON')
+        real_rb, reads = Path.read_bytes, []
+
+        def rb(self_, *a, **k):
+            raw = real_rb(self_, *a, **k)
+            if str(self_) == str(p):
+                reads.append(1)
+                km._atomic_write(p, '["bbbb", NOT JSON' + " " * len(reads))   # torn again, a new size each time
+            return raw
+        Path.read_bytes = rb
+        try:
             with self.assertRaises(km._StateUnreadable) as cm:
                 km._read_state_json(p)
         finally:
             Path.read_bytes = real_rb
+        self.assertEqual(len(reads), 3, "three tries, then the reader stops chasing the file")
         self.assertIn("replaced meanwhile", str(cm.exception))
-        self.assertEqual(p.read_bytes(), good, "the republished good file is untouched")
-        self.assertEqual(list(km.jd.STATE.glob("session-order.json.corrupt-*")), [], "nothing was moved aside")
-        self.assertEqual(km._read_state_json(p), [A, B], "the next read is a fresh, clean one")
+        self.assertEqual(list(km.jd.STATE.glob("session-order.json.corrupt-*")), [], "nothing of a peer's was moved aside")
 
     def test_bytes_that_cannot_be_moved_aside_leave_the_store_unreadable_not_empty(self):
         p = self._path()

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -187,6 +187,28 @@ class FlagsStoreUnreadableRefuses(unittest.TestCase):
 import contextlib
 import errno
 import json
+import shutil
+import subprocess
+from unittest import mock
+
+
+@contextlib.contextmanager
+def _stat_fault(target):
+    """Fail every stat of ONE path with an EACCES for the duration of the block -- the arm the read-fault
+    injector never reaches (review find, 2026-09-08): every reader stats BEFORE it reads (the display
+    readers key their cache on it), and a state dir that cannot be searched faults exactly there.
+    Everything else stats normally."""
+    real_stat = Path.stat
+    tgt = str(target)
+    def st(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EACCES, "injected EACCES")
+        return real_stat(self, *a, **k)
+    Path.stat = st
+    try:
+        yield
+    finally:
+        Path.stat = real_stat
 
 
 @contextlib.contextmanager
@@ -262,7 +284,7 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
         km._state_fault_seen.clear()
         self.notices = []
         self._notice = km._sync_notice
-        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok, kind))
 
     def tearDown(self):
         km._sync_notice = self._notice
@@ -273,6 +295,75 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
 
     def _path(self):
         return jd.STATE / "session-flags.json"
+
+    def test_a_stat_fault_serves_the_last_read_value_and_refuses_the_writers(self):
+        # the STAT arm (review find, 2026-09-08: every injector faulted the read, so the reader's stat
+        # arm and the proved reader's were unpinned -- reverting either to a silent `return {}` passed)
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        self.assertEqual(km._session_flags(), {self.OTHER: {"postalServiceOff": True}})   # primes the cache
+        key1 = km._flags_cache[str(self._path())][0]
+        before = self._path().read_bytes()
+        with _stat_fault(self._path()):
+            self.assertEqual(km._session_flags(), {self.OTHER: {"postalServiceOff": True}},
+                             "the stat arm serves the LAST value read, not {}")
+            self.assertEqual(km._flags_cache[str(self._path())], (key1, {self.OTHER: {"postalServiceOff": True}}),
+                             "and caches nothing new")
+            with self.assertRaises(km._StateUnreadable) as cm:
+                km._session_flags_proved()                              # the proved reader raises on the stat
+            self.assertIn("stat failed: [Errno 13]", str(cm.exception))
+            with self.assertRaises(km._StateUnreadable):
+                km._set_session_flag(self.SID, "hideFromFeed", True)     # so a writer refuses
+        self.assertEqual(self._path().read_bytes(), before, "the refused write left the file alone")
+        bad = [t for t, ok, _k in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "one notice for the episode, from the display reader's stat arm")
+        self.assertIn("stat failed: [Errno 13]", bad[0])
+        km._flags_cache.clear()
+        with _stat_fault(self._path()):
+            self.assertEqual(km._session_flags(), {}, "a cold cache serves the empty default under a stat fault")
+            self.assertNotIn(str(self._path()), km._flags_cache, "…uncached")
+
+    def test_the_fault_notice_is_filed_under_the_refused_kind_not_sync(self):
+        # review find, 2026-09-08: filed under the ring's default (sync) kind, the notice wore the
+        # machine-sync label and a mute on that log silenced every disk-fault notice with it
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        with _reads_fault(self._path()):
+            km._session_flags()
+        self.assertEqual([(ok, k) for _t, ok, k in self.notices], [(False, "refused")])
+
+    def test_a_quarantine_tells_the_dashboard_once_under_the_refused_kind(self):
+        # review find, 2026-09-08: a quarantine reset the store to empty with only a stderr line, so
+        # from the dashboard every flag (postal isolation included) simply reset itself
+        torn = b'{"' + self.OTHER.encode() + b'": {"postalServiceOff": tr'
+        self._path().write_bytes(torn)
+        self.assertEqual(km._session_flags_proved(), {})
+        self.assertEqual(len(self.notices), 1, "one notice for the move")
+        text, ok, kind = self.notices[0]
+        self.assertEqual((ok, kind), (False, "refused"))
+        self.assertIn("session-flags.json could not be parsed and was moved aside to session-flags.json.corrupt-", text)
+        self.assertIn("start over empty", text)
+        aside = list(jd.STATE.glob("session-flags.json.corrupt-*"))
+        self.assertEqual(len(aside), 1)
+        self.assertIn(aside[0].name, text, "the notice names the sidecar, so the bytes can be found")
+        self.assertEqual(km._session_flags_proved(), {})                # the next read is an ENOENT …
+        self.assertEqual(len(self.notices), 1, "… and files nothing more: a corrupt file speaks exactly once")
+
+    def test_valid_json_of_the_wrong_shape_is_quarantined_not_read_as_empty(self):
+        # review find, 2026-09-08: a LIST where the flags dict belongs read as a proved empty store and
+        # was overwritten by the next writer -- a file none of our writers produce, gone without a trace
+        wrong = b'["' + self.OTHER.encode() + b'"]'
+        self._path().write_bytes(wrong)
+        self.assertEqual(km._session_flags_proved(), {}, "empty only AFTER the bytes are moved aside")
+        aside = list(jd.STATE.glob("session-flags.json.corrupt-*"))
+        self.assertEqual(len(aside), 1, "quarantined like torn bytes")
+        self.assertEqual(aside[0].read_bytes(), wrong)
+        self.assertFalse(self._path().exists())
+        self.assertEqual([k for _t, _ok, k in self.notices], ["refused"])
+        self._path().write_bytes(wrong)
+        km._flags_cache.clear()
+        self.assertEqual(km._session_flags(), {}, "the display reader quarantines it the same way")
+        self.assertEqual(len(list(jd.STATE.glob("session-flags.json.corrupt-*"))), 2)
 
     def test_a_fault_serves_the_last_read_value_and_caches_nothing_new(self):
         km._set_session_flag(self.OTHER, "postalServiceOff", True)
@@ -309,7 +400,7 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
         km._flags_cache.clear()
         with _reads_fault(self._path()):
             km._session_flags(); km._session_flags(); km._session_flags()
-        bad = [t for t, ok in self.notices if not ok]
+        bad = [t for t, ok, _k in self.notices if not ok]
         self.assertEqual(len(bad), 1, "one notice per fault episode, however many builds read the store")
         self.assertIn("session-flags.json could not be read", bad[0])
         self.assertIn("[Errno 5]", bad[0])
@@ -318,7 +409,7 @@ class FlagsDisplayReaderServesUnproved(unittest.TestCase):
         with _reads_fault(self._path()):
             km._flags_cache.clear()
             km._session_flags()
-        self.assertEqual(len([t for t, ok in self.notices if not ok]), 2, "a fresh episode speaks again")
+        self.assertEqual(len([t for t, ok, _k in self.notices if not ok]), 2, "a fresh episode speaks again")
 
 
 class FlagsWsRefusal(unittest.TestCase):
@@ -373,6 +464,28 @@ class FlagsWsRefusal(unittest.TestCase):
         self.assertEqual(sent, [], "no frame on success -- the next push carries the value")
         self.assertTrue(km._session_flag(self.SID, "hideFromFeed"))
         self.assertEqual(self.dirty, [1])
+
+    def test_a_refusal_carries_the_painted_value_when_it_is_on(self):
+        # `value` is what the display path still PAINTS, so the pane repaints a refused toggle to it. Every
+        # other case here paints off (review find, 2026-09-08: a constant False survived), so this one
+        # paints ON for both arms: the flag is set, and the master is on (the bell's default with no
+        # override). The file then moves on (a new stat key) so the faulted read is a real miss served
+        # from the primed cache, not a cache hit
+        km._set_session_flag(self.SID, "hideFromFeed", True)
+        km._set_notify_all(True)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        km._session_flags(); km._notify_cards()                         # prime the display caches
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)       # bump the flags file's stat key
+        p = jd.STATE / "session-flags.json"
+        before = p.read_bytes()
+        for flag in ("hideFromFeed", "notify"):
+            client, sent = self._client()
+            with _reads_fault(p):
+                km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": flag, "value": False}, client)
+            self.assertEqual(len(sent), 1)
+            self.assertEqual(sent[0]["gesture"], "flag")
+            self.assertIs(sent[0]["value"], True, "%s: the kernel still paints ON, and the frame says so" % flag)
+        self.assertEqual(p.read_bytes(), before)
 
 
 class SessionBellJudgedAgainstAProvedMaster(unittest.TestCase):
@@ -450,7 +563,7 @@ class FlagsWsWriteFailure(unittest.TestCase):
         vars(km).get("_state_write_fault_seen", {}).clear()
         self.dirty, self.notices = [], []
         km._mark_views_dirty = lambda: self.dirty.append(1)
-        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok))
 
     def tearDown(self):
         jd.STATE, km._mark_views_dirty, km._sync_notice = self.saved
@@ -501,6 +614,23 @@ class FlagsWsWriteFailure(unittest.TestCase):
         self.assertEqual(len([t for t, ok in self.notices if not ok]), 2, "a new episode is filed again")
         self.assertTrue(km._session_flag(self.SID, "hideFromFeed"), "nothing applied: the store keeps the value")
 
+    def test_a_failed_rename_refuses_the_same_way_and_leaves_no_temp_behind(self):
+        # the publish's OTHER fault point (review find, 2026-09-08): the temp WROTE, and the rename over
+        # the live file failed (EACCES on the directory, EROFS). The same refusal on the socket, and
+        # _atomic_write's unlink means the failed publish leaves no `<name>.tmp.*` beside the store
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        p = jd.STATE / "session-flags.json"
+        before = p.read_bytes()
+        client, sent = self._client()
+        with mock.patch.object(km.os, "replace", side_effect=PermissionError(errno.EACCES, "Permission denied")):
+            km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": True}, client)
+        self.assertTrue(client["alive"])
+        self.assertEqual(p.read_bytes(), before)
+        self.assertEqual([m["type"] for m in sent], ["settingRefused"])
+        self.assertIn("session-flags.json could not be written (write failed: [Errno 13] Permission denied)", sent[0]["text"])
+        self.assertEqual(list(jd.STATE.glob("session-flags.json.tmp.*")), [], "the failed publish left no temp behind")
+
     def test_the_setter_raises_the_plain_exception_never_the_os_error(self):
         p = jd.STATE / "session-flags.json"
         with _writes_fault(p):
@@ -510,6 +640,118 @@ class FlagsWsWriteFailure(unittest.TestCase):
         self.assertEqual(str(cm.exception), "session-flags.json could not be written (write failed: [Errno 28] No space left on device)")
         self.assertEqual((cm.exception.path.name, cm.exception.fault), ("session-flags.json", "write failed: [Errno 28] No space left on device"))
         self.assertFalse(p.exists(), "nothing was published")
+
+
+class SyncNoticeRowsCarryAKind(unittest.TestCase):
+    """The ring the shell's bell mirrors carries each row's KIND (review find, 2026-09-08): "sync" by
+    default (a machine sync, the ring's original tenant), "refused" for a state-file fault or a
+    quarantine, so the shell files the two apart and a mute on one never hides the other."""
+
+    def setUp(self):
+        self._ring, self._seq = list(km._SYNC_NOTICES), km._SYNC_SEQ
+
+    def tearDown(self):
+        km._SYNC_NOTICES[:] = self._ring
+        km._SYNC_SEQ = self._seq
+
+    def test_the_default_is_sync_and_a_fault_files_refused(self):
+        km._sync_notice("pushed this machine's build to TESTHOST")
+        self.assertEqual(km._sync_notice_rows()[-1]["kind"], "sync")
+        km._sync_notice("a fault", ok=False, kind="refused")
+        row = km._sync_notice_rows()[-1]
+        self.assertEqual((row["kind"], row["ok"]), ("refused", False))
+        km._state_fault_seen.clear(); km._state_write_fault_seen.clear()
+        km._note_state_fault(km._StateUnreadable(Path("/x/session-flags.json"), "read failed: [Errno 5] Input/output error"))
+        row = km._sync_notice_rows()[-1]
+        self.assertEqual(row["kind"], "refused", "the display-read fault reaches the bell under its own kind")
+        self.assertIn("session-flags.json could not be read", row["text"])
+        km._note_state_fault(km._StateUnwritable(Path("/x/session-flags.json"), "write failed: [Errno 28] No space left on device"))
+        km._state_fault_seen.clear(); km._state_write_fault_seen.clear()
+        row = km._sync_notice_rows()[-1]
+        self.assertEqual(row["kind"], "refused", "and so does a write fault")
+        self.assertIn("session-flags.json could not be written", row["text"])
+
+
+NODE = shutil.which("node")
+VIEW_JS = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "ui", "romp-timeline-view.js")
+
+# The timeline's Obsidian-desktop fallback writer of session-flags.json, executed in node with a stubbed
+# fs (the tests/test_timeline_touch.py harness shape). Synthetic sids; ROMP_STATE_DIR is a temp dir and fs
+# is stubbed besides, so no real file is ever touched.
+_WRITER_HARNESS = r"""
+const { TimelinePanel } = require(process.argv[1]);
+const fs = require('fs'), path = require('path');
+process.env.ROMP_STATE_DIR = process.argv[2];
+const fp = path.join(process.argv[2], 'session-flags.json');
+const SID = '11111111-2222-3333-4444-555555555555', OTHER = '99999999-8888-7777-6666-555555555555';
+const real = { readFileSync: fs.readFileSync, writeFileSync: fs.writeFileSync, renameSync: fs.renameSync, mkdirSync: fs.mkdirSync };
+function run(readImpl) {
+  const writes = [], renames = [];
+  fs.readFileSync = function (p) { if (String(p) === fp) return readImpl(); return real.readFileSync.apply(fs, arguments); };
+  fs.writeFileSync = function (p, data) { writes.push([String(p), String(data)]); };
+  fs.renameSync = function (a, b) { renames.push([String(a), String(b)]); };
+  fs.mkdirSync = function () {};
+  try {
+    const v = Object.create(TimelinePanel.prototype);
+    v._setSessionFlag({ id: SID }, 'hideFromFeed', true);
+  } finally { Object.assign(fs, real); }
+  return { writes, renames };
+}
+const err = (code) => Object.assign(new Error(code), { code });
+const r = {};
+process.versions.electron = '1.0.0-test';                   // the Electron guard: the writer runs at all
+r.eio = run(() => { throw err('EIO'); });                   // a read fault
+r.torn = run(() => '{"' + OTHER + '": {"postalServiceOff": tr');   // torn bytes
+r.list = run(() => '["' + OTHER + '"]');                   // valid JSON of the wrong shape
+r.enoent = run(() => { throw err('ENOENT'); });             // a legitimately missing store
+r.clean = run(() => JSON.stringify({ [OTHER]: { postalServiceOff: true } }));
+delete process.versions.electron;
+r.noElectron = run(() => { throw err('ENOENT'); });         // a bare-node run: nothing at all
+process.stdout.write(JSON.stringify({ fp, ...r }));
+"""
+
+
+@unittest.skipUnless(NODE, "node not available")
+class TimelineFallbackFlagWriter(unittest.TestCase):
+    """The timeline's Obsidian-desktop fallback writer of session-flags.json (review find, 2026-09-08)
+    had the exact shape the kernel dropped: any read fault or torn bytes became {} and was written over
+    EVERY session's flags, in place -- so the kernel's strict reader could observe 0 bytes mid-write
+    and quarantine the very file being written. It now refuses on anything but a missing file, and
+    publishes tmp + rename, like _persistOrder."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        out = subprocess.run([NODE, "-e", _WRITER_HARNESS, VIEW_JS, cls.td.name],
+                             capture_output=True, text=True, timeout=60)
+        if out.returncode != 0:
+            raise RuntimeError(out.stderr)
+        cls.r = json.loads(out.stdout)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_a_read_fault_torn_bytes_or_the_wrong_shape_write_nothing(self):
+        for case in ("eio", "torn", "list"):
+            self.assertEqual(self.r[case]["writes"], [], "%s: never written over a store that could not be read" % case)
+            self.assertEqual(self.r[case]["renames"], [], case)
+
+    def test_a_missing_store_is_written_atomically(self):
+        fp = self.r["fp"]
+        writes, renames = self.r["enoent"]["writes"], self.r["enoent"]["renames"]
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0][0], fp + ".tmp", "the bytes go to the temp, never the live file")
+        self.assertEqual(json.loads(writes[0][1]), {"11111111-2222-3333-4444-555555555555": {"hideFromFeed": True}})
+        self.assertEqual(renames, [[fp + ".tmp", fp]], "one atomic publish")
+
+    def test_a_clean_read_keeps_the_other_sessions_flags(self):
+        writes = self.r["clean"]["writes"]
+        self.assertEqual(json.loads(writes[0][1]), {"99999999-8888-7777-6666-555555555555": {"postalServiceOff": True},
+                                                    "11111111-2222-3333-4444-555555555555": {"hideFromFeed": True}})
+
+    def test_without_electron_nothing_is_touched(self):
+        self.assertEqual((self.r["noElectron"]["writes"], self.r["noElectron"]["renames"]), ([], []))
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -103,6 +103,315 @@ class AutoNudgeWiring(unittest.TestCase):
             td.cleanup()
 
 
+class FlagsStoreUnreadableRefuses(unittest.TestCase):
+    """The state-readers audit (rank 5): the session-flags reader used to fold ANY read fault to {}
+    and CACHE it, so _set_session_flag copied that empty, applied one edit, and atomically wrote it
+    back — erasing every session's flags (including the postalServiceOff isolation boundaries) under
+    a silent success. The setters now read PROVED: a read fault refuses the write loudly and the
+    file is left exactly as it was. Synthetic sids only."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    OTHER = "99999999-8888-7777-6666-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _path(self):
+        return jd.STATE / "session-flags.json"
+
+    def _fault_reads_of(self, target):
+        """Fail BOTH read_bytes (the fix's proved reader) and read_text (origin/main's reader) for one
+        path, so the same test injects the fault on either tree — green on the fix, RED on main where
+        the fold-to-{} erases the flags."""
+        import errno
+        real_rb, real_rt = Path.read_bytes, Path.read_text
+        tgt = str(target)
+        def rb(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rb(self, *a, **k)
+        def rt(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rt(self, *a, **k)
+        Path.read_bytes, Path.read_text = rb, rt
+        return (real_rb, real_rt)
+
+    def test_a_flag_toggle_is_refused_when_the_flags_store_cannot_be_read(self):
+        # a populated store: the OTHER session is isolated from the postal bus — a safety boundary
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        before = self._path().read_bytes()
+        saved = self._fault_reads_of(self._path())
+        raised = None
+        try:
+            km._set_session_flag(self.SID, "hideFromFeed", True)   # a fresh edit on another sid
+        except Exception as e:                                     # noqa: BLE001 — on main it never raises
+            raised = e
+        finally:
+            Path.read_bytes, Path.read_text = saved
+        km._flags_cache.clear()
+        # THE erasure the audit is about: on origin/main the read folds to {}, the setter writes
+        # {SID:{hideFromFeed}} and the OTHER session's isolation boundary is GONE — this assertion is
+        # what turns RED there. The fix refuses the write, so the file is byte-for-byte unchanged.
+        self.assertEqual(self._path().read_bytes(), before,
+                         "the flags file must be unchanged when its file can't be read (main erases it here)")
+        self.assertTrue(km._session_flag(self.OTHER, "postalServiceOff"),
+                        "the pre-existing isolation flag survives the refused toggle")
+        self.assertEqual(type(raised).__name__, "_StateUnreadable",
+                         "the write is refused LOUDLY, not folded to a fabricated empty (got %r)" % raised)
+
+    def test_a_torn_flags_file_is_quarantined_aside_not_overwritten(self):
+        torn = b'{"sid": {"hideFromFeed": true'
+        self._path().write_bytes(torn)
+        km._flags_cache.clear()
+        self.assertEqual(km._session_flags_proved(), {}, "the store starts empty only after the bytes are saved")
+        q = list(jd.STATE.glob("session-flags.json.corrupt-*"))
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q[0].read_bytes(), torn, "the quarantine holds the ORIGINAL bytes")
+        self.assertFalse(self._path().exists())
+
+    def test_enoent_flags_still_reads_empty_with_no_quarantine(self):
+        self.assertEqual(km._session_flags(), {}, "a missing store is legitimately empty")
+        self.assertEqual(km._session_flags_proved(), {})
+        self.assertEqual(list(jd.STATE.glob("session-flags.json.corrupt-*")), [])
+
+
+import contextlib
+import errno
+import json
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO (the proved reader's read_bytes and the pre-fix
+    reader's read_text alike) for the duration of the block; everything else reads normally."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
+class StateUnreadableIsAPlainException(unittest.TestCase):
+    """The WS receive loop re-raises (BrokenPipeError, ConnectionResetError, OSError) as a genuine
+    socket failure and tears the connection down; every other exception falls to its logging arm
+    and the next message still processes. A store-read fault must be the second kind: one handler
+    branch that forgets to catch it costs a logged line, never the dashboard's socket."""
+
+    def test_it_is_an_exception_but_never_an_oserror(self):
+        self.assertTrue(issubclass(km._StateUnreadable, Exception))
+        self.assertFalse(issubclass(km._StateUnreadable, OSError),
+                         "as an OSError the WS loop would classify a read fault as a socket failure")
+
+    def test_it_names_the_file_and_the_fault_in_plain_words(self):
+        e = km._StateUnreadable(Path("/tmp/x/session-flags.json"), "read failed: [Errno 5] Input/output error")
+        self.assertEqual(str(e), "session-flags.json could not be read (read failed: [Errno 5] Input/output error)")
+        self.assertEqual((e.path.name, e.fault), ("session-flags.json", "read failed: [Errno 5] Input/output error"))
+
+
+class FlagsDisplayReaderServesUnproved(unittest.TestCase):
+    """The DISPLAY reader under a fault: the last value this kernel read if it holds one, else {}
+    -- and NEITHER is cached under the file's stat key. A reader that cached what a fault produced
+    would keep serving it after the disk recovered (same key, a cache HIT never reads), which is how
+    the pre-fix reader turned a transient EIO into a permanent empty."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    OTHER = "99999999-8888-7777-6666-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        km._state_fault_seen.clear()
+        self.notices = []
+        self._notice = km._sync_notice
+        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+
+    def tearDown(self):
+        km._sync_notice = self._notice
+        jd.STATE = self.saved
+        km._flags_cache.clear()
+        km._state_fault_seen.clear()
+        self.td.cleanup()
+
+    def _path(self):
+        return jd.STATE / "session-flags.json"
+
+    def test_a_fault_serves_the_last_read_value_and_caches_nothing_new(self):
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        first = km._session_flags()                                    # a clean read primes the cache
+        key1 = km._flags_cache[str(self._path())][0]
+        self.assertEqual(first, {self.OTHER: {"postalServiceOff": True}})
+        # the file moves on (a second session's flag lands), so the stat key changes and the next
+        # read is a MISS -- a primed cache under the same key would be a hit and never read at all
+        km._set_session_flag(self.SID, "hideFromFeed", True)
+        key2 = self._path().stat(); key2 = (key2.st_mtime_ns, key2.st_size)
+        self.assertNotEqual(key1, key2, "the write must move the stat key, or this test reads nothing")
+        with _reads_fault(self._path()):
+            served = km._session_flags()
+            self.assertEqual(served, {self.OTHER: {"postalServiceOff": True}},
+                             "the fault serves the LAST value this kernel read, not the unread file and not {}")
+            self.assertEqual(km._flags_cache[str(self._path())][0], key1,
+                             "nothing is cached under the NEW key -- the fault produced no value worth keeping")
+        # the disk recovers: the reader reads the real, newer file (a reader that had cached the
+        # fault's value under key2 would serve the stale copy here forever)
+        self.assertEqual(km._session_flags(), {self.OTHER: {"postalServiceOff": True}, self.SID: {"hideFromFeed": True}})
+
+    def test_a_fault_on_a_cold_cache_serves_the_empty_default_uncached(self):
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        with _reads_fault(self._path()):
+            self.assertEqual(km._session_flags(), {}, "no known-good yet: the empty default, unproved")
+            self.assertNotIn(str(self._path()), km._flags_cache, "…and it is NOT cached")
+        self.assertEqual(km._session_flags(), {self.OTHER: {"postalServiceOff": True}},
+                         "the real flags read once the fault clears -- the empty was never latched")
+
+    def test_the_fault_is_loud_once_per_episode_and_a_clean_read_rearms_it(self):
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        with _reads_fault(self._path()):
+            km._session_flags(); km._session_flags(); km._session_flags()
+        bad = [t for t, ok in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "one notice per fault episode, however many builds read the store")
+        self.assertIn("session-flags.json could not be read", bad[0])
+        self.assertIn("[Errno 5]", bad[0])
+        km._session_flags()                                            # the clean read ends the episode
+        self.assertNotIn(str(self._path()), km._state_fault_seen)
+        with _reads_fault(self._path()):
+            km._flags_cache.clear()
+            km._session_flags()
+        self.assertEqual(len([t for t, ok in self.notices if not ok]), 2, "a fresh episode speaks again")
+
+
+class FlagsWsRefusal(unittest.TestCase):
+    """The setSessionFlag WS arm under a store fault: the file is untouched, the poster gets a
+    `settingRefused` frame addressed to its toggle (sid + flag) on its OWN socket, and nothing
+    escapes _dispatch_ws. A `warn` frame did not reach the timeline page (no handler) so the lane
+    gear kept showing the refused state until a reload."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    OTHER = "99999999-8888-7777-6666-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty)
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty = self.saved
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _client(self):
+        sent = []
+        return {"app": "timeline", "wid": "w1", "alive": True,
+                "send": lambda raw: sent.append(json.loads(raw))}, sent
+
+    def test_a_refused_toggle_answers_the_poster_and_leaves_the_file_alone(self):
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        p = jd.STATE / "session-flags.json"
+        before = p.read_bytes()
+        for flag in ("hideFromFeed", "notify"):                       # both arms of the branch: the plain setter and the tri-state bell
+            client, sent = self._client()
+            with _reads_fault(p):
+                km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": flag, "value": True}, client)
+            self.assertEqual(p.read_bytes(), before, "%s: the flags file is byte-for-byte unchanged" % flag)
+            self.assertEqual(len(sent), 1, "%s: exactly one frame, on the delivering socket" % flag)
+            fr = sent[0]
+            self.assertEqual((fr["type"], fr["sid"], fr["flag"], fr["itemId"]), ("settingRefused", self.SID, flag, ""))
+            self.assertEqual(fr["gesture"], "flag", "the frame names its gesture; no pane infers it from empty fields")
+            self.assertIs(fr["value"], False, "the value the kernel still paints for this flag rides along (here: unset -> off)")
+            self.assertIn("couldn't save that setting", fr["text"])
+            self.assertIn("session-flags.json could not be read", fr["text"])
+            self.assertNotIn("warn", fr["type"])
+        self.assertEqual(self.dirty, [], "a refused write marks nothing dirty -- there is nothing new to push")
+
+    def test_a_clean_toggle_still_lands_and_sends_no_refusal(self):
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": True}, client)
+        self.assertEqual(sent, [], "no frame on success -- the next push carries the value")
+        self.assertTrue(km._session_flag(self.SID, "hideFromFeed"))
+        self.assertEqual(self.dirty, [1])
+
+
+class SessionBellJudgedAgainstAProvedMaster(unittest.TestCase):
+    """_set_notify_session judges the click against the MASTER bell, which lives in the OTHER store
+    (notify-cards.json). Read through the display reader, a fault there folded the master to off, so a
+    click matching that fabricated master popped the session's stored override and rewrote
+    session-flags.json without it -- the user's mute erased under the success path. The master is read
+    PROVED now: a fault on the bells file refuses the flags write exactly like a fault on the flags file."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty)
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty = self.saved
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        self.td.cleanup()
+
+    def test_a_session_bell_click_is_refused_when_the_bells_store_cannot_be_read(self):
+        km._set_notify_all(True)                                   # the master is ON …
+        km._set_notify_session(self.SID, False)                    # … and this session is MUTED (a stored override)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        flags_p, cards_p = jd.STATE / "session-flags.json", jd.STATE / "notify-cards.json"
+        self.assertEqual(json.loads(flags_p.read_text()), {self.SID: {"notify": False}})
+        before = flags_p.read_bytes()
+        raised = None
+        with _reads_fault(cards_p):                                # the OTHER store faults
+            try:
+                km._set_notify_session(self.SID, False)            # the user clicks mute again (or the pane re-sends it)
+            except Exception as e:                                 # noqa: BLE001 -- before the fix it never raises
+                raised = e
+        # before the fix: the master folded to off, False == off, the override was POPPED and the flags file
+        # rewritten as {} -- the mute gone. Now the write is refused and the file is byte-for-byte unchanged.
+        self.assertEqual(flags_p.read_bytes(), before, "the flags file must be unchanged when the bells file can't be read")
+        self.assertEqual(type(raised).__name__, "_StateUnreadable", "refused loudly (got %r)" % raised)
+        self.assertIn("notify-cards.json", str(raised), "the refusal names the store that faulted")
+
+    def test_the_ws_arm_refuses_a_session_bell_on_the_other_store_s_fault(self):
+        km._set_notify_all(True); km._set_notify_session(self.SID, False)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        flags_p, cards_p = jd.STATE / "session-flags.json", jd.STATE / "notify-cards.json"
+        before = flags_p.read_bytes()
+        sent = []
+        client = {"app": "timeline", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _reads_fault(cards_p):
+            km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "notify", "value": False}, client)
+        self.assertEqual(flags_p.read_bytes(), before)
+        self.assertEqual(len(sent), 1)
+        self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["flag"]), ("settingRefused", "flag", "notify"))
+        self.assertIn("notify-cards.json could not be read", sent[0]["text"])
+        self.assertEqual(self.dirty, [])
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -210,6 +210,25 @@ def _reads_fault(target):
         Path.read_bytes, Path.read_text = real_rb, real_rt
 
 
+@contextlib.contextmanager
+def _writes_fault(target):
+    """Fail the PUBLISH of ONE state file with an ENOSPC for the duration of the block: _atomic_write
+    writes `<name>.tmp.<pid>.<tid>.<n>` beside the file and renames it over, so failing every write_text
+    of that shape is the disk refusing this file's publish while every other path, and every read, behaves."""
+    real = Path.write_text
+    prefix = Path(target).name + ".tmp."
+
+    def wt(self, *a, **k):
+        if self.name.startswith(prefix):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real(self, *a, **k)
+    Path.write_text = wt
+    try:
+        yield
+    finally:
+        Path.write_text = real
+
+
 class StateUnreadableIsAPlainException(unittest.TestCase):
     """The WS receive loop re-raises (BrokenPipeError, ConnectionResetError, OSError) as a genuine
     socket failure and tears the connection down; every other exception falls to its logging arm
@@ -410,6 +429,87 @@ class SessionBellJudgedAgainstAProvedMaster(unittest.TestCase):
         self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["flag"]), ("settingRefused", "flag", "notify"))
         self.assertIn("notify-cards.json could not be read", sent[0]["text"])
         self.assertEqual(self.dirty, [])
+
+
+class FlagsWsWriteFailure(unittest.TestCase):
+    """The setSessionFlag WS arm when the store READS but its PUBLISH fails (ENOSPC, EROFS, EACCES): the
+    maintainer's fold on PR #1019 -- a user gesture's WRITE step is a fault boundary too. Before, the arm
+    caught only _StateUnreadable, so the OSError out of _atomic_write escaped _dispatch_ws to the receive
+    loop, which re-raises any OSError as a socket failure: the dashboard was DROPPED without a word. Now
+    the publish raises _StateUnwritable, the arm answers the same settingRefused frame ("could not be
+    written"), the file is untouched, the fault is filed once per episode on the path's registry, and a
+    landed write ends the episode."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    OTHER = "99999999-8888-7777-6666-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty, km._sync_notice)
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear(); km._notify_cards_cache.clear(); km._state_fault_seen.clear()
+        vars(km).get("_state_write_fault_seen", {}).clear()
+        self.dirty, self.notices = [], []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty, km._sync_notice = self.saved
+        km._flags_cache.clear(); km._notify_cards_cache.clear(); km._state_fault_seen.clear()
+        vars(km).get("_state_write_fault_seen", {}).clear()
+        self.td.cleanup()
+
+    def _client(self):
+        sent = []
+        return {"app": "timeline", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}, sent
+
+    def test_a_failed_publish_answers_the_poster_instead_of_dropping_the_socket(self):
+        km._set_session_flag(self.OTHER, "postalServiceOff", True)
+        km._flags_cache.clear()
+        p = jd.STATE / "session-flags.json"
+        before = p.read_bytes()
+        with _writes_fault(p):
+            for flag in ("hideFromFeed", "notify"):                   # the plain setter and the tri-state bell
+                client, sent = self._client()
+                try:
+                    km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": flag, "value": True}, client)
+                except OSError:
+                    self.fail("%s: the OSError escaped _dispatch_ws -- the receive loop re-raises it and drops the client" % flag)
+                self.assertTrue(client["alive"])
+                self.assertEqual(p.read_bytes(), before, "%s: the flags file is byte-for-byte unchanged" % flag)
+                self.assertEqual(len(sent), 1, "%s: exactly one frame, on the delivering socket" % flag)
+                fr = sent[0]
+                self.assertEqual((fr["type"], fr["gesture"], fr["sid"], fr["flag"]), ("settingRefused", "flag", self.SID, flag))
+                self.assertIn("couldn't save that setting", fr["text"])
+                self.assertIn("session-flags.json could not be written", fr["text"])
+                self.assertIn("No space left on device", fr["text"])
+                self.assertNotIn(".tmp.", fr["text"], "errno + strerror only, never the temp path")
+                self.assertIs(fr["value"], False, "the value the kernel still paints rides along")
+        self.assertEqual(self.dirty, [], "a refused write marks nothing dirty")
+        self.assertEqual(len([t for t, ok in self.notices if not ok]), 1, "the fault is filed ONCE per episode, not per click")
+        self.assertIn("could not be written", self.notices[0][0])
+        self.assertIn("not saved", self.notices[0][0])
+        # the disk heals: the next click lands, ends the episode, and a fresh fault speaks again
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": True}, client)
+        self.assertEqual(sent, [])
+        self.assertTrue(km._session_flag(self.SID, "hideFromFeed"))
+        self.assertNotIn(str(p), km._state_write_fault_seen, "a landed write ends the episode")
+        with _writes_fault(p):
+            client, sent = self._client()
+            km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": False}, client)
+        self.assertEqual([m["type"] for m in sent], ["settingRefused"])
+        self.assertEqual(len([t for t, ok in self.notices if not ok]), 2, "a new episode is filed again")
+        self.assertTrue(km._session_flag(self.SID, "hideFromFeed"), "nothing applied: the store keeps the value")
+
+    def test_the_setter_raises_the_plain_exception_never_the_os_error(self):
+        p = jd.STATE / "session-flags.json"
+        with _writes_fault(p):
+            with self.assertRaises(km._StateUnwritable) as cm:
+                km._set_session_flag(self.SID, "hideFromFeed", True)
+        self.assertNotIsInstance(cm.exception, OSError, "an OSError is what the receive loop reads as a dead socket")
+        self.assertEqual(str(cm.exception), "session-flags.json could not be written (write failed: [Errno 28] No space left on device)")
+        self.assertEqual((cm.exception.path.name, cm.exception.fault), ("session-flags.json", "write failed: [Errno 28] No space left on device"))
+        self.assertFalse(p.exists(), "nothing was published")
 
 
 if __name__ == "__main__":

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -423,6 +423,25 @@ def _reads_fault(target):
         Path.read_bytes, Path.read_text = real_rb, real_rt
 
 
+@contextlib.contextmanager
+def _writes_fault(target):
+    """Fail the PUBLISH of ONE state file with an ENOSPC for the duration of the block: _atomic_write
+    writes `<name>.tmp.<pid>.<tid>.<n>` beside the file and renames it over, so failing every write_text
+    of that shape is the disk refusing this file's publish while every other path, and every read, behaves."""
+    real = Path.write_text
+    prefix = Path(target).name + ".tmp."
+
+    def wt(self, *a, **k):
+        if self.name.startswith(prefix):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real(self, *a, **k)
+    Path.write_text = wt
+    try:
+        yield
+    finally:
+        Path.write_text = real
+
+
 class NotifyDisplayReaderServesUnproved(unittest.TestCase):
     """The DISPLAY reader of the bells under a fault: the last value this kernel read if it holds
     one, else {} -- neither cached under the file's stat key, so the recovered disk is read again."""
@@ -579,6 +598,30 @@ class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
     def test_notify_turns_refuses_in_the_route_shape(self):
         self._refused("/notify-turns")
 
+    def _refused_publish(self, path):
+        # the store READS but its PUBLISH fails: the maintainer's fold on PR #1019 (the write step is a fault
+        # boundary too). Before, the OSError out of _atomic_write reached do_POST's catch-all as a 500
+        # traceback -- which `romp tag`-style callers and a federation forward read as an unreachable kernel
+        km._set_notify_card("11111111-2222-3333-4444-555555555555:g1", True)
+        km._notify_cards_cache.clear()
+        p = jd.STATE / "notify-cards.json"
+        before = p.read_bytes()
+        with _writes_fault(p):
+            status, body = self._post(path, {"on": True})
+        self.assertEqual(status, 200, "%s: a failed publish rides the route's own 200 shape, never a 500" % path)
+        self.assertEqual((body["ok"], body["retryable"]), (False, True))
+        self.assertIn("notify-cards.json could not be written", body["error"])
+        self.assertIn("No space left on device", body["error"])
+        self.assertIn("try again", body["error"])
+        self.assertEqual(p.read_bytes(), before, "%s: the bells file is untouched" % path)
+        self.assertEqual(self.sent, [], "%s: no dashboard is told the switch flipped -- it did not" % path)
+
+    def test_notify_all_refuses_a_failed_publish_in_the_route_shape(self):
+        self._refused_publish("/notify-all")
+
+    def test_notify_turns_refuses_a_failed_publish_in_the_route_shape(self):
+        self._refused_publish("/notify-turns")
+
     def test_a_clean_post_still_answers_ok_and_broadcasts(self):
         status, body = self._post("/notify-turns", {"on": True})
         self.assertEqual((status, body), (200, {"ok": True, "on": True}))
@@ -663,6 +706,60 @@ class CardBellJudgedAgainstAProvedDefault(unittest.TestCase):
         self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["itemId"]), ("settingRefused", "bell", self.SID + ":g1"))
         self.assertIn("session-flags.json could not be read", sent[0]["text"])
         self.assertEqual(self.dirty, [])
+
+
+class NotifyWsWriteFailure(unittest.TestCase):
+    """The cardNotify WS arm when the bells store READS but its PUBLISH fails: the maintainer's fold on PR
+    #1019. Before, the arm caught only _StateUnreadable and the OSError out of _atomic_write escaped
+    _dispatch_ws to the receive loop, which dropped the client. Now the poster gets the same settingRefused
+    frame, addressed to the card, saying the file could not be written; the store is untouched; the fault
+    is filed once per episode."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty, km._sync_notice)
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear(); km._flags_cache.clear(); km._state_fault_seen.clear()
+        vars(km).get("_state_write_fault_seen", {}).clear()
+        self.dirty, self.notices = [], []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty, km._sync_notice = self.saved
+        km._notify_cards_cache.clear(); km._flags_cache.clear(); km._state_fault_seen.clear()
+        vars(km).get("_state_write_fault_seen", {}).clear()
+        self.td.cleanup()
+
+    def test_a_failed_publish_answers_the_poster_instead_of_dropping_the_socket(self):
+        km._set_notify_card(self.SID + ":g1", True, self.SID)
+        km._notify_cards_cache.clear()
+        p = jd.STATE / "notify-cards.json"
+        before = p.read_bytes()
+        sent = []
+        client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _writes_fault(p):
+            for _ in range(2):                                             # two clicks on the same full disk
+                try:
+                    km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g2", "sid": self.SID, "value": True}, client)
+                except OSError:
+                    self.fail("the OSError escaped _dispatch_ws -- the receive loop re-raises it and drops the client")
+        self.assertTrue(client["alive"])
+        self.assertEqual(p.read_bytes(), before, "the bells file is byte-for-byte unchanged")
+        self.assertEqual(len(sent), 2, "every click is answered on the delivering socket")
+        fr = sent[0]
+        self.assertEqual((fr["type"], fr["gesture"], fr["itemId"], fr["sid"]), ("settingRefused", "bell", self.SID + ":g2", self.SID))
+        self.assertIn("couldn't save that bell", fr["text"])
+        self.assertIn("notify-cards.json could not be written", fr["text"])
+        self.assertIs(fr["value"], False, "what the kernel still paints for this card (no override, master off)")
+        self.assertEqual(self.dirty, [])
+        self.assertEqual(len([t for t, ok in self.notices if not ok]), 1, "filed once per episode, not per click")
+        km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g2", "sid": self.SID, "value": True}, client)
+        self.assertEqual(len(sent), 2, "the disk heals: the click lands and nothing more is said")
+        self.assertEqual(self.dirty, [1])
+        km._notify_cards_cache.clear()
+        self.assertIs(km._notify_cards().get(self.SID + ":g2"), True)
 
 
 if __name__ == "__main__":

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -314,5 +314,356 @@ class NotifyWiring(unittest.TestCase):
         self.assertIn("_push_forward(_buzzed)", self.src)
 
 
+class NotifyStoreUnreadableRefuses(unittest.TestCase):
+    """The state-readers audit (rank 9): _notify_cards used to fold ANY read fault to {} and CACHE
+    it, so _set_notify_all / _set_notify_turns / _set_notify_card copied that empty, applied one
+    edit, and atomically wrote it back — erasing every per-card, session and master bell override
+    under a silent success. The setters now read PROVED: a read fault refuses the write loudly and
+    the file is left exactly as it was. Synthetic ids only."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _path(self):
+        return jd.STATE / "notify-cards.json"
+
+    def _fault_reads_of(self, target):
+        """Fail BOTH read_bytes (the fix's proved reader) and read_text (origin/main's reader) for one
+        path — green on the fix, RED on main where the fold-to-{} erases the overrides."""
+        import errno
+        real_rb, real_rt = Path.read_bytes, Path.read_text
+        tgt = str(target)
+        def rb(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rb(self, *a, **k)
+        def rt(self, *a, **k):
+            if str(self) == tgt:
+                raise OSError(errno.EIO, "injected EIO")
+            return real_rt(self, *a, **k)
+        Path.read_bytes, Path.read_text = rb, rt
+        return (real_rb, real_rt)
+
+    def test_a_master_bell_toggle_is_refused_when_the_store_cannot_be_read(self):
+        # a populated store: one per-card override the user set deliberately
+        km._set_notify_card(self.SID + ":g1", True)
+        km._notify_cards_cache.clear()
+        before = self._path().read_bytes()
+        saved = self._fault_reads_of(self._path())
+        raised = None
+        try:
+            km._set_notify_all(True)               # flip the master — on main this erases g1's override
+        except Exception as e:                     # noqa: BLE001 — on main it never raises
+            raised = e
+        finally:
+            Path.read_bytes, Path.read_text = saved
+        km._notify_cards_cache.clear()
+        # THE erasure the audit is about: on origin/main the read folds to {}, the setter writes {"*":true}
+        # and the per-card override is GONE — this assertion turns RED there. The fix refuses the write.
+        self.assertEqual(self._path().read_bytes(), before,
+                         "the notify file must be unchanged when its file can't be read (main erases it here)")
+        self.assertEqual(km._notify_cards().get(self.SID + ":g1"), True,
+                         "the pre-existing bell override survives the refused toggle")
+        self.assertEqual(type(raised).__name__, "_StateUnreadable",
+                         "the write is refused LOUDLY, not folded to a fabricated empty (got %r)" % raised)
+
+    def test_a_torn_notify_file_is_quarantined_aside_not_overwritten(self):
+        torn = b'{"*": true, "sid:g1":'
+        self._path().write_bytes(torn)
+        km._notify_cards_cache.clear()
+        self.assertEqual(km._notify_cards_proved(), {}, "the store starts empty only after the bytes are saved")
+        q = list(jd.STATE.glob("notify-cards.json.corrupt-*"))
+        self.assertEqual(len(q), 1)
+        self.assertEqual(q[0].read_bytes(), torn, "the quarantine holds the ORIGINAL bytes")
+        self.assertFalse(self._path().exists())
+
+    def test_enoent_notify_still_reads_empty_with_no_quarantine(self):
+        self.assertEqual(km._notify_cards(), {}, "a missing store is legitimately empty")
+        self.assertEqual(km._notify_cards_proved(), {})
+        self.assertEqual(list(jd.STATE.glob("notify-cards.json.corrupt-*")), [])
+
+
+import contextlib
+import errno
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from unittest import mock
+
+
+@contextlib.contextmanager
+def _reads_fault(target):
+    """Fail every byte read of ONE path with an EIO for the duration of the block."""
+    real_rb, real_rt = Path.read_bytes, Path.read_text
+    tgt = str(target)
+    def rb(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rb(self, *a, **k)
+    def rt(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EIO, "injected EIO")
+        return real_rt(self, *a, **k)
+    Path.read_bytes, Path.read_text = rb, rt
+    try:
+        yield
+    finally:
+        Path.read_bytes, Path.read_text = real_rb, real_rt
+
+
+class NotifyDisplayReaderServesUnproved(unittest.TestCase):
+    """The DISPLAY reader of the bells under a fault: the last value this kernel read if it holds
+    one, else {} -- neither cached under the file's stat key, so the recovered disk is read again."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        km._state_fault_seen.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        km._state_fault_seen.clear()
+        self.td.cleanup()
+
+    def _path(self):
+        return jd.STATE / "notify-cards.json"
+
+    def test_a_fault_serves_the_last_read_value_and_caches_nothing_new(self):
+        km._set_notify_card(self.SID + ":g1", True)
+        km._notify_cards_cache.clear()
+        self.assertEqual(km._notify_cards(), {self.SID + ":g1": True})   # primes the cache
+        key1 = km._notify_cards_cache[str(self._path())][0]
+        km._set_notify_all(True)                                        # the file moves on: a new stat key
+        st = self._path().stat()
+        self.assertNotEqual(key1, (st.st_mtime_ns, st.st_size))
+        with _reads_fault(self._path()):
+            self.assertEqual(km._notify_cards(), {self.SID + ":g1": True}, "the last value read, not {}")
+            self.assertEqual(km._notify_cards_cache[str(self._path())][0], key1, "the fault cached nothing under the new key")
+        self.assertEqual(km._notify_cards(), {self.SID + ":g1": True, km.NOTIFY_ALL_KEY: True},
+                         "the real, newer file reads once the fault clears")
+
+    def test_a_fault_on_a_cold_cache_serves_the_empty_default_uncached(self):
+        km._set_notify_card(self.SID + ":g1", True)
+        km._notify_cards_cache.clear()
+        with _reads_fault(self._path()):
+            self.assertEqual(km._notify_cards(), {})
+            self.assertNotIn(str(self._path()), km._notify_cards_cache)
+        self.assertEqual(km._notify_cards(), {self.SID + ":g1": True})
+
+
+class NotifyWsRefusal(unittest.TestCase):
+    """The cardNotify WS arm under a store fault: the file is untouched, the poster gets a
+    `settingRefused` frame addressed to its card (itemId) on its OWN socket, nothing escapes. The
+    feed page has no `warn` handler, so the old frame left the bell painted in the refused state."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty)
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty = self.saved
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def test_a_refused_bell_answers_the_poster_and_leaves_the_file_alone(self):
+        km._set_notify_card(self.SID + ":g1", True)
+        km._notify_cards_cache.clear()
+        p = jd.STATE / "notify-cards.json"
+        before = p.read_bytes()
+        sent = []
+        client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _reads_fault(p):
+            km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g2", "sid": self.SID, "value": True}, client)
+        self.assertEqual(p.read_bytes(), before, "the bells file is byte-for-byte unchanged")
+        self.assertEqual(len(sent), 1)
+        fr = sent[0]
+        self.assertEqual((fr["type"], fr["itemId"], fr["sid"], fr["flag"]), ("settingRefused", self.SID + ":g2", self.SID, ""))
+        self.assertEqual(fr["gesture"], "bell")
+        self.assertIs(fr["value"], False, "the bell state the kernel still paints for this card rides along (here: no override, master off)")
+        self.assertIn("couldn't save that bell", fr["text"])
+        self.assertIn("notify-cards.json could not be read", fr["text"])
+        self.assertEqual(self.dirty, [])
+
+    def test_a_clean_bell_still_lands(self):
+        sent = []
+        client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g2", "sid": self.SID, "value": True}, client)
+        self.assertEqual(sent, [])
+        self.assertEqual(km._notify_cards().get(self.SID + ":g2"), True)
+        self.assertEqual(self.dirty, [1])
+
+
+class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
+    """POST /notify-all and /notify-turns under a store fault answer 200 with the route's own
+    refusal body -- {ok:false, retryable:true, error} -- never a 5xx: the shell's post() reads
+    ok:false as the refusal it is, whereas a non-2xx reached it as raw JSON inside an HTTP error;
+    and a federation forward treats any non-200 as a tunnel hiccup. Live server: the POST needs a
+    real Content-Length read."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty, km._send_to_app)
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km._mark_views_dirty = lambda: None
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty, km._send_to_app = self.saved
+        km._notify_cards_cache.clear()
+        self.td.cleanup()
+
+    def _post(self, path, body):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method="POST",
+                                     data=json.dumps(body).encode(),
+                                     headers={"Content-Type": "application/json", "X-Romp-Token": km.TOKEN})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+    def _refused(self, path):
+        km._set_notify_card("11111111-2222-3333-4444-555555555555:g1", True)   # a populated store
+        km._notify_cards_cache.clear()
+        p = jd.STATE / "notify-cards.json"
+        before = p.read_bytes()
+        with _reads_fault(p):
+            status, body = self._post(path, {"on": True})
+        self.assertEqual(status, 200, "%s: the refusal rides the route's own 200 shape, never a 5xx" % path)
+        self.assertEqual((body["ok"], body["retryable"]), (False, True))
+        self.assertIn("notify-cards.json could not be read", body["error"])
+        self.assertIn("try again", body["error"])
+        self.assertEqual(p.read_bytes(), before, "%s: the bells file is untouched" % path)
+        self.assertEqual(self.sent, [], "%s: no dashboard is told the switch flipped -- it did not" % path)
+
+    def test_notify_all_refuses_in_the_route_shape(self):
+        self._refused("/notify-all")
+
+    def test_notify_turns_refuses_in_the_route_shape(self):
+        self._refused("/notify-turns")
+
+    def test_a_clean_post_still_answers_ok_and_broadcasts(self):
+        status, body = self._post("/notify-turns", {"on": True})
+        self.assertEqual((status, body), (200, {"ok": True, "on": True}))
+        self.assertIn(("shell", {"type": "notifyTurns", "on": True}), self.sent)
+
+
+class ShellSwitchesReadTheRefusal(unittest.TestCase):
+    """The bell popover's switches post through one post() helper. With the routes refusing as 200
+    ok:false, a helper that resolved on any 2xx would run the SUCCESS arm -- flipping the switch to
+    the state the kernel just refused. It must reject on ok:false with the route's `error`, so the
+    switch stays where it was and the reason toasts through the same fail() the transport errors use."""
+
+    def test_post_rejects_an_ok_false_body_with_its_error_text(self):
+        js = km._LANDING_PUSH_JS
+        post = js[js.index("function post(path,obj){"):js.index("function b64u(")]
+        self.assertIn("if(d&&d.ok===false)throw new Error(d.error||'the kernel refused it');", post)
+        # the throw sits AFTER the JSON parse and BEFORE the value is handed to the callers
+        self.assertLess(post.index("return r.json()"), post.index("d.ok===false"))
+        self.assertIn("return d;", post)
+        # both switches take the fail arm, which toasts and leaves isOn / turnsOn untouched
+        self.assertIn("post('/notify-all',{on:want}).then(function(){isOn=want;paint();},fail)", js)
+        self.assertIn("post('/notify-turns',{on:wantT}).then(function(){turnsOn=wantT;paint();},fail)", js)
+
+
+class CardBellJudgedAgainstAProvedDefault(unittest.TestCase):
+    """_set_notify_card judges the click against the card's DEFAULT -- the session's own bell, which
+    lives in the OTHER store (session-flags.json), else the master. Read through the display reader, a
+    fault there folded the session's bell to "unset" and the click was judged against the master
+    instead: a mute matching that fabricated default was DELETED under the success path -- the user's
+    override erased. The default is read PROVED now: a fault on the flags file refuses the bells write
+    exactly like a fault on the bells file."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty)
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        self.dirty = []
+        km._mark_views_dirty = lambda: self.dirty.append(1)
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty = self.saved
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        self.td.cleanup()
+
+    def _seed(self):
+        # the master is OFF, this session's bell is ON (its own override), and one of its cards is MUTED
+        # (a stored card override False, which differs from its default True)
+        km._set_notify_all(False)
+        km._set_session_flag(self.SID, "notify", True)
+        km._set_notify_card(self.SID + ":g1", False, self.SID)
+        km._flags_cache.clear(); km._notify_cards_cache.clear()
+        cards_p = jd.STATE / "notify-cards.json"
+        self.assertEqual(json.loads(cards_p.read_text()), {self.SID + ":g1": False})
+        return cards_p, jd.STATE / "session-flags.json"
+
+    def test_a_card_bell_click_is_refused_when_the_flags_store_cannot_be_read(self):
+        cards_p, flags_p = self._seed()
+        before = cards_p.read_bytes()
+        raised = None
+        with _reads_fault(flags_p):                                # the OTHER store faults
+            try:
+                km._set_notify_card(self.SID + ":g1", False, self.SID)   # the mute re-sent (a second click, a pane retry)
+            except Exception as e:                                 # noqa: BLE001 -- before the fix it never raises
+                raised = e
+        # before the fix: the session's bell folded to unset, the default fell to the master (off), False ==
+        # off, and the override was DELETED -- the file rewritten as {}. Now the write is refused.
+        self.assertEqual(cards_p.read_bytes(), before, "the bells file must be unchanged when the flags file can't be read")
+        self.assertEqual(type(raised).__name__, "_StateUnreadable", "refused loudly (got %r)" % raised)
+        self.assertIn("session-flags.json", str(raised), "the refusal names the store that faulted")
+
+    def test_the_ws_arm_refuses_a_card_bell_on_the_other_store_s_fault(self):
+        cards_p, flags_p = self._seed()
+        before = cards_p.read_bytes()
+        sent = []
+        client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _reads_fault(flags_p):
+            km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g1", "sid": self.SID, "value": False}, client)
+        self.assertEqual(cards_p.read_bytes(), before)
+        self.assertEqual(len(sent), 1)
+        self.assertEqual((sent[0]["type"], sent[0]["gesture"], sent[0]["itemId"]), ("settingRefused", "bell", self.SID + ":g1"))
+        self.assertIn("session-flags.json could not be read", sent[0]["text"])
+        self.assertEqual(self.dirty, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -396,11 +396,32 @@ class NotifyStoreUnreadableRefuses(unittest.TestCase):
 
 import contextlib
 import errno
+import shutil
+import subprocess
 import threading
 import urllib.error
 import urllib.request
 from http.server import ThreadingHTTPServer
 from unittest import mock
+
+
+@contextlib.contextmanager
+def _stat_fault(target):
+    """Fail every stat of ONE path with an EACCES for the duration of the block -- the arm the read-fault
+    injector never reaches (review find, 2026-09-08): every reader stats BEFORE it reads (the display
+    readers key their cache on it), and a state dir that cannot be searched faults exactly there.
+    Everything else stats normally."""
+    real_stat = Path.stat
+    tgt = str(target)
+    def st(self, *a, **k):
+        if str(self) == tgt:
+            raise OSError(errno.EACCES, "injected EACCES")
+        return real_stat(self, *a, **k)
+    Path.stat = st
+    try:
+        yield
+    finally:
+        Path.stat = real_stat
 
 
 @contextlib.contextmanager
@@ -454,8 +475,12 @@ class NotifyDisplayReaderServesUnproved(unittest.TestCase):
         km._notify_cards_cache.clear()
         km._flags_cache.clear()
         km._state_fault_seen.clear()
+        self.notices = []
+        self._notice = km._sync_notice
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok, kind))
 
     def tearDown(self):
+        km._sync_notice = self._notice
         jd.STATE = self.saved
         km._notify_cards_cache.clear()
         km._flags_cache.clear()
@@ -464,6 +489,72 @@ class NotifyDisplayReaderServesUnproved(unittest.TestCase):
 
     def _path(self):
         return jd.STATE / "notify-cards.json"
+
+    def test_a_stat_fault_serves_the_last_read_value_and_refuses_the_writers(self):
+        km._set_notify_card(self.SID + ":g1", True)
+        km._notify_cards_cache.clear()
+        self.assertEqual(km._notify_cards(), {self.SID + ":g1": True})   # primes the cache
+        key1 = km._notify_cards_cache[str(self._path())][0]
+        before = self._path().read_bytes()
+        with _stat_fault(self._path()):
+            self.assertEqual(km._notify_cards(), {self.SID + ":g1": True}, "the stat arm serves the LAST value read")
+            self.assertEqual(km._notify_cards_cache[str(self._path())], (key1, {self.SID + ":g1": True}), "and caches nothing new")
+            with self.assertRaises(km._StateUnreadable) as cm:
+                km._notify_cards_proved()
+            self.assertIn("stat failed: [Errno 13]", str(cm.exception))
+            with self.assertRaises(km._StateUnreadable):
+                km._set_notify_all(True)                                 # a writer refuses on the stat fault too
+        self.assertEqual(self._path().read_bytes(), before)
+        bad = [t for t, ok, _k in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "one notice for the episode, from the display reader's stat arm")
+        self.assertIn("notify-cards.json could not be read (stat failed: [Errno 13]", bad[0])
+        km._notify_cards_cache.clear()
+        with _stat_fault(self._path()):
+            self.assertEqual(km._notify_cards(), {}, "a cold cache serves the empty default under a stat fault")
+            self.assertNotIn(str(self._path()), km._notify_cards_cache, "…uncached")
+
+    def test_the_prune_on_a_card_leaving_skips_the_pass_on_a_fault_loud_once(self):
+        # the body's claim, unpinned until now (review find, 2026-09-08: deleting the prune's try/except
+        # passed the suite): the prune that runs when a card leaves the feed skips its pass on a fault
+        # instead of pruning against a fabricated {} and writing the truncation over every override
+        km._set_notify_card(self.SID + ":g1", True)
+        km._set_notify_card(self.SID + ":g2", True)
+        km._notify_cards_cache.clear()
+        before = self._path().read_bytes()
+        with _reads_fault(self._path()):
+            km._prune_notify_cards({self.SID + ":g1"})                  # g2 left the feed: a clean pass drops it
+            km._prune_notify_cards({self.SID + ":g1"})
+        self.assertEqual(self._path().read_bytes(), before, "a fault must not prune against a fabricated {} and write it")
+        bad = [t for t, ok, _k in self.notices if not ok]
+        self.assertEqual(len(bad), 1, "loud once per episode, not once per pass")
+        self.assertIn("notify-cards.json could not be read", bad[0])
+        km._prune_notify_cards({self.SID + ":g1"})                      # the disk recovers: the pass prunes as before
+        self.assertEqual(km._notify_cards_proved(), {self.SID + ":g1": True})
+
+    def test_a_quarantine_tells_the_dashboard_once_under_the_refused_kind(self):
+        # review find, 2026-09-08: a quarantine reset every bell override with only a stderr line
+        torn = b'{"*": true, "' + self.SID.encode() + b':g1":'
+        self._path().write_bytes(torn)
+        self.assertEqual(km._notify_cards_proved(), {})
+        self.assertEqual(len(self.notices), 1)
+        text, ok, kind = self.notices[0]
+        self.assertEqual((ok, kind), (False, "refused"))
+        self.assertIn("notify-cards.json could not be parsed and was moved aside to notify-cards.json.corrupt-", text)
+        self.assertIn("start over empty", text)
+        self.assertEqual(km._notify_cards_proved(), {})                  # the next read is an ENOENT …
+        self.assertEqual(len(self.notices), 1, "… and files nothing more")
+
+    def test_valid_json_of_the_wrong_shape_is_quarantined_not_read_as_empty(self):
+        # review find, 2026-09-08: a LIST where the bells dict belongs read as a proved empty store and
+        # was overwritten by the next bell click -- a file none of our writers produce, gone
+        wrong = b'["' + self.SID.encode() + b':g1"]'
+        self._path().write_bytes(wrong)
+        self.assertEqual(km._notify_cards_proved(), {}, "empty only AFTER the bytes are moved aside")
+        aside = list(jd.STATE.glob("notify-cards.json.corrupt-*"))
+        self.assertEqual(len(aside), 1, "quarantined like torn bytes")
+        self.assertEqual(aside[0].read_bytes(), wrong)
+        self.assertFalse(self._path().exists())
+        self.assertEqual([k for _t, _ok, k in self.notices], ["refused"])
 
     def test_a_fault_serves_the_last_read_value_and_caches_nothing_new(self):
         km._set_notify_card(self.SID + ":g1", True)
@@ -536,13 +627,33 @@ class NotifyWsRefusal(unittest.TestCase):
         self.assertEqual(km._notify_cards().get(self.SID + ":g2"), True)
         self.assertEqual(self.dirty, [1])
 
+    def test_a_refusal_carries_the_painted_value_when_the_bell_is_on(self):
+        # `value` is what the display path still PAINTS for the card. Every other case here paints off
+        # (review find, 2026-09-08: a constant False survived), so this one paints ON: the master is on and
+        # the card has no override. The file then moves on (a new stat key) so the faulted read is a real
+        # miss served from the primed cache, not a cache hit
+        km._set_notify_all(True)
+        km._notify_cards_cache.clear()
+        km._notify_cards()                                              # prime the display cache
+        km._set_notify_card(self.SID + ":g9", False, self.SID)          # a stored mute elsewhere: bumps the stat key
+        p = jd.STATE / "notify-cards.json"
+        before = p.read_bytes()
+        sent = []
+        client = {"app": "feed", "wid": "w1", "alive": True, "send": lambda raw: sent.append(json.loads(raw))}
+        with _reads_fault(p):
+            km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": self.SID + ":g2", "sid": self.SID, "value": False}, client)
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(sent[0]["gesture"], "bell")
+        self.assertIs(sent[0]["value"], True, "no override, master on: the card paints ON, and the frame says so")
+        self.assertEqual(p.read_bytes(), before)
+
 
 class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
-    """POST /notify-all and /notify-turns under a store fault answer 200 with the route's own
-    refusal body -- {ok:false, retryable:true, error} -- never a 5xx: the shell's post() reads
-    ok:false as the refusal it is, whereas a non-2xx reached it as raw JSON inside an HTTP error;
-    and a federation forward treats any non-200 as a tunnel hiccup. Live server: the POST needs a
-    real Content-Length read."""
+    """POST /notify-all and /notify-turns under a store fault -- a read fault, or a publish that
+    fails -- answer 200 with the shape every kernel refusal wears, {ok:false, error} (as /send and
+    /new answer theirs), never a 5xx: the shell's post() consumes that shape, whereas a non-2xx
+    reached it as raw JSON inside an HTTP error. No `retryable` key: nothing reads one (review find,
+    2026-09-08). Live server: the POST needs a real Content-Length read."""
 
     @classmethod
     def setUpClass(cls):
@@ -586,7 +697,8 @@ class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
         with _reads_fault(p):
             status, body = self._post(path, {"on": True})
         self.assertEqual(status, 200, "%s: the refusal rides the route's own 200 shape, never a 5xx" % path)
-        self.assertEqual((body["ok"], body["retryable"]), (False, True))
+        self.assertIs(body["ok"], False)
+        self.assertNotIn("retryable", body, "%s: no key the shell's post() never reads" % path)
         self.assertIn("notify-cards.json could not be read", body["error"])
         self.assertIn("try again", body["error"])
         self.assertEqual(p.read_bytes(), before, "%s: the bells file is untouched" % path)
@@ -609,7 +721,8 @@ class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
         with _writes_fault(p):
             status, body = self._post(path, {"on": True})
         self.assertEqual(status, 200, "%s: a failed publish rides the route's own 200 shape, never a 500" % path)
-        self.assertEqual((body["ok"], body["retryable"]), (False, True))
+        self.assertIs(body["ok"], False)
+        self.assertNotIn("retryable", body, "%s: no key the shell's post() never reads" % path)
         self.assertIn("notify-cards.json could not be written", body["error"])
         self.assertIn("No space left on device", body["error"])
         self.assertIn("try again", body["error"])
@@ -628,22 +741,76 @@ class NotifyRoutesRefuseInTheirOwnShape(unittest.TestCase):
         self.assertIn(("shell", {"type": "notifyTurns", "on": True}), self.sent)
 
 
+_POST_HARNESS = r"""
+const src = process.argv[1], answers = JSON.parse(process.argv[2]);
+let i = 0;
+global.fetch = function (path) {
+  const a = answers[i++];
+  return Promise.resolve({ ok: a.status < 400, status: a.status,
+    json: () => (a.body === undefined ? Promise.reject(new Error('no json')) : Promise.resolve(a.body)),
+    text: () => Promise.resolve(a.text || '') });
+};
+eval(src + '\nglobal.post = post;');                     // the popover's post(), verbatim from the shell
+const out = [];
+(async () => {
+  for (const a of answers) {
+    try { out.push({ resolved: await post(a.path, {}) }); }
+    catch (e) { out.push({ rejected: String(e && e.message) }); }
+  }
+  process.stdout.write(JSON.stringify(out));
+})();
+"""
+
+
 class ShellSwitchesReadTheRefusal(unittest.TestCase):
     """The bell popover's switches post through one post() helper. With the routes refusing as 200
     ok:false, a helper that resolved on any 2xx would run the SUCCESS arm -- flipping the switch to
-    the state the kernel just refused. It must reject on ok:false with the route's `error`, so the
-    switch stays where it was and the reason toasts through the same fail() the transport errors use."""
+    the state the kernel just refused. It must reject on the refusal shape ({ok:false, error}) with
+    the route's `error`, so the switch stays where it was and the reason toasts through the same
+    fail() the transport errors use. And ONLY on that shape (review find, 2026-09-08): the same
+    helper serves the test button, and /push/test answers 200 {ok:false, status, detail} by design
+    for a refused or unsubscribed test push -- rejecting every ok:false made the button's own result
+    line ('The push service refused it: <status> <detail>') unreachable behind a generic failure."""
 
     def test_post_rejects_an_ok_false_body_with_its_error_text(self):
         js = km._LANDING_PUSH_JS
         post = js[js.index("function post(path,obj){"):js.index("function b64u(")]
-        self.assertIn("if(d&&d.ok===false)throw new Error(d.error||'the kernel refused it');", post)
+        self.assertIn("if(d&&d.ok===false&&d.error)throw new Error(d.error);", post)
         # the throw sits AFTER the JSON parse and BEFORE the value is handed to the callers
         self.assertLess(post.index("return r.json()"), post.index("d.ok===false"))
         self.assertIn("return d;", post)
         # both switches take the fail arm, which toasts and leaves isOn / turnsOn untouched
         self.assertIn("post('/notify-all',{on:want}).then(function(){isOn=want;paint();},fail)", js)
         self.assertIn("post('/notify-turns',{on:wantT}).then(function(){turnsOn=wantT;paint();},fail)", js)
+        # …and the test button reads the push service's verdict off the RESOLVED body, so a refusal
+        # there must reach it as a value, not as a rejection
+        handler = js[js.index("if(act==='test')"):]
+        self.assertIn("(d&&d.status?('The push service refused it: '+d.status+' '+(d.detail||'')+'.')", handler)
+
+    @unittest.skipUnless(shutil.which("node"), "node not available")
+    def test_post_executed_passes_a_push_test_verdict_through_and_rejects_only_a_refusal(self):
+        js = km._LANDING_PUSH_JS
+        post = js[js.index("function post(path,obj){"):js.index("function b64u(")]
+        answers = [
+            # /push/test's designed answers: a refused push and an unsubscribed device, both 200 ok:false
+            # WITHOUT `error` -- they must resolve, so the result arm can say what the service said
+            {"path": "/push/test", "status": 200, "body": {"ok": False, "status": 410, "detail": "Gone; the dead subscription was removed"}},
+            {"path": "/push/test", "status": 200, "body": {"ok": False, "status": 0, "detail": "this device isn't subscribed yet"}},
+            # a switch route's refusal: 200 ok:false WITH the reason -- rejects with exactly that text
+            {"path": "/notify-all", "status": 200, "body": {"ok": False, "error": "notify-cards.json could not be read (read failed: [Errno 5] Input/output error) \u2014 the change did not land; try again"}},
+            # a success, and a transport error, behave as they always did
+            {"path": "/notify-turns", "status": 200, "body": {"ok": True, "on": True}},
+            {"path": "/notify-turns", "status": 503, "text": "kernel busy"},
+        ]
+        out = subprocess.run([shutil.which("node"), "-e", _POST_HARNESS, post, json.dumps(answers)],
+                             capture_output=True, text=True, timeout=60)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        got = json.loads(out.stdout)
+        self.assertEqual(got[0], {"resolved": answers[0]["body"]}, "a refused test push reaches the result arm")
+        self.assertEqual(got[1], {"resolved": answers[1]["body"]}, "an unsubscribed device reaches the result arm")
+        self.assertEqual(got[2], {"rejected": answers[2]["body"]["error"]}, "a switch refusal rejects with the route's reason")
+        self.assertEqual(got[3], {"resolved": {"ok": True, "on": True}})
+        self.assertEqual(got[4], {"rejected": "kernel busy"})
 
 
 class CardBellJudgedAgainstAProvedDefault(unittest.TestCase):
@@ -724,7 +891,7 @@ class NotifyWsWriteFailure(unittest.TestCase):
         vars(km).get("_state_write_fault_seen", {}).clear()
         self.dirty, self.notices = [], []
         km._mark_views_dirty = lambda: self.dirty.append(1)
-        km._sync_notice = lambda text, ok=True: self.notices.append((text, ok))
+        km._sync_notice = lambda text, ok=True, kind="sync": self.notices.append((text, ok))
 
     def tearDown(self):
         jd.STATE, km._mark_views_dirty, km._sync_notice = self.saved

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3872,22 +3872,35 @@ class TimelinePanel {
   }
 
   // Persist a per-session flag. Web dashboard: the host WS hook (→ kernel setSessionFlag → rebuild feed).
-  // Obsidian/headless fallback: write the same session-flags.json the kernel's build_feed reads.
+  // Obsidian desktop fallback: write the same session-flags.json the kernel's build_feed reads, with the
+  // discipline the kernel's own writer has (review find, 2026-09-08). Before this it was the exact shape
+  // the kernel dropped: any read fault or torn bytes became {} and was written over EVERY session's flags
+  // (postal isolation included), and the write truncated the live file in place, so the kernel's strict
+  // reader could observe 0 bytes mid-write and quarantine the very file being written. Now it mirrors
+  // _persistOrder / _setViews: Electron-or-nothing (a bare-node test run must never touch the real file),
+  // the kernel's state root, a refusal on any read fault or non-object parse (only a MISSING file reads as
+  // empty; the kernel quarantines torn bytes on its own next read), and an atomic tmp + rename publish.
   _setSessionFlag(s, flag, value) {
     try {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSetFlag === 'function') {
         window.__rompTimelineSetFlag(s.id, flag, value); return;
       }
+      if (typeof process === 'undefined' || !process.versions || !process.versions.electron) return;
       const fs = require('fs'), os = require('os'), path = require('path');
-      const dir = path.join(os.homedir(), '.local', 'state', 'romp');
+      const dir = process.env.ROMP_STATE_DIR
+        || path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'romp');
       const fp = path.join(dir, 'session-flags.json');
       let cur = {};
-      try { cur = JSON.parse(fs.readFileSync(fp, 'utf8')) || {}; } catch (e) {}
+      try { cur = JSON.parse(fs.readFileSync(fp, 'utf8')); }
+      catch (e) { if (!e || e.code !== 'ENOENT') return; }   // unreadable or torn: never write over a store we could not read
+      if (!cur || typeof cur !== 'object' || Array.isArray(cur)) return;   // valid JSON of the wrong shape: not ours to overwrite
       const f = (cur[s.id] && typeof cur[s.id] === 'object') ? cur[s.id] : {};
       if (value) f[flag] = true; else delete f[flag];
       if (Object.keys(f).length) cur[s.id] = f; else delete cur[s.id];
       fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(fp, JSON.stringify(cur));
+      const tmp = fp + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(cur));
+      fs.renameSync(tmp, fp);
     } catch (e) { /* no host hook + no Node fs → can't persist */ }
   }
 

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -863,6 +863,8 @@ class TimelinePanel {
     this._lockNow = false;
     this._compactClicked = {};   // sid → click ts: show the compacting cue OPTIMISTICALLY until the real state catches up
     this._pendingFlags = {};     // sid → {flag: value}: an optimistic eye-toggle held STICKY across pushes until the kernel's data confirms it (no flicker-back)
+    this._laneRefusal = null;    // {sid, flag, text}: the kernel's refusal of the last lane-gear toggle, shown in the gear until dismissed or retried
+    this._laneMenuBuild = null;  // the last-opened lane gear's rebuild-in-place, so a refusal arriving while it is open repaints it (like _viewsDialogBuild; every use is gated on _laneMenu being open)
     this._dismissed = new Set(); // sids cleared via the dead-lane Clear pill, held STICKY the same way (see _reconcileDismissed)
     this._views = null;          // the kernel-echoed views blob (data.views); null until the first push
     this._pendingViews = null;   // an optimistic edit held sticky until a push echoes it (see _reconcileViews)
@@ -2889,6 +2891,38 @@ class TimelinePanel {
     this.draw();
   }
 
+  // the kernel's refusal of a gesture this page posted (the store it edits could not be read), answered on
+  // THIS page's socket and naming the gesture. A lane-gear flag (gesture 'flag', sid + flag): end the
+  // optimistic state ON THIS EVENT — the flag's sticky latch drops and the lane repaints to the value the
+  // kernel still paints (the frame carries it: what the next push shows; not a value recorded at the click,
+  // which a second click before the first refusal made wrong) — and the reason shows in the gear (rebuilt in
+  // place if it is open, on its next open otherwise) until dismissed or until the toggle is tried again.
+  // Filed in the shell's bell under its own `refused` kind, so it is findable after the fact and muting judge
+  // warnings never mutes it. Before this the kernel sent a `warn`, which this page never rendered, so the
+  // gear kept showing the refused state until a reload. The feed's bell and the chat's tab menu handle the
+  // same frame for their gestures.
+  settingRefused(m) {
+    const sid = String((m && m.sid) || ''), flag = String((m && m.flag) || '');
+    const text = String((m && m.text) || "couldn't save that setting");
+    if (m && m.gesture === 'flag' && sid && flag) {
+      const pend = this._pendingFlags[sid];
+      if (pend) { delete pend[flag]; if (!Object.keys(pend).length) delete this._pendingFlags[sid]; }
+      if (typeof m.value === 'boolean') {
+        // both copies a click may have written: the current frame's session, and the one the open gear built from
+        const targets = [((this.data && this.data.sessions) || []).find((x) => x.id === sid),
+                         this._laneMenu && this._laneMenu._sid === sid ? this._laneMenu._session : null];
+        for (const s of targets) if (s) s[flag] = m.value;
+      }
+      this._laneRefusal = { sid, flag, text };
+      if (this._laneMenu && this._laneMenu._sid === sid && this._laneMenuBuild) this._laneMenuBuild();
+    }
+    try {
+      if (typeof window !== 'undefined' && window.parent && window.parent !== window)
+        window.parent.postMessage({ romp: 'notify', kind: 'refused', text, sid }, '*');
+    } catch (e) { /* no parent frame (Obsidian, headless) */ }
+    this.draw();
+  }
+
   // ── the NAME-KEYED tag editor (user ruling 2026-08-24), shared by the dialog and the lane gear ──
   // One union group = one tag identity. Edits stay routed under the hood: an ADD lands on the LOCAL
   // store when the name exists locally, else the tag's single home; a REMOVE removes the
@@ -3720,6 +3754,7 @@ class TimelinePanel {
     menu.setAttribute('style', 'position:fixed;z-index:1001;width:280px;' + MENU_STYLE);
     menu.dataset.rompMenu = '1';   // the echo writers skip in-menu presses (T213)
     menu._sid = s.id;
+    menu._session = s;             // the copy build() reads; a refusal restores it alongside the frame's
     menu.addEventListener('click', (e) => e.stopPropagation());   // inside clicks must not reach the doc closer
     const build = () => {
       menu.textContent = '';
@@ -3742,6 +3777,7 @@ class TimelinePanel {
         row.addEventListener('click', (e) => {
           e.stopPropagation();
           const next = t.value(!on);                 // the flag value that flips this toggle
+          if (this._laneRefusal && this._laneRefusal.sid === s.id && this._laneRefusal.flag === t.flag) this._laneRefusal = null;   // a retry retires the last refusal
           s[t.flag] = next;                          // optimistic …
           (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {})[t.flag] = next;   // … sticky until the kernel confirms
           this._setSessionFlag(s, t.flag, next);
@@ -3749,6 +3785,17 @@ class TimelinePanel {
           this.draw();
           build();                                   // repaint states in place; the panel stays open
         });
+      }
+      // the kernel's refusal of this lane's last toggle (settingRefused): the same dismissible row the
+      // views dialog wears for a refused tag edit, here because the gear is where the click was made
+      if (this._laneRefusal && this._laneRefusal.sid === s.id) {
+        const er = menu.createDiv();
+        er.setAttribute('style', 'display:flex;align-items:center;gap:6px;margin:4px 8px;padding:4px 8px;'
+          + 'border:1px solid #F85B5A;border-radius:5px;color:#F85B5A;font-size:0.82em;line-height:1.3;');
+        er.createSpan({ text: '⚠ ' + this._laneRefusal.text });
+        const ex = er.createSpan({ text: '✕' });
+        ex.setAttribute('style', 'margin-left:auto;cursor:pointer;opacity:0.7;flex:0 0 auto;');
+        ex.addEventListener('click', (e) => { e.stopPropagation(); this._laneRefusal = null; build(); });
       }
       // ── Tags (the user 2026-08-24: taggable from the gear too, not only the filter dialog) ──
       // The SAME name-keyed editor the dialog rows carry — the shared builders, never a fork:
@@ -3778,6 +3825,7 @@ class TimelinePanel {
       }
     };
     build();
+    this._laneMenuBuild = build;    // a settingRefused arriving while the gear is open repaints it in place
     const h = this._menuHost(anchorEl.getBoundingClientRect());
     h.doc.body.appendChild(menu);   // a cross-document append ADOPTS the node; its listeners are kept
     const left = Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 300);   // clamp on-screen

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -128,7 +128,13 @@ export function sdkProblemNotices(rows: SdkNoticeRow[], seen: Set<string>): { no
 // The Log is a browser-side store the kernel cannot write to, which is why this rides the payload and
 // mirrors here rather than being appended server-side. Same episode-identity contract as the SDK ring:
 // the kernel signs each occurrence (its start + the ring's sequence).
-export interface SyncNoticeRow { sig: string; t: number; text: string; ok?: boolean }
+//
+// `kind` (review find, 2026-09-08): the ring also carries the kernel's state-file faults (a store that
+// could not be read, or held bytes it could not parse and moved aside). Filed under "sync" they wore
+// the machine-sync label, and muting that log (the one kind that records successes, so a plausible
+// mute) silenced every disk-fault notice with it. The kernel names the row's kind; this side ALLOWLISTS
+// it, so a remote kernel's payload can only ever land in one of the two kinds the bell knows here.
+export interface SyncNoticeRow { sig: string; t: number; text: string; ok?: boolean; kind?: string }
 
 export function syncNotices(rows: SyncNoticeRow[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
   const notices: BadgeNotice[] = [];
@@ -137,7 +143,7 @@ export function syncNotices(rows: SyncNoticeRow[], seen: Set<string>): { notices
     if (!r || !r.sig || !r.text) continue;
     active.add(r.sig);
     if (seen.has(r.sig)) continue;
-    notices.push({ kind: "sync", text: cap(r.text, 240), sig: r.sig, sid: "", itemId: "" });
+    notices.push({ kind: r.kind === "refused" ? "refused" : "sync", text: cap(r.text, 240), sig: r.sig, sid: "", itemId: "" });
   }
   return { notices, active };
 }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -5294,6 +5294,19 @@ window.addEventListener("message", (e: MessageEvent) => {
     renderModal();
     applyExtHover();
     if (extHoverEid) document.querySelector(".dot-hl[data-eid]")?.scrollIntoView({ block: "center" });
+  } else if (m.type === "settingRefused" && typeof m.text === "string" && m.text) {
+    // the kernel refused a bell toggle this page posted (its store could not be read): end the optimistic
+    // state ON THIS EVENT — the card's sticky latch drops and the bell repaints to what the payload holds
+    // (the paint key reads the latch) — and say why. A SOFT refusal: nothing typed was lost, so the fading
+    // toast (the chat's weight for the same class), never the must-dismiss dialog; the shell's bell keeps the
+    // durable record under its own `refused` kind, so muting judge warnings never mutes these. A `warn`
+    // frame had no handler on this page, so the bell stayed painted as if the click had landed until a reload.
+    if (m.gesture === "bell" && typeof m.itemId === "string" && m.itemId) pendingNotify.delete(m.itemId);
+    render();
+    window.parent?.postMessage({ romp: "notify", kind: "refused", text: m.text,
+                                 sid: typeof m.sid === "string" ? m.sid : "",
+                                 itemId: typeof m.itemId === "string" ? m.itemId : "" }, "*");
+    feedToast(m.text);
   } else if (m.type === "err" && typeof m.text === "string" && m.text) {
     // the dialog interrupts; the bell KEEPS it (the user 2026-07-29) — dismissing the modal must not erase
     // the fact that a message never landed. Same {romp:'notify'} bridge the card-badge mirror below uses.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13081,6 +13081,19 @@ window.addEventListener("message", (e: MessageEvent) => {
   }
   else if (m.type === "nextTab") cycleTab(1);
   else if (m.type === "prevTab") cycleTab(-1);
+  else if (m.type === "settingRefused" && typeof m.text === "string" && m.text) {
+    // the kernel refused a gesture this page posted (its store could not be read): the optimistic state ends
+    // on THIS event, not on the next push, and the reason toasts (the warn toast is this pane's soft-refusal
+    // surface; nothing typed was lost) and is filed in the shell's bell under its own `refused` kind
+    if (m.gesture === "flag" && typeof m.sid === "string" && typeof m.flag === "string" && m.sid && m.flag) {
+      // a tab-menu flag: repaint the local copy to the value the kernel still paints (the frame carries it —
+      // what the next push shows), not to a value recorded at the click, which a second click made wrong
+      const s = sessions.get(m.sid);
+      if (s && typeof m.value === "boolean") (s as any)[m.flag] = m.value;
+    }
+    notifyShell("refused", m.text, typeof m.sid === "string" ? m.sid : "");
+    warnToast(m.text);
+  }
   else if (m.type === "warn" && typeof m.text === "string" && m.text) {
     // A warn arriving while a create is in flight IS that create's verdict (a name the kernel won't take,
     // an unreadable parent, the SDK setup hint). It gets a dialog naming the reason and takes the

--- a/ui/webview/setting-refused.test.ts
+++ b/ui/webview/setting-refused.test.ts
@@ -1,5 +1,6 @@
 // The kernel's `settingRefused` frame: a dashboard gesture that edits a small state store (a lane/tab flag,
-// a card bell, a drag) was REFUSED because the store could not be read, and the refusal is answered on the
+// a card bell, a drag) was REFUSED because the store could not be read -- or, since the maintainer's fold on
+// PR #1019, because its publish failed (_StateUnwritable) -- and the refusal is answered on the
 // posting socket, addressed to the gesture (sid / itemId / flag). The rule it exists for: a refused gesture
 // must reach the eye that made it AND end the optimistic state on that event. Before it, the kernel sent a
 // `warn`, which only the chat page renders -- a refused bell on the feed page and a refused lane flag on the
@@ -33,7 +34,10 @@ test("the kernel answers a refused store write on the DELIVERING socket, address
   for (const what of ['"that setting", "flag"', '"that bell", "bell"', '"the new order", "order"']) {
     const call = KERNEL.indexOf("_refuse_setting(client, e, " + what);
     assert.ok(call > 0, what);
-    const block = KERNEL.slice(KERNEL.lastIndexOf("except _StateUnreadable as e:", call), call);
+    // the arm catches the read fault AND the write fault (the write step is a fault boundary too); anchoring on
+    // the read-only literal fell back to a catch thousands of lines above and sliced in unrelated warn frames
+    const block = KERNEL.slice(KERNEL.lastIndexOf("except (_StateUnreadable, _StateUnwritable) as e:", call), call);
+    assert.ok(block.length < 2000, "the arm's own except sits just above its refusal: " + what);
     assert.doesNotMatch(block, /"type": "warn"/, "no store-fault arm answers with a warn frame: " + what);
   }
 });
@@ -106,7 +110,7 @@ test("the shell's bell knows the `refused` kind: listed, labelled, explained, an
   // anomaly stamp) never mutes a change of yours that did not land
   assert.match(KERNEL, /var KINDS=\[[^\]]*'refused','undelivered'\]/);
   assert.match(KERNEL, /refused:'not saved'/);
-  assert.match(KERNEL, /refused:"a change you made \\u2014 a lane or tab setting, a card bell, a tag or view, a lane order \\u2014 was not saved because romp could not read the file that holds it/);
+  assert.match(KERNEL, /refused:"a change you made \\u2014 a lane or tab setting, a card bell, a tag or view, a lane order \\u2014 was not saved because the file that holds it could not be read or written/);
   assert.match(KERNEL, /\.rerr-chip\.k-refused\{color:#ffd166;border-color:rgba\(255,209,102,0\.6\)\}/);
   // and every pane files under it -- none under `warn`
   for (const src of [FEED, RENDER, VIEW]) assert.doesNotMatch(src.slice(src.indexOf("settingRefused")), /kind: ['"]warn['"]/);

--- a/ui/webview/setting-refused.test.ts
+++ b/ui/webview/setting-refused.test.ts
@@ -5,8 +5,11 @@
 // must reach the eye that made it AND end the optimistic state on that event. Before it, the kernel sent a
 // `warn`, which only the chat page renders -- a refused bell on the feed page and a refused lane flag on the
 // timeline page stayed painted as if they had landed until a reload, their sticky latches never released.
-// No jsdom for the renderers, so the pane handlers are pinned at source (the card-notify / undelivered-err
-// pattern); the boot dispatch is exercised for real.
+// The feed and chat handlers are pinned at source (the card-notify / undelivered-err pattern: their pages
+// need a DOM); the timeline's runs for real -- romp-timeline-view.js loads under plain node, and
+// Object.create(TimelinePanel.prototype) drives the method the way tests/test_timeline_touch.py does (review
+// find, 2026-09-08: the regex pins could not tell a released latch from a wiped one). The boot dispatch is
+// exercised for real too.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -40,6 +43,52 @@ test("the kernel answers a refused store write on the DELIVERING socket, address
     assert.ok(block.length < 2000, "the arm's own except sits just above its refusal: " + what);
     assert.doesNotMatch(block, /"type": "warn"/, "no store-fault arm answers with a warn frame: " + what);
   }
+});
+
+test("timeline (executed): only the refused sid+flag leaves the latch; both copies repaint to the frame's value; the gear rebuilds only when open for that sid", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { TimelinePanel } = require(path.join(ROOT, "ui", "romp-timeline-view.js"));
+  const mk = (over: Record<string, unknown> = {}) => {
+    const v: any = Object.create(TimelinePanel.prototype);
+    v._pendingFlags = { s1: { notify: true, hideFromFeed: true }, s2: { notify: true } };
+    v.data = { sessions: [{ id: "s1", notify: true, hideFromFeed: true }, { id: "s2", notify: true }] };
+    v._laneMenu = { _sid: "s1", _session: { id: "s1", notify: true } };
+    v.builds = 0; v._laneMenuBuild = function () { this.builds++; };
+    v.draws = 0; v.draw = function () { this.draws++; };
+    Object.assign(v, over);
+    return v;
+  };
+  const posted: any[] = [];
+  (globalThis as any).window = { parent: { postMessage: (m: any) => posted.push(m) } };
+  try {
+    const v = mk();
+    v.settingRefused({ type: "settingRefused", gesture: "flag", sid: "s1", flag: "notify", value: false, text: "couldn't save that setting" });
+    assert.deepEqual(v._pendingFlags, { s1: { hideFromFeed: true }, s2: { notify: true } }, "only s1's notify latch is released");
+    assert.equal(v.data.sessions[0].notify, false, "the frame's session repaints to the kernel's painted value");
+    assert.equal(v._laneMenu._session.notify, false, "so does the copy the open gear built from");
+    assert.equal(v.data.sessions[1].notify, true, "another session is untouched");
+    assert.deepEqual(v._laneRefusal, { sid: "s1", flag: "notify", text: "couldn't save that setting" });
+    assert.equal(v.builds, 1, "the gear is open for s1: rebuilt in place");
+    assert.equal(v.draws, 1);
+    assert.deepEqual(posted, [{ romp: "notify", kind: "refused", text: "couldn't save that setting", sid: "s1" }], "filed in the shell's bell under its own kind");
+    // the gear open for ANOTHER lane is neither rebuilt nor repainted
+    const w = mk({ _laneMenu: { _sid: "s2", _session: { id: "s2", notify: true } } });
+    w.settingRefused({ type: "settingRefused", gesture: "flag", sid: "s1", flag: "notify", value: false, text: "x" });
+    assert.equal(w.builds, 0);
+    assert.equal(w._laneMenu._session.notify, true);
+    assert.equal(w.data.sessions[0].notify, false, "the frame's session still repaints");
+    // the last latch on a sid releases the whole entry; a frame without a boolean value repaints nothing
+    const u = mk({ _pendingFlags: { s1: { hideFromFeed: true } } });
+    u.settingRefused({ type: "settingRefused", gesture: "flag", sid: "s1", flag: "hideFromFeed", text: "x" });
+    assert.deepEqual(u._pendingFlags, {});
+    assert.equal(u.data.sessions[0].hideFromFeed, true);
+    // a bell gesture (the feed's) touches no lane state and rebuilds no gear
+    const b = mk();
+    b.settingRefused({ type: "settingRefused", gesture: "bell", sid: "s1", itemId: "s1:g1", value: true, text: "x" });
+    assert.deepEqual(b._pendingFlags, { s1: { notify: true, hideFromFeed: true }, s2: { notify: true } });
+    assert.equal(b.builds, 0);
+    assert.equal(b.draws, 1, "…but still repaints, and files the text");
+  } finally { delete (globalThis as any).window; }
 });
 
 test("both timeline boots (VS Code and the kernel's inline browser twin) hand the frame to the panel", () => {
@@ -110,7 +159,10 @@ test("the shell's bell knows the `refused` kind: listed, labelled, explained, an
   // anomaly stamp) never mutes a change of yours that did not land
   assert.match(KERNEL, /var KINDS=\[[^\]]*'refused','undelivered'\]/);
   assert.match(KERNEL, /refused:'not saved'/);
-  assert.match(KERNEL, /refused:"a change you made \\u2014 a lane or tab setting, a card bell, a tag or view, a lane order \\u2014 was not saved because the file that holds it could not be read or written/);
+  // the tooltip covers BOTH things filed under the kind (review find, 2026-09-08): a change that did not
+  // save (a read OR a write fault), and a state file that could not be read or was moved aside
+  assert.match(KERNEL, /refused:"a setting that could not be saved, or a state file that could not be read\. A change you made \\u2014 a lane or tab setting, a card bell, a lane order \\u2014 was not saved because romp could not read or write the file that holds it/);
+  assert.match(KERNEL, /refused:"[^"]*could not be read \(the last values are shown until it can\), or held bytes romp could not parse and was moved aside/);
   assert.match(KERNEL, /\.rerr-chip\.k-refused\{color:#ffd166;border-color:rgba\(255,209,102,0\.6\)\}/);
   // and every pane files under it -- none under `warn`
   for (const src of [FEED, RENDER, VIEW]) assert.doesNotMatch(src.slice(src.indexOf("settingRefused")), /kind: ['"]warn['"]/);

--- a/ui/webview/setting-refused.test.ts
+++ b/ui/webview/setting-refused.test.ts
@@ -1,0 +1,114 @@
+// The kernel's `settingRefused` frame: a dashboard gesture that edits a small state store (a lane/tab flag,
+// a card bell, a drag) was REFUSED because the store could not be read, and the refusal is answered on the
+// posting socket, addressed to the gesture (sid / itemId / flag). The rule it exists for: a refused gesture
+// must reach the eye that made it AND end the optimistic state on that event. Before it, the kernel sent a
+// `warn`, which only the chat page renders -- a refused bell on the feed page and a refused lane flag on the
+// timeline page stayed painted as if they had landed until a reload, their sticky latches never released.
+// No jsdom for the renderers, so the pane handlers are pinned at source (the card-notify / undelivered-err
+// pattern); the boot dispatch is exercised for real.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { dispatchFrame } from "./timeline-boot";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const VIEW = fs.readFileSync(path.join(ROOT, "ui", "romp-timeline-view.js"), "utf8");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const BOOT = fs.readFileSync(path.join(ROOT, "ui", "webview", "timeline-boot.ts"), "utf8");
+
+test("the kernel answers a refused store write on the DELIVERING socket, addressed to the gesture", () => {
+  const fn = KERNEL.slice(KERNEL.indexOf("def _refuse_setting("), KERNEL.indexOf("\ndef _session_order():"));
+  assert.match(fn, /_reply\(client, \{"type": "settingRefused", "gesture": str\(gesture\), "sid": str\(sid or ""\),\n\s+"itemId": str\(item_id or ""\), "flag": str\(flag or ""\),\n\s+"value": value if isinstance\(value, bool\) else None, "text": text\}\)/);
+  assert.match(fn, /if not client or not callable\(client\.get\("send"\)\):\n\s+return/, "a dead socket is the client's problem; the refusal already stands");
+  // every store-fault arm of _dispatch_ws refuses through it, naming its gesture -- the flag toggle carries
+  // sid + flag + the value the kernel still paints, the bell the card + its painted value, the drag neither
+  // (no shipped pane posts it; the contract holds all the same)
+  assert.match(KERNEL, /_refuse_setting\(client, e, "that setting", "flag", sid=msg\["id"\], flag=msg\["flag"\],\n\s+value=_painted_flag_value\(str\(msg\["id"\]\), str\(msg\["flag"\]\)\)\)/);
+  assert.match(KERNEL, /_refuse_setting\(client, e, "that bell", "bell", sid=msg\.get\("sid"\) or "", item_id=msg\["itemId"\],\n\s+value=bool\(_notify_card_effective\(_notify_cards\(\), str\(msg\["itemId"\]\), str\(msg\.get\("sid"\) or ""\)\)\)\)/);
+  assert.match(KERNEL, /_refuse_setting\(client, e, "the new order", "order"\)/);
+  // ...and none of those except blocks still sends the frame no pane but the chat renders
+  for (const what of ['"that setting", "flag"', '"that bell", "bell"', '"the new order", "order"']) {
+    const call = KERNEL.indexOf("_refuse_setting(client, e, " + what);
+    assert.ok(call > 0, what);
+    const block = KERNEL.slice(KERNEL.lastIndexOf("except _StateUnreadable as e:", call), call);
+    assert.doesNotMatch(block, /"type": "warn"/, "no store-fault arm answers with a warn frame: " + what);
+  }
+});
+
+test("both timeline boots (VS Code and the kernel's inline browser twin) hand the frame to the panel", () => {
+  assert.match(BOOT, /if \(m\.type === "settingRefused" && panel\.settingRefused\) \{ panel\.settingRefused\(m\); return true; \}/);
+  const bootStart = KERNEL.indexOf("_TIMELINE_BOOT = ");
+  const boot = KERNEL.slice(bootStart, KERNEL.indexOf('"""', bootStart + 60));
+  assert.match(boot, /else if\(m\.type==="settingRefused"&&panel\.settingRefused\)panel\.settingRefused\(m\);/);
+  // for real: the frame reaches the panel method, an older panel without it is skipped, never thrown at
+  const got: any[] = [];
+  assert.equal(dispatchFrame({ settingRefused: (m: any) => got.push(m) }, { type: "settingRefused", sid: "s1", flag: "notify", text: "couldn't save that setting" }), true);
+  assert.equal(got[0].flag, "notify");
+  assert.equal(dispatchFrame({}, { type: "settingRefused" }), false);
+});
+
+test("timeline: the lane gear's latch drops, the lane repaints to the kernel's painted value, the gear says why", () => {
+  const fn = VIEW.slice(VIEW.indexOf("  settingRefused(m) {"), VIEW.indexOf("\n  }", VIEW.indexOf("  settingRefused(m) {")));
+  assert.match(fn, /if \(m && m\.gesture === 'flag' && sid && flag\) \{/, "the frame names its gesture; nothing is inferred from empty fields");
+  // the sticky latch for THAT sid+flag is released (a push no longer re-applies the refused value)
+  assert.match(fn, /const pend = this\._pendingFlags\[sid\];\n\s+if \(pend\) \{ delete pend\[flag\];/);
+  // the value the kernel still paints (carried by the frame) lands on both copies a click may have written --
+  // never a value recorded at the click, which a second click before the first refusal made wrong
+  assert.match(fn, /if \(typeof m\.value === 'boolean'\) \{/);
+  assert.match(fn, /for \(const s of targets\) if \(s\) s\[flag\] = m\.value;/);
+  assert.doesNotMatch(VIEW, /_pendingFlagsPrev/, "no per-flag pre-click slot remains");
+  // the refusal is shown in the gear (rebuilt in place if open) and filed in the shell's bell under its own kind
+  assert.match(fn, /this\._laneRefusal = \{ sid, flag, text \};/);
+  assert.match(fn, /if \(this\._laneMenu && this\._laneMenu\._sid === sid && this\._laneMenuBuild\) this\._laneMenuBuild\(\);/);
+  assert.match(fn, /window\.parent\.postMessage\(\{ romp: 'notify', kind: 'refused', text, sid \}, '\*'\);/);
+  assert.match(fn, /this\.draw\(\);/);
+  // the gear renders the refusal row for THIS lane, dismissible, in the dialog's refusal dress
+  assert.match(VIEW, /if \(this\._laneRefusal && this\._laneRefusal\.sid === s\.id\) \{\n\s+const er = menu\.createDiv\(\);/);
+  assert.match(VIEW, /er\.createSpan\(\{ text: '⚠ ' \+ this\._laneRefusal\.text \}\);/);
+  assert.match(VIEW, /ex\.addEventListener\('click', \(e\) => \{ e\.stopPropagation\(\); this\._laneRefusal = null; build\(\); \}\);/);
+  assert.match(VIEW, /this\._laneMenuBuild = build;/);
+});
+
+test("feed: the card bell's latch drops, the card repaints, the reason toasts (soft) and is filed in the bell", () => {
+  const i = FEED.indexOf('} else if (m.type === "settingRefused" && typeof m.text === "string" && m.text) {');
+  assert.ok(i > 0, "the feed page handles the frame");
+  const arm = FEED.slice(i, FEED.indexOf('} else if (m.type === "err"', i));
+  assert.match(arm, /if \(m\.gesture === "bell" && typeof m\.itemId === "string" && m\.itemId\) pendingNotify\.delete\(m\.itemId\);/);
+  assert.match(arm, /\n\s+render\(\);/, "the repaint follows the release: the paint key reads the latch");
+  // a bell toggle is a SOFT refusal (nothing typed was lost): the fading toast, never the must-dismiss dialog
+  assert.match(arm, /feedToast\(m\.text\);/);
+  assert.doesNotMatch(arm, /showErrDialog/);
+  assert.match(arm, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: "refused", text: m\.text,/);
+  // the release precedes the paint, and the paint key still reads the latch (else the bell would not repaint)
+  assert.ok(arm.indexOf("pendingNotify.delete") < arm.indexOf("render();"));
+  assert.match(FEED, /\+ "\|" \+ \(pendingNotify\.has\(it\.itemId\) \? String\(pendingNotify\.get\(it\.itemId\)\) : ""\)/);
+  // and the page still has NO warn handler: undelivered-err.test.ts pins that, and it stays true on purpose
+  assert.doesNotMatch(FEED, /m\.type === "warn"/);
+});
+
+test("chat: the tab menu's local copy repaints to the kernel's painted value, the reason toasts and is filed", () => {
+  assert.doesNotMatch(RENDER, /pendingFlagPrev/, "no per-flag pre-click slot remains");
+  const i = RENDER.indexOf('else if (m.type === "settingRefused" && typeof m.text === "string" && m.text) {');
+  assert.ok(i > 0, "the chat page handles the frame");
+  const arm = RENDER.slice(i, RENDER.indexOf('else if (m.type === "warn"', i));
+  assert.match(arm, /if \(m\.gesture === "flag" && typeof m\.sid === "string" && typeof m\.flag === "string" && m\.sid && m\.flag\) \{/);
+  assert.match(arm, /if \(s && typeof m\.value === "boolean"\) \(s as any\)\[m\.flag\] = m\.value;/);
+  assert.match(arm, /notifyShell\("refused", m\.text, typeof m\.sid === "string" \? m\.sid : ""\);/);
+  assert.match(arm, /warnToast\(m\.text\);/);
+});
+
+test("the shell's bell knows the `refused` kind: listed, labelled, explained, and worn in the warning yellow", () => {
+  // KINDS drives the filter row, KINDLBL the chip, DESC the tooltip -- a kind missing from any of the three
+  // renders as an unlabelled entry with no way to mute it. Its own kind, so muting `warn` (the judge's
+  // anomaly stamp) never mutes a change of yours that did not land
+  assert.match(KERNEL, /var KINDS=\[[^\]]*'refused','undelivered'\]/);
+  assert.match(KERNEL, /refused:'not saved'/);
+  assert.match(KERNEL, /refused:"a change you made \\u2014 a lane or tab setting, a card bell, a tag or view, a lane order \\u2014 was not saved because romp could not read the file that holds it/);
+  assert.match(KERNEL, /\.rerr-chip\.k-refused\{color:#ffd166;border-color:rgba\(255,209,102,0\.6\)\}/);
+  // and every pane files under it -- none under `warn`
+  for (const src of [FEED, RENDER, VIEW]) assert.doesNotMatch(src.slice(src.indexOf("settingRefused")), /kind: ['"]warn['"]/);
+});
+

--- a/ui/webview/sync-notice-mirror.test.ts
+++ b/ui/webview/sync-notice-mirror.test.ts
@@ -23,6 +23,19 @@ test("a finished sync logs once, under its own kind", () => {
   assert.deepEqual([...active].sort(), ["sync|100|1", "sync|100|2"]);
 });
 
+test("a row's kind is honoured through an allowlist: refused stays refused, everything else is sync", () => {
+  // review find, 2026-09-08: the kernel's state-file faults (a store it could not read, or moved aside)
+  // ride the same ring; filed under sync they wore the machine-sync label, and muting that log muted
+  // them. The kernel names the kind; a value the bell does not know (a newer remote kernel) reads as sync
+  const { notices } = syncNotices(
+    [{ ...row("sync|100|1", "session-flags.json could not be read (read failed: [Errno 5] Input/output error)", false), kind: "refused" },
+      { ...row("sync|100|2", "pushed this machine's build to api"), kind: "sync" },
+      row("sync|100|3", "a row from a kernel that predates the field"),
+      { ...row("sync|100|4", "a kind this bell does not know", false), kind: "bogus" }], new Set());
+  assert.deepEqual(notices.map((n) => n.kind), ["refused", "sync", "sync", "sync"]);
+  assert.match(notices[0].text, /could not be read/);
+});
+
 test("a SUCCESS is an entry, not only a failure", () => {
   // the whole point: an unwatched push that worked used to leave no record either
   const { notices } = syncNotices([row("sync|100|1", "pushed this machine's build to api")], new Set());

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -45,6 +45,9 @@ export function dispatchFrame(panel: any, m: any): boolean {
   // the kernel's pick memory moved (a pin, a Latest un-pin, a refused pin dropped — from any surface or
   // dashboard) or its catalog grew: the lane picker re-reads /models so its family rows send the fresh default
   if (m.type === "models" && panel.refreshModels) { panel.refreshModels(); return true; }
+  // the kernel refused a gesture this page posted (a lane flag whose store could not be read): the panel
+  // ends its optimistic state on this event and shows the reason in the gear
+  if (m.type === "settingRefused" && panel.settingRefused) { panel.settingRefused(m); return true; }
   if (m.type === "tagEditFailed" && panel.tagEditFailed) { panel.tagEditFailed(m); return true; }
   return false;
 }


### PR DESCRIPTION
Flag, order and bell writes are refused when their state file can't be read, never written over an empty

Three kernel state stores shared one unsafe shape. Each reader folded ANY stat/read/JSON
fault into an empty value the same way a genuinely-missing file reads empty, and two of
them CACHED that fabricated empty under the file's real (mtime_ns, size) key. Every
read-modify-write writer then copied the empty, applied its one edit, and atomically
wrote it back -- so a transient EIO/EACCES on read, or torn bytes, erased the whole store
under a success ack, with no notice:

- session-flags.json: `_set_session_flag`/`_set_notify_session` -> every session's flags,
  including the postalServiceOff postal-isolation boundaries.
- session-order.json: `_merge_session_order` (a drag) and `_ordered` (every push) -> the
  user's saved lane/tab order, replaced with plain discovery order under no gesture.
- notify-cards.json: `_set_notify_all`/`_set_notify_turns`/`_set_notify_card` -> every
  per-card, per-session and master bell override.

(The fourth store, timeline-views.json, has the same defect and the same fix in the next
commit, kept apart because open PRs rewrite its write path.)

The fix. ONE strict reader, `_read_state_json(path, st=None)`, distinguishes the fault
classes the old `except Exception: {}` conflated: a MISSING file returns None (a fresh
install has no files, byte-for-byte as before); an UNREADABLE existing file (a stat or
read fault) raises `_StateUnreadable`; torn or non-JSON bytes are QUARANTINED aside and
then read as None, so the store starts empty ONLY after the evidence is preserved. It reads
bytes (a non-UTF-8 torn file quarantines rather than escaping as a UnicodeDecodeError) and
never caches.

The quarantine wears the shape the goal-store and ledger quarantines wear, so one
convention reads across all three: `<file>.corrupt-<utc stamp>`, a `-n` suffix for a
second collision in the same second, an `os.replace`, and a same-file re-check (inode,
mtime, size against the stat taken before the read) so an atomic publish that landed
before the re-check is never moved aside -- the caller gets a transient `_StateUnreadable`
and its next read is a fresh one. Bytes that cannot be moved (a read-only state dir) leave
the store UNREADABLE, so a writer refuses, rather than read as empty over evidence that
was not preserved. The fault text is errno + strerror only (never a path, never the
per-second stamp), so the once-per-fault-text registries below dedupe a disk that stays
broken.

Decision A: `_StateUnreadable` is a plain Exception, NOT an OSError. The WS receive loop
re-raises `(BrokenPipeError, ConnectionResetError, OSError)` as a genuine socket failure
and tears the connection down; every other exception falls to its logging arm and the next
message still processes. The review found a handler path where a read fault could escape
(the views heal, fixed in the next commit); as an OSError that escape would have dropped
the dashboard's socket, as an Exception it costs one logged line. The class carries `path`
and `fault`, and its `str()` is plain ("session-flags.json could not be read (read failed:
[Errno 5] Input/output error)"), so every surface that shows the reason shows the same
words.

The mutation path is proved. Each store gets a `_X_proved()` snapshot that reads through
the strict reader and lets `_StateUnreadable` propagate; every RMW writer snapshots
through it and refuses on a fault instead of writing over an empty. That includes the
value a click is JUDGED against when it lives in the other store: `_set_notify_card`
takes the card's default from the session's own bell (session-flags.json) and
`_set_notify_session` compares against the master (notify-cards.json). Read through the
display readers, a fault on the other store folded that default -- a mute matching the
fabricated default was then DELETED under the success path, the user's override erased
-- so both now read it proved, and a fault on either store refuses the write.

The display path never raises: build_feed / build_timeline / build_session all run under
_push's single outer try, so a reader that raised would abort every client's push and
wedge the board. Each display reader instead serves the last value this kernel read (its
cache entry; for the order, a last-known-good copy latched on every clean read or write)
or, on a cold start with nothing read yet, the empty default -- UNPROVED either way, never
cached and never latched as the new known-good, so no writer persists it -- and files
exactly ONE visible error per fault EPISODE (one stderr line + one dashboard
sync-notice); a repeated identical fault files nothing new, and a clean read clears the
episode (event-based, no timer). The sync-notice ring is the surface the views store's
stale-writer guard already uses (the shell's bell files it under its sync kind); a
dedicated kernel-fault surface is a follow-up. `_write_session_order`'s audit read is the
display read, which never raises, so it needs no guard.

Decision B: refusals answer in each surface's EXISTING contract, never a frame the pane
cannot render.

- HTTP. POST /notify-all and /notify-turns answer 200 `{"ok": false, "retryable": true,
  "error": ...}` -- the routes' own refusal shape -- never a 5xx: `romp tag` posts with
  `curl -sf`, which turns any 5xx into "kernel not reachable (is romp running?)", the wrong
  reason, and `_remote_forward` treats every non-200 as a tunnel hiccup; both read a 200
  ok:false body as the refusal it is. The shell's bell popover posts its switches through
  one `post()` helper that resolved on any 2xx and would have run the SUCCESS arm on an
  ok:false body, flipping the switch to the state the kernel had just refused; it now
  rejects on ok:false with the route's `error`, so the switch stays put and the reason
  toasts through the same `fail()` the transport errors use.

- WS. The setSessionFlag, cardNotify and reorderTabs/writeOrder arms catch the fault and
  answer the DELIVERING socket with one frame, `{"type": "settingRefused", gesture, sid,
  itemId, flag, value, text}` (`_refuse_setting`, through `_reply` -- the targeted idiom
  the settingStale stand-down and the saveFile acks use, never a broadcast). `gesture`
  names the kind ("flag" / "bell" / "order"; "views" in the next commit) so no pane
  infers it from which fields are empty; `value` is what the kernel's display path still
  paints for that flag or bell -- the value the next push carries -- so the pane repaints
  the refused toggle to it on THIS event rather than to a value it recorded at the click
  (two clicks before the first refusal made such a record wrong until the next push). The
  `warn` frame the first draft sent did neither: only the chat page renders `warn`, so a
  refused bell on the feed page and a refused lane flag on the timeline page stayed
  painted as if they had landed, their sticky latches never released, until a reload.
  Every pane that posts one of these gestures handles the frame:
  - the feed (a card bell) drops that card's `pendingNotify` latch and repaints (the paint
    key reads the latch, so the bell returns to the payload's value), toasts the text -- a
    soft refusal, nothing typed was lost, so never the must-dismiss dialog -- and files it in
    the shell's bell. The page still has NO `warn` handler; undelivered-err.test.ts's pin of
    that stays true on purpose.
  - the timeline (a lane-gear flag): both boots (timeline-boot.ts and the kernel's inline
    twin) dispatch the frame to the panel; `settingRefused` drops the sid+flag entry of
    `_pendingFlags`, repaints the lane to the frame's `value` (on the current frame's
    session and on the copy the open gear built from), shows a dismissible refusal row in
    the gear -- rebuilt in place while open, shown on the next open otherwise, retired by a
    retry -- and files it in the shell's bell.
  - the chat (a tab-menu flag) repaints the session's local copy to the frame's `value`,
    toasts the text and files it in the shell's bell.
  - reorderTabs/writeOrder: no shipped pane posts it today (the strip and the lanes write
    the viewer's own arrangement), so the frame has no latch to release; the contract holds
    for the op all the same.
  The shell's bell gets a kind of its own for these, `refused` ("not saved"; its tooltip
  says what it means; the warning-yellow chip): filing them under `warn` would have let a
  user who muted the judge's anomaly stamps mute refusals of their own changes with them.
  The error center's filter row grows from 13 kinds to 14.
  Internal callers (the order GC on every push, the bell prune on a card leaving) skip the
  pass on a fault, loud once per episode, instead of writing.

Unchanged: the ENOENT case reads empty exactly as before; a clean read reads and caches
exactly as before; every route's success shape and every success push are untouched.

Tests (module runs on this commit; the full suite is left to CI, not run on the
development machine):

- tests/test_kernel_session_flags.py (21): a flag toggle under a read fault leaves the
  file byte-for-byte unchanged and raises (on main the file is left holding only the new
  toggle, the isolation boundary gone); the display reader serves the last cached value
  over a fault and caches nothing under the file's NEW stat key (the key is bumped by a
  second write first, since a primed cache under the same key is a hit and never reads),
  serves {} uncached on a cold cache, and re-reads the real file once the fault clears; one
  notice per episode, re-armed by a clean read; the WS arm answers `settingRefused` with
  gesture, sid, flag and the painted value for both the plain setter and the tri-state
  bell, the file untouched, nothing marked dirty, nothing escaping; a session-bell click
  with the BELLS file unreadable is refused and the flags file unchanged (before: the mute
  popped and the file rewritten as {}), directly and through the WS arm; `_StateUnreadable`
  is an Exception and not an OSError.
- tests/test_kernel_order.py (31): a drag under a fault is refused with the file unchanged
  (main drops the untouched lane); `_ordered` renders the last-known order and persists
  nothing; the display reader serves the known-good on every faulted read and latches
  nothing when there is none; the WS drag arm refuses on the socket; the quarantine's `-n`
  suffix, its republished-before-the-re-check case (the good file is never moved), the
  cannot-move case (unreadable, not empty), the `os.replace`, and the stamp-free fault text.
- tests/test_notify_bells.py (44): the master bell toggle under a fault leaves the file
  unchanged (main leaves just {"*": true}); the display reader's fault behaviour as for the
  flags; the WS bell arm refuses on the socket addressed to the card, with gesture and the
  painted value; a card-bell click with the FLAGS file unreadable is refused and the bells
  file unchanged (before: the override deleted), directly and through the WS arm; POST
  /notify-all and /notify-turns under a fault answer 200 ok:false retryable with the file
  untouched and no dashboard told the switch flipped; the shell's `post()` rejects an
  ok:false body.
- tests/test_error_center.py (15): the filter row's kind count and label order take
  "not saved".
- tests/test_kernel.py: the SessionOrderStable seam injects the persisted order at
  `_session_order_proved`, the mutation snapshot `_ordered` reads.
- ui/webview/setting-refused.test.ts: the kernel frame's fields and every store-fault arm
  answering through it with its gesture (none with a `warn`); both boots dispatching the
  frame (the dispatch exercised for real); the timeline's latch release, repaint to the
  frame's value, gear row and bell filing; the feed's latch release, repaint, toast (no
  dialog); the chat's repaint, toast and filing; the `refused` kind listed, labelled,
  explained and worn, and every pane filing under it.

The tests drive the setters directly (`_set_session_flag`, `_set_notify_session`,
`_merge_session_order` + `_write_session_order`, `_set_notify_all`, `_set_notify_card`) --
internal entries, the code the WS arms and routes call -- and the real `_dispatch_ws` with
a fake client capturing `send`. Mutants checked one module at a time, every one red: each
display reader caching the fault value (or the order reader latching [] as its known-good);
each of the three WS arms with its catch deleted (the fault escapes `_dispatch_ws`); the
notify routes answering 503; the refusal frame reverting to `warn`, dropping `value`,
dropping `gesture`; the card default or the session master read through the display
reader again; `_StateUnreadable` back to an OSError; the quarantine's re-check removed; its
`-n` suffix loop removed. The extension suite ran once on the two-commit tip (typecheck
clean); the files it flagged were folded and re-run singly, as were the files the review
fold touched.



## Tier

**fix** — a bug fix with tests that fail before it.

## Notes for review

- Tests were run per module on the development machine (the touched Python modules one process at a time; the touched TS test files singly after a tests build; `tsc --noEmit` clean); the full suite is left to this PR's CI.
- This PR deliberately leaves the **timeline-views** store (tags, lenses, tag order) untouched: it has the same defect, but **#1001** (tag edits as acknowledged writes with a write sequence) and the PRs stacked on it (#997, #1007) rewrite that store's write path. A follow-up carrying the views half is ready on this branch's parent and will be re-derived onto #1001 once it lands, so the two do not collide.
- The new `refused` bell kind ("not saved") gives store refusals their own kind instead of borrowing the judge-anomaly `warn`; a dedicated kernel-fault surface for the once-per-episode state-file notices (today they ride the `sync` kind) is a follow-up.
- **#1019** (goal store) fixes a pre-existing `KeyError` in the WS `clearAll` handler that a test here also ran into; this PR does not touch that line, so the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
