### PR TITLE
The chat pane's saved scroll spot follows the reader, and a re-show of the view on screen keeps their place

### DIFF
--- a/ui/webview/chat-windowing.test.ts
+++ b/ui/webview/chat-windowing.test.ts
@@ -109,7 +109,8 @@ test("a new message while scrolled UP keeps the viewport put (no backwards jump)
 });
 
 test("an oversized view (window grew past the cap) re-collapses to the tail on switch", () => {
-  assert.match(RENDER, /if \(!pendingAnchor && pendingAnchorT == null\s*\n?\s*&& v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{/);
+  // `!reshow &&` leads since T249: the re-collapse is a SWITCH rule, never applied to a re-show of the view on screen
+  assert.match(RENDER, /if \(!reshow && !pendingAnchor && pendingAnchorT == null\s*\n?\s*&& v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{/);
   assert.match(RENDER, /v\.rendered = 0; v\.winStart = 0; v\.avgTurnH = undefined; v\.stick = true;/);
 });
 

--- a/ui/webview/prebuild-wiring.test.ts
+++ b/ui/webview/prebuild-wiring.test.ts
@@ -34,7 +34,7 @@ test("a pass builds each off-screen tab's hidden DOM via ensureView + syncView",
   assert.match(RENDER, /function runPrebuild\(deadline: IdleDeadline\): void/);
   // ensureView, then (a re-collapse of an overgrown hidden view — #934 fold), then syncView
   assert.match(RENDER, /ensureView\(id\);[\s\S]*?syncView\(id\);/);
-  assert.match(RENDER, /v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{\s*\n\s*v\.rendered = 0; v\.winStart = 0;/,
+  assert.match(RENDER, /v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{[^\n]*\n\s*v\.rendered = 0; v\.winStart = 0;/,   // a trailing comment may follow the brace (T249)
     "an overgrown hidden view is re-collapsed to the tail window in idle, off the click path");
   // one malformed tab must not abort pre-building the rest
   assert.match(RENDER, /try \{[\s\S]*ensureView\(id\);[\s\S]*syncView\(id\);[\s\S]*\} catch/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -54,6 +54,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
@@ -10017,6 +10018,14 @@ function showActive() {
   syncHostOfflineFoot();   // the tab we just switched to may sit on an unreachable host
   touchMru(activeId!); // record activation order so close returns to the previous tab
   const v = ensureView(activeId!);
+  // A RE-SHOW of the view already on screen keeps the reader's place across its rebuild (T249, the user
+  // 2026-09-07: a full show of a shown tab landed on the spot saved when the tab was last LEFT — a bubble
+  // they had read minutes ago — three seconds after they had scrolled to the bottom). Captured BEFORE the
+  // rebuild the way appendActive does, restored after landActive; a tab switch is not a re-show (the
+  // entering view is still display:none), so the leaving-tab save, the nav trail's spot and the jump
+  // button keep their explicit semantics. The decision and the saved-spot rule live in scroll-keep.ts.
+  const reshow = keepPlaceAcrossShow(v, v.el.style.display !== "none", content.clientHeight > 0, !!pendingAnchor || pendingAnchorT != null);
+  const keepAnchor = reshow && !nearBottom(content) ? captureScrollAnchor(content, v) : null;
   // Bound the switch. A view the user scrolled to the top of has had its window expanded to the WHOLE
   // transcript (winStart crept to 0 via lazy-expand), and compact mode renders the whole folded stream —
   // either way, revealing thousands of nodes is the big-session switch lag (the user 2026-06-25: 4144 turns
@@ -10025,8 +10034,8 @@ function showActive() {
   // scrolling up lazily reloads. Both render paths honour winStart, so this works in either mode. Skip when
   // a deep-link is pending (its target may be in the collapsed head). A small view (≤ cap) is left untouched
   // → the no-op fast path reveals it instantly.
-  if (!pendingAnchor && pendingAnchorT == null
-      && v.el.querySelectorAll(".turn").length > WINDOW_CAP) {
+  if (!reshow && !pendingAnchor && pendingAnchorT == null
+      && v.el.querySelectorAll(".turn").length > WINDOW_CAP) {   // a SWITCH rule: a re-show of the view on screen never snaps it to the tail (T249)
     v.rendered = 0; v.winStart = 0; v.avgTurnH = undefined; v.stick = true;   // → firstBuild rebuilds the tail, lands at bottom
   }
   for (const [vid, vv] of views) vv.el.style.display = vid === activeId ? "" : "none";
@@ -10040,7 +10049,11 @@ function showActive() {
   // the "Loading transcript…" hint — so it renders synchronously below via syncView, never deferred. The
   // `length > 0` guard is what stops a zero-event session from flashing (or sticking on) "Loading…".
   const heavy = s.events.length > 0 && (v.el.childNodes.length === 0 || (settings.compact && (v.rendered !== s.events.length || v.stale)));
-  if (!heavy) { syncView(activeId!); landActive(content, v); return; }
+  if (!heavy) {
+    syncView(activeId!); landActive(content, v);
+    if (keepAnchor) restoreScrollAnchor(content, v, keepAnchor);   // the line being read stays put across the rebuild (T249)
+    return;
+  }
   if (v.el.childNodes.length === 0) {   // truly empty → the ROMP LOADER holds the spot (the standing
     // wait-state rule: swirl + wordmark + pulsing accent dots — never a bare hint). Removed by the
     // deferred build replacing this view's children — the content event — and that build always
@@ -10060,8 +10073,10 @@ function showActive() {
     if (activeId !== target) return;    // switched away before the build ran → don't build the tab we left
     const vv = views.get(target);
     if (!vv || !sessions.has(target)) return;
+    const cc = document.getElementById("content");
     syncView(target);                   // the heavy build now (clears the loading hint)
-    landActive(document.getElementById("content"), vv);
+    landActive(cc, vv);
+    if (keepAnchor && cc) restoreScrollAnchor(cc, vv, keepAnchor);   // same keep on the deferred path (T249)
   });
 }
 
@@ -10305,6 +10320,21 @@ jumpBtn.onclick = () => {
   }
 }
 window.addEventListener("resize", updateJumpBtn);
+// The per-view saved spot FOLLOWS the reader (T249, the user 2026-09-07). landActive lands every show no
+// anchor scrolled on `v.stick ? bottom : v.scrollTop`, and until now those were written only by a tab
+// switch (the tab being LEFT), the jump button, the box-resize compensation and the nav trail — never by
+// the reader's own scrolling. So the spot named where the tab was when last left, and a full show of a
+// shown tab (a fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback)
+// snapped the reader back there. Every scroll of the active view now records its position and its
+// follow-mode (the same nearBottom threshold appendActive and the jump chip read), passive, no timer.
+// Programmatic scrolls (a land, an anchor restore) fire the same event, so the record is always the truth.
+{
+  const c = document.getElementById("content");
+  if (c) c.addEventListener("scroll", () => {
+    if (c.clientHeight <= 0) return;
+    followReader(activeId ? views.get(activeId) : null, c.scrollTop, nearBottom(c));
+  }, { passive: true });
+}
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for
 // #tabbar; extended to #ledger 2026-07-05). Both are `flex: 0 0 auto` directly above the `flex: 1 1 auto`
 // #content scroll area, so when one grows — a working dot wraps the tab strip to a second row, a ledger

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -1,0 +1,64 @@
+// T249 (the user 2026-09-07, a screen recording): on a session served through the relay from an attached
+// kernel, the chat pane snapped the reader's scroll back to an earlier position ~3 s after they scrolled to
+// the bottom — the exact spot the tab had been left at, a blue bubble at the top of the viewport.
+//
+// The writer: landActive's closing rule, `if (!v.shown || v.stick) bottom else v.scrollTop`, fed by a saved
+// spot nothing updated while the reader scrolled (only a tab switch's leaving-tab save, the jump button,
+// the resize compensation and the nav trail wrote it). Any full show of an already-shown tab — a
+// fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback — landed the reader
+// on that stale spot. Fix: (1) the #content scroll listener keeps the active view's saved spot and
+// follow-mode current; (2) a show of a view already on screen anchors the reader's place across its rebuild
+// like the live append does, and the big-view re-collapse-to-tail is a switch-only rule. Executed rules +
+// render.ts wiring pins, red on main's render.ts. Synthetic values only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { followReader, landSpot, keepPlaceAcrossShow, type KeepView } from "./scroll-keep";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the recording: a tab left scrolled up, the reader scrolls to the bottom, a full show lands at the bottom — not the stale spot", () => {
+  const v: KeepView = { scrollTop: 1180, stick: false, shown: true };   // saved when the tab was last LEFT: a bubble at the top
+  assert.equal(landSpot(v), 1180, "before any gesture a re-show lands on the saved spot (unchanged rule)");
+  followReader(v, 9400, true);                                          // the user's smooth scroll to the bottom
+  assert.equal(landSpot(v), "bottom", "a full show now follows the reader to the bottom");
+  followReader(v, 3020, false);                                         // they scroll back up to read
+  assert.equal(landSpot(v), 3020, "…and lands exactly where they are reading");
+});
+
+test("followReader touches only a shown view, and a missing view is a no-op", () => {
+  const fresh: KeepView = { scrollTop: 0, stick: true, shown: false };
+  followReader(fresh, 500, false);
+  assert.deepEqual(fresh, { scrollTop: 0, stick: true, shown: false }, "an unshown view's first land still goes to the bottom");
+  assert.doesNotThrow(() => followReader(null, 1, true));
+  assert.doesNotThrow(() => followReader(undefined, 1, true));
+});
+
+test("keepPlaceAcrossShow: only a displayed, visible, already-shown view with no navigation pending", () => {
+  const v: KeepView = { scrollTop: 300, stick: false, shown: true };
+  assert.equal(keepPlaceAcrossShow(v, true, true, false), true, "a re-show of the view on screen");
+  assert.equal(keepPlaceAcrossShow(v, false, true, false), false, "a tab SWITCH: the entering view is not displayed yet — its explicit spot semantics stand");
+  assert.equal(keepPlaceAcrossShow(v, true, false, false), false, "a hidden pane has nothing to keep");
+  assert.equal(keepPlaceAcrossShow(v, true, true, true), false, "a deep link / moment lands where it says");
+  assert.equal(keepPlaceAcrossShow({ ...v, shown: false }, true, true, false), false, "a first show lands at the bottom");
+});
+
+test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
+  assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow \} from "\.\/scroll-keep";/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\)\);\n\s*\}, \{ passive: true \}\);/);
+  // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
+  assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) content\.scrollTop = content\.scrollHeight;\n\s*else content\.scrollTop = v\.scrollTop;/);
+});
+
+test("render.ts: showActive keeps the reader's place across a re-show of the view already on screen, on both build paths", () => {
+  const m = RENDER.match(/^function showActive\(\) \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "showActive");
+  const body = m![1];
+  assert.match(body, /const reshow = keepPlaceAcrossShow\(v, v\.el\.style\.display !== "none", content\.clientHeight > 0, !!pendingAnchor \|\| pendingAnchorT != null\);/);
+  assert.match(body, /const keepAnchor = reshow && !nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null;/, "captured BEFORE the rebuild, like appendActive");
+  const restores = body.match(/if \(keepAnchor(?: && cc)?\) restoreScrollAnchor\(/g) || [];
+  assert.equal(restores.length, 2, "restored after landActive on the light path AND inside the deferred heavy build");
+  // the big-view re-collapse to the tail is a SWITCH rule: a re-show of the view on screen must not snap it to the bottom
+  assert.match(body, /if \(!reshow && !pendingAnchor && pendingAnchorT == null\n\s*&& v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\)/);
+});

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -1,0 +1,44 @@
+// Where a full show of the ACTIVE view lands, and how the per-view saved spot is kept (T249, the user
+// 2026-09-07: the chat pane snapped their scroll back to an earlier position a few seconds after they
+// scrolled, on a session served through the relay from an attached kernel).
+//
+// landActive ends every show that no anchor scrolled with ONE rule: an unshown or follow-mode view lands at
+// the bottom, any other view lands on its saved `scrollTop`. Until now that saved spot was written only by a
+// tab switch (the tab being LEFT), the jump-to-bottom button, the tab-strip/ledger resize compensation and
+// the nav trail — never by the reader's own scrolling. So the spot named where the tab was when it was
+// last left, and every full show of an already-shown tab (a fork/first-build frame, a settings rerender, a
+// revive failure, a dismissal's fallback) landed the reader back there: they had scrolled to the bottom,
+// a frame arrived, and the view jumped up to a bubble they had read minutes earlier.
+//
+// Two rules, both pure so node --test executes them:
+//  1. the saved spot FOLLOWS the reader — the #content scroll listener records the active shown view's
+//     position and follow-mode on every scroll (followReader), so landActive's rule lands where they are;
+//  2. a show of a view that is ALREADY on screen keeps the reader's place across its rebuild the way the
+//     live append does (keepPlaceAcrossShow → captureScrollAnchor before, restoreScrollAnchor after): a
+//     rebuild can move content above the viewport, and only an anchor keeps the line being read still.
+//     A tab SWITCH is not that: the entering view is not displayed yet, so its explicit spot semantics
+//     (the leaving-tab save, the nav trail's remembered spot, the jump button) are untouched.
+// Event-based throughout: the scroll event and the show itself; no timer, no age threshold.
+
+export interface KeepView { scrollTop: number; stick: boolean; shown: boolean; }
+
+/** The reader scrolled the active view: its saved spot and follow-mode follow them. A view not yet shown
+ *  keeps its defaults (its first land goes to the bottom regardless), and a hidden pane never scrolls. */
+export function followReader(v: KeepView | null | undefined, scrollTop: number, near: boolean): void {
+  if (!v || !v.shown) return;
+  v.scrollTop = scrollTop;
+  v.stick = near;
+}
+
+/** landActive's landing when no anchor scrolled: "bottom" for an unshown or follow-mode view, else the saved spot. */
+export function landSpot(v: KeepView): number | "bottom" {
+  return (!v.shown || v.stick) ? "bottom" : v.scrollTop;
+}
+
+/** Must this show keep the reader's place across the rebuild? Only when the view is the one on screen
+ *  already (displayed, in a visible pane), has been shown before, and nothing is navigating (no pending
+ *  anchor or moment: a deep link lands where it says). A tab switch fails `displayed`; a first show fails
+ *  `shown`; a hidden pane has nothing to keep. */
+export function keepPlaceAcrossShow(v: KeepView, displayed: boolean, visible: boolean, navigating: boolean): boolean {
+  return v.shown && displayed && visible && !navigating;
+}

--- a/ui/webview/tab-switch-defer.test.ts
+++ b/ui/webview/tab-switch-defer.test.ts
@@ -13,7 +13,8 @@ test("showActive renders a built view synchronously, defers an unbuilt/changed o
   // the heavy gate is also fronted by `s.events.length > 0` so a zero-event session never defers / never
   // shows the "Loading transcript…" hint — it renders the empty placeholder synchronously (the user 2026-06-19)
   assert.match(RENDER, /const heavy = s\.events\.length > 0 && \(v\.el\.childNodes\.length === 0 \|\| \(settings\.compact && \(v\.rendered !== s\.events\.length \|\| v\.stale\)\)\);/);
-  assert.match(RENDER, /if \(!heavy\) \{ syncView\(activeId!\); landActive\(content, v\); return; \}/);   // cached/incremental → instant
+  // cached/incremental → instant; since T249 the light path also restores the re-show anchor after the land
+  assert.match(RENDER, /if \(!heavy\) \{\s*\n\s*syncView\(activeId!\); landActive\(content, v\);\n\s*if \(keepAnchor\) restoreScrollAnchor\(content, v, keepAnchor\);[^\n]*\n\s*return;\n\s*\}/);
 });
 
 test("the heavy build is deferred via rAF, replacing any in-flight one, and skipped if we switched away", () => {
@@ -25,5 +26,6 @@ test("the heavy build is deferred via rAF, replacing any in-flight one, and skip
 
 test("the landing (scroll/anchor/diagnostics) is factored so sync + deferred paths land identically", () => {
   assert.match(RENDER, /function landActive\(content: HTMLElement \| null, v: View\): void/);
-  assert.match(RENDER, /landActive\(document\.getElementById\("content"\), vv\);/);   // called after the deferred build
+  // called after the deferred build, on the #content read once for the land and the T249 re-show anchor restore
+  assert.match(RENDER, /const cc = document\.getElementById\("content"\);\n\s*syncView\(target\);[^\n]*\n\s*landActive\(cc, vv\);\n\s*if \(keepAnchor && cc\) restoreScrollAnchor\(cc, vv, keepAnchor\);/);
 });


### PR DESCRIPTION
## What

The chat pane snapped the reader's scroll back to an earlier position a few seconds after they scrolled, on a session served through the relay from an attached kernel (the user 2026-09-07, a screen recording: a smooth scroll to the bottom, then ~3 s later an instantaneous jump back up to a bubble read minutes earlier, with no gesture).

**The writer.** `landActive` closes every show that no anchor scrolled with one rule: a follow-mode view lands at the bottom, any other lands on its saved `v.scrollTop`. That saved spot was written only by a tab switch (the tab being LEFT), the jump-to-bottom button, the tab-strip/ledger resize compensation and the nav trail. The reader's own scrolling never updated it. So it named where the tab was when it was last left, and every full show of an already-shown tab (a fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback) landed the reader back there. On the recorded session, served through the relay by a restarted attached kernel with no active-tab knowledge (the gap romp-on/romp#1032 closed), such frames arrive on the file-stat cadence; the writer itself is a bug for any full show of a shown tab, whatever the trigger.

**The fix, two rules** (pure in `ui/webview/scroll-keep.ts`, executed by node, wired in render.ts):

1. The saved spot follows the reader: the `#content` scroll listener records the active shown view's position and follow-mode on every scroll (the same `nearBottom` threshold appendActive and the jump chip read). Passive, no timer; a programmatic land fires the same event, so the record is always the truth.
2. A re-show of the view already on screen keeps the reader's place across its rebuild: `showActive` captures a scroll anchor before `syncView` and restores it after `landActive`, on both the light and the deferred heavy path, exactly as the live append does. The big-view re-collapse to the tail becomes a switch-only rule. A tab switch is not a re-show (the entering view is still `display:none`), so the leaving-tab save, the nav trail's remembered spot and the jump button keep their explicit semantics.

Event-based throughout: the scroll event and the show itself. No age threshold, no debounce.

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New: `ui/webview/scroll-keep-on-show.test.ts` — replays the recording against the two rules (a tab left scrolled up, the reader scrolls to the bottom, a full show lands at the bottom, not the stale spot; scrolled back up, it lands where they read), the decision table for when a show keeps the place, and render.ts wiring pins (red on main's render.ts). Two pins on the re-collapse condition follow its new shape (`chat-windowing.test.ts`, `prebuild-wiring.test.ts`). Suites: node 3262 passed (`npm test`, typecheck clean); the 28 Python modules that read the browser sources 834 passed, with the two `ViewBuilder` nudge tests failing only inside that partial selection and passing alone (the known ordering artifact); the kernel is untouched.

Not done here, deliberately, because the fix is on the critical path: a two-real-kernel harness run (relay, restarted attached kernel, scroll, wait through pushes) before and after. The writer was convicted by reading; the harness run is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
