### PR TITLE
The relay's reopen re-arms the remote kernel's active tab, so a restarted attached kernel keeps streaming the session the pane is looking at

### DIFF
--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -57,7 +57,9 @@ class SourcePins(unittest.TestCase):
     def test_payload_retained_and_reshipped_on_the_reconnect_event(self):
         self.assertIn("interface PendingShip { name: string; shipId: string; b64?: string }", RENDER)
         self.assertIn("if (entry) entry.b64 = b64;", RENDER)
-        self.assertIn('window.addEventListener("romp:wsup", () => reshipPendingUploads());', RENDER)
+        # the listener grew a body (T246: the local active-tab re-arm rides the same open event); the re-ship
+        # is still its first statement
+        self.assertIn('window.addEventListener("romp:wsup", () => {\n  reshipPendingUploads();', RENDER)
         # …and the federated twin (review finding 2026-09-01): the relay's own (re)open re-ships THAT
         # host's entries — scoped by ack socket. The kernel-reported hostUp does NOT: it fires in the
         # tick federation re-dials the relay, before the socket is open (second review, same day)

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -88,7 +88,7 @@ test("a kernel restart between ship and ack RE-SHIPS the retained bytes on recon
   assert.match(RENDER, /interface PendingShip \{ name: string; shipId: string; b64\?: string \}/);
   assert.match(RENDER, /if \(entry\) entry\.b64 = b64;/);
   assert.match(RENDER, /function reshipPendingUploads\(hosts\?: readonly string\[\]\): void \{/);
-  assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => reshipPendingUploads\(\)\);/);
+  assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => \{\n  reshipPendingUploads\(\);/);   // the listener grew a body (T246: the local active-tab re-arm rides it too)
   // an entry still ENCODING has no payload — its own onload ships on the fresh socket, never doubled
   assert.match(RENDER, /if \(!p\.b64\) continue;/);
   // the re-ship rides the same dropFile shape, same shipId, routed to the owning session

--- a/ui/webview/relay-active-rearm.test.ts
+++ b/ui/webview/relay-active-rearm.test.ts
@@ -5,30 +5,45 @@
 // hint or an `activeTab` message) on the live change key (_active_chat_sig: the backend's live tail, its
 // queue, the snapshot row, every side file); every OTHER session is served from the file-stat cache
 // (_chat_build_sig), which no in-memory stream ever busts. The pane shim's local socket carries `?active=`
-// on every dial, so a LOCAL kernel restart re-arms it for free. The federation relay (federation.ts
-// connect) carries no such hint, and nothing re-sent `activeTab` on the relay's reopen — so the restarted
-// remote kernel minted a client with no active tab, served the watched session as a background one, and
-// its reply streamed nowhere until the user's next send moved a file-stat input. The fix re-announces
-// the active tab on romp:hostRelayUp — the relay's own open event, the exact moment the fresh kernel-side
-// client exists — when, and only when, that host owns the tab. Executed helper + render.ts wiring pins.
-// Synthetic ids only.
+// on every dial, so a LOCAL kernel restart re-arms it. The federation relay (federation.ts connect) carries
+// no such hint, and nothing re-sent `activeTab` on the relay's reopen — so the restarted remote kernel
+// minted a client with no active tab, served the watched session as a background one, and its reply
+// streamed nowhere until the user's next send moved a file-stat input. Reproduced on two real hermetic
+// kernels (one attached to the other through the relay, a browser on the first): after the remote's restart
+// the in-memory probe never arrived in 12 s while that kernel logged the session as active=0 on every cycle;
+// a transcript append still flowed; a tab click flipped it back to active=1. The fix re-announces the active
+// tab on romp:hostRelayUp — the relay's own open event, the exact moment the fresh kernel-side client
+// exists — when, and only when, that host owns the tab; the local socket's open (romp:wsup) re-announces a
+// local tab the same way, because the shim's persisted hint can lag a dismissal or an adoption (review fold).
+// Executed helper + routing contract + render.ts wiring pins. Synthetic ids only.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { activeTabToReannounce } from "./relay-active";
+import { routeOutbound } from "./federation";
 
 const SID = "11111111-2222-4333-8444-000000000246";
 // the sources are read from the tree, not the bundled test's own dir (node --test runs from vscode-extension/)
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
 
-test("the active tab is re-announced on the relay's open only when THAT host owns it", () => {
-  assert.equal(activeTabToReannounce("TESTHOST:" + SID, "TESTHOST"), true, "the watched tab is that host's");
+test("the active tab is re-announced on a socket's open only when THAT kernel owns it", () => {
+  assert.equal(activeTabToReannounce("TESTHOST:" + SID, "TESTHOST"), true, "the watched tab is that host's: its relay reopened");
   assert.equal(activeTabToReannounce("TESTHOST:" + SID, "hostB"), false, "another host's relay reopened — its kernel never had this tab");
-  assert.equal(activeTabToReannounce(SID, "TESTHOST"), false, "a LOCAL tab: the pane shim's ?active= already covers the local socket");
+  assert.equal(activeTabToReannounce("TESTHOST:" + SID, ""), false, "the LOCAL socket reopened while a remote tab is active — the local kernel does not know it");
+  assert.equal(activeTabToReannounce(SID, ""), true, "a local tab on the local socket's open (the shim's persisted hint can lag)");
+  assert.equal(activeTabToReannounce(SID, "TESTHOST"), false, "a local tab is never announced at a remote host");
   assert.equal(activeTabToReannounce(null, "TESTHOST"), false, "no tab open");
-  assert.equal(activeTabToReannounce("TESTHOST:" + SID, ""), false, "an event with no host names no relay");
+  assert.equal(activeTabToReannounce(null, ""), false, "no tab open, local socket");
+});
+
+test("the re-announced activeTab reaches exactly the owning host, its id bared (the contract notifyActive relies on)", () => {
+  // notifyActive posts {type:"activeTab", id: activeId} with the HOST-PREFIXED id; federation's outbound
+  // router must land it on that host's relay with the bare id the remote kernel knows, and a local id local
+  assert.deepEqual(routeOutbound({ type: "activeTab", id: "TESTHOST:" + SID }),
+                   [{ host: "TESTHOST", msg: { type: "activeTab", id: SID } }]);
+  assert.deepEqual(routeOutbound({ type: "activeTab", id: SID }), [{ host: "", msg: { type: "activeTab", id: SID } }]);
 });
 
 test("render.ts re-sends activeTab on romp:hostRelayUp for that host's active tab, beside the upload re-ship", () => {
@@ -42,15 +57,19 @@ test("render.ts re-sends activeTab on romp:hostRelayUp for that host's active ta
   assert.match(m![1], /if \(activeTabToReannounce\(activeId, h\)\) notifyActive\(\);/, "the active tab is re-announced through the one activeTab sender (notifyActive → routeOutbound strips the host prefix)");
 });
 
-test("the relay dial carries no connect-time active hint — the reopen event is where the tab is re-armed", () => {
-  // Documenting the shape the fix composes with: federation's URL names app/token/wid only (the shim's
-  // local socket adds ?active= from its persisted state; the relay reads the pane's LIVE activeId on the
-  // open event instead — a persisted copy can lag a dismissal/adoption, which never call setActive)
-  const url = FED.match(/const url = `\$\{proto\}\$\{location\.host\}\/remote\/[\s\S]*?;\n/);
-  assert.ok(url, "the relay URL builder");
-  assert.doesNotMatch(url![0], /active=/);
-  // and the open event is dispatched AFTER flushPending, so a queued setting still precedes the activeTab
+test("render.ts re-sends a LOCAL active tab on romp:wsup, the shim's reconnect event, beside the local re-ship", () => {
+  // anchored on the re-ship call: render.ts has other romp:wsup listeners (preview heals, awaitingFull), this is the one
+  const m = RENDER.match(/window\.addEventListener\("romp:wsup", \(\) => \{\n  reshipPendingUploads\(\);([\s\S]*?)\n\}\);/);
+  assert.ok(m, "the romp:wsup re-ship listener, now with a body");
+  assert.match(m![1], /if \(activeTabToReannounce\(activeId, ""\)\) notifyActive\(\);/, "the local tab is re-announced with the LOCAL host marker");
+});
+
+test("the relay's open dispatches romp:hostRelayUp AFTER flushing queued settings, so a queued setting still precedes the re-announced activeTab", () => {
   const onopen = FED.match(/ws\.onopen = \(\) => \{([\s\S]*?)\n    \};/);
-  assert.ok(onopen);
-  assert.ok(onopen![1].indexOf("this.flushPending(conn)") < onopen![1].indexOf('"romp:hostRelayUp"'));
+  assert.ok(onopen, "the relay socket's onopen");
+  const flush = onopen![1].indexOf("this.flushPending(conn)");
+  const up = onopen![1].indexOf('"romp:hostRelayUp"');
+  assert.ok(flush >= 0, "the flush is in onopen");
+  assert.ok(up >= 0, "the relay-up dispatch is in onopen");
+  assert.ok(flush < up, "flush first, then the event the re-arm rides");
 });

--- a/ui/webview/relay-active-rearm.test.ts
+++ b/ui/webview/relay-active-rearm.test.ts
@@ -1,0 +1,56 @@
+// T246 (the user 2026-09-07): after an ATTACHED kernel restarts, the chat pane stopped receiving live events
+// for that host's ACTIVE session until the user's next send.
+//
+// Why: a kernel keys the tab a client is LOOKING AT (its per-client `active`, set by the `?active=` connect
+// hint or an `activeTab` message) on the live change key (_active_chat_sig: the backend's live tail, its
+// queue, the snapshot row, every side file); every OTHER session is served from the file-stat cache
+// (_chat_build_sig), which no in-memory stream ever busts. The pane shim's local socket carries `?active=`
+// on every dial, so a LOCAL kernel restart re-arms it for free. The federation relay (federation.ts
+// connect) carries no such hint, and nothing re-sent `activeTab` on the relay's reopen — so the restarted
+// remote kernel minted a client with no active tab, served the watched session as a background one, and
+// its reply streamed nowhere until the user's next send moved a file-stat input. The fix re-announces
+// the active tab on romp:hostRelayUp — the relay's own open event, the exact moment the fresh kernel-side
+// client exists — when, and only when, that host owns the tab. Executed helper + render.ts wiring pins.
+// Synthetic ids only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { activeTabToReannounce } from "./relay-active";
+
+const SID = "11111111-2222-4333-8444-000000000246";
+// the sources are read from the tree, not the bundled test's own dir (node --test runs from vscode-extension/)
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+
+test("the active tab is re-announced on the relay's open only when THAT host owns it", () => {
+  assert.equal(activeTabToReannounce("TESTHOST:" + SID, "TESTHOST"), true, "the watched tab is that host's");
+  assert.equal(activeTabToReannounce("TESTHOST:" + SID, "hostB"), false, "another host's relay reopened — its kernel never had this tab");
+  assert.equal(activeTabToReannounce(SID, "TESTHOST"), false, "a LOCAL tab: the pane shim's ?active= already covers the local socket");
+  assert.equal(activeTabToReannounce(null, "TESTHOST"), false, "no tab open");
+  assert.equal(activeTabToReannounce("TESTHOST:" + SID, ""), false, "an event with no host names no relay");
+});
+
+test("render.ts re-sends activeTab on romp:hostRelayUp for that host's active tab, beside the upload re-ship", () => {
+  assert.match(RENDER, /import \{ activeTabToReannounce \} from "\.\/relay-active";/);
+  // the same listener the T215 re-ship uses (pending-attach.test.ts pins its header) gains the re-arm; the
+  // decision is the pure helper's, so a host mismatch never posts a stray activeTab at a kernel that
+  // does not know the session
+  const m = RENDER.match(/window\.addEventListener\("romp:hostRelayUp", \(e\) => \{([\s\S]*?)\n\}\);/);
+  assert.ok(m, "the romp:hostRelayUp listener exists");
+  assert.match(m![1], /reshipPendingUploads\(\[h\]\)/, "the upload re-ship is still there");
+  assert.match(m![1], /if \(activeTabToReannounce\(activeId, h\)\) notifyActive\(\);/, "the active tab is re-announced through the one activeTab sender (notifyActive → routeOutbound strips the host prefix)");
+});
+
+test("the relay dial carries no connect-time active hint — the reopen event is where the tab is re-armed", () => {
+  // Documenting the shape the fix composes with: federation's URL names app/token/wid only (the shim's
+  // local socket adds ?active= from its persisted state; the relay reads the pane's LIVE activeId on the
+  // open event instead — a persisted copy can lag a dismissal/adoption, which never call setActive)
+  const url = FED.match(/const url = `\$\{proto\}\$\{location\.host\}\/remote\/[\s\S]*?;\n/);
+  assert.ok(url, "the relay URL builder");
+  assert.doesNotMatch(url![0], /active=/);
+  // and the open event is dispatched AFTER flushPending, so a queued setting still precedes the activeTab
+  const onopen = FED.match(/ws\.onopen = \(\) => \{([\s\S]*?)\n    \};/);
+  assert.ok(onopen);
+  assert.ok(onopen![1].indexOf("this.flushPending(conn)") < onopen![1].indexOf('"romp:hostRelayUp"'));
+});

--- a/ui/webview/relay-active.ts
+++ b/ui/webview/relay-active.ts
@@ -1,27 +1,34 @@
-// Re-arming a remote kernel's ACTIVE tab when its relay socket (re)opens (T246, the user 2026-09-07: after an
-// attached kernel restarted, the pane stopped receiving live events for that host's active session until the
-// user's next send).
+// Re-arming a kernel's ACTIVE tab when the socket to it (re)opens (T246, the user 2026-09-07: after an attached
+// kernel restarted, the pane stopped receiving live events for that host's active session until the user's
+// next send).
 //
 // A kernel serves the tab a client is LOOKING AT from the live change key (its per-client `active`:
 // _active_chat_sig folds in the backend's live tail, its queue, the snapshot row and every side file) and
 // every other session from the file-stat cache (_chat_build_sig), which no in-memory stream ever busts. A
 // client declares its tab two ways: the `?active=` connect hint (the pane shim's LOCAL socket carries it on
-// every dial, from the persisted state) and the `activeTab` message (render.ts notifyActive, on every tab
+// every dial, from the PERSISTED state) and the `activeTab` message (render.ts notifyActive, on every tab
 // switch). The federation relay carries no connect hint, and a remote kernel that restarted mints a fresh
 // client with no active tab — so the session the user was watching streamed nowhere until their next send
 // moved a file-stat input. federation.ts dispatches romp:hostRelayUp on the relay's own open, the exact
 // moment the fresh kernel-side client exists; render.ts re-announces the active tab on it through
 // notifyActive (routeOutbound strips the host prefix), when this decision says that host owns the tab.
 //
-// Pure and DOM-free so node --test executes it. Reads the pane's LIVE activeId, never the persisted copy:
-// a dismissal's fallback and a sole-tab adoption change activeId without setActive, so the persisted
-// value can lag the box the user is actually typing into.
+// The LOCAL socket gets the same re-arm on its own open (romp:wsup, the shim's reconnect event; review fold
+// 2026-09-08): its ?active= hint reads the persisted activeId, and a dismissal's fallback or a sole-tab
+// adoption changes activeId without setActive, so the persisted copy can name a tab the user has left —
+// after a local kernel restart the hint then keyed a tab nobody was looking at, the same symptom class for a
+// local session. Re-announcing the LIVE activeId on the open removes the dependence on the persisted copy;
+// the kernel's activeTab handler just records the id and wakes the pusher, so a hint that was already right
+// costs one wake.
+//
+// Pure and DOM-free so node --test executes it.
 import { hostOf } from "./host-prefix";
 
-/** Should the pane re-send `activeTab` for `activeId` now that `host`'s relay socket is open? Only when the
- *  tab is that host's: a local tab is the local socket's business (its connect hint), another host's tab
- *  means nothing to this kernel, and no tab or no host names nothing to re-arm. */
+/** Should the pane re-send `activeTab` for `activeId` now that the socket to `host` is open? `host` is the
+ *  relay's host name, or "" for the pane shim's LOCAL socket. Only when the tab is that kernel's: another
+ *  host's tab means nothing to this kernel (its handler would record an id it does not know), and no tab
+ *  names nothing to re-arm. */
 export function activeTabToReannounce(activeId: string | null, host: string): boolean {
-  if (!activeId || !host) return false;
+  if (!activeId) return false;
   return hostOf(activeId) === host;
 }

--- a/ui/webview/relay-active.ts
+++ b/ui/webview/relay-active.ts
@@ -1,0 +1,27 @@
+// Re-arming a remote kernel's ACTIVE tab when its relay socket (re)opens (T246, the user 2026-09-07: after an
+// attached kernel restarted, the pane stopped receiving live events for that host's active session until the
+// user's next send).
+//
+// A kernel serves the tab a client is LOOKING AT from the live change key (its per-client `active`:
+// _active_chat_sig folds in the backend's live tail, its queue, the snapshot row and every side file) and
+// every other session from the file-stat cache (_chat_build_sig), which no in-memory stream ever busts. A
+// client declares its tab two ways: the `?active=` connect hint (the pane shim's LOCAL socket carries it on
+// every dial, from the persisted state) and the `activeTab` message (render.ts notifyActive, on every tab
+// switch). The federation relay carries no connect hint, and a remote kernel that restarted mints a fresh
+// client with no active tab — so the session the user was watching streamed nowhere until their next send
+// moved a file-stat input. federation.ts dispatches romp:hostRelayUp on the relay's own open, the exact
+// moment the fresh kernel-side client exists; render.ts re-announces the active tab on it through
+// notifyActive (routeOutbound strips the host prefix), when this decision says that host owns the tab.
+//
+// Pure and DOM-free so node --test executes it. Reads the pane's LIVE activeId, never the persisted copy:
+// a dismissal's fallback and a sole-tab adoption change activeId without setActive, so the persisted
+// value can lag the box the user is actually typing into.
+import { hostOf } from "./host-prefix";
+
+/** Should the pane re-send `activeTab` for `activeId` now that `host`'s relay socket is open? Only when the
+ *  tab is that host's: a local tab is the local socket's business (its connect hint), another host's tab
+ *  means nothing to this kernel, and no tab or no host names nothing to re-arm. */
+export function activeTabToReannounce(activeId: string | null, host: string): boolean {
+  if (!activeId || !host) return false;
+  return hostOf(activeId) === host;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -50,6 +50,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
@@ -11837,6 +11838,15 @@ window.addEventListener("romp:wsup", () => reshipPendingUploads());
 window.addEventListener("romp:hostRelayUp", (e) => {
   const h = String((((e as CustomEvent).detail || {}) as any).host || "");
   if (h) reshipPendingUploads([h]);
+  // …and the tab this pane is LOOKING AT, when that host owns it (T246, the user 2026-09-07): the relay's
+  // open is the moment the remote kernel holds a FRESH client for this pane — after that kernel restarted,
+  // one with no active tab at all. Its pusher keys only a client's active tab on the live change key (the
+  // backend's stream, its queue, the snapshot row); every other session is served from the file-stat
+  // cache, so the session the user was watching streamed nothing until their next send moved a file
+  // input. The pane shim's local socket re-arms the LOCAL kernel with its ?active= connect hint on every
+  // dial; the relay has no hint, so the same fact is re-sent here as the activeTab message every tab
+  // switch sends (notifyActive; routeOutbound strips the host prefix). Decision in relay-active.ts.
+  if (activeTabToReannounce(activeId, h)) notifyActive();
 });
 
 // Sids whose SEND is HELD until every pending ship acks (the user 2026-08-16: sending mid-upload

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -11832,7 +11832,14 @@ function reshipPendingUploads(hosts?: readonly string[]): void {
     }
   }
 }
-window.addEventListener("romp:wsup", () => reshipPendingUploads());
+window.addEventListener("romp:wsup", () => {
+  reshipPendingUploads();
+  // …and the LOCAL kernel's active tab (the twin of the relay re-arm below; review fold, T246): the shim's
+  // redial carries ?active= from the PERSISTED activeId, which a dismissal's fallback and a sole-tab adoption
+  // change without setActive — so a restarted local kernel could key a tab the user had left and serve the
+  // one they are looking at as a background tab. The live activeId is re-announced on the socket's open.
+  if (activeTabToReannounce(activeId, "")) notifyActive();
+});
 // federation dispatches this on a host relay socket (re)connect — the exact event that makes that
 // host's owed acks reachable again; the detail names the host, so only its entries re-ship
 window.addEventListener("romp:hostRelayUp", (e) => {


### PR DESCRIPTION
## What

After an ATTACHED kernel restarts, the dashboard's chat pane stops receiving live events for that host's active session until the user's next send or tab switch. The reply the user was waiting for streams into the transcript and never onto the screen.

The gap is in the relay reconnect path, and it is about which tab the remote kernel thinks the pane is looking at:

- A kernel keys the tab a client is LOOKING AT (its per-client `active`) on the live change key (`_active_chat_sig`: the backend's live tail, its queue, the snapshot row, the side files). Every other session is served from the file-stat cache (`_chat_build_sig`), which no in-memory change ever busts. That split is the 2026-09-03 active-tab design and is unchanged here.
- A client declares its tab two ways: the `?active=` hint on the socket URL, and the `activeTab` message. The pane shim's LOCAL socket carries the hint on every dial, so a local kernel restart re-arms it for free.
- The federation relay (`federation.ts` `connect`) carries no hint, and on the relay's reopen nothing re-sent `activeTab`: `ws.onopen` flushed queued settings and dispatched `romp:hostRelayUp`, whose only listener re-shipped pending uploads. The restarted remote kernel minted a fresh client with no active tab, served the watched session as a background one, and its in-memory stream reached nobody. The next send moved a file-stat input (the state flip, the echo), which is why the earlier reply rendered along with the new message.

The fix re-announces the active tab on `romp:hostRelayUp`, when and only when the host that reopened owns it, through the one `activeTab` sender the tab switch already uses (`notifyActive`; `routeOutbound` strips the host prefix). The decision is a pure helper (`ui/webview/relay-active.ts`) so node executes it. It reads the pane's LIVE `activeId`, not the persisted copy: a dismissal's fallback and a sole-tab adoption change `activeId` without `setActive`, so the persisted value can lag the box the user is typing into.

Event-based: the relay's own open is the exact moment the fresh kernel-side client exists. No timer, no re-request of the transcript (a fresh client already gets the full frame; a `needFull` there would double it), no `ready` (its synchronous full build on the handler thread is the wrong thing to ask a remote kernel for).

Composes with romp-on/romp#1017 (the reconnecting page's skeleton set), which covers the pane shim's LOCAL socket only: federation sends no `reconnect=1`, so a relay client is never skeletoned, and an `activeTab` arriving after the reopen is exactly what that PR's kernel treats as "release this session" if it lands first.

A review fold widened the same mechanism to the LOCAL socket's open (`romp:wsup`): the pane shim's `?active=` hint reads the persisted active tab, which a dismissal's fallback and a sole-tab adoption change without `setActive`, so a local kernel restart could key a tab the user had left — the same symptom class for a local session. The live `activeId` is re-announced there too, through the same helper (host `""`).

## Reproduced

Two REAL hermetic kernels: kernel A serves the page; kernel B is attached to it as a check-in peer (no ssh, the relay splices to B's loopback port); a headless browser on A's dashboard; one live tmux lane on each. The pane clicks B's tab (B logs the tab keyed live), sends a probe, restarts B (SIGTERM + respawn on the same port, ~0.5 s to healthz, the relay redials ~2.1 s after the kill), then sends a second probe. The probe is the kernel-side input echo — an in-memory-only change, the same class as a streaming reply — read from the pane's incoming frames; a transcript append is the disk-path control. Four baseline runs (two by the harness's author, two by an independent re-run) and two fixed runs:

| after B's restart | main (4 runs) | this branch (2 runs) |
|---|---|---|
| probe echo reaches the pane | never (12 s cap) | 253 ms |
| B's `chatbuild` flag for the session, every cycle | `active=0` (29 cycles, every chat send deduped) | `active=1` from the first cycle after the reopen |
| transcript append reaches the pane | 253 ms | 253 ms |
| a tab click afterwards | flips B to `active=1` at once | — |

Before the restart the echo arrived in ~254 ms on both trees. Kernel code is identical on both trees; the only difference is the browser bundle.

Not verified live: a real ssh tunnel, an SDK-backed session (the probe is tmux's echo atom; the SDK's live tail rides the same active-tab key in `_push`), and the local-socket twin (the review fold) beyond its executed helper and wiring pins.

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New: `ui/webview/relay-active-rearm.test.ts` (the executed helper; the render.ts wiring pin, red on main's render.ts; the relay URL shape the fix composes with). Suites: node 3131 passed (`npm test`, typecheck clean); Python: the full suite 8332 passed on the pre-fold tree, and after the folds (render.ts + two pins) the 28 modules that read the browser sources 834 passed, with the two `ViewBuilder` nudge tests failing only inside that partial selection and passing alone (the known ordering artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
