### PR TITLE
The tag updater reports what the restart actually did and never latches on a failed launch

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -850,6 +850,19 @@ State is written under `${XDG_STATE_HOME:-~/.local/state}/romp/`. Transcripts
 are read in place from where Claude Code writes them (`~/.claude/projects/`)
 and never copied.
 
+The self-updater's report, `update-report.json`, is read once, by the next
+kernel boot or by the running kernel's banner poll, and archived as
+`update-report-last.json`; `update.log` beside it has the updater's full
+output. An update that landed on disk but was not restarted into (no manager,
+or a manager that did not take the restart request or did not answer it within
+60 seconds) is filed in the Log with the step that runs it: `romp refresh` when
+a manager is there, `romp up` when none is. A boot that already runs the landed
+release says so instead of asking for another restart. A report that is not a
+JSON object is moved aside, never deleted, to
+`update-report.json.corrupt-<UTC stamp>` (the same `-1`, `-2` suffix rule) with
+one Log entry under the `refused` kind; one that cannot be moved stays where it
+is and is said once per fault.
+
 Three small files there hold settings you set by hand: `session-flags.json`
 (per-session flags, the postal isolation switch among them), `session-order.json`
 (the saved tab and lane order) and `notify-cards.json` (the bell overrides). A

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4451,6 +4451,12 @@ def _set_thinking_summaries(enabled, gt=None):
 # machines. `romp update [host]` remains the other direction (pushing THIS build to remotes).
 _UPDATE_AVAIL = [""]     # newest remote release tag when newer than ours ("" = none/unknown)
 _UPDATE_STATE = [""]     # "" | "running" — one update at a time; the banner reads this
+_NO_MANAGER_WHY = "no manager is running this kernel"   # the script's why when it had no manager port to ask; the
+#                                        consumer keys the restart hint on it (review find, 2026-09-08)
+_RESTART_REQUEST_MAX_S = 60   # curl --max-time on the script's restart request: a manager that accepts and never
+#                                        answers ends in a report instead of a latch held for good
+_UPDATE_REPORT_FAULT = [""]   # the move-aside fault of a junk report still on disk, said once per episode (a move
+#                                        or a readable report ends it)
 _UPDATE_MODES = ("ask", "auto", "off")
 
 
@@ -4577,19 +4583,29 @@ def _run_update(tag):
     def report(d):
         return "printf '%%s' %s > %s\n" % (q(json.dumps(d)), rep)
     if mport.isdigit():
+        # --max-time (review find, 2026-09-08): a manager that accepted the connection and never
+        # answered (wedged mid-restart, or a stale port something else holds open) held curl for good,
+        # so no report was ever written and the latch stood with nothing to consume. curl's exit 28 is
+        # that timeout, read as not restarted with a why of its own; any other non-zero exit is a
+        # request the manager did not take. `rc` is read once, off the curl itself, never off a
+        # test in an `elif` (whose `$?` is the previous test's).
         restart = (("  printf '{\"t\": %%s, \"action\": \"self-update\", \"tag\": \"%s\"}\\n' \"$(date +%%s)\" >> %s\n"
                     % (tag, aud))
-                   + "  if curl -fsS -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>>%s; then\n"
-                   % (int(mport), log)
+                   + "  curl -fsS --max-time %d -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>>%s; rc=$?\n"
+                   % (_RESTART_REQUEST_MAX_S, int(mport), log)
+                   + "  if [ \"$rc\" -eq 0 ]; then\n"
                    + "    " + report({"ok": True, "tag": tag, "restarted": True})
+                   + "  elif [ \"$rc\" -eq 28 ]; then\n"
+                   + "    " + report({"ok": True, "tag": tag, "restarted": False,
+                                      "why": "the manager on port %d did not answer the restart request within %d s"
+                                             % (int(mport), _RESTART_REQUEST_MAX_S)})
                    + "  else\n"
                    + "    " + report({"ok": True, "tag": tag, "restarted": False,
                                       "why": "the manager on port %d did not take the restart request" % int(mport)})
                    + "  fi\n")
     else:
         restart = ("  : # no manager — the new code arms on the next romp start (the report says so)\n"
-                   + "  " + report({"ok": True, "tag": tag, "restarted": False,
-                                    "why": "no manager is running this kernel"}))
+                   + "  " + report({"ok": True, "tag": tag, "restarted": False, "why": _NO_MANAGER_WHY}))
     # advance() — the tree lands EXACTLY on the release commit. The fast-forward is the normal
     # release-to-release move, EXCEPT for an install sitting DETACHED off every tag: the
     # pre-2026-08-31 drift banner's Update ran `git checkout --detach origin/main` on plain
@@ -4634,14 +4650,30 @@ def _run_update(tag):
     return True
 
 
-def _consume_update_report(running_only=False):
+def _update_restart_hint(rep):
+    """The step that runs an update that landed on disk but was not restarted into, worded for the
+    case the report describes (review find, 2026-09-08). `romp refresh` asks the MANAGER to restart
+    every kernel, so it is the step when a manager was there and did not take (or answer) the
+    request; with no manager it exits 1, so the no-manager report names `romp up`, which starts the
+    manager and its kernels (`romp on` is a retired spelling). The no-manager case is the script's
+    constant why, or a report with no why at all: the pre-2026-09 script wrote ok + restarted:false
+    ONLY when it had no manager port to ask."""
+    why = rep.get("why")
+    if not why or why == _NO_MANAGER_WHY:
+        return "restart romp yourself to run it (`romp refresh` needs the manager; `romp up` starts one)"
+    return "restart romp yourself (`romp refresh`) to run it"
+
+
+def _consume_update_report(running_only=False, _tries=3):
     """File the updater child's report as a sync notice, ONCE (the file renames on consumption).
     Two callers: the next boot (the success path — the restart took the reporting kernel down), and
     /update-check's poll on the still-running kernel (the failure path, and the no-manager success),
-    which passes running_only to also clear the in-flight latch."""
+    which passes running_only to also clear the in-flight latch. `_tries` bounds the re-read a
+    report replaced under the quarantine gets (see the identity check below)."""
     p = jd.STATE / "update-report.json"
     try:
-        rep = json.loads(p.read_text())
+        st = p.stat()          # BEFORE the read: the quarantine below moves only the file whose bytes it read
+        rep = json.loads(p.read_bytes())
     except (OSError, ValueError):
         return None
     if not isinstance(rep, dict):
@@ -4653,17 +4685,38 @@ def _consume_update_report(running_only=False):
         # readers wear (`.corrupt-<utc stamp>`, `-n` for a second one in the same second), so a
         # second unreadable report never overwrites the first's bytes -- a plain `.bad` did. Its
         # notice rings the bell's `refused` kind, the class every moved-aside state file rings.
+        # And, as those quarantines do (review find, 2026-09-08): the move takes only the file whose
+        # bytes were read (same inode, mtime and size as the stat before the read), because the
+        # child's `printf >` is not atomic, and a poll that read the torn first bytes of a REAL report
+        # would otherwise carry the finished report off as junk; replaced bytes get their own read,
+        # bounded by `_tries`. A file that cannot be moved (a read-only state dir) stays put and is
+        # said ONCE per fault episode, never silently swallowed: the latch clears either way, since
+        # something was written, and the poll is told the reason.
+        why_not = None
         try:
+            cur = p.stat()
+            if (cur.st_ino, cur.st_mtime_ns, cur.st_size) != (st.st_ino, st.st_mtime_ns, st.st_size):
+                return _consume_update_report(running_only, _tries - 1) if _tries > 1 else None
             stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
             aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
             while aside.exists():
                 n += 1
                 aside = p.with_name("%s.corrupt-%s-%d" % (p.name, stamp, n))
             os.replace(p, aside)
-        except OSError:
-            return None
+        except FileNotFoundError:
+            return None                                  # gone meanwhile: a sibling consume moved it
+        except OSError as e:
+            why_not = "could not be moved aside: %s" % _errno_text(e)   # stamp-free, so the episode dedupes
         if running_only:
             _UPDATE_STATE[0] = ""
+        if why_not is not None:
+            why = ("the updater's report could not be read, and %s; it is still update-report.json under "
+                   "~/.local/state/romp, next to update.log, which says what actually happened" % why_not)
+            if _UPDATE_REPORT_FAULT[0] != why_not:
+                _UPDATE_REPORT_FAULT[0] = why_not
+                _sync_notice("romp's self-update ended without a readable outcome: %s" % why, ok=False, kind="refused")
+            return {"ok": False, "tag": "", "why": why}
+        _UPDATE_REPORT_FAULT[0] = ""                     # moved: the fault episode is over
         why = ("the updater's report could not be read — it is kept as %s under ~/.local/state/romp, next "
                "to update.log, which says what actually happened" % aside.name)
         _sync_notice("romp's self-update ended without a readable outcome: %s" % why, ok=False, kind="refused")
@@ -4672,6 +4725,7 @@ def _consume_update_report(running_only=False):
         p.rename(jd.STATE / "update-report-last.json")   # consumed — never re-filed on later boots
     except OSError:
         return None
+    _UPDATE_REPORT_FAULT[0] = ""                         # a readable report: any junk episode is over
     if running_only:
         _UPDATE_STATE[0] = ""
     tag = str(rep.get("tag") or "a new release")
@@ -4685,15 +4739,21 @@ def _consume_update_report(running_only=False):
         # it, instead of asking for one more restart.
         why = rep.get("why") or "it was not restarted"
         try:
-            runs_it = (not running_only) and _kernel_ver() == tag
+            # Release NUMBERS, compared the way _update_check compares them (review find, 2026-09-08):
+            # _kernel_ver reads "vX.Y.Z+" on every release checkout (the tag sits on the release PR's
+            # merge commit, the VERSION bump one commit before it), so a bare string compare against
+            # the tag never matched, and the boot that already ran the tag was told to restart again.
+            # Equal, not newer: the text says this start runs THIS release, and a report is consumed
+            # by the first boot after it is written, so a boot past the tag has a report of its own.
+            cur, want = _semver((_kernel_ver() or "").rstrip("+")), _semver(tag)
+            runs_it = (not running_only) and cur is not None and cur == want
         except Exception:
             runs_it = False
         if runs_it:
             _sync_notice("romp updated itself to %s on disk and this start is running it (%s, so the restart "
                          "that brought it up was yours)" % (tag, why))
         else:
-            _sync_notice("romp updated itself to %s on disk, but %s — restart romp yourself (`romp refresh`, "
-                         "or `romp on` if no manager answers) to run it" % (tag, why))
+            _sync_notice("romp updated itself to %s on disk, but %s — %s" % (tag, why, _update_restart_hint(rep)))
     else:
         _sync_notice("romp could not update itself to %s: %s — nothing was restarted; update.log under "
                      "~/.local/state/romp has the full output" % (tag, rep.get("why") or "the update failed"),
@@ -4723,7 +4783,7 @@ def _update_check():
         return
     if latest == _UPDATE_AVAIL[0]:
         return                                      # already discovered and acted on this kernel run
-    _UPDATE_AVAIL[0] = latest
+    prev, _UPDATE_AVAIL[0] = _UPDATE_AVAIL[0], latest
     if _update_mode() == "auto":
         tried = ""
         try:
@@ -4745,8 +4805,11 @@ def _update_check():
             # written — writing it first spent the version's one automatic try on a launch that
             # never happened, and the next pass then reported it as "ran once without landing" —
             # and the discovery slot re-arms so the next pass tries again instead of standing on
-            # a version it never attempted (the launch failure itself is already in the Log)
-            _UPDATE_AVAIL[0] = ""
+            # a version it never attempted (the launch failure itself is already in the Log).
+            # Unless the refusal is that ANOTHER update is still in flight (review find, 2026-09-08):
+            # its tag is what /update-check reports as pending, nothing about it changed, so the slot
+            # goes back to it; the newer release is found again once the latch is free.
+            _UPDATE_AVAIL[0] = prev if _UPDATE_STATE[0] == "running" else ""
             return
         _atomic_write(jd.STATE / "update-attempted.json", json.dumps({"tag": latest, "t": int(time.time())}))
     else:
@@ -36684,8 +36747,10 @@ _UPD_JS = (
     "if(!waiting)return;"
     "if(d.boot&&bootNow&&d.boot!==bootNow){location.reload();return;}"
     "if(d.failed){waiting=false;go.hidden=false;go.disabled=false;show('The update did not finish: '+d.failed);return;}"
+    # the kernel words the step by case (`romp refresh` exits 1 with no manager, where `romp up` is
+    # the step; review find, 2026-09-08); the fallback is the manager case, for an older kernel
     "if(d.updated){waiting=false;show('romp updated to '+d.updated+' on disk'+(d.why?', but '+d.why:'')"
-    "+' \\u2014 restart romp yourself (romp refresh) to run it.');return;}"
+    "+' \\u2014 '+(d.hint||'restart romp yourself (romp refresh) to run it')+'.');return;}"
     "setTimeout(poll,3000);}).catch(function(){if(waiting)setTimeout(poll,3000);});}"
     "go.onclick=function(){go.disabled=true;dm.hidden=true;waiting=true;"
     "show('Updating romp \\u2014 this can take a minute; the dashboard reloads when it restarts\\u2026');"
@@ -38527,7 +38592,7 @@ class Handler(BaseHTTPRequestHandler):
                 # kernel answering after a successful update (same trick as the restart flow); polling
                 # this route is also what consumes a report the still-running kernel would otherwise
                 # sit on (the failure path, and the no-manager success).
-                failed = updated = why = ""
+                failed = updated = why = hint = ""
                 if _UPDATE_STATE[0] == "running":
                     # PEEK before consuming: a success that is about to restart belongs to the NEXT
                     # kernel's boot — consuming it here would file the notice into this dying
@@ -38548,6 +38613,7 @@ class Handler(BaseHTTPRequestHandler):
                         elif rep is not None:
                             updated = str(rep.get("tag") or "")
                             why = str(rep.get("why") or "")     # why the new code is not running yet
+                            hint = _update_restart_hint(rep)    # the step that runs it, worded for the case
                 # a DISMISSED identifier never re-derives an offer on a page load (the user
                 # 2026-08-31: the per-page-load re-offer was a notice-spam compounder)
                 dis = _dismissed_updates()
@@ -38558,7 +38624,7 @@ class Handler(BaseHTTPRequestHandler):
                     "cur": _kernel_ver() or "",
                     "tag": ("" if _UPDATE_AVAIL[0] in dis else _UPDATE_AVAIL[0]),
                     "mode": _update_mode(),
-                    "state": _UPDATE_STATE[0], "failed": failed, "updated": updated, "why": why,
+                    "state": _UPDATE_STATE[0], "failed": failed, "updated": updated, "why": why, "hint": hint,
                     # the pending MAIN-DRIFT offer (2026-08-15): a page loaded after the push can
                     # re-derive it, and a stale page can revalidate before acting
                     "drift": (("pull" if _MAIN_DRIFT[0] else "restart") if dsha else ""),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4649,15 +4649,24 @@ def _consume_update_report(running_only=False):
         # 500'd every /update-check poll and crashed the boot that found it. The child wrote
         # SOMETHING, so nothing is in flight any more: set the file aside as evidence (never
         # deleted), say so once, and answer like any other ended update.
+        # The sidecar wears the quarantine convention the goal store, the ledgers and the state
+        # readers wear (`.corrupt-<utc stamp>`, `-n` for a second one in the same second), so a
+        # second unreadable report never overwrites the first's bytes -- a plain `.bad` did. Its
+        # notice rings the bell's `refused` kind, the class every moved-aside state file rings.
         try:
-            p.rename(p.with_name(p.name + ".bad"))
+            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            aside, n = p.with_name("%s.corrupt-%s" % (p.name, stamp)), 0
+            while aside.exists():
+                n += 1
+                aside = p.with_name("%s.corrupt-%s-%d" % (p.name, stamp, n))
+            os.replace(p, aside)
         except OSError:
             return None
         if running_only:
             _UPDATE_STATE[0] = ""
-        why = ("the updater's report could not be read — it is kept as update-report.json.bad under "
-               "~/.local/state/romp, next to update.log, which says what actually happened")
-        _sync_notice("romp's self-update ended without a readable outcome: %s" % why, ok=False)
+        why = ("the updater's report could not be read — it is kept as %s under ~/.local/state/romp, next "
+               "to update.log, which says what actually happened" % aside.name)
+        _sync_notice("romp's self-update ended without a readable outcome: %s" % why, ok=False, kind="refused")
         return {"ok": False, "tag": "", "why": why}
     try:
         p.rename(jd.STATE / "update-report-last.json")   # consumed — never re-filed on later boots
@@ -4670,10 +4679,21 @@ def _consume_update_report(running_only=False):
         _sync_notice("romp updated itself to %s and restarted into it" % tag)
     elif rep.get("ok"):
         # landed on disk, not running: the script says why (no manager, or a manager that did not
-        # take the restart request). Only a restart the user runs gets the new code running.
-        _sync_notice("romp updated itself to %s on disk, but %s — restart romp yourself (`romp refresh`, "
-                     "or `romp on` if no manager answers) to run it"
-                     % (tag, rep.get("why") or "it was not restarted"))
+        # take the restart request). Only a restart the user runs gets the new code running -- and
+        # when this consume is the BOOT's (nothing polled before the user restarted by hand), that
+        # restart has already happened: a kernel whose own version IS the tag says this start runs
+        # it, instead of asking for one more restart.
+        why = rep.get("why") or "it was not restarted"
+        try:
+            runs_it = (not running_only) and _kernel_ver() == tag
+        except Exception:
+            runs_it = False
+        if runs_it:
+            _sync_notice("romp updated itself to %s on disk and this start is running it (%s, so the restart "
+                         "that brought it up was yours)" % (tag, why))
+        else:
+            _sync_notice("romp updated itself to %s on disk, but %s — restart romp yourself (`romp refresh`, "
+                         "or `romp on` if no manager answers) to run it" % (tag, why))
     else:
         _sync_notice("romp could not update itself to %s: %s — nothing was restarted; update.log under "
                      "~/.local/state/romp has the full output" % (tag, rep.get("why") or "the update failed"),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4565,11 +4565,31 @@ def _run_update(tag):
     # detached script outlives this kernel, so the dying kernel's cut row can only join to a reason
     # written at curl time (auto deploys used to leave the row anonymous).
     aud = q(str(jd.STATE / "restart-audit.jsonl"))
-    restart = (("  printf '{\"t\": %%s, \"action\": \"self-update\", \"tag\": \"%s\"}\\n' \"$(date +%%s)\" >> %s\n"
-                % (tag, aud))
-               + "  curl -s -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
-        else "  : # no manager — the new code arms on the next romp start (the report says so)\n"
-    ok_rep = {"ok": True, "tag": tag, "restarted": bool(mport.isdigit())}
+    # The report is written AFTER the restart request, saying what the request actually did. It
+    # used to be written first, claiming restarted:true whenever a manager port was known — so a
+    # manager that never took the request (gone, or a stale port) left an "updated and restarted"
+    # report on disk. /update-check deliberately leaves an ok+restarted report for the NEXT boot to
+    # file, and that boot never came: the in-flight latch held for the kernel's life, the banner
+    # read "updating…" forever, and every later update was refused. Now curl's exit decides:
+    # request taken → restarted:true (the next boot files it); refused → restarted:false with the
+    # reason, which the still-running kernel's poll consumes into "updated on disk — restart it
+    # yourself". curl's own error lands in update.log (-f: a non-2xx answer is not a restart).
+    def report(d):
+        return "printf '%%s' %s > %s\n" % (q(json.dumps(d)), rep)
+    if mport.isdigit():
+        restart = (("  printf '{\"t\": %%s, \"action\": \"self-update\", \"tag\": \"%s\"}\\n' \"$(date +%%s)\" >> %s\n"
+                    % (tag, aud))
+                   + "  if curl -fsS -X POST 'http://127.0.0.1:%d/restart-all' >/dev/null 2>>%s; then\n"
+                   % (int(mport), log)
+                   + "    " + report({"ok": True, "tag": tag, "restarted": True})
+                   + "  else\n"
+                   + "    " + report({"ok": True, "tag": tag, "restarted": False,
+                                      "why": "the manager on port %d did not take the restart request" % int(mport)})
+                   + "  fi\n")
+    else:
+        restart = ("  : # no manager — the new code arms on the next romp start (the report says so)\n"
+                   + "  " + report({"ok": True, "tag": tag, "restarted": False,
+                                    "why": "no manager is running this kernel"}))
     # advance() — the tree lands EXACTLY on the release commit. The fast-forward is the normal
     # release-to-release move, EXCEPT for an install sitting DETACHED off every tag: the
     # pre-2026-08-31 drift banner's Update ran `git checkout --detach origin/main` on plain
@@ -4596,14 +4616,21 @@ def _run_update(tag):
         + advance
         + "if git fetch %s refs/tags/%s:refs/tags/%s >> %s 2>&1 && advance "
           "&& ./install.sh >> %s 2>&1; then\n" % (_release_remote(), tag, tag, log, log)
-        + "  printf '%%s' %s > %s\n" % (q(json.dumps(ok_rep)), rep)
         + restart
         + "else\n"
-        + "  printf '%%s' %s > %s\n" % (q(json.dumps({"ok": False, "tag": tag,
-                                                      "why": "the fetch, fast-forward or install failed"})), rep)
+        + "  " + report({"ok": False, "tag": tag, "why": "the fetch, fast-forward or install failed"})
         + "fi\n")
-    subprocess.Popen(["bash", "-c", script], start_new_session=True, cwd=str(ROOT),
-                     stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        subprocess.Popen(["bash", "-c", script], start_new_session=True, cwd=str(ROOT),
+                         stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as e:
+        # the latch was taken above; a spawn that raises must give it back, or the kernel reads
+        # "running" for the rest of its life with nothing running — every later update refused,
+        # every banner waiting on a child that never existed. Loud, not silent: the Log says why.
+        _UPDATE_STATE[0] = ""
+        _sync_notice("romp could not start the update to %s: %s — nothing was launched and nothing "
+                     "moved" % (tag, e), ok=False)
+        return False
     return True
 
 
@@ -4617,6 +4644,21 @@ def _consume_update_report(running_only=False):
         rep = json.loads(p.read_text())
     except (OSError, ValueError):
         return None
+    if not isinstance(rep, dict):
+        # parses, but is not an object (null, [], a number): every .get below would raise — which
+        # 500'd every /update-check poll and crashed the boot that found it. The child wrote
+        # SOMETHING, so nothing is in flight any more: set the file aside as evidence (never
+        # deleted), say so once, and answer like any other ended update.
+        try:
+            p.rename(p.with_name(p.name + ".bad"))
+        except OSError:
+            return None
+        if running_only:
+            _UPDATE_STATE[0] = ""
+        why = ("the updater's report could not be read — it is kept as update-report.json.bad under "
+               "~/.local/state/romp, next to update.log, which says what actually happened")
+        _sync_notice("romp's self-update ended without a readable outcome: %s" % why, ok=False)
+        return {"ok": False, "tag": "", "why": why}
     try:
         p.rename(jd.STATE / "update-report-last.json")   # consumed — never re-filed on later boots
     except OSError:
@@ -4627,7 +4669,11 @@ def _consume_update_report(running_only=False):
     if rep.get("ok") and rep.get("restarted"):
         _sync_notice("romp updated itself to %s and restarted into it" % tag)
     elif rep.get("ok"):
-        _sync_notice("romp updated itself to %s — no manager is running, so restart romp yourself to run it" % tag)
+        # landed on disk, not running: the script says why (no manager, or a manager that did not
+        # take the restart request). Only a restart the user runs gets the new code running.
+        _sync_notice("romp updated itself to %s on disk, but %s — restart romp yourself (`romp refresh`, "
+                     "or `romp on` if no manager answers) to run it"
+                     % (tag, rep.get("why") or "it was not restarted"))
     else:
         _sync_notice("romp could not update itself to %s: %s — nothing was restarted; update.log under "
                      "~/.local/state/romp has the full output" % (tag, rep.get("why") or "the update failed"),
@@ -4674,8 +4720,15 @@ def _update_check():
                 _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest,
                                        "boot": _BOOT_ID})
             return
+        if not _run_update(latest):
+            # a refused launch is not an attempt: nothing ran, so the once-only marker is not
+            # written — writing it first spent the version's one automatic try on a launch that
+            # never happened, and the next pass then reported it as "ran once without landing" —
+            # and the discovery slot re-arms so the next pass tries again instead of standing on
+            # a version it never attempted (the launch failure itself is already in the Log)
+            _UPDATE_AVAIL[0] = ""
+            return
         _atomic_write(jd.STATE / "update-attempted.json", json.dumps({"tag": latest, "t": int(time.time())}))
-        _run_update(latest)
     else:
         if latest in _dismissed_updates():
             return                    # Not-now'd THIS release, durably — a newer one offers again
@@ -36611,7 +36664,8 @@ _UPD_JS = (
     "if(!waiting)return;"
     "if(d.boot&&bootNow&&d.boot!==bootNow){location.reload();return;}"
     "if(d.failed){waiting=false;go.hidden=false;go.disabled=false;show('The update did not finish: '+d.failed);return;}"
-    "if(d.updated){waiting=false;show('romp updated to '+d.updated+' \\u2014 restart romp (the \\u21bb button) to run it.');return;}"
+    "if(d.updated){waiting=false;show('romp updated to '+d.updated+' on disk'+(d.why?', but '+d.why:'')"
+    "+' \\u2014 restart romp yourself (romp refresh) to run it.');return;}"
     "setTimeout(poll,3000);}).catch(function(){if(waiting)setTimeout(poll,3000);});}"
     "go.onclick=function(){go.disabled=true;dm.hidden=true;waiting=true;"
     "show('Updating romp \\u2014 this can take a minute; the dashboard reloads when it restarts\\u2026');"
@@ -38453,22 +38507,27 @@ class Handler(BaseHTTPRequestHandler):
                 # kernel answering after a successful update (same trick as the restart flow); polling
                 # this route is also what consumes a report the still-running kernel would otherwise
                 # sit on (the failure path, and the no-manager success).
-                failed = updated = ""
+                failed = updated = why = ""
                 if _UPDATE_STATE[0] == "running":
                     # PEEK before consuming: a success that is about to restart belongs to the NEXT
                     # kernel's boot — consuming it here would file the notice into this dying
                     # process's in-memory ring and the new kernel would find nothing to log. Only a
-                    # failure, or a success with no manager to restart, is this kernel's to file.
+                    # failure, or a success whose restart did not happen (no manager, or a manager
+                    # that did not take the request), is this kernel's to file. A report that is
+                    # not an object is as ended as a failure — the consume sets it aside; peeking
+                    # `.get` on it used to 500 every poll for the kernel's life.
                     try:
-                        _peek = json.loads((jd.STATE / "update-report.json").read_text())
+                        _peek, _have = json.loads((jd.STATE / "update-report.json").read_text()), True
                     except (OSError, ValueError):
-                        _peek = None
-                    if _peek is not None and not (_peek.get("ok") and _peek.get("restarted")):
+                        _peek, _have = None, False     # no report yet, or a write still in progress
+                    # `_have`, not `_peek is not None`: a report that parses to null is a report
+                    if _have and not (isinstance(_peek, dict) and _peek.get("ok") and _peek.get("restarted")):
                         rep = _consume_update_report(running_only=True)
                         if rep is not None and not rep.get("ok"):
                             failed = str(rep.get("why") or "the pull or install failed")
                         elif rep is not None:
                             updated = str(rep.get("tag") or "")
+                            why = str(rep.get("why") or "")     # why the new code is not running yet
                 # a DISMISSED identifier never re-derives an offer on a page load (the user
                 # 2026-08-31: the per-page-load re-offer was a notice-spam compounder)
                 dis = _dismissed_updates()
@@ -38479,7 +38538,7 @@ class Handler(BaseHTTPRequestHandler):
                     "cur": _kernel_ver() or "",
                     "tag": ("" if _UPDATE_AVAIL[0] in dis else _UPDATE_AVAIL[0]),
                     "mode": _update_mode(),
-                    "state": _UPDATE_STATE[0], "failed": failed, "updated": updated,
+                    "state": _UPDATE_STATE[0], "failed": failed, "updated": updated, "why": why,
                     # the pending MAIN-DRIFT offer (2026-08-15): a page loaded after the push can
                     # re-derive it, and a stale page can revalidate before acting
                     "drift": (("pull" if _MAIN_DRIFT[0] else "restart") if dsha else ""),
@@ -38617,7 +38676,14 @@ class Handler(BaseHTTPRequestHandler):
                 if tag:
                     if _UPDATE_STATE[0] != "running":
                         _audit_restart_request("self-update", tag=tag, addr=str(self.client_address[0]))
-                        _run_update(tag)
+                        if not _run_update(tag) and _UPDATE_STATE[0] != "running":
+                            # nothing launched (the spawn failed; the Log has the reason) and nothing
+                            # else is in flight: a 200 and a "running" push here would leave every
+                            # window waiting on a child that never existed. The banner shows this
+                            # text and re-offers. (A refusal because a concurrent click already
+                            # started it is the "running" answer below, truthfully.)
+                            return self._send(500, "romp could not start the update to %s; the Log has the reason"
+                                              % tag, "text/plain")
                         _send_to_app("shell", {"type": "updateAvail", "state": "running", "boot": _BOOT_ID})
                     return self._send(200, json.dumps({"ok": True, "state": _UPDATE_STATE[0]}), "application/json")
                 # ONE snapshot of what the kernel found: the kind and the commit it advertised come

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -376,7 +376,7 @@ class RunUpdate(Fresh):
         self.assertIn("update-report.json", script)
         # the restart rides the SUCCESS branch only: everything after `if` up to `else` has it,
         # the failure branch does not
-        ok_branch, fail_branch = script.split("else\n", 1)
+        ok_branch, fail_branch = script.split("\nelse\n", 1)      # the OUTER else, column 0
         self.assertIn("/restart-all'", ok_branch,
                       "the self-update deploy bounces IMMEDIATELY (T160, the user's call from live "
                       "experience — the quiet window cost minutes per push; explicit "
@@ -386,6 +386,8 @@ class RunUpdate(Fresh):
                       "the script stamps restart-audit.jsonl at curl time, so the dying kernel's "
                       "restart-cuts row joins to a named reason instead of reading anonymous")
         self.assertNotIn("/restart-all", fail_branch)
+        self.assertLess(ok_branch.index("/restart-all'"), ok_branch.index("update-report.json"),
+                        "the report is written AFTER the restart request, with what the request did")
         self.assertEqual(km._UPDATE_STATE[0], "running")
 
     def test_no_manager_means_no_restart_leg(self):
@@ -402,6 +404,56 @@ class RunUpdate(Fresh):
         with mock.patch.object(km.subprocess, "Popen"):
             self.assertTrue(km._run_update("v0.7.0"))
             self.assertFalse(km._run_update("v0.7.0"), "one update at a time")
+
+
+class HonestLaunch(Fresh):
+    """A launch that did not happen is neither an update in flight nor an attempt."""
+
+    def test_a_spawn_that_raises_gives_the_latch_back_and_says_so(self):
+        # the raise used to escape _run_update with the in-flight latch still set: every later
+        # update refused for the kernel's life, every banner waiting on a child that never existed
+        with mock.patch.object(km.subprocess, "Popen", side_effect=OSError("resource temporarily unavailable")):
+            self.assertFalse(km._run_update("v0.0.9"))
+        self.assertEqual(km._UPDATE_STATE[0], "", "nothing is running")
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertFalse(ns[0]["ok"])
+        self.assertIn("v0.0.9", ns[0]["text"])
+        self.assertIn("resource temporarily unavailable", ns[0]["text"])
+        with mock.patch.object(km.subprocess, "Popen"):
+            self.assertTrue(km._run_update("v0.0.9"), "the next launch is not refused")
+
+    def _auto_pass(self):
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.0.8"), \
+             mock.patch.object(km, "_latest_release_tag", return_value="v0.0.9"), \
+             mock.patch.object(km, "_send_to_app"):
+            km._set_update_mode("auto")
+            km._update_check()
+
+    def test_a_refused_auto_launch_is_not_an_attempt(self):
+        # another update holds the in-flight latch. The pass must not spend the version's one
+        # automatic try on a launch that never happened — the marker used to be written FIRST, and
+        # the next pass then reported "ran once without landing" about a run that never ran — nor
+        # stand on the discovery as acted-on
+        km._UPDATE_STATE[0] = "running"
+        with mock.patch.object(km.subprocess, "Popen", side_effect=AssertionError("must not spawn")):
+            self._auto_pass()
+        self.assertFalse((jd.STATE / "update-attempted.json").exists(), "a refusal is not an attempt")
+        self.assertEqual(km._UPDATE_AVAIL[0], "", "the discovery re-arms — the next pass tries again")
+        km._UPDATE_STATE[0] = ""                                  # the in-flight update ended
+        ran = []
+        with mock.patch.object(km, "_run_update", side_effect=lambda tag: ran.append(tag) or True):
+            self._auto_pass()
+        self.assertEqual(ran, ["v0.0.9"], "the retry the re-armed slot stands for")
+        self.assertEqual(json.loads((jd.STATE / "update-attempted.json").read_text())["tag"], "v0.0.9",
+                         "the marker records a launch that happened")
+
+    def test_a_spawn_failure_in_auto_mode_leaves_no_marker_and_no_latch(self):
+        with mock.patch.object(km.subprocess, "Popen", side_effect=OSError("no bash")):
+            self._auto_pass()                                     # used to raise out of the pass
+        self.assertFalse((jd.STATE / "update-attempted.json").exists())
+        self.assertEqual((km._UPDATE_STATE[0], km._UPDATE_AVAIL[0]), ("", ""))
+        self.assertTrue(any(not n["ok"] and "v0.0.9" in n["text"] for n in self.notices()))
 
 
 class ReportConsumption(Fresh):
@@ -431,6 +483,23 @@ class ReportConsumption(Fresh):
         (jd.STATE / "update-report.json").write_text(json.dumps({"ok": False, "tag": "v0.7.0"}))
         km._consume_update_report(running_only=True)
         self.assertEqual(km._UPDATE_STATE[0], "")
+
+    def test_a_boot_that_finds_a_non_object_report_does_not_crash(self):
+        # main() calls _consume_update_report() bare: `.get` on a parsed null / [] / number raised
+        # and took the boot down with it — after the rename, so the next boot came up with nothing
+        p = jd.STATE / "update-report.json"
+        p.write_text("[]")
+        rep = km._consume_update_report()
+        self.assertIsInstance(rep, dict)
+        self.assertFalse(rep["ok"])
+        self.assertFalse(p.exists())
+        self.assertFalse((jd.STATE / "update-report-last.json").exists(), "not an outcome — not archived as one")
+        self.assertEqual((jd.STATE / "update-report.json.bad").read_text(), "[]", "set aside as evidence, never deleted")
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertFalse(ns[0]["ok"])
+        self.assertIn("update-report.json.bad", ns[0]["text"])
+        self.assertIsNone(km._consume_update_report(), "the next boot finds nothing to file")
 
 
 class Routes(Fresh):
@@ -519,6 +588,65 @@ class Routes(Fresh):
                          "the banner click is the user's own deliberate cut, onto the commit the banner named")
         km._MAIN_DRIFT[0] = ""
 
+    def test_an_update_that_landed_but_did_not_restart_is_consumed_with_its_reason(self):
+        # the manager did not take the restart request: the child reports ok + restarted:false +
+        # why, and the still-running kernel's poll consumes THAT into the truthful next step. The
+        # kernel used to sit on "running" forever (the child claimed restarted:true before asking),
+        # and its only not-restarted wording blamed a missing manager
+        km._UPDATE_STATE[0] = "running"
+        why = "the manager on port 7777 did not take the restart request"
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": True, "tag": "v0.0.9",
+                                                                 "restarted": False, "why": why}))
+        _, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+        d = json.loads(body)
+        self.assertEqual((d["updated"], d["why"], d["failed"], d["state"]), ("v0.0.9", why, "", ""))
+        self.assertFalse((jd.STATE / "update-report.json").exists(), "consumed")
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertTrue(ns[0]["ok"])
+        for s in ("v0.0.9", "on disk", why, "romp refresh"):
+            self.assertIn(s, ns[0]["text"])
+        self.assertNotIn("no manager is running", ns[0]["text"], "a manager IS running — it did not take the request")
+
+    def test_a_report_that_is_not_an_object_is_set_aside_and_the_poll_still_answers(self):
+        # null / [] / a number parse but carry nothing: `.get` on them 500'd every poll for the
+        # kernel's life (never consumed, so every poll hit the same file again)
+        p, bad = jd.STATE / "update-report.json", jd.STATE / "update-report.json.bad"
+        for junk in ("null", "[]", "3"):
+            km._UPDATE_STATE[0] = "running"
+            with km._SYNC_LOCK:
+                del km._SYNC_NOTICES[:]
+            p.write_text(junk)
+            status, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+            self.assertEqual(status, 200, junk)
+            d = json.loads(body)
+            self.assertEqual(d["state"], "", "nothing is in flight — the child wrote SOMETHING")
+            self.assertIn("update-report.json.bad", d["failed"])
+            self.assertFalse(p.exists())
+            self.assertEqual(bad.read_text(), junk, "evidence kept, never deleted")
+            bad.unlink()
+            ns = self.notices()
+            self.assertEqual((len(ns), ns[0]["ok"]), (1, False))
+            status, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+            self.assertEqual((status, json.loads(body)["failed"]), (200, ""), "the next poll is quiet")
+            self.assertEqual(len(self.notices()), 1, "said once")
+
+    def test_the_update_click_hears_a_failed_launch_instead_of_waiting_on_it(self):
+        # a spawn that fails after the click: the route used to answer 200 and push state:'running'
+        # to every window with the latch set — every banner waited forever on a child that never
+        # existed, and every later click was refused
+        km._UPDATE_AVAIL[0] = "v0.0.9"
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        pushed = []
+        with mock.patch.object(km.subprocess, "Popen", side_effect=OSError("no bash")), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: pushed.append(m)):
+            code, body = self._post("/update")
+        self.assertEqual(code, 500, body)
+        self.assertIn("could not start the update to v0.0.9", body)
+        self.assertEqual(pushed, [], "no 'running' push for a launch that did not happen")
+        self.assertEqual(km._UPDATE_STATE[0], "", "not latched — the next click can try again")
+        self.assertTrue(any(not n["ok"] and "v0.0.9" in n["text"] for n in self.notices()), "the Log says why")
+
 
 class Wiring(unittest.TestCase):
     """Source pins: the check runs at boot, the banner ships on the landing page, the gear posts."""
@@ -573,6 +701,12 @@ class Wiring(unittest.TestCase):
         # honest marked-option injection when a stored value is off this page's list
         self.assertIn("setShow(upm, v.updateMode)", self.gear)
         self.assertIn('msg.get("type") == "setUpdateMode"', self.src)
+
+    def test_the_banner_names_the_restart_the_user_must_run_when_the_update_landed_on_disk(self):
+        # `updated` from /update-check means ON DISK, not running: the banner carries the reason
+        # the restart did not happen and names the step that runs the new code
+        self.assertIn("(d.why?', but '+d.why:'')", self.src)
+        self.assertIn("restart romp yourself (romp refresh) to run it.", self.src)
 
 
 class ReleaseChannelMigration(unittest.TestCase):
@@ -681,6 +815,58 @@ class ReleaseChannelMigration(unittest.TestCase):
             log = (km.jd.STATE / "update.log").read_text()
             self.assertNotIn("return to the release channel", log,
                              "the fast-forward is the whole move — no fallback, no log line")
+
+    def _run_with_manager(self, tag, inst, curl_exit):
+        """Like _run, but WITH a manager port and a fake `curl` on PATH standing in for the manager
+        door: it records whether the report already existed when the restart was requested, then
+        exits as told (0: the manager took it; 7: curl's connection refused). Nothing is dialed."""
+        for f in ("update.log", "update-report.json"):
+            try:
+                (km.jd.STATE / f).unlink()
+            except OSError:
+                pass
+        calls = []
+        with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append(a)), \
+             mock.patch.object(km, "ROOT", Path(inst)), \
+             mock.patch.object(km, "_release_remote", return_value="origin"), \
+             mock.patch.dict(km.os.environ, {"ROMP_MANAGER_PORT": "7777"}):
+            km._UPDATE_STATE[0] = ""
+            self.assertTrue(km._run_update(tag))
+        km._UPDATE_STATE[0] = ""
+        fake, seen = os.path.join(inst, "fake-bin"), os.path.join(inst, "curl-saw")
+        os.makedirs(fake)
+        with open(os.path.join(fake, "curl"), "w") as f:
+            f.write("#!/bin/sh\nif [ -e \"$T_REPORT\" ]; then echo present > \"$T_SEEN\"; "
+                    "else echo absent > \"$T_SEEN\"; fi\nexit \"$T_CURL_EXIT\"\n")
+        os.chmod(os.path.join(fake, "curl"), 0o755)
+        env = {**os.environ, "PATH": fake + os.pathsep + os.environ.get("PATH", ""),
+               "T_REPORT": str(km.jd.STATE / "update-report.json"), "T_SEEN": seen,
+               "T_CURL_EXIT": str(curl_exit)}
+        subprocess.run(["bash", "-c", calls[0][0][2]], cwd=inst, env=env, capture_output=True, text=True)
+        rep = json.loads((km.jd.STATE / "update-report.json").read_text())
+        with open(seen) as f:
+            return rep, f.read().strip()
+
+    def test_the_report_says_what_the_restart_request_actually_did(self):
+        # The manager door can be shut (gone, or a stale port). The report used to be written
+        # BEFORE the request, claiming restarted:true — an "updated and restarted" report the
+        # running kernel leaves for a next boot that never comes: latch wedged, banner "updating…"
+        # forever, every later update refused. Executed end to end on a real repo pair.
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            g(inst, "checkout", "-q", "--detach", "v9.9.8")
+            rep, saw = self._run_with_manager("v9.9.9", inst, curl_exit=7)
+        self.assertEqual(saw, "absent", "the report is written AFTER the restart request, never before")
+        self.assertEqual((rep["ok"], rep["restarted"]), (True, False))
+        self.assertIn("port 7777", rep["why"])
+        self.assertIn("did not take the restart request", rep["why"])
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            g(inst, "checkout", "-q", "--detach", "v9.9.8")
+            rep, saw = self._run_with_manager("v9.9.9", inst, curl_exit=0)
+        self.assertEqual(saw, "absent")
+        self.assertEqual((rep["ok"], rep["restarted"], rep.get("why")), (True, True, None),
+                         "a request the manager took is the one report the next boot files")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -382,6 +382,9 @@ class RunUpdate(Fresh):
                       "experience — the quiet window cost minutes per push; explicit "
                       "`romp refresh --quiet` still drains)")
         self.assertNotIn("when=quiet", ok_branch, "no drain default on the deploy path")
+        self.assertIn("if curl -fsS -X POST 'http://127.0.0.1:", ok_branch,
+                      "-f: a non-2xx answer from whatever holds the manager port is not a restart — the "
+                      "report's `restarted` is read from curl's exit, never assumed")
         self.assertIn('"action": "self-update"', ok_branch,
                       "the script stamps restart-audit.jsonl at curl time, so the dying kernel's "
                       "restart-cuts row joins to a named reason instead of reading anonymous")
@@ -494,12 +497,56 @@ class ReportConsumption(Fresh):
         self.assertFalse(rep["ok"])
         self.assertFalse(p.exists())
         self.assertFalse((jd.STATE / "update-report-last.json").exists(), "not an outcome — not archived as one")
-        self.assertEqual((jd.STATE / "update-report.json.bad").read_text(), "[]", "set aside as evidence, never deleted")
+        aside = sorted(jd.STATE.glob("update-report.json.corrupt-*"))
+        self.assertEqual(len(aside), 1, aside)
+        self.assertEqual(aside[0].read_text(), "[]", "set aside as evidence, never deleted")
         ns = self.notices()
         self.assertEqual(len(ns), 1)
         self.assertFalse(ns[0]["ok"])
-        self.assertIn("update-report.json.bad", ns[0]["text"])
+        self.assertEqual(ns[0].get("kind"), "refused", "a state file moved aside rings the refused bell, like every quarantine")
+        self.assertIn(aside[0].name, ns[0]["text"])
         self.assertIsNone(km._consume_update_report(), "the next boot finds nothing to file")
+
+    def test_a_second_unreadable_report_in_the_same_second_keeps_the_first(self):
+        # the sidecar wears the quarantine convention (`.corrupt-<stamp>`, `-n` for a same-second
+        # repeat): a plain `.bad` was one fixed name, so a second junk report overwrote the first's bytes
+        p = jd.STATE / "update-report.json"
+        real = km.time.strftime
+        fixed = lambda fmt, *a: "20260101T000000Z" if fmt == "%Y%m%dT%H%M%SZ" else real(fmt, *a)
+        with mock.patch.object(km.time, "strftime", side_effect=fixed):
+            for junk in ("[]", "null"):
+                p.write_text(junk)
+                self.assertFalse(km._consume_update_report()["ok"])
+        kept = {x.name: x.read_text() for x in jd.STATE.glob("update-report.json.corrupt-*")}
+        self.assertEqual(kept, {"update-report.json.corrupt-20260101T000000Z": "[]",
+                                "update-report.json.corrupt-20260101T000000Z-1": "null"})
+
+    def test_a_boot_that_already_runs_the_landed_tag_does_not_ask_for_another_restart(self):
+        # the report says "on disk, not restarted"; when nobody polled before the user restarted by
+        # hand, the boot that RUNS the tag is the one consuming it — its notice says this start runs
+        # it, instead of asking for the restart that just happened
+        rep = {"ok": True, "tag": "v0.0.9", "restarted": False, "why": "no manager is running this kernel"}
+        (jd.STATE / "update-report.json").write_text(json.dumps(rep))
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.0.9"):
+            km._consume_update_report()
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertTrue(ns[0]["ok"])
+        self.assertIn("this start is running it", ns[0]["text"])
+        self.assertIn("no manager is running this kernel", ns[0]["text"])
+        self.assertNotIn("restart romp yourself", ns[0]["text"])
+        # a kernel on any other version (or one whose version reader has nothing) still asks; and
+        # the still-running kernel's poll (running_only) never claims to run it, whatever it reports
+        for ver, running_only in (("v0.0.8", False), (None, False), ("v0.0.9", True)):
+            with km._SYNC_LOCK:
+                del km._SYNC_NOTICES[:]
+            (jd.STATE / "update-report.json").write_text(json.dumps(rep))
+            with mock.patch.object(km, "_kernel_ver", return_value=ver):
+                km._consume_update_report(running_only=running_only)
+            ns = self.notices()
+            self.assertEqual(len(ns), 1, (ver, running_only))
+            self.assertIn("restart romp yourself", ns[0]["text"], (ver, running_only))
+            self.assertNotIn("this start is running it", ns[0]["text"], (ver, running_only))
 
 
 class Routes(Fresh):
@@ -611,7 +658,7 @@ class Routes(Fresh):
     def test_a_report_that_is_not_an_object_is_set_aside_and_the_poll_still_answers(self):
         # null / [] / a number parse but carry nothing: `.get` on them 500'd every poll for the
         # kernel's life (never consumed, so every poll hit the same file again)
-        p, bad = jd.STATE / "update-report.json", jd.STATE / "update-report.json.bad"
+        p = jd.STATE / "update-report.json"
         for junk in ("null", "[]", "3"):
             km._UPDATE_STATE[0] = "running"
             with km._SYNC_LOCK:
@@ -621,10 +668,12 @@ class Routes(Fresh):
             self.assertEqual(status, 200, junk)
             d = json.loads(body)
             self.assertEqual(d["state"], "", "nothing is in flight — the child wrote SOMETHING")
-            self.assertIn("update-report.json.bad", d["failed"])
+            self.assertIn("update-report.json.corrupt-", d["failed"])
             self.assertFalse(p.exists())
-            self.assertEqual(bad.read_text(), junk, "evidence kept, never deleted")
-            bad.unlink()
+            aside = list(jd.STATE.glob("update-report.json.corrupt-*"))
+            self.assertEqual(len(aside), 1, aside)
+            self.assertEqual(aside[0].read_text(), junk, "evidence kept, never deleted")
+            aside[0].unlink()
             ns = self.notices()
             self.assertEqual((len(ns), ns[0]["ok"]), (1, False))
             status, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
@@ -776,6 +825,8 @@ class ReleaseChannelMigration(unittest.TestCase):
                              "HEAD landed exactly on the tag — back on the release channel")
             rep = json.loads((km.jd.STATE / "update-report.json").read_text())
             self.assertTrue(rep.get("ok"), rep)
+            self.assertEqual((rep.get("restarted"), rep.get("why")), (False, "no manager is running this kernel"),
+                             "the no-manager leg says what did not happen, and why")
             log = (km.jd.STATE / "update.log").read_text()
             self.assertIn("return to the release channel", log,
                           "the move is LOUD in the update log, never a silent history jump")

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -382,9 +382,11 @@ class RunUpdate(Fresh):
                       "experience — the quiet window cost minutes per push; explicit "
                       "`romp refresh --quiet` still drains)")
         self.assertNotIn("when=quiet", ok_branch, "no drain default on the deploy path")
-        self.assertIn("if curl -fsS -X POST 'http://127.0.0.1:", ok_branch,
+        self.assertIn("curl -fsS --max-time 60 -X POST 'http://127.0.0.1:", ok_branch,
                       "-f: a non-2xx answer from whatever holds the manager port is not a restart — the "
-                      "report's `restarted` is read from curl's exit, never assumed")
+                      "report's `restarted` is read from curl's exit, never assumed; --max-time: a manager "
+                      "that accepts and never answers ends the request instead of holding the latch with no "
+                      "report (review find, 2026-09-08)")
         self.assertIn('"action": "self-update"', ok_branch,
                       "the script stamps restart-audit.jsonl at curl time, so the dying kernel's "
                       "restart-cuts row joins to a named reason instead of reading anonymous")
@@ -426,8 +428,8 @@ class HonestLaunch(Fresh):
         with mock.patch.object(km.subprocess, "Popen"):
             self.assertTrue(km._run_update("v0.0.9"), "the next launch is not refused")
 
-    def _auto_pass(self):
-        with mock.patch.object(km, "_kernel_ver", return_value="v0.0.8"), \
+    def _auto_pass(self, cur="v0.0.8"):
+        with mock.patch.object(km, "_kernel_ver", return_value=cur), \
              mock.patch.object(km, "_latest_release_tag", return_value="v0.0.9"), \
              mock.patch.object(km, "_send_to_app"):
             km._set_update_mode("auto")
@@ -450,6 +452,23 @@ class HonestLaunch(Fresh):
         self.assertEqual(ran, ["v0.0.9"], "the retry the re-armed slot stands for")
         self.assertEqual(json.loads((jd.STATE / "update-attempted.json").read_text())["tag"], "v0.0.9",
                          "the marker records a launch that happened")
+
+    def test_a_refusal_for_an_update_already_in_flight_keeps_that_updates_tag(self):
+        # the pass found v0.0.9 while the update to v0.0.8 was still running: the launch is refused
+        # (one at a time), and the re-arm must give the slot BACK to the in-flight update's tag, not
+        # blank it: /update-check's `tag` names what is pending, and nothing about the running
+        # update changed (review find, 2026-09-08). Once it ends, the next pass tries v0.0.9.
+        km._UPDATE_STATE[0] = "running"
+        km._UPDATE_AVAIL[0] = "v0.0.8"
+        with mock.patch.object(km.subprocess, "Popen", side_effect=AssertionError("must not spawn")):
+            self._auto_pass(cur="v0.0.7")
+        self.assertEqual(km._UPDATE_AVAIL[0], "v0.0.8", "the in-flight update's tag stays pending")
+        self.assertFalse((jd.STATE / "update-attempted.json").exists())
+        km._UPDATE_STATE[0] = ""                                  # the in-flight update ended
+        ran = []
+        with mock.patch.object(km, "_run_update", side_effect=lambda tag: ran.append(tag) or True):
+            self._auto_pass(cur="v0.0.7")
+        self.assertEqual(ran, ["v0.0.9"], "the newer release is tried once the slot is free")
 
     def test_a_spawn_failure_in_auto_mode_leaves_no_marker_and_no_latch(self):
         with mock.patch.object(km.subprocess, "Popen", side_effect=OSError("no bash")):
@@ -521,23 +540,111 @@ class ReportConsumption(Fresh):
         self.assertEqual(kept, {"update-report.json.corrupt-20260101T000000Z": "[]",
                                 "update-report.json.corrupt-20260101T000000Z-1": "null"})
 
+    def test_the_quarantine_moves_only_the_file_whose_bytes_it_read(self):
+        # the ledger and state-reader quarantines stat BEFORE the read and decline when the file is
+        # no longer the one whose bytes failed (review find, 2026-09-08): here the child's real
+        # report lands between the read of the junk and the move, and the move must NOT carry the
+        # real report off as junk. The fresh bytes get their own (bounded) read instead.
+        p = jd.STATE / "update-report.json"
+        p.write_text("[]")
+        real_loads, fresh = json.loads, {"ok": True, "tag": "v0.0.9", "restarted": False,
+                                         "why": "the manager on port 7777 did not take the restart request"}
+        def loads_then_publish(raw, *a, **kw):
+            d = real_loads(raw, *a, **kw)
+            if not isinstance(d, dict):                           # the junk was read: a peer publishes now
+                p.write_text(json.dumps(fresh))
+            return d
+        with mock.patch.object(km.json, "loads", side_effect=loads_then_publish):
+            km._UPDATE_STATE[0] = "running"
+            rep = km._consume_update_report(running_only=True)
+        self.assertEqual(rep, fresh, "the replacement is what gets consumed")
+        self.assertEqual(list(jd.STATE.glob("update-report.json.corrupt-*")), [], "nothing was moved aside")
+        self.assertTrue((jd.STATE / "update-report-last.json").exists(), "the real report was archived as one")
+        self.assertEqual(km._UPDATE_STATE[0], "")
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertIn("v0.0.9", ns[0]["text"])
+        self.assertNotIn("could not be read", ns[0]["text"])
+
+    def test_a_junk_report_that_cannot_be_moved_aside_is_said_once_and_stays(self):
+        # a read-only state dir: the move fails. Silence here left the latch cleared with no word on
+        # why (review find, 2026-09-08); the convention is one loud notice per fault episode, the
+        # junk left in place as evidence, and the poll told the reason. A move that later succeeds
+        # ends the episode, so the next unmovable file speaks again.
+        p = jd.STATE / "update-report.json"
+        p.write_text("[]")
+        denied = PermissionError(13, "Permission denied")
+        with mock.patch.object(km.os, "replace", side_effect=denied):
+            km._UPDATE_STATE[0] = "running"
+            rep = km._consume_update_report(running_only=True)
+            self.assertEqual(km._UPDATE_STATE[0], "", "the child wrote SOMETHING: nothing is in flight")
+            self.assertFalse(rep["ok"])
+            self.assertIn("could not be moved aside", rep["why"])
+            self.assertIn("Permission denied", rep["why"])
+            self.assertTrue(p.exists(), "the evidence stays where it is")
+            ns = self.notices()
+            self.assertEqual(len(ns), 1)
+            self.assertEqual((ns[0]["ok"], ns[0].get("kind")), (False, "refused"))
+            self.assertIn("Permission denied", ns[0]["text"])
+            self.assertFalse(km._consume_update_report()["ok"], "the boot finds it again")
+            self.assertEqual(len(self.notices()), 1, "the same fault is said once per episode")
+        self.assertFalse(km._consume_update_report()["ok"])
+        self.assertEqual(len(list(jd.STATE.glob("update-report.json.corrupt-*"))), 1, "moved once it can be")
+        self.assertEqual(len(self.notices()), 2, "the move is its own word")
+        p.write_text("null")
+        with mock.patch.object(km.os, "replace", side_effect=denied):
+            km._consume_update_report()
+        self.assertEqual(len(self.notices()), 3, "a fault after a proved move is a new episode")
+
+    def test_the_restart_hint_names_the_step_that_works_for_the_case(self):
+        # `romp refresh` asks the manager; with no manager it exits 1 (review find, 2026-09-08). So
+        # the no-manager report's hint names `romp up`, the manager-refused report's names `romp
+        # refresh`, and a report from before the `why` field (main's no-manager shape: ok, not
+        # restarted, nothing else) reads as the no-manager case it was.
+        cases = ((dict(why="no manager is running this kernel"), "romp up"),
+                 (dict(why="the manager on port 7777 did not take the restart request"), "romp refresh"),
+                 (dict(why="the manager on port 7777 did not answer the restart request within 60 s"), "romp refresh"),
+                 (dict(), "romp up"))
+        for extra, cmd in cases:
+            with km._SYNC_LOCK:
+                del km._SYNC_NOTICES[:]
+            (jd.STATE / "update-report.json").write_text(json.dumps({"ok": True, "tag": "v0.0.9",
+                                                                     "restarted": False, **extra}))
+            km._consume_update_report(running_only=True)
+            ns = self.notices()
+            self.assertEqual(len(ns), 1, extra)
+            self.assertIn("`%s`" % cmd, ns[0]["text"], extra)
+            self.assertNotIn("romp on", ns[0]["text"], "a retired spelling: the manager runs as `romp up`")
+            # the no-manager hint may still NAME `romp refresh` (to say it needs the manager) but never
+            # as the step; the manager hint never sends the user to start a manager that is there
+            other = "(`romp refresh`) to run it" if cmd == "romp up" else "`romp up`"
+            self.assertNotIn(other, ns[0]["text"], extra)
+
     def test_a_boot_that_already_runs_the_landed_tag_does_not_ask_for_another_restart(self):
         # the report says "on disk, not restarted"; when nobody polled before the user restarted by
         # hand, the boot that RUNS the tag is the one consuming it — its notice says this start runs
         # it, instead of asking for the restart that just happened
+        # "v0.0.9+" FIRST: every release tag sits on the release PR's merge commit, not on the
+        # VERSION-bump commit, so a checkout exactly on the tag reads the + (per _kernel_ver's own
+        # docstring); a bare string compare made this arm dead on every real release (review
+        # find, 2026-09-08). The bare shape still counts (a tag placed on the bump commit itself).
         rep = {"ok": True, "tag": "v0.0.9", "restarted": False, "why": "no manager is running this kernel"}
-        (jd.STATE / "update-report.json").write_text(json.dumps(rep))
-        with mock.patch.object(km, "_kernel_ver", return_value="v0.0.9"):
-            km._consume_update_report()
-        ns = self.notices()
-        self.assertEqual(len(ns), 1)
-        self.assertTrue(ns[0]["ok"])
-        self.assertIn("this start is running it", ns[0]["text"])
-        self.assertIn("no manager is running this kernel", ns[0]["text"])
-        self.assertNotIn("restart romp yourself", ns[0]["text"])
+        for ver in ("v0.0.9+", "v0.0.9"):
+            with km._SYNC_LOCK:
+                del km._SYNC_NOTICES[:]
+            (jd.STATE / "update-report.json").write_text(json.dumps(rep))
+            with mock.patch.object(km, "_kernel_ver", return_value=ver):
+                km._consume_update_report()
+            ns = self.notices()
+            self.assertEqual(len(ns), 1, ver)
+            self.assertTrue(ns[0]["ok"], ver)
+            self.assertIn("this start is running it", ns[0]["text"], ver)
+            self.assertIn("no manager is running this kernel", ns[0]["text"], ver)
+            self.assertNotIn("restart romp yourself", ns[0]["text"], ver)
         # a kernel on any other version (or one whose version reader has nothing) still asks; and
         # the still-running kernel's poll (running_only) never claims to run it, whatever it reports
-        for ver, running_only in (("v0.0.8", False), (None, False), ("v0.0.9", True)):
+        for ver, running_only in (("v0.0.8", False), ("v0.0.8+", False), ("v0.0.10", False), (None, False),
+                                  ("v0.0.9", True), ("v0.0.9+", True)):
             with km._SYNC_LOCK:
                 del km._SYNC_NOTICES[:]
             (jd.STATE / "update-report.json").write_text(json.dumps(rep))
@@ -655,6 +762,53 @@ class Routes(Fresh):
             self.assertIn(s, ns[0]["text"])
         self.assertNotIn("no manager is running", ns[0]["text"], "a manager IS running — it did not take the request")
 
+    def test_update_check_carries_the_restart_hint_for_the_case(self):
+        # the banner shows the kernel's hint verbatim, so the no-manager case names the command
+        # that works there (`romp refresh` exits 1 with no manager; review find, 2026-09-08)
+        for why, cmd in (("no manager is running this kernel", "romp up"),
+                         ("the manager on port 7777 did not take the restart request", "romp refresh")):
+            km._UPDATE_STATE[0] = "running"
+            (jd.STATE / "update-report.json").write_text(json.dumps({"ok": True, "tag": "v0.0.9",
+                                                                     "restarted": False, "why": why}))
+            _, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+            d = json.loads(body)
+            self.assertEqual((d["updated"], d["why"]), ("v0.0.9", why))
+            self.assertIn(cmd, d["hint"], why)
+            self.assertNotIn("romp on", d["hint"])
+        km._UPDATE_STATE[0] = ""
+        _, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+        self.assertEqual(json.loads(body)["hint"], "", "no hint when nothing landed")
+
+    def test_two_clicks_launch_one_update_and_the_second_hears_running(self):
+        # two windows click Update: one child, and the second click is told `running` so its banner
+        # joins the wait instead of racing a second launch. The route's guard for a launch refused
+        # BECAUSE a concurrent click just took the latch (_run_update False AND the latch set) is the
+        # `running` answer too, never the 500 a failed spawn earns (review find, 2026-09-08).
+        km._UPDATE_AVAIL[0] = "v0.0.9"
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        spawned, pushed = [], []
+        with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: spawned.append(a)), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: pushed.append(m)):
+            first = self._post("/update")
+            second = self._post("/update")
+        self.assertEqual((first[0], json.loads(first[1])), (200, {"ok": True, "state": "running"}))
+        self.assertEqual((second[0], json.loads(second[1])), (200, {"ok": True, "state": "running"}))
+        launches = [a for a in spawned if a[0][:2] == ["bash", "-c"]]    # the seam also sees git helpers
+        self.assertEqual(len(launches), 1, ("one launch for two clicks", [a[0][:2] for a in spawned]))
+        self.assertEqual([m.get("state") for m in pushed], ["running"], "one running push")
+        self.assertEqual(self.notices(), [], "nothing failed, so nothing is filed")
+        # the race itself: the launch is refused because the latch was taken between the route's
+        # check and _run_update's own (a concurrent click won)
+        km._UPDATE_STATE[0] = ""
+        def won_the_race(tag):
+            km._UPDATE_STATE[0] = "running"
+            return False
+        with mock.patch.object(km, "_run_update", side_effect=won_the_race), \
+             mock.patch.object(km, "_send_to_app"):
+            code, body = self._post("/update")
+        self.assertEqual((code, json.loads(body)["state"]), (200, "running"))
+        km._UPDATE_STATE[0] = ""
+
     def test_a_report_that_is_not_an_object_is_set_aside_and_the_poll_still_answers(self):
         # null / [] / a number parse but carry nothing: `.get` on them 500'd every poll for the
         # kernel's life (never consumed, so every poll hit the same file again)
@@ -755,7 +909,9 @@ class Wiring(unittest.TestCase):
         # `updated` from /update-check means ON DISK, not running: the banner carries the reason
         # the restart did not happen and names the step that runs the new code
         self.assertIn("(d.why?', but '+d.why:'')", self.src)
-        self.assertIn("restart romp yourself (romp refresh) to run it.", self.src)
+        # the kernel words the step by case (`romp refresh` exits 1 with no manager; review find,
+        # 2026-09-08): the banner shows its hint, with the manager case as the fallback text
+        self.assertIn("(d.hint||'restart romp yourself (romp refresh) to run it')", self.src)
 
 
 class ReleaseChannelMigration(unittest.TestCase):
@@ -884,19 +1040,20 @@ class ReleaseChannelMigration(unittest.TestCase):
             km._UPDATE_STATE[0] = ""
             self.assertTrue(km._run_update(tag))
         km._UPDATE_STATE[0] = ""
-        fake, seen = os.path.join(inst, "fake-bin"), os.path.join(inst, "curl-saw")
+        fake, seen, args = os.path.join(inst, "fake-bin"), os.path.join(inst, "curl-saw"), os.path.join(inst, "curl-args")
         os.makedirs(fake)
         with open(os.path.join(fake, "curl"), "w") as f:
-            f.write("#!/bin/sh\nif [ -e \"$T_REPORT\" ]; then echo present > \"$T_SEEN\"; "
+            f.write("#!/bin/sh\nprintf '%s ' \"$@\" > \"$T_ARGS\"\n"
+                    "if [ -e \"$T_REPORT\" ]; then echo present > \"$T_SEEN\"; "
                     "else echo absent > \"$T_SEEN\"; fi\nexit \"$T_CURL_EXIT\"\n")
         os.chmod(os.path.join(fake, "curl"), 0o755)
         env = {**os.environ, "PATH": fake + os.pathsep + os.environ.get("PATH", ""),
-               "T_REPORT": str(km.jd.STATE / "update-report.json"), "T_SEEN": seen,
+               "T_REPORT": str(km.jd.STATE / "update-report.json"), "T_SEEN": seen, "T_ARGS": args,
                "T_CURL_EXIT": str(curl_exit)}
         subprocess.run(["bash", "-c", calls[0][0][2]], cwd=inst, env=env, capture_output=True, text=True)
         rep = json.loads((km.jd.STATE / "update-report.json").read_text())
-        with open(seen) as f:
-            return rep, f.read().strip()
+        with open(seen) as f, open(args) as a:
+            return rep, f.read().strip(), a.read().strip()
 
     def test_the_report_says_what_the_restart_request_actually_did(self):
         # The manager door can be shut (gone, or a stale port). The report used to be written
@@ -906,18 +1063,79 @@ class ReleaseChannelMigration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             g, inst = self._repos(tmp)
             g(inst, "checkout", "-q", "--detach", "v9.9.8")
-            rep, saw = self._run_with_manager("v9.9.9", inst, curl_exit=7)
+            rep, saw, args = self._run_with_manager("v9.9.9", inst, curl_exit=7)
         self.assertEqual(saw, "absent", "the report is written AFTER the restart request, never before")
+        self.assertIn("--max-time 60", args, "the request is bounded: a manager that never answers cannot "
+                                             "hold the latch with no report (review find, 2026-09-08)")
         self.assertEqual((rep["ok"], rep["restarted"]), (True, False))
         self.assertIn("port 7777", rep["why"])
         self.assertIn("did not take the restart request", rep["why"])
         with tempfile.TemporaryDirectory() as tmp:
             g, inst = self._repos(tmp)
             g(inst, "checkout", "-q", "--detach", "v9.9.8")
-            rep, saw = self._run_with_manager("v9.9.9", inst, curl_exit=0)
+            rep, saw, _ = self._run_with_manager("v9.9.9", inst, curl_exit=0)
         self.assertEqual(saw, "absent")
         self.assertEqual((rep["ok"], rep["restarted"], rep.get("why")), (True, True, None),
                          "a request the manager took is the one report the next boot files")
+
+    def test_a_restart_request_the_manager_never_answers_is_not_a_restart(self):
+        # curl's exit 28 is its own timeout: the manager accepted the connection and never answered.
+        # Without --max-time that curl hung for good, the report was never written, and the latch
+        # held with nothing to consume (review find, 2026-09-08). The timeout reads as not restarted,
+        # with a why of its own, and the running kernel's poll consumes it like the refused case.
+        with tempfile.TemporaryDirectory() as tmp:
+            g, inst = self._repos(tmp)
+            g(inst, "checkout", "-q", "--detach", "v9.9.8")
+            rep, saw, args = self._run_with_manager("v9.9.9", inst, curl_exit=28)
+        self.assertEqual(saw, "absent")
+        self.assertIn("--max-time 60", args)
+        self.assertEqual((rep["ok"], rep["restarted"]), (True, False))
+        self.assertIn("port 7777", rep["why"])
+        self.assertIn("did not answer the restart request within 60 s", rep["why"])
+        self.assertNotIn("did not take", rep["why"], "a timeout is its own reason, not a refusal")
+
+
+class BootOnTheTag(Fresh):
+    """The boot that already runs the landed tag, judged by the REAL version reader on a repo shaped
+    like every release: VERSION bumped in one commit, the tag on the commit after it (the release
+    PR's merge), so a checkout exactly on the tag reads `vX.Y.Z+`. The mocked arms above pin the
+    comparison; this pins the shape the comparison must survive (review find, 2026-09-08)."""
+
+    def test_a_release_checkout_reads_the_plus_and_the_boot_still_says_it_runs_it(self):
+        env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid"}
+        def g(cwd, *args):
+            r = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, "git %s: %s%s" % (" ".join(args), r.stdout, r.stderr))
+            return r.stdout.strip()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src")
+            os.makedirs(src)
+            g(src, "init", "-q", "-b", "main")
+            with open(os.path.join(src, "VERSION"), "w") as f:
+                f.write("9.9.9\n")
+            g(src, "add", "VERSION")
+            g(src, "commit", "-qm", "VERSION 9.9.9")                       # the bump
+            g(src, "commit", "-qm", "merge the release PR", "--allow-empty")   # where the tag lands
+            g(src, "tag", "v9.9.9")
+            saved_ver, saved_head = km._VER, dict(km._HEAD_CACHE)
+            try:
+                with mock.patch.object(km, "ROOT", Path(src)):
+                    km._VER = None
+                    km._HEAD_CACHE.update(ts=0.0, full=None, short=None)
+                    self.assertEqual(km._kernel_ver(), "v9.9.9+", "the shape every release checkout reads")
+                    (jd.STATE / "update-report.json").write_text(json.dumps(
+                        {"ok": True, "tag": "v9.9.9", "restarted": False, "why": "no manager is running this kernel"}))
+                    rep = km._consume_update_report()
+            finally:
+                km._VER = saved_ver
+                km._HEAD_CACHE.clear()
+                km._HEAD_CACHE.update(saved_head)
+        self.assertTrue(rep["ok"])
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertIn("this start is running it", ns[0]["text"])
+        self.assertNotIn("restart romp yourself", ns[0]["text"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The tag updater (`romp update` / the dashboard's Update banner / the 6-hourly auto pass) runs a detached script that fast-forwards the checkout onto the release tag and asks the manager to restart the kernel. Verified on `main`, the script wrote its report `{"ok": true, "restarted": true}` **before** the `curl … /restart-all` whose exit it ignored, so a restart request nothing took was reported as a restart. Nothing on the running kernel ever consumed an ok+restarted report, so `_UPDATE_STATE` stayed `running`: after one failed restart the updater was wedged until someone restarted the kernel by hand, with the banner saying "running". Three neighbours of the same shape: `_run_update` latched its in-flight state before `Popen`, so a spawn that raised left it latched; the update-attempted marker was written even when the launch was refused, so the next auto pass never retried; and `_consume_update_report` (and the `/update-check` peek) assumed a dict, so a report that parsed as `null` / `[]` / a number made every poll answer 500 and crashed the boot that found it.

## What changes

**The report says what the restart request did.** The script's restart leg is now `if curl -fsS -X POST …/restart-all; then <ok, restarted: true> else <ok, restarted: false, why: "the manager on port N did not take the restart request"> fi`, written after curl returns; the no-manager leg writes `restarted: false` with its own why. `-f` makes a non-2xx answer from whatever holds the port read as not-restarted; curl's stderr goes to `update.log`. The audit row is still stamped at curl time.

**The consumer knows the difference.** An ok-but-not-restarted report clears the latch and files "romp updated itself to X on disk, but <why> — restart romp yourself (`romp refresh`, or `romp on` if no manager answers) to run it". When the consume is the **boot's** and this kernel's own version already is the tag (nothing polled before the user restarted by hand), the notice says this start is running it instead of asking for one more restart. `/update-check` carries `why`, and its peek uses a read-and-parsed sentinel, so a `null` report is consumed like any other rather than never.

**A launch that did not happen is not an attempt.** `try` around `Popen`: a raise gives the latch back and files one not-ok notice with the error. The attempted marker is written only when the launch returned True; a refused auto launch re-arms the pending-update flag so the next pass retries for real. `POST /update` answers 500 (text/plain, "romp could not start the update to X; the Log has the reason") when the spawn failed, judged by the return **and** the latch, so a concurrent click still hears `running`; the banner shows the body and re-enables Update.

**A report that is not an object is set aside, never a 500.** It moves to `update-report.json.corrupt-<utc stamp>` (`-n` for a second one in the same second; `os.replace`), the convention the goal store, ledgers and state readers wear, with one notice under the bell's `refused` kind; the latch clears and the poll answers `failed` with the sidecar's name. The boot continues.

The banner's stale hint names `romp refresh`.

## Judgment calls

- `curl -fsS` rather than `-s`: the only cost is that a 4xx from something else on the manager port reads as "not restarted", which is the truthful reading.
- The ok+restarted report is now written **after** curl returns, so a manager that restarts this kernel faster than one `printf` would delay the "updated and restarted" notice to the boot after next. Read against `bin/romp-manager`: the immediate `/restart-all` sends SIGTERM synchronously and answers 200; the detached child survives (own session, single-pid kill, `exec`'d kernel), and the printf runs microseconds after curl exits against a full kernel exit + spawn + Python boot. Not a practical window.
- A headless auto-mode kernel with a failed restart request keeps `running` until a page polls `/update-check` (the two consume sites are that poll and the next boot). On `main` the same case wedged forever, page or no page; the auto pass now at least retries once a poll has consumed. Left as is.
- `_run_main_update` (the main-drift converge, #1024) is untouched; the only shared state is the append-only notice ring.

## Tests

`tests/test_kernel_update.py`: the report order pin (the restart request precedes the report write); a real-script run with a fake `curl` prepended on `PATH` that records whether the report existed when it ran, and reads `restarted` from curl's exit; `curl -fsS` and the no-manager `why` pinned; a spawn that raises gives the latch back, files the error, and the click hears a 500; a refused auto launch writes no marker and re-arms; a boot that finds a non-object report continues, sets it aside under the quarantine name and says so once; two junk reports under a pinned stamp keep both sidecars; a `null` report is consumed by the poll; `/update-check` carries `why`; a boot whose own version is the landed tag says this start runs it, while another version, an empty version reader and the running kernel's poll all still ask for the restart; the banner names `romp refresh`. Twelve of these fail on `main` (e.g. `1195 not less than 997 : the report is written AFTER the restart request`, `KeyError: 'why'`, `'list' object has no attribute 'get'`). Source mutants — report written before curl, curl's exit ignored, the `try` removed, the marker written regardless, either `isinstance` guard removed, `why` dropped, a failed spawn acked, the `.bad` rename, the fail-open arm — each fail at least one test.

Module counts on this tree: `tests/test_kernel_update.py` 50 passed; `tests/test_main_drift_notice.py` 49 passed. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



CI on 6506530e: all seven jobs green.
