### PR TITLE
A PR watch is acknowledged only once it is saved, and its landing mail retires the watch only once it is delivered

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -707,6 +707,17 @@ class CodexBackend:
         return (c or "").strip() if isinstance(c, str) else ""
 
     # ── liveness / identity ──────────────────────────────────────────────────────────────────────
+    def end_marker(self, sid):
+        """What this backend's own record says about `sid` after it refused a send — never a liveness
+        probe: True when the session is marked dead (the end marker set when its client dies or the
+        session is ended), None when it holds no session by that id, False when the session stands
+        (the refusal was something else; the caller retries)."""
+        s = self._session(sid)
+        if not s:
+            return None
+        with s.lock:
+            return bool(s.dead)
+
     def owns(self, sid):
         s = self._session(sid)
         if not s:

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -298,6 +298,7 @@ class CodexBackend:
         return self.root / "registry.lock"
 
     def _load_registry(self):
+        self._registry_unreadable = False   # end_marker: while set, "not held" is a reader's fault, not no record
         try:
             rows = json.loads(self._reg_path().read_text())
             if not isinstance(rows, dict):
@@ -310,6 +311,7 @@ class CodexBackend:
             # as unrelated-looking spawn/send errors (2026-08-14 review)
             self.log("codex registry unreadable at load — existing sessions will be missing "
                      "until it is repaired: %s" % e)
+            self._registry_unreadable = True
             rows = {}
         with self._sessions_lock:
             for sid, r in rows.items():
@@ -711,9 +713,15 @@ class CodexBackend:
         """What this backend's own record says about `sid` after it refused a send — never a liveness
         probe: True when the session is marked dead (the end marker set when its client dies or the
         session is ended), None when it holds no session by that id, False when the session stands
-        (the refusal was something else; the caller retries)."""
+        (the refusal was something else; the caller retries). With the registry UNREADABLE at load the
+        backend holds none of the sessions it should, so "not held" RAISES instead of answering None:
+        a reader's fault the caller waits on, never a record's absence it can act on (review find,
+        2026-09-08; before it, a corrupt registry.json read every uuid as no record and ended a Codex
+        registrant's watch). The flag lasts the process: the registry is read once, at load."""
         s = self._session(sid)
         if not s:
+            if getattr(self, "_registry_unreadable", False):
+                raise RuntimeError("Codex registry was unreadable at load: no record of %s can be read" % sid)
             return None
         with s.lock:
             return bool(s.dead)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16147,7 +16147,6 @@ PR_WATCH_FILE = jd.STATE / "pr-watches.json"
 PR_WATCH_EVERY = 60          # the base poll cadence (seconds)
 PR_WATCH_BUSY_EVERY = 90     # …relaxed while checks are visibly still running
 PR_WATCH_MAX_FAILS = 3       # consecutive gh failures before the loud retire
-PR_WATCH_NORECORD_CHECKS = 3 # consecutive refused sends with NO record of the session before it counts as ended
 # STALLED-FAILURE ESCALATION (T143, the ~6h invisible-ask specimen: the worker's failure notice
 # landed in a session a restart had killed, and the USER discovered the stalled PR). A FAILED check
 # no longer retires the watch: the failure mail goes to the owner as before, but the watch HOLDS
@@ -16161,7 +16160,14 @@ PR_WATCH_NORECORD_CHECKS = 3 # consecutive refused sends with NO record of the s
 # reset on each would never fire.
 PR_WATCH_ESCALATE_S = 2 * 3600
 _pr_watches = []             # [{pr, repo, sid, at} + runtime {_next, _fails, _busy}]
-_pr_watch_lock = threading.Lock()
+_pr_watch_lock = threading.Lock()   # held across the DISK WRITE too (_pr_watches_save_locked), so two saves
+#                              cannot land out of order and resurrect a retired row, and a registration is
+#                              acknowledged only once it is on disk: a rolled-back row is never observed. The
+#                              trade, stated (review find, 2026-09-08): a hung state-dir write on the HTTP
+#                              handler holds this lock for the write's duration, and with it the pusher's
+#                              awaiting lift (_kernel_watch_armed) and the supervisor's tick. _atomic_write
+#                              has no timeout of its own; bounding it would take a writer thread, which is
+#                              more machinery than the stall is worth today.
 _PR_WATCH_KEYS = ("pr", "repo", "sid", "at", "escalate", "failedAt", "escalated", "sent", "sentDetail")
 _pr_watch_save_faults = {}   # fault text → True: the save faults already said this episode. A failed save is
 #                              told ONCE per fault episode (one stderr line, one Log row) and the episode ends
@@ -16399,7 +16405,9 @@ def _pr_watch_end_marker(sid):
     """What the durable records say about `sid`, independent of ownership. True from the first
     backend whose record is an explicit end marker (an SDK reg with alive=false, a Codex session
     marked dead — both written at session end); False when a record says the session stands; None
-    when no backend holds a record (an absent or unreadable reg, or a name-shaped tmux sid);
+    when no backend holds a record (no reg file at all, or a name-shaped tmux sid), a durable fact:
+    the SDK backend never unlinks a reg, and a reg that exists but would not read is RAISED by its
+    reader, never answered None (review find, 2026-09-08);
     _PR_WATCH_UNREAD when a reader raised and no other backend answered — a reader's fault can
     neither end nor clear a watch. A durable end marker IS authority, where a liveness probe is not,
     so the tick reads it BEFORE any send: a notice addressed to a uuid no backend holds live must
@@ -16420,36 +16428,25 @@ def _pr_watch_end_marker(sid):
     return _PR_WATCH_UNREAD if raised else None
 
 
-def _pr_watch_norecord(r, key, what):
-    """The no-record arm, counted on the row per `key` (runtime, like _fails): ("wait", why) until
-    PR_WATCH_NORECORD_CHECKS consecutive checks, then ("ended", why). One read never decides — an
-    absent reg and an unreadable one look the same, and one of them is transient."""
-    counts = r.setdefault("_norec", {})
-    counts[key] = int(counts.get(key) or 0) + 1
-    if counts[key] >= PR_WATCH_NORECORD_CHECKS:
-        return "ended", "%s for %d checks" % (what, counts[key])
-    return "wait", "%s (check %d of %d)" % (what, counts[key], PR_WATCH_NORECORD_CHECKS)
-
-
 def _pr_watch_refusal(r, sid):
     """Classify a send that `sid`'s backend just REFUSED by return: ("ended", why) or ("wait", why),
     from the durable records (_pr_watch_end_marker), never from a liveness probe: a slow `tmux
     list-sessions` or a swallowed live_sessions error reads as an EMPTY live set, and an empty set
     must never end a watch or divert its mail. An explicit end marker → ended. A record that says
-    alive → wait (the refusal was something else), and the no-record count resets. No record → the
-    counted arm (_pr_watch_norecord). A record that could not be read → wait, uncounted: a reader's
-    fault never ends a watch."""
+    alive → wait (the refusal was something else). No record → ended, on the first read: an absent
+    reg is a durable fact (the backend never unlinks one), and the three-check count that once stood
+    here approximated the event the readers now report themselves, since a reg that exists but would
+    not read RAISES (review find, 2026-09-08). A record that could not be read → wait, uncounted: a
+    reader's fault never ends a watch."""
     sid = str(sid)
     m = _pr_watch_end_marker(sid)
     if m is True:
-        r.setdefault("_norec", {}).pop(sid, None)
         return "ended", "its record says it ended"
     if m is False:
-        r.setdefault("_norec", {}).pop(sid, None)
         return "wait", "its record says it is alive, yet the send was refused"
     if m == _PR_WATCH_UNREAD:
         return "wait", "its record could not be read"
-    return _pr_watch_norecord(r, sid, "no record of the session")
+    return "ended", "no record of the session"
 
 
 def _pr_watch_contact_sid(target):
@@ -16482,18 +16479,21 @@ def _pr_watch_contact_sid(target):
 
 def _pr_watch_undelivered_once(r, reason, line):
     """A notice the row could not place, said once per REASON per kernel run — stderr and the Log —
-    so a retrying row is visible without a line every 60 s, a changed reason (a count that advanced,
-    a contact that stopped answering) is said once more, and a repeated one stays silent. The set of
-    reasons said is what the closing notice reads: a story that opened on the Log closes on it."""
+    so a retrying row is visible without a line every 60 s, a changed reason (a contact that stopped
+    answering, a record that turned) is said once more, and a repeated one stays silent. The set of
+    reasons said is what the closing notice reads: a story that opened on the Log closes on it.
+    Filed under the bell's `refused` kind, like every notice this module could not place and every
+    state file it could not write: a mute on the machine-sync kind must not hide a fault (review
+    find, 2026-09-08)."""
     said = r.setdefault("_undelivered", set())
     if reason in said:
         return
     said.add(reason)
     sys.stderr.write(line + "\n")
-    _sync_notice(line, ok=False)
+    _sync_notice(line, ok=False, kind="refused")
 
 
-def _pr_watch_deliver_stamped(r, verdict, detail):
+def _pr_watch_deliver_stamped(r, verdict, detail, now=None):
     """Deliver a watch's ONE terminal mail and say whether the row is SETTLED; the tick retires the
     row only on True. The order is STAMP → decide from the records → send → classify a refusal →
     retire. The verdict is written into the row (`sent`/`sentDetail`) and SAVED before anything
@@ -16505,44 +16505,54 @@ def _pr_watch_deliver_stamped(r, verdict, detail):
     an explicit end marker means the registrant has ENDED — no send, straight to the contact leg.
     No record at all splits on the sid's SHAPE, a structural fact of the backends: SDK and Codex
     sids are uuids, tmux sids are session NAMES. A uuid nobody holds is not sent — routed to tmux it
-    would be "accepted" by a shell that never existed — and takes the counted no-record arm (three
-    consecutive ticks → ended, saying so). A name-shaped sid with no record is a tmux registrant and
-    is sent as ever; tmux's send never refuses (a missing session is reported only on stderr, in its
-    own thread), so a dead tmux registrant's notice still reads as accepted — the gap that stood
-    before this change stands, stated, and a liveness probe is not its fix. Otherwise the SEND goes
-    first — the backend's own send path handles what no live set can show (a dormant reg it wakes, a
-    comment thread that SdkBackend.live_sessions never lists) — and only a send REFUSED by return is
-    classified (_pr_watch_refusal): "wait" keeps the stamp and the row for the next tick, said once
-    per reason on the Log, with no repeat warning (a known failure, nothing landed); "ended" takes
-    the contact leg. A PARK counts as acceptance (an account-wide hold or a queue ahead parks the
-    notice for the drain, whose be.send return is dropped) — pre-existing, and the refusal signal now
-    exists for a follow-up.
+    would be "accepted" by a shell that never existed — and has ENDED, decided on the first read: no
+    reg file is a durable fact (the SDK backend never unlinks one), and a reg that exists but would
+    not read is a reader's fault its reader RAISES, so the three-check count that once stood here
+    approximated an event the readers now report (review find, 2026-09-08). A name-shaped sid with no
+    record is a tmux registrant and is sent as ever; tmux's send never refuses (a missing session is
+    reported only on stderr, in its own thread), so a dead tmux registrant's notice still reads as
+    accepted — the gap that stood before this change stands, stated, and a liveness probe is not its
+    fix. Otherwise the SEND goes first — the backend's own send path handles what no live set can show
+    (a dormant reg it wakes, a comment thread that SdkBackend.live_sessions never lists) — and only a
+    send REFUSED by return is classified (_pr_watch_refusal): "wait" keeps the stamp and the row for
+    the next tick, said once per reason on the Log, with no repeat warning (a known failure, nothing
+    landed); "ended" takes the contact leg. A PARK counts as acceptance (an account-wide hold or a
+    queue ahead parks the notice for the drain, whose be.send return is dropped) — pre-existing, and
+    the refusal signal now exists for a follow-up.
 
     The contact leg: the escalation contact (per-watch `escalate` or the box default) resolved by
     _pr_watch_contact_sid, then the same records-first order — its end marker, its shape, a send,
     its refusal classified — worded for the contact and logged where it went. An UNRESOLVED contact
-    name never counts toward ending: the row waits, said once, and the awaiting box shows the mail
-    pending — a name the live set failed to list is not a session that ended. Only when the
-    registrant has ended AND no contact can take it (none named, the same session, or ended / gone
-    for three checks too) does the row retire LOUDLY: one Log row naming repo#n, why the registrant
-    counts as ended, and why no contact could — never silently, never an unbounded 60 s loop. A row
-    whose refusals were logged and is then delivered files one ok row closing the story. A stamped
-    row that outlives a RESTART goes out with the notice saying it may repeat, and a loud retire of
-    such a row says a copy may have gone out."""
+    name is waited on, said once, with the awaiting box showing the mail pending (a name the live set
+    failed to list is not a session that ended), and the wait is BOUNDED (review find, 2026-09-08): a
+    name that never resolves (mistyped, or a box default naming a session nobody starts again) kept
+    the row armed forever, one tmux fork per tick with the once-said Log row its only trace. The wait
+    starts at the first unresolved tick (runtime, like _fails: a restart re-arms it, which only
+    lengthens the wait) and ends at PR_WATCH_ESCALATE_S, the bound this module already keeps for
+    waiting on the named contact. Only when the registrant has ended AND no contact can take it (none
+    named, the same session, ended or unrecorded too, or unresolved past the bound) does the row
+    retire LOUDLY: one stderr line and one Log row under the bell's `refused` kind (a notice that
+    could not be placed is a fault, like a state file that could not be written), naming repo#n, why
+    the registrant counts as ended, and why no contact could. Never silently; the waits left
+    open-ended are a record that says alive yet refuses the send, and a record that could not be
+    read, each ending on its own event (the send taken, the read healed, the record turning into an
+    end marker). A row whose refusals were logged and is then delivered files one ok row closing the
+    story. A stamped row that outlives a RESTART goes out with the notice saying it may repeat, and a
+    loud retire of such a row says a copy may have gone out."""
     if r.get("sent") != verdict:
         r["sent"], r["sentDetail"] = verdict, detail
         if not _pr_watches_save():
             r.pop("sent", None)
             r.pop("sentDetail", None)
             return False
+    now = time.time() if now is None else float(now)
     sid, ref, replay = str(r["sid"]), "%s#%s" % (r["repo"], r["pr"]), bool(r.get("_replay"))
     said_before = bool(r.get("_undelivered"))
     m = _pr_watch_end_marker(sid)
     if m is True:
         state, why = "ended", "its record says it ended"
     elif m is None and _PR_WATCH_UUID_RE.fullmatch(sid):
-        state, why = _pr_watch_norecord(r, sid, "no record of the session")
-        held = "was not sent to session %s (%s)" % (sid[:8], why)
+        state, why = "ended", "no record of the session"
     else:
         if _pr_watch_deliver(sid, _pr_watch_notice(verdict, r["repo"], r["pr"], detail, replay=replay)):
             if said_before:
@@ -16563,8 +16573,7 @@ def _pr_watch_deliver_stamped(r, verdict, detail):
         if tm is True:
             tstate, twhy = "ended", "its record says it ended"
         elif tm is None and _PR_WATCH_UUID_RE.fullmatch(tsid):
-            tstate, twhy = _pr_watch_norecord(r, tsid, "no record of the contact")
-            held = "was not sent to the escalation contact %s (%s)" % (target, twhy)
+            tstate, twhy = "ended", "no record of the contact"
         else:
             if _pr_watch_deliver(tsid, _pr_watch_notice(verdict, r["repo"], r["pr"], detail, replay=replay,
                                                         ended_owner=sid)):
@@ -16581,20 +16590,26 @@ def _pr_watch_deliver_stamped(r, verdict, detail):
     elif target and tsid == sid:
         contact = "its escalation contact is that same session"
     elif target:
-        # unresolved: WAIT, uncounted — a name the live set failed to list is not a session that
-        # ended; a mistyped name shows as pending in the awaiting box and once here
-        _pr_watch_undelivered_once(r, "contact unresolved",
-                                   "pr-watches: the %s notice for %s is waiting — %s, and its escalation contact "
-                                   "%s does not resolve to a session; retrying every %ds until it does"
-                                   % (verdict, ref, ended, target, PR_WATCH_EVERY))
-        return False
+        # unresolved: WAIT, said once (a name the live set failed to list is not a session that ended;
+        # the name shows as pending in the awaiting box), BOUNDED at PR_WATCH_ESCALATE_S from the first
+        # unresolved tick: a name that never resolves is not a wait but a drop with nobody told, and
+        # the loud retire below is what tells them (review find, 2026-09-08)
+        since = r.setdefault("_unresolvedAt", now)
+        if now - since < PR_WATCH_ESCALATE_S:
+            _pr_watch_undelivered_once(r, "contact unresolved",
+                                       "pr-watches: the %s notice for %s is waiting — %s, and its escalation contact "
+                                       "%s does not resolve to a session; retrying every %ds until it does, for up to %dh"
+                                       % (verdict, ref, ended, target, PR_WATCH_EVERY, PR_WATCH_ESCALATE_S // 3600))
+            return False
+        contact = ("its escalation contact %s did not resolve to a session for %dh"
+                   % (target, max(1, int((now - since) // 3600))))
     else:
         contact = "no escalation contact is named"
     line = ("pr-watches: the %s notice for %s could not be delivered — %s and %s; the watch is dropped%s"
             % (verdict, ref, ended, contact,
                " (a copy may have gone out before the last restart)" if replay else ""))
     sys.stderr.write(line + "\n")
-    _sync_notice(line, ok=False)
+    _sync_notice(line, ok=False, kind="refused")
     return True
 
 
@@ -16610,7 +16625,7 @@ def _pr_watch_tick(now):
         if r.get("sent"):
             # a filed verdict whose mail is still owed (a refused injection, or a restart between the
             # stamp and the retire): deliver THAT, never re-derive it from gh — the stamp is the event
-            if _pr_watch_deliver_stamped(r, r["sent"], str(r.get("sentDetail") or "")):
+            if _pr_watch_deliver_stamped(r, r["sent"], str(r.get("sentDetail") or ""), now=now):
                 done.append(r)
             else:
                 r["_next"] = now + PR_WATCH_EVERY
@@ -16620,7 +16635,7 @@ def _pr_watch_tick(now):
             r["_fails"] = int(r.get("_fails") or 0) + 1
             r["_next"] = now + PR_WATCH_EVERY
             if r["_fails"] >= PR_WATCH_MAX_FAILS:
-                if _pr_watch_deliver_stamped(r, "error", detail):
+                if _pr_watch_deliver_stamped(r, "error", detail, now=now):
                     done.append(r)
             continue
         r["_fails"] = 0
@@ -16651,7 +16666,7 @@ def _pr_watch_tick(now):
                     _pr_watch_deliver(tsid, _pr_watch_stalled_notice(r, now))
             r["_next"] = now + PR_WATCH_EVERY
             continue
-        if _pr_watch_deliver_stamped(r, verdict, detail):
+        if _pr_watch_deliver_stamped(r, verdict, detail, now=now):
             done.append(r)
         else:
             r["_next"] = now + PR_WATCH_EVERY

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16367,9 +16367,16 @@ def _pr_watch_deliver(sid, text):
     (_send_or_park's None: be.send returned False for a session it no longer holds) or raised. The
     watch ticks keep their row on False and retry; the PR tick classifies the refusal from the
     backend's own record (_pr_watch_refusal), so it never retries forever against a session that
-    has ended."""
+    has ended. A uuid-shaped sid is never handed to tmux, whichever way it got there (the record
+    read said nothing, or a reader's fault left it unread): SDK and Codex sids are uuids and tmux
+    sids are names, so a uuid the router disowns is a session no record-holding backend holds — tmux
+    would "accept" the notice for a shell that never existed. It reads as refused instead, and the
+    caller classifies it from the records."""
     try:
-        return _send_or_park(Sessions.backend_for(sid), sid, text) is not None
+        be = Sessions.backend_for(sid)
+        if be is _TMUX and _PR_WATCH_UUID_RE.fullmatch(str(sid)):
+            return False
+        return _send_or_park(be, sid, text) is not None
     except Exception:
         return False
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16131,7 +16131,12 @@ def _cache_remote_views(r, rviews):
 # A session registers interest in a PR; the KERNEL polls gh for the terminal state and delivers the
 # outcome as one [romp] notice to the registering session. Registrations persist (pr-watches.json)
 # and re-arm on boot exactly like the reconnect intent — a kernel restart moves the watch, never
-# kills it. Polling an external system is the legitimate acquisition of an unobservable event (the
+# kills it. Durability is the contract at both ends: a registration is acknowledged only once it is
+# ON DISK (a failed save refuses it, retryably), and a landing's notice retires the row only once
+# its injection is accepted, with the verdict stamped into the file BEFORE the injection (see
+# _pr_watch_deliver_stamped) so a crash in between can never lose the one mail a delegating session
+# is waiting on, nor mail it twice without saying so. Polling an external system is the legitimate
+# acquisition of an unobservable event (the
 # USAGE_POLL precedent): modest cadence, a touch slower while checks visibly run. Terminal means
 # MERGED, CLOSED, or a FAILED check — both ends of the standing watcher rule — and a gh failure is
 # LOUD: three consecutive errors deliver a failure notice and retire the watch, never a silent dead
@@ -16142,6 +16147,7 @@ PR_WATCH_FILE = jd.STATE / "pr-watches.json"
 PR_WATCH_EVERY = 60          # the base poll cadence (seconds)
 PR_WATCH_BUSY_EVERY = 90     # …relaxed while checks are visibly still running
 PR_WATCH_MAX_FAILS = 3       # consecutive gh failures before the loud retire
+PR_WATCH_NORECORD_CHECKS = 3 # consecutive refused sends with NO record of the session before it counts as ended
 # STALLED-FAILURE ESCALATION (T143, the ~6h invisible-ask specimen: the worker's failure notice
 # landed in a session a restart had killed, and the USER discovered the stalled PR). A FAILED check
 # no longer retires the watch: the failure mail goes to the owner as before, but the watch HOLDS
@@ -16156,6 +16162,10 @@ PR_WATCH_MAX_FAILS = 3       # consecutive gh failures before the loud retire
 PR_WATCH_ESCALATE_S = 2 * 3600
 _pr_watches = []             # [{pr, repo, sid, at} + runtime {_next, _fails, _busy}]
 _pr_watch_lock = threading.Lock()
+_PR_WATCH_KEYS = ("pr", "repo", "sid", "at", "escalate", "failedAt", "escalated", "sent", "sentDetail")
+_pr_watch_save_faults = {}   # fault text → True: the save faults already said this episode. A failed save is
+#                              told ONCE per fault episode (one stderr line, one Log row) and the episode ends
+#                              on the EVENT — a save that lands clears the registry — never on a clock.
 
 
 def _pr_watches_load():
@@ -16171,6 +16181,16 @@ def _pr_watches_load():
         # boot re-arm (the reconnect-intent precedent): fresh counters, poll immediately
         for r in _pr_watches:
             r["_next"], r["_fails"], r["_busy"] = 0, 0, False
+            if r.get("sent") not in ("merged", "closed", "error"):
+                # a stamp is one of the three verdicts the tick files, or it is not a stamp: a torn or
+                # hand-edited value would otherwise replay as a notice the tick never wrote (the strict
+                # reader's rule — _read_state_json — applied to one field)
+                r.pop("sent", None)
+                r.pop("sentDetail", None)
+            # a row stamped `sent` was mid-delivery when the last kernel died (stamp → mail → retire,
+            # and it got as far as the stamp): whether its mail landed is unknowable, so it goes out
+            # once more with the notice SAYING so — never silently twice, never silently dropped
+            r["_replay"] = bool(r.get("sent"))
 
 
 def _kernel_watch_armed(sid):
@@ -16182,34 +16202,71 @@ def _kernel_watch_armed(sid):
         return any(str(r.get("sid")) == str(sid) for r in _pr_watches)
 
 
-def _pr_watches_save():
-    with _pr_watch_lock:
-        rows = [{k: r[k] for k in ("pr", "repo", "sid", "at", "escalate", "failedAt", "escalated")
-                 if k in r} for r in _pr_watches]
+def _pr_watches_save_locked():
+    """Persist the rows; the caller HOLDS _pr_watch_lock, so the write itself sits under it (two
+    concurrent saves cannot land out of order and resurrect a retired row). Returns the FAULT TEXT
+    when the write did not land, "" when it did — the caller that owns a gesture names the fault to
+    the user, and reads it from its own save, never from the shared registry. A failed write is said
+    ONCE per fault episode — one stderr line with the traceback and one Log row under the bell's
+    `refused` kind (a state file that could not be written, like every other), keyed on the errno
+    text (_errno_text: never str(e), whose temp path carries a per-call sequence) — and the next
+    landed write ends the episode: a save that fails every tick for an hour says so once, not sixty
+    times, and never silently."""
+    rows = [{k: r[k] for k in _PR_WATCH_KEYS if k in r} for r in _pr_watches]
     try:
         _atomic_write(PR_WATCH_FILE, json.dumps(rows))
-    except Exception:
-        sys.stderr.write("pr-watches save: %s\n" % traceback.format_exc())
+    except Exception as e:
+        fault = _errno_text(e)
+        if fault not in _pr_watch_save_faults:
+            _pr_watch_save_faults[fault] = True
+            line = ("pr-watches: could not save %s (%s) — a watch registered now is refused, and a landed "
+                    "PR's notice waits until the file takes writes again" % (PR_WATCH_FILE.name, fault))
+            sys.stderr.write("%s\n%s" % (line, traceback.format_exc()))
+            _sync_notice(line, ok=False, kind="refused")
+        return fault
+    _pr_watch_save_faults.clear()
+    return ""
+
+
+def _pr_watches_save():
+    """True when the rows are on disk (the tick's stamp and retire saves ask only that)."""
+    with _pr_watch_lock:
+        return not _pr_watches_save_locked()
 
 
 def add_pr_watch(pr, repo, sid, now=None, escalate=""):
     """Register (idempotently) a landing watch: one mail to `sid` when repo#pr reaches a terminal
     state. `escalate` names the session pinged if a FAILED check sits unresolved past the bound
-    (T143 — the delegating manager registers itself; the kernel infers nothing). Returns the row."""
+    (T143 — the delegating manager registers itself; the kernel infers nothing). Returns (row, fault)
+    like add_watch: (row, "") once the registration is ON DISK; (None, fault) when a fresh row could
+    not be saved — lookup, append, persist and rollback are ONE locked transaction, so a row a restart
+    would forget is never acknowledged, never seen by a concurrent registration, and never on disk to
+    resurrect at boot; and (row, fault) when the watch already stands but a NEW escalation target
+    could not be saved (rolled back too) — the caller tells the two apart, because "nothing is
+    watching" would be false in the second case. The disk write sits inside the lock on purpose: a
+    hung state-dir write holds the tick and _kernel_watch_armed for its duration, which is the price
+    of never observing, acknowledging, or persisting a row the transaction then rolls back."""
     pr, repo, sid = int(pr), str(repo).strip(), str(sid).strip()
     with _pr_watch_lock:
         for r in _pr_watches:
             if r["pr"] == pr and r["repo"] == repo and r["sid"] == sid:
+                fault = ""
                 if escalate and not r.get("escalate"):
                     r["escalate"] = str(escalate).strip()
-                return {k: r[k] for k in ("pr", "repo", "sid", "at")}
+                    fault = _pr_watches_save_locked()
+                    if fault:
+                        r.pop("escalate", None)
+                return {k: r[k] for k in ("pr", "repo", "sid", "at")}, fault
         row = {"pr": pr, "repo": repo, "sid": sid, "at": int(now if now is not None else time.time()),
                "_next": 0, "_fails": 0, "_busy": False}
         if escalate:
             row["escalate"] = str(escalate).strip()
         _pr_watches.append(row)
-    _pr_watches_save()
-    return {k: row[k] for k in ("pr", "repo", "sid", "at")}
+        fault = _pr_watches_save_locked()
+        if fault:
+            _pr_watches.remove(row)          # rolled back under the same lock: refused means gone
+            return None, fault
+        return {k: row[k] for k in ("pr", "repo", "sid", "at")}, ""
 
 
 def _pr_watch_verdict(d):
@@ -16235,24 +16292,33 @@ def _pr_watch_verdict(d):
     return None, ("busy" if busy else "")
 
 
-def _pr_watch_notice(verdict, repo, pr, detail=""):
+def _pr_watch_notice(verdict, repo, pr, detail="", replay=False, ended_owner=""):
     """The one mail a landing watch sends — the [romp] mechanics-notice family (it is ABOUT romp's
     own watch service, like the restart notice): plain, practical, no reply expected. PURE for the
-    voice test."""
+    voice test. `replay`: the delivery stamp outlived a kernel restart, so an earlier copy may have
+    landed — the notice says so rather than pretending to be the first. `ended_owner`: the sid that
+    registered the watch has ENDED and this copy goes to its escalation contact, who never asked —
+    the notice names the session it was watching for and says why it arrives here."""
     ref = "%s#%s" % (repo, pr)
+    who = (("romp was watching for session %s" % str(ended_owner)[:8]) if ended_owner
+           else "you asked romp to watch")
     if verdict == "merged":
-        body = "[romp] The pull request you asked romp to watch has MERGED: %s. This watch is done." % ref
+        body = "[romp] The pull request %s has MERGED: %s. This watch is done." % (who, ref)
     elif verdict == "closed":
-        body = ("[romp] The pull request you asked romp to watch was CLOSED without merging: %s. "
-                "This watch is done." % ref)
+        body = ("[romp] The pull request %s was CLOSED without merging: %s. "
+                "This watch is done." % (who, ref))
     elif verdict == "failed":
-        body = ("[romp] The pull request you asked romp to watch has a FAILED check (%s): %s. "
+        body = ("[romp] The pull request %s has a FAILED check (%s): %s. "
                 "It will not land on its own — it needs your attention. This watch is done."
-                % (detail or "a check", ref))
+                % (who, detail or "a check", ref))
     else:   # the loud gh-failure retire
         body = ("[romp] romp could not read %s (gh said: %s) after several tries, so this watch was "
                 "dropped — check `gh auth status` on this machine and re-register with `romp watch-pr` "
                 "if you still need it." % (ref, detail or "an unknown error"))
+    if ended_owner:
+        body += " That session has ended, so this comes to you as the escalation contact named for it."
+    if replay:
+        body += " This may repeat a notice sent just before romp last restarted."
     # romp-injected: the chat classifies by MARKER, never by prose (T130) — without it this notice
     # rendered as a generic tagged machine message instead of wearing the romp attribution the
     # nudges wear; romp-system marks the mechanics-notice family; the tag stays as the shape's id.
@@ -16295,31 +16361,260 @@ def _pr_watch_read(pr, repo):
 
 
 def _pr_watch_deliver(sid, text):
-    """The landing mail, through the same park-aware injection /send uses (a rate-limited or
-    compacting session gets it when it can take it). Best-effort by design: a dead session's mail
-    has no recipient, and the watch is already done."""
+    """One watch notice, through the same park-aware injection /send uses (a rate-limited or
+    compacting session gets it when it can take it). Returns whether the BACKEND accepted it —
+    parked, or handed over and not refused. False when the backend refused the handover
+    (_send_or_park's None: be.send returned False for a session it no longer holds) or raised. The
+    watch ticks keep their row on False and retry; the PR tick classifies the refusal from the
+    backend's own record (_pr_watch_refusal), so it never retries forever against a session that
+    has ended."""
     try:
-        _send_or_park(Sessions.backend_for(sid), sid, text)
-        return True
+        return _send_or_park(Sessions.backend_for(sid), sid, text) is not None
     except Exception:
         return False
 
 
+_PR_WATCH_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+_PR_WATCH_UNREAD = "unread"      # _pr_watch_end_marker: a record reader raised and no other backend answered
+
+
+def _pr_watch_record_backends():
+    """The backends that keep a DURABLE record of their sessions — the SDK backend (regs on disk) and
+    the Codex backend (its registry and dead marks) — whichever are built. tmux keeps none: a tmux
+    session's identity is its NAME, held by tmux itself. Read directly, never through
+    Sessions.backend_for: ownership routes by owns(), and owns() is False for exactly the records that
+    decide a landing mail's fate — an SDK reg that is absent or unreadable, a Codex session marked
+    dead — so those sids fall to tmux, whose send accepts anything."""
+    return [b for b in (_sdk(), _codex()) if b]
+
+
+def _pr_watch_end_marker(sid):
+    """What the durable records say about `sid`, independent of ownership. True from the first
+    backend whose record is an explicit end marker (an SDK reg with alive=false, a Codex session
+    marked dead — both written at session end); False when a record says the session stands; None
+    when no backend holds a record (an absent or unreadable reg, or a name-shaped tmux sid);
+    _PR_WATCH_UNREAD when a reader raised and no other backend answered — a reader's fault can
+    neither end nor clear a watch. A durable end marker IS authority, where a liveness probe is not,
+    so the tick reads it BEFORE any send: a notice addressed to a uuid no backend holds live must
+    never fall to tmux and read as accepted."""
+    sid = str(sid)
+    raised = False
+    for be in _pr_watch_record_backends():
+        fn = getattr(be, "end_marker", None)
+        if not fn:
+            continue
+        try:
+            m = fn(sid)
+        except Exception:
+            raised = True
+            continue
+        if m is not None:
+            return bool(m)
+    return _PR_WATCH_UNREAD if raised else None
+
+
+def _pr_watch_norecord(r, key, what):
+    """The no-record arm, counted on the row per `key` (runtime, like _fails): ("wait", why) until
+    PR_WATCH_NORECORD_CHECKS consecutive checks, then ("ended", why). One read never decides — an
+    absent reg and an unreadable one look the same, and one of them is transient."""
+    counts = r.setdefault("_norec", {})
+    counts[key] = int(counts.get(key) or 0) + 1
+    if counts[key] >= PR_WATCH_NORECORD_CHECKS:
+        return "ended", "%s for %d checks" % (what, counts[key])
+    return "wait", "%s (check %d of %d)" % (what, counts[key], PR_WATCH_NORECORD_CHECKS)
+
+
+def _pr_watch_refusal(r, sid):
+    """Classify a send that `sid`'s backend just REFUSED by return: ("ended", why) or ("wait", why),
+    from the durable records (_pr_watch_end_marker), never from a liveness probe: a slow `tmux
+    list-sessions` or a swallowed live_sessions error reads as an EMPTY live set, and an empty set
+    must never end a watch or divert its mail. An explicit end marker → ended. A record that says
+    alive → wait (the refusal was something else), and the no-record count resets. No record → the
+    counted arm (_pr_watch_norecord). A record that could not be read → wait, uncounted: a reader's
+    fault never ends a watch."""
+    sid = str(sid)
+    m = _pr_watch_end_marker(sid)
+    if m is True:
+        r.setdefault("_norec", {}).pop(sid, None)
+        return "ended", "its record says it ended"
+    if m is False:
+        r.setdefault("_norec", {}).pop(sid, None)
+        return "wait", "its record says it is alive, yet the send was refused"
+    if m == _PR_WATCH_UNREAD:
+        return "wait", "its record could not be read"
+    return _pr_watch_norecord(r, sid, "no record of the session")
+
+
+def _pr_watch_contact_sid(target):
+    """The escalation contact's sid, or "" when `target` cannot be resolved this tick. A sid is taken
+    as-is (a uuid, or a tmux session name the names registry knows). A NAME resolves first through
+    _sid_of — which for an SDK/Codex session reads the LIVE SET, the probe this module distrusts —
+    and, when that hands the name back unchanged, through the durable record the SDK backend keeps:
+    its regs carry the session's name (SdkBackend.sid_for_name: exactly one alive reg with that name,
+    else nothing). Unresolved is "": the caller WAITS and says so once, and never counts it toward
+    ending — a name the live set failed to list is not a session that ended, and a send to a bare
+    name would fall to tmux, whose send accepts anything."""
+    try:
+        tsid = _sid_of(target)
+    except Exception:
+        tsid = target
+    if tsid != target or _name_of(tsid):
+        return tsid
+    for be in _pr_watch_record_backends():
+        fn = getattr(be, "sid_for_name", None)
+        if not fn:
+            continue
+        try:
+            hit = fn(target)
+        except Exception:
+            hit = ""
+        if hit:
+            return str(hit)
+    return ""
+
+
+def _pr_watch_undelivered_once(r, reason, line):
+    """A notice the row could not place, said once per REASON per kernel run — stderr and the Log —
+    so a retrying row is visible without a line every 60 s, a changed reason (a count that advanced,
+    a contact that stopped answering) is said once more, and a repeated one stays silent. The set of
+    reasons said is what the closing notice reads: a story that opened on the Log closes on it."""
+    said = r.setdefault("_undelivered", set())
+    if reason in said:
+        return
+    said.add(reason)
+    sys.stderr.write(line + "\n")
+    _sync_notice(line, ok=False)
+
+
+def _pr_watch_deliver_stamped(r, verdict, detail):
+    """Deliver a watch's ONE terminal mail and say whether the row is SETTLED; the tick retires the
+    row only on True. The order is STAMP → decide from the records → send → classify a refusal →
+    retire. The verdict is written into the row (`sent`/`sentDetail`) and SAVED before anything
+    else, so the file always says whether a delivery was attempted; a stamp that does not land never
+    delivers (with the mail out and the stamp lost, a crash before the retire would replay the row at
+    boot as a fresh verdict and mail it again with no way to say so).
+
+    Then the durable records (_pr_watch_end_marker, every record-holding backend, ownership aside):
+    an explicit end marker means the registrant has ENDED — no send, straight to the contact leg.
+    No record at all splits on the sid's SHAPE, a structural fact of the backends: SDK and Codex
+    sids are uuids, tmux sids are session NAMES. A uuid nobody holds is not sent — routed to tmux it
+    would be "accepted" by a shell that never existed — and takes the counted no-record arm (three
+    consecutive ticks → ended, saying so). A name-shaped sid with no record is a tmux registrant and
+    is sent as ever; tmux's send never refuses (a missing session is reported only on stderr, in its
+    own thread), so a dead tmux registrant's notice still reads as accepted — the gap that stood
+    before this change stands, stated, and a liveness probe is not its fix. Otherwise the SEND goes
+    first — the backend's own send path handles what no live set can show (a dormant reg it wakes, a
+    comment thread that SdkBackend.live_sessions never lists) — and only a send REFUSED by return is
+    classified (_pr_watch_refusal): "wait" keeps the stamp and the row for the next tick, said once
+    per reason on the Log, with no repeat warning (a known failure, nothing landed); "ended" takes
+    the contact leg. A PARK counts as acceptance (an account-wide hold or a queue ahead parks the
+    notice for the drain, whose be.send return is dropped) — pre-existing, and the refusal signal now
+    exists for a follow-up.
+
+    The contact leg: the escalation contact (per-watch `escalate` or the box default) resolved by
+    _pr_watch_contact_sid, then the same records-first order — its end marker, its shape, a send,
+    its refusal classified — worded for the contact and logged where it went. An UNRESOLVED contact
+    name never counts toward ending: the row waits, said once, and the awaiting box shows the mail
+    pending — a name the live set failed to list is not a session that ended. Only when the
+    registrant has ended AND no contact can take it (none named, the same session, or ended / gone
+    for three checks too) does the row retire LOUDLY: one Log row naming repo#n, why the registrant
+    counts as ended, and why no contact could — never silently, never an unbounded 60 s loop. A row
+    whose refusals were logged and is then delivered files one ok row closing the story. A stamped
+    row that outlives a RESTART goes out with the notice saying it may repeat, and a loud retire of
+    such a row says a copy may have gone out."""
+    if r.get("sent") != verdict:
+        r["sent"], r["sentDetail"] = verdict, detail
+        if not _pr_watches_save():
+            r.pop("sent", None)
+            r.pop("sentDetail", None)
+            return False
+    sid, ref, replay = str(r["sid"]), "%s#%s" % (r["repo"], r["pr"]), bool(r.get("_replay"))
+    said_before = bool(r.get("_undelivered"))
+    m = _pr_watch_end_marker(sid)
+    if m is True:
+        state, why = "ended", "its record says it ended"
+    elif m is None and _PR_WATCH_UUID_RE.fullmatch(sid):
+        state, why = _pr_watch_norecord(r, sid, "no record of the session")
+        held = "was not sent to session %s (%s)" % (sid[:8], why)
+    else:
+        if _pr_watch_deliver(sid, _pr_watch_notice(verdict, r["repo"], r["pr"], detail, replay=replay)):
+            if said_before:
+                _sync_notice("pr-watches: the %s notice for %s reached session %s after the earlier refusal"
+                             % (verdict, ref, sid[:8]))
+            return True
+        state, why = _pr_watch_refusal(r, sid)
+        held = "was not accepted by session %s (%s)" % (sid[:8], why)
+    if state == "wait":
+        _pr_watch_undelivered_once(r, why, "pr-watches: the %s notice for %s %s — the watch stays armed and "
+                                           "retries every %ds" % (verdict, ref, held, PR_WATCH_EVERY))
+        return False
+    ended = "the session that registered the watch (%s) has ended (%s)" % (sid[:8], why)
+    target = str(r.get("escalate") or _watch_escalate_default() or "").strip()
+    tsid = _pr_watch_contact_sid(target) if target else ""
+    if tsid and tsid != sid:
+        tm = _pr_watch_end_marker(tsid)
+        if tm is True:
+            tstate, twhy = "ended", "its record says it ended"
+        elif tm is None and _PR_WATCH_UUID_RE.fullmatch(tsid):
+            tstate, twhy = _pr_watch_norecord(r, tsid, "no record of the contact")
+            held = "was not sent to the escalation contact %s (%s)" % (target, twhy)
+        else:
+            if _pr_watch_deliver(tsid, _pr_watch_notice(verdict, r["repo"], r["pr"], detail, replay=replay,
+                                                        ended_owner=sid)):
+                _sync_notice("pr-watches: the %s notice for %s went to %s%s — %s"
+                             % (verdict, ref, target, " after the earlier refusal" if said_before else "", ended))
+                return True
+            tstate, twhy = _pr_watch_refusal(r, tsid)
+            held = "was not accepted by the escalation contact %s (%s)" % (target, twhy)
+        if tstate == "wait":
+            _pr_watch_undelivered_once(r, twhy, "pr-watches: the %s notice for %s %s; %s — retrying every %ds"
+                                                % (verdict, ref, held, ended, PR_WATCH_EVERY))
+            return False
+        contact = "its escalation contact %s has ended too (%s)" % (target, twhy)
+    elif target and tsid == sid:
+        contact = "its escalation contact is that same session"
+    elif target:
+        # unresolved: WAIT, uncounted — a name the live set failed to list is not a session that
+        # ended; a mistyped name shows as pending in the awaiting box and once here
+        _pr_watch_undelivered_once(r, "contact unresolved",
+                                   "pr-watches: the %s notice for %s is waiting — %s, and its escalation contact "
+                                   "%s does not resolve to a session; retrying every %ds until it does"
+                                   % (verdict, ref, ended, target, PR_WATCH_EVERY))
+        return False
+    else:
+        contact = "no escalation contact is named"
+    line = ("pr-watches: the %s notice for %s could not be delivered — %s and %s; the watch is dropped%s"
+            % (verdict, ref, ended, contact,
+               " (a copy may have gone out before the last restart)" if replay else ""))
+    sys.stderr.write(line + "\n")
+    _sync_notice(line, ok=False)
+    return True
+
+
 def _pr_watch_tick(now):
-    """One supervisor-pass sweep over the registered watches (rate-gated per row)."""
+    """One supervisor-pass sweep over the registered watches (rate-gated per row). Every retiring
+    notice goes through _pr_watch_deliver_stamped, and a row retires only on its True."""
     with _pr_watch_lock:
         rows = list(_pr_watches)
     done = []
     for r in rows:
         if now < r.get("_next", 0):
             continue
+        if r.get("sent"):
+            # a filed verdict whose mail is still owed (a refused injection, or a restart between the
+            # stamp and the retire): deliver THAT, never re-derive it from gh — the stamp is the event
+            if _pr_watch_deliver_stamped(r, r["sent"], str(r.get("sentDetail") or "")):
+                done.append(r)
+            else:
+                r["_next"] = now + PR_WATCH_EVERY
+            continue
         verdict, detail = _pr_watch_read(r["pr"], r["repo"])
         if verdict == "error":
             r["_fails"] = int(r.get("_fails") or 0) + 1
             r["_next"] = now + PR_WATCH_EVERY
             if r["_fails"] >= PR_WATCH_MAX_FAILS:
-                _pr_watch_deliver(r["sid"], _pr_watch_notice("error", r["repo"], r["pr"], detail))
-                done.append(r)
+                if _pr_watch_deliver_stamped(r, "error", detail):
+                    done.append(r)
             continue
         r["_fails"] = 0
         if verdict is None:
@@ -16349,14 +16644,16 @@ def _pr_watch_tick(now):
                     _pr_watch_deliver(tsid, _pr_watch_stalled_notice(r, now))
             r["_next"] = now + PR_WATCH_EVERY
             continue
-        _pr_watch_deliver(r["sid"], _pr_watch_notice(verdict, r["repo"], r["pr"], detail))
-        done.append(r)
+        if _pr_watch_deliver_stamped(r, verdict, detail):
+            done.append(r)
+        else:
+            r["_next"] = now + PR_WATCH_EVERY
     if done:
         with _pr_watch_lock:
             for r in done:
                 if r in _pr_watches:
                     _pr_watches.remove(r)
-        _pr_watches_save()
+        _pr_watches_save()       # a retire that fails to land replays at boot, told (the _replay sentence)
 
 
 # ── kernel-owned GENERIC watches (T121 part 2, 2026-08-27): the pr-watch machinery, generalized —
@@ -16487,6 +16784,14 @@ def _watch_awaiting(sid):
             it["watchId"] = str(r["id"])
         items.append(it)
     for r in prs:
+        if r.get("sent"):
+            # the PR reached its verdict; what is owed now is the NOTICE (a refused injection, or a
+            # restart between the stamp and the retire) — the box says so instead of "to land"
+            what = "PR #%s (%s): %s — mail pending" % (
+                r.get("pr"), r.get("repo"), {"merged": "merged", "closed": "closed"}.get(r["sent"], "gh unreadable"))
+            descs.append(what)
+            items.append(_awaiting_item("watches", "pr:%s#%s" % (r.get("repo"), r.get("pr")), what, r.get("at")))
+            continue
         descs.append("PR #%s (%s) to land" % (r.get("pr"), r.get("repo")))
         items.append(_awaiting_item("watches", "pr:%s#%s" % (r.get("repo"), r.get("pr")),
                                     "PR #%s (%s)" % (r.get("pr"), r.get("repo")), r.get("at")))
@@ -23933,7 +24238,10 @@ def _send_or_park(be, sid, text, echo=None):
     at turn end (never folded into a send batch, which would bury it as text the same way).
 
     Returns True when PARKED, False when handed over now, so a route can tell its caller which: POST
-    /send answers `queued` and `romp send` prints it. An agent sending ITSELF a slash command from inside
+    /send answers `queued` and `romp send` prints it — and None when the backend REFUSED the handover
+    (be.send returned False: a session it no longer holds), which is falsy like a handover for the
+    callers that only ask "queued?" and distinct for the one that must know (a watch notice retires
+    only on acceptance). Nothing is echoed for a refused send: the session never got it. An agent sending ITSELF a slash command from inside
     its own turn otherwise read 'ok' and had no way to know the command was waiting for that turn to end
     (2026-09-03, a /clear that then never fired).
 
@@ -23957,7 +24265,8 @@ def _send_or_park(be, sid, text, echo=None):
         return True
     if _park_behind_queue(sid, op):
         return True
-    be.send(sid, text)
+    if be.send(sid, text) is False:
+        return None                                      # refused by the backend: not parked, not delivered
     if echo:
         _optimistic_echo(sid, text, author=echo)
     return False
@@ -40593,7 +40902,22 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "error":
                         'no session answers to "%s"' % who}), "application/json")
                 esc = str(b.get("escalate") or "").strip()
-                row = add_pr_watch(prn, repo, tsid, escalate=esc)
+                row, fault = add_pr_watch(prn, repo, tsid, escalate=esc)
+                if fault:
+                    # the save failed (ENOSPC, EACCES, …). A fresh watch acknowledged now would be
+                    # forgotten at the next restart, so nothing is registered; a watch that already
+                    # STANDS keeps standing and only the new escalation target is refused — two
+                    # different truths, told apart. The ok:false shape of the refusals above, plus
+                    # `retryable` (the disk, not the ask); the fault is the one THIS save raised.
+                    err = ("the watch on %s#%d stands, but the escalation target could not be saved (%s) — "
+                           "retry once romp's state directory takes writes again" % (repo, prn, fault)
+                           if row is not None else
+                           "the watch could not be saved (%s) — nothing is watching %s#%d; retry once romp's "
+                           "state directory takes writes again" % (fault, repo, prn))
+                    res = {"ok": False, "retryable": True, "error": err}
+                    if row is not None:
+                        res["watch"] = row
+                    return self._send(200, json.dumps(res), "application/json")
                 return self._send(200, json.dumps({"ok": True, "watch": row}), "application/json")
             if u.path == "/watch":
                 # Register a GENERIC predicate watch (T121 part 2): the kernel runs `cmd` on a

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8767,6 +8767,29 @@ class SdkBackend:
             return a
         return "key" if self.work_key_configured else "login"
 
+    def sid_for_name(self, name: str) -> str:
+        """The sid of the ONE alive session (not a comment thread) whose reg carries `name`, else "".
+        The regs are this backend's durable record of its sessions, so a name resolves here without
+        the live set; two alive regs with the same name resolve to nothing — a guess would mail the
+        wrong session."""
+        name = str(name or "")
+        if not name:
+            return ""
+        hits = [str(reg.get("sid")) for reg in list_regs(self.state_dir)
+                if reg.get("alive") and not reg.get("threadOf") and reg.get("name") == name and reg.get("sid")]
+        return hits[0] if len(hits) == 1 else ""
+
+    def end_marker(self, sid: str):
+        """What this backend's own DURABLE record says about `sid`, for a caller whose send it just
+        refused — never a liveness probe. True: the reg is present and says alive=false, the explicit
+        end marker written at session end. False: the reg says alive (the refusal was something else;
+        the caller retries). None: no readable reg — absent, or unreadable right now, which one read
+        cannot tell apart; the caller counts such reads, never decides from one."""
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return None
+        return not bool(reg.get("alive"))
+
     def owns(self, sid: str) -> bool:
         """Whether this backend has a registry entry for `sid`. Memoized on the reg file's (mtime, size):
         Sessions.backend_for asks this for every session in every pusher tick job — 130+ reg opens and

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -19,6 +19,7 @@ and the kernel degrades gracefully when the SDK is absent.
 from __future__ import annotations
 import asyncio
 import difflib
+import errno
 import hashlib
 import json
 import os
@@ -8782,10 +8783,22 @@ class SdkBackend:
     def end_marker(self, sid: str):
         """What this backend's own DURABLE record says about `sid`, for a caller whose send it just
         refused — never a liveness probe. True: the reg is present and says alive=false, the explicit
-        end marker written at session end. False: the reg says alive (the refusal was something else;
-        the caller retries). None: no readable reg — absent, or unreadable right now, which one read
-        cannot tell apart; the caller counts such reads, never decides from one."""
-        reg = read_reg(self.state_dir, sid)
+        end marker written at session end. False: the record stands (the refusal was something else;
+        the caller retries): a reg that says alive, or a session RUNNING in this process, whatever the
+        disk says this instant (the proof owns() and _ensure already take). None: NO reg file, which is
+        durable, since this backend never unlinks a reg. A reg that EXISTS but would not read or parse
+        RAISES (EMFILE, EIO, EACCES, torn JSON: the transient class owns() was repaired for on
+        2026-09-07), so the caller waits on a reader's fault instead of counting it as no record. The
+        first version read through read_reg, which answers None for an unreadable reg exactly as for
+        an absent one, and never looked at self.sessions: a running session whose reg would not read
+        was classed as no record, its landing mail withheld, and its watch retired as ended (review
+        find, 2026-09-08)."""
+        s = self.sessions.get(sid)
+        if s is not None and s.thread.is_alive():
+            return False
+        reg = read_reg_for_rmw(self.state_dir, sid)
+        if reg is None:
+            raise OSError(errno.EIO, "reg for %s exists but would not read" % sid[:8])
         if not reg:
             return None
         return not bool(reg.get("alive"))

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -160,6 +160,10 @@ for a in "$@"; do [[ "$a" == http* ]] && url="$a"; done
 if [[ -n "${MOCK_CURL_FAIL_SEND:-}" && "$url" == */send ]]; then exit 22; fi
 if [[ -n "${MOCK_CURL_FAIL_NEW:-}" && "$url" == */new ]]; then exit 7; fi
 if [[ -n "${MOCK_CURL_SEND_QUEUED:-}" && "$url" == */send ]]; then echo '{"ok": true, "queued": true}'; exit 0; fi
+if [[ -n "${MOCK_CURL_WATCH_PR_REFUSE:-}" && "$url" == */watch-pr ]]; then
+  echo '{"ok": false, "retryable": true, "error": "the watch could not be saved ([Errno 28] No space left on device) - nothing is watching TESTORG/testrepo#7; retry once the state directory takes writes again"}'
+  exit 0
+fi
 if [[ -n "${MOCK_CURL_NEW_400:-}" && "$url" == */new ]]; then
   for a in "$@"; do
     if [[ "$a" == "-f" || "$a" == -[!-]*f* ]]; then exit 22; fi
@@ -413,6 +417,18 @@ MOCK
     [[ "$output" == *"--session <name> required"* ]]
     run run_romp watch-pr
     [ "$status" -eq 2 ]
+}
+
+@test "watch-pr: a refused registration is relayed, never reported as watching" {
+    # the kernel refuses a watch whose save failed (ok:false, retryable): the CLI prints that
+    # refusal and exits non-zero — the caller must never read "watching" for a watch nobody holds
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run env ROMP_SID=11111111-2222-3333-4444-555555555555 MOCK_CURL_WATCH_PR_REFUSE=1 "$ROMP_SCRIPT" watch-pr 7 --repo TESTORG/testrepo
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"romp watch-pr: refused — the watch could not be saved ([Errno 28]"* ]]
+    [[ "$output" != *"romp watch-pr: watching"* ]]
 }
 
 @test "tag: --rename rides the payload and counts as an edit" {

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -585,8 +585,10 @@ class DeliveryTargets(unittest.TestCase):
     `tmux list-sessions` or a swallowed live_sessions error, and never lists a comment thread — so a
     blip diverted a running registrant's mail with a false "has ended". Now the durable records
     decide (an explicit end marker before any send; a uuid nobody holds is never sent; a record that
-    says alive sends first), refusals are classified from the same records, no record is counted
-    three checks, and an unresolved contact name only waits. Runs the REAL _pr_watch_deliver →
+    says alive sends first), refusals are classified from the same records, a uuid with no record has
+    ended on the first read (an absent reg is durable: the backend never unlinks one, and a reg it
+    cannot read RAISES, which waits uncounted), and an unresolved contact name waits, bounded. Runs
+    the REAL _pr_watch_deliver →
     _send_or_park → backend path, with the record readers and Sessions.backend_for routed to the fake
     and Sessions.live() EMPTY throughout (or raising). What the fake cannot stage — ownership by
     owns() falling through to tmux — RealRouting covers with real backends."""
@@ -633,6 +635,9 @@ class DeliveryTargets(unittest.TestCase):
     def _log(self):
         return [(r["ok"], r["text"]) for r in km._sync_notice_rows()]
 
+    def _kinds(self):
+        return [r["kind"] for r in km._sync_notice_rows()]
+
     # a live registrant refused by return: wait, said once per reason, closed on delivery
     def test_a_live_registrant_refused_by_return_keeps_the_row_and_retries(self):
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
@@ -647,6 +652,9 @@ class DeliveryTargets(unittest.TestCase):
         self.assertEqual([ok for ok, _ in log], [False], "the same reason twice is said once")
         self.assertIn("was not accepted by session 11111111 (its record says it is alive, yet the send was refused)",
                       log[0][1])
+        self.assertEqual(self._kinds(), ["refused"],
+                         "a notice that could not be placed is a fault, filed under the bell's refused kind "
+                         "(review find, 2026-09-08)")
         self.be.refuse = False
         km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
         self.assertEqual([s for s, _ in self.be.sent], [SID])
@@ -655,6 +663,7 @@ class DeliveryTargets(unittest.TestCase):
         log = self._log()
         self.assertEqual([ok for ok, _ in log], [False, True], "the story that opened on the Log closes on it")
         self.assertIn("reached session 11111111 after the earlier refusal", log[1][1])
+        self.assertEqual(self._kinds(), ["refused", "sync"], "the closing row is news, not a fault")
 
     def test_a_changed_reason_is_said_once_more_and_a_repeated_one_stays_silent(self):
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
@@ -697,6 +706,7 @@ class DeliveryTargets(unittest.TestCase):
                      "no escalation contact is named", "dropped"):
             self.assertIn(must, log[0][1])
         self.assertNotIn("a copy may have gone out", log[0][1], "no restart happened — no such caveat")
+        self.assertEqual(self._kinds(), ["refused"], "a dropped notice is a fault the bell files under refused")
         self.assertIn("could not be delivered", err.getvalue())
 
     def test_an_ended_registrant_whose_contact_has_ended_too_retires_loudly(self):
@@ -756,37 +766,23 @@ class DeliveryTargets(unittest.TestCase):
         self.assertIn("you asked romp to watch", self.be.sent[0][1])
         self.assertEqual((km._pr_watches, self._log()), ([], []), "retired, nothing to log")
 
-    # no record for a uuid: never sent, counted, three checks
-    def test_a_uuid_with_no_record_is_never_sent_and_ends_after_three_checks(self):
+    # no record for a uuid: never sent, ended on the first read (an absent reg is durable)
+    def test_a_uuid_with_no_record_is_never_sent_and_ends_on_the_first_check(self):
+        # the three-check count this replaced stood in for an event the readers now report themselves:
+        # an absent reg is a durable fact, since the SDK backend never unlinks one, and a reg that
+        # exists but would not read RAISES and waits uncounted (review find, 2026-09-08)
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
         self.be.regs = {}                                     # the fake holds no record for the sid
-        with redirect_stderr(io.StringIO()):
+        with redirect_stderr(io.StringIO()) as err:
             km._pr_watch_tick(100.0)
-            self.assertEqual(len(km._pr_watches), 1, "check 1: kept")
-            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
-            self.assertEqual(len(km._pr_watches), 1, "check 2: kept")
-            log = self._log()
-            self.assertEqual([ok for ok, _ in log], [False, False], "each advanced count is a changed reason")
-            self.assertIn("was not sent to session 11111111 (no record of the session (check 1 of 3))", log[0][1])
-            self.assertIn("(check 2 of 3)", log[1][1])
-            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
-        self.assertEqual((km._pr_watches, self.be.sent), ([], []), "check 3: ended — and never once sent")
+        self.assertEqual((km._pr_watches, self.be.sent), ([], []), "ended on the first read, and never once sent")
         log = self._log()
-        self.assertEqual([ok for ok, _ in log], [False, False, False])
-        self.assertIn("has ended (no record of the session for 3 checks) and no escalation contact is named; "
-                      "the watch is dropped", log[2][1])
-
-    def test_a_record_that_reappears_alive_resets_the_no_record_count(self):
-        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
-        self.be.regs = {}
-        with redirect_stderr(io.StringIO()):
-            km._pr_watch_tick(100.0)
-            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
-            self.be.regs, self.be.refuse = {SID: True}, True  # the record is back, alive (the send still declined)
-            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
-            self.be.regs = {}
-            km._pr_watch_tick(100.0 + 3 * km.PR_WATCH_EVERY)
-        self.assertEqual(len(km._pr_watches), 1, "the count restarted: one no-record check since, not four")
+        self.assertEqual([ok for ok, _ in log], [False], "one row tells the whole story")
+        self.assertIn("has ended (no record of the session) and no escalation contact is named; "
+                      "the watch is dropped", log[0][1])
+        self.assertNotIn("check", log[0][1], "no count to advance")
+        self.assertEqual(self._kinds(), ["refused"])
+        self.assertIn("could not be delivered", err.getvalue())
 
     def test_a_backend_without_a_record_reader_reads_as_no_record(self):
         self.be = _NoRecordBackend()                          # send refuses; nothing to read
@@ -795,8 +791,8 @@ class DeliveryTargets(unittest.TestCase):
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
         with redirect_stderr(io.StringIO()):
             km._pr_watch_tick(100.0)
-        self.assertEqual((self.be.sent, len(km._pr_watches)), ([], 1))
-        self.assertIn("(no record of the session (check 1 of 3))", self._log()[0][1])
+        self.assertEqual((self.be.sent, km._pr_watches), ([], []), "no reader, no record: ended, never sent")
+        self.assertIn("has ended (no record of the session) and no escalation contact", self._log()[0][1])
 
     # the live set is irrelevant: empty or raising, the send is attempted
     def test_a_live_set_that_reads_empty_or_raises_never_stops_the_send(self):
@@ -835,11 +831,36 @@ class DeliveryTargets(unittest.TestCase):
         log = self._log()
         self.assertEqual([ok for ok, _ in log], [False], "said once, however long it waits")
         self.assertIn("its escalation contact mgr does not resolve to a session; retrying", log[0][1])
+        self.assertEqual(self._kinds(), ["refused"])
         self.assertIn("mail pending", km._watch_awaiting(SID)["why"], "the box shows what is owed")
         self.be.names = {"mgr": MGR}                          # the durable record now carries the name
         self.be.regs[MGR] = True
         km._pr_watch_tick(100.0 + 5 * km.PR_WATCH_EVERY)
         self.assertEqual(([s for s, _ in self.be.sent], km._pr_watches), ([MGR], []))
+
+    def test_an_unresolved_contact_name_is_waited_on_to_the_bound_then_dropped_loudly(self):
+        # the wait above is BOUNDED (review find, 2026-09-08): a name that never resolves (mistyped, or
+        # a box default naming a session nobody starts again) otherwise kept the row armed forever, one
+        # tmux fork per tick with the once-said Log row its only trace. At PR_WATCH_ESCALATE_S from the
+        # first unresolved tick, the bound this module already keeps for waiting on the named contact,
+        # the row retires the loud way: one stderr line and one bell row under the refused kind
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._sid_of = lambda who: who
+        self.be.regs = {SID: False}
+        with redirect_stderr(io.StringIO()) as err:
+            km._pr_watch_tick(100.0)                                            # the wait starts here
+            km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S - 1)
+            self.assertEqual(len(km._pr_watches), 1, "inside the bound: still waiting")
+            self.assertEqual([ok for ok, _ in self._log()], [False], "…and still said once")
+            km._pr_watch_tick(100.0 + km.PR_WATCH_ESCALATE_S + km.PR_WATCH_EVERY)
+        self.assertEqual((self.be.sent, km._pr_watches), ([], []), "past the bound: dropped, never sent to a bare name")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False, False], "the wait's one row, then the drop's one row")
+        for must in ("TESTORG/testrepo#7", "could not be delivered", "has ended (its record says it ended)",
+                     "its escalation contact mgr did not resolve to a session for 2h", "the watch is dropped"):
+            self.assertIn(must, log[1][1])
+        self.assertEqual(self._kinds(), ["refused", "refused"])
+        self.assertIn("did not resolve to a session for 2h", err.getvalue())
 
     def test_a_contact_name_resolves_through_the_backends_record_when_the_live_set_fails(self):
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
@@ -910,6 +931,9 @@ class RealRouting(unittest.TestCase):
     def _log(self):
         return [(r["ok"], r["text"]) for r in km._sync_notice_rows()]
 
+    def _kinds(self):
+        return [r["kind"] for r in km._sync_notice_rows()]
+
     def _dead_codex(self, sid):
         s = self.cb._Session(sid, "t1", "web", "/tmp")
         s.dead = True
@@ -973,28 +997,111 @@ class RealRouting(unittest.TestCase):
         km._pr_watch_tick(100.0)
         self.assertEqual(([n for n, _ in self.tmux], km._pr_watches), (["mgr"], []))
 
-    def test_an_absent_sdk_reg_for_a_uuid_sid_never_reaches_tmux_and_ends_after_three_checks(self):
+    def test_an_absent_sdk_reg_for_a_uuid_sid_never_reaches_tmux_and_ends_on_the_first_check(self):
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
         self.assertIs(km.Sessions.backend_for(SID), km._TMUX, "the routing fact: an absent reg falls to tmux")
+        self.assertIsNone(km._pr_watch_end_marker(SID), "no reg file: no record, a durable fact")
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.tmux, km._pr_watches), ([], []), "ended on the first read; never sent")
+        self.assertIn("has ended (no record of the session) and no escalation contact is named", self._log()[-1][1])
+
+    def _reg_path(self):
+        return Path(self.td.name) / "sdk" / (SID + ".json")
+
+    def _unreadable_reg(self):
+        """A reg that EXISTS but would not read: the path becomes a directory, so stat succeeds and
+        read_text raises (EISDIR, the OSError class EMFILE, EIO and EACCES belong to), root or not."""
+        p = self._reg_path()
+        if p.exists():
+            p.unlink()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.mkdir()
+
+    def _running(self, sid):
+        """A session running in THIS process, as SdkBackend.sessions holds one: a live thread. Its send
+        is recorded, never run (a real send there would spawn a CLI)."""
+        import types
+        self.sdk.sessions[sid] = types.SimpleNamespace(thread=types.SimpleNamespace(is_alive=lambda: True))
+        self.sdk_sent = []
+        self.sdk.send = lambda s, text: self.sdk_sent.append((s, text)) or True
+
+    def test_a_running_registrant_whose_reg_would_not_read_is_sent_its_mail_never_ended(self):
+        # BEFORE (review find, 2026-09-08): SdkBackend.end_marker read through read_reg, which answers
+        # None for an unreadable reg exactly as for an absent one, and never looked at the running
+        # sessions. A live registrant whose reg was transiently unreadable (EMFILE, EIO, EACCES) read
+        # as "no record": its mail was withheld and, three ticks later, its watch retired as ended.
+        # main delivered it: owns() takes the live thread as proof and _ensure serves it from memory
+        self.sb.write_reg(Path(self.td.name), SID, {"sid": SID, "alive": True, "name": "web"})
+        self._unreadable_reg()
+        self._running(SID)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.assertIs(km.Sessions.backend_for(SID), self.sdk, "the routing fact: a live thread is proof enough")
+        self.assertIs(km._pr_watch_end_marker(SID), False, "running in this process: the record stands")
+        km._pr_watch_tick(100.0)
+        self.assertEqual([s for s, _ in self.sdk_sent], [SID], "the mail went to the registrant, first tick")
+        self.assertIn("has MERGED", self.sdk_sent[0][1])
+        self.assertEqual((self.tmux, km._pr_watches, self._log()), ([], [], []), "retired; nothing false on the Log")
+
+    def test_a_reg_that_would_not_read_with_no_running_session_waits_uncounted_and_recovers(self):
+        self.sb.write_reg(Path(self.td.name), SID, {"sid": SID, "alive": True, "name": "web"})
+        self._unreadable_reg()
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.assertFalse(self.sdk.owns(SID), "the routing fact: an unreadable reg with no thread is not owned")
+        with self.assertRaises(OSError):
+            self.sdk.end_marker(SID)
+        self.assertEqual(km._pr_watch_end_marker(SID), km._PR_WATCH_UNREAD, "a reader's fault, never no record")
         with redirect_stderr(io.StringIO()):
             km._pr_watch_tick(100.0)
             km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
-            self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1), "two checks: kept, never sent")
+        self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1), "waits; never handed to tmux")
+        self.assertNotIn("_norec", km._pr_watches[0], "uncounted")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False], "said once")
+        self.assertIn("its record could not be read", log[0][1])
+        self.assertEqual(self._kinds(), ["refused"])
+        self._reg_path().rmdir()                              # the read heals onto an ended reg
+        self.sb.write_reg(Path(self.td.name), SID, {"sid": SID, "alive": False, "name": "web"})
+        with redirect_stderr(io.StringIO()):
             km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
         self.assertEqual((self.tmux, km._pr_watches), ([], []))
-        self.assertIn("no record of the session for 3 checks", self._log()[-1][1])
+        self.assertIn("has ended (its record says it ended)", self._log()[-1][1])
 
-    def test_a_corrupt_sdk_reg_reads_as_no_record_never_as_a_tmux_session(self):
-        p = Path(self.td.name) / "sdk" / (SID + ".json")
+    def test_a_corrupt_sdk_reg_is_a_readers_fault_that_waits_never_a_tmux_session_nor_an_ending(self):
+        # torn JSON reads like a read error: the file is there, so it is not "no record"
+        p = self._reg_path()
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text("{not json")
         km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
         self.assertFalse(self.sdk.owns(SID), "the routing fact: an unreadable reg is not owned")
         self.assertIs(km.Sessions.backend_for(SID), km._TMUX)
+        self.assertEqual(km._pr_watch_end_marker(SID), km._PR_WATCH_UNREAD)
         with redirect_stderr(io.StringIO()):
             km._pr_watch_tick(100.0)
         self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1))
-        self.assertIn("(no record of the session (check 1 of 3))", self._log()[0][1])
+        self.assertIn("(its record could not be read)", self._log()[0][1])
+        self.assertNotIn("no record", self._log()[0][1])
+
+    def test_a_codex_registry_unreadable_at_load_leaves_a_uuid_registrant_waiting_never_ended(self):
+        # the Codex record-holder's twin of the SDK case: with its registry unreadable at load the
+        # backend holds NO sessions, so every uuid read as "no record" and a Codex registrant's watch
+        # ended (on the first read now; on the third before). Unreadable at load is a reader's fault
+        # the backend now reports for every sid it does not hold (review find, 2026-09-08)
+        p = self.cx._reg_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json")
+        self.cx = self.cb.CodexBackend(Path(self.td.name), notify=lambda *a, **k: None, log=lambda m: None)
+        km._codex = lambda: self.cx
+        with self.assertRaises(Exception):
+            self.cx.end_marker(SID)
+        self.assertEqual(km._pr_watch_end_marker(SID), km._PR_WATCH_UNREAD)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1), "waits, uncounted; never tmux, never ended")
+        self.assertIn("its record could not be read", self._log()[0][1])
+        self._dead_codex(SID)                                 # a session it DOES hold still answers from its mark
+        self.assertIs(self.cx.end_marker(SID), True)
 
     def test_a_name_shaped_registrant_goes_to_tmux_the_standing_gap(self):
         km.add_pr_watch(7, "TESTORG/testrepo", "web", now=0)
@@ -1023,7 +1130,9 @@ class RealRouting(unittest.TestCase):
 class EndMarkerReaders(unittest.TestCase):
     """The backends' own durable-record readers, executed against real files and real session
     objects: True = an explicit end marker, False = the record says the session stands, None = no
-    record. Only these three answers exist; a live set is never consulted."""
+    record. Three answers and a RAISE (a record that exists but would not read: a reader's fault the
+    caller waits on, review find 2026-09-08); a live set is never consulted, the RUNNING set is (a
+    thread in this process is a record too)."""
 
     @classmethod
     def setUpClass(cls):
@@ -1043,11 +1152,11 @@ class EndMarkerReaders(unittest.TestCase):
             self.sb.write_reg(Path(td), SID, {"sid": SID, "name": "mgr", "alive": False})
             self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), MGR, "an ended reg does not compete")
 
-    def test_the_sdk_reader_reads_the_reg_alive_flag_and_nothing_else(self):
+    def test_the_sdk_reader_reads_the_reg_alive_flag_the_running_set_and_nothing_else(self):
         import types
         with tempfile.TemporaryDirectory() as td:
-            be = types.SimpleNamespace(state_dir=Path(td))
-            self.assertIsNone(self.sb.SdkBackend.end_marker(be, SID), "no reg → no record")
+            be = types.SimpleNamespace(state_dir=Path(td), sessions={})
+            self.assertIsNone(self.sb.SdkBackend.end_marker(be, SID), "no reg file → no record (durable: never unlinked)")
             self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": True})
             self.assertIs(self.sb.SdkBackend.end_marker(be, SID), False, "alive → the session stands")
             self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": True, "threadOf": MGR})
@@ -1055,17 +1164,33 @@ class EndMarkerReaders(unittest.TestCase):
             self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": False})
             self.assertIs(self.sb.SdkBackend.end_marker(be, SID), True, "alive=false → the explicit end marker")
             (Path(td) / "sdk" / (SID + ".json")).write_text("{not json")
-            self.assertIsNone(self.sb.SdkBackend.end_marker(be, SID), "unreadable → no record, never a verdict")
+            with self.assertRaises(OSError, msg="exists but would not read → a reader's fault, RAISED, never no record"):
+                self.sb.SdkBackend.end_marker(be, SID)
+            # a session running in this process stands whatever the disk says this instant, the proof
+            # owns() and _ensure already take (review find, 2026-09-08)
+            be.sessions[SID] = types.SimpleNamespace(thread=types.SimpleNamespace(is_alive=lambda: True))
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), False, "running → stands, over an unreadable reg")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": False})
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), False, "…and over an alive=false reg, this instant")
+            be.sessions[SID].thread.is_alive = lambda: False
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), True, "a finished thread is no proof: the disk decides")
 
     def test_the_codex_reader_reads_the_dead_mark(self):
         import types
         s = types.SimpleNamespace(lock=threading.RLock(), dead=False)
-        be = types.SimpleNamespace(_session=lambda sid: s)
+        be = types.SimpleNamespace(_session=lambda sid: s, _registry_unreadable=False)
         self.assertIs(self.cb.CodexBackend.end_marker(be, SID), False)
         s.dead = True
         self.assertIs(self.cb.CodexBackend.end_marker(be, SID), True)
-        self.assertIsNone(self.cb.CodexBackend.end_marker(types.SimpleNamespace(_session=lambda sid: None), SID),
-                          "no session by that id → no record")
+        none = types.SimpleNamespace(_session=lambda sid: None, _registry_unreadable=False)
+        self.assertIsNone(self.cb.CodexBackend.end_marker(none, SID), "no session by that id → no record")
+        # its registry unreadable at load: the backend holds none of the sessions it should, so "not
+        # held" is a reader's fault, raised, never no record (review find, 2026-09-08)
+        broken = types.SimpleNamespace(_session=lambda sid: None, _registry_unreadable=True)
+        with self.assertRaises(Exception):
+            self.cb.CodexBackend.end_marker(broken, SID)
+        held = types.SimpleNamespace(_session=lambda sid: s, _registry_unreadable=True)
+        self.assertIs(self.cb.CodexBackend.end_marker(held, SID), True, "a session it holds still answers from its mark")
 
 
 class Route(unittest.TestCase):

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -4,7 +4,10 @@ interest in a PR, the KERNEL polls gh for the terminal state — MERGED, CLOSED,
 both ends of the standing watcher rule — and delivers ONE [romp] mail, surviving the kernel
 restarts that killed every shell loop this replaces. Registrations persist and re-arm on boot (the
 reconnect-intent idiom); a gh failure retires the watch LOUDLY after three consecutive errors.
+Durability at both ends (DurableRegistration, DeliveryOrder): a watch is acknowledged only once it
+is on disk, and its landing mail retires it only once the injection is accepted, stamped first.
 Synthetic only — gh fully stubbed."""
+import io
 import json
 import os
 import tempfile
@@ -12,6 +15,7 @@ import threading
 import unittest
 import urllib.request
 import urllib.error
+from contextlib import redirect_stderr
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -28,6 +32,74 @@ km = SourceFileLoader("romp_kernel_prw", os.path.join(BIN, "romp-kernel")).load_
 jd = km.jd
 
 SID = "11111111-2222-3333-4444-555555555555"
+
+
+_ENOSPC_CALLS = [0]
+ENOSPC = "[Errno 28] No space left on device"
+
+
+def _enospc(path, text, mode=None):
+    """The disk refusing the state file — _atomic_write's shape, raising what a full disk raises:
+    errno + strerror + the TEMP path, which carries a per-call sequence, so str(e) differs on every
+    call and only the errno projection can dedupe an episode."""
+    _ENOSPC_CALLS[0] += 1
+    raise OSError(28, "No space left on device", "%s.tmp.%d" % (path, _ENOSPC_CALLS[0]))
+
+
+_MODS = {}
+
+
+def _backend_mod(which):
+    """The real sdk_backend / codex_backend modules, loaded once for the tests that execute their readers."""
+    if which not in _MODS:
+        _MODS[which] = SourceFileLoader("romp_%s_prw" % which,
+                                        os.path.join(os.path.dirname(BIN), "kernel", which + ".py")).load_module()
+    return _MODS[which]
+
+
+class _FakeBackend:
+    """SDK-shaped, answering from a record the TEST writes: `regs` maps sid → alive flag (a reg
+    present); an absent sid is no reg; `names` maps a session name → sid (the regs' name field).
+    send() REFUSES (returns False, never raises) unless the reg is present and alive — a dormant
+    alive reg and a comment thread are both taken, as SdkBackend._ensure does; `refuse` forces a
+    refusal for a live one; `marker_raises` makes the record reader itself fail. Nothing here
+    consults a live set: that is the point. What this fake cannot stage is the real routing —
+    ownership by owns(), the fall-through to tmux — which RealRouting covers with real backends."""
+
+    def __init__(self, regs=None, refuse=False, marker_raises=False, names=None):
+        self.regs, self.refuse, self.marker_raises, self.sent = dict(regs or {}), refuse, marker_raises, []
+        self.names = dict(names or {})
+
+    def owns(self, sid):
+        return sid in self.regs
+
+    def forwards_sends(self):
+        return True
+
+    def busy(self, sid):
+        return False
+
+    def send(self, sid, text):
+        if not self.regs.get(sid) or self.refuse:
+            return False
+        self.sent.append((sid, text))
+        return True
+
+    def end_marker(self, sid):
+        if self.marker_raises:
+            raise RuntimeError("the reg reader broke")
+        if sid not in self.regs:
+            return None
+        return not self.regs[sid]
+
+    def sid_for_name(self, name):
+        return self.names.get(name, "")
+
+
+class _NoRecordBackend(_FakeBackend):
+    """A backend with no record reader at all (tmux-like), whose send still refuses."""
+    end_marker = None
+    sid_for_name = None
 
 
 class Verdict(unittest.TestCase):
@@ -69,6 +141,117 @@ class Notice(unittest.TestCase):
             for word in ("card", "board", "goal", "column", "nudge"):
                 self.assertNotIn(word, n.lower(), "no board vocabulary in an injected body")
 
+    def test_a_replayed_notice_says_it_may_repeat(self):
+        # a delivery stamp that outlived a restart: the mail may already have landed, and the
+        # notice says so instead of posing as the first copy (DeliveryOrder pins when this rides)
+        n = km._pr_watch_notice("merged", "TESTORG/testrepo", 7, replay=True)
+        self.assertIn("This may repeat a notice sent just before romp last restarted.", n)
+        self.assertTrue(n.endswith("<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"),
+                        "the marker tail stays last")
+        for word in ("card", "board", "goal", "column", "nudge"):
+            self.assertNotIn(word, n.lower())
+        self.assertNotIn("may repeat", km._pr_watch_notice("merged", "TESTORG/testrepo", 7),
+                         "…and only when replayed")
+
+    def test_a_hand_off_to_the_escalation_contact_names_the_ended_session(self):
+        # the registrant ENDED and the notice goes to its escalation contact, who never asked: the
+        # body names the session it was watching for and why it arrives here — never "you asked"
+        n = km._pr_watch_notice("merged", "TESTORG/testrepo", 7, ended_owner=SID)
+        self.assertIn("romp was watching for session 11111111 has MERGED: TESTORG/testrepo#7", n)
+        self.assertNotIn("you asked", n)
+        self.assertIn("That session has ended, so this comes to you as the escalation contact named for it.", n)
+        self.assertTrue(n.endswith("<!-- romp-injected --><!-- romp-system --><!-- romp-tag: pr-watch -->"))
+        for word in ("card", "board", "goal", "column", "nudge"):
+            self.assertNotIn(word, n.lower())
+
+
+class DurableRegistration(unittest.TestCase):
+    """A watch is acknowledged only once it is ON DISK. Before: the save ran outside the lock,
+    swallowed its exception and returned nothing; add_pr_watch handed back the row regardless, the
+    route acked it, and the next kernel restart forgot the watch — its landing mail never came."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._atomic_write)
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+        getattr(km, "_pr_watch_save_faults", {}).clear()
+        km._SYNC_NOTICES.clear()
+
+    def tearDown(self):
+        km.PR_WATCH_FILE, km._pr_watches[:], km._atomic_write = self._saved
+        getattr(km, "_pr_watch_save_faults", {}).clear()
+        km._SYNC_NOTICES.clear()
+        self.td.cleanup()
+
+    def test_a_failed_save_refuses_the_watch_and_keeps_no_row(self):
+        km._atomic_write = _enospc
+        with redirect_stderr(io.StringIO()):
+            row, fault = km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000)
+        self.assertIsNone(row, "no row is acknowledged that a restart would forget")
+        self.assertEqual(fault, ENOSPC, "the fault is named — errno text, never the per-call temp path")
+        self.assertEqual(km._pr_watches, [], "the append is rolled back — memory and disk agree")
+        self.assertFalse(km.PR_WATCH_FILE.exists())
+        self.assertFalse(km._kernel_watch_armed(SID), "nothing is armed for the session")
+
+    def test_a_save_fault_is_said_once_per_episode_and_a_landed_write_re_arms(self):
+        km._atomic_write = _enospc
+        err = io.StringIO()
+        with redirect_stderr(err):
+            km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000)
+            km.add_pr_watch(8, "TESTORG/testrepo", SID, now=1001)       # the same fault, again
+        self.assertEqual(err.getvalue().count("pr-watches: could not save"), 1, "one line per fault episode")
+        self.assertIn("[Errno 28] No space left on device", err.getvalue())
+        rows = km._sync_notice_rows()
+        self.assertEqual([(r["ok"], "could not save pr-watches.json" in r["text"]) for r in rows],
+                         [(False, True)], "…and one Log row, marked as a failure")
+        self.assertEqual([r["kind"] for r in rows], ["refused"],
+                         "a state file that could not be written is the bell's refused kind, never a machine sync")
+        km._atomic_write = self._saved[2]                                # the disk takes writes again
+        self.assertEqual(km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000)[1], "")
+        self.assertEqual(km._pr_watch_save_faults, {}, "a landed write ends the episode")
+        km._atomic_write = _enospc
+        with redirect_stderr(io.StringIO()):
+            self.assertIsNone(km.add_pr_watch(9, "TESTORG/testrepo", SID, now=1002)[0])
+        self.assertEqual(len(km._sync_notice_rows()), 2, "a new episode is a new line")
+        self.assertEqual([r["pr"] for r in km._pr_watches], [7], "the refused row is gone; the saved one stands")
+
+    def test_an_escalation_target_added_to_an_existing_watch_is_persisted_or_refused(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=1000, escalate="mgr")
+        self.assertEqual(json.loads(km.PR_WATCH_FILE.read_text())[0].get("escalate"), "mgr",
+                         "the edit reaches the file, not just memory")
+        km.add_pr_watch(8, "TESTORG/testrepo", SID, now=1000)
+        km._atomic_write = _enospc
+        with redirect_stderr(io.StringIO()):
+            row, fault = km.add_pr_watch(8, "TESTORG/testrepo", SID, now=1000, escalate="mgr")
+        self.assertEqual((row["pr"], fault), (8, ENOSPC), "the standing watch is returned WITH the fault: two truths")
+        self.assertNotIn("escalate", km._pr_watches[1], "the target that did not land is rolled back")
+        self.assertEqual(len(km._pr_watches), 2, "…and the watch itself, already durable, stands")
+
+    def test_every_save_runs_under_the_watch_lock(self):
+        # the claim "one locked transaction" and "the write sits under the lock", executed: a fresh
+        # row, an escalation target, the tick's stamp and its retire each publish with the lock HELD
+        # (a save outside it let a concurrent registration observe and persist a row later rolled back)
+        held, real = [], km._atomic_write
+
+        def spy(path, text, mode=None):
+            held.append(km._pr_watch_lock.locked())
+            return real(path, text, mode)
+        km._atomic_write = spy
+        saved = (km._pr_watch_read, km._pr_watch_deliver, getattr(km, "_pr_watch_end_marker", None))
+        km._pr_watch_read = lambda pr, repo: ("merged", "")
+        km._pr_watch_deliver = lambda sid, text: True
+        km._pr_watch_end_marker = lambda sid: False                              # the registrant stands
+        try:
+            km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)                    # the fresh row
+            km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")    # the escalation target
+            km._pr_watch_tick(100.0)                                             # the stamp, then the retire
+        finally:
+            km._pr_watch_read, km._pr_watch_deliver, km._pr_watch_end_marker = saved
+        self.assertEqual(held, [True, True, True, True], "four saves, every one under _pr_watch_lock")
+        self.assertEqual(km._pr_watches, [])
+
 
 class Persistence(unittest.TestCase):
     """Registration is intent: survives a restart, re-arms fresh (the reconnect-intent idiom)."""
@@ -94,6 +277,19 @@ class Persistence(unittest.TestCase):
         r = km._pr_watches[0]
         self.assertEqual((r["pr"], r["repo"], r["sid"], r["at"]), (7, "TESTORG/testrepo", SID, 1000))
         self.assertEqual((r["_next"], r["_fails"]), (0, 0), "re-armed fresh: polls immediately")
+
+    def test_a_persisted_stamp_that_is_not_a_verdict_is_dropped_on_load(self):
+        # the strict-reader rule applied to one field: only the three verdicts the tick files are a
+        # stamp; a torn or hand-edited value must not replay as a notice the tick never wrote
+        km.PR_WATCH_FILE.write_text(json.dumps([
+            {"pr": 7, "repo": "TESTORG/testrepo", "sid": SID, "at": 1, "sent": "bogus", "sentDetail": "x"},
+            {"pr": 8, "repo": "TESTORG/testrepo", "sid": SID, "at": 2, "sent": "merged", "sentDetail": ""}]))
+        km._pr_watches_load()
+        bogus, good = km._pr_watches
+        self.assertNotIn("sent", bogus)
+        self.assertNotIn("sentDetail", bogus)
+        self.assertFalse(bogus["_replay"], "nothing to replay: the row polls gh afresh")
+        self.assertEqual((good["sent"], good["_replay"]), ("merged", True))
 
     def test_registration_is_idempotent(self):
         km.add_pr_watch(7, "TESTORG/testrepo", SID)
@@ -124,15 +320,18 @@ class Tick(unittest.TestCase):
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
-        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._pr_watch_read, km._pr_watch_deliver)
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._pr_watch_read, km._pr_watch_deliver,
+                       getattr(km, "_pr_watch_refusal", None), getattr(km, "_pr_watch_end_marker", None))
         km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
         km._pr_watches[:] = []
         self.mail = []
         km._pr_watch_deliver = lambda sid, text: self.mail.append((sid, text)) or True
+        km._pr_watch_end_marker = lambda sid: False                                    # the registrant stands
+        km._pr_watch_refusal = lambda r, sid: ("wait", "a live registrant refusing")   # DeliveryTargets covers the rest
 
     def tearDown(self):
-        km.PR_WATCH_FILE, km._pr_watches[:], km._pr_watch_read, km._pr_watch_deliver = \
-            self._saved[0], self._saved[1], self._saved[2], self._saved[3]
+        (km.PR_WATCH_FILE, km._pr_watches[:], km._pr_watch_read, km._pr_watch_deliver,
+         km._pr_watch_refusal, km._pr_watch_end_marker) = self._saved
         self.td.cleanup()
 
     def test_merged_delivers_once_and_retires(self):
@@ -231,6 +430,619 @@ class Tick(unittest.TestCase):
         self.assertEqual(self.mail, [])
 
 
+class DeliveryOrder(unittest.TestCase):
+    """STAMP → deliver → retire. Before: deliver's bool was ignored and the row retired regardless —
+    a refused injection lost the one event a delegating session was waiting on — and a crash between
+    the two mailed it again at boot with nothing to say so."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = (km.PR_WATCH_FILE, list(km._pr_watches), km._pr_watch_read, km._pr_watch_deliver,
+                       km._atomic_write, getattr(km, "_pr_watch_refusal", None),
+                       getattr(km, "_pr_watch_end_marker", None))
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+        getattr(km, "_pr_watch_save_faults", {}).clear()
+        km._SYNC_NOTICES.clear()
+        km._pr_watch_read = lambda pr, repo: ("merged", "")
+        km._pr_watch_end_marker = lambda sid: False                                    # the registrant stands
+        km._pr_watch_refusal = lambda r, sid: ("wait", "a live registrant refusing")   # DeliveryTargets covers an ended one
+        self.mail = []
+
+    def tearDown(self):
+        (km.PR_WATCH_FILE, km._pr_watches[:], km._pr_watch_read, km._pr_watch_deliver,
+         km._atomic_write, km._pr_watch_refusal, km._pr_watch_end_marker) = self._saved
+        getattr(km, "_pr_watch_save_faults", {}).clear()
+        km._SYNC_NOTICES.clear()
+        self.td.cleanup()
+
+    def _on_disk(self):
+        return json.loads(km.PR_WATCH_FILE.read_text())
+
+    def _accept(self, sid, text):
+        self.mail.append((sid, text))
+        return True
+
+    def test_the_stamp_is_on_disk_when_the_injection_runs(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        seen = []
+
+        def deliver(sid, text):
+            seen.append([(r.get("sent"), r.get("sentDetail")) for r in self._on_disk()])
+            return True
+        km._pr_watch_deliver = deliver
+        km._pr_watch_tick(100.0)
+        self.assertEqual(seen, [[("merged", "")]], "the verdict was durable BEFORE the mail went out")
+        self.assertEqual((km._pr_watches, self._on_disk()), ([], []), "…and retired once it was accepted")
+
+    def test_a_refused_injection_keeps_the_row_and_retries_next_tick(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        tries = []
+        km._pr_watch_deliver = lambda sid, text: tries.append(text) or False
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual(len(tries), 1)
+        self.assertEqual(len(km._pr_watches), 1, "not retired: nothing was delivered")
+        self.assertEqual(self._on_disk()[0]["sent"], "merged", "the stamp stays — the verdict is filed")
+        self.assertTrue(km._kernel_watch_armed(SID), "the session's wait is still carried")
+        km._pr_watch_read = lambda pr, repo: self.fail("a filed verdict is never re-derived from gh")
+        km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY - 1)
+        self.assertEqual(len(tries), 1, "rate-gated like any row")
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(len(tries), 2, "retried on the next tick")
+        self.assertNotIn("may repeat", tries[1], "a KNOWN failure: nothing landed, so no repeat warning")
+        rows = km._sync_notice_rows()
+        self.assertEqual([r["ok"] for r in rows], [False], "the refusal is on the Log once, not once per tick")
+        self.assertIn("was not accepted by session", rows[0]["text"])
+        km._pr_watch_deliver = self._accept
+        km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual(len(self.mail), 1)
+        self.assertIn("has MERGED", self.mail[0][1])
+        self.assertEqual((km._pr_watches, self._on_disk()), ([], []), "retired on the confirmed delivery")
+
+    def test_a_stamp_that_cannot_land_never_delivers(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_deliver = self._accept
+        km._atomic_write = _enospc
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual(self.mail, [], "no mail without a durable stamp: at boot it would read as a fresh verdict")
+        self.assertEqual(len(km._pr_watches), 1)
+        self.assertNotIn("sent", km._pr_watches[0], "a stamp that did not land is not held in memory either")
+        self.assertIsNone(self._on_disk()[0].get("sent"))
+        km._atomic_write = self._saved[4]                                 # the disk is back
+        km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(len(self.mail), 1, "stamped, delivered, retired")
+        self.assertEqual(km._pr_watches, [])
+
+    def test_a_crash_between_the_stamp_and_the_retire_is_told_never_silent(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+
+        def died(sid, text):                       # the kernel dies with the mail in flight
+            raise RuntimeError("kernel killed mid-delivery")
+        km._pr_watch_deliver = died
+        with self.assertRaises(RuntimeError):
+            km._pr_watch_tick(100.0)
+        self.assertEqual(self._on_disk()[0]["sent"], "merged", "the crash left the stamp on disk")
+        km._pr_watches[:] = []                     # the restart
+        km._pr_watches_load()
+        km._pr_watch_read = lambda pr, repo: self.fail("a stamped verdict is never re-derived from gh")
+        km._pr_watch_deliver = self._accept
+        km._pr_watch_tick(200.0)
+        self.assertEqual(len(self.mail), 1, "delivered once more — whether the first copy landed is unknowable")
+        self.assertIn("has MERGED", self.mail[0][1])
+        self.assertIn("This may repeat a notice sent just before romp last restarted.", self.mail[0][1],
+                      "…and the notice SAYS it may be a repeat: never silently twice")
+        self.assertEqual((km._pr_watches, self._on_disk()), ([], []))
+        km._pr_watch_tick(300.0)
+        self.assertEqual(len(self.mail), 1, "and never a third")
+
+    def test_the_awaiting_box_says_the_notice_is_owed_once_the_pr_landed(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        aw = km._watch_awaiting(SID)
+        self.assertEqual((aw["items"][0]["label"], aw["why"]),
+                         ("PR #7 (TESTORG/testrepo)", "waiting on PR #7 (TESTORG/testrepo) to land"))
+        km._pr_watch_deliver = lambda sid, text: False        # the PR landed; the notice is what is owed
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        aw = km._watch_awaiting(SID)
+        self.assertEqual(aw["items"][0]["label"], "PR #7 (TESTORG/testrepo): merged — mail pending",
+                         "the box says what is owed, not 'to land' for a PR that landed")
+        self.assertEqual(aw["why"], "waiting on PR #7 (TESTORG/testrepo): merged — mail pending")
+        self.assertEqual(aw["items"][0]["id"], "pr:TESTORG/testrepo#7", "same row identity")
+
+    def test_the_gh_failure_retire_keeps_the_same_order(self):
+        km.add_pr_watch(9, "TESTORG/testrepo", SID, now=0)
+        km._pr_watch_read = lambda pr, repo: ("error", "auth required")
+        km._pr_watch_deliver = lambda sid, text: False
+        with redirect_stderr(io.StringIO()):
+            for i in range(3):
+                km._pr_watch_tick(100.0 + i * km.PR_WATCH_EVERY)
+        self.assertEqual(len(km._pr_watches), 1, "the loud retire is owed, not lost")
+        self.assertEqual((self._on_disk()[0]["sent"], self._on_disk()[0]["sentDetail"]), ("error", "auth required"))
+        km._pr_watch_deliver = self._accept
+        km._pr_watch_tick(100.0 + 3 * km.PR_WATCH_EVERY)
+        self.assertEqual(len(self.mail), 1)
+        self.assertIn("auth required", self.mail[0][1])
+        self.assertEqual(km._pr_watches, [])
+
+
+MGR = "22222222-2222-3333-4444-555555555555"
+THREAD = "33333333-2222-3333-4444-555555555555"
+
+
+def _live_raises():
+    raise RuntimeError("tmux list-sessions timed out")
+
+
+class DeliveryTargets(unittest.TestCase):
+    """The decision procedure against an SDK-shaped fake whose record the test writes. Before the
+    first fix, _pr_watch_deliver returned True whenever the send did not raise, and no backend raises
+    for a dead session (SDK/Codex send return False, tmux's send reports a missing session only on
+    stderr; _send_or_park dropped be.send's return), so an ended registrant's landing mail was
+    dropped silently. The first fix pre-classified from Sessions.live() — which reads EMPTY on a slow
+    `tmux list-sessions` or a swallowed live_sessions error, and never lists a comment thread — so a
+    blip diverted a running registrant's mail with a false "has ended". Now the durable records
+    decide (an explicit end marker before any send; a uuid nobody holds is never sent; a record that
+    says alive sends first), refusals are classified from the same records, no record is counted
+    three checks, and an unresolved contact name only waits. Runs the REAL _pr_watch_deliver →
+    _send_or_park → backend path, with the record readers and Sessions.backend_for routed to the fake
+    and Sessions.live() EMPTY throughout (or raising). What the fake cannot stage — ownership by
+    owns() falling through to tmux — RealRouting covers with real backends."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self._saved = {n: getattr(km, n) for n in
+                       ("PR_WATCH_FILE", "_pr_watch_read", "_compacting_now", "_working_now", "_limit_hold",
+                        "_optimistic_echo", "_sid_of", "_name_of", "_watch_escalate_default",
+                        "_pr_watch_record_backends")}
+        self._saved_rows = list(km._pr_watches)
+        self._saved_live, self._saved_be = km.Sessions.live, km.Sessions.backend_for
+        km.PR_WATCH_FILE = Path(self.td.name) / "pr-watches.json"
+        km._pr_watches[:] = []
+        km._pr_watch_save_faults.clear()
+        km._SYNC_NOTICES.clear()
+        km._pending_ops.clear()
+        km._pr_watch_read = lambda pr, repo: ("merged", "")
+        km._compacting_now = lambda sid, *a, **k: False
+        km._working_now = lambda sid, *a, **k: False
+        km._limit_hold = lambda sid, *a, **k: False
+        km._optimistic_echo = lambda *a, **k: None
+        km._sid_of = lambda who: MGR if who == "mgr" else who
+        km._name_of = lambda sid: "mgr" if sid == MGR else None
+        km._watch_escalate_default = lambda: ""
+        self.be = _FakeBackend()
+        km._pr_watch_record_backends = lambda: [self.be]
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km.Sessions.live = staticmethod(lambda: {})        # a blip's answer, held for the whole class
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(km, n, v)
+        km._pr_watches[:] = self._saved_rows
+        km.Sessions.live, km.Sessions.backend_for = staticmethod(self._saved_live), staticmethod(self._saved_be)
+        km._pr_watch_save_faults.clear()
+        km._SYNC_NOTICES.clear()
+        km._pending_ops.clear()
+        self.td.cleanup()
+
+    def _on_disk(self):
+        return json.loads(km.PR_WATCH_FILE.read_text())
+
+    def _log(self):
+        return [(r["ok"], r["text"]) for r in km._sync_notice_rows()]
+
+    # a live registrant refused by return: wait, said once per reason, closed on delivery
+    def test_a_live_registrant_refused_by_return_keeps_the_row_and_retries(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs, self.be.refuse = {SID: True}, True      # the record says alive; the send is declined
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(self.be.sent, [])
+        self.assertEqual(len(km._pr_watches), 1, "not accepted → not retired; never diverted")
+        self.assertEqual(self._on_disk()[0]["sent"], "merged", "stamped, awaiting the retry")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False], "the same reason twice is said once")
+        self.assertIn("was not accepted by session 11111111 (its record says it is alive, yet the send was refused)",
+                      log[0][1])
+        self.be.refuse = False
+        km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual([s for s, _ in self.be.sent], [SID])
+        self.assertNotIn("may repeat", self.be.sent[0][1], "a known failure carried no repeat warning")
+        self.assertEqual(km._pr_watches, [])
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False, True], "the story that opened on the Log closes on it")
+        self.assertIn("reached session 11111111 after the earlier refusal", log[1][1])
+
+    def test_a_changed_reason_is_said_once_more_and_a_repeated_one_stays_silent(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs, self.be.refuse = {SID: True}, True
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)                 # same reason: silent
+            self.be.marker_raises = True                                  # the reason changes
+            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+            km._pr_watch_tick(100.0 + 3 * km.PR_WATCH_EVERY)             # repeated: silent
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False, False])
+        self.assertIn("its record says it is alive", log[0][1])
+        self.assertIn("its record could not be read", log[1][1])
+
+    # the record says ended: no send to the registrant, the contact leg
+    def test_an_ended_registrant_with_a_contact_hands_the_notice_to_the_contact(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.be.regs = {SID: False, MGR: True}                # alive=false: the explicit end marker
+        km._pr_watch_tick(100.0)
+        self.assertEqual([s for s, _ in self.be.sent], [MGR], "the notice went to the contact; none to the ended sid")
+        self.assertIn("romp was watching for session 11111111 has MERGED: TESTORG/testrepo#7", self.be.sent[0][1])
+        self.assertIn("That session has ended", self.be.sent[0][1])
+        self.assertEqual((km._pr_watches, self._on_disk()), ([], []), "settled: retired")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [True])
+        self.assertIn("went to mgr — the session that registered the watch (11111111) has ended "
+                      "(its record says it ended)", log[0][1])
+
+    def test_an_ended_registrant_with_no_contact_retires_loudly_never_silently(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs = {SID: False}
+        with redirect_stderr(io.StringIO()) as err:
+            km._pr_watch_tick(100.0)
+        self.assertEqual(self.be.sent, [], "nothing can take it — and nothing was sent to the ended sid")
+        self.assertEqual((km._pr_watches, self._on_disk()), ([], []), "…so the row retires — never a 60 s loop forever")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False], "…and LOUDLY: one Log row")
+        for must in ("TESTORG/testrepo#7", "could not be delivered", "has ended (its record says it ended)",
+                     "no escalation contact is named", "dropped"):
+            self.assertIn(must, log[0][1])
+        self.assertNotIn("a copy may have gone out", log[0][1], "no restart happened — no such caveat")
+        self.assertIn("could not be delivered", err.getvalue())
+
+    def test_an_ended_registrant_whose_contact_has_ended_too_retires_loudly(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.be.regs = {SID: False, MGR: False}
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.be.sent, km._pr_watches), ([], []))
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False])
+        self.assertIn("its escalation contact mgr has ended too (its record says it ended)", log[0][1])
+
+    def test_an_ended_registrant_whose_contact_refuses_waits_then_hands_off(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.be.regs, self.be.refuse = {SID: False, MGR: True}, True    # the contact stands, declines
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.be.sent, len(km._pr_watches)), ([], 1), "kept for the contact's retry")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False])
+        self.assertIn("was not accepted by the escalation contact mgr (its record says it is alive, yet the send "
+                      "was refused); the session that registered the watch (11111111) has ended", log[0][1])
+        self.be.refuse = False
+        km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(([s for s, _ in self.be.sent], km._pr_watches), ([MGR], []))
+        self.assertIn("went to mgr after the earlier refusal", self._log()[1][1])
+
+    def test_a_contact_that_is_the_ended_session_itself_is_no_contact(self):
+        km._sid_of = lambda who: SID if who == "mgr" else who   # the target names the registrant
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.be.regs = {SID: False}
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.be.sent, km._pr_watches), ([], []))
+        self.assertIn("its escalation contact is that same session", self._log()[0][1])
+
+    def test_a_loud_retire_of_a_replayed_row_says_a_copy_may_have_gone_out(self):
+        # the stamp outlived a restart: whether the pre-crash injection landed is unknowable, and
+        # the loud retire must not claim "could not be delivered" without that caveat
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        km._pr_watches[0]["sent"], km._pr_watches[0]["sentDetail"] = "merged", ""
+        km._pr_watches_save()
+        km._pr_watches[:] = []
+        km._pr_watches_load()                                 # the restart
+        self.be.regs = {SID: False}
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual(km._pr_watches, [])
+        self.assertIn("the watch is dropped (a copy may have gone out before the last restart)", self._log()[0][1])
+
+    # a comment thread: never in the live set, its record says alive, taken by its backend
+    def test_a_thread_registrant_is_delivered_on_the_first_attempt(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", THREAD, now=0, escalate="mgr")
+        self.be.regs = {THREAD: True, MGR: True}              # Sessions.live() stays {} — threads are never listed
+        km._pr_watch_tick(100.0)
+        self.assertEqual([s for s, _ in self.be.sent], [THREAD], "delivered to the thread itself, first try")
+        self.assertIn("you asked romp to watch", self.be.sent[0][1])
+        self.assertEqual((km._pr_watches, self._log()), ([], []), "retired, nothing to log")
+
+    # no record for a uuid: never sent, counted, three checks
+    def test_a_uuid_with_no_record_is_never_sent_and_ends_after_three_checks(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs = {}                                     # the fake holds no record for the sid
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            self.assertEqual(len(km._pr_watches), 1, "check 1: kept")
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+            self.assertEqual(len(km._pr_watches), 1, "check 2: kept")
+            log = self._log()
+            self.assertEqual([ok for ok, _ in log], [False, False], "each advanced count is a changed reason")
+            self.assertIn("was not sent to session 11111111 (no record of the session (check 1 of 3))", log[0][1])
+            self.assertIn("(check 2 of 3)", log[1][1])
+            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual((km._pr_watches, self.be.sent), ([], []), "check 3: ended — and never once sent")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False, False, False])
+        self.assertIn("has ended (no record of the session for 3 checks) and no escalation contact is named; "
+                      "the watch is dropped", log[2][1])
+
+    def test_a_record_that_reappears_alive_resets_the_no_record_count(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs = {}
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+            self.be.regs, self.be.refuse = {SID: True}, True  # the record is back, alive (the send still declined)
+            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+            self.be.regs = {}
+            km._pr_watch_tick(100.0 + 3 * km.PR_WATCH_EVERY)
+        self.assertEqual(len(km._pr_watches), 1, "the count restarted: one no-record check since, not four")
+
+    def test_a_backend_without_a_record_reader_reads_as_no_record(self):
+        self.be = _NoRecordBackend()                          # send refuses; nothing to read
+        km._pr_watch_record_backends = lambda: [self.be]
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.be.sent, len(km._pr_watches)), ([], 1))
+        self.assertIn("(no record of the session (check 1 of 3))", self._log()[0][1])
+
+    # the live set is irrelevant: empty or raising, the send is attempted
+    def test_a_live_set_that_reads_empty_or_raises_never_stops_the_send(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.be.regs = {SID: True, MGR: True}
+        km.Sessions.live = staticmethod(_live_raises)         # the probe itself is broken
+        km._pr_watch_tick(100.0)
+        self.assertEqual([s for s, _ in self.be.sent], [SID], "the registrant got its own mail")
+        self.assertEqual((km._pr_watches, self._log()), ([], []))
+
+    def test_a_record_reader_that_raises_fails_open(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.be.regs, self.be.refuse, self.be.marker_raises = {SID: True}, True, True
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+        self.assertEqual(len(km._pr_watches), 1, "a reader's fault never ends a watch — and is never counted")
+        self.assertEqual(len(self._log()), 1)
+        self.assertIn("(its record could not be read)", self._log()[0][1])
+        self.be.refuse, self.be.marker_raises = False, False
+        km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual(([s for s, _ in self.be.sent], km._pr_watches), ([SID], []))
+
+    # the contact's name: durable resolution, and an unresolved name only waits
+    def test_an_unresolved_contact_name_waits_uncounted_and_is_never_sent_bare(self):
+        # _sid_of reads the live set — the probe — and hands an unresolvable NAME back unchanged; a
+        # send to it would fall to tmux, whose send never refuses. A name the live set failed to
+        # list is not a session that ended: the row waits, said once, and is never dropped for it
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._sid_of = lambda who: who
+        self.be.regs = {SID: False}
+        with redirect_stderr(io.StringIO()):
+            for i in range(5):
+                km._pr_watch_tick(100.0 + i * km.PR_WATCH_EVERY)
+        self.assertEqual((self.be.sent, len(km._pr_watches)), ([], 1), "nothing went to a bare name; nothing ended")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False], "said once, however long it waits")
+        self.assertIn("its escalation contact mgr does not resolve to a session; retrying", log[0][1])
+        self.assertIn("mail pending", km._watch_awaiting(SID)["why"], "the box shows what is owed")
+        self.be.names = {"mgr": MGR}                          # the durable record now carries the name
+        self.be.regs[MGR] = True
+        km._pr_watch_tick(100.0 + 5 * km.PR_WATCH_EVERY)
+        self.assertEqual(([s for s, _ in self.be.sent], km._pr_watches), ([MGR], []))
+
+    def test_a_contact_name_resolves_through_the_backends_record_when_the_live_set_fails(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._sid_of = lambda who: who                          # the live set lists nobody
+        self.be.regs, self.be.names = {SID: False, MGR: True}, {"mgr": MGR}
+        km._pr_watch_tick(100.0)
+        self.assertEqual(([s for s, _ in self.be.sent], km._pr_watches), ([MGR], []))
+
+    def test_send_or_park_tells_a_refused_handover_apart_and_echoes_nothing_for_it(self):
+        echoed = []
+        km._optimistic_echo = lambda sid, text, author="human": echoed.append(text)
+        self.assertIsNone(km._send_or_park(self.be, SID, "hello", echo="human"), "refused: neither parked nor handed")
+        self.assertEqual(echoed, [], "no echo for a message the session never got")
+        self.be.regs = {SID: True}
+        self.assertIs(km._send_or_park(self.be, SID, "hello", echo="human"), False, "handed over now")
+        self.assertEqual(echoed, ["hello"])
+
+
+class RealRouting(unittest.TestCase):
+    """Through the REAL Sessions.backend_for and REAL backends: a fresh SdkBackend over a temp state
+    dir, a fresh CodexBackend, and tmux's send replaced by a recorder. The routing fact this class
+    pins: Sessions.backend_for picks by owns(), and owns() is False for exactly the records that
+    decide a landing mail — an SDK reg that is absent or unreadable, a Codex session marked dead — so
+    those sids fall to _TMUX, whose send returns True unconditionally; before this change their
+    notices "were accepted" by a shell that never existed and the rows retired with no Log row. The
+    decision now reads the records first, independent of ownership, and a uuid nobody holds is never
+    sent. Only the gates the module already patches are patched; sends never reach a live SDK reg (a
+    real send there would spawn a CLI)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        state = Path(self.td.name)
+        sb, cb = _backend_mod("sdk_backend"), _backend_mod("codex_backend")
+        self.sb, self.cb = sb, cb
+        self.sdk = sb.SdkBackend(state, "claude", lambda *a, **k: None)             # reconcile=False: no boot sweep
+        self.cx = cb.CodexBackend(state, notify=lambda *a, **k: None, log=lambda m: None)
+        self.tmux = []
+        self._saved = {n: getattr(km, n) for n in
+                       ("PR_WATCH_FILE", "NAMES", "_pr_watch_read", "_compacting_now", "_working_now", "_limit_hold",
+                        "_optimistic_echo", "_tmux_send", "_sdk", "_codex", "_watch_escalate_default")}
+        self._saved_rows = list(km._pr_watches)
+        km.PR_WATCH_FILE = state / "pr-watches.json"
+        km.NAMES = state / "names"
+        km.NAMES.mkdir()
+        km._pr_watches[:] = []
+        km._pr_watch_save_faults.clear()
+        km._SYNC_NOTICES.clear()
+        km._pending_ops.clear()
+        km._pr_watch_read = lambda pr, repo: ("merged", "")
+        km._compacting_now = lambda sid, *a, **k: False
+        km._working_now = lambda sid, *a, **k: False
+        km._limit_hold = lambda sid, *a, **k: False
+        km._optimistic_echo = lambda *a, **k: None
+        km._watch_escalate_default = lambda: ""
+        km._tmux_send = lambda name, text, **kw: self.tmux.append((name, text))
+        km._sdk = lambda: self.sdk
+        km._codex = lambda: self.cx
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            setattr(km, n, v)
+        km._pr_watches[:] = self._saved_rows
+        km._pr_watch_save_faults.clear()
+        km._SYNC_NOTICES.clear()
+        km._pending_ops.clear()
+        self.td.cleanup()
+
+    def _log(self):
+        return [(r["ok"], r["text"]) for r in km._sync_notice_rows()]
+
+    def _dead_codex(self, sid):
+        s = self.cb._Session(sid, "t1", "web", "/tmp")
+        s.dead = True
+        self.cx._put_session(s)
+
+    def _tmux_contact(self, name):
+        (km.NAMES / name).write_text("%s\t/tmp\n" % name)    # a tmux session: its sid IS its name
+
+    def test_a_dead_codex_registrant_never_reaches_tmux_and_retires_loudly(self):
+        self._dead_codex(SID)
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.assertIs(km.Sessions.backend_for(SID), km._TMUX, "the routing fact: a dead Codex sid falls to tmux")
+        self.assertIs(km._pr_watch_end_marker(SID), True, "…while its record says it ended")
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.tmux, km._pr_watches), ([], []), "never sent to a shell that never existed; retired")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False])
+        self.assertIn("has ended (its record says it ended) and no escalation contact is named", log[0][1])
+
+    def test_a_dead_codex_registrant_with_a_tmux_contact_hands_off(self):
+        self._dead_codex(SID)
+        self._tmux_contact("mgr")
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        km._pr_watch_tick(100.0)
+        self.assertEqual([n for n, _ in self.tmux], ["mgr"], "the contact — a tmux session by name — got it")
+        self.assertIn("romp was watching for session 11111111 has MERGED", self.tmux[0][1])
+        self.assertEqual(km._pr_watches, [])
+        self.assertIn("went to mgr", self._log()[0][1])
+
+    def test_an_sdk_reg_with_alive_false_hands_off_to_the_contact(self):
+        self.sb.write_reg(Path(self.td.name), SID, {"sid": SID, "name": "web", "alive": False})
+        self._tmux_contact("mgr")
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        self.assertIs(km.Sessions.backend_for(SID), self.sdk, "owned (the reg exists) — the one case the old order reached")
+        km._pr_watch_tick(100.0)
+        self.assertEqual(([n for n, _ in self.tmux], km._pr_watches), (["mgr"], []))
+
+    def test_an_absent_sdk_reg_for_a_uuid_sid_never_reaches_tmux_and_ends_after_three_checks(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.assertIs(km.Sessions.backend_for(SID), km._TMUX, "the routing fact: an absent reg falls to tmux")
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+            km._pr_watch_tick(100.0 + km.PR_WATCH_EVERY)
+            self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1), "two checks: kept, never sent")
+            km._pr_watch_tick(100.0 + 2 * km.PR_WATCH_EVERY)
+        self.assertEqual((self.tmux, km._pr_watches), ([], []))
+        self.assertIn("no record of the session for 3 checks", self._log()[-1][1])
+
+    def test_a_corrupt_sdk_reg_reads_as_no_record_never_as_a_tmux_session(self):
+        p = Path(self.td.name) / "sdk" / (SID + ".json")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json")
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+        self.assertFalse(self.sdk.owns(SID), "the routing fact: an unreadable reg is not owned")
+        self.assertIs(km.Sessions.backend_for(SID), km._TMUX)
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        self.assertEqual((self.tmux, len(km._pr_watches)), ([], 1))
+        self.assertIn("(no record of the session (check 1 of 3))", self._log()[0][1])
+
+    def test_a_name_shaped_registrant_goes_to_tmux_the_standing_gap(self):
+        km.add_pr_watch(7, "TESTORG/testrepo", "web", now=0)
+        km._pr_watch_tick(100.0)
+        self.assertEqual([n for n, _ in self.tmux], ["web"], "a tmux registrant is sent as ever")
+        self.assertEqual((km._pr_watches, self._log()), ([], []),
+                         "tmux's send never refuses: accepted, retired, nothing to log — the documented gap")
+
+    def test_a_contact_name_resolves_through_the_sdk_regs_when_the_live_set_lists_nobody(self):
+        self._dead_codex(SID)
+        self.sb.write_reg(Path(self.td.name), MGR, {"sid": MGR, "name": "mgr", "alive": True})
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0, escalate="mgr")
+        saved_live, saved_deliver = km.Sessions.live, km._pr_watch_deliver
+        km.Sessions.live = staticmethod(lambda: {})           # the probe lists nobody
+        got = []
+        km._pr_watch_deliver = lambda sid, text: got.append(sid) or True   # a real send here would spawn a CLI
+        try:
+            self.assertEqual(self.sdk.sid_for_name("mgr"), MGR)
+            km._pr_watch_tick(100.0)
+        finally:
+            km.Sessions.live, km._pr_watch_deliver = staticmethod(saved_live), saved_deliver
+        self.assertEqual((got, km._pr_watches, self.tmux), ([MGR], [], []),
+                         "resolved from the reg's name, not the live set; nothing fell to tmux")
+
+
+class EndMarkerReaders(unittest.TestCase):
+    """The backends' own durable-record readers, executed against real files and real session
+    objects: True = an explicit end marker, False = the record says the session stands, None = no
+    record. Only these three answers exist; a live set is never consulted."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sb, cls.cb = _backend_mod("sdk_backend"), _backend_mod("codex_backend")
+
+    def test_the_sdk_name_reader_resolves_exactly_one_alive_reg(self):
+        import types
+        with tempfile.TemporaryDirectory() as td:
+            be = types.SimpleNamespace(state_dir=Path(td))
+            self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), "", "no regs → nothing")
+            self.sb.write_reg(Path(td), MGR, {"sid": MGR, "name": "mgr", "alive": True})
+            self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), MGR)
+            self.sb.write_reg(Path(td), THREAD, {"sid": THREAD, "name": "mgr", "alive": True, "threadOf": MGR})
+            self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), MGR, "a thread never answers to a name")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "name": "mgr", "alive": True})
+            self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), "", "two alive → ambiguous → nothing")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "name": "mgr", "alive": False})
+            self.assertEqual(self.sb.SdkBackend.sid_for_name(be, "mgr"), MGR, "an ended reg does not compete")
+
+    def test_the_sdk_reader_reads_the_reg_alive_flag_and_nothing_else(self):
+        import types
+        with tempfile.TemporaryDirectory() as td:
+            be = types.SimpleNamespace(state_dir=Path(td))
+            self.assertIsNone(self.sb.SdkBackend.end_marker(be, SID), "no reg → no record")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": True})
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), False, "alive → the session stands")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": True, "threadOf": MGR})
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), False, "a thread's reg reads the same way")
+            self.sb.write_reg(Path(td), SID, {"sid": SID, "alive": False})
+            self.assertIs(self.sb.SdkBackend.end_marker(be, SID), True, "alive=false → the explicit end marker")
+            (Path(td) / "sdk" / (SID + ".json")).write_text("{not json")
+            self.assertIsNone(self.sb.SdkBackend.end_marker(be, SID), "unreadable → no record, never a verdict")
+
+    def test_the_codex_reader_reads_the_dead_mark(self):
+        import types
+        s = types.SimpleNamespace(lock=threading.RLock(), dead=False)
+        be = types.SimpleNamespace(_session=lambda sid: s)
+        self.assertIs(self.cb.CodexBackend.end_marker(be, SID), False)
+        s.dead = True
+        self.assertIs(self.cb.CodexBackend.end_marker(be, SID), True)
+        self.assertIsNone(self.cb.CodexBackend.end_marker(types.SimpleNamespace(_session=lambda sid: None), SID),
+                          "no session by that id → no record")
+
+
 class Route(unittest.TestCase):
     """POST /watch-pr over the real Handler: registration + refusals; token-gated."""
 
@@ -272,6 +1084,43 @@ class Route(unittest.TestCase):
         self.assertTrue(r["ok"])
         self.assertEqual(r["watch"]["sid"], SID)
         self.assertEqual(json.loads(km.PR_WATCH_FILE.read_text())[0]["pr"], 7)
+
+    def test_a_watch_whose_save_failed_is_refused_retryably_never_acked(self):
+        saved = km._atomic_write
+        km._atomic_write = _enospc
+        getattr(km, "_pr_watch_save_faults", {}).clear()
+        try:
+            with redirect_stderr(io.StringIO()):
+                st, r = self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "web"})
+        finally:
+            km._atomic_write = saved
+            getattr(km, "_pr_watch_save_faults", {}).clear()
+        self.assertEqual(st, 200)
+        self.assertEqual((r["ok"], r["retryable"]), (False, True), "the route's refusal shape, marked retryable")
+        self.assertIn("could not be saved (%s)" % ENOSPC, r["error"])
+        self.assertIn("nothing is watching TESTORG/testrepo#7", r["error"])
+        self.assertEqual(km._pr_watches, [], "the refused row is not held in memory either")
+        self.assertFalse(km.PR_WATCH_FILE.exists())
+
+    def test_a_standing_watch_whose_new_escalation_target_failed_to_save_is_told_apart(self):
+        st, r = self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "web"})
+        self.assertTrue(r["ok"])
+        saved = km._atomic_write
+        km._atomic_write = _enospc
+        try:
+            with redirect_stderr(io.StringIO()):
+                st, r = self._post({"pr": 7, "repo": "TESTORG/testrepo", "name": "web", "escalate": "mgr"})
+        finally:
+            km._atomic_write = saved
+            km._pr_watch_save_faults.clear()
+        self.assertEqual((st, r["ok"], r["retryable"]), (200, False, True))
+        self.assertIn("the watch on TESTORG/testrepo#7 stands, but the escalation target could not be saved (%s)"
+                      % ENOSPC, r["error"], "the truth: the watch stands; only the target was refused")
+        self.assertNotIn("nothing is watching", r["error"])
+        self.assertEqual(r["watch"]["pr"], 7, "…and the standing watch rides the reply")
+        self.assertEqual([(x["pr"], x.get("escalate")) for x in json.loads(km.PR_WATCH_FILE.read_text())],
+                         [(7, None)], "on disk: the watch, no target")
+        self.assertNotIn("escalate", km._pr_watches[0])
 
     def test_refusals_are_loud_and_shaped(self):
         self.assertEqual(self._post({"repo": "TESTORG/testrepo", "name": "web"})[0], 400)

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -930,6 +930,31 @@ class RealRouting(unittest.TestCase):
         self.assertEqual([ok for ok, _ in log], [False])
         self.assertIn("has ended (its record says it ended) and no escalation contact is named", log[0][1])
 
+    def test_a_uuid_whose_record_reader_raises_waits_and_never_reaches_tmux(self):
+        # the SDK reader raising leaves the marker UNREAD, so the send still goes to the router —
+        # which disowns the sid (owns() stats the reg) and picks tmux. The deliver guard refuses a
+        # uuid there, the refusal classifies as "could not be read", and the row waits, uncounted
+        km.add_pr_watch(7, "TESTORG/testrepo", SID, now=0)
+
+        def boom(sid):
+            raise OSError(5, "input/output error")
+        self.sdk.end_marker = boom                       # the fresh instance's reader faults this tick
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(100.0)
+        del self.sdk.end_marker                          # the class's real reader is back
+        self.assertEqual(self.tmux, [], "a uuid is never handed to tmux, however it reached the router")
+        self.assertEqual(len(km._pr_watches), 1, "the row waits")
+        self.assertIsNone(km._pr_watches[0].get("_norec", {}).get(SID), "a reader's fault is not counted")
+        log = self._log()
+        self.assertEqual([ok for ok, _ in log], [False])
+        self.assertIn("its record could not be read", log[0][1])
+        # the reader recovering resolves it: the reg says alive=false → ended → loud retire (no contact)
+        self.sb.write_reg(Path(self.td.name), SID, {"sid": SID, "alive": False, "name": "web"})
+        with redirect_stderr(io.StringIO()):
+            km._pr_watch_tick(200.0)
+        self.assertEqual((self.tmux, km._pr_watches), ([], []))
+        self.assertIn("has ended (its record says it ended)", self._log()[-1][1])
+
     def test_a_dead_codex_registrant_with_a_tmux_contact_hands_off(self):
         self._dead_codex(SID)
         self._tmux_contact("mgr")


### PR DESCRIPTION
A PR watch (`romp watch-pr`, the awaiting box's "PR #n: to land" rows) had two silent ends, verified on `main`:

- **Registration.** `_pr_watches_save` wrote outside the watch lock, swallowed its exception into a stderr traceback and returned nothing; `add_pr_watch` appended under the lock, saved after it, and returned the row regardless; the `/watch-pr` route acked unconditionally. A watch whose save failed (ENOSPC, EACCES) was reported as "watching", lived only in memory, and was forgotten at the next restart. Its "your PR landed" mail never came and nothing said why. A new escalation target added to an existing watch was never saved at all.
- **Delivery.** `_pr_watch_tick` retired the row without reading the deliver's bool, and that bool was True whenever the send did not *raise*, which no backend does for a dead session: `SdkBackend.send` and `CodexBackend.send` return False, `TmuxBackend.send` returns True and reports a missing session only on stderr, `_send_or_park` dropped the return, and `Sessions.backend_for` routes by `owns()`, which is False for an absent or unreadable SDK reg and for a Codex session marked dead, so exactly those sids fell to tmux. A landing mail for a registrant that had ended was dropped and the row retired silently; a crash between the injection and the retire replayed the row at boot and mailed it twice with nothing to say so.

## What changes

**A watch is acknowledged only once it is on disk.** `add_pr_watch` is one locked transaction returning `(row, fault)`, the sibling `add_watch`'s shape. The disk write sits inside the lock on purpose, the price of never observing, acknowledging or persisting a row the transaction then rolls back. A failed save is said once per fault episode, keyed on the errno text in the store's own registry and cleared by a landed write, under the bell's `refused` kind like every state file that could not be written. The route answers its existing refusal shape plus `retryable`, naming the fault, and distinguishes a fresh row that was not saved ("nothing is watching repo#n") from a standing watch whose new escalation target was not saved.

**Acceptance means the backend accepted.** `_send_or_park` returns None when the backend refused the handover and echoes nothing for it, falsy like a handover for the callers that only ask "queued?", distinct for the one that must know.

**The decision procedure: stamp, records, send, classify, retire.** The verdict is saved into the row before anything else, so the file always says whether a delivery was attempted, and a stamp that cannot land never delivers. Then the **durable records** decide, read from every record-holding backend independent of ownership: an SDK reg with `alive: false` or a Codex dead mark is the explicit end marker written at session end, and a durable end marker is authority where a liveness probe is not. An ended registrant takes the contact leg with no send. No record at all splits on the sid's shape, a structural fact of the backends: SDK and Codex sids are uuids, tmux sids are names. A uuid nobody holds is never sent (routed to tmux it would be "accepted" for a shell that never existed) and is counted, three consecutive ticks ending it loudly; a name-shaped sid is a tmux registrant and is sent as ever. Otherwise the send goes first, because the backend's own send path handles what no live set can show (a dormant reg it wakes, a comment thread the live set never lists), and only a send refused by return is classified from the same records: alive, wait; no record, counted; a reader that raised, wait uncounted. The guard sits where every watch send passes: `_pr_watch_deliver` refuses a uuid the router hands to tmux, however it got there.

**The contact leg.** The escalation contact (per-watch or the box default) is resolved by sid, then by name through the live set, then through the SDK regs' own names (`SdkBackend.sid_for_name`, exactly one alive reg with that name). An unresolved name never counts toward ending: the row waits, said once, and the awaiting box shows the mail pending, because a name the live set failed to list is not a session that ended. The contact's own refusal is classified the same way. Only when the registrant has ended and no contact can take it does the row retire loudly, with why, and with "a copy may have gone out before the last restart" when the row was replayed.

**Restart.** A row loaded with a stamp is replayed once more with the notice saying it may repeat a notice sent just before the restart: at-least-once, told, rather than at-most-once and silently lost. The loader accepts only the three verdicts it writes as a stamp.

**The Log tells the story once per reason**, and closes it: a row that logged "stays armed and retries" logs one line when the notice finally lands.

The awaiting box renders a stamped row as "merged, mail pending" instead of "to land".

## Judgment calls and residuals

- **tmux.** Its send never refuses, so a dead tmux registrant's notice still reads as accepted and the row retires. The gap that stood before stands, stated; a liveness probe is not its fix.
- **A park counts as acceptance.** Under an account-wide limit hold or a queue ahead, the notice parks for the drain, whose `be.send` return is dropped. Pre-existing; the refusal signal now exists for a follow-up.
- **Generic watches** (`_watch_tick`, untouched) use the same deliver helper: a refused or uuid-to-tmux send now retries within their existing cap and drops on stderr, instead of retiring on a mail nothing took.
- **`/send`** still answers `ok: true, queued: false` for a send the backend refused. Pre-existing; follow-up candidate now that the signal is free.
- The no-record counter is runtime, like `_fails`: a restart re-arms it, which only lengthens the wait.
- The T143 failed-hold path's deliver return is still not read (its saves now report once per episode).

## Tests

`tests/test_pr_watch.py`: registration (a failed save refuses the watch and keeps no row; one line per fault episode, keyed on errno text, cleared by a landed write; an escalation target added to a standing watch is persisted or refused; the route tells the two refusals apart; every save runs under the lock, by an `_atomic_write` spy); delivery order (stamp on disk before the injection; a stamp that cannot land never delivers; a crash between stamp and retire is told); **RealRouting**, through the real `Sessions.backend_for` and real SDK and Codex backends over a temp state dir with tmux's send replaced by a recorder: a dead Codex registrant never reaches tmux and retires loudly or hands off to a tmux contact; an `alive: false` SDK reg hands off; an absent or corrupt SDK reg for a uuid never reaches tmux and ends after three checks; a reader that raises leaves the row waiting, uncounted, with nothing sent, and recovers; a name-shaped registrant goes to tmux (the documented gap); a contact name resolves through the SDK regs when the live set lists nobody; **DeliveryTargets** on a fake backend carrying the SDK's record shape: a live registrant refused by return keeps the row; the contact's own wait arm; a contact that is the ended session itself; a backend without a record reader; a changed reason is said once more and a repeated one stays silent; an unresolved contact name waits uncounted and is never sent bare; **EndMarkerReaders** on the real readers against reg files and session objects; the loader drops a stamp that is not a verdict; a replayed notice says it may repeat. Source mutants (probe classified as ended, fail-open arm to ended, counter off by one, arms swapped, the identity guards, the deliver guard, the rollback, the lock) each fail at least one test. `tests/romp.bats`: the CLI relays a refused registration and exits 1.

Module counts on this tree, one runner at a time: `tests/test_pr_watch.py` 59 passed; `tests/test_generic_watch.py` 16; `tests/test_awaiting_rows.py` 19; `tests/test_kernel_limit_queue.py` 20; `tests/test_injected_voice.py` 8 (190 subtests); `tests/test_codex_backend.py` 64; `tests/test_sdk_backend.py` 230 passed, 35 skipped; `bats tests/romp.bats` 112 of 112. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



CI on d96b68aa: all seven jobs green.
