### PR TITLE
The env-file-vs-declaration check judges the source the launch selects, so its silence is truthful

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -277,22 +277,24 @@ on: the remembered pick becomes the box's expectation and the env var goes
 inert (it described the unpicked design), so re-seeded spawns are judged
 against your pick, never against stale doctrine.
 
-The declaration is also checked against `service.env` once, when the kernel
-starts. Under `ROMP_EXPECTED_AUTH=login`, a file that selects an API key
-source (a `ROMP_API_KEY_CMD=` line, a `ROMP_API_KEY_REF=` line, or an
-`ANTHROPIC_API_KEY=` line with a value) is a contradiction: that source is
-injected at launch for every session without an explicit Billing pick, so
-those sessions bill the key. One problem line in the Log panel says so before
-anything launches, naming the file and the variable but never a value; fix
-whichever side is wrong. A file whose source configuration is invalid (both
-provider lines, say) is still a selection, and the line says so instead: those
-sessions will try the source and fail to launch rather than bill the login.
-Under `key`, a key source in the file agrees with the declaration and nothing
-is said. With no key source selected, Romp injects nothing and Claude Code's
-own credential applies (see [API keys from a secret manager at
-runtime](#api-keys-from-a-secret-manager-at-runtime)), so nothing is said;
-nor with no declaration, nor once a Billing pick has made it inert. The
-per-init check above still confirms each landing.
+The declaration is also checked once, when the kernel starts, against the
+key source a launch would select. Under `ROMP_EXPECTED_AUTH=login`, a selected
+API key source (a `ROMP_API_KEY_CMD=` line, a `ROMP_API_KEY_REF=` line, or an
+`ANTHROPIC_API_KEY=` line with a value in `service.env`; for a foreground
+manager, the same names exported in its environment) is a contradiction: that
+source is injected at launch for every session without an explicit Billing
+pick, so those sessions bill the key. One problem line in the Log panel says so
+before anything launches, naming the file or the environment and the variable
+but never a value; fix whichever side is wrong. A source that is selected but
+cannot be used (both provider lines in the file; a provider line removed while
+the marker beside the file still names it) is still a selection, and the line
+says so instead: those sessions will try the source and fail to launch rather
+than bill the login. Under `key`, a selected source agrees with the declaration
+and nothing is said. With no key source selected anywhere the launch looks,
+Romp injects nothing and Claude Code's own credential applies (see [API keys
+from a secret manager at runtime](#api-keys-from-a-secret-manager-at-runtime)),
+so nothing is said; nor with no declaration, nor once a Billing pick has made
+it inert. The per-init check above still confirms each landing.
 
 The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
 Fable 5) are drawn once, aggregated across every connected host's login as the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2115,13 +2115,18 @@ def _check_key_file_agrees(startup: str, live: str) -> None:
 _ENV_FILE_AUTH_CHECKED = False   # the env-file-vs-declaration check (one line, once per process)
 
 
-def _check_env_file_vs_declaration(log, state_dir, path: str | None = None) -> str:
-    """Say ONCE per process, as a problem-ring line, when the env file selects an API key source while
-    ROMP_EXPECTED_AUTH=login declares that the sessions bill the machine login. The two cannot both
-    hold: a source the file selects — an `ANTHROPIC_API_KEY=` line with a value, a `ROMP_API_KEY_REF=`
-    line, or a `ROMP_API_KEY_CMD=` line — is injected at launch for every session without an explicit
-    Billing pick (effective_auth and default_auth answer "key" whenever a source is configured), so
-    those sessions bill the key. Without this line the first sign is _note_auth_source's per-init
+def _check_env_file_vs_declaration(log, state_dir) -> str:
+    """Say ONCE per process, as a problem-ring line, when the API key source the LAUNCH would select
+    contradicts ROMP_EXPECTED_AUTH=login, which declares that the sessions bill the machine login. The two
+    cannot both hold: a selected source — an `ANTHROPIC_API_KEY=` line with a value, a `ROMP_API_KEY_REF=`
+    line, or a `ROMP_API_KEY_CMD=` line in the env file, and for a foreground manager the same names
+    exported in its environment — is injected at launch for every session without an explicit Billing
+    pick (effective_auth and default_auth answer "key" whenever a source is configured), so those
+    sessions bill the key. The selection is keysource.select_source, the launch's own (work_api_key_source),
+    so the check's silence is truthful: the file's lines alone missed the durable provider MARKER beside
+    the file (a removed provider the launch still tries, and fails on) and the foreground environment
+    (a review of the merged check, 2026-09-08). The startup key is PEEKED, never claimed: the claim and
+    its once-only semantics belong to the launch (startup_api_key). Without this line the first sign is _note_auth_source's per-init
     mismatch, after a launch has already billed the wrong account, and that line names the helper and
     the file without saying which line. A file whose source configuration is INVALID (both provider
     lines; a garbled line) is still a selection — `configured` is True, so nothing falls back to the
@@ -2144,22 +2149,26 @@ def _check_env_file_vs_declaration(log, state_dir, path: str | None = None) -> s
     exp, src = _declared_auth(state_dir)
     if exp != "login" or src != "env":
         return ""
-    p = path or _keysrc.service_env_path()
-    source = _keysrc.read_source(p)
+    p = _keysrc.service_env_path()
+    startup = _WORK_KEY if _WORK_KEY is not None else (os.environ.get("ANTHROPIC_API_KEY") or "")   # a peek
+    source = _keysrc.select_source(startup)
     if not source.configured:
-        return ""                    # no source selected (a missing file, an empty key line): the sessions fall
-    _ENV_FILE_AUTH_CHECKED = True    # to Claude Code's own credential, and there is nothing to weigh against the declaration
+        return ""                    # the launch selects nothing anywhere it looks (file, marker, environment):
+    _ENV_FILE_AUTH_CHECKED = True    # the sessions fall to Claude Code's own credential, nothing to weigh
+    from_env = source.kind == "environment" or "from the environment" in (source.error or "") \
+        or not _keysrc.read_source(p).configured and source.kind != "error"
+    where = "the manager's environment" if from_env else p
     if source.kind == "error":
         log("auth: %s selects an API key source that cannot be used (%s) while ROMP_EXPECTED_AUTH=login. Every "
             "session without an explicit Billing pick will try that source and fail to launch rather than bill "
-            "the machine login. Fix the file, or change the declaration to match what it should select."
-            % (p, source.error or "invalid API key source configuration"), problem=True)
+            "the machine login. Fix the source, or change the declaration to match what it should select."
+            % (where, source.error or "invalid API key source configuration"), problem=True)
         return "error"
     var = _keysrc.source_var(source.kind)
     log("auth: %s sets %s while ROMP_EXPECTED_AUTH=login. The declaration says the sessions bill the machine "
-        "login, but the key source this file selects is injected at launch for every session without an "
-        "explicit Billing pick, so they bill the key. Fix whichever side is wrong: remove the line, or change "
-        "the declaration to match what the file selects." % (p, var), problem=True)
+        "login, but the key source it selects is injected at launch for every session without an explicit "
+        "Billing pick, so they bill the key. Fix whichever side is wrong: remove the line (or the export), or "
+        "change the declaration to match what is selected." % (where, var), problem=True)
     return var
 
 

--- a/tests/test_env_file_vs_declaration.py
+++ b/tests/test_env_file_vs_declaration.py
@@ -54,12 +54,12 @@ class _Env(unittest.TestCase):
         self.path = os.path.join(self.d, "service.env")
         self._before = {v: os.environ.get(v) for v in ("ROMP_SERVICE_ENV_FILE", "ROMP_SERVICE_ENV",
                                                        "ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY",
-                                                       "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD")}
+                                                       "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ROMP_SUPERVISED")}
         os.environ["ROMP_SERVICE_ENV_FILE"] = self.path
         os.environ["ROMP_SERVICE_ENV"] = self.path
         # every source variable, the key command included: a box that runs its manager on
         # ROMP_API_KEY_CMD exports it to every shell, and the environment fallback would read it
-        for v in ("ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD"):
+        for v in ("ROMP_EXPECTED_AUTH", "ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ROMP_SUPERVISED"):
             os.environ.pop(v, None)
         self._checked = sb._ENV_FILE_AUTH_CHECKED
         sb._ENV_FILE_AUTH_CHECKED = False
@@ -74,6 +74,7 @@ class _Env(unittest.TestCase):
         sb._ENV_FILE_AUTH_CHECKED = self._checked
         ks._CACHE = ((), "")
         ks._AUTHORITATIVE_PATHS.pop(self.path, None)
+        getattr(ks, "_ENV_PROVIDER_PATHS", {}).pop(self.path, None)
 
     def write_env(self, body, path=None):
         p = path or self.path
@@ -181,6 +182,68 @@ class EnvFileVsDeclaration(_Backend):
         self.assertNotIn(CMD, text)
         self.assertTrue(sb._ENV_FILE_AUTH_CHECKED, "said once: the one shot is spent")
         self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), "")
+
+    # The check judges the source the LAUNCH would select (keysource.select_source), not the file's lines
+    # alone: the durable provider marker beside the file and, for a foreground manager, the exported
+    # sources are part of that decision, and a silence that ignored them read "the sessions fall to
+    # Claude Code's own credential" where they would in fact try a removed provider, or bill an exported
+    # key (the review of the merged check, 2026-09-08).
+    def test_login_declared_over_a_removed_provider_whose_marker_remains_says_the_source_cannot_be_used(self):
+        # the shape the invalid-file branch exists for: the reference line is gone, the marker beside the
+        # file still names the provider, so every unpicked session tries it and fails to launch
+        self.write_env("ROMP_PERF=1\n")
+        ks.remember_file_source(self.path, "op")
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        said = []
+        log = lambda m, problem=None: said.append((str(m), problem))
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), "error")
+        self.assertEqual(len(said), 1)
+        text, problem = said[0]
+        self.assertTrue(problem)
+        self.assertIn("cannot be used", text)
+        self.assertIn("was removed", text)
+        self.assertIn(self.path, text, "the marker sits beside the file: the file is named")
+
+    def test_login_declared_over_an_exported_provider_names_the_environment(self):
+        # a foreground `romp up` from a shell that exported the key command: the file selects nothing, the
+        # environment does, and unpicked sessions bill the key
+        os.environ[ks.CMD_VAR] = CMD
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        be = self.construct()
+        lines = self.flagged(be)
+        self.assertEqual(len(lines), 1, be.problems())
+        self.assertIn(ks.CMD_VAR, lines[0])
+        self.assertIn("environment", lines[0])
+        self.assertNotIn(self.path, lines[0], "the file selected nothing; it is not what is named")
+        self.assertFalse(any(CMD in m for m in self.logged))
+        self.assertEqual(be.default_auth({}), "key", "the sentence describes what the launch does")
+
+    def test_login_declared_over_a_startup_key_names_the_key_variable_and_never_claims_it(self):
+        # the startup key the manager's environment carried: the launch claims it later; the check only
+        # PEEKS, so the claim's once-only semantics (tests/test_session_auth.py) are untouched
+        sb._WORK_KEY = None                    # not yet claimed
+        os.environ[ks.KEY_VAR] = KEY
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        said = []
+        log = lambda m, problem=None: said.append((str(m), problem))
+        self.assertEqual(sb._check_env_file_vs_declaration(log, self.state), ks.KEY_VAR)
+        self.assertIn("environment", said[0][0])
+        self.assertEqual(os.environ.get(ks.KEY_VAR), KEY, "peeked, not claimed")
+        self.assertIsNone(sb._WORK_KEY)
+        self.assertFalse(any(KEY in m for m, _ in said))
+
+    def test_a_supervised_manager_ignores_the_environment_here_too(self):
+        # under the service unit keysource reads the file only (an inherited export cannot establish a
+        # fallback), so the launch selects nothing and the check is rightly quiet
+        os.environ["ROMP_SUPERVISED"] = "1"
+        sb._WORK_KEY = KEY
+        os.environ["ROMP_EXPECTED_AUTH"] = "login"
+        try:
+            be = self.construct()
+            self.assertEqual(self.flagged(be), [], be.problems())
+            self.assertFalse(sb._ENV_FILE_AUTH_CHECKED)
+        finally:
+            os.environ.pop("ROMP_SUPERVISED", None)
 
     def test_the_direct_call_returns_the_variable_it_named_and_files_a_problem(self):
         self.write_env("%s=%s\n" % (ks.REF_VAR, REF))


### PR DESCRIPTION
Follow-up to #1002, from the review of the merged check.

## What was wrong
`_check_env_file_vs_declaration` read `service.env`'s lines only (`keysource.read_source`) and returned quietly when they selected nothing, with a comment saying the sessions then fall to Claude Code's own credential. The launch decides through `keysource.select_source`, which also honours the durable provider **marker** beside the file and, for a foreground manager, the **exported** `ROMP_API_KEY_CMD` / `ROMP_API_KEY_REF` or a startup `ANTHROPIC_API_KEY`. Two shapes were therefore silent under `ROMP_EXPECTED_AUTH=login` although the contradiction is real:

- a provider line removed while the marker still names it: the removed-provider error, still `configured`, so every unpicked session tries the source and fails to launch (the exact shape the "cannot be used" branch exists for);
- a foreground `romp up` with an exported source: the environment source, so unpicked sessions bill the key.

## The fix
The check asks `keysource.select_source`, the launch's own selection, with the startup key **peeked** rather than claimed so `startup_api_key`'s once-only claim stays the launch's. It names the file when the file (or its marker) selected the source and "the manager's environment" otherwise, still through `keysource.source_var`. A supervised manager ignores its environment in keysource, so the check is quiet there, truthfully. The comment and the docs sentence no longer read as covering a removed provider or a foreground export.

## Tests (red before, in `tests/test_env_file_vs_declaration.py`)
A removed provider whose marker remains is said to be unusable, naming the file; an exported key command is named against the environment; a startup key is named and is **not** claimed by the check; a supervised manager with an exported key stays quiet. Auth suites (env-file, keyswap, expected-auth, session-auth, runtime key source and auth, credential boundary, session env, state isolation, injected voice): 364 passed with the shell's key variables unset.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)