### PR TITLE
Serve tokens are minted once under a lock, born 0600, and never rotated by a read fault

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -551,6 +551,15 @@ user account). Local tools (the CLI, hooks, the bus, the editor extension) read
 that file and send it automatically, so you never type it. Only liveness probes
 (`/healthz`, `/version`, `/busy`, and the bus's `/ping`) are exempt.
 
+The kernel and the bus mint that file when it is missing, one mint between them
+under a sibling lock file, `serve-token.lock`. An existing token is never
+replaced: a file left looser than `0600` is tightened at the next start (its
+value is kept, so every client stays valid), and a token that exists but cannot
+be read, or a symlink at that path, refuses to start instead of minting a
+replacement nobody else holds. Under the service that refusal repeats in
+`manager.log` every 10 seconds until you repair the file; the kernel then comes
+back on its own.
+
 A browser cannot read that file, which is why the link `romp` prints carries the
 token in it. The first visit trades it for a year-long cookie, so the bare
 `http://127.0.0.1:29855/` works from then on; `romp url` prints the link again

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12,7 +12,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
 import math
-import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
+import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools, fcntl
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 from importlib.machinery import SourceFileLoader
@@ -993,37 +993,142 @@ def _dist_ver():
         return 0
 
 
+def _serve_token_read_or_mint(f, who):
+    """Read the serve token at `f`, or mint one: under a lock, born 0600, never rotated by a fault.
+
+    Every client holds a COPY of this token (bin/romp and the hooks read the file, the bus and each
+    session's MCP process load it at their own start, peers fetch it at attach), so the one thing
+    this must never do is quietly replace it: a rotated token strands all of them with a credential
+    the daemon no longer accepts, and nothing says why. The old loader did exactly that on ANY read
+    fault (an EACCES or EIO fell through to the mint), minted by truncating the live file in place (a
+    concurrent reader saw an empty file and minted its own), and took no lock (two starters each
+    wrote their own). The contract now — KEEP IN SYNC with postal_service.py's copy; the bus imports nothing
+    from kernel/ by design, so it carries the same shape rather than this function:
+      - FileNotFoundError is the ONLY mint trigger. Any other read fault (a file that is not UTF-8
+        text included) raises RuntimeError naming the path and the errno. At import that refuses to
+        start the daemon, which is visible and repairable; the token every client holds stays valid.
+      - An EMPTY or whitespace-only file is a torn earlier mint (no client can hold a token that was
+        never written), so it is minted over, and said on stderr.
+      - The mint sweeps any `serve-token.*.tmp` a crashed attempt left (safe under the lock), writes
+        its own with O_EXCL at 0600, checks the write length, fsyncs, and os.replace()s it onto the
+        path: the live file appears with the token already inside, at 0600 from its first byte, and
+        the live path is never opened for writing at all.
+      - A non-empty token that is not 0600 is tightened in place, and said on stderr.
+      - `serve-token.lock` (0600) is flock'd around all of that, so the kernel and the bus booting
+        together mint once between them. When the lock itself cannot be taken, an existing non-empty
+        0600 token is returned as is (nothing to mint, nothing to tighten) and every other case is a
+        fault: minting or tightening without the lock is the race this exists to close."""
+    lock = f.with_name(f.name + ".lock")
+
+    def fault(path, what, e):
+        code = getattr(e, "errno", None)
+        why = ("%s, errno %s" % (errno.errorcode.get(code, type(e).__name__), code) if code is not None
+               else type(e).__name__)
+        raise RuntimeError(
+            "%s: cannot %s (%s). romp did NOT replace the serve token, so every client holding it "
+            "stays valid. Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN), then start "
+            "again." % (path, what, why)) from e
+
+    def read():
+        try:
+            return f.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeDecodeError) as e:   # a token that is not text is a fault too, never a mint
+            fault(f, "read it", e)
+
+    def mode():
+        try:
+            return stat.S_IMODE(os.stat(f).st_mode)
+        except OSError as e:
+            fault(f, "stat it", e)
+
+    def mint(why):
+        if why:
+            print("[%s] serve token %s: %s; minting a fresh one" % (who, f, why), file=sys.stderr)
+        v = base64.urlsafe_b64encode(os.urandom(18)).decode().rstrip("=")
+        tmp = f.with_name("%s.%d.tmp" % (f.name, os.getpid()))
+        fd = None
+        try:
+            for stale in f.parent.glob(f.name + ".*.tmp"):
+                try:
+                    os.unlink(stale)         # under the lock, so any temp here is a crashed earlier attempt, any pid's
+                except FileNotFoundError:
+                    pass
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            data = v.encode()
+            n = os.write(fd, data)
+            if n != len(data):
+                raise OSError(errno.EIO, "short write, %d of %d bytes" % (n, len(data)))
+            os.fsync(fd)
+            os.close(fd)
+            fd = None
+            os.replace(str(tmp), str(f))
+        except OSError as e:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            fault(f, "mint it (via %s)" % tmp.name, e)
+        return v
+
+    lfd = None
+    try:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        lfd = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(lfd, fcntl.LOCK_EX)
+    except OSError as e:
+        if lfd is not None:
+            try:
+                os.close(lfd)
+            except OSError:
+                pass
+        v = read()                           # a read fault is its own RuntimeError
+        if v and mode() == 0o600:
+            print("[%s] serve token: could not lock %s (%s); using the existing 0600 token as is"
+                  % (who, lock, e), file=sys.stderr)
+            return v
+        fault(lock, "take the lock, which minting or tightening the token needs", e)
+    try:
+        v = read()
+        if v is None:
+            return mint(None)
+        if not v:
+            return mint("the file is empty, a torn earlier mint that no client can be holding")
+        m = mode()
+        if m != 0o600:
+            try:
+                os.chmod(f, 0o600)
+            except OSError as e:
+                fault(f, "tighten its mode from %o to 0600" % m, e)
+            print("[%s] serve token %s was mode %o; tightened to 0600" % (who, f, m), file=sys.stderr)
+        return v
+    finally:
+        try:
+            fcntl.flock(lfd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(lfd)
+
+
 def _load_token():
     """The serve token, baked into launch so the human never passes --token: ROMP_SERVE_TOKEN if
     set, else a stable random token persisted under the state dir at 0600 — file perms are the
     same-user gate (Jupyter's model). Required on EVERY request, loopback included: loopback is
     reachable by any local user, so a token-free loopback would let a same-host co-tenant drive
     sessions. Local clients read the file (same user) and send X-Romp-Token; browsers carry
-    ?token= once and ride the auto-set cookie."""
+    ?token= once and ride the auto-set cookie. The file is read or minted by
+    _serve_token_read_or_mint (locked, born 0600, never rotated by a read fault); a fault there at
+    import refuses to start the kernel rather than hand out a token no client holds."""
     t = (os.environ.get("ROMP_SERVE_TOKEN") or "").strip()
     if t:
         return t
-    f = jd.STATE / "serve-token"
-    try:
-        v = f.read_text().strip()
-        if v:
-            return v
-    except OSError:
-        pass
-    v = base64.urlsafe_b64encode(os.urandom(18)).decode().rstrip("=")
-    try:
-        jd.STATE.mkdir(parents=True, exist_ok=True)
-        # 0600 from birth, not written-then-chmod'd: between those two calls the file carried the
-        # token at the umask's mercy, and the whole same-user gate is this file's mode.
-        fd = os.open(str(f), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        try:
-            os.write(fd, v.encode())
-        finally:
-            os.close(fd)
-        os.chmod(f, 0o600)                       # a PRE-EXISTING file keeps its old mode through O_CREAT
-    except OSError:
-        pass
-    return v
+    return _serve_token_read_or_mint(jd.STATE / "serve-token", "kernel")
 
 TOKEN = _load_token()
 
@@ -1033,7 +1138,8 @@ def _persist_repo_root():
     _discover_remote_clone): the running kernel knows exactly where it lives, so probes read this
     file over ssh FIRST instead of guessing conventional dirs — the guess list missed a clone at
     ~/projects/romp while that machine's kernel was literally up, reporting "romp not installed"
-    (the user 2026-08-11). Best-effort, like the serve-token mint above."""
+    (the user 2026-08-11). Best-effort, unlike the serve-token mint above, which refuses rather
+    than degrade: a wrong repo-root misleads a probe, a wrong token strands every client."""
     try:
         jd.STATE.mkdir(parents=True, exist_ok=True)
         (jd.STATE / "repo-root").write_text(str(ROOT) + "\n")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1006,31 +1006,50 @@ def _serve_token_read_or_mint(f, who):
     from kernel/ by design, so it carries the same shape rather than this function:
       - FileNotFoundError is the ONLY mint trigger. Any other read fault (a file that is not UTF-8
         text included) raises RuntimeError naming the path and the errno. At import that refuses to
-        start the daemon, which is visible and repairable; the token every client holds stays valid.
+        start the daemon. Under bin/romp-manager that is not one message: the manager respawns on
+        its crash-loop backoff, so the traceback repeats in manager.log (every 10 s at the cap)
+        until the file is repaired, and then the kernel comes back by itself; the token every
+        client holds stays valid throughout (review find, 2026-09-08).
+      - A SYMLINK at the token path is refused the same way, by lstat before any read: a read or a
+        chmod through a link lands on its target, some other file, whose bytes and mode are not
+        this gate's (review find, 2026-09-08). A dangling link is refused too, not minted over.
       - An EMPTY or whitespace-only file is a torn earlier mint (no client can hold a token that was
         never written), so it is minted over, and said on stderr.
       - The mint sweeps any `serve-token.*.tmp` a crashed attempt left (safe under the lock), writes
         its own with O_EXCL at 0600, checks the write length, fsyncs, and os.replace()s it onto the
         path: the live file appears with the token already inside, at 0600 from its first byte, and
         the live path is never opened for writing at all.
-      - A non-empty token that is not 0600 is tightened in place, and said on stderr.
+      - A non-empty token with any mode bit outside 0600 (group, other, the owner's execute) has
+        those bits stripped in place, and said on stderr; a TIGHTER mode (0400) is left alone. The
+        check was equality with 0600, which widened 0400 and called it a repair (review find,
+        2026-09-08).
       - `serve-token.lock` (0600) is flock'd around all of that, so the kernel and the bus booting
-        together mint once between them. When the lock itself cannot be taken, an existing non-empty
-        0600 token is returned as is (nothing to mint, nothing to tighten) and every other case is a
-        fault: minting or tightening without the lock is the race this exists to close."""
+        together mint once between them. The lock is probed LOCK_NB first: a starter that finds it
+        held says so on stderr, then waits for the holder (the silent block looked like a hang:
+        review find, 2026-09-08). When the lock itself cannot be taken, an existing non-empty token
+        with nothing to tighten is returned as is (nothing to mint either) and every other case is
+        a fault naming the LOCK and what it was needed for: minting or tightening without the lock
+        is the race this exists to close, and the token file is not the thing to repair."""
     lock = f.with_name(f.name + ".lock")
 
-    def fault(path, what, e):
+    def fault(path, what, e, fix="Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN)"):
         code = getattr(e, "errno", None)
         why = ("%s, errno %s" % (errno.errorcode.get(code, type(e).__name__), code) if code is not None
                else type(e).__name__)
         raise RuntimeError(
             "%s: cannot %s (%s). romp did NOT replace the serve token, so every client holding it "
-            "stays valid. Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN), then start "
-            "again." % (path, what, why)) from e
+            "stays valid. %s, then start again." % (path, what, why, fix)) from e
 
     def read():
         try:
+            if stat.S_ISLNK(os.lstat(f).st_mode):
+                # refused BEFORE anything reads or chmods through it: both land on the target, some
+                # other file (review find, 2026-09-08). lstat sees a dangling link too; read_text
+                # would call that absent and mint over it.
+                fault(f, "use it: the token path is a symlink, and romp reads or tightens no token "
+                         "through a link", OSError(errno.ELOOP, os.strerror(errno.ELOOP)),
+                      fix="Replace the link with a regular file that is yours and mode 0600 (or set "
+                          "ROMP_SERVE_TOKEN)")
             return f.read_text(encoding="utf-8").strip()
         except FileNotFoundError:
             return None
@@ -1039,9 +1058,12 @@ def _serve_token_read_or_mint(f, who):
 
     def mode():
         try:
-            return stat.S_IMODE(os.stat(f).st_mode)
+            return stat.S_IMODE(os.lstat(f).st_mode)   # lstat, like read(): the file's own mode, never a link target's
         except OSError as e:
             fault(f, "stat it", e)
+
+    def loose(m):
+        return m & ~0o600                    # any bit outside rw-------: group, other, execute, set-id, sticky
 
     def mint(why):
         if why:
@@ -1081,7 +1103,15 @@ def _serve_token_read_or_mint(f, who):
     try:
         f.parent.mkdir(parents=True, exist_ok=True)
         lfd = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
-        fcntl.flock(lfd, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(lfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # another starter (the kernel and the bus boot together) is reading or minting: say so
+            # once, then wait for it. The blocking take is the right wait; it was just silent, and a
+            # starter stuck behind a wedged holder looked hung (review find, 2026-09-08).
+            print("[%s] serve token: waiting for the holder of %s (another starter is reading or "
+                  "minting it)" % (who, lock), file=sys.stderr)
+            fcntl.flock(lfd, fcntl.LOCK_EX)
     except OSError as e:
         if lfd is not None:
             try:
@@ -1089,11 +1119,18 @@ def _serve_token_read_or_mint(f, who):
             except OSError:
                 pass
         v = read()                           # a read fault is its own RuntimeError
-        if v and mode() == 0o600:
-            print("[%s] serve token: could not lock %s (%s); using the existing 0600 token as is"
-                  % (who, lock, e), file=sys.stderr)
+        m = mode() if v else None
+        if v and not loose(m):
+            print("[%s] serve token: could not lock %s (%s); using the existing token as is (mode "
+                  "%04o, nothing to tighten)" % (who, lock, e, m), file=sys.stderr)
             return v
-        fault(lock, "take the lock, which minting or tightening the token needs", e)
+        # the refusal names the LOCK, the fault, and what the lock was needed for. It used to send the
+        # operator to make the token file 0600, also when no such file existed (review find, 2026-09-08).
+        need = ("that minting a token needs; no token file exists to fall back on" if v is None else
+                "that minting a token needs; the token file is empty, a torn earlier mint" if not v else
+                "that tightening the token file from mode %04o needs" % m)
+        fault(lock, "take the lock %s" % need, e,
+              fix="Make the lock file yours, or remove it (or set ROMP_SERVE_TOKEN)")
     try:
         v = read()
         if v is None:
@@ -1101,12 +1138,13 @@ def _serve_token_read_or_mint(f, who):
         if not v:
             return mint("the file is empty, a torn earlier mint that no client can be holding")
         m = mode()
-        if m != 0o600:
+        if loose(m):
+            want = m & 0o600                 # strip what is loose, add nothing: 0640 -> 0600, 0444 -> 0400
             try:
-                os.chmod(f, 0o600)
+                os.chmod(f, want)
             except OSError as e:
-                fault(f, "tighten its mode from %o to 0600" % m, e)
-            print("[%s] serve token %s was mode %o; tightened to 0600" % (who, f, m), file=sys.stderr)
+                fault(f, "tighten its mode from %04o to %04o" % (m, want), e)
+            print("[%s] serve token %s was mode %04o; tightened to %04o" % (who, f, m, want), file=sys.stderr)
         return v
     finally:
         try:
@@ -1124,7 +1162,11 @@ def _load_token():
     sessions. Local clients read the file (same user) and send X-Romp-Token; browsers carry
     ?token= once and ride the auto-set cookie. The file is read or minted by
     _serve_token_read_or_mint (locked, born 0600, never rotated by a read fault); a fault there at
-    import refuses to start the kernel rather than hand out a token no client holds."""
+    import refuses to start the kernel rather than hand out a token no client holds (under
+    bin/romp-manager the respawn backoff repeats that refusal until the file is repaired, then the
+    kernel returns by itself). The result, TOKEN, is the ONE value this kernel serves: the request
+    gate compares against it and the check-in handshake announces it. Nothing re-reads the file at
+    runtime: a re-read could mint a token the gate rejects (review find, 2026-09-08)."""
     t = (os.environ.get("ROMP_SERVE_TOKEN") or "").strip()
     if t:
         return t
@@ -16038,8 +16080,13 @@ def _via_forward(body, path):
 
 
 def _checkin_payload(r):
+    # TOKEN, the value the request gate compares against (ROMP_SERVE_TOKEN already folded in at
+    # import): the payload carries the SERVED token and never touches the file at runtime. A
+    # `_load_token()` here minted onto disk when the file was missing (a token this kernel did not
+    # serve, handed to the hub and every local reader) and swallowed a read fault into the 15 s
+    # handshake retry (review find, 2026-09-08).
     return {"host": _self_host(), "kernelPort": r.get("rk_port"), "busPort": r.get("rb_port"),
-            "token": _load_token()}
+            "token": TOKEN}
 
 
 def _handshake_due(r, ssh_pid, now):

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -92,21 +92,33 @@ SESSION_FLAGS = STATE.parent / "session-flags.json"   # the kernel's per-session
 # one line: FileNotFoundError is the only mint trigger, the mint lands by rename of a 0600 temp,
 # and it all happens under serve-token.lock. A fault raises RuntimeError, which at import refuses to
 # start the bus (or a session's MCP process): the old loader minted its OWN token on any read fault
-# and every request it then made was a silent 403.
+# and every request it then made was a silent 403. The refusal is not one message: the bus is started
+# again by whatever needs it (a kernel boot's _ensure_postal_bus, a session's MCP process running
+# `ensure`), and the kernel's own copy of this refusal repeats on bin/romp-manager's respawn backoff
+# (a traceback in manager.log every 10 s at the cap), so both repeat until the file is repaired and
+# stop by themselves once it is, with the token every client holds untouched throughout (review
+# find, 2026-09-08).
 def _serve_token_read_or_mint(f, who):
     lock = f.with_name(f.name + ".lock")
 
-    def fault(path, what, e):
+    def fault(path, what, e, fix="Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN)"):
         code = getattr(e, "errno", None)
         why = ("%s, errno %s" % (errno.errorcode.get(code, type(e).__name__), code) if code is not None
                else type(e).__name__)
         raise RuntimeError(
             "%s: cannot %s (%s). romp did NOT replace the serve token, so every client holding it "
-            "stays valid. Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN), then start "
-            "again." % (path, what, why)) from e
+            "stays valid. %s, then start again." % (path, what, why, fix)) from e
 
     def read():
         try:
+            if stat.S_ISLNK(os.lstat(f).st_mode):
+                # refused BEFORE anything reads or chmods through it: both land on the target, some
+                # other file (review find, 2026-09-08). lstat sees a dangling link too; read_text
+                # would call that absent and mint over it.
+                fault(f, "use it: the token path is a symlink, and romp reads or tightens no token "
+                         "through a link", OSError(errno.ELOOP, os.strerror(errno.ELOOP)),
+                      fix="Replace the link with a regular file that is yours and mode 0600 (or set "
+                          "ROMP_SERVE_TOKEN)")
             return f.read_text(encoding="utf-8").strip()
         except FileNotFoundError:
             return None
@@ -115,9 +127,12 @@ def _serve_token_read_or_mint(f, who):
 
     def mode():
         try:
-            return stat.S_IMODE(os.stat(f).st_mode)
+            return stat.S_IMODE(os.lstat(f).st_mode)   # lstat, like read(): the file's own mode, never a link target's
         except OSError as e:
             fault(f, "stat it", e)
+
+    def loose(m):
+        return m & ~0o600                    # any bit outside rw-------: group, other, execute, set-id, sticky
 
     def mint(why):
         if why:
@@ -157,7 +172,15 @@ def _serve_token_read_or_mint(f, who):
     try:
         f.parent.mkdir(parents=True, exist_ok=True)
         lfd = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
-        fcntl.flock(lfd, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(lfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # another starter (the kernel and the bus boot together) is reading or minting: say so
+            # once, then wait for it. The blocking take is the right wait; it was just silent, and a
+            # starter stuck behind a wedged holder looked hung (review find, 2026-09-08).
+            print("[%s] serve token: waiting for the holder of %s (another starter is reading or "
+                  "minting it)" % (who, lock), file=sys.stderr)
+            fcntl.flock(lfd, fcntl.LOCK_EX)
     except OSError as e:
         if lfd is not None:
             try:
@@ -165,11 +188,18 @@ def _serve_token_read_or_mint(f, who):
             except OSError:
                 pass
         v = read()                           # a read fault is its own RuntimeError
-        if v and mode() == 0o600:
-            print("[%s] serve token: could not lock %s (%s); using the existing 0600 token as is"
-                  % (who, lock, e), file=sys.stderr)
+        m = mode() if v else None
+        if v and not loose(m):
+            print("[%s] serve token: could not lock %s (%s); using the existing token as is (mode "
+                  "%04o, nothing to tighten)" % (who, lock, e, m), file=sys.stderr)
             return v
-        fault(lock, "take the lock, which minting or tightening the token needs", e)
+        # the refusal names the LOCK, the fault, and what the lock was needed for. It used to send the
+        # operator to make the token file 0600, also when no such file existed (review find, 2026-09-08).
+        need = ("that minting a token needs; no token file exists to fall back on" if v is None else
+                "that minting a token needs; the token file is empty, a torn earlier mint" if not v else
+                "that tightening the token file from mode %04o needs" % m)
+        fault(lock, "take the lock %s" % need, e,
+              fix="Make the lock file yours, or remove it (or set ROMP_SERVE_TOKEN)")
     try:
         v = read()
         if v is None:
@@ -177,12 +207,13 @@ def _serve_token_read_or_mint(f, who):
         if not v:
             return mint("the file is empty, a torn earlier mint that no client can be holding")
         m = mode()
-        if m != 0o600:
+        if loose(m):
+            want = m & 0o600                 # strip what is loose, add nothing: 0640 -> 0600, 0444 -> 0400
             try:
-                os.chmod(f, 0o600)
+                os.chmod(f, want)
             except OSError as e:
-                fault(f, "tighten its mode from %o to 0600" % m, e)
-            print("[%s] serve token %s was mode %o; tightened to 0600" % (who, f, m), file=sys.stderr)
+                fault(f, "tighten its mode from %04o to %04o" % (m, want), e)
+            print("[%s] serve token %s was mode %04o; tightened to %04o" % (who, f, m, want), file=sys.stderr)
         return v
     finally:
         try:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -36,6 +36,8 @@
 # ~/.claude/romp-postal-nopush; disable everything with ~/.claude/romp-postal-off.
 
 import base64
+import errno
+import fcntl
 import hashlib
 import hmac
 import json
@@ -45,6 +47,7 @@ import re
 import shutil
 import signal
 import socket
+import stat
 import subprocess
 import sys
 import threading
@@ -82,25 +85,119 @@ SESSION_FLAGS = STATE.parent / "session-flags.json"   # the kernel's per-session
 # through an ssh forward authorizes with the DIALED machine's token (?token=), which rides the
 # kernel's /peer notifies only (never /tunnels rows, which a page reads too; since 2026-09-08 a
 # restarted bus gets every token re-notified, see peers_snapshot).
+#
+# _serve_token_read_or_mint is a COPY of the kernel's (kernel.py, same name; KEEP IN SYNC): the bus
+# imports nothing from kernel/ by design, and the two daemons boot together, so they must agree on
+# the whole contract, not just the path. Why it is shaped this way is in the kernel's docstring; in
+# one line: FileNotFoundError is the only mint trigger, the mint lands by rename of a 0600 temp,
+# and it all happens under serve-token.lock. A fault raises RuntimeError, which at import refuses to
+# start the bus (or a session's MCP process): the old loader minted its OWN token on any read fault
+# and every request it then made was a silent 403.
+def _serve_token_read_or_mint(f, who):
+    lock = f.with_name(f.name + ".lock")
+
+    def fault(path, what, e):
+        code = getattr(e, "errno", None)
+        why = ("%s, errno %s" % (errno.errorcode.get(code, type(e).__name__), code) if code is not None
+               else type(e).__name__)
+        raise RuntimeError(
+            "%s: cannot %s (%s). romp did NOT replace the serve token, so every client holding it "
+            "stays valid. Make the file yours and mode 0600 (or set ROMP_SERVE_TOKEN), then start "
+            "again." % (path, what, why)) from e
+
+    def read():
+        try:
+            return f.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeDecodeError) as e:   # a token that is not text is a fault too, never a mint
+            fault(f, "read it", e)
+
+    def mode():
+        try:
+            return stat.S_IMODE(os.stat(f).st_mode)
+        except OSError as e:
+            fault(f, "stat it", e)
+
+    def mint(why):
+        if why:
+            print("[%s] serve token %s: %s; minting a fresh one" % (who, f, why), file=sys.stderr)
+        v = base64.urlsafe_b64encode(os.urandom(18)).decode().rstrip("=")
+        tmp = f.with_name("%s.%d.tmp" % (f.name, os.getpid()))
+        fd = None
+        try:
+            for stale in f.parent.glob(f.name + ".*.tmp"):
+                try:
+                    os.unlink(stale)         # under the lock, so any temp here is a crashed earlier attempt, any pid's
+                except FileNotFoundError:
+                    pass
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            data = v.encode()
+            n = os.write(fd, data)
+            if n != len(data):
+                raise OSError(errno.EIO, "short write, %d of %d bytes" % (n, len(data)))
+            os.fsync(fd)
+            os.close(fd)
+            fd = None
+            os.replace(str(tmp), str(f))
+        except OSError as e:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            fault(f, "mint it (via %s)" % tmp.name, e)
+        return v
+
+    lfd = None
+    try:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        lfd = os.open(str(lock), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(lfd, fcntl.LOCK_EX)
+    except OSError as e:
+        if lfd is not None:
+            try:
+                os.close(lfd)
+            except OSError:
+                pass
+        v = read()                           # a read fault is its own RuntimeError
+        if v and mode() == 0o600:
+            print("[%s] serve token: could not lock %s (%s); using the existing 0600 token as is"
+                  % (who, lock, e), file=sys.stderr)
+            return v
+        fault(lock, "take the lock, which minting or tightening the token needs", e)
+    try:
+        v = read()
+        if v is None:
+            return mint(None)
+        if not v:
+            return mint("the file is empty, a torn earlier mint that no client can be holding")
+        m = mode()
+        if m != 0o600:
+            try:
+                os.chmod(f, 0o600)
+            except OSError as e:
+                fault(f, "tighten its mode from %o to 0600" % m, e)
+            print("[%s] serve token %s was mode %o; tightened to 0600" % (who, f, m), file=sys.stderr)
+        return v
+    finally:
+        try:
+            fcntl.flock(lfd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(lfd)
+
+
 def _load_serve_token():
     t = (os.environ.get("ROMP_SERVE_TOKEN") or "").strip()
     if t:
         return t
-    f = STATE.parent / "serve-token"              # ~/.local/state/romp/serve-token (STATE is romp/postal)
-    try:
-        v = f.read_text().strip()
-        if v:
-            return v
-    except OSError:
-        pass
-    v = base64.urlsafe_b64encode(os.urandom(18)).decode().rstrip("=")
-    try:
-        f.parent.mkdir(parents=True, exist_ok=True)
-        f.write_text(v)
-        os.chmod(f, 0o600)
-    except OSError:
-        pass
-    return v
+    # ~/.local/state/romp/serve-token (STATE is romp/postal): the kernel's file, shared.
+    return _serve_token_read_or_mint(STATE.parent / "serve-token", "postal")
 
 
 SERVE_TOKEN = _load_serve_token()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -8131,7 +8131,10 @@ class CheckinMechanics(unittest.TestCase):
         os.environ["ROMP_HOST_NAME"] = "TESTHOST"
         p = km._checkin_payload({"rk_port": 50003, "rb_port": 50004, "local_port": 50001})
         self.assertEqual((p["host"], p["kernelPort"], p["busPort"]), ("TESTHOST", 50003, 50004))
-        self.assertTrue(p["token"], "the token is HANDED to the hub — it never fetches credentials")
+        self.assertEqual(p["token"], km.TOKEN,
+                         "the token is HANDED to the hub, which never fetches credentials, and it is the one "
+                         "this kernel SERVES: a re-read of the file at runtime could mint one the gate "
+                         "rejects (review find, 2026-09-08)")
 
     def test_checkin_apply_records_a_sshless_row(self):
         payload, status = km.checkin_apply({"host": "TESTHOST", "kernelPort": 50003,

--- a/tests/test_kernel_serve_token_mode.py
+++ b/tests/test_kernel_serve_token_mode.py
@@ -15,7 +15,14 @@ The old loader failed the second job in three ways, each pinned here by a case t
 TightenMode (a loose existing file is chmod'd, its value kept), EmptyFileMints (a 0-byte or
 whitespace file is a torn earlier mint and is minted over, aloud), LockFailureIsFailClosed (no
 lock: a good 0600 token is returned, anything else is a refusal) and StaleTempsAreSwept (a crashed
-attempt's temp, any pid's, is removed before the mint) pin the rest of the contract, and
+attempt's temp, any pid's, is removed before the mint) pin the rest of the contract. From review
+(2026-09-08): CheckinCarriesServedToken (the handshake announces TOKEN and never touches the file),
+TempIsExclusive (O_EXCL is behaviour, not source text: a file already at the temp path is never
+written over), SymlinkIsRefused (a link at the token path is a fault, its target untouched),
+LockWaitIsAnnounced (a starter blocked by another holder says so before waiting), ImportRefusalIsLoud
+(a read fault at import exits the kernel non-zero with the file untouched, in a subprocess), and the
+tighter-mode cases in TightenMode and LockFailureIsFailClosed (0400 is left alone; only bits outside
+0600 go).
 ServeTokenLoadersMatch pins the bus's copy of the routine to the kernel's, since the bus imports
 nothing from kernel/ and carries its own: AST identity with the docstring stripped (any divergence
 is red), plus the named invariants as a readable second layer.
@@ -28,12 +35,16 @@ Synthetic only: hermetic temp STATE, placeholder tokens.
 """
 import ast
 import contextlib
+import fcntl
 import io
 import os
 import re
 import stat
+import subprocess
+import sys
 import tempfile
 import threading
+import time
 import unittest
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -73,7 +84,7 @@ class _TokenFile(unittest.TestCase):
         for p in [self.f, self.lock] + list(km.jd.STATE.glob("serve-token.*.tmp")):
             if p.is_dir():
                 p.rmdir()                    # LockFailureIsFailClosed plants a directory at the lock path
-            elif p.exists():
+            elif p.is_symlink() or p.exists():   # SymlinkIsRefused plants links, one of them dangling
                 p.unlink()
 
     def _restore(self):
@@ -114,10 +125,11 @@ class ServeTokenFileMode(_TokenFile):
                          "place, so there is no pre-existing inode to tighten (TightenMode covers the "
                          "one case where there is)")
 
-    def test_a_pre_existing_loose_file_is_still_tightened(self):
+    def test_a_loose_empty_file_is_minted_over_and_the_new_inode_is_born_0600(self):
         # An empty serve-token left at 0644 (a torn earlier mint, or one written before this change)
         # is minted over: the rename swaps in a NEW inode born 0600, so the loose mode goes with the
-        # old one.
+        # old one. (Named for what it exercises, the mint-over path, not the tighten: review find,
+        # 2026-09-08. TightenMode covers a NON-empty loose file.)
         self.f.write_text("")                # empty → a torn earlier mint → falls through to the mint
         os.chmod(self.f, 0o644)
         with contextlib.redirect_stderr(io.StringIO()):
@@ -197,25 +209,32 @@ class TokenBirth(_TokenFile):
         torn window a concurrent reader fell into). Expected first error on the old loader: the
         rename count is 0, because it wrote the live file in place."""
         os.umask(0o022)
-        swaps, opens = [], []
-        real_replace, real_open = os.replace, os.open
+        swaps, opens, synced = [], [], []
+        real_replace, real_open, real_fsync = os.replace, os.open, os.fsync
 
         def _replace(src, dst, *a, **k):
-            swaps.append((str(src), str(dst), _mode(src), Path(src).read_text()))
+            # what had been fsynced by the instant of the swap: the inode list is behaviour the source-text
+            # pin on `os.fsync(` cannot see (review find, 2026-09-08)
+            swaps.append((str(src), str(dst), _mode(src), Path(src).read_text(), os.stat(src).st_ino, list(synced)))
             return real_replace(src, dst, *a, **k)
 
         def _open(path, flags, *a, **k):
             opens.append((str(path), flags))
             return real_open(path, flags, *a, **k)
 
-        os.replace, os.open = _replace, _open
+        def _fsync(fd):
+            synced.append(os.fstat(fd).st_ino)
+            return real_fsync(fd)
+
+        os.replace, os.open, os.fsync = _replace, _open, _fsync
         try:
             tok = km._load_token()
         finally:
-            os.replace, os.open = real_replace, real_open
+            os.replace, os.open, os.fsync = real_replace, real_open, real_fsync
 
         self.assertEqual(len(swaps), 1, "the mint must land by one rename of a finished temp file")
-        src, dst, mode, body = swaps[0]
+        src, dst, mode, body, ino, synced_before_swap = swaps[0]
+        self.assertIn(ino, synced_before_swap, "the temp is fsynced BEFORE it is swapped in, or a crash right after the rename can leave an empty token")
         self.assertEqual(dst, str(self.f))
         self.assertEqual(mode, 0o600, "the temp is born 0600 under a 022 umask: the open mode, not the umask, decides")
         self.assertEqual(body, tok, "the temp already holds the whole token when it is swapped in")
@@ -295,6 +314,37 @@ class TightenMode(_TokenFile):
         self.assertIn("0600", err.getvalue())
         self.assertEqual(self._temps(), [], "no mint happened")
 
+    def test_a_tighter_token_is_left_alone(self):
+        """0400 has no bit outside 0600, so there is nothing to tighten. The check used to be EQUALITY
+        with 0600, which widened a read-only token to 0600 and reported the change as a repair
+        (review find, 2026-09-08). Expected first error on that shape: 0o600 != 0o400."""
+        self.f.write_text("tight-DO-NOT-USE\n")
+        os.chmod(self.f, 0o400)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._load_token(), "tight-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o400, "a mode tighter than 0600 is not widened")
+        self.assertEqual(err.getvalue(), "", "and nothing is said: nothing was changed")
+        self.assertEqual(self.f.read_text(), "tight-DO-NOT-USE\n")
+
+    def test_only_the_bits_outside_0600_are_stripped(self):
+        """0640 keeps its owner bits and loses the group read; 0444 keeps the owner's read only. The
+        repair removes what is loose and adds nothing, and the notice names both modes. Expected
+        first error on the equality shape: 0o600 != 0o400 at the 0444 case (it was widened)."""
+        for before, after in ((0o640, 0o600), (0o444, 0o400)):
+            with self.subTest(mode="%04o" % before):
+                self._clear()
+                self.f.write_text("keep-me-DO-NOT-USE\n")
+                os.chmod(self.f, before)
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertEqual(km._load_token(), "keep-me-DO-NOT-USE")
+                self.assertEqual(_mode(self.f), after)
+                self.assertIn("%04o" % before, err.getvalue(), "the notice names the mode it found")
+                self.assertIn("%04o" % after, err.getvalue(), "and the one it left")
+                self.assertEqual(self.f.read_text(), "keep-me-DO-NOT-USE\n", "tightening the mode rewrites nothing")
+                self.assertEqual(self._temps(), [])
+
     def test_a_good_0600_token_is_returned_silently(self):
         self.f.write_text("fine-DO-NOT-USE\n")
         os.chmod(self.f, 0o600)
@@ -347,13 +397,203 @@ class LockFailureIsFailClosed(_TokenFile):
             km._load_token()
         self.assertIn(str(self.lock), str(cm.exception), "the refusal names the lock path")
         self.assertIn("EISDIR", str(cm.exception))
+        self.assertIn("0644", str(cm.exception), "and says what the lock was needed for: tightening that mode")
         self.assertEqual(_mode(self.f), 0o644, "no unlocked write of any kind, not even a chmod")
-        # (c) no token: cannot be minted without the lock, so it is a refusal, and nothing appears
+        # (d) a TIGHTER token (0400): nothing to tighten either, so it is returned under the missing
+        # lock like a 0600 one (the equality check refused it: review find, 2026-09-08)
+        os.chmod(self.f, 0o400)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._load_token(), "good-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o400)
+        # (c) no token: cannot be minted without the lock, so it is a refusal, and nothing appears.
+        # The refusal names the LOCK and the fault it hit, and says there is no token file: the old
+        # message sent the operator to make a file that did not exist 0600 (review find, 2026-09-08).
         self.f.unlink()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as cm:
             km._load_token()
+        msg = str(cm.exception)
+        self.assertIn(str(self.lock), msg, "the lock is the thing to repair, and it is named")
+        self.assertIn("EISDIR", msg, "with the actual fault")
+        self.assertIn("no token file", msg, "and the fact that there is nothing on disk to fall back on")
+        self.assertNotIn("Make the file yours", msg, "it does not send the operator to fix a token file that does not exist")
         self.assertFalse(self.f.exists(), "nothing minted unlocked")
         self.assertEqual(self._temps(), [])
+
+
+class LockWaitIsAnnounced(_TokenFile):
+    def test_a_starter_blocked_by_another_holder_says_so_before_waiting(self):
+        """The kernel and the bus boot together, so the second starter blocks on serve-token.lock
+        until the first has read or minted. Blocking flock is the right (event-based) wait, but it
+        said nothing, so a starter stuck behind a wedged holder looked hung (review find,
+        2026-09-08): the lock is probed LOCK_NB first and one stderr line names it before the
+        blocking take. Expected first error on the silent shape: the line never appears while the
+        loader sits in flock, and the wait below runs out."""
+        self.f.write_text("held-DO-NOT-USE\n")
+        os.chmod(self.f, 0o600)
+        holder = os.open(str(self.lock), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(holder, fcntl.LOCK_EX)   # a separate open file description, so the loader's flock conflicts
+        err, out = io.StringIO(), []
+
+        def run():
+            with contextlib.redirect_stderr(err):
+                out.append(km._load_token())
+
+        t = threading.Thread(target=run, daemon=True)
+        try:
+            t.start()
+            deadline = time.monotonic() + 5
+            while str(self.lock) not in err.getvalue() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertIn(str(self.lock), err.getvalue(), "the wait is said on stderr, naming the lock")
+            self.assertIn("waiting", err.getvalue())
+            self.assertTrue(t.is_alive(), "and the starter IS waiting: the line announces the block, it does not skip it")
+            self.assertEqual(out, [])
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            os.close(holder)
+        t.join(10)
+        self.assertEqual(out, ["held-DO-NOT-USE"], "the holder's release lets it through to the token")
+
+
+class SymlinkIsRefused(_TokenFile):
+    def test_a_symlink_at_the_token_path_is_a_fault_and_its_target_is_untouched(self):
+        """chmod and stat follow a link, so a symlink at the token path had the loader reading some
+        other file as the token and rewriting THAT file's mode (review find, 2026-09-08). A link is
+        refused outright by lstat before any read, naming the path; the target keeps its bytes and
+        its mode. Expected first error on the following shape: RuntimeError not raised (it returned
+        the target's content and chmod'd the target to 0600)."""
+        target = km.jd.STATE / "elsewhere-DO-NOT-USE"
+        target.write_text("linked-DO-NOT-USE\n")
+        os.chmod(target, 0o644)
+        self.addCleanup(target.unlink)
+        self.f.symlink_to(target)
+        with self.assertRaises(RuntimeError) as cm:
+            km._load_token()
+        msg = str(cm.exception)
+        self.assertIn(str(self.f), msg, "the refusal names the token path")
+        self.assertIn("symlink", msg, "and says what is wrong with it")
+        self.assertEqual(_mode(target), 0o644, "the target's mode is not rewritten through the link")
+        self.assertEqual(target.read_text(), "linked-DO-NOT-USE\n", "nor its bytes")
+        self.assertTrue(self.f.is_symlink(), "the link is left for the operator to remove")
+        self.assertEqual(self._temps(), [])
+
+    def test_a_dangling_symlink_is_refused_too_not_minted_over(self):
+        """A link to nothing reads as FileNotFoundError, the one mint trigger, so the following shape
+        minted and os.replace'd the fresh file over the link. It is a symlink all the same, and the
+        same refusal; nothing is minted."""
+        self.f.symlink_to(km.jd.STATE / "nowhere-DO-NOT-USE")
+        with self.assertRaises(RuntimeError) as cm:
+            km._load_token()
+        self.assertIn("symlink", str(cm.exception))
+        self.assertTrue(self.f.is_symlink(), "the link is still a link: nothing was renamed over it")
+        self.assertFalse(self.f.exists(), "and nothing was minted at its target")
+        self.assertEqual(self._temps(), [])
+
+
+class TempIsExclusive(_TokenFile):
+    def test_a_file_already_at_this_pids_temp_path_is_not_written_over(self):
+        """O_EXCL on the temp was pinned by source text alone, and an O_EXCL-to-O_TRUNC mutant passed
+        every behavioural case, because the sweep removes any temp before the open ever meets one
+        (review find, 2026-09-08). With the sweep held off (os.unlink interposed to leave the planted
+        file), a file already at this pid's temp path must make the open fail EEXIST, not be
+        truncated and written over. Expected first error on the O_TRUNC mutant: RuntimeError not
+        raised (the planted bytes were replaced by a fresh token and the mint went through)."""
+        planted = self.f.with_name("serve-token.%d.tmp" % os.getpid())
+        planted.write_text("planted-DO-NOT-USE")
+        real_unlink = os.unlink
+
+        def _keep_planted(path, *a, **k):
+            if str(path) == str(planted):
+                return                        # the sweep (and the failed mint's cleanup) would remove it
+            return real_unlink(path, *a, **k)
+
+        os.unlink = _keep_planted
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                km._load_token()
+        finally:
+            os.unlink = real_unlink
+        self.assertIn("EEXIST", str(cm.exception), "the exclusive open met the existing file and said so")
+        self.assertEqual(planted.read_text(), "planted-DO-NOT-USE", "the existing temp was not truncated or written")
+        self.assertFalse(self.f.exists(), "and no token was minted from it")
+
+
+class CheckinCarriesServedToken(_TokenFile):
+    """The check-in handshake hands the hub the token this kernel SERVES: `TOKEN`, the value the request
+    gate compares against (ROMP_SERVE_TOKEN is already folded into it at import). `_checkin_payload`
+    used to call `_load_token()` at runtime, so a token file missing at handshake time minted a fresh
+    one onto disk and announced it: the hub and every local reader of the file then held a token this
+    kernel refused; and a read fault there raised into `_checkin_handshake`'s broad except and became
+    a silent 15 s retry (review find, 2026-09-08). Expected first error on that shape: the file exists
+    after the call, holding a token that is not km.TOKEN."""
+    ROW = {"rk_port": 50003, "rb_port": 50004, "local_port": 50001}
+
+    def setUp(self):
+        super().setUp()
+        self._host = os.environ.get("ROMP_HOST_NAME")
+        os.environ["ROMP_HOST_NAME"] = "TESTHOST"    # keeps _self_host() off the machine's name and its fallback file
+
+    def tearDown(self):
+        if self._host is None:
+            os.environ.pop("ROMP_HOST_NAME", None)
+        else:
+            os.environ["ROMP_HOST_NAME"] = self._host
+
+    def test_with_no_token_file_the_payload_carries_TOKEN_and_mints_nothing(self):
+        p = km._checkin_payload(dict(self.ROW))
+        self.assertEqual(p["token"], km.TOKEN, "the hub gets the token this kernel's gate accepts")
+        self.assertFalse(self.f.exists(), "the handshake never mints: a runtime mint is a token nobody serves")
+        self.assertEqual(self._temps(), [])
+        self.assertFalse(self.lock.exists(), "nor takes the lock: the handshake touches nothing on disk")
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads through mode 0, so the fault cannot be staged")
+    def test_an_unreadable_token_file_is_neither_read_nor_a_swallowed_refusal(self):
+        self.f.write_text("on-disk-DO-NOT-USE\n")
+        os.chmod(self.f, 0)
+        p = km._checkin_payload(dict(self.ROW))     # must not raise: the payload reads no file at all
+        self.assertEqual(p["token"], km.TOKEN)
+        os.chmod(self.f, 0o600)
+        self.assertEqual(self.f.read_text(), "on-disk-DO-NOT-USE\n", "the file is untouched")
+        self.assertEqual(self._temps(), [])
+        self.assertFalse(self.lock.exists(), "the handshake never touches the file, so it never needs the lock")
+
+
+class ImportRefusalIsLoud(unittest.TestCase):
+    """The docstrings say a read fault at import refuses to start the daemon, and that under
+    bin/romp-manager the refusal repeats on the respawn backoff until the file is repaired (review find,
+    2026-09-08: the sentence used to call it one visible message). The import half is pinned here, in a
+    subprocess since the in-process `km` is already loaded: a mode-0 token under a fresh ROMP_STATE_DIR
+    makes the kernel's import exit non-zero with the refusal on stderr, and the file's bytes and mode
+    are as they were, no temp minted beside it. The manager half is bin/romp-manager's own contract
+    (MAX_BACKOFF_MS), not this module's. Expected first error on a loader that mints over a read fault:
+    returncode 0, the file holding a fresh token."""
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads through mode 0, so the fault cannot be staged")
+    def test_a_read_fault_at_import_exits_nonzero_with_the_refusal_and_leaves_the_file(self):
+        state = Path(tempfile.mkdtemp())
+        f = state / "serve-token"
+        f.write_text("old-token-DO-NOT-USE\n")
+        os.chmod(f, 0)
+        self.addCleanup(lambda: (os.chmod(f, 0o600), f.unlink()))
+        env = dict(os.environ)
+        env.pop("ROMP_SERVE_TOKEN", None)    # with it set the loader never touches the file
+        env["ROMP_STATE_DIR"] = str(state)
+        env["ROMP_KERNEL_NO_OPEN"] = "1"
+        loads = [("romp_event_model", os.path.join(BIN, "romp-event-model")),
+                 ("romp_judge", os.path.join(BIN, "romp-judge")),
+                 ("romp_kernel", os.path.join(BIN, "romp-kernel"))]   # the same three loads as this module's own
+        code = ("from importlib.machinery import SourceFileLoader\n"
+                "for name, path in %r:\n"
+                "    SourceFileLoader(name, path).load_module()\n" % (loads,))
+        r = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True, timeout=120)
+        self.assertNotEqual(r.returncode, 0, "the import refuses to start the kernel; stderr:\n%s" % r.stderr[-2000:])
+        self.assertIn("did NOT replace the serve token", r.stderr, "and says so, in the loader's own words")
+        self.assertIn(str(f), r.stderr, "naming the path")
+        self.assertEqual(stat.S_IMODE(os.stat(f).st_mode), 0, "the file's mode is as it was")
+        os.chmod(f, 0o600)
+        self.assertEqual(f.read_text(), "old-token-DO-NOT-USE\n", "and so are its bytes: nothing was rotated")
+        self.assertEqual(sorted(p.name for p in state.glob("serve-token.*.tmp")), [],
+                         "no temp beside it: nothing was minted (the 0600 lock the read was taken under may stay)")
 
 
 class ServeTokenLoadersMatch(unittest.TestCase):
@@ -409,6 +649,9 @@ class ServeTokenLoadersMatch(unittest.TestCase):
                 self.assertIn("n != len(data)", body, "the short-write check")
                 self.assertIn("os.fsync(", body)
                 self.assertIn("os.replace(", body, "the mint lands by rename")
+                self.assertIn("os.lstat(", body, "the mode is the token's own: a link at the path is refused, never followed")
+                self.assertNotIn("os.stat(", body, "stat follows a link")
+                self.assertIn("fcntl.LOCK_NB", body, "the lock is probed before the blocking take, so a wait is said")
                 self.assertNotIn("O_TRUNC", body, "the live path is never truncated")
                 self.assertNotIn("write_text(", body, "no umask-mode write of the token")
 

--- a/tests/test_kernel_serve_token_mode.py
+++ b/tests/test_kernel_serve_token_mode.py
@@ -1,24 +1,42 @@
 #!/usr/bin/env python3
-"""The serve-token file's MODE is the same-user gate on the whole kernel: anything that reads it can
-drive every session. `_load_token` used to `write_text()` and then `chmod 0600`, so between those two
-calls the token sat on disk at whatever the umask allowed (0644 on a stock account, 0666 under a
-permissive one). Opening the file 0600 closes that window.
+"""The serve-token file is the same-user gate on the whole kernel, and every client holds a COPY of
+it (bin/romp and the hooks read the file, the bus and each session's MCP process load it at start,
+peers fetch it at attach). So `_load_token` has two jobs beyond returning a string: the file must be
+0600 from its first byte, and an EXISTING token must never be replaced behind those clients' backs.
 
-This is consistency, not an exploit: `judge.py` chmods the state root to 0700 at import, long before
-the token is minted, so the loose file already sat behind a tight door. But the credential's own mode
-is what the docstring above `_load_token` names as the gate, so it should be right from birth rather
-than a moment later — and the state root's mode is not something this function gets to assume.
+The old loader failed the second job in three ways, each pinned here by a case that fails on it:
+  - ANY read fault fell through to the mint (`except OSError: pass`), so an EACCES or EIO rotated
+    the token: the kernel came up with a credential nobody else held. UnreadableIsNotRotated.
+  - Two starters (kernel and bus boot together) each minted their own, last writer winning while
+    the loser served a token the file no longer held. ServeTokenFlock.
+  - The mint opened the LIVE path with O_TRUNC, so a concurrent reader saw an empty file and
+    minted its own. TokenBirth pins the temp-then-rename shape and that the live path is never
+    opened for writing at all.
+TightenMode (a loose existing file is chmod'd, its value kept), EmptyFileMints (a 0-byte or
+whitespace file is a torn earlier mint and is minted over, aloud), LockFailureIsFailClosed (no
+lock: a good 0600 token is returned, anything else is a refusal) and StaleTempsAreSwept (a crashed
+attempt's temp, any pid's, is removed before the mint) pin the rest of the contract, and
+ServeTokenLoadersMatch pins the bus's copy of the routine to the kernel's, since the bus imports
+nothing from kernel/ and carries its own: AST identity with the docstring stripped (any divergence
+is red), plus the named invariants as a readable second layer.
 
-The mode test has to INTERPOSE on os.chmod. Without that the trailing chmod repairs the mode before
-anything can observe it, and the assertion passes on the unfixed code too.
+ServeTokenFileMode is the original mode case. It INTERPOSES on os.chmod because the old shape's
+trailing chmod repaired the mode before anything could observe it; the shape now needs no chmod on
+a fresh mint at all, and that is what the case asserts.
 
-Synthetic only — hermetic temp STATE, placeholder token.
+Synthetic only: hermetic temp STATE, placeholder tokens.
 """
+import ast
+import contextlib
+import io
 import os
+import re
 import stat
 import tempfile
+import threading
 import unittest
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -36,31 +54,46 @@ def _mode(p):
     return stat.S_IMODE(os.stat(p).st_mode)
 
 
-class ServeTokenFileMode(unittest.TestCase):
+class _TokenFile(unittest.TestCase):
+    """Every case starts and ends with no token, no lock and no temp under the test's own STATE.
+    ROMP_SERVE_TOKEN is moved out of the way (with it set the loader returns it verbatim and never
+    touches the file), and the umask is 0 so only the loader's own modes protect what it writes."""
+
     def setUp(self):
         self.f = km.jd.STATE / "serve-token"
+        self.lock = self.f.with_name("serve-token.lock")
         km.jd.STATE.mkdir(parents=True, exist_ok=True)
-        if self.f.exists():
-            self.f.unlink()
-        # _load_token returns ROMP_SERVE_TOKEN verbatim and never touches the file while it is set,
-        # so the mint path is only reachable with it out of the way.
+        self._env = self._umask = None
+        self.addCleanup(self._restore)      # registered FIRST: a failing _clear() must not leak a zeroed umask
         self._env = os.environ.pop("ROMP_SERVE_TOKEN", None)
-        self._umask = os.umask(0)            # the widest case: only the open mode protects the file
-        self.addCleanup(self._restore)
+        self._umask = os.umask(0)
+        self._clear()
+
+    def _clear(self):
+        for p in [self.f, self.lock] + list(km.jd.STATE.glob("serve-token.*.tmp")):
+            if p.is_dir():
+                p.rmdir()                    # LockFailureIsFailClosed plants a directory at the lock path
+            elif p.exists():
+                p.unlink()
 
     def _restore(self):
-        os.umask(self._umask)
+        self._clear()
+        if self._umask is not None:
+            os.umask(self._umask)
         if self._env is not None:
             os.environ["ROMP_SERVE_TOKEN"] = self._env
-        if self.f.exists():
-            self.f.unlink()
 
+    def _temps(self):
+        return sorted(p.name for p in km.jd.STATE.glob("serve-token.*.tmp"))
+
+
+class ServeTokenFileMode(_TokenFile):
     def test_minted_0600_before_any_chmod_can_repair_it(self):
         chmods = []
         real_chmod = os.chmod
 
         def _no_chmod(path, mode, *a, **k):
-            """Record the repair and DON'T perform it — the mode the open() gave the file is the
+            """Record the repair and DON'T perform it: the mode the file was created with is the
             whole question, and a chmod one line later hides the answer."""
             chmods.append((str(path), mode))
 
@@ -76,17 +109,19 @@ class ServeTokenFileMode(unittest.TestCase):
                          "the serve token must be 0600 from the open() that created it: writing it "
                          "first and chmod'ing after leaves the credential at the umask's mercy for "
                          "the gap between the two calls")
-        self.assertEqual(chmods, [(str(self.f), 0o600)],
-                         "the chmod after the write must stay — it is what tightens a PRE-EXISTING "
-                         "file, whose mode O_CREAT does not touch")
+        self.assertEqual(chmods, [],
+                         "a fresh mint needs no chmod at all: the temp is opened 0600 and renamed into "
+                         "place, so there is no pre-existing inode to tighten (TightenMode covers the "
+                         "one case where there is)")
 
     def test_a_pre_existing_loose_file_is_still_tightened(self):
-        # O_CREAT applies its mode only when it actually creates the file. An empty serve-token left
-        # at 0644 (a stale one, or one written before this change) re-mints through the same path and
-        # must come out 0600 — that is the chmod's remaining job, so it does not get dropped.
-        self.f.write_text("")                # empty → falsy → falls through to the mint
+        # An empty serve-token left at 0644 (a torn earlier mint, or one written before this change)
+        # is minted over: the rename swaps in a NEW inode born 0600, so the loose mode goes with the
+        # old one.
+        self.f.write_text("")                # empty → a torn earlier mint → falls through to the mint
         os.chmod(self.f, 0o644)
-        tok = km._load_token()
+        with contextlib.redirect_stderr(io.StringIO()):
+            tok = km._load_token()
         self.assertEqual(self.f.read_text().strip(), tok)
         self.assertEqual(_mode(self.f), 0o600,
                          "a token file that already existed at 0644 must not keep that mode")
@@ -100,6 +135,290 @@ class ServeTokenFileMode(unittest.TestCase):
         finally:
             os.environ.pop("ROMP_SERVE_TOKEN", None)
         self.assertFalse(self.f.exists(), "the env override must not mint or persist anything")
+        self.assertFalse(self.lock.exists(), "nor take the lock: there is nothing on disk to guard")
+
+
+class ServeTokenFlock(_TokenFile):
+    def test_racing_starters_read_one_token_and_the_lock_file_is_0600(self):
+        """N starters with no token on disk. Without the lock each one reads 'absent' and mints its
+        own, so N distinct tokens come back and N-1 callers hold one the file no longer has. The
+        barrier inside os.urandom widens that window deterministically: on the unlocked shape every
+        racer reaches the mint before any of them writes. Under the lock only the FIRST racer ever
+        gets there (the rest block on flock and then read its token), so it waits out the barrier
+        alone and moves on. Expected first error on the old loader: 6 != 1 at the one-token check."""
+        n = 6
+        gate = threading.Barrier(n)
+        real_urandom = os.urandom
+        mints = []
+
+        def _urandom(k):
+            mints.append(threading.get_ident())
+            try:
+                gate.wait(timeout=1.0)
+            except threading.BrokenBarrierError:
+                pass                          # under the lock the first racer is here alone: move on
+            return real_urandom(k)
+
+        out, errs = [], []
+
+        def run():
+            try:
+                out.append(km._load_token())
+            except BaseException as e:        # surfaced by the assertion below, never swallowed
+                errs.append(repr(e))
+
+        os.urandom = _urandom
+        try:
+            ts = [threading.Thread(target=run) for _ in range(n)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(15)
+        finally:
+            os.urandom = real_urandom
+
+        self.assertEqual(errs, [], "no racer may fail: a fresh mint is the ordinary first boot")
+        self.assertEqual(len(out), n)
+        self.assertEqual(len(set(out)), 1,
+                         "every starter must come away holding the SAME token: %d distinct ones means "
+                         "the losers now hold credentials the daemon will refuse" % len(set(out)))
+        self.assertEqual(self.f.read_text().strip(), out[0])
+        self.assertEqual(len(mints), 1, "exactly one starter minted; the rest read its token under the lock")
+        self.assertTrue(self.lock.exists(), "the lock is a sibling file, serve-token.lock")
+        self.assertEqual(_mode(self.lock), 0o600)
+        self.assertEqual(self._temps(), [], "no temp survives a finished mint")
+
+
+class TokenBirth(_TokenFile):
+    def test_token_is_0600_from_its_first_byte_and_the_live_path_is_never_opened_for_writing(self):
+        """Under a stock 022 umask. The mint must land by renaming a FINISHED temp onto the path:
+        os.replace is interposed to stat and read the temp at the instant of the swap, and os.open is
+        interposed to record every open of the live path (there must be none: O_TRUNC on it is the
+        torn window a concurrent reader fell into). Expected first error on the old loader: the
+        rename count is 0, because it wrote the live file in place."""
+        os.umask(0o022)
+        swaps, opens = [], []
+        real_replace, real_open = os.replace, os.open
+
+        def _replace(src, dst, *a, **k):
+            swaps.append((str(src), str(dst), _mode(src), Path(src).read_text()))
+            return real_replace(src, dst, *a, **k)
+
+        def _open(path, flags, *a, **k):
+            opens.append((str(path), flags))
+            return real_open(path, flags, *a, **k)
+
+        os.replace, os.open = _replace, _open
+        try:
+            tok = km._load_token()
+        finally:
+            os.replace, os.open = real_replace, real_open
+
+        self.assertEqual(len(swaps), 1, "the mint must land by one rename of a finished temp file")
+        src, dst, mode, body = swaps[0]
+        self.assertEqual(dst, str(self.f))
+        self.assertEqual(mode, 0o600, "the temp is born 0600 under a 022 umask: the open mode, not the umask, decides")
+        self.assertEqual(body, tok, "the temp already holds the whole token when it is swapped in")
+        self.assertTrue(Path(src).name.startswith("serve-token.") and src.endswith(".tmp"), src)
+        self.assertEqual(Path(src).parent, self.f.parent, "same directory, so the rename is atomic")
+        self.assertFalse(Path(src).exists(), "the temp is gone after the swap")
+        live = [flags for path, flags in opens if path == str(self.f)]
+        self.assertEqual(live, [], "the live token path is never opened for writing at all")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertEqual(self.f.read_text(), tok)
+
+
+class UnreadableIsNotRotated(_TokenFile):
+    @unittest.skipIf(os.geteuid() == 0, "root reads through mode 0, so the fault cannot be staged")
+    def test_an_unreadable_existing_token_is_a_fault_not_a_rotation(self):
+        """An existing token the loader cannot read is the one case that must NOT mint: every
+        client still holds the old value, and a fresh one would strand them all. Expected first
+        error on the old loader: RuntimeError not raised (it returned a new random token while the
+        file kept the old one, which is exactly the strand)."""
+        self.f.write_text("old-token-DO-NOT-USE\n")
+        os.chmod(self.f, 0)
+        with self.assertRaises(RuntimeError) as cm:
+            km._load_token()
+        msg = str(cm.exception)
+        self.assertIn(str(self.f), msg, "the refusal names the file to fix")
+        self.assertIn("EACCES", msg, "and the errno, by name")
+        self.assertIn("NOT replace", msg, "and says the token every client holds is still the token")
+        os.chmod(self.f, 0o600)
+        self.assertEqual(self.f.read_text(), "old-token-DO-NOT-USE\n", "the file is untouched, byte for byte")
+        self.assertEqual(self._temps(), [], "no temp left behind by a mint that must not have started")
+
+    def test_a_token_that_is_not_utf8_text_is_a_fault_not_a_rotation(self):
+        """A read fault that is not an OSError: bytes that do not decode. It must reach the same
+        refusal, naming the path, with the file untouched. Old loader: UnicodeDecodeError escaped
+        its `except OSError` and the loader raised THAT (the case errors rather than fails on it)."""
+        raw = b"\xff\xfe\x00tok"
+        self.f.write_bytes(raw)
+        os.chmod(self.f, 0o600)
+        with self.assertRaises(RuntimeError) as cm:
+            km._load_token()
+        self.assertIn(str(self.f), str(cm.exception), "the refusal names the file to fix")
+        self.assertIn("UnicodeDecodeError", str(cm.exception), "and what was wrong with it")
+        self.assertEqual(self.f.read_bytes(), raw, "the file is untouched, byte for byte")
+        self.assertEqual(self._temps(), [])
+
+
+class StaleTempsAreSwept(_TokenFile):
+    def test_another_pids_crashed_temp_is_removed_by_the_next_mint(self):
+        """A `serve-token.<pid>.tmp` left by a starter that died between open and rename is swept
+        before the next mint writes its own: the lock is held, so any temp beside the token is a
+        crashed attempt, whichever pid named it. Old loader: no temps at all, so the planted file
+        simply stays (assertFalse on its existence fails)."""
+        stale = self.f.with_name("serve-token.99999.tmp")
+        stale.write_text("half-written-DO-NOT-USE")
+        tok = km._load_token()
+        self.assertFalse(stale.exists(), "the stale temp is gone")
+        self.assertEqual(self.f.read_text(), tok, "and the token was minted")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertEqual(self._temps(), [])
+
+
+class TightenMode(_TokenFile):
+    def test_a_loose_existing_token_is_tightened_and_returned_unchanged(self):
+        """A readable token at 0644 (written by hand, or by a loader older than the 0600 open) is
+        the gate with the door open. Its VALUE is fine, so it is kept and the mode is repaired, and
+        the repair is said once on stderr. Expected first error on the old loader: 0o644 != 0o600,
+        since it only chmod'd on the mint path and a readable file never reached it."""
+        self.f.write_text("keep-me-DO-NOT-USE\n")
+        os.chmod(self.f, 0o644)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            tok = km._load_token()
+        self.assertEqual(tok, "keep-me-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertEqual(self.f.read_text(), "keep-me-DO-NOT-USE\n", "tightening the mode rewrites nothing")
+        self.assertIn("644", err.getvalue())
+        self.assertIn("0600", err.getvalue())
+        self.assertEqual(self._temps(), [], "no mint happened")
+
+    def test_a_good_0600_token_is_returned_silently(self):
+        self.f.write_text("fine-DO-NOT-USE\n")
+        os.chmod(self.f, 0o600)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._load_token(), "fine-DO-NOT-USE")
+        self.assertEqual(err.getvalue(), "", "the ordinary boot says nothing")
+        self.assertEqual(_mode(self.f), 0o600)
+
+
+class EmptyFileMints(_TokenFile):
+    def test_an_empty_or_whitespace_file_is_a_torn_mint_and_is_minted_over_aloud(self):
+        """A 0-byte (or whitespace-only) token file is treated as ABSENT, not as a fault: no client
+        can be holding a token that was never written, so nothing is stranded by minting over it,
+        and the old in-place shape could leave exactly this behind. It is said on stderr because
+        the file's existence is evidence of an earlier interrupted start. Expected first error on
+        the old loader: 'empty' not found in '' (it minted, but silently)."""
+        for body in ("", "  \n"):
+            self._clear()
+            self.f.write_text(body)
+            os.chmod(self.f, 0o644)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                tok = km._load_token()
+            self.assertTrue(tok, "a token was minted")
+            self.assertEqual(self.f.read_text(), tok)
+            self.assertEqual(_mode(self.f), 0o600, "the swapped-in inode is born 0600; the loose mode left with the old one")
+            self.assertIn("empty", err.getvalue(), "the torn earlier mint is said on stderr")
+            self.assertEqual(self._temps(), [])
+
+
+class LockFailureIsFailClosed(_TokenFile):
+    def test_no_lock_tolerates_only_a_good_0600_token(self):
+        """A directory planted at the lock path makes os.open(O_RDWR|O_CREAT) fail with EISDIR, the
+        same way an unwritable state dir or a foreign file there would. Without the lock the loader
+        may return an existing, non-empty, 0600 token (nothing to mint, nothing to tighten) and must
+        refuse everything else: minting or chmod'ing unlocked is the race again. Expected first
+        error on the old loader: RuntimeError not raised at (b), since it had no lock to fail."""
+        self.lock.mkdir()
+        # (a) a good token: returned as is, and the missing lock is said on stderr
+        self.f.write_text("good-DO-NOT-USE")
+        os.chmod(self.f, 0o600)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._load_token(), "good-DO-NOT-USE")
+        self.assertIn(str(self.lock), err.getvalue())
+        # (b) a loose token: cannot be tightened without the lock, so it is a refusal, and no chmod happens
+        os.chmod(self.f, 0o644)
+        with self.assertRaises(RuntimeError) as cm:
+            km._load_token()
+        self.assertIn(str(self.lock), str(cm.exception), "the refusal names the lock path")
+        self.assertIn("EISDIR", str(cm.exception))
+        self.assertEqual(_mode(self.f), 0o644, "no unlocked write of any kind, not even a chmod")
+        # (c) no token: cannot be minted without the lock, so it is a refusal, and nothing appears
+        self.f.unlink()
+        with self.assertRaises(RuntimeError):
+            km._load_token()
+        self.assertFalse(self.f.exists(), "nothing minted unlocked")
+        self.assertEqual(self._temps(), [])
+
+
+class ServeTokenLoadersMatch(unittest.TestCase):
+    """The bus imports nothing from kernel/ (by design: it is one self-contained file, and the two
+    daemons boot together), so postal_service.py carries its OWN copy of _serve_token_read_or_mint.
+    Two layers pin the copies together. The AST identity (docstring stripped) is the gate: ANY
+    divergence is red, so a fix to one copy that forgets the other cannot land. The named invariants
+    are the readable layer that says WHAT a divergence broke. The gate exists because three
+    postal-only mutants got past the invariants alone in review: the tighten removed, the
+    lock-failure arm returning any non-empty token regardless of mode, and the empty file raising
+    instead of minting; each is also killed by its own postal case in tests/test_postal_token.py."""
+    KERNEL = Path(HERE).parent / "kernel" / "kernel.py"
+    POSTAL = Path(HERE).parent / "postal" / "postal_service.py"
+
+    @staticmethod
+    def _body(src, name):
+        m = re.search(r"^def %s\(.*?(?=^\S)" % re.escape(name), src, re.S | re.M)
+        assert m, "no top-level def %s" % name
+        return m.group(0)
+
+    @staticmethod
+    def _func(path, name):
+        """The top-level def as an AST, with a leading docstring removed (the kernel's copy carries
+        the reasoning; the bus's copy points at it)."""
+        for node in ast.parse(path.read_text(), filename=str(path)).body:
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                first = node.body[0] if node.body else None
+                if (isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant)
+                        and isinstance(first.value.value, str)):
+                    node.body = node.body[1:]
+                return node
+        raise AssertionError("no top-level def %s in %s" % (name, path.name))
+
+    def test_both_copies_are_one_function_once_the_docstring_is_stripped(self):
+        k = self._func(self.KERNEL, "_serve_token_read_or_mint")
+        p = self._func(self.POSTAL, "_serve_token_read_or_mint")
+        # unparse first for a readable line diff; ast.dump is the strict gate (it sees what unparse normalizes)
+        self.assertEqual(ast.unparse(k).splitlines(), ast.unparse(p).splitlines(),
+                         "the bus's copy has drifted from the kernel's")
+        self.assertEqual(ast.dump(k), ast.dump(p))
+
+    def test_both_copies_keep_the_invariants(self):
+        for path in (self.KERNEL, self.POSTAL):
+            body = self._body(path.read_text(), "_serve_token_read_or_mint")
+            with self.subTest(file=path.name):
+                self.assertIn("fcntl.flock(", body, "the read-or-mint runs under an flock")
+                self.assertIn("fcntl.LOCK_EX", body)
+                self.assertIn('".lock"', body, "the lock is the sibling serve-token.lock")
+                self.assertIn("except FileNotFoundError", body, "absence is the ONLY mint trigger")
+                self.assertIn("RuntimeError", body, "any other fault is a refusal, never a rotation")
+                self.assertIn("os.O_EXCL", body, "the temp is created exclusively")
+                self.assertIn("0o600", body)
+                self.assertIn("n != len(data)", body, "the short-write check")
+                self.assertIn("os.fsync(", body)
+                self.assertIn("os.replace(", body, "the mint lands by rename")
+                self.assertNotIn("O_TRUNC", body, "the live path is never truncated")
+                self.assertNotIn("write_text(", body, "no umask-mode write of the token")
+
+    def test_both_loaders_route_through_the_shared_shape(self):
+        k = self._body(self.KERNEL.read_text(), "_load_token")
+        p = self._body(self.POSTAL.read_text(), "_load_serve_token")
+        self.assertIn("_serve_token_read_or_mint(", k)
+        self.assertIn("_serve_token_read_or_mint(", p)
+        for body in (k, p):
+            self.assertNotIn("read_text(", body, "the loader itself touches no file; the helper does, under the lock")
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -13,10 +13,12 @@ kernel's tests pin in tests/test_kernel_serve_token_mode.py, whose docstring car
 born 0600 by rename of a finished temp with the live path never opened for writing, one mint among
 racing starters under serve-token.lock, an unreadable existing token is a refusal, never a rotation
 (the old bus loader minted its OWN token on any read fault, and every request it then made was a
-silent 403), a loose token is tightened and kept, an empty file is minted over aloud, and without the
-lock only a good 0600 token is returned. The last three each kill a postal-only mutant that the
-kernel tests' invariant pins let through in review; the kernel tests' AST-identity pin now catches
-any such drift as well, and these say what it broke.
+silent 403), a loose token is tightened and kept (only the bits outside 0600 go; a tighter 0400 is
+left alone), a symlink at the token path is refused with its target untouched, an empty file is
+minted over aloud, and without the lock only a token with nothing to tighten is returned, the
+refusal otherwise naming the lock. The tighten, empty-file and lock-failure cases each kill a
+postal-only mutant that the kernel tests' invariant pins let through in review; the kernel tests'
+AST-identity pin now catches any such drift as well, and these say what it broke.
 
 Synthetic only — hermetic temp state dir, placeholder names, no real session data.
 """
@@ -45,9 +47,25 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text("[]")
 os.environ["ROMP_SESSIONS_FILE"] = _SESS
-ps = SourceFileLoader("romp_postal_token", os.path.join(BIN, "romp-postal-service")).load_module()
+# An INVENTED token, assigned (not setdefault) for the load only: with the runner's own ROMP_SERVE_TOKEN
+# exported, TOK was that real token, and _PostalTokenFile._restore wrote it to disk under the test's
+# state dir (review find, 2026-09-08). Nothing real ever reaches this file now. The variable is put
+# back the moment the bus has captured it: pytest imports every collected module before any test
+# runs, so an import-time write that STAYED would change what every sibling module sends or captures
+# from os.environ (the hazard test_color_route.py and test_perf_stats.py describe); a write this
+# module made for itself must not outlive its own import.
+_prev_serve_token = os.environ.get("ROMP_SERVE_TOKEN")
+os.environ["ROMP_SERVE_TOKEN"] = "bus-test-token-DO-NOT-USE"
+try:
+    ps = SourceFileLoader("romp_postal_token", os.path.join(BIN, "romp-postal-service")).load_module()
+finally:
+    if _prev_serve_token is None:
+        os.environ.pop("ROMP_SERVE_TOKEN", None)
+    else:
+        os.environ["ROMP_SERVE_TOKEN"] = _prev_serve_token
 
 TOK = ps.SERVE_TOKEN
+assert TOK == "bus-test-token-DO-NOT-USE", "the gate's constant is the invented token, never the runner's"
 
 
 def _code(port, path, headers=None, method="GET", data=None):
@@ -308,9 +326,9 @@ def _mode(p):
 
 class _PostalTokenFile(unittest.TestCase):
     """Drives _load_serve_token against the file the kernel mints (STATE.parent / "serve-token").
-    SERVE_TOKEN, the module constant the gate compares against, was minted at import and is not
-    touched; each case ends by putting TOK back so the file and the constant agree again. The umask
-    is 0 so only the loader's own modes protect what it writes."""
+    SERVE_TOKEN, the module constant the gate compares against, is the invented TOK from import and
+    is not touched; each case ends by putting TOK back so the file and the constant agree again. The
+    umask is 0 so only the loader's own modes protect what it writes."""
 
     def setUp(self):
         self.f = ps.STATE.parent / "serve-token"
@@ -325,7 +343,7 @@ class _PostalTokenFile(unittest.TestCase):
         for p in [self.f, self.lock] + list(self.f.parent.glob("serve-token.*.tmp")):
             if p.is_dir():
                 p.rmdir()                    # PostalLockFailureIsFailClosed plants a directory at the lock path
-            elif p.exists():
+            elif p.is_symlink() or p.exists():   # PostalSymlinkIsRefused plants a link
                 p.unlink()
 
     def _restore(self):
@@ -456,6 +474,47 @@ class PostalTightenMode(_PostalTokenFile):
         self.assertIn("0600", err.getvalue())
         self.assertEqual(self._temps(), [])
 
+    def test_a_tighter_token_is_left_alone_and_only_loose_bits_are_stripped(self):
+        """0400 has nothing outside 0600 and is left as is, silently; 0640 loses its group read and
+        keeps its owner bits. The equality check widened 0400 to 0600 and called it a repair (review
+        find, 2026-09-08). Expected first error on that shape: 0o600 != 0o400."""
+        self.f.write_text("tight-DO-NOT-USE\n")
+        os.chmod(self.f, 0o400)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(ps._load_serve_token(), "tight-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o400, "a mode tighter than 0600 is not widened")
+        self.assertEqual(err.getvalue(), "", "and nothing is said: nothing was changed")
+        self._clear()
+        self.f.write_text("keep-me-DO-NOT-USE\n")
+        os.chmod(self.f, 0o640)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(ps._load_serve_token(), "keep-me-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertIn("0640", err.getvalue())
+        self.assertIn("0600", err.getvalue())
+
+
+class PostalSymlinkIsRefused(_PostalTokenFile):
+    def test_a_symlink_at_the_token_path_is_a_fault_and_its_target_is_untouched(self):
+        """stat and chmod follow a link, so the following shape read some other file as the token and
+        rewrote that file's mode (review find, 2026-09-08). Expected first error on it: RuntimeError
+        not raised."""
+        target = self.f.parent / "elsewhere-DO-NOT-USE"
+        target.write_text("linked-DO-NOT-USE\n")
+        os.chmod(target, 0o644)
+        self.addCleanup(target.unlink)
+        self.f.symlink_to(target)
+        with self.assertRaises(RuntimeError) as cm:
+            ps._load_serve_token()
+        self.assertIn(str(self.f), str(cm.exception), "the refusal names the token path")
+        self.assertIn("symlink", str(cm.exception))
+        self.assertEqual(_mode(target), 0o644, "the target's mode is not rewritten through the link")
+        self.assertEqual(target.read_text(), "linked-DO-NOT-USE\n")
+        self.assertTrue(self.f.is_symlink(), "the link is left for the operator to remove")
+        self.assertEqual(self._temps(), [])
+
 
 class PostalEmptyFileMints(_PostalTokenFile):
     def test_an_empty_or_whitespace_file_is_a_torn_mint_and_is_minted_over_aloud(self):
@@ -493,9 +552,16 @@ class PostalLockFailureIsFailClosed(_PostalTokenFile):
         self.assertIn(str(self.lock), str(cm.exception), "the refusal names the lock path")
         self.assertIn("EISDIR", str(cm.exception))
         self.assertEqual(_mode(self.f), 0o644, "no unlocked write of any kind, not even a chmod")
+        os.chmod(self.f, 0o400)               # (d) tighter than 0600: nothing to tighten, so returned like a 0600 one
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(ps._load_serve_token(), "good-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o400)
         self.f.unlink()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as cm:
             ps._load_serve_token()
+        self.assertIn(str(self.lock), str(cm.exception), "with no token file, the refusal names the lock and the fault")
+        self.assertIn("no token file", str(cm.exception))
+        self.assertNotIn("Make the file yours", str(cm.exception), "not a token file that does not exist (review find, 2026-09-08)")
         self.assertFalse(self.f.exists(), "nothing minted unlocked")
         self.assertEqual(self._temps(), [])
 

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -7,11 +7,25 @@ the 0600 file) and ?token= (a peer bus dialing through the ssh forward with the 
 machine's token). Also pins the peer-token plumbing: /peer notifies carry the peer's
 token, a token-less down notify keeps the last known one, and the dialer sends ?token=.
 
+The Postal* classes pin the bus's COPY of the serve-token read-or-mint (`_serve_token_read_or_mint`,
+the same shape as the kernel's; the bus imports nothing from kernel/) to the same contract the
+kernel's tests pin in tests/test_kernel_serve_token_mode.py, whose docstring carries the reasoning:
+born 0600 by rename of a finished temp with the live path never opened for writing, one mint among
+racing starters under serve-token.lock, an unreadable existing token is a refusal, never a rotation
+(the old bus loader minted its OWN token on any read fault, and every request it then made was a
+silent 403), a loose token is tightened and kept, an empty file is minted over aloud, and without the
+lock only a good 0600 token is returned. The last three each kill a postal-only mutant that the
+kernel tests' invariant pins let through in review; the kernel tests' AST-identity pin now catches
+any such drift as well, and these say what it broke.
+
 Synthetic only — hermetic temp state dir, placeholder names, no real session data.
 """
+import contextlib
+import io
 import json
 import os
 import socket
+import stat
 import tempfile
 import threading
 import time
@@ -288,6 +302,202 @@ class TrackedIsABoolean(_BusServer):
             self.assertIs(dialed[0][2]["tracked"], True, "a real true rides the wire as itself")
         finally:
             ps._http, ps.my_name, ps.my_id, ps._heartbeat = saved
+def _mode(p):
+    return stat.S_IMODE(os.stat(p).st_mode)
+
+
+class _PostalTokenFile(unittest.TestCase):
+    """Drives _load_serve_token against the file the kernel mints (STATE.parent / "serve-token").
+    SERVE_TOKEN, the module constant the gate compares against, was minted at import and is not
+    touched; each case ends by putting TOK back so the file and the constant agree again. The umask
+    is 0 so only the loader's own modes protect what it writes."""
+
+    def setUp(self):
+        self.f = ps.STATE.parent / "serve-token"
+        self.lock = self.f.with_name("serve-token.lock")
+        self._env = self._umask = None
+        self.addCleanup(self._restore)      # registered FIRST: a failing _clear() must not leak a zeroed umask
+        self._env = os.environ.pop("ROMP_SERVE_TOKEN", None)
+        self._umask = os.umask(0)
+        self._clear()
+
+    def _clear(self):
+        for p in [self.f, self.lock] + list(self.f.parent.glob("serve-token.*.tmp")):
+            if p.is_dir():
+                p.rmdir()                    # PostalLockFailureIsFailClosed plants a directory at the lock path
+            elif p.exists():
+                p.unlink()
+
+    def _restore(self):
+        self._clear()
+        self.f.write_text(TOK)
+        os.chmod(self.f, 0o600)
+        if self._umask is not None:
+            os.umask(self._umask)
+        if self._env is not None:
+            os.environ["ROMP_SERVE_TOKEN"] = self._env
+
+    def _temps(self):
+        return sorted(p.name for p in self.f.parent.glob("serve-token.*.tmp"))
+
+
+class PostalTokenBirth(_PostalTokenFile):
+    def test_token_is_0600_from_its_first_byte_and_the_live_path_is_never_opened_for_writing(self):
+        """Expected first error on the old loader: the rename count is 0 (it wrote the live file with
+        write_text, at the umask's mode, and chmod'd it a line later)."""
+        os.umask(0o022)
+        swaps, opens = [], []
+        real_replace, real_open = os.replace, os.open
+
+        def _replace(src, dst, *a, **k):
+            swaps.append((str(src), str(dst), _mode(src), Path(src).read_text()))
+            return real_replace(src, dst, *a, **k)
+
+        def _open(path, flags, *a, **k):
+            opens.append((str(path), flags))
+            return real_open(path, flags, *a, **k)
+
+        os.replace, os.open = _replace, _open
+        try:
+            tok = ps._load_serve_token()
+        finally:
+            os.replace, os.open = real_replace, real_open
+
+        self.assertEqual(len(swaps), 1, "the mint must land by one rename of a finished temp file")
+        src, dst, mode, body = swaps[0]
+        self.assertEqual(dst, str(self.f))
+        self.assertEqual(mode, 0o600, "the temp is born 0600 under a 022 umask")
+        self.assertEqual(body, tok, "the temp already holds the whole token when it is swapped in")
+        self.assertEqual(Path(src).parent, self.f.parent, "same directory, so the rename is atomic")
+        self.assertFalse(Path(src).exists(), "the temp is gone after the swap")
+        self.assertEqual([fl for path, fl in opens if path == str(self.f)], [],
+                         "the live token path is never opened for writing at all")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertEqual(self.f.read_text(), tok)
+
+
+class PostalTokenFlock(_PostalTokenFile):
+    def test_racing_starters_read_one_token_and_the_lock_file_is_0600(self):
+        """The barrier inside os.urandom holds every unlocked racer at the mint until all have read
+        'absent'; under the lock only the first racer gets there and waits it out alone. Expected
+        first error on the old loader: 6 != 1 at the one-token check."""
+        n = 6
+        gate = threading.Barrier(n)
+        real_urandom = os.urandom
+        mints = []
+
+        def _urandom(k):
+            mints.append(threading.get_ident())
+            try:
+                gate.wait(timeout=1.0)
+            except threading.BrokenBarrierError:
+                pass
+            return real_urandom(k)
+
+        out, errs = [], []
+
+        def run():
+            try:
+                out.append(ps._load_serve_token())
+            except BaseException as e:        # surfaced by the assertion below, never swallowed
+                errs.append(repr(e))
+
+        os.urandom = _urandom
+        try:
+            ts = [threading.Thread(target=run) for _ in range(n)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join(15)
+        finally:
+            os.urandom = real_urandom
+
+        self.assertEqual(errs, [])
+        self.assertEqual(len(out), n)
+        self.assertEqual(len(set(out)), 1, "every starter must come away holding the SAME token")
+        self.assertEqual(self.f.read_text().strip(), out[0])
+        self.assertEqual(len(mints), 1, "exactly one starter minted; the rest read its token under the lock")
+        self.assertTrue(self.lock.exists())
+        self.assertEqual(_mode(self.lock), 0o600)
+        self.assertEqual(self._temps(), [])
+
+
+class PostalUnreadableIsNotRotated(_PostalTokenFile):
+    @unittest.skipIf(os.geteuid() == 0, "root reads through mode 0, so the fault cannot be staged")
+    def test_an_unreadable_existing_token_is_a_fault_not_a_rotation(self):
+        """Expected first error on the old loader: RuntimeError not raised (it returned a fresh
+        random token the kernel would refuse, while the file kept the real one)."""
+        self.f.write_text("old-token-DO-NOT-USE\n")
+        os.chmod(self.f, 0)
+        with self.assertRaises(RuntimeError) as cm:
+            ps._load_serve_token()
+        msg = str(cm.exception)
+        self.assertIn(str(self.f), msg, "the refusal names the file to fix")
+        self.assertIn("EACCES", msg, "and the errno, by name")
+        self.assertIn("NOT replace", msg)
+        os.chmod(self.f, 0o600)
+        self.assertEqual(self.f.read_text(), "old-token-DO-NOT-USE\n", "the file is untouched, byte for byte")
+        self.assertEqual(self._temps(), [])
+
+
+class PostalTightenMode(_PostalTokenFile):
+    def test_a_loose_existing_token_is_tightened_and_returned_unchanged(self):
+        """Kills the postal-only mutant that drops the tighten. Old loader: 0o644 != 0o600 (a
+        readable file never reached its chmod)."""
+        self.f.write_text("keep-me-DO-NOT-USE\n")
+        os.chmod(self.f, 0o644)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            tok = ps._load_serve_token()
+        self.assertEqual(tok, "keep-me-DO-NOT-USE")
+        self.assertEqual(_mode(self.f), 0o600)
+        self.assertEqual(self.f.read_text(), "keep-me-DO-NOT-USE\n", "tightening the mode rewrites nothing")
+        self.assertIn("644", err.getvalue())
+        self.assertIn("0600", err.getvalue())
+        self.assertEqual(self._temps(), [])
+
+
+class PostalEmptyFileMints(_PostalTokenFile):
+    def test_an_empty_or_whitespace_file_is_a_torn_mint_and_is_minted_over_aloud(self):
+        """Kills the postal-only mutant that raises on an empty file instead of minting over it.
+        Old loader: 'empty' not found in '' (it minted, but silently)."""
+        for body in ("", "  \n"):
+            self._clear()
+            self.f.write_text(body)
+            os.chmod(self.f, 0o644)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                tok = ps._load_serve_token()
+            self.assertTrue(tok, "a token was minted")
+            self.assertEqual(self.f.read_text(), tok)
+            self.assertEqual(_mode(self.f), 0o600)
+            self.assertIn("empty", err.getvalue(), "the torn earlier mint is said on stderr")
+            self.assertEqual(self._temps(), [])
+
+
+class PostalLockFailureIsFailClosed(_PostalTokenFile):
+    def test_no_lock_tolerates_only_a_good_0600_token(self):
+        """Kills the postal-only mutant whose lock-failure arm returns any non-empty token
+        regardless of mode (case b). Old loader: the lock path is not said on stderr at (a), and
+        the refusals at (b) and (c) are not raised either."""
+        self.lock.mkdir()
+        self.f.write_text("good-DO-NOT-USE")
+        os.chmod(self.f, 0o600)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(ps._load_serve_token(), "good-DO-NOT-USE")
+        self.assertIn(str(self.lock), err.getvalue())
+        os.chmod(self.f, 0o644)
+        with self.assertRaises(RuntimeError) as cm:
+            ps._load_serve_token()
+        self.assertIn(str(self.lock), str(cm.exception), "the refusal names the lock path")
+        self.assertIn("EISDIR", str(cm.exception))
+        self.assertEqual(_mode(self.f), 0o644, "no unlocked write of any kind, not even a chmod")
+        self.f.unlink()
+        with self.assertRaises(RuntimeError):
+            ps._load_serve_token()
+        self.assertFalse(self.f.exists(), "nothing minted unlocked")
+        self.assertEqual(self._temps(), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The serve token is the one credential every romp client holds a copy of: `bin/romp` and the hooks read the file, the bus and each session's MCP process load it at their own start, peers fetch it at attach. Two loaders read it, the kernel's `_load_token` and the bus's `_load_serve_token`, both at import time. Verified on `main`, both treated an existing token they could not read as absent and **minted a new one**: an EACCES or EIO on the read fell through to the mint, a silent rotation that stranded every client holding the old token with nothing to say why. The kernel's mint opened the live file with `O_TRUNC` in place, so a concurrent reader saw an empty file, and it took no lock, so two starters each wrote their own. The bus's mint wrote the file and then chmod'd it, a window at the umask's mode.

## What changes

One shape in both loaders, `_serve_token_read_or_mint(f, who)`:

- **A missing file is the only mint trigger.** Any other read or stat fault raises a `RuntimeError` naming the path and the errno, and saying that romp did not replace the token. At import that refuses to start the daemon, which is visible and repairable, while the token every client holds stays valid. A non-UTF-8 token reads as the same refusal.
- **The mint is atomic and born 0600.** The value is written to `serve-token.<pid>.tmp` opened `O_EXCL` at 0600, length-checked, fsynced and `os.replace`d onto the path. The live path is never opened for writing. Temps left by a crashed earlier starter are removed under the lock.
- **One mint between the kernel and the bus.** A sibling `serve-token.lock` (0600) is `flock`'d around read-or-mint, so the two daemons booting together mint once. When the lock itself cannot be taken, an existing non-empty 0600 token is returned as is, since there is nothing to mint or tighten; every other case is a refusal, because minting or tightening without the lock is the race this closes.
- **A loose token is tightened**, not replaced: a non-empty token that is not 0600 is chmod'd under the lock and said on stderr. An empty or whitespace-only file is a torn earlier mint (no client can hold a token that was never written) and is minted over, said on stderr.

The bus carries its own copy of the function with a keep-in-sync marker, the way the repo already duplicates its kernel/bus routines, because the bus imports nothing from `kernel/` by design; a test compares the two bodies as syntax trees with docstrings stripped, so any divergence fails.

## Judgment calls and residuals

- Fail-closed at import is the right failure: a silently rotated token strands every client and peer; a refusal to start is one message the operator sees.
- `_load_token` is also called at runtime from the check-in handshake, inside a broad `except` that turns any exception into a failed handshake retried each pass. That site is untouched: a refusal there is a retried handshake rather than a loud line, and `main`'s behavior there was worse (a silent mint of a token the kernel itself does not serve). Follow-up material.
- A starter blocked on the lock waits for the holder with nothing said. Blocking `flock` is the event-based mechanism; a non-blocking probe that announces the wait would add visibility. Left as a follow-up.
- `O_EXCL` on the temp and the fsync are pinned by source text and the tree-identity test, not behaviorally.

## Tests

`tests/test_kernel_serve_token_mode.py`: six threads racing the mint read one token and the lock file exists 0600; the token is 0600 from its first byte (an interposed `os.replace` and `os.open` under a 022 umask, and the live path is never opened for writing); an unreadable existing token is a refusal naming the path and its bytes are unchanged; a non-UTF-8 token is the same refusal; a 0644 token is tightened and its value returned; an empty file is minted over and said; a directory at the lock path is a refusal except for a good 0600 token; a crashed other pid's temp is removed by the mint; the two copies are identical as syntax trees. `tests/test_postal_token.py`: the bus twins of birth, race, unreadable, tighten, lock failure and empty file. On `main`, nine of the kernel module's tests and the bus's new tests fail (`6 != 1`, `RuntimeError not raised`, `420 != 384`, the missing helper). Source mutants (the read fault turned back into a mint, the flock removed, the lock-failure arm ignoring the mode, the tighten removed, in-place writes, `O_EXCL` dropped) each fail at least one test, and the postal copy's policy arms now fail their own.

Module counts on this tree, one runner at a time: `tests/test_kernel_serve_token_mode.py` 15 passed (2 subtests); `tests/test_postal_token.py` 13; `tests/test_postal_self_host.py` 9; `tests/test_ledger_unproved_reads.py` 20; `tests/test_token_login_page.py` 8; `tests/test_mention_pins.py` 8. On `main` the kernel module fails 12 of 15 and the bus module 6 of 13, each with the first error the commit body names. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
