### PR TITLE
The tag-group chip keeps its hue on hover — and still answers the fold cue

### DIFF
--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -359,11 +359,13 @@ body.chat-theme-yatharth #tabs .tab-row-line { display: none; }
 body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 /* TAB SECTIONS — groups are tags (the user 2026-09-04): one header per home tag in the strip, the
    untagged trail behind a plain separator. A header reads as a LABEL, not a session (the user
-   2026-09-06): a disclosure chevron that flips with the fold, the tag's color as a short bar, the name
-   small and letter-spaced, and the member count (the folded-away count while folded). No state class,
-   no close, no pip of its own — none of a tab's dress; folded, one small MEMBER-derived mark follows the
-   count (the state pip below), and hover/focus brighten the label and color the chevron in the accent
-   (a fold cue), never a row wash (a "select me" cue). The header is focusable (Enter or Space fold),
+   2026-09-06): a disclosure chevron that flips with the fold, the tag as THE CHIP it wears everywhere
+   (T251), and the member count (the folded-away count while folded). No state class, no close, no pip
+   of its own — none of a tab's dress; folded, one small MEMBER-derived mark follows the count (the
+   state pip below), and hover/focus brighten the label and color the chevron in the accent (a fold
+   cue), never a row wash (a "select me" cue). The chip is coloured by IDENTITY, so it brightens by a
+   filter rather than to --fg (T251b: --fg would erase the tag; the chip's inline colour is what the
+   header's colour rule cannot reach) — the same lift the plain name used to get, on the tag's own hue. The header is focusable (Enter or Space fold),
    drags to reorder the groups (tagOrder), and the header under a dragged group wears the accent
    insertion cue. 0.82em is the surface's sub-line size (the menus' sub-lines) — labels match labels,
    and nothing here nests an em inside it. Tokens only, so the header reads in every theme without a
@@ -373,6 +375,10 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
   user-select: none; border-radius: 6px 6px 0 0; outline: none; }
 .tab-group-head:hover, .tab-group-head:focus-visible { color: var(--fg); }
 .tab-group-head:hover .tab-group-caret, .tab-group-head:focus-visible .tab-group-caret { color: var(--accent); }
+/* the chip's fold cue (T251b): a brightness lift keeps the tag's identity colour (a --fg swap would erase
+   it) and, unlike a background wash, is a property the chip's inline style never sets — so the rule wins
+   by construction; the uncoloured "(no tags)" chip lifts from --dim toward --fg, the old label's exact cue */
+.tab-group-head:hover .tab-group-chip, .tab-group-head:focus-visible .tab-group-chip { filter: brightness(1.3); }
 .tab-group-head:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
 /* the section holding the active tab: unfoldable while active (no fold action on its header), so no
    pointer cursor promising a click — it still drags to reorder the groups */

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -382,8 +382,36 @@ test("the header's structure and gestures read as a label: chevron (flips with t
     "captured before the tab rule (chat-focus-model.test pins that rule's two-line shape)");
   assert.match(RENDER, /if \(h && h\.tabIndex >= 0\) h\.focus\(\); else focusActiveTab\(\);/,
     "…falling back to the active tab when the group is gone or now holds it");
-  // hover/focus: the label brightens and the chevron takes the accent — no row wash (that reads "select me")
+  // hover/focus: the count brightens to --fg, the chevron takes the accent, and the CHIP brightens by a
+  // filter on its own identity colour (T251b — a --fg swap would erase the tag) — no row wash ("select me")
   assert.match(CSS, /\.tab-group-head:hover, \.tab-group-head:focus-visible \{ color: var\(--fg\); \}/);
+  assert.match(CSS, /\.tab-group-head:hover \.tab-group-chip, \.tab-group-head:focus-visible \.tab-group-chip \{ filter: brightness\(1\.3\); \}/);
+  {
+    // the RENDERED outcome, not the sheet's text: the chip's inline style is what the header's colour rule
+    // cannot reach (inline beats class), so the cue must be a property the chip never sets inline. Run the
+    // real builder against a stub document and read the style it writes.
+    const created: { tag: string; attrs: Record<string, string>; kids: unknown[] }[] = [];
+    const g = globalThis as any;
+    const saved = g.document;
+    const savedWin = g.window;
+    g.document = {
+      createElement: (tag: string) => { const n = { tag, attrs: {} as Record<string, string>, kids: [] as unknown[],
+        setAttribute(k: string, v: string) { this.attrs[k] = v; }, appendChild(c: unknown) { this.kids.push(c); },
+        addEventListener() { /* unused by tagChip */ } }; created.push(n); return n; },
+      createTextNode: (t: string) => ({ text: t }),
+      addEventListener() { /* the module wires its closers + the menu-echo writer at load (T107) */ },
+    };
+    g.window = { addEventListener() { /* the storage listener at load */ } };
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { tagChip } = require("./tag-menu");
+      const chip = tagChip("infra", "#54B204", { inheritSize: true });
+      const style: string = chip.attrs.style;
+      assert.match(style, /color:#54B204;/, "the identity colour rides inline — the header's --fg rule cannot recolour it…");
+      assert.ok(!/filter\s*:/.test(style), "…so the fold cue is a FILTER, a property the chip never sets inline: the class rule wins by construction");
+      assert.ok(!/font-size/.test(style), "and the header-hosted chip inherits the header's size");
+    } finally { g.document = saved; g.window = savedWin; }
+  }
   assert.match(CSS, /\.tab-group-head:hover \.tab-group-caret, \.tab-group-head:focus-visible \.tab-group-caret \{ color: var\(--accent\); \}/);
   for (const m of CSS.matchAll(/\n\.tab-group-head:hover[^{\n]*\{([^}]*)\}/g)) assert.doesNotMatch(m[1], /background/, "no wash on hover");
   assert.match(CSS, /\.tab-group-head:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);


### PR DESCRIPTION
Follow-up to the tag-chip change (the manager's adversarial pass): the header's hover/focus rule brightens the row to `--fg` as the fold cue, but the chip now writes its identity colour inline, which that rule cannot reach — so on hover and keyboard focus the name stopped responding while the caret and count still did, and two comments plus a pin kept describing the old brightening.

The cue is restored on the chip's own terms: a **brightness filter** on `.tab-group-head:hover .tab-group-chip` and its focus-visible twin. A filter lifts the tag's colour without erasing it (a `--fg` swap would have made every tag read the same on hover), and unlike a background wash it is a property the chip's inline style never sets, so the class rule wins by construction — the inline-beats-class trap the review named. The uncoloured '(no tags)' chip lifts from `--dim` toward `--fg`, the old label's exact cue. Both themes; no row wash (the 'select me' cue the doctrine bans) — the header's no-background-on-hover pin still holds.

The two comments now describe the chip's lift, and the pin asserts the **rendered outcome** rather than the sheet's text: the real `tagChip` runs against a stub document and its inline style is read back — the identity colour is inline (so `--fg` cannot recolour it) and no filter is set inline (so the rule's cue lands). 3270/3270 extension tests green; typecheck clean; rest-vs-hover illustration in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)