### PR TITLE
T248: Suggest /compact is one value across attached machines, and names no workers

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -916,7 +916,7 @@ def _version_info():
             # The top-level fields above stay: this tab's own gear and older kernels read those.
             "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
                          "conserveMemory": _conserve_on(),
-                         "compactSuggest": _compact_suggest_on(),   # T208: per-install, default OFF
+                         "compactSuggest": _compact_suggest_on(),   # default OFF; one value across machines (T248)
                          "fileEditing": _file_editing_on(),
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
@@ -5556,10 +5556,13 @@ def _set_auto_nudge(enabled, gt=None):
 
 
 def _compact_suggest_on():
-    """The compaction-suggestion regime's own per-install toggle (T208, the user 2026-09-01: the
-    regime must NOT ship default-on to every install — it stays behind this install's config).
-    OFF by default: the key is absent from a fresh install's blob and absent reads False — no
-    setdefault, deliberately, so shipping the feature never turns it on anywhere."""
+    """The compaction-suggestion regime's toggle. OFF by default (T208, the user 2026-09-01: the
+    regime must NOT ship default-on): the key is absent from a fresh install's blob and absent
+    reads False — no setdefault, deliberately, so shipping the feature never turns it on anywhere.
+    Each kernel stores its own copy, and the gear's click reaches every attached kernel (federation.ts
+    KERNEL_SETTING, like setFileEditing) so the mesh holds ONE value (T248, the user 2026-09-07: it
+    shipped per-install, and a session on an attached machine whose copy was on got the suggestion
+    while the gear they were looking at showed the box off with the mixed mark)."""
     return bool(_auto_nudge_data().get("compactSuggestEnabled"))
 
 
@@ -7847,19 +7850,22 @@ def _closer_pending(sid, path, now, store):
 
 
 # ── the compaction SUGGESTION (the user 2026-08-30, via the nightly optimizer) ──────────────────
-# The ~300k RECYCLE rule stays workers-only; every OTHER session gets a suggestion it decides on
-# itself: once its context crosses each threshold below AND it has been idle at least an hour, it
-# is told — in the person's voice, marker-free (the rename-ping precedent) — that a /compact at a
-# natural boundary would keep it snappy. Event-keyed end to end: the CROSSING arms it, a per-
-# threshold latch on the auto-nudge blob makes each fire once per episode, the idle gate reads the
-# settle event's age at fire time (_settle_event_key — the hook-ledger seam), and the latch re-arms
-# only on the session's own CONTEXT RESET (compact//clear/rewind), observed as the authoritative
-# token counter falling back below the latched threshold — a session that ignores the suggestion
-# is never re-asked (its counter never falls, the latch stands), one that acts hears nothing until
-# it has genuinely filled up again (the manager's amendment, 2026-08-30). Workers are excluded by
-# their roster tags (*_workers in the session-tag store), comment-thread forks by their registry
-# marker, and anything mid-turn by the progressing-state gate. Rides the auto-nudge tick's
-# alive-session walk — no new poll, no timer.
+# Every session gets a suggestion it decides on itself: once its context crosses each threshold
+# below AND it has been idle at least an hour, it is told — in the person's voice, marker-free (the
+# rename-ping precedent) — that a /compact at a natural boundary would keep it snappy. Event-keyed
+# end to end: the CROSSING arms it, a per-threshold latch on the auto-nudge blob makes each fire
+# once per episode, the idle gate reads the settle event's age at fire time (_settle_event_key —
+# the hook-ledger seam), and the latch re-arms only on the session's own CONTEXT RESET
+# (compact//clear/rewind), observed as the authoritative token counter falling back below the
+# latched threshold — a session that ignores the suggestion is never re-asked (its counter never
+# falls, the latch stands), one that acts hears nothing until it has genuinely filled up again (the
+# manager's amendment, 2026-08-30). Excluded at fire time: muted sessions (the per-session
+# opt-out), comment-thread forks (their registry marker) and anything mid-turn (the
+# progressing-state gate). Session TAGS are not a gate (T248, the user 2026-09-07): the first cut
+# skipped every member of a *_workers tag on the theory that a manager layer owned those sessions,
+# but that roster is a convention the user runs on top of romp, not something romp knows about —
+# to romp every session is a session. Rides the auto-nudge tick's alive-session walk — no new
+# poll, no timer.
 COMPACT_SUGGEST_TOKENS = (400_000, 800_000)
 COMPACT_SUGGEST_IDLE_S = 3600
 def _compact_suggest_body(name):
@@ -7875,23 +7881,6 @@ def _compact_suggest_body(name):
     return ("It's been quiet here for a while and this conversation has built up a lot of context. "
             "When you next reach a natural stopping point, run `romp compact %s` in your shell to "
             "compact it and keep things snappy; your call, nothing is waiting on it." % name)
-
-
-def _worker_tag_member(sid):
-    """True when any *_workers tag in the session-tag store holds this sid — the worker rosters ARE
-    session tags (the `romp tag` headless-edit workflow), and the recycle rule owns those sessions."""
-    try:
-        d = json.loads(_views_path().read_text())
-    except (OSError, ValueError):
-        return False
-    for t in (d.get("tags") or []):
-        if not str(t.get("name") or "").lower().endswith("workers"):
-            continue
-        for m in (t.get("members") or []):
-            ms = m.get("sid") if isinstance(m, dict) else str(m or "")
-            if ms == sid or (isinstance(ms, str) and ms.split(":", 1)[-1] == sid):
-                return True
-    return False
 
 
 def _compact_suggest_tick(sid, tm, now):
@@ -7938,8 +7927,6 @@ def _compact_suggest_tick(sid, tm, now):
     #                                                    (the nudge gate, the interrupt-block tick;
     #                                                    a routed review caught this one missing,
     #                                                    2026-09-01)
-    if _worker_tag_member(sid):
-        return False                                   # the recycle rule owns workers
     if _thread_reg(sid).get("threadOf"):
         return False                                   # a comment-thread fork is not first-class
     if (tm or {}).get("state", "") in _PROGRESSING_STATES:
@@ -41931,8 +41918,10 @@ class Handler(BaseHTTPRequestHandler):
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setCompactSuggest" and msg.get("enabled") is not None:
-            # T208 opt-in — kernel-side like autoNudge, gt-gated like every queued setting. Only a
-            # real apply acts at once on turn-on (instead of waiting out the pusher's 0.5 s backstop)
+            # T208 opt-in — kernel-side like autoNudge, broadcast by federation.ts KERNEL_SETTING so
+            # one click answers for every attached kernel (T248), gt-gated like every queued setting
+            # (a queued flush must not undo a newer choice). Only a real apply acts at once on
+            # turn-on (instead of waiting out the pusher's 0.5 s backstop)
             # — a stood-down toggle is not new information — through the same wrap as setAutoNudge
             # (_ws_act_now_tick: single-flight, no dead-wait sweep, a failure logged not raised)
             if _set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:

--- a/tests/test_compact_suggest.py
+++ b/tests/test_compact_suggest.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-"""The kernel-level compaction SUGGESTION (the user 2026-08-30, via the nightly optimizer). The
-~300k recycle rule stays workers-only; every OTHER session is told — once idle at least an hour,
-first past 400k context tokens, again past 800k — that a /compact at a natural boundary would keep
-it snappy, its call. Event-keyed end to end: the CROSSING arms it; a per-threshold latch on the
-auto-nudge blob makes each fire once per episode; the idle gate reads the settle event's age AT
-FIRE TIME; and the latch re-arms only on the session's own context RESET (compact//clear/rewind),
-observed as the authoritative token counter falling back below the latched threshold — ignored =
-silent forever, acted+regrown+idle = one fresh suggestion per threshold (the manager's amendment).
-Workers (their roster tags), comment-thread forks, and mid-turn sessions are excluded at fire
-time. The voice render is pinned in test_injected_voice.py. SYNTHETIC fixtures only."""
+"""The kernel-level compaction SUGGESTION (the user 2026-08-30, via the nightly optimizer). Every
+session is told — once idle at least an hour, first past 400k context tokens, again past 800k —
+that a /compact at a natural boundary would keep it snappy, its call. Event-keyed end to end: the
+CROSSING arms it; a per-threshold latch on the auto-nudge blob makes each fire once per episode; the
+idle gate reads the settle event's age AT FIRE TIME; and the latch re-arms only on the session's own
+context RESET (compact//clear/rewind), observed as the authoritative token counter falling back
+below the latched threshold — ignored = silent forever, acted+regrown+idle = one fresh suggestion
+per threshold (the manager's amendment). Muted sessions, comment-thread forks, and mid-turn
+sessions are excluded at fire time. Session tags are NOT a gate (T248, the user 2026-09-07: a
+"workers" roster is a convention they run on top of romp, not something romp knows about; the
+first cut skipped every member of a *_workers tag). The voice render is pinned in
+test_injected_voice.py. SYNTHETIC fixtures only."""
 import contextlib
 import io
 import json
@@ -147,12 +149,16 @@ class CompactSuggest(_Fixture):
         self.assertEqual(self.sent, [])
 
     # ── the exclusions ──
-    def test_a_worker_tagged_session_is_never_suggested(self):
+    def test_a_session_inside_a_workers_tag_is_suggested_like_any_other(self):
+        # T248 (the user 2026-09-07): a session on an attached machine inside a "workers" roster tag is
+        # an ordinary session to romp — the tag is the user's own convention. Red before: the first
+        # cut's _worker_tag_member gate returned False for every member of a *_workers tag.
         (jd.STATE / "timeline-views.json").write_text(json.dumps(
             {"active": "all", "tags": [{"id": "t1", "name": "notes_workers",
                                         "members": [{"host": "", "sid": SID}]}]}))
-        self.assertFalse(self._tick(450_000), "the recycle rule owns workers")
-        self.assertEqual(self.sent, [])
+        self.assertTrue(self._tick(450_000), "a tag is not a gate")
+        self.assertEqual(len(self.sent), 1)
+        self.assertFalse(hasattr(km, "_worker_tag_member"), "the tag-roster gate is gone, not bypassed")
 
     def test_a_muted_session_is_never_suggested(self):
         # the user's explicit per-session opt-out (hideFromFeed) — every sibling injector honors

--- a/ui/webview/compact-suggest-mesh.test.ts
+++ b/ui/webview/compact-suggest-mesh.test.ts
@@ -1,0 +1,59 @@
+// Suggest /compact is ONE value across every attached machine (T248, the user 2026-09-07: their gear
+// showed the box unchecked with the mixed mark, yet a session on an attached machine received the
+// suggestion that night — the attached kernel's own copy was on). The first cut (T208) made the setting
+// per-install on purpose; the user overruled that: no mixed state for this setting, ever. So the checkbox
+// now rides federation's KERNEL_SETTING broadcast like setFileEditing — one click writes every attached
+// kernel, and the mixed mark for this control can only be transient (the next fill clears it). The gt
+// gating stays: a queued flush must not undo a newer choice. Its copy and gate also stop naming
+// "workers": a workers roster is a convention the user runs on top of romp, not something romp knows.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const read = (...p: string[]) => fs.readFileSync(path.join(ROOT, ...p), "utf8");
+const GEAR = read("ui", "webview", "gear.js");
+const FED = read("ui", "webview", "federation.ts");
+const KERNEL = read("bin", "romp-kernel");
+
+test("setCompactSuggest is a KERNEL_SETTING: one click writes every attached kernel (T248)", () => {
+  const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(setSrc, "federation.ts's KERNEL_SETTING set located");
+  assert.ok(setSrc![1].includes('"setCompactSuggest"'),
+    "the set carries it — the broadcast is what makes the one answer reach every machine");
+  // the gear still stamps the gesture: the kernel orders applies by gt, so a queued flush from a frozen
+  // tab can never undo a newer choice made elsewhere
+  assert.ok(GEAR.includes("post({ type: 'setCompactSuggest', enabled: csg.checked, gt: gclock.stamp('compact-suggest') })"),
+    "the post is gesture-stamped, unchanged");
+  assert.ok(!GEAR.includes("Suggest /compact are kernel-side but PER-INSTALL"),
+    "the gear's routing comment no longer calls it per-install");
+});
+
+test("the Suggest /compact copy names no workers and promises every connected machine (T248)", () => {
+  const at = GEAR.indexOf("id=rs-suggestcompact");
+  assert.ok(at > 0, "the checkbox exists");
+  const sub = GEAR.slice(at, GEAR.indexOf("</label>", at));
+  assert.ok(!/workers/i.test(sub), "no 'workers' in the copy — not a romp concept");
+  assert.ok(!sub.includes("keeps its own copy"), "no per-install sentence");
+  assert.ok(sub.includes("Applies on every connected machine’s kernel."),
+    "the fileEditing wording: the setting follows to every attached kernel");
+  assert.ok(sub.includes("Off by default for a fresh install"), "the default stays stated");
+  assert.ok(/muted sessions/.test(sub) && /mid-turn/.test(sub), "the muted and mid-turn exclusions stay named");
+});
+
+test("the suggestion's gate reads no session tags: a *_workers roster is not romp's concept (T248)", () => {
+  assert.ok(!KERNEL.includes("def _worker_tag_member"), "the tag-roster gate is deleted, not bypassed");
+  assert.ok(!KERNEL.includes("_worker_tag_member("), "…and nothing calls it");
+  const start = KERNEL.indexOf("# ── the compaction SUGGESTION");
+  const end = KERNEL.indexOf("\ndef _compact_suggest_body(", start);
+  assert.ok(start > 0 && end > start, "the regime's block comment located");
+  const block = KERNEL.slice(start, end);
+  assert.ok(!/recycle|owns workers|workers are excluded|workers-only/i.test(block),
+    "the block comment carries neither the recycle framing nor the workers exclusion");
+  assert.ok(block.includes("Session TAGS are not a gate"), "…and says so in romp's terms");
+  const tick = KERNEL.slice(KERNEL.indexOf("def _compact_suggest_tick("), KERNEL.indexOf("\ndef ", KERNEL.indexOf("def _compact_suggest_tick(") + 10));
+  assert.ok(/hideFromFeed/.test(tick) && /threadOf/.test(tick) && /_PROGRESSING_STATES/.test(tick),
+    "the muted, comment-thread and mid-turn gates stay");
+  assert.ok(!/worker/i.test(tick), "no worker gate in the tick");
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -65,12 +65,18 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // default-comment trio (setCommentModel/Effort/Fast, the user 2026-08-29) rides the same way. Broadcast in
 // routeOutbound rather than routed. setFileEditing is the viewer's edit opt-in (the user 2026-08-22:
 // one consent popup answers for the mesh — every kernel's save route gates on its own copy, so the
-// broadcast is what makes the one yes reach them all). Deliberately NOT here: setDefaultDir (a path on
-// one machine, meaningless on another) and setColormap/setPalette (the viewer's display prefs, which the
-// local kernel persists for this browser).
+// broadcast is what makes the one yes reach them all). setCompactSuggest rides the same way (T248, the
+// user 2026-09-07: it shipped per-install and a session on an attached machine, whose kernel's own copy
+// was on, received the suggestion while their gear showed the box off with the mixed mark — they want
+// no mixed state for this setting, ever; one click writes every machine, so the mark can only be
+// transient). Deliberately NOT here: setDefaultDir (a path on one machine, meaningless on another),
+// setColormap/setPalette (the viewer's display prefs, which the local kernel persists for this browser)
+// and the Thinking summaries toggle (per-install: whoever reads the summaries turns it on where they read
+// them).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
                                 "setJudgeEffort", "setIndexEffort", "setUpdateMode",
                                 "setDistillModel", "setDistillEffort", "setFileEditing",
+                                "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast"]);
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -80,7 +80,7 @@ var GEAR_HTML =
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-suggestcompact>" +
   '<span><b>Suggest /compact</b><span class=rs-mixed hidden></span>' +
-  '<span class=rs-sub>When a session has been idle over an hour with a lot of context built up (first past 400k tokens, again past 800k), send it ONE suggestion to /compact at a natural boundary — its call, once per fill-up. Never sent to workers, muted sessions, or anything mid-turn. Off by default for a fresh install; this kernel keeps its own copy.</span>' +
+  '<span class=rs-sub>When a session has been idle over an hour with a lot of context built up (first past 400k tokens, again past 800k), send it ONE suggestion to /compact at a natural boundary — its call, once per fill-up. Never sent to muted sessions or anything mid-turn. Off by default for a fresh install. Applies on every connected machine’s kernel.</span>' +
   '</span></label>' +
   "<label class='rs-row'><input type=checkbox id=rs-conserve>" +
   '<span><b>Conserve memory</b><span class=rs-mixed hidden></span>' +
@@ -447,9 +447,9 @@ function initGear(post) {
   // applies by it and stands a stale flush down instead of walking the mesh back to an hours-old
   // pick (a frozen tab's flush did exactly that). Stamp in the message literal, never at send/flush
   // time.
-  // Thinking summaries and Suggest /compact are kernel-side but PER-INSTALL: each post goes to the
-  // LOCAL kernel only — deliberately not in federation's KERNEL_SETTING set (gear.test.ts pins the
-  // membership), so neither queues for or reaches another machine. Stamped all the same: two
+  // Thinking summaries is kernel-side but PER-INSTALL: the post goes to the LOCAL kernel only —
+  // deliberately not in federation's KERNEL_SETTING set (thinking-summaries.test.ts pins the
+  // membership), so it neither queues for nor reaches another machine. Stamped all the same: two
   // dashboards on one kernel still race, and the kernel orders every setting by `gt`.
   if (ths) ths.addEventListener('change', function () { post({ type: 'setThinkingSummaries', enabled: ths.checked, gt: gclock.stamp('thinking-summaries') }); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -507,7 +507,8 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setCommentModel", model: "claude-opus-5" },
                      { type: "setCommentEffort", effort: "high" },
                      { type: "setCommentFast", fast: "on" },
-                     { type: "setFileEditing", enabled: true }]) {
+                     { type: "setFileEditing", enabled: true },
+                     { type: "setCompactSuggest", enabled: true }]) {   // T248: no longer per-install
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
     assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);
     for (const r of routes) assert.deepEqual(r.msg, msg, "the kernels are host-blind: same message to each");


### PR DESCRIPTION
The user's report (2026-09-07): the gear showed **Suggest /compact** unchecked with the mixed mark, yet a session on an attached machine received the compaction suggestion that night. The setting shipped per-install (T208): the attached kernel's own copy was on, the kernel serving the dashboard was off. They want no mixed state for this setting, ever, and its copy and gate must stop referring to "workers" (their convention on top of romp, not a romp concept).

**Change**
- `setCompactSuggest` joins federation's `KERNEL_SETTING`: one click is broadcast to every attached kernel, like `setFileEditing`. The gesture-stamp gating is untouched, so a queued flush cannot undo a newer choice.
- `_compact_suggest_tick` no longer excludes members of a `*_workers` session tag; `_worker_tag_member` is deleted. Muted, comment-thread and mid-turn gates stay. Comments drop the recycle/workers framing.
- Gear copy: no "Never sent to workers", no "this kernel keeps its own copy"; keeps the muted and mid-turn exclusions and the fresh-install default; ends with "Applies on every connected machine's kernel".

**Tests (red before)**
- `ui/webview/compact-suggest-mesh.test.ts` (membership, copy, gate).
- `tests/test_compact_suggest.py::CompactSuggest::test_a_session_inside_a_workers_tag_is_suggested_like_any_other`.
- `tests/test_injected_voice.py` unchanged and green (the message body did not change).

**Not covered here**: a machine attached after the click keeps its own copy until the next click; no browser-broadcast setting converges at attach time today, and the gear's mixed mark shows that case.
