### PR TITLE
A deferred build's reveal clamp is never recorded as the reader's scroll; the settings rerender keeps the reader's anchor; a live seek counts as navigation

### DIFF
--- a/ui/webview/prebuild-wiring.test.ts
+++ b/ui/webview/prebuild-wiring.test.ts
@@ -34,7 +34,7 @@ test("a pass builds each off-screen tab's hidden DOM via ensureView + syncView",
   assert.match(RENDER, /function runPrebuild\(deadline: IdleDeadline\): void/);
   // ensureView, then (a re-collapse of an overgrown hidden view — #934 fold), then syncView
   assert.match(RENDER, /ensureView\(id\);[\s\S]*?syncView\(id\);/);
-  assert.match(RENDER, /v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{[^\n]*\n\s*v\.rendered = 0; v\.winStart = 0;/,   // a trailing comment may follow the brace (T249)
+  assert.match(RENDER, /v\.el\.querySelectorAll\("\.turn"\)\.length > WINDOW_CAP\) \{\s*\n\s*v\.rendered = 0; v\.winStart = 0;/,
     "an overgrown hidden view is re-collapsed to the tail window in idle, off the click path");
   // one malformed tab must not abort pre-building the rest
   assert.match(RENDER, /try \{[\s\S]*ensureView\(id\);[\s\S]*syncView\(id\);[\s\S]*\} catch/);
@@ -55,5 +55,5 @@ test("pre-building is wired into the lifecycle: switch, content arrival, updates
   const staleRebuilds = RENDER.match(/schedulePrebuild\(\); \/\/ rebuild the now-stale off-screen view/g) || [];
   assert.ok(staleRebuilds.length >= 2, "both update() and chatTail() re-warm a now-stale off-screen view");
   // a compact-mode flip resets every view → cancel the stale plan, then re-warm under the new setting
-  assert.match(RENDER, /cancelPrebuild\(\);[\s\S]*showActive\(\);\s*\n\s*schedulePrebuild\(\); \/\/ rebuild every off-screen view/);
+  assert.match(RENDER, /cancelPrebuild\(\);[\s\S]*showActive\(keep\);\s*\n\s*schedulePrebuild\(\); \/\/ rebuild every off-screen view/);   // rerenderAll hands showActive the anchor it captured before the clear (T249 review fold)
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9807,8 +9807,15 @@ function toggleToolGroup(key: string): void {
 // next syncView rebuilds it via the right path, then repaint the active one.
 function rerenderAll(): void {
   cancelPrebuild(); // the queued plan is now stale (every view reset below) — re-warm after showActive
+  // The reader's place, captured BEFORE the clear below empties the active view (T249 review find, 2026-09-08):
+  // a settings change re-renders the transcript under a reader who may be scrolled up, and once the DOM is
+  // gone there is no anchor to capture and the box no longer overflows. Near the bottom → nothing to keep
+  // (follow mode lands there); a hidden pane has nothing to keep either. showActive restores it after the land.
+  const content = document.getElementById("content");
+  const av = activeId ? views.get(activeId) : null;
+  const keep = av && av.shown && content && content.clientHeight > 0 && !nearBottom(content) ? captureScrollAnchor(content, av) : null;
   for (const v of views.values()) { while (v.el.firstChild) v.el.removeChild(v.el.firstChild); v.rendered = 0; v.stale = false; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; }
-  showActive();
+  showActive(keep);
   schedulePrebuild(); // rebuild every off-screen view in idle under the new setting, so switches stay instant
 }
 
@@ -9955,7 +9962,10 @@ function runPrebuild(deadline: IdleDeadline): void {
   renderingOwnerSid = savedOwnerSid;
 }
 
-function showActive() {
+// `keep` (review find, 2026-09-08): a caller that must EMPTY the view before showing it (rerenderAll on a
+// settings change) captures the reader's anchor first and hands it here — by the time this runs there is
+// no DOM left to capture from and the emptied box no longer overflows. undefined = capture here.
+function showActive(keep?: { uuid: string; y: number } | null) {
   const content = document.getElementById("content");
   if (!content) return;
   placeReviveLoader();   // session-local: shows over THIS pane only while the reviving tab is active
@@ -10025,8 +10035,11 @@ function showActive() {
   // rebuild the way appendActive does, restored after landActive; a tab switch is not a re-show (the
   // entering view is still display:none), so the leaving-tab save, the nav trail's spot and the jump
   // button keep their explicit semantics. The decision and the saved-spot rule live in scroll-keep.ts.
-  const reshow = keepPlaceAcrossShow(v, v.el.style.display !== "none", content.clientHeight > 0, !!pendingAnchor || pendingAnchorT != null);
-  const keepAnchor = reshow && !nearBottom(content) ? captureScrollAnchor(content, v) : null;
+  // a live durable seek for this tab is navigation too: landActive re-arms pendingAnchor from it after this
+  // decision, and a restore over its landing would undo the jump the reader asked for (review find, 2026-09-08)
+  const navigating = !!pendingAnchor || pendingAnchorT != null || (!!seek && seek.sid === activeId);
+  const reshow = keepPlaceAcrossShow(v, v.el.style.display !== "none", content.clientHeight > 0, navigating);
+  const keepAnchor = reshow ? (keep !== undefined ? keep : (!nearBottom(content) ? captureScrollAnchor(content, v) : null)) : null;
   // Bound the switch. A view the user scrolled to the top of has had its window expanded to the WHOLE
   // transcript (winStart crept to 0 via lazy-expand), and compact mode renders the whole folded stream —
   // either way, revealing thousands of nodes is the big-session switch lag (the user 2026-06-25: 4144 turns
@@ -10035,8 +10048,9 @@ function showActive() {
   // scrolling up lazily reloads. Both render paths honour winStart, so this works in either mode. Skip when
   // a deep-link is pending (its target may be in the collapsed head). A small view (≤ cap) is left untouched
   // → the no-op fast path reveals it instantly.
+  // …and a SWITCH rule only: a re-show of the view on screen never snaps it to the tail (T249)
   if (!reshow && !pendingAnchor && pendingAnchorT == null
-      && v.el.querySelectorAll(".turn").length > WINDOW_CAP) {   // a SWITCH rule: a re-show of the view on screen never snaps it to the tail (T249)
+      && v.el.querySelectorAll(".turn").length > WINDOW_CAP) {
     v.rendered = 0; v.winStart = 0; v.avgTurnH = undefined; v.stick = true;   // → firstBuild rebuilds the tail, lands at bottom
   }
   for (const [vid, vv] of views) vv.el.style.display = vid === activeId ? "" : "none";
@@ -10328,12 +10342,19 @@ window.addEventListener("resize", updateJumpBtn);
 // shown tab (a fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback)
 // snapped the reader back there. Every scroll of the active view now records its position and its
 // follow-mode (the same nearBottom threshold appendActive and the jump chip read), passive, no timer.
-// Programmatic scrolls (a land, an anchor restore) fire the same event, so the record is always the truth.
+// Programmatic scrolls (a land, an anchor restore) fire the same event, so the record is always the truth —
+// with ONE exception, the transient a DEFERRED build leaves (review find, 2026-09-08): showActive reveals
+// the entering view before its heavy build runs in the next frame, the browser clamps scrollTop to that
+// stale or empty DOM's bottom, and the clamp's scroll event is dispatched BEFORE the frame callback that
+// lands the view — recorded, it read as "the reader is at the bottom" and the land went there instead of
+// the saved spot (a compact-mode switch to a tab with an unbuilt update; a settings rerender). While a
+// build is pending the position is the clamp's, not the reader's, so nothing is recorded; the build's own
+// land fires the next scroll event, and that one is the truth. The pending build is the event, no timer.
 {
   const c = document.getElementById("content");
   if (c) c.addEventListener("scroll", () => {
     if (c.clientHeight <= 0) return;
-    followReader(activeId ? views.get(activeId) : null, c.scrollTop, nearBottom(c));
+    followReader(activeId ? views.get(activeId) : null, c.scrollTop, nearBottom(c), pendingBuildRaf != null);
   }, { passive: true });
 }
 // Boxes ABOVE the transcript grow/shrink → keep the chat text visually anchored (the user 2026-06-30 for

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -8,8 +8,12 @@
 // fork/first-build frame, a settings rerender, a revive failure, a dismissal's fallback — landed the reader
 // on that stale spot. Fix: (1) the #content scroll listener keeps the active view's saved spot and
 // follow-mode current; (2) a show of a view already on screen anchors the reader's place across its rebuild
-// like the live append does, and the big-view re-collapse-to-tail is a switch-only rule. Executed rules +
-// render.ts wiring pins, red on main's render.ts. Synthetic values only.
+// like the live append does, and the big-view re-collapse-to-tail is a switch-only rule. Review folds
+// (2026-09-08): a DEFERRED build's reveal clamps the scroll and fires a scroll event before the build lands,
+// so nothing is recorded while a build is pending (else a compact-mode switch to a tab with an unbuilt update
+// landed at the bottom, not its saved spot); rerenderAll captures the reader's anchor before it empties the
+// DOM and hands it to showActive; a live seek counts as navigation. Executed rules + render.ts wiring pins,
+// red on the previous render.ts. Synthetic values only.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -35,6 +39,20 @@ test("followReader touches only a shown view, and a missing view is a no-op", ()
   assert.doesNotThrow(() => followReader(undefined, 1, true));
 });
 
+test("a deferred build's reveal clamp is NOT the reader: nothing is recorded while a build is pending, the land's own scroll is", () => {
+  // the compact-mode switch the review traced: B was left mid-read (3000, not following); A's long scroll
+  // reveals B's stale, shorter DOM → the browser clamps to B's bottom and fires a scroll event BEFORE the
+  // deferred build lands. Recorded, that read as follow-mode and the land went to the bottom.
+  const b: KeepView = { scrollTop: 3000, stick: false, shown: true };
+  followReader(b, 9000, true, /* building */ true);
+  assert.deepEqual(b, { scrollTop: 3000, stick: false, shown: true }, "the clamp left the saved spot alone");
+  assert.equal(landSpot(b), 3000, "the deferred land goes where the tab was left");
+  followReader(b, 3000, false, false);                                 // the land's own scroll event, build done
+  assert.equal(landSpot(b), 3000);
+  followReader(b, 9000, true, false);                                  // the reader really scrolls to the bottom later
+  assert.equal(landSpot(b), "bottom");
+});
+
 test("keepPlaceAcrossShow: only a displayed, visible, already-shown view with no navigation pending", () => {
   const v: KeepView = { scrollTop: 300, stick: false, shown: true };
   assert.equal(keepPlaceAcrossShow(v, true, true, false), true, "a re-show of the view on screen");
@@ -44,19 +62,34 @@ test("keepPlaceAcrossShow: only a displayed, visible, already-shown view with no
   assert.equal(keepPlaceAcrossShow({ ...v, shown: false }, true, true, false), false, "a first show lands at the bottom");
 });
 
+test("render.ts: the reshow decision counts a live durable seek for the tab as navigation, and rerenderAll hands showActive the anchor it captured BEFORE emptying the DOM", () => {
+  assert.match(RENDER, /const navigating = !!pendingAnchor \|\| pendingAnchorT != null \|\| \(!!seek && seek\.sid === activeId\);/);
+  assert.match(RENDER, /^function showActive\(keep\?: \{ uuid: string; y: number \} \| null\) \{/m);
+  assert.match(RENDER, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/);
+  const ra = RENDER.match(/^function rerenderAll\(\): void \{([\s\S]*?)\n\}/m);
+  assert.ok(ra, "rerenderAll");
+  const body = ra![1];
+  const cap = body.indexOf("captureScrollAnchor(content, av)");
+  const clear = body.indexOf("v.el.removeChild(v.el.firstChild)");
+  const show = body.indexOf("showActive(keep);");
+  assert.ok(cap >= 0 && clear >= 0 && show >= 0, "capture, clear and show are all there");
+  assert.ok(cap < clear && clear < show, "captured before the clear, handed to the show");
+});
+
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
   assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow \} from "\.\/scroll-keep";/);
-  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\)\);\n\s*\}, \{ passive: true \}\);/);
+  // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, nearBottom\(c\), pendingBuildRaf != null\);\n\s*\}, \{ passive: true \}\);/);
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
   assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) content\.scrollTop = content\.scrollHeight;\n\s*else content\.scrollTop = v\.scrollTop;/);
 });
 
 test("render.ts: showActive keeps the reader's place across a re-show of the view already on screen, on both build paths", () => {
-  const m = RENDER.match(/^function showActive\(\) \{([\s\S]*?)\n\}/m);
+  const m = RENDER.match(/^function showActive\(keep\?: \{ uuid: string; y: number \} \| null\) \{([\s\S]*?)\n\}/m);
   assert.ok(m, "showActive");
   const body = m![1];
-  assert.match(body, /const reshow = keepPlaceAcrossShow\(v, v\.el\.style\.display !== "none", content\.clientHeight > 0, !!pendingAnchor \|\| pendingAnchorT != null\);/);
-  assert.match(body, /const keepAnchor = reshow && !nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null;/, "captured BEFORE the rebuild, like appendActive");
+  assert.match(body, /const reshow = keepPlaceAcrossShow\(v, v\.el\.style\.display !== "none", content\.clientHeight > 0, navigating\);/);
+  assert.match(body, /const keepAnchor = reshow \? \(keep !== undefined \? keep : \(!nearBottom\(content\) \? captureScrollAnchor\(content, v\) : null\)\) : null;/, "captured BEFORE the rebuild, like appendActive — or handed in by a caller that had to empty the DOM first");
   const restores = body.match(/if \(keepAnchor(?: && cc)?\) restoreScrollAnchor\(/g) || [];
   assert.equal(restores.length, 2, "restored after landActive on the light path AND inside the deferred heavy build");
   // the big-view re-collapse to the tail is a SWITCH rule: a re-show of the view on screen must not snap it to the bottom

--- a/ui/webview/scroll-keep.ts
+++ b/ui/webview/scroll-keep.ts
@@ -12,20 +12,29 @@
 //
 // Two rules, both pure so node --test executes them:
 //  1. the saved spot FOLLOWS the reader — the #content scroll listener records the active shown view's
-//     position and follow-mode on every scroll (followReader), so landActive's rule lands where they are;
+//     position and follow-mode on every scroll (followReader), so landActive's rule lands where they are —
+//     except while a DEFERRED build is pending (review find, 2026-09-08): showActive reveals the entering
+//     view a frame before its heavy build, the browser clamps scrollTop to that stale or empty DOM, and the
+//     clamp's scroll event arrives before the frame callback that lands the view; recorded, it sent a
+//     compact-mode tab switch and a settings rerender to the bottom instead of the saved spot. The pending
+//     build is the event that marks the transient, so `building` suppresses the record until it lands;
 //  2. a show of a view that is ALREADY on screen keeps the reader's place across its rebuild the way the
 //     live append does (keepPlaceAcrossShow → captureScrollAnchor before, restoreScrollAnchor after): a
 //     rebuild can move content above the viewport, and only an anchor keeps the line being read still.
 //     A tab SWITCH is not that: the entering view is not displayed yet, so its explicit spot semantics
-//     (the leaving-tab save, the nav trail's remembered spot, the jump button) are untouched.
+//     (the leaving-tab save, the nav trail's remembered spot, the jump button) are untouched. A caller that
+//     must EMPTY the view before showing it (rerenderAll, on a settings change) captures the anchor first
+//     and hands it to showActive, which by then has no DOM to capture from.
 // Event-based throughout: the scroll event and the show itself; no timer, no age threshold.
 
 export interface KeepView { scrollTop: number; stick: boolean; shown: boolean; }
 
 /** The reader scrolled the active view: its saved spot and follow-mode follow them. A view not yet shown
- *  keeps its defaults (its first land goes to the bottom regardless), and a hidden pane never scrolls. */
-export function followReader(v: KeepView | null | undefined, scrollTop: number, near: boolean): void {
-  if (!v || !v.shown) return;
+ *  keeps its defaults (its first land goes to the bottom regardless), a hidden pane never scrolls, and while
+ *  a deferred build is pending (`building`) the position is the reveal's clamp, not the reader's — the
+ *  build's own land fires the next scroll event, and that one is recorded. */
+export function followReader(v: KeepView | null | undefined, scrollTop: number, near: boolean, building = false): void {
+  if (!v || !v.shown || building) return;
   v.scrollTop = scrollTop;
   v.stick = near;
 }


### PR DESCRIPTION
## What

Follow-up to romp-on/romp#1036 (the chat pane's saved scroll spot follows the reader). Its adversarial review, three lenses with a refuter pair per finding, upheld one regression and two gaps, all fixed here.

**Regression (two lenses, reproduced in headless Chromium).** `showActive` reveals the entering view a frame before its heavy build runs; the browser clamps `scrollTop` to that stale or empty DOM's bottom, and the clamp's scroll event is dispatched BEFORE the frame callback that lands the view. The new `#content` listener recorded that clamp as "at the bottom, following", so the deferred `landActive` went to the bottom instead of the saved spot. Concretely: compact mode, tab B left mid-read, B receives an update in the background, the user clicks B before the idle prebuild caught up. On main before #1036 that click landed on B's saved spot; after #1036 it landed at the bottom. Fix: nothing is recorded while a deferred build is pending (`pendingBuildRaf != null`); the build's own land fires the next scroll event, and that one is the truth. The pending build is the event, no timer.

**Settings rerender.** `rerenderAll` (every settings change) empties every view before `showActive` can capture an anchor, so the case #1036's comments listed as kept was inert and, with the clamp, landed at the bottom. It now captures the active view's anchor before the clear and hands it to `showActive(keep)`, which restores it after the land.

**Seek.** A live durable seek for the tab counts as navigation in the reshow decision, so the anchor restore never undoes the jump `landActive` re-arms from it.

Also restores the `prebuild-wiring` pin #1036 loosened without need (its regex matched the other re-collapse site all along).

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

`ui/webview/scroll-keep-on-show.test.ts` gains the executed clamp case (a scroll during a pending build leaves the saved spot alone; the deferred land goes where the tab was left; a later real scroll is recorded) and pins for the listener's guard, the rerenderAll capture-before-clear ordering, the seek gate and `showActive`'s keep parameter; the pins are red on the merged main's render.ts. Suites: node 3268 passed (`npm test`, typecheck clean); the 28 Python modules that read the browser sources 834 passed, with the two `ViewBuilder` nudge tests failing only inside that partial selection and passing alone (the known ordering artifact); the kernel is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
