### PR TITLE
A restart asked of a peer stays on that peer, and /restart refuses a malformed body instead of restarting everything

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -314,7 +314,10 @@ Your sessions now show up in its interface from whatever network you are on.
 Because the laptop is the end that connects, the always-on machine never holds a
 way in to it; untick the box and it forgets you. Romp calls this checking in,
 and the always-on machine the hub, which is where `romp checkin` and
-`romp checkout` get their names.
+`romp checkout` get their names. Restarting Romp from the hub's interface
+restarts the machines linked to it as well, and a checked-in machine is asked to
+restart itself only: anything attached to that machine alone is restarted from
+its own interface.
 
 #### Hand the connection to a different machine
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15596,9 +15596,15 @@ def _ask_peer_to_pull(host):
     # made the peer we had just updated fan out: it restarted the hub back (mid-sweep, before the
     # report was written) and cut in-flight turns on machines nobody asked to restart. This step
     # exists so THAT peer runs what it just pulled; the hub walks its own rows (_fleet_restart_run).
-    rst, _rj = _peer_call(r, "POST", "/restart", {"fleet": False}, timeout=10)
+    rst, rj = _peer_call(r, "POST", "/restart", {"fleet": False}, timeout=10)
     if rst != 200:
-        return True, detail + "; it took the commits but did not ack the restart — restart romp on %s" % host
+        # The peer's own words ride along (review find, 2026-09-08): its /restart refuses a body it
+        # cannot take with a JSON error, and a kernel that never answered comes back as {"error"} from
+        # _peer_call. This answer's readers, the sweep's report row and the sync notice, could only
+        # say "did not ack" before, with no why.
+        why = str((rj or {}).get("error") or (rj or {}).get("detail") or ("HTTP %s" % rst))
+        return True, detail + ("; it took the commits but did not ack the restart (%s) — restart romp on %s"
+                               % (why, host))
     return True, detail + "; restarting it"
 
 
@@ -15606,7 +15612,9 @@ def _ask_peer_to_pull(host):
 # Restart used to mean "this machine's kernel", which is a half-truth on a fleet: the remotes kept running
 # their old processes on their old code, and nothing said so. Restart now covers every REACHABLE kernel,
 # syncing on the way where a clean fast-forward can be proven in either direction, and reports per host
-# what it did and what it skipped.
+# what it did and what it skipped. A checked-in peer, which this machine has no ssh route to, is ASKED
+# to fast-forward and restart ITSELF only (_ask_peer_to_pull): machines attached to that peer alone are
+# not restarted by this sweep, they are restarted from the peer's own dashboard (review find, 2026-09-08).
 #
 # What it will NOT do is the whole point of the report. A diverged remote, a dirty tree either side, a
 # relationship this repo cannot even evaluate: those are skipped with the reason named, never guessed at.
@@ -15739,13 +15747,18 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
     _restart_this_kernel("fleet-restart: the local half of the fleet Restart", manager_port=manager_port)
 
 
-def _restart_scope_from_body(raw_body):
+def _restart_scope_from_body(raw_body, read_error=None):
     """What a POST /restart body asks for → (broad, error). Empty body: the default, every reachable
     kernel — each dashboard's ↻ sends a bodiless POST. Otherwise the body must be a JSON object holding
     at most a boolean `fleet` (false = this kernel only); anything else comes back as `error`, naming
     what was wrong, and the caller restarts NOTHING. The refusal is the point: this used to be a bare
     `except Exception: pass` around `.get("fleet", True)`, so junk, a JSON array, null, a non-boolean
-    value or a typo key ({"fleat": false}) all silently took the BROADEST action with a 200."""
+    value or a typo key ({"fleat": false}) all silently took the BROADEST action with a 200.
+    `read_error` is do_POST's own complaint about the read (a short read, a Content-Length int() cannot
+    parse): a body that was announced but never arrived whole is refused the same way, since letting
+    it pass as "no body" would hand it the broad default (review find, 2026-09-08)."""
+    if read_error:
+        return None, "body could not be read: %s" % read_error
     if not raw_body:
         return True, None
     try:
@@ -15753,16 +15766,21 @@ def _restart_scope_from_body(raw_body):
     except Exception:
         return None, "body is not JSON"
 
-    def clip(v):   # a BOUNDED echo of the offending value: a 1 MB body must not come back as a 1 MB error
-        if isinstance(v, (str, list)):
-            v = v[:80]                                # slice before serializing where the value allows it
-        return json.dumps(v)[:80]
+    def clip(v, n=60):
+        # A BOUNDED echo of the offending key or value: a 1 MB body must not come back as a 1 MB error.
+        # The cut lands INSIDE the quotes and is marked, so a long string still echoes as one complete
+        # quoted thing and the words after it survive; the first cut sliced the serialized text and
+        # took the closing quote with it (review find, 2026-09-08). Keys echo with repr, values as JSON.
+        if isinstance(v, str):          # ensure_ascii off, or the marker itself comes back as \u2026
+            return json.dumps(v[:n] + "…" if len(v) > n else v, ensure_ascii=False)
+        s = json.dumps(v, ensure_ascii=False)
+        return s if len(s) <= n else s[:n] + "…"
     if not isinstance(b, dict):
         return None, "body must be a JSON object, got %s" % clip(b)
     extra = sorted(set(b) - {"fleet"})
     if extra:
         return None, ("unknown key(s) %s — only 'fleet' is understood"
-                      % ", ".join(repr(k[:80]) for k in extra[:8])[:80])
+                      % ", ".join(repr(k[:60] + "…" if len(k) > 60 else k) for k in extra[:8]))
     if "fleet" in b and not isinstance(b["fleet"], bool):
         return None, "'fleet' must be true or false, got %s" % clip(b["fleet"])
     return bool(b.get("fleet", True)), None
@@ -37818,12 +37836,21 @@ class Handler(BaseHTTPRequestHandler):
         # foreign origin — the federated dashboard — and a denial clears the echo).
         self._cors_origin = self.headers.get("Origin") if self._origin_ok() else None
         raw_body = b""
+        # A body that was ANNOUNCED but did not arrive whole is remembered, not folded into "no body"
+        # (review find, 2026-09-08): this read used to swallow a short read, a dead client and an
+        # unparsable Content-Length into an EMPTY raw_body, and on /restart empty means the broad
+        # default, so a client that announced a peer-only body and died before sending it restarted
+        # every reachable kernel. Only /restart refuses on it today; the other routes keep reading
+        # raw_body as they did.
+        _body_err = None
         try:
             n = int(self.headers.get("Content-Length") or 0)   # read the body (keep-alive safety + POST payloads)
             if n:
                 raw_body = self.rfile.read(n)
-        except Exception:
-            pass
+                if len(raw_body) != n:
+                    _body_err = "read %d of the %d bytes Content-Length announced" % (len(raw_body), n)
+        except Exception as e:
+            _body_err = str(e)[:120] or e.__class__.__name__
         try:
             ok, self._set_cookie, why = self._authorize(q)
             self._cors_origin = self.headers.get("Origin") if ok else None   # echoed by _send (CORS delivery)
@@ -37844,7 +37871,7 @@ class Handler(BaseHTTPRequestHandler):
                 # The body is a JSON object with at most a boolean `fleet`, or empty (every ↻ button);
                 # anything else is a 400 that names the problem and restarts NOTHING. A malformed body
                 # must never widen the action — it used to fall through to the broad default.
-                _fleet, _bad = _restart_scope_from_body(raw_body)
+                _fleet, _bad = _restart_scope_from_body(raw_body, _body_err)
                 if _bad:
                     return self._send(400, json.dumps({"ok": False, "error": _bad}), "application/json")
                 # WHO ASKED, on the record (the user 2026-07-31): a restart blinks every dashboard, and

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15591,7 +15591,12 @@ def _ask_peer_to_pull(host):
     if not j.get("ok"):
         return False, "%s refused: %s" % (host, j.get("detail") or j.get("error") or ("HTTP %s" % st))
     detail = str(j.get("detail") or "pulled this machine's commits")
-    rst, _rj = _peer_call(r, "POST", "/restart", {}, timeout=10)
+    # Peer-only scope, said outright. The peer's /restart defaults to the broad kind — every machine
+    # IT holds a row for, and it always holds at least this hub — so the empty body this used to send
+    # made the peer we had just updated fan out: it restarted the hub back (mid-sweep, before the
+    # report was written) and cut in-flight turns on machines nobody asked to restart. This step
+    # exists so THAT peer runs what it just pulled; the hub walks its own rows (_fleet_restart_run).
+    rst, _rj = _peer_call(r, "POST", "/restart", {"fleet": False}, timeout=10)
     if rst != 200:
         return True, detail + "; it took the commits but did not ack the restart — restart romp on %s" % host
     return True, detail + "; restarting it"
@@ -15732,6 +15737,35 @@ def _fleet_restart_run(manager_port=_PORT_FROM_ENV):
     except OSError:
         sys.stderr.write("fleet-restart: could not write the report: %s\n" % traceback.format_exc())
     _restart_this_kernel("fleet-restart: the local half of the fleet Restart", manager_port=manager_port)
+
+
+def _restart_scope_from_body(raw_body):
+    """What a POST /restart body asks for → (broad, error). Empty body: the default, every reachable
+    kernel — each dashboard's ↻ sends a bodiless POST. Otherwise the body must be a JSON object holding
+    at most a boolean `fleet` (false = this kernel only); anything else comes back as `error`, naming
+    what was wrong, and the caller restarts NOTHING. The refusal is the point: this used to be a bare
+    `except Exception: pass` around `.get("fleet", True)`, so junk, a JSON array, null, a non-boolean
+    value or a typo key ({"fleat": false}) all silently took the BROADEST action with a 200."""
+    if not raw_body:
+        return True, None
+    try:
+        b = json.loads(raw_body)
+    except Exception:
+        return None, "body is not JSON"
+
+    def clip(v):   # a BOUNDED echo of the offending value: a 1 MB body must not come back as a 1 MB error
+        if isinstance(v, (str, list)):
+            v = v[:80]                                # slice before serializing where the value allows it
+        return json.dumps(v)[:80]
+    if not isinstance(b, dict):
+        return None, "body must be a JSON object, got %s" % clip(b)
+    extra = sorted(set(b) - {"fleet"})
+    if extra:
+        return None, ("unknown key(s) %s — only 'fleet' is understood"
+                      % ", ".join(repr(k[:80]) for k in extra[:8])[:80])
+    if "fleet" in b and not isinstance(b["fleet"], bool):
+        return None, "'fleet' must be true or false, got %s" % clip(b["fleet"])
+    return bool(b.get("fleet", True)), None
 
 
 def _audit_restart_request(action, **kw):
@@ -37806,11 +37840,13 @@ class Handler(BaseHTTPRequestHandler):
                 # nothing saying so. The remote half runs in a thread (each host is seconds of network)
                 # and writes its report to disk BEFORE restarting this kernel, because this process does
                 # not survive to report anything. `fleet:false` keeps the local-only behaviour.
-                _fleet = True
-                try:
-                    _fleet = json.loads(raw_body or b"{}").get("fleet", True)
-                except Exception:
-                    pass
+                #
+                # The body is a JSON object with at most a boolean `fleet`, or empty (every ↻ button);
+                # anything else is a 400 that names the problem and restarts NOTHING. A malformed body
+                # must never widen the action — it used to fall through to the broad default.
+                _fleet, _bad = _restart_scope_from_body(raw_body)
+                if _bad:
+                    return self._send(400, json.dumps({"ok": False, "error": _bad}), "application/json")
                 # WHO ASKED, on the record (the user 2026-07-31): a restart blinks every dashboard, and
                 # a run of them traced to this route was unattributable — the CLI path audits itself
                 # (bin/romp → restart-audit.jsonl) but the HTTP door was silent. Same file, so one log

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -170,6 +170,56 @@ class ReportSurvivesTheRestart(unittest.TestCase):
                       "manager_port=_mport)", src)
 
 
+class AnAskStaysOnThatPeer(unittest.TestCase):
+    """The sweep's "ask" leg tells a checked-in peer to pull and then to restart — and that restart
+    must name the peer-only scope. The peer's /restart defaults to the broad kind, and the peer always
+    holds at least one row: this hub. So the empty body the ask used to send made the freshly updated
+    peer fan out and restart the hub back, mid-sweep, before the report was on disk — a restart that
+    cascaded onto machines nobody asked to restart. The hub walks its own rows; each ask is one host."""
+
+    def setUp(self):
+        self._saved = {n: getattr(km, n) for n in
+                       ("_fleet_restart_plan", "_peer_call", "_peer_hub_name", "_local_head",
+                        "_local_branch", "_restart_this_kernel")}
+        self._remotes = dict(km._remotes)
+        km._fleet_restart_plan = lambda r: ("ask", "checked in here; asking it to fast-forward itself")
+        km._peer_hub_name = lambda r: "hubname"
+        km._local_head = lambda short=False: ("abc1234" if short else LOCAL_SHA)
+        km._local_branch = lambda: "main"
+        km._restart_this_kernel = lambda reason="", manager_port=None: None   # never a real restart
+        self.calls = []
+
+        def _peer_call(r, method, path, body=None, timeout=8):
+            self.calls.append((method, path, body))
+            return 200, ({"ok": True, "detail": "pulled 3 commits from hubname"}
+                         if path == "/tunnels/pull" else {"ok": True, "restarting": True, "fleet": False})
+        km._peer_call = _peer_call
+        km._remotes.clear()
+        km._remotes["TESTHOST"] = row(checkin_peer=True, kernel_sha=REMOTE_SHA, local_port=52025,
+                                      token="peertok")
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(km, n, v)
+        km._remotes.clear()
+        km._remotes.update(self._remotes)
+
+    def test_the_sweep_asks_each_peer_for_a_restart_of_itself_only(self):
+        km._fleet_restart_run()
+        report = json.loads(km.FLEET_REPORT.read_text())
+        self.assertEqual([(m, p) for m, p, _ in self.calls], [("POST", "/tunnels/pull"), ("POST", "/restart")])
+        self.assertEqual(self.calls[1][2], {"fleet": False},
+                         "the peer restarts ITSELF; an empty body would let it fan out onto this hub")
+        self.assertEqual([(x["host"], x["ok"], x["action"]) for x in report["rows"]],
+                         [("TESTHOST", True, "ask")])
+        self.assertIn("restarting it", report["rows"][0]["detail"])
+
+    def test_the_ask_alone_carries_the_same_scope(self):
+        ok, detail = km._ask_peer_to_pull("TESTHOST")
+        self.assertTrue(ok)
+        self.assertEqual(self.calls[-1], ("POST", "/restart", {"fleet": False}))
+
+
 class GlyphSaysTheFleetState(unittest.TestCase):
     """The rail's network glyph carries the whole verdict, so drift/disconnection reads without opening
     the panel (the user 2026-07-29): top node = this machine, the two below = the remotes."""

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -219,6 +219,27 @@ class AnAskStaysOnThatPeer(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(self.calls[-1], ("POST", "/restart", {"fleet": False}))
 
+    def test_a_restart_the_peer_refuses_lands_in_the_report_with_its_reason(self):
+        """The peer's /restart can refuse (a 400 naming why, since it stopped taking a malformed body
+        as the broad default), and the sweep's report row is that answer's only reader. It used to
+        drop the text and say just "did not ack": the row keeps the peer's own words, next to what is
+        left to do by hand (review find, 2026-09-08)."""
+        def _peer_call(r, method, path, body=None, timeout=8):
+            self.calls.append((method, path, body))
+            if path == "/tunnels/pull":
+                return 200, {"ok": True, "detail": "pulled 3 commits from hubname"}
+            return 400, {"ok": False, "error": "body could not be read: read 0 of the 16 bytes announced"}
+        km._peer_call = _peer_call
+        km._fleet_restart_run()
+        report = json.loads(km.FLEET_REPORT.read_text())
+        [x] = report["rows"]
+        self.assertEqual((x["host"], x["ok"], x["action"]), ("TESTHOST", True, "ask"),
+                         "the commits DID land; that is not a failed row")
+        self.assertIn("pulled 3 commits", x["detail"])
+        self.assertIn("did not ack the restart", x["detail"])
+        self.assertIn("body could not be read", x["detail"], "the peer's reason, not a bare 'did not ack'")
+        self.assertIn("restart romp on TESTHOST", x["detail"], "and what is left to do")
+
 
 class GlyphSaysTheFleetState(unittest.TestCase):
     """The rail's network glyph carries the whole verdict, so drift/disconnection reads without opening

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4,6 +4,7 @@ consume). The WS transport + HTTP serving aren't unit-tested; the projection —
 (chat), goals→feed cards, ledger→TOC — is. Synthetic fleet only: invented text, placeholder
 UUIDs; no real session data.
 """
+import contextlib
 import json
 import os
 import re
@@ -6771,6 +6772,98 @@ class ServeSecurity(unittest.TestCase):
         finally:
             if saved is not None:
                 os.environ["ROMP_MANAGER_PORT"] = saved
+
+    def _post_restart(self, data):
+        """POST /restart with `data` as the body → (status, decoded JSON). Content-Type says JSON the
+        way _peer_call does (the ↻ buttons send no body and no headers); the handler never reads it,
+        the body decides."""
+        import urllib.request, urllib.error, json as _json
+        req = urllib.request.Request("http://127.0.0.1:%d/restart?token=testtok" % self.port,
+                                     method="POST", data=data,
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, _json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, _json.loads(e.read().decode())
+
+    @contextlib.contextmanager
+    def _restart_legs_faked(self):
+        """Both restart legs replaced by recorders (NOTHING may restart under a test), and one
+        synthetic attached row so the broad leg is reachable: with no rows the handler folds every
+        scope to the local leg and the two would be indistinguishable. Yields the recorders; each
+        leg sets its Event, because the handler ACKS FIRST and acts after — a client can hold the
+        200 before the leg has run, so callers wait on the Event rather than peeking at the list."""
+        import threading
+        legs = {"local": [], "broad": [], "localDone": threading.Event(), "broadDone": threading.Event()}
+        saved = (km._restart_this_kernel, km._fleet_restart_run, dict(km._remotes),
+                 os.environ.pop("ROMP_MANAGER_PORT", None))   # belt and braces: no manager to reach either
+
+        def _local(reason="", manager_port=None):
+            legs["local"].append(reason); legs["localDone"].set()
+
+        def _broad(manager_port=None):
+            legs["broad"].append(manager_port); legs["broadDone"].set()
+        km._restart_this_kernel, km._fleet_restart_run = _local, _broad
+        km._remotes.clear()
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "kernel_port": 29855}
+        try:
+            yield legs
+        finally:
+            km._restart_this_kernel, km._fleet_restart_run = saved[0], saved[1]
+            km._remotes.clear(); km._remotes.update(saved[2])
+            if saved[3] is not None:
+                os.environ["ROMP_MANAGER_PORT"] = saved[3]
+
+    def test_restart_body_picks_the_scope_and_a_bodiless_post_keeps_its_default(self):
+        """The body says WHICH restart: nothing (every ↻ button — the landing rail, gear.js, strip.ts
+        all send a bodiless POST) keeps the broad default; {"fleet": false} is this kernel only —
+        the scope the hub asks of a peer it just updated (_ask_peer_to_pull); {"fleet": true} says
+        the default out loud. The ack's `fleet` and the leg that actually runs must agree."""
+        with self._restart_legs_faked() as legs:
+            code, ack = self._post_restart(b"")
+            self.assertEqual((code, ack["ok"], ack["restarting"], ack["fleet"]), (200, True, True, True))
+            self.assertTrue(legs["broadDone"].wait(5), "a bodiless POST takes the broad leg, as before")
+            legs["broadDone"].clear()
+            code, ack = self._post_restart(b'{"fleet": true}')
+            self.assertEqual((code, ack["fleet"]), (200, True))
+            self.assertTrue(legs["broadDone"].wait(5))
+            self.assertEqual(legs["local"], [], "neither well-formed broad request touched the local leg")
+            code, ack = self._post_restart(b'{"fleet": false}')
+            self.assertEqual((code, ack["ok"], ack["restarting"], ack["fleet"]), (200, True, True, False))
+            self.assertTrue(legs["localDone"].wait(5), "fleet:false restarts THIS kernel only")
+            self.assertEqual(legs["local"], ["http /restart (local-only)"])
+            self.assertEqual(len(legs["broad"]), 2, "the peer-only request never fanned out")
+
+    def test_restart_refuses_a_malformed_body_instead_of_restarting_everything(self):
+        """Anything that is not a JSON object with at most a boolean `fleet` is a 400 whose JSON error
+        names the problem, and NOTHING restarts. Before this, the parse sat in a bare except that
+        fell through to the default, so every one of these took the BROADEST action with a 200:
+        junk, an array, null, a string, a non-boolean value, a typo key, a stray extra key."""
+        cases = [(b"not json", "not JSON"),
+                 (b"[]", "JSON object"),
+                 (b"null", "JSON object"),
+                 (b'"x"', "JSON object"),
+                 (b'{"fleet": "no"}', "true or false"),
+                 (b'{"fleet": 1}', "true or false"),
+                 (b'{"fleet": null}', "true or false"),
+                 (b'{"fleat": false}', "'fleat'"),
+                 (b'{"fleet": false, "x": 1}', "'x'")]
+        with self._restart_legs_faked() as legs:
+            for body, names in cases:
+                with self.subTest(body=body):
+                    code, ack = self._post_restart(body)
+                    self.assertEqual(code, 400, "%r must be refused, not acted on" % body)
+                    self.assertFalse(ack["ok"])
+                    self.assertIn(names, ack["error"], "the error says what was wrong with %r" % body)
+                    self.assertNotIn("restarting", ack)
+            # A well-formed request AFTER the refusals is the first and only thing that runs: had any
+            # refusal queued a restart, its leg would be on record ahead of this one.
+            code, ack = self._post_restart(b'{"fleet": false}')
+            self.assertEqual((code, ack["fleet"]), (200, False))
+            self.assertTrue(legs["localDone"].wait(5))
+            self.assertEqual(legs["local"], ["http /restart (local-only)"])
+            self.assertEqual(legs["broad"], [], "no malformed body ever reached the broad leg")
 
     def test_tick_endpoint_wakes_producer(self):
         """POST /tick is the event-driven judge trigger: the Stop / UserPromptSubmit hooks poke it the

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6797,7 +6797,12 @@ class ServeSecurity(unittest.TestCase):
         import threading
         legs = {"local": [], "broad": [], "localDone": threading.Event(), "broadDone": threading.Event()}
         saved = (km._restart_this_kernel, km._fleet_restart_run, dict(km._remotes),
-                 os.environ.pop("ROMP_MANAGER_PORT", None))   # belt and braces: no manager to reach either
+                 os.environ.get("ROMP_MANAGER_PORT"))
+        # A DEAD manager port, never an absent one (tests/conftest.py: absent is the one unsafe state,
+        # since _run_main_update maps it to the live default; the poison "1" is safe against every
+        # consumer). Both legs are faked below, so nothing dials it either way; the handler hands the
+        # value it acked with to whichever leg runs, and the tests check that (review find, 2026-09-08).
+        os.environ["ROMP_MANAGER_PORT"] = "1"
 
         def _local(reason="", manager_port=None):
             legs["local"].append(reason); legs["localDone"].set()
@@ -6812,7 +6817,9 @@ class ServeSecurity(unittest.TestCase):
         finally:
             km._restart_this_kernel, km._fleet_restart_run = saved[0], saved[1]
             km._remotes.clear(); km._remotes.update(saved[2])
-            if saved[3] is not None:
+            if saved[3] is None:
+                os.environ.pop("ROMP_MANAGER_PORT", None)
+            else:
                 os.environ["ROMP_MANAGER_PORT"] = saved[3]
 
     def test_restart_body_picks_the_scope_and_a_bodiless_post_keeps_its_default(self):
@@ -6828,12 +6835,23 @@ class ServeSecurity(unittest.TestCase):
             code, ack = self._post_restart(b'{"fleet": true}')
             self.assertEqual((code, ack["fleet"]), (200, True))
             self.assertTrue(legs["broadDone"].wait(5))
-            self.assertEqual(legs["local"], [], "neither well-formed broad request touched the local leg")
+            legs["broadDone"].clear()
+            # `{}` is what a not-yet-updated hub's _ask_peer_to_pull still sends: it handed {} to
+            # _peer_call, which serializes any non-None body, so the wire carries the two bytes `{}`,
+            # not an empty body. A well-formed object with no key keeps the broad default; tightening
+            # _restart_scope_from_body to REQUIRE the key would 400 every mixed-version sweep with
+            # nothing else here going red (review find, 2026-09-08).
+            code, ack = self._post_restart(b"{}")
+            self.assertEqual((code, ack["ok"], ack["restarting"], ack["fleet"]), (200, True, True, True))
+            self.assertTrue(legs["broadDone"].wait(5), "an older hub's {} still takes the broad leg")
+            self.assertEqual(legs["local"], [], "no well-formed broad request touched the local leg")
             code, ack = self._post_restart(b'{"fleet": false}')
             self.assertEqual((code, ack["ok"], ack["restarting"], ack["fleet"]), (200, True, True, False))
             self.assertTrue(legs["localDone"].wait(5), "fleet:false restarts THIS kernel only")
             self.assertEqual(legs["local"], ["http /restart (local-only)"])
-            self.assertEqual(len(legs["broad"]), 2, "the peer-only request never fanned out")
+            self.assertEqual(legs["broad"], ["1", "1", "1"],
+                             "three broad requests, no more, each handed the dead port conftest floors "
+                             "(an absent port is the unsafe state, never what a test runs under)")
 
     def test_restart_refuses_a_malformed_body_instead_of_restarting_everything(self):
         """Anything that is not a JSON object with at most a boolean `fleet` is a 400 whose JSON error
@@ -6864,6 +6882,81 @@ class ServeSecurity(unittest.TestCase):
             self.assertTrue(legs["localDone"].wait(5))
             self.assertEqual(legs["local"], ["http /restart (local-only)"])
             self.assertEqual(legs["broad"], [], "no malformed body ever reached the broad leg")
+
+    def _post_restart_raw(self, announced, body):
+        """POST /restart announcing `announced` as its Content-Length and sending `body`, then
+        half-closing the socket so the handler's read meets EOF instead of waiting for the rest:
+        the shape a client that died mid-upload, or one whose Content-Length lies, leaves behind.
+        urllib cannot send that, it always tells the truth about the length. → (status, JSON)."""
+        import socket, json as _json
+        s = socket.create_connection(("127.0.0.1", self.port), timeout=5)
+        try:
+            s.sendall(("POST /restart?token=testtok HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                       "Content-Type: application/json\r\nContent-Length: %s\r\n\r\n" % announced).encode()
+                      + body)
+            s.shutdown(socket.SHUT_WR)
+            data = b""
+            while True:
+                chunk = s.recv(65536)
+                if not chunk:
+                    break
+                data += chunk
+        finally:
+            s.close()
+        head, _, payload = data.partition(b"\r\n\r\n")
+        return int(head.split(b" ")[1]), _json.loads(payload.decode() or "{}")
+
+    def test_restart_refuses_a_body_that_did_not_arrive_whole(self):
+        """A body that was ANNOUNCED but could not be read whole is a 400 that names the shortfall, and
+        nothing restarts. The do_POST read used to fold a short read, a dead client or an unparsable
+        Content-Length into an EMPTY body, and on this route empty means the broad default: a client
+        that announced a peer-only body and died before sending it restarted every reachable kernel,
+        and one cut off mid-body was read as whatever prefix arrived (review find, 2026-09-08)."""
+        cases = [("64", b"", "0 of the 64"),                        # announced, never sent: WAS the broad default
+                 ("64", b'{"fleet": false}', "16 of the 64"),       # cut short: WAS taken as a complete request
+                 ("abc", b"", "invalid literal")]                   # a Content-Length int() cannot read
+        with self._restart_legs_faked() as legs:
+            for announced, body, names in cases:
+                with self.subTest(announced=announced, body=body):
+                    code, ack = self._post_restart_raw(announced, body)
+                    self.assertEqual(code, 400, "an unreadable body must be refused, not acted on")
+                    self.assertFalse(ack["ok"])
+                    self.assertIn("body could not be read", ack["error"])
+                    self.assertIn(names, ack["error"], "the error says what the read got: %r" % ack)
+                    self.assertNotIn("restarting", ack)
+            # A well-formed request AFTER the refusals is the first and only leg on record.
+            code, ack = self._post_restart(b'{"fleet": false}')
+            self.assertEqual((code, ack["fleet"]), (200, False))
+            self.assertTrue(legs["localDone"].wait(5))
+            self.assertEqual(legs["local"], ["http /restart (local-only)"])
+            self.assertEqual(legs["broad"], [], "no unreadable body ever took the broad default")
+
+    def test_restart_error_echo_is_bounded_and_keeps_its_explanation(self):
+        """The refusal echoes the offending key or value, BOUNDED (a 1 MB body must not come back as
+        a 1 MB error), and the cut lands INSIDE the quotes, marked: the echo still reads as one
+        complete quoted thing and the explanation after it survives. The first cut sliced the
+        serialized text, so a long key came back as an unclosed `'kkkk` and a long value as an
+        unclosed `"xxxx` (review find, 2026-09-08)."""
+        long_key = "k" * 300
+        broad, err = km._restart_scope_from_body(json.dumps({long_key: 1}).encode())
+        self.assertIsNone(broad)
+        self.assertLess(len(err), 200, "bounded: %d chars" % len(err))
+        self.assertTrue(err.endswith("only 'fleet' is understood"), "the explanation survives: %r" % err)
+        self.assertIn("'" + "k" * 60 + "…'", err, "the key is clipped, marked, and still quoted: %r" % err)
+        broad, err = km._restart_scope_from_body(json.dumps({"fleet": "x" * 300}).encode())
+        self.assertIsNone(broad)
+        self.assertLess(len(err), 200)
+        self.assertTrue(err.startswith("'fleet' must be true or false, got \"xxx"), err)
+        self.assertTrue(err.endswith('…"'), "the echoed value keeps its closing quote: %r" % err)
+        broad, err = km._restart_scope_from_body(json.dumps(["x" * 300]).encode())
+        self.assertLess(len(err), 200)
+        self.assertTrue(err.startswith('body must be a JSON object, got ["xxx'), err)
+        # and through the door, since the caller reads the message, not the tuple
+        with self._restart_legs_faked() as legs:
+            code, ack = self._post_restart(json.dumps({long_key: 1}).encode())
+            self.assertEqual(code, 400)
+            self.assertTrue(ack["error"].endswith("only 'fleet' is understood"), ack["error"])
+            self.assertEqual(legs["broad"], [])
 
     def test_tick_endpoint_wakes_producer(self):
         """POST /tick is the event-driven judge trigger: the Stop / UserPromptSubmit hooks poke it the

--- a/tests/test_peer_fast_forward.py
+++ b/tests/test_peer_fast_forward.py
@@ -115,6 +115,9 @@ class AskingThePeer(unittest.TestCase):
         self.assertEqual([c[1] for c in calls], ["/tunnels/pull", "/restart"],
                          "a pull alone leaves the OLD kernel running and still reporting the old sha")
         self.assertEqual(calls[0][2], {"host": "hubname"}, "the peer is handed the name it knows us by")
+        self.assertEqual(calls[1][2], {"fleet": False},
+                         "and told to restart ITSELF only — its /restart defaults to the broad kind, "
+                         "which would fan back out onto this hub (tests/test_fleet_restart.py)")
         self.assertIn("pulled 8 commits", detail)
         self.assertIn("restarting it", detail)
 

--- a/tests/test_peer_fast_forward.py
+++ b/tests/test_peer_fast_forward.py
@@ -143,6 +143,19 @@ class AskingThePeer(unittest.TestCase):
         (ok, detail), _ = self._ask([(200, {"ok": True, "detail": "pulled 2 commits"}), (0, {"error": "gone"})])
         self.assertTrue(ok, "the commits DID land — that is not a failure")
         self.assertIn("restart romp on %s" % PEER, detail, "and it says what is left to do")
+        self.assertIn("gone", detail, "and why the restart never acked, in _peer_call's own words")
+
+    def test_a_restart_the_peer_refuses_comes_back_with_its_reason(self):
+        """The peer's /restart refuses a body it cannot take with a 400 naming why (it no longer
+        takes a malformed one as the broad default). This function was that text's only reader and
+        it discarded it, leaving "did not ack" with no why (review find, 2026-09-08)."""
+        (ok, detail), calls = self._ask([(200, {"ok": True, "detail": "pulled 2 commits"}),
+                                         (400, {"ok": False, "error": "body is not JSON"})])
+        self.assertTrue(ok, "the commits DID land")
+        self.assertEqual(len(calls), 2)
+        self.assertIn("did not ack the restart", detail)
+        self.assertIn("body is not JSON", detail, "the peer's own words, not a bare 'did not ack'")
+        self.assertIn("restart romp on %s" % PEER, detail)
 
     def test_an_ssh_attached_host_is_refused_with_the_direction_that_works(self):
         km._remotes[PEER] = _row(checkin_peer=False)


### PR DESCRIPTION
A restart asked of a peer stays on that peer, and /restart refuses a malformed body instead of restarting everything

Two defects in the kernel's restart door, both taking the broadest action when
nobody asked for it.

1. `_ask_peer_to_pull` (the sweep's "ask" leg for a checked-in peer, and the
   drift banner's "tell it to update itself") POSTed `{}` to the peer's
   /restart. The peer's handler defaults that to the broad scope: every machine
   the PEER holds a row for, and it always holds at least one, the hub that
   asked. So the freshly updated peer fanned out and restarted the hub back,
   mid-sweep, before the report was written, and cut in-flight turns on
   machines nobody asked to restart. Fix: the ask says `{"fleet": false}`, so
   the peer restarts itself only; the hub is already walking its own rows one
   host at a time. An older peer reads the explicit false the same way, and a
   newer peer asked by an older hub still sees `{}`, a well-formed object, and
   behaves as before.

2. The /restart handler parsed `json.loads(raw_body or b"{}").get("fleet",
   True)` inside a bare `except Exception: pass`, so junk, a JSON array, null,
   a string, a non-boolean value, a typo key ({"fleat": false}) or a stray
   extra key all fell through to the broad default with a 200. Fix:
   `_restart_scope_from_body`. The body is empty, or a JSON object holding at
   most a boolean `fleet`; anything else is a 400 whose JSON error names what
   was wrong ("body is not JSON", "body must be a JSON object, got []",
   "'fleet' must be true or false, got \"no\"", "unknown key(s) 'fleat' — only
   'fleet' is understood"), and nothing restarts.

Unchanged: a bodiless POST keeps its meaning. Every ↻ button (the landing
rail, gear.js, strip.ts) sends one and still gets the default; `{"fleet":
false}` still restarts this kernel only and `{"fleet": true}` still says the
default out loud; the ack shape and the audit line are untouched.

Tests, each reproduced against a git-archive of origin/main first:
- tests/test_fleet_restart.py::AnAskStaysOnThatPeer (2 tests): the sweep's
  ask and the bare `_ask_peer_to_pull` both POST `{"fleet": False}` to
  /restart. On main: `{} != {'fleet': False}`.
- tests/test_peer_fast_forward.py::AskingThePeer::test_it_pulls_then_restarts
  now pins the same body. On main: `{} != {'fleet': False}`.
- tests/test_kernel.py::ServeSecurity::
  test_restart_refuses_a_malformed_body_instead_of_restarting_everything:
  nine bodies -> 400 + JSON error, both restart legs faked and asserted never
  called. On main every subtest fails `200 != 400` and the legs record the
  restarts that went out (seven broad; two local, where the value was merely falsy).
- tests/test_kernel.py::ServeSecurity::
  test_restart_body_picks_the_scope_and_a_bodiless_post_keeps_its_default
  pins the unchanged meanings above (it passes on main too; it guards the
  compatibility claim, not the fix).

Module counts on this tree: tests/test_kernel.py 466 passed (+9 subtests);
tests/test_fleet_restart.py 20 passed; tests/test_peer_fast_forward.py 24
passed; tests/test_restart_audit.py 2 passed (it already sends
`{"fleet": false}` through the changed handler). Full suite left to CI (not
run on the development machine).



## Tier

**fix** — a bug fix with tests that fail before it.

## Notes for review

- Tests were run per module on the development machine (`test_kernel.py -k ServeSecurity`, `test_fleet_restart.py`, `test_peer_fast_forward.py`, `test_restart_audit.py`, one process at a time); the full suite is left to this PR's CI. Every restart leg is faked in the tests; nothing here can restart a real kernel.
- A bodiless POST keeps its meaning (the ↻ buttons in the landing page, the gear and the strip send no body); only a body that is present and malformed is refused, and it is refused before the audit line and before either restart leg.
- An older peer kernel receiving the hub's new `{"fleet": false}` restarts itself only under the old handler too, so mixed versions behave; an older hub asking a newer peer still sends an empty body and keeps the old broad default until that hub updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
