### PR TITLE
Kernel and bus request bodies are authorized, bounded and type-checked before they act

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,6 +52,21 @@ These are for scripting and for agents rather than daily use:
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
 | `romp refresh --quiet` | Refresh at the next quiet window instead — waits for sessions to finish their turns (15-min backstop) |
 
+Raw `POST` callers, anything that talks to the kernel's routes directly rather
+than through `romp`, follow one body contract, and the postal bus's own routes
+share it. The request carries the serve token (`X-Romp-Token`, or `?token=`)
+and is authorized before its body is read. The body is delimited by
+`Content-Length` alone: no `Transfer-Encoding` (411), the header once and a
+plain decimal (400 otherwise), and at most 1 MiB (413 beyond that, refused
+before a byte is read). A body that arrives short of its announced length is
+400, one that stalls for 30 seconds is 408, and every refusal closes the
+connection. The body is a JSON object; an array, string, number or `null` is a
+400 naming what arrived, echoed bounded and well formed. A flag field
+(`delete`, `on`, `mkdir`, `tracked`, and the like) is a JSON boolean: `true`
+and `false` apply, an absent field or an explicit `null` reads as the route's
+default, and anything else (the string `"false"`, `0`, `1`) is a 400 naming the
+field, with nothing acted on.
+
 `--env` gives one session its own environment, so two sessions in the same
 directory can run with different toggles (a `FEATURE_FLAG=1`, a `CLAUDE_CODE_*`
 switch) without editing the directory's `.claude/settings*.json`, which reaches

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2745,7 +2745,7 @@ def _clear_state_fault(path):
     _state_fault_seen.pop(str(path), None)
 
 
-def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", value=None):
+def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", value=None, log=None):
     """A dashboard gesture (a lane/tab flag, a card bell, a drag, a view change) that this kernel
     REFUSED because the store it edits could not be read -- or, since the maintainer's fold on PR
     #1019, WRITTEN (_StateUnwritable: the publish itself failed): one stderr line, and the refusal answered
@@ -2759,9 +2759,11 @@ def _refuse_setting(client, exc, what, gesture, sid="", item_id="", flag="", val
     gesture with no single value (an order, a whole-blob view write). A `warn` frame did none of
     this: only the chat page renders `warn`, so a refused bell on the feed page and a refused lane
     flag on the timeline page stayed painted as if they had landed until a reload. A dead socket is
-    the client's problem: the refusal already stands."""
+    the client's problem: the refusal already stands. `log`, when given, is what stderr gets INSTEAD of
+    `text`: a flag refusal's text echoes the client's value for the client, and the log line names only
+    the field and its type (_flag_type_note; review find, 2026-09-08)."""
     text = "couldn't save %s \u2014 %s; try again" % (what, exc)
-    sys.stderr.write("romp-kernel: %s\n" % text)
+    sys.stderr.write("romp-kernel: %s\n" % (log or text))
     if not client or not callable(client.get("send")):
         return
     _reply(client, {"type": "settingRefused", "gesture": str(gesture), "sid": str(sid or ""),
@@ -19400,20 +19402,63 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
 # and allocated its declared length -- with no token, see _read_post_body).
 _POST_MAX_BYTES = 1024 * 1024
 
+# The longest the kernel waits for an announced, in-bounds body to ARRIVE. The cap above bounds what
+# one request can make a handler buffer; this bounds how long it can hold the handler's thread while
+# sending it (review find, 2026-09-08): an authorized client that announced 1 MiB and trickled it a
+# byte at a time pinned a thread for as long as it liked, since the socket had no timeout. Every
+# shipped client sends its body in one write, so 30 s is generous; a read that stalls past it answers
+# 408 and closes.
+_POST_BODY_TIMEOUT = 30.0
+
 
 def _clip_json(v, n=60):
     """A BOUNDED, WELL-FORMED echo of an offending request value for an error message: a 1 MB body must
-    never come back as a 1 MB error. The cut lands INSIDE a string's quotes and is marked, so a long
-    string still echoes as one complete quoted thing and the words after it survive (a slice of the
-    serialized text took the closing quote with it); ensure_ascii is off, or the marker itself comes
-    back as \\u2026. The same shape as the /restart helper's clip."""
-    if isinstance(v, str):
-        return json.dumps(v[:n] + "\u2026" if len(v) > n else v, ensure_ascii=False)
+    never come back as a 1 MB error. Every string is cut INSIDE its quotes and marked, at any depth, so a
+    long string still echoes as one complete quoted thing and the words after it survive; a container
+    is cut at the ELEMENT level, its first few members and a marker member, and nests no deeper than
+    four levels, so the echo is valid JSON whatever arrived (review find, 2026-09-08: a slice of the
+    serialized text cut a container mid-token, and ["xxx... came back with its quote and bracket open);
+    a number past n digits echoes as a marked string, since a cut decimal is a mid-token cut too.
+    Members are dropped until the whole echo fits about 4n characters; ensure_ascii is off, or the
+    marker itself comes back as \\u2026. The same shape as the /restart helper's clip."""
+    mark = "\u2026"
+
+    def cut(x, keep, depth):
+        if isinstance(x, str):
+            return x[:n] + mark if len(x) > n else x
+        if isinstance(x, dict):
+            if not x:
+                return {}
+            if depth >= 4 or keep == 0:
+                return {mark: mark}
+            items = list(x.items())
+            out = {cut(str(k), keep, depth + 1): cut(val, keep, depth + 1) for k, val in items[:keep]}
+            if len(items) > keep:
+                out[mark] = mark
+            return out
+        if isinstance(x, (list, tuple)):
+            if not x:
+                return []
+            if depth >= 4 or keep == 0:
+                return [mark]
+            out = [cut(val, keep, depth + 1) for val in x[:keep]]
+            if len(x) > keep:
+                out.append(mark)
+            return out
+        if isinstance(x, (int, float)) and not isinstance(x, bool):
+            s = str(x)                                   # a number past n digits (json.loads takes an int of
+            return x if len(s) <= n else s[:n] + mark    # up to 4300) echoes as a marked STRING: a cut
+        return x                                         # decimal would be a mid-token cut
+
     try:
-        s = json.dumps(v, ensure_ascii=False)
+        for keep in (8, 4, 2, 1, 0):
+            s = json.dumps(cut(v, keep, 0), ensure_ascii=False)
+            if len(s) <= 4 * n or keep == 0:
+                return s
     except (TypeError, ValueError):
-        s = repr(v)
-    return s if len(s) <= n else s[:n] + "\u2026"
+        pass
+    s = repr(v)
+    return s if len(s) <= n else s[:n] + mark
 
 
 def _json_object_body(raw):
@@ -19435,11 +19480,15 @@ def _json_object_body(raw):
 
 
 def _as_bool(v, field, default=False):
-    """A request flag as the boolean it claims to be -> (value, error). Absent (None) is `default`; JSON
-    true/false pass through; anything else -- the string "false", 0/1, "no" -- is refused with `error`
-    naming the field, and the caller must NOT act. Never coerces: bool("false") is True, which is how a
-    string used to enable auto-nudge, file editing, the master bell and auto-update, pause retries
-    across every session, make a directory, and delete a tag."""
+    """A request flag as the boolean it claims to be -> (value, error). Absent is `default`, and so is an
+    EXPLICIT JSON null: the routes read their fields with .get(), under which the two are one value, and
+    null is how a client says "no value", the absent case spelled out, not a third kind of flag (review
+    find, 2026-09-08: the rule is stated here and in docs/reference.md, and pinned by the tests, so that
+    "a present non-boolean is refused" is read with null excepted). JSON true/false pass through;
+    anything else -- the string "false", 0/1, "no" -- is refused with `error` naming the field, and the
+    caller must NOT act. Never coerces: bool("false") is True, which is how a string used to enable
+    auto-nudge, file editing, the master bell and auto-update, pause retries across every session, make a
+    directory, and delete a tag."""
     if v is None:
         return default, None
     if v is True or v is False:
@@ -19447,17 +19496,43 @@ def _as_bool(v, field, default=False):
     return None, "'%s' must be true or false, got %s" % (field, _clip_json(v))
 
 
-def _refuse_ws_flag(client, op, err):
+def _json_type_name(v):
+    """The JSON type of a decoded value, for a log line that must not carry the value itself."""
+    if v is None:
+        return "null"
+    if v is True or v is False:
+        return "a boolean"
+    if isinstance(v, str):
+        return "a string"
+    if isinstance(v, (int, float)):
+        return "a number"
+    if isinstance(v, list):
+        return "an array"
+    if isinstance(v, dict):
+        return "an object"
+    return type(v).__name__
+
+
+def _flag_type_note(field, v):
+    """What a refused flag was, for the kernel's OWN log: the field name and the value's JSON type, never
+    the value. The echo of the value belongs in the frame the sending client gets (it asked); the stderr
+    line used to carry up to 60 characters of whatever a client put in the field (review find,
+    2026-09-08), and a log is read by people who never sent it."""
+    return "'%s' is %s, not a boolean" % (field, _json_type_name(v))
+
+
+def _refuse_ws_flag(client, op, err, field="", value=None):
     """A WS frame carried a flag that is not a boolean: one stderr line, and a `warn` frame -- the frame
     the dispatcher answers a malformed request with (a bad session name, a failed login step) -- on the
-    delivering socket. The shipped panes send real booleans, so nothing on screen needs repainting; this
-    reaches the client that sent the string, and the log. The two flags whose pages never render `warn`
-    (setSessionFlag on the timeline, cardNotify on the feed) refuse through _refuse_setting instead, on
-    the settingRefused frame those pages repaint from."""
-    text = "%s: %s" % (op, err)
-    sys.stderr.write("romp-kernel: refused %s\n" % text)
+    delivering socket. The frame carries `err` with its bounded echo of the value (the sender sees what
+    it sent); the stderr line names only the op, the field and the value's type (_flag_type_note). The
+    shipped panes send real booleans, so nothing on screen needs repainting; this reaches the client
+    that sent the string, and the log. The two flags whose pages never render `warn` (setSessionFlag on
+    the timeline, cardNotify on the feed) refuse through _refuse_setting instead, on the settingRefused
+    frame those pages repaint from."""
+    sys.stderr.write("romp-kernel: refused %s: %s\n" % (op, _flag_type_note(field, value)))
     if client and callable(client.get("send")):
-        _reply(client, {"type": "warn", "text": text})
+        _reply(client, {"type": "warn", "text": "%s: %s" % (op, err)})
 
 
 def _parse_send_body(raw):
@@ -40909,9 +40984,11 @@ class Handler(BaseHTTPRequestHandler):
         raising on a run past the interpreter's conversion limit, which 500'd with a traceback); a
         declared length past _POST_MAX_BYTES is refused with 413 before a byte of it is read; and a body
         SHORTER than announced (a dead client, a short read) is refused with 400 naming the shortfall
-        rather than passing as the bytes that did arrive. An absent Content-Length is an empty body (the
-        bodiless POSTs: /tick, /restart). PR #1027 does the announced-vs-arrived check for /restart inside
-        its own parse; the two compose."""
+        rather than passing as the bytes that did arrive; a body that STALLS (an authorized client
+        trickling it) is refused with 408 once the read has waited _POST_BODY_TIMEOUT, so a slow sender
+        cannot pin a handler thread. An absent Content-Length is an empty body (the bodiless POSTs:
+        /tick, /restart). PR #1027 does the announced-vs-arrived check for /restart inside its own
+        parse; the two compose."""
         if self.headers.get("Transfer-Encoding"):
             self.close_connection = True
             return None, (411, "Transfer-Encoding is not accepted; send the body with a Content-Length")
@@ -40931,7 +41008,28 @@ class Handler(BaseHTTPRequestHandler):
         if n > _POST_MAX_BYTES:
             self.close_connection = True
             return None, (413, "request body of %d bytes exceeds the %d-byte limit" % (n, _POST_MAX_BYTES))
-        raw = self.rfile.read(n) if n else b""
+        if not n:
+            return b"", None
+        # The read runs under a socket timeout (_POST_BODY_TIMEOUT), restored afterwards so a served
+        # keep-alive connection waits for its next request exactly as before. `connection` is the
+        # socket the stdlib handler set up; a unit-test handler over a BytesIO has none, and a fake
+        # rfile that stalls raises the same socket.timeout the real one would.
+        sock = getattr(self, "connection", None)
+        prior = sock.gettimeout() if sock is not None else None
+        try:
+            if sock is not None:
+                sock.settimeout(_POST_BODY_TIMEOUT)
+            raw = self.rfile.read(n)
+        except socket.timeout:
+            self.close_connection = True
+            return None, (408, "body could not be read: %d bytes announced, not all of it arrived within %g s"
+                          % (n, _POST_BODY_TIMEOUT))
+        finally:
+            if sock is not None:
+                try:
+                    sock.settimeout(prior)
+                except OSError:
+                    pass                                     # the socket is already gone; the close stands
         if len(raw) < n:
             self.close_connection = True
             return None, (400, "body could not be read: read %d of the %d bytes Content-Length announced" % (len(raw), n))
@@ -42406,7 +42504,7 @@ class Handler(BaseHTTPRequestHandler):
         if msg and msg.get("type") == "setGlobalRetryPaused":
             paused, ferr = _as_bool(msg.get("value"), "value")
             if ferr:                                   # a string here paused retries across EVERY session
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "value", msg.get("value"))
                 return
             _set_retry_paused(paused)
             _mark_views_dirty()
@@ -42484,7 +42582,8 @@ class Handler(BaseHTTPRequestHandler):
                 # the lane gear's own refusal frame (settingRefused, which the timeline page renders and
                 # repaints from; a `warn` never reaches it), addressed like the store-fault refusal below
                 _refuse_setting(client, ferr, "that setting", "flag", sid=msg["id"], flag=msg["flag"],
-                                value=_painted_flag_value(str(msg["id"]), str(msg["flag"])))
+                                value=_painted_flag_value(str(msg["id"]), str(msg["flag"])),
+                                log="refused %s: %s" % (msg["type"], _flag_type_note("value", msg.get("value"))))
                 return
             try:
                 if str(msg["flag"]) == "notify":
@@ -42614,7 +42713,8 @@ class Handler(BaseHTTPRequestHandler):
                 # the bell's own refusal frame (settingRefused, which the feed page renders and repaints
                 # from; a `warn` never reaches it), addressed like the store-fault refusal below
                 _refuse_setting(client, ferr, "that bell", "bell", sid=msg.get("sid") or "", item_id=msg["itemId"],
-                                value=bool(_notify_card_effective(_notify_cards(), str(msg["itemId"]), str(msg.get("sid") or ""))))
+                                value=bool(_notify_card_effective(_notify_cards(), str(msg["itemId"]), str(msg.get("sid") or ""))),
+                                log="refused %s: %s" % (msg["type"], _flag_type_note("value", msg.get("value"))))
                 return
             try:
                 _set_notify_card(str(msg["itemId"]), value, str(msg.get("sid") or ""))
@@ -42648,7 +42748,7 @@ class Handler(BaseHTTPRequestHandler):
             # reads the flag fresh each pass, so flipping it needs no restart
             enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             _set_conserve(enabled)
             _push_soon()
@@ -42658,7 +42758,7 @@ class Handler(BaseHTTPRequestHandler):
             # that made the losing gesture hears it
             enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             if _set_auto_nudge(enabled, gt=_gesture_ms(msg)) is not None:
                 # turn-ON acts at once instead of waiting out the pusher's 0.5 s backstop; turning off
@@ -42679,7 +42779,7 @@ class Handler(BaseHTTPRequestHandler):
             # (_ws_act_now_tick: single-flight, no dead-wait sweep, a failure logged not raised)
             enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             if _set_compact_suggest(enabled, gt=_gesture_ms(msg)) is not None:
                 _ws_act_now_tick()
@@ -42695,7 +42795,7 @@ class Handler(BaseHTTPRequestHandler):
             # A stale gesture stamp stands down (a queued flush must not undo a newer choice).
             enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             if _set_file_editing(enabled, gt=_gesture_ms(msg)) is None:
                 _tell_stale_gesture(client, msg)
@@ -42705,7 +42805,7 @@ class Handler(BaseHTTPRequestHandler):
             # backend reads the store at each session's next connect, so nothing else to do here.
             enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
-                _refuse_ws_flag(client, msg["type"], ferr)
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             if _set_thinking_summaries(enabled, gt=_gesture_ms(msg)) is None:
                 _tell_stale_gesture(client, msg)
@@ -42887,7 +42987,7 @@ class Handler(BaseHTTPRequestHandler):
                 # "that folder doesn't exist" dialog and chose to make it (see createDirMissing below).
                 mk, ferr = _as_bool(msg.get("mkdir"), "mkdir")
                 if ferr:
-                    _refuse_ws_flag(client, msg["type"], ferr)
+                    _refuse_ws_flag(client, msg["type"], ferr, "mkdir", msg.get("mkdir"))
                     return
                 cwd, derr = _resolve_create_dir(msg.get("dir"), create=mk)
                 live = _live_names(_tmux_sessions())

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13492,8 +13492,8 @@ def _drive(msg, client):
     elif t == "mcpAction" and msg.get("server"):
         # enable / disable / reconnect ONE MCP server (SDK control requests). The panel refetches after,
         # so the truth on screen is always the CLI's own status — never an optimistic guess.
-        err = be.mcp_action(sid, str(msg["server"]), str(msg.get("action") or "toggle"),
-                            bool(msg.get("enabled", True)))
+        enabled, ferr = _as_bool(msg.get("enabled"), "enabled", default=True)
+        err = ferr or be.mcp_action(sid, str(msg["server"]), str(msg.get("action") or "toggle"), enabled)
         client["send"](json.dumps({"type": "mcpResult", "id": sid, "server": str(msg["server"]),
                                    "error": err or ""}))
         _push_soon()
@@ -19390,6 +19390,74 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
             time.sleep(0.85)
             _TMUX.send_keys(name, "Enter")                          # accept the hookless /model confirm
     threading.Thread(target=go, daemon=True).start() if _async else go()
+
+
+# The most a POST body may carry. Every POST this kernel serves is a JSON control request -- a /send
+# or /deliver message text, a tag edit, a push subscription, a settings flip -- tens of KB at the very
+# most; attachments never ride POST (they ride the WS, under _WS_MAX_MESSAGE). 1 MiB is an order of
+# magnitude of headroom over the largest legitimate body, and the bound on what one request can make a
+# handler thread buffer (the server is threaded: before the cap, each oversize POST pinned a thread
+# and allocated its declared length -- with no token, see _read_post_body).
+_POST_MAX_BYTES = 1024 * 1024
+
+
+def _clip_json(v, n=60):
+    """A BOUNDED, WELL-FORMED echo of an offending request value for an error message: a 1 MB body must
+    never come back as a 1 MB error. The cut lands INSIDE a string's quotes and is marked, so a long
+    string still echoes as one complete quoted thing and the words after it survive (a slice of the
+    serialized text took the closing quote with it); ensure_ascii is off, or the marker itself comes
+    back as \\u2026. The same shape as the /restart helper's clip."""
+    if isinstance(v, str):
+        return json.dumps(v[:n] + "\u2026" if len(v) > n else v, ensure_ascii=False)
+    try:
+        s = json.dumps(v, ensure_ascii=False)
+    except (TypeError, ValueError):
+        s = repr(v)
+    return s if len(s) <= n else s[:n] + "\u2026"
+
+
+def _json_object_body(raw):
+    """A POST body as the JSON object the session-management routes expect -> (body, error). Empty is
+    {} (the route then names its missing fields). Otherwise the body must decode AND be an object;
+    anything else comes back as `error` naming what arrived, and the route answers 400 without acting.
+    Before this the routes did `(b or {}).get(...)`: a JSON string, number or non-empty array is truthy,
+    so `.get` raised AttributeError into do_POST's catch-all -- a 500 whose body was a traceback
+    (absolute paths included) for what is a malformed request."""
+    if not raw:
+        return {}, None
+    try:
+        b = json.loads(raw)
+    except ValueError:                                # json.JSONDecodeError and a non-UTF-8 body alike
+        return None, "body is not JSON"
+    if not isinstance(b, dict):
+        return None, "body must be a JSON object, got %s" % _clip_json(b)
+    return b, None
+
+
+def _as_bool(v, field, default=False):
+    """A request flag as the boolean it claims to be -> (value, error). Absent (None) is `default`; JSON
+    true/false pass through; anything else -- the string "false", 0/1, "no" -- is refused with `error`
+    naming the field, and the caller must NOT act. Never coerces: bool("false") is True, which is how a
+    string used to enable auto-nudge, file editing, the master bell and auto-update, pause retries
+    across every session, make a directory, and delete a tag."""
+    if v is None:
+        return default, None
+    if v is True or v is False:
+        return v, None
+    return None, "'%s' must be true or false, got %s" % (field, _clip_json(v))
+
+
+def _refuse_ws_flag(client, op, err):
+    """A WS frame carried a flag that is not a boolean: one stderr line, and a `warn` frame -- the frame
+    the dispatcher answers a malformed request with (a bad session name, a failed login step) -- on the
+    delivering socket. The shipped panes send real booleans, so nothing on screen needs repainting; this
+    reaches the client that sent the string, and the log. The two flags whose pages never render `warn`
+    (setSessionFlag on the timeline, cardNotify on the feed) refuse through _refuse_setting instead, on
+    the settingRefused frame those pages repaint from."""
+    text = "%s: %s" % (op, err)
+    sys.stderr.write("romp-kernel: refused %s\n" % text)
+    if client and callable(client.get("send")):
+        _reply(client, {"type": "warn", "text": text})
 
 
 def _parse_send_body(raw):
@@ -40830,6 +40898,45 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    def _read_post_body(self):
+        """The POST body, read only AFTER _authorize passed and only within bounds -> (bytes, None), or
+        (None, (status, error)) with the connection marked to close (the unread body would otherwise be
+        parsed as the next request on this keep-alive socket). Bodies are delimited by Content-Length
+        alone: a Transfer-Encoding (chunked) request is refused with 411 rather than having its chunk
+        framing read as a body of length 0 and its bytes as a further request; the header must appear at
+        most once and be a plain decimal of at most 20 digits (a duplicate or a non-decimal value used to
+        be silently read as no body, inside a bare `except: pass`; the digit bound keeps int() from
+        raising on a run past the interpreter's conversion limit, which 500'd with a traceback); a
+        declared length past _POST_MAX_BYTES is refused with 413 before a byte of it is read; and a body
+        SHORTER than announced (a dead client, a short read) is refused with 400 naming the shortfall
+        rather than passing as the bytes that did arrive. An absent Content-Length is an empty body (the
+        bodiless POSTs: /tick, /restart). PR #1027 does the announced-vs-arrived check for /restart inside
+        its own parse; the two compose."""
+        if self.headers.get("Transfer-Encoding"):
+            self.close_connection = True
+            return None, (411, "Transfer-Encoding is not accepted; send the body with a Content-Length")
+        get_all = getattr(self.headers, "get_all", None)   # an HTTPMessage in service; a plain dict in unit tests
+        if callable(get_all):
+            lengths = get_all("Content-Length") or []
+        else:
+            lengths = [] if self.headers.get("Content-Length") is None else [self.headers.get("Content-Length")]
+        if len(lengths) > 1:
+            self.close_connection = True
+            return None, (400, "body could not be read: more than one Content-Length header")
+        cl = str(lengths[0]).strip() if lengths else "0"
+        if not re.fullmatch(r"[0-9]{1,20}", cl):
+            self.close_connection = True
+            return None, (400, "body could not be read: Content-Length %s is an invalid literal for a byte count (decimal digits only)" % _clip_json(cl))
+        n = int(cl)
+        if n > _POST_MAX_BYTES:
+            self.close_connection = True
+            return None, (413, "request body of %d bytes exceeds the %d-byte limit" % (n, _POST_MAX_BYTES))
+        raw = self.rfile.read(n) if n else b""
+        if len(raw) < n:
+            self.close_connection = True
+            return None, (400, "body could not be read: read %d of the %d bytes Content-Length announced" % (len(raw), n))
+        return raw, None
+
     @_perf_http_timed
     def do_POST(self):
         u = urlparse(self.path)
@@ -40840,27 +40947,20 @@ class Handler(BaseHTTPRequestHandler):
         # runs; the _authorize call site then refines it (a valid token authorizes a
         # foreign origin — the federated dashboard — and a denial clears the echo).
         self._cors_origin = self.headers.get("Origin") if self._origin_ok() else None
-        raw_body = b""
-        # A body that was ANNOUNCED but did not arrive whole is remembered, not folded into "no body"
-        # (review find, 2026-09-08): this read used to swallow a short read, a dead client and an
-        # unparsable Content-Length into an EMPTY raw_body, and on /restart empty means the broad
-        # default, so a client that announced a peer-only body and died before sending it restarted
-        # every reachable kernel. Only /restart refuses on it today; the other routes keep reading
-        # raw_body as they did.
-        _body_err = None
-        try:
-            n = int(self.headers.get("Content-Length") or 0)   # read the body (keep-alive safety + POST payloads)
-            if n:
-                raw_body = self.rfile.read(n)
-                if len(raw_body) != n:
-                    _body_err = "read %d of the %d bytes Content-Length announced" % (len(raw_body), n)
-        except Exception as e:
-            _body_err = str(e)[:120] or e.__class__.__name__
         try:
             ok, self._set_cookie, why = self._authorize(q)
             self._cors_origin = self.headers.get("Origin") if ok else None   # echoed by _send (CORS delivery)
             if not ok:
-                return self._send(403, "forbidden: " + why, "text/plain")
+                # The body is still UNREAD: nothing an unauthenticated caller sends is buffered. It used
+                # to be read first, whatever its declared length, so a token-less loopback or tailnet
+                # client could make this kernel allocate and pin a handler thread per oversize POST.
+                # Unread bytes make the connection unusable for keep-alive, so it closes with the denial.
+                self.close_connection = True
+                return self._send(403, "forbidden: " + why, "text/plain", headers={"Connection": "close"})
+            raw_body, berr = self._read_post_body()
+            if berr is not None:
+                return self._send(berr[0], json.dumps({"ok": False, "error": berr[1]}), "application/json",
+                                  headers={"Connection": "close"})
             if u.path == "/restart":
                 # The web Restart button (↻ in the rail). Ack FIRST, then restart — the manager SIGTERMs
                 # this kernel and its exit handler spawns a fresh one, so new Python code loads (the
@@ -40876,7 +40976,9 @@ class Handler(BaseHTTPRequestHandler):
                 # The body is a JSON object with at most a boolean `fleet`, or empty (every ↻ button);
                 # anything else is a 400 that names the problem and restarts NOTHING. A malformed body
                 # must never widen the action — it used to fall through to the broad default.
-                _fleet, _bad = _restart_scope_from_body(raw_body, _body_err)
+                # A short or unparsable body never reaches this route: _read_post_body refused it with a 400
+                # naming the shortfall before any route ran, so the scope parser's own body-error is None here.
+                _fleet, _bad = _restart_scope_from_body(raw_body, None)
                 if _bad:
                     return self._send(400, json.dumps({"ok": False, "error": _bad}), "application/json")
                 # WHO ASKED, on the record (the user 2026-07-31): a restart blinks every dashboard, and
@@ -40912,10 +41014,9 @@ class Handler(BaseHTTPRequestHandler):
             if u.path == "/update-dismiss":
                 # the banner's Not-now, PERSISTED (the user 2026-08-31): the dismissal outlives the
                 # page and the kernel — event-keyed, a NEW sha/tag offers again. Body: {"tag": id}.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 _dismiss_update((b or {}).get("tag"))
                 return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/update":
@@ -40952,10 +41053,11 @@ class Handler(BaseHTTPRequestHandler):
                 # posts here first, and only a 200 flips the bell — the device push subscription is
                 # a separate, best-effort leg on top. Every connected shell repaints at once, and
                 # the dirty mark rebuilds the feed so per-card bells show their new effective state.
-                try:
-                    _on = bool(json.loads(raw_body or b"{}").get("on"))
-                except (ValueError, AttributeError):
-                    return self._send(400, "bad json", "text/plain")
+                b, err = _json_object_body(raw_body)
+                if not err:
+                    _on, err = _as_bool(b.get("on"), "on")
+                if err:
+                    return self._send(400, json.dumps({"ok": False, "error": err}), "application/json")
                 try:
                     _set_notify_all(_on)
                 except (_StateUnreadable, _StateUnwritable) as e:
@@ -40975,10 +41077,11 @@ class Handler(BaseHTTPRequestHandler):
                 # the popover's turn-finished switch (2026-09-05): kernel-authoritative like the
                 # master, its own shell push so every open dashboard's row agrees. No dirty mark —
                 # the feed carries nothing that reads it.
-                try:
-                    _on = bool(json.loads(raw_body or b"{}").get("on"))
-                except (ValueError, AttributeError):
-                    return self._send(400, "bad json", "text/plain")
+                b, err = _json_object_body(raw_body)
+                if not err:
+                    _on, err = _as_bool(b.get("on"), "on")
+                if err:
+                    return self._send(400, json.dumps({"ok": False, "error": err}), "application/json")
                 try:
                     _set_notify_turns(_on)
                 except (_StateUnreadable, _StateUnwritable) as e:
@@ -41386,10 +41489,9 @@ class Handler(BaseHTTPRequestHandler):
                 # Same validation and the same no-silent-fallback rule as the WS op: when the SDK
                 # backend is unavailable, say so (ok:false + reason), never hand back a mystery tmux
                 # session. An already-live name is a success (idempotent open), not an error.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 nm = str((b or {}).get("name") or "").strip()
                 if not nm or not NAME_RE.match(nm):
                     return self._send(400, json.dumps({"ok": False, "error":
@@ -41433,7 +41535,10 @@ class Handler(BaseHTTPRequestHandler):
                         return self._send(400, json.dumps({"ok": False, "error": terr}), "application/json")
                 tags_req = list(tags_req or [])
                 # mkdir:true makes a missing dir (the WS op's "create it" answer, available headlessly too)
-                cwd, derr = _resolve_create_dir(b.get("dir"), create=bool(b.get("mkdir")))
+                mk, ferr = _as_bool(b.get("mkdir"), "mkdir")
+                if ferr:
+                    return self._send(400, json.dumps({"ok": False, "error": ferr}), "application/json")
+                cwd, derr = _resolve_create_dir(b.get("dir"), create=mk)
                 if derr:
                     return self._send(200, json.dumps({"ok": False, "error": derr,
                                                        "dirStatus": _dir_status(b.get("dir"))}),
@@ -41545,10 +41650,9 @@ class Handler(BaseHTTPRequestHandler):
                 # ("at" empty = the whole conversation, the tip fork). Same contract as the op:
                 # parent untouched, explicit new name, and the fork discoverable the moment we ack
                 # (be.fork writes names/ synchronously inside _fork_session). Loud on refusal.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 parent = str((b or {}).get("parent") or "").strip()
                 nm = str((b or {}).get("name") or "").strip()
                 if not parent or not nm:
@@ -41586,10 +41690,9 @@ class Handler(BaseHTTPRequestHandler):
                 # "name": <new-name>}. Sessions are uuid-keyed with the name as a label, so a rename
                 # never breaks mailboxes/goals/history; the by-name POISONING guard mirrors /fork's
                 # (a second session under one live name breaks every by-name surface). Loud errors.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 target = str((b or {}).get("target") or "").strip()
                 nm = str((b or {}).get("name") or "").strip()
                 if not target or not nm:
@@ -41628,10 +41731,9 @@ class Handler(BaseHTTPRequestHandler):
                 # NOW and the reply carries the outcome; a busy one parks the move behind its turn and
                 # the reply says so (queued: true) — the CLI cannot tell whether that later fires, so it
                 # reports the park honestly rather than waiting on a turn of unknown length. Loud errors.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 target = str((b or {}).get("target") or "").strip()
                 raw_dir = str((b or {}).get("dir") or "").strip()
                 if not target or not raw_dir:
@@ -41667,10 +41769,9 @@ class Handler(BaseHTTPRequestHandler):
                 # "bg": <swatch hex>}. Only a swatch from a known palette is accepted (its palette
                 # supplies the fg word) — GET /palette lists the choosable ones. A recolor is a
                 # names-registry write, so a dormant session works by sid, same as /rename. Loud errors.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 target = str((b or {}).get("target") or "").strip()
                 bg = str((b or {}).get("bg") or "").strip()
                 if not target or not bg:
@@ -41702,10 +41803,9 @@ class Handler(BaseHTTPRequestHandler):
                 # restarts that killed every shell loop it replaces. Body: {"pr": <n>,
                 # "repo": "owner/name", "id"|"name": <session>}. Repo is explicit here (the CLI
                 # infers it from the caller's checkout); the session resolves like /send's.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 try:
                     prn = int(b.get("pr"))
                 except Exception:
@@ -41729,10 +41829,9 @@ class Handler(BaseHTTPRequestHandler):
                 # watch retires; a timeout mails the giving-up notice (never a silent dead loop).
                 # Body: {"cmd": "...", "id"|"name": <session>, "every"?: s, "timeoutS"?: s,
                 # "note"?: "..."} — or {"cancel": <watch id>} to retire one early.
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 if b.get("cancel"):
                     ok = cancel_watch(str(b["cancel"]).strip())
                     return self._send(200, json.dumps({"ok": ok} if ok else
@@ -41769,14 +41868,16 @@ class Handler(BaseHTTPRequestHandler):
                 # — host:NAME included, since the blob stores ids and a stored name would be a
                 # member nothing ever matches — refuse loudly. /group is the pre-rename alias
                 # (same-day rename; an un-updated remote's bin/romp still posts there).
-                try:
-                    b = json.loads(raw_body or b"{}")
-                except Exception:
-                    b = {}
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
                 name = str((b or {}).get("name") or "").strip()
                 if not name:
                     return self._send(400, json.dumps({"ok": False, "error": "name required"}),
                                       "application/json")
+                dele, ferr = _as_bool(b.get("delete"), "delete")   # checked before the --host forward too
+                if ferr:
+                    return self._send(400, json.dumps({"ok": False, "error": ferr}), "application/json")
                 # --host (tag federation v0, the user 2026-08-24): the edit targets an ATTACHED
                 # kernel's store, through the tunnel it already holds — Model A home-kernel
                 # ownership, no sync engine. The body forwards minus `host`; the TARGET resolves
@@ -41832,7 +41933,7 @@ class Handler(BaseHTTPRequestHandler):
                 rn = b.get("rename")
                 t, err = _edit_tag(name, add=ids["add"], remove=ids["remove"],
                                    color=(str(color) if isinstance(color, str) else None),
-                                   delete=bool(b.get("delete")),
+                                   delete=dele,
                                    rename=(str(rn) if isinstance(rn, str) else None))
                 if err:
                     return self._send(200, json.dumps({"ok": False, "error": err}), "application/json")
@@ -41846,12 +41947,11 @@ class Handler(BaseHTTPRequestHandler):
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
                 # set_working goes through the kernel (no tmux @romp-working) and an SDK session can publish a
                 # note too. Body: {"id": <sid>, "text": <note|"">}. (the user 2026-06-26.)
-                try:
-                    body = json.loads(raw_body or b"{}")
-                except Exception:
-                    body = None
-                sid = str((body or {}).get("id") or "")
-                if not isinstance(body, dict) or not sid:
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                sid = str(body.get("id") or "")
+                if not sid:
                     return self._send(400, json.dumps({"ok": False, "error": "id required"}), "application/json")
                 r = _host_for_sid(sid)
                 if r is not None:                                   # remote session → forward over its -L tunnel
@@ -41865,12 +41965,11 @@ class Handler(BaseHTTPRequestHandler):
                 # enqueues it (SDK). {id, text} → {injected: bool}; the bus re-delivers to the maildir if false.
                 # Runs synchronously (the tmux inject polls the pane up to a few seconds) — fine on the
                 # threaded server. (the user 2026-06-26.)
-                try:
-                    body = json.loads(raw_body or b"{}")
-                except Exception:
-                    body = None
-                sid = str((body or {}).get("id") or "")
-                text = (body or {}).get("text") if isinstance(body, dict) else None
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                sid = str(body.get("id") or "")
+                text = body.get("text")
                 if not sid or not isinstance(text, str) or not text:
                     return self._send(400, json.dumps({"ok": False, "error": "id and text required"}), "application/json")
                 # POSTAL ISOLATION gate (the user 2026-07-10): /deliver is the agent-mail wake, so a
@@ -41891,11 +41990,10 @@ class Handler(BaseHTTPRequestHandler):
                 # Surface a revived tmux session stuck on Claude's resume picker (it blocks before any hook
                 # fires). The bus's `romp-postal picker-check` (run by romp on resume) calls this so it never
                 # shells tmux. {id}. Synchronous poll up to _PICKER_GRACE — fine on the threaded server.
-                try:
-                    body = json.loads(raw_body or b"{}")
-                except Exception:
-                    body = None
-                sid = str((body or {}).get("id") or "")
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                sid = str(body.get("id") or "")
                 if not sid:
                     return self._send(400, json.dumps({"ok": False, "error": "id required"}), "application/json")
                 _picker_check(sid)
@@ -41988,7 +42086,10 @@ class Handler(BaseHTTPRequestHandler):
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
-                pub = checkin_set(host, bool((body or {}).get("on")))
+                on, ferr = _as_bool(body.get("on"), "on")
+                if ferr:
+                    return self._send(400, json.dumps({"ok": False, "error": ferr}), "application/json")
+                pub = checkin_set(host, on)
                 if pub is None:
                     return self._send(404, json.dumps({"ok": False, "error": "no attached host '%s' — attach it first" % host}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "tunnel": pub}), "application/json")
@@ -41996,11 +42097,10 @@ class Handler(BaseHTTPRequestHandler):
                 # the postal bus asks for the sending session's walked root-ask record at relay
                 # time (T126) — best-effort: {} when the chain resolves nothing, and the bus
                 # degrades to an unenriched relay either way
-                try:
-                    body = json.loads(raw_body or b"{}")
-                except Exception:
-                    body = {}
-                rec = _walk_root_record(str((body or {}).get("sid") or ""))
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                rec = _walk_root_record(str(body.get("sid") or ""))
                 return self._send(200, json.dumps(rec or {}), "application/json")
             if u.path == "/redial":
                 # A CONSUMER just needed a host and found it unreachable (the postal bus parking mail,
@@ -42008,11 +42108,10 @@ class Handler(BaseHTTPRequestHandler):
                 # signal now instead of waiting out the backoff ladder (the user 2026-08-16, on flaky
                 # wifi). Best-effort by design — an unknown host is a quiet no-op, never an error the
                 # caller has to handle on top of the failure it is already reporting.
-                try:
-                    body = json.loads(raw_body or b"{}")
-                except Exception:
-                    body = {}
-                h = str((body or {}).get("host") or "")
+                body, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                h = str(body.get("host") or "")
                 if h:
                     _demand_redial(h, "timeout")
                 return self._send(200, json.dumps({"ok": True}), "application/json")
@@ -42028,7 +42127,10 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps(fw), "application/json")
                 if not isinstance(body, dict) or "on" not in body:
                     return self._send(400, json.dumps({"ok": False, "error": "on required"}), "application/json")
-                _set_auto_update_remotes(bool(body.get("on")))
+                on, ferr = _as_bool(body.get("on"), "on")
+                if ferr:
+                    return self._send(400, json.dumps({"ok": False, "error": ferr}), "application/json")
+                _set_auto_update_remotes(on)
                 _tunnel_wake.set()   # apply on the NEXT pass, not up to 3s later — turning it on acts at once
                 return self._send(200, json.dumps({"ok": True, "on": _auto_update_remotes_on()}), "application/json")
             if u.path == "/tunnels/forget":
@@ -42302,7 +42404,11 @@ class Handler(BaseHTTPRequestHandler):
             _push_soon()
             return
         if msg and msg.get("type") == "setGlobalRetryPaused":
-            _set_retry_paused(msg.get("value"))
+            paused, ferr = _as_bool(msg.get("value"), "value")
+            if ferr:                                   # a string here paused retries across EVERY session
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            _set_retry_paused(paused)
             _mark_views_dirty()
             return
         if msg and msg.get("type") == "ready":
@@ -42373,11 +42479,18 @@ class Handler(BaseHTTPRequestHandler):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
             # re-broadcast so the feed drops/restores that session's cards immediately. The notify
             # bell is tri-state (an override on the master default) → its own setter.
+            value, ferr = _as_bool(msg.get("value"), "value")
+            if ferr:
+                # the lane gear's own refusal frame (settingRefused, which the timeline page renders and
+                # repaints from; a `warn` never reaches it), addressed like the store-fault refusal below
+                _refuse_setting(client, ferr, "that setting", "flag", sid=msg["id"], flag=msg["flag"],
+                                value=_painted_flag_value(str(msg["id"]), str(msg["flag"])))
+                return
             try:
                 if str(msg["flag"]) == "notify":
-                    _set_notify_session(str(msg["id"]), bool(msg.get("value")))
+                    _set_notify_session(str(msg["id"]), value)
                 else:
-                    _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
+                    _set_session_flag(str(msg["id"]), str(msg["flag"]), value)
             except (_StateUnreadable, _StateUnwritable) as e:
                 # the flags store could not be read, or its publish failed: refuse on the DELIVERING socket,
                 # addressed to the toggle (sid + flag) so the lane gear / tab menu ends its optimistic state
@@ -42468,7 +42581,15 @@ class Handler(BaseHTTPRequestHandler):
                     body["color"] = e["color"]
                 if isinstance(e.get("rename"), str):
                     body["rename"] = e["rename"]
-                if e.get("delete"):
+                dele, ferr = _as_bool(e.get("delete"), "delete")
+                if ferr:
+                    # a string here forwarded a DELETE; refused on the op's own failure frame, where a
+                    # refused edit lands, so the asking dashboard hears it
+                    _send_to_view("timeline", {"type": "tagEditFailed", "host": host, "name": nm,
+                                               "error": "editTag: " + ferr, "queued": False},
+                                  (client or {}).get("wid") or "")
+                    return
+                if dele:
                     body["delete"] = True
                 ans, err = _forward_tag_edit(host, body)
                 if err or not (ans or {}).get("ok", False):
@@ -42488,8 +42609,15 @@ class Handler(BaseHTTPRequestHandler):
             # completes). Persisted to notify-cards.json; build_feed echoes it back as ask.notify.
             # sid rides so the override can be resolved against the card's own default (session, else
             # the master) and deleted when it merely restates it.
+            value, ferr = _as_bool(msg.get("value"), "value")
+            if ferr:
+                # the bell's own refusal frame (settingRefused, which the feed page renders and repaints
+                # from; a `warn` never reaches it), addressed like the store-fault refusal below
+                _refuse_setting(client, ferr, "that bell", "bell", sid=msg.get("sid") or "", item_id=msg["itemId"],
+                                value=bool(_notify_card_effective(_notify_cards(), str(msg["itemId"]), str(msg.get("sid") or ""))))
+                return
             try:
-                _set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))
+                _set_notify_card(str(msg["itemId"]), value, str(msg.get("sid") or ""))
             except (_StateUnreadable, _StateUnwritable) as e:
                 # the bells store could not be read, or its publish failed: refuse on the DELIVERING socket,
                 # addressed to the card (itemId) so the feed drops that bell's optimistic latch and says why
@@ -42518,19 +42646,27 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "setConserve" and msg.get("enabled") is not None:
             # the gear's conserve-memory toggle (T148) — kernel-side like autoNudge; the sweep
             # reads the flag fresh each pass, so flipping it needs no restart
-            _set_conserve(bool(msg.get("enabled")))
+            enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            _set_conserve(enabled)
             _push_soon()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             # feed gear → server-side Auto Nudge on/off; a stale gesture stamp stands down (no
             # apply — and no tick: a stood-down toggle is not new information), and the dashboard
             # that made the losing gesture hears it
-            if _set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
+            enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            if _set_auto_nudge(enabled, gt=_gesture_ms(msg)) is not None:
                 # turn-ON acts at once instead of waiting out the pusher's 0.5 s backstop; turning off
                 # has nothing to act on (the tick is a no-op when off, so this also spares the WS
                 # thread the listing fork). The single-flight rule, the dead-wait sweep skip and the
                 # try/except that keeps a failing tick from reading as a socket failure are all
                 # _ws_act_now_tick's; the stale reply below stays outside it (a real client write)
-                if msg["enabled"]:
+                if enabled:
                     _ws_act_now_tick()
             else:
                 _tell_stale_gesture(client, msg)
@@ -42541,7 +42677,11 @@ class Handler(BaseHTTPRequestHandler):
             # turn-on (instead of waiting out the pusher's 0.5 s backstop)
             # — a stood-down toggle is not new information — through the same wrap as setAutoNudge
             # (_ws_act_now_tick: single-flight, no dead-wait sweep, a failure logged not raised)
-            if _set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None:
+            enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            if _set_compact_suggest(enabled, gt=_gesture_ms(msg)) is not None:
                 _ws_act_now_tick()
             else:
                 _tell_stale_gesture(client, msg)
@@ -42553,13 +42693,21 @@ class Handler(BaseHTTPRequestHandler):
             # The viewer's Edit consent popup (the user 2026-08-22) — a kernel-side setting like
             # setAutoNudge, broadcast by federation.ts KERNEL_SETTING so one yes answers the mesh.
             # A stale gesture stamp stands down (a queued flush must not undo a newer choice).
-            if _set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+            enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            if _set_file_editing(enabled, gt=_gesture_ms(msg)) is None:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setThinkingSummaries" and msg.get("enabled") is not None:
             # The gear's Thinking summaries checkbox (2026-09-01) — kernel-side like setFileEditing but
             # PER-INSTALL (not a KERNEL_SETTING: nothing to propagate), gt-gated all the same; the SDK
             # backend reads the store at each session's next connect, so nothing else to do here.
-            if _set_thinking_summaries(bool(msg["enabled"]), gt=_gesture_ms(msg)) is None:
+            enabled, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr)
+                return
+            if _set_thinking_summaries(enabled, gt=_gesture_ms(msg)) is None:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the
@@ -42737,7 +42885,11 @@ class Handler(BaseHTTPRequestHandler):
             else:
                 # the session dir is fixed at creation — validate now. mkdir: the user already saw the
                 # "that folder doesn't exist" dialog and chose to make it (see createDirMissing below).
-                cwd, derr = _resolve_create_dir(msg.get("dir"), create=bool(msg.get("mkdir")))
+                mk, ferr = _as_bool(msg.get("mkdir"), "mkdir")
+                if ferr:
+                    _refuse_ws_flag(client, msg["type"], ferr)
+                    return
+                cwd, derr = _resolve_create_dir(msg.get("dir"), create=mk)
                 live = _live_names(_tmux_sessions())
                 # `parent` / `tags` (tab groups on tags, the user 2026-09-04): validated up front, like
                 # POST /new — an unknown parent or a malformed tags list refuses the create loudly,
@@ -42747,7 +42899,7 @@ class Handler(BaseHTTPRequestHandler):
                 terr = _tags_error(msg.get("tags")) if msg.get("tags") is not None else None
                 if derr:
                     st = _dir_status(msg.get("dir"))
-                    if st["canCreate"] and not msg.get("mkdir"):
+                    if st["canCreate"] and not mk:
                         # A missing directory is a QUESTION, not a failure: the client raises "create it or
                         # edit it" and comes back with mkdir set. Before this the create just warned and the
                         # "Opening…" cue span for 30s over a session that was never going to exist (the user

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -663,9 +663,14 @@ def _kernel_post(path, body, timeout=2):
     """POST a small JSON body to the kernel (loopback, X-Romp-Token from the shared 0600 file) — the bus's
     one-way control channel for the
     ops the kernel owns now that the bus never shells tmux: the working-note, mail delivery/wake, the
-    status-bar chrome, and the resume-picker check. Returns the parsed JSON response dict, or None
-    (unreachable kernel / non-2xx / parse error → the caller degrades). No-op (None) under the
-    ROMP_SESSIONS_FILE test seam, which signals a test running with no live kernel."""
+    status-bar chrome, and the resume-picker check. Returns the parsed JSON response dict; None when
+    the kernel could not be reached or its answer could not be parsed (the caller degrades); or, for a
+    kernel that REFUSED the request (a 4xx/5xx), {"ok": False, "status": <code>, "error": <its text>},
+    logged here by status with a bounded slice of the kernel's own reason, so a refusal never reads as
+    a dead kernel (review find, 2026-09-08: every non-2xx came back as None, and the kernel's 413 on an
+    oversize /deliver body was filed as "deferred" and re-posted forever). A caller that tests
+    `resp.get("ok")` or `resp.get("injected")` sees a refusal as the failure it is. No-op (None) under
+    the ROMP_SESSIONS_FILE test seam, which signals a test running with no live kernel."""
     if os.environ.get("ROMP_SESSIONS_FILE"):
         return None
     import urllib.request
@@ -677,6 +682,14 @@ def _kernel_post(path, body, timeout=2):
             if getattr(r, "status", 200) // 100 != 2:
                 return None
             return json.loads(r.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as e:
+        text = ""
+        try:
+            text = " ".join((e.read(512) or b"").decode("utf-8", "replace").split())   # a bounded slice: the
+        except Exception:                                                                # kernel's reason, never
+            pass                                                                         # a whole error page
+        _log("kernel refused POST %s: HTTP %d %s" % (path, e.code, text))
+        return {"ok": False, "status": int(e.code), "error": text}
     except Exception:
         return None
 
@@ -703,7 +716,10 @@ def _publish_working(sid, text):
     """Publish/clear THIS session's working-note via the kernel's backend-agnostic store (POST /working) — no
     tmux. The kernel owns the store and both backends read it (it appears in GET /sessions' `working` field),
     so an SDK session can publish a note too."""
-    return _kernel_post("/working", {"id": str(sid), "text": text}) is not None if sid else False
+    if not sid:
+        return False
+    r = _kernel_post("/working", {"id": str(sid), "text": text})
+    return r is not None and r.get("ok") is not False        # None: unreachable; ok false: the kernel refused
 
 def all_agents(threads=False):
     agents = local_agents(threads=threads)
@@ -1263,13 +1279,89 @@ def format_push(msgs):
                % msgs[0].get("from", ""))
     return "\n".join(out)
 
+def _deliver_body_bytes(sid, msgs):
+    """The exact wire size of the /deliver POST carrying `msgs`: the banner in its JSON envelope,
+    serialized as _kernel_post serializes it (ensure_ascii on, so non-ASCII text and every newline
+    inflate past the banner's own length)."""
+    return len(json.dumps({"id": sid, "text": format_push(msgs)}).encode("utf-8"))
+
+
+def _push_chunks(sid, msgs):
+    """Split a recipient's pending mail into /deliver bodies that fit under _PUSH_MAX_BYTES, oldest
+    first -> (chunks, oversize). Each chunk is a non-empty run of consecutive messages whose whole body
+    fits; `oversize` are the messages whose body ALONE does not, which no chunk can carry. The banner
+    used to be one body for the whole box (review find, 2026-09-08): past the kernel's cap it was
+    refused, and the refusal re-posted on every retry pass."""
+    chunks, cur, oversize = [], [], []
+    for m in msgs:
+        if cur and _deliver_body_bytes(sid, cur + [m]) <= _PUSH_MAX_BYTES:
+            cur.append(m)
+            continue
+        if cur:
+            chunks.append(cur)
+            cur = []
+        if _deliver_body_bytes(sid, [m]) <= _PUSH_MAX_BYTES:
+            cur = [m]
+        else:
+            oversize.append(m)
+    if cur:
+        chunks.append(cur)
+    return chunks, oversize
+
+
+_OVERSIZE_NAMED = set()   # mids of oversize mail already named in the log: a message left for the drain
+#                           is re-claimed by every retry pass, and one line per message is the record
+
+
+def _bounce_oversize(sid, m):
+    """One message whose /deliver body alone exceeds _PUSH_MAX_BYTES: it can never ride the live wake
+    (the kernel refuses the body before reading it), so it is not posted, and never was going to land
+    however often the retry pass re-posted it. A LOCAL sender hears it, the way a peer's refusal reaches
+    a sender through _bounce_apply: the message leaves the recipient's box (the drain already claimed it)
+    and a bus-authored note names the size and the limit, without echoing the body, which would make
+    the note itself oversize. A message with no local sender to tell (a bus-authored note; relayed mail,
+    whose sender lives on another host and was acked at relay time) stays in new/ for the turn-end drain
+    and check_inbox, which have no size cap, and is named in the log once."""
+    n = _deliver_body_bytes(sid, [m])
+    mid, frm_id = m.get("id", ""), m.get("from_id", "")
+    if frm_id and not m.get("from_host") and frm_id != sid:
+        to = _name_for_id(sid) or sid
+        why = ("your message is %d bytes as delivered, over the %d-byte limit for delivery into a session"
+               % (n, _PUSH_MAX_BYTES))
+        deliver(frm_id, "romp-postal", "", "undeliverable to '%s': %s. Send a shorter message, or write "
+                "the text to a file and send its path. (The message is not echoed here because of its "
+                "size.)" % (to, why), kind="coordinate")
+        _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid, "to": to,
+                                      "host": "", "why": why})
+        _log("push to %s: message %s is %d bytes, over the %d-byte /deliver limit; bounced to its sender %s"
+             % (sid, mid, n, _PUSH_MAX_BYTES, frm_id))
+        return
+    if not restore(sid, mid):
+        deliver(sid, m.get("from", "?"), frm_id, m.get("body", ""), park=m.get("park", False),
+                kind=m.get("kind", ""), from_host=m.get("from_host", ""))
+    if mid not in _OVERSIZE_NAMED:
+        _OVERSIZE_NAMED.add(mid)
+        _log("push to %s: message %s is %d bytes, over the %d-byte /deliver limit, and has no local sender "
+             "to bounce to; it waits in new/ for the turn-end drain" % (sid, mid, n, _PUSH_MAX_BYTES))
+
+
 def _push(sid, agent):
     """Live-deliver pending mail to a session by WAKING it through the kernel (POST /deliver) — the kernel
     injects the banner into the pane (tmux, draft-preserving) or enqueues it (SDK); the bus never shells tmux.
     Coarse-skip a clearly not-ready session (remote / not idle-or-working) to avoid a needless drain; the
     kernel does the fine pane-safety (at a ❯ prompt, out of copy-mode, a draft it can safely stash) and tells
     us whether it injected. Not injected → put the mail back for the maildir-drain backstop. Returns True iff
-    injected (so a revive poll knows to stop). `agent` is the GET /sessions row (id, state, backend, remote)."""
+    every message that can ride the wake was injected (so a revive poll knows to stop). `agent` is the GET
+    /sessions row (id, state, backend, remote).
+
+    The box goes over in CHUNKS under _PUSH_MAX_BYTES (review find, 2026-09-08): the kernel reads a POST
+    body only up to _POST_MAX_BYTES, and one banner for the whole box crossed that once enough mail had
+    piled up for one recipient, refused with 413 before a byte was read, filed here as "deferred", and
+    re-posted identically on every retry pass, so the live wake for that recipient never came. Chunks
+    post oldest first; the first that does not land stops the run, and it and everything after it are
+    restored. A single message too large for any chunk is handled by _bounce_oversize. The log line
+    names the cause (a kernel that could not be reached, one that answered a status, or a pane that
+    was not safe) where every deferral used to read the same."""
     if _push_disabled() or not agent:
         return False
     if os.environ.get("ROMP_SESSIONS_FILE"):                  # test seam: no live kernel → leave it for the drain (don't churn the maildir)
@@ -1284,19 +1376,36 @@ def _push(sid, agent):
         msgs = res.get("messages", [])
         if not msgs:
             return False                                      # nothing, or loop-guard paused
-        resp = _kernel_post("/deliver", {"id": sid, "text": format_push(msgs)}, timeout=12)
-        if resp and resp.get("injected"):
-            return True
+        chunks, oversize = _push_chunks(sid, msgs)
+        for m in oversize:
+            _bounce_oversize(sid, m)
+        landed, held, cause = 0, [], ""
+        for i, chunk in enumerate(chunks):
+            resp = _kernel_post("/deliver", {"id": sid, "text": format_push(chunk)}, timeout=12)
+            if resp and resp.get("injected"):
+                landed += len(chunk)
+                continue
+            if resp is None:
+                cause = "kernel unreachable"
+            elif resp.get("status"):
+                cause = "kernel answered HTTP %s" % resp["status"]   # the reason is in _kernel_post's line
+            else:
+                cause = "not injected"                        # the pane was not safe to paste into
+            held = [m for c in chunks[i:] for m in c]
+            break
+        if not held:
+            return bool(landed)
         # Not injected → UNCLAIM: put each message back under its ORIGINAL id (restore), so a
         # deferred push doesn't mint a second identity for the same message. Only if the file is
         # gone (recalled/swept mid-push) do we fall back to a re-send, which costs a new id but
         # never loses the mail.
-        for m in msgs:
+        for m in held:
             if not restore(sid, m.get("id", "")):
                 deliver(sid, m.get("from", "?"), m.get("from_id", ""), m.get("body", ""),
                         park=m.get("park", False), kind=m.get("kind", ""),
                         from_host=m.get("from_host", ""))
-        _log("push to %s deferred; %d msg(s) restored for the drain backstop" % (sid, len(msgs)))
+        _log("push to %s deferred (%s); %d msg(s) restored for the drain backstop%s"
+             % (sid, cause, len(held), (" after %d landed" % landed) if landed else ""))
         return False
     except Exception as e:
         _log("push error for %s: %s" % (sid, e))
@@ -1334,26 +1443,77 @@ def _wake_when_ready(sid):
 # request (one mail, a peer table, an exchange of presence and acks), tens of KB at most.
 _POST_MAX_BYTES = 1024 * 1024
 
+# The longest the bus waits for an announced, in-bounds body to ARRIVE -- the kernel's _POST_BODY_TIMEOUT,
+# mirrored (review find, 2026-09-08): with no timeout on the socket, a handler thread was pinned for as
+# long as an authorized client cared to trickle its body. Every client sends its body in one write, so
+# 30 s is generous; a read that stalls past it answers 408 and closes.
+_POST_BODY_TIMEOUT = 30.0
+
+# The most one /deliver body the bus BUILDS may carry (review find, 2026-09-08): the kernel reads a POST
+# only up to _POST_MAX_BYTES, and this is what _push measures each chunk of a recipient's box against,
+# the exact wire size, envelope and escaping included, so no chunk is ever refused on size. The gap
+# under the cap is headroom, not a measurement allowance.
+_PUSH_MAX_BYTES = 900 * 1024
+
 
 def _clip_json(v, n=60):
     """A BOUNDED, WELL-FORMED echo of an offending request value for an error message: a large body must
-    never come back as a large error. The cut lands INSIDE a string's quotes and is marked, so a long
-    string still echoes as one complete quoted thing (a slice of the serialized text took the closing
-    quote with it); ensure_ascii is off, or the marker itself comes back as \\u2026. The kernel's shape."""
-    if isinstance(v, str):
-        return json.dumps(v[:n] + "\u2026" if len(v) > n else v, ensure_ascii=False)
+    never come back as a large error. Every string is cut INSIDE its quotes and marked, at any depth, so
+    a long string still echoes as one complete quoted thing; a container is cut at the ELEMENT level,
+    its first few members and a marker member, and nests no deeper than four levels, so the echo is
+    valid JSON whatever arrived (review find, 2026-09-08: a slice of the serialized text cut a container
+    mid-token, and ["xxx... came back with its quote and bracket open); a number past n digits echoes as
+    a marked string, since a cut decimal is a mid-token cut too. Members are dropped until the whole
+    echo fits about 4n characters; ensure_ascii is off, or the marker itself comes back as \\u2026. The
+    kernel's shape."""
+    mark = "\u2026"
+
+    def cut(x, keep, depth):
+        if isinstance(x, str):
+            return x[:n] + mark if len(x) > n else x
+        if isinstance(x, dict):
+            if not x:
+                return {}
+            if depth >= 4 or keep == 0:
+                return {mark: mark}
+            items = list(x.items())
+            out = {cut(str(k), keep, depth + 1): cut(val, keep, depth + 1) for k, val in items[:keep]}
+            if len(items) > keep:
+                out[mark] = mark
+            return out
+        if isinstance(x, (list, tuple)):
+            if not x:
+                return []
+            if depth >= 4 or keep == 0:
+                return [mark]
+            out = [cut(val, keep, depth + 1) for val in x[:keep]]
+            if len(x) > keep:
+                out.append(mark)
+            return out
+        if isinstance(x, (int, float)) and not isinstance(x, bool):
+            s = str(x)                                   # a number past n digits (json.loads takes an int of
+            return x if len(s) <= n else s[:n] + mark    # up to 4300) echoes as a marked STRING: a cut
+        return x                                         # decimal would be a mid-token cut
+
     try:
-        s = json.dumps(v, ensure_ascii=False)
+        for keep in (8, 4, 2, 1, 0):
+            s = json.dumps(cut(v, keep, 0), ensure_ascii=False)
+            if len(s) <= 4 * n or keep == 0:
+                return s
     except (TypeError, ValueError):
-        s = repr(v)
-    return s if len(s) <= n else s[:n] + "\u2026"
+        pass
+    s = repr(v)
+    return s if len(s) <= n else s[:n] + mark
 
 
 def _as_bool(v, field, default=False):
-    """A request flag as the boolean it claims to be -> (value, error). Absent (None) is `default`; JSON
-    true/false pass through; anything else -- the string "false", 0/1, "no" -- is refused with `error`
-    naming the field, and the caller must NOT act. Never coerces: bool("false") is True, which is how a
-    string used to arm a tracked delegation and mark a down peer bus up."""
+    """A request flag as the boolean it claims to be -> (value, error). Absent is `default`, and so is an
+    EXPLICIT JSON null: the routes read their fields with .get(), under which the two are one value, and
+    null is the absent case spelled out, not a third kind of flag (review find, 2026-09-08; the kernel's
+    _as_bool states the same rule). JSON true/false pass through; anything else -- the string "false",
+    0/1, "no" -- is refused with `error` naming the field, and the caller must NOT act. Never coerces:
+    bool("false") is True, which is how a string used to arm a tracked delegation and mark a down peer
+    bus up."""
     if v is None:
         return default, None
     if v is True or v is False:
@@ -1391,7 +1551,9 @@ class Handler(BaseHTTPRequestHandler):
         instead of parsing: a Transfer-Encoding request (411; bodies are delimited by Content-Length
         alone), more than one Content-Length (400), a non-decimal one or a digit run past 20 (400), a
         length past _POST_MAX_BYTES (413, before a byte is read), a body shorter than announced (400,
-        naming the shortfall), and a decodable body that is not an object (400, naming what arrived). It
+        naming the shortfall), one that stalls past _POST_BODY_TIMEOUT (408; the read runs under a socket
+        timeout, so a trickling client cannot pin a handler thread), and a decodable body that is not an
+        object (400, naming what arrived). It
         used to be `json.loads(rfile.read(int(Content-Length)))` unchecked: the first of two lengths was
         trusted, nothing was capped, and a non-object came back parsed so the route's first `.get`
         raised AttributeError out of the handler -- the connection dropped with a traceback on stderr
@@ -1411,7 +1573,26 @@ class Handler(BaseHTTPRequestHandler):
         n = int(cl)
         if n > _POST_MAX_BYTES:
             raise _RefusedBody(413, "request body of %d bytes exceeds the %d-byte limit" % (n, _POST_MAX_BYTES))
-        raw = self.rfile.read(n) if n else b""
+        raw = b""
+        if n:
+            # The read runs under a socket timeout (_POST_BODY_TIMEOUT), put back afterwards; a unit-test
+            # handler over a BytesIO has no connection, and a fake rfile that stalls raises the same
+            # socket.timeout the real one would.
+            sock = getattr(self, "connection", None)
+            prior = sock.gettimeout() if sock is not None else None
+            try:
+                if sock is not None:
+                    sock.settimeout(_POST_BODY_TIMEOUT)
+                raw = self.rfile.read(n)
+            except socket.timeout:
+                raise _RefusedBody(408, "body could not be read: %d bytes announced, not all of it arrived within %g s"
+                                   % (n, _POST_BODY_TIMEOUT))
+            finally:
+                if sock is not None:
+                    try:
+                        sock.settimeout(prior)
+                    except OSError:
+                        pass                             # the socket is already gone; the refusal closes it anyway
         if len(raw) < n:
             raise _RefusedBody(400, "body could not be read: read %d of the %d bytes Content-Length announced" % (len(raw), n))
         data = json.loads(raw) if raw else {}
@@ -2282,8 +2463,9 @@ def _bounce_apply(host, b):
     outbox_del(host, mid)
     if not msg:
         return
-    note = ("undeliverable to '%s' on %s: %s\n\n(your message follows)\n%s"
-            % (msg.get("to") or "?", host, (b or {}).get("why") or "refused", msg.get("body") or ""))
+    note = "undeliverable to '%s' on %s: %s" % (msg.get("to") or "?", host, (b or {}).get("why") or "refused")
+    if not (b or {}).get("omitBody"):   # a SIZE bounce (_budget_relays) names the problem instead of repeating it
+        note += "\n\n(your message follows)\n%s" % (msg.get("body") or "")
     if msg.get("frm_id"):
         deliver(msg["frm_id"], "romp-postal", "", note, kind="coordinate")
     _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
@@ -2640,8 +2822,43 @@ def _drop_peer_name_dupes(host, bus_id):
         PEER_STATE.pop(k, None)
 
 
+# The most of one host's outbox a single exchange carries (review find, 2026-09-08). The dialed bus reads
+# the request only up to _POST_MAX_BYTES, and the request also carries presence, holds, reads and acks,
+# so the relays get half of it. build_exchange_request used to send the WHOLE outbox: a backlog past the
+# cap (a dozen 100 KB reports parked through one tunnel outage) was 413'd, and the dialer re-sent the
+# identical request on every backoff, forever: every message to that peer parked on a healthy link,
+# against the parking contract above (a link being DOWN is the only reason to park).
+_RELAY_BUDGET_BYTES = _POST_MAX_BYTES // 2
+
+
+def _budget_relays(host, msgs, budget=None):
+    """The oldest-first prefix of `msgs` that fits `budget` bytes serialized -> the relays for ONE
+    exchange; the rest ride the next round (the dialed side answers at once when it has acks to return,
+    so nothing waits out a long-poll). The first relay that fits always rides, so every round makes
+    progress. A relay that alone exceeds the budget can never cross, so it is bounced through the path a
+    peer's refusal takes (_bounce_arrived: to our local sender, or backward to the origin that forwarded
+    it) as a note naming the size, without the body, and leaves the outbox instead of being retried
+    forever."""
+    budget = _RELAY_BUDGET_BYTES if budget is None else budget
+    out, used = [], 0
+    for m in msgs:
+        n = len(json.dumps(m).encode("utf-8"))
+        if n > budget:
+            _log("peer %s: relay %s is %d bytes, over the %d-byte exchange limit; bounced to its sender"
+                 % (host, m.get("mid"), n, budget))
+            _bounce_arrived(host, {"mid": m.get("mid"), "omitBody": True,
+                                   "why": "message of %d bytes exceeds the %d-byte relay limit" % (n, budget)})
+            continue
+        if used + n > budget:
+            break
+        out.append(m)
+        used += n
+    return out
+
+
 def peer_exchange_handle(data):
-    """The DIALED side of one exchange. Returns (payload, status)."""
+    """The DIALED side of one exchange. Returns (payload, status). Relays ride under _RELAY_BUDGET_BYTES
+    (_budget_relays), the request side's bound mirrored, so the response is bounded the same way."""
     host = str((data or {}).get("host") or "").strip()
     if not host:
         return {"error": "host required"}, 400
@@ -2695,12 +2912,12 @@ def peer_exchange_handle(data):
 
     a2, b2 = _drain_backflow()
     acks, bounces = acks + a2, bounces + b2
-    rel, reads = outbox_list(host), readbox_list(host)
+    rel, reads = _budget_relays(host, outbox_list(host)), readbox_list(host)
     if not rel and not reads and data.get("wait") and not acks and not bounces:
         # nothing to hand back → park on the wake so anything we accept mid-wait crosses instantly
         _peer_wake(host).clear()
         _peer_wake(host).wait(EXCHANGE_WAIT)
-        rel, reads = outbox_list(host), readbox_list(host)
+        rel, reads = _budget_relays(host, outbox_list(host)), readbox_list(host)
         a2, b2 = _drain_backflow()
         acks, bounces = acks + a2, bounces + b2
     # `reads` stay parked until the dialer's NEXT request readAcks them — a response can vanish
@@ -2711,13 +2928,18 @@ def peer_exchange_handle(data):
             "relays": rel, "acks": acks, "bounces": bounces, "reads": reads}, 200
 
 def build_exchange_request(host, wait=True):
+    """The DIALER's request for one exchange. The relays are the outbox's oldest-first prefix under
+    _RELAY_BUDGET_BYTES (_budget_relays); the rest ride the next round, so a backlog drains over a few
+    exchanges instead of being refused whole."""
     p = _pending(host)
     with _peer_lock:
         acks, bounces, read_acks = list(p["acks"]), list(p["bounces"]), list(p.get("readAcks") or [])
+    relays = _budget_relays(host, outbox_list(host))          # may bounce (a backward bounce joins the
+    #                                                           origin's pending queue): after the snapshot
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
             "presence": fleet_presence(host), "holds": holds_payload(host),
             "tier": my_tier_of(host),                # how WE hold the dialed host's mail
-            "relays": outbox_list(host),
+            "relays": relays,
             "acks": acks, "bounces": bounces,
             "reads": readbox_list(host), "readAcks": read_acks, "wait": bool(wait)}
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1330,21 +1330,94 @@ def _wake_when_ready(sid):
     except Exception as e:
         _log("wake wait failed for %s: %s" % (sid, e))
 
+# The most a POST body may carry -- the kernel's bound, mirrored: every bus route takes a JSON control
+# request (one mail, a peer table, an exchange of presence and acks), tens of KB at most.
+_POST_MAX_BYTES = 1024 * 1024
+
+
+def _clip_json(v, n=60):
+    """A BOUNDED, WELL-FORMED echo of an offending request value for an error message: a large body must
+    never come back as a large error. The cut lands INSIDE a string's quotes and is marked, so a long
+    string still echoes as one complete quoted thing (a slice of the serialized text took the closing
+    quote with it); ensure_ascii is off, or the marker itself comes back as \\u2026. The kernel's shape."""
+    if isinstance(v, str):
+        return json.dumps(v[:n] + "\u2026" if len(v) > n else v, ensure_ascii=False)
+    try:
+        s = json.dumps(v, ensure_ascii=False)
+    except (TypeError, ValueError):
+        s = repr(v)
+    return s if len(s) <= n else s[:n] + "\u2026"
+
+
+def _as_bool(v, field, default=False):
+    """A request flag as the boolean it claims to be -> (value, error). Absent (None) is `default`; JSON
+    true/false pass through; anything else -- the string "false", 0/1, "no" -- is refused with `error`
+    naming the field, and the caller must NOT act. Never coerces: bool("false") is True, which is how a
+    string used to arm a tracked delegation and mark a down peer bus up."""
+    if v is None:
+        return default, None
+    if v is True or v is False:
+        return v, None
+    return None, "'%s' must be true or false, got %s" % (field, _clip_json(v))
+
+
+class _RefusedBody(Exception):
+    """A request body Handler._body refused before or instead of parsing it: `status` and `error` are the
+    answer, and the connection closes with it (the body is unread or unusable, so the socket cannot
+    carry a next request)."""
+
+    def __init__(self, status, error):
+        super().__init__(error)
+        self.status, self.error = status, error
+
+
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *a):
         pass   # keep stdout/stderr clean; the bus log is for real events only
 
-    def _send(self, obj, code=200):
+    def _send(self, obj, code=200, close=False):
         body = json.dumps(obj).encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
+        if close:
+            self.send_header("Connection", "close")
         self.end_headers()
         self.wfile.write(body)
 
     def _body(self):
-        n = int(self.headers.get("Content-Length", 0) or 0)
-        return json.loads(self.rfile.read(n)) if n else {}
+        """The request body as the JSON object every route expects, read only within bounds -- the
+        kernel's _read_post_body, mirrored. Refused as _RefusedBody(status, error), each before or
+        instead of parsing: a Transfer-Encoding request (411; bodies are delimited by Content-Length
+        alone), more than one Content-Length (400), a non-decimal one or a digit run past 20 (400), a
+        length past _POST_MAX_BYTES (413, before a byte is read), a body shorter than announced (400,
+        naming the shortfall), and a decodable body that is not an object (400, naming what arrived). It
+        used to be `json.loads(rfile.read(int(Content-Length)))` unchecked: the first of two lengths was
+        trusted, nothing was capped, and a non-object came back parsed so the route's first `.get`
+        raised AttributeError out of the handler -- the connection dropped with a traceback on stderr
+        instead of the 400 do_POST answers for undecodable JSON."""
+        if self.headers.get("Transfer-Encoding"):
+            raise _RefusedBody(411, "Transfer-Encoding is not accepted; send the body with a Content-Length")
+        get_all = getattr(self.headers, "get_all", None)   # an HTTPMessage in service; a plain dict in unit tests
+        if callable(get_all):
+            lengths = get_all("Content-Length") or []
+        else:
+            lengths = [] if self.headers.get("Content-Length") is None else [self.headers.get("Content-Length")]
+        if len(lengths) > 1:
+            raise _RefusedBody(400, "body could not be read: more than one Content-Length header")
+        cl = str(lengths[0]).strip() if lengths else "0"
+        if not re.fullmatch(r"[0-9]{1,20}", cl):
+            raise _RefusedBody(400, "body could not be read: Content-Length %s is an invalid literal for a byte count (decimal digits only)" % _clip_json(cl))
+        n = int(cl)
+        if n > _POST_MAX_BYTES:
+            raise _RefusedBody(413, "request body of %d bytes exceeds the %d-byte limit" % (n, _POST_MAX_BYTES))
+        raw = self.rfile.read(n) if n else b""
+        if len(raw) < n:
+            raise _RefusedBody(400, "body could not be read: read %d of the %d bytes Content-Length announced" % (len(raw), n))
+        data = json.loads(raw) if raw else {}
+        if not isinstance(data, dict):
+            raise _RefusedBody(400, "body must be a JSON object, got %s" % _clip_json(data))
+        return data
 
     def _authorized(self):
         """Serve-token gate, every route but /ping (see the SERVE_TOKEN block). Local clients send
@@ -1421,6 +1494,9 @@ class Handler(BaseHTTPRequestHandler):
                                "~/.local/state/romp/serve-token)"}, 403)
         try:
             data = self._body()
+        except _RefusedBody as e:
+            self.close_connection = True
+            return self._send({"error": e.error}, e.status, close=True)
         except Exception:
             return self._send({"error": "bad json"}, 400)
         if u.path == "/peer":                      # the kernel's tunnel-transition notify (peer-bus mode)
@@ -1447,7 +1523,10 @@ class Handler(BaseHTTPRequestHandler):
             kind = str(data.get("kind", "")).strip().lower()
             if kind not in ("delegate", "coordinate", "question"):
                 kind = ""                              # legacy/CLI mail may be undeclared; never invent one
-            tracked = bool(data.get("tracked")) and kind == "delegate"   # report-back delegation
+            tracked, terr = _as_bool(data.get("tracked"), "tracked")   # report-back delegation
+            if terr:                                   # a string here armed tracking on a plain send
+                return self._send({"error": terr}, 400)
+            tracked = tracked and kind == "delegate"
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
             #   about the flag ever appears in message prose (the injected-voice rule)
             if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
@@ -1791,7 +1870,10 @@ def peer_update(data):
     prev = PEERS.get(host) or {}
     tok = str(data.get("token") or "") or prev.get("token") or ""
     trust = str(data.get("trust") or "") or prev.get("trust") or "directed"
-    PEERS[host] = {"port": port, "up": bool(data.get("up")), "at": int(time.time()),
+    up, uerr = _as_bool(data.get("up"), "up")
+    if uerr:                                           # a string here marked a DOWN tunnel up
+        return {"error": uerr}, 400
+    PEERS[host] = {"port": port, "up": up, "at": int(time.time()),
                    "token": tok, "trust": trust}
     _peer_threads_reconcile(host)                    # an up peer gets its dialer; a down one is woken to exit
     return {"ok": True, "up": sum(1 for p in PEERS.values() if p["up"])}, 200
@@ -2988,7 +3070,10 @@ def _mcp_call(name, args):
             return ("Cannot send: this session's own identity did not resolve (no session id), so "
                     "the mail would arrive anonymously and the recipient could not place or answer "
                     "it. This is a session-identity bug worth surfacing to the user.", True)
-        tracked = bool(args.get("tracked")) and kind == "delegate"
+        tracked, terr = _as_bool(args.get("tracked"), "tracked")
+        if terr:
+            return ("Cannot send: %s. Pass a JSON boolean (tracked: true), not a string." % terr, True)
+        tracked = tracked and kind == "delegate"
         try:
             payload = {"to": to, "from": me or "unknown", "from_id": mid, "body": body, "kind": kind}
             if tracked:

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -18,7 +18,11 @@ Mirrors tests/test_kernel_ws_auth.py's module load order.
 import io
 import json
 import os
+import socket
+import threading
 import unittest
+from http.client import HTTPMessage
+from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 import tempfile
 
@@ -377,6 +381,197 @@ class BusyDrainWriteGate(unittest.TestCase):
         self.assertEqual(status, 200, "the count is a healthz-style probe — no token needed")
         self.assertEqual(json.loads(body).get("busy"), 3)
         self.assertEqual(self.spy.refreshed, 0, "a plain /busy never holds")
+
+
+class _RfileSpy:
+    """A request body that RECORDS every read: the gate under test must refuse before reading any of it."""
+
+    def __init__(self, data=b""):
+        self.data, self.reads = data, []
+
+    def read(self, n=-1):
+        self.reads.append(n)
+        out, self.data = self.data[:n], self.data[n:]
+        return out
+
+
+def _serve_post(path, headers=None, body=b"", rfile=None):
+    """Drive the REAL do_POST dispatcher over a fake socket -> (status, response headers, body text,
+    handler). `headers` is a dict or an http.client.HTTPMessage -- the type the live server parses
+    into, and the one that can carry a header TWICE (a dict cannot)."""
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    h.headers = headers if headers is not None else {}
+    h.path = path
+    h.command = "POST"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = rfile if rfile is not None else io.BytesIO(body)
+    h.close_connection = False                       # keep-alive until the handler says otherwise
+    captured = {"headers": {}}
+
+    def send_response(code, *a):
+        captured["status"] = code
+
+    def send_header(k, v):
+        captured["headers"][k] = v
+
+    h.send_response = send_response
+    h.send_header = send_header
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_POST()
+    return captured.get("status"), captured["headers"], h.wfile.getvalue().decode("utf-8", "replace"), h
+
+
+class PostBodyGate(unittest.TestCase):
+    """POST bodies are read only AFTER _authorize passes, and only within bounds. do_POST used to read
+    the whole body FIRST -- `int(Content-Length or 0)` inside a bare except, no cap -- so a token-less
+    loopback or tailnet client could make the kernel buffer any number of bytes and pin one handler
+    thread per oversize POST (the server is threaded); a non-decimal or duplicate Content-Length was
+    silently read as no body; a Transfer-Encoding request had its chunk framing parsed as the next
+    request; and a denied request left its unread body on a keep-alive socket. Every refusal here
+    wears the route family's JSON shape and closes the connection."""
+    TEN_MB = str(10 * 1024 * 1024)
+
+    def test_an_unauthenticated_post_is_denied_before_its_body_is_read(self):
+        spy = _RfileSpy()
+        st, hdrs, body, h = _serve_post("/send", {"Content-Length": self.TEN_MB}, rfile=spy)
+        self.assertEqual(st, 403)
+        self.assertEqual(spy.reads, [], "no byte of an unauthenticated body is read")
+        self.assertTrue(h.close_connection, "an unread body cannot stay on a keep-alive socket")
+        self.assertEqual(hdrs.get("Connection"), "close")
+
+    def test_an_oversize_post_is_413_before_any_read_and_a_bounded_one_is_served(self):
+        spy = _RfileSpy()
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK,
+                                                 "Content-Length": str(km._POST_MAX_BYTES + 1)}, rfile=spy)
+        self.assertEqual(st, 413)
+        r = json.loads(body)
+        self.assertIs(r["ok"], False)
+        self.assertIn(str(km._POST_MAX_BYTES), r["error"], "the refusal names the limit")
+        self.assertEqual(spy.reads, [], "refused on the declared length, before a byte is read")
+        self.assertTrue(h.close_connection)
+        self.assertEqual(hdrs.get("Connection"), "close")
+        # the same route, an in-bounds body: read, parsed and served (the cap is a cap, not a lockout)
+        raw = b'{"log": false}'
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Content-Length": str(len(raw))}, body=raw)
+        self.assertEqual(st, 200)
+        self.assertEqual(json.loads(body), {"ok": True, "log": False})
+
+    def test_a_non_decimal_content_length_is_400_and_unread(self):
+        for cl in ("12abc", "-1", "0x10", " ", "1e3", "\u0661\u0662"):   # the last: Arabic-Indic digits, which str.isdigit accepts
+            spy = _RfileSpy(b"{}")
+            st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Content-Length": cl}, rfile=spy)
+            self.assertEqual(st, 400, cl)
+            self.assertIn("Content-Length", json.loads(body)["error"], cl)
+            self.assertEqual(spy.reads, [], cl)
+            self.assertTrue(h.close_connection, cl)
+
+    def test_two_content_length_headers_are_400_and_unread(self):
+        m = HTTPMessage()
+        m["X-Romp-Token"] = TOK
+        m["Content-Length"] = "2"
+        m["Content-Length"] = "4"                        # Message.__setitem__ APPENDS: two headers, as on the wire
+        spy = _RfileSpy(b"{}{}")
+        st, hdrs, body, h = _serve_post("/perf", m, rfile=spy)
+        self.assertEqual(st, 400)
+        self.assertIn("more than one Content-Length", json.loads(body)["error"])
+        self.assertEqual(spy.reads, [], "neither length is trusted")
+        self.assertTrue(h.close_connection)
+
+    def test_transfer_encoding_is_411_and_unread(self):
+        spy = _RfileSpy(b"2\r\n{}\r\n0\r\n\r\n")
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Transfer-Encoding": "chunked"}, rfile=spy)
+        self.assertEqual(st, 411)
+        self.assertIn("Transfer-Encoding", json.loads(body)["error"])
+        self.assertEqual(spy.reads, [], "chunk framing is never read as a body")
+        self.assertTrue(h.close_connection)
+
+    def test_a_digit_run_past_any_byte_count_is_400_not_a_conversion_error(self):
+        # 5000 digits pass a bare [0-9]+ and then int() raises past the interpreter's conversion limit
+        # (4300 digits on 3.11+) -- into do_POST's catch-all as a 500 traceback with the socket left open
+        spy = _RfileSpy(b"{}")
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Content-Length": "9" * 5000}, rfile=spy)
+        self.assertEqual(st, 400)
+        err = json.loads(body)["error"]
+        self.assertIn("Content-Length", err)
+        self.assertLess(len(err), 200, "the offending value echoes clipped, not in full")
+        self.assertEqual(spy.reads, [])
+        self.assertTrue(h.close_connection)
+
+    def test_an_absent_content_length_is_an_empty_body_never_a_read(self):
+        # the hook's bodiless POST /tick, and any bodiless POST: served on an empty body without a read
+        spy = _RfileSpy(b"")
+        st, hdrs, body, h = _serve_post("/tick", {"X-Romp-Token": TOK}, rfile=spy)
+        self.assertEqual((st, json.loads(body)), (200, {"ok": True, "woke": True}))
+        self.assertEqual(spy.reads, [], "nothing to read: no read")
+        self.assertFalse(h.close_connection, "a served request keeps its keep-alive")
+        spy = _RfileSpy(b"")
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK}, rfile=spy)
+        self.assertEqual(st, 400)
+        self.assertEqual(json.loads(body)["error"], 'body must be {"log": true|false}',
+                         "the route saw an EMPTY body (its own refusal), not a gate refusal")
+        self.assertEqual(spy.reads, [])
+
+
+def _raw_post(port, path, headers, body=b"", half_close=True):
+    """One hand-built POST over a real socket -> (status, JSON body, response head). `headers` is a list
+    of (name, value) pairs, so a header can be sent twice; `half_close` ends the client's sending side
+    after `body`, so the server's read of an announced-but-short body sees EOF rather than hanging.
+    Connection: close on the request, so the response is followed by EOF and the read loop ends."""
+    lines = ["POST %s HTTP/1.1" % path, "Host: 127.0.0.1", "Connection: close"] + \
+            ["%s: %s" % kv for kv in headers]
+    req = ("\r\n".join(lines) + "\r\n\r\n").encode() + body
+    s = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        s.sendall(req)
+        if half_close:
+            s.shutdown(socket.SHUT_WR)
+        data = b""
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        s.close()
+    head, _, payload = data.partition(b"\r\n\r\n")
+    return int(head.split(b" ", 2)[1]), json.loads(payload.decode() or "{}"), head.decode()
+
+
+class PostBodyGateOverTheWire(unittest.TestCase):
+    """The same gate against the REAL server and a real socket: the header object is the HTTPMessage
+    the live server parses into, and the body arrives (or does not) over TCP."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def test_a_body_shorter_than_announced_is_refused_naming_the_shortfall(self):
+        # a dead client / short read: 100 bytes announced, 10 arrive, then EOF. The 10 bytes must not
+        # pass as the body (here they would have been "body is not JSON" -- a guess at a truncated
+        # request); the refusal names the shortfall and closes.
+        st, r, head = _raw_post(self.port, "/rename", [("X-Romp-Token", TOK), ("Content-Length", "100")],
+                                body=b'{"target":')
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r, {"ok": False, "error": "body could not be read: read 10 of the 100 bytes Content-Length announced"})
+        self.assertIn("Connection: close", head)
+
+    def test_two_content_length_headers_on_the_wire_are_400(self):
+        st, r, head = _raw_post(self.port, "/rename",
+                                [("X-Romp-Token", TOK), ("Content-Length", "2"), ("Content-Length", "4")],
+                                body=b"{}{}")
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r["error"], "body could not be read: more than one Content-Length header")
+        self.assertIn("Connection: close", head)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -20,6 +20,7 @@ import json
 import os
 import socket
 import threading
+import time
 import unittest
 from http.client import HTTPMessage
 from http.server import ThreadingHTTPServer
@@ -395,12 +396,15 @@ class _RfileSpy:
         return out
 
 
-def _serve_post(path, headers=None, body=b"", rfile=None):
+def _serve_post(path, headers=None, body=b"", rfile=None, connection=None):
     """Drive the REAL do_POST dispatcher over a fake socket -> (status, response headers, body text,
     handler). `headers` is a dict or an http.client.HTTPMessage -- the type the live server parses
-    into, and the one that can carry a header TWICE (a dict cannot)."""
+    into, and the one that can carry a header TWICE (a dict cannot). `connection`, when given, stands
+    in for the socket the body read puts its timeout on."""
     h = km.Handler.__new__(km.Handler)
     h.client_address = ("127.0.0.1", 0)
+    if connection is not None:
+        h.connection = connection
     h.headers = headers if headers is not None else {}
     h.path = path
     h.command = "POST"
@@ -500,6 +504,48 @@ class PostBodyGate(unittest.TestCase):
         self.assertEqual(spy.reads, [])
         self.assertTrue(h.close_connection)
 
+    def test_a_body_that_stalls_is_408_and_closes_and_the_socket_timeout_is_restored(self):
+        # review find, 2026-09-08: the in-bounds read had no socket timeout, so an AUTHORIZED client
+        # that announced a body and trickled it pinned a handler thread for as long as it liked
+        class Stall:
+            reads = []
+
+            def read(self, n=-1):
+                self.reads.append(n)
+                raise socket.timeout("timed out")           # what the real rfile raises past the deadline
+
+        class Sock:
+            def __init__(self):
+                self.timeouts, self._t = [], None
+
+            def gettimeout(self):
+                return self._t
+
+            def settimeout(self, t):
+                self.timeouts.append(t)
+                self._t = t
+        sock = Sock()
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Content-Length": "100"},
+                                        rfile=Stall(), connection=sock)
+        self.assertEqual(st, 408)
+        r = json.loads(body)
+        self.assertIs(r["ok"], False)
+        self.assertEqual(r["error"], "body could not be read: 100 bytes announced, not all of it arrived within %g s"
+                         % km._POST_BODY_TIMEOUT)
+        self.assertTrue(h.close_connection, "a half-arrived body cannot stay on a keep-alive socket")
+        self.assertEqual(hdrs.get("Connection"), "close")
+        self.assertEqual(sock.timeouts, [km._POST_BODY_TIMEOUT, None],
+                         "the read ran under the body timeout, and the socket's own (none) came back")
+        self.assertEqual(Stall.reads, [100], "the read was attempted once, for the announced length")
+        # a body that ARRIVES under the same timeout is served, and the timeout is restored just the same
+        sock = Sock()
+        raw = b'{"log": false}'
+        st, hdrs, body, h = _serve_post("/perf", {"X-Romp-Token": TOK, "Content-Length": str(len(raw))},
+                                        body=raw, connection=sock)
+        self.assertEqual((st, json.loads(body)), (200, {"ok": True, "log": False}))
+        self.assertEqual(sock.timeouts, [km._POST_BODY_TIMEOUT, None])
+        self.assertFalse(h.close_connection)
+
     def test_an_absent_content_length_is_an_empty_body_never_a_read(self):
         # the hook's bodiless POST /tick, and any bodiless POST: served on an empty body without a read
         spy = _RfileSpy(b"")
@@ -572,6 +618,27 @@ class PostBodyGateOverTheWire(unittest.TestCase):
         self.assertEqual(st, 400, r)
         self.assertEqual(r["error"], "body could not be read: more than one Content-Length header")
         self.assertIn("Connection: close", head)
+
+    def test_a_trickling_body_is_408_over_the_wire_and_the_connection_closes(self):
+        # 100 bytes announced, 10 sent, the sending side left OPEN (no half-close, so no EOF): before the
+        # body timeout this read blocked for as long as the client cared to hold the socket
+        saved = km._POST_BODY_TIMEOUT
+        km._POST_BODY_TIMEOUT = 0.5
+        try:
+            t0 = time.monotonic()
+            st, r, head = _raw_post(self.port, "/rename", [("X-Romp-Token", TOK), ("Content-Length", "100")],
+                                    body=b'{"target":', half_close=False)
+            took = time.monotonic() - t0
+        finally:
+            km._POST_BODY_TIMEOUT = saved
+        self.assertEqual(st, 408, r)
+        self.assertEqual(r, {"ok": False, "error": "body could not be read: 100 bytes announced, not all of it arrived within 0.5 s"})
+        self.assertIn("Connection: close", head)
+        self.assertLess(took, 5, "answered on the body timeout, not on the client giving up")
+        # the server is still serving: the next request lands
+        st, r, head = _raw_post(self.port, "/rename", [("X-Romp-Token", TOK), ("Content-Length", "2")], body=b"{}")
+        self.assertEqual(st, 400, r)
+        self.assertNotIn("announced", r.get("error", ""))
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -769,3 +769,171 @@ def _gear_src():
 def _gear_css_src():
     import pathlib
     return (pathlib.Path(__file__).resolve().parent.parent / "ui" / "webview" / "gear.css").read_text()
+
+
+class WsFlagsMustBeBooleans(unittest.TestCase):
+    """Every WS flag the dashboards send takes JSON true/false and nothing else. Each handler used to
+    coerce with bool(), so the STRING "false" enabled auto-nudge, file editing, compact suggestions,
+    thinking summaries and conserve-memory, paused API retries across every session, set a lane flag,
+    armed a card bell, forwarded a tag DELETE to its home kernel, made a directory and enabled an MCP
+    server. Now a non-boolean is refused on the delivering socket -- a `warn` frame naming the field;
+    setSessionFlag and cardNotify on the settingRefused frame their pages (timeline, feed) render and
+    repaint from, a `warn` never reaching either; editTag on its own tagEditFailed frame; mcpAction in
+    its mcpResult error -- and the setting is untouched. The shipped panes send real booleans
+    (render.ts, feed.ts, timeline-boot.ts), so their frames are unchanged."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    BAD = ("false", "true", "no", 1, 0)
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._mark_views_dirty, km._push_soon, km._ws_act_now_tick)
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+        km._mark_views_dirty = lambda: None
+        km._push_soon = lambda: None
+        km._ws_act_now_tick = lambda: None           # turn-on acts at once in service; not under test here
+
+    def tearDown(self):
+        jd.STATE, km._mark_views_dirty, km._push_soon, km._ws_act_now_tick = self.saved
+        km._flags_cache.clear()
+        self.td.cleanup()
+
+    def _client(self):
+        sent = []
+        return {"app": "chat", "wid": "w1", "alive": True,
+                "send": lambda raw: sent.append(json.loads(raw))}, sent
+
+    def _refused(self, frame, op, field):
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, frame, client)
+        self.assertEqual(len(sent), 1, (op, frame, sent))
+        self.assertEqual(sent[0]["type"], "warn", (op, sent))
+        self.assertEqual(sent[0]["text"], "%s: '%s' must be true or false, got %s"
+                         % (op, field, json.dumps(frame[field])))
+
+    def _refused_setting(self, frame, gesture, field, sid, flag="", item_id=""):
+        """The two page-handled flags refuse on settingRefused, addressed to the toggle, carrying the
+        value the kernel still paints (nothing was written, so: the default, off)."""
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, frame, client)
+        self.assertEqual(len(sent), 1, (gesture, frame, sent))
+        fr = sent[0]
+        self.assertEqual((fr["type"], fr["gesture"], fr["sid"], fr["flag"], fr["itemId"]),
+                         ("settingRefused", gesture, sid, flag, item_id), fr)
+        self.assertIs(fr["value"], False, "the painted value rides along: nothing was written")
+        self.assertIn("'%s' must be true or false, got %s" % (field, json.dumps(frame[field])), fr["text"])
+        self.assertTrue(fr["text"].startswith("couldn't save"), fr["text"])
+
+    def test_kernel_settings_refuse_strings_and_apply_real_booleans(self):
+        warn = lambda frame, op, field: self._refused(frame, op, field)
+        lane = lambda frame, op, field: self._refused_setting(frame, "flag", field, self.SID, flag="hideFromFeed")
+        cases = (
+            ("setAutoNudge", "enabled", {}, km._auto_nudge_on, warn),
+            ("setCompactSuggest", "enabled", {}, km._compact_suggest_on, warn),
+            ("setFileEditing", "enabled", {}, km._file_editing_on, warn),
+            ("setThinkingSummaries", "enabled", {}, km._thinking_summaries_on, warn),
+            ("setConserve", "enabled", {}, km._conserve_on, warn),
+            ("setGlobalRetryPaused", "value", {}, km._retry_paused_on, warn),
+            ("setSessionFlag", "value", {"id": self.SID, "flag": "hideFromFeed"},
+             lambda: km._session_flag(self.SID, "hideFromFeed"), lane),
+        )
+        for op, field, extra, reader, refused in cases:
+            before = reader()                        # each setting's own default (auto-nudge ships ON)
+            for bad in self.BAD:
+                refused(dict({"type": op, field: bad}, **extra), op, field)
+                km._flags_cache.clear()
+                self.assertEqual(reader(), before, "%s: %r left the setting untouched" % (op, bad))
+            for want in (not before, before):        # a real boolean flips it, and flips it back
+                client, sent = self._client()
+                km.Handler._dispatch_ws(None, dict({"type": op, field: want}, **extra), client)
+                km._flags_cache.clear()
+                self.assertEqual(reader(), want, "%s: a real %r applies" % (op, want))
+                self.assertEqual(sent, [], "%s: no frame on success" % op)
+
+    def test_the_session_bell_and_the_card_bell_refuse_strings(self):
+        card = self.SID + ":g1"
+        for bad in self.BAD:
+            self._refused_setting({"type": "setSessionFlag", "id": self.SID, "flag": "notify", "value": bad},
+                                  "flag", "value", self.SID, flag="notify")
+            self._refused_setting({"type": "cardNotify", "itemId": card, "sid": self.SID, "value": bad},
+                                  "bell", "value", self.SID, item_id=card)
+        km._flags_cache.clear()
+        self.assertEqual(km._session_flags(), {}, "no bell override was written")
+        self.assertEqual(km._notify_cards(), {}, "no card override was written")
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, {"type": "cardNotify", "itemId": card, "sid": self.SID, "value": True}, client)
+        self.assertEqual(sent, [])
+        self.assertIs(km._notify_cards().get(card), True, "a real true arms the card (the master is off)")
+        km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "notify", "value": True},
+                                self._client()[0])
+        km._flags_cache.clear()
+        self.assertEqual(km._session_flags().get(self.SID), {"notify": True})
+
+    def test_create_session_refuses_a_string_mkdir_before_touching_the_disk(self):
+        calls = []
+        saved = km._resolve_create_dir
+        km._resolve_create_dir = (lambda raw, create=False:
+                                  calls.append((raw, create)) or ("", "stubbed: no directory here"))
+        try:
+            for bad in self.BAD:
+                self._refused({"type": "createSession", "name": "fresh", "dir": "/nonexistent/TESTHOST",
+                               "mkdir": bad}, "createSession", "mkdir")
+            self.assertEqual(calls, [], "no directory is resolved, let alone created, on a malformed flag")
+        finally:
+            km._resolve_create_dir = saved
+
+    def test_edit_tag_refuses_a_string_delete_on_its_own_failure_frame(self):
+        fwd, views = [], []
+        saved = (km._forward_tag_edit, km._send_to_view)
+        km._forward_tag_edit = lambda host, body: fwd.append((host, body)) or ({"ok": True, "tag": {}}, None)
+        km._send_to_view = lambda app, msg, wid: views.append((app, msg, wid))
+        try:
+            for bad in self.BAD:
+                client, sent = self._client()
+                km.Handler._dispatch_ws(None, {"type": "editTag",
+                                               "edit": {"host": "TESTHOST", "name": "pool", "delete": bad}}, client)
+                self.assertEqual(sent, [], "the refusal rides tagEditFailed, where a refused edit lands")
+                app, msg, wid = views.pop()
+                self.assertEqual((app, msg["type"], msg["host"], msg["name"], msg["queued"], wid),
+                                 ("timeline", "tagEditFailed", "TESTHOST", "pool", False, "w1"))
+                self.assertEqual(msg["error"], "editTag: 'delete' must be true or false, got %s" % json.dumps(bad))
+            self.assertEqual(fwd, [], "nothing crossed to the home kernel (a string used to forward a DELETE)")
+            km.Handler._dispatch_ws(None, {"type": "editTag", "edit": {"host": "TESTHOST", "name": "pool", "delete": True}},
+                                    self._client()[0])
+            self.assertEqual(fwd, [("TESTHOST", {"name": "pool", "delete": True})])
+            km.Handler._dispatch_ws(None, {"type": "editTag", "edit": {"host": "TESTHOST", "name": "pool", "delete": False}},
+                                    self._client()[0])
+            self.assertEqual(fwd[-1], ("TESTHOST", {"name": "pool"}), "a real false forwards no delete key, as before")
+            self.assertEqual(views, [], "no failure frame for a real boolean")
+        finally:
+            km._forward_tag_edit, km._send_to_view = saved
+
+    def test_mcp_action_refuses_a_string_enabled_in_its_result_frame(self):
+        calls = []
+
+        class BE:
+            def mcp_action(self, sid, name, action, enabled=True):
+                calls.append((sid, name, action, enabled))
+                return ""
+        saved = (km.Sessions.backend_for, km._name_of, km._sdk)
+        km.Sessions.backend_for = staticmethod(lambda sid: BE())
+        km._name_of = lambda sid: "web" if sid == self.SID else None    # _kernel_knows: ours
+        km._sdk = lambda: None
+        try:
+            for bad in self.BAD:
+                client, sent = self._client()
+                self.assertTrue(km._drive({"type": "mcpAction", "id": self.SID, "server": "postal",
+                                           "action": "enable", "enabled": bad}, client), "consumed: refused, not passed on")
+                self.assertEqual(len(sent), 1, sent)
+                self.assertEqual((sent[0]["type"], sent[0]["server"]), ("mcpResult", "postal"))
+                self.assertEqual(sent[0]["error"], "'enabled' must be true or false, got %s" % json.dumps(bad))
+            self.assertEqual(calls, [], "no control request reaches the session on a malformed flag")
+            client, sent = self._client()
+            km._drive({"type": "mcpAction", "id": self.SID, "server": "postal", "action": "enable", "enabled": False}, client)
+            self.assertEqual(calls, [(self.SID, "postal", "enable", False)], "a real false rides through as itself")
+            self.assertEqual(sent[0]["error"], "")
+            km._drive({"type": "mcpAction", "id": self.SID, "server": "postal", "action": "reconnect"}, client)
+            self.assertEqual(calls[-1], (self.SID, "postal", "reconnect", True), "absent keeps its old default")
+        finally:
+            km.Sessions.backend_for = staticmethod(saved[0])
+            km._name_of, km._sdk = saved[1], saved[2]

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -869,6 +869,57 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
         km._flags_cache.clear()
         self.assertEqual(km._session_flags().get(self.SID), {"notify": True})
 
+    def test_the_log_names_the_field_and_its_type_never_the_value(self):
+        # review find, 2026-09-08: the stderr line carried up to 60 characters of whatever a client put
+        # in the field; the echo belongs in the frame the sender gets, the log names the field and type
+        import io
+        leak = "SECRET-VALUE-TESTHOST"
+        frames = (
+            ({"type": "setAutoNudge", "enabled": leak}, "'enabled' is a string, not a boolean", "warn"),
+            ({"type": "setGlobalRetryPaused", "value": [leak]}, "'value' is an array, not a boolean", "warn"),
+            ({"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": leak},
+             "'value' is a string, not a boolean", "settingRefused"),
+            ({"type": "cardNotify", "itemId": self.SID + ":g1", "sid": self.SID, "value": {"k": leak}},
+             "'value' is an object, not a boolean", "settingRefused"),
+            ({"type": "createSession", "name": "fresh", "dir": "/nonexistent/TESTHOST", "mkdir": 7},
+             "'mkdir' is a number, not a boolean", "warn"),
+        )
+        for frame, note, kind in frames:
+            client, sent = self._client()
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                km.Handler._dispatch_ws(None, frame, client)
+            line = err.getvalue()
+            self.assertIn("romp-kernel: refused %s: %s" % (frame["type"], note), line, (frame, line))
+            self.assertNotIn(leak, line, "the client's value stays out of the kernel's log")
+            self.assertEqual(len(sent), 1, (frame, sent))
+            self.assertEqual(sent[0]["type"], kind)
+            field = [k for k in ("enabled", "value", "mkdir") if k in frame][0]
+            self.assertIn("'%s' must be true or false, got %s" % (field, json.dumps(frame[field])), sent[0]["text"],
+                          "the sender still sees what it sent")
+
+    def test_an_explicit_null_value_reads_as_absent(self):
+        # the rule _as_bool states (review find, 2026-09-08): null takes the field's default (off), where a
+        # string or a number is refused; no frame, since nothing was refused
+        km._set_session_flag(self.SID, "hideFromFeed", True)
+        km._flags_cache.clear()
+        self.assertTrue(km._session_flag(self.SID, "hideFromFeed"))
+        client, sent = self._client()
+        km.Handler._dispatch_ws(None, {"type": "setSessionFlag", "id": self.SID, "flag": "hideFromFeed", "value": None}, client)
+        km._flags_cache.clear()
+        self.assertFalse(km._session_flag(self.SID, "hideFromFeed"))
+        self.assertEqual(sent, [])
+
+    def test_no_ws_handler_coerces_a_gated_flag_with_bool(self):
+        # moved here from ui/timeline-flags.test.ts (review find, 2026-09-08): a kernel source pin
+        # belongs in the kernel's own lane, where a kernel change runs it. The behaviour itself is
+        # test_kernel_settings_refuse_strings_and_apply_real_booleans above; this catches a coercion
+        # slipped back in beside the gate
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        for field in ('msg.get("value")', 'msg.get("enabled")', 'msg.get("mkdir")', 'e.get("delete")',
+                      'b.get("delete")', 'b.get("on")', 'b.get("mkdir")', 'body.get("on")', 'msg["enabled"]'):
+            self.assertNotIn("bool(%s)" % field, src, "%s is checked by _as_bool, never coerced" % field)
+
     def test_create_session_refuses_a_string_mkdir_before_touching_the_disk(self):
         calls = []
         saved = km._resolve_create_dir

--- a/tests/test_kernel_tab_flags.py
+++ b/tests/test_kernel_tab_flags.py
@@ -30,7 +30,10 @@ class TabFlags(unittest.TestCase):
     def test_kernel_handles_a_chat_side_setSessionFlag(self):
         text = open(KPATH).read()
         self.assertIn('msg.get("type") == "setSessionFlag"', text)
-        self.assertIn("_set_session_flag(str(msg[\"id\"]), str(msg[\"flag\"]), bool(msg.get(\"value\")))", text)
+        # the value is a checked boolean, never a bool() coercion: bool("false") is True (the string a
+        # third-party client sent used to flip the flag ON)
+        self.assertIn('value, ferr = _as_bool(msg.get("value"), "value")', text)
+        self.assertIn("_set_session_flag(str(msg[\"id\"]), str(msg[\"flag\"]), value)", text)
 
     def test_set_session_flag_round_trips(self):
         sid = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -527,7 +527,9 @@ class HeadlessParity(unittest.TestCase):
     def test_the_new_route_can_create_the_directory_too(self):
         import inspect
         src = inspect.getsource(km.Handler)
-        self.assertIn('_resolve_create_dir(b.get("dir"), create=bool(b.get("mkdir")))', src,
+        self.assertIn('mk, ferr = _as_bool(b.get("mkdir"), "mkdir")', src,
+                      "mkdir is a checked boolean: a string \"false\" used to create the directory")
+        self.assertIn('_resolve_create_dir(b.get("dir"), create=mk)', src,
                       "`romp new` gets the same create-it answer the dashboard offers")
         self.assertIn('"dirStatus": _dir_status(b.get("dir"))', src,
                       "a headless caller is told WHY, in the same shape the picker reads")

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -283,12 +283,16 @@ class NotifyWiring(unittest.TestCase):
     def test_the_ws_handler_persists_the_card_toggle(self):
         self.assertIn('msg.get("type") == "cardNotify"', self.src)
         # sid rides so delete-if-default resolves against the card's own default
-        self.assertIn('_set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))',
+        # the flag is a checked boolean, never bool()-coerced (a string "false" used to arm the bell)
+        self.assertIn('value, ferr = _as_bool(msg.get("value"), "value")', self.src)
+        # ...and refused on the frame the FEED page renders (settingRefused, addressed to the card), never a warn
+        self.assertIn('_refuse_setting(client, ferr, "that bell", "bell", sid=msg.get("sid") or "", item_id=msg["itemId"],',
                       self.src)
+        self.assertIn('_set_notify_card(str(msg["itemId"]), value, str(msg.get("sid") or ""))', self.src)
 
     def test_the_session_bell_routes_to_its_tristate_setter(self):
         # setSessionFlag's pop-on-false is right for the view flags but would eat a mute
-        self.assertIn('_set_notify_session(str(msg["id"]), bool(msg.get("value")))', self.src)
+        self.assertIn('_set_notify_session(str(msg["id"]), value)', self.src)
 
     def test_the_master_has_both_routes_and_broadcasts(self):
         # GET paints the bell at boot; POST flips it, rebuilds the feed (per-card bells repaint

--- a/tests/test_postal_delivery.py
+++ b/tests/test_postal_delivery.py
@@ -3,9 +3,15 @@
 (the user 2026-06-26): drain the maildir, hand the banner to the kernel, and put the mail BACK if the kernel
 didn't inject — so the maildir-drain stays the backstop and the bus never shells tmux. Synthetic only.
 """
+import io
+import json
 import os
 import tempfile
+import threading
 import unittest
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -85,6 +91,235 @@ class PushThroughKernel(unittest.TestCase):
         self.assertIn('_kernel_post("/deliver"', src, "the live-push wakes via the kernel")
         self.assertNotIn("paste-buffer", src, "no tmux pane-inject remains in the bus")
         self.assertNotIn("capture-pane", src, "no tmux pane-capture remains in the bus")
+
+
+class PushIsChunkedUnderTheKernelsCap(unittest.TestCase):
+    """The kernel reads a POST body only up to _POST_MAX_BYTES (1 MiB). The bus used to hand it ONE
+    /deliver banner for a recipient's whole box: past the cap the kernel refused it with 413 before
+    reading a byte, _kernel_post folded the refusal into None, and _push filed it as the same "deferred"
+    every safe-pane deferral logs and re-posted the identical banner on every retry pass, forever (review
+    find, 2026-09-08). Now the box crosses in chunks measured against the exact wire size, a refusal is
+    logged by status and reads as one, and a single message no chunk can carry is bounced to its sender."""
+    SID = "11111111-2222-3333-4444-555555555555"
+    SENDER = "22222222-3333-4444-5555-666666666666"
+
+    def setUp(self):
+        self._seam = os.environ.pop("ROMP_SESSIONS_FILE", None)
+        self.saved = (pm._drain, pm._kernel_post, pm.deliver, pm.restore, pm._push_disabled, pm._log,
+                      pm._name_for_id, pm._tl_append)
+        self.posted, self.delivered, self.restored, self.logged = [], [], [], []
+        pm._push_disabled = lambda: False
+        pm.deliver = lambda sid, frm, frm_id, body, **k: self.delivered.append((sid, frm, frm_id, body, k)) or "n1"
+        pm.restore = lambda sid, mid: self.restored.append((sid, mid)) or True
+        pm._log = lambda msg: self.logged.append(msg)
+        pm._name_for_id = lambda sid: "api" if sid == self.SID else None
+        pm._tl_append = lambda fname, obj: None
+        pm._OVERSIZE_NAMED.clear()
+
+    def tearDown(self):
+        if self._seam is not None:
+            os.environ["ROMP_SESSIONS_FILE"] = self._seam
+        (pm._drain, pm._kernel_post, pm.deliver, pm.restore, pm._push_disabled, pm._log,
+         pm._name_for_id, pm._tl_append) = self.saved
+        pm._OVERSIZE_NAMED.clear()
+
+    def _msg(self, mid, size, **k):
+        m = {"from": "web", "from_id": self.SENDER, "body": "x" * size, "id": mid, "kind": "coordinate",
+             "park": False, "from_host": ""}
+        m.update(k)
+        return m
+
+    def _inject_all(self, path, body, timeout=2):
+        self.posted.append(body)
+        return {"ok": True, "injected": True}
+
+    def test_one_body_for_the_whole_box_would_cross_the_cap_so_it_is_split_oldest_first(self):
+        msgs = [self._msg("m1", 600_000), self._msg("m2", 600_000), self._msg("m3", 1000)]
+        self.assertGreater(pm._deliver_body_bytes(self.SID, msgs), pm._POST_MAX_BYTES,
+                           "the shape the chunking replaces: one banner for these three is over the cap")
+        chunks, oversize = pm._push_chunks(self.SID, msgs)
+        self.assertEqual(([[m["id"] for m in c] for c in chunks], oversize), ([["m1"], ["m2", "m3"]], []))
+
+    def test_a_box_past_the_cap_crosses_in_chunks_each_under_it(self):
+        msgs = [self._msg("m1", 600_000), self._msg("m2", 600_000), self._msg("m3", 1000)]
+        pm._drain = lambda sid: {"messages": msgs}
+        pm._kernel_post = self._inject_all
+        self.assertTrue(pm._push(self.SID, {"id": self.SID, "state": "idle"}))
+        self.assertEqual(len(self.posted), 2, "two bodies: m1 alone, then m2 with m3")
+        for body in self.posted:
+            self.assertEqual(body["id"], self.SID)
+            self.assertLessEqual(len(json.dumps(body).encode("utf-8")), pm._PUSH_MAX_BYTES,
+                                 "measured as _kernel_post serializes it")
+        self.assertIn("<!-- romp-msg-id: m1 -->", self.posted[0]["text"])
+        self.assertIn("<!-- romp-msg-id: m2 -->", self.posted[1]["text"])
+        self.assertIn("<!-- romp-msg-id: m3 -->", self.posted[1]["text"])
+        self.assertEqual((self.restored, self.delivered), ([], []), "everything landed: nothing put back")
+
+    def test_a_chunk_that_does_not_land_holds_it_and_the_rest_and_names_the_cause(self):
+        msgs = [self._msg("m1", 600_000), self._msg("m2", 600_000), self._msg("m3", 1000)]
+        pm._drain = lambda sid: {"messages": msgs}
+        answers = iter([{"ok": True, "injected": True}, None])
+        pm._kernel_post = lambda path, body, timeout=2: (self.posted.append(body), next(answers))[1]
+        self.assertFalse(pm._push(self.SID, {"id": self.SID, "state": "idle"}), "not everything landed")
+        self.assertEqual(len(self.posted), 2, "the run stops at the first chunk that does not land")
+        self.assertEqual(self.restored, [(self.SID, "m2"), (self.SID, "m3")],
+                         "the chunk that failed and everything after it go back under their own ids")
+        self.assertEqual(self.delivered, [])
+        line = self.logged[-1]
+        self.assertIn("deferred (kernel unreachable)", line)
+        self.assertIn("2 msg(s) restored", line)
+        self.assertIn("after 1 landed", line)
+
+    def test_a_pane_deferral_and_a_kernel_refusal_read_differently_in_the_log(self):
+        # both used to log the same "deferred" line, so a size refusal was indistinguishable from a pane
+        # that was not safe to paste into
+        pm._drain = lambda sid: {"messages": [self._msg("m1", 1000)]}
+        pm._kernel_post = lambda path, body, timeout=2: {"ok": True, "injected": False}
+        self.assertFalse(pm._push(self.SID, {"id": self.SID, "state": "idle"}))
+        self.assertIn("deferred (not injected)", self.logged[-1])
+        pm._kernel_post = lambda path, body, timeout=2: {"ok": False, "status": 413,
+                                                         "error": "request body of 2000000 bytes exceeds the 1048576-byte limit"}
+        self.assertFalse(pm._push(self.SID, {"id": self.SID, "state": "idle"}))
+        self.assertIn("deferred (kernel answered HTTP 413)", self.logged[-1])
+        self.assertEqual(self.restored, [(self.SID, "m1"), (self.SID, "m1")], "restored under its own id either way")
+
+    def test_kernel_post_logs_a_refusal_by_status_and_returns_it_as_one(self):
+        saved = urllib.request.urlopen
+
+        def refuse(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 413, "Payload Too Large", {}, io.BytesIO(
+                b'{"ok": false, "error": "request body of 2000000 bytes exceeds the 1048576-byte limit"}'))
+        urllib.request.urlopen = refuse
+        try:
+            r = pm._kernel_post("/deliver", {"id": self.SID, "text": "hello"})
+        finally:
+            urllib.request.urlopen = saved
+        self.assertEqual((r["ok"], r["status"]), (False, 413), "a refusal is not None (None is an unreachable kernel)")
+        self.assertIn("exceeds the 1048576-byte limit", r["error"])
+        self.assertEqual(len(self.logged), 1, self.logged)
+        self.assertIn("kernel refused POST /deliver: HTTP 413", self.logged[0])
+        self.assertIn("exceeds the 1048576-byte limit", self.logged[0], "the kernel's own reason reaches the log")
+
+        def refuse_long(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 400, "Bad Request", {}, io.BytesIO(b"y" * 100_000))
+        urllib.request.urlopen = refuse_long
+        try:
+            r = pm._kernel_post("/working", {"id": self.SID, "text": ""})
+        finally:
+            urllib.request.urlopen = saved
+        self.assertEqual(r["status"], 400)
+        self.assertLess(len(self.logged[-1]), 600, "a bounded slice of the refusal body, never the whole")
+
+        def unreachable(req, timeout=None):
+            raise urllib.error.URLError("connection refused")
+        urllib.request.urlopen = unreachable
+        try:
+            self.assertIsNone(pm._kernel_post("/working", {"id": self.SID, "text": ""}), "unreachable stays None")
+        finally:
+            urllib.request.urlopen = saved
+
+    def test_a_single_oversize_message_is_bounced_to_its_local_sender_not_reposted(self):
+        big = self._msg("m-big", 1_000_000)
+        pm._drain = lambda sid: {"messages": [big, self._msg("m-small", 1000)]}
+        pm._kernel_post = self._inject_all
+        self.assertTrue(pm._push(self.SID, {"id": self.SID, "state": "idle"}), "the rest of the box landed")
+        self.assertEqual(len(self.posted), 1)
+        self.assertNotIn("m-big", self.posted[0]["text"], "the oversize message is never posted")
+        self.assertEqual(self.restored, [], "and not put back: it left the recipient's box")
+        self.assertEqual(len(self.delivered), 1, "its sender hears it")
+        sid, frm, frm_id, note, k = self.delivered[0]
+        self.assertEqual((sid, frm, frm_id, k.get("kind")), (self.SENDER, "romp-postal", "", "coordinate"))
+        self.assertIn("undeliverable to 'api'", note)
+        self.assertIn("%d-byte limit" % pm._PUSH_MAX_BYTES, note)
+        self.assertNotIn("xxxxxxxx", note, "the note names the size instead of repeating the body")
+        self.assertLess(len(note), 600)
+        self.assertTrue(any("m-big" in l and "bounced to its sender" in l for l in self.logged), self.logged)
+
+    def test_an_oversize_message_with_no_local_sender_waits_for_the_drain_and_is_named_once(self):
+        relayed = self._msg("m-far", 1_000_000, from_host="TESTHOST")   # acked to its host at relay time
+        pm._drain = lambda sid: {"messages": [relayed]}
+        pm._kernel_post = lambda *a, **k: self.fail("an oversize body must never be posted")
+        for _ in range(3):                                   # the retry pass re-claims it every 5 s
+            self.assertFalse(pm._push(self.SID, {"id": self.SID, "state": "idle"}))
+        self.assertEqual(self.restored, [(self.SID, "m-far")] * 3, "put back under its own id each pass")
+        self.assertEqual(self.delivered, [], "a remote sender has no local box to bounce into")
+        named = [l for l in self.logged if "m-far" in l]
+        self.assertEqual(len(named), 1, named)
+        self.assertIn("waits in new/ for the turn-end drain", named[0])
+
+    def test_publish_working_reads_a_refusal_as_failure(self):
+        pm._kernel_post = lambda path, body, timeout=2: {"ok": False, "status": 400, "error": "id required"}
+        self.assertFalse(pm._publish_working(self.SID, "note"), "a refusal used to pass the `is not None` test")
+        pm._kernel_post = lambda path, body, timeout=2: {"ok": True}
+        self.assertTrue(pm._publish_working(self.SID, "note"))
+        pm._kernel_post = lambda path, body, timeout=2: None
+        self.assertFalse(pm._publish_working(self.SID, "note"))
+
+
+class _FakeKernel(BaseHTTPRequestHandler):
+    """The kernel's /deliver gate, in shape: 413 before reading a body announced past the cap; within it,
+    the body is read and injected."""
+    protocol_version = "HTTP/1.1"
+    seen = []
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        if n > pm._POST_MAX_BYTES:
+            self.close_connection = True
+            self._answer(413, {"ok": False, "error": "request body of %d bytes exceeds the %d-byte limit"
+                               % (n, pm._POST_MAX_BYTES)})
+            return
+        raw = self.rfile.read(n)
+        _FakeKernel.seen.append((self.path, len(raw)))
+        self._answer(200, {"ok": True, "injected": True})
+
+    def _answer(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        if code != 200:
+            self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+class PushOverTheWire(unittest.TestCase):
+    """_push with the real _kernel_post, a real maildir and a fake kernel wearing the real gate's shape:
+    two 600 KB messages, which as one banner would be refused, cross as two POSTs and the box empties."""
+    SID = "33333333-4444-5555-6666-777777777777"
+
+    def setUp(self):
+        self._seam = os.environ.pop("ROMP_SESSIONS_FILE", None)
+        self.saved = (pm.KERNEL_BASE, pm._push_disabled, pm._log)
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), _FakeKernel)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        pm.KERNEL_BASE = "http://127.0.0.1:%d" % self.srv.server_address[1]
+        pm._push_disabled = lambda: False
+        self.logged = []
+        pm._log = lambda msg: self.logged.append(msg)
+        _FakeKernel.seen = []
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+        if self._seam is not None:
+            os.environ["ROMP_SESSIONS_FILE"] = self._seam
+        pm.KERNEL_BASE, pm._push_disabled, pm._log = self.saved
+        pm.STREAKS.pop(self.SID, None)
+
+    def test_two_large_messages_cross_as_two_posts_and_the_box_empties(self):
+        pm.deliver(self.SID, "web", "22222222-3333-4444-5555-666666666666", "a" * 600_000, kind="coordinate")
+        pm.deliver(self.SID, "web", "22222222-3333-4444-5555-666666666666", "b" * 600_000, kind="coordinate")
+        self.assertTrue(pm._push(self.SID, {"id": self.SID, "state": "idle"}))
+        self.assertEqual([p for p, n in _FakeKernel.seen], ["/deliver", "/deliver"])
+        for path, n in _FakeKernel.seen:
+            self.assertLessEqual(n, pm._POST_MAX_BYTES)
+        self.assertEqual(pm.read_box(self.SID, consume=False), [], "both landed: nothing left in new/")
+        self.assertEqual([l for l in self.logged if "deferred" in l or "refused" in l], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -5,7 +5,9 @@ over POST /peer on tunnel transitions. Synthetic only."""
 import json
 import os
 import tempfile
+import threading
 import unittest
+from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -63,6 +65,13 @@ class PeerMode(unittest.TestCase):
         self.assertEqual(pm.PEERS, {}, "a refused notify records no row")
         payload, status = pm.peer_update({"host": "TESTHOST", "port": 50002, "up": False})
         self.assertEqual((status, pm.PEERS["TESTHOST"]["up"]), (200, False), "a real false rides through as itself")
+
+    def test_peer_update_reads_an_explicit_null_up_as_absent(self):
+        # the rule _as_bool states (review find, 2026-09-08): null is the absent case spelled out, so it
+        # takes the field's default (down), where a string or a number is refused
+        payload, status = pm.peer_update({"host": "TESTHOST", "port": 50002, "up": None})
+        self.assertEqual(status, 200, payload)
+        self.assertEqual(pm.PEERS["TESTHOST"]["up"], False)
 
     def test_peer_update_validates(self):
         for bad in ({}, {"host": "", "port": 1}, {"host": "h"}, {"host": "h", "port": "x"},
@@ -131,11 +140,10 @@ os.environ["XDG_STATE_HOME"] = _B_STATE
 pmb = SourceFileLoader("romp_postal_peers_b", os.path.join(BIN, "romp-postal-service")).load_module()
 
 
-class TwoBusExchange(unittest.TestCase):
+class _TwoBusHarness(unittest.TestCase):
     """The two-bus harness (plans/postal-peer-buses.md): A and B are two module instances with
     separate state dirs; the "tunnel" is a direct call — A builds a request, B handles it, A applies
-    the response. Covers mail both directions, end-to-end acks, dedupe on a resent relay, bounce to
-    the sender on a dead recipient, presence gossip, and the version handshake."""
+    the response. No tests of its own: TwoBusExchange and ExchangeRelaysAreBudgeted run on it."""
 
     def setUp(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
@@ -182,6 +190,11 @@ class TwoBusExchange(unittest.TestCase):
         self.assertEqual(status, 200)
         pm.peer_exchange_apply("srv", req, resp)
         return resp
+
+
+class TwoBusExchange(_TwoBusHarness):
+    """Covers mail both directions, end-to-end acks, dedupe on a resent relay, bounce to the sender on a
+    dead recipient, presence gossip, and the version handshake."""
 
     def test_quarantine_holds_cross_the_exchange_both_ways(self):
         # Slice 4 of the federation UI (the user 2026-07-25): each side's exchange payload carries a
@@ -408,6 +421,106 @@ class ThreeBusRelay(unittest.TestCase):
         verdict, bounce = pmb._relay_in("hosta", m)
         self.assertEqual(verdict, "bounce", "one hop max: an already-hopped message bounces, never re-forwards")
         self.assertIn("no live session", bounce["why"])
+
+
+class ExchangeRelaysAreBudgeted(_TwoBusHarness):
+    """One exchange carries the outbox's oldest-first prefix under _RELAY_BUDGET_BYTES (half the dialed
+    bus's 1 MiB body cap); the rest ride the next round. The request used to carry the WHOLE outbox
+    (review find, 2026-09-08): a backlog past the cap was 413'd by the dialed bus's _body gate and the
+    dialer re-sent the identical request on every backoff, forever, so every message to that peer parked
+    on a healthy link. A single relay over the budget is bounced to its sender instead of retried."""
+
+    def _park(self, n, size, prefix="big"):
+        for i in range(n):
+            pm.outbox_put("srv", {"mid": "%s%02d" % (prefix, i), "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                                  "body": "R" * size, "kind": "coordinate", "t": i})
+
+    def test_a_backlog_past_the_cap_drains_over_successive_exchanges(self):
+        self._park(12, 100_000)
+        self.assertGreater(len(json.dumps({"relays": pm.outbox_list("srv")}).encode()), pm._POST_MAX_BYTES,
+                           "the whole outbox would not fit one request")
+        rounds = 0
+        while pm.outbox_list("srv") and rounds < 10:
+            req = pm.build_exchange_request("srv", wait=False)
+            self.assertLessEqual(len(json.dumps(req).encode("utf-8")), pm._POST_MAX_BYTES,
+                                 "every request fits the dialed bus's cap")
+            self.assertTrue(req["relays"], "progress every round")
+            resp, status = pmb.peer_exchange_handle(req)
+            self.assertEqual(status, 200)
+            pm.peer_exchange_apply("srv", req, resp)
+            rounds += 1
+        self.assertEqual(pm.outbox_list("srv"), [], "the backlog drained")
+        self.assertGreaterEqual(rounds, 2, "over more than one exchange")
+        box = pmb.read_box("sid-b", consume=True)
+        self.assertEqual(len(box), 12, "every message arrived exactly once")
+        self.assertEqual(sorted(len(m["body"]) for m in box), [100_000] * 12)
+
+    def test_the_budget_holds_through_the_dialed_bus_s_own_body_gate(self):
+        # the HTTP layer in the path: the dialed bus's _body reads a request only up to _POST_MAX_BYTES,
+        # and a 413 would raise out of _peer_http here
+        self._park(12, 100_000)
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), pmb.Handler)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            rounds = 0
+            while pm.outbox_list("srv") and rounds < 10:
+                req = pm.build_exchange_request("srv", wait=False)
+                resp = pm._peer_http(srv.server_address[1], req, token=pmb.SERVE_TOKEN)
+                pm.peer_exchange_apply("srv", req, resp)
+                rounds += 1
+        finally:
+            srv.shutdown()
+            srv.server_close()
+        self.assertEqual(pm.outbox_list("srv"), [])
+        self.assertEqual(len(pmb.read_box("sid-b", consume=True)), 12)
+
+    def test_a_single_relay_over_the_budget_is_bounced_to_its_sender_naming_the_size(self):
+        logged, saved = [], pm._log
+        pm._log = lambda msg: logged.append(msg)
+        try:
+            pm.outbox_put("srv", {"mid": "huge", "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                                  "body": "Z" * (pm._RELAY_BUDGET_BYTES + 1000), "kind": "coordinate", "t": 1})
+            pm.outbox_put("srv", {"mid": "small", "to": "beta", "frm": "alpha", "frm_id": "sid-a",
+                                  "body": "hi", "kind": "", "t": 2})
+            req = pm.build_exchange_request("srv", wait=False)
+        finally:
+            pm._log = saved
+        self.assertEqual([m["mid"] for m in req["relays"]], ["small"], "the oversize relay never rides")
+        self.assertEqual([m["mid"] for m in pm.outbox_list("srv")], ["small"], "and left the outbox")
+        back = pm.read_box("sid-a", consume=True)
+        self.assertEqual(len(back), 1, "the sender got the bounce note")
+        self.assertIn("undeliverable to 'beta' on srv", back[0]["body"])
+        self.assertIn("exceeds the %d-byte relay limit" % pm._RELAY_BUDGET_BYTES, back[0]["body"])
+        self.assertNotIn("ZZZZ", back[0]["body"], "the note names the size instead of repeating the body")
+        self.assertEqual(back[0]["from"], "romp-postal")
+        self.assertTrue(any("relay huge is" in l and "bounced to its sender" in l for l in logged), logged)
+
+    def test_a_forwarded_relay_over_the_budget_bounces_backward_to_its_origin(self):
+        pm.outbox_put("srv", {"mid": "fwd", "to": "beta", "frm": "gamma", "frm_id": "sid-c", "origin": "hostc",
+                              "body": "Z" * (pm._RELAY_BUDGET_BYTES + 1000), "kind": "", "t": 1})
+        req = pm.build_exchange_request("srv", wait=False)
+        self.assertEqual(req["relays"], [])
+        self.assertEqual(pm.outbox_list("srv"), [])
+        b = pm._pending("hostc")["bounces"]
+        self.assertEqual(len(b), 1, "the bounce rides back to the origin on its next exchange")
+        self.assertEqual(b[0]["mid"], "fwd")
+        self.assertIn("relay limit", b[0]["why"])
+        self.assertTrue(b[0]["omitBody"])
+        self.assertEqual(pm.read_box("sid-c", consume=True), [], "nothing lands locally for mail we only forwarded")
+
+    def test_the_dialed_side_budgets_its_response_relays_too(self):
+        for i in range(12):
+            pmb.outbox_put("hosta", {"mid": "back%02d" % i, "to": "alpha", "frm": "beta", "frm_id": "sid-b",
+                                     "body": "Q" * 100_000, "kind": "", "t": i})
+        resp = self._exchange()
+        self.assertLess(len(resp["relays"]), 12)
+        self.assertLessEqual(len(json.dumps(resp["relays"]).encode()), pm._RELAY_BUDGET_BYTES)
+        rounds = 1
+        while pmb.outbox_list("hosta") and rounds < 10:   # each request acks the last response's relays
+            self._exchange()
+            rounds += 1
+        self.assertEqual(pmb.outbox_list("hosta"), [])
+        self.assertEqual(len(pm.read_box("sid-a", consume=True)), 12)
 
 
 class RecallAndReceipts(unittest.TestCase):

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -54,6 +54,16 @@ class PeerMode(unittest.TestCase):
                          "a down transition keeps the row for introspection, marked down")
         self.assertEqual(payload["up"], 0)
 
+    def test_peer_update_refuses_a_non_boolean_up_and_records_nothing(self):
+        # `up` used to be coerced with bool(), so a notify carrying the STRING "false" marked the peer UP
+        for bad in ("false", "true", 1, 0, "up"):
+            payload, status = pm.peer_update({"host": "TESTHOST", "port": 50002, "up": bad})
+            self.assertEqual(status, 400, (bad, payload))
+            self.assertEqual(payload["error"], "'up' must be true or false, got %s" % json.dumps(bad))
+        self.assertEqual(pm.PEERS, {}, "a refused notify records no row")
+        payload, status = pm.peer_update({"host": "TESTHOST", "port": 50002, "up": False})
+        self.assertEqual((status, pm.PEERS["TESTHOST"]["up"]), (200, False), "a real false rides through as itself")
+
     def test_peer_update_validates(self):
         for bad in ({}, {"host": "", "port": 1}, {"host": "h"}, {"host": "h", "port": "x"},
                     {"host": "h", "port": 0}, {"host": "h", "port": True}):

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -14,6 +14,7 @@ import os
 import socket
 import tempfile
 import threading
+import time
 import unittest
 import urllib.error
 import urllib.request
@@ -183,6 +184,22 @@ class BusBodiesAreObjects(_BusServer):
         self.assertEqual(r["error"], 'body must be a JSON object, got "' + "x" * 60 + '\u2026"')
         self.assertLess(len(r["error"]), 100)
 
+    def test_a_container_holding_a_long_string_echoes_well_formed(self):
+        # review find, 2026-09-08: a slice of the serialized container cut mid-token, so the echo came
+        # back with its quote and bracket open; the cut now lands inside the string, at any depth
+        st, r = self._post("/send", json.dumps(["x" * 100_000]).encode())
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r["error"], 'body must be a JSON object, got ["' + "x" * 60 + '\u2026"]')
+        st, r = self._post("/send", json.dumps(list(range(1000))).encode())
+        self.assertEqual(st, 400, r)
+        echo = r["error"].split("got ", 1)[1]
+        self.assertEqual(json.loads(echo), [0, 1, 2, 3, 4, 5, 6, 7, "\u2026"], "cut at the element level")
+        self.assertLess(len(r["error"]), 300)
+        st, r = self._post("/send", json.dumps(int("7" * 4000)).encode())
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r["error"], 'body must be a JSON object, got "' + "7" * 60 + '\u2026"',
+                         "a number past the bound echoes as a marked string: a cut decimal would be a mid-token cut")
+
 
 class BusBodyGate(_BusServer):
     """The bus reads a body only within bounds -- the kernel's gate, mirrored. _body() used to trust the
@@ -215,6 +232,27 @@ class BusBodyGate(_BusServer):
         st, r, head = self._raw("/send", [("Transfer-Encoding", "chunked")], body=b"2\r\n{}\r\n0\r\n\r\n")
         self.assertEqual(st, 411, r)
         self.assertIn("Transfer-Encoding", r.get("error", ""))
+
+    def test_a_trickling_body_is_408_and_closes(self):
+        # review find, 2026-09-08: the in-bounds read had no socket timeout, so an AUTHORIZED client that
+        # announced a body and trickled it pinned a handler thread for as long as it liked. 100 bytes
+        # announced, 10 sent, the sending side left OPEN (no half-close, so no EOF to end the read)
+        saved = ps._POST_BODY_TIMEOUT
+        ps._POST_BODY_TIMEOUT = 0.5
+        try:
+            t0 = time.monotonic()
+            st, r, head = self._raw("/send", [("Content-Length", "100")], body=b'{"to": "ap', half_close=False)
+            took = time.monotonic() - t0
+        finally:
+            ps._POST_BODY_TIMEOUT = saved
+        self.assertEqual((st, r.get("error")),
+                         (408, "body could not be read: 100 bytes announced, not all of it arrived within 0.5 s"))
+        self.assertIn("Connection: close", head)
+        self.assertLess(took, 5, "answered on the body timeout, not on the client giving up")
+        # the server is still serving, and a body that arrives whole is read as before
+        st, r, head = self._raw("/send", [("Content-Length", "2")], body=b"{}")
+        self.assertEqual(st, 400, r)
+        self.assertIn("sender identity required", r.get("error", ""))
 
 
 class TrackedIsABoolean(_BusServer):

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -11,6 +11,7 @@ Synthetic only — hermetic temp state dir, placeholder names, no real session d
 """
 import json
 import os
+import socket
 import tempfile
 import threading
 import unittest
@@ -111,6 +112,144 @@ class PeerTokenPlumbing(unittest.TestCase):
             srv.shutdown()
             srv.server_close()
         self.assertEqual(seen.get("path"), "/peer-exchange?token=peer-tok")
+
+
+class _BusServer(unittest.TestCase):
+    """A live bus for the request-body classes below (no tests of its own): one server per class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), ps.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def _post(self, path, raw):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), data=raw, method="POST",
+                                     headers={"X-Romp-Token": TOK, "Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+        except Exception as e:                        # the handler raised and the socket closed under us
+            return None, {"error": repr(e)}
+
+    def _raw(self, path, headers, body=b"", half_close=True):
+        """One hand-built POST over a real socket -> (status, JSON body, response head): a header can be
+        sent twice, and `half_close` ends the sending side after `body` so a short body reads as EOF."""
+        lines = ["POST %s HTTP/1.1" % path, "Host: 127.0.0.1", "Connection: close",
+                 "X-Romp-Token: " + TOK] + ["%s: %s" % kv for kv in headers]
+        req = ("\r\n".join(lines) + "\r\n\r\n").encode() + body
+        s = socket.create_connection(("127.0.0.1", self.port), timeout=10)
+        try:
+            s.sendall(req)
+            if half_close:
+                s.shutdown(socket.SHUT_WR)
+            data = b""
+            while True:
+                chunk = s.recv(65536)
+                if not chunk:
+                    break
+                data += chunk
+        finally:
+            s.close()
+        head, _, payload = data.partition(b"\r\n\r\n")
+        return int(head.split(b" ", 2)[1]), json.loads(payload.decode() or "{}"), head.decode()
+
+
+class BusBodiesAreObjects(_BusServer):
+    """Every bus route takes a JSON OBJECT. _body() used to hand back whatever json.loads produced, so
+    an array, string, number or null body reached `data.get(...)` and raised AttributeError out of the
+    handler: the connection dropped with a traceback on the bus's stderr. Now: the bus's own JSON 400,
+    naming what arrived; undecodable JSON keeps its refusal."""
+
+    def test_a_non_object_body_is_a_400_naming_what_arrived(self):
+        for raw, echo in ((b"[]", "[]"), (b'"x"', '"x"'), (b"1", "1"), (b"null", "null")):
+            for path in ("/send", "/peer", "/peer-exchange"):
+                st, r = self._post(path, raw)
+                self.assertEqual(st, 400, (path, raw, r))
+                self.assertEqual(r.get("error"), "body must be a JSON object, got " + echo, (path, raw))
+        st, r = self._post("/send", b"{nope")
+        self.assertEqual((st, r.get("error")), (400, "bad json"), "undecodable JSON keeps its refusal")
+
+    def test_a_long_string_body_echoes_clipped_inside_its_quotes(self):
+        st, r = self._post("/send", json.dumps("x" * 100_000).encode())
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r["error"], 'body must be a JSON object, got "' + "x" * 60 + '\u2026"')
+        self.assertLess(len(r["error"]), 100)
+
+
+class BusBodyGate(_BusServer):
+    """The bus reads a body only within bounds -- the kernel's gate, mirrored. _body() used to trust the
+    first of two Content-Length headers, cap nothing, and pass whatever bytes arrived as the body."""
+
+    def test_two_content_length_headers_are_400_and_close(self):
+        st, r, head = self._raw("/send", [("Content-Length", "2"), ("Content-Length", "4")], body=b"{}{}")
+        self.assertEqual((st, r.get("error")), (400, "body could not be read: more than one Content-Length header"))
+        self.assertIn("Connection: close", head)
+
+    def test_a_non_decimal_content_length_is_400(self):
+        st, r, head = self._raw("/send", [("Content-Length", "12abc")], body=b"{}")
+        self.assertEqual(st, 400, r)
+        self.assertIn("invalid literal for a byte count", r.get("error", ""))
+
+    def test_an_oversize_announcement_is_413_before_any_read(self):
+        # announced past the cap, nothing sent: refused on the declared length before any read (the old
+        # bus read to EOF, got b"", and answered "bad json")
+        st, r, head = self._raw("/send", [("Content-Length", str(ps._POST_MAX_BYTES + 1))])
+        self.assertEqual(st, 413, r)
+        self.assertIn(str(ps._POST_MAX_BYTES), r.get("error", ""))
+        self.assertIn("Connection: close", head)
+
+    def test_a_body_shorter_than_announced_is_400_naming_the_shortfall(self):
+        st, r, head = self._raw("/send", [("Content-Length", "100")], body=b'{"to": "ap')
+        self.assertEqual((st, r.get("error")), (400, "body could not be read: read 10 of the 100 bytes Content-Length announced"))
+        self.assertIn("Connection: close", head)
+
+    def test_transfer_encoding_is_411(self):
+        st, r, head = self._raw("/send", [("Transfer-Encoding", "chunked")], body=b"2\r\n{}\r\n0\r\n\r\n")
+        self.assertEqual(st, 411, r)
+        self.assertIn("Transfer-Encoding", r.get("error", ""))
+
+
+class TrackedIsABoolean(_BusServer):
+    """`tracked` arms a report-back delegation. Both doors coerced it with bool(), so the STRING "false"
+    tracked a send. Now a non-boolean is refused -- HTTP /send with a 400 naming the field, the MCP tool
+    in its error return -- before any recipient is resolved or the bus dialed. The MCP schema declares
+    the field boolean and `romp mail send --tracked` sends True, so real callers are unchanged."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def test_http_send_refuses_a_string_tracked_before_resolving_anyone(self):
+        for bad in ("false", "true", 1, "yes"):
+            st, r = self._post("/send", json.dumps({"to": "api", "from": "web", "from_id": self.SID,
+                                                    "body": "hello", "kind": "delegate", "tracked": bad}).encode())
+            self.assertEqual(st, 400, (bad, r))
+            self.assertEqual(r.get("error"), "'tracked' must be true or false, got %s" % json.dumps(bad))
+
+    def test_the_mcp_tool_refuses_a_string_tracked_before_dialing_the_bus(self):
+        dialed = []
+
+        def http(*a, **k):
+            dialed.append(a)
+            raise ps.BusError("stubbed: the bus is not dialed here")
+        saved = (ps._http, ps.my_name, ps.my_id, ps._heartbeat)
+        ps._http, ps.my_name, ps.my_id, ps._heartbeat = http, (lambda: "web"), (lambda: self.SID), (lambda mid, me: None)
+        try:
+            for bad in ("false", "true", 1):
+                text, is_err = ps._mcp_call("send_message", {"to": "api", "body": "hello", "kind": "delegate", "tracked": bad})
+                self.assertTrue(is_err, (bad, text))
+                self.assertIn("'tracked' must be true or false, got %s" % json.dumps(bad), text)
+            self.assertEqual(dialed, [], "the bus is never dialed with a malformed flag")
+            ps._mcp_call("send_message", {"to": "api", "body": "hello", "kind": "delegate", "tracked": True})
+            self.assertEqual(dialed[0][:2], ("POST", "/send"))
+            self.assertIs(dialed[0][2]["tracked"], True, "a real true rides the wire as itself")
+        finally:
+            ps._http, ps.my_name, ps.my_id, ps._heartbeat = saved
 
 
 if __name__ == "__main__":

--- a/tests/test_rename_route.py
+++ b/tests/test_rename_route.py
@@ -95,5 +95,62 @@ class RenameRoute(unittest.TestCase):
         self.assertEqual(st, 400)
 
 
+class NonObjectBodies(unittest.TestCase):
+    """Every session-management route takes a JSON OBJECT. A body that decodes to anything else -- an
+    array, a string, a number, null -- used to reach `(b or {}).get(...)` (a truthy non-dict passes the
+    `or`) and raise AttributeError into do_POST's catch-all: a 500 whose body was a Python traceback
+    naming absolute paths. Now every one of them answers 400 in the route family's JSON shape, naming
+    what arrived, and acts on nothing."""
+    ROUTES = ("/new", "/fork", "/rename", "/move", "/color", "/watch-pr", "/watch", "/tag", "/group",
+              "/update-dismiss", "/working", "/deliver", "/picker-check", "/walk-root", "/redial")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def _post_raw(self, path, raw):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d%s" % (self.port, path), data=raw,
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, r.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+    def test_a_non_object_body_is_a_400_naming_what_arrived_never_a_500(self):
+        for path in self.ROUTES:
+            for raw, echo in ((b"[]", "[]"), (b'"x"', '"x"'), (b"1", "1"), (b"null", "null"), (b"[1]", "[1]")):
+                st, body = self._post_raw(path, raw)
+                self.assertEqual(st, 400, "%s %r -> %s %s" % (path, raw, st, body[:160]))
+                self.assertNotIn("Traceback", body)
+                r = json.loads(body)
+                self.assertIs(r.get("ok"), False, (path, raw))
+                self.assertEqual(r.get("error"), "body must be a JSON object, got " + echo, (path, raw))
+
+    def test_an_undecodable_body_is_a_400_too_not_a_guess_at_its_fields(self):
+        for path in self.ROUTES:
+            st, body = self._post_raw(path, b"{not json")
+            self.assertEqual(st, 400, (path, st, body[:160]))
+            self.assertEqual(json.loads(body).get("error"), "body is not JSON", path)
+
+    def test_a_long_string_body_echoes_clipped_inside_its_quotes(self):
+        # a 100 KB string must not come back as a 100 KB error, and the cut must land INSIDE the quotes
+        # with a marker -- a slice of the serialized text took the closing quote with it
+        st, body = self._post_raw("/rename", json.dumps("x" * 100_000).encode())
+        self.assertEqual(st, 400)
+        err = json.loads(body)["error"]
+        self.assertEqual(err, 'body must be a JSON object, got "' + "x" * 60 + '\u2026"')
+        self.assertLess(len(err), 100)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rename_route.py
+++ b/tests/test_rename_route.py
@@ -151,6 +151,32 @@ class NonObjectBodies(unittest.TestCase):
         self.assertEqual(err, 'body must be a JSON object, got "' + "x" * 60 + '\u2026"')
         self.assertLess(len(err), 100)
 
+    def test_a_container_holding_a_long_string_echoes_well_formed_at_any_depth(self):
+        # review find, 2026-09-08: the echo was well formed only for a top-level string; a container
+        # holding a long one was sliced as serialized text and came back with its quote and bracket
+        # open. Every string is now cut inside its quotes, a container at the element level, and the
+        # nesting is bounded, so the echo parses whatever arrived
+        cases = (
+            (["x" * 100_000], ["x" * 60 + "\u2026"]),
+            ([{"a": ["y" * 5000]}], [{"a": ["y" * 60 + "\u2026"]}]),
+            (list(range(1000)), [0, 1, 2, 3, 4, 5, 6, 7, "\u2026"]),
+            ([[[[[[1]]]]]], [[[[["\u2026"]]]]]),
+            ([{"k%d" % i: "v" * 200 for i in range(50)}], None),
+            (int("7" * 4000), "7" * 60 + "\u2026"),          # a number past the bound: a marked string,
+        )                                                    # since a cut decimal is a mid-token cut
+        for raw, want in cases:
+            st, body = self._post_raw("/rename", json.dumps(raw).encode())
+            self.assertEqual(st, 400, (str(raw)[:80], body[:160]))
+            err = json.loads(body)["error"]
+            self.assertTrue(err.startswith("body must be a JSON object, got "), err)
+            echo = err[len("body must be a JSON object, got "):]
+            self.assertLess(len(echo), 300, "bounded whatever the size of what arrived")
+            parsed = json.loads(echo)                        # well formed: the whole point
+            if want is not None:
+                self.assertEqual(parsed, want, (str(raw)[:80], echo))
+        st, body = self._post_raw("/rename", json.dumps([{"a": ["y" * 5000]}]).encode())
+        self.assertEqual(json.loads(body)["error"], 'body must be a JSON object, got [{"a": ["' + "y" * 60 + '\u2026"]}]')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -906,15 +906,15 @@ class WiringPins(unittest.TestCase):
         self.src = inspect.getsource(km.Handler._dispatch_ws)
 
     def test_auto_nudge_branch_gates_on_the_stamp_and_skips_the_tick_on_stand_down(self):
-        self.assertIn('_set_auto_nudge(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None', self.src,
+        self.assertIn('_set_auto_nudge(enabled, gt=_gesture_ms(msg)) is not None', self.src,
                       "a stood-down toggle must not fire the nudge tick either — no new information")
 
     def test_file_editing_branch_passes_the_stamp(self):
-        self.assertIn('_set_file_editing(bool(msg["enabled"]), gt=_gesture_ms(msg))', self.src)
+        self.assertIn('_set_file_editing(enabled, gt=_gesture_ms(msg))', self.src)
 
     def test_compact_suggest_branch_gates_on_the_stamp_and_skips_the_tick_on_stand_down(self):
         # T208's WS branch mirrors setAutoNudge's: gt-gated, immediate tick only on a real apply
-        self.assertIn('_set_compact_suggest(bool(msg["enabled"]), gt=_gesture_ms(msg)) is not None', self.src)
+        self.assertIn('_set_compact_suggest(enabled, gt=_gesture_ms(msg)) is not None', self.src)
 
     def test_update_mode_branch_passes_the_stamp(self):
         self.assertIn('_set_update_mode(str(msg["mode"]), gt=_gesture_ms(msg))', self.src)
@@ -1215,7 +1215,7 @@ class ThinkingSummariesSetting(_Base):
     def test_the_setting_is_reported_but_not_broadcast(self):
         import inspect
         src = inspect.getsource(km.Handler._dispatch_ws)
-        self.assertIn('_set_thinking_summaries(bool(msg["enabled"]), gt=_gesture_ms(msg))', src,
+        self.assertIn('_set_thinking_summaries(enabled, gt=_gesture_ms(msg))', src,
                       "the WS branch hands the gesture stamp to the store")
         fed = Path(BIN).parent / "ui" / "webview" / "federation.ts"
         self.assertNotIn("setThinkingSummaries", fed.read_text(),

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -262,6 +262,19 @@ class HostForward(TagRoute):
         st, r = self._post({"name": "team", "host": "alpha", "add": ["web"]})
         self.assertFalse(r["ok"]); self.assertIn("never landed", r["error"])
 
+    def test_a_string_delete_is_refused_before_the_host_forward(self):
+        # the flag is checked ahead of the --host arm (review find, 2026-09-08: pinned by no test until
+        # now), so a malformed delete never crosses to the home kernel, where an un-updated kernel
+        # would still coerce it with bool()
+        for bad in ("true", "false", 1):
+            st, r = self._post({"name": "team", "host": "alpha", "delete": bad})
+            self.assertEqual(st, 400, (bad, r))
+            self.assertEqual(r.get("error"), "'delete' must be true or false, got %s" % json.dumps(bad))
+        self.assertEqual(self.forwarded, [], "nothing reaches the tunnel while the flag is malformed")
+        st, r = self._post({"name": "team", "host": "alpha", "delete": True})
+        self.assertEqual(self.forwarded, [("alpha", "/tag", {"name": "team", "delete": True})],
+                         "a real boolean forwards as itself")
+
 
 class RenameAndHomeFrame(TagRoute):
     """Federation v1: /tag gains rename (collision-refusing), and a bare sid routed here from a
@@ -426,6 +439,29 @@ class HttpFlagsMustBeBooleans(TagRoute):
                          "the cut lands inside the quotes, marked -- never an unclosed quote or 5000 chars")
         self.assertLess(len(r["error"]), 100)
         self.assertFalse(km._notify_all_on())
+
+    def test_a_container_flag_value_echoes_well_formed_too(self):
+        # review find, 2026-09-08: a long string INSIDE a container used to clip to an unclosed quote
+        st, r = self._post_to("/notify-all", {"on": {"nested": ["a" * 5000]}})
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r.get("error"), "'on' must be true or false, got " + '{"nested": ["' + "a" * 60 + '\u2026"]}')
+        self.assertFalse(km._notify_all_on())
+
+    def test_an_explicit_null_flag_reads_as_absent(self):
+        # the rule _as_bool states (review find, 2026-09-08): null is the absent case spelled out, so it
+        # takes the route's default -- an edit, not a delete; the bell off -- where a string or a number
+        # is refused
+        self._post({"name": "pool", "add": ["web"]})
+        st, r = self._post({"name": "pool", "delete": None})
+        self.assertEqual((st, r.get("ok")), (200, True), r)
+        self.assertEqual([g["name"] for g in self._views()[1]["tags"]], ["pool"], "null is not a delete")
+        self._post_to("/notify-all", {"on": True})
+        self.assertTrue(km._notify_all_on())
+        st, r = self._post_to("/notify-all", {"on": None})
+        self.assertEqual((st, r.get("ok"), r.get("on")), (200, True, False), r)
+        self._post_to("/notify-all", {"on": True})
+        st, r = self._post_to("/notify-all", {})
+        self.assertEqual((st, r.get("on")), (200, False), "the same answer an absent field gets")
 
     def test_auto_update_takes_only_a_boolean(self):
         self.assertFalse(km._auto_update_remotes_on())

--- a/tests/test_tag_route.py
+++ b/tests/test_tag_route.py
@@ -371,5 +371,108 @@ class GroupAliasSurvives(TagRoute):
         self.assertEqual(resp["tag"]["members"], [SID], "a live name resolved through the alias route too")
 
 
+class HttpFlagsMustBeBooleans(TagRoute):
+    """The kernel's HTTP flag fields take JSON true/false and nothing else. Each used to be coerced with
+    bool(), so the STRING "false" deleted a tag, turned a master bell on, armed auto-update, flipped
+    check-in on a host and made a directory. Now a non-boolean is a 400 naming the field and the
+    setting is untouched; `romp tag` / `romp checkin` and the pages send real booleans, so their calls
+    are unchanged."""
+
+    def _post_to(self, path, body):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d%s" % (self.port, path), data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json",
+                     "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_a_string_delete_refuses_and_the_tag_survives(self):
+        self._post({"name": "pool", "add": ["web"]})
+        for bad in ("false", "true", 1, "no"):
+            st, r = self._post({"name": "pool", "delete": bad})
+            self.assertEqual(st, 400, (bad, r))
+            self.assertEqual(r.get("error"), "'delete' must be true or false, got %s" % json.dumps(bad))
+            self.assertEqual([g["name"] for g in self._views()[1]["tags"]], ["pool"],
+                             "the tag survives a refused delete (a string used to delete it)")
+        st, r = self._post({"name": "pool", "delete": False})
+        self.assertTrue(r.get("ok"), r)
+        self.assertEqual(r["tag"]["name"], "pool", "a real false is an edit, not a delete")
+        st, r = self._post({"name": "pool", "delete": True})
+        self.assertTrue(r.get("deleted"), r)
+        self.assertEqual(self._views()[1]["tags"], [])
+
+    def test_the_master_bells_take_only_booleans(self):
+        for path, reader in (("/notify-all", km._notify_all_on), ("/notify-turns", km._notify_turns_on)):
+            self.assertFalse(reader(), path)
+            for bad in ("false", "true", 1, "no", "on"):
+                st, r = self._post_to(path, {"on": bad})
+                self.assertEqual(st, 400, (path, bad, r))
+                self.assertEqual(r.get("error"), "'on' must be true or false, got %s" % json.dumps(bad))
+                self.assertFalse(reader(), "%s: a refused flip leaves the bell as it was" % path)
+            st, r = self._post_to(path, {"on": True})
+            self.assertEqual((st, r.get("ok"), r.get("on")), (200, True, True), (path, r))
+            self.assertTrue(reader(), path)
+            st, r = self._post_to(path, {"on": False})
+            self.assertEqual((st, r.get("on")), (200, False), (path, r))
+            self.assertFalse(reader(), path)
+
+    def test_a_long_flag_value_echoes_clipped_and_well_formed(self):
+        st, r = self._post_to("/notify-all", {"on": "a" * 5000})
+        self.assertEqual(st, 400, r)
+        self.assertEqual(r.get("error"), "'on' must be true or false, got \"" + "a" * 60 + '\u2026"',
+                         "the cut lands inside the quotes, marked -- never an unclosed quote or 5000 chars")
+        self.assertLess(len(r["error"]), 100)
+        self.assertFalse(km._notify_all_on())
+
+    def test_auto_update_takes_only_a_boolean(self):
+        self.assertFalse(km._auto_update_remotes_on())
+        for bad in ("false", "true", 1, "yes"):
+            st, r = self._post_to("/tunnels/autoupdate", {"on": bad})
+            self.assertEqual(st, 400, (bad, r))
+            self.assertEqual(r.get("error"), "'on' must be true or false, got %s" % json.dumps(bad))
+            self.assertFalse(km._auto_update_remotes_on(), "a refused flip never starts pushing code")
+        st, r = self._post_to("/tunnels/autoupdate", {"on": True})
+        self.assertEqual((st, r.get("on")), (200, True), r)
+        self.assertTrue(km._auto_update_remotes_on())
+        st, r = self._post_to("/tunnels/autoupdate", {"on": False})
+        self.assertFalse(km._auto_update_remotes_on())
+
+    def test_checkin_refuses_a_string_before_looking_the_host_up(self):
+        calls = []
+        saved = km.checkin_set
+        km.checkin_set = lambda host, on: calls.append((host, on)) or {"host": host}
+        try:
+            for bad in ("false", "true", 0):
+                st, r = self._post_to("/tunnels/checkin", {"host": "TESTHOST", "on": bad})
+                self.assertEqual(st, 400, (bad, r))
+                self.assertEqual(r.get("error"), "'on' must be true or false, got %s" % json.dumps(bad))
+            self.assertEqual(calls, [], "nothing reaches the tunnel while the flag is malformed")
+            st, r = self._post_to("/tunnels/checkin", {"host": "TESTHOST", "on": False})
+            self.assertEqual((st, r.get("ok")), (200, True), r)
+            self.assertEqual(calls, [("TESTHOST", False)], "a real boolean rides through as itself")
+        finally:
+            km.checkin_set = saved
+
+    def test_new_refuses_a_string_mkdir_before_touching_the_disk(self):
+        calls = []
+        saved = km._resolve_create_dir
+        km._resolve_create_dir = (lambda raw, create=False:
+                                  calls.append((raw, create)) or ("", "stubbed: no directory here"))
+        try:
+            for bad in ("true", "false", 1):
+                st, r = self._post_to("/new", {"name": "fresh", "dir": "/nonexistent/TESTHOST", "mkdir": bad})
+                self.assertEqual(st, 400, (bad, r))
+                self.assertEqual(r.get("error"), "'mkdir' must be true or false, got %s" % json.dumps(bad))
+            self.assertEqual(calls, [], "no directory is resolved, let alone created, on a malformed flag")
+            st, r = self._post_to("/new", {"name": "fresh", "dir": "/nonexistent/TESTHOST", "mkdir": True})
+            self.assertEqual(calls, [("/nonexistent/TESTHOST", True)], "a real true asks for the create")
+            self.assertEqual((st, r.get("ok"), r.get("error")), (200, False, "stubbed: no directory here"))
+        finally:
+            km._resolve_create_dir = saved
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -88,7 +88,9 @@ class PostalTrackedWire(unittest.TestCase):
         # source pins on the /send route: coordinate/question can never carry it, and the
         # cross-host relay branch deliberately drops it (a satellite with an unreachable primary
         # would hide work)
-        self.assertIn('tracked = bool(data.get("tracked")) and kind == "delegate"', PSRC)
+        self.assertIn('tracked, terr = _as_bool(data.get("tracked"), "tracked")', PSRC,
+                      "a checked boolean: the string \"false\" used to arm tracking")
+        self.assertIn('tracked = tracked and kind == "delegate"', PSRC)
         self.assertIn("`tracked` deliberately does NOT ride the relay", PSRC)
         self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)', PSRC)
 

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -91,3 +91,19 @@ test("every timeline dot's white border is thin (0.75px) — romp + user dots al
   assert.match(SRC, /el\('circle', \{ cx, cy, r: lit \? DOT_R \+ 2 : DOT_R, fill: color, stroke: PAL\(\)\.dotRing, 'stroke-width': 0\.75 \}\)/);
   assert.doesNotMatch(SRC, /stroke: '#e8eef5', 'stroke-width': 1\.5/, "the old 1.5px dot border is gone");
 });
+
+test("the lane toggle hands the kernel a JSON boolean, and the kernel refuses anything else", () => {
+  // the sender: the web host hook coerces to a real boolean before posting — never a string
+  const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
+  assert.match(BOOT, /__rompTimelineSetFlag: \(id: string, flag: string, value: unknown\) => post\(\{ type: "setSessionFlag", id, flag, value: !!value \}\)/);
+  // the receiver: setSessionFlag takes only true/false. bool("false") is True, which is how a string
+  // used to set a lane flag; a non-boolean is now refused on the delivering socket and nothing is written
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.ok(KERNEL.includes('value, ferr = _as_bool(msg.get("value"), "value")\n            if ferr:'),
+    "setSessionFlag checks the flag before either setter runs");
+  // ...and refuses on the frame THIS page renders (settingRefused, addressed to sid + flag), never a warn
+  assert.ok(KERNEL.includes('_refuse_setting(client, ferr, "that setting", "flag", sid=msg["id"], flag=msg["flag"],'),
+    "the refusal reaches the lane gear, which repaints from settingRefused");
+  assert.ok(KERNEL.includes('_set_session_flag(str(msg["id"]), str(msg["flag"]), value)'), "the checked value reaches the setter");
+  assert.ok(!KERNEL.includes('bool(msg.get("value"))'), "no WS handler coerces a value flag with bool()");
+});

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -92,18 +92,13 @@ test("every timeline dot's white border is thin (0.75px) — romp + user dots al
   assert.doesNotMatch(SRC, /stroke: '#e8eef5', 'stroke-width': 1\.5/, "the old 1.5px dot border is gone");
 });
 
-test("the lane toggle hands the kernel a JSON boolean, and the kernel refuses anything else", () => {
-  // the sender: the web host hook coerces to a real boolean before posting — never a string
+test("the lane toggle hands the kernel a JSON boolean", () => {
+  // the sender: the web host hook coerces to a real boolean before posting, never a string. The
+  // receiver's side (setSessionFlag refuses a non-boolean on the settingRefused frame this page renders,
+  // writes nothing, and no handler coerces with bool()) is pinned in the kernel's own lane,
+  // tests/test_kernel_session_flags.py WsFlagsMustBeBooleans, by driving the dispatcher rather than
+  // reading kernel.py as text from here (review find, 2026-09-08: a cross-lane source pin fails the
+  // extension build on a kernel edit that keeps the behaviour).
   const BOOT = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "timeline-boot.ts"), "utf8");
   assert.match(BOOT, /__rompTimelineSetFlag: \(id: string, flag: string, value: unknown\) => post\(\{ type: "setSessionFlag", id, flag, value: !!value \}\)/);
-  // the receiver: setSessionFlag takes only true/false. bool("false") is True, which is how a string
-  // used to set a lane flag; a non-boolean is now refused on the delivering socket and nothing is written
-  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.ok(KERNEL.includes('value, ferr = _as_bool(msg.get("value"), "value")\n            if ferr:'),
-    "setSessionFlag checks the flag before either setter runs");
-  // ...and refuses on the frame THIS page renders (settingRefused, addressed to sid + flag), never a warn
-  assert.ok(KERNEL.includes('_refuse_setting(client, ferr, "that setting", "flag", sid=msg["id"], flag=msg["flag"],'),
-    "the refusal reaches the lane gear, which repaints from settingRefused");
-  assert.ok(KERNEL.includes('_set_session_flag(str(msg["id"]), str(msg["flag"]), value)'), "the checked value reaches the setter");
-  assert.ok(!KERNEL.includes('bool(msg.get("value"))'), "no WS handler coerces a value flag with bool()");
 });


### PR DESCRIPTION
Three shapes of the same defect on the kernel's HTTP door and the postal bus, verified on `main`:

- **The body was read before the caller was authorized.** `do_POST` read whatever Content-Length the request declared, inside a bare `except: pass`, and only then ran `_authorize`. A token-less loopback or tailnet client could make the kernel allocate and pin a handler thread per oversize POST; a duplicate or non-decimal Content-Length was silently read as no body.
- **Non-object bodies were 500s with tracebacks.** The session-management routes did `(b or {}).get(...)` on the parsed body. A JSON string, number or non-empty array is truthy, so `.get` raised into the catch-all and the client got a traceback naming absolute paths for what is a malformed request. The bus's `/send`, `/peer` and `/peer-exchange` had the same shape.
- **Request flags were coerced with `bool()`.** `bool("false")` is True, so a string enabled auto-nudge, file editing, the master bell and auto-update, paused retries across every session, made a directory, or deleted a tag.

## What changes

**Authorize, then read, within bounds.** `Handler._read_post_body` runs only after `_authorize` passed. Transfer-Encoding is refused with 411 (the body is delimited by Content-Length alone; chunk framing would otherwise be read as a zero-length body and its bytes as the next request); more than one Content-Length, or a value that is not a plain decimal of at most twenty digits, is 400; a declared length past 1 MiB is 413 before a byte is read; a body that arrives shorter than announced (a dead client, a half-close) is 400 naming the shortfall, never "no body". Every refusal closes the connection and says so in the header, because the unread bytes would be parsed as the next request on a keep-alive socket. An absent Content-Length is an empty body, which is what the bodiless POSTs (`/tick` from the hook, `/restart`) send. A 403 now closes too, since the body is unread.

**A body is an object or a 400.** `_json_object_body` answers `(body, error)`: empty is `{}` (the route then names its missing fields), undecodable is "body is not JSON", anything that is not an object is refused naming what arrived through a bounded echo that clips inside the quotes so the error text is always well formed and short. Fifteen routes use it: `/update-dismiss`, `/notify-all`, `/notify-turns`, `/new`, `/fork`, `/rename`, `/move`, `/color`, `/watch-pr`, `/watch`, `/tag` and `/group`, `/working`, `/deliver`, `/picker-check`, `/walk-root`, `/redial`. The bus's `_body` is the kernel gate's twin (411, 400, 413, short read, non-object) and closes on refusal.

**A flag is a JSON boolean or a refusal.** `_as_bool` passes `true`/`false`, keeps the handler's previous default when the field is absent, and refuses anything else naming the field. HTTP sites answer 400; WebSocket sites answer on the socket that sent the frame: the settings ops with a `warn` frame, `editTag` with its own `tagEditFailed`, and `setSessionFlag` and `cardNotify` with the `settingRefused` frame the feed and timeline pages render. On the bus, `tracked` on `/send` and the MCP `send_message` tool, and `up` on peer updates. Every shipped sender already posts real booleans; the refusal reaches only a client that did not.

## Judgment calls

- The 1 MiB cap: every kernel POST is a small JSON control request. Attachments ride the WebSocket, whose own limit is 80 MB. Each shipped client was read: the hook's `/tick` is bodiless, the CLI posts `curl -d` bodies bounded by argv, postal and the kernel's own forwards set Content-Length through urllib and http.client, and the extension's only POST is the manager's bodiless `/ensure`.
- Transfer-Encoding is 411 rather than 413: the request is not too large, it is unframed.
- Absent flags keep their old defaults; only a present non-boolean is refused. The one default that shifts is `mcpAction`, where an explicit `null` now reads as the default (enabled) instead of False; the UI never sends null.
- MCP `send_message`'s `tracked` is the one gated site whose sender is a model rather than shipped code. The refusal text names the fix, so one call recovers.
- The bus caps at 1 MiB too. Nothing shipped produces a mail body that large; a producer-side cap on the `/deliver` banner (the bus concatenates a recipient's pending mail) is a follow-up.

## Unchanged, and residuals

`/restart`'s body parse is owned by #1027 (`_restart_scope_from_body`); its `fleet` flag is on that PR's side, and the two compose. `/judge-settings`' `propagate` is kernel-to-kernel and forwarded bodies strip it. The request-scoped hints left as truthiness are listed in the commit body (`floating`, `nudge`, `manual`, `boot`, `ok`/`keep`, `live`, `generate`, `hidden`); nothing persists from them. `do_POST`'s catch-all 500 is unchanged; the routes above no longer reach it for these inputs.

## Tests

`tests/test_kernel_auth_hardening.py` drives the real `do_POST` through a fake socket and a real loopback server: an unauthenticated 10 MB POST answers 403 with zero reads; an oversize declared length is 413 before any read and the next in-bounds request is served; non-decimal and duplicate Content-Length, Transfer-Encoding, a 5000-digit length, a short body over the wire, and the bodiless `/tick` (a guard of the branch a mutant escaped). `tests/test_rename_route.py` posts `[]`, `"x"`, `1`, `null`, `[1]`, malformed JSON and a 100 KB string to all fifteen routes. `tests/test_tag_route.py` and `tests/test_kernel_session_flags.py` send non-boolean flags to every gated HTTP and WebSocket site and assert the stub behind each never ran and the right frame came back. `tests/test_postal_token.py` and `tests/test_postal_peers.py` cover the bus gate and its flags. `ui/timeline-flags.test.ts` pins the boolean sender and the kernel gate. Mutants (the read moved back before auth, each gate check removed, `bool()` restored, a route's guard reverted, the bus's refusal swallowed) each fail a test.

Module counts on this tree, one runner at a time: `tests/test_kernel_auth_hardening.py` 38; `tests/test_rename_route.py` 7; `tests/test_tag_route.py` 99; `tests/test_kernel_session_flags.py` 39; `tests/test_notify_bells.py` 53; `tests/test_postal_token.py` 16; `tests/test_postal_peers.py` 26; `tests/test_new_session_dir.py` 47; `tests/test_setting_gesture_order.py` 72; `tests/test_tracked_delegation.py` 13; `tests/test_perf_stats.py` 41; `tests/test_op_credential_boundary.py` 5; `ui/timeline-flags.test.ts` 10 of 10. Full suite left to CI.

Rebased over #1027 (merged): its pre-auth read block, which recorded a short read for `/restart` alone, is superseded by the gate, which refuses a short or unparsable body with a 400 before any route runs, so `/restart`'s scope parser now receives no body error. The gate's refusals use #1027's vocabulary ("body could not be read: read N of the M bytes Content-Length announced", "… is an invalid literal for a byte count"), so its `/restart` test holds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
