### PR TITLE
The usage readout opens a per-session spend modal with a stacked histogram by session

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29237,14 +29237,19 @@ def _spend_scope():
     """Which figure the rail shows for THIS host, mirrored for the usage modal so its numbers are the
     rail's: "total" on a no-login (key-only) machine — every turn there bills the key, and legacy files
     predate the split — or "keyed" when a login's windows sit beside the key's spend, where only the
-    turns whose session billed the key are dollars anyone pays (_usage's two arms, the user 2026-08-08)."""
+    turns whose session billed the key are dollars anyone pays (_usage's two arms, the user 2026-08-08) —
+    or "computed" for a login with no key at all, where the rail shows no spend and every recorded
+    figure is a computed cost, not a bill."""
     try:
         o = json.loads((jd.STATE / "usage.json").read_text())
     except Exception:
         o = {}
     if o.get("apiKey") or not _claude_account():
         return "total"
-    return "keyed" if _auth_key_present() else "total"
+    if _auth_key_present():
+        return "keyed"
+    return "computed"   # a login and no key: the rail shows NO spend for this host (its third arm), and the
+    #                     ledger's figures are computed costs nobody is billed — the modal says so (review find)
 
 
 def _spend_detail(now=None):
@@ -29257,8 +29262,11 @@ def _spend_detail(now=None):
     dense arrays over the top-N sessions by dollars plus ONE "other" stack and ONE "unattributed"
     stack — a bucket written before bySid existed, or the part of a bucket no sid accounts for, is
     shown as such, never dropped or folded into a session (fail loudly). Local ledger only: a remote's
-    row carries no bySid through the relay today, so the payload counts the other machines the fleet
-    totals include and the modal says "this machine only" rather than omitting them silently.
+    row carries no bySid through the relay today, so the payload counts the other machines whose spend
+    the hover's totals include and the modal says "this machine only" rather than omitting them silently.
+    The table's totals and the ranking cover exactly the day keys the daily chart draws — the last 90
+    local dates — not every bucket the recorder still holds (it keeps the 90 most RECENT spend days,
+    which can reach further back; review find).
     Bucket keys are the recorder's LOCAL time; tz/tzOffsetMin let a viewer elsewhere label that."""
     now = time.time() if now is None else now
     try:
@@ -29292,9 +29300,12 @@ def _spend_detail(now=None):
             out[str(sid)] = (float(s.get("usd") or 0), int(s.get("tok") or 0), int(s.get("turns") or 0))
         return out
 
+    today = datetime.fromtimestamp(now).date()
+    day_keys = [(today - timedelta(days=i)).isoformat() for i in range(_DETAIL_DAYS - 1, -1, -1)]
+    day_set = set(day_keys)
     totals, keyt, un = {}, {}, [0.0, 0, 0]
-    for e in days.values():
-        if not isinstance(e, dict):
+    for k, e in days.items():
+        if k not in day_set or not isinstance(e, dict):
             continue
         tu, tt, tn = _tot(e)
         bs = _by(e)
@@ -29315,6 +29326,9 @@ def _spend_detail(now=None):
                     r = keyt.setdefault(str(sid), [0.0, 0, 0])
                     r[0] += float(k.get("usd") or 0); r[1] += int(k.get("tok") or 0); r[2] += int(k.get("turns") or 0)
         un[0] += max(0.0, tu - au); un[1] += max(0, tt - at); un[2] += max(0, tn - an)
+    # a session that contributed nothing under this scope (a login-only session in the keyed scope) is
+    # not a row and not a stack: an all-zero stack with a legend chip says nothing (review find)
+    totals = {sid: v for sid, v in totals.items() if v[0] > 0 or v[1] > 0 or v[2] > 0}
     try:
         live = set(_live_names(_tmux_sessions()).values())
     except Exception:
@@ -29369,15 +29383,22 @@ def _spend_detail(now=None):
         return {"keys": keys, "stacks": stacks}
 
     h0 = int(now // 3600) - (_SERIES_HOURS - 1)
-    hour_keys = [time.strftime("%Y-%m-%dT%H", time.localtime((h0 + i) * 3600)) for i in range(_SERIES_HOURS)]
-    today = datetime.fromtimestamp(now).date()
-    day_keys = [(today - timedelta(days=i)).isoformat() for i in range(_DETAIL_DAYS - 1, -1, -1)]
+    hour_keys = []
+    for i in range(_SERIES_HOURS):
+        # the recorder keys by local hour, so a fall-back transition writes two epoch hours under ONE
+        # key: one slot for it here too, not a labeled empty twin (review find)
+        k = time.strftime("%Y-%m-%dT%H", time.localtime((h0 + i) * 3600))
+        if not hour_keys or hour_keys[-1] != k:
+            hour_keys.append(k)
     with _remotes_lock:
-        up = sum(1 for r in _remotes.values() if r.get("status") == "up" and r.get("usage"))
+        # the machines the hover's spend totals include: the same predicate as its rows — a remote
+        # that reports spend windows — never any remote with a usage payload (review find)
+        up = sum(1 for r in _remotes.values()
+                 if r.get("status") == "up" and isinstance((r.get("usage") or {}).get("spend"), dict))
     lt = time.localtime(now)
     return {"host": _self_host(), "hosts": 1 + up, "scope": scope,
             "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
-            "windows": _spend_windows(keyed_only=keyed), "recordedAt": _spend_recorded_at(),
+            "recordedAt": _spend_recorded_at(),
             "topN": _DETAIL_TOP_N, "sessions": sessions,
             "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
             "hours": _series(hours, hour_keys), "days": _series(days, day_keys)}
@@ -36638,7 +36659,9 @@ return h;}
 // The ONE API-spend section for the whole hover (the user 2026-08-13): every host's windows summed —
 // one shared key is one number — plus the summed $/hour over the last 7 days as an area graph. A host
 // that ships no series (an older kernel) still joins the window sums; the graph adds only contributors.
-function fleetSpendHTML(sets,rowsOnly){var sum={},series=null,hosts=0,per=[],legacyN=0;
+var _spendRowsOnly=false;   // set by spendRowsHTML for the modal's first section (T247); the signature below is pinned
+function spendRowsHTML(sets){_spendRowsOnly=true;try{return fleetSpendHTML(sets);}finally{_spendRowsOnly=false;}}
+function fleetSpendHTML(sets){var sum={},series=null,hosts=0,per=[],legacyN=0,rowsOnly=_spendRowsOnly;
 sets.forEach(function(e){var sp=e.det&&e.det._spend;if(!sp)return;hosts++;
 if(sp.week&&typeof sp.week.usd==='number')per.push({host:e.host,usd:sp.week.usd});
 SPEND_WINS.forEach(function(w){var v=sp[w[0]];if(!v)return;
@@ -36661,7 +36684,7 @@ if(!ks.length)return '';
 // above this section and read as the spend's age): the newest contributing host's last-record
 // moment — the recorder writes per turn result, so this is an event time, not a poll time
 var sAt=0;sets.forEach(function(e){var a=e.det&&e.det._spendAt;if(typeof a==='number'&&a>sAt)sAt=a;});
-var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>'+(rowsOnly?'Totals':'API spend')+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
+var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>API spend'+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
 +ks.map(function(k){var v=sum[k];
 // the rolling month's caveats ride its label: a ledger younger than 30 days ("since <date>"), and
 // the machines whose older build could contribute only a calendar month (left out, counted)
@@ -36674,10 +36697,10 @@ var row='<div class=ru-tip-row><span class=ru-tip-k>'+lab+'</span>'
 if(v.split&&(v.tokIn+v.tokOut+v.tokCacheR+v.tokCacheW)>0)row+='<div class="ru-tip-row ru-tip-sub"><span class=ru-tip-k></span>'
 +'<span class=ru-tip-v>'+fmtTok(v.tokCacheR)+' cache read \u00b7 '+fmtTok(v.tokCacheW)+' cache write \u00b7 '+fmtTok(v.tokIn)+' in \u00b7 '+fmtTok(v.tokOut)+' out</span></div>';
 return row;}).join('');
-// rowsOnly: the usage MODAL's first section is THESE SAME window numbers (T247) — the fleet sums the
-// hover shows, one renderer, so the two levels can never disagree; the graph and the machine line
-// stay the hover's (the modal draws its own stacked histogram instead)
-if(rowsOnly)return h+'</div>';
+// rowsOnly: the usage MODAL's first section is THESE SAME window numbers (T247) — the sums across
+// every machine the hover shows, one renderer, so the two levels can never disagree; the graph and
+// the machine line stay the hover's (the modal draws its own stacked histogram instead)
+if(rowsOnly)return h.replace('<span>API spend','<span>Totals')+'</div>';
 // every machine in the sum, BY NAME (the user 2026-08-13: a host with no login \u2014 the devbox \u2014 vanished
 // from the hover entirely when the per-host spend rows collapsed into this one section; '3 machines'
 // with two names visible reads as a bug). One line, largest first, week numbers like the graph.
@@ -36770,7 +36793,7 @@ var SP={data:null,err:'',range:'hours',measure:'usd',open:false,allRows:false};
 var SP_OTHER='#4a5361',SP_NONE='#6b7a8c';   // "other" and a session with no identity color: neutrals, never a hue
 function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
-function spHead(){return '<div class=rsp-top><span>API spend'+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
+function spHead(){return '<div class=rsp-top><span>'+(SP.data&&SP.data.scope==='computed'?'Spend (computed)':'API spend')+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
 +'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
 function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';SP.allRows=false;
 spPanel.innerHTML=spHead()+'<div class=rsp-load>'+__ROMP_LOADER__+'</div>';   // the loader FIRST (the loader rule)
@@ -36820,13 +36843,17 @@ return h+'</tbody></table>';}
 function renderSpend(){if(!spPanel)return;var d=SP.data,h=spHead();
 if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+esc(SP.err):'')+'. '
 +'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
-// 1. the SAME window numbers the hover shows — the fleet sums, rows only (one renderer, two levels)
-var rows=fleetSpendHTML(LAST||[],true);
-h+='<div class=rsp-sec>'+(rows||'<div class=ru-tip-name><span>API spend</span></div><div class=rsp-note>Nothing recorded yet.</div>')+'</div>';
+// 1. the SAME window numbers the hover shows — the sums across every machine, rows only (one renderer)
+var rows=spendRowsHTML(LAST||[]);
+// a login with no key (scope "computed"): the rail shows no API spend for this machine on purpose, and
+// what the ledger holds is a computed cost nobody is billed — said here, not dressed up as a bill
+var computed=d.scope==='computed';
+h+='<div class=rsp-sec>'+(rows||('<div class=ru-tip-name><span>Totals</span></div><div class=rsp-note>'
++(computed?'No API spend on this machine: its sessions run on a login. The figures below are computed costs, not a bill.':'Nothing recorded yet.')+'</div>'))+'</div>';
 // 2. per session — THIS machine's ledger; when other machines join the totals above, say so
 var many=(d.hosts||1)>1;
 h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 this machine only':'')+'</span>'
-+'<span class=ru-tip-reset>'+(d.scope==='keyed'?'key-billed turns':'all turns')+' \u00b7 last '+((d.days&&d.days.keys)?d.days.keys.length:90)+' days</span></div>';
++'<span class=ru-tip-reset>'+(d.scope==='keyed'?'key-billed turns':computed?'computed cost, not billed':'all turns')+' \u00b7 last '+((d.days&&d.days.keys)?d.days.keys.length:90)+' days</span></div>';
 if(many)h+='<div class=rsp-note>Per-session detail covers '+esc(d.host||'this machine')+' only; the other '+(d.hosts-1)+' machine'+(d.hosts>2?'s':'')+' in the totals above do not share theirs yet.</div>';
 h+='<div id=rsp-table>'+sessionTable(d)+'</div></div>';
 // 3. the histogram — the two ranges the ledger itself holds; dollars by default, tokens on a toggle
@@ -36864,9 +36891,10 @@ if(!(mx>0)){box.innerHTML='<div class=rsp-note>Nothing recorded in this range.</
 var top=niceTop(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(1,slot-gap),PADT=6;
 var Y=function(v){return H-Math.max(0,Math.min(1,v/top))*(H-PADT);};
 var fmt=function(v){return meas==='usd'?fmtUsd(v):fmtTok(Math.round(v));};
-// axis labels: whole dollars from $10 up (the readouts' rule); below that a 1-2-5 ceiling's half is
-// a half-dollar, and rounding it away would label two lines with the same number
-var afmt=function(v){if(meas!=='usd')return fmtTok(Math.round(v));return v>=10||v===Math.round(v)?fmtUsd(v):'$'+v.toFixed(1);};
+// axis labels wear whole dollars like every spend surface (no cents anywhere, the user 2026-08-09);
+// a half-line whose value is not a whole dollar (a $5 ceiling's $2.50) stays an unlabeled hairline
+// rather than rounding into a twin of another label
+var afmt=function(v){if(meas!=='usd')return fmtTok(Math.round(v));return v===Math.round(v)?fmtUsd(v):'';};
 // EVERY attribute quoted (review of the first render): this markup goes through innerHTML, i.e. the HTML
 // parser, where an unquoted value swallows the closing slash (`class=rsp-grid/>` is a line with the value
 // "rsp-grid/" left OPEN) and every later element became that line's child — an empty chart
@@ -36876,7 +36904,7 @@ var svg='<svg class="rsp-svg" viewBox="0 0 '+W+' '+H+'" width="'+W+'" height="'+
 // recessive hairline gridlines at thirds + the ceiling, labels overlaid in HTML (the hover graph's grammar)
 var ylab='';[top,top/2].forEach(function(g){var gy=Y(g);
 svg+='<line x1="0" y1="'+gy.toFixed(1)+'" x2="'+W+'" y2="'+gy.toFixed(1)+'" class="rsp-grid"></line>';
-ylab+='<span class=ru-tip-gy style="top:'+(gy+1).toFixed(0)+'px">'+afmt(g)+'</span>';});
+var al=afmt(g);if(al)ylab+='<span class=ru-tip-gy style="top:'+(gy+1).toFixed(0)+'px">'+al+'</span>';});
 // one column per bucket, stacked bottom-up in stack order (top-N by dollars, then other, then
 // unattributed); a 2px surface gap between touching segments; the topmost segment's top corners
 // rounded (4px data-end, square at the baseline) — the dataviz mark specs
@@ -36894,8 +36922,8 @@ svg+='</svg>';
 // daily range → the 1st and 15th. The keys are the KERNEL's local time — named when the viewer's differs.
 var xlab='';for(var i=0;i<n;i++){var k=ser.keys[i],m;
 if(SP.range==='hours'){m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T00$/.exec(k);if(m){var dd=new Date(+m[1],+m[2]-1,+m[3]);
-xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(2)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
-else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(2)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
+xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
+else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
 var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+(s.kind==='sid'&&!s.live?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
 +(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+esc(spStackName(s))+'</span>';}).join('')+'</div>';
 var tzNote='';var mine=-(new Date().getTimezoneOffset());

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29229,6 +29229,160 @@ def _spend_recorded_at():
         return None
 
 
+_DETAIL_TOP_N = 10       # stacks the histogram names; every further session folds into ONE "other" stack
+_DETAIL_DAYS = 90        # the day ledger's own depth (the recorder prunes to 90 days)
+
+
+def _spend_scope():
+    """Which figure the rail shows for THIS host, mirrored for the usage modal so its numbers are the
+    rail's: "total" on a no-login (key-only) machine — every turn there bills the key, and legacy files
+    predate the split — or "keyed" when a login's windows sit beside the key's spend, where only the
+    turns whose session billed the key are dollars anyone pays (_usage's two arms, the user 2026-08-08)."""
+    try:
+        o = json.loads((jd.STATE / "usage.json").read_text())
+    except Exception:
+        o = {}
+    if o.get("apiKey") or not _claude_account():
+        return "total"
+    return "keyed" if _auth_key_present() else "total"
+
+
+def _spend_detail(now=None):
+    """GET /spend/detail — the usage modal's per-SESSION story (T247, the user 2026-09-07, who wanted
+    to click the usage readout and see how much each session used, with a stacked histogram colored
+    by session). Read from spend.json's bySid maps (T100's per-session attribution) — the ledger, never
+    a transcript recount — with names and identity colors resolved HERE from the names registry
+    (sid-keyed, rename-proof; a dead or archived session keeps its last known name and reads dimmed).
+    Two ranges at the ledger's own granularity: the 192 hour buckets and the 90 day buckets, each as
+    dense arrays over the top-N sessions by dollars plus ONE "other" stack and ONE "unattributed"
+    stack — a bucket written before bySid existed, or the part of a bucket no sid accounts for, is
+    shown as such, never dropped or folded into a session (fail loudly). Local ledger only: a remote's
+    row carries no bySid through the relay today, so the payload counts the other machines the fleet
+    totals include and the modal says "this machine only" rather than omitting them silently.
+    Bucket keys are the recorder's LOCAL time; tz/tzOffsetMin let a viewer elsewhere label that."""
+    now = time.time() if now is None else now
+    try:
+        d = json.loads((jd.STATE / "spend.json").read_text())
+    except Exception:
+        d = {}
+    days = d.get("days") if isinstance(d.get("days"), dict) else {}
+    hours = d.get("hours") if isinstance(d.get("hours"), dict) else {}
+    scope = _spend_scope()
+    keyed = scope == "keyed"
+    KINDS = ("tokIn", "tokOut", "tokCacheR", "tokCacheW")
+
+    def _tot(e):
+        """(usd, tok, turns) of a bucket under the scope."""
+        if keyed:
+            e = e.get("key") if isinstance(e.get("key"), dict) else {}
+            return float(e.get("usd") or 0), int(e.get("tok") or 0), int(e.get("turns") or 0)
+        return (float(e.get("usd") or 0), sum(int(e.get(k) or 0) for k in KINDS), int(e.get("turns") or 0))
+
+    def _by(e):
+        """{sid: (usd, tok, turns)} under the scope, or None when the bucket predates attribution."""
+        by = e.get("bySid") if isinstance(e.get("bySid"), dict) else None
+        if by is None:
+            return None
+        out = {}
+        for sid, s in by.items():
+            if not isinstance(s, dict):
+                continue
+            if keyed:
+                s = s.get("key") if isinstance(s.get("key"), dict) else {}
+            out[str(sid)] = (float(s.get("usd") or 0), int(s.get("tok") or 0), int(s.get("turns") or 0))
+        return out
+
+    totals, keyt, un = {}, {}, [0.0, 0, 0]
+    for e in days.values():
+        if not isinstance(e, dict):
+            continue
+        tu, tt, tn = _tot(e)
+        bs = _by(e)
+        if bs is None:
+            un[0] += tu; un[1] += tt; un[2] += tn
+            continue
+        au = at = an = 0
+        for sid, (u, t, n) in bs.items():
+            r = totals.setdefault(sid, [0.0, 0, 0])
+            r[0] += u; r[1] += t; r[2] += n
+            au += u; at += t; an += n
+        if not keyed:
+            # the key-billed sub-count rides beside each session's total: on a mixed host the table
+            # shows the split where the hover would (a login turn's computed cost is dollars nobody pays)
+            for sid, s in e["bySid"].items():
+                k = s.get("key") if isinstance(s, dict) and isinstance(s.get("key"), dict) else None
+                if k:
+                    r = keyt.setdefault(str(sid), [0.0, 0, 0])
+                    r[0] += float(k.get("usd") or 0); r[1] += int(k.get("tok") or 0); r[2] += int(k.get("turns") or 0)
+        un[0] += max(0.0, tu - au); un[1] += max(0, tt - at); un[2] += max(0, tn - an)
+    try:
+        live = set(_live_names(_tmux_sessions()).values())
+    except Exception:
+        live = set()
+    sessions = []
+    for sid, (u, t, n) in totals.items():
+        bg, fg = _identity_of(sid)
+        row = {"sid": sid, "name": _name_of(sid) or "", "bg": bg, "fg": fg, "live": sid in live,
+               "usd": round(u, 4), "tok": t, "turns": n}
+        if sid in keyt:
+            k = keyt[sid]
+            row["key"] = {"usd": round(k[0], 4), "tok": k[1], "turns": k[2]}
+        sessions.append(row)
+    sessions.sort(key=lambda s: (-s["usd"], -s["tok"], s["name"]))
+    top = [s["sid"] for s in sessions[:_DETAIL_TOP_N]]
+    meta = {s["sid"]: s for s in sessions}
+
+    def _series(buckets, keys):
+        idx = {k: i for i, k in enumerate(keys)}
+        n = len(keys)
+        per = {sid: ([0.0] * n, [0] * n) for sid in top}
+        other, una, others = ([0.0] * n, [0] * n), ([0.0] * n, [0] * n), set()
+        for k, e in buckets.items():
+            i = idx.get(k)
+            if i is None or not isinstance(e, dict):
+                continue
+            tu, tt, _ = _tot(e)
+            bs = _by(e)
+            if bs is None:
+                una[0][i] += tu; una[1][i] += tt
+                continue
+            au = at = 0
+            for sid, (u, t, _n) in bs.items():
+                au += u; at += t
+                dst = per.get(sid)
+                if dst is None:
+                    dst = other
+                    others.add(sid)
+                dst[0][i] += u; dst[1][i] += t
+            una[0][i] += max(0.0, tu - au); una[1][i] += max(0, tt - at)
+        stacks = []
+        for sid in top:
+            s = meta[sid]
+            stacks.append({"kind": "sid", "sid": sid, "name": s["name"], "bg": s["bg"], "live": s["live"],
+                           "usd": [round(v, 4) for v in per[sid][0]], "tok": per[sid][1]})
+        if any(other[0]) or any(other[1]):
+            stacks.append({"kind": "other", "name": "other", "count": len(others),
+                           "usd": [round(v, 4) for v in other[0]], "tok": other[1]})
+        if any(una[0]) or any(una[1]):
+            stacks.append({"kind": "unattributed", "name": "unattributed",
+                           "usd": [round(v, 4) for v in una[0]], "tok": una[1]})
+        return {"keys": keys, "stacks": stacks}
+
+    h0 = int(now // 3600) - (_SERIES_HOURS - 1)
+    hour_keys = [time.strftime("%Y-%m-%dT%H", time.localtime((h0 + i) * 3600)) for i in range(_SERIES_HOURS)]
+    today = datetime.fromtimestamp(now).date()
+    day_keys = [(today - timedelta(days=i)).isoformat() for i in range(_DETAIL_DAYS - 1, -1, -1)]
+    with _remotes_lock:
+        up = sum(1 for r in _remotes.values() if r.get("status") == "up" and r.get("usage"))
+    lt = time.localtime(now)
+    return {"host": _self_host(), "hosts": 1 + up, "scope": scope,
+            "tz": time.strftime("%Z", lt), "tzOffsetMin": int((getattr(lt, "tm_gmtoff", 0) or 0) // 60),
+            "windows": _spend_windows(keyed_only=keyed), "recordedAt": _spend_recorded_at(),
+            "topN": _DETAIL_TOP_N, "sessions": sessions,
+            "unattributed": {"usd": round(un[0], 4), "tok": un[1], "turns": un[2]},
+            "hours": _series(hours, hour_keys), "days": _series(days, day_keys)}
+
+
 def _spend_windows(keyed_only=False):
     """API-mode usage windows MIRRORING the subscription bars (the user 2026-08-04, who wanted the two
     auth modes to read identically at a glance): rolling 5h and 7d summed from spend.json's hour
@@ -36173,6 +36327,8 @@ _LANDING_ESC_JS = """
 function onEsc(e){if(e.key!=='Escape')return;
 var closed=false;
 if(window.__rompKeysClose&&window.__rompKeysClose()){closed=true;}
+else{var sp=document.getElementById('rsp-back');
+if(sp&&!sp.hidden&&window.__rompCloseSpend){window.__rompCloseSpend();closed=true;}
 else{var ru=document.getElementById('ru-back');
 if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
 else{var er=document.getElementById('rerr-back');
@@ -36180,7 +36336,7 @@ if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;
 else{var bp=document.getElementById('rbell-back');
 if(bp&&!bp.hidden&&window.__rompCloseBellPop){window.__rompCloseBellPop();closed=true;}
 else{var nt=document.getElementById('rnet-back');
-if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}}
+if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}}}
 if(closed){e.preventDefault();e.stopPropagation();}}
 document.addEventListener('keydown',onEsc,true);
 ['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
@@ -36482,7 +36638,7 @@ return h;}
 // The ONE API-spend section for the whole hover (the user 2026-08-13): every host's windows summed —
 // one shared key is one number — plus the summed $/hour over the last 7 days as an area graph. A host
 // that ships no series (an older kernel) still joins the window sums; the graph adds only contributors.
-function fleetSpendHTML(sets){var sum={},series=null,hosts=0,per=[],legacyN=0;
+function fleetSpendHTML(sets,rowsOnly){var sum={},series=null,hosts=0,per=[],legacyN=0;
 sets.forEach(function(e){var sp=e.det&&e.det._spend;if(!sp)return;hosts++;
 if(sp.week&&typeof sp.week.usd==='number')per.push({host:e.host,usd:sp.week.usd});
 SPEND_WINS.forEach(function(w){var v=sp[w[0]];if(!v)return;
@@ -36505,7 +36661,7 @@ if(!ks.length)return '';
 // above this section and read as the spend's age): the newest contributing host's last-record
 // moment — the recorder writes per turn result, so this is an event time, not a poll time
 var sAt=0;sets.forEach(function(e){var a=e.det&&e.det._spendAt;if(typeof a==='number'&&a>sAt)sAt=a;});
-var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>API spend'+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
+var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>'+(rowsOnly?'Totals':'API spend')+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
 +ks.map(function(k){var v=sum[k];
 // the rolling month's caveats ride its label: a ledger younger than 30 days ("since <date>"), and
 // the machines whose older build could contribute only a calendar month (left out, counted)
@@ -36518,6 +36674,10 @@ var row='<div class=ru-tip-row><span class=ru-tip-k>'+lab+'</span>'
 if(v.split&&(v.tokIn+v.tokOut+v.tokCacheR+v.tokCacheW)>0)row+='<div class="ru-tip-row ru-tip-sub"><span class=ru-tip-k></span>'
 +'<span class=ru-tip-v>'+fmtTok(v.tokCacheR)+' cache read \u00b7 '+fmtTok(v.tokCacheW)+' cache write \u00b7 '+fmtTok(v.tokIn)+' in \u00b7 '+fmtTok(v.tokOut)+' out</span></div>';
 return row;}).join('');
+// rowsOnly: the usage MODAL's first section is THESE SAME window numbers (T247) — the fleet sums the
+// hover shows, one renderer, so the two levels can never disagree; the graph and the machine line
+// stay the hover's (the modal draws its own stacked histogram instead)
+if(rowsOnly)return h+'</div>';
 // every machine in the sum, BY NAME (the user 2026-08-13: a host with no login \u2014 the devbox \u2014 vanished
 // from the hover entirely when the per-host spend rows collapsed into this one section; '3 machines'
 // with two names visible reads as a bug). One line, largest first, week numbers like the graph.
@@ -36598,7 +36758,158 @@ var done=function(){_ruBusy=false;el.style.opacity='';};
 // are computed at render time, so repainting makes "updated/recorded … ago" keep climbing — a dead
 // kernel route shows visibly aging data, never a frozen "3m ago" that quietly lies for hours
 pullFleet().then(done,function(){if(ROWS.length)renderRows(ROWS,SELF);done();});}
-el.addEventListener('click',function(){pull(true);});
+// ── The usage MODAL (T247, the user 2026-09-07): the CLICK on the readout opens the deeper level of
+// the same story — gist (the rail) → hover (per host, the windows) → modal (per SESSION: who spent
+// what, and a histogram of spend over time stacked by session in each session's identity color).
+// Shell-native like #rnet-back: a centered card over the dimmed, unchanged dashboard; Esc (via
+// _LANDING_ESC_JS) and a backdrop tap close it. The data is /spend/detail — names and colors resolved
+// kernel-side, the ledger's bySid series — fetched on open behind the romp loader, never scraped from
+// the hover's HTML. The click still kicks the hover's own refresh (pull), so both levels are fresh.
+var spBack=document.getElementById('rsp-back'),spPanel=document.getElementById('rsp-panel'),spTip=null;
+var SP={data:null,err:'',range:'hours',measure:'usd',open:false,allRows:false};
+var SP_OTHER='#4a5361',SP_NONE='#6b7a8c';   // "other" and a session with no identity color: neutrals, never a hue
+function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
+function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
+function spHead(){return '<div class=rsp-top><span>API spend'+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
++'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
+function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';SP.allRows=false;
+spPanel.innerHTML=spHead()+'<div class=rsp-load>'+__ROMP_LOADER__+'</div>';   // the loader FIRST (the loader rule)
+fetch('/spend/detail',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+.then(function(d){SP.data=d;if(SP.open)renderSpend();},function(e){SP.err=String((e&&e.message)||e);if(SP.open)renderSpend();});}
+function closeSpend(){SP.open=false;if(spBack)spBack.hidden=true;spTipHide();}
+window.__rompCloseSpend=closeSpend;
+window.__rompOpenSpend=openSpend;
+if(spBack)spBack.onclick=function(e){if(e.target===spBack)closeSpend();};
+// ONE listener on the STABLE panel (the click-safety rule): every control is a data-act, acknowledged
+// at once (the pressed state flips before the chart re-renders) — never a handler on a node a render
+// rebuilds. The close ✕ and the retry ride the same door.
+if(spPanel)spPanel.addEventListener('click',function(e){var t=e.target,b=null;
+while(t&&t!==spPanel){if(t.getAttribute&&t.getAttribute('data-act')){b=t;break;}t=t.parentNode;}
+if(!b)return;var a=b.getAttribute('data-act');
+if(a==='close'){closeSpend();return;}
+if(a==='retry'){openSpend();return;}
+if(a==='table:all'){SP.allRows=true;var tb=document.getElementById('rsp-table');if(tb)tb.innerHTML=sessionTable(SP.data);return;}
+var m=/^(range|measure):(\\w+)$/.exec(a);if(!m)return;
+SP[m[1]]=m[2];
+var sib=b.parentNode.querySelectorAll('[data-act^="'+m[1]+':"]');
+for(var i=0;i<sib.length;i++){if(sib[i]===b)sib[i].classList.add('on');else sib[i].classList.remove('on');}
+renderChart();});
+function sessionTable(d){var ss=d.sessions||[],un=d.unattributed;
+if(!ss.length&&!(un&&(un.usd>0||un.tok>0)))return '<div class=rsp-note>No per-session records yet.</div>';
+// the key-billed split shows where the hover would show it: the TOTAL scope on a mixed host, where a
+// session's key dollars differ from its computed total
+var keyCol=d.scope!=='keyed'&&ss.some(function(s){return s.key&&typeof s.key.usd==='number'&&Math.round(s.key.usd)!==Math.round(s.usd);});
+var h='<table class=rsp-tbl><thead><tr><th></th><th>session</th><th class=n>dollars</th>'+(keyCol?'<th class=n>key-billed</th>':'')
++'<th class=n>turns</th><th class=n>tokens</th></tr></thead><tbody>';
+// the table folds to the histogram's own top-N (progressive disclosure: the chart stays in view under
+// a long roster); one click shows every session
+var lim=(SP.allRows||ss.length<=(d.topN||10)+2)?ss.length:(d.topN||10),shown=ss.slice(0,lim);
+shown.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'><td><i class=rsp-sw style="background:'+spColor(s)+'"></i></td>'
++'<td class=rsp-name>'+esc(spName(s))+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
++'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
++'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
+if(lim<ss.length){var rest=ss.slice(lim),ru=0,rt=0,rn=0;rest.forEach(function(s){ru+=s.usd||0;rt+=s.tok||0;rn+=s.turns||0;});
+h+='<tr class=rsp-dead><td><i class=rsp-sw style="background:'+SP_OTHER+'"></i></td><td class=rsp-name>'+rest.length+' more session'+(rest.length===1?'':'s')
++' <button class=rsp-btn data-act=table:all>show all</button></td><td class=n>'+fmtUsd(ru)+'</td>'+(keyCol?'<td class=n></td>':'')+'<td class=n>'+rn+'</td><td class=n>'+fmtTok(rt)+'</td></tr>';}
+// spend recorded before per-session attribution existed (T100, 2026-08-24), or the part of a bucket no
+// session accounts for: shown as its own row, never dropped or folded into a session (fail loudly)
+if(un&&(un.usd>0||un.tok>0))h+='<tr class=rsp-dead><td><i class="rsp-sw rsp-hatch"></i></td>'
++'<td class=rsp-name>unattributed<span class=ru-tip-reset> \u00b7 recorded before per-session tracking</span></td>'
++'<td class=n>'+fmtUsd(un.usd)+'</td>'+(keyCol?'<td class=n>\u2014</td>':'')+'<td class=n>'+(un.turns||0)+'</td><td class=n>'+fmtTok(un.tok||0)+'</td></tr>';
+return h+'</tbody></table>';}
+function renderSpend(){if(!spPanel)return;var d=SP.data,h=spHead();
+if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+esc(SP.err):'')+'. '
++'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
+// 1. the SAME window numbers the hover shows — the fleet sums, rows only (one renderer, two levels)
+var rows=fleetSpendHTML(LAST||[],true);
+h+='<div class=rsp-sec>'+(rows||'<div class=ru-tip-name><span>API spend</span></div><div class=rsp-note>Nothing recorded yet.</div>')+'</div>';
+// 2. per session — THIS machine's ledger; when other machines join the totals above, say so
+var many=(d.hosts||1)>1;
+h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 this machine only':'')+'</span>'
++'<span class=ru-tip-reset>'+(d.scope==='keyed'?'key-billed turns':'all turns')+' \u00b7 last '+((d.days&&d.days.keys)?d.days.keys.length:90)+' days</span></div>';
+if(many)h+='<div class=rsp-note>Per-session detail covers '+esc(d.host||'this machine')+' only; the other '+(d.hosts-1)+' machine'+(d.hosts>2?'s':'')+' in the totals above do not share theirs yet.</div>';
+h+='<div id=rsp-table>'+sessionTable(d)+'</div></div>';
+// 3. the histogram — the two ranges the ledger itself holds; dollars by default, tokens on a toggle
+h+='<div class=rsp-sec><div class=ru-tip-name><span>Spend over time</span></div>'
++'<div class=rsp-ctl>'
++'<button class="rsp-btn'+(SP.range==='hours'?' on':'')+'" data-act=range:hours>8 days \u00b7 by hour</button>'
++'<button class="rsp-btn'+(SP.range==='days'?' on':'')+'" data-act=range:days>90 days \u00b7 by day</button>'
++'<span class=rsp-gap></span>'
++'<button class="rsp-btn'+(SP.measure==='usd'?' on':'')+'" data-act=measure:usd>dollars</button>'
++'<button class="rsp-btn'+(SP.measure==='tok'?' on':'')+'" data-act=measure:tok>tokens</button>'
++'</div><div id=rsp-chart></div></div>';
+spPanel.innerHTML=h;renderChart();}
+// 1-2-5 ceilings: the y-axis top is the nearest clean number above the tallest bucket
+function niceTop(mx){if(!(mx>0))return 1;var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),f=mx/p;return (f<=1?1:f<=2?2:f<=5?5:10)*p;}
+function spFill(s){return s.kind==='unattributed'?'url(#rsp-hatch)':s.kind==='other'?SP_OTHER:spColor(s);}
+function spStackName(s){return s.kind==='other'?('other ('+(s.count||0)+' session'+(s.count===1?'':'s')+')'):s.kind==='unattributed'?'unattributed':spName(s);}
+function spTipShow(x,y,name,val,sub){if(!spTip){spTip=document.createElement('div');spTip.id='rsp-tip';document.body.appendChild(spTip);}
+// values lead, labels follow; built with textContent — a session name is user data
+spTip.textContent='';var b=document.createElement('b');b.textContent=val;spTip.appendChild(b);
+spTip.appendChild(document.createTextNode(' \u00b7 '+name+' \u00b7 '+sub));
+spTip.style.display='block';
+var w=spTip.offsetWidth,hh=spTip.offsetHeight;
+spTip.style.left=Math.max(6,Math.min(window.innerWidth-w-6,x+12))+'px';
+spTip.style.top=Math.max(6,(y-hh-12))+'px';}
+function spTipHide(){if(spTip)spTip.style.display='none';}
+function spBucketLabel(k,range){if(range==='hours'){var m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T(\\d\\d)$/.exec(k);
+return m?(Number(m[2])+'/'+Number(m[3])+' '+m[4]+':00\u2013'+(('0'+((Number(m[4])+1)%24)).slice(-2))+':00'):k;}
+var n=/^(\\d{4})-(\\d\\d)-(\\d\\d)$/.exec(k);return n?(Number(n[2])+'/'+Number(n[3])):k;}
+function renderChart(){var box=document.getElementById('rsp-chart');if(!box||!SP.data)return;
+var d=SP.data,ser=d[SP.range],meas=SP.measure;
+if(!ser||!ser.keys||!ser.keys.length){box.innerHTML='<div class=rsp-note>No history yet.</div>';return;}
+var stacks=ser.stacks||[],n=ser.keys.length,W=Math.max(320,box.clientWidth||600),H=200;
+var tots=[],mx=0;for(var i=0;i<n;i++){var t=0;for(var s=0;s<stacks.length;s++){t+=(stacks[s][meas]&&stacks[s][meas][i])||0;}tots.push(t);if(t>mx)mx=t;}
+if(!(mx>0)){box.innerHTML='<div class=rsp-note>Nothing recorded in this range.</div>';return;}
+var top=niceTop(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(1,slot-gap),PADT=6;
+var Y=function(v){return H-Math.max(0,Math.min(1,v/top))*(H-PADT);};
+var fmt=function(v){return meas==='usd'?fmtUsd(v):fmtTok(Math.round(v));};
+// axis labels: whole dollars from $10 up (the readouts' rule); below that a 1-2-5 ceiling's half is
+// a half-dollar, and rounding it away would label two lines with the same number
+var afmt=function(v){if(meas!=='usd')return fmtTok(Math.round(v));return v>=10||v===Math.round(v)?fmtUsd(v):'$'+v.toFixed(1);};
+// EVERY attribute quoted (review of the first render): this markup goes through innerHTML, i.e. the HTML
+// parser, where an unquoted value swallows the closing slash (`class=rsp-grid/>` is a line with the value
+// "rsp-grid/" left OPEN) and every later element became that line's child — an empty chart
+var svg='<svg class="rsp-svg" viewBox="0 0 '+W+' '+H+'" width="'+W+'" height="'+H+'">'
++'<defs><pattern id="rsp-hatch" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">'
++'<rect width="6" height="6" fill="rgba(138,151,166,0.18)"></rect><line x1="0" y1="0" x2="0" y2="6" stroke="#8a97a6" stroke-width="1.5"></line></pattern></defs>';
+// recessive hairline gridlines at thirds + the ceiling, labels overlaid in HTML (the hover graph's grammar)
+var ylab='';[top,top/2].forEach(function(g){var gy=Y(g);
+svg+='<line x1="0" y1="'+gy.toFixed(1)+'" x2="'+W+'" y2="'+gy.toFixed(1)+'" class="rsp-grid"></line>';
+ylab+='<span class=ru-tip-gy style="top:'+(gy+1).toFixed(0)+'px">'+afmt(g)+'</span>';});
+// one column per bucket, stacked bottom-up in stack order (top-N by dollars, then other, then
+// unattributed); a 2px surface gap between touching segments; the topmost segment's top corners
+// rounded (4px data-end, square at the baseline) — the dataviz mark specs
+for(var i=0;i<n;i++){if(!(tots[i]>0))continue;var x=i*slot+gap/2,segs=[];
+for(var s=0;s<stacks.length;s++){var v=(stacks[s][meas]&&stacks[s][meas][i])||0;if(v>0)segs.push([s,v]);}
+var acc=0;for(var j=0;j<segs.length;j++){var si=segs[j][0],v=segs[j][1],yb=Y(acc),yt=Y(acc+v);acc+=v;
+var last=(j===segs.length-1),y0=yt+(last?0:1),y1=yb-(j===0?0:1),hgt=y1-y0;if(hgt<0.6){y0=y1-0.6;hgt=0.6;}
+var r=Math.min(4,bw/2,hgt);var dpath;
+if(last&&r>=1.5){dpath='M'+x.toFixed(1)+','+y1.toFixed(1)+' L'+x.toFixed(1)+','+(y0+r).toFixed(1)+' Q'+x.toFixed(1)+','+y0.toFixed(1)+' '+(x+r).toFixed(1)+','+y0.toFixed(1)
++' L'+(x+bw-r).toFixed(1)+','+y0.toFixed(1)+' Q'+(x+bw).toFixed(1)+','+y0.toFixed(1)+' '+(x+bw).toFixed(1)+','+(y0+r).toFixed(1)+' L'+(x+bw).toFixed(1)+','+y1.toFixed(1)+' Z';}
+else{dpath='M'+x.toFixed(1)+','+y0.toFixed(1)+' h'+bw.toFixed(1)+' v'+hgt.toFixed(1)+' h-'+bw.toFixed(1)+' Z';}
+svg+='<path class="rsp-seg" d="'+dpath+'" fill="'+spFill(stacks[si])+'" data-i="'+i+'" data-s="'+si+'"></path>';}}
+svg+='</svg>';
+// x labels: hourly range → weekday initials at the ledger's local midnights (the hover graph's rule);
+// daily range → the 1st and 15th. The keys are the KERNEL's local time — named when the viewer's differs.
+var xlab='';for(var i=0;i<n;i++){var k=ser.keys[i],m;
+if(SP.range==='hours'){m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T00$/.exec(k);if(m){var dd=new Date(+m[1],+m[2]-1,+m[3]);
+xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(2)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
+else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(2)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
+var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+(s.kind==='sid'&&!s.live?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
++(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+esc(spStackName(s))+'</span>';}).join('')+'</div>';
+var tzNote='';var mine=-(new Date().getTimezoneOffset());
+if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote='<div class=rsp-note>Bucket times are '+esc(d.tz||'the kernel\u2019s clock')+' (the machine that recorded them), not your local time.</div>';
+box.innerHTML=svg+ylab+'<div class=ru-tip-gx>'+xlab+'</div>'+leg+tzNote;
+// the per-segment hover: session · value · bucket, the mark itself the hit target
+var svgEl=box.querySelector('svg');if(!svgEl)return;
+svgEl.onpointermove=function(e){var t=e.target;if(!t||!t.classList||!t.classList.contains('rsp-seg')){spTipHide();return;}
+var i=+t.getAttribute('data-i'),si=+t.getAttribute('data-s'),s=stacks[si];if(!s)return;
+var v=(s[meas]&&s[meas][i])||0,o=(s[meas==='usd'?'tok':'usd']&&s[meas==='usd'?'tok':'usd'][i])||0;
+spTipShow(e.clientX,e.clientY,spStackName(s),fmt(v),(meas==='usd'?fmtTok(Math.round(o))+' tok':fmtUsd(o))+' \u00b7 '+spBucketLabel(ser.keys[i],SP.range));};
+svgEl.onpointerleave=spTipHide;}
+window.addEventListener('resize',function(){if(SP.open&&SP.data)renderChart();});
+el.addEventListener('click',function(){pull(true);openSpend();});
 setInterval(function(){pull(false);},60000);     // backup auto-refresh: re-read usage.json every 60s
 pull(false);                                     // fill on load, independent of the timeline-forward path
 // (The old vertical-fit degrade ladder (fitRail/data-ruc, the user 2026-06-27/07-01) is gone: it shrank the
@@ -38366,6 +38677,45 @@ def _landing():
             # anywhere over it closes the modal (see _LANDING_USAGE_JS). Faint dim so it reads as tap-to-close.
             "#ru-back{position:fixed;inset:0;z-index:290;display:none;background:rgba(0,0,0,0.4)}"
             "#ru-back.on{display:block}"
+            # ── the usage MODAL (T247): one treatment with #rnet-back (the panel rule) — a centered card
+            # over rgba(0,0,0,0.55), the dashboard behind it untouched. Sizes reused from the hover
+            # (11px body, 10px annotations, 8px axis labels) and the net panel's card + 14px header —
+            # no new font size. Data colors are the sessions' identity colors; the accent is chrome only
+            # (the pressed toggle), never a data or status color.
+            "#rsp-back{position:fixed;inset:0;z-index:205;display:flex;align-items:center;justify-content:center;"
+            "background:rgba(0,0,0,0.55)}#rsp-back[hidden]{display:none}"
+            "#rsp-panel{width:min(880px,94%);max-height:92vh;overflow:auto;background:#252526;border:1px solid #3a3a3a;"
+            "border-radius:10px;box-shadow:0 12px 36px #000000aa;padding:16px 20px;color:#cfd6dd;"
+            "font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;line-height:1.4}"
+            ".rsp-top{display:flex;align-items:center;gap:8px;font-size:14px;font-weight:600;color:#e8eaed;"
+            "margin:0 0 12px;padding-bottom:10px;border-bottom:1px solid #34343a}.rsp-top span{flex:1 1 auto}"
+            ".rsp-x{background:none;border:none;color:#9aa0a6;font-size:16px;line-height:1;cursor:pointer;padding:0 2px}"
+            ".rsp-x:hover{color:#fff}"
+            ".rsp-sec{margin-top:14px}.rsp-sec:first-of-type{margin-top:0}"
+            ".rsp-note{opacity:.6;font-size:10px;margin:4px 0 6px}"
+            ".rsp-err{color:#f2b8b5;margin:10px 0}"
+            ".rsp-load{display:flex;justify-content:center;padding:40px 0}"
+            ".rsp-tbl{width:100%;border-collapse:collapse;margin-top:4px}"
+            ".rsp-tbl th{text-align:left;font-weight:400;opacity:.55;padding:2px 6px 4px 0;border-bottom:1px solid rgba(255,255,255,0.08)}"
+            ".rsp-tbl td{padding:3px 6px 3px 0;border-bottom:1px solid rgba(255,255,255,0.05);white-space:nowrap}"
+            ".rsp-tbl .n{text-align:right;font-variant-numeric:tabular-nums}"
+            ".rsp-tbl td.rsp-name{width:100%;max-width:0;overflow:hidden;text-overflow:ellipsis}"
+            ".rsp-dead{opacity:.55}"   # a session no longer running keeps its last known name, dimmed
+            ".rsp-sw{display:inline-block;width:10px;height:10px;border-radius:3px;vertical-align:-1px;background:#6b7a8c}"
+            # unattributed spend wears a TEXTURE, not a hue: it is not a session, and texture is the
+            # dataviz fallback for a class that must never be confused with one
+            ".rsp-hatch{background:repeating-linear-gradient(45deg,rgba(138,151,166,0.9) 0 1.5px,rgba(138,151,166,0.18) 1.5px 5px)}"
+            ".rsp-ctl{display:flex;align-items:center;gap:4px;margin:6px 0 8px}.rsp-gap{flex:0 0 12px}"
+            ".rsp-btn{background:none;border:1px solid rgba(255,255,255,0.14);border-radius:5px;color:#cfd6dd;font:inherit;"
+            "padding:2px 8px;cursor:pointer}"
+            ".rsp-btn.on{background:var(--accent,#9cd2ff);color:var(--accent-fg,#0c1a2e);border-color:transparent}"
+            "#rsp-chart{position:relative}.rsp-svg{display:block;width:100%;background:rgba(255,255,255,0.04);border-radius:3px}"
+            ".rsp-grid{stroke:rgba(255,255,255,0.10);stroke-width:1}"
+            ".rsp-seg{cursor:pointer}.rsp-seg:hover{filter:brightness(1.18)}"
+            ".rsp-leg{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:6px}.rsp-chip{display:inline-flex;align-items:center;gap:5px}"
+            "#rsp-tip{position:fixed;z-index:310;pointer-events:none;display:none;background:#1e1e1e;border:1px solid #3a3a3a;"
+            "border-radius:6px;padding:5px 8px;color:#cfd6dd;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
+            "box-shadow:0 5px 18px rgba(0,0,0,0.45)}#rsp-tip b{color:#e8eef5;font-weight:700}"
             "#ru-tip{position:fixed;z-index:300;background:#1e1e1e;border:1px solid #3a3a3a;border-radius:7px;"
             "padding:8px 10px;font:500 11px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
@@ -38655,6 +39005,17 @@ def _landing():
             "box-shadow:0 12px 36px rgba(31,26,20,0.18)}"
             "body.theme-light #ru-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 5px 18px rgba(31,26,20,0.18)}"
+            # the usage modal's light steps (T247): same card + hairlines as the other light panels;
+            # the data colors are the sessions' own and do not flip
+            "body.theme-light #rsp-panel{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
+            "box-shadow:0 12px 36px rgba(31,26,20,0.18)}"
+            "body.theme-light .rsp-top{color:#1F1E1D;border-bottom-color:rgba(0,0,0,0.10)}"
+            "body.theme-light .rsp-x{color:#5D574E}body.theme-light .rsp-x:hover{color:#1F1E1D}"
+            "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
+            "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
+            "body.theme-light .rsp-svg{background:rgba(0,0,0,0.04)}body.theme-light .rsp-grid{stroke:rgba(0,0,0,0.10)}"
+            "body.theme-light #rsp-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
+            "box-shadow:0 5px 18px rgba(31,26,20,0.18)}body.theme-light #rsp-tip b{color:#1F1E1D}"
             "body.theme-light .ru-tip-name{color:#1F1E1D}"
             "body.theme-light .ru-name{color:#5D574E}"
             "body.theme-light .ru-pct{color:#1F1E1D}"
@@ -38812,6 +39173,10 @@ def _landing():
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings data-keycmd=settings.open aria-label=Settings title=Settings>⛭</button>"
             "</nav>"
+            # the usage MODAL (T247): the click on the rail's readout opens the per-session breakdown +
+            # stacked histogram here — shell-native like #rnet-back, a centered card over the dimmed,
+            # unchanged dashboard (filled by _LANDING_USAGE_JS on open; Esc + backdrop tap close it).
+            "<div id=rsp-back hidden><div id=rsp-panel role=dialog aria-label=\"API spend\"></div></div>"
             # the rail's network popover — manage federated remote kernels (driven by _LANDING_REMOTES_JS).
             "<div id=rnet-back hidden><div id=rnet-panel>"
             "<div class=rnet-top><span>Remote kernels</span><button id=rnet-x aria-label=Close>×</button></div>"
@@ -38889,7 +39254,7 @@ def _landing():
             # 2026-07-28). Loaded BEFORE the errs script, which reads it (with a dim fallback if absent).
             + ("<script src=/dist/age-color-global.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
-            "<script>" + _LANDING_USAGE_JS + "</script>"
+            "<script>" + _LANDING_USAGE_JS.replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"
             "<script>" + _LANDING_ESC_JS + "</script>"
@@ -39551,6 +39916,11 @@ class Handler(BaseHTTPRequestHandler):
                     pass
                 return self._send(200, json.dumps({"rows": _fleet_usage(), "host": _self_host()}),
                                   "application/json", cache="no-cache")
+            if p == "/spend/detail":                          # the usage MODAL's per-session breakdown (T247):
+                # who spent what and spend over time stacked by session, read from the ledger's bySid
+                # maps with names + colors resolved kernel-side — the same read class as /usage, and
+                # the shell fetches it on open rather than scraping the hover's HTML.
+                return self._send(200, json.dumps(_spend_detail()), "application/json", cache="no-cache")
             if p == "/mcp":                                   # the MCP panel's data (the user 2026-08-05): `/mcp`
                 # in a romp session hits the CLI's INTERACTIVE panel, which an SDK session can't render — it
                 # just says "use a terminal". These are the SAME facts via the SDK's designed control request

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29371,6 +29371,8 @@ def _spend_detail(now=None):
             una[0][i] += max(0.0, tu - au); una[1][i] += max(0, tt - at)
         stacks = []
         for sid in top:
+            if not (any(per[sid][0]) or any(per[sid][1])):
+                continue          # a top-N session with nothing in THIS range: no empty stack, no legend chip (review find)
             s = meta[sid]
             stacks.append({"kind": "sid", "sid": sid, "name": s["name"], "bg": s["bg"], "live": s["live"],
                            "usd": [round(v, 4) for v in per[sid][0]], "tok": per[sid][1]})
@@ -36577,7 +36579,9 @@ el.innerHTML=aggBarsHTML(LAST)+apiCellHTML(LAST);
 // the rail. The mobile modal keeps its own pull-then-open path (openIt).
 if(tip.style.display==='block'&&!tip.classList.contains('ru-modal')){var th=tipHTML();
 if(th){tip.innerHTML=th;var rr=el.getBoundingClientRect();
-tip.style.top=Math.max(6,rr.top-tip.offsetHeight-8)+'px';}}}
+tip.style.top=Math.max(6,rr.top-tip.offsetHeight-8)+'px';}}
+// the spend modal's Totals section is these same rows: an open modal follows every landing too (T247)
+if(typeof SP!=='undefined'&&SP.open&&SP.data){var ts=document.getElementById('rsp-totals');if(ts)ts.innerHTML=totalsHTML(SP.data);}}
 // The single-payload path the timeline still posts (and the mobile panel's own fetch): treat it as this
 // machine's row, leaving any other account's bars alone.
 function render(u){notices(u);
@@ -36748,10 +36752,14 @@ tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
 // Pulls fresh first so the numbers aren't a stale boot snapshot; any tap or Escape dismisses.
 window.__rompUsagePanel=function(){
 function openIt(){var h=tipHTML();if(!h)return;
-tip.innerHTML=h;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.display='block';
+// the deeper level is one tap away here too (T247): the rail — and its click — do not exist on a
+// phone, and a compact view must never dead-end (progressive disclosure)
+tip.innerHTML=h+'<div class=ru-tip-age><button class=rsp-btn id=ru-bysession>By session \u2192</button></div>';
+tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.display='block';
 back.classList.add('on');
 var off=function(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');
 window.__rompUsageClose=null;};
+var bs=document.getElementById('ru-bysession');if(bs)bs.onclick=function(e){e.stopPropagation();off();openSpend();};
 // Escape lands via _LANDING_ESC_JS (shell AND pane documents — the shell-only listener this modal
 // used to bind was deaf whenever focus sat inside a pane iframe); the backdrop tap stays.
 window.__rompUsageClose=off;
@@ -36802,7 +36810,12 @@ fetch('/spend/detail',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Er
 function closeSpend(){SP.open=false;if(spBack)spBack.hidden=true;spTipHide();}
 window.__rompCloseSpend=closeSpend;
 window.__rompOpenSpend=openSpend;
-if(spBack)spBack.onclick=function(e){if(e.target===spBack)closeSpend();};
+// a click whose press and release land on different elements is dispatched at their common
+// ancestor — the backdrop — so a drag-select of table figures that ends outside the card read as a
+// tap and closed the modal (review find). The press must have begun on the backdrop too.
+var spDown=false;
+if(spBack){spBack.onpointerdown=function(e){spDown=(e.target===spBack);};
+spBack.onclick=function(e){var d=spDown;spDown=false;if(e.target===spBack&&d)closeSpend();};}
 // ONE listener on the STABLE panel (the click-safety rule): every control is a data-act, acknowledged
 // at once (the pressed state flips before the chart re-renders) — never a handler on a node a render
 // rebuilds. The close ✕ and the retry ride the same door.
@@ -36840,16 +36853,20 @@ if(un&&(un.usd>0||un.tok>0))h+='<tr class=rsp-dead><td><i class="rsp-sw rsp-hatc
 +'<td class=rsp-name>unattributed<span class=ru-tip-reset> \u00b7 recorded before per-session tracking</span></td>'
 +'<td class=n>'+fmtUsd(un.usd)+'</td>'+(keyCol?'<td class=n>\u2014</td>':'')+'<td class=n>'+(un.turns||0)+'</td><td class=n>'+fmtTok(un.tok||0)+'</td></tr>';
 return h+'</tbody></table>';}
-function renderSpend(){if(!spPanel)return;var d=SP.data,h=spHead();
-if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+esc(SP.err):'')+'. '
-+'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
-// 1. the SAME window numbers the hover shows — the sums across every machine, rows only (one renderer)
-var rows=spendRowsHTML(LAST||[]);
+// 1. the SAME window numbers the hover shows — the sums across every machine, rows only (one renderer).
+// Its own node: renderRows re-renders it whenever fresh rows land while the modal is open, so the
+// two levels agree at every moment, not only at the instant the modal opened (review find)
+function totalsHTML(d){var rows=spendRowsHTML(LAST||[]);
 // a login with no key (scope "computed"): the rail shows no API spend for this machine on purpose, and
 // what the ledger holds is a computed cost nobody is billed — said here, not dressed up as a bill
 var computed=d.scope==='computed';
-h+='<div class=rsp-sec>'+(rows||('<div class=ru-tip-name><span>Totals</span></div><div class=rsp-note>'
-+(computed?'No API spend on this machine: its sessions run on a login. The figures below are computed costs, not a bill.':'Nothing recorded yet.')+'</div>'))+'</div>';
+return rows||('<div class=ru-tip-name><span>Totals</span></div><div class=rsp-note>'
++(computed?'No API spend on this machine: its sessions run on a login. The figures below are computed costs, not a bill.':'Nothing recorded yet.')+'</div>');}
+function renderSpend(){if(!spPanel)return;var d=SP.data,h=spHead();
+if(!d){h+='<div class=rsp-err>Couldn\u2019t load the spend detail'+(SP.err?': '+esc(SP.err):'')+'. '
++'<button class=rsp-btn data-act=retry>Try again</button></div>';spPanel.innerHTML=h;return;}
+var computed=d.scope==='computed';
+h+='<div class=rsp-sec id=rsp-totals>'+totalsHTML(d)+'</div>';
 // 2. per session — THIS machine's ledger; when other machines join the totals above, say so
 var many=(d.hosts||1)>1;
 h+='<div class=rsp-sec><div class=ru-tip-name><span>By session'+(many?' \u00b7 this machine only':'')+'</span>'
@@ -39041,6 +39058,7 @@ def _landing():
             "body.theme-light .rsp-x{color:#5D574E}body.theme-light .rsp-x:hover{color:#1F1E1D}"
             "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
             "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
+            "body.theme-light .rsp-err{color:#9A3324}"   # the dark-only pink read 1.7:1 on the white card (review find)
             "body.theme-light .rsp-svg{background:rgba(0,0,0,0.04)}body.theme-light .rsp-grid{stroke:rgba(0,0,0,0.10)}"
             "body.theme-light #rsp-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"
             "box-shadow:0 5px 18px rgba(31,26,20,0.18)}body.theme-light #rsp-tip b{color:#1F1E1D}"

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -1,0 +1,84 @@
+// Drives the served landing page (tests/test_spend_modal_headless.py serves it) with playwright:
+// click the usage readout → the spend modal opens over the dimmed dashboard, renders the per-session
+// table + the stacked histogram with its unattributed stack, the toggles re-render, a segment hover
+// shows the tooltip, Escape closes it. Prints one JSON line of observations; screenshots when asked.
+const { chromium } = require('playwright');
+(async () => {
+  const url = process.argv[2], shots = process.argv[3] || '';
+  const b = await chromium.launch();
+  const pg = await b.newPage({ viewport: { width: 1280, height: 820 } });
+  const errs = [];
+  pg.on('pageerror', (e) => errs.push(String(e)));
+  await pg.goto(url);
+  await pg.waitForSelector('#rail-usage', { timeout: 20000 });
+  await pg.evaluate(() => { const bt = document.getElementById('romp-boot'); if (bt) bt.remove(); });
+  await pg.waitForFunction(() => document.getElementById('rail-usage').children.length > 0, null, { timeout: 20000 });
+  const hiddenBefore = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
+  await pg.evaluate(() => document.getElementById('rail-usage').click());
+  await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden, null, { timeout: 5000 });
+  const loaderSeen = await pg.evaluate(() => !!document.querySelector('#rsp-panel .rsp-load, #rsp-panel .rsp-tbl'));
+  await pg.waitForSelector('#rsp-panel .rsp-tbl', { timeout: 15000 });
+  await pg.waitForSelector('#rsp-chart .rsp-svg', { timeout: 15000 });
+  const out = await pg.evaluate(() => ({
+    head: document.querySelector('#rsp-panel .rsp-top span').textContent,
+    legend: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent),
+    rows: Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent),
+    deadRows: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr.rsp-dead').length,
+    segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
+    hatched: document.querySelectorAll('#rsp-chart .rsp-seg[fill="url(#rsp-hatch)"]').length,
+    backdrop: getComputedStyle(document.getElementById('rsp-back')).backgroundColor,
+    windows: Array.from(document.querySelectorAll('#rsp-panel .ru-tip-fleetspend .ru-tip-row .ru-tip-k')).map((e) => e.textContent),
+    xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent).join(''),
+    ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
+    railOpacity: getComputedStyle(document.getElementById('rail-usage')).opacity,
+  }));
+  if (shots) { await pg.screenshot({ path: shots + '-dark.png' }); const ch = await pg.$('#rsp-chart'); if (ch) await ch.screenshot({ path: shots + '-chart.png' }); }
+  const foldBefore = await pg.evaluate(() => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length);
+  const foldBtn = await pg.$('#rsp-panel [data-act="table:all"]');
+  if (foldBtn) { await foldBtn.click(); await pg.waitForFunction((n) => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length > n, foldBefore, { timeout: 5000 }); }
+  const foldAfter = await pg.evaluate(() => document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr').length);
+  await pg.click('#rsp-panel [data-act="measure:tok"]');
+  await pg.click('#rsp-panel [data-act="range:days"]');
+  await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:days"]').classList.contains('on')
+    && document.querySelector('#rsp-panel [data-act="measure:tok"]').classList.contains('on'), null, { timeout: 5000 });
+  const days = await pg.evaluate(() => ({
+    legend: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent),
+    segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
+    ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
+    xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent),
+  }));
+  // hover the TALLEST segment (a sliver has no reliable hit box); measured in the page, scrolled into view
+  const bb = await pg.evaluate(() => {
+    let best = null;
+    document.querySelectorAll('#rsp-chart .rsp-seg').forEach((el) => {
+      const r = el.getBoundingClientRect();
+      if (!best || r.height > best.height) best = { x: r.x, y: r.y, width: r.width, height: r.height, d: el.getAttribute('d') };
+    });
+    if (best) { const svg = document.querySelector('#rsp-chart svg'); svg.scrollIntoView({ block: 'center' }); const r2 = document.querySelector('#rsp-chart .rsp-seg'); }
+    return best;
+  });
+  if (!bb || !(bb.height > 0)) throw new Error('no measurable segment: ' + JSON.stringify(bb));
+  const bb2 = await pg.evaluate((d) => { const el = Array.from(document.querySelectorAll('#rsp-chart .rsp-seg')).find((e) => e.getAttribute('d') === d); const r = el.getBoundingClientRect(); return { x: r.x, y: r.y, width: r.width, height: r.height }; }, bb.d);
+  await pg.mouse.move(bb2.x + bb2.width / 2, bb2.y + bb2.height / 2);
+  await pg.waitForFunction(() => { const t = document.getElementById('rsp-tip'); return t && t.style.display === 'block'; }, null, { timeout: 5000 });
+  const tip = await pg.evaluate(() => document.getElementById('rsp-tip').textContent);
+  if (shots) await pg.screenshot({ path: shots + '-days-tokens.png' });
+  await pg.mouse.move(5, 5);
+  if (shots) {
+    await pg.click('#rsp-panel [data-act="measure:usd"]');
+    await pg.click('#rsp-panel [data-act="range:hours"]');
+    await pg.evaluate(() => document.body.classList.add('theme-light'));
+    await pg.waitForTimeout(150);
+    await pg.screenshot({ path: shots + '-light.png' });
+    await pg.evaluate(() => document.body.classList.remove('theme-light'));
+  }
+  await pg.keyboard.press('Escape');
+  const hiddenAfter = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
+  // reopen by click, close by backdrop tap
+  await pg.evaluate(() => document.getElementById('rail-usage').click());
+  await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden, null, { timeout: 5000 });
+  await pg.mouse.click(8, 8);
+  const hiddenAfterTap = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
+  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, foldBefore, foldAfter, errs }));
+  await b.close();
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -79,6 +79,33 @@ const { chromium } = require('playwright');
   await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden, null, { timeout: 5000 });
   await pg.mouse.click(8, 8);
   const hiddenAfterTap = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
-  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, foldBefore, foldAfter, errs }));
+  // a drag-select from a table cell that ends over the backdrop is not a tap
+  await pg.evaluate(() => document.getElementById('rail-usage').click());
+  await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden && document.querySelector('#rsp-panel .rsp-tbl td.n'), null, { timeout: 5000 });
+  const cell = await (await pg.$('#rsp-panel .rsp-tbl td.n')).boundingBox();
+  await pg.mouse.move(cell.x + 2, cell.y + cell.height / 2); await pg.mouse.down(); await pg.mouse.move(5, 5, { steps: 4 }); await pg.mouse.up();
+  const hiddenAfterDrag = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
+  // the light theme's error line, over a failed fetch
+  const lightErr = await pg.evaluate(async () => {
+    document.body.classList.add('theme-light');
+    const f = window.fetch; window.fetch = () => Promise.reject(new Error('boom'));
+    try { window.__rompOpenSpend(); await new Promise((r) => setTimeout(r, 200)); return getComputedStyle(document.querySelector('#rsp-panel .rsp-err')).color; }
+    finally { window.fetch = f; document.body.classList.remove('theme-light'); }
+  });
+  await pg.keyboard.press('Escape');
+  // the phone: no rail; the Usage panel's button is the door
+  await pg.setViewportSize({ width: 390, height: 844 });
+  await pg.reload(); await pg.waitForSelector('#mtabs [data-act="usage"]', { timeout: 20000 });
+  await pg.evaluate(() => { const bt = document.getElementById('romp-boot'); if (bt) bt.remove(); });
+  const mobile = await pg.evaluate(async () => {
+    const railHidden = getComputedStyle(document.querySelector('.pane-rail')).display === 'none';
+    window.__rompUsagePanel();
+    for (let i = 0; i < 50 && !document.getElementById('ru-bysession'); i++) await new Promise((r) => setTimeout(r, 100));
+    const panelOpened = !!document.getElementById('ru-bysession') && document.getElementById('ru-back').classList.contains('on');
+    if (panelOpened) document.getElementById('ru-bysession').click();
+    const modalOpened = !document.getElementById('rsp-back').hidden && !document.getElementById('ru-back').classList.contains('on');
+    return { railHidden, panelOpened, modalOpened };
+  });
+  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, mobile, foldBefore, foldAfter, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -123,7 +123,7 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(web["turns"], 48 * 40)
         self.assertEqual(api["tok"], 96000 * 40)
         self.assertEqual(d["topN"], km._DETAIL_TOP_N)
-        self.assertIn("windows", d)
+        self.assertNotIn("windows", d, "the modal's window rows are the hover's own (no second parse, no dead payload)")
         self.assertEqual(d["tzOffsetMin"], int((time.localtime(NOW).tm_gmtoff or 0) // 60))
 
     def test_unattributed_spend_is_shown_never_dropped(self):
@@ -179,7 +179,8 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(d["scope"], "keyed")
         by = {s["name"]: s for s in d["sessions"]}
         self.assertAlmostEqual(by["web"]["usd"], 2.0, places=3, msg="the key-billed dollars only")
-        self.assertEqual(by["api"]["usd"], 0.0, "a login-only session bills nothing to the key")
+        self.assertNotIn("api", by, "a login-only session bills nothing to the key: not a row, not a stack")
+        self.assertEqual([s["name"] for s in d["days"]["stacks"]], ["web"])
         self.assertEqual(d["unattributed"]["usd"], 0.0)
         # the TOTAL scope, same ledger: the split rides beside the totals where the hover would show it
         km._claude_account = lambda: ""
@@ -191,10 +192,58 @@ class SpendDetail(unittest.TestCase):
         self.assertNotIn("key", by2["api"])
 
     def test_other_machines_are_counted_so_the_modal_can_say_this_machine_only(self):
-        km._remotes["peer"] = {"host": "peer", "status": "up", "usage": {"apiKey": True}}
-        km._remotes["down"] = {"host": "down", "status": "down", "usage": {"apiKey": True}}
+        # the hover's predicate exactly: a remote counts when it reports SPEND windows (review find: a
+        # login-only remote contributes bars, not spend, and must not be named as a machine "in the totals")
+        km._remotes["peer"] = {"host": "peer", "status": "up", "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
+        km._remotes["bars"] = {"host": "bars", "status": "up", "usage": {"fiveHour": {"pct": 5}}}
+        km._remotes["down"] = {"host": "down", "status": "down", "usage": {"apiKey": True, "spend": {"day": {"usd": 1}}}}
         d = km._spend_detail(now=NOW)
-        self.assertEqual(d["hosts"], 2, "one live peer joins the fleet totals; its bySid does not reach us")
+        self.assertEqual(d["hosts"], 2, "one live peer with spend joins the totals; its bySid does not reach us")
+
+    def test_a_login_without_a_key_is_the_computed_scope(self):
+        # the rail's THIRD arm: windows present, no key → the rail shows no spend at all; the modal must
+        # not dress computed costs up as API spend (review find)
+        km._claude_account = lambda: "acct-digest"
+        km._auth_key_present = lambda: False
+        (km.jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}}))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["scope"], "computed")
+        self.assertEqual(d["sessions"][0]["name"], "web", "the computed costs are still per session")
+        html = km._landing()
+        self.assertIn("computed cost, not billed", html)
+        self.assertIn("Spend (computed)", html)
+
+    def test_totals_cover_the_days_the_chart_draws_not_every_bucket_kept(self):
+        # the recorder keeps the 90 most RECENT spend days, which can reach past 90 calendar days; the
+        # header says "last 90 days", so a bucket older than the chart's window counts nowhere (review find)
+        d0 = km._spend_detail(now=NOW)
+        led = json.loads((km.jd.STATE / "spend.json").read_text())
+        led["days"][_day(120)] = _bucket(999.0, 9990000, 99, {TESTS: {"usd": 999.0, "turns": 99, "tok": 9990000}})
+        (km.jd.STATE / "spend.json").write_text(json.dumps(led))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual([s["name"] for s in d["sessions"]], [s["name"] for s in d0["sessions"]], "the ranking is unmoved")
+        self.assertEqual(d["sessions"][2]["usd"], d0["sessions"][2]["usd"], "tests' total is the chart's window, not the ledger's reach")
+        self.assertEqual(d["unattributed"], d0["unattributed"])
+
+    def test_a_fall_back_transition_writes_one_slot_per_local_hour(self):
+        # TZ-pinned: 192 epoch hours across a fall-back hold 191 distinct local keys; the recorder merges
+        # both 01:00s into one key, so the series holds one slot for it, not a labeled empty twin
+        import os as _os
+        saved = _os.environ.get("TZ")
+        _os.environ["TZ"] = "America/Los_Angeles"
+        time.tzset()
+        try:
+            fall = time.mktime((2026, 11, 1, 12, 0, 0, 0, 0, -1))
+            d = km._spend_detail(now=fall)
+            hk = d["hours"]["keys"]
+            self.assertEqual(len(hk), len(set(hk)), "no duplicate hour key")
+            self.assertEqual(len(hk), km._SERIES_HOURS - 1)
+        finally:
+            if saved is None:
+                _os.environ.pop("TZ", None)
+            else:
+                _os.environ["TZ"] = saved
+            time.tzset()
 
     def test_an_empty_or_missing_ledger_answers_with_zeros_not_an_error(self):
         (km.jd.STATE / "spend.json").unlink()
@@ -221,7 +270,8 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("rl-word", html)
         self.assertIn("this machine only", html)
         self.assertIn("recorded before per-session tracking", html, "unattributed spend is named, never folded")
-        self.assertIn("fleetSpendHTML(LAST||[],true)", html, "the modal's window numbers are the hover's own renderer")
+        self.assertIn("var rows=spendRowsHTML(LAST||[]);", html, "the modal's window numbers are the hover's own renderer")
+        self.assertIn("function fleetSpendHTML(sets){", html, "…whose signature the other suites pin, untouched")
         self.assertIn("body.theme-light #rsp-panel{", html, "a light-theme step of its own")
 
 

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""T247 (the user 2026-09-07): clicking the dashboard's usage readout opens a modal with a per-session
+spend breakdown and a stacked histogram of spend over time colored by session. The data is GET
+/spend/detail: the ledger's bySid maps (T100's per-session attribution) with names and identity colors
+resolved kernel-side, two ranges at the ledger's own granularity (192 hours, 90 days), the top-N sessions
+as stacks plus ONE "other" and ONE "unattributed" stack — spend recorded before attribution existed, or
+the part of a bucket no sid accounts for, is shown as such, never dropped (fail loudly). Hermetic state
+root, synthetic ledger, the notes-api demo sessions (web/api/tests), placeholder uuids, TESTHOST."""
+import inspect
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_spenddetail", os.path.join(BIN, "romp-kernel")).load_module()
+
+WEB, API, TESTS = ("11111111-2222-3333-4444-000000000001", "11111111-2222-3333-4444-000000000002",
+                   "11111111-2222-3333-4444-000000000003")
+NOW = time.mktime((2026, 9, 7, 15, 30, 0, 0, 0, -1))   # a fixed afternoon; keys built the recorder's way
+
+
+def _hour(n):
+    return time.strftime("%Y-%m-%dT%H", time.localtime(NOW - n * 3600))
+
+
+def _day(n):
+    return time.strftime("%Y-%m-%d", time.localtime(NOW - n * 86400))
+
+
+def _bucket(usd, tok, turns, by=None, key=None):
+    e = {"usd": usd, "turns": turns, "tokIn": tok // 4, "tokOut": tok // 4, "tokCacheR": tok // 4,
+         "tokCacheW": tok - 3 * (tok // 4)}
+    if key is not None:
+        e["key"] = key
+    if by is not None:
+        e["bySid"] = by
+    return e
+
+
+def write_ledger(state, extra_sids=0):
+    hours = {}
+    for n in range(0, 60):
+        # web spends every hour, api every other, tests rarely
+        by = {WEB: {"usd": 1.0, "turns": 2, "tok": 20000}}
+        if n % 2 == 0:
+            by[API] = {"usd": 0.5, "turns": 1, "tok": 8000}
+        if n % 10 == 0:
+            by[TESTS] = {"usd": 0.25, "turns": 1, "tok": 3000}
+        tot_usd = sum(v["usd"] for v in by.values())
+        tot_tok = sum(v["tok"] for v in by.values())
+        tot_turns = sum(v["turns"] for v in by.values())
+        hours[_hour(n)] = _bucket(tot_usd, tot_tok, tot_turns, by)
+    # an hour that predates per-session attribution: no bySid at all → unattributed, never dropped
+    hours[_hour(70)] = _bucket(3.0, 30000, 4)
+    days = {}
+    for n in range(0, 40):
+        by = {WEB: {"usd": 24.0, "turns": 48, "tok": 480000}, API: {"usd": 6.0, "turns": 12, "tok": 96000}}
+        if n % 5 == 0:
+            by[TESTS] = {"usd": 0.6, "turns": 2, "tok": 7200}
+        for i in range(extra_sids):   # many small sessions, to overflow the top-N into "other"
+            by["11111111-2222-3333-4444-0000000001%02d" % i] = {"usd": 0.1, "turns": 1, "tok": 1000}
+        days[_day(n)] = _bucket(sum(v["usd"] for v in by.values()), sum(v["tok"] for v in by.values()),
+                                sum(v["turns"] for v in by.values()), by)
+    # a PARTIAL day: the bucket total exceeds what its sids account for (a turn recorded sid-less)
+    days[_day(2)]["usd"] += 5.0
+    days[_day(2)]["tokIn"] += 50000
+    days[_day(2)]["turns"] += 1
+    # two days before attribution existed: whole-bucket unattributed
+    days[_day(50)] = _bucket(40.0, 400000, 30)
+    days[_day(51)] = _bucket(41.0, 410000, 31)
+    (state / "spend.json").write_text(json.dumps({"days": days, "hours": hours}))
+
+
+class SpendDetail(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        state = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.NAMES, km._live_names, km._tmux_sessions, km._self_host,
+                       km._claude_account, km._auth_key_present, dict(km._remotes))
+        km.jd.STATE = state
+        km.NAMES = state / "names"
+        km.NAMES.mkdir()
+        (km.NAMES / WEB).write_text("web\t/tmp/notes-api\t#1EA1EB\t#ffffff\n")
+        (km.NAMES / API).write_text("api\t/tmp/notes-api\t#54B204\t#ffffff\n")
+        (km.NAMES / TESTS).write_text("tests\t/tmp/notes-api\n")          # no identity color
+        km._live_names = lambda tm: {"web": WEB, "api": API}                # tests is no longer running
+        km._tmux_sessions = lambda: []
+        km._self_host = lambda: "TESTHOST"
+        km._claude_account = lambda: ""                                     # a key-only machine: total scope
+        km._auth_key_present = lambda: True
+        km._remotes.clear()
+        (state / "usage.json").write_text(json.dumps({"apiKey": True}))
+        write_ledger(state)
+
+    def tearDown(self):
+        (km.jd.STATE, km.NAMES, km._live_names, km._tmux_sessions, km._self_host,
+         km._claude_account, km._auth_key_present, saved_remotes) = self._saved
+        km._remotes.clear()
+        km._remotes.update(saved_remotes)
+        self.td.cleanup()
+
+    def test_sessions_are_named_colored_sorted_and_flagged_live(self):
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["host"], "TESTHOST")
+        self.assertEqual(d["hosts"], 1)
+        self.assertEqual(d["scope"], "total")
+        names = [s["name"] for s in d["sessions"]]
+        self.assertEqual(names, ["web", "api", "tests"], "sorted by dollars, largest first")
+        web, api, tests = d["sessions"]
+        self.assertEqual((web["bg"], web["fg"]), ("#1EA1EB", "#ffffff"), "identity color from the registry")
+        self.assertEqual(tests["bg"], "", "a session without an identity color says so (the client draws neutral)")
+        self.assertTrue(web["live"] and api["live"] and not tests["live"], "a dead session keeps its name, flagged")
+        self.assertAlmostEqual(web["usd"], 24.0 * 40, places=3)
+        self.assertEqual(web["turns"], 48 * 40)
+        self.assertEqual(api["tok"], 96000 * 40)
+        self.assertEqual(d["topN"], km._DETAIL_TOP_N)
+        self.assertIn("windows", d)
+        self.assertEqual(d["tzOffsetMin"], int((time.localtime(NOW).tm_gmtoff or 0) // 60))
+
+    def test_unattributed_spend_is_shown_never_dropped(self):
+        d = km._spend_detail(now=NOW)
+        un = d["unattributed"]
+        # two pre-attribution days + the partial day's remainder
+        self.assertAlmostEqual(un["usd"], 40.0 + 41.0 + 5.0, places=3)
+        self.assertEqual(un["turns"], 30 + 31 + 1)
+        self.assertEqual(un["tok"], 400000 + 410000 + 50000)
+        kinds = [s["kind"] for s in d["days"]["stacks"]]
+        self.assertEqual(kinds, ["sid", "sid", "sid", "unattributed"], "one stack per session, then the unattributed stack")
+        una = d["days"]["stacks"][-1]
+        keys = d["days"]["keys"]
+        self.assertEqual(len(keys), 90)
+        self.assertEqual(keys[-1], _day(0), "dense, oldest first, today last")
+        self.assertAlmostEqual(una["usd"][keys.index(_day(50))], 40.0, places=3)
+        self.assertAlmostEqual(una["usd"][keys.index(_day(2))], 5.0, places=3, msg="the partial day's remainder")
+        self.assertEqual(una["tok"][keys.index(_day(2))], 50000)
+        hk = d["hours"]["keys"]
+        self.assertEqual(len(hk), km._SERIES_HOURS)
+        self.assertEqual(hk[-1], _hour(0))
+        hun = [s for s in d["hours"]["stacks"] if s["kind"] == "unattributed"][0]
+        self.assertAlmostEqual(hun["usd"][hk.index(_hour(70))], 3.0, places=3, msg="a pre-attribution hour, whole")
+        web = [s for s in d["hours"]["stacks"] if s.get("name") == "web"][0]
+        self.assertAlmostEqual(web["usd"][hk.index(_hour(5))], 1.0, places=3)
+        self.assertEqual(web["tok"][hk.index(_hour(5))], 20000)
+        self.assertFalse(web["usd"][hk.index(_hour(100))], "an hour with nothing recorded is a true zero")
+
+    def test_beyond_the_top_n_sessions_fold_into_one_other_stack(self):
+        write_ledger(km.jd.STATE, extra_sids=12)
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(len(d["sessions"]), 15, "the table lists EVERY session")
+        kinds = [s["kind"] for s in d["days"]["stacks"]]
+        self.assertEqual(kinds.count("sid"), km._DETAIL_TOP_N)
+        self.assertEqual(kinds[-2:], ["other", "unattributed"])
+        other = d["days"]["stacks"][-2]
+        self.assertEqual(other["count"], 15 - km._DETAIL_TOP_N)
+        keys = d["days"]["keys"]
+        self.assertAlmostEqual(other["usd"][keys.index(_day(1))], 0.1 * (15 - km._DETAIL_TOP_N), places=3)
+        self.assertEqual(d["hours"]["stacks"][0]["name"], "web", "stack order is the table's: top by dollars")
+
+    def test_the_keyed_scope_reads_each_sids_key_split_like_the_rail(self):
+        # a login's windows beside the key's spend: the rail sums ONLY key-billed turns, so does the modal
+        km._claude_account = lambda: "acct-digest"
+        (km.jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}}))
+        state = km.jd.STATE
+        days = {_day(0): _bucket(10.0, 100000, 10, {WEB: {"usd": 6.0, "turns": 6, "tok": 60000,
+                                                           "key": {"usd": 2.0, "turns": 2, "tok": 20000}},
+                                                     API: {"usd": 4.0, "turns": 4, "tok": 40000}},
+                                  key={"usd": 2.0, "turns": 2, "tok": 20000})}
+        (state / "spend.json").write_text(json.dumps({"days": days, "hours": {}}))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["scope"], "keyed")
+        by = {s["name"]: s for s in d["sessions"]}
+        self.assertAlmostEqual(by["web"]["usd"], 2.0, places=3, msg="the key-billed dollars only")
+        self.assertEqual(by["api"]["usd"], 0.0, "a login-only session bills nothing to the key")
+        self.assertEqual(d["unattributed"]["usd"], 0.0)
+        # the TOTAL scope, same ledger: the split rides beside the totals where the hover would show it
+        km._claude_account = lambda: ""
+        d2 = km._spend_detail(now=NOW)
+        self.assertEqual(d2["scope"], "total")
+        by2 = {s["name"]: s for s in d2["sessions"]}
+        self.assertAlmostEqual(by2["web"]["usd"], 6.0, places=3)
+        self.assertEqual(by2["web"]["key"], {"usd": 2.0, "tok": 20000, "turns": 2})
+        self.assertNotIn("key", by2["api"])
+
+    def test_other_machines_are_counted_so_the_modal_can_say_this_machine_only(self):
+        km._remotes["peer"] = {"host": "peer", "status": "up", "usage": {"apiKey": True}}
+        km._remotes["down"] = {"host": "down", "status": "down", "usage": {"apiKey": True}}
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["hosts"], 2, "one live peer joins the fleet totals; its bySid does not reach us")
+
+    def test_an_empty_or_missing_ledger_answers_with_zeros_not_an_error(self):
+        (km.jd.STATE / "spend.json").unlink()
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["sessions"], [])
+        self.assertEqual(d["days"]["stacks"], [])
+        self.assertEqual(len(d["days"]["keys"]), 90)
+
+    def test_the_route_and_the_shell_are_wired(self):
+        ksrc = inspect.getsource(km.Handler.do_GET) if hasattr(km.Handler, "do_GET") else open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('if p == "/spend/detail":', ksrc, "the kernel route exists")
+        self.assertIn("json.dumps(_spend_detail())", ksrc)
+        html = km._landing()
+        self.assertIn("id=rsp-back hidden", html, "the modal's shell-native backdrop, hidden until the click")
+        self.assertIn("fetch('/spend/detail'", html, "the shell fetches the route on open, never scrapes the hover")
+        self.assertIn("el.addEventListener('click',function(){pull(true);openSpend();});", html,
+                      "the click on the readout opens the modal (and still kicks the hover's refresh)")
+        self.assertIn("if(sp&&!sp.hidden&&window.__rompCloseSpend){window.__rompCloseSpend();closed=true;}", html,
+                      "Escape closes it through the shell's one Escape chain")
+        self.assertIn("#rsp-back{position:fixed;inset:0;z-index:205;display:flex;align-items:center;justify-content:center;"
+                      "background:rgba(0,0,0,0.55)}", html, "the panel rule: a centered card over rgba(0,0,0,0.55)")
+        self.assertNotIn("__ROMP_LOADER__", html.split("_LANDING_JS")[0] if "_LANDING_JS" in html else html,
+                         "the loader markup is spliced, not left as a placeholder")
+        self.assertIn("rl-word", html)
+        self.assertIn("this machine only", html)
+        self.assertIn("recorded before per-session tracking", html, "unattributed spend is named, never folded")
+        self.assertIn("fleetSpendHTML(LAST||[],true)", html, "the modal's window numbers are the hover's own renderer")
+        self.assertIn("body.theme-light #rsp-panel{", html, "a light-theme step of its own")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""T247, the served-page pins: the landing page is served from a hermetic kernel module (its own
+_landing() HTML, /spend/detail and /usage/fleet answered from a synthetic ledger — placeholder uuids,
+TESTHOST, the notes-api demo sessions), and a real browser clicks the usage readout. Pins the modal's
+open/close contract (click opens over the 0.55 backdrop; Escape and a backdrop tap close), the table
+and the stacked histogram with its unattributed stack, the toggles, and the segment tooltip. Skips
+LOUDLY without a playwright: set ROMP_PLAYWRIGHT_NODE_PATH to a node_modules holding it (CI does
+not; this is the maintainer's screenshot harness too — pass ROMP_SHOTS=<path-prefix> for PNGs)."""
+import json
+import os
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_spendmodal", os.path.join(BIN, "romp-kernel")).load_module()
+
+import sys
+sys.path.insert(0, HERE)
+import test_spend_detail as _sd   # noqa: E402  the same synthetic world (the module, not its classes:
+#                                   an imported TestCase would be collected here a second time)
+write_ledger, WEB, API, TESTS = _sd.write_ledger, _sd.WEB, _sd.API, _sd.TESTS
+
+
+def _node_path():
+    for cand in (os.environ.get("ROMP_PLAYWRIGHT_NODE_PATH", ""), os.path.join(ROOT, "vscode-extension", "node_modules")):
+        if cand and os.path.isdir(os.path.join(cand, "playwright")):
+            return cand
+    return ""
+
+
+class SpendModalServed(unittest.TestCase):
+    def setUp(self):
+        np = _node_path()
+        if not np:
+            self.skipTest("no playwright: set ROMP_PLAYWRIGHT_NODE_PATH to a node_modules that holds it")
+        self.node_path = np
+        self.td = tempfile.TemporaryDirectory()
+        state = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.NAMES, km._live_names, km._tmux_sessions, km._self_host,
+                       km._claude_account, km._auth_key_present)
+        km.jd.STATE = state
+        km.NAMES = state / "names"
+        km.NAMES.mkdir()
+        (km.NAMES / WEB).write_text("web\t/tmp/notes-api\t#1EA1EB\t#ffffff\n")
+        (km.NAMES / API).write_text("api\t/tmp/notes-api\t#54B204\t#ffffff\n")
+        (km.NAMES / TESTS).write_text("tests\t/tmp/notes-api\t#4EA8A9\t#ffffff\n")
+        km._live_names = lambda tm: {"web": WEB, "api": API}
+        km._tmux_sessions = lambda: []
+        km._self_host = lambda: "TESTHOST"
+        km._claude_account = lambda: ""
+        km._auth_key_present = lambda: True
+        (state / "usage.json").write_text(json.dumps({"apiKey": True}))
+        write_ledger(state, extra_sids=12)
+        html = km._landing().encode()
+        blank = b"<!doctype html><html><body style='margin:0;background:#1e1e1e'></body></html>"
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def _out(self, code, body, ctype):
+                self.send_response(code)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                p = self.path.split("?", 1)[0]
+                if p == "/":
+                    return self._out(200, html, "text/html; charset=utf-8")
+                if p == "/spend/detail":
+                    return self._out(200, json.dumps(km._spend_detail()).encode(), "application/json")
+                if p == "/usage/fleet":
+                    return self._out(200, json.dumps({"rows": [{"host": "", "acct": "", "usage": km._usage()}],
+                                                      "host": "TESTHOST"}).encode(), "application/json")
+                if p == "/usage":
+                    return self._out(200, json.dumps(km._usage() or {}).encode(), "application/json")
+                if p.startswith("/media/") or p.startswith("/dist/"):
+                    f = os.path.join(ROOT, p.lstrip("/"))
+                    if os.path.isfile(f):
+                        ct = "image/svg+xml" if f.endswith(".svg") else "application/javascript" if f.endswith(".js") else "application/octet-stream"
+                        return self._out(200, open(f, "rb").read(), ct)
+                    return self._out(404, b"", "text/plain")
+                if p in ("/chat", "/feed", "/timeline", "/fleet", "/dashboard"):
+                    return self._out(200, blank, "text/html; charset=utf-8")
+                return self._out(200, b"{}", "application/json")
+
+            def do_POST(self):
+                return self._out(200, b"{}", "application/json")
+
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+
+    def tearDown(self):
+        if hasattr(self, "srv"):
+            self.srv.shutdown()
+            self.srv.server_close()
+        if hasattr(self, "_saved"):
+            (km.jd.STATE, km.NAMES, km._live_names, km._tmux_sessions, km._self_host,
+             km._claude_account, km._auth_key_present) = self._saved
+            self.td.cleanup()
+
+    def test_click_opens_the_modal_with_table_and_stacked_histogram_and_escape_closes_it(self):
+        shots = os.environ.get("ROMP_SHOTS", "")
+        env = dict(os.environ, NODE_PATH=self.node_path)
+        r = subprocess.run(["node", os.path.join(HERE, "spend_modal_headless.js"), "http://127.0.0.1:%d/" % self.port, shots],
+                           capture_output=True, text=True, timeout=180, env=env)
+        self.assertEqual(r.returncode, 0, "the driver failed:\n" + r.stderr[-3000:])
+        o = json.loads(r.stdout.strip().splitlines()[-1])
+        self.assertTrue(o["hiddenBefore"], "closed until the click")
+        self.assertTrue(o["loaderSeen"], "the loader (or the content) is up the instant the modal opens")
+        self.assertEqual(o["out"]["backdrop"], "rgba(0, 0, 0, 0.55)", "the panel rule's backdrop")
+        self.assertEqual(o["out"]["head"], "API spend · TESTHOST")
+        rows = o["out"]["rows"]
+        self.assertTrue(rows[0].startswith("web"), rows[0])
+        self.assertTrue(rows[1].startswith("api"), rows[1])
+        self.assertTrue(any(r.startswith("tests") and "not running" in r for r in rows), "a dead session keeps its name, dimmed")
+        self.assertTrue(o["out"]["rows"][2].startswith("tests"), "the top rows are the histogram's stacks, in order")
+        self.assertTrue(any(r.startswith("unattributed") for r in rows), "pre-attribution spend is a row of its own")
+        self.assertGreaterEqual(o["out"]["deadRows"], 2)
+        self.assertEqual(o["foldBefore"], 10 + 1 + 1, "the table folds to the top-N, a '5 more' row, and the unattributed row")
+        self.assertEqual(o["foldAfter"], 15 + 1, "show all: every session, plus the unattributed row")
+        self.assertTrue(any("5 more sessions" in r for r in rows), rows)
+        leg = o["out"]["legend"]
+        self.assertEqual(leg[0], "web", "stack order is the table's: top by dollars")
+        self.assertEqual(leg[-1], "unattributed", "the pre-attribution hour is a stack of its own")
+        self.assertNotIn("other (5 sessions)", leg, "the small sessions have no hourly records: no empty 'other' stack")
+        self.assertIn("other (5 sessions)", o["days"]["legend"], "beyond the top-N the daily range folds them into one stack")
+        self.assertEqual(o["days"]["legend"][-1], "unattributed")
+        self.assertGreater(o["out"]["segs"], 60)
+        self.assertGreaterEqual(o["out"]["hatched"], 1, "the unattributed stack wears the hatch, not a hue")
+        self.assertIn("1 hour", o["out"]["windows"], "the same window rows the hover shows")
+        self.assertIn("1 month", "".join(o["out"]["windows"]))
+        self.assertTrue(o["out"]["ylabels"] and o["out"]["ylabels"][0].startswith("$"), o["out"]["ylabels"])
+        self.assertTrue(o["out"]["xlabels"], "weekday initials at the ledger's midnights")
+        self.assertTrue(o["days"]["segs"] > 0 and not o["days"]["ylabels"][0].startswith("$"), "tokens on the toggle")
+        self.assertTrue(any("/" in x for x in o["days"]["xlabels"]), "date labels on the daily range")
+        self.assertIn("·", o["tip"], "a segment hover names value · session · bucket")
+        self.assertTrue(o["hiddenAfter"], "Escape closes it")
+        self.assertTrue(o["hiddenAfterTap"], "a backdrop tap closes it")
+        own = [e for e in o["errs"] if "rsp" in e or "Spend" in e or "spend" in e]
+        self.assertEqual(own, [], "no page errors from the modal's own code")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -82,7 +82,9 @@ class SpendModalServed(unittest.TestCase):
                 if p == "/":
                     return self._out(200, html, "text/html; charset=utf-8")
                 if p == "/spend/detail":
-                    return self._out(200, json.dumps(km._spend_detail()).encode(), "application/json")
+                    # the fixture's OWN clock (review find: served with the wall clock, the 192-hour window
+                    # slid off the anchored ledger within days and the hourly pins became a time bomb)
+                    return self._out(200, json.dumps(km._spend_detail(now=_sd.NOW)).encode(), "application/json")
                 if p == "/usage/fleet":
                     return self._out(200, json.dumps({"rows": [{"host": "", "acct": "", "usage": km._usage()}],
                                                       "host": "TESTHOST"}).encode(), "application/json")
@@ -136,9 +138,9 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["foldAfter"], 15 + 1, "show all: every session, plus the unattributed row")
         self.assertTrue(any("5 more sessions" in r for r in rows), rows)
         leg = o["out"]["legend"]
-        self.assertEqual(leg[0], "web", "stack order is the table's: top by dollars")
-        self.assertEqual(leg[-1], "unattributed", "the pre-attribution hour is a stack of its own")
-        self.assertNotIn("other (5 sessions)", leg, "the small sessions have no hourly records: no empty 'other' stack")
+        self.assertEqual(leg, ["web", "api", "tests", "unattributed"],
+                         "the hourly legend names only the stacks the hourly chart draws — no chip for a "
+                         "top-N session with nothing in this range, no empty 'other' (review find)")
         self.assertIn("other (5 sessions)", o["days"]["legend"], "beyond the top-N the daily range folds them into one stack")
         self.assertEqual(o["days"]["legend"][-1], "unattributed")
         self.assertGreater(o["out"]["segs"], 60)
@@ -152,6 +154,10 @@ class SpendModalServed(unittest.TestCase):
         self.assertIn("·", o["tip"], "a segment hover names value · session · bucket")
         self.assertTrue(o["hiddenAfter"], "Escape closes it")
         self.assertTrue(o["hiddenAfterTap"], "a backdrop tap closes it")
+        self.assertFalse(o["hiddenAfterDrag"], "…but a drag-select that ends over the backdrop does not (review find)")
+        self.assertTrue(o["mobile"]["railHidden"] and o["mobile"]["panelOpened"] and o["mobile"]["modalOpened"],
+                        "on a phone the Usage panel's 'By session' button is the door (review find): " + json.dumps(o["mobile"]))
+        self.assertEqual(o["lightErr"], "rgb(154, 51, 36)", "the error line has a light-theme step")
         own = [e for e in o["errs"] if "rsp" in e or "Spend" in e or "spend" in e]
         self.assertEqual(own, [], "no page errors from the modal's own code")
 


### PR DESCRIPTION
**Feature (T247).** Clicking the dashboard's usage readout opens a full-screen modal with a per-session spend breakdown and a stacked histogram of spend over time colored by session. The user's ask (2026-09-07 evening PT): click the usage thing and get a detailed breakdown of how much each session used, with a stacked histogram-style chart colored by session.

**Design points**
- **Progressive disclosure.** Gist (the rail) → hover (per host, the windows) → modal (per session). The hover stays as it was; the click is the deeper level and still kicks the hover's own refresh. On a phone, where the rail does not exist, the Usage panel ends in a "By session" button that opens the modal.
- **Panel rule.** Shell-native like the remote-kernels panel: a centered card over a translucent 0.55 backdrop, the dashboard behind it dimmed and unchanged. Esc (the shell's one Escape chain) and a backdrop tap close it; a drag-select of table figures that ends over the backdrop does not.
- **Content, top to bottom.** The same window numbers the hover shows, from the hover's own renderer in a rows-only mode, re-rendered whenever fresh rows land while the modal is open so the two levels agree at every moment. A per-session table sorted by dollars: identity swatch, name, dollars, turns, tokens, and the key-billed split where the hover would show it. It folds to the histogram's top-N with a "show all" row so the chart stays in view under a long roster; a dead or archived session keeps its last known name, dimmed. Then the stacked histogram.
- **Histogram.** x = time buckets, y = dollars by default with a tokens toggle. Two ranges at the ledger's own granularity: 8 days by hour and 90 days by day. One stack per top-N session in its identity color, plus one "other" stack and one "unattributed" stack; a range omits stacks that are all zero in it. Buckets predating per-session attribution, or the part of a bucket no sid accounts for, render hatched as unattributed, never dropped or folded (fail loudly). A segment hover names value · session · bucket. Weekday initials mark the ledger's local midnights; the 1st and 15th mark the daily range; the bucket timezone is named when it differs from the viewer's.
- **Data route.** `GET /spend/detail` reads the ledger's `bySid` maps, resolves names and identity colors kernel-side from the names registry, mirrors the rail's three-way decision (total on a key-only machine, keyed beside a login's windows, computed for a login with no key, where the modal says the figures are computed costs and not a bill), and returns dense series for both ranges. Totals and ranking cover exactly the ninety day keys the daily chart draws. The shell fetches it on open behind the romp loader and never scrapes the hover's HTML.
- **Multi-host.** Local ledger only. A remote's row carries no `bySid` through the relay today, so the payload counts the other live machines that report spend (the hover's own predicate) and the modal says "this machine only" under the totals rather than omitting them silently. Carrying remote per-session series through the relay is the natural follow-up.
- **Click safety.** One delegated listener on the stable panel; every control is a `data-act`; the pressed state flips before the chart re-renders.
- **Type and color.** The hover's sizes (11 / 10 / 8) plus the net panel's card and 14px header, no new font size. The romp accent is chrome only (the pressed toggle). Data colors are the sessions' identity colors; "other" and a colorless session wear neutrals; unattributed wears a texture. Light theme has its own steps for the card, hairlines and the error line; identity colors do not flip. Whole dollars everywhere, axis labels included.
- **Dataviz.** 2px surface gaps between stacked segments, 4px rounded data-ends on the top segment, hairline recessive gridlines at a 1-2-5 ceiling and its half, legend always present, text in text tokens, a table view beside the chart.

**Adversarial review.** Two lenses, thirteen findings, each verified hermetically or in a browser against the served page, all folded across two follow-up commits: totals over the chart's own window; the third "computed" scope; the machine count on the hover's predicate; zero-only sessions and all-zero range stacks dropped; DST duplicate hour keys collapsed; "fleet" rephrased out of new prose; an unread `windows` payload removed; the phone door; the Totals section following the hover; the drag-select; the light error color; the served harness on its fixture's clock. Two pins CI caught: the hover renderer's signature is pinned by two suites (rows-only mode now rides a closure flag behind a wrapper), and the extension's whole-dollars scan is a literal search for `toFixed(2)`.

**Tests.** The route over a hermetic state root with a synthetic ledger (placeholder uuids, `TESTHOST`, the notes-api demo sessions): sorted, named, colored and live-flagged rows; unattributed and partial buckets; the other-stack fold beyond top-N; the keyed and computed scopes; the window-bounded totals; the machine count; a fall-back DST transition; an empty ledger; the shell wiring pins. A served-page test drives the real landing page with playwright, skipping loudly without one: click → modal over the 0.55 backdrop → table and fold → histogram with the hatched stack → toggles → segment tooltip → Escape, backdrop tap, and a surviving drag-select → the light error color → a 390px pass through the Usage panel's button. It doubles as the screenshot harness. Its first run caught a bug source pins could not: an unquoted last attribute in the inline SVG is not self-closing under the HTML parser, so every bar became that element's child and the chart drew nothing.

**Left out.** Remote per-session data through the relay (the modal says "this machine only" when other machines join the totals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
