### PR TITLE
T252: a message sent mid-turn appears where it was sent and stays there

### DIFF
--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -24,6 +24,7 @@ All fixtures synthetic.
 """
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -143,7 +144,10 @@ class ServedSync(unittest.TestCase):
              "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
         Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
         claude = os.path.join(cls.lab, "claude")
-        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         # a CLOSED turn: an open one would invite the boot reconcile to resume it — no real CLI here
         Path(proj, SID + ".jsonl").write_text(

--- a/tests/test_paste_to_focus_browser.py
+++ b/tests/test_paste_to_focus_browser.py
@@ -17,6 +17,7 @@ dev box with the extension installed, which is where ships are gated. All fixtur
 """
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -139,7 +140,10 @@ class ServedPaste(unittest.TestCase):
             {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
              "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
         claude = os.path.join(cls.lab, "claude")
-        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         # a CLOSED turn: an open one would invite the boot reconcile to resume it — no real CLI here
         Path(proj, SID + ".jsonl").write_text(

--- a/tests/test_pending_in_place.py
+++ b/tests/test_pending_in_place.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""T252 (the user 2026-09-07): a message sent while the session is mid-turn appears where it was sent and
+stays there. The pending bubble is drawn at its SEND POSITION from the first paint — right after the last
+kernel event at the press — so the steps that stream in afterwards land below it, and the absorbed atom the
+kernel places at the send time replaces it in the same spot. No "joined mid-turn" header, no jump/✕ cue.
+
+The executed guard drives the real /chat page against a hermetic kernel: the socket's outbound send is
+dropped in the page (the message never reaches the kernel, so nothing parks or echoes — the client's bubble
+is the only copy, which is the case under test), the composer sends, two tool steps are appended to the
+transcript, and then the CLI's own record of a mid-turn splice — a `queued_command` attachment stamped with
+the SEND time — lands the atom above those steps. Asserted: the bubble's position in scroll space never
+changes while steps stream in below it; a scrolled-up reader is not moved; the landed message takes the
+bubble's slot; no header and no cue exist at any point. Red on main: the bubble rode the tail, so it moved
+below the streamed steps and the landing appeared higher up with a header and a cue.
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none). SYNTHETIC fixtures only.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TEXT = "and also update the docstring"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+try { await page.waitForSelector(".turn.turn-user", { timeout: 20000 }); }
+catch (e) {   // say what the page held instead of a bare timeout
+  const st = await page.evaluate(() => ({ turns: Array.from(document.querySelectorAll(".turn")).map((t) => t.className.slice(5, 40)),
+    threads: Array.from(document.querySelectorAll(".thread")).map((t) => (t.style.display || "shown") + "/" + t.childElementCount),
+    tabs: (document.getElementById("tabs") || {}).textContent, text: (document.body.innerText || "").replace(/\s+/g, " ").slice(0, 200) }));
+  console.error("no user turn rendered: " + JSON.stringify(st)); process.exit(1);
+}
+await page.waitForTimeout(600);
+// the send never reaches the kernel: the client's bubble is the only copy of the message
+await page.evaluate(() => {
+  const orig = WebSocket.prototype.send;
+  window.__dropped = 0;
+  WebSocket.prototype.send = function (d) {
+    try { const m = JSON.parse(d); if (m && m.type === "sendMessage") { window.__dropped++; return; } } catch (e) {}
+    return orig.call(this, d);
+  };
+});
+const measure = () => page.evaluate((text) => {
+  const content = document.getElementById("content");
+  const c = content.getBoundingClientRect();
+  const yOf = (n) => Math.round(content.scrollTop + n.getBoundingClientRect().top - c.top);
+  const turns = Array.from(document.querySelectorAll(".turn[data-unit]"));
+  const pending = document.querySelector(".turn-queued");
+  const landed = turns.find((t) => t.classList.contains("turn-user") && (t.textContent || "").includes(text)) || null;
+  const tools = turns.filter((t) => t.classList.contains("turn-tool") || t.classList.contains("turn-toolgroup"));
+  return {
+    scrollTop: content.scrollTop, scrollHeight: content.scrollHeight,
+    pending: pending ? { y: yOf(pending), unit: Number(pending.dataset.unit), idx: turns.indexOf(pending) } : null,
+    landed: landed ? { y: yOf(landed), unit: Number(landed.dataset.unit), idx: turns.indexOf(landed) } : null,
+    toolIdx: tools.map((t) => turns.indexOf(t)),
+    header: document.querySelectorAll(".absorbed-tag").length, cue: document.querySelectorAll(".turn-absorbed-cue").length,
+    dropped: window.__dropped,
+  };
+}, cfg.text);
+await page.fill("#composer-input", cfg.text);
+await page.press("#composer-input", "Enter");
+await page.waitForSelector(".turn-queued", { timeout: 10000 });
+await page.waitForTimeout(300);
+const pressed = await measure();
+// a scrolled-up reader: nothing that follows may move the viewport
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = Math.max(0, c.scrollTop - 150); });
+await page.waitForTimeout(200);
+const scrolled = await measure();
+// two tool steps stream in while the CLI holds the send
+// the steps are on the page when the transcript's unit classes change (compact mode folds consecutive tools:
+// on main all three Bashes fold into one group; with the fix the bubble splits the run into a lone tool and a group)
+const classesOf = () => page.evaluate(() => JSON.stringify(Array.from(document.querySelectorAll(".turn[data-unit]")).map((t) => t.className)));
+const beforeSteps = await classesOf();
+fs.appendFileSync(cfg.transcript, cfg.steps.map((r) => JSON.stringify(r)).join("\n") + "\n");
+await page.waitForFunction((was) => JSON.stringify(Array.from(document.querySelectorAll(".turn[data-unit]")).map((t) => t.className)) !== was, beforeSteps, { timeout: 20000 });
+await page.waitForTimeout(500);
+const streamed = await measure();
+// shots show the tail (the reader's scroll position was already measured); the landing below does not read scrollTop
+const shot = async (name) => { if (!cfg.shots) return; await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollHeight; }); await page.waitForTimeout(150); await page.screenshot({ path: cfg.shots + name }); };
+await shot("-pending.png");
+// the CLI takes it at the boundary: its attachment record carries the SEND time, so the atom lands above the steps
+fs.appendFileSync(cfg.transcript, JSON.stringify(cfg.landing) + "\n");
+await page.waitForFunction((text) => Array.from(document.querySelectorAll(".turn.turn-user")).some((t) => (t.textContent || "").includes(text)), cfg.text, { timeout: 20000 });
+await page.waitForTimeout(500);
+const landed = await measure();
+await shot("-landed.png");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ pressed, scrolled, streamed, landed }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedPendingInPlace(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="pending-in-place-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        shutil.copytree(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # a running turn: the reply is tall enough to overflow the pane, then a tool call whose result is in
+        t0 = int(time.time()) - 900
+        cls.t0 = t0
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "tighten the notes-api search"}},
+            {"type": "assistant", "timestamp": iso(t0 + 10), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "\n\n".join("Paragraph %d of the reply." % i for i in range(14))}]}},
+            {"type": "user", "timestamp": iso(t0 + 39), "uuid": "u2", "parentUuid": "a1", "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "drop the unused import"}},
+            {"type": "assistant", "timestamp": iso(t0 + 41), "uuid": "a2", "parentUuid": "u2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a2_0", "name": "Bash", "input": {"command": "uv run pytest -q"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 50), "uuid": "tr1", "parentUuid": "a2", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a2_0", "content": "3 passed"}]}},
+        ]
+        cls.transcript = os.path.join(proj, SID + ".jsonl")
+        Path(cls.transcript).write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # the steps the session runs while the send waits, and the splice the CLI writes when it takes it
+        cls.steps = [
+            {"type": "assistant", "timestamp": iso(t0 + 60), "uuid": "a3", "parentUuid": "tr1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a3_0", "name": "Bash", "input": {"command": "uv run pytest -q tests/test_search.py"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 61), "uuid": "tr2", "parentUuid": "a3", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a3_0", "content": "5 passed"}]}},
+            {"type": "assistant", "timestamp": iso(t0 + 62), "uuid": "a4", "parentUuid": "tr2", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "tool_use",
+                         "content": [{"type": "tool_use", "id": "tu_a4_0", "name": "Bash", "input": {"command": "git diff --stat"}}]}},
+            {"type": "user", "timestamp": iso(t0 + 63), "uuid": "tr3", "parentUuid": "a4", "sessionId": SID,
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_a4_0", "content": "1 file changed"}]}},
+        ]
+        cls.landing = {"type": "attachment", "timestamp": iso(t0 + 55), "uuid": "att1", "parentUuid": "tr3", "isSidechain": False,
+                       "sessionId": SID, "attachment": {"type": "queued_command", "prompt": TEXT}}
+        cls.port = _free_port()
+        cls.token = "testtok-pendinginplace"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_pending_bubble_holds_its_send_position_and_the_landing_replaces_it_in_place(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "text": TEXT,
+                       "transcript": self.transcript, "steps": self.steps, "landing": self.landing,
+                       "shots": os.environ.get("PENDING_IN_PLACE_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        pr, sc, st, ld = r["pressed"], r["scrolled"], r["streamed"], r["landed"]
+        self.assertEqual(pr["dropped"], 1, "the send was dropped at the socket: the client's bubble is the only copy (%r)" % pr)
+        self.assertIsNotNone(pr["pending"], "the press drew the pending bubble: %r" % pr)
+        self.assertEqual(pr["header"] + pr["cue"] + st["header"] + st["cue"] + ld["header"] + ld["cue"], 0,
+                         "no 'joined mid-turn' header and no cue at any point: %r" % r)
+        # THE RULE: the bubble keeps its slot while steps stream in below it
+        self.assertIsNotNone(st["pending"], "still pending after the steps: %r" % st)
+        self.assertEqual(st["pending"]["y"], pr["pending"]["y"],
+                         "the bubble did not move in scroll space: pressed at %r, after the steps %r" % (pr["pending"], st["pending"]))
+        new_tools = [i for i in st["toolIdx"] if i not in pr["toolIdx"]] or st["toolIdx"][-1:]
+        self.assertTrue(all(i > st["pending"]["idx"] for i in new_tools), "the streamed steps sit BELOW the bubble: %r" % st)
+        self.assertEqual(st["scrollTop"], sc["scrollTop"], "a scrolled-up reader is not moved by the steps: %r → %r" % (sc["scrollTop"], st["scrollTop"]))
+        # the landing takes the bubble's slot
+        self.assertIsNone(ld["pending"], "the landing retired the bubble: %r" % ld)
+        self.assertIsNotNone(ld["landed"], "the landed message is on the page: %r" % ld)
+        self.assertEqual(ld["landed"]["idx"], st["pending"]["idx"], "same slot in the transcript: bubble %r, landed %r" % (st["pending"], ld["landed"]))
+        self.assertLessEqual(abs(ld["landed"]["y"] - st["pending"]["y"]), 40,
+                             "same place on the page (the bare group's one-line head is the only difference): bubble y %r, landed y %r" % (st["pending"]["y"], ld["landed"]["y"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scroll_marks_growth.py
+++ b/tests/test_scroll_marks_growth.py
@@ -24,6 +24,7 @@ ride ui/webview/scroll-marks.test.ts. All fixtures synthetic.
 """
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -141,7 +142,10 @@ class ServedNotchFollowsGrowth(unittest.TestCase):
              "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
         Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
         claude = os.path.join(cls.lab, "claude")
-        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         # a user message near the top, three consecutive tool calls (compact mode folds them into ONE tool
         # group — a unit that owns several .turn nodes once expanded), then a tall-ish assistant reply — the

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -31,6 +31,7 @@ All fixtures synthetic.
 import base64
 import json
 import os
+import re
 import shutil
 import signal
 import socket
@@ -200,7 +201,10 @@ class _ShipLab(unittest.TestCase):
         Path(cls.state, "usage.json").write_text(json.dumps(
             {"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))  # park sends: no CLI spawns in the lab
         claude = os.path.join(cls.lab, "claude")
-        proj = os.path.join(claude, "projects", cwd.replace("/", "-"))
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir). A slashes-only munge missed the '_' pytest's temp root can carry,
+        # so the kernel found no transcript and drew an API-error turn instead (the batch-only flake, 2026-09-08).
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         # a CLOSED turn (user + replied assistant): an OPEN one would invite the boot
         # reconcile to resume it — this lab must never spawn a real CLI

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -21,8 +21,8 @@ test("a delta gap asks the kernel for a full session instead of freezing", () =>
   // coordinate space, and counting it masked a genuine 1-event gap (the user 2026-08-09)
   assert.match(RENDER, /if \(from > kernelLen\) \{/,
     "chatTail must treat a too-far-ahead delta as its own case, not fold it into the silent return");
-  assert.match(RENDER, /stripOptimistic\(s\);\s*\n\s*const kernelLen = s\.events\.length;/,
-    "…in kernel coordinates: our injections are stripped first (since T252 a bubble sits at its send slot, mid-array)");
+  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/,
+    "…in kernel coordinates: our injections are counted out (since T252 a bubble sits at its send slot, mid-array) — and only counted here, the strip happens once the delta is applied");
   assert.match(RENDER, /requestFullSession\(msg\.id\);/, "…and request a re-base");
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id \}\)/,
     "the resync request must actually reach the kernel");

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -21,8 +21,8 @@ test("a delta gap asks the kernel for a full session instead of freezing", () =>
   // coordinate space, and counting it masked a genuine 1-event gap (the user 2026-08-09)
   assert.match(RENDER, /if \(from > kernelLen\) \{/,
     "chatTail must treat a too-far-ahead delta as its own case, not fold it into the silent return");
-  assert.match(RENDER, /while \(kernelLen > 0 && isOptimistic\(s\.events\[kernelLen - 1\]\)\) kernelLen--;/,
-    "…in kernel coordinates, with the injected tail excluded");
+  assert.match(RENDER, /stripOptimistic\(s\);\s*\n\s*const kernelLen = s\.events\.length;/,
+    "…in kernel coordinates: our injections are stripped first (since T252 a bubble sits at its send slot, mid-array)");
   assert.match(RENDER, /requestFullSession\(msg\.id\);/, "…and request a re-base");
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id \}\)/,
     "the resync request must actually reach the kernel");

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -95,14 +95,14 @@ test("retire needs a NEW landed atom (after the send's anchor); kernel provision
 // queued one are the same state, so they wear the same dashed bubble — and the look then only ever moves
 // provisional→settled. It first shipped as a 0.6-opacity SOLID bubble, which invented a third look and made a
 // queued send flip solid→dashed (backwards, as if it had un-landed).
-test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — never a solid user bubble", () => {
+test("an optimistic echo is a kernel-invisible QUEUED event at its send slot — never a solid user bubble", () => {
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   const SP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "send-pending.ts"), "utf8");
   assert.match(SP, /export const OPT_PREFIX = "optimistic:";/);
   assert.match(RENDER, /const isOptimistic = \(e: ChatEvent\): boolean => isOptimisticUuid\(e\.uuid\);/);
   assert.match(RENDER, /const mk = \(p: PendingSend\) => \(\{ md: p\.text, optimistic: true, cancelable: true, imgPaths: p\.imgPaths, lost: p\.lost, qts: p\.ts \}\);/);   // the echo carries its dragged-image paths (2026-08-25); cancelable from the press (2026-08-30); `lost` after a connection drop, `qts` its identity for the ✕ (2026-09-06)
-  // stale ones pop cheaply off the end (always tail-appended)
-  assert.match(RENDER, /while \(s\.events\.length && isOptimistic\(s\.events\[s\.events\.length - 1\]\)\) s\.events\.pop\(\);/);
+  // stale ones are stripped wherever they sit — since T252 a bubble is spliced at its send slot, not the tail
+  assert.match(RENDER, /if \(isOptimistic\(e\)\) \{ s\.events\.splice\(i, 1\); continue; \}/);
   // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
   // leftovers (a `!e.pending` guard on a field no event carries, and a stylesheet paragraph describing
   // the deleted rendering as if it shipped) misdirected the 2026-08-09 bug hunt and are pinned out
@@ -115,24 +115,31 @@ test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — n
 });
 
 test("nothing known-queued → a bare group wearing the honest 'sending…' header", () => {
-  assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts \}\);/);
+  assert.match(RENDER, /s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts,/,
+    "one bare group per send slot (T252: right after the send's anchor, never the tail)");
   // "N queued messages" stays unclaimable pre-confirmation — but NO label was the user's 2026-08-30
   // bug (a mid-compaction send sat unlabeled and uncuttable): the bare group now states exactly what
   // is known, and the reflow recounts it in the same vocabulary after a ✕
   assert.match(RENDER, /label\.dataset\.bare = "1";/);
   // the wording is the pure helper's (send-pending.ts bareGroupLabel, per-bubble since 2026-09-06), and
   // the render feeds it the bubbles' own states
-  assert.match(RENDER, /fillBareLabel\(label, nLost, ev\.texts\.length - nLost\);/);
+  assert.match(RENDER, /fillBareLabel\(label, nLost, texts\.length - nLost\);/);
   assert.deepEqual(bareGroupLabel(0, 1).parts.map((p) => p.text), ["sending…"]);
   assert.deepEqual(bareGroupLabel(0, 2).parts.map((p) => p.text), ["sending 2…"]);
   assert.match(RENDER, /if \(label\.dataset\.bare === "1"\) \{/, "reflow keeps the bare vocabulary");
   assert.match(RENDER, /if \(!ev\.bare\) \{/, "the standard 'N queued' header still needs confirmation");
 });
 
-test("something IS queued → ours merges into that group, counted under its header", () => {
-  assert.match(RENDER, /s\.events\[qj\] = \{ \.\.\.q, texts: \[\.\.\.q\.texts, \.\.\.inject\.map\(mk\)\] \};/);
-  // and the extension is undone before the counts run, so reconcile only ever reads kernel truth
-  assert.match(RENDER, /if \(q\.texts\.some\(\(t\) => t\.optimistic\)\) s\.events\[qi\] = \{ \.\.\.q, texts: q\.texts\.filter\(\(t\) => !t\.optimistic\) \};/);
+test("something IS queued → the kernel's copy of OUR text is hidden and ours stays at its slot (T252)", () => {
+  // one bubble per message: the kernel's queued group at the tail keeps its OTHER texts, our copy in it is
+  // hidden (a client-only mark), and the hide is undone with every other injection before the counts run
+  assert.match(RENDER, /function hideQueuedCopy\(s: Session, p: PendingSend\)/);
+  assert.match(RENDER, /for \(const p of r\.unqueue\) \{ const h = hideQueuedCopy\(s, p\); if \(h\) heldBy\.set\(p, h\); \}/);
+  assert.match(RENDER, /texts\[k\] = \{ \.\.\.t, hiddenByPending: true \};/);
+  assert.match(RENDER, /const texts = ev\.texts\.filter\(\(t\) => !t\.hiddenByPending\);/, "the renderer draws the visible copies only");
+  assert.match(RENDER, /map\(\(t\) => t\.hiddenByPending \? \{ \.\.\.t, hiddenByPending: undefined \} : t\)/, "the strip clears the marks");
+  // a copy hidden out of a HELD group hands the hold's reason to our bubble
+  assert.match(RENDER, /held: g\.sends\.map\(\(p\) => heldBy\.get\(p\)\)\.find\(\(h\) => !!h\)/);
 });
 
 test("an unconfirmed echo keeps its tooltip AND carries a ✕ from the press (the 2026-08-30 rule)", () => {
@@ -164,7 +171,7 @@ test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body
 test("chatTail speaks the KERNEL's coordinates — the injected tail is not part of its space", () => {
   // counting the injected bubble in the gap check masked a genuine 1-event desync (the repair never
   // fired) and let a delta land PAST the bubble, freezing it into resident events as fake history
-  assert.match(RENDER, /let kernelLen = s\.events\.length;\s*\n\s*while \(kernelLen > 0 && isOptimistic\(s\.events\[kernelLen - 1\]\)\) kernelLen--;/);
+  assert.match(RENDER, /stripOptimistic\(s\);\s*\n\s*const kernelLen = s\.events\.length;/);
   assert.match(RENDER, /if \(from > kernelLen\) \{/);
 });
 
@@ -197,7 +204,8 @@ test("reconcile: inject on nothing, suppress on kernel provisionals, retire only
   reconcile([{ kind: "assistant", md: "working on the prior turn" }], p);   // the press
   r = reconcile([{ kind: "queued", texts: [{ md: "continue" }] }], p);
   assert.equal(r.keep.length, 1);
-  assert.equal(r.inject.length, 0, "no double render beside the kernel's own copy");
+  assert.equal(r.inject.length, 1, "ours stays drawn at its slot (T252)…");
+  assert.equal(r.unqueue.length, 1, "…and the kernel's copy is the one hidden: one bubble per message");
   // …same for the kernel's unlanded echo atom (uuid keeps the backend's echo: prefix)
   r = reconcile([{ kind: "user", md: "continue", uuid: "echo:abc123" }], p);
   assert.equal(r.keep.length, 1);

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -84,7 +84,7 @@ test("retire needs a NEW landed atom (after the send's anchor); kernel provision
   assert.match(RENDER, /const r = reconcilePending\(s\.events as TailEvent\[\], list\);/);
   assert.doesNotMatch(RENDER, /OPT_TAIL_SCAN/);
   assert.match(RENDER, /if \(r\.keep\.length\) pendingSent\.set\(s\.id, r\.keep\); else pendingSent\.delete\(s\.id\);/);
-  assert.match(RENDER, /const inject = r\.inject;/);
+  assert.match(RENDER, /const inject = r\.inject\.filter\(\(p\) => !covered\.has\(p\)\);/);
   // and no clock anywhere in the file's decision: the TTL is gone for good
   assert.doesNotMatch(RENDER, /OPT_TTL_MS/);
   const SP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "send-pending.ts"), "utf8");
@@ -134,8 +134,8 @@ test("something IS queued → the kernel's copy of OUR text is hidden and ours s
   // one bubble per message: the kernel's queued group at the tail keeps its OTHER texts, our copy in it is
   // hidden (a client-only mark), and the hide is undone with every other injection before the counts run
   assert.match(RENDER, /function hideQueuedCopy\(s: Session, p: PendingSend\)/);
-  assert.match(RENDER, /for \(const p of r\.unqueue\) \{ const h = hideQueuedCopy\(s, p\); if \(h\) heldBy\.set\(p, h\); \}/);
-  assert.match(RENDER, /texts\[k\] = \{ \.\.\.t, hiddenByPending: true \};/);
+  assert.match(RENDER, /for \(const p of r\.unqueue\) \{\s*\n\s*const hid = hideQueuedCopy\(s, p\);/);
+  assert.match(RENDER, /texts\[k\] = \{ \.\.\.texts\[k\], hiddenByPending: true \};/);
   assert.match(RENDER, /const texts = ev\.texts\.filter\(\(t\) => !t\.hiddenByPending\);/, "the renderer draws the visible copies only");
   assert.match(RENDER, /map\(\(t\) => t\.hiddenByPending \? \{ \.\.\.t, hiddenByPending: undefined \} : t\)/, "the strip clears the marks");
   // a copy hidden out of a HELD group hands the hold's reason to our bubble
@@ -171,7 +171,7 @@ test("EVERY ✕ stops our re-injection first; the optimistic one cancels by body
 test("chatTail speaks the KERNEL's coordinates — the injected tail is not part of its space", () => {
   // counting the injected bubble in the gap check masked a genuine 1-event desync (the repair never
   // fired) and let a delta land PAST the bubble, freezing it into resident events as fake history
-  assert.match(RENDER, /stripOptimistic\(s\);\s*\n\s*const kernelLen = s\.events\.length;/);
+  assert.match(RENDER, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/);
   assert.match(RENDER, /if \(from > kernelLen\) \{/);
 });
 

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -13,7 +13,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a queued ChatEvent carries the pending messages (backend-agnostic, per-message md)", () => {
   // idx = backend-queue position (SDK); park = _pending_ops position (compaction/model parking, any backend)
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
+  assert.match(RENDER, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/);   // imgPaths: the echo's dragged-image thumbnails (2026-08-25); romp flags: T243; lost + qts: the pending entry's connection-drop state and its identity for the ✕ (2026-09-06)
 });
 
 test("renderQueued draws a wireframe-hourglass header (singular/plural) + one markdown bubble per queued message", () => {
@@ -31,7 +31,7 @@ test("renderQueued draws a wireframe-hourglass header (singular/plural) + one ma
   assert.match(RENDER, /el\("div", "queued-head"\)/);
   // one faint "you" bubble per pending message, rendered as markdown (like a landed message — the
   // user-text renderer, newlines kept, so the queued→landed swap changes nothing on screen)
-  assert.match(RENDER, /for \(const t of ev\.texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\)/);
+  assert.match(RENDER, /for \(const t of texts\)[\s\S]*?el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\)/);
   assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\)/);
 });
 
@@ -40,7 +40,7 @@ test("a queued slash command renders as a command chip, not a plain 'message' (t
   assert.match(RENDER, /function renderSlashCmd\(bubble: HTMLElement, text: string\): boolean/);
   assert.match(RENDER, /el\("span", "slash-cmd-chip"\)/);
   // the header counts commands vs. prose to pick the noun
-  assert.match(RENDER, /const nCmd = ev\.texts\.filter\(\(t\) => SLASH_CMD_RE\.test\(t\.md\)\)\.length;/);
+  assert.match(RENDER, /const nCmd = texts\.filter\(\(t\) => SLASH_CMD_RE\.test\(t\.md\)\)\.length;/);
 });
 
 test("a cancelable queued bubble carries an explicit ✕ — messages AND parked commands (the user 2026-07-08)", () => {
@@ -247,7 +247,7 @@ test("the kernel flags a romp-injected queued entry from the same markers as a l
 });
 
 test("what romp itself queued wears the LANDED romp grammar, split as landed: notice card vs gray romp bubble (T243)", () => {
-  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/, "the queued text shape carries the flags");
+  assert.match(RENDER, /romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/, "the queued text shape carries the flags");
   const body = RENDER.split("function renderQueued(")[1].split("\nfunction ")[0];
   assert.match(body, /const bubble = el\("div", "queued-bubble md" \+ \(t\.cancelable \? " cancelable" : ""\)\s*\n\s*\+ \(t\.romp \? " queued-romp" : ""\) \+ \(t\.rompSystem \? " queued-sys" : ""\)\);/);
   // a SYSTEM notice → the landed card's own builder, nested; a one-line notice gets no body repeating its head
@@ -283,8 +283,8 @@ test("what romp itself queued wears the LANDED romp grammar, split as landed: no
 
 test("the header noun counts romp's own entries honestly (T243)", () => {
   assert.match(RENDER, /function queuedCountText\(n: number, nCmd: number, nSys = 0, nNudge = 0\): string/);
-  assert.match(RENDER, /const nSys = ev\.texts\.filter\(\(t\) => !!t\.rompSystem\)\.length;/);
-  assert.match(RENDER, /const nNudge = ev\.texts\.filter\(\(t\) => !!t\.romp && !t\.rompSystem\)\.length;/);
+  assert.match(RENDER, /const nSys = texts\.filter\(\(t\) => !!t\.rompSystem\)\.length;/);
+  assert.match(RENDER, /const nNudge = texts\.filter\(\(t\) => !!t\.romp && !t\.rompSystem\)\.length;/);
   // the ✕'s recount sees them too
   assert.match(RENDER, /const nSys = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-sys"\)\)\.length;/);
   assert.match(RENDER, /const nNudge = bubbles\.filter\(\(b\) => b\.classList\.contains\("queued-romp"\) && !b\.classList\.contains\("queued-sys"\)\)\.length;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -381,10 +381,14 @@ function reconcileOptimistic(s: Session): void {
   // no "N queued messages" header to claim what we can't back. Groups come highest slot first, so each
   // splice leaves the lower slots valid. A copy hidden out of a HELD kernel group (a usage limit holds
   // every send) hands its reason to our bubble, so the wait still says what it is waiting for.
-  for (const g of injectionGroups(s.events as TailEvent[], inject))
+  const groups = injectionGroups(s.events as TailEvent[], inject);
+  for (const g of groups)
     s.events.splice(g.idx, 0, { kind: "queued", bare: true, texts: g.sends.map(mk), uuid: OPT_PREFIX + g.sends[0].ts,
                                 held: g.sends.map((p) => heldBy.get(p)).find((h) => !!h) });
-  settle(inject.map((p) => p.text));
+  // the signature carries each group's SLOT beside its texts: chatTail repaints from the kernel index it was
+  // handed, trusting the DOM prefix — which also needs the bubble's slot unchanged. A slot that moves (a floor
+  // event arriving) marks the view stale, so the window is rebuilt (second review).
+  settle(groups.flatMap((g) => g.sends.map((p) => g.idx + ":" + p.text)));
 }
 
 // Undo our own injections wherever they sit — the bare groups we spliced in (T252: at their send slots, no

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -38,7 +38,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
-import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, injectionGroups, scanFrom, dropPending, bareGroupLabel } from "./send-pending";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, injectionGroups, queuedCopyToHide, dropPending, bareGroupLabel } from "./send-pending";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -363,8 +363,12 @@ function reconcileOptimistic(s: Session): void {
   const r = reconcilePending(s.events as TailEvent[], list);
   if (r.keep.length) pendingSent.set(s.id, r.keep); else pendingSent.delete(s.id);
   const heldBy = new Map<PendingSend, NonNullable<Extract<ChatEvent, { kind: "queued" }>["held"]>>();
-  for (const p of r.unqueue) { const h = hideQueuedCopy(s, p); if (h) heldBy.set(p, h); }
-  const inject = r.inject;
+  const covered = new Set<PendingSend>();   // a kernel copy that stays shown (non-cancelable: no recall exists) covers ours
+  for (const p of r.unqueue) {
+    const hid = hideQueuedCopy(s, p);
+    if (hid === null) covered.add(p); else if (hid.held) heldBy.set(p, hid.held);
+  }
+  const inject = r.inject.filter((p) => !covered.has(p));
   if (!inject.length) { settle([]); return; }
   // cancelable from the PRESS (the user 2026-08-30, who sent mid-compaction and sat in an unlabeled,
   // uncancellable beat until the kernel's park round-tripped): the ✕ on an optimistic bubble drops our
@@ -396,21 +400,19 @@ function stripOptimistic(s: Session): void {
   }
 }
 
-// Hide ONE copy of this send's text in the kernel's queued group (the newest copy — the kernel's group
-// lists the queue in order and ours is the latest press with that text): ours is drawn at its slot, so the
-// tail copy would be the same message twice. Returns the group's `held` so the bubble can carry the reason.
-function hideQueuedCopy(s: Session, p: PendingSend): Extract<ChatEvent, { kind: "queued" }>["held"] | undefined {
+// Hide ONE copy of this send's text in the kernel's queued group (send-pending.ts queuedCopyToHide picks
+// it: the newest not-yet-hidden copy, never one the kernel marked non-cancelable): ours is drawn at its
+// slot, so the tail copy would be the same message twice. Returns the group's `held` so the bubble can
+// carry the reason — or null when no copy is hidden, in which case the kernel's copy keeps covering ours.
+function hideQueuedCopy(s: Session, p: PendingSend): { held?: Extract<ChatEvent, { kind: "queued" }>["held"] } | null {
   const qi = tailQueuedIdx(s.events);
-  if (qi < 0) return undefined;
+  if (qi < 0) return { held: undefined };            // nothing queued at the tail: nothing to hide, ours shows
   const q = s.events[qi] as Extract<ChatEvent, { kind: "queued" }>;
-  for (let k = q.texts.length - 1; k >= 0; k--) {
-    const t = q.texts[k];
-    if (t.hiddenByPending || t.optimistic || t.md.trim() !== p.text.trim()) continue;
-    const texts = q.texts.slice(); texts[k] = { ...t, hiddenByPending: true };
-    s.events[qi] = { ...q, texts };
-    return q.held || undefined;
-  }
-  return undefined;
+  const k = queuedCopyToHide(q.texts, p.text);
+  if (k < 0) return null;                            // no copy to hide (or a non-cancelable one): the kernel's bubble stays
+  const texts = q.texts.slice(); texts[k] = { ...texts[k], hiddenByPending: true };
+  s.events[qi] = { ...q, texts };
+  return { held: q.held || undefined };
 }
 
 // Record a composer send as in-flight and show its optimistic bubble NOW (before any kernel push).
@@ -13420,9 +13422,10 @@ function chatTail(msg: any) {
   // fired, PR #107's desync class), and a delta starting exactly one past kernel truth landed BEYOND
   // the injected bubble, freezing it into the resident events as fake history the reconcile's strip
   // loop could never pop (the user 2026-08-09). Since T252 a bubble sits at its send slot, mid-array,
-  // where it would also SHIFT every kernel index after it — so strip first, then read kernel lengths.
-  stripOptimistic(s);
-  const kernelLen = s.events.length;
+  // where it would also SHIFT every kernel index after it — so the gap check COUNTS kernel events here,
+  // and the strip itself waits until the delta is going to be applied: stripping ahead of the two early
+  // returns left s.events without the bubble while the DOM still showed it (review of the first cut).
+  const kernelLen = s.events.reduce((n, e) => n + (isOptimistic(e) ? 0 : 1), 0);
   if (from > kernelLen) {
     // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would
     // fabricate a transcript that silently skips them. This used to just `return` and "wait for the next
@@ -13438,6 +13441,7 @@ function chatTail(msg: any) {
     return;
   }
   if (from < 0) return;                            // below the loaded head → our resident tail is still valid
+  stripOptimistic(s);                              // kernel coordinates from here on (re-injected below)
   const wasLen = s.events.length;
   s.events.length = from;                          // drop the (now superseded) tail...
   for (const e of (msg.events || [])) s.events.push(e);   // ...and append the freshly-changed suffix

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -38,7 +38,7 @@ import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindi
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
 import { StagedStack } from "./staged-messages";
-import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, dropPending, cueAnchor, bareGroupLabel } from "./send-pending";
+import { type PendingSend, type TailEvent, OPT_PREFIX, isOptimisticUuid, newPending, reconcilePending, injectionGroups, scanFrom, dropPending, bareGroupLabel } from "./send-pending";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -167,7 +167,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: client-only, the pending entry's identity (its press time) so the ✕ removes ITS entry (send-pending.ts)
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; imgPaths?: string[]; lost?: string; qts?: number; hiddenByPending?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }   // imgPaths: an optimistic echo's dragged-image attachments → thumbnails, the landed form's own renderer (the user 2026-08-25); lost: client-only, the connection dropped after this unconfirmed send; qts: client-only, the pending entry's identity (its press time) so the ✕ removes ITS entry (send-pending.ts)
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -291,9 +291,12 @@ const order: string[] = [];           // positional tab order (for cycling)
 // ── client-side optimistic echo (the user 2026-07-15) ── a composer send clears the box instantly, but the
 // message only reappears in the chat once the kernel round-trips it back (its own provisional). Sending to a
 // busy/slow thread, the kernel's provisional could briefly VANISH in the echo→landed gap — so a just-sent
-// message looked lost for a beat. We drop a local optimistic bubble at the tail the moment you hit Enter and
-// keep RE-injecting it on every push until the kernel's payload demonstrably carries the message, then let it
-// go — the immediacy is client-owned, independent of every server-side timing subtlety.
+// message looked lost for a beat. We drop a local optimistic bubble the moment you hit Enter — AT ITS SEND
+// POSITION, right after the last kernel event at the press (T252, the user 2026-09-07), so the steps that
+// stream in while the CLI holds the send land below it and the absorbed atom the kernel places at the send
+// time replaces it in the same spot — and keep RE-injecting it on every push until the kernel's payload
+// demonstrably carries the message, then let it go — the immediacy is client-owned, independent of every
+// server-side timing subtlety.
 // It rides the QUEUED idiom (the user 2026-07-16): to the reader an unconfirmed send and a queued one are the
 // same state — sent, nothing's happened yet — so they wear the same dashed bubble. That also means the look
 // only ever moves provisional→settled: dashed→solid when it lands, dashed→dashed (invisible) when it really
@@ -314,13 +317,6 @@ const order: string[] = [];           // positional tab order (for cycling)
 // last 30 events, so an absorbed landing placed above them never ended the bubble (2026-09-06 review).
 const pendingSent = new Map<string, PendingSend[]>();
 const isOptimistic = (e: ChatEvent): boolean => isOptimisticUuid(e.uuid);
-// sid → MID-TURN CUES: where a pending bubble sat when its message landed ABOVE the tail. A send fed
-// into a running turn is taken by the CLI at a later tool boundary and placed at its SEND time (kernel
-// ev.absorbed), so the bubble the user was watching at the bottom vanishes and the message is somewhere
-// higher up. The cue stays under the event the bubble sat under — "delivered into the running turn at
-// HH:MM · jump" — until jump or ✕ (the user 2026-09-05). Keyed on the landing, never on a timer.
-type AbsorbedCue = { after: string; target: string; landedAt: number | null };
-const absorbedCues = new Map<string, AbsorbedCue[]>();
 
 // The kernel's own queued group, if one is at the tail. Ours merges INTO it when present: the session is
 // provably holding messages, so this send will queue behind them — no reason to show it as a separate lone
@@ -351,14 +347,7 @@ function reconcileOptimistic(s: Session): void {
       if (v) v.stale = true;
     }
   };
-  // undo our own injections. A standalone bare group is tail-appended (pop it); a kernel group we EXTENDED is
-  // restored by dropping the optimistic texts off our clone — so `landed` below only ever sees kernel truth.
-  while (s.events.length && isOptimistic(s.events[s.events.length - 1])) s.events.pop();
-  const qi = tailQueuedIdx(s.events);
-  if (qi >= 0) {
-    const q = s.events[qi] as Extract<ChatEvent, { kind: "queued" }>;
-    if (q.texts.some((t) => t.optimistic)) s.events[qi] = { ...q, texts: q.texts.filter((t) => !t.optimistic) };
-  }
+  stripOptimistic(s);   // kernel truth only below: our bubbles and our hide marks are re-derived from it
   const list = pendingSent.get(s.id);
   if (!list || !list.length) { settle([]); return; }
   // The decision reads KERNEL truth only (our injections are stripped above) — send-pending.ts: a
@@ -368,11 +357,13 @@ function reconcileOptimistic(s: Session): void {
   // the gap); the kernel's NEVER-DELIVERED verdict after the anchor retires it (that bubble now carries
   // the text and the resend); its PROVISIONAL — echo atom or queued bubble — suppresses ours for this
   // push and nothing more, so if it blinks, ours steps straight back in, and proves the kernel has the
-  // send (a "not confirmed" label is cleared). A landing that retired an ABSORBED atom's bubble may owe
-  // a mid-turn cue (noteAbsorbedLanding).
+  // send (a "not confirmed" label is cleared). The kernel's QUEUED copy of a send is different (T252): it
+  // sits in the kernel's group at the tail while the bubble the user watches is ours, at its send slot —
+  // so that copy is hidden and ours stays, one bubble per message; the group keeps its other texts.
   const r = reconcilePending(s.events as TailEvent[], list);
   if (r.keep.length) pendingSent.set(s.id, r.keep); else pendingSent.delete(s.id);
-  for (const { idx } of r.landed) noteAbsorbedLanding(s, idx);
+  const heldBy = new Map<PendingSend, NonNullable<Extract<ChatEvent, { kind: "queued" }>["held"]>>();
+  for (const p of r.unqueue) { const h = hideQueuedCopy(s, p); if (h) heldBy.set(p, h); }
   const inject = r.inject;
   if (!inject.length) { settle([]); return; }
   // cancelable from the PRESS (the user 2026-08-30, who sent mid-compaction and sat in an unlabeled,
@@ -382,16 +373,44 @@ function reconcileOptimistic(s: Session): void {
   // `qts` is the entry's identity: the ✕ removes THAT entry, never the first with the same text (two
   // identical sends can sit in different states — one lost, one received).
   const mk = (p: PendingSend) => ({ md: p.text, optimistic: true, cancelable: true, imgPaths: p.imgPaths, lost: p.lost, qts: p.ts });
-  const qj = tailQueuedIdx(s.events);
-  if (qj >= 0) {
-    // something IS queued here → ours queues behind it: show it in that group, under its header, counted
-    const q = s.events[qj] as Extract<ChatEvent, { kind: "queued" }>;
-    s.events[qj] = { ...q, texts: [...q.texts, ...inject.map(mk)] };
-  } else {
-    // nothing known-queued → a BARE dashed bubble: no "N queued messages" header to claim what we can't back
-    s.events.push({ kind: "queued", bare: true, texts: inject.map(mk), uuid: OPT_PREFIX + inject[0].ts });
-  }
+  // A BARE dashed bubble at each send's slot — right after its anchor (send-pending.ts injectionGroups):
+  // no "N queued messages" header to claim what we can't back. Groups come highest slot first, so each
+  // splice leaves the lower slots valid. A copy hidden out of a HELD kernel group (a usage limit holds
+  // every send) hands its reason to our bubble, so the wait still says what it is waiting for.
+  for (const g of injectionGroups(s.events as TailEvent[], inject))
+    s.events.splice(g.idx, 0, { kind: "queued", bare: true, texts: g.sends.map(mk), uuid: OPT_PREFIX + g.sends[0].ts,
+                                held: g.sends.map((p) => heldBy.get(p)).find((h) => !!h) });
   settle(inject.map((p) => p.text));
+}
+
+// Undo our own injections wherever they sit — the bare groups we spliced in (T252: at their send slots, no
+// longer only at the tail), the optimistic texts we once merged into a kernel group, and the hide marks on
+// the kernel's queued copies — so every reader below sees KERNEL truth only. Every ingest path that applies
+// a kernel INDEX (chatTail's `from`) strips first: a bubble sitting mid-array would shift that index.
+function stripOptimistic(s: Session): void {
+  for (let i = s.events.length - 1; i >= 0; i--) {
+    const e = s.events[i];
+    if (isOptimistic(e)) { s.events.splice(i, 1); continue; }
+    if (e.kind === "queued" && e.texts.some((t) => t.optimistic || t.hiddenByPending))
+      s.events[i] = { ...e, texts: e.texts.filter((t) => !t.optimistic).map((t) => t.hiddenByPending ? { ...t, hiddenByPending: undefined } : t) };
+  }
+}
+
+// Hide ONE copy of this send's text in the kernel's queued group (the newest copy — the kernel's group
+// lists the queue in order and ours is the latest press with that text): ours is drawn at its slot, so the
+// tail copy would be the same message twice. Returns the group's `held` so the bubble can carry the reason.
+function hideQueuedCopy(s: Session, p: PendingSend): Extract<ChatEvent, { kind: "queued" }>["held"] | undefined {
+  const qi = tailQueuedIdx(s.events);
+  if (qi < 0) return undefined;
+  const q = s.events[qi] as Extract<ChatEvent, { kind: "queued" }>;
+  for (let k = q.texts.length - 1; k >= 0; k--) {
+    const t = q.texts[k];
+    if (t.hiddenByPending || t.optimistic || t.md.trim() !== p.text.trim()) continue;
+    const texts = q.texts.slice(); texts[k] = { ...t, hiddenByPending: true };
+    s.events[qi] = { ...q, texts };
+    return q.held || undefined;
+  }
+  return undefined;
 }
 
 // Record a composer send as in-flight and show its optimistic bubble NOW (before any kernel push).
@@ -427,32 +446,6 @@ function registerOptimistic(id: string, text: string, imgPaths?: string[]): void
     appendActive();
     if (content && wasAtBottom) content.scrollTop = content.scrollHeight;
   }
-}
-
-// A landing just retired a pending bubble. When the landed atom is ABSORBED (kernel ev.absorbed: a
-// mid-turn splice, placed at its send time) and it landed ABOVE the tail, the bubble the user was
-// watching at the bottom is gone and the message is somewhere higher up — leave a cue under the event
-// the bubble sat under (cueAnchor). It landed AT the tail → the swap was in place, no cue owed. Keyed
-// on the landing itself; dismissed by the user's jump or ✕, never by a timer. The anchor is an event
-// the chat DRAWS in its current mode: compact mode (the default) hides thinking, and a cue hung on a
-// hidden event never rendered and could never be dismissed (2026-09-06 review).
-const cueRendered = (e: TailEvent): boolean => !(settings.compact && e.kind === "thinking");
-function noteAbsorbedLanding(s: Session, idx: number): void {
-  const ev = s.events[idx] as (ChatEvent & { absorbed?: boolean; landedAt?: number }) | undefined;
-  if (!ev || !ev.absorbed || !ev.uuid) return;
-  const after = cueAnchor(s.events as TailEvent[], idx, cueRendered);
-  if (!after) return;
-  const cues = absorbedCues.get(s.id) || [];
-  if (cues.some((c) => c.target === ev.uuid)) return;
-  cues.push({ after, target: ev.uuid, landedAt: typeof ev.landedAt === "number" ? ev.landedAt : null });
-  absorbedCues.set(s.id, cues);
-  const v = views.get(s.id);
-  if (v) v.stale = true;
-}
-
-function dismissAbsorbedCue(sid: string, target: string): void {
-  const cues = (absorbedCues.get(sid) || []).filter((c) => c.target !== target);
-  if (cues.length) absorbedCues.set(sid, cues); else absorbedCues.delete(sid);
 }
 
 // The socket (or the VS Code pipe) went DOWN: every send still unconfirmed may never have reached the
@@ -2379,7 +2372,7 @@ function contentOffsetFrame(content: HTMLElement, v: View, s: Session):
   // on a fully rendered conversation (T245). scrollTop + client-rect top is the position IN THE SCROLL
   // CONTENT, invariant under scrolling: pure scrolling still moves nothing. The gate counts UNITS, never
   // nodes: one unit may own several .turn nodes — appendItem tags an expanded tool/retry group's child
-  // turns and every absorbed cue with their unit — so a node-count gate silently dropped the frame back
+  // turns with their unit — so a node-count gate silently dropped the frame back
   // to the sum whenever a group stood open (review of the first cut, 2026-09-08: 14px off, and the notch
   // changed basis on every expand and collapse).
   if (exact.size > 0 && exact.size === unitTotal && !v.el.querySelector(".tx-spacer") && content.scrollHeight > 0) {
@@ -2653,11 +2646,6 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     // a TYPED follow-up (resumed a goal) → a compact "↩ Follow-up · <goal>" header, the romp goal-context
     // quote + markers already stripped server-side. Same header the pending queued render uses (consistency).
     if (ev.followUp && !romp) turn.appendChild(followUpHeader(ev.goal, ev.fuCtx, ev.uuid ? "u:" + ev.uuid : undefined));
-    // "joined mid-turn" (kernel ev.absorbed): the CLI queued this send behind a running turn and took it
-    // at a later tool boundary; the transcript places it at its SEND time, so it reads above steps that
-    // were already running. The header says why; when the session took it (ev.landedAt) is one level
-    // deeper, on hover. Human bubbles only — a romp nudge's own tag row already says what it is.
-    if ((ev as any).absorbed && !romp && !injected && !tagged) turn.appendChild(absorbedHeader((ev as any).landedAt));
     const hasImgs = !!(ev.images && ev.images.length);
     if (ev.md || hasImgs) {
       if (romp) {
@@ -3687,46 +3675,6 @@ function compactTokens(n: number): string {
 // strip is display-only, and this is where the hidden part can be audited. Expansion survives the chat's
 // re-renders via fuExpanded (keyed by the turn's uuid / queue slot), NOT DOM state that a rebuild would lose.
 const fuExpanded = new Set<string>();
-const hhmm = (epoch: number): string => markerLabel(epoch, null, Date.now()).hm;
-
-function absorbedHeader(landedAt?: number | null): HTMLElement {
-  const h = el("div", "absorbed-tag");
-  h.textContent = "joined mid-turn";
-  h.title = "Sent while the session was working; it waited behind the steps in progress"
-    + (typeof landedAt === "number" ? ", and the session took it at " + hhmm(landedAt) : "") + ".";
-  return h;
-}
-
-// The mid-turn cue (absorbedCues): where a pending bubble sat when its message landed higher up. The
-// interrupt marker's chrome — a rail ring and one dim line — plus jump/✕ in the small-button rest.
-// Buttons ride the body delegate (data-act): the tail rebuilds every push.
-function renderAbsorbedCue(c: AbsorbedCue): HTMLElement {
-  const turn = el("div", "turn turn-absorbed-cue");
-  turn.dataset.cueTarget = c.target;
-  turn.appendChild(dot("ring"));
-  const line = el("div", "absorbed-cue-line");
-  line.title = "The session took your message at a tool boundary while it was working, so it appears above the steps that were already running.";
-  line.appendChild(document.createTextNode("delivered into the running turn"
-    + (c.landedAt != null ? " at " + hhmm(c.landedAt) : "")));
-  const jump = el("button", "absorbed-cue-act") as HTMLButtonElement;
-  jump.type = "button"; jump.textContent = "jump"; jump.title = "Scroll to the message";
-  jump.dataset.act = "abjump"; jump.dataset.target = c.target;
-  const x = el("button", "absorbed-cue-act") as HTMLButtonElement;
-  x.type = "button"; x.textContent = "✕"; x.title = "Dismiss this note";
-  x.dataset.act = "abdismiss"; x.dataset.target = c.target;
-  line.appendChild(jump); line.appendChild(x);
-  turn.appendChild(line);
-  return turn;
-}
-
-// The mid-turn cue(s) hung under this item's event(s) — rendered with the item, so the note keeps its
-// place as the tail grows past it.
-function appendAbsorbedCues(v: View, s: Session, uuids: (string | undefined)[], tag: (n: HTMLElement) => HTMLElement): void {
-  const cues = absorbedCues.get(s.id);
-  if (!cues || !cues.length) return;
-  for (const c of cues) if (uuids.includes(c.after)) v.el.appendChild(tag(renderAbsorbedCue(c)));
-}
-
 function followUpHeader(goal?: string, ctx?: string, key?: string): HTMLElement {
   const h = el("div", "followup-tag");
   const k = key || "";
@@ -3846,6 +3794,10 @@ function fillBareLabel(label: HTMLElement, nLost: number, nSending: number): voi
 }
 
 function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
+  // a copy hidden for a send drawn at its own slot (T252 hideQueuedCopy) is not rendered here; a group left
+  // with nothing visible renders as a zero-height unit (the unit still exists for the scroll↔unit map)
+  const texts = ev.texts.filter((t) => !t.hiddenByPending);
+  if (!texts.length) { const hid = el("div", "turn turn-queued turn-queued-hidden"); hid.style.display = "none"; return hid; }
   const turn = el("div", "turn turn-queued");
   // A BARE group is romp's own optimistic echo with nothing else known-queued: "N queued messages" is a
   // claim we can't back for a send the session hasn't confirmed (the user 2026-07-16) — so it wears its
@@ -3862,16 +3814,21 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // nothing confirming it since, reads "not confirmed" in warn amber — "sending…" would claim a
     // progress romp cannot see — and the ✕ is its way back to the composer; the others in the same
     // group still read "sending…". One label, both counts when both states are present.
-    const nLost = ev.texts.filter((t) => t.lost).length;
-    fillBareLabel(label, nLost, ev.texts.length - nLost);
+    const nLost = texts.filter((t) => t.lost).length;
+    fillBareLabel(label, nLost, texts.length - nLost);
+    if (ev.held) {   // the reason a hidden kernel copy carried (a usage limit holds every send): the wait says so
+      label.appendChild(document.createTextNode(" · " + ev.held.what
+        + (ev.held.resetsAt ? " · in " + fmtReset(ev.held.resetsAt, Math.floor(Date.now() / 1000)) : "")));
+      if (ev.held.detail) label.title = ev.held.detail;
+    }
     head.appendChild(label);
     turn.appendChild(head);
   }
   if (!ev.bare) {
-    const n = ev.texts.length;
-    const nCmd = ev.texts.filter((t) => SLASH_CMD_RE.test(t.md)).length;
-    const nSys = ev.texts.filter((t) => !!t.rompSystem).length;
-    const nNudge = ev.texts.filter((t) => !!t.romp && !t.rompSystem).length;
+    const n = texts.length;
+    const nCmd = texts.filter((t) => SLASH_CMD_RE.test(t.md)).length;
+    const nSys = texts.filter((t) => !!t.rompSystem).length;
+    const nNudge = texts.filter((t) => !!t.romp && !t.rompSystem).length;
     const head = el("div", "queued-head");
     head.appendChild(hourglassIcon());
     // While a question is pending, say WHAT it's waiting on: a message you'd already written when the picker
@@ -3901,9 +3858,9 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
   // identical texts FOLLOW it" — the queue drains from the FRONT, so a duplicate landing ahead leaves every
   // later duplicate's count untouched (counting the ones BEFORE renumbered them, review 2026-09-07)
   const totalSig = new Map<string, number>();
-  for (const t of ev.texts) { const k = strHash32(t.md); totalSig.set(k, (totalSig.get(k) || 0) + 1); }
+  for (const t of texts) { const k = strHash32(t.md); totalSig.set(k, (totalSig.get(k) || 0) + 1); }
   const seenSig = new Map<string, number>();
-  for (const t of ev.texts) {
+  for (const t of texts) {
     if (t.followUp && !t.romp) turn.appendChild(followUpHeader(t.goal, t.fuCtx, t.idx !== undefined ? "q:" + t.idx : undefined));
     const bubble = el("div", "queued-bubble md" + (t.cancelable ? " cancelable" : "")
                       + (t.romp ? " queued-romp" : "") + (t.rompSystem ? " queued-sys" : ""));
@@ -6468,7 +6425,6 @@ function dropProvisional(): { queued: string[]; draft: string } {
     const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
     draft = (activeId === id && ta) ? ta.value : (drafts.get(id) ?? "");
     pendingSent.delete(id);                // the optimistic bubbles belong to a tab that is going away
-    absorbedCues.delete(id);
     dismissSession(id, "close");           // drops it from sessions/order/views and reselects
   }
   return { queued, draft };
@@ -6528,7 +6484,6 @@ function failProvisional(why: string): void {
   const draft = (activeId === id && ta0) ? ta0.value : (drafts.get(id) ?? "");
   const held = [...queued, draft].filter(Boolean).join("\n\n");
   pendingSent.delete(id);            // the dashed "received" bubbles fold into the held text instead
-  absorbedCues.delete(id);
   failedProvisionals.add(id);
   const s = sessions.get(id);
   // "closed" gives the tab the dead treatment (struck label, plain ✕) — but the composer stays LIVE
@@ -9643,7 +9598,6 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
         v.el.appendChild(tag(child)); adv(i);
       });
     }
-    appendAbsorbedCues(v, s, it.indices.map((i) => s.events[i]?.uuid), tag);
   } else if (it.kind === "retrygroup") {
     const notes = it.indices.map((i) => s.events[i]) as Extract<ChatEvent, { kind: "retried" }>[];
     const key = retryGroupKey(notes[0]);
@@ -9657,11 +9611,9 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
         v.el.appendChild(tag(child)); adv(i);
       });
     }
-    appendAbsorbedCues(v, s, it.indices.map((i) => s.events[i]?.uuid), tag);
   } else {
     v.el.appendChild(tag(renderEvent(s.events[it.index], prevEpoch, turnWorkedSecs(s.events, it.index, working))));
     adv(it.index);
-    appendAbsorbedCues(v, s, [s.events[it.index]?.uuid], tag);
   }
   return prevEpoch;
 }
@@ -13463,13 +13415,14 @@ function chatTail(msg: any) {
   }
   // msg.from is a GLOBAL transcript index; the resident events are the tail [headFrom, …) → map to local.
   const from = (msg.from | 0) - (s.headFrom || 0);
-  // The kernel's coordinate space ends at ITS OWN events — our injected optimistic tail is not in it.
+  // The kernel's coordinate space ends at ITS OWN events — our injected optimistic bubbles are not in it.
   // Comparing `from` against the inflated length masked a genuine 1-event gap (the repair below never
   // fired, PR #107's desync class), and a delta starting exactly one past kernel truth landed BEYOND
   // the injected bubble, freezing it into the resident events as fake history the reconcile's strip
-  // loop could never pop (the user 2026-08-09).
-  let kernelLen = s.events.length;
-  while (kernelLen > 0 && isOptimistic(s.events[kernelLen - 1])) kernelLen--;
+  // loop could never pop (the user 2026-08-09). Since T252 a bubble sits at its send slot, mid-array,
+  // where it would also SHIFT every kernel index after it — so strip first, then read kernel lengths.
+  stripOptimistic(s);
+  const kernelLen = s.events.length;
   if (from > kernelLen) {
     // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would
     // fabricate a transcript that silently skips them. This used to just `return` and "wait for the next
@@ -15391,21 +15344,6 @@ setupSettings();
     forkspot: (elx) => {
       const cut = (elx.closest(".fork-spot") as HTMLElement | null)?.dataset.cut || "";
       if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, cut);
-    },
-    // the mid-turn cue (absorbedCues): "jump" scrolls to the absorbed message and retires the note — its
-    // job, explaining the vanished bubble, is done; ✕ retires it in place. Delegated like qx: the tail
-    // rebuilds every push. The node goes NOW (the acknowledgement); the map keeps it gone.
-    abjump: (elx) => {
-      const target = elx.dataset.target || "";
-      const sidC = owningSidOf(elx) || activeId;
-      if (sidC) dismissAbsorbedCue(sidC, target);
-      (elx.closest(".turn-absorbed-cue") as HTMLElement | null)?.remove();
-      if (target) scrollToAnchor(target);
-    },
-    abdismiss: (elx) => {
-      const sidC = owningSidOf(elx) || activeId;
-      if (sidC) dismissAbsorbedCue(sidC, elx.dataset.target || "");
-      (elx.closest(".turn-absorbed-cue") as HTMLElement | null)?.remove();
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -93,7 +93,7 @@ test("with every unit rendered the frame is the scrollbar's own truth: real midd
   const frameBody = RENDER.split("function contentOffsetFrame(")[1].split("\nfunction ")[0];
   assert.match(frameBody, /const nodes = Array\.from\(v\.el\.querySelectorAll<HTMLElement>\("\.turn\[data-unit\]"\)\);/);
   assert.match(frameBody, /exact\.set\(u, content\.scrollTop \+ \(r\.top - cRect\.top\) \+ r\.height \/ 2\);/, "scroll-space middle, invariant under scrolling");
-  // one unit may own several .turn nodes (an expanded tool group's children, absorbed cues — appendItem tags them
+  // one unit may own several .turn nodes (an expanded tool group's children — appendItem tags them
   // all with the unit): the unit's FIRST node is its root, and the gate counts UNITS against a spacer-free view,
   // never nodes — the first cut's node count dropped the frame back to the sum whenever a group stood open
   assert.match(frameBody, /if \(Number\.isFinite\(u\) && !exact\.has\(u\)\) \{/, "first node per unit");

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -21,7 +21,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
+import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, queuedCopyToHide, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
 
 const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = read("render.ts");
@@ -208,6 +208,51 @@ test("several pending sends: each after its own anchor, in send order; same anch
   assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", seen: [], queued: 0 }), 0);
 });
 
+test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {
+  // the anchor skips the kernel's echo atoms (an echo is not a stable place to bound the landing scan), but as a
+  // PLACEMENT that inverted consecutive sends: the second message sat above the first until both landed. A user
+  // event the kernel stamped at or before the press — an echo, a never-delivered bubble, a landed atom — is
+  // older than this send, so the bubble goes below it, exactly where the absorbed atom will be placed by time.
+  const isoAt = (s: number) => new Date(s * 1000).toISOString();
+  const S = Math.floor(T0 / 1000);
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 30) }];
+  const first = press(tail, "first message");
+  const echoed: TailEvent[] = [...tail, { kind: "user", md: "first message", uuid: "echo:1", ts: isoAt(S - 2) }];
+  reconcilePending(echoed, first);                              // the kernel's echo covers the first send
+  const second = newPending("second message", undefined, T0);   // pressed with the echo as the newest event
+  const list = [...first, second];
+  const r = reconcilePending(echoed, list);
+  assert.equal(second.at?.after, "a1", "the scan anchor still skips the echo");
+  assert.deepEqual(r.inject, [second]);
+  assert.deepEqual(injectionGroups(echoed, r.inject), [{ idx: 2, sends: [second] }], "…but the bubble is placed below it");
+  // a never-delivered bubble from an earlier send: older than this press, so below it too
+  const lost: TailEvent[] = [...tail, { kind: "user", md: "older", uuid: "echo:9", undelivered: true, ts: isoAt(S - 5) }];
+  const p = press(lost, "newer");
+  assert.deepEqual(injectionGroups(lost, reconcilePending(lost, p).inject), [{ idx: 2, sends: [p[0]] }]);
+  // a user event stamped AFTER the press is a later send: the bubble stays above it
+  const later: TailEvent[] = [...tail, { kind: "user", md: "someone else's later message", uuid: "u7", ts: isoAt(S + 30) }];
+  const q = newPending("mine", undefined, T0);
+  reconcilePending(tail, [q]);                                  // pressed against the tail before u7 arrived
+  assert.deepEqual(injectionGroups(later, reconcilePending(later, [q]).inject), [{ idx: 1, sends: [q] }]);
+});
+
+test("queuedCopyToHide: the newest not-yet-hidden copy of the text, never a copy the kernel marked non-cancelable", () => {
+  // the kernel marks a queued copy cancelable:false when no recall exists (a tmux queue): that copy stays the
+  // one bubble shown, with its honest "can't be recalled" tooltip, and ours is suppressed as before — hiding it
+  // behind our bubble's ✕ offered a cancel the kernel would refuse (review of the first cut)
+  const texts = [{ md: "a" }, { md: "b", cancelable: false }, { md: "a", hiddenByPending: true }, { md: "a" }];
+  assert.equal(queuedCopyToHide(texts, "a"), 3, "the newest visible copy");
+  assert.equal(queuedCopyToHide(texts.slice(0, 3), "a"), 0, "…skipping one already hidden");
+  assert.equal(queuedCopyToHide(texts, "b"), -1, "a non-cancelable copy is never hidden");
+  assert.equal(queuedCopyToHide(texts, "zzz"), -1);
+  assert.equal(queuedCopyToHide([{ md: " a " }], "a"), 0, "trimmed match, like every other text test");
+  // render.ts: a copy the helper refuses keeps covering our bubble (the send leaves `inject`)
+  assert.match(RENDER, /const k = queuedCopyToHide\(q\.texts, p\.text\);/);
+  assert.match(RENDER, /if \(k < 0\) return null;\s*\/\/ no copy to hide/);
+  assert.match(RENDER, /const hid = hideQueuedCopy\(s, p\);\s*\n\s*if \(hid === null\) covered\.add\(p\); else if \(hid\.held\) heldBy\.set\(p, hid\.held\);/);
+  assert.match(RENDER, /const inject = r\.inject\.filter\(\(p\) => !covered\.has\(p\)\);/);
+});
+
 test("the kernel's queued copy at the tail is hidden for a send drawn in place — one bubble per message (T252)", () => {
   const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
   const list = press(tail, TEXT);
@@ -228,6 +273,12 @@ test("render.ts draws the bubble at its slot, strips its own injections before a
   assert.match(RENDER, /function stripOptimistic\(s: Session\): void \{/, "one strip, used by every ingest path");
   const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("s.events.length = from;"));
   assert.match(tail, /stripOptimistic\(s\);/, "the delta's kernel index is applied to KERNEL events only — a mid-array bubble would shift it");
+  // …but only once the delta is going to be applied: stripping before the gap/head early returns left s.events
+  // without the bubble while the DOM still showed it (review of the first cut)
+  const afterReturns = tail.slice(tail.indexOf("if (from < 0) return;"));
+  assert.match(afterReturns, /stripOptimistic\(s\);/, "the strip sits after both early returns");
+  assert.doesNotMatch(tail.slice(0, tail.indexOf("if (from > kernelLen) {")), /stripOptimistic\(s\);/, "…and not before the gap check");
+  assert.match(tail, /const kernelLen = s\.events\.reduce\(\(n, e\) => n \+ \(isOptimistic\(e\) \? 0 : 1\), 0\);/, "the gap check counts kernel events without mutating");
   for (const gone of ["absorbedHeader", "absorbedCues", "noteAbsorbedLanding", "renderAbsorbedCue", "appendAbsorbedCues", "dismissAbsorbedCue", "cueRendered", "abjump", "abdismiss", "absorbed-tag", "turn-absorbed-cue"])
     assert.ok(!RENDER.includes(gone), gone + " is gone from render.ts");
   for (const gone of [".absorbed-tag", ".turn-absorbed-cue", ".absorbed-cue-line", ".absorbed-cue-act"])

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -3,12 +3,15 @@
 // pending bubble at the bottom vanished and the message reappeared higher up with no cue; and the
 // client's bubble had a 20 s lifetime, so when the kernel's own echo was pruned early the send simply
 // looked delivered. Now: (1) a pending send has NO lifetime — it ends on a landing, the kernel's
-// never-delivered verdict, or the user's ✕; (2) a landed absorbed atom wears a "joined mid-turn" header
-// and, when it landed above the tail, leaves a cue where the bubble sat ("delivered into the running
-// turn at HH:MM · jump"); (3) every composer send posts a clientDiag breadcrumb (never the text).
+// never-delivered verdict, or the user's ✕; (2) the pending bubble is drawn AT ITS SEND POSITION from the
+// start — right after its anchor, the last stable kernel event at the press — so the steps that stream
+// in afterwards land below it and the absorbed atom, which the kernel places at the send time, replaces
+// it in the same spot (T252, the user 2026-09-07: a header plus a button that jumps somewhere and later
+// disappears is weird; the first cut's "joined mid-turn" header and the jump/✕ cue are gone);
+// (3) every composer send posts a clientDiag breadcrumb (never the text).
 // The 2026-09-06 adversarial review then fixed the decision's frame: (4) every verdict is read from the
-// events AFTER the send's anchor, never from a 30-event tail count; (5) the cue anchors on a RENDERED
-// event; (6) the lost verdict shares the anchor; (7) exact text, one landing per send; (8) a connection
+// events AFTER the send's anchor, never from a 30-event tail count; (5) [retired with the cue];
+// (6) the lost verdict shares the anchor; (7) exact text, one landing per send; (8) a connection
 // drop repaints once; (9) the bare label is per bubble; (10) the kernel's own copy clears "not confirmed".
 // Round 3 of that review: (11) receipt is attributed per send, like landings; (12) the ✕ removes the
 // bubble's own entry; (13) a stamp taken late reads the events' own times. Round 4: (14) a late stamp
@@ -18,7 +21,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { newPending, pendingBody, reconcilePending, dropPending, cueAnchor, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
+import { newPending, pendingBody, reconcilePending, dropPending, injectionGroups, scanFrom, landedIn, provisionalIn, bareGroupLabel, type TailEvent, type PendingSend } from "./send-pending";
 
 const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const RENDER = read("render.ts");
@@ -70,7 +73,7 @@ test("it clears on the kernel's echo (suppressed) and ends on the landing (retir
     { kind: "tool", uuid: "t9" },
   ], list);
   assert.equal(r.keep.length, 0, "a landed user atom ends it");
-  assert.deepEqual(r.landed.map((l) => l.idx), [1], "…naming the landed event, for the cue");
+  assert.deepEqual(r.landed.map((l) => l.idx), [1], "…naming the landed event: the slot the bubble held");
 });
 
 test("an image send lands even though the paths are gone from the text", () => {
@@ -166,39 +169,73 @@ test("what was already there at the press is background: an older identical mess
   assert.equal(r.inject.length, 1, "…and cover nothing: our bubble shows beside the older copies (two sends, two bubbles)");
 });
 
-// ── (5) the cue anchors on a rendered event ──────────────────────────────────────────────────────
+// ── (5) the bubble sits at its send position: right after its anchor, from the first paint ────────
 
-test("cueAnchor: the last kernel event after the landed atom, or null when it landed at the tail", () => {
-  const events: TailEvent[] = [
-    { kind: "user", uuid: "u1", md: "first comment" },
-    { kind: "user", uuid: "att1", md: "second comment", absorbed: true },
-    { kind: "tool", uuid: "t1" },
-    { kind: "tool", uuid: "t2" },
-    { kind: "user", uuid: "echo:9", md: "a third send, still pending at the kernel" },
-    { kind: "queued", uuid: "optimistic:123", texts: [{ md: "ours" }] },
-  ];
-  assert.equal(cueAnchor(events, 1), "t2", "under the event the bubble sat under — never our injection or the kernel's echo");
-  assert.equal(cueAnchor(events.slice(0, 2), 1), null, "landed AT the tail: the swap was in place, no cue owed");
-  assert.equal(cueAnchor([events[0], events[1], { kind: "tool" }], 1), null, "nothing stable to hang it on");
+test("the pending bubble is placed right after its anchor and stays there while steps stream in below (T252)", () => {
+  const tail: TailEvent[] = [{ kind: "user", md: "first", uuid: "u1" }, { kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, TEXT);
+  assert.equal(list[0].at?.after, "a1", "anchored to the last stable kernel event at the press");
+  let r = reconcilePending(tail, list);
+  assert.deepEqual(injectionGroups(tail, r.inject), [{ idx: 2, sends: [list[0]] }], "at the press the slot IS the tail");
+  // two tool steps stream in while the CLI holds the send: they land below the bubble, the bubble does not move
+  const streaming: TailEvent[] = [...tail, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }];
+  r = reconcilePending(streaming, list);
+  assert.equal(r.inject.length, 1, "still pending, still drawn");
+  assert.deepEqual(injectionGroups(streaming, r.inject), [{ idx: 2, sends: [list[0]] }], "same slot: after a1, above t1 and t2");
+  // the CLI takes it at the boundary: the kernel places the absorbed atom at its SEND time — the bubble's slot
+  const landed: TailEvent[] = [...tail, { kind: "user", md: TEXT, uuid: "att1", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }];
+  r = reconcilePending(landed, list);
+  assert.deepEqual(r.landed.map((l) => l.idx), [2], "the landing replaces the bubble in place: same index");
+  assert.equal(r.keep.length, 0);
 });
 
-test("cueAnchor skips what the chat does not draw: a thinking tail anchors on the tool before it in compact mode", () => {
-  const events: TailEvent[] = [
-    { kind: "user", uuid: "u1", md: "first comment" },
-    { kind: "user", uuid: "att1", md: "second comment", absorbed: true },
-    { kind: "tool", uuid: "t1" },
-    { kind: "thinking", uuid: "th1" },
-  ];
-  const compact = (e: TailEvent) => e.kind !== "thinking";
-  assert.equal(cueAnchor(events, 1, compact), "t1", "compact mode hides thinking — the cue needs an item that renders");
-  assert.equal(cueAnchor(events, 1), "th1", "full mode draws the thinking block, so the bubble did sit under it");
-  assert.equal(cueAnchor([events[0], events[1], events[3]], 1, compact), null, "only hidden events after the landing: no place for a cue");
-  // render.ts hands over the current mode's rule, and compact mode is what hides thinking (compact.ts)
-  assert.match(RENDER, /const cueRendered = \(e: TailEvent\): boolean => !\(settings\.compact && e\.kind === "thinking"\);/);
-  assert.match(RENDER, /const after = cueAnchor\(s\.events as TailEvent\[\], idx, cueRendered\);/);
+test("several pending sends: each after its own anchor, in send order; same anchor → one group in order", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, "one", "two");                 // pressed against the same frame
+  const later: TailEvent[] = [...tail, { kind: "tool", uuid: "t1" }];
+  const third = newPending("three", undefined, T0 + 9);
+  const all = [...list, third];
+  const r = reconcilePending(later, all);                  // the third is stamped now, after t1
+  assert.equal(third.at?.after, "t1");
+  assert.deepEqual(injectionGroups(later, r.inject), [
+    { idx: 2, sends: [third] },                            // highest slot first, so the caller can splice bottom-up
+    { idx: 1, sends: [list[0], list[1]] },                 // one bare group for the two that share an anchor, in send order
+  ]);
+  // no events at all: the only slot is the head, which is also the tail
+  const none = press([], "hello");
+  assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
+  // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
+  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", seen: [], queued: 0 }), 0);
 });
 
-// ── (6) the lost verdict shares the anchor ───────────────────────────────────────────────────────
+test("the kernel's queued copy at the tail is hidden for a send drawn in place — one bubble per message (T252)", () => {
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const list = press(tail, TEXT);
+  const r = reconcilePending([...tail, { kind: "tool", uuid: "t1" }, { kind: "queued", texts: [{ md: TEXT }] }], list);
+  assert.equal(list[0].received, true, "the kernel's copy proves receipt");
+  assert.deepEqual(r.inject, [list[0]], "…but ours stays drawn, at its slot");
+  assert.deepEqual(r.unqueue, [list[0]], "and the caller drops the kernel's tail copy for it");
+  // an ECHO atom covers ours as before: the kernel draws that atom itself, at the send time
+  const r2 = reconcilePending([...tail, { kind: "user", md: TEXT, uuid: "echo:1" }], press(tail, TEXT));
+  assert.equal(r2.inject.length, 0);
+  assert.equal(r2.unqueue.length, 0);
+});
+
+test("render.ts draws the bubble at its slot, strips its own injections before applying kernel indices, and carries no header or cue", () => {
+  assert.match(RENDER, /for \(const g of injectionGroups\(s\.events as TailEvent\[\], inject\)\)\s*\n?\s*s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts/,
+    "the bare group is spliced at the slot, never pushed at the tail");
+  assert.doesNotMatch(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true/, "no tail push remains");
+  assert.match(RENDER, /function stripOptimistic\(s: Session\): void \{/, "one strip, used by every ingest path");
+  const tail = RENDER.slice(RENDER.indexOf("function chatTail(msg: any) {"), RENDER.indexOf("s.events.length = from;"));
+  assert.match(tail, /stripOptimistic\(s\);/, "the delta's kernel index is applied to KERNEL events only — a mid-array bubble would shift it");
+  for (const gone of ["absorbedHeader", "absorbedCues", "noteAbsorbedLanding", "renderAbsorbedCue", "appendAbsorbedCues", "dismissAbsorbedCue", "cueRendered", "abjump", "abdismiss", "absorbed-tag", "turn-absorbed-cue"])
+    assert.ok(!RENDER.includes(gone), gone + " is gone from render.ts");
+  for (const gone of [".absorbed-tag", ".turn-absorbed-cue", ".absorbed-cue-line", ".absorbed-cue-act"])
+    assert.ok(!CSS.includes(gone), gone + " is gone from styles.css");
+  // the "not confirmed" state and the ✕ on the pending bubble itself stay
+  assert.match(RENDER, /if \(t\.optimistic && t\.lost\) bubble\.dataset\.lost = "1";/);
+  assert.match(RENDER, /if \(t\.optimistic\) x\.dataset\.qopt = "1";/);
+});
 
 test("a resend of a never-delivered message is not retired by the old verdict — only a verdict after the send counts", () => {
   // the flow the never-delivered bubble offers: copy to composer, Enter — the old bubble is still in the tail
@@ -284,7 +321,7 @@ test("the bare group's label counts lost and sending bubbles separately", () => 
   assert.match(bareGroupLabel(1, 1).title, /^The connection dropped after this was sent[\s\S]*The rest: on its way/);
   // render.ts builds the label from the bubbles' own states, and the ✕'s recount reads them back off the
   // surviving bubbles (data-lost) — never off the label's previous class
-  assert.match(RENDER, /const nLost = ev\.texts\.filter\(\(t\) => t\.lost\)\.length;\s*\n\s*fillBareLabel\(label, nLost, ev\.texts\.length - nLost\);/);
+  assert.match(RENDER, /const nLost = texts\.filter\(\(t\) => t\.lost\)\.length;\s*\n\s*fillBareLabel\(label, nLost, texts\.length - nLost\);/);
   assert.match(RENDER, /if \(t\.optimistic && t\.lost\) bubble\.dataset\.lost = "1";/);
   assert.match(RENDER, /const nLost = bubbles\.filter\(\(b\) => \(b as HTMLElement\)\.dataset\.lost === "1"\)\.length;\s*\n\s*fillBareLabel\(label, nLost, bubbles\.length - nLost\);/);
   assert.doesNotMatch(RENDER, /label\.classList\.contains\("lost"\)/);
@@ -360,10 +397,11 @@ test("queued copies are handed out by position: one new copy confirms one send; 
   const list = press(tail, "continue", "continue");
   let r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }] }], list);
   assert.deepEqual(list.map((p) => p.received), [true, undefined]);
-  assert.deepEqual(r.inject, [list[1]], "one kernel copy, one of ours: two bubbles for two sends");
+  assert.deepEqual(r.inject, [list[0], list[1]], "both drawn in place (T252); the kernel's one copy is hidden for the first");
+  assert.deepEqual(r.unqueue, [list[0]]);
   r = reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }, { md: "continue" }] }], list);
   assert.deepEqual(list.map((p) => p.received), [true, true]);
-  assert.equal(r.inject.length, 0);
+  assert.deepEqual(r.unqueue, [list[0], list[1]], "two kernel copies, both hidden: two bubbles for two sends, in place");
   // a second press that already saw the first send's copy counts it as background, not as its own
   const a = press(tail, "continue");
   reconcilePending([...tail, { kind: "queued", texts: [{ md: "continue" }] }], a);
@@ -473,11 +511,13 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
     const list = [late()];
     let r = reconcilePending([step, q], list);
     assert.equal(list[0].at?.queued, 0, "the frame's one copy is presumed this press's, not background");
-    assert.equal(r.inject.length, 0, "the kernel's copy covers our bubble for the whole wait: no double bubble beside it");
+    assert.equal(r.inject.length, 1, "ours stays drawn at its send slot (T252)…");
+    assert.equal(r.unqueue.length, 1, "…and the kernel's copy is the one hidden: no double bubble");
     assert.equal(list[0].received, true);
-    // every later push, the same copy keeps covering it — the entry never sat uncovered until the CLI took it
+    // every later push, the same copy keeps proving receipt — the entry never sat unconfirmed until the CLI took it
     r = reconcilePending([step, q], list);
-    assert.equal(r.inject.length, 0);
+    assert.equal(r.inject.length, 1);
+    assert.equal(r.unqueue.length, 1);
     // …and when the CLI takes the text, the landing ends the bubble (a tmux route: no echo in between)
     r = reconcilePending([step, { kind: "user", md: TEXT, uuid: "u1", ts: isoAt(S + 40) }], list);
     assert.deepEqual(r.landed.map((l) => l.idx), [1]);
@@ -494,20 +534,23 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   assert.deepEqual(early[0].at, { after: "a1", seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
-  assert.equal(r.inject.length, 0);
+  assert.equal(r.inject.length, 1);
+  assert.equal(r.unqueue.length, 1, "the copy that follows is this send's: hidden, ours drawn, receipt proven");
   assert.equal(early[0].received, true);
   // two identical sends pressed against the same placeholder frame own one copy EACH — and when the frame
   // lists only one of them (the kernel had not received the second), the second waits for its own
   const pair = [late(), late()];
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], pair);
   assert.deepEqual(pair.map((p) => p.at?.queued), [0, 0]);
-  assert.equal(r.inject.length, 0, "both copies are the pair's: neither bubble doubles");
+  assert.equal(r.inject.length, 2, "both copies are the pair's: both hidden, both of ours drawn");
+  assert.equal(r.unqueue.length, 2);
   const pair2 = [late(), late()];
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], pair2);
   assert.deepEqual(pair2.map((p) => p.at?.queued), [0, 0], "fewer copies than presses: the count floors at zero");
-  assert.equal(r.inject.length, 1, "one copy covers one send; the other waits for its own");
+  assert.equal(r.inject.length, 2, "both drawn; one copy proves one send, the other waits for its own");
+  assert.equal(r.unqueue.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }, { md: TEXT }] }], pair2);
-  assert.equal(r.inject.length, 0);
+  assert.equal(r.unqueue.length, 2);
   // a press-time stamp presumes nothing: its frame predates the press, so every listed copy is background
   const prompt = press([step, { kind: "queued", texts: [{ md: TEXT }] }], TEXT);
   assert.equal(prompt[0].at?.queued, 1);
@@ -519,40 +562,6 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   assert.equal(dropPending(covered, TEXT), mine);
   assert.equal(covered.length, 0);
 });
-
-// ── (2) the absorbed header and the mid-turn cue ─────────────────────────────────────────────────
-
-test("the landed absorbed atom wears the 'joined mid-turn' header, with the taken-at time one level deeper", () => {
-  assert.match(RENDER, /if \(\(ev as any\)\.absorbed && !romp && !injected && !tagged\) turn\.appendChild\(absorbedHeader\(\(ev as any\)\.landedAt\)\);/);
-  assert.match(RENDER, /function absorbedHeader\(landedAt\?: number \| null\): HTMLElement \{\s*\n\s*const h = el\("div", "absorbed-tag"\);\s*\n\s*h\.textContent = "joined mid-turn";/);
-  assert.match(RENDER, /h\.title = "Sent while the session was working[^"]*"\s*\n\s*\+ \(typeof landedAt === "number" \? ", and the session took it at " \+ hhmm\(landedAt\) : ""\)/,
-    "the time rides the tooltip, not the one-line head");
-  // one header family: the follow-up header's size and alignment, dim rather than accent
-  assert.match(CSS, /\.absorbed-tag \{ max-width: 72%; margin-bottom: 1px; font-size: 0\.82em; color: var\(--dim\); \}/);
-});
-
-test("a landing above the tail leaves the cue where the bubble sat; jump scrolls to the atom; both actions retire it", () => {
-  // recorded at the landing that retired the bubble (never re-derived per build), keyed to the anchor event
-  assert.match(RENDER, /for \(const \{ idx \} of r\.landed\) noteAbsorbedLanding\(s, idx\);/);
-  assert.match(RENDER, /function noteAbsorbedLanding\(s: Session, idx: number\): void \{[\s\S]{0,400}?if \(!ev \|\| !ev\.absorbed \|\| !ev\.uuid\) return;\s*\n\s*const after = cueAnchor\(s\.events as TailEvent\[\], idx, cueRendered\);\s*\n\s*if \(!after\) return;/);
-  assert.match(RENDER, /cues\.push\(\{ after, target: ev\.uuid, landedAt: typeof ev\.landedAt === "number" \? ev\.landedAt : null \}\);/);
-  // rendered with the anchor item on every window build (single events, tool groups, retry groups), so it keeps its place
-  assert.equal((RENDER.match(/appendAbsorbedCues\(v, s, /g) || []).length, 3, "hung under every item shape appendItem renders");
-  assert.match(RENDER, /line\.appendChild\(document\.createTextNode\("delivered into the running turn"\s*\n\s*\+ \(c\.landedAt != null \? " at " \+ hhmm\(c\.landedAt\) : ""\)\)\);/);
-  // click-safe: data-act on the body delegate; jump = scrollToAnchor on the atom's uuid, and the cue is done
-  assert.match(RENDER, /jump\.dataset\.act = "abjump"; jump\.dataset\.target = c\.target;/);
-  assert.match(RENDER, /x\.dataset\.act = "abdismiss"; x\.dataset\.target = c\.target;/);
-  assert.match(RENDER, /abjump: \(elx\) => \{[\s\S]{0,400}?dismissAbsorbedCue\(sidC, target\);[\s\S]{0,200}?if \(target\) scrollToAnchor\(target\);/);
-  assert.match(RENDER, /abdismiss: \(elx\) => \{[\s\S]{0,300}?dismissAbsorbedCue\(sidC, elx\.dataset\.target \|\| ""\);/);
-  // the interrupt marker's chrome, shared by selector rather than copied
-  assert.match(CSS, /\.turn-absorbed-cue \.dot, \.turn-interrupt \.dot \{ background: var\(--dim\); border: none; \}/);
-  assert.match(CSS, /\.absorbed-cue-line, \.interrupt-line \{[^}]*font-style: italic/);
-  assert.match(CSS, /\.absorbed-cue-act,\n\.undelivered-act \{/);
-  // the cue leaves with its tab, like the pending sends
-  assert.equal((RENDER.match(/absorbedCues\.delete\(id\);/g) || []).length, 2);
-});
-
-// ── (3) the breadcrumb ───────────────────────────────────────────────────────────────────────────
 
 test("every composer send posts a clientDiag breadcrumb — sid, time, length, route; never the text", () => {
   const m = RENDER.match(/vscodeApi\.postMessage\(\{ type: "clientDiag", surface: "chat", what: "send",\s*\n\s*data: \{ ([^}]*) \} \}\);/);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -272,6 +272,36 @@ test("the placement floor is the last user event AT THE PRESS, by identity, neve
   assert.doesNotMatch(read("send-pending.ts").split("export function placementIndex(")[1].split("\n}")[0], /eventSecond|pressS|p\.ts/, "placement reads no clock");
 });
 
+test("the text fallback finds the floor by ORDINAL, so a later send of the same text never pulls the bubble down (third review)", () => {
+  // A = "ok" pressed and echoed; B = "next" pressed with echo:A the newest user event; A lands, two steps stream,
+  // then the user sends "ok" again. The fallback used to take the LAST same-text user event — the new send's echo —
+  // and B's bubble dropped to the tail under a message pressed after it, until B landed.
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1" }];
+  const echoedA: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "echo:A" }];
+  const b = newPending("next", undefined, T0);
+  reconcilePending(echoedA, [b]);
+  assert.equal(b.at?.place, "echo:A");
+  assert.equal(b.at?.placeOrd, 1, "one same-text user event from the anchor through the floor");
+  const later: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "uA", absorbed: true }, { kind: "tool", uuid: "t1" }, { kind: "tool", uuid: "t2" }, { kind: "user", md: "ok", uuid: "echo:C" }];
+  assert.deepEqual(injectionGroups(later, reconcilePending(later, [b]).inject), [{ idx: 2, sends: [b] }], "below uA, above t1 — not under the newer echo");
+  const laterLanded: TailEvent[] = [...later.slice(0, 4), { kind: "user", md: "ok", uuid: "uC" }];
+  assert.deepEqual(injectionGroups(laterLanded, reconcilePending(laterLanded, [b]).inject), [{ idx: 2, sends: [b] }], "…nor under its landed atom");
+  // two identical echoes as the tail: the floor is the SECOND, so after both land the bubble sits below the second
+  const twin: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "echo:A1" }, { kind: "user", md: "ok", uuid: "echo:A2" }];
+  const c = newPending("next", undefined, T0 + 1);
+  reconcilePending(twin, [c]);
+  assert.equal(c.at?.placeOrd, 2);
+  const twinLanded: TailEvent[] = [...tail, { kind: "user", md: "ok", uuid: "uA1" }, { kind: "user", md: "ok", uuid: "uA2" }, { kind: "tool", uuid: "t1" }];
+  assert.deepEqual(injectionGroups(twinLanded, reconcilePending(twinLanded, [c]).inject), [{ idx: 3, sends: [c] }]);
+  // the floor sits ABOVE the anchor (steps followed the last message before the press): the anchor already covers
+  // it, and a later same-text send must not become a floor
+  const stepsAfter: TailEvent[] = [{ kind: "user", md: "ok", uuid: "u0" }, { kind: "tool", uuid: "t0" }, { kind: "assistant", md: "…", uuid: "a1" }];
+  const d = press(stepsAfter, "next")[0];
+  assert.equal(d.at?.placeOrd, 0, "no same-text event after the anchor: the floor is not in play");
+  const stepsAfterLater: TailEvent[] = [...stepsAfter, { kind: "tool", uuid: "t3" }, { kind: "user", md: "ok", uuid: "echo:D" }];
+  assert.deepEqual(injectionGroups(stepsAfterLater, reconcilePending(stepsAfterLater, [d]).inject), [{ idx: 3, sends: [d] }], "right after the anchor");
+});
+
 test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
   // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
   // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle
@@ -577,7 +607,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, placeOrd: 0, seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -627,7 +657,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, placeOrd: 0, seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -229,11 +229,56 @@ test("a send pressed while an earlier send's echo is the newest event is placed 
   const lost: TailEvent[] = [...tail, { kind: "user", md: "older", uuid: "echo:9", undelivered: true, ts: isoAt(S - 5) }];
   const p = press(lost, "newer");
   assert.deepEqual(injectionGroups(lost, reconcilePending(lost, p).inject), [{ idx: 2, sends: [p[0]] }]);
-  // a user event stamped AFTER the press is a later send: the bubble stays above it
+  // a user event that arrives AFTER the press is a later send: the bubble stays above it
   const later: TailEvent[] = [...tail, { kind: "user", md: "someone else's later message", uuid: "u7", ts: isoAt(S + 30) }];
   const q = newPending("mine", undefined, T0);
   reconcilePending(tail, [q]);                                  // pressed against the tail before u7 arrived
   assert.deepEqual(injectionGroups(later, reconcilePending(later, [q]).inject), [{ idx: 1, sends: [q] }]);
+});
+
+test("the placement floor is the last user event AT THE PRESS, by identity, never a clock (second review)", () => {
+  // a press-time frame already proves precedence: every event resident at the press is older than the send. Comparing
+  // the client's press second with the kernel host's stamps re-inverted the order whenever the kernel clock led by more
+  // than the gap between two presses (a phone, a remote browser), and misplaced a bubble below a later-received event
+  // when the client clock led. So the press records the last user event's uuid (an echo counts) as the floor.
+  const isoAt = (s: number) => new Date(s * 1000).toISOString();
+  const S = Math.floor(T0 / 1000);
+  const tail: TailEvent[] = [{ kind: "assistant", md: "…", uuid: "a1", ts: isoAt(S - 30) }];
+  // kernel host 3 s AHEAD: the first send's echo is stamped after the second press's second
+  const echoed: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "echo:1", ts: isoAt(S + 3) }];
+  const second = newPending("second", undefined, T0);
+  let r = reconcilePending(echoed, [second]);
+  assert.equal(second.at?.place, "echo:1", "the floor is recorded at the press");
+  assert.deepEqual(injectionGroups(echoed, r.inject), [{ idx: 2, sends: [second] }], "below the echo, whatever the clocks say");
+  // the echo → landed swap: the floor's uuid is gone, the landed atom carries its text — still the floor
+  const landedFirst: TailEvent[] = [...tail, { kind: "user", md: "first", uuid: "u1", absorbed: true, ts: isoAt(S + 3) }, { kind: "tool", uuid: "t1" }];
+  r = reconcilePending(landedFirst, [second]);
+  assert.deepEqual(injectionGroups(landedFirst, r.inject), [{ idx: 2, sends: [second] }], "below the landed first message, above the later tool");
+  // client clock AHEAD: a peer's message the kernel receives after the press, stamped at or before the press second,
+  // was not resident at the press — the bubble stays above it
+  const peerLater: TailEvent[] = [...tail, { kind: "user", md: "a peer's message", uuid: "u9", ts: isoAt(S - 1) }];
+  const mine = newPending("mine", undefined, T0);
+  reconcilePending(tail, [mine]);
+  assert.deepEqual(injectionGroups(peerLater, reconcilePending(peerLater, [mine]).inject), [{ idx: 1, sends: [mine] }]);
+  // no user event at the press: no floor, the anchor rules
+  const bare = press(tail, "alone");
+  assert.equal(bare[0].at?.place, null);
+  assert.deepEqual(injectionGroups(tail, reconcilePending(tail, bare).inject), [{ idx: 1, sends: [bare[0]] }]);
+  // a LATE entry (pressed against no frame) reads the frame's own stamps for its floor, like its anchor
+  const lateFrame: TailEvent[] = [...tail, { kind: "user", md: "older", uuid: "echo:5", ts: isoAt(S - 2) }, { kind: "user", md: "newer", uuid: "echo:6", ts: isoAt(S + 2) }];
+  const late: PendingSend = { ...newPending("late one", undefined, T0), late: true };
+  reconcilePending(lateFrame, [late]);
+  assert.equal(late.at?.place, "echo:5", "the last user event the kernel stamped before the press");
+  assert.doesNotMatch(read("send-pending.ts").split("export function placementIndex(")[1].split("\n}")[0], /eventSecond|pressS|p\.ts/, "placement reads no clock");
+});
+
+test("a bubble that changes slot marks the view stale, so the incremental repaint never trusts a shifted prefix (second review)", () => {
+  // chatTail lowers v.rendered to the kernel index and the normal-mode append path re-renders from there, assuming
+  // the DOM prefix still matches s.events — which also requires the bubble's SLOT to be unchanged. The settle
+  // signature therefore carries each group's slot beside its texts.
+  const fn = RENDER.split("function reconcileOptimistic(")[1].split("\nfunction ")[0];
+  assert.match(fn, /settle\(groups\.flatMap\(\(g\) => g\.sends\.map\(\(p\) => g\.idx \+ ":" \+ p\.text\)\)\);/);
+  assert.match(fn, /const groups = injectionGroups\(s\.events as TailEvent\[\], inject\);/);
 });
 
 test("queuedCopyToHide: the newest not-yet-hidden copy of the text, never a copy the kernel marked non-cancelable", () => {
@@ -267,7 +312,7 @@ test("the kernel's queued copy at the tail is hidden for a send drawn in place �
 });
 
 test("render.ts draws the bubble at its slot, strips its own injections before applying kernel indices, and carries no header or cue", () => {
-  assert.match(RENDER, /for \(const g of injectionGroups\(s\.events as TailEvent\[\], inject\)\)\s*\n?\s*s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts/,
+  assert.match(RENDER, /const groups = injectionGroups\(s\.events as TailEvent\[\], inject\);\s*\n\s*for \(const g of groups\)\s*\n\s*s\.events\.splice\(g\.idx, 0, \{ kind: "queued", bare: true, texts: g\.sends\.map\(mk\), uuid: OPT_PREFIX \+ g\.sends\[0\]\.ts/,
     "the bare group is spliced at the slot, never pushed at the tail");
   assert.doesNotMatch(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true/, "no tail push remains");
   assert.match(RENDER, /function stripOptimistic\(s: Session\): void \{/, "one strip, used by every ingest path");
@@ -532,7 +577,7 @@ test("a send pressed against no frame (a placeholder tab): the first frame's cop
   // a first frame that predates the send entirely stamps exactly as a press-time stamp would
   list = [late()];
   reconcilePending([frame[0], frame[1]], list);
-  assert.deepEqual(list[0].at, { after: "a1", seen: ["u-old"], queued: 0 });
+  assert.deepEqual(list[0].at, { after: "a1", place: "u-old", placeText: TEXT, seen: ["u-old"], queued: 0 });
   // a press-time stamp reads no stamp: its frame predates the press by construction, so an identical
   // message that landed within the press's own second is still background
   const prompt = press([frame[1], { kind: "user", md: TEXT, uuid: "u-same-second", ts: isoAt(Math.floor(T0 / 1000)) }], TEXT);
@@ -582,7 +627,7 @@ test("a late stamp presumes the first frame's newest queued copy of the text is 
   // follows covers it, exactly as at a press-time stamp
   const early = [late()];
   let r = reconcilePending([step], early);
-  assert.deepEqual(early[0].at, { after: "a1", seen: [], queued: 0 });
+  assert.deepEqual(early[0].at, { after: "a1", place: null, placeText: undefined, seen: [], queued: 0 });
   assert.equal(r.inject.length, 1);
   r = reconcilePending([step, { kind: "queued", texts: [{ md: TEXT }] }], early);
   assert.equal(r.inject.length, 1);

--- a/ui/webview/send-pending.test.ts
+++ b/ui/webview/send-pending.test.ts
@@ -205,7 +205,7 @@ test("several pending sends: each after its own anchor, in send order; same anch
   const none = press([], "hello");
   assert.deepEqual(injectionGroups([], reconcilePending([], none).inject), [{ idx: 0, sends: [none[0]] }]);
   // an anchor that left the resident window: everything resident is later than the send, so the slot is the head
-  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", seen: [], queued: 0 }), 0);
+  assert.equal(scanFrom([{ kind: "tool", uuid: "zz" }], { after: "gone", place: null, seen: [], queued: 0 }), 0);
 });
 
 test("a send pressed while an earlier send's echo is the newest event is placed BELOW that echo (review of the first cut)", () => {

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -234,8 +234,10 @@ export function scanFrom(events: TailEvent[], at: SendBase): number {
 
 export type Reconciled = {
   keep: PendingSend[];                        // still pending after this push
-  inject: PendingSend[];                      // …and not covered by a kernel provisional → show ours
-  landed: { p: PendingSend; idx: number }[];  // retired by a landing; idx = the landed event's index
+  inject: PendingSend[];                      // …and drawn by us: not covered by the kernel's echo atom (a queued
+                                              //   copy does not cover — ours stays in place and the copy is hidden, T252)
+  unqueue: PendingSend[];                     // …whose kernel cover is a QUEUED copy: the caller hides that copy
+  landed: { p: PendingSend; idx: number }[];  // retired by a landing; idx = the landed event's index — the slot the bubble held
   lost: PendingSend[];                        // retired by the kernel's never-delivered verdict
 };
 
@@ -272,7 +274,7 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
   const lateOwn = new Map<string, number>();
   for (const p of list) if (!p.at && p.late) lateOwn.set(p.text, (lateOwn.get(p.text) || 0) + 1);
   for (const p of list) if (!p.at) p.at = stampBase(events, p, p.late ? lateOwn.get(p.text) || 1 : 0);
-  const r: Reconciled = { keep: [], inject: [], landed: [], lost: [] };
+  const r: Reconciled = { keep: [], inject: [], unqueue: [], landed: [], lost: [] };
   const claimed = new Map<string, number>();           // "index\0text" → copies of that text in that landing taken by earlier entries THIS push
   const takenCopies = new Map<string, Set<number>>();  // text → queued-copy positions taken by an earlier entry THIS push
   for (const p of list) {
@@ -294,14 +296,14 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     // a ✕ on it must not hand its echo to the next entry; an echo is one text, so one entry in `seen` is
     // the whole of it) — else the first queued copy beyond this entry's press-time count that no
     // earlier entry took this push.
-    let covered = false;
+    let covered = false, byQueued = false;
     if (echoIdx >= 0) {
       covered = true;
       const u = events[echoIdx].uuid;
       if (u) for (const q of list) if (q !== p && q.at && q.text === p.text && !q.at.seen.includes(u)) q.at.seen.push(u);
     } else if (copies > at.queued) {
       const taken = takenCopies.get(p.text) || new Set<number>();
-      for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; break; }
+      for (let k = at.queued; k < copies; k++) if (!taken.has(k)) { taken.add(k); covered = true; byQueued = true; break; }
       takenCopies.set(p.text, taken);
     }
     if (covered) p.received = true;             // the kernel holds this send: proven once, latched
@@ -314,7 +316,11 @@ export function reconcilePending(events: TailEvent[], list: PendingSend[]): Reco
     }
     if (lostIdx >= 0) { r.lost.push(p); continue; }
     r.keep.push(p);
-    if (!covered) r.inject.push(p);
+    // The kernel's ECHO atom covers ours: the kernel draws that atom itself, at the send time. A QUEUED copy
+    // does not: it sits in the kernel's group at the tail, and the bubble the user watches is ours, at its
+    // send slot — so ours stays drawn and the caller hides that copy, one bubble per message (T252).
+    if (!covered || byQueued) r.inject.push(p);
+    if (covered && byQueued) r.unqueue.push(p);
   }
   // Every landing claimed this push is spoken for: one copy per claim becomes background for every
   // pending send with the same text that STAYS, on every push after (the retired entry's claim would
@@ -340,19 +346,23 @@ export function dropPending(list: PendingSend[], text: string, ts?: number): Pen
   return i >= 0 ? list.splice(i, 1)[0] : undefined;
 }
 
-/** Where the pending bubble SAT when its message landed higher up: the uuid of the last RENDERED kernel
- *  event after `landedIdx` (the bubble rode the tail, under that event). null when the landed atom is
- *  itself the tail — the swap happened in place and no cue is owed. The client's own injections and the
- *  kernel's echo atoms are skipped: neither is a stable place to hang a note. `rendered` says which
- *  events the chat draws in its current mode — compact mode (the default) hides thinking, and a cue
- *  anchored to a hidden event is never drawn and can never be dismissed (2026-09-06 review). */
-export function cueAnchor(events: TailEvent[], landedIdx: number, rendered: (e: TailEvent) => boolean = () => true): string | null {
-  for (let j = events.length - 1; j > landedIdx; j--) {
-    const e = events[j];
-    if (!stableUuid(e) || !rendered(e)) continue;
-    return e.uuid!;
+/** Where the caller draws the pending bubbles: each at the index right AFTER its anchor — the last stable
+ *  kernel event at the press — so the steps that stream in afterwards land below it and the absorbed atom,
+ *  which the kernel places at the send time, replaces it in the same slot (T252, the user 2026-09-07: the
+ *  bubble used to ride the tail and then vanish, its message reappearing higher up under a header and a
+ *  cue). Sends that share an anchor form ONE group, in send order; groups come highest index first, so a
+ *  caller splicing them into the events array bottom-up keeps every lower index valid. No anchor (nothing
+ *  stable at the press) or an anchor that left the resident window puts the bubble at the head: everything
+ *  resident is later than the send (scanFrom). */
+export type InjectionGroup = { idx: number; sends: PendingSend[] };
+export function injectionGroups(events: TailEvent[], inject: PendingSend[]): InjectionGroup[] {
+  const byIdx = new Map<number, PendingSend[]>();
+  for (const p of inject) {
+    const idx = p.at ? scanFrom(events, p.at) : events.length;
+    const g = byIdx.get(idx);
+    if (g) g.push(p); else byIdx.set(idx, [p]);
   }
-  return null;
+  return [...byIdx.entries()].sort((x, y) => y[0] - x[0]).map(([idx, sends]) => ({ idx, sends }));
 }
 
 /** The bare group's one-line header, from its bubbles' OWN states: the lost ones (the connection dropped

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -41,7 +41,12 @@ export type SendBase = {
                           //   (not a stable place to bound the landing scan), but for placement an echo is exactly the
                           //   earlier send the bubble must follow. null → no user event at the press, the anchor rules
   placeText?: string;     // that event's text: when its uuid leaves (the echo → landed swap), the landed atom carrying
-                          //   the same text after the anchor is the floor
+                          //   the same text after the anchor is the floor…
+  placeOrd?: number;      //   …found by ORDINAL: how many same-text user events sit after the anchor through the floor
+                          //   at the press (the floor itself included). Events before the floor only ever swap echo →
+                          //   landed in place, so the k-th match stays the floor while a LATER send of the same text
+                          //   (its echo, its atom) lands beyond it and is never taken (third review). 0 → the floor sits
+                          //   at or above the anchor, which already covers it: no fallback
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
@@ -218,10 +223,19 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
   let after: string | null = null;
   for (let i = events.length - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
-  let place: string | null = null, placeText: string | undefined;
+  let place: string | null = null, placeText: string | undefined, placeOrd = 0;
+  let floorIdx = -1;
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
-    if (e.kind === "user" && e.uuid && !isOptimisticUuid(e.uuid) && beforeSend(e)) { place = e.uuid; placeText = typeof e.md === "string" ? e.md : undefined; break; }
+    if (e.kind === "user" && e.uuid && !isOptimisticUuid(e.uuid) && beforeSend(e)) { place = e.uuid; placeText = typeof e.md === "string" ? e.md : undefined; floorIdx = i; break; }
+  }
+  if (floorIdx >= 0 && placeText !== undefined) {
+    let anchorIdx = -1;
+    if (after !== null) for (let i = events.length - 1; i >= 0; i--) if (events[i].uuid === after) { anchorIdx = i; break; }
+    for (let i = anchorIdx + 1; i <= floorIdx; i++) {
+      const e = events[i];
+      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, placeText)) placeOrd++;
+    }
   }
   const seen: string[] = [];
   let queued = 0;
@@ -234,7 +248,7 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, place, placeText, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, place, placeText, placeOrd, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -383,21 +397,29 @@ export function injectionGroups(events: TailEvent[], inject: PendingSend[]): Inj
  *  (an echo is not a stable place to bound the LANDING scan, since the landed atom replaces it under a new
  *  uuid) but which is older than this send all the same. Without it a second message pressed while the
  *  first's echo was the newest event sat ABOVE it until both landed (review of the first cut). The floor is
- *  found by identity: its uuid, or — once the echo has become the landed atom — the last user event after
- *  the anchor carrying its text. Never by comparing the client's clock with the kernel's stamps: the frame
+ *  found by identity: its uuid, or — once the echo has become the landed atom — the k-th user event after
+ *  the anchor carrying its text, k being how many such events sat through the floor at the press (a later
+ *  send of the same text lands beyond the k-th and is never taken; the last match used to be, and pulled
+ *  the bubble to the tail under a newer message — third review). A floor at or above the anchor is already
+ *  covered by the anchor. Never by comparing the client's clock with the kernel's stamps: the frame
  *  resident at the press is older than the send by construction, and a clock comparison re-inverted the
  *  order whenever the kernel clock led the client by more than the gap between two presses (second
  *  review). A user event that arrives after the press is a later send and stays below the bubble. */
 export function placementIndex(events: TailEvent[], p: PendingSend): number {
   const at = p.at!;
   let idx = scanFrom(events, at);
-  if (!at.place) return idx;
+  if (!at.place || !(at.placeOrd && at.placeOrd > 0)) return idx;   // no floor after the anchor: the anchor rules
   for (let j = events.length - 1; j >= idx; j--) if (events[j].uuid === at.place) return j + 1;
   if (at.placeText !== undefined) {
-    for (let j = events.length - 1; j >= idx; j--) {
+    let n = 0, last = -1;
+    for (let j = idx; j < events.length; j++) {
       const e = events[j];
-      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) return j + 1;
+      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) {
+        n++; last = j;
+        if (n === at.placeOrd) return j + 1;              // the floor, under its landed uuid
+      }
     }
+    if (last >= 0) return last + 1;                       // fewer matches than at the press (a pruned echo): the newest stands in
   }
   return idx;
 }

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -16,7 +16,9 @@
 // visible on — the durable record is the kernel's (a persisted echo, the dropped marking, the fed-text
 // guard in prune_live), but if it blinks, ours steps straight back in; a copy seen after the press also
 // proves the kernel RECEIVED that one send (`received`, attributed per send like a landing). Nothing here
-// reads a clock: the one comparison of stamps (a late stamp, stampBase) orders two events.
+// reads a clock for a press-time entry: the frame resident at the press is older than the send by
+// construction, so its anchor AND its placement floor are recorded by identity; only a LATE stamp (stampBase)
+// compares stamps to order events.
 //
 // THE ANCHOR (2026-09-06 review): every decision is read from the events AFTER the send, never from a
 // count of tail events. At the first reconcile after the press the entry records the uuid of the last
@@ -34,6 +36,12 @@
 
 export type SendBase = {
   after: string | null;   // uuid of the last stable kernel event at the press; null → nothing to anchor on, scan from the head
+  place: string | null;   // PLACEMENT FLOOR: uuid of the last USER event at the press, an echo included (T252 second
+                          //   review) — older than this send, so the bubble is drawn below it; the anchor skips echoes
+                          //   (not a stable place to bound the landing scan), but for placement an echo is exactly the
+                          //   earlier send the bubble must follow. null → no user event at the press, the anchor rules
+  placeText?: string;     // that event's text: when its uuid leaves (the echo → landed swap), the landed atom carrying
+                          //   the same text after the anchor is the floor
   seen: string[];         // uuids of the user events carrying the text that are background for this send: what
                           //   the press found, and what an earlier same-text entry claimed since — ONE ENTRY PER
                           //   COPY (a record of several sends lists its uuid once per spoken-for block)
@@ -210,6 +218,11 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   const beforeSend = (e: TailEvent): boolean => { const s = eventSecond(e); return s === null || s < pressS; };
   let after: string | null = null;
   for (let i = events.length - 1; i >= 0; i--) if (stableUuid(events[i]) && beforeSend(events[i])) { after = events[i].uuid!; break; }
+  let place: string | null = null, placeText: string | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind === "user" && e.uuid && !isOptimisticUuid(e.uuid) && beforeSend(e)) { place = e.uuid; placeText = typeof e.md === "string" ? e.md : undefined; break; }
+  }
   const seen: string[] = [];
   let queued = 0;
   for (const e of events) {
@@ -221,7 +234,7 @@ export function stampBase(events: TailEvent[], p: PendingSend, own: number = p.l
   // the queued presumption (above): a late stamp's newest `own` copies are this press's, so the count of
   // background copies stops short of them — at zero when the frame lists fewer than presumed (the kernel
   // had not received every press yet; the copies still to come cover those entries in order)
-  return { after, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
+  return { after, place, placeText, seen, queued: Math.max(0, queued - (p.late ? own : 0)) };
 }
 
 /** The first index AFTER the send's anchor — or 0 when there is no anchor, or when the anchor has left the
@@ -365,22 +378,26 @@ export function injectionGroups(events: TailEvent[], inject: PendingSend[]): Inj
   return [...byIdx.entries()].sort((x, y) => y[0] - x[0]).map(([idx, sends]) => ({ idx, sends }));
 }
 
-/** The slot for one send: after its scan anchor, and after every USER event the kernel stamped at or before
- *  the press — an earlier send's echo atom, a never-delivered bubble, a landed atom — which the anchor rule
- *  skips (an echo is not a stable place to bound the LANDING scan, since the landed atom replaces it under a
- *  new uuid) but which is older than this send all the same. Without this a second message pressed while the
- *  first's echo was the newest event sat ABOVE it until both landed (review of the first cut). The rule is the
- *  kernel's own: it places the absorbed atom by its send time, so the bubble sits where the atom will land.
- *  A user event stamped after the press is a later send and stays below the bubble. */
+/** The slot for one send: after its scan anchor, and after its PLACEMENT FLOOR — the last user event at the
+ *  press (an earlier send's echo atom, a never-delivered bubble, a landed atom), which the anchor rule skips
+ *  (an echo is not a stable place to bound the LANDING scan, since the landed atom replaces it under a new
+ *  uuid) but which is older than this send all the same. Without it a second message pressed while the
+ *  first's echo was the newest event sat ABOVE it until both landed (review of the first cut). The floor is
+ *  found by identity: its uuid, or — once the echo has become the landed atom — the last user event after
+ *  the anchor carrying its text. Never by comparing the client's clock with the kernel's stamps: the frame
+ *  resident at the press is older than the send by construction, and a clock comparison re-inverted the
+ *  order whenever the kernel clock led the client by more than the gap between two presses (second
+ *  review). A user event that arrives after the press is a later send and stays below the bubble. */
 export function placementIndex(events: TailEvent[], p: PendingSend): number {
   const at = p.at!;
   let idx = scanFrom(events, at);
-  const pressS = Math.floor(p.ts / 1000);
-  for (let j = events.length - 1; j >= idx; j--) {
-    const e = events[j];
-    if (e.kind !== "user" || isOptimisticUuid(e.uuid)) continue;
-    const s = eventSecond(e);
-    if (s !== null && s <= pressS) { idx = j + 1; break; }
+  if (!at.place) return idx;
+  for (let j = events.length - 1; j >= idx; j--) if (events[j].uuid === at.place) return j + 1;
+  if (at.placeText !== undefined) {
+    for (let j = events.length - 1; j >= idx; j--) {
+      const e = events[j];
+      if (e.kind === "user" && !isOptimisticUuid(e.uuid) && typeof e.md === "string" && sameText(e.md, at.placeText)) return j + 1;
+    }
   }
   return idx;
 }

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -358,11 +358,47 @@ export type InjectionGroup = { idx: number; sends: PendingSend[] };
 export function injectionGroups(events: TailEvent[], inject: PendingSend[]): InjectionGroup[] {
   const byIdx = new Map<number, PendingSend[]>();
   for (const p of inject) {
-    const idx = p.at ? scanFrom(events, p.at) : events.length;
+    const idx = p.at ? placementIndex(events, p) : events.length;
     const g = byIdx.get(idx);
     if (g) g.push(p); else byIdx.set(idx, [p]);
   }
   return [...byIdx.entries()].sort((x, y) => y[0] - x[0]).map(([idx, sends]) => ({ idx, sends }));
+}
+
+/** The slot for one send: after its scan anchor, and after every USER event the kernel stamped at or before
+ *  the press — an earlier send's echo atom, a never-delivered bubble, a landed atom — which the anchor rule
+ *  skips (an echo is not a stable place to bound the LANDING scan, since the landed atom replaces it under a
+ *  new uuid) but which is older than this send all the same. Without this a second message pressed while the
+ *  first's echo was the newest event sat ABOVE it until both landed (review of the first cut). The rule is the
+ *  kernel's own: it places the absorbed atom by its send time, so the bubble sits where the atom will land.
+ *  A user event stamped after the press is a later send and stays below the bubble. */
+export function placementIndex(events: TailEvent[], p: PendingSend): number {
+  const at = p.at!;
+  let idx = scanFrom(events, at);
+  const pressS = Math.floor(p.ts / 1000);
+  for (let j = events.length - 1; j >= idx; j--) {
+    const e = events[j];
+    if (e.kind !== "user" || isOptimisticUuid(e.uuid)) continue;
+    const s = eventSecond(e);
+    if (s !== null && s <= pressS) { idx = j + 1; break; }
+  }
+  return idx;
+}
+
+/** Which copy of `text` in a kernel queued group the caller hides for a send drawn at its own slot: the NEWEST
+ *  copy not already hidden (the group lists the queue in order; ours is the latest press with that text), or -1
+ *  when there is none — including when the only copies are ones the kernel marked cancelable:false (no recall
+ *  exists there: a tmux queue). That copy stays the one bubble shown, with its honest tooltip, and ours is
+ *  suppressed as before: hidden behind our bubble's ✕ it offered a cancel the kernel would refuse (review of the
+ *  first cut). */
+export function queuedCopyToHide(texts: { md?: string; cancelable?: boolean; hiddenByPending?: boolean; optimistic?: boolean }[], text: string): number {
+  for (let k = texts.length - 1; k >= 0; k--) {
+    const t = texts[k];
+    if (t.hiddenByPending || t.optimistic || typeof t.md !== "string" || !sameText(t.md, text)) continue;
+    if (t.cancelable === false) return -1;
+    return k;
+  }
+  return -1;
 }
 
 /** The bare group's one-line header, from its bubbles' OWN states: the lost ones (the connection dropped

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1892,19 +1892,13 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   font-size: 0.82em; color: var(--vscode-errorForeground, #f48771);
   letter-spacing: 0.02em; margin-right: 4px;
 }
-.absorbed-cue-act,
 .undelivered-act {
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
   border: 1px solid var(--card-border); background: transparent; color: var(--dim);   /* T141: the one button rest */
   cursor: pointer; user-select: none; font-style: normal;
   transition: color 0.12s ease, border-color 0.12s ease;
 }
-.absorbed-cue-act:hover, .undelivered-act:hover { color: var(--fg); border-color: var(--accent); }
-/* "joined mid-turn" header (kernel ev.absorbed): the CLI took this message at a later tool boundary and the
-   transcript places it at its SEND time, so it reads above steps that were already running — the header says
-   why. The follow-up header's size and alignment (one header family over an outgoing bubble); dim, not the
-   accent: a note, not a link. */
-.absorbed-tag { max-width: 72%; margin-bottom: 1px; font-size: 0.82em; color: var(--dim); }
+.undelivered-act:hover { color: var(--fg); border-color: var(--accent); }
 /* a pending bubble whose confirmation is in doubt — the connection dropped after the press (send-pending.ts
    `lost`): the bare group's label counts it in a warn-amber "not confirmed" part; the group's other bubbles
    keep their dim "sending…" part beside it (one label, per-bubble state) */
@@ -2869,11 +2863,10 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .chip-interrupting { background: var(--st-working-bg); color: var(--st-working-fg, #332600); opacity: 0.75; }
 /* the stop button's click-ack is now REMOVAL + the optimistic chip flip (the user 2026-07-05): the word
    "interrupting…" no longer rides the fixed-width button (it overflowed onto the elapsed timer). */
-/* the transcript's interrupt MARKER — the compact-divider's language for "you stopped it here". The mid-turn
-   CUE (.turn-absorbed-cue: where a pending bubble sat when its message landed higher up) wears the same
-   chrome — a rail ring and one dim italic line — plus jump/✕ in .absorbed-cue-act's small-button rest. */
-.turn-absorbed-cue .dot, .turn-interrupt .dot { background: var(--dim); border: none; }
-.absorbed-cue-line, .interrupt-line { display: flex; align-items: center; gap: 6px; color: var(--dim); font-size: 0.82em; font-style: italic; }
+/* the transcript's interrupt MARKER — the compact-divider's language for "you stopped it here": a rail ring
+   and one dim italic line. */
+.turn-interrupt .dot { background: var(--dim); border: none; }
+.interrupt-line { display: flex; align-items: center; gap: 6px; color: var(--dim); font-size: 0.82em; font-style: italic; }
 .interrupt-square { width: 8px; height: 8px; border-radius: 2px; background: var(--dim); flex: none; }
 
 /* rail dots are nav handles: hover white-highlights this turn's event on the

--- a/vscode-extension/src/followup-render.test.ts
+++ b/vscode-extension/src/followup-render.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("queued payload is per-message {md, followUp?, goal?, fuCtx?}, not raw strings", () => {
   // `optimistic` (romp's own unconfirmed echo) rides along at the end — see optimistic-send.test.ts
-  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number \}\[\]/);
+  assert.match(SRC, /kind: "queued"; texts: \{ md: string; followUp\?: boolean; goal\?: string; fuCtx\?: string; idx\?: number; park\?: number; cancelable\?: boolean; optimistic\?: boolean; romp\?: boolean; rompSystem\?: boolean; rompAuto\?: boolean; imgPaths\?: string\[\]; lost\?: string; qts\?: number; hiddenByPending\?: boolean \}\[\]/);
 });
 
 test("renderQueued renders markdown (not raw text) + the follow-up header", () => {


### PR DESCRIPTION
The user's decision (2026-09-07): a message sent while the session is mid-turn must simply appear where it was sent and stay there. The merged mid-turn-sends change explained the bubble's move with a "joined mid-turn" header and a jump/✕ cue; both are gone.

**Change**
- The pending bubble is drawn at its **send position** from the first paint: right after its anchor (the last stable kernel event at the press). Steps that stream in while the CLI holds the send land below it; the absorbed atom the kernel places at the send time replaces it in the same slot.
- `send-pending.ts`: `injectionGroups` (slot per send, grouped per anchor, spliced bottom-up); `Reconciled.unqueue` (a kernel **queued** copy no longer covers our bubble; the copy is hidden instead, one bubble per message; an echo atom covers as before); `cueAnchor` deleted.
- `render.ts`: splice at the slot; `stripOptimistic` before any kernel index is applied (`chatTail`); `hideQueuedCopy` + a held group's reason carried onto our bubble; header/cue code, delegates and CSS removed. The "not confirmed" state and the ✕ on the bubble stay.
- Kernel fields `absorbed` / `landedAt` are untouched (judges read them).

**Tests (red before)**
- `ui/webview/send-pending.test.ts`: placement after the anchor, slot kept while steps stream, landing at the same index, groups per anchor, queued-copy hiding, render/CSS pins (no header, no cue, splice not push, strip before delta).
- `tests/test_pending_in_place.py`: served page, send dropped at the socket, two streamed tool steps, then the CLI's `queued_command` attachment lands the atom in the bubble's slot; position unchanged, reader not moved, no header/cue. Skips without a browser.

**Scroll**: placing in place never moves the viewport; at the press the slot is the tail, so the existing at-bottom reveal is unchanged.

**Served-test hardening (same PR)**: five served tests munged the transcript's project dir with slashes only; the kernel maps every non-alphanumeric character to `-`, and pytest's temp root can carry an underscore, so the kernel found no transcript and drew an API-error turn. That was the "fails only in batch runs" pattern reported on T248. They now munge like the kernel and dump the page state on a timeout.
