### PR TITLE
The p2p updater re-checks a peer's tree before resetting it, binds to the advertised commit, and pushes the head the user has

### DIFF
--- a/cli/update.py
+++ b/cli/update.py
@@ -74,7 +74,7 @@ def main(argv):
     hosts = [a for a in argv if not a.startswith("-")]
     if not hosts:                                                   # no host → the out-of-date attached remotes
         try:
-            tuns = _get(u, "/tunnels").get("tunnels", [])
+            tuns = _get(u, "/tunnels?fresh=1").get("tunnels", [])    # judged against the head this checkout is at NOW, not the dashboard's 15 s cache
         except Exception as e:
             sys.stderr.write("romp update: couldn't list remotes: %s\n" % e)
             return 2

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14152,6 +14152,36 @@ def list_remotes():
         return [_remote_public(r) for r in _remotes.values()]
 
 
+def _tunnels_listing(fresh=False):
+    """The GET /tunnels payload. `fresh` re-reads this checkout's HEAD first, for a caller about to ACT on
+    the rows' `outOfDate` — the CLI's no-host `romp update` picks the hosts it pushes to from this listing.
+    The dashboard's polls read the 15 s head cache (a poll must not fork git), and a listing built from
+    that cache within 15 s of a local commit says every peer sitting on the previous commit is up to date,
+    so that command prints "all attached remotes are up to date" and pushes nothing. `known` = hosts
+    attached before but not now, so the popover can list them as persistent re-attach rows instead of
+    making you retype them."""
+    if fresh:
+        _fresh_local_head()
+    return {"tunnels": list_remotes(),
+            "known": list_known(),
+            "viaReach": _bus_via_reach(),   # hosts one relay hop away (trust-by-origin rows hang here)
+            "remoteHolds": _bus_remote_holds(),   # quarantine holds on OTHER machines (direct peers + one relay hop)
+            "autoUpdate": _auto_update_remotes_on(),   # the popover checkbox reflects the KERNEL, not this tab
+            "peerTiers": _bus_peer_tiers(),   # host → how IT holds OUR mail (both-direction display)
+            # THIS machine's build, top-level so the panel can name it with no hosts attached: a remote's
+            # sha is unreadable without your own beside it (the user 2026-07-30), which is the comparison
+            # every other line in the panel is implicitly asking you to make.
+            "local": {"ver": _kernel_ver() or "", "sha": _kernel_sha() or "", "host": _self_host()},
+            "peersMode": _postal_peers_on()}
+
+
+def _fresh_listing_asked(q):
+    """Whether a GET /tunnels query asks for the listing judged against the head this checkout is at now:
+    exactly `?fresh=1`. parse_qs hands back ["0"] for `?fresh=0`, so a truthiness test would re-read HEAD
+    for `0` and `no` while a blank `?fresh=` read as not fresh; the contract is the one spelling."""
+    return q.get("fresh", [""])[0] == "1"
+
+
 def _poll_remote_sessions(r):
     """GET the remote kernel's /sessions THROUGH the -L tunnel; return its id-bearing rows (each `{id, name,
     …}` — the same unified list _session_rows serves here). None on any failure — leave the last-known
@@ -14906,20 +14936,43 @@ def _local_head(short=False):
     rarely moves."""
     now = time.time()
     if now - _HEAD_CACHE["ts"] > 15:
-        full = short_s = None
-        try:
-            r = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "HEAD"],
-                               capture_output=True, text=True, timeout=3)
-            if r.returncode == 0:
-                full = r.stdout.strip() or None
-            if full:
-                s = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--short", "HEAD"],
-                                   capture_output=True, text=True, timeout=3)
-                short_s = (s.stdout.strip() if s.returncode == 0 else "") or full[:8]
-        except Exception:
-            pass
+        full, short_s = _read_head()
         _HEAD_CACHE.update(ts=now, full=full, short=short_s)
     return _HEAD_CACHE["short"] if short else _HEAD_CACHE["full"]
+
+
+def _read_head():
+    """One read of this checkout's HEAD straight from git → (full, short); (None, None) outside a checkout.
+    The poll cache and the transport both fill from here, so they can never disagree on HOW HEAD is read."""
+    full = short_s = None
+    try:
+        r = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+                           capture_output=True, text=True, timeout=3)
+        if r.returncode == 0:
+            full = r.stdout.strip() or None
+        if full:
+            s = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--short", "HEAD"],
+                               capture_output=True, text=True, timeout=3)
+            short_s = (s.stdout.strip() if s.returncode == 0 else "") or full[:8]
+    except Exception:
+        pass
+    return full, short_s
+
+
+def _fresh_local_head():
+    """The committed HEAD as it is RIGHT NOW, for a decision about to act on it: a push, a pull, the
+    restart-all plan, the listing `romp update` chooses hosts from. `_local_head` serves the dashboard's
+    polls from a 15 s cache, which is exactly wrong there: a commit made seconds before `romp update` is
+    the one the user means, and the cached read still names its parent, so the peer came back "already up
+    to date" one commit behind, or the restart it was told to expect carried the old sha. This reads git
+    ITSELF and then writes the cache: the value acted on is the value read, never a cache entry that a
+    poller's own in-flight read could refill with the older head across a bare invalidation; and the
+    write puts that same value in front of every display in the call (the audit-row sha, the detail, the
+    expectation) and the dashboard's next poll. Returns the full 40-hex sha, or "" when this is not a
+    checkout (the caller says so)."""
+    full, short_s = _read_head()
+    _HEAD_CACHE.update(ts=time.time(), full=full, short=short_s)
+    return full if full and re.fullmatch(r"[0-9a-f]{40}", full) else ""
 
 
 def _shas_agree(a, b):
@@ -15170,7 +15223,11 @@ def _discover_remote_clone(host):
     overrides) — then a romp-serve found on PATH (non-login, then login shell) resolved to the repo
     that holds it, then conventional dirs. KEEP the source order IN SYNC with _start_remote_kernel.
     Returns (dir, head, dirty, error) — error set (and the rest blank) on any failure, naming
-    everything tried. Shared by the push (_update_remote) and pull (_pull_remote) directions."""
+    everything tried; `dirty` is "" (clean), "1" (uncommitted changes of any kind: an unstaged edit's
+    porcelain line starts with a SPACE, so the first character alone is not a verdict), or "STATERR" when
+    `git status` itself failed there (an index lock, a corrupt index, an I/O error): a command that could
+    not see the tree must never answer "clean", because that answer green-lights a reset of it. Shared by
+    the push (_update_remote) and pull (_pull_remote) directions."""
     disc = (
         'R=""; SR="${ROMP_REPO_ROOT:-$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/repo-root" 2>/dev/null)}"; '
         'if [ -n "$SR" ] && [ -d "$SR/.git" ]; then R="$SR"; fi; '
@@ -15181,7 +15238,8 @@ def _discover_remote_clone(host):
         'if [ -d "$d/.git" ]; then R="$d"; break; fi; done; fi; '
         'if [ -z "$R" ]; then echo NOROMP; exit 0; fi; '
         'echo "DIR:$R"; echo "HEAD:$(git -C "$R" rev-parse HEAD 2>/dev/null)"; '
-        'echo "DIRTY:$(git -C "$R" status --porcelain 2>/dev/null | head -c 1)"')
+        'if ds=$(git -C "$R" status --porcelain 2>/dev/null); then '
+        'if [ -n "$ds" ]; then echo DIRTY:1; else echo DIRTY:; fi; else echo DIRTY:STATERR; fi')
     try:
         d = subprocess.run([SSH_BIN] + _SSH_OPTS + ["--", host, disc], capture_output=True, text=True, timeout=25)
     except Exception as e:
@@ -15205,10 +15263,13 @@ def _update_remote(host):
     BatchMode/no-multiplexing ssh every other remote call uses:
       1. ssh-discover the remote romp clone (conventional dirs, mirrors _start_remote_kernel) + its HEAD; REFUSE
          on a dirty remote tree (won't silently clobber uncommitted remote work).
-      2. `git push --force` local HEAD to a scratch ref on the remote (a NON-checked-out ref, so no bare-repo /
-         denyCurrentBranch dance).
-      3. ssh: REFUSE if the remote has DIVERGED (its own commits not in local — don't clobber), else reset the
-         remote to that ref, delete the scratch ref, and `romp refresh` to restart.
+      2. `git push --force` the local HEAD's exact sha to a scratch ref on the remote (a NON-checked-out ref,
+         so no bare-repo / denyCurrentBranch dance).
+      3. ssh: bind to that sha (REFUSE unless the scratch ref resolves to the commit this call advertised — any
+         concurrent sender force-pushes the same ref), REFUSE if the remote has DIVERGED (its own commits not
+         in local — don't clobber), re-check its tree IN THE SAME SHELL (step 1's answer is an ssh round-trip
+         old; a status that fails, or an edit that landed since, refuses), else reset the remote to that sha,
+         delete the scratch ref, and restart it.
     Returns (ok, detail), fail-loud. Requires a CLEAN local tree — we push COMMITS, so uncommitted local work
     isn't sent; the caller is told to commit first."""
     host = str(host or "").strip()
@@ -15225,7 +15286,7 @@ def _update_remote(host):
                        "When it is behind this build, Update asks it to fast-forward itself; otherwise "
                        "sync from that machine's own dashboard" % host)
     kport = int((_rr or {}).get("kernel_port") or _REMOTE_KERNEL_PORT)   # for the restart's port poll
-    lfull = _local_head()
+    lfull = _fresh_local_head()          # the head the user HAS, not the one the dashboard last polled
     if not lfull:
         return False, "local kernel isn't a git checkout — nothing to push"
     # We push the committed HEAD; uncommitted local edits are not sent ("just take what is committed on local"
@@ -15234,6 +15295,9 @@ def _update_remote(host):
     rdir, rhead, rdirty, derr = _discover_remote_clone(host)
     if derr:
         return False, derr
+    if rdirty == "STATERR":
+        return False, ("could not read the tree state on %s (git status failed there) — not touching a "
+                       "checkout whose state is unknown" % host)
     if rdirty:
         return False, "remote %s has uncommitted changes — commit or discard them there first (won't clobber)" % host
     if rhead and rhead == lfull:
@@ -15246,25 +15310,39 @@ def _update_remote(host):
                 # restart, or one nobody asked for) — expect it again rather than read its gap as death
                 rr["restartExpected"] = {"sha": lfull, "t": time.time(), "quiet": None}
                 return True, ("already up to date (%s) — that kernel has not restarted into it yet"
-                              % (_local_head(short=True) or lfull[:8]))
-        return True, "already up to date (%s)" % (_local_head(short=True) or lfull[:8])
+                              % lfull[:8])
+        return True, "already up to date (%s)" % lfull[:8]
     # (2) push local HEAD to a scratch ref on the remote (non-checked-out → no denyCurrentBranch issue)
     env = dict(os.environ, GIT_SSH_COMMAND="%s %s" % (SSH_BIN, " ".join(_SSH_OPTS)))
     push_url = "%s:%s" % (host, rdir)
     try:
         p = subprocess.run(["git", "-C", str(ROOT), "push", "--force", push_url,
-                            "HEAD:refs/heads/%s" % _P2P_REF],
+                            "%s:refs/heads/%s" % (lfull, _P2P_REF)],   # the advertised sha, not a HEAD that may move
                            capture_output=True, text=True, timeout=120, env=env)
     except Exception as e:
         return False, "git push to %s failed: %s" % (host, str(e)[:160])
     if p.returncode != 0:
         return False, "git push to %s failed: %s" % (host, (_ssh_err(p.stderr) or p.stdout or "").strip()[:160])
-    # (3) verify no divergence, reset the remote to the pushed HEAD, clean up, restart
+    # (3) bind to the advertised sha, verify no divergence, re-check the tree, reset the remote to that sha,
+    #     clean up, restart
     apply_cmd = (
-        'LOGDIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"; mkdir -p "$LOGDIR"; R=%s; '
-        'if ! git -C "$R" merge-base --is-ancestor HEAD %s 2>/dev/null; then '
+        'LOGDIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"; mkdir -p "$LOGDIR"; R=%s; WANT=%s; '
+        # Every git step below names WANT, the exact commit this call pushed, never the scratch ref: that ref
+        # is force-pushed by any sender, so between our push and this apply another machine can have moved
+        # it, and "reset to the ref" would install THEIR build under OUR report. A ref that does not resolve
+        # to WANT is left alone (it is that other sender's to apply) and this call refuses.
+        'GOT="$(git -C "$R" rev-parse --verify --quiet refs/heads/%s 2>/dev/null)"; '
+        'if [ "$GOT" != "$WANT" ]; then echo "REFMISMATCH:$GOT"; exit 0; fi; '
+        'if ! git -C "$R" merge-base --is-ancestor HEAD "$WANT" 2>/dev/null; then '
         'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo DIVERGED; exit 0; fi; '
-        'git -C "$R" reset --hard %s >/dev/null 2>&1 || { git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo RESETFAIL; exit 0; }; '
+        # Re-check dirtiness HERE, in the same shell as the reset: the discover probe's answer is an ssh
+        # round-trip old, and an edit that landed since would be destroyed by `reset --hard` on the strength
+        # of a stale "clean". A status that FAILS is its own refusal, not a clean tree.
+        'if ! AS=$(git -C "$R" status --porcelain 2>/dev/null); then '
+        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo STATERR; exit 0; fi; '
+        'if [ -n "$AS" ]; then '
+        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo DIRTYNOW; exit 0; fi; '
+        'git -C "$R" reset --hard "$WANT" >/dev/null 2>&1 || { git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo RESETFAIL; exit 0; }; '
         'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; '
         'NEW="$(git -C "$R" rev-parse --short HEAD)"; '
         # RESTART the kernel THROUGH THE MANAGER (the user 2026-07-04: the manager is romp's durable supervisor —
@@ -15317,9 +15395,9 @@ def _update_remote(host):
         'UP=0; for i in 1 2 3 4 5 6 7 8; do sleep 1; if bash -c "exec 3<>/dev/tcp/127.0.0.1/%d" 2>/dev/null; then UP=1; break; fi; done; '
         'if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve" >>"$LOGDIR/kernel.log" 2>&1 </dev/null &  sleep 1; fi; '
         'echo "SYNCED:$NEW:FALLBACK"'
-    ) % (shlex.quote(rdir), _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF,
-         _local_machine_label(), (_local_head(short=True) or lfull[:8]), kport,
-         _local_machine_label(), (_local_head(short=True) or lfull[:8]), kport)
+    ) % (shlex.quote(rdir), lfull, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF,
+         _local_machine_label(), lfull[:8], kport,
+         _local_machine_label(), lfull[:8], kport)
     # The apply KILLS the running kernel before booting its replacement, so it must be immune to the
     # ssh dying between the two halves — exactly what a flaky link does (the user 2026-07-11:
     # every drop mid-apply left the host kernel-LESS, and each banner Retry re-killed whatever a
@@ -15362,14 +15440,18 @@ def _update_remote(host):
         short, _, mode = rest.partition(":")
         mode = mode.strip()
         _expect(mode == "QUIET")
-        short = short.strip() or _local_head(short=True) or "HEAD"
+        short = short.strip() or lfull[:8]
         if mode == "QUIET":
             return True, "synced to %s — restarting at its next quiet window" % short
         if mode == "FALLBACK":
             return True, ("synced to %s + restarting now (no manager owns that kernel there — an "
                           "immediate restart)" % short)
         return True, "synced to %s + restarting" % short
-    _unexpect()                                   # nothing restarted: DIVERGED / RESETFAIL / NOLAUNCH / error
+    _unexpect()                       # nothing restarted: REFMISMATCH / DIVERGED / STATERR / DIRTYNOW / RESETFAIL / NOLAUNCH / error
+    if tag == "REFMISMATCH":
+        return False, ("pushed %s, but the scratch ref on %s now holds %s — another push moved it between "
+                       "ours and the apply; nothing was reset there. Push again."
+                       % (lfull[:8], host, (rest[:8] if rest else "nothing")))
     if tag == "DIVERGED":
         # Two very different causes land here, and the old wording only described the first, which is
         # why a rewritten local history read as an unexplained refusal (the user 2026-07-22): either the
@@ -15382,6 +15464,12 @@ def _update_remote(host):
                        "git push --force %s:<remote-romp-dir> HEAD:refs/heads/%s "
                        "then, on %s: git reset --hard %s && git update-ref -d refs/heads/%s"
                        % (host, host, host, _P2P_REF, host, _P2P_REF, _P2P_REF))
+    if tag == "STATERR":
+        return False, ("pushed, but reading the tree state on %s failed right before the apply — not resetting "
+                       "a checkout whose state is unknown" % host)
+    if tag == "DIRTYNOW":
+        return False, ("pushed, but the tree on %s has uncommitted changes — nothing was reset there; commit "
+                       "or discard them, then push again" % host)
     if tag == "RESETFAIL":
         return False, "pushed, but the remote couldn't check out the new code"
     if tag == "NOLAUNCH":
@@ -15431,7 +15519,7 @@ def _pull_remote(host):
     if _rr is not None and _rr.get("checkin_peer"):
         return False, ("no ssh path to %s from this machine (it checked in here over its own tunnel) — "
                        "sync from that machine's own dashboard" % host)
-    lfull = _local_head()
+    lfull = _fresh_local_head()          # the head this tree is AT, not the one the dashboard last polled
     if not lfull:
         return False, "local kernel isn't a git checkout — nowhere to pull to"
     try:
@@ -15449,7 +15537,11 @@ def _pull_remote(host):
     if derr:
         return False, derr
     if rhead and rhead == lfull:
-        return True, "already up to date (%s)" % (_local_head(short=True) or lfull[:8])
+        return True, "already up to date (%s)" % lfull[:8]
+    if not re.fullmatch(r"[0-9a-f]{40}", rhead):
+        # nothing to bind the merge to: without the commit the peer reported, "whatever the fetch brought
+        # back" is the only target, and that is exactly the thing a concurrent fetch can swap under us
+        return False, "%s did not report which commit it is on — nothing fetched" % host
     env = dict(os.environ, GIT_SSH_COMMAND="%s %s" % (SSH_BIN, " ".join(_SSH_OPTS)))
     try:
         f = subprocess.run(["git", "-C", str(ROOT), "fetch", "%s:%s" % (host, rdir), "HEAD"],
@@ -15459,15 +15551,24 @@ def _pull_remote(host):
     if f.returncode != 0:
         return False, "git fetch from %s failed: %s" % (host, (_ssh_err(f.stderr) or f.stdout or "").strip()[:160])
     try:
-        anc = subprocess.run(["git", "-C", str(ROOT), "merge-base", "--is-ancestor", "HEAD", "FETCH_HEAD"],
+        # Every step binds to the EXACT commit the peer reported, and the fetch only has to have brought
+        # it: FETCH_HEAD never enters the decision (it is a mutable name — any other fetch into this
+        # checkout, a second peer or a hand-run `git fetch`, rewrites it between our fetch and our merge).
+        # The one refusal left is the honest one: the peer no longer stands where it said it did.
+        got = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--verify", "--quiet", rhead + "^{commit}"],
+                             capture_output=True, text=True, timeout=10)
+        if got.returncode != 0 or (got.stdout or "").strip() != rhead:
+            return False, ("%s has moved off the commit it reported (%s) — nothing merged; try again"
+                           % (host, rhead[:8]))
+        anc = subprocess.run(["git", "-C", str(ROOT), "merge-base", "--is-ancestor", "HEAD", rhead],
                              capture_output=True, text=True, timeout=10)
         if anc.returncode != 0:
             return False, ("local and %s have diverged — a pull would need a merge, which is yours to "
                            "do by hand" % host)
-        n = subprocess.run(["git", "-C", str(ROOT), "rev-list", "--count", "HEAD..FETCH_HEAD"],
+        n = subprocess.run(["git", "-C", str(ROOT), "rev-list", "--count", "HEAD..%s" % rhead],
                            capture_output=True, text=True, timeout=10)
         count = (n.stdout or "").strip() or "?"
-        m = subprocess.run(["git", "-C", str(ROOT), "merge", "--ff-only", "FETCH_HEAD"],
+        m = subprocess.run(["git", "-C", str(ROOT), "merge", "--ff-only", rhead],
                            capture_output=True, text=True, timeout=30)
     except Exception as e:
         return False, str(e)[:200]
@@ -15680,6 +15781,10 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
     rows = []
     with _remotes_lock:
         remotes = [dict(x) for x in _remotes.values()]
+    # ONE head for the whole plan, read now: the polls' cache can be 15 s behind a commit made just before
+    # Restart, and a row judged against the old head reads a peer sitting on it as "already on this build"
+    # (a restart where a push was owed). Every row below is judged against this same commit.
+    _fresh_local_head()
     for r in remotes:
         host = r.get("host") or "?"
         action, reason = _fleet_restart_plan(r)
@@ -37323,21 +37428,9 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps({"hosts": _ssh_config_hosts()}),
                                   "application/json", cache="no-cache")
             if p == "/tunnels":                               # attached remote kernels + state (drives the federated dashboard)
-                # `known` = hosts attached before but not now, so the popover can list them as persistent
-                # re-attach rows instead of making you retype them.
-                return self._send(200, json.dumps({"tunnels": list_remotes(),
-                                                   "known": list_known(),
-                                                   "viaReach": _bus_via_reach(),   # hosts one relay hop away (trust-by-origin rows hang here)
-                                                   "remoteHolds": _bus_remote_holds(),   # quarantine holds on OTHER machines (direct peers + one relay hop)
-                                                   "autoUpdate": _auto_update_remotes_on(),   # the popover checkbox reflects the KERNEL, not this tab
-                                                   "peerTiers": _bus_peer_tiers(),   # host → how IT holds OUR mail (both-direction display)
-                                                   # THIS machine's build, top-level so the panel can name it with
-                                                   # no hosts attached: a remote's sha is unreadable without your
-                                                   # own beside it (the user 2026-07-30), which is the comparison
-                                                   # every other line in the panel is implicitly asking you to make.
-                                                   "local": {"ver": _kernel_ver() or "", "sha": _kernel_sha() or "",
-                                                             "host": _self_host()},
-                                                   "peersMode": _postal_peers_on()}),
+                # `?fresh=1` = the caller is about to ACT on `outOfDate` (the CLI's `romp update`), so the
+                # listing is judged against the head this checkout is at now, not the polls' cache
+                return self._send(200, json.dumps(_tunnels_listing(fresh=_fresh_listing_asked(q))),
                                   "application/json", cache="no-cache")
             if p == "/tunnels/pairs":                         # how attached machines hold EACH OTHER's mail —
                 # read live from each machine's kernel through its tunnel (the popover's "Between your

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14982,26 +14982,29 @@ def _shas_agree(a, b):
     return bool(a and b and (a.startswith(b) or b.startswith(a)))
 
 
-def _remote_out_of_date(r):
+def _remote_out_of_date(r, head=None):
     """True iff this remote is running a DIFFERENT commit than the local kernel's HEAD — i.e. a push would
     change it. Compared against the LIVE HEAD (what `_update_remote` actually pushes), NOT the kernel's cached
     startup sha, so pushing HEAD makes the remote match HEAD and the flag CLEARS afterward (the user 2026-07-04
-    — mixing the cached compare with a live-HEAD push is exactly why the banner never went away)."""
-    return bool(r.get("kernel_sha") and _local_head(short=True)
-                and not _shas_agree(r.get("kernel_sha"), _local_head(short=True)))
+    — mixing the cached compare with a live-HEAD push is exactly why the banner never went away). `head` is
+    the sha to compare against when the caller holds one (the restart-all run judges every row against the
+    single head it read); None reads the polls' cache, as the dashboard does."""
+    lh = head if head is not None else _local_head(short=True)
+    return bool(r.get("kernel_sha") and lh and not _shas_agree(r.get("kernel_sha"), lh))
 
 
 _BEHIND_CACHE = {}   # (remote sha base, local full HEAD) → drift dict; both key parts name immutable commits
 
 
-def _behind_info(remote_sha):
+def _behind_info(remote_sha, head=None):
     """HOW an out-of-date remote's commit relates to local HEAD, for the popover row: `behind` = commits a
     push would deliver, `ahead` = commits the REMOTE has that this repo lacks (a push would clobber them, and
     _update_remote refuses — so the row must say 'ahead'/'diverged', never a false 'behind'), `date` = the
     remote commit's date. behind/ahead are None when the remote's sha isn't in this repo at all (it was
     updated from some other machine) — the row says so instead of guessing. Memoized per (remote sha, local
-    HEAD): git runs only when either commit actually changes, not on every /tunnels poll."""
-    base, lfull = _sha_base(remote_sha), _local_head()
+    HEAD): git runs only when either commit actually changes, not on every /tunnels poll. `head` = the local
+    sha to relate to when the caller holds one (see _remote_out_of_date); None reads the polls' cache."""
+    base, lfull = _sha_base(remote_sha), (head if head is not None else _local_head())
     if not base or not lfull:
         return {"behind": None, "ahead": None, "date": ""}
     key = (base, lfull)
@@ -15032,7 +15035,7 @@ def _behind_info(remote_sha):
     return info
 
 
-def _is_fast_forward(r):
+def _is_fast_forward(r, head=None):
     """Whether pushing local HEAD to this remote would be a STRAIGHT FAST-FORWARD — the remote's commit is an
     ancestor of ours, so the push only ADDS commits and can destroy nothing (the user 2026-07-24, who wanted
     the automatic push to fire exactly when that is observed).
@@ -15042,10 +15045,10 @@ def _is_fast_forward(r):
     as zero: an unknown relationship is precisely the case we must not auto-push into, since we cannot show it
     would clobber nothing. Same for diverged (ahead > 0) — `_update_remote` refuses those anyway, so
     auto-firing them would just manufacture failures. Those cases keep the manual Push button, which explains
-    the situation and lets the user decide."""
-    if not _remote_out_of_date(r):
+    the situation and lets the user decide. `head` pins the comparison, as in _remote_out_of_date."""
+    if not _remote_out_of_date(r, head=head):
         return False
-    d = _behind_info(r.get("kernel_sha") or "")
+    d = _behind_info(r.get("kernel_sha") or "", head=head)
     b, a = d.get("behind"), d.get("ahead")
     return isinstance(b, int) and isinstance(a, int) and b > 0 and a == 0
 
@@ -15119,7 +15122,16 @@ def _auto_push_remote(host):
     (CLAUDE.md: fail loudly) — a silently failing auto-push would look exactly like an up-to-date remote."""
     _set_auto_push(host, "pushing", "pushing this machine's build over SSH")
     try:
-        ok, detail = _update_remote(host)
+        head = _fresh_local_head()
+        with _remotes_lock:
+            base = _sha_base((_remotes.get(host) or {}).get("kernel_sha") or "")
+        with _auto_push_lock:
+            # _maybe_auto_push keyed this attempt on the polls' CACHED head, but the push uses the head read
+            # just now, which that read also wrote into the cache: the next supervisor pass then computed a
+            # new key for the same advance and fired a second push, which came back "already up to date" and
+            # logged "pushed" twice (review find, 2026-09-08). Key the attempt on the sha the push uses.
+            _auto_push_tried[host] = (base, head)
+        ok, detail = _update_remote(host, head=head)
     except Exception as e:
         ok, detail = False, str(e)
     if ok:
@@ -15225,8 +15237,10 @@ def _discover_remote_clone(host):
     Returns (dir, head, dirty, error) — error set (and the rest blank) on any failure, naming
     everything tried; `dirty` is "" (clean), "1" (uncommitted changes of any kind: an unstaged edit's
     porcelain line starts with a SPACE, so the first character alone is not a verdict), or "STATERR" when
-    `git status` itself failed there (an index lock, a corrupt index, an I/O error): a command that could
-    not see the tree must never answer "clean", because that answer green-lights a reset of it. Shared by
+    `git status` itself failed there (a corrupt index, an I/O error; NOT an index lock, which `git status`
+    reads through unbothered, so a lock surfaces later as RESETFAIL when the reset cannot take it): a
+    command that could not see the tree must never answer "clean", because that answer green-lights a
+    reset of it. Shared by
     the push (_update_remote) and pull (_pull_remote) directions."""
     disc = (
         'R=""; SR="${ROMP_REPO_ROOT:-$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/repo-root" 2>/dev/null)}"; '
@@ -15256,7 +15270,7 @@ def _discover_remote_clone(host):
     return rdir, rhead, rdirty, ""
 
 
-def _update_remote(host):
+def _update_remote(host, head=None):
     """PEER-TO-PEER update (the user 2026-07-04, who wanted p2p pushing by default, no GH backstop — just take what is
     committed on local). Push THIS kernel's committed HEAD straight to `host` over ssh and restart it, so the
     remote runs exactly the local code — GitHub/origin is never involved. Three steps, all over the same
@@ -15269,9 +15283,11 @@ def _update_remote(host):
          concurrent sender force-pushes the same ref), REFUSE if the remote has DIVERGED (its own commits not
          in local — don't clobber), re-check its tree IN THE SAME SHELL (step 1's answer is an ssh round-trip
          old; a status that fails, or an edit that landed since, refuses), else reset the remote to that sha,
-         delete the scratch ref, and restart it.
+         delete the scratch ref (only while it still names that sha), and restart it.
     Returns (ok, detail), fail-loud. Requires a CLEAN local tree — we push COMMITS, so uncommitted local work
-    isn't sent; the caller is told to commit first."""
+    isn't sent; the caller is told to commit first. `head` = the full sha to push when the caller has already
+    read it with _fresh_local_head (the automatic push keys its once-per-advance gate on that same value);
+    None reads it here."""
     host = str(host or "").strip()
     if not host:
         return False, "no host"
@@ -15286,7 +15302,7 @@ def _update_remote(host):
                        "When it is behind this build, Update asks it to fast-forward itself; otherwise "
                        "sync from that machine's own dashboard" % host)
     kport = int((_rr or {}).get("kernel_port") or _REMOTE_KERNEL_PORT)   # for the restart's port poll
-    lfull = _fresh_local_head()          # the head the user HAS, not the one the dashboard last polled
+    lfull = head if head is not None else _fresh_local_head()   # the head the user HAS, not the one the dashboard last polled
     if not lfull:
         return False, "local kernel isn't a git checkout — nothing to push"
     # We push the committed HEAD; uncommitted local edits are not sent ("just take what is committed on local"
@@ -15333,17 +15349,23 @@ def _update_remote(host):
         # to WANT is left alone (it is that other sender's to apply) and this call refuses.
         'GOT="$(git -C "$R" rev-parse --verify --quiet refs/heads/%s 2>/dev/null)"; '
         'if [ "$GOT" != "$WANT" ]; then echo "REFMISMATCH:$GOT"; exit 0; fi; '
+        # Every cleanup below is GUARDED by WANT (`update-ref -d <ref> <old>` deletes only while the ref still
+        # holds <old>): the gate above is one read, and a concurrent sender's push can land under the same
+        # name right after it. An unguarded delete removed THEIR ref and handed their apply a REFMISMATCH on
+        # nothing (review find, 2026-09-08). A guard that fails sets K, which trails the outcome tag so the
+        # detail can say the ref was left for that sender's own apply.
+        'K=""; '
         'if ! git -C "$R" merge-base --is-ancestor HEAD "$WANT" 2>/dev/null; then '
-        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo DIVERGED; exit 0; fi; '
+        'git -C "$R" update-ref -d refs/heads/%s "$WANT" 2>/dev/null || K=":REFKEPT"; echo "DIVERGED$K"; exit 0; fi; '
         # Re-check dirtiness HERE, in the same shell as the reset: the discover probe's answer is an ssh
         # round-trip old, and an edit that landed since would be destroyed by `reset --hard` on the strength
         # of a stale "clean". A status that FAILS is its own refusal, not a clean tree.
         'if ! AS=$(git -C "$R" status --porcelain 2>/dev/null); then '
-        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo STATERR; exit 0; fi; '
+        'git -C "$R" update-ref -d refs/heads/%s "$WANT" 2>/dev/null || K=":REFKEPT"; echo "STATERR$K"; exit 0; fi; '
         'if [ -n "$AS" ]; then '
-        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo DIRTYNOW; exit 0; fi; '
-        'git -C "$R" reset --hard "$WANT" >/dev/null 2>&1 || { git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; echo RESETFAIL; exit 0; }; '
-        'git -C "$R" update-ref -d refs/heads/%s 2>/dev/null; '
+        'git -C "$R" update-ref -d refs/heads/%s "$WANT" 2>/dev/null || K=":REFKEPT"; echo "DIRTYNOW$K"; exit 0; fi; '
+        'git -C "$R" reset --hard "$WANT" >/dev/null 2>&1 || { git -C "$R" update-ref -d refs/heads/%s "$WANT" 2>/dev/null || K=":REFKEPT"; echo "RESETFAIL$K"; exit 0; }; '
+        'git -C "$R" update-ref -d refs/heads/%s "$WANT" 2>/dev/null || K=":REFKEPT"; '
         'NEW="$(git -C "$R" rev-parse --short HEAD)"; '
         # RESTART the kernel THROUGH THE MANAGER (the user 2026-07-04: the manager is romp's durable supervisor —
         # "there is never an invisible orphan" — so a restart should keep/leave the remote MANAGER-owned, not
@@ -15353,7 +15375,7 @@ def _update_remote(host):
         # which spawns a SUPERVISED kernel — UPGRADING the orphan to properly managed. ensure needs node; if it
         # can't run (or the port never returns) we relaunch romp-serve bare as a last resort so the host isn't
         # left dead. The port poll confirms whichever path brought it back.
-        'if [ ! -x "$R/bin/romp-serve" ]; then echo "NOLAUNCH:$NEW"; exit 0; fi; '
+        'if [ ! -x "$R/bin/romp-serve" ]; then echo "NOLAUNCH:$NEW$K"; exit 0; fi; '
         # NEVER AN ANONYMOUS SIGTERM (T238, the T121 rule): a restart-audit row lands BEFORE whichever
         # restart happens, so the far kernel's cut row carries WHO and WHY (the p2p update, from this
         # machine, to this sha) — nine restarts in three hours had no reason on record. The QUIET row
@@ -15377,7 +15399,7 @@ def _update_remote(host):
         'OWNED="$("$R/bin/romp-manager" status 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); '
         'print(1 if any(int(k.get(\'port\') or 0)==%d for k in (d.get(\'kernels\') or [])) else 0)" 2>/dev/null || echo 0)"; fi; '
         'if [ "$OWNED" = 1 ]; then '
-        'if "$R/bin/romp-manager" restart-all --quiet >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:QUIET"; exit 0; fi; fi; '
+        'if "$R/bin/romp-manager" restart-all --quiet >>"$LOGDIR/update.log" 2>&1; then echo "SYNCED:$NEW:QUIET$K"; exit 0; fi; fi; '
         # LAST RESORT (no owning manager answering on this host): the immediate path below — audit row,
         # kill, then `ensure` upgrades the host to a supervised kernel.
         'python3 -c "import json,time;print(json.dumps({\'t\':int(time.time()),\'action\':\'p2p-update\','
@@ -15394,7 +15416,7 @@ def _update_remote(host):
         'if command -v node >/dev/null 2>&1 && [ -x "$R/bin/romp-manager" ]; then "$R/bin/romp-manager" ensure >>"$LOGDIR/update.log" 2>&1 || true; fi; '
         'UP=0; for i in 1 2 3 4 5 6 7 8; do sleep 1; if bash -c "exec 3<>/dev/tcp/127.0.0.1/%d" 2>/dev/null; then UP=1; break; fi; done; '
         'if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve" >>"$LOGDIR/kernel.log" 2>&1 </dev/null &  sleep 1; fi; '
-        'echo "SYNCED:$NEW:FALLBACK"'
+        'echo "SYNCED:$NEW:FALLBACK$K"'
     ) % (shlex.quote(rdir), lfull, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF, _P2P_REF,
          _local_machine_label(), lfull[:8], kport,
          _local_machine_label(), lfull[:8], kport)
@@ -15434,58 +15456,72 @@ def _update_remote(host):
         _unexpect()
         return False, "pushed, but the remote reset/restart failed: " + str(e)[:150]
     aout = (a.stdout or "").strip()
+    # ":REFKEPT" trails any outcome whose cleanup found the scratch ref no longer at WANT: another sender's
+    # push landed under the name after the gate, and the guarded delete left it for that sender's own apply
+    kept = aout.endswith(":REFKEPT")
+    if kept:
+        aout = aout[:-len(":REFKEPT")]
     tag, _, rest = aout.partition(":")
     tag, rest = tag.strip(), rest.strip()
-    if tag == "SYNCED":
-        short, _, mode = rest.partition(":")
-        mode = mode.strip()
-        _expect(mode == "QUIET")
-        short = short.strip() or lfull[:8]
-        if mode == "QUIET":
-            return True, "synced to %s — restarting at its next quiet window" % short
-        if mode == "FALLBACK":
-            return True, ("synced to %s + restarting now (no manager owns that kernel there — an "
-                          "immediate restart)" % short)
-        return True, "synced to %s + restarting" % short
-    _unexpect()                       # nothing restarted: REFMISMATCH / DIVERGED / STATERR / DIRTYNOW / RESETFAIL / NOLAUNCH / error
-    if tag == "REFMISMATCH":
-        return False, ("pushed %s, but the scratch ref on %s now holds %s — another push moved it between "
-                       "ours and the apply; nothing was reset there. Push again."
-                       % (lfull[:8], host, (rest[:8] if rest else "nothing")))
-    if tag == "DIVERGED":
-        # Two very different causes land here, and the old wording only described the first, which is
-        # why a rewritten local history read as an unexplained refusal (the user 2026-07-22): either the
-        # remote really has its own commits, or LOCAL history was rewritten (rebase/filter-repo/amend),
-        # after which the remote's HEAD is an ancestor of nothing and the guard fires forever. Name both
-        # and give the exact way out, so the fix doesn't need a code read.
-        return False, ("remote %s has diverged — not clobbering. Either it has its own commits, or local "
-                       "history was rewritten (rebase/filter-repo), which orphans the remote's HEAD. To "
-                       "discard what's on %s and force it to match local: "
-                       "git push --force %s:<remote-romp-dir> HEAD:refs/heads/%s "
-                       "then, on %s: git reset --hard %s && git update-ref -d refs/heads/%s"
-                       % (host, host, host, _P2P_REF, host, _P2P_REF, _P2P_REF))
-    if tag == "STATERR":
-        return False, ("pushed, but reading the tree state on %s failed right before the apply — not resetting "
-                       "a checkout whose state is unknown" % host)
-    if tag == "DIRTYNOW":
-        return False, ("pushed, but the tree on %s has uncommitted changes — nothing was reset there; commit "
-                       "or discard them, then push again" % host)
-    if tag == "RESETFAIL":
-        return False, "pushed, but the remote couldn't check out the new code"
-    if tag == "NOLAUNCH":
-        return False, "pushed + reset, but found no romp/romp-serve launcher to restart the kernel"
-    return False, (_ssh_err(a.stderr) or aout or "remote apply failed").strip()[:180]
+
+    def _verdict():
+        if tag == "SYNCED":
+            short, _, mode = rest.partition(":")
+            mode = mode.strip()
+            _expect(mode == "QUIET")
+            short = short.strip() or lfull[:8]
+            if mode == "QUIET":
+                return True, "synced to %s — restarting at its next quiet window" % short
+            if mode == "FALLBACK":
+                return True, ("synced to %s + restarting now (no manager owns that kernel there — an "
+                              "immediate restart)" % short)
+            return True, "synced to %s + restarting" % short
+        _unexpect()                       # nothing restarted: REFMISMATCH / DIVERGED / STATERR / DIRTYNOW / RESETFAIL / NOLAUNCH / error
+        if tag == "REFMISMATCH":
+            return False, ("pushed %s, but the scratch ref on %s now holds %s — another push moved it between "
+                           "ours and the apply; nothing was reset there. Push again."
+                           % (lfull[:8], host, (rest[:8] if rest else "nothing")))
+        if tag == "DIVERGED":
+            # Two very different causes land here, and the old wording only described the first, which is
+            # why a rewritten local history read as an unexplained refusal (the user 2026-07-22): either the
+            # remote really has its own commits, or LOCAL history was rewritten (rebase/filter-repo/amend),
+            # after which the remote's HEAD is an ancestor of nothing and the guard fires forever. Name both
+            # and give the exact way out, so the fix doesn't need a code read.
+            return False, ("remote %s has diverged — not clobbering. Either it has its own commits, or local "
+                           "history was rewritten (rebase/filter-repo), which orphans the remote's HEAD. To "
+                           "discard what's on %s and force it to match local: "
+                           "git push --force %s:<remote-romp-dir> HEAD:refs/heads/%s "
+                           "then, on %s: git reset --hard %s && git update-ref -d refs/heads/%s"
+                           % (host, host, host, _P2P_REF, host, _P2P_REF, _P2P_REF))
+        if tag == "STATERR":
+            return False, ("pushed, but reading the tree state on %s failed right before the apply — not resetting "
+                           "a checkout whose state is unknown" % host)
+        if tag == "DIRTYNOW":
+            return False, ("pushed, but the tree on %s has uncommitted changes — nothing was reset there; commit "
+                           "or discard them, then push again" % host)
+        if tag == "RESETFAIL":
+            return False, "pushed, but the remote couldn't check out the new code"
+        if tag == "NOLAUNCH":
+            return False, "pushed + reset, but found no romp/romp-serve launcher to restart the kernel"
+        return False, (_ssh_err(a.stderr) or aout or "remote apply failed").strip()[:180]
+
+    ok, detail = _verdict()
+    if kept:
+        detail += ("; the scratch ref on %s now holds another sender's push, left alone for that sender's own "
+                   "apply" % host)
+    return ok, detail
 
 
-def _is_fast_pull(r):
+def _is_fast_pull(r, head=None):
     """Whether pulling this remote's commits would be a STRAIGHT FAST-FORWARD of the local checkout —
     the remote is strictly AHEAD (it has commits we lack, we have none it lacks), both counts actually
     known. The mirror of _is_fast_forward, for the other direction (the user 2026-07-27: the attaching
     side owns BOTH directions of sync — the remote has no ssh route back). None is NOT zero, same as
-    the push gate: an unprovable relationship is exactly what must not be pulled automatically."""
-    if not _remote_out_of_date(r):
+    the push gate: an unprovable relationship is exactly what must not be pulled automatically. `head`
+    pins the comparison, as in _remote_out_of_date."""
+    if not _remote_out_of_date(r, head=head):
         return False
-    d = _behind_info(r.get("kernel_sha") or "")
+    d = _behind_info(r.get("kernel_sha") or "", head=head)
     b, a = d.get("behind"), d.get("ahead")
     return isinstance(b, int) and isinstance(a, int) and a > 0 and b == 0
 
@@ -15740,7 +15776,7 @@ def _restart_remote_kernel(host):
     return False, (_ssh_err(a.stderr) or out or "remote restart failed").strip()[:180]
 
 
-def _fleet_restart_plan(r):
+def _fleet_restart_plan(r, head=None):
     """What a fleet restart would do to ONE remote row → (action, reason). Pure decision, so the report
     and the tests can both read it without any ssh happening:
       sync-push  — it is strictly behind us and the push can only add commits
@@ -15748,24 +15784,26 @@ def _fleet_restart_plan(r):
       ask        — a checked-in peer we can only ASK to fast-forward itself (no ssh route from here)
       restart    — same build: nothing to sync, just bring the process back
       skip       — anything we cannot prove is safe; the reason says which
+    `head` = the local sha the row is judged against, handed down by _fleet_restart_run so every row of one
+    run is judged against the same commit; None reads the polls' cache.
     """
     host = r.get("host") or "?"
     if r.get("status") != "up":
         return "skip", "not connected right now (romp is still dialing it)"
-    if not _remote_out_of_date(r):
+    if not _remote_out_of_date(r, head=head):
         return ("ask", "checked in here; asking it to restart itself") if r.get("checkin_peer") \
             else ("restart", "already on this build")
     if r.get("checkin_peer"):
-        return ("ask", "checked in here; asking it to fast-forward itself") if _is_ask_pull(r) \
+        return ("ask", "checked in here; asking it to fast-forward itself") if _is_ask_pull(r, head=head) \
             else ("skip", "checked in over its own tunnel and not provably behind — sync it from its own "
                           "dashboard")
-    if _is_fast_forward(r):
+    if _is_fast_forward(r, head=head):
         return "sync-push", "behind this build; pushing and restarting"
-    if _is_fast_pull(r):
+    if _is_fast_pull(r, head=head):
         if _local_branch() != "main":
             return "skip", "%s is ahead, but this checkout isn't on main — pull it yourself" % host
         return "sync-pull", "ahead of this build; fast-forwarding this machine onto it"
-    d = _behind_info(r.get("kernel_sha") or "")
+    d = _behind_info(r.get("kernel_sha") or "", head=head)
     b, a = d.get("behind"), d.get("ahead")
     if isinstance(b, int) and isinstance(a, int) and b > 0 and a > 0:
         return "skip", "diverged (it has %d commit(s) this machine lacks) — not clobbering either side" % a
@@ -15781,13 +15819,18 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
     rows = []
     with _remotes_lock:
         remotes = [dict(x) for x in _remotes.values()]
-    # ONE head for the whole plan, read now: the polls' cache can be 15 s behind a commit made just before
-    # Restart, and a row judged against the old head reads a peer sitting on it as "already on this build"
-    # (a restart where a push was owed). Every row below is judged against this same commit.
-    _fresh_local_head()
+    # The head every row is planned against: read from git ONCE here and carried as a VALUE, never re-read
+    # through the polls' cache per row. The cache can be 15 s behind a commit made just before Restart (a peer
+    # sitting on that commit then reads as "already on this build" and gets a restart where a push was owed),
+    # and a row is minutes of ssh, so per-row cache reads judged later rows against whatever HEAD had become
+    # by then and the report against a third reading (review find, 2026-09-08). The one event that moves it
+    # on purpose is a sync-pull below, which fast-forwards this checkout: it is re-read right there, so the
+    # rows after it are judged against the commit the pull brought in (a peer still on the old head is owed
+    # a push of it, not a bare restart).
+    head = _fresh_local_head()
     for r in remotes:
         host = r.get("host") or "?"
-        action, reason = _fleet_restart_plan(r)
+        action, reason = _fleet_restart_plan(r, head=head)
         try:
             if action == "skip":
                 rows.append({"host": host, "ok": None, "action": "skipped", "detail": reason})
@@ -15798,6 +15841,7 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
                 ok, detail = _pull_remote(host)
                 if ok:
                     detail += "; this machine restarts below"
+                    head = _fresh_local_head()          # HEAD moved by design: later rows are judged against it
             elif action == "ask":
                 ok, detail = _ask_peer_to_pull(host)
             else:
@@ -15806,7 +15850,7 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
         except Exception as e:                    # one bad host must never strand the rest of the fleet
             rows.append({"host": host, "ok": False, "action": action, "detail": str(e)[:180]})
     report = {"t": int(time.time()), "boot": _BOOT_ID, "rows": rows,
-              "local": {"head": _local_head(short=True) or "", "branch": _local_branch() or ""}}
+              "local": {"head": head[:7] if head else "", "branch": _local_branch() or ""}}
     try:
         _atomic_write(FLEET_REPORT, json.dumps(report))
     except OSError:
@@ -16028,11 +16072,12 @@ def _restart_this_kernel(reason="", manager_port=_PORT_FROM_ENV):
         pass                                       # no manager reachable → nothing to restart
 
 
-def _is_ask_pull(r):
+def _is_ask_pull(r, head=None):
     """Whether this remote can be TOLD to fast-forward itself: a checked-in peer (no ssh from here) that is
     strictly BEHIND us, so what it pulls only ADDS commits. Same provable-fast-forward bar as the push gate
-    — a diverged or unknown relationship is never driven automatically, and never offered as one click."""
-    return bool(r.get("checkin_peer")) and _is_fast_forward(r)
+    — a diverged or unknown relationship is never driven automatically, and never offered as one click.
+    `head` pins the comparison, as in _remote_out_of_date."""
+    return bool(r.get("checkin_peer")) and _is_fast_forward(r, head=head)
 
 
 def _start_remote(host):

--- a/tests/test_auto_update_remotes.py
+++ b/tests/test_auto_update_remotes.py
@@ -31,8 +31,8 @@ class FastForwardGate(unittest.TestCase):
 
     def _patched(self, behind, ahead, ood=True):
         saved = (km._remote_out_of_date, km._behind_info)
-        km._remote_out_of_date = lambda r: ood
-        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead, "date": ""}
+        km._remote_out_of_date = lambda r, head=None: ood
+        km._behind_info = lambda sha, head=None: {"behind": behind, "ahead": ahead, "date": ""}
         return saved
 
     def _restore(self, saved):
@@ -100,8 +100,8 @@ class AutoPushFiring(unittest.TestCase):
         km._auto_push.clear()
         km._auto_push_tried.clear()
         self._saved = (km._remote_out_of_date, km._behind_info, km._local_head)
-        km._remote_out_of_date = lambda r: True
-        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": ""}
+        km._remote_out_of_date = lambda r, head=None: True
+        km._behind_info = lambda sha, head=None: {"behind": 2, "ahead": 0, "date": ""}
         km._local_head = lambda short=False: (LOCAL[:8] if short else LOCAL)
         self.calls = []
 
@@ -155,14 +155,14 @@ class AutoPushFiring(unittest.TestCase):
         self.assertEqual(self.calls, [], "off means off")
 
     def test_a_diverged_remote_never_fires(self):
-        km._behind_info = lambda sha: {"behind": 1, "ahead": 1, "date": ""}
+        km._behind_info = lambda sha, head=None: {"behind": 1, "ahead": 1, "date": ""}
         self._run(self._row())
         self.assertEqual(self.calls, [], "a push that could clobber is never automatic")
 
     def test_an_up_to_date_host_clears_a_settled_phase(self):
         # the EVENT that ends a push is the remote reporting our sha — never a timer
         km._set_auto_push("TESTHOST", "waiting", "pushed; waiting for it to restart")
-        km._remote_out_of_date = lambda r: False
+        km._remote_out_of_date = lambda r, head=None: False
         self._run(self._row())
         self.assertIsNone(km._auto_push_state("TESTHOST"), "the restarted remote matching us ends the phase")
 
@@ -181,8 +181,8 @@ class PublishedToTheClient(unittest.TestCase):
 
     def test_the_row_publishes_the_fast_forward_verdict_and_live_phase(self):
         saved = (km._remote_out_of_date, km._behind_info)
-        km._remote_out_of_date = lambda r: True
-        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": "2026-07-24"}
+        km._remote_out_of_date = lambda r, head=None: True
+        km._behind_info = lambda sha, head=None: {"behind": 2, "ahead": 0, "date": "2026-07-24"}
         km._set_auto_push("TESTHOST", "pushing", "pushing this machine's build over SSH")
         try:
             pub = km._remote_public({"host": "TESTHOST", "kernel_port": 1, "local_port": 2,

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -52,11 +52,11 @@ class Plan(unittest.TestCase):
             setattr(km, n, v)
 
     def _stub(self, out_of_date=False, ff=False, pull=False, ask=False, behind=None, ahead=None):
-        km._remote_out_of_date = lambda r: out_of_date
-        km._is_fast_forward = lambda r: ff
-        km._is_fast_pull = lambda r: pull
-        km._is_ask_pull = lambda r: ask
-        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead}
+        km._remote_out_of_date = lambda r, head=None: out_of_date
+        km._is_fast_forward = lambda r, head=None: ff
+        km._is_fast_pull = lambda r, head=None: pull
+        km._is_ask_pull = lambda r, head=None: ask
+        km._behind_info = lambda sha, head=None: {"behind": behind, "ahead": ahead}
 
     def test_a_disconnected_host_is_skipped_and_says_romp_is_still_dialing(self):
         self._stub()
@@ -125,12 +125,12 @@ class ReportSurvivesTheRestart(unittest.TestCase):
 
     def test_a_failing_host_lands_in_the_report_and_the_sweep_continues(self):
         saved = {n: getattr(km, n) for n in ("_fleet_restart_plan", "_restart_remote_kernel",
-                                            "_restart_this_kernel", "_local_head", "_local_branch")}
-        km._fleet_restart_plan = lambda r: ("restart", "already on this build")
+                                            "_restart_this_kernel", "_fresh_local_head", "_local_branch")}
+        km._fleet_restart_plan = lambda r, head=None: ("restart", "already on this build")
         km._restart_remote_kernel = lambda h: (_ for _ in ()).throw(RuntimeError("ssh exploded"))
         # audits its reason since 2026-07-31; carries the handler's ack-time port since 2026-08-27
         km._restart_this_kernel = lambda reason="", manager_port=None: None
-        km._local_head = lambda short=False: "abc1234"
+        km._fresh_local_head = lambda: "abc1234" + "0" * 33     # the run reads the head once, from git
         km._local_branch = lambda: "main"
         km._remotes.clear()
         km._remotes["web"] = row(host="web")
@@ -160,7 +160,7 @@ class ReportSurvivesTheRestart(unittest.TestCase):
         km._update_remote = lambda h: did.append(("push", h)) or (True, "synced")
         km._restart_remote_kernel = lambda h: did.append(("restart", h)) or (True, "restarted")
         km._restart_this_kernel = lambda reason="", manager_port=None: None
-        km._behind_info = lambda sha: {"behind": 1, "ahead": 0, "date": ""}   # strictly behind: a push only adds
+        km._behind_info = lambda sha, head=None: {"behind": 1, "ahead": 0, "date": ""}   # strictly behind: a push only adds
         km._local_branch = lambda: "main"
         km._HEAD_CACHE.update(ts=9e18, full=stale, short=stale[:7])             # what the polls last read
         def fake(argv, **kw):
@@ -182,6 +182,80 @@ class ReportSurvivesTheRestart(unittest.TestCase):
         self.assertEqual(did, [("push", "TESTHOST")], "behind the head the user has: pushed, not merely restarted")
         self.assertEqual(report["rows"][0]["action"], "sync-push")
         self.assertEqual(report["local"]["head"], fresh[:7], "the report names the head the plan was judged against")
+
+    def _run_two_rows(self, first, second, git_head, on_restart=None, on_pull=None, drift=None):
+        """Drive _fleet_restart_run over peers `web` (on `first`) and `api` (on `second`) with git answering
+        `git_head[0]` for HEAD; the mocked actions record what happened and may move `git_head` or the cache
+        as a real row's minutes of ssh would. `drift` = how a peer's sha relates to the head it is judged
+        against (strictly behind unless given). Returns (actions done, the report)."""
+        saved = {n: getattr(km, n) for n in ("_update_remote", "_pull_remote", "_restart_remote_kernel",
+                                            "_restart_this_kernel", "_behind_info", "_local_branch")}
+        hc, run = dict(km._HEAD_CACHE), km.subprocess.run
+        did = []
+        def restart(h):
+            did.append(("restart", h))
+            if on_restart:
+                on_restart()
+            return True, "restarted"
+        def pull(h):
+            did.append(("pull", h))
+            if on_pull:
+                on_pull()
+            return True, "pulled"
+        km._update_remote = lambda h, **kw: did.append(("push", h)) or (True, "synced")
+        km._pull_remote, km._restart_remote_kernel = pull, restart
+        km._restart_this_kernel = lambda reason="", manager_port=None: None
+        km._behind_info = drift or (lambda sha, head=None: {"behind": 1, "ahead": 0, "date": ""})
+        km._local_branch = lambda: "main"
+        def fake(argv, **kw):
+            if argv[0] == "git" and "rev-parse" in argv:                         # what git says NOW
+                h = git_head[0]
+                return subprocess.CompletedProcess(argv, 0, h[:7] if "--short" in argv else h, "")
+            return run(argv, **kw)
+        km.subprocess.run = fake
+        km._remotes.clear()
+        km._remotes["web"] = row(host="web", kernel_sha=first[:7])
+        km._remotes["api"] = row(host="api", kernel_sha=second[:7])
+        try:
+            km._fleet_restart_run()
+            return did, json.loads(km.FLEET_REPORT.read_text())
+        finally:
+            for n, v in saved.items():
+                setattr(km, n, v)
+            km.subprocess.run = run
+            km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(hc)
+            km._remotes.clear()
+
+    def test_every_row_is_judged_against_the_one_head_read_before_the_plan(self):
+        # Two peers in the identical state, both on the head this checkout is at. The first row's ssh runs
+        # long enough for the polls' 15 s head cache to expire, and a commit lands locally meanwhile. Judged
+        # per row THROUGH the cache, the second peer read as behind the new commit and was pushed to where its
+        # twin got a bare restart, and the report named a head neither row had been planned against. The run
+        # reads the head once and carries the value (review find, 2026-09-08).
+        before, after = "5" * 40, "6" * 40
+        git_head = [before]
+        def twenty_seconds_of_ssh():
+            git_head[0] = after                    # a commit lands mid-run...
+            km._HEAD_CACHE["ts"] -= 20             # ...and the first row outlives the cache's TTL
+        did, report = self._run_two_rows(before, before, git_head, on_restart=twenty_seconds_of_ssh)
+        self.assertEqual(did, [("restart", "web"), ("restart", "api")], "twins get the same verdict")
+        self.assertEqual([x["action"] for x in report["rows"]], ["restart", "restart"])
+        self.assertEqual(report["local"]["head"], before[:7], "the report names the head every row was judged against")
+
+    def test_a_sync_pull_moves_the_head_the_rows_after_it_are_judged_against(self):
+        # web is one commit ahead; api sits where this checkout started. The pull fast-forwards this machine
+        # onto web's commit, and that IS new information: api is now behind it and owed a push. A head pinned
+        # across the pull would have called api "already on this build" and bare-restarted it one commit
+        # behind, so the run re-reads the head after a pull and only there.
+        old, new = "7" * 40, "8" * 40
+        git_head = [old]
+        def fast_forwarded():
+            git_head[0] = new
+        ahead = lambda sha, head=None: ({"behind": 0, "ahead": 1, "date": ""} if sha == new[:7]   # web, before the pull
+                                        else {"behind": 1, "ahead": 0, "date": ""})              # api, judged after it
+        did, report = self._run_two_rows(new, old, git_head, on_pull=fast_forwarded, drift=ahead)
+        self.assertEqual(did, [("pull", "web"), ("push", "api")], "the peer still on the old head is pushed the pulled commit")
+        self.assertEqual(report["local"]["head"], new[:7], "the report names the head this machine restarts on")
 
     def test_the_route_hands_the_report_back_and_the_page_shows_it_once(self):
         src = inspect.getsource(km.Handler)

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -15,6 +15,7 @@ Synthetic only — placeholder hosts/shas, no ssh, no restarts.
 import inspect
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -147,6 +148,40 @@ class ReportSurvivesTheRestart(unittest.TestCase):
             self.assertFalse(x["ok"])
             self.assertIn("ssh exploded", x["detail"])
         self.assertEqual(report["local"]["head"], "abc1234")
+
+    def test_the_plan_is_judged_against_the_head_this_checkout_is_at_now(self):
+        # the polls' head cache can be 15 s behind a commit made just before Restart: a peer sitting on the
+        # previous commit then reads as "already on this build" and gets a bare restart where a push was owed
+        stale, fresh = "3" * 40, "4" * 40
+        saved = {n: getattr(km, n) for n in ("_update_remote", "_restart_remote_kernel", "_restart_this_kernel",
+                                            "_behind_info", "_local_branch")}
+        hc, run = dict(km._HEAD_CACHE), km.subprocess.run
+        did = []
+        km._update_remote = lambda h: did.append(("push", h)) or (True, "synced")
+        km._restart_remote_kernel = lambda h: did.append(("restart", h)) or (True, "restarted")
+        km._restart_this_kernel = lambda reason="", manager_port=None: None
+        km._behind_info = lambda sha: {"behind": 1, "ahead": 0, "date": ""}   # strictly behind: a push only adds
+        km._local_branch = lambda: "main"
+        km._HEAD_CACHE.update(ts=9e18, full=stale, short=stale[:7])             # what the polls last read
+        def fake(argv, **kw):
+            if argv[0] == "git" and "rev-parse" in argv:                        # what git says NOW
+                return subprocess.CompletedProcess(argv, 0, fresh[:7] if "--short" in argv else fresh, "")
+            return run(argv, **kw)
+        km.subprocess.run = fake
+        km._remotes.clear()
+        km._remotes["TESTHOST"] = row(kernel_sha=stale[:7])                      # the peer is on the OLD commit
+        try:
+            km._fleet_restart_run()
+            report = json.loads(km.FLEET_REPORT.read_text())
+        finally:
+            for n, v in saved.items():
+                setattr(km, n, v)
+            km.subprocess.run = run
+            km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(hc)
+            km._remotes.clear()
+        self.assertEqual(did, [("push", "TESTHOST")], "behind the head the user has: pushed, not merely restarted")
+        self.assertEqual(report["rows"][0]["action"], "sync-push")
+        self.assertEqual(report["local"]["head"], fresh[:7], "the report names the head the plan was judged against")
 
     def test_the_route_hands_the_report_back_and_the_page_shows_it_once(self):
         src = inspect.getsource(km.Handler)

--- a/tests/test_kernel_pkill_self_match.py
+++ b/tests/test_kernel_pkill_self_match.py
@@ -49,7 +49,8 @@ def _apply_script():
 
     from unittest import mock
     with mock.patch.object(km.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(km, "_local_head", side_effect=lambda short=False: "cafe1234" if not short else "cafe123"):
+         mock.patch.object(km, "_local_head", side_effect=lambda short=False: "cafe1234" * 5 if not short else "cafe123"), \
+         mock.patch.object(km, "_fresh_local_head", return_value="cafe1234" * 5):
         km._update_remote("TESTHOST")
     return seen.get("apply", "")
 

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -37,8 +37,8 @@ class FastPullGate(unittest.TestCase):
 
     def _fp(self, behind, ahead, ood=True):
         saved = (km._remote_out_of_date, km._behind_info)
-        km._remote_out_of_date = lambda r: ood
-        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead, "date": ""}
+        km._remote_out_of_date = lambda r, head=None: ood
+        km._behind_info = lambda sha, head=None: {"behind": behind, "ahead": ahead, "date": ""}
         try:
             return km._is_fast_pull({"host": "TESTHOST", "kernel_sha": REMOTE})
         finally:
@@ -212,8 +212,8 @@ class AutoPullFiring(unittest.TestCase):
         km._auto_push.clear()
         km._auto_push_tried.clear()
         self._saved = (km._remote_out_of_date, km._behind_info, km._local_head, km._local_branch)
-        km._remote_out_of_date = lambda r: True
-        km._behind_info = lambda sha: {"behind": 0, "ahead": 2, "date": ""}   # strictly ahead → pull side
+        km._remote_out_of_date = lambda r, head=None: True
+        km._behind_info = lambda sha, head=None: {"behind": 0, "ahead": 2, "date": ""}   # strictly ahead → pull side
         km._local_head = lambda short=False: (LOCAL[:8] if short else LOCAL)
         km._local_branch = lambda: "main"
         self.calls = []
@@ -267,7 +267,7 @@ class AutoPullFiring(unittest.TestCase):
     def test_a_checked_in_peer_that_is_BEHIND_is_asked_to_update_itself(self):
         # the third direction (the user 2026-07-28): the peer owns the only ssh between the machines, so
         # the fast-forward is driven through the tunnel IT holds instead of offered as an impossible push
-        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": ""}
+        km._behind_info = lambda sha, head=None: {"behind": 2, "ahead": 0, "date": ""}
         self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
         self.assertEqual(self.calls, [("_auto_ask_peer", "TESTHOST")])
 
@@ -275,7 +275,7 @@ class AutoPullFiring(unittest.TestCase):
         # same bar as the push gate: diverged, or a build this repo has never seen, is not driven at all
         for drift in ({"behind": 2, "ahead": 1, "date": ""}, {"behind": None, "ahead": None, "date": ""}):
             km._auto_push_tried.clear()
-            km._behind_info = lambda sha, d=drift: d
+            km._behind_info = lambda sha, head=None, d=drift: d
             self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
         self.assertEqual(self.calls, [])
 
@@ -289,7 +289,7 @@ class AutoPullFiring(unittest.TestCase):
         # after a pull the drift clears at once (HEAD moved) but the RUNNING kernel is the old build —
         # the 'pulled … restart romp' trace must outlive the clearing event, until the restart itself
         km._set_auto_push("TESTHOST", "pulled", "pulled 2 commits from TESTHOST — restart romp to run it")
-        km._remote_out_of_date = lambda r: False
+        km._remote_out_of_date = lambda r, head=None: False
         self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
         st = km._auto_push_state("TESTHOST")
         self.assertEqual((st or {}).get("phase"), "pulled")

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -68,7 +68,8 @@ class PullRemote(unittest.TestCase):
         km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(self._hc)
         km._remotes.clear()
 
-    def _wire(self, dirty="", rhead=REMOTE, ancestor_rc=0, merge_rc=0, count="3", status_rc=0):
+    def _wire(self, dirty="", rhead=REMOTE, ancestor_rc=0, merge_rc=0, count="3", status_rc=0, present=True,
+              head=LOCAL):
         calls = []
 
         def fake(argv, **kw):
@@ -83,8 +84,12 @@ class PullRemote(unittest.TestCase):
                 return _R(out=count)
             if argv[0] == "git" and "merge" in argv:
                 return _R(rc=merge_rc, err="not a fast-forward" if merge_rc else "")
-            if argv[0] == "git" and "rev-parse" in argv:
+            if argv[0] == "git" and "rev-parse" in argv and any(str(x).endswith("^{commit}") for x in argv):
+                return _R(out=rhead) if present else _R(rc=1)   # is the reported commit here after the fetch?
+            if argv[0] == "git" and "rev-parse" in argv and "--short" in argv:
                 return _R(out="bbbbbbb")
+            if argv[0] == "git" and "rev-parse" in argv:
+                return _R(out=head)                     # this checkout's HEAD, read by the pull itself
             cmd = argv[-1]                          # ssh: the clone discovery
             if "for d in" in cmd:
                 return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % rhead)
@@ -150,6 +155,51 @@ class PullRemote(unittest.TestCase):
         ok, detail = km._pull_remote("TESTHOST")
         self.assertTrue(ok)
         self.assertIn("already up to date", detail)
+
+    def test_the_merge_binds_to_the_commit_the_peer_reported_never_FETCH_HEAD(self):
+        # FETCH_HEAD is a mutable name: any other fetch into this checkout rewrites it between our fetch
+        # and our merge. Every step after the fetch names the exact sha the peer reported, and FETCH_HEAD
+        # enters no decision at all.
+        calls = self._wire()
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        for step in ("merge-base", "rev-list", "merge"):
+            argv = next(a for a in calls if a[0] == "git" and step in a)
+            self.assertTrue(any(REMOTE in str(x) for x in argv), "%s binds to the sha: %r" % (step, argv))
+        self.assertFalse(any("FETCH_HEAD" in str(x) for a in calls for x in a), "FETCH_HEAD is never consulted")
+        verify = next(a for a in calls if a[0] == "git" and "rev-parse" in a and "--verify" in a)
+        self.assertIn(REMOTE + "^{commit}", verify, "the fetch must have brought the reported commit itself")
+
+    def test_a_peer_that_moved_off_the_commit_it_reported_is_refused(self):
+        # the fetch did not bring the commit the peer reported (it rewound or was rewritten since the
+        # probe): the one honest refusal, naming the peer and that commit — a LOCAL fetch that rewrote
+        # FETCH_HEAD in the meantime can no longer be blamed on it
+        calls = self._wire(present=False)
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("moved off", detail)
+        self.assertIn(REMOTE[:8], detail)
+        self.assertIn("nothing merged", detail)
+        self.assertFalse(any(a[0] == "git" and "merge" in a for a in calls), "no merge of an absent commit")
+
+    def test_a_local_move_since_the_last_poll_does_not_hide_a_pull(self):
+        # the polls' cache says this tree is at the peer's commit; git says it was moved back since (a
+        # reset within the 15 s window). The cached gate answered "already up to date" and skipped a pull
+        # that would have moved the tree; the pull reads the head this tree is AT.
+        km._HEAD_CACHE.update(ts=9e18, full=REMOTE, short=REMOTE[:8])
+        self._wire(rhead=REMOTE, head=LOCAL)
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertNotIn("already up to date", detail)
+        self.assertIn("pulled 3 commits from TESTHOST", detail)
+
+    def test_a_peer_that_reports_no_commit_is_not_pulled(self):
+        # with no reported commit there is nothing to bind the merge to — refuse before fetching
+        calls = self._wire(rhead="")
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("did not report", detail)
+        self.assertFalse(any(a[0] == "git" and "fetch" in a for a in calls), "nothing fetched")
 
 
 class AutoPullFiring(unittest.TestCase):

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -113,7 +113,8 @@ class UpdateRemote(unittest.TestCase):
         push = next(a for a in calls if a[0] == "git" and "push" in a)
         self.assertIn("--force", push)
         self.assertIn("TESTHOST:/home/u/romp", push)
-        self.assertTrue(any(str(x).startswith("HEAD:refs/heads/") for x in push), "pushes HEAD to a scratch ref")
+        self.assertIn(self.LFULL + ":refs/heads/" + km._P2P_REF, push,
+                      "pushes the exact advertised sha to the scratch ref, not a HEAD that may move under it")
 
     def test_the_apply_restarts_through_the_manager_quiet_window_with_an_audit_row(self):
         # T238: the remote apply used to `pkill` the far kernel outright — an anonymous, immediate
@@ -258,6 +259,67 @@ class UpdateRemote(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIn("already up to date", detail)
 
+    def test_a_commit_made_just_before_the_update_is_what_gets_pushed(self):
+        # The dashboard's polls read HEAD through a 15 s cache. A `romp update` inside that window used to
+        # read the SAME cache, so a commit made a second earlier was invisible to it: the peer sat on the
+        # previous commit, which equalled the cached head, and the update returned "already up to date"
+        # having pushed nothing (and when it did push, the restart it told itself to expect named the old
+        # sha). The transport reads the head the user actually has.
+        stale, fresh = "3" * 40, "4" * 40
+        calls = self._wire(rhead=stale, apply_out="SYNCED:4444444:QUIET")   # the peer is on the OLD commit
+        km._HEAD_CACHE.update(ts=9e18, full=stale, short=stale[:8])          # the cache still says so too
+        km._remotes["TESTHOST"] = {"host": "TESTHOST"}
+        self.addCleanup(km._remotes.pop, "TESTHOST", None)
+        real = km.subprocess.run
+        def fake(argv, **kw):
+            if argv[0] == "git" and "rev-parse" in argv and "HEAD" in argv:
+                calls.append(argv)
+                return _R(out=fresh)                                          # what git says NOW
+            return real(argv, **kw)
+        km.subprocess.run = fake
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertNotIn("already up to date", detail)
+        push = next(a for a in calls if a[0] == "git" and "push" in a)
+        self.assertIn(fresh + ":refs/heads/" + km._P2P_REF, push, "the head the user has is what travels")
+        self.assertEqual(km._remotes["TESTHOST"]["restartExpected"]["sha"], fresh,
+                         "and it is the sha the far kernel is expected to come back on")
+        apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
+        self.assertIn("WANT=" + fresh, apply, "the apply is bound to the same sha")
+        self.assertEqual(km._local_head(), fresh, "the polling cache was refreshed by the same read")
+
+    def test_a_head_that_is_not_a_full_sha_is_refused_not_pushed(self):
+        # the transport insists on the exact 40-hex commit it binds the peer to; anything else (a truncated
+        # or garbled rev-parse answer) is "not a checkout", said so, and nothing is pushed
+        calls = self._wire()
+        real = km.subprocess.run
+        def fake(argv, **kw):
+            if argv[0] == "git" and "rev-parse" in argv:
+                return _R(out="abc1234")
+            return real(argv, **kw)
+        km.subprocess.run = fake
+        self.assertEqual(km._fresh_local_head(), "")
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("git checkout", detail)
+        self.assertFalse(any(a[0] == "git" and "push" in a for a in calls), "nothing pushed")
+
+    def test_a_refusal_at_the_apply_reaches_the_row_and_the_log_as_a_failure(self):
+        # the apply's refusals are not successes: the automatic push publishes them on the row's phase
+        # and in the Log ring with the reason, never as a bare tag and never as "pushed"
+        self._wire(apply_out="DIRTYNOW")
+        self.addCleanup(km._set_auto_push, "TESTHOST", None)
+        before = km._sync_notice_count()
+        ok = km._auto_push_remote("TESTHOST")
+        self.assertFalse(ok)
+        st = km._auto_push_state("TESTHOST")
+        self.assertEqual(st["phase"], "failed")
+        self.assertIn("uncommitted changes", st["detail"])
+        self.assertIn("TESTHOST", st["detail"])
+        rows = [r for r in km._sync_notice_rows(limit=5) if r["text"].find("TESTHOST") >= 0]
+        self.assertTrue(rows and rows[-1]["ok"] is False and "uncommitted changes" in rows[-1]["text"], rows)
+        self.assertEqual(km._sync_notice_count(), before + 1)
+
     def test_a_dirty_local_is_not_refused_it_pushes_committed_head(self):
         # "just take what is committed on local" (the user 2026-07-04): a dirty working tree is NOT a blocker —
         # _update_remote pushes the committed HEAD and never asks you to commit first.
@@ -359,6 +421,221 @@ class UpdateRemote(unittest.TestCase):
         self.assertIn("running", detail)
 
 
+class ApplyHonesty(unittest.TestCase):
+    """The scripts the p2p updater ships over ssh, EXECUTED against a real throwaway git repo (SSH_BIN is
+    swapped for a stub that runs the command locally under a scrubbed env — the same harness the clone
+    discovery tests use). The probe used to answer a FAILING `git status` as a clean tree; the apply used to
+    go from the ancestry check straight to `reset --hard <scratch ref>` with no look at the tree it was about
+    to overwrite and no check that the ref still named the commit this machine pushed. Synthetic repo, no
+    real machine data; the only faked calls are the LOCAL `git push` (the scratch ref is planted directly)
+    and the local head read."""
+
+    def setUp(self):
+        self._run, self._hc, self._ssh = km.subprocess.run, dict(km._HEAD_CACHE), km.SSH_BIN
+        km._HEAD_CACHE.update(ts=0.0, full=None, short=None)
+        self.home = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.home, True)
+        self.repo = os.path.join(self.home, "romp")
+        env = dict(os.environ, GIT_CONFIG_GLOBAL="/dev/null", GIT_CONFIG_NOSYSTEM="1", HOME=self.home)
+        def g(*a, **kw):
+            return subprocess.run(["git", "-C", self.repo] + list(a), capture_output=True, text=True,
+                                  env=env, check=True, **kw).stdout.strip()
+        self.g = g
+        os.makedirs(self.repo)
+        subprocess.run(["git", "init", "-q", "-b", "main", self.repo], check=True, env=env)
+        self.f = os.path.join(self.repo, "f")
+        def commit(text, msg):
+            with open(self.f, "w") as fh:
+                fh.write(text)
+            g("add", "f"); g("-c", "user.name=romp-test", "-c", "user.email=romp-test@TESTHOST", "commit", "-qm", msg)
+            return g("rev-parse", "HEAD")
+        self.A = commit("a\n", "A")            # where the peer sits
+        self.B = commit("b\n", "B")            # this machine's head, a child of A
+        g("reset", "-q", "--hard", self.A)
+        self.C = commit("c\n", "C")            # another sender's build: also a child of A, not B
+        g("reset", "-q", "--hard", self.A)
+        stub = os.path.join(self.home, "ssh")
+        with open(stub, "w") as fh:            # run the probe/apply locally, scrubbed env, fixture HOME
+            fh.write('#!/usr/bin/env bash\nfor last in "$@"; do :; done\n'
+                     'exec env -i HOME="%s" PATH="/usr/bin:/bin" ROMP_REPO_ROOT="%s" bash -c "$last"\n'
+                     % (self.home, self.repo))
+        os.chmod(stub, 0o755)
+        km.SSH_BIN = stub
+        km._remotes["TESTHOST"] = {"host": "TESTHOST"}
+
+    def tearDown(self):
+        km.subprocess.run, km.SSH_BIN = self._run, self._ssh
+        km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(self._hc)
+        km._remotes.pop("TESTHOST", None)
+
+    def _drive(self, lfull, landed=None, between=None):
+        """Run _update_remote with the local head at `lfull`; the faked `git push` plants the scratch ref at
+        `landed` (what actually arrived on the peer) and runs `between` (an event in the window between the
+        probe and the apply). Returns (ok, detail, argv list)."""
+        calls, real, g = [], self._run, self.g
+        def fake(argv, **kw):
+            calls.append(argv)
+            if argv[0] == "git" and "push" in argv:
+                if landed:
+                    g("update-ref", "refs/heads/" + km._P2P_REF, landed)
+                if between:
+                    between()
+                return _R()
+            if argv[0] == "git" and "rev-parse" in argv and "HEAD" in argv:
+                return _R(out=lfull)
+            return real(argv, **kw)                 # the ssh legs run for real through the stub
+        km.subprocess.run = fake
+        try:
+            ok, detail = km._update_remote("TESTHOST")
+        finally:
+            km.subprocess.run = real                # the repo reads below must see the REAL git
+        return ok, detail, calls
+
+    def _scratch(self):
+        r = subprocess.run(["git", "-C", self.repo, "rev-parse", "--verify", "--quiet", "refs/heads/" + km._P2P_REF],
+                           capture_output=True, text=True)
+        return r.stdout.strip()
+
+    def test_an_edit_landing_after_the_probe_is_refused_and_survives(self):
+        # the probe saw a clean tree; an edit lands before the apply; the apply must see it itself
+        def edit():
+            with open(self.f, "w") as fh:
+                fh.write("late edit\n")
+        ok, detail, calls = self._drive(self.B, landed=self.B, between=edit)
+        self.assertFalse(ok, detail)
+        self.assertIn("uncommitted changes", detail)
+        self.assertIn("TESTHOST", detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A, "nothing was reset")
+        self.assertEqual(open(self.f).read(), "late edit\n", "the late edit is intact")
+        self.assertEqual(self._scratch(), "", "the scratch ref is cleaned up")
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"], "no restart is expected of it")
+
+    def test_an_unstaged_edit_already_there_is_refused_at_the_probe(self):
+        # the most common dirty state: an unstaged edit to a tracked file, whose porcelain line starts with
+        # a SPACE (" M f"). The probe used to report the first character, the parser stripped it, and the
+        # peer read as CLEAN: the push went ahead, and the apply's re-check then blamed the peer for an
+        # edit that predated the probe.
+        with open(self.f, "w") as fh:
+            fh.write("edit before the probe\n")
+        ok, detail, calls = self._drive(self.B, landed=self.B)
+        self.assertFalse(ok, detail)
+        self.assertIn("uncommitted changes", detail)
+        self.assertFalse(any(a[0] == "git" and "push" in a for a in calls), "refused at the probe: nothing pushed")
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A)
+        self.assertEqual(open(self.f).read(), "edit before the probe\n")
+        self.assertEqual(self._scratch(), "")
+
+    def test_a_status_that_fails_right_before_the_apply_refuses_and_cleans_up(self):
+        # the probe saw a healthy tree; by the apply its index is unreadable (a lock, a corruption). The
+        # same-shell re-check answers STATERR: nothing is reset, the scratch ref is removed, no restart is
+        # expected, and the row says the tree state could not be read — never the bare tag, never "synced"
+        def corrupt():
+            with open(os.path.join(self.repo, ".git", "index"), "w") as fh:
+                fh.write("garbage")
+        ok, detail, calls = self._drive(self.B, landed=self.B, between=corrupt)
+        self.assertFalse(ok, detail)
+        self.assertIn("TESTHOST", detail)
+        self.assertIn("right before the apply", detail)
+        self.assertIn("state is unknown", detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A, "nothing was reset")
+        self.assertEqual(self._scratch(), "", "the scratch ref is cleaned up")
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"])
+
+    def test_a_failing_status_on_the_peer_is_unknown_never_clean(self):
+        # an index git cannot read: `git status` dies while `rev-parse HEAD` still answers, so the old
+        # probe printed an empty (clean) DIRTY field and the push went ahead
+        with open(os.path.join(self.repo, ".git", "index"), "w") as fh:
+            fh.write("garbage")
+        ok, detail, calls = self._drive(self.B, landed=self.B)
+        self.assertFalse(ok, detail)
+        self.assertIn("state is unknown", detail)
+        self.assertIn("TESTHOST", detail)
+        self.assertFalse(any(a[0] == "git" and "push" in a for a in calls), "nothing was pushed")
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A)
+
+    def test_the_apply_binds_to_the_advertised_commit_not_the_scratch_ref(self):
+        # another sender force-pushed the scratch ref between our push and our apply: the ref names THEIR
+        # build. The old apply reset to the ref and reported our sha as synced.
+        ok, detail, calls = self._drive(self.B, landed=self.C)
+        self.assertFalse(ok, detail)
+        self.assertIn("another push moved it", detail)
+        self.assertIn(self.B[:8], detail)
+        self.assertIn(self.C[:8], detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A, "nothing was reset")
+        self.assertEqual(self._scratch(), self.C, "the other sender's ref is left for its own apply")
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"])
+
+    def test_a_clean_apply_resets_to_exactly_the_advertised_commit(self):
+        # the positive path of the same script: clean tree, ref at our sha → the checkout lands on it (the
+        # fixture has no launcher, so the script stops at NOLAUNCH after the reset, before any restart)
+        ok, detail, calls = self._drive(self.B, landed=self.B)
+        self.assertFalse(ok)
+        self.assertIn("launcher", detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.B)
+        self.assertEqual(self._scratch(), "", "the scratch ref is cleaned up after the reset")
+        apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "reset --hard" in a[-1])
+        self.assertIn("WANT=" + self.B, apply)
+        self.assertIn('reset --hard "$WANT"', apply)
+        self.assertNotIn("reset --hard " + km._P2P_REF, apply, "never the mutable scratch ref")
+        self.assertNotIn("reset --hard %s" % km._P2P_REF, apply)
+        # order inside the one shell: bind, ancestry, tree re-check, then the reset
+        i = apply.index
+        self.assertLess(i('rev-parse --verify --quiet refs/heads/' + km._P2P_REF), i("merge-base --is-ancestor"))
+        self.assertLess(i("merge-base --is-ancestor"), i("status --porcelain"))
+        self.assertLess(i("status --porcelain"), i('reset --hard "$WANT"'))
+        self.assertLess(i("STATERR"), i("DIRTYNOW"), "a failed status refuses before the content is even looked at")
+
+
+class UpdateListing(unittest.TestCase):
+    """The listing the no-host `romp update` chooses hosts from (GET /tunnels?fresh=1) is judged against
+    the head this checkout is at NOW; the dashboard's polls keep reading the 15 s cache (a poll must not
+    fork git)."""
+    STALE, FRESH = "3" * 40, "4" * 40
+
+    def setUp(self):
+        self._run, self._hc = km.subprocess.run, dict(km._HEAD_CACHE)
+        km._BEHIND_CACHE.clear()
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801, "token": "t",
+                                   "status": "up", "sids": [], "kernel_sha": self.STALE[:7]}   # on the OLD commit
+        km._HEAD_CACHE.update(ts=9e18, full=self.STALE, short=self.STALE[:7])                    # what the polls last read
+        fresh = self.FRESH
+        def fake(argv, **kw):
+            if argv[0] == "git" and "rev-parse" in argv and "HEAD" in argv:
+                return _R(out=fresh[:7] if "--short" in argv else fresh)                       # what git says NOW
+            return _R(rc=1)
+        km.subprocess.run = fake
+
+    def tearDown(self):
+        km.subprocess.run = self._run
+        km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(self._hc)
+        km._BEHIND_CACHE.clear()
+        km._remotes.pop("TESTHOST", None)
+
+    def test_a_fresh_listing_is_judged_against_the_head_the_user_has(self):
+        polled = next(t for t in km._tunnels_listing()["tunnels"] if t["host"] == "TESTHOST")
+        self.assertFalse(polled["outOfDate"], "the polls' listing reads the cache")
+        acted = next(t for t in km._tunnels_listing(fresh=True)["tunnels"] if t["host"] == "TESTHOST")
+        self.assertTrue(acted["outOfDate"], "the listing a command acts on sees the commit made just now")
+        self.assertEqual(acted["localSha"], self.FRESH[:7])
+
+    def test_the_route_and_the_cli_agree_on_the_flag(self):
+        import inspect
+        from urllib.parse import parse_qs
+        self.assertIn('_tunnels_listing(fresh=_fresh_listing_asked(q))', inspect.getsource(km.Handler))
+        self.assertIn('_get(u, "/tunnels?fresh=1")', open(os.path.join(BIN, "romp-update")).read())
+        # the contract is the one spelling the CLI sends: parse_qs yields ["0"] for ?fresh=0, so a
+        # truthiness test re-read HEAD for 0 and no while a blank ?fresh= did not
+        self.assertTrue(km._fresh_listing_asked(parse_qs("fresh=1")))
+        for query in ("fresh=0", "fresh=", "fresh=no", "", "other=1"):
+            self.assertFalse(km._fresh_listing_asked(parse_qs(query)), query)
+            row = next(t for t in km._tunnels_listing(fresh=km._fresh_listing_asked(parse_qs(query)))["tunnels"]
+                       if t["host"] == "TESTHOST")
+            self.assertFalse(row["outOfDate"], "%r must not re-read HEAD" % query)
+        row = next(t for t in km._tunnels_listing(fresh=km._fresh_listing_asked(parse_qs("fresh=1")))["tunnels"]
+                   if t["host"] == "TESTHOST")
+        self.assertTrue(row["outOfDate"])
+
+
 class UpdateEndpoint(unittest.TestCase):
     def test_post_tunnels_update_calls_update_remote_and_reports(self):
         import inspect
@@ -442,6 +719,15 @@ class RompUpdateCLI(unittest.TestCase):
                                                {"host": "gpu1", "outOfDate": False}]}
         self.assertEqual(ru.main([]), 0)
         self.assertEqual(self.posted, [("/tunnels/update", {"host": "TESTHOST"})], "only the stale remote is updated")
+
+    def test_no_arg_asks_for_a_listing_judged_against_the_current_head(self):
+        # the hosts this command pushes to are chosen from the listing's outOfDate; a listing built from
+        # the polls' 15 s head cache within 15 s of a local commit says "all up to date" and pushes nothing
+        seen = []
+        ru._get = lambda u, path: seen.append(path) or {"tunnels": [{"host": "TESTHOST", "outOfDate": True}]}
+        self.assertEqual(ru.main([]), 0)
+        self.assertEqual(seen, ["/tunnels?fresh=1"], "the kernel re-reads HEAD for the listing this command acts on")
+        self.assertEqual(self.posted, [("/tunnels/update", {"host": "TESTHOST"})])
 
     def test_no_arg_all_current_updates_nothing(self):
         ru._get = lambda u, path: {"tunnels": [{"host": "gpu1", "outOfDate": False}]}

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -320,6 +320,51 @@ class UpdateRemote(unittest.TestCase):
         self.assertTrue(rows and rows[-1]["ok"] is False and "uncommitted changes" in rows[-1]["text"], rows)
         self.assertEqual(km._sync_notice_count(), before + 1)
 
+    def test_the_automatic_push_is_keyed_on_the_sha_it_used_not_the_polls_cache(self):
+        # The supervisor hook gates one attempt per (remote sha, local head) and keys it on the polls' CACHED
+        # head. The push reads the head the user has and writes it into that cache, so the next pass computed
+        # a NEW key for the SAME advance and fired a second push, which came back "already up to date ... has
+        # not restarted into it yet" and logged "pushed" twice. The attempt is keyed on the sha the push used.
+        stale, fresh, remote = "3" * 40, "4" * 40, "2" * 40
+        calls, saved = [], (km._behind_info, km.threading.Thread, km._auto_update_remotes_on())
+        def fake(argv, **kw):
+            calls.append(argv)
+            if argv[0] == "git" and "push" in argv:
+                return _R()
+            if argv[0] == "git" and "rev-parse" in argv and "HEAD" in argv:
+                return _R(out=fresh[:7] if "--short" in argv else fresh)             # what git says NOW
+            cmd = argv[-1]
+            if "for d in" in cmd:
+                return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % remote)         # the peer never restarts
+            if "merge-base" in cmd or "reset --hard" in cmd:
+                return _R(out="SYNCED:4444444:QUIET")
+            return _R()
+        km.subprocess.run = fake
+        km._behind_info = lambda sha, head=None: {"behind": 1, "ahead": 0, "date": ""}   # a straight fast-forward
+        class _Now:                                                                 # the worker, run inline
+            def __init__(self, target=None, args=(), daemon=None):
+                self._t, self._a = target, args
+            def start(self):
+                self._t(*self._a)
+        km.threading.Thread = _Now
+        km._set_auto_update_remotes(True)
+        km._auto_push.clear(); km._auto_push_tried.clear()
+        km._HEAD_CACHE.update(ts=9e18, full=stale, short=stale[:7])                # what the polls last read
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "kernel_sha": remote[:7]}
+        before = km._sync_notice_count()
+        try:
+            km._maybe_auto_push(dict(km._remotes["TESTHOST"]))                      # this pass pushes
+            km._maybe_auto_push(dict(km._remotes["TESTHOST"]))                      # the next pass: same advance
+        finally:
+            km._behind_info, km.threading.Thread = saved[0], saved[1]
+            km._set_auto_update_remotes(saved[2])
+            km._auto_push.clear(); km._auto_push_tried.clear()
+            km._remotes.pop("TESTHOST", None)
+        pushes = [a for a in calls if a[0] == "git" and "push" in a]
+        self.assertEqual(len(pushes), 1, "one advance, one push")
+        self.assertIn(fresh + ":refs/heads/" + km._P2P_REF, pushes[0], "the head the user has is what travelled")
+        self.assertEqual(km._sync_notice_count(), before + 1, "and one Log notice, not a duplicate 'pushed'")
+
     def test_a_dirty_local_is_not_refused_it_pushes_committed_head(self):
         # "just take what is committed on local" (the user 2026-07-04): a dirty working tree is NOT a blocker —
         # _update_remote pushes the committed HEAD and never asks you to commit first.
@@ -496,6 +541,30 @@ class ApplyHonesty(unittest.TestCase):
                            capture_output=True, text=True)
         return r.stdout.strip()
 
+    def _sibling_push_at_the_apply(self, dirty=False):
+        """Make the apply's own `git status` the moment another sender's push lands: the scratch ref moves
+        from our B to their C (a child of A, not of B) AFTER the sha gate has passed on B, which is the one
+        window the gate cannot see. Done with a `git` shim first on the apply shell's PATH that acts once,
+        when armed, and otherwise hands straight to the real git; the probe's status runs before the push and
+        so before the arming. `dirty` also lands an edit there, so the apply refuses. Returns the `between`
+        hook that arms it."""
+        import shlex
+        real_git, shim_dir, marker = shutil.which("git"), os.path.join(self.home, "bin"), os.path.join(self.home, "armed")
+        os.makedirs(shim_dir)
+        with open(os.path.join(shim_dir, "git"), "w") as fh:
+            fh.write('#!/usr/bin/env bash\n'
+                     'if [ "$3" = status ] && [ -e %s ]; then rm -f %s; %s -C %s update-ref refs/heads/%s %s; %sfi\n'
+                     'exec %s "$@"\n' % (shlex.quote(marker), shlex.quote(marker), shlex.quote(real_git),
+                                         shlex.quote(self.repo), km._P2P_REF, self.C,
+                                         ('printf "late edit\\n" >%s; ' % shlex.quote(self.f)) if dirty else "",
+                                         shlex.quote(real_git)))
+        os.chmod(os.path.join(shim_dir, "git"), 0o755)
+        with open(km.SSH_BIN, "w") as fh:
+            fh.write('#!/usr/bin/env bash\nfor last in "$@"; do :; done\n'
+                     'exec env -i HOME="%s" PATH="%s:/usr/bin:/bin" ROMP_REPO_ROOT="%s" bash -c "$last"\n'
+                     % (self.home, shim_dir, self.repo))
+        return lambda: open(marker, "w").close()
+
     def test_an_edit_landing_after_the_probe_is_refused_and_survives(self):
         # the probe saw a clean tree; an edit lands before the apply; the apply must see it itself
         def edit():
@@ -526,7 +595,8 @@ class ApplyHonesty(unittest.TestCase):
         self.assertEqual(self._scratch(), "")
 
     def test_a_status_that_fails_right_before_the_apply_refuses_and_cleans_up(self):
-        # the probe saw a healthy tree; by the apply its index is unreadable (a lock, a corruption). The
+        # the probe saw a healthy tree; by the apply its index is unreadable (a corruption; an index LOCK is
+        # not this case, `git status` reads through one and the reset then fails as RESETFAIL). The
         # same-shell re-check answers STATERR: nothing is reset, the scratch ref is removed, no restart is
         # expected, and the row says the tree state could not be read — never the bare tag, never "synced"
         def corrupt():
@@ -564,6 +634,33 @@ class ApplyHonesty(unittest.TestCase):
         self.assertEqual(self.g("rev-parse", "HEAD"), self.A, "nothing was reset")
         self.assertEqual(self._scratch(), self.C, "the other sender's ref is left for its own apply")
         self.assertNotIn("restartExpected", km._remotes["TESTHOST"])
+
+    def test_a_sibling_senders_ref_landing_after_the_gate_survives_a_refusal(self):
+        # the gate passed on our B; then another sender's push moved the scratch ref to their C and an edit
+        # made the tree dirty. The refusal's cleanup used to delete the ref UNCONDITIONALLY: that sender's
+        # apply then found nothing under the name and was told a phantom push had moved it. The delete is
+        # guarded by our sha, so their ref survives, and the detail says it was left for them.
+        arm = self._sibling_push_at_the_apply(dirty=True)
+        ok, detail, _ = self._drive(self.B, landed=self.B, between=arm)
+        self.assertFalse(ok, detail)
+        self.assertIn("uncommitted changes", detail)
+        self.assertIn("another sender", detail)
+        self.assertIn("left alone", detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.A, "nothing was reset")
+        self.assertEqual(open(self.f).read(), "late edit\n")
+        self.assertEqual(self._scratch(), self.C, "the other sender's ref is left for its own apply")
+        self.assertNotIn("restartExpected", km._remotes["TESTHOST"])
+
+    def test_a_sibling_senders_ref_landing_after_the_gate_survives_the_reset_too(self):
+        # the same window on the success path: our reset to B goes ahead (the gate held, the tree is clean)
+        # and the cleanup after it finds the ref at their C, so it stays; the outcome still names what it did
+        arm = self._sibling_push_at_the_apply()
+        ok, detail, _ = self._drive(self.B, landed=self.B, between=arm)
+        self.assertFalse(ok)                                   # the fixture has no launcher: NOLAUNCH after the reset
+        self.assertIn("launcher", detail)
+        self.assertIn("another sender", detail)
+        self.assertEqual(self.g("rev-parse", "HEAD"), self.B, "our reset went ahead")
+        self.assertEqual(self._scratch(), self.C, "their ref survives our cleanup")
 
     def test_a_clean_apply_resets_to_exactly_the_advertised_commit(self):
         # the positive path of the same script: clean tree, ref at our sha → the checkout lands on it (the
@@ -616,6 +713,30 @@ class UpdateListing(unittest.TestCase):
         self.assertFalse(polled["outOfDate"], "the polls' listing reads the cache")
         acted = next(t for t in km._tunnels_listing(fresh=True)["tunnels"] if t["host"] == "TESTHOST")
         self.assertTrue(acted["outOfDate"], "the listing a command acts on sees the commit made just now")
+        self.assertEqual(acted["localSha"], self.FRESH[:7])
+
+    def test_the_handler_serves_the_fresh_listing_for_the_flag_and_the_cached_one_without(self):
+        # the same three requests the CLI and the dashboard make, through the real Handler on a loopback
+        # server (the /tunnels tests' shape), so the wiring is exercised rather than pinned as source text
+        import http.client
+        import threading
+        from http.server import ThreadingHTTPServer
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.server_close)
+        self.addCleanup(srv.shutdown)
+        def get(path):
+            c = http.client.HTTPConnection("127.0.0.1", srv.server_address[1], timeout=5)
+            c.request("GET", path, headers={"X-Romp-Token": km.TOKEN})     # the serve token gates every route
+            resp = c.getresponse()
+            raw = resp.read()
+            c.close()
+            self.assertEqual(resp.status, 200, raw)
+            return next(t for t in json.loads(raw.decode())["tunnels"] if t["host"] == "TESTHOST")
+        self.assertFalse(get("/tunnels")["outOfDate"], "a poll reads the cache")
+        self.assertFalse(get("/tunnels?fresh=0")["outOfDate"], "only the one spelling asks for a re-read")
+        acted = get("/tunnels?fresh=1")
+        self.assertTrue(acted["outOfDate"], "the listing `romp update` acts on sees the commit made just now")
         self.assertEqual(acted["localSha"], self.FRESH[:7])
 
     def test_the_route_and_the_cli_agree_on_the_flag(self):

--- a/tests/test_kernel_ssh_noise.py
+++ b/tests/test_kernel_ssh_noise.py
@@ -92,7 +92,8 @@ class DivergedMessageIsActionable(unittest.TestCase):
                 return subprocess.CompletedProcess(argv, 0, "DIVERGED\n", PQ_WARNING)
             return subprocess.CompletedProcess(argv, 0, "DIR:/home/u/romp\nHEAD:deadbeef\nDIRTY:\n", PQ_WARNING)
         with mock.patch.object(km.subprocess, "run", side_effect=fake_run), \
-             mock.patch.object(km, "_local_head", side_effect=lambda short=False: "cafe1234" if not short else "cafe123"):
+             mock.patch.object(km, "_local_head", side_effect=lambda short=False: "cafe1234" * 5 if not short else "cafe123"), \
+             mock.patch.object(km, "_fresh_local_head", return_value="cafe1234" * 5):
             return km._update_remote("TESTHOST")
 
     def test_names_the_rewritten_history_cause_and_the_remedy(self):

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -436,7 +436,7 @@ class DriftWiring(unittest.TestCase):
         # drift pass could hit between "checkout ahead" and "row on disk" — and the local converge's
         # row carries the sha it deploys, so a quiet `romp refresh` is matched, not guessed at
         ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
-        reset = ksrc.index("reset --hard %s >/dev/null 2>&1 || {")
+        reset = ksrc.index('reset --hard "$WANT" >/dev/null 2>&1 || {')
         row = ksrc.index("\\'action\\':\\'p2p-update\\',")     # the shell script's escaped spelling
         owned = ksrc.index("'OWNED=0; if command -v node")
         self.assertLess(reset, row, "the row says the checkout IS at the sha: it follows the reset")

--- a/tests/test_peer_fast_forward.py
+++ b/tests/test_peer_fast_forward.py
@@ -56,8 +56,8 @@ class AskGate(unittest.TestCase):
 
     def _gate(self, behind, ahead, checkin=True, ood=True):
         saved = (km._remote_out_of_date, km._behind_info)
-        km._remote_out_of_date = lambda r: ood
-        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead, "date": ""}
+        km._remote_out_of_date = lambda r, head=None: ood
+        km._behind_info = lambda sha, head=None: {"behind": behind, "ahead": ahead, "date": ""}
         try:
             return km._is_ask_pull(_row(checkin_peer=checkin))
         finally:
@@ -78,8 +78,8 @@ class AskGate(unittest.TestCase):
 
     def test_the_row_publishes_the_verdict(self):
         saved = (km._remote_out_of_date, km._behind_info)
-        km._remote_out_of_date = lambda r: True
-        km._behind_info = lambda sha: {"behind": 3, "ahead": 0, "date": "2026-07-28"}
+        km._remote_out_of_date = lambda r, head=None: True
+        km._behind_info = lambda sha, head=None: {"behind": 3, "ahead": 0, "date": "2026-07-28"}
         try:
             pub = km._remote_public(_row())
         finally:


### PR DESCRIPTION
The p2p updater re-checks a peer's tree before resetting it, binds to the advertised commit, and pushes the head the user has

Defects in the peer-to-peer updater (kernel/kernel.py: _update_remote and
the shell it ships, _discover_remote_clone, _pull_remote, _local_head and
its callers; cli/update.py):

1. The remote APPLY went from `merge-base --is-ancestor` straight to
   `git reset --hard <scratch ref>`. Its only view of the peer's working
   tree was the DISCOVER probe, an ssh round-trip earlier, so an edit that
   landed on the peer in that window was reset away: uncommitted work on
   another machine destroyed, reported as "synced".
2. The probe answered `DIRTY:$(git status --porcelain | head -c 1)`. Two
   ways that read a dirty or unreadable tree as CLEAN: a `git status` that
   FAILED (an index lock, a corrupt index, an I/O error) printed an empty
   field; and an unstaged edit to a tracked file, the most common dirty
   state, prints ` M f`, whose first character is a SPACE the parser
   stripped. Either way the push and reset went ahead.
3. Both the reset and the pull bound to mutable names, not to the commit
   in hand: the apply reset to `romp-p2p-sync` (a scratch ref every sender
   force-pushes, so a concurrent sender's build could be installed under
   this machine's report), and the pull merged `FETCH_HEAD` (rewritten by
   any other fetch into the checkout between our fetch and our merge).
4. Every decision about what to ship read `_local_head()`, the 15 s cache
   the dashboard polls through. Within 15 s of a local commit: `romp
   update <host>` compared the peer to the PREVIOUS head and came back
   "already up to date" with nothing pushed; the no-host `romp update`
   chose hosts by the listing's `outOfDate`, computed from the same cache,
   and printed "all attached remotes are up to date"; the restart-all
   plan judged a peer sitting on the previous commit "already on this
   build" and restarted it where a push was owed; and when a push did
   happen, the restart the far kernel was told to expect and the
   restart-audit reason named the old sha.

The fix, inside the existing shapes:

- The discover probe answers one token per state: `DIRTY:` (clean),
  `DIRTY:1` (any status output at all), `DIRTY:STATERR` (status itself
  failed). `_update_remote` refuses on STATERR before any push, saying the
  state is unknown, never that the tree is clean.
- The apply script re-checks the tree IN THE SAME SHELL immediately before
  `reset --hard`: a status that fails answers STATERR, any status output
  answers DIRTYNOW; both delete the scratch ref, reset nothing, and exit.
  The DIRTYNOW detail states only what is true (the tree has uncommitted
  changes; nothing was reset) and makes no claim about when they appeared.
- The apply binds to the exact 40-hex sha this call advertised: the push
  refspec is `<sha>:refs/heads/romp-p2p-sync` (not `HEAD:`), the script
  resolves the scratch ref and refuses with REFMISMATCH unless it equals
  that sha (leaving the ref alone: it is the other sender's to apply), and
  the ancestry check and the reset both name the sha. Every local short
  sha the push reports (the audit-row reason, the details, the restart
  expectation) derives from that same sha, never from a later cache read.
- The pull verifies that the fetch brought the commit the peer's probe
  REPORTED (`rev-parse --verify <sha>^{commit}`) and runs merge-base /
  rev-list / merge --ff-only on that sha. FETCH_HEAD enters no decision.
  It refuses up front when the peer reported no commit, and the one
  refusal left after the fetch is the honest one: the peer moved off the
  commit it reported.
- `_fresh_local_head()` reads HEAD from git itself (through `_read_head`,
  the one reader the poll cache also fills from) and then WRITES the
  cache, so the value acted on is the value read and every display in the
  call agrees with it. It is read by `_update_remote`, `_pull_remote`, the
  restart-all run (once, so every row is judged against the same commit),
  and the GET /tunnels listing when asked: `_tunnels_listing(fresh=True)`,
  which the no-host `romp update` requests as `/tunnels?fresh=1`. The
  dashboard's polls keep the cache and its 15 s TTL unchanged.

Every refusal returns (False, detail) and so reaches the user through the
surfaces the path already has: the `/tunnels/update` and `/tunnels/pull`
502 body, the automatic push's failed row phase plus its Log notice
(`_auto_push_remote`), and the restart-all report row. None is reported
as a success; a refusal at the apply also withdraws the restart
expectation, as DIVERGED already did.

Unchanged: the restart half of the apply (manager quiet window, fallback,
audit rows, setsid), the DIVERGED/RESETFAIL/NOLAUNCH handling and wording,
the pull's clean-local-tree and ff-only rules, `_fleet_restart_plan`
itself (still a pure decision), `_restart_remote_kernel` (discovers,
never resets), and the polls' head cache.

Tests (synthetic fixtures, TESTHOST, a throwaway git repo). The new
ApplyHonesty class EXECUTES the real probe and apply scripts against that
repo through an SSH_BIN stub (the clone-discovery harness), faking only
the local `git push` and head read. Each new test fails on origin/main:
- tests/test_kernel_remote_update.py
  - an edit landing after the probe is refused and survives (main reset
    the repo; the edit was gone)
  - an unstaged edit already there is refused at the probe (main pushed)
  - a failing status on the peer is unknown, never clean (main pushed and
    tried the reset)
  - a status that fails right before the apply refuses and cleans up
    (main reset or failed the reset; no scratch-ref cleanup, no reason)
  - the apply binds to the advertised commit, not the scratch ref (main
    installed the other sender's commit)
  - a clean apply resets to exactly the advertised commit
  - a commit made just before the update is what gets pushed (main:
    "already up to date", nothing pushed)
  - a head that is not a full sha is refused, not pushed
  - a refusal at the apply reaches the row and the Log as a failure
    (main surfaced the bare tag)
  - `romp update` with no host asks for `/tunnels?fresh=1`; the listing
    judges outOfDate against the head the user has (UpdateListing)
- tests/test_kernel_remote_pull.py: the merge binds to the reported
  commit and never consults FETCH_HEAD; a peer that moved off the commit
  it reported is refused; a peer that reports no commit is not pulled; a
  local move since the last poll does not hide a pull
- tests/test_fleet_restart.py: the restart-all plan is judged against the
  head this checkout is at now (main restarted where a push was owed)
The apply-STATERR case and the 40-hex pin exist to kill mutants (a
dropped `exit 0`, a dropped `update-ref -d`, a dropped tag handler; a
short head), each verified by hand one at a time. Two fixtures that
stubbed the head with an 8-char sha now stub the transport's read with a
full one (test_kernel_pkill_self_match.py, test_kernel_ssh_noise.py);
test_main_drift_notice.py's pin on the apply's reset line follows the
new literal.

Module runs on this tree, one process at a time: test_kernel_remote_update
57 passed, test_kernel_remote_pull 24, test_fleet_restart 19,
test_main_drift_notice 49, test_remote_clone_discovery 7,
test_kernel_fork_burn 5, test_kernel_pkill_self_match 3,
test_kernel_ssh_noise 10. Full suite left to CI (not run on the
development machine).



## Tier

**fix** — a bug fix with tests that fail before it.

## Notes for review

- Tests were run per module on the development machine (the touched modules, one process at a time); the full suite is left to this PR's CI. The `ApplyHonesty` class executes the real probe and apply scripts against a throwaway repository through an `SSH_BIN` stub, faking only the local push and the head read, so the shell paths are exercised as shipped.
- `bin/romp-update` is a symlink to `cli/update.py`; the no-host `romp update` now asks the kernel for a listing computed against a freshly read head (`GET /tunnels?fresh=1`, the flag honored only for the literal `1`), so a commit made seconds earlier is what gets pushed. Dashboard polls never pass the flag, so their cost is unchanged.
- Deliberately unchanged and named in the body: the residual sub-second window between the apply's same-shell status check and its reset (not closable atomically), and the poll cache's TTL for display.
- Sits on today's main (83b1f3a4, after #1024); the drift module's one source pin on the apply's reset line follows the new spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
