### PR TITLE
The main-drift converge compares shas by prefix agreement and moves only onto the advertised commit, refusing loudly on a failed fetch or status

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4113,17 +4113,46 @@ def _dismiss_update(ident):
         sys.stderr.write("update-dismiss: store write failed\n")
 
 
+def _sha8(s):
+    """The eight-character spelling of a sha for STATE and DISPLAY — the drift slots (_MAIN_DRIFT), the
+    in-place latch, the banner — with any '-dirty' suffix stripped; '' stays ''. Never use it to
+    COMPARE two shas (that is _sha_same): it only clamps downward, and a sha that came out SHORTER
+    than eight would still disagree with its own eight-character spelling."""
+    return (_sha_base(s) or "")[:8]
+
+
+def _sha_same(a, b):
+    """Whether two drift-verdict inputs name the SAME commit: '-dirty' stripped, then the shorter is a
+    prefix of the longer — _shas_agree's rule (the p2p path's) with a floor: the shorter must be at
+    least seven characters, git's own minimum for an auto abbreviation; below that, exact equality
+    (nothing git prints is that short, and a stray fragment must not agree with everything). The
+    verdict's three readers shorten INDEPENDENTLY — `rev-parse --short` for the running build floors
+    at seven on a small object store (a `--depth 1` clone) and widens past eight on a large one, and
+    carries '-dirty' on an uncommitted tree; `--short=8` for the checkout and the ls-remote slice for
+    origin sit at eight — so compared as strings, a checkout at the very commit the kernel runs read
+    as permanent drift: a 'ready on disk' banner that never cleared in ask mode, and in auto mode an
+    unwarranted full restart (every in-flight turn cut) once per cool-down, forever."""
+    a, b = _sha_base(a) or "", _sha_base(b) or ""
+    if not a or not b:
+        return False
+    short, long_ = (a, b) if len(a) <= len(b) else (b, a)
+    return long_.startswith(short) if len(short) >= 7 else a == b
+
+
 def _main_drift_verdict(origin, checkout, running):
     """(kind, target) — the pure decision. kind: "pull" (origin ahead of the checkout: fetch + advance
     + restart), "restart" (the checkout is ahead of the running kernel: restart alone), or "" (in sync
     or unknowable). A sha that could not be read ('' anywhere) is unknown → no verdict: guessing would
-    invent a notice. Comparison is by INEQUALITY, not ancestry — the checkout only ever moves by
-    fast-forwarding to origin/main here, so a differing sha IS new information, and a wrongly-diverged
-    checkout surfaces in the pull step's own fast-forward refusal rather than being guessed at."""
-    if origin and checkout and origin != checkout:
-        return ("pull", origin)
-    if checkout and running and checkout != running:
-        return ("restart", checkout)
+    invent a notice. Comparison is by prefix AGREEMENT (_sha_same: dirty-stripped, width-tolerant),
+    not ancestry — the checkout only ever moves by fast-forwarding to origin/main here, so a differing
+    commit IS new information, and a wrongly-diverged checkout is refused by the pull step's own
+    fast-forward check (_run_main_update) rather than being guessed at. The target is the eight-
+    character spelling (_sha8): the slots, the latch and the banner all carry that one form."""
+    origin, checkout, running = _sha_base(origin) or "", _sha_base(checkout) or "", _sha_base(running) or ""
+    if origin and checkout and not _sha_same(origin, checkout):
+        return ("pull", _sha8(origin))
+    if checkout and running and not _sha_same(checkout, running):
+        return ("restart", _sha8(checkout))
     return ("", "")
 
 
@@ -4521,7 +4550,7 @@ def _main_drift_check():
         # for the rest of the window, and a pull must not wait on a park that already delivered
         # (review find). When a stand-down ends without that landing — the row expired, the park
         # died with its manager — say so once and let the converge proceed on its own terms.
-        if running != checkout and _parked_quiet_deploy(checkout):
+        if not _sha_same(running, checkout) and _parked_quiet_deploy(checkout):
             if _QUIET_PARKED_LOGGED[0] != checkout:
                 _QUIET_PARKED_LOGGED[0] = checkout
                 sys.stderr.write("romp-kernel: converge: %s already parked as a quiet deploy — leaving it "
@@ -4537,7 +4566,7 @@ def _main_drift_check():
             _MAIN_DRIFT[slot] = ""
             return
         _LAST_AUTO_CONVERGE[0] = time.time()
-        _run_main_update(kind)
+        _run_main_update(kind, target=target)
     else:
         if target in _dismissed_updates():
             return                    # Not-now'd THIS sha, durably — a NEW sha offers again
@@ -4555,36 +4584,74 @@ def _main_drift_check():
 _PORT_FROM_ENV = object()
 
 
-def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
+def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target=""):
     """Converge on newest main: advance the checkout (fast-forward only; a DIRTY shared tree refuses
     LOUDLY — peer sessions' uncommitted work is never discarded) and bounce every kernel through the
     manager. `kind` "restart" skips the pull (the checkout is already ahead). The bounce is IMMEDIATE
     for every caller (T160, the user 2026-08-28: deploys cut in-flight turns now; the parked quiet
     window cost minutes per push and boot reconcile resumes cut turns either way) — pass
     immediate=False to ride the manager's quiet-window gate explicitly.
-    `manager_port` is the value the /update handler resolved before its ack (see _PORT_FROM_ENV)."""
+    `manager_port` is the value the /update handler resolved before its ack (see _PORT_FROM_ENV).
+    `target` is the commit the verdict ADVERTISED (the notice's sha, or the one auto mode acted on):
+    the pull moves the checkout onto exactly that commit, never onto the remote's ref — a ref can
+    move (or, after a failed fetch, sit stale) between the verdict and the move, and a ref checkout
+    is not a fast-forward operation, so it landed on a rewound or diverged main without a word.
+    Every step reads its own exit code: a failing `git status` is UNKNOWN, never clean (a tree that
+    cannot be read is not a tree that may be moved), and a failed fetch aborts instead of checking
+    out whatever the stale local ref points at. Every refusal is said on the sync surface
+    (_sync_notice, ok=False — the row every updater failure already lands on) and re-arms the notice."""
     if kind == "pull":
+        remote = _release_remote()
+        target = _sha8(target)
+
+        def refuse(why, r=None):
+            # the OUTCOME first: the row is capped downstream (300 chars on the wire, 240 in the
+            # badge), so git's own words come LAST and trimmed, never pushing "left alone" off the end
+            if r is not None:
+                said = (r.stderr or r.stdout or "").strip()[-120:]
+                why += (" (git: %s)" % said) if said else (" (git exited %d)" % r.returncode)
+            _sync_notice("main moved at %s, but %s." % (remote, why), ok=False)
+            _MAIN_DRIFT[0] = ""                   # every refusal re-arms: the notice re-fires once cured
         try:
-            dirty = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
-                                   capture_output=True, text=True, timeout=10).stdout.strip()
-            remote = _release_remote()
-            if dirty:
-                _sync_notice("main moved at %s, but the romp checkout has uncommitted work, so it "
-                             "was left alone. Commit or stash it, then Update again." % remote, ok=False)
-                _MAIN_DRIFT[0] = ""                   # let the notice re-fire once the tree is clean
+            if not target:
+                refuse("the checkout was left alone: no commit was named for the move. Update again "
+                       "once the next check has read main")
                 return
-            subprocess.run(["git", "fetch", remote, "main"], cwd=str(ROOT),
-                           capture_output=True, text=True, timeout=60)
-            r = subprocess.run(["git", "checkout", "--detach", "%s/main" % remote], cwd=str(ROOT),
+            st = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
+                                capture_output=True, text=True, timeout=10)
+            if st.returncode != 0:
+                refuse("the checkout was left alone: its state could not be read, so it was not "
+                       "assumed clean", st)
+                return
+            if st.stdout.strip():
+                refuse("the romp checkout has uncommitted work, so it was left alone. Commit or "
+                       "stash it, then Update again")
+                return
+            f = subprocess.run(["git", "fetch", remote, "main"], cwd=str(ROOT),
+                               capture_output=True, text=True, timeout=60)
+            if f.returncode != 0:
+                refuse("the checkout was left alone: the fetch failed", f)
+                return
+            anc = subprocess.run(["git", "merge-base", "--is-ancestor", "HEAD", target], cwd=str(ROOT),
+                                 capture_output=True, text=True, timeout=10)
+            if anc.returncode == 1:
+                # a real non-ancestor: the histories diverged — never merged on the user's behalf
+                refuse("the checkout was left alone: %s is not a fast-forward of it — the histories "
+                       "diverged, which is yours to move by hand" % target)
+                return
+            if anc.returncode != 0:
+                # git could not even name it (128): the fetch did not bring the advertised commit
+                # (main was rewound), or the short prefix is ambiguous — the next check re-reads main
+                refuse("the checkout was left alone: the fetch did not bring %s, so it could not be "
+                       "verified; the next check re-reads main" % target, anc)
+                return
+            r = subprocess.run(["git", "checkout", "--detach", target], cwd=str(ROOT),
                                capture_output=True, text=True, timeout=30)
             if r.returncode != 0:
-                _sync_notice("main moved at %s, but advancing the checkout failed: %s"
-                             % (remote, (r.stderr or r.stdout or "").strip()[-200:]), ok=False)
-                _MAIN_DRIFT[0] = ""
+                refuse("the checkout did not advance onto %s" % target, r)
                 return
         except Exception as e:
-            _sync_notice("main moved at %s, but the pull step failed: %s" % (_release_remote(), e), ok=False)
-            _MAIN_DRIFT[0] = ""
+            refuse("the pull step failed: %s" % e)
             return
     if kind == "pull":
         pulled = _checkout_sha()   # ONE read: verdict input and converge target must be the same
@@ -4606,15 +4673,20 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV):
     if manager_port is _PORT_FROM_ENV:
         manager_port = os.environ.get("ROMP_MANAGER_PORT")
     try:
-        import urllib.request
         # the reason joins the dying kernel's restart-cuts.jsonl row to WHO restarted it (see
         # _recent_restart_reason) — the auto converge used to leave the row anonymous
         _audit_restart_request("main-converge", tag=kind, when=("now" if immediate else "quiet"),
                                sha=_checkout_sha())      # what a quiet row deploys (T240d: _parked_quiet_deploy)
-        req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"
-                                     % (int(manager_port or 7432),
-                                        "" if immediate else "?when=quiet"), method="POST")
-        urllib.request.urlopen(req, timeout=5).read()
+        # http.client, the way _restart_this_kernel dials: urllib's default opener honours
+        # HTTP_PROXY / http_proxy, so under a proxy environment this loopback POST went to the
+        # proxy and the code on disk never restarted — reported only as "restart request failed"
+        c = http.client.HTTPConnection("127.0.0.1", int(manager_port or 7432), timeout=5)
+        c.request("POST", "/restart-all%s" % ("" if immediate else "?when=quiet"))
+        resp = c.getresponse()
+        resp.read()
+        c.close()
+        if resp.status >= 400:
+            raise RuntimeError("the manager answered HTTP %d" % resp.status)
     except Exception as e:
         _sync_notice("romp is updated on disk but the restart request failed (%s) — "
                      "restart it yourself: romp refresh" % e, ok=False)
@@ -15367,6 +15439,10 @@ def _pull_remote(host):
                             capture_output=True, text=True, timeout=10)
     except Exception as e:
         return False, str(e)[:200]
+    if st.returncode != 0:
+        # a tree whose state cannot be read is UNKNOWN, never clean: the fast-forward rewrites it
+        return False, "reading this machine's tree state failed (%s) — nothing pulled" % (
+            (st.stderr or st.stdout or "").strip()[:160] or "git status exited %d" % st.returncode)
     if (st.stdout or "").strip():
         return False, "this machine's tree has uncommitted changes — commit or stash them first (won't clobber)"
     rdir, rhead, _rdirty, derr = _discover_remote_clone(host)   # a DIRTY remote is fine: we take its COMMITS
@@ -37468,14 +37544,19 @@ class Handler(BaseHTTPRequestHandler):
                         _run_update(tag)
                         _send_to_app("shell", {"type": "updateAvail", "state": "running", "boot": _BOOT_ID})
                     return self._send(200, json.dumps({"ok": True, "state": _UPDATE_STATE[0]}), "application/json")
-                kind = "pull" if _MAIN_DRIFT[0] else ("restart" if _MAIN_DRIFT[1] else "")
+                # ONE snapshot of what the kernel found: the kind and the commit it advertised come
+                # from the same read, so a slot emptied meanwhile (a refusal re-arming, a sync
+                # landing) can never pair a "pull" with an empty target — an unbound move
+                d0, d1 = _MAIN_DRIFT[0], _MAIN_DRIFT[1]
+                kind = "pull" if d0 else ("restart" if d1 else "")
                 if kind:
-                    _audit_restart_request("main-converge", tag=_MAIN_DRIFT[0] or _MAIN_DRIFT[1],
+                    _audit_restart_request("main-converge", tag=d0 or d1,
                                            addr=str(self.client_address[0]))
                     # same ack-time port resolution as /restart: the daemon thread's env read could
                     # otherwise land after this response, on a value the caller has already restored
                     threading.Thread(target=_run_main_update, args=(kind, True),
-                                     kwargs={"manager_port": os.environ.get("ROMP_MANAGER_PORT")},
+                                     kwargs={"manager_port": os.environ.get("ROMP_MANAGER_PORT"),
+                                             "target": d0 or d1},
                                      daemon=True).start()
                     _send_to_app("shell", {"type": "updateAvail", "state": "running", "boot": _BOOT_ID})
                     return self._send(200, json.dumps({"ok": True, "state": "converging"}), "application/json")

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -68,13 +68,13 @@ class PullRemote(unittest.TestCase):
         km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(self._hc)
         km._remotes.clear()
 
-    def _wire(self, dirty="", rhead=REMOTE, ancestor_rc=0, merge_rc=0, count="3"):
+    def _wire(self, dirty="", rhead=REMOTE, ancestor_rc=0, merge_rc=0, count="3", status_rc=0):
         calls = []
 
         def fake(argv, **kw):
             calls.append(argv)
             if argv[0] == "git" and "status" in argv:
-                return _R(out=dirty)
+                return _R(out=dirty, rc=status_rc, err="fatal: not a git repository" if status_rc else "")
             if argv[0] == "git" and "fetch" in argv:
                 return _R()
             if argv[0] == "git" and "merge-base" in argv:
@@ -116,6 +116,17 @@ class PullRemote(unittest.TestCase):
         ok, detail = km._pull_remote("TESTHOST")
         self.assertFalse(ok)
         self.assertIn("uncommitted", detail)
+
+    def test_a_failed_status_is_unknown_never_clean(self):
+        # rc 128 with nothing on stdout read as a CLEAN tree before: the fetch and the fast-forward
+        # then ran over a tree whose state nobody had read. Unknown refuses, and names the failure.
+        calls = self._wire(status_rc=128)
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("tree state failed", detail)
+        self.assertIn("not a git repository", detail, "the refusal carries git's own words")
+        self.assertFalse(any(a[0] == "git" and ("fetch" in a or "merge" in a) for a in calls),
+                         "nothing fetched or moved past the refusal")
 
     def test_a_clean_fast_forward_pulls_and_says_what_to_do_next(self):
         calls = self._wire()

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -506,8 +506,8 @@ class Routes(Fresh):
         km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = "aaaa1111", ""
         ran = []
         with mock.patch.object(km, "_run_main_update",   # the route hands over its ack-time port too
-                               side_effect=lambda kind, immediate=False, manager_port=None:
-                                   ran.append((kind, immediate))):
+                               side_effect=lambda kind, immediate=False, manager_port=None, target="":
+                                   ran.append((kind, immediate, target))):
             code, body = self._post("/update")
             self.assertEqual(code, 200)
             self.assertIn("converging", body)
@@ -515,7 +515,8 @@ class Routes(Fresh):
                 if ran:
                     break
                 time.sleep(0.01)
-        self.assertEqual(ran, [("pull", True)], "the banner click is the user's own deliberate cut")
+        self.assertEqual(ran, [("pull", True, "aaaa1111")],
+                         "the banner click is the user's own deliberate cut, onto the commit the banner named")
         km._MAIN_DRIFT[0] = ""
 
 

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -84,13 +84,58 @@ class DriftVerdict(unittest.TestCase):
         self.assertEqual(km._main_drift_verdict("aaaa1111", "", "bbbb2222"), ("", ""))
         self.assertEqual(km._main_drift_verdict("", "", ""), ("", ""))
 
+    def test_a_dirty_tree_at_the_running_commit_is_in_sync(self):
+        # the running build's sha carries '-dirty' whenever the checkout had uncommitted work when the
+        # kernel resolved it (_kernel_sha); the checkout's reader never appends it. On a shared
+        # main-tracking tree that is the normal state — and it read as permanent drift: a 'ready on
+        # disk' banner that never cleared in ask mode, and in auto mode a full restart, every
+        # in-flight turn cut, once per cool-down for as long as the tree stayed dirty
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "aaaa1111-dirty"), ("", ""))
+
+    def test_sha_width_never_reads_as_drift(self):
+        # `rev-parse --short` auto-widens past eight characters on a big repo; `--short=8` and the
+        # ls-remote slice never do — the same commit spelled at two widths is not two commits
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "aaaa11112"), ("", ""))
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111" + "0" * 32, "aaaa1111"), ("", ""))
+
+    def test_a_seven_char_running_sha_at_the_checkouts_commit_is_in_sync(self):
+        # the other direction: git's auto abbreviation FLOORS at seven on a small object store — a
+        # `--depth 1` clone (an install shape the repo's own bug template names) spells the running
+        # build at seven while `--short=8` spells the checkout at eight. A downward clamp to eight
+        # cannot see that these agree; prefix agreement can
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "aaaa111"), ("", ""))
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "aaaa111-dirty"), ("", ""))
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa111", "aaaa111"), ("", ""),
+                         "and origin vs a seven-character checkout the same way")
+
+    def test_seven_against_eight_is_still_drift_when_the_commits_differ(self):
+        # agreement is a prefix match, never a shrug: a different seven-character commit restarts,
+        # and the target keeps the eight-character spelling the slots and the banner carry
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "cccc333"), ("restart", "aaaa1111"))
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "cccc333-dirty"), ("restart", "aaaa1111"))
+        self.assertEqual(km._main_drift_verdict("bbbb222", "aaaa1111", "aaaa1111"), ("pull", "bbbb222"))
+
+    def test_below_gits_floor_only_exact_equality_agrees(self):
+        # nothing git prints is shorter than seven; a stray fragment must not agree with everything
+        self.assertFalse(km._sha_same("aaaa11", "aaaa1111"), "six characters: a fragment, not a prefix match")
+        self.assertTrue(km._sha_same("aaa", "aaa"), "equal strings still agree (the cool-down tests' fixtures)")
+        self.assertFalse(km._sha_same("", "aaaa1111"), "unknown agrees with nothing")
+        self.assertTrue(km._sha_same("aaaa111", "aaaa1111" + "0" * 32), "seven against forty")
+
+    def test_a_dirty_tree_behind_the_checkout_still_wants_a_restart(self):
+        # normalization strips the suffix, never the disagreement: real drift is still drift, and the
+        # target it names is the eight-character spelling the banner and the in-place latch compare
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "cccc3333-dirty"), ("restart", "aaaa1111"))
+        self.assertEqual(km._main_drift_verdict("bbbb2222", "aaaa1111", "aaaa1111-dirty"), ("pull", "bbbb2222"))
+
 
 class DriftWiring(unittest.TestCase):
     def test_off_mode_silences_the_watcher_and_auto_converges_unattended(self):
         src = inspect.getsource(km._main_drift_check)
         self.assertIn('if _update_mode() == "off":', src)
         self.assertIn('if _update_mode() == "auto":', src)
-        self.assertIn("_run_main_update(kind)", src)
+        self.assertIn("_run_main_update(kind, target=target)", src,
+                      "the auto converge hands down the commit it advertised — the move is bound to it")
         self.assertIn('"kind": "main"', src, "ask mode fires the shared banner with the drift variant")
 
     def test_a_dirty_shared_tree_refuses_loudly_and_rearms(self):
@@ -98,7 +143,9 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('"status", "--porcelain"', src)
         self.assertIn("uncommitted work", src, "the refusal names the real problem")
         self.assertIn('_MAIN_DRIFT[0] = ""', src, "the notice re-fires once the tree is clean")
-        self.assertIn('"checkout", "--detach", "%s/main" % remote', src, "advance is the repo's own convention")
+        self.assertIn('"checkout", "--detach", target', src,
+                      "the move lands on the ADVERTISED commit, never the remote's ref (ConvergePullStep drives it)")
+        self.assertNotIn('"%s/main" % remote', src, "a ref can move, or sit stale after a failed fetch")
         self.assertIn("remote = _release_remote()", src,
                       "the walk targets the RELEASE remote, never a literal origin (a fork layout's stale mirror)")
 
@@ -128,7 +175,7 @@ class DriftWiring(unittest.TestCase):
         km._update_mode = lambda: "auto"
         km._checkout_sha = lambda: "aaa"
         km._kernel_sha = lambda: "aaa"
-        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        km._run_main_update = lambda kind, immediate=False, target="": ran.append(kind)
         try:
             km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
             km._LAST_AUTO_CONVERGE[0] = 0.0
@@ -162,7 +209,7 @@ class DriftWiring(unittest.TestCase):
         km._checkout_sha = lambda: "aaa"
         km._kernel_sha = lambda: "aaa"
         km._origin_main_sha = lambda: "bbb"
-        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        km._run_main_update = lambda kind, immediate=False, target="": ran.append(kind)
         try:
             km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
             km._LAST_AUTO_CONVERGE[0] = 0.0                       # a FRESH process: module memory is empty
@@ -251,7 +298,7 @@ class DriftWiring(unittest.TestCase):
         km._update_mode = lambda: "auto"
         km._kernel_code_changed = lambda a, b: True
         km._CONVERGE_COOLDOWN_S = 0.0      # isolate the stand-down: the cool-down is T240's own gate
-        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        km._run_main_update = lambda kind, immediate=False, target="": ran.append(kind)
         km._checkout_sha = lambda: "f3dc387a" + "0" * 32
         km._origin_main_sha = km._checkout_sha
         km._kernel_sha = lambda: "aaaaaaaa" + "0" * 32
@@ -340,15 +387,23 @@ class DriftWiring(unittest.TestCase):
             check()
             self.assertEqual(ran, [], "fifty no-restart rows do not hide a live park")
             # LANDED, cut row lost (review find): the kernel already runs the checkout, the row is still
-            # unconsumed — nothing is owed, so a pull must not wait on it (and says nothing about a park)
+            # unconsumed — nothing is owed, so a pull must not wait on it (and says nothing about a park).
+            # "Runs the checkout" is read the way the verdict reads it (_sha_same): the running sha
+            # carries '-dirty' on a shared tree with uncommitted work, and is seven characters on a
+            # shallow clone — a raw string compare called both "restart still owed" and stood the
+            # pull down behind a park that had already delivered
             ran.clear()
             km._QUIET_PARKED_LOGGED[0] = ""
             audit.write_text(json.dumps({"t": int(now - 240), "action": "p2p-update",
                                          "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
-            km._kernel_sha = km._checkout_sha
+            km._kernel_sha = lambda: "f3dc387a" + "0" * 32 + "-dirty"
             km._origin_main_sha = lambda: "bbbbbbbb" + "0" * 32
             out = check()
             self.assertEqual(ran, ["pull"], "the parked restart already delivered: the pull proceeds")
+            self.assertNotIn("already parked", out)
+            km._kernel_sha = lambda: "f3dc387"                     # the shallow clone's seven-character spelling
+            out = check()
+            self.assertEqual(ran, ["pull", "pull"], "spelled at seven, the kernel still runs the checkout")
             self.assertNotIn("already parked", out)
             km._kernel_sha = lambda: "aaaaaaaa" + "0" * 32
             km._origin_main_sha = km._checkout_sha
@@ -453,8 +508,11 @@ class DriftWiring(unittest.TestCase):
 
     def test_the_route_acts_only_on_what_the_kernel_itself_found(self):
         src = inspect.getsource(km)
-        self.assertIn('kind = "pull" if _MAIN_DRIFT[0] else ("restart" if _MAIN_DRIFT[1] else "")', src,
+        self.assertIn('d0, d1 = _MAIN_DRIFT[0], _MAIN_DRIFT[1]', src,
+                      "one snapshot: a re-read could pair a pull with an emptied target — an unbound move")
+        self.assertIn('kind = "pull" if d0 else ("restart" if d1 else "")', src,
                       "no version or kind is ever taken from the client")
+        self.assertIn('"target": d0 or d1', src, "the click converges onto the commit the banner named")
 
 
 if __name__ == "__main__":
@@ -656,3 +714,180 @@ class PlainInstallCopy(unittest.TestCase):
         self.assertNotIn("restarts every kernel", src)
         self.assertIn("Update pulls them and restarts romp.", src)
         self.assertIn("Update restarts romp onto it.", src)
+
+
+class ConvergePullStep(unittest.TestCase):
+    """The pull step DRIVEN, every subprocess scripted: each guard stops the sequence where it claims,
+    nothing is checked out or restarted past a refusal, and the move lands on the commit the verdict
+    advertised — never on the remote's ref. Before this, the fetch's exit code went unread (a failed
+    fetch re-checked-out the stale local ref and reported success), `git status` read as CLEAN
+    whenever it failed, the checkout followed `<remote>/main` with no ancestry check, and the restart
+    POST rode urllib, whose default opener honours HTTP_PROXY. Every refusal lands on the sync
+    surface (_sync_notice, ok=False) — the row the updater's failures already use — and re-arms."""
+
+    TARGET = "abcd1234"
+
+    def setUp(self):
+        self._saved = (km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._INPLACE_TRIED[0])
+        km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = self.TARGET, ""
+        km._INPLACE_TRIED[0] = ""
+        self.notices, self.posts, self.calls, self.dials = [], [], [], []
+
+    def tearDown(self):
+        km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._INPLACE_TRIED[0] = self._saved
+
+    def _drive(self, target=TARGET, fail=(), status_out="", status_rc=0, proxy="", err="", answer=200):
+        """`fail`: step names that exit 1, or a {step: rc} dict; `err`: the stderr a failing step
+        prints (default '<step>: boom'); `answer`: the manager's HTTP status to the restart POST."""
+        import subprocess
+        import urllib.request
+        from unittest import mock
+        rec = self
+        rcs = fail if isinstance(fail, dict) else {s: 1 for s in fail}
+
+        def fake_run(argv, **kw):
+            step = ("status" if "status" in argv else "fetch" if "fetch" in argv
+                    else "merge-base" if "merge-base" in argv else "checkout" if "checkout" in argv
+                    else "rev-parse" if "rev-parse" in argv else "other")
+            rec.calls.append((step, list(argv)))
+            rc, out = rcs.get(step, 0), ""
+            if step == "status":
+                rc, out = status_rc, status_out
+            elif step == "rev-parse":
+                out = rec.TARGET + "\n"
+            return subprocess.CompletedProcess(argv, rc, stdout=out,
+                                               stderr=(err or "%s: boom" % step) if rc else "")
+
+        class FakeConn:
+            def __init__(self, host, port, timeout=0):
+                rec.dials.append((host, int(port)))
+
+            def request(self, method, path, *a, **k):
+                rec.posts.append((method, path))
+
+            def getresponse(self):
+                r = mock.MagicMock()
+                r.status = answer
+                r.read = lambda: b""
+                return r
+
+            def close(self):
+                pass
+
+        env = {"HTTP_PROXY": proxy, "http_proxy": proxy} if proxy else {}
+        with mock.patch.object(km.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(km, "_sync_notice", side_effect=lambda m, ok=True: rec.notices.append((m, ok))), \
+             mock.patch.object(km, "_kernel_sha", return_value="cur-sha"), \
+             mock.patch.object(km, "_kernel_code_changed", return_value=True), \
+             mock.patch.object(km, "_rebuild_dist", return_value=(True, "")), \
+             mock.patch.object(km, "_audit_restart_request", lambda *a, **k: None), \
+             mock.patch.object(km.http.client, "HTTPConnection", FakeConn), \
+             mock.patch.object(urllib.request, "urlopen",
+                               side_effect=AssertionError("the restart POST must not ride urllib")), \
+             mock.patch.dict(km.os.environ, env):
+            km._run_main_update("pull", immediate=True, manager_port="1", target=target)
+        return [s for s, _ in self.calls if s != "other"]
+
+    def _refusals(self):
+        return [m for m, ok in self.notices if not ok]
+
+    def test_the_happy_path_moves_onto_the_advertised_commit_and_restarts(self):
+        steps = self._drive()
+        self.assertEqual(steps[:4], ["status", "fetch", "merge-base", "checkout"], steps)
+        self.assertEqual(set(steps[4:]), {"rev-parse"}, "after the move, only the checkout re-reads")
+        fetch = next(a for s, a in self.calls if s == "fetch")
+        self.assertEqual(fetch[-3:], ["fetch", "origin", "main"],
+                         "main from the release remote (the scripted `git remote` lists none: a plain install's origin)")
+        anc = next(a for s, a in self.calls if s == "merge-base")
+        self.assertEqual(anc[-3:], ["--is-ancestor", "HEAD", self.TARGET], "a fast-forward from HEAD, proven")
+        co = next(a for s, a in self.calls if s == "checkout")
+        self.assertEqual(co[-2:], ["--detach", self.TARGET], "the move lands on the sha the verdict named")
+        self.assertFalse(any(a.endswith("/main") for a in co), "never the ref: it can move, or sit stale")
+        self.assertEqual(self.posts, [("POST", "/restart-all")])
+        self.assertEqual(self.dials, [("127.0.0.1", 1)])
+        self.assertEqual(self._refusals(), [], "nothing refused; the restart went out")
+
+    def test_the_restart_post_ignores_a_proxy_environment(self):
+        # urllib's default opener would have sent this loopback POST to the proxy — the updated code
+        # on disk then never restarted, and the only trace was "restart request failed"
+        self._drive(proxy="http://proxy.invalid:3128")
+        self.assertEqual(self.posts, [("POST", "/restart-all")])
+        self.assertEqual(self.dials, [("127.0.0.1", 1)], "dialled direct, whatever HTTP_PROXY says")
+        self.assertEqual(self._refusals(), [])
+
+    def test_a_refused_restart_answer_is_said_not_swallowed(self):
+        # urlopen raised on a 4xx/5xx; http.client hands the status back — an answer of 500 from the
+        # manager is still a restart that did not happen, and the notice must say so
+        self._drive(answer=500)
+        self.assertEqual(self.posts, [("POST", "/restart-all")], "the POST went out")
+        said = [m for m, ok in self.notices if not ok and "restart request failed" in m]
+        self.assertEqual(len(said), 1, self.notices)
+        self.assertIn("HTTP 500", said[0])
+        self.assertIn("romp refresh", said[0], "and names the way out")
+
+    def test_a_failed_fetch_aborts_before_any_move(self):
+        # a realistic ssh failure is ~190 chars of stderr; the row is capped at 300 on the wire and
+        # 240 in the badge, so the OUTCOME leads and git's words come last, trimmed
+        ssh_err = "ssh: connect to host git.example.invalid port 22: Connection timed out\n" * 4
+        steps = self._drive(fail=("fetch",), err=ssh_err)
+        self.assertEqual(steps, ["status", "fetch"], "the sequence stops AT the fetch")
+        self.assertEqual(self.posts, [], "nothing restarted onto an unmoved checkout")
+        said = [m for m in self._refusals() if "the fetch failed" in m]
+        self.assertEqual(len(said), 1, self.notices)
+        self.assertIn("left alone", said[0], "the outcome survives a long git error")
+        self.assertLess(said[0].index("left alone"), said[0].index("git:"), "outcome first, git's words after")
+        self.assertIn("Connection timed out", said[0], "and git's words are still there")
+        self.assertLessEqual(len(said[0]), 240, "inside the badge's cap")
+        self.assertEqual(km._MAIN_DRIFT[0], "", "the notice re-arms")
+
+    def test_a_commit_that_is_not_a_fast_forward_of_head_is_refused(self):
+        # merge-base --is-ancestor exits 1: a real non-ancestor — the histories diverged, which is
+        # never merged on the user's behalf; the checkout stays where it is
+        steps = self._drive(fail=("merge-base",))
+        self.assertEqual(steps, ["status", "fetch", "merge-base"])
+        self.assertEqual(self.posts, [])
+        said = [m for m in self._refusals() if "not a fast-forward" in m and self.TARGET in m]
+        self.assertEqual(len(said), 1, "the refusal names the commit: %r" % self.notices)
+        self.assertIn("diverged", said[0])
+        self.assertIn("yours to move by hand", said[0])
+        self.assertNotIn("did not bring", said[0], "a divergence is not a missing commit")
+        self.assertEqual(km._MAIN_DRIFT[0], "")
+
+    def test_a_commit_the_fetch_did_not_bring_is_said_as_such(self):
+        # merge-base exits 128: git cannot name the advertised commit — main was rewound after the
+        # verdict, or the short prefix is ambiguous. Not a divergence: the next check re-reads main
+        steps = self._drive(fail={"merge-base": 128}, err="fatal: Not a valid commit name abcd1234")
+        self.assertEqual(steps, ["status", "fetch", "merge-base"])
+        self.assertEqual(self.posts, [])
+        said = [m for m in self._refusals() if "did not bring" in m and self.TARGET in m]
+        self.assertEqual(len(said), 1, self.notices)
+        self.assertIn("re-reads main", said[0])
+        self.assertIn("Not a valid commit name", said[0], "git's words, after the outcome")
+        self.assertNotIn("diverged", said[0])
+        self.assertEqual(km._MAIN_DRIFT[0], "")
+
+    def test_a_failing_status_is_unknown_never_clean(self):
+        # rc 128 with nothing on stdout: the old `.stdout.strip()` read saw "" and called it clean,
+        # then moved a tree whose state nobody had actually read
+        steps = self._drive(status_rc=128)
+        self.assertEqual(steps, ["status"], "stops at the status read")
+        self.assertEqual(self.posts, [])
+        refusals = self._refusals()
+        self.assertTrue(any("its state could not be read" in m and "left alone" in m for m in refusals), refusals)
+        self.assertFalse(any("uncommitted work" in m for m in refusals), "not mistaken for a dirty tree either")
+        self.assertEqual(km._MAIN_DRIFT[0], "")
+
+    def test_a_dirty_tree_still_refuses_with_the_standing_wording(self):
+        steps = self._drive(status_out=" M kernel/kernel.py\n")
+        self.assertEqual(steps, ["status"])
+        self.assertEqual(self.posts, [])
+        self.assertTrue(any("uncommitted work" in m for m in self._refusals()))
+        self.assertEqual(km._MAIN_DRIFT[0], "")
+
+    def test_an_empty_target_refuses_before_touching_git(self):
+        # binding is mandatory: with no advertised commit there is nothing to bind the move to
+        steps = self._drive(target="")
+        self.assertEqual(steps, [], "no status, no fetch, no move")
+        self.assertEqual(self.posts, [])
+        self.assertTrue(any("no commit was named" in m for m in self._refusals()), self.notices)
+        self.assertEqual(km._MAIN_DRIFT[0], "")

--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -321,13 +321,28 @@ class PreDeathRebuild(unittest.TestCase):
         from unittest.mock import patch
         km._rebuild_dist = lambda: (self.order.append("rebuild"), (rebuild_ok, "boom"))[1]
 
-        def fake_urlopen(req, timeout=0):
-            self.order.append("post")
-            class R:
-                def read(self):
-                    return b""
-            return R()
-        with patch("urllib.request.urlopen", fake_urlopen):
+        order = self.order
+
+        class FakeConn:
+            # the restart POST dials http.client the way _restart_this_kernel does — never urllib,
+            # whose default opener honours HTTP_PROXY and diverted the loopback POST under a proxy
+            def __init__(self, host, port, timeout=0):
+                pass
+
+            def request(self, method, path, *a, **k):
+                order.append("post")
+
+            def getresponse(self):
+                class R:
+                    status = 200
+
+                    def read(self):
+                        return b""
+                return R()
+
+            def close(self):
+                pass
+        with patch.object(km.http.client, "HTTPConnection", FakeConn):
             km._run_main_update("restart", immediate=True, manager_port="1")
 
     def test_the_rebuild_lands_before_the_restart_post(self):


### PR DESCRIPTION
The main-drift converge compares shas by prefix agreement and moves only onto the advertised commit, refusing loudly on a failed fetch or status

Two defects in kernel/kernel.py's main-drift machinery. Both were reproduced
by test against origin/main 6c6a01a6 from a git-archive copy (the failure
text of each new test on that tree is recorded below).

1. The verdict compared shas spelled by different readers. _kernel_sha() is
   `rev-parse --short` (auto-width: seven on a small object store such as a
   `--depth 1` clone, past eight on a large one) plus "-dirty" on an
   uncommitted tree; _checkout_sha() is `--short=8`; _origin_main_sha() is the
   ls-remote sha sliced to eight. _main_drift_verdict compared them as
   strings, so on a dirty main-tracking checkout (and on a shallow clone) every
   pass read "the checkout is ahead of the running kernel" for the very commit
   the kernel was running. In ask mode: a "ready on disk" banner that never
   cleared. In auto mode: a full restart (every in-flight turn cut) once per
   cool-down, for as long as the tree stayed dirty. The verdict now compares
   through _sha_same: "-dirty" stripped, then the shorter is a prefix of the
   longer, provided the shorter is at least seven characters (git's own floor;
   below it exact equality, so a stray fragment agrees with nothing). The same
   comparison replaces the raw `running != checkout` in the quiet-park
   stand-down, the one other place the verdict's inputs are compared. The
   target keeps the eight-character spelling (_sha8, now state/display only)
   that the slots, the in-place latch and the banner carry.

2. The pull step trusted every subprocess. `git fetch` ran with its exit code
   unread, then `git checkout --detach <remote>/main` moved onto a REF (not the
   commit the notice named) with no ancestry check, `git status --porcelain`
   was read as clean whenever it FAILED, and the restart POST rode
   urllib.request.urlopen, whose default opener honours HTTP_PROXY. So a fetch
   failure checked out the stale local ref and reported success, a rewound or
   diverged main was walked onto without a word, an unreadable tree was moved
   anyway, and under a proxy environment the updated code on disk never
   restarted (the only trace: "restart request failed"). Now _run_main_update
   takes the advertised commit (`target`, handed down by the auto path and by
   the /update route from one snapshot of _MAIN_DRIFT), checks the fetch's
   exit code, proves `merge-base --is-ancestor HEAD <target>` and checks out
   exactly <target>, treats a non-zero `git status` as unknown rather than
   clean, refuses an empty target, and dials the manager over http.client the
   way _restart_this_kernel already does (a >= 400 answer is a failure, as
   urlopen's HTTPError was). Every refusal lands on the sync-notice surface
   (_sync_notice, ok=False - the row the updater's failures already use) with
   the OUTCOME first and git's own words last, trimmed to 120 characters, so
   a realistic ssh error never pushes "left alone" past the row's caps (300 on
   the wire, 240 in the badge); merge-base's exit 1 (the histories diverged,
   yours to move by hand) and 128 (the fetch did not bring the advertised
   commit; the next check re-reads main) are told apart. Each refusal re-arms
   the notice. _pull_remote's own `git status` read gets the same exit-code
   check: a failing status refuses instead of proceeding as clean.

Unchanged: the verdict's agreement-not-ancestry rule, the pull-outranks-
restart ordering, the dirty-tree refusal and its wording, the in-place
(no-kernel-code) converge, the cool-down and quiet-park stand-down, the
immediate-by-default bounce and its audit row, and the raw _kernel_sha()
still flowing into _kernel_code_changed (a "-dirty" argument there fails the
diff and takes the restart path - the safe direction, left as is).

Tests (each fails on origin/main 6c6a01a6 unless marked a guard):
- tests/test_main_drift_notice.py DriftVerdict: a dirty running sha at the
  checkout's commit is in sync (main returned ("restart", "aaaa1111")); a
  wider or full-length spelling is in sync; a SEVEN-character running sha at
  an eight-character checkout is in sync, dirty or not (("restart",
  "aaaa1111") before); seven against eight for a DIFFERENT commit still
  restarts/pulls (guard); below the seven floor only exact equality agrees.
  Under the mutant "_sha_same returns a == b" three of these fail. The
  quiet-park stand-down is driven too: with the running sha at the checkout's
  commit spelled "-dirty" and then at seven characters, a landed park no
  longer holds the pull (reverting that line to a raw != fails it: [] !=
  ['pull']).
- tests/test_main_drift_notice.py ConvergePullStep drives the pull step with
  subprocess scripted: a failed fetch stops at the fetch with nothing checked
  out or restarted, and with ~300 chars of ssh stderr the notice still leads
  with "left alone", keeps git's words, and fits 240; merge-base exit 1 is
  refused as a divergence and exit 128 as "did not bring <sha>", neither
  reaching checkout; a failing status refuses rather than reading clean; an
  empty target refuses before any git call; the happy path fetches
  ["fetch", <remote>, "main"], proves the ancestry, checks out the advertised
  sha (never the ref) and POSTs /restart-all over http.client with urlopen
  patched to raise, with and without HTTP_PROXY set; a 500 answer from the
  manager yields the ok=False "restart request failed ... HTTP 500 ... romp
  refresh" notice (kills the mutant that drops the >= 400 check). On main
  these fail with TypeError (no `target` keyword); with that keyword dropped
  they fail behaviorally: steps ['status','fetch','checkout',...] where a stop
  was owed, and posts [] where the restart was owed.
- tests/test_restart_classifier.py PreDeathRebuild now stubs
  http.client.HTTPConnection; on main the POST never lands (['rebuild'] !=
  ['rebuild', 'post']).
- tests/test_kernel_update.py: the /update click carries the banner's commit
  (main handed ('pull', True, '')).
- tests/test_kernel_remote_pull.py: a failing status refuses the peer pull
  (main returned ok=True).
- Source pins updated to the new spellings (the bound checkout, the snapshot,
  the target hand-down). No TS or bats test pins these lines.

Module counts on the final tree: test_main_drift_notice.py 49 passed,
test_restart_classifier.py 22, test_kernel_update.py 39,
test_kernel_remote_pull.py 20. Full suite left to CI (not run on the
development machine).



## Tier

**fix** — a bug fix with tests that fail before it.

## Notes for review

- Tests were run per module on the development machine (the four touched modules, one process at a time); the full suite is left to this PR's CI.
- Deliberately unchanged and named in the body: the raw running sha still feeds `_kernel_code_changed` / `_converge_classes` (a `-dirty` argument fails `git diff` and takes the restart path, the safe direction). A `_SHA` resolved once at boot on a dirty tree keeps its suffix for the kernel's life; both are follow-up candidates for the same normalization.
- The converge step hands git the eight-character advertised sha; a `merge-base` exit of 128 (the fetch did not bring it, or an ambiguous prefix) is now told apart from a real divergence (exit 1) in the refusal's wording, and the next check re-reads main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
