### PR TITLE
Tag-group headers wear the tag's own chip — one vocabulary with the tags bar

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -19,7 +19,7 @@ import { applyTheme } from "./theme";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
-import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
+import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
@@ -5030,13 +5030,14 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
   caret.textContent = "▸";                       // turned down by CSS while open (.tab-group-head:not(.collapsed))
   caret.setAttribute("aria-hidden", "true");
   head.appendChild(caret);
-  const swatch = el("span", "tab-group-swatch");  // the tag's color as a short bar — a dot beside a name is a session pip
-  if (sec.color) swatch.style.background = sec.color;
-  swatch.setAttribute("aria-hidden", "true");
-  head.appendChild(swatch);
-  const label = el("span", "tab-group-name");
-  label.textContent = name;
-  head.appendChild(label);
+  // the tag as THE CHIP it wears everywhere (T251, the user 2026-09-07: the swatch+name pair read as a
+  // plain label; the chip says "this is the tag" the way the tags bar and the feed say it, so which
+  // tabs belong to which group reads at a glance). The shared builder from tag-menu.ts — one
+  // vocabulary, never a lookalike — inheriting the header's own sub-line size (no nested em). The
+  // count rides right after it in the same row.
+  const chip = tagChip(name, sec.color, { inheritSize: true });
+  chip.classList.add("tab-group-chip");
+  head.appendChild(chip);
   const n = el("span", "tab-group-count");
   n.textContent = words.count;   // folded: the hidden members — a pinned one shows itself; all pinned: the total (headWords)
   head.appendChild(n);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -384,8 +384,9 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-group-caret { display: inline-block; flex: 0 0 auto; width: 0.9em; text-align: center; transition: transform 0.12s ease; }
 .tab-group-head:not(.collapsed) .tab-group-caret { transform: rotate(90deg); }
 /* the tag's color as a short bar, not a dot: a dot beside a name is a session pip */
-.tab-group-swatch { flex: 0 0 auto; width: 3px; height: 12px; border-radius: 1px; background: var(--dim); }
-.tab-group-name { font-weight: 600; }
+/* the tag's CHIP (T251) — the shared tag-menu builder's pill, sized by the header (no nested em); flex-none
+   so a wrapping strip never squeezes it, and a tab's own vertical rhythm stays the ceiling */
+.tab-group-chip { flex: 0 0 auto; font-weight: 600; line-height: 1.2; }
 .tab-group-count { opacity: 0.7; }
 /* the folded header's member-state pip (after the count, small — subordinate to the label): the tab's
    status colors by the tab's own rule (tab-state.ts) — working gold, blocked/waiting red, retrying the

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -350,9 +350,10 @@ test("the section chrome is a LABEL's (the user 2026-09-06): the surface's sub-l
   assert.match(head, /letter-spacing: 0\.04em;/);
   assert.match(head, /color: var\(--dim\);/);
   assert.match(CSS, /\.tab-group-count \{ opacity: 0\.7; \}/, "the count inherits the header's size — no em nested inside an em");
-  assert.match(CSS, /\.tab-group-name \{ font-weight: 600; \}/);
-  assert.match(CSS, /\.tab-group-swatch \{ flex: 0 0 auto; width: 3px; height: 12px; border-radius: 1px; background: var\(--dim\); \}/,
-    "the tag's color as a short bar — a 7px dot beside a name is a session pip");
+  // T251 (the user 2026-09-07): the swatch+name pair retired for THE CHIP the tag wears everywhere —
+  // the shared tag-menu builder's pill, bold like the name it replaces, sized by the header
+  assert.match(CSS, /\.tab-group-chip \{ flex: 0 0 auto; font-weight: 600; line-height: 1\.2; \}/);
+  assert.doesNotMatch(CSS, /\.tab-group-swatch|\.tab-group-name \{/, "the bar and the plain name are gone");
   assert.doesNotMatch(CSS, /\.tab-group-dot/, "the dot is gone");
   const sizes = new Set(Array.from(CSS.matchAll(/\n\.tab-group-[^{\n]*\{[^}]*font-size: ([^;]+);/g)).map((m) => m[1]));
   assert.deepEqual([...sizes], ["0.82em"], "one font-size across every section rule");
@@ -362,14 +363,13 @@ test("the section chrome is a LABEL's (the user 2026-09-06): the surface's sub-l
 test("the header's structure and gestures read as a label: chevron (flips with the fold) → color bar → name → count; a keyboard button; hover/focus say fold, never open; tokens only (the user 2026-09-06)", () => {
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
   const at = (t: string) => { const i = head.indexOf(t); assert.ok(i >= 0, "present: " + t); return i; };
-  assert.ok(at('el("span", "tab-group-caret")') < at('el("span", "tab-group-swatch")')
-    && at('el("span", "tab-group-swatch")') < at('el("span", "tab-group-name")')
-    && at('el("span", "tab-group-name")') < at('el("span", "tab-group-count")'), "chevron, bar, name, count");
+  assert.ok(at('el("span", "tab-group-caret")') < at('tagChip(name, sec.color, { inheritSize: true })')
+    && at('tagChip(name, sec.color, { inheritSize: true })') < at('el("span", "tab-group-count")'), "chevron, the tag's CHIP, count");
   assert.match(head, /caret\.textContent = "▸";/);
   assert.match(CSS, /\.tab-group-head:not\(\.collapsed\) \.tab-group-caret \{ transform: rotate\(90deg\); \}/,
     "the fold state flips it — the sheet's fold-caret idiom, a CSS transition, no timer");
   assert.match(CSS, /\.tab-group-caret \{[^}]*transition: transform 0\.12s ease;/);
-  assert.match(head, /if \(sec\.color\) swatch\.style\.background = sec\.color;/, "the tag's color from the views store");
+  assert.match(head, /tagChip\(name, sec\.color, \{ inheritSize: true \}\)/, "the tag's color from the views store, on the SHARED chip (T251)");
   // none of a tab's affordances
   assert.ok(!head.includes("tab-close") && !head.includes("tabStateClass(") && !head.includes("tab-dot") && !head.includes("tabCtxGauge("),
     "no close, no state class of its own, no tab pip, no gauge");
@@ -1523,7 +1523,10 @@ test("assistive tech hears a label: decoration is aria-hidden, the header's name
   // folded into the name — and the active section's header as "button, expanded" with no focus and a
   // no-op click
   assert.match(MAKE_HEAD, /caret\.setAttribute\("aria-hidden", "true"\);/, "the chevron is decoration");
-  assert.match(MAKE_HEAD, /swatch\.setAttribute\("aria-hidden", "true"\);/, "so is the color bar");
+  // T251: the color bar retired for the tag's CHIP, which carries the NAME — words, not decoration, so it is
+  // never aria-hidden (the header's explicit aria-label still outranks name-from-content)
+  assert.match(MAKE_HEAD, /const chip = tagChip\(name, sec\.color, \{ inheritSize: true \}\);/, "the chip carries the name");
+  assert.ok(!/chip\.setAttribute\("aria-hidden"/.test(MAKE_HEAD), "…and is words, never hidden decoration");
   assert.match(MAKE_HEAD, /pip\.setAttribute\("aria-hidden", "true"\);[^\n]*\n\s*spoken \+= "; " \+ pip\.title;/, "the pip too — its phrase rides the label instead");
   assert.match(MAKE_HEAD, /let spoken = words\.label;/, "the label starts as headWords' (name and count, in words — executed above)");
   assert.match(MAKE_HEAD, /head\.setAttribute\("aria-label", spoken\);\s*\n\s*head\.draggable = true;/, "set once, after the pip; an aria-label outranks name-from-content, so the header says what was appended and nothing that leaked in");
@@ -1536,4 +1539,16 @@ test("assistive tech hears a label: decoration is aria-hidden, the header's name
   assert.equal(MAKE_HEAD.split('"role", "button"').length - 1, 1);
   assert.ok(MAKE_HEAD.indexOf('"role", "group"') < MAKE_HEAD.indexOf('"role", "button"'), "the active branch first, as the source reads");
   assert.equal(headWords("archived", 2, 2, true, false).label, "archived, 2 sessions folded");
+});
+
+
+test("the group header wears the SHARED tag chip — one vocabulary with the tags bar and the feed (T251)", () => {
+  const MENU = ui("webview", "tag-menu.ts");
+  assert.match(MENU, /export function tagChip\(label: string, color\?: string \| null, opts\?: \{ inheritSize\?: boolean \}\): HTMLElement \{/,
+    "the chip is a named builder, not a lookalike");
+  assert.match(MENU, /const chip = tagChip\(c\.label, c\.color\);/, "the tags bar builds its chips through it");
+  assert.match(MENU, /\("var\(--dim, " \+ TAG_BTN_GRAY \+ "\)"\)/, "the uncoloured fallback is a THEME TOKEN — the light theme is never handed a dark gray");
+  const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
+  assert.match(head, /chip\.classList\.add\("tab-group-chip"\);/);
+  assert.ok(!/font-size/.test(head), "the header sets no size of its own — the chip inherits the header's 0.82em (no nested em)");
 });

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -168,6 +168,22 @@ export const TAG_BTN_ACCENT = "#9cd2ff";   // the romp accent (--accent) — pin
 export const TAG_BTN_BORDER = "rgba(255,255,255,0.10)";   // the feed's --card-border, stated by value
 export const TAG_BTN_WASH = "rgba(156,210,255,0.12)";     // the feed .on's faint accent wash, ditto
 
+/** THE TAG CHIP (one vocabulary, T251 — the user 2026-09-07: a group header must show its tag the way
+ *  the tag is shown everywhere else): the outline pill in the tag's own colour, the shape the strip's
+ *  tags bar and the feed's tag chips wear. `inheritSize` drops the pill's own 0.82em for a host that
+ *  already sits at the surface's sub-line size (the group header), so no em nests inside an em (the
+ *  fonts rule). The uncoloured fallback is the theme's --dim (a token, so the light theme is never
+ *  handed a dark gray), with the constant as the file:// fallback. */
+export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean }): HTMLElement {
+  const col = color || ("var(--dim, " + TAG_BTN_GRAY + ")");
+  const chip = document.createElement("span");
+  chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
+    + "border-radius:9px;" + (opts && opts.inheritSize ? "" : "font-size:0.82em;")
+    + "border:1px solid " + col + ";color:" + col + ";background:transparent;white-space:nowrap;");
+  chip.appendChild(document.createTextNode(label));
+  return chip;
+}
+
 export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
                               lens: TagLens, unions: { name: string; color?: string | null; members: string[]; }[],
                               onApply: (l: TagLens) => void,
@@ -183,12 +199,7 @@ export function syncTagFilter(btn: HTMLElement, chipsHost: HTMLElement,
   btn.setAttribute("aria-pressed", narrowed ? "true" : "false");
   chipsHost.textContent = "";
   for (const c of lensChips(lens, unions as never)) {
-    const col = c.color || TAG_BTN_GRAY;
-    const chip = document.createElement("span");
-    chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
-      + "border-radius:9px;font-size:0.82em;border:1px solid " + col + ";color:" + col + ";"
-      + "background:transparent;white-space:nowrap;");
-    chip.appendChild(document.createTextNode(c.label));
+    const chip = tagChip(c.label, c.color);
     const x = document.createElement("span");
     x.textContent = "✕";
     x.setAttribute("style", "cursor:pointer;opacity:0.75;color:" + TAG_BTN_GRAY + ";font-size:0.9em;");


### PR DESCRIPTION
The user (2026-09-07): when the strip is grouped by tag, render each group's tag the way tags are shown everywhere else — the little chip — with the count riding along, so which tabs belong to which group reads at a glance; the thin color swatch beside a plain name did not say 'this is a tag'.

The chip builder is extracted from `syncTagFilter` into tag-menu.ts's **`tagChip`** and used by **both** the strip's tags bar and the group header — one builder, never a lookalike. In the header it inherits the header's own sub-line size (no em nested inside an em), replaces the swatch+name pair, and the count sits right after it in the same row. The uncolored fallback becomes the theme's `--dim` token (constant as the file:// fallback), so the light theme is never handed a dark gray. Everything else on the header is untouched: caret and fold, drag-and-drop and keyboard, holds-active, the collapsed pip and its tooltip, the count semantics, the delegate paths (`data-group`, `role=button`). Header height stays a tab's — verified in both themes, one group collapsed (shots in the report).

Pins: the swatch/name CSS and structure pins retargeted to the chip with reasons; the aria pin now asserts the chip carries the NAME as words (never hidden decoration); a new pin holds the shared builder, the tags bar using it, the theme-token fallback, and the header setting no size of its own. 3262/3262 extension tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)