### PR TITLE
Chat: a queued message is editable until the session takes it

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -51,6 +51,16 @@ A pull request number in a message, a card, or a note (`#123`, `PR #123`, or
 directory has as its `origin` remote; when that remote is not on GitHub, the number stays
 plain text.
 
+**A message that has not gone yet.** Send to a busy session and your message waits as a
+dashed bubble under an hourglass until the session takes it — while it compacts, while a
+turn runs, or in the beat before the kernel confirms the send. Until then it is still
+yours: the **✕** in its corner pulls it back into the composer, and the **✎** beside it loads
+the text into the composer under an editing pill, so you can change your mind without
+losing your place in the queue. Send replaces the message where it was, a follow-up keeps
+its context, and Esc or the pill's ✕ leaves it as it was. If the session takes the message
+before the edit lands, romp says so and gives your edited words back to the composer
+rather than sending them twice.
+
 **Opening a markdown document.** A markdown link in the chat opens in the file viewer,
 rendered, with **Raw** one click away — a path on the session's machine, or a link to a
 file served from the dashboard's own address (a published report, an evidence doc). Figures

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28216,9 +28216,17 @@ def _replace_followup_body(text, body):
         i += 1
     head = "\n".join(lines[:i])
     rest = "\n".join(lines[i:])
-    m = re.search(r"((?:\s*<!--.*?-->)+\s*)$", rest, flags=re.S)     # the trailing marker block, as composed
-    tail = m.group(1) if m else ""
-    return (head + "\n\n" if head else "") + body + tail
+    # The trailing marker block, one comment at a time: a comment can never span another's close, so an
+    # inline <!-- x --> INSIDE the old body cannot anchor the tail and drag old words behind the new body
+    # (review find, 2026-09-08: the .*? form under re.S did exactly that). Of the block, only the WRAPPER's
+    # own markers survive (romp-note / romp-injected / romp-auto / romp-goal-id, _followup_body's tail): a
+    # marker that described the old BODY, like the Continue button's romp-canned, would make the typed
+    # replacement render as the canned gesture row, so it goes with the words it described.
+    cmt = r"<!--(?:(?!-->).)*-->"
+    m = re.search(r"((?:\s*%s)+\s*)$" % cmt, rest, flags=re.S)
+    keep = [c for c in re.findall(cmt, m.group(1), flags=re.S)
+            if re.match(r"<!--\s*romp-(?:note|injected|auto|goal-id)\b", c)] if m else []
+    return (head + "\n\n" if head else "") + body + ("\n\n" + "".join(keep) if keep else "")
 
 
 def _edit_parked(sid, park, md, text):
@@ -28235,6 +28243,11 @@ def _edit_parked(sid, park, md, text):
     body = (text or "").strip()
     if not body:
         return "nothing to send — to drop the message, use its ✕"
+    if _is_slash_command(body):
+        # an edit swaps the WORDS of a ("send", ...) op and nothing else, so a command edited in would stay a
+        # send and reach the model as text, skipping the fire-alone park and the kernel-side setters every
+        # typed command gets (review find, 2026-09-08). The composer mirrors this refusal (SLASH_CMD_RE).
+        return "a queued message cannot become a command: cancel it with its ✕ and type the command"
     with _pending_ops_lock:
         ops = _pending_ops.get(sid) or []
         inflight_head = bool(ops) and ops[0] is _inflight_ops.get(sid)   # the head is with the backend this instant
@@ -28264,6 +28277,10 @@ def _edit_backend_queued(be, sid, idx, md, text):
     body = (text or "").strip()
     if not body:
         return "nothing to send — to drop the message, use its ✕"
+    if _is_slash_command(body):
+        # replace_queued swaps the queued text in place, so SdkBackend.send's /compact and /clear cues would
+        # never fire for a command edited in; same refusal as _edit_parked (review find, 2026-09-08)
+        return "a queued message cannot become a command: cancel it with its ✕ and type the command"
     try:
         pending = be.pending_queued(sid)
     except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15251,7 +15251,7 @@ def _drive(msg, client):
         return False
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
-              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
+              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "editQueued", "setModel", "setEffort", "setMode", "setFast",
               "setAuth", "endSession", "renameSession", "moveSession", "stopTask", "rewindFiles", "mcpAction", "forkSession",
               "commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote",
               "commentMerge")
@@ -15466,6 +15466,35 @@ def _drive(msg, client):
             # had already gone through, or never reached this kernel. sid only: the body is the user's text
             sys.stderr.write("queued-cancel miss: %s (body-only)\n" % sid)
         client["send"](json.dumps({"type": "cancelResult", "ok": not err, "id": sid,
+                                   "md": md, "text": err or ""}))
+        _push_soon()
+    elif t == "editQueued" and msg.get("park") is not None:
+        # ✎ on a PARKED message (the user 2026-09-08): replace its words in place — same slot, same
+        # follow-up context. The result frame is authoritative like the ✕'s: ok:false means the message
+        # left the queue meanwhile (or the chip is not a message), and the client hands the typed words
+        # back to the composer instead of leaving them nowhere.
+        err = _edit_parked(sid, int(msg["park"]), str(msg.get("md") or ""), str(msg.get("text") or ""))
+        client["send"](json.dumps({"type": "editResult", "ok": not err, "id": sid,
+                                   "md": str(msg.get("md") or ""), "text": err or ""}))
+        _push_soon()
+    elif t == "editQueued" and msg.get("idx") is not None and hasattr(be, "edit_queued"):
+        # ✎ on a backend-queue message: replaced under the backend's lock, drift-guarded by the body.
+        err = _edit_backend_queued(be, sid, int(msg["idx"]), str(msg.get("md") or ""), str(msg.get("text") or ""))
+        client["send"](json.dumps({"type": "editResult", "ok": not err, "id": sid,
+                                   "md": str(msg.get("md") or ""), "text": err or ""}))
+        _push_soon()
+    elif t == "editQueued" and msg.get("md"):
+        # ✎ at the OPTIMISTIC stage: no park/idx has round-tripped yet, so locate the send by body wherever
+        # it landed — the FIFO first, then the backend's queue (the ws is ordered: the send op was processed
+        # before this edit). Neither holding it means it already forwarded into the CLI: the honest refusal.
+        md = str(msg["md"])
+        new_text = str(msg.get("text") or "")
+        err = _edit_parked(sid, -1, md, new_text)
+        if err and hasattr(be, "edit_queued"):
+            err2 = _edit_backend_queued(be, sid, -1, md, new_text)
+            if err2 is None:
+                err = None
+        client["send"](json.dumps({"type": "editResult", "ok": not err, "id": sid,
                                    "md": md, "text": err or ""}))
         _push_soon()
     elif t == "dismissEcho" and hasattr(be, "dismiss_echo"):
@@ -28093,6 +28122,18 @@ def _cancel_miss_text(md):
             "and will be answered in the current turn")
 
 
+def _edit_miss_text(md):
+    """The user-facing 'too late' for an EDIT whose target already left the queue — the ✕'s twin
+    (_cancel_miss_text): once the session has the message there is no recall, so the words it answers
+    are the ones it got. The client hands the edited text back to the composer on this frame, so
+    nothing is lost and nothing is sent twice (the user 2026-09-08)."""
+    body = (md or "").strip()
+    if body.startswith("/"):
+        return "too late to edit %s — the session already has it" % body.split()[0]
+    return ("too late to edit — the message already reached the session as it was, "
+            "and will be answered in the current turn")
+
+
 def _cancel_parked(sid, park, md):
     """Remove ONE parked op — the queued bubble's ✕ (the user 2026-07-08). Verified by body text: if the
     park list shifted between the push and the click (ops applied / another cancel), the index alone
@@ -28157,6 +28198,84 @@ def _cancel_backend_queued(be, sid, idx, md):
         return _cancel_miss_text(md)
     got = be.unqueue(sid, idx, pending[idx])
     return None if got is not None else _cancel_miss_text(md)
+
+
+def _replace_followup_body(text, body):
+    """`text` with its user-visible BODY replaced by `body` and everything else kept byte for byte. A plain
+    send IS its body. A romp FOLLOW-UP keeps its leading goal-context quote and its trailing romp markers —
+    the follow-up judge reopens the goal off the romp-goal-id marker — so an edited follow-up still files
+    under its goal. The inverse of _split_followup's body read: _split_followup(_replace_followup_body(t,
+    b))[1] == b.strip(). The queued bubble's ✎ hands the kernel the BODY the bubble showed (the ✕'s drift
+    guard reads the same body), and the kernel keeps the wrapper the client never saw."""
+    body = (body or "").strip()
+    if not text or not _FOLLOWUP_GOAL_RE.search(text):
+        return body
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines) and lines[i].lstrip().startswith(">"):
+        i += 1
+    head = "\n".join(lines[:i])
+    rest = "\n".join(lines[i:])
+    m = re.search(r"((?:\s*<!--.*?-->)+\s*)$", rest, flags=re.S)     # the trailing marker block, as composed
+    tail = m.group(1) if m else ""
+    return (head + "\n\n" if head else "") + body + tail
+
+
+def _edit_parked(sid, park, md, text):
+    """Replace the BODY of one parked SEND in place — the queued bubble's ✎ (the user 2026-09-08). Same
+    slot in the FIFO (park order IS delivery order, so the edited message still goes where it would
+    have), same echo author, and a follow-up keeps its goal quote and markers (_replace_followup_body).
+    Verified by body text and refused on the in-flight head exactly as _cancel_parked is: the locate and
+    the swap are ONE step under the queue lock, so the drain cannot pop the head between them. Only a
+    send is editable — a command / compact / model chip has no words to change (cancel it and type it
+    again), and a non-send match is refused with its own sentence rather than the 'too late' one, which
+    would be a lie. Returns None on success, else the text for the client to toast. Logged like the
+    cancel: sid and kind, never the body, which is user text."""
+    sid = str(sid)
+    body = (text or "").strip()
+    if not body:
+        return "nothing to send — to drop the message, use its ✕"
+    with _pending_ops_lock:
+        ops = _pending_ops.get(sid) or []
+        inflight_head = bool(ops) and ops[0] is _inflight_ops.get(sid)   # the head is with the backend this instant
+        if not (0 <= park < len(ops)) or (md and _parked_md(ops[park]) != md):
+            park = next((j for j, op in enumerate(ops)
+                         if _parked_md(op) == md and not (j == 0 and inflight_head)), -1) if md else -1
+            if park < 0:
+                return _edit_miss_text(md)
+        if park == 0 and inflight_head:
+            return _edit_miss_text(md)            # too late, not a wrong-op rewrite
+        op = ops[park]
+        if op[0] != "send":
+            return "only a queued message can be edited — cancel this %s and type it again" % (
+                "command" if op[0] in ("command", "compact") else "change")
+        sys.stderr.write("parked-op edit: %s send\n" % sid)
+        ops[park] = ("send", _replace_followup_body(op[1], body)) + tuple(op[2:])
+        _save_pending_ops()
+    _mark_views_dirty()
+    return None
+
+
+def _edit_backend_queued(be, sid, idx, md, text):
+    """edit_queued with _cancel_backend_queued's DRIFT GUARD: re-locate the entry by body if the backend
+    queue moved between the push and the click, then replace it in place under the backend's lock
+    (edit_queued's `expect`), keeping a follow-up's wrapper. Returns None on success; on a MISS — the
+    message already forwarded to the CLI, where no recall exists — the 'too late' text to toast."""
+    body = (text or "").strip()
+    if not body:
+        return "nothing to send — to drop the message, use its ✕"
+    try:
+        pending = be.pending_queued(sid)
+    except Exception:
+        pending = []
+    if md:
+        if not (0 <= idx < len(pending)) or _split_followup(pending[idx])[1] != md:
+            idx = next((i for i, q in enumerate(pending) if _split_followup(q)[1] == md), -1)
+    if not (0 <= idx < len(pending)):
+        return _edit_miss_text(md)
+    old = pending[idx]
+    got = be.edit_queued(sid, idx, _replace_followup_body(old, body), old)
+    return None if got is not None else _edit_miss_text(md)
 
 
 def _queue_recallable(be, sid):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4275,6 +4275,23 @@ class SdkSession:
             self._persist_queue()
         return item
 
+    def replace_queued(self, idx: int, text: str, expect: str | None = None) -> str | None:
+        """Replace the queued turn at `idx` IN PLACE — the chat's edit of a message that has not started
+        (the user 2026-09-08): same _pending position (the queue drains front-first, so the edited message
+        still goes where it would have), new words. `expect` verifies — and, on a shifted index,
+        re-locates — the exact old text UNDER the lock, exactly as unqueue does, so the input generator
+        consuming entries between the caller's snapshot and this swap can never rewrite the wrong
+        message. Returns the OLD text, or None on a miss: the entry is gone (fed to the CLI, where no
+        recall exists) and nothing was changed."""
+        with self._lock:
+            if expect is not None and not (0 <= idx < len(self._pending) and self._pending[idx] == expect):
+                idx = next((i for i, q in enumerate(self._pending) if q == expect), -1)
+            if not (0 <= idx < len(self._pending)):
+                return None
+            old, self._pending[idx] = self._pending[idx], text
+        self._persist_queue()
+        return old
+
     def _persist_queue(self):
         """Mirror _pending to the registry (reg['queue']) so queued turns survive a kernel death —
         the boot reconcile resumes any session whose persisted queue is non-empty and the __init__
@@ -9464,6 +9481,38 @@ class SdkBackend:
             self._persist_echoes(sid)                      # the canceled echo leaves the restart mirror too
             self._wake_push()                              # repaint without the echo so it stops reading as sent
         return text
+
+    def edit_queued(self, sid: str, idx: int, text: str, expect: str | None = None) -> str | None:
+        """Edit the queued turn at `idx` in place for an SDK session (the kernel's editQueued route) —
+        unqueue's twin: returns the OLD text, or None on a miss the caller surfaces loudly. The message's
+        optimistic echo (send()'s blue 'you' bubble, matched by its exact old text like unqueue does) is
+        re-worded too, so the live tail shows the edited message and the landing scan matches the record
+        the transcript will write. The kernel gates the chat's ✎ on the backend having `edit_queued`."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if not s:
+            return None
+        old = s.replace_queued(idx, text, expect)
+        if old is not None:
+            with self._live_lock:
+                for a in (self._live.get(sid) or {}).values():
+                    if a.get("_echo_text") != old:
+                        continue
+                    a["_echo_text"] = text
+                    m = a.get("message")
+                    if isinstance(m, dict):
+                        c = m.get("content")
+                        if isinstance(c, list):
+                            for b in c:
+                                if isinstance(b, dict) and b.get("type") == "text":
+                                    b["text"] = text
+                                    break
+                        elif isinstance(c, str):
+                            m["content"] = text
+                    break                                  # one echo per edited message
+            self._persist_echoes(sid)                      # the restart mirror carries the new words
+            self._wake_push()                              # repaint with them
+        return old
 
     def queue_recallable(self, sid: str) -> bool:
         """Can a ✕ on this session's queued bubble still win? False while a turn is running UN-HELD:

--- a/tests/test_kernel_parked_ops_lock.py
+++ b/tests/test_kernel_parked_ops_lock.py
@@ -400,6 +400,63 @@ class OneLockAroundEveryMutation(_Drain):
         self.assertEqual(self.be.calls, [("send", "first")])
         self.assertNotIn(SID, km._pending_ops)
 
+    def test_an_edit_during_an_in_flight_send_is_too_late_and_the_original_is_delivered(self):
+        # the ✎'s reachable race (review find, 2026-09-08): the drain pops a send run under the lock and
+        # delivers it with the lock released, so a ✎ landing in that window finds the send gone from the FIFO.
+        # It is refused as too late (the words the session gets are the ORIGINAL ones), and the op behind
+        # the in-flight send is untouched: never a rewrite of the wrong op
+        self.be.open = False
+        in_send, release = threading.Event(), threading.Event()
+
+        def send(sid, text):
+            self.be.calls.append(("send", text))
+            in_send.set()
+            release.wait(5)
+            self.be.open = True
+            return True
+        self.be.send = send
+        first, behind = ("send", "first", "human"), ("model", "opus")
+        km._pending_ops[SID] = [first, behind]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        with redirect_stderr(io.StringIO()):
+            walker.start()
+            self.assertTrue(in_send.wait(5))               # the send is popped and with the backend; the lock is free
+            err = km._edit_parked(SID, 0, "first", "first, edited")
+            self.assertEqual(km._pending_ops.get(SID), [behind], "the edit touched nothing still queued")
+            release.set()
+            walker.join(5)
+        self.assertEqual(err, km._edit_miss_text("first"), "too late, honestly")
+        self.assertEqual(self.be.calls, [("send", "first")], "the ORIGINAL words were delivered, once")
+
+    def test_an_edit_before_the_drain_reaches_the_send_wins_and_the_edited_words_go(self):
+        # the other side of the race: while the drain is inside the backend call for the HEAD (a model pick,
+        # recorded in flight), a ✎ on the send queued behind it lands under the lock, and the drain's next
+        # step delivers the EDITED words. The in-flight head itself is refused as too late, as the ✕ does
+        self.be.open = False
+        entered, release = threading.Event(), threading.Event()
+
+        def set_model(sid, value):
+            self.be.calls.append(("model", value))
+            entered.set()
+            release.wait(5)
+            return True
+        self.be.set_model = set_model
+        head, msg = ("model", "opus"), ("send", "hello", "human")
+        km._pending_ops[SID] = [head, msg]
+        walker = threading.Thread(target=km._apply_pending_ops, name="drain-under-test", daemon=True)
+        with redirect_stderr(io.StringIO()):
+            walker.start()
+            self.assertTrue(entered.wait(5))
+            self.assertIs(km._inflight_ops.get(SID), head)
+            err_head = km._edit_parked(SID, 0, "/model opus", "x")
+            err_msg = km._edit_parked(SID, 1, "hello", "hello, edited")
+            release.set()
+            walker.join(5)
+        self.assertEqual(err_head, km._edit_miss_text("/model opus"), "the head the backend holds is too late")
+        self.assertIsNone(err_msg, "the send behind it is still the user's to change")
+        self.assertEqual(self.be.calls, [("model", "opus"), ("send", "hello, edited")])
+        self.assertNotIn(SID, km._pending_ops)
+
     def test_the_drain_yields_to_a_handler_holding_the_lock_and_the_push_still_runs(self):
         # the drain is the first job of every cycle; its top-of-walk acquire is non-blocking, so a cycle
         # that finds a handler holding the lock skips the drain rather than stalling every session's push;

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -408,6 +408,93 @@ class SendPathsPark(unittest.TestCase):
                       "the timeline's and the composer's /effort park mid-compaction (_route_meta_command)")
 
 
+class QueuedEdit(unittest.TestCase):
+    """The queued bubble's ✎ (the user 2026-09-08): a message that has not reached the session is still the
+    user's to change. Same slot, same follow-up context, only the words; refused with the ✕'s honesty when
+    the entry is gone or is with the backend this instant. SYNTHETIC fixtures only."""
+
+    def setUp(self):
+        km._pending_ops.clear()
+        km._inflight_ops.clear()
+
+    def tearDown(self):
+        km._pending_ops.clear()
+        km._inflight_ops.clear()
+        try:
+            os.unlink(km._PENDING_OPS_FILE)
+        except OSError:
+            pass
+
+    def test_edit_parked_replaces_the_send_in_place(self):
+        km._pending_ops[SID] = [("model", "opus"), ("send", "draft one", "human"), ("send", "another", "human")]
+        self.assertIsNone(km._edit_parked(SID, 1, "draft one", "draft two"))
+        self.assertEqual(km._pending_ops[SID], [("model", "opus"), ("send", "draft two", "human"), ("send", "another", "human")],
+                         "same slot, same echo author, new words")
+        self.assertEqual(km._parked_md(km._pending_ops[SID][1]), "draft two", "the bubble shows the new body")
+
+    def test_edit_parked_relocates_by_body_and_refuses_the_gone_and_the_in_flight(self):
+        km._pending_ops[SID] = [("send", "a", "human"), ("send", "b", "human")]
+        self.assertIsNone(km._edit_parked(SID, 0, "b", "b2"), "a stale index re-locates by body")
+        self.assertEqual([op[1] for op in km._pending_ops[SID]], ["a", "b2"])
+        self.assertEqual(km._edit_parked(SID, 5, "gone", "x"), km._edit_miss_text("gone"))
+        km._inflight_ops[SID] = km._pending_ops[SID][0]
+        self.assertEqual(km._edit_parked(SID, 0, "a", "a2"), km._edit_miss_text("a"),
+                         "the head the backend holds this instant is too late, never a wrong-op rewrite")
+        self.assertEqual(km._pending_ops[SID][0][1], "a")
+
+    def test_edit_parked_refuses_a_command_chip_and_an_empty_body(self):
+        km._pending_ops[SID] = [("compact",), ("command", "/model opus", "human"), ("send", "words", "human")]
+        self.assertIn("only a queued message can be edited", km._edit_parked(SID, 0, "/compact", "x"))
+        self.assertIn("only a queued message can be edited", km._edit_parked(SID, 1, "/model opus", "x"))
+        self.assertIn("nothing to send", km._edit_parked(SID, 2, "words", "   "))
+        self.assertEqual(km._pending_ops[SID][2][1], "words", "a refusal changes nothing")
+
+    def test_a_follow_up_keeps_its_goal_quote_and_markers(self):
+        fu = ("> Ship the notes API\n> its goal context\n\nfirst words\n\n"
+              "<!-- romp-note: the HTML comments below are part of an external tracking system --><!-- romp-goal-id: g7 -->")
+        new = km._replace_followup_body(fu, "second words")
+        goal, body, is_fu, ctx = km._split_followup(new)
+        self.assertEqual((goal, body, is_fu), ("Ship the notes API", "second words", True))
+        self.assertEqual(ctx, "Ship the notes API\nits goal context")
+        self.assertIn("<!-- romp-goal-id: g7 -->", new, "the judge still files the edited follow-up under its goal")
+        self.assertTrue(new.startswith("> Ship the notes API\n> its goal context\n\nsecond words"))
+        self.assertEqual(km._replace_followup_body("plain", "edited"), "edited", "a plain send IS its body")
+        km._pending_ops[SID] = [("send", fu, "human")]
+        self.assertIsNone(km._edit_parked(SID, 0, "first words", "second words"), "the ✎ hands the BODY the bubble showed; the kernel keeps the wrapper")
+        self.assertEqual(km._split_followup(km._pending_ops[SID][0][1])[1], "second words")
+
+    def test_edit_backend_queued_uses_the_drift_guard_and_keeps_a_followups_wrapper(self):
+        class _BE:
+            def __init__(self):
+                self.q = ["alpha", "> goal\n\nbody\n\n<!-- romp-goal-id: g1 -->"]
+            def pending_queued(self, sid):
+                return list(self.q)
+            def edit_queued(self, sid, idx, text, expect=None):
+                if not (0 <= idx < len(self.q)) or self.q[idx] != expect:
+                    return None
+                old, self.q[idx] = self.q[idx], text
+                return old
+        be = _BE()
+        self.assertIsNone(km._edit_backend_queued(be, SID, 5, "body", "new body"), "a stale index re-locates by body")
+        self.assertEqual(km._split_followup(be.q[1])[1], "new body")
+        self.assertIn("<!-- romp-goal-id: g1 -->", be.q[1])
+        self.assertEqual(km._edit_backend_queued(be, SID, 0, "gone", "x"), km._edit_miss_text("gone"))
+        self.assertEqual(be.q[0], "alpha", "a miss rewrites nothing")
+
+    def test_drive_routes_the_three_edit_arms_and_answers_editResult(self):
+        import inspect
+        src = inspect.getsource(km._drive)
+        self.assertIn('t == "editQueued" and msg.get("park") is not None', src)
+        self.assertIn('_edit_parked(sid, int(msg["park"]), str(msg.get("md") or ""), str(msg.get("text") or ""))', src)
+        self.assertIn('t == "editQueued" and msg.get("idx") is not None and hasattr(be, "edit_queued")', src)
+        self.assertIn('_edit_backend_queued(be, sid, int(msg["idx"]), str(msg.get("md") or ""), str(msg.get("text") or ""))', src)
+        self.assertIn('elif t == "editQueued" and msg.get("md"):', src,
+                      "the optimistic stage: locate by body, the FIFO first, then the backend queue")
+        self.assertEqual(src.count('"type": "editResult"'), 3, "every arm answers with an authoritative frame")
+        ksrc = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('"apiRetry", "editQueued"', ksrc, "the op routes to the owning kernel across linked machines (ID_OPS)")
+
+
 class QueuedBubble(unittest.TestCase):
     def test_build_session_renders_the_op_queue_in_park_order(self):
         import inspect

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -6,6 +6,7 @@ parked message rendering BEFORE the model change parked ahead of it). A repeated
 replaces its earlier parked op in place. Same event-corroborated _compacting_now gate as ever; a parked
 send stamps its optimistic echo only when it actually fires (an early echo killed the compacting cue).
 SYNTHETIC fixtures only."""
+import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -34,6 +35,7 @@ km._limit_hold = lambda sid: None
 km._TMUX_PROMPT_HOLD_S = 0.0
 
 SID = "11111111-2222-3333-4444-555555555555"
+THEIRS = "99999999-8888-7777-6666-555555555555"   # a session another machine's kernel owns
 
 
 class _FakeBackend:
@@ -408,6 +410,26 @@ class SendPathsPark(unittest.TestCase):
                       "the timeline's and the composer's /effort park mid-compaction (_route_meta_command)")
 
 
+class _EditableQueueBackend:
+    """A backend that owns its queue and can re-word an entry (SdkBackend.edit_queued's contract): `expect`
+    re-verified at swap time, the OLD text returned, None on a miss that touches nothing. Shared by the
+    _edit_backend_queued tests and the executing _drive harness below (review find, 2026-09-08)."""
+
+    def __init__(self, pending=None):
+        self.q = list(pending or [])
+        self.edits = []                       # every edit_queued call, so a refusal can prove it never reached the backend
+
+    def pending_queued(self, sid):
+        return list(self.q)
+
+    def edit_queued(self, sid, idx, text, expect=None):
+        self.edits.append((idx, text, expect))
+        if not (0 <= idx < len(self.q)) or self.q[idx] != expect:
+            return None
+        old, self.q[idx] = self.q[idx], text
+        return old
+
+
 class QueuedEdit(unittest.TestCase):
     """The queued bubble's ✎ (the user 2026-09-08): a message that has not reached the session is still the
     user's to change. Same slot, same follow-up context, only the words; refused with the ✕'s honesty when
@@ -464,22 +486,53 @@ class QueuedEdit(unittest.TestCase):
         self.assertEqual(km._split_followup(km._pending_ops[SID][0][1])[1], "second words")
 
     def test_edit_backend_queued_uses_the_drift_guard_and_keeps_a_followups_wrapper(self):
-        class _BE:
-            def __init__(self):
-                self.q = ["alpha", "> goal\n\nbody\n\n<!-- romp-goal-id: g1 -->"]
-            def pending_queued(self, sid):
-                return list(self.q)
-            def edit_queued(self, sid, idx, text, expect=None):
-                if not (0 <= idx < len(self.q)) or self.q[idx] != expect:
-                    return None
-                old, self.q[idx] = self.q[idx], text
-                return old
-        be = _BE()
+        be = _EditableQueueBackend(["alpha", "> goal\n\nbody\n\n<!-- romp-goal-id: g1 -->"])
         self.assertIsNone(km._edit_backend_queued(be, SID, 5, "body", "new body"), "a stale index re-locates by body")
         self.assertEqual(km._split_followup(be.q[1])[1], "new body")
         self.assertIn("<!-- romp-goal-id: g1 -->", be.q[1])
         self.assertEqual(km._edit_backend_queued(be, SID, 0, "gone", "x"), km._edit_miss_text("gone"))
         self.assertEqual(be.q[0], "alpha", "a miss rewrites nothing")
+
+    def test_an_edit_cannot_turn_a_message_into_a_slash_command(self):
+        # review find (2026-09-08): both arms replaced the body without _is_slash_command, so "/model opus" typed
+        # into the edit stayed a ("send", ...) op and reached the model as TEXT, skipping the fire-alone parking
+        # and the kernel-side setters every typed command gets. Both arms refuse, and nothing changes.
+        km._pending_ops[SID] = [("send", "words", "human")]
+        self.assertIn("cannot become a command", km._edit_parked(SID, 0, "words", "/model opus"))
+        self.assertEqual(km._pending_ops[SID], [("send", "words", "human")], "a refusal changes nothing")
+        be = _EditableQueueBackend(["alpha"])
+        self.assertIn("cannot become a command", km._edit_backend_queued(be, SID, 0, "alpha", "/compact"))
+        self.assertEqual((be.q, be.edits), (["alpha"], []), "the refusal never reaches the backend")
+        # a PATH is not a command (_is_slash_command's own rule): "/tmp/x is broken" still edits
+        self.assertIsNone(km._edit_parked(SID, 0, "words", "/tmp/x is broken"))
+        self.assertEqual(km._pending_ops[SID][0][1], "/tmp/x is broken")
+
+    def test_an_edited_continue_lands_as_the_users_words_not_the_canned_gesture(self):
+        # review find (2026-09-08): the Continue button's body carries <!-- romp-canned: continue -->, which
+        # describes the canned WORDS, and _replace_followup_body kept every trailing comment as wrapper, so the
+        # typed replacement went out still marked canned and the chat drew it as the Continue gesture row.
+        # Only romp's WRAPPER markers (note, injected, auto, goal-id) survive an edit.
+        fu = km._followup_body(SID + ":g7", "Ship the notes API", km.CONTINUE_TEXT + "\n\n<!-- romp-canned: continue -->")
+        self.assertIn("<!-- romp-canned: continue -->", fu, "the fixture is the button's real composition")
+        new = km._replace_followup_body(fu, "also add the tests first")
+        self.assertNotIn("romp-canned", new)
+        self.assertIn("<!-- romp-goal-id: " + SID + ":g7 -->", new, "the judge still files it under its goal")
+        self.assertIn("<!-- romp-note:", new)
+        self.assertEqual(km._split_followup(new)[1], "also add the tests first")
+        self.assertTrue(new.startswith("> Ship the notes API\n\nalso add the tests first\n\n<!-- romp-note:"), new)
+
+    def test_a_comment_inside_the_old_body_is_not_part_of_the_marker_tail(self):
+        # review find (2026-09-08): the tail regex ran with re.S and matched ANY comment, so a body holding an
+        # inline <!-- x --> anchored it there and the old words after the comment came back behind the NEW
+        # body. The docstring's inverse holds: _split_followup(_replace_followup_body(t, b))[1] == b.strip().
+        fu = "> goal\n\nsee <!-- x --> then more\n\n<!-- romp-goal-id: g -->"
+        self.assertEqual(km._replace_followup_body(fu, "new"), "> goal\n\nnew\n\n<!-- romp-goal-id: g -->")
+        fu2 = ("> Ship the notes API\n\nsee <!-- a --> then words\n\n"
+               "<!-- romp-note: the HTML comments below are part of an external tracking system --><!-- romp-goal-id: g7 -->")
+        new2 = km._replace_followup_body(fu2, "second words")
+        self.assertEqual(km._split_followup(new2)[1], "second words")
+        self.assertTrue(new2.endswith("<!-- romp-note: the HTML comments below are part of an external tracking system --><!-- romp-goal-id: g7 -->"))
+        self.assertNotIn("then words", new2)
 
     def test_drive_routes_the_three_edit_arms_and_answers_editResult(self):
         import inspect
@@ -493,6 +546,94 @@ class QueuedEdit(unittest.TestCase):
         self.assertEqual(src.count('"type": "editResult"'), 3, "every arm answers with an authoritative frame")
         ksrc = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"apiRetry", "editQueued"', ksrc, "the op routes to the owning kernel across linked machines (ID_OPS)")
+
+
+class QueuedEditDrive(unittest.TestCase):
+    """editQueued driven through _drive with a capturing client (tests/test_drive_foreign_sid.py's harness): the
+    three arms EXECUTE, and the editResult frame the client keys its restore on (id + md, ok, text) is asserted,
+    not the handler's source text (review find, 2026-09-08). SYNTHETIC sids only."""
+
+    def setUp(self):
+        self.sent = []
+        self.client = {"send": lambda s: self.sent.append(json.loads(s))}
+        self.be = _EditableQueueBackend()
+        self._saved = (km._name_of, km._sdk, km.Sessions.backend_for, km._push_soon)
+        km._name_of = lambda sid: "web" if sid == SID else None
+        km._sdk = lambda: None
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._push_soon = lambda *a, **k: None
+        km._pending_ops.clear()
+        km._inflight_ops.clear()
+
+    def tearDown(self):
+        km._name_of, km._sdk, backend_for, km._push_soon = self._saved
+        km.Sessions.backend_for = staticmethod(backend_for)
+        km._pending_ops.clear()
+        km._inflight_ops.clear()
+        try:
+            os.unlink(km._PENDING_OPS_FILE)
+        except OSError:
+            pass
+
+    def _edit(self, **fields):
+        msg = {"type": "editQueued", "id": SID}
+        msg.update(fields)
+        self.assertTrue(km._drive(msg, self.client), "a drive op is consumed")
+        self.assertEqual(len(self.sent), 1, "exactly one answer frame")
+        return self.sent[0]
+
+    def test_the_park_arm_replaces_the_fifo_send_and_answers_ok(self):
+        km._pending_ops[SID] = [("send", "a", "human")]
+        self.assertEqual(self._edit(park=0, md="a", text="b"),
+                         {"type": "editResult", "ok": True, "id": SID, "md": "a", "text": ""})
+        self.assertEqual(km._pending_ops[SID], [("send", "b", "human")])
+
+    def test_the_park_arm_answers_ok_false_with_the_reason_when_the_chip_is_not_a_message(self):
+        km._pending_ops[SID] = [("compact",)]
+        frame = self._edit(park=0, md="/compact", text="x")
+        self.assertEqual((frame["ok"], frame["md"]), (False, "/compact"))
+        self.assertIn("only a queued message can be edited", frame["text"])
+        self.assertEqual(km._pending_ops[SID], [("compact",)])
+
+    def test_the_idx_arm_rewords_the_backend_queue_under_its_drift_guard(self):
+        self.be.q = ["alpha", "beta"]
+        self.assertEqual(self._edit(idx=1, md="beta", text="beta 2"),
+                         {"type": "editResult", "ok": True, "id": SID, "md": "beta", "text": ""})
+        self.assertEqual(self.be.q, ["alpha", "beta 2"])
+        self.assertEqual(self.be.edits, [(1, "beta 2", "beta")], "the swap carried the exact old text")
+
+    def test_the_optimistic_arm_tries_the_fifo_then_the_backend_queue(self):
+        km._pending_ops[SID] = [("send", "p", "human")]
+        self.assertTrue(self._edit(md="p", text="p 2")["ok"], "the FIFO holds it")
+        self.assertEqual((km._pending_ops[SID][0][1], self.be.edits), ("p 2", []))
+        self.sent.clear()
+        self.be.q = ["alpha"]
+        frame = self._edit(md="alpha", text="alpha 2")          # the FIFO misses, the backend holds it
+        self.assertEqual(frame, {"type": "editResult", "ok": True, "id": SID, "md": "alpha", "text": ""},
+                         "the second locate WINS and the frame says so")
+        self.assertEqual(self.be.q, ["alpha 2"])
+
+    def test_the_optimistic_arm_misses_everywhere_with_the_too_late_text(self):
+        frame = self._edit(md="gone", text="x")
+        self.assertEqual((frame["ok"], frame["md"], frame["text"]), (False, "gone", km._edit_miss_text("gone")))
+
+    def test_a_slash_command_is_refused_at_every_arm(self):
+        km._pending_ops[SID] = [("send", "a", "human")]
+        self.be.q = ["alpha"]
+        for fields in ({"park": 0, "md": "a"}, {"idx": 0, "md": "alpha"}, {"md": "a"}):
+            self.sent.clear()
+            frame = self._edit(text="/model opus", **fields)
+            self.assertFalse(frame["ok"], fields)
+            self.assertIn("cannot become a command", frame["text"], fields)
+        self.assertEqual((km._pending_ops[SID][0][1], self.be.q, self.be.edits), ("a", ["alpha"], []))
+
+    def test_a_foreign_sid_is_refused_and_nothing_is_edited(self):
+        km._pending_ops[SID] = [("send", "a", "human")]
+        self.be.q = ["alpha"]
+        self.assertTrue(km._drive({"type": "editQueued", "id": THEIRS, "park": 0, "md": "a", "text": "b"}, self.client))
+        self.assertEqual(self.sent[0]["type"], "err", "refused loudly, in the pane that fired it")
+        self.assertEqual(self.sent[0]["copy"], "b", "the typed words ride back")
+        self.assertEqual((km._pending_ops[SID][0][1], self.be.q), ("a", ["alpha"]))
 
 
 class QueuedBubble(unittest.TestCase):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -4140,6 +4140,39 @@ class PendingQueue(unittest.TestCase):
         self.assertIsNone(self.be.unqueue("qx2", 0, "already forwarded"))
         self.assertEqual(s.pending(), ["survivor"], "a miss never pops a different message")
 
+    def test_replace_queued_edits_in_place_and_keeps_order(self):
+        # the chat's ✎ on a queued message (the user 2026-09-08): new words, same slot — the queue drains
+        # front-first, so the edited message still goes exactly where it would have
+        s = self._sess("qed1")
+        s.enqueue("alpha"); s.enqueue("beta"); s.enqueue("gamma")
+        self.assertEqual(self.be.edit_queued("qed1", 1, "beta, revised"), "beta", "the OLD text comes back")
+        self.assertEqual(s.pending(), ["alpha", "beta, revised", "gamma"])
+        self.assertEqual(self.be.pending_queued("qed1"), ["alpha", "beta, revised", "gamma"])
+        self.assertIsNone(self.be.edit_queued("qed1", 9, "x"), "out-of-range idx is a safe no-op")
+        self.assertIsNone(self.be.edit_queued("no-such-sid", 0, "x"), "unknown session → None")
+
+    def test_edit_queued_expect_relocates_under_the_lock_and_a_miss_touches_nothing(self):
+        s = self._sess("qed2")
+        s.enqueue("alpha"); s.enqueue("beta")
+        s.unqueue(0)                                     # the queue shifts after the caller's snapshot
+        self.assertEqual(self.be.edit_queued("qed2", 1, "beta 2", "beta"), "beta", "stale idx 1 re-locates to 'beta'")
+        self.assertEqual(s.pending(), ["beta 2"])
+        self.assertIsNone(self.be.edit_queued("qed2", 0, "late words", "already forwarded"), "a miss is None…")
+        self.assertEqual(s.pending(), ["beta 2"], "…and rewrites nothing else")
+
+    def test_edit_queued_rewords_the_optimistic_echo(self):
+        # unqueue drops the echo of a cancelled message; an edit re-words it, so the live tail shows the
+        # edited message and the landing scan matches the record the transcript will write
+        sid = "qed3"
+        s = self._sess(sid)
+        s.enqueue("first draft")
+        self.be._live.setdefault(sid, {})["echo:x"] = {"type": "user", "_echo_text": "first draft",
+            "message": {"role": "user", "content": [{"type": "text", "text": "first draft"}]}}
+        self.assertEqual(self.be.edit_queued(sid, 0, "second draft"), "first draft")
+        a = self.be._live[sid]["echo:x"]
+        self.assertEqual(a["_echo_text"], "second draft")
+        self.assertEqual(a["message"]["content"][0]["text"], "second draft")
+
     def test_queue_recallable_only_while_a_recall_can_win(self):
         # the ✕ affordance gate (the user 2026-07-20): during a running UN-HELD turn the input
         # generator forwards a queued send into the CLI within milliseconds — a cancel there can only

--- a/ui/webview/queued-edit.test.ts
+++ b/ui/webview/queued-edit.test.ts
@@ -1,0 +1,85 @@
+// EDITING a queued message (the user 2026-09-08): a message that has not reached the session yet — held in
+// the SDK backend's queue (idx), parked in romp's FIFO (park), or still at the optimistic "sending…" stage
+// — is the user's to change until it goes. The ✎ beside the ✕ loads the text into the composer under an
+// editing pill; send posts editQueued and the kernel replaces the entry IN PLACE (same slot, a follow-up's
+// wrapper kept), answering editResult like the ✕'s cancelResult. No jsdom harness → source pins, the
+// repo's convention (queued-indicator.test.ts is the ✕'s twin of this file).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const SDKBE = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
+
+test("an editable queued bubble carries a ✎ beside its ✕ — the same three stages, the same recall gate, user words only", () => {
+  assert.match(RENDER, /if \(t\.cancelable && !t\.romp && !isCmd && \(t\.idx !== undefined \|\| t\.park !== undefined \|\| t\.optimistic\)\)/,
+    "romp's notices and slash commands are not edited — a command is cancelled and typed again");
+  assert.match(RENDER, /bubble\.classList\.add\("editable"\);/);
+  assert.match(RENDER, /el\("button", "queued-edit"\)/);
+  assert.match(RENDER, /ed\.dataset\.act = "qedit";/, "delegated through the stable document.body delegate, like the ✕");
+  assert.match(RENDER, /if \(t\.idx !== undefined\) ed\.dataset\.qidx = String\(t\.idx\);/);
+  assert.match(RENDER, /if \(t\.park !== undefined\) ed\.dataset\.qpark = String\(t\.park\);/);
+  assert.match(RENDER, /if \(t\.optimistic\) ed\.dataset\.qopt = "1";/);
+  assert.match(RENDER, /\(ed as any\)\._qmd = t\.md;/, "the body rides along: the kernel's drift guard and the composer read it");
+  assert.doesNotMatch(RENDER, /bubble\.addEventListener\("click"/, "the bubble itself still carries no listener");
+  assert.match(CSS, /\.queued-bubble\.editable \{ padding-right: 52px; \}/, "room for both corner controls");
+  assert.match(CSS, /\.queued-edit \{\s*\n\s*position: absolute; top: 3px; right: 26px;/);
+  assert.match(CSS, /\.queued-edit:hover \{ color: var\(--accent\)/, "accent, not red — it changes the message, it does not remove it");
+});
+
+test("the qedit delegate loads the composer under an editing pill (the rewind edit's grammar)", () => {
+  assert.match(RENDER, /qedit: \(el\) => \{/);
+  assert.match(RENDER, /if \(sidQ !== activeId\) \{ warnToast\("open that session's chat to edit its queued message"\); return; \}/,
+    "the edit rides the ACTIVE composer — another session's bubble is declined, never edited in the wrong box");
+  assert.match(RENDER, /beginQueuedEdit\(sidQ, ref\);/);
+  assert.match(RENDER, /type QueuedEditRef = \{ md: string; idx\?: number; park\?: number; qts\?: number; optimistic\?: boolean \};/);
+  assert.match(RENDER, /const queuedEdits = new Map<string, QueuedEditRef>\(\);/);
+  assert.match(RENDER, /function beginQueuedEdit\(sid: string, ref: QueuedEditRef\): void \{\s*\n\s*if \(composerEdits\.has\(sid\)\) cancelComposerEdit\(sid\);/,
+    "one edit at a time: a rewind edit yields to a queued edit…");
+  assert.match(RENDER, /function beginComposerEdit\(sid: string, uuid: string, orig: string\): void \{\s*\n\s*if \(queuedEdits\.has\(sid\)\) cancelQueuedEdit\(sid\);/,
+    "…and a queued edit yields to a rewind edit");
+  assert.match(RENDER, /label\.textContent = "Editing queued message — send replaces it in the queue";/);
+  assert.match(RENDER, /if \(activeId && queuedEdits\.has\(activeId\)\) \{ cancelQueuedEdit\(activeId\); return; \}/, "Escape cancels it first");
+});
+
+test("send in queued-edit mode posts editQueued with the old body and keeps the words if the kernel refuses", () => {
+  assert.match(RENDER, /const qmsg: Record<string, unknown> = \{ type: "editQueued", id: activeId, md: qedit\.md, text: typed \};/);
+  assert.match(RENDER, /if \(qedit\.idx !== undefined\) qmsg\.idx = qedit\.idx;/);
+  assert.match(RENDER, /if \(qedit\.park !== undefined\) qmsg\.park = qedit\.park;/);
+  assert.match(RENDER, /if \(!typed\) return;\s*\/\/ an empty edit is not a send — to drop the message, use its ✕/);
+  assert.match(RENDER, /pendingEditRestores\.set\(activeId \+ " " \+ qedit\.md, \{ typed, ref: qedit \}\);/);
+  assert.match(RENDER, /applyQueuedEditLocally\(activeId, qedit, typed\);/, "the bubble shows the new words at once (acknowledge the click)");
+  assert.doesNotMatch(RENDER, /registerOptimistic\(activeId, typed\);\s*\n\s*queuedEdits/, "an edit is not a new send — no optimistic send entry");
+  // the verdict frame: cancelResult's twin
+  assert.match(RENDER, /m\.type === "editResult" && typeof m\.id === "string"/);
+  assert.match(RENDER, /applyQueuedEditLocally\(m\.id, stash\.ref, stash\.typed, true\);/, "the optimistic repaint is reversed");
+  assert.match(RENDER, /if \(m\.id === activeId\) restoreToComposer\(stash\.typed\);/, "the typed words come back — never lost, never sent twice");
+  assert.match(RENDER, /pendingEditRestores\.delete\(key\);/);
+});
+
+test("the optimistic repaint touches the client's copy of the queue AND our own pending-send entry", () => {
+  assert.match(RENDER, /function applyQueuedEditLocally\(sid: string, ref: QueuedEditRef, text: string, back = false\): void/);
+  assert.match(RENDER, /if \(p\.text === from && \(ref\.qts === undefined \|\| p\.ts === ref\.qts\)\) \{ p\.text = to; p\.body = pendingBody\(to, p\.imgPaths\); \}/,
+    "our pending entry follows the edit, or the pending reconcile would paint the old words back");
+  assert.match(RENDER, /if \(e\.kind !== "queued"\) continue;[\s\S]*?t\.md = to;/);
+});
+
+test("the kernel replaces the entry in place at every stage and answers with an authoritative editResult", () => {
+  assert.match(KERNEL, /def _edit_parked\(sid, park, md, text\):/);
+  assert.match(KERNEL, /def _edit_backend_queued\(be, sid, idx, md, text\):/);
+  assert.match(KERNEL, /def _replace_followup_body\(text, body\):/, "a follow-up keeps its goal quote and markers");
+  assert.match(KERNEL, /ops\[park\] = \("send", _replace_followup_body\(op\[1\], body\)\) \+ tuple\(op\[2:\]\)/, "same slot, same echo author");
+  assert.match(KERNEL, /if park == 0 and inflight_head:\s*\n\s*return _edit_miss_text\(md\)/, "the head the backend holds is too late, like the ✕");
+  assert.equal(KERNEL.split('"type": "editResult"').length - 1, 3, "one reply per arm: park + idx + the optimistic md-only arm");
+  assert.match(KERNEL, /def _edit_miss_text\(md\):/);
+  assert.match(KERNEL, /too late to edit — the message already reached the session as it was/);
+  assert.match(KERNEL, /"cancelQueued", "dismissEcho", "apiRetry", "editQueued"/, "routes to the owning kernel across linked machines");
+  assert.match(SDKBE, /def replace_queued\(self, idx: int, text: str, expect: str \| None = None\) -> str \| None:/,
+    "the swap re-verifies the exact old text under the session lock — never a wrong-message rewrite");
+  assert.match(SDKBE, /def edit_queued\(self, sid: str, idx: int, text: str, expect: str \| None = None\) -> str \| None:/);
+  assert.match(SDKBE, /a\["_echo_text"\] = text/, "the optimistic echo is re-worded, so the live tail shows the edited message");
+});

--- a/ui/webview/queued-edit.test.ts
+++ b/ui/webview/queued-edit.test.ts
@@ -83,3 +83,47 @@ test("the kernel replaces the entry in place at every stage and answers with an 
   assert.match(SDKBE, /def edit_queued\(self, sid: str, idx: int, text: str, expect: str \| None = None\) -> str \| None:/);
   assert.match(SDKBE, /a\["_echo_text"\] = text/, "the optimistic echo is re-worded, so the live tail shows the edited message");
 });
+
+// ---- review finds (2026-09-08) --------------------------------------------------------------------------
+// The qedit branch of sendComposer, from its head to the editQueued post: every refusal below must sit in
+// this window, so the words are still in the box (and the bubble unchanged) when the branch bails.
+const QEDIT_BRANCH = RENDER.slice(RENDER.indexOf("const qedit = queuedEdits.get(activeId);\n    if (qedit) {"),
+                                  RENDER.indexOf('const qmsg: Record<string, unknown> = { type: "editQueued"'));
+
+test("a queued edit cannot become a command: the kernel refuses in both arms and the composer keeps the words", () => {
+  assert.ok(QEDIT_BRANCH.length > 0, "the qedit branch precedes the editQueued post");
+  assert.match(QEDIT_BRANCH, /if \(SLASH_CMD_RE\.test\(typed\)\) \{ warnToast\("A queued message cannot become a command\. Cancel it with its ✕ and type the command\."\); return; \}/,
+    "the words stay in the box under the pill; nothing is posted (the kernel would deliver a command as text)");
+  for (const head of ["def _edit_parked(sid, park, md, text):", "def _edit_backend_queued(be, sid, idx, md, text):"]) {
+    const arm = KERNEL.slice(KERNEL.indexOf(head));
+    assert.match(arm, /^[\s\S]*?if not body:\s*\n\s*return "nothing to send[^\n]*\n\s*if _is_slash_command\(body\):\s*\n(?:\s*#[^\n]*\n)*\s*return "a queued message cannot become a command: cancel it with its ✕ and type the command"/,
+      head + " refuses a slash-command body right after the empty-body check, before anything is replaced");
+  }
+});
+
+test("⌘/Ctrl+⏎ cannot stage a queued edit as a NEW message while the original stays queued", () => {
+  assert.match(RENDER, /if \(composerEdits\.has\(activeId\)\) \{ warnToast\("An edit replaces a past message[^\n]*\n\s*if \(queuedEdits\.has\(activeId\)\) \{ warnToast\("This edit replaces a queued message\. Send it normally\."\); return; \}/,
+    "staging is refused while a queued edit owns the box, as it is for a rewind edit");
+});
+
+test("an editQueued is refused BEFORE the box is cleared when the host is down or the tab is provisional", () => {
+  assert.match(QEDIT_BRANCH, /if \(hostIsDown\(activeId\) \|\| isProvisionalId\(activeId\)\) \{\s*\n\s*if \(hostIsDown\(activeId\)\) vscodeApi\?\.postMessage\(\{ type: "redial"/,
+    "deliver()'s guard: a down host drops the frame and no editResult would ever hand the words back");
+  assert.match(QEDIT_BRANCH, /It's still in the box/);
+});
+
+test("editResult ok:false lands the typed words in that session's draft when the tab changed mid-round-trip", () => {
+  assert.match(RENDER, /if \(m\.id === activeId\) restoreToComposer\(stash\.typed\);\s*\n\s*else \{\n(?:[^\n]*\n){0,4}?\s*drafts\.set\(m\.id, [^\n]*stash\.typed[^\n]*\);\s*\n\s*persistDrafts\(\);/,
+    "neither the bubble nor the box holds them, so the draft store must; the next switch back shows them");
+});
+
+test("the ✎ holds the draft it displaces and gives it back when the edit ends; a closed session forgets its edit", () => {
+  assert.match(RENDER, /const queuedEditHeld = new Map<string, string>\(\);/);
+  assert.match(RENDER, /function beginQueuedEdit\(sid: string, ref: QueuedEditRef\): void \{[\s\S]*?if \(ta\.value\.trim\(\)\) queuedEditHeld\.set\(sid, ta\.value\);[\s\S]*?ta\.value = ref\.md;/,
+    "the in-progress draft is held BEFORE the queued text overwrites the box");
+  assert.match(RENDER, /function cancelQueuedEdit\(sid: string\): void \{\s*\n\s*if \(!queuedEdits\.delete\(sid\)\) return;\s*\n\s*restoreHeldDraft\(sid\);/);
+  assert.match(RENDER, /applyQueuedEditLocally\(activeId, qedit, typed\);\s*\n\s*restoreHeldDraft\(activeId\);/, "…and after a send");
+  assert.match(RENDER, /function restoreHeldDraft\(sid: string\): void \{[\s\S]*?if \(held\) drafts\.set\(sid, held\); else \{ drafts\.delete\(sid\); draftStartedAt\.delete\(sid\); \}/);
+  assert.match(RENDER, /queuedEdits\.delete\(id\); queuedEditHeld\.delete\(id\);[^\n]*\n\s*drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\);/,
+    "a close clears the queued edit with the rewind edit, so a stale pill never survives its session");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13884,6 +13884,9 @@ const queuedEdits = new Map<string, QueuedEditRef>();
 // the typed text + the entry it replaced, keyed sid + " " + old body, so a failed edit can give the words
 // back and undo the optimistic repaint (one-shot, ok or not — pendingCancelRestores' twin)
 const pendingEditRestores = new Map<string, { typed: string; ref: QueuedEditRef }>();
+// the in-progress draft the ✎ displaced, per session, handed back when the edit ends (cancelled or sent) so
+// correcting a queued message never costs a half-typed one (review find, 2026-09-08)
+const queuedEditHeld = new Map<string, string>();
 
 function beginQueuedEdit(sid: string, ref: QueuedEditRef): void {
   if (composerEdits.has(sid)) cancelComposerEdit(sid);   // one edit at a time: a rewind edit yields to this one
@@ -13891,16 +13894,28 @@ function beginQueuedEdit(sid: string, ref: QueuedEditRef): void {
   composerCitations.delete(sid);   // the queued text carries its own context (a follow-up keeps it kernel-side)
   if (sid !== activeId) return;
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (ta) { ta.value = ref.md; growComposer(ta); ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+  if (ta) {
+    if (ta.value.trim()) queuedEditHeld.set(sid, ta.value);   // hold the draft this edit displaces
+    ta.value = ref.md; growComposer(ta); ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length);
+  }
   renderComposerChips(sid);
 }
 
 function cancelQueuedEdit(sid: string): void {
   if (!queuedEdits.delete(sid)) return;
+  restoreHeldDraft(sid);
+}
+
+// The queued edit is over (cancelled, or sent): the box goes back to the draft the ✎ displaced, or empties,
+// and the pill goes with it. The draft store follows either way, so a tab switch or a reload sees the same.
+function restoreHeldDraft(sid: string): void {
+  const held = queuedEditHeld.get(sid) || "";
+  queuedEditHeld.delete(sid);
+  if (held) drafts.set(sid, held); else { drafts.delete(sid); draftStartedAt.delete(sid); }
+  persistDrafts();
   if (sid !== activeId) return;
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (ta) { ta.value = ""; composerManualH = null; ta.style.height = ""; }
-  drafts.delete(sid); persistDrafts();
+  if (ta) { ta.value = held; composerManualH = null; ta.style.height = ""; if (held) growComposer(ta); }
   renderComposerChips(sid);
 }
 
@@ -15099,6 +15114,7 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
     // closed session was ACTIVE: the shared chip strip above the composer still shows its chip until
     // someone repaints it, and that stale chip's ✕ targets the dead id (whose map entry is gone), so the
     // click early-returns and the chip can't even be dismissed — hence the repaint below.
+    queuedEdits.delete(id); queuedEditHeld.delete(id);   // a queued edit goes with the rewind edit's pill (review find, 2026-09-08)
     drafts.delete(id); composerCitations.delete(id); composerEdits.delete(id); composerFiles.delete(id); persistDrafts();
   } else {
     persistDrafts();   // a host drop / omission KEEPS it all (see DismissWhy) — the stash above may have updated the copy
@@ -15336,6 +15352,13 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       if (stash) {
         applyQueuedEditLocally(m.id, stash.ref, stash.typed, true);
         if (m.id === activeId) restoreToComposer(stash.typed);
+        else {
+          // the tab changed mid-round-trip (review find, 2026-09-08): the words land in THAT session's draft,
+          // which setActive puts back in the box on the next switch to it, as the paste-verify restore does
+          const d = drafts.get(m.id);
+          drafts.set(m.id, d && d.trim() ? d.replace(/\s*$/, "") + "\n" + stash.typed : stash.typed);
+          persistDrafts();
+        }
       }
       const rv = m.id === activeId && activeId ? views.get(activeId) : null;
       if (rv) { rv.stale = true; appendActive(); }
@@ -15692,7 +15715,8 @@ function setupComposer() {
   // ⌘/Ctrl+⏎ — STAGE the box instead of sending (the user 2026-08-15): the text and its citation
   // chips move to the staged strip, the box clears, focus stays for the next highlight-and-comment.
   // The states that already own the box refuse loudly rather than staging a lie: a picker answer
-  // answers NOW or sends normally; an edit replaces a past message; attachments ride a normal send.
+  // answers NOW or sends normally; an edit replaces a past message, or a queued one; attachments ride a
+  // normal send.
   const stageComposer = () => {
     if (!activeId) return;
     const typed = ta.value.trim();
@@ -15701,6 +15725,7 @@ function setupComposer() {
     if (!typed && !(composerCitations.get(activeId) || []).some((c) => c.quote)) return;
     if (composerAnswersAsk()) { warnToast("A picker is waiting on this box — answer it, or send normally."); return; }
     if (composerEdits.has(activeId)) { warnToast("An edit replaces a past message — send it normally."); return; }
+    if (queuedEdits.has(activeId)) { warnToast("This edit replaces a queued message. Send it normally."); return; }   // staged, the words would go as a NEW message behind the unchanged original (review find, 2026-09-08)
     if ((composerFiles.get(activeId) || []).length) { warnToast("Attachments can't be staged — send them with a normal message."); return; }
     stagedMsgs.push(activeId, { text: typed, cites: (composerCitations.get(activeId) || []).slice() });
     composerCitations.delete(activeId); renderComposerChips(activeId);   // the chips now live on the staged item
@@ -15787,16 +15812,27 @@ function setupComposer() {
     const qedit = queuedEdits.get(activeId);
     if (qedit) {
       if (!typed) return;   // an empty edit is not a send — to drop the message, use its ✕
+      // Two refusals that leave the box exactly as it is (review finds, 2026-09-08). A down host DROPS the
+      // frame (federation posts nothing to a closed socket) and no editResult ever comes back to hand the
+      // words over, so the plain send's deliver() guard applies here, BEFORE the box is cleared; a provisional
+      // tab has no session behind it and nothing queued. And a slash command cannot be edited INTO a queued
+      // message: the kernel would deliver it as text, skipping the routing every typed command gets (the
+      // fire-alone park, the /model and /effort setters, the /clear confirm below), so the kernel refuses it
+      // too; this mirror keeps the words in the box instead of round-tripping them.
+      if (hostIsDown(activeId) || isProvisionalId(activeId)) {
+        if (hostIsDown(activeId)) vscodeApi?.postMessage({ type: "redial", host: String(activeId).slice(0, String(activeId).indexOf(":")) });
+        warnToast("Can't reach the session right now, so the edit wasn't sent. It's still in the box: send again when the link is back.");
+        return;
+      }
+      if (SLASH_CMD_RE.test(typed)) { warnToast("A queued message cannot become a command. Cancel it with its ✕ and type the command."); return; }
       const qmsg: Record<string, unknown> = { type: "editQueued", id: activeId, md: qedit.md, text: typed };
       if (qedit.idx !== undefined) qmsg.idx = qedit.idx;
       if (qedit.park !== undefined) qmsg.park = qedit.park;
       vscodeApi?.postMessage(qmsg);
       pendingEditRestores.set(activeId + " " + qedit.md, { typed, ref: qedit });
       queuedEdits.delete(activeId);
-      renderComposerChips(activeId);
       applyQueuedEditLocally(activeId, qedit, typed);
-      drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();
-      ta.value = ""; composerManualH = null; ta.style.height = "";
+      restoreHeldDraft(activeId);   // the pill goes; the box gets back the draft the ✎ displaced, or empties
       return;
     }
     const sid = activeId;   // the session this send (and any confirm below) was armed for

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -40,7 +40,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack, quoteReplyBody, stagedPosts } from "./staged-messages";
-import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel } from "./send-pending";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, queuedCopyToHide, dropPending, bareGroupLabel, sentAtLabel, pendingBody } from "./send-pending";
 import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldMemory } from "./queued-held";
 import { reloadHoldReason } from "./reload-hold";
 import { liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
@@ -4300,6 +4300,25 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       if (isCmd) x.dataset.qcmd = "1";
       (x as any)._qmd = t.md;   // the bubble's body — the kernel's drift guard + the composer restore read it
       xHost.appendChild(x);
+    }
+    // EDITABLE — a ✎ beside the ✕ (the user 2026-09-08): a message that has not reached the session is
+    // still the user's to change. The same three stages the ✕ covers (backend queue, parked, optimistic),
+    // and the same recall gate (cancelable); romp's own words and slash commands are not edited — a
+    // command is cancelled and typed again, and romp's notices are not the user's to reword. Delegated
+    // like the ✕ (data-act="qedit"); the composer takes the text under an editing pill (beginQueuedEdit),
+    // and send replaces the message where it sits — see the editQueued path in sendComposer.
+    if (t.cancelable && !t.romp && !isCmd && (t.idx !== undefined || t.park !== undefined || t.optimistic)) {
+      bubble.classList.add("editable");
+      const ed = el("button", "queued-edit");
+      ed.textContent = "✎";
+      ed.title = "edit this queued message — it keeps its place in the queue";
+      ed.dataset.act = "qedit";
+      if (t.idx !== undefined) ed.dataset.qidx = String(t.idx);
+      if (t.park !== undefined) ed.dataset.qpark = String(t.park);
+      if (t.optimistic) ed.dataset.qopt = "1";
+      if (t.optimistic && t.qts !== undefined) ed.dataset.qts = String(t.qts);   // OUR entry's identity, as on the ✕: a kernel copy's qts is its enqueue stamp, not an entry (T252c)
+      (ed as any)._qmd = t.md;
+      xHost.appendChild(ed);
     }
     turn.appendChild(bubble);
   }
@@ -13852,7 +13871,70 @@ function renderStagedStrip(id: string | null, opts?: { reveal?: "last" }): void 
   list.scrollTop = opts?.reveal === "last" ? list.scrollHeight : (stagedScroll.get(id) || 0);
 }
 
+// ---- editing a QUEUED message (the user 2026-09-08) --------------------------------------------------
+// A message that has not reached the session yet — parked in romp's FIFO, held in the SDK backend's own
+// queue, or still at the optimistic "sending…" stage — is the user's to change until it goes. The ✎ on its
+// bubble loads the text into the composer under an EDITING pill (the rewind edit's grammar, one level
+// deeper: "Editing queued message"), and send REPLACES it in place: same queue slot, same follow-up
+// context, only the words. The kernel verifies the entry by body (editQueued's md — the ✕'s drift guard)
+// and answers editResult; ok:false means the message left the queue meanwhile, so the typed words go
+// back to the composer and the queue repaints from the kernel — nothing is lost, nothing is sent twice.
+type QueuedEditRef = { md: string; idx?: number; park?: number; qts?: number; optimistic?: boolean };
+const queuedEdits = new Map<string, QueuedEditRef>();
+// the typed text + the entry it replaced, keyed sid + " " + old body, so a failed edit can give the words
+// back and undo the optimistic repaint (one-shot, ok or not — pendingCancelRestores' twin)
+const pendingEditRestores = new Map<string, { typed: string; ref: QueuedEditRef }>();
+
+function beginQueuedEdit(sid: string, ref: QueuedEditRef): void {
+  if (composerEdits.has(sid)) cancelComposerEdit(sid);   // one edit at a time: a rewind edit yields to this one
+  queuedEdits.set(sid, ref);
+  composerCitations.delete(sid);   // the queued text carries its own context (a follow-up keeps it kernel-side)
+  if (sid !== activeId) return;
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (ta) { ta.value = ref.md; growComposer(ta); ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+  renderComposerChips(sid);
+}
+
+function cancelQueuedEdit(sid: string): void {
+  if (!queuedEdits.delete(sid)) return;
+  if (sid !== activeId) return;
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  if (ta) { ta.value = ""; composerManualH = null; ta.style.height = ""; }
+  drafts.delete(sid); persistDrafts();
+  renderComposerChips(sid);
+}
+
+// The optimistic half of an edit: the queued bubble shows the NEW words at once (the acknowledge-the-click
+// rule) — in the client's copy of the kernel events and in our own pending-send entry, so neither the next
+// re-render nor the pending reconcile paints the old text back before the kernel's push confirms. `back`
+// reverses it (editResult ok:false: the session has the old words).
+function applyQueuedEditLocally(sid: string, ref: QueuedEditRef, text: string, back = false): void {
+  const from = back ? text : ref.md, to = back ? ref.md : text;
+  for (const p of pendingSent.get(sid) || []) {
+    if (p.text === from && (ref.qts === undefined || p.ts === ref.qts)) { p.text = to; p.body = pendingBody(to, p.imgPaths); }
+  }
+  const s = sessions.get(sid);
+  if (s) {
+    for (let i = s.events.length - 1, n = 0; i >= 0 && n < 10; i--, n++) {   // a queued group only ever sits at the tail
+      const e = s.events[i];
+      if (e.kind !== "queued") continue;
+      for (const t of e.texts) {
+        if (t.md !== from) continue;
+        if (ref.idx !== undefined && t.idx !== undefined && t.idx !== ref.idx) continue;
+        if (ref.park !== undefined && t.park !== undefined && t.park !== ref.park) continue;
+        t.md = to;
+      }
+    }
+  }
+  // the held-copy memory follows too (T262i): reconcileHeld keys an id-less copy by TEXT, so a previous-push copy
+  // left with the old words would read as vanished on the next push and be held as a phantom of them
+  const mem = heldQueued.get(sid);
+  if (mem) for (const c of mem.prev) if (c.md === from) c.md = to;
+  if (sid === activeId) { const v = views.get(sid); if (v) { v.stale = true; appendActive(); } }
+}
+
 function beginComposerEdit(sid: string, uuid: string, orig: string): void {
+  if (queuedEdits.has(sid)) cancelQueuedEdit(sid);   // …and a queued edit yields to a rewind edit
   composerEdits.set(sid, { uuid, orig });
   composerCitations.delete(sid);   // an edit replaces the message wholesale — mixed goal/quote context would mislead
   if (sid !== activeId) return;
@@ -13903,6 +13985,22 @@ function renderComposerChips(id: string | null): void {
     chip.appendChild(label);
     const x = el("button", "composer-chip-x"); x.setAttribute("aria-label", "Cancel edit"); x.textContent = "✕";
     x.addEventListener("click", (e) => { e.stopPropagation(); cancelComposerEdit(id); });
+    chip.appendChild(x);
+    strip.appendChild(chip);
+    return;
+  }
+  // the QUEUED edit's pill (the user 2026-09-08): the rewind pill's grammar, saying what send does instead
+  const qedit = id ? queuedEdits.get(id) : undefined;
+  if (qedit && id) {
+    strip.style.display = "flex";
+    const chip = el("div", "composer-chip composer-chip-edit");
+    chip.title = "the message keeps its place in the queue and goes as edited — ✕ (or Esc) leaves it as it was";
+    const mark = el("span", "composer-chip-mark"); mark.textContent = "✎"; chip.appendChild(mark);
+    const label = el("span", "composer-chip-label");
+    label.textContent = "Editing queued message — send replaces it in the queue";
+    chip.appendChild(label);
+    const x = el("button", "composer-chip-x"); x.setAttribute("aria-label", "Cancel edit"); x.textContent = "✕";
+    x.addEventListener("click", (e) => { e.stopPropagation(); cancelQueuedEdit(id); });
     chip.appendChild(x);
     strip.appendChild(chip);
     return;
@@ -15225,6 +15323,24 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       if (rv) { rv.stale = true; appendActive(); }
     }
   }
+  // The kernel's verdict on an editQueued (the user 2026-09-08) — cancelResult's twin. ok:false: the message
+  // left the queue before the edit reached it (or the chip was never a message), so the optimistic repaint is
+  // reversed, the typed words go back to the composer (never lost, never sent twice), and the queue repaints
+  // from the kernel's events, which hold what the session actually has.
+  else if (m.type === "editResult" && typeof m.id === "string") {
+    const key = m.id + " " + (typeof m.md === "string" ? m.md : "");
+    const stash = pendingEditRestores.get(key);
+    pendingEditRestores.delete(key);
+    if (!m.ok) {
+      if (typeof m.text === "string" && m.text) warnToast(m.text);
+      if (stash) {
+        applyQueuedEditLocally(m.id, stash.ref, stash.typed, true);
+        if (m.id === activeId) restoreToComposer(stash.typed);
+      }
+      const rv = m.id === activeId && activeId ? views.get(activeId) : null;
+      if (rv) { rv.stale = true; appendActive(); }
+    }
+  }
   // The identity palette changed (gear → Session colors): refresh the right-click menu's swatch set so a
   // menu opened after the switch offers the NEW palette (the kernel remaps + repaints sessions itself).
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
@@ -15664,6 +15780,25 @@ function setupComposer() {
       ta.value = ""; composerManualH = null; ta.style.height = "";
       return;
     }
+    // A QUEUED-message edit → editQueued: the entry is replaced in place, kernel-side. No registerOptimistic
+    // (nothing new is sent — the bubble already exists and only changes words; applyQueuedEditLocally shows
+    // them now). The kernel's push confirms; editResult ok:false (the message left the queue meanwhile)
+    // hands the typed words back to the composer. Attachments wait for the next normal send, as for an edit.
+    const qedit = queuedEdits.get(activeId);
+    if (qedit) {
+      if (!typed) return;   // an empty edit is not a send — to drop the message, use its ✕
+      const qmsg: Record<string, unknown> = { type: "editQueued", id: activeId, md: qedit.md, text: typed };
+      if (qedit.idx !== undefined) qmsg.idx = qedit.idx;
+      if (qedit.park !== undefined) qmsg.park = qedit.park;
+      vscodeApi?.postMessage(qmsg);
+      pendingEditRestores.set(activeId + " " + qedit.md, { typed, ref: qedit });
+      queuedEdits.delete(activeId);
+      renderComposerChips(activeId);
+      applyQueuedEditLocally(activeId, qedit, typed);
+      drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();
+      ta.value = ""; composerManualH = null; ta.style.height = "";
+      return;
+    }
     const sid = activeId;   // the session this send (and any confirm below) was armed for
     const deliver = () => {
       if (activeId !== sid) return;   // a confirm outlived a tab switch — never send into the wrong session
@@ -16064,6 +16199,7 @@ function setupComposer() {
       // for "tab mode" — focus the active tab so ←/→ switch sessions (the user 2026-06-25). Enter on a
       // tab drops back in (onTabKey). Any draft text stays in the box, untouched.
       e.preventDefault();
+      if (activeId && queuedEdits.has(activeId)) { cancelQueuedEdit(activeId); return; }
       if (activeId && composerEdits.has(activeId)) { cancelComposerEdit(activeId); return; }
       focusActiveTab();
       return;
@@ -16527,6 +16663,23 @@ setupSettings();
       bub?.remove();
       if (grp) reflowQueuedGroup(grp);
       if (contentX && wasAtBottom) writeScroll(contentX, contentX.scrollHeight, "queued-x", true);
+    },
+    // ✎ on a queued bubble (the user 2026-09-08): edit the message while it is still romp's to change.
+    // Delegated like the ✕ (the tail rebuilds every push). The edit rides the ACTIVE composer, so a bubble
+    // owned by another session (a comment thread's popover) is declined with a pointer rather than edited
+    // in the wrong box. The acknowledgement is the composer filling + the editing pill, at once.
+    qedit: (el) => {
+      if (!activeId) return;
+      const qmd = (el as any)._qmd as string | undefined;
+      if (!qmd) return;
+      const sidQ = owningSidOf(el) || activeId;
+      if (sidQ !== activeId) { warnToast("open that session's chat to edit its queued message"); return; }
+      const ref: QueuedEditRef = { md: qmd };
+      if (el.dataset.qidx !== undefined) ref.idx = Number(el.dataset.qidx);
+      if (el.dataset.qpark !== undefined) ref.park = Number(el.dataset.qpark);
+      if (el.dataset.qts !== undefined) ref.qts = Number(el.dataset.qts);
+      if (el.dataset.qopt === "1") ref.optimistic = true;
+      beginQueuedEdit(sidQ, ref);
     },
     // a comment highlight or its turn badge (the user 2026-08-13): open the thread's popover at the
     // click. Delegated — marks and badges are re-created on every transcript rebuild — and so is

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1889,6 +1889,17 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   color: var(--dim); background: transparent; border: 0; border-radius: 6px; padding: 0;
 }
 .queued-x:hover { color: var(--vscode-errorForeground, #f48771); background: rgba(255, 255, 255, 0.08); }
+/* EDITABLE — a ✎ beside the ✕ (the user 2026-09-08): a message that has not reached the session yet is still
+   the user's to change. Same corner, same dim-until-hover treatment; the ACCENT (not red) on its own hover — it
+   changes the message, it does not remove it. The bubble reserves room for both controls. */
+.queued-bubble.editable { padding-right: 52px; }
+.queued-edit {
+  position: absolute; top: 3px; right: 26px; width: 20px; height: 20px;
+  display: flex; align-items: center; justify-content: center;
+  font: inherit; font-size: 0.82em; line-height: 1; cursor: pointer;
+  color: var(--dim); background: transparent; border: 0; border-radius: 6px; padding: 0;
+}
+.queued-edit:hover { color: var(--accent); background: rgba(255, 255, 255, 0.08); }
 /* A notice romp itself queued (T243) wears the LANDED romp notice card nested inside the queued bubble: the
    dashed "you" dress comes off the wrapper (the card brings its own gray tone), and the ✕ moves inside the
    card's corner so it reads as the card's control. */


### PR DESCRIPTION
## What

A message sent to a busy session waits as a dashed bubble — parked while the session compacts, held in the SDK backend's queue behind a running turn, or at the optimistic "sending…" stage. Until now the only way to change it was the ✕: pull it back into the composer and send again, at the back of the queue. It is still the user's message while it waits, so it is now **editable in place**.

## Design points

- **The control.** The queued bubble wears a ✎ beside its ✕, at the same three stages and behind the same recall gate (`cancelable`); romp's own notices and slash commands are not edited (a command is cancelled and typed again). Delegated through the body delegate like the ✕, so a mid-press rebuild cannot eat the click.
- **The editing surface is the composer**, under an "Editing queued message — send replaces it in the queue" pill — the rewind edit's grammar, one level deeper. Esc or the pill's ✕ leaves the message as it was. A rewind edit and a queued edit yield to each other; one edit at a time.
- **In place, kernel-side.** Send posts `editQueued {md, text, idx|park}` (body-only at the optimistic stage). `_edit_parked` swaps the send's words in its FIFO slot under the queue lock — same echo author, the in-flight head refused as too late, exactly as `_cancel_parked` does. `_edit_backend_queued` → `SdkBackend.edit_queued` → `SdkSession.replace_queued` re-verifies the exact old text under the session lock (a shifted index re-locates by body) and re-words the message's optimistic echo so the live tail shows the edited words.
- **A follow-up keeps its context.** `_replace_followup_body` keeps the goal quote and the trailing romp markers (the inverse of `_split_followup`'s body read), so an edited follow-up still files under its goal.
- **Authoritative result frame.** Every arm answers `editResult`; `ok:false` (the message left the queue meanwhile) reverses the optimistic repaint, hands the typed words back to the composer, and repaints the queue from the kernel. Nothing is lost and nothing is sent twice. `editQueued` joins `ID_OPS` so it routes to the owning kernel across linked machines.

## Tests

- `test_sdk_backend.py::PendingQueue`: in place + order kept, `expect` re-locates under the lock, a miss touches nothing, the echo is re-worded.
- `test_kernel_send_park.py::QueuedEdit`: `_edit_parked` in place, body re-locate, gone and in-flight refusals, command-chip and empty-body refusals, follow-up wrapper kept end to end; `_edit_backend_queued` drift guard; the three drive arms answer `editResult`; `ID_OPS` pin.
- `ui/webview/queued-edit.test.ts`: the ✎ and its gate, the `qedit` delegate, the pill, the send path, `editResult` handling, the optimistic repaint, CSS.
- Guide: "A message that has not gone yet" under The chat.

Targeted Python suites (send-park, pending-queue, kernel queue/cancel, parked-ops lock + liveness), the extension typecheck and all node tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
