### PR TITLE
T248b: kernel-side settings converge across attached machines without a click

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,6 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
+import math
 import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
@@ -864,6 +865,7 @@ def _version_info():
                 pass
     except OSError:
         pass
+    _mv, _mgt = _mesh_settings_snapshot()   # value AND stamp of each mesh-adopted store from ONE read (T248b)
     return {"kernel_sha": _kernel_sha(), "kernel_ver": _kernel_ver(), "pid": os.getpid(), "started": int(_STARTED),
             "boot": _BOOT_ID,   # lets a page retire update offers from a previous kernel life (2026-08-15)
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
@@ -891,12 +893,12 @@ def _version_info():
             # the API added beyond the shipped seed, and the last refresh failure — so a stale list
             # is a visible fact in `romp version`, never a guess
             "modelCatalog": _catalog_public_status(),
-            "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
-            "compactSuggest": _compact_suggest_on(),   # T208+: its gear checkbox rides the same read
+            "autoNudge": _mv["autoNudge"],   # server-side toggle state → the gear checkbox reflects the kernel
+            "compactSuggest": _mv["compactSuggest"],   # T208+: its gear checkbox rides the same read
             "conserveMemory": _conserve_on(),   # the T148 toggle: close idle tab-less claude processes
             "login": _login_state(),         # the in-dashboard login flow's state/url/err (T157) — never a secret
             "acctLabel": _claude_account_label(),   # which login this box holds ("" = none) — the gear's Billing row
-            "fileEditing": _file_editing_on(),   # dashboard raw-mode editing opt-in → gates the viewer's Edit
+            "fileEditing": _mv["fileEditing"],   # dashboard raw-mode editing opt-in → gates the viewer's Edit
             # per-install: SDK sessions ask for reasoning summaries (gear checkbox). Top-level only — not
             # in the "settings" sub-dict below, whose mixed marks promise a cross-machine write this never makes
             "thinkingSummaries": _thinking_summaries_on(),
@@ -914,10 +916,14 @@ def _version_info():
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
-            "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
+            # The three a PEER adopts (T248b, _adopt_peer_settings) ride one snapshot per store with their
+            # stamps below: read separately, a click landing between the value read and the stamp read
+            # handed the peer (old value, new stamp), which it persisted and the equal-stamp rule then
+            # froze on both machines (the change's second review).
+            "settings": {"autoNudge": _mv["autoNudge"], "updateMode": _update_mode(),
                          "conserveMemory": _conserve_on(),
-                         "compactSuggest": _compact_suggest_on(),   # default OFF; one value across machines (T248)
-                         "fileEditing": _file_editing_on(),
+                         "compactSuggest": _mv["compactSuggest"],   # default OFF; one value across machines (T248)
+                         "fileEditing": _mv["fileEditing"],
                          "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
                          "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
                          "distillModel": jd._state_str("distill-model", "triage"),
@@ -929,7 +935,7 @@ def _version_info():
             # the gear stamps its next gesture above these instead of trusting the device clock.
             # Top-level, not lifted into /tunnels rows — a remote's newer stamp reaches the dashboard
             # through its settingStale frame, and Apply anyway is the designed path from there.
-            "settingsGt": _settings_gt(),
+            "settingsGt": {**_settings_gt(), **_mgt},   # the adopted stores' stamps from the SAME snapshot as their values
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
             "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
@@ -33300,6 +33306,25 @@ _MESH_ADOPTED_SETTINGS = (("compactSuggest", "compact-suggest", _set_compact_sug
                           ("fileEditing", "file-editing", _set_file_editing))
 
 
+def _mesh_settings_snapshot():
+    """(values, stamps) for the three mesh-adopted stores, each store read ONCE so a value and its stamp
+    are one snapshot: the auto-nudge blob carries autoNudge/compactSuggest and both stamps, file-editing.json
+    carries fileEditing and its stamp. /version serves these for a polling peer's _adopt_peer_settings, which
+    takes the pair as one fact — two reads let a click landing between them hand the peer (old value, new
+    stamp), a pair it persisted and the equal-stamp rule then froze on both machines."""
+    d = _auto_nudge_data()
+    try:
+        fe = json.loads((jd.STATE / "file-editing.json").read_text())
+    except Exception:
+        fe = None
+    fe = fe if isinstance(fe, dict) else {}
+    values = {"autoNudge": bool(d.get("enabled")), "compactSuggest": bool(d.get("compactSuggestEnabled")),
+              "fileEditing": bool(fe.get("enabled"))}
+    stamps = {"auto-nudge": _gt_int(d.get("gt")), "compact-suggest": _gt_int(d.get("compactSuggestGt")),
+              "file-editing": _gt_int(fe.get("gt"))}
+    return values, stamps
+
+
 def _adopt_peer_settings(host, rver):
     """Adopt every kernel-side boolean in `rver` (_poll_remote_version's dict for a peer) whose stamp is
     newer than the local store's — the value when it differs, the stamp alone when it agrees. Returns
@@ -33312,8 +33337,9 @@ def _adopt_peer_settings(host, rver):
     adopted = []
     for key, store, setter in _MESH_ADOPTED_SETTINGS:
         val, pgt = st.get(key), gts.get(store)
-        if not isinstance(val, bool) or isinstance(pgt, bool) or not isinstance(pgt, (int, float)) or pgt <= 0:
-            continue
+        if not isinstance(val, bool) or isinstance(pgt, bool) or not isinstance(pgt, (int, float)) \
+                or not math.isfinite(pgt) or pgt <= 0:
+            continue                                   # json can carry NaN/Infinity: not a stamp, and int() of it raises
         pgt = int(pgt)
         if pgt <= _setting_stored_gt(store):
             continue                                   # older or equal: nothing newer to learn

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16505,7 +16505,12 @@ def _poll_remote_version(r):
     `autoNudge` is that machine's own copy of a setting the gear presents as one switch for everything you
     are running, so the dashboard can say when the machines disagree instead of showing one kernel's answer
     for all of them (the user 2026-08-14). None — never False — when the remote didn't say, so an older
-    kernel that has no such field reads as unknown rather than as off."""
+    kernel that has no such field reads as unknown rather than as off.
+
+    `settingsGt` (T248b): every store's last-applied gesture stamp beside `settings`, so the supervisor
+    can adopt a peer's newer pick without a click (_adopt_peer_settings). None when the peer sends none
+    (an older kernel) — the first cut consumed the field here without carrying it across, so nothing
+    ever converged in production while the hand-built test dicts passed (its review, 2026-09-08)."""
     import urllib.parse
     try:
         c = http.client.HTTPConnection("127.0.0.1", int(r["local_port"]), timeout=4)
@@ -16520,9 +16525,11 @@ def _poll_remote_version(r):
         sha = j.get("kernel_sha") or None
         an = j.get("autoNudge")
         st = j.get("settings")
+        gts = j.get("settingsGt")
         return {"sha": sha, "ver": str(j.get("kernel_ver") or ""),
                 "autoNudge": an if isinstance(an, bool) else None,
-                "settings": st if isinstance(st, dict) else None} if sha else None
+                "settings": st if isinstance(st, dict) else None,
+                "settingsGt": gts if isinstance(gts, dict) else None} if sha else None
     except Exception:
         return None
 
@@ -33281,8 +33288,11 @@ def _setting_kept_value(name):
 # with a DIFFERENT value, is adopted through the setting's own gt-gated setter under the PEER's stamp:
 # the poll observing a newer stamp is the event, and gesture-time ordering gives latest-wins on both
 # sides with no ping-pong (the adopter's stamp then equals the peer's, and an equal stamp is never
-# adopted — the same rule the setters apply to a stale flush). Equal stamps or equal values write
-# nothing; a peer that sends no stamps (an older kernel) or junk teaches nothing. Scope: the three
+# adopted — the same rule the setters apply to a stale flush). A SAME value under a newer stamp is
+# adopted too, for its stamp: the dashboard mints its next gesture above the LOCAL kernel's stamps only
+# (gear.js learnAll on /version's settingsGt), so a lagging stamp let a later local click apply here,
+# stand down on the peer, and be adopted away again one pass later (the first cut's review). Equal
+# stamps write nothing; a peer that sends no stamps (an older kernel) or junk teaches nothing. Scope: the three
 # boolean settings that ride the browser broadcast and have no other propagation leg (the judge tiers
 # fan out over /judge-settings; update mode is a per-install boot policy by design).
 _MESH_ADOPTED_SETTINGS = (("compactSuggest", "compact-suggest", _set_compact_suggest),
@@ -33291,9 +33301,10 @@ _MESH_ADOPTED_SETTINGS = (("compactSuggest", "compact-suggest", _set_compact_sug
 
 
 def _adopt_peer_settings(host, rver):
-    """Adopt every kernel-side boolean in `rver` (a peer's /version dict) whose stamp is newer than the
-    local store's and whose value differs. Returns the store names adopted. Runs on the supervisor
-    thread: the setters' stand-down verdicts are consumed here (no delivering socket to answer)."""
+    """Adopt every kernel-side boolean in `rver` (_poll_remote_version's dict for a peer) whose stamp is
+    newer than the local store's — the value when it differs, the stamp alone when it agrees. Returns
+    the store names adopted. Runs on the supervisor thread: the setters' stand-down verdicts are
+    consumed here (no delivering socket to answer)."""
     st = (rver or {}).get("settings") if isinstance(rver, dict) else None
     gts = (rver or {}).get("settingsGt") if isinstance(rver, dict) else None
     if not isinstance(st, dict) or not isinstance(gts, dict):
@@ -33306,13 +33317,12 @@ def _adopt_peer_settings(host, rver):
         pgt = int(pgt)
         if pgt <= _setting_stored_gt(store):
             continue                                   # older or equal: nothing newer to learn
-        if bool(_setting_kept_value(store)) == val:
-            continue                                   # the values agree: nothing to converge
-        applied = setter(val, gt=pgt)
+        applied = setter(val, gt=pgt)                  # a same value lands too — the setter treats a newer
+        #                                                stamp as an apply (the echo rule needs an EQUAL one)
         _pop_stale_notice()                            # no WS gesture made this: never leave a verdict for one
         if applied is not None:
             adopted.append(store)
-            sys.stderr.write("setting %s: adopted %s's newer pick (%s, gesture %d) — one value across machines\n"
+            sys.stderr.write("setting %s: adopted %s's newer pick (%s, gesture %d) — one value, one stamp across machines\n"
                              % (store, host, val, pgt))
     return adopted
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18691,6 +18691,7 @@ def _tunnel_supervisor():
                         r["kernel_ver"] = (rver or {}).get("ver") or ""
                         r["auto_nudge"] = (rver or {}).get("autoNudge")   # None = that kernel didn't say
                         r["settings"] = (rver or {}).get("settings")      # its whole kernel-side dict (None = older kernel)
+                        r["settingsGt"] = (rver or {}).get("settingsGt")  # each store's last-applied stamp (T248b: the adopt seam)
                     if ruse is not None:
                         # {} = the host ANSWERED with nothing to show → clear; None = no answer (blip/
                         # rate-gate) → keep the last reading (see _poll_remote_usage)
@@ -18713,6 +18714,14 @@ def _tunnel_supervisor():
                     # row and may spawn a worker. Runs here, in the one supervisor, so an advance is pushed
                     # exactly once no matter how many dashboards are open.
                     _maybe_auto_push(r)
+                    # Kernel-side settings converge without a click (T248b): a peer whose stamp for a
+                    # setting is newer than ours, with a different value, is adopted through the setting's
+                    # own gt-gated setter. Outside the lock too: the setters take their own locks and write
+                    # their stores. Loud on a fault, never fatal to the supervisor.
+                    try:
+                        _adopt_peer_settings(r.get("host") or "?", rver)
+                    except Exception:
+                        _tunnel_log(r.get("host") or "?", "adopt-settings", error=traceback.format_exc()[-400:])
                     # tag federation v2, the reattach half (also outside the lock — it round-trips the
                     # tunnel): a host that answers this pass applies any journaled tag edits that
                     # failed while it was unreachable. Steady state costs one cached-list scan.
@@ -33260,6 +33269,52 @@ def _setting_kept_value(name):
     if name == "thinking-summaries":
         return _thinking_summaries_on()
     return jd._state_str(name, "")   # the judge-tier stores are bare value files
+
+
+# ── kernel-side settings converge across attached machines WITHOUT a click (T248b) ──────────────
+# The gear's click is broadcast to every attached kernel (federation.ts KERNEL_SETTING), but a machine
+# attached AFTER the click kept its own copy until the next one, with a mixed mark to show it — and the
+# user's standard for these settings is consistent ALWAYS (2026-09-08, after Suggest /compact fired
+# from an attached kernel whose copy was on while the gear showed the box off). The tunnel supervisor
+# already lifts each up peer's /version "settings" dict onto its /tunnels row every poll; it now lifts
+# "settingsGt" beside it and hands both here. A peer's stamp NEWER than our store's last-applied stamp,
+# with a DIFFERENT value, is adopted through the setting's own gt-gated setter under the PEER's stamp:
+# the poll observing a newer stamp is the event, and gesture-time ordering gives latest-wins on both
+# sides with no ping-pong (the adopter's stamp then equals the peer's, and an equal stamp is never
+# adopted — the same rule the setters apply to a stale flush). Equal stamps or equal values write
+# nothing; a peer that sends no stamps (an older kernel) or junk teaches nothing. Scope: the three
+# boolean settings that ride the browser broadcast and have no other propagation leg (the judge tiers
+# fan out over /judge-settings; update mode is a per-install boot policy by design).
+_MESH_ADOPTED_SETTINGS = (("compactSuggest", "compact-suggest", _set_compact_suggest),
+                          ("autoNudge", "auto-nudge", _set_auto_nudge),
+                          ("fileEditing", "file-editing", _set_file_editing))
+
+
+def _adopt_peer_settings(host, rver):
+    """Adopt every kernel-side boolean in `rver` (a peer's /version dict) whose stamp is newer than the
+    local store's and whose value differs. Returns the store names adopted. Runs on the supervisor
+    thread: the setters' stand-down verdicts are consumed here (no delivering socket to answer)."""
+    st = (rver or {}).get("settings") if isinstance(rver, dict) else None
+    gts = (rver or {}).get("settingsGt") if isinstance(rver, dict) else None
+    if not isinstance(st, dict) or not isinstance(gts, dict):
+        return []
+    adopted = []
+    for key, store, setter in _MESH_ADOPTED_SETTINGS:
+        val, pgt = st.get(key), gts.get(store)
+        if not isinstance(val, bool) or isinstance(pgt, bool) or not isinstance(pgt, (int, float)) or pgt <= 0:
+            continue
+        pgt = int(pgt)
+        if pgt <= _setting_stored_gt(store):
+            continue                                   # older or equal: nothing newer to learn
+        if bool(_setting_kept_value(store)) == val:
+            continue                                   # the values agree: nothing to converge
+        applied = setter(val, gt=pgt)
+        _pop_stale_notice()                            # no WS gesture made this: never leave a verdict for one
+        if applied is not None:
+            adopted.append(store)
+            sys.stderr.write("setting %s: adopted %s's newer pick (%s, gesture %d) — one value across machines\n"
+                             % (store, host, val, pgt))
+    return adopted
 
 
 # Every gt-gated store, by the name _setting_stale is called with — the vocabulary the settingStale

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -123,7 +123,7 @@ class ApplySettings(unittest.TestCase):
         # kernel lifts onto its /tunnels row, and the row serializer forwards it (None = older kernel)
         import inspect
         src = inspect.getsource(km)
-        self.assertIn('"settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode()', src)
+        self.assertIn('"settings": {"autoNudge": _mv["autoNudge"], "updateMode": _update_mode()', src)   # T248b: one snapshot per adopted store
         self.assertIn('"settings": r.get("settings") if isinstance(r.get("settings"), dict) else None', src)
         self.assertIn('r["settings"] = (rver or {}).get("settings")', src)
 

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Kernel-side settings converge across attached machines WITHOUT a click (T248b, the user 2026-09-08: the
+Suggest /compact setting must be consistent always; a machine attached after the click keeping its own copy
+until the next click, with a mixed mark to show it, does not meet that).
+
+The seam is the tunnel supervisor's poll: it already lifts each up peer's /version "settings" dict onto the
+peer's /tunnels row. It now lifts "settingsGt" beside it and hands both to _adopt_peer_settings: when a
+peer's stamp for a setting is NEWER than the local store's last-applied stamp and the values differ, the
+peer's value is applied through the setting's own gt-gated setter with the PEER's stamp. The poll observing
+a newer stamp is the event; gesture-time ordering makes it latest-wins on both sides with no ping-pong (an
+adopter's stamp equals the peer's afterwards, and an equal stamp is never adopted). Generalized to the three
+boolean kernel settings that ride the browser broadcast and nothing else: compactSuggest, autoNudge and
+fileEditing — the same three lines each, one table row apiece.
+
+Two hermetic "kernels" here are two state roots served by one loaded module (jd.STATE swapped per call),
+which is exactly what the seam sees: a peer is its /version dict, nothing more. Synthetic host names, no
+sockets, no live state.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_mesh_adopt", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+KERNEL_SRC = open(os.path.join(BIN, "romp-kernel")).read()
+SETTERS = {"compact-suggest": km._set_compact_suggest, "auto-nudge": km._set_auto_nudge, "file-editing": km._set_file_editing}
+READERS = {"compact-suggest": km._compact_suggest_on, "auto-nudge": km._auto_nudge_on, "file-editing": km._file_editing_on}
+KEYS = {"compact-suggest": "compactSuggest", "auto-nudge": "autoNudge", "file-editing": "fileEditing"}
+
+
+class _Kernel:
+    """One hermetic state root; `with k:` makes the loaded module act as that kernel."""
+
+    def __init__(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.root = Path(self.td.name)
+
+    def __enter__(self):
+        self._saved = jd.STATE
+        jd.STATE = self.root
+        km._autonudge_cache.clear()
+        return self
+
+    def __exit__(self, *a):
+        km._autonudge_cache.clear()
+        jd.STATE = self._saved
+
+    def version(self):
+        """What this kernel's /version says to a polling peer: the settings dict + every store's stamp."""
+        with self:
+            return {"settings": {KEYS[n]: READERS[n]() for n in KEYS}, "settingsGt": km._settings_gt()}
+
+    def set(self, store, value, gt):
+        with self:
+            return SETTERS[store](value, gt=gt)
+
+    def read(self, store):
+        with self:
+            return READERS[store](), km._setting_stored_gt(store)
+
+    def adopt(self, host, rver):
+        with self:
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                out = km._adopt_peer_settings(host, rver)
+            return out, err.getvalue()
+
+    def close(self):
+        self.td.cleanup()
+
+
+class AdoptPeerSettings(unittest.TestCase):
+    def setUp(self):
+        self.a, self.b = _Kernel(), _Kernel()
+
+    def tearDown(self):
+        self.a.close(); self.b.close()
+
+    def test_a_newer_peer_pick_is_applied_with_the_peers_stamp(self):
+        self.b.set("compact-suggest", True, 2_000)
+        adopted, err = self.a.adopt("TESTHOST", self.b.version())
+        self.assertEqual(adopted, ["compact-suggest"])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 2_000), "the peer's value, under the peer's stamp")
+        self.assertIn("TESTHOST", err, "the adoption is said, and names the machine it came from")
+
+    def test_an_older_peer_pick_stands_down_and_leaves_no_stale_verdict_behind(self):
+        self.a.set("compact-suggest", True, 3_000)
+        self.b.set("compact-suggest", False, 2_000)
+        adopted, _ = self.a.adopt("TESTHOST", self.b.version())
+        self.assertEqual(adopted, [])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 3_000), "the newer local pick keeps")
+        with self.a:
+            self.assertIsNone(km._pop_stale_notice(), "no delivering socket here: a stand-down verdict must not leak to the next WS gesture")
+
+    def test_an_equal_stamp_is_never_adopted_whatever_the_value(self):
+        self.a.set("compact-suggest", True, 2_000)
+        self.b.set("compact-suggest", True, 2_000)
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "same news again: no write")
+        self.b.set("compact-suggest", False, 2_000)     # an echo: same stamp → refused by b's own setter
+        self.assertEqual(self.b.read("compact-suggest"), (True, 2_000))
+        # a hand-built peer dict with an equal stamp and a different value: not newer → not adopted (determinism)
+        rver = {"settings": {"compactSuggest": False}, "settingsGt": {"compact-suggest": 2_000}}
+        self.assertEqual(self.a.adopt("TESTHOST", rver)[0], [])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
+
+    def test_the_same_value_under_a_newer_stamp_writes_nothing(self):
+        self.a.set("compact-suggest", True, 2_000)
+        self.b.set("compact-suggest", True, 5_000)
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "the values agree: nothing to converge")
+        self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
+
+    def test_an_older_kernel_or_a_junk_dict_adopts_nothing(self):
+        self.a.set("compact-suggest", False, 1_000)
+        for rver in (None, {}, {"settings": {"compactSuggest": True}},                       # no settingsGt: older kernel
+                     {"settings": {"compactSuggest": True}, "settingsGt": {}},
+                     {"settings": {"compactSuggest": "yes"}, "settingsGt": {"compact-suggest": 9_000}},   # not a bool
+                     {"settings": {"compactSuggest": True}, "settingsGt": {"compact-suggest": "9000"}},   # not a stamp
+                     {"settings": "x", "settingsGt": {"compact-suggest": 9_000}}):
+            self.assertEqual(self.a.adopt("TESTHOST", rver)[0], [], repr(rver))
+        self.assertEqual(self.a.read("compact-suggest"), (False, 1_000))
+
+    def test_no_ping_pong_between_two_kernels(self):
+        self.a.set("compact-suggest", False, 1_000)
+        self.b.set("compact-suggest", True, 2_000)
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], ["compact-suggest"])   # a polls b: adopts
+        self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], [], "b polls a: equal stamps, nothing")
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "a polls b again: nothing")
+        self.assertEqual(self.a.read("compact-suggest"), self.b.read("compact-suggest"), "one value, one stamp")
+
+    def test_the_newest_click_wins_on_both_sides(self):
+        # clicked on a at 4_000 (off) and on b at 3_000 (on) while apart; when they see each other, 4_000 wins everywhere
+        self.a.set("compact-suggest", False, 4_000)
+        self.b.set("compact-suggest", True, 3_000)
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "a holds the newer pick")
+        self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], ["compact-suggest"])
+        self.assertEqual(self.b.read("compact-suggest"), (False, 4_000))
+
+    def test_auto_nudge_and_file_editing_converge_the_same_way(self):
+        # each store's fresh-install default differs (Auto Nudge ships on, file editing off): the peer's pick
+        # is the OTHER value, since a pick equal to what we hold has nothing to converge
+        for store in ("auto-nudge", "file-editing"):
+            default = self.a.read(store)[0]
+            self.b.set(store, not default, 2_000)
+            adopted, _ = self.a.adopt("TESTHOST", self.b.version())
+            self.assertIn(store, adopted, store)
+            self.assertEqual(self.a.read(store), (not default, 2_000), store)
+            self.a.set(store, default, 3_000)
+            self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], [store], store + ": the newer pick flows back")
+            self.assertEqual(self.b.read(store), (default, 3_000), store)
+
+
+class ThePollSeam(unittest.TestCase):
+    def test_the_supervisor_lifts_the_stamps_and_adopts_outside_the_lock(self):
+        sup = KERNEL_SRC.split("def _tunnel_supervisor():")[1].split("\ndef ")[0]
+        self.assertIn('r["settings"] = (rver or {}).get("settings")', sup)
+        self.assertIn('r["settingsGt"] = (rver or {}).get("settingsGt")', sup, "the stamps ride the row beside the values")
+        self.assertIn("_adopt_peer_settings(r.get(\"host\") or \"?\", rver)", sup)
+        # the setters take their own locks and write files: they run in the OUTSIDE-the-lock block, like the auto update
+        before_lock_exit = sup.split("if auto_check:")[0]
+        self.assertNotIn("_adopt_peer_settings(", before_lock_exit, "never under _remotes_lock")
+
+    def test_the_table_names_exactly_the_three_broadcast_booleans(self):
+        self.assertEqual([row[0] for row in km._MESH_ADOPTED_SETTINGS], ["compactSuggest", "autoNudge", "fileEditing"])
+        self.assertEqual([row[1] for row in km._MESH_ADOPTED_SETTINGS], ["compact-suggest", "auto-nudge", "file-editing"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -138,6 +138,16 @@ class AdoptPeerSettings(unittest.TestCase):
         self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], ["compact-suggest"])
         self.assertEqual(self.b.read("compact-suggest"), (False, 7_001), "the click held on both machines")
 
+    def test_a_non_finite_stamp_skips_only_its_own_setting(self):
+        # json can carry NaN/Infinity; int() of either raises, and an exception mid-loop would skip the peer's
+        # remaining settings every pass (second review, nit)
+        self.b.set("file-editing", True, 2_000)
+        rver = {"settings": {"compactSuggest": True, "fileEditing": True},
+                "settingsGt": {"compact-suggest": float("nan"), "file-editing": 2_000}}
+        self.assertEqual(self.a.adopt("TESTHOST", rver)[0], ["file-editing"])
+        rver["settingsGt"]["compact-suggest"] = float("inf")
+        self.assertEqual(self.a.adopt("TESTHOST", rver)[0], [], "…and inf is not a stamp either")
+
     def test_an_older_kernel_or_a_junk_dict_adopts_nothing(self):
         self.a.set("compact-suggest", False, 1_000)
         for rver in (None, {}, {"settings": {"compactSuggest": True}},                       # no settingsGt: older kernel
@@ -229,6 +239,52 @@ class ThroughTheRealPoll(unittest.TestCase):
         self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
         self.assertEqual(self.a.read("file-editing"), (True, 2_000))
         self.assertEqual(self.a.read("auto-nudge")[1], 0, "no stamp for it in the peer's dict: untouched")
+
+
+class TheEmitterIsOneSnapshotPerStore(unittest.TestCase):
+    """The consumer takes a peer's (value, stamp) as one snapshot, so the peer's /version must read each
+    store's value and stamp from ONE read: two reads with a click landing between them yield (old value,
+    new stamp), which the adopter persists and the equal-stamp rule then freezes on both machines (the
+    second review of this change)."""
+
+    def setUp(self):
+        self.k = _Kernel()
+
+    def tearDown(self):
+        self.k.close()
+
+    def test_version_reports_a_value_and_stamp_from_the_same_read(self):
+        # the blob reader is wrapped so that the settings sub-dict's VALUE readers see the pre-click blob while
+        # the stamp reader sees the post-click one — exactly a click landing between two separate reads
+        import inspect
+        with self.k:
+            km._set_compact_suggest(False, gt=5_000)
+            old = dict(km._auto_nudge_data())
+            km._set_compact_suggest(True, gt=9_000)
+            new = dict(km._auto_nudge_data())
+            real = km._auto_nudge_data
+            def torn():
+                caller = inspect.stack()[1].function
+                return dict(old) if caller in ("_compact_suggest_on", "_auto_nudge_on") else dict(new)
+            km._auto_nudge_data = torn
+            try:
+                v = km._version_info()
+            finally:
+                km._auto_nudge_data = real
+        pair = (v["settings"]["compactSuggest"], v["settingsGt"]["compact-suggest"])
+        self.assertIn(pair, [(False, 5_000), (True, 9_000)], "value and stamp come from one snapshot: %r" % (pair,))
+        self.assertEqual(v["compactSuggest"], v["settings"]["compactSuggest"], "the top-level field rides the same snapshot")
+
+    def test_version_builds_the_three_adopted_settings_from_the_snapshot_helper(self):
+        src = KERNEL_SRC.split("def _version_info():")[1].split("\ndef ")[0]
+        self.assertIn("_mesh_settings_snapshot()", src)
+        with self.k:
+            km._set_file_editing(True, gt=4_000)
+            values, stamps = km._mesh_settings_snapshot()
+        self.assertEqual(values["fileEditing"], True)
+        self.assertEqual(stamps["file-editing"], 4_000)
+        self.assertEqual(set(values), {"autoNudge", "compactSuggest", "fileEditing"})
+        self.assertEqual(set(stamps), {"auto-nudge", "compact-suggest", "file-editing"})
 
 
 class ThePollSeam(unittest.TestCase):

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -275,6 +275,21 @@ class TheEmitterIsOneSnapshotPerStore(unittest.TestCase):
         self.assertIn(pair, [(False, 5_000), (True, 9_000)], "value and stamp come from one snapshot: %r" % (pair,))
         self.assertEqual(v["compactSuggest"], v["settings"]["compactSuggest"], "the top-level field rides the same snapshot")
 
+    def test_the_snapshot_reads_the_blob_exactly_once(self):
+        # the torn-read test above tears by CALLER, so a helper that read the blob twice (values, then stamps)
+        # would still pass it; this counts the reads inside one snapshot (third review, nit)
+        with self.k:
+            km._set_compact_suggest(True, gt=9_000)
+            real = km._auto_nudge_data
+            calls = []
+            km._auto_nudge_data = lambda: (calls.append(1), real())[1]
+            try:
+                values, stamps = km._mesh_settings_snapshot()
+            finally:
+                km._auto_nudge_data = real
+        self.assertEqual(len(calls), 1, "one read of the auto-nudge blob for its two values and two stamps")
+        self.assertEqual((values["compactSuggest"], stamps["compact-suggest"]), (True, 9_000))
+
     def test_version_builds_the_three_adopted_settings_from_the_snapshot_helper(self):
         src = KERNEL_SRC.split("def _version_info():")[1].split("\ndef ")[0]
         self.assertIn("_mesh_settings_snapshot()", src)

--- a/tests/test_mesh_settings_adopt.py
+++ b/tests/test_mesh_settings_adopt.py
@@ -13,15 +13,23 @@ boolean kernel settings that ride the browser broadcast and nothing else: compac
 fileEditing — the same three lines each, one table row apiece.
 
 Two hermetic "kernels" here are two state roots served by one loaded module (jd.STATE swapped per call),
-which is exactly what the seam sees: a peer is its /version dict, nothing more. Synthetic host names, no
-sockets, no live state.
+which is exactly what the seam sees: a peer is its /version dict, nothing more — and one class drives that
+dict through the REAL poll (_poll_remote_version against a loopback stand-in for the peer's /version), the
+gap the first cut's review caught: the poll copied four fixed keys and dropped settingsGt, so nothing ever
+converged in production while the hand-built dicts here passed. A same value under a NEWER peer stamp lifts
+the local stamp too (review, second finding): the dashboard mints its next gesture above the LOCAL kernel's
+stamps only, so a lagging stamp let a later local click apply locally, stand down on the peer, and then be
+adopted away again — the gear-says-off, kernel-holds-on state this exists to end. Synthetic host names,
+loopback only, no live state.
 """
 import contextlib
 import io
 import json
 import os
 import tempfile
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -115,11 +123,20 @@ class AdoptPeerSettings(unittest.TestCase):
         self.assertEqual(self.a.adopt("TESTHOST", rver)[0], [])
         self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
 
-    def test_the_same_value_under_a_newer_stamp_writes_nothing(self):
-        self.a.set("compact-suggest", True, 2_000)
-        self.b.set("compact-suggest", True, 5_000)
-        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "the values agree: nothing to converge")
-        self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
+    def test_the_same_value_under_a_newer_stamp_lifts_the_local_stamp(self):
+        # the value already agrees, but the STAMP is newer: adopt it, or the local dashboard — which mints its
+        # next gesture above the local kernel's stamps only — clicks below the peer's stamp, applies locally,
+        # stands down on the peer, and is adopted away again one pass later (review of the first cut)
+        self.a.set("compact-suggest", True, 5_000)
+        self.b.set("compact-suggest", True, 7_000)          # a device whose clock runs ahead clicked ON on b
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], ["compact-suggest"])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 7_000), "same value, the peer's stamp")
+        # a's dashboard now learns 7_000 from a's own /version and mints the OFF click above it: it wins everywhere
+        self.a.set("compact-suggest", False, 7_001)
+        self.assertEqual(self.a.read("compact-suggest"), (False, 7_001))
+        self.assertEqual(self.a.adopt("TESTHOST", self.b.version())[0], [], "b's older pick teaches a nothing")
+        self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], ["compact-suggest"])
+        self.assertEqual(self.b.read("compact-suggest"), (False, 7_001), "the click held on both machines")
 
     def test_an_older_kernel_or_a_junk_dict_adopts_nothing(self):
         self.a.set("compact-suggest", False, 1_000)
@@ -159,6 +176,59 @@ class AdoptPeerSettings(unittest.TestCase):
             self.a.set(store, default, 3_000)
             self.assertEqual(self.b.adopt("TESTHOST2", self.a.version())[0], [store], store + ": the newer pick flows back")
             self.assertEqual(self.b.read(store), (default, 3_000), store)
+
+
+class _FakePeer(BaseHTTPRequestHandler):
+    """A stand-in peer kernel: /version answers with whatever PAYLOAD holds (the loopback shape
+    tests/test_auto_nudge_every_kernel.py uses)."""
+    PAYLOAD = {}
+
+    def do_GET(self):
+        body = json.dumps(self.PAYLOAD).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+class ThroughTheRealPoll(unittest.TestCase):
+    """The dict the supervisor hands to _adopt_peer_settings is _poll_remote_version's return, not the
+    peer's /version JSON: the poll must carry the stamps across, or nothing ever converges."""
+
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), _FakePeer)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.a = _Kernel()
+
+    def tearDown(self):
+        self.srv.shutdown(); self.srv.server_close(); self.a.close()
+
+    def _poll(self, payload):
+        _FakePeer.PAYLOAD = payload
+        return km._poll_remote_version({"local_port": self.port, "token": "tok"})
+
+    def test_the_poll_carries_the_peers_stamps_beside_its_settings(self):
+        got = self._poll({"kernel_sha": "abc1234", "settings": {"compactSuggest": True},
+                          "settingsGt": {"compact-suggest": 2_000, "auto-nudge": 0}})
+        self.assertEqual(got["settings"], {"compactSuggest": True})
+        self.assertEqual(got["settingsGt"], {"compact-suggest": 2_000, "auto-nudge": 0})
+
+    def test_an_older_kernel_or_junk_stamps_poll_as_none(self):
+        self.assertIsNone(self._poll({"kernel_sha": "abc1234", "settings": {"compactSuggest": True}})["settingsGt"])
+        self.assertIsNone(self._poll({"kernel_sha": "abc1234", "settingsGt": "2000"})["settingsGt"])
+
+    def test_a_polled_peer_is_adopted_end_to_end(self):
+        rver = self._poll({"kernel_sha": "abc1234", "settings": {"compactSuggest": True, "autoNudge": True, "fileEditing": True},
+                           "settingsGt": {"compact-suggest": 2_000, "file-editing": 2_000}})
+        self.assertEqual(sorted(self.a.adopt("TESTHOST", rver)[0]), ["compact-suggest", "file-editing"])
+        self.assertEqual(self.a.read("compact-suggest"), (True, 2_000))
+        self.assertEqual(self.a.read("file-editing"), (True, 2_000))
+        self.assertEqual(self.a.read("auto-nudge")[1], 0, "no stamp for it in the peer's dict: untouched")
 
 
 class ThePollSeam(unittest.TestCase):

--- a/ui/webview/setting-stale.test.ts
+++ b/ui/webview/setting-stale.test.ts
@@ -43,7 +43,7 @@ test("/version reports every gt-gated store's last-applied stamp, and the gear s
   // already read /version on every open; now it learns each store's stamp there and mints every
   // gesture at max(Date.now(), seen + 1) (ui/webview/gesture-clock.js; gesture-clock.test.ts drives
   // the module). The kernel side is behavior-tested in test_setting_gesture_order.py.
-  assert.match(KERNEL, /"settingsGt": _settings_gt\(\),/, "/version carries the stamps (ints only — the route is auth-exempt)");
+  assert.match(KERNEL, /"settingsGt": \{\*\*_settings_gt\(\), \*\*_mgt\},/, "/version carries the stamps (ints only — the route is auth-exempt); the three mesh-adopted stores' stamps ride the same snapshot as their values (T248b)");
   assert.match(KERNEL, /def _settings_gt\(\):/);
   assert.match(KERNEL, /def _setting_stored_gt\(name\):/, "one switch mirrors _setting_kept_value's");
   assert.match(GEAR, /var gclock = require\('\.\/gesture-clock\.js'\);/, "the gear loads the clock");


### PR DESCRIPTION
Follow-up to the Suggest /compact fix: the user's standard is that this setting is consistent always. One click already reached every attached kernel, but a machine attached **after** the click kept its own copy until the next click, shown only by the gear's mixed mark.

**Change** (`kernel/kernel.py`)
- The tunnel supervisor lifts each up peer's `settingsGt` beside the `settings` dict it already lifts on every poll, and calls `_adopt_peer_settings(host, rver)` outside the remotes lock.
- A peer's stamp newer than the local store's, with a different value, is applied through the setting's own gt-gated setter under the **peer's** stamp. Latest-wins on both sides, no ping-pong (the adopter's stamp then equals the peer's; equal stamps are never adopted). Equal stamps or equal values write nothing; no stamps (older kernel) or junk teach nothing; stand-down verdicts are consumed on the supervisor thread.
- **Generalized** to `compactSuggest`, `autoNudge` and `fileEditing`: each is one row of the same table (the judge tiers fan out over `/judge-settings` already; update mode is a per-install boot policy by design).

**Tests (red before)**: `tests/test_mesh_settings_adopt.py` — hermetic two-kernel unit tests at the poll seam (newer → applied; older → stands down; equal → no write; same value → no write; junk/older kernel → nothing; no ping-pong; newest click wins both ways; the three settings generalize) plus source pins on the lift and the outside-the-lock call.

**Review fixes (second commit)**: the poll now returns `settingsGt` (the first cut consumed it without carrying it across, so nothing converged in production while hand-built test dicts passed); a same value under a newer peer stamp now lifts the local stamp too (otherwise the dashboard, which mints above the local kernel's stamps only, could click below the peer's stamp and have the click adopted away one pass later). Tests drive a loopback peer through the real poll.

**Review fixes (fourth commit)**: `/version` now reads each adopted store's value and stamp from one snapshot (`_mesh_settings_snapshot`): read separately, a click landing between the two reads handed a polling peer an (old value, new stamp) pair, which the adopter persisted and the equal-stamp rule then froze on both machines. A NaN/Infinity stamp no longer raises mid-loop (it skips only its own setting).
