### PR TITLE
T245: scrollbar message notches follow a turn that grows after the paint, and read the real scrollbar when everything is rendered

### DIFF
--- a/tests/test_scroll_marks_growth.py
+++ b/tests/test_scroll_marks_growth.py
@@ -11,9 +11,16 @@ smaller frame. Nothing keyed the paint on "a rendered unit changed height".
 
 The executed guard here drives the real /chat page: after the first paint a rendered turn GROWS (a block
 appended to the last turn — the same thing a late figure does), and the user message's notch must follow
-the scrollbar's truth (red on main: the notch stays where the stale frame put it). Skips LOUDLY without the
-extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
-ui/webview/scroll-marks.test.ts. All fixtures synthetic.
+the scrollbar's truth (red on main: the notch stays where the stale frame put it).
+
+Second executed guard (review of the fix, 2026-09-08): with every unit rendered the frame reads the real
+scrollbar, and that must hold when ONE UNIT OWNS SEVERAL .turn NODES — compact mode tags an expanded tool
+group's child turns, and any absorbed cue, with their unit's data-unit. The first cut gated the exact frame
+on the NODE count equalling the unit count, so opening a tool group silently dropped the frame back to the
+virtual sum (measured 11px off on a five-unit page) and the notch changed basis on every expand/collapse.
+
+Both skip LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins
+ride ui/webview/scroll-marks.test.ts. All fixtures synthetic.
 """
 import json
 import os
@@ -53,7 +60,12 @@ catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
-await page.waitForSelector(".scroll-marks .scroll-mark", { timeout: 20000 });
+try { await page.waitForSelector(".scroll-marks .scroll-mark", { timeout: 20000 }); }
+catch (e) {   // say what the page held instead of a bare timeout
+  const st = await page.evaluate(() => ({ turns: document.querySelectorAll(".turn[data-unit]").length,
+    box: (document.querySelector(".scroll-marks") || {}).outerHTML || null, sh: document.getElementById("content")?.scrollHeight }));
+  console.error("no notch painted: " + JSON.stringify(st)); process.exit(1);
+}
 await page.waitForTimeout(600);
 const measure = () => page.evaluate(() => {
   const content = document.getElementById("content");
@@ -64,7 +76,10 @@ const measure = () => page.evaluate(() => {
   const tr = turn.getBoundingClientRect();
   const mid = content.scrollTop + (tr.top - c.top) + tr.height / 2;
   const expected = Math.round((mid / content.scrollHeight) * (c.height - 4));
-  return { marks, expected, scrollHeight: content.scrollHeight, turns: document.querySelectorAll(".turn[data-unit]").length };
+  const nodes = Array.from(document.querySelectorAll(".turn[data-unit]"));
+  return { marks, expected, scrollHeight: content.scrollHeight, turns: nodes.length,
+           units: new Set(nodes.map((n) => n.dataset.unit)).size, groups: document.querySelectorAll(".turn-toolgroup").length,
+           groupOpen: !!document.querySelector(".turn-toolgroup.expanded") };
 });
 const before = await measure();
 // a rendered unit GROWS after the paint — exactly what a late-loading figure does to its turn
@@ -79,6 +94,24 @@ await page.waitForTimeout(400);            // several frames — the repaint is 
 const after = await measure();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "-after-growth.png" });
 fs.writeSync(1, "RESULT:" + JSON.stringify({ before, after }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+# same page, same first paint; then the tool group is OPENED (compact mode is the default: its three child
+# turns join the DOM tagged with the group's unit) and CLOSED again, the notch measured in each state
+DRIVER_EXPAND = DRIVER.split("const before = await measure();")[0] + r"""
+const collapsed = await measure();
+await page.click(".turn-toolgroup .toolgroup-line");
+await page.waitForSelector(".turn-toolgroup.expanded", { timeout: 10000 });
+await page.waitForTimeout(400);
+const expanded = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-group-open.png" });
+await page.click(".turn-toolgroup .toolgroup-line");
+await page.waitForSelector(".turn-toolgroup:not(.expanded)", { timeout: 10000 });
+await page.waitForTimeout(400);
+const closed = await measure();
+fs.writeSync(1, "RESULT:" + JSON.stringify({ collapsed, expanded, closed }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -110,14 +143,27 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
         claude = os.path.join(cls.lab, "claude")
         proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
         os.makedirs(proj, exist_ok=True)
-        # a user message near the top, then a tall-ish assistant reply — the notch marks the user turn
+        # a user message near the top, three consecutive tool calls (compact mode folds them into ONE tool
+        # group — a unit that owns several .turn nodes once expanded), then a tall-ish assistant reply — the
+        # notch marks the user turn
         t0 = "2026-09-07T00:00:%02d.000Z"
         recs = [{"type": "user", "uuid": "11111111-2222-3333-4444-555555555555", "parentUuid": None,
-                 "timestamp": t0 % 0, "sessionId": SID, "message": {"role": "user", "content": "plot the retry curve"}},
-                {"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
-                 "parentUuid": "11111111-2222-3333-4444-555555555555", "timestamp": t0 % 5, "sessionId": SID,
-                 "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
-                             "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(12))}]}}]
+                 "timestamp": t0 % 0, "sessionId": SID, "message": {"role": "user", "content": "plot the retry curve"}}]
+        prev = "11111111-2222-3333-4444-555555555555"
+        for k in range(3):
+            a = "33333333-4444-5555-6666-77777777777%d" % k
+            r = "44444444-5555-6666-7777-88888888888%d" % k
+            recs.append({"type": "assistant", "uuid": a, "parentUuid": prev, "timestamp": t0 % (1 + k), "sessionId": SID,
+                         "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                                     "content": [{"type": "tool_use", "id": "tu_%d" % k, "name": "Bash",
+                                                  "input": {"command": "uv run pytest -q tests/test_retry_%d.py" % k}}]}})
+            recs.append({"type": "user", "uuid": r, "parentUuid": a, "timestamp": t0 % (1 + k), "sessionId": SID,
+                         "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_%d" % k, "content": "3 passed"}]}})
+            prev = r
+        recs.append({"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
+                     "parentUuid": prev, "timestamp": t0 % 5, "sessionId": SID,
+                     "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                                 "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(12))}]}})
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         cls.port = _free_port()
         cls.token = "testtok-notchgrowth"
@@ -146,14 +192,14 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
             cls.kernel.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def test_a_notch_follows_its_message_when_a_rendered_turn_grows_after_the_paint(self):
-        cfg = os.path.join(self.lab, "cfg.json")
+    def _drive(self, script, name):
+        cfg = os.path.join(self.lab, name + ".json")
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
                        "shots": os.environ.get("NOTCH_GROWTH_SHOTS", "")}, f)
-        driver = os.path.join(self.lab, "driver.mjs")
+        driver = os.path.join(self.lab, name + ".mjs")
         with open(driver, "w") as f:
-            f.write(DRIVER)
+            f.write(script)
         p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
                            env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
         if p.returncode == 3:
@@ -161,7 +207,10 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
         self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
-        r = json.loads(line[len("RESULT:"):])
+        return json.loads(line[len("RESULT:"):])
+
+    def test_a_notch_follows_its_message_when_a_rendered_turn_grows_after_the_paint(self):
+        r = self._drive(DRIVER, "growth")
         b, a = r["before"], r["after"]
         self.assertEqual(len(b["marks"]), 1, "one notch: the one user message (%r)" % b)
         self.assertGreater(a["scrollHeight"], b["scrollHeight"] + 1000, "the rendered turn did grow: %r → %r" % (b["scrollHeight"], a["scrollHeight"]))
@@ -174,6 +223,22 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
         self.assertTrue(d_before <= 3 and d_after <= 3,
                         "notch vs its message — before growth: notch %r expected %r (off by %d); after growth: notch %r expected %r (off by %d)"
                         % (b["marks"], b["expected"], d_before, a["marks"], a["expected"], d_after))
+
+    def test_the_exact_frame_holds_when_one_unit_owns_several_turn_nodes(self):
+        r = self._drive(DRIVER_EXPAND, "expand")
+        c, e, z = r["collapsed"], r["expanded"], r["closed"]
+        self.assertEqual(c["groups"], 1, "compact mode folded the three tool calls into one group: %r" % c)
+        self.assertTrue(e["groupOpen"] and not c["groupOpen"] and not z["groupOpen"], "the group opened, then closed: %r" % r)
+        # the expansion is the input under test: MORE .turn nodes than units, every unit still rendered, no spacer
+        self.assertGreater(e["turns"], e["units"], "an open group's child turns carry the group's unit: %r" % e)
+        self.assertEqual(e["units"], c["units"], "the unit set did not change: %r vs %r" % (c, e))
+        self.assertEqual(len(c["marks"]), 1, "one notch: the one user message (%r)" % c)
+        d = {k: abs(v["marks"][0] - v["expected"]) for k, v in (("collapsed", c), ("expanded", e), ("closed", z))}
+        # red before the fix: collapsed and closed read the scrollbar's truth, expanded fell back to the unit-height
+        # sum (off by the turn gaps it omits) — so the notch changed basis on every expand and collapse
+        self.assertTrue(all(x <= 3 for x in d.values()),
+                        "notch vs its message, off by %r px — collapsed: notch %r expected %r; expanded: notch %r expected %r; closed: notch %r expected %r"
+                        % (d, c["marks"], c["expected"], e["marks"], e["expected"], z["marks"], z["expected"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_scroll_marks_growth.py
+++ b/tests/test_scroll_marks_growth.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""T245 (the user 2026-09-07): the chat scrollbar's blue user-message notches drifted once a turn with many
+inline figures was on screen — a notch sat well below the thumb while the message it marked was in view.
+
+Convicted at the source: contentOffsetFrame is a virtual prefix-sum over cached measured unit heights, and
+the cache is refreshed only inside a paint (paintScrollMarks ← scheduleRailSticky's rAF, whose triggers are
+scroll, resize and a few render-side callers). previewFull's figures are lazy, async-decoded images with
+no intrinsic size before load, so every figure that loads after the paint grows its turn and the content's
+scrollHeight with NO repaint: the native thumb moves to the new truth while the notches keep the stale,
+smaller frame. Nothing keyed the paint on "a rendered unit changed height".
+
+The executed guard here drives the real /chat page: after the first paint a rendered turn GROWS (a block
+appended to the last turn — the same thing a late figure does), and the user message's notch must follow
+the scrollbar's truth (red on main: the notch stays where the stale frame put it). Skips LOUDLY without the
+extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
+ui/webview/scroll-marks.test.ts. All fixtures synthetic.
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector(".scroll-marks .scroll-mark", { timeout: 20000 });
+await page.waitForTimeout(600);
+const measure = () => page.evaluate(() => {
+  const content = document.getElementById("content");
+  const c = content.getBoundingClientRect();
+  const marks = Array.from(document.querySelectorAll(".scroll-marks .scroll-mark")).map((m) => parseFloat(m.style.top));
+  // the FIRST user turn's slot middle in scroll space, as the scrollbar sees it
+  const turn = document.querySelector(".turn.turn-user[data-unit]");
+  const tr = turn.getBoundingClientRect();
+  const mid = content.scrollTop + (tr.top - c.top) + tr.height / 2;
+  const expected = Math.round((mid / content.scrollHeight) * (c.height - 4));
+  return { marks, expected, scrollHeight: content.scrollHeight, turns: document.querySelectorAll(".turn[data-unit]").length };
+});
+const before = await measure();
+// a rendered unit GROWS after the paint — exactly what a late-loading figure does to its turn
+await page.evaluate(() => {
+  const turns = document.querySelectorAll(".turn[data-unit]");
+  const last = turns[turns.length - 1];
+  const block = document.createElement("div");
+  block.style.height = "1500px"; block.textContent = "late figure stand-in";
+  last.appendChild(block);
+});
+await page.waitForTimeout(400);            // several frames — the repaint is event-keyed, not timed; this is slack
+const after = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-after-growth.png" });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ before, after }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedNotchFollowsGrowth(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="notch-growth-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        os.makedirs(proj, exist_ok=True)
+        # a user message near the top, then a tall-ish assistant reply — the notch marks the user turn
+        t0 = "2026-09-07T00:00:%02d.000Z"
+        recs = [{"type": "user", "uuid": "11111111-2222-3333-4444-555555555555", "parentUuid": None,
+                 "timestamp": t0 % 0, "sessionId": SID, "message": {"role": "user", "content": "plot the retry curve"}},
+                {"type": "assistant", "uuid": "22222222-3333-4444-5555-666666666666",
+                 "parentUuid": "11111111-2222-3333-4444-555555555555", "timestamp": t0 % 5, "sessionId": SID,
+                 "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                             "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(12))}]}}]
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.port = _free_port()
+        cls.token = "testtok-notchgrowth"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        env.pop("ROMP_STATE_DIR", None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_a_notch_follows_its_message_when_a_rendered_turn_grows_after_the_paint(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "shots": os.environ.get("NOTCH_GROWTH_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        b, a = r["before"], r["after"]
+        self.assertEqual(len(b["marks"]), 1, "one notch: the one user message (%r)" % b)
+        self.assertGreater(a["scrollHeight"], b["scrollHeight"] + 1000, "the rendered turn did grow: %r → %r" % (b["scrollHeight"], a["scrollHeight"]))
+        d_before = abs(b["marks"][0] - b["expected"])
+        d_after = abs(a["marks"][0] - a["expected"])
+        # THE FIX, two halves in one verdict so the evidence carries both numbers: (1) with every unit rendered
+        # the frame is the scrollbar's own truth (on main the notch sat off its message by the turn gaps the
+        # unit-height sum omits); (2) after a rendered unit grows — no scroll, no resize, no new event — the
+        # notch follows (on main it stayed on the stale frame's position)
+        self.assertTrue(d_before <= 3 and d_after <= 3,
+                        "notch vs its message — before growth: notch %r expected %r (off by %d); after growth: notch %r expected %r (off by %d)"
+                        % (b["marks"], b["expected"], d_before, a["marks"], a["expected"], d_after))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -762,7 +762,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; }
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; ro?: ResizeObserver; }
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -2129,10 +2129,25 @@ function contentOffsetFrame(content: HTMLElement, v: View, s: Session):
   // remember every rendered unit's measured height — the virtual frame feeds on them
   let uh = unitHeights.get(activeId!);
   if (!uh) { uh = new Map(); unitHeights.set(activeId!, uh); }
-  for (const node of Array.from(v.el.querySelectorAll<HTMLElement>(".turn[data-unit]"))) {
+  const nodes = Array.from(v.el.querySelectorAll<HTMLElement>(".turn[data-unit]"));
+  const exact = new Map<number, number>();               // unit → its real middle in scroll space (fully rendered only)
+  for (const node of nodes) {
     const u = Number(node.dataset.unit);
     const h = node.offsetHeight;
     if (Number.isFinite(u) && h > 0) uh.set(u, h);
+    if (Number.isFinite(u)) {
+      const r = node.getBoundingClientRect();
+      exact.set(u, content.scrollTop + (r.top - cRect.top) + r.height / 2);
+    }
+  }
+  // EXACT when every unit is rendered (no spacers): the scrollbar the user reads the notches against spans
+  // content.scrollHeight, and each unit's real middle in scroll space is known — the unit-height sum below
+  // omits the gaps between turns and everything that is not a unit, so it sat a few dozen pixels off even
+  // on a fully rendered conversation (T245). scrollTop + client-rect top is the position IN THE SCROLL
+  // CONTENT, invariant under scrolling: pure scrolling still moves nothing.
+  if (nodes.length > 0 && nodes.length === unitTotal && exact.size === unitTotal && content.scrollHeight > 0) {
+    const shx = content.scrollHeight;
+    return { sh: shx, offsetOf: (i: number): number | null => exact.get(i) ?? null };
   }
   const avg = v.avgTurnH ?? 60;
   // one prefix-sum pass per paint (O(n)), then O(1) per mark
@@ -8827,6 +8842,17 @@ function ensureView(id: string): View {
     // with a null/absent ref node just appends, so this is safe whether or not the picker node exists yet.
     content?.insertBefore(elv, document.getElementById("live-ask"));
     v = { el: elv, rendered: 0, scrollTop: 0, stick: true, shown: false, stale: false, winStart: 0, winEnd: 0 };
+    // THE event the scrollbar overlays were missing (T245, the user 2026-09-07): a rendered unit CHANGED
+    // HEIGHT after the paint — a lazy figure sizing in, a fold toggling. The notch/rail frame feeds on the
+    // rendered units' measured heights, but it was refreshed only inside a paint, and the paint ran only
+    // on scroll, resize and a few render-side callers — so 54 figures loading after the paint grew the
+    // turn and the native thumb moved to the new truth while the notches kept the stale frame, and a notch
+    // for a message on screen read as "below". The view element's box grows with any child, so one observer
+    // per view re-runs the shared rAF paint exactly when the geometry changes. No timer, no per-image hook.
+    if (typeof ResizeObserver === "function") {
+      v.ro = new ResizeObserver(() => scheduleRailSticky());
+      v.ro.observe(elv);
+    }
     views.set(id, v);
   }
   return v;
@@ -12674,7 +12700,7 @@ function upsert(msg: any) {
   }
   if (forked) {
     const v = views.get(msg.id);
-    if (v) { v.el.remove(); views.delete(msg.id); }
+    if (v) { v.ro?.disconnect(); v.el.remove(); views.delete(msg.id); }
   }
   if ("ledger" in msg) ledgers.set(msg.id, msg.ledger ?? null);
   if (!existed) order.push(msg.id);
@@ -13108,7 +13134,7 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
     persistDrafts();   // a host drop / omission KEEPS it all (see DismissWhy) — the stash above may have updated the copy
   }
   const v = views.get(id);
-  if (v) { v.el.remove(); views.delete(id); }
+  if (v) { v.ro?.disconnect(); v.el.remove(); views.delete(id); }
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
   const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2135,17 +2135,21 @@ function contentOffsetFrame(content: HTMLElement, v: View, s: Session):
     const u = Number(node.dataset.unit);
     const h = node.offsetHeight;
     if (Number.isFinite(u) && h > 0) uh.set(u, h);
-    if (Number.isFinite(u)) {
+    if (Number.isFinite(u) && !exact.has(u)) {   // a unit's FIRST .turn node is its root (see the gate below)
       const r = node.getBoundingClientRect();
       exact.set(u, content.scrollTop + (r.top - cRect.top) + r.height / 2);
     }
   }
-  // EXACT when every unit is rendered (no spacers): the scrollbar the user reads the notches against spans
+  // EXACT when every unit is rendered (no spacer): the scrollbar the user reads the notches against spans
   // content.scrollHeight, and each unit's real middle in scroll space is known — the unit-height sum below
   // omits the gaps between turns and everything that is not a unit, so it sat a few dozen pixels off even
   // on a fully rendered conversation (T245). scrollTop + client-rect top is the position IN THE SCROLL
-  // CONTENT, invariant under scrolling: pure scrolling still moves nothing.
-  if (nodes.length > 0 && nodes.length === unitTotal && exact.size === unitTotal && content.scrollHeight > 0) {
+  // CONTENT, invariant under scrolling: pure scrolling still moves nothing. The gate counts UNITS, never
+  // nodes: one unit may own several .turn nodes — appendItem tags an expanded tool/retry group's child
+  // turns and every absorbed cue with their unit — so a node-count gate silently dropped the frame back
+  // to the sum whenever a group stood open (review of the first cut, 2026-09-08: 14px off, and the notch
+  // changed basis on every expand and collapse).
+  if (exact.size > 0 && exact.size === unitTotal && !v.el.querySelector(".tx-spacer") && content.scrollHeight > 0) {
     const shx = content.scrollHeight;
     return { sh: shx, offsetOf: (i: number): number | null => exact.get(i) ?? null };
   }

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -93,7 +93,12 @@ test("with every unit rendered the frame is the scrollbar's own truth: real midd
   const frameBody = RENDER.split("function contentOffsetFrame(")[1].split("\nfunction ")[0];
   assert.match(frameBody, /const nodes = Array\.from\(v\.el\.querySelectorAll<HTMLElement>\("\.turn\[data-unit\]"\)\);/);
   assert.match(frameBody, /exact\.set\(u, content\.scrollTop \+ \(r\.top - cRect\.top\) \+ r\.height \/ 2\);/, "scroll-space middle, invariant under scrolling");
-  assert.match(frameBody, /if \(nodes\.length > 0 && nodes\.length === unitTotal && exact\.size === unitTotal && content\.scrollHeight > 0\) \{\s*\n\s*const shx = content\.scrollHeight;\s*\n\s*return \{ sh: shx, offsetOf: \(i: number\): number \| null => exact\.get\(i\) \?\? null \};/);
+  // one unit may own several .turn nodes (an expanded tool group's children, absorbed cues — appendItem tags them
+  // all with the unit): the unit's FIRST node is its root, and the gate counts UNITS against a spacer-free view,
+  // never nodes — the first cut's node count dropped the frame back to the sum whenever a group stood open
+  assert.match(frameBody, /if \(Number\.isFinite\(u\) && !exact\.has\(u\)\) \{/, "first node per unit");
+  assert.doesNotMatch(frameBody, /nodes\.length === unitTotal/, "no node-count gate");
+  assert.match(frameBody, /if \(exact\.size > 0 && exact\.size === unitTotal && !v\.el\.querySelector\("\.tx-spacer"\) && content\.scrollHeight > 0\) \{\s*\n\s*const shx = content\.scrollHeight;\s*\n\s*return \{ sh: shx, offsetOf: \(i: number\): number \| null => exact\.get\(i\) \?\? null \};/);
   // the virtual prefix-sum stays the fallback while spacers hide units
   assert.match(frameBody, /for \(let u = 0; u < unitTotal; u\+\+\) \{ t \+= uh\.get\(u\) \?\? avg; pre\.push\(t\); \}/);
 });

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -38,7 +38,10 @@ test("the frame is VIRTUAL: one cached-height prefix over ALL units, independent
   assert.match(RENDER, /\(i >= 0 && i < unitTotal\) \? pre\[i\] \+ \(pre\[i \+ 1\] - pre\[i\]\) \/ 2 : null/,
     "every unit slots at its virtual middle — uniform semantics, no per-basis seams");
   const frameBody = RENDER.slice(RENDER.indexOf("function contentOffsetFrame("), RENDER.indexOf("function ensureScrollMarks("));
-  assert.ok(!/scrollTop|tx-spacer|winStart|slotIn/.test(frameBody),
+  // the VIRTUAL branch never reads the scroll position or the window (T129); the fully-rendered EXACT branch
+  // above it converts client rects into scroll space, which is scroll-invariant (T245)
+  const virtualBody = frameBody.split("const avg = v.avgTurnH ?? 60;")[1] || frameBody;
+  assert.ok(!/scrollTop|tx-spacer|winStart|slotIn/.test(virtualBody),
     "nothing scroll-coupled inside the frame — no live offsets, no spacer reads, no window bounds");
 });
 
@@ -74,4 +77,23 @@ test("marks translate EVENT indices to DISPLAY UNITS before asking the frame", (
   assert.match(RENDER, /const u = evUnit\[i\];/);
   assert.match(RENDER, /const off = frame\.offsetOf\(u\);/, "notches ask the frame in unit space");
   assert.match(RENDER, /const off = frame\.offsetOf\(evUnit\[idx\]\);/, "comment ticks too — one translation, both overlays");
+});
+
+// ── T245 (the user 2026-09-07): a notch sat below the thumb while its message was on screen ───────────────
+test("a rendered unit changing height re-runs the shared paint — the event the frame was missing (T245)", () => {
+  const ev = RENDER.split("function ensureView(id: string): View {")[1].split("\n}")[0];
+  assert.match(ev, /v\.ro = new ResizeObserver\(\(\) => scheduleRailSticky\(\)\);\s*\n\s*v\.ro\.observe\(elv\);/,
+    "one observer per view element: a lazy figure sizing in or a fold toggling repaints notches AND rail ticks");
+  assert.match(RENDER, /ro\?: ResizeObserver; \}/, "the View carries its observer");
+  assert.equal((RENDER.match(/v\.ro\?\.disconnect\(\); v\.el\.remove\(\);/g) || []).length, 2, "both view-removal sites disconnect it");
+  assert.doesNotMatch(ev, /setTimeout|setInterval/, "no timer stands in for the event");
+});
+
+test("with every unit rendered the frame is the scrollbar's own truth: real middles over content.scrollHeight (T245)", () => {
+  const frameBody = RENDER.split("function contentOffsetFrame(")[1].split("\nfunction ")[0];
+  assert.match(frameBody, /const nodes = Array\.from\(v\.el\.querySelectorAll<HTMLElement>\("\.turn\[data-unit\]"\)\);/);
+  assert.match(frameBody, /exact\.set\(u, content\.scrollTop \+ \(r\.top - cRect\.top\) \+ r\.height \/ 2\);/, "scroll-space middle, invariant under scrolling");
+  assert.match(frameBody, /if \(nodes\.length > 0 && nodes\.length === unitTotal && exact\.size === unitTotal && content\.scrollHeight > 0\) \{\s*\n\s*const shx = content\.scrollHeight;\s*\n\s*return \{ sh: shx, offsetOf: \(i: number\): number \| null => exact\.get\(i\) \?\? null \};/);
+  // the virtual prefix-sum stays the fallback while spacers hide units
+  assert.match(frameBody, /for \(let u = 0; u < unitTotal; u\+\+\) \{ t \+= uh\.get\(u\) \?\? avg; pre\.push\(t\); \}/);
 });


### PR DESCRIPTION
## Summary
A blue user-message notch sat well below the scrollbar thumb while the message it marked was on screen, in a session whose last turn renders dozens of inline figures.

**Cause.** The notch and comment-rail frame is a virtual prefix-sum over the rendered units' measured heights, refreshed only inside a paint, and the paint ran only on scroll, resize and a few render-side callers. Inline figures are lazy, async-decoded images with no intrinsic size before load, so every figure loading after the paint grew its turn and `scrollHeight` with no repaint: the thumb moved, the notches kept the stale frame. Reproduced in the served harness: a rendered turn grown by 1500 px after the paint left the notch at 78 px while its message's true position moved to 31 px.

**Fix, keyed on the missing event ("a rendered unit changed height").**
- One `ResizeObserver` per view element re-runs the shared rAF paint; notches and comment-rail ticks share the frame, so one observer covers both. Disconnected when a view is dropped. No timer, no per-image hook.
- With every unit rendered (no spacers) the frame is the scrollbar's own truth: each unit's real middle in scroll space over `content.scrollHeight`. The unit-height sum omits the gaps between turns, so it sat 27 px off even on a fully rendered conversation. The virtual prefix-sum stays the fallback while spacers hide units; pure scrolling still moves nothing.

**Side issue checked.** A landed slash command reaches the chat as a `cmdGesture` event, not a user event, so the notch painter never sees its expanded wrapper form; the `SLASH_CMD_RE` skip covers the raw echo. No change.

## Tests
- `tests/test_scroll_marks_growth.py` — drives the real /chat page; red first (before growth off by 27 px, after growth off by 47 px and unmoved); skips loudly without a browser
- `ui/webview/scroll-marks.test.ts` — the observer, its disconnects, the exact fully-rendered frame; the virtual branch's no-scrollTop pin scoped to that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
