### PR TITLE
Usage modal: no unattributed stack from float residue, honest other count, light pressed toggle, loader backstop, dim once, phone door

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -37536,8 +37536,11 @@ if(spPending){try{spPending.abort();}catch(e){}}
 var spAbort=new AbortController(),ms=(window.__rompSpendTimeoutMs|0)||20000;spPending=spAbort;
 var spTimer=setTimeout(function(){spAbort.abort();},ms);
 fetch('/spend/detail',{cache:'no-store',signal:spAbort.signal}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
-.then(function(d){clearTimeout(spTimer);if(spPending===spAbort)spPending=null;SP.data=d;if(SP.open)renderSpend();},
-function(e){clearTimeout(spTimer);if(spPending===spAbort)spPending=null;if(!SP.open||spAbort!==spPending&&SP.data)return;
+.then(function(d){clearTimeout(spTimer);var mine=(spPending===spAbort);if(mine)spPending=null;if(!SP.open||!mine)return;SP.data=d;renderSpend();},
+// a SUPERSEDED fetch (a re-open aborted it) yields whatever it carries: its AbortError rejects on the
+// next tick, while the successor is still loading and SP.data is null — a guard that leaned on SP.data
+// painted a false "no answer after 20 s" over the loader (review find). Ownership decides, nothing else.
+function(e){clearTimeout(spTimer);var mine=(spPending===spAbort);if(mine)spPending=null;if(!SP.open||!mine)return;
 SP.err=(e&&e.name==='AbortError')?('no answer from the kernel after '+Math.round(ms/1000)+' s'):String((e&&e.message)||e);renderSpend();});}
 function closeSpend(){SP.open=false;if(spBack)spBack.hidden=true;spTipHide();if(spPending){try{spPending.abort();}catch(e){}spPending=null;}}
 window.__rompCloseSpend=closeSpend;
@@ -37673,7 +37676,7 @@ var xlab='';for(var i=0;i<n;i++){var k=ser.keys[i],m;
 if(SP.range==='hours'){m=/^(\\d{4})-(\\d\\d)-(\\d\\d)T00$/.exec(k);if(m){var dd=new Date(+m[1],+m[2]-1,+m[3]);
 xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+['S','M','T','W','T','F','S'][dd.getDay()]+'</span>';}}
 else{m=/^(\\d{4})-(\\d\\d)-(01|15)$/.exec(k);if(m)xlab+='<span style="left:'+(((i+0.5)*slot)/W*100).toFixed(1)+'%">'+Number(m[2])+'/'+Number(m[3])+'</span>';}}
-var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+(s.kind==='sid'&&!s.live?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
+var leg='<div class=rsp-leg>'+stacks.map(function(s){return '<span class="rsp-chip'+((s.kind==='sid'&&!s.live)||s.kind==='unattributed'?' rsp-dead':'')+'"><i class="rsp-sw'+(s.kind==='unattributed'?' rsp-hatch':'')+'"'
 +(s.kind==='unattributed'?'':' style="background:'+(s.kind==='other'?SP_OTHER:spColor(s))+'"')+'></i>'+esc(spStackName(s))+'</span>';}).join('')+'</div>';
 var tzNote='';var mine=-(new Date().getTimezoneOffset());
 if(typeof d.tzOffsetMin==='number'&&d.tzOffsetMin!==mine)tzNote='<div class=rsp-note>Bucket times are '+esc(d.tz||'the kernel\u2019s clock')+' (the machine that recorded them), not your local time.</div>';
@@ -39797,7 +39800,8 @@ def _landing():
             "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
             "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
             # the PRESSED toggle's light step, written out (T247b review): `.rsp-btn.on` (0,2,0) lost to
-            # `body.theme-light .rsp-btn` (0,1,1,0) and painted dark text and a hairline on the clay chip.
+            # `body.theme-light .rsp-btn` (0,2,1 — two classes and the body type) and painted dark text
+            # and a hairline on the clay chip; this rule is (0,3,1) and wins outright.
             # CSS state rules must win the cascade — pin the tiebreak, never rely on it.
             "body.theme-light .rsp-btn.on{background:var(--accent,#C2410C);color:var(--accent-fg,#FFF8F2);border-color:transparent}"
             "body.theme-light .rsp-err{color:#9A3324}"   # the dark-only pink read 1.7:1 on the white card (review find)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -29926,6 +29926,10 @@ def _spend_recorded_at():
 
 _DETAIL_TOP_N = 10       # stacks the histogram names; every further session folds into ONE "other" stack
 _DETAIL_DAYS = 90        # the day ledger's own depth (the recorder prunes to 90 days)
+_SPEND_GRAIN = 5e-5      # a bucket's dollars minus its sids' dollars below this is rounding, not spend: the recorder
+#                          rounds the bucket sum and each sid's sum to 6 places INDEPENDENTLY, so a fully attributed
+#                          bucket carries +1e-6..+6e-6 residues (28 of 113 live hour buckets did, T247b review) — and
+#                          anything that rounds to 0 at the 4 places the payload carries is zero
 
 
 def _spend_scope():
@@ -30020,7 +30024,8 @@ def _spend_detail(now=None):
                 if k:
                     r = keyt.setdefault(str(sid), [0.0, 0, 0])
                     r[0] += float(k.get("usd") or 0); r[1] += int(k.get("tok") or 0); r[2] += int(k.get("turns") or 0)
-        un[0] += max(0.0, tu - au); un[1] += max(0, tt - at); un[2] += max(0, tn - an)
+        res = tu - au
+        un[0] += res if res >= _SPEND_GRAIN else 0.0; un[1] += max(0, tt - at); un[2] += max(0, tn - an)
     # a session that contributed nothing under this scope (a login-only session in the keyed scope) is
     # not a row and not a stack: an all-zero stack with a legend chip says nothing (review find)
     totals = {sid: v for sid, v in totals.items() if v[0] > 0 or v[1] > 0 or v[2] > 0}
@@ -30061,22 +30066,28 @@ def _spend_detail(now=None):
                 dst = per.get(sid)
                 if dst is None:
                     dst = other
-                    others.add(sid)
+                    if u > 0 or t > 0:
+                        others.add(sid)   # "other (N sessions)" counts contributors only — the table's own fold
+                        #                   (a login-only session in the keyed scope adds (0,0,0); T247b review)
                 dst[0][i] += u; dst[1][i] += t
-            una[0][i] += max(0.0, tu - au); una[1][i] += max(0, tt - at)
+            res = tu - au
+            una[0][i] += res if res >= _SPEND_GRAIN else 0.0; una[1][i] += max(0, tt - at)
+        # presence is tested on the ROUNDED values the payload carries: a residue that rounds to nothing
+        # must not hang a stack (a hatched "unattributed" chip with no bars, T247b review)
         stacks = []
         for sid in top:
-            if not (any(per[sid][0]) or any(per[sid][1])):
+            usd = [round(v, 4) for v in per[sid][0]]
+            if not (any(usd) or any(per[sid][1])):
                 continue          # a top-N session with nothing in THIS range: no empty stack, no legend chip (review find)
             s = meta[sid]
             stacks.append({"kind": "sid", "sid": sid, "name": s["name"], "bg": s["bg"], "live": s["live"],
-                           "usd": [round(v, 4) for v in per[sid][0]], "tok": per[sid][1]})
-        if any(other[0]) or any(other[1]):
-            stacks.append({"kind": "other", "name": "other", "count": len(others),
-                           "usd": [round(v, 4) for v in other[0]], "tok": other[1]})
-        if any(una[0]) or any(una[1]):
-            stacks.append({"kind": "unattributed", "name": "unattributed",
-                           "usd": [round(v, 4) for v in una[0]], "tok": una[1]})
+                           "usd": usd, "tok": per[sid][1]})
+        ousd = [round(v, 4) for v in other[0]]
+        if any(ousd) or any(other[1]):
+            stacks.append({"kind": "other", "name": "other", "count": len(others), "usd": ousd, "tok": other[1]})
+        uusd = [round(v, 4) for v in una[0]]
+        if any(uusd) or any(una[1]):
+            stacks.append({"kind": "unattributed", "name": "unattributed", "usd": uusd, "tok": una[1]})
         return {"keys": keys, "stacks": stacks}
 
     h0 = int(now // 3600) - (_SERIES_HOURS - 1)
@@ -37467,7 +37478,7 @@ window.__rompUsagePanel=function(){
 function openIt(){var h=tipHTML();if(!h)return;
 // the deeper level is one tap away here too (T247): the rail — and its click — do not exist on a
 // phone, and a compact view must never dead-end (progressive disclosure)
-tip.innerHTML=h+'<div class=ru-tip-age><button class=rsp-btn id=ru-bysession>By session \u2192</button></div>';
+tip.innerHTML=h+'<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>By session \u2192</button></div>';   // its own row, the hover's button size (T247b review: inside .ru-tip-age it read as a 10px annotation at .55)
 tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.display='block';
 back.classList.add('on');
 var off=function(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');
@@ -37516,11 +37527,19 @@ function spName(s){return s.name||('session '+String(s.sid||'').slice(0,8));}
 function spColor(s){return (s.bg&&/^#[0-9a-fA-F]{3,8}$/.test(s.bg))?s.bg:SP_NONE;}
 function spHead(){return '<div class=rsp-top><span>'+(SP.data&&SP.data.scope==='computed'?'Spend (computed)':'API spend')+(SP.data&&SP.data.host?' \u00b7 '+esc(SP.data.host):'')+'</span>'
 +'<button class=rsp-x data-act=close aria-label=Close>\u00d7</button></div>';}
+var spPending=null;   // the in-flight detail fetch's controller: a close or a re-open aborts it
 function openSpend(){if(!spBack||!spPanel)return;SP.open=true;spBack.hidden=false;SP.data=null;SP.err='';SP.allRows=false;
 spPanel.innerHTML=spHead()+'<div class=rsp-load>'+__ROMP_LOADER__+'</div>';   // the loader FIRST (the loader rule)
-fetch('/spend/detail',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
-.then(function(d){SP.data=d;if(SP.open)renderSpend();},function(e){SP.err=String((e&&e.message)||e);if(SP.open)renderSpend();});}
-function closeSpend(){SP.open=false;if(spBack)spBack.hidden=true;spTipHide();}
+// the loader ends on the EVENT (the answer) — with a backstop that cannot trap (T247b review: a hung
+// socket spun the loader forever): a generous timer aborts the fetch onto the error + retry path
+if(spPending){try{spPending.abort();}catch(e){}}
+var spAbort=new AbortController(),ms=(window.__rompSpendTimeoutMs|0)||20000;spPending=spAbort;
+var spTimer=setTimeout(function(){spAbort.abort();},ms);
+fetch('/spend/detail',{cache:'no-store',signal:spAbort.signal}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
+.then(function(d){clearTimeout(spTimer);if(spPending===spAbort)spPending=null;SP.data=d;if(SP.open)renderSpend();},
+function(e){clearTimeout(spTimer);if(spPending===spAbort)spPending=null;if(!SP.open||spAbort!==spPending&&SP.data)return;
+SP.err=(e&&e.name==='AbortError')?('no answer from the kernel after '+Math.round(ms/1000)+' s'):String((e&&e.message)||e);renderSpend();});}
+function closeSpend(){SP.open=false;if(spBack)spBack.hidden=true;spTipHide();if(spPending){try{spPending.abort();}catch(e){}spPending=null;}}
 window.__rompCloseSpend=closeSpend;
 window.__rompOpenSpend=openSpend;
 // a click whose press and release land on different elements is dispatched at their common
@@ -37558,8 +37577,8 @@ shown.forEach(function(s){h+='<tr'+(s.live?'':' class=rsp-dead')+'><td><i class=
 +'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
 +'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
 if(lim<ss.length){var rest=ss.slice(lim),ru=0,rt=0,rn=0;rest.forEach(function(s){ru+=s.usd||0;rt+=s.tok||0;rn+=s.turns||0;});
-h+='<tr class=rsp-dead><td><i class=rsp-sw style="background:'+SP_OTHER+'"></i></td><td class=rsp-name>'+rest.length+' more session'+(rest.length===1?'':'s')
-+' <button class=rsp-btn data-act=table:all>show all</button></td><td class=n>'+fmtUsd(ru)+'</td>'+(keyCol?'<td class=n></td>':'')+'<td class=n>'+rn+'</td><td class=n>'+fmtTok(rt)+'</td></tr>';}
+h+='<tr class=rsp-fold><td><i class=rsp-sw style="background:'+SP_OTHER+'"></i></td><td class=rsp-name><span class=rsp-muted>'+rest.length+' more session'+(rest.length===1?'':'s')
++'</span> <button class=rsp-btn data-act=table:all>show all</button></td><td class=n>'+fmtUsd(ru)+'</td>'+(keyCol?'<td class=n></td>':'')+'<td class=n>'+rn+'</td><td class=n>'+fmtTok(rt)+'</td></tr>';}
 // spend recorded before per-session attribution existed (T100, 2026-08-24), or the part of a bucket no
 // session accounts for: shown as its own row, never dropped or folded into a session (fail loudly)
 if(un&&(un.usd>0||un.tok>0))h+='<tr class=rsp-dead><td><i class="rsp-sw rsp-hatch"></i></td>'
@@ -39458,7 +39477,12 @@ def _landing():
             ".rsp-tbl td{padding:3px 6px 3px 0;border-bottom:1px solid rgba(255,255,255,0.05);white-space:nowrap}"
             ".rsp-tbl .n{text-align:right;font-variant-numeric:tabular-nums}"
             ".rsp-tbl td.rsp-name{width:100%;max-width:0;overflow:hidden;text-overflow:ellipsis}"
-            ".rsp-dead{opacity:.55}"   # a session no longer running keeps its last known name, dimmed
+            # a session no longer running keeps its last known name, dimmed ONCE (T247b review): the row's
+            # cells carry the dimming, the annotation inside stays at the row's level (it used to compound
+            # .55 × .6 to a 2.3:1 read), and a legend chip dims on its own; the fold row is a CONTROL row —
+            # its count is muted, its "show all" is never dimmed (it read as disabled)
+            ".rsp-dead td{opacity:.55}.rsp-dead .ru-tip-reset{opacity:1}.rsp-chip.rsp-dead{opacity:.55}"
+            ".rsp-fold .rsp-muted{opacity:.55}"
             ".rsp-sw{display:inline-block;width:10px;height:10px;border-radius:3px;vertical-align:-1px;background:#6b7a8c}"
             # unattributed spend wears a TEXTURE, not a hue: it is not a session, and texture is the
             # dataviz fallback for a class that must never be confused with one
@@ -39503,6 +39527,7 @@ def _landing():
             # margin-left:auto right-aligns every value to one edge, so the bar rows and the numbers-only
             # spend rows (no track span, the user 2026-08-08) read as one table.
             ".ru-tip-v{min-width:30px;text-align:right;font-variant-numeric:tabular-nums;margin-left:auto}"
+            ".ru-tip-more{margin-top:8px;text-align:center}"   # the phone panel's door into the spend modal (T247b)
             ".ru-tip-age{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);"
             "opacity:.55;font-size:10px}"
             # (The per-host .ru-set/.ru-host rail sets are gone, the user 2026-08-08: the collapsed rail
@@ -39771,6 +39796,10 @@ def _landing():
             "body.theme-light .rsp-x{color:#5D574E}body.theme-light .rsp-x:hover{color:#1F1E1D}"
             "body.theme-light .rsp-tbl th{border-bottom-color:rgba(0,0,0,0.10)}body.theme-light .rsp-tbl td{border-bottom-color:rgba(0,0,0,0.06)}"
             "body.theme-light .rsp-btn{border-color:rgba(0,0,0,0.18);color:#1F1E1D}"
+            # the PRESSED toggle's light step, written out (T247b review): `.rsp-btn.on` (0,2,0) lost to
+            # `body.theme-light .rsp-btn` (0,1,1,0) and painted dark text and a hairline on the clay chip.
+            # CSS state rules must win the cascade — pin the tiebreak, never rely on it.
+            "body.theme-light .rsp-btn.on{background:var(--accent,#C2410C);color:var(--accent-fg,#FFF8F2);border-color:transparent}"
             "body.theme-light .rsp-err{color:#9A3324}"   # the dark-only pink read 1.7:1 on the white card (review find)
             "body.theme-light .rsp-svg{background:rgba(0,0,0,0.04)}body.theme-light .rsp-grid{stroke:rgba(0,0,0,0.10)}"
             "body.theme-light #rsp-tip{background:#FFFFFF;border-color:rgba(0,0,0,0.12);color:#1F1E1D;"

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -22,6 +22,7 @@ const { chromium } = require('playwright');
   const out = await pg.evaluate(() => ({
     head: document.querySelector('#rsp-panel .rsp-top span').textContent,
     legend: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent),
+    chipOpacity: Array.from(document.querySelectorAll('#rsp-chart .rsp-chip')).map((e) => e.textContent + ':' + getComputedStyle(e).opacity),
     rows: Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent),
     deadRows: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr.rsp-dead').length,
     segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
@@ -102,10 +103,14 @@ const { chromium } = require('playwright');
   });
   // the loader's backstop: a fetch that never answers ends on the error + retry path (T247b)
   const timeout = await pg.evaluate(async () => {
-    const f = window.fetch; window.__rompSpendTimeoutMs = 300;
+    const f = window.fetch; window.__rompSpendTimeoutMs = 1000;
     window.fetch = (u, o) => new Promise((res, rej) => { if (o && o.signal) o.signal.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError'))); });
-    try { window.__rompOpenSpend(); await new Promise((r) => setTimeout(r, 900));
-      const err = document.querySelector('#rsp-panel .rsp-err'); return { err: err ? err.textContent : null, retry: !!document.querySelector('#rsp-panel [data-act="retry"]') }; }
+    try {
+      // a re-open while the first fetch is pending: the superseded fetch's abort must NOT paint an error
+      window.__rompOpenSpend(); window.__rompOpenSpend(); await new Promise((r) => setTimeout(r, 150));
+      const early = { err: !!document.querySelector('#rsp-panel .rsp-err'), loader: !!document.querySelector('#rsp-panel .rsp-load') };
+      await new Promise((r) => setTimeout(r, 1400));
+      const err = document.querySelector('#rsp-panel .rsp-err'); return { early, err: err ? err.textContent : null, retry: !!document.querySelector('#rsp-panel [data-act="retry"]') }; }
     finally { window.fetch = f; delete window.__rompSpendTimeoutMs; }
   });
   await pg.keyboard.press('Escape');

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -85,6 +85,32 @@ const { chromium } = require('playwright');
   const cell = await (await pg.$('#rsp-panel .rsp-tbl td.n')).boundingBox();
   await pg.mouse.move(cell.x + 2, cell.y + cell.height / 2); await pg.mouse.down(); await pg.mouse.move(5, 5, { steps: 4 }); await pg.mouse.up();
   const hiddenAfterDrag = await pg.evaluate(() => document.getElementById('rsp-back').hidden);
+  // the light theme's PRESSED toggle: accent chip, --accent-fg text, no hairline (T247b)
+  const lightBtn = await pg.evaluate(() => {
+    document.body.classList.add('theme-light');
+    const b = document.querySelector('#rsp-panel .rsp-btn.on'); const cs = getComputedStyle(b);
+    const out = { color: cs.color, border: cs.borderTopColor, bg: cs.backgroundColor };
+    document.body.classList.remove('theme-light'); return out;
+  });
+  // dim once: a dead row's annotation sits at the row's level, and the fold row's button is a control
+  const dim = await pg.evaluate(() => {
+    const dead = document.querySelector('#rsp-panel tr.rsp-dead td.rsp-name');
+    const ann = dead && dead.querySelector('.ru-tip-reset');
+    const btn = document.querySelector('#rsp-panel [data-act="table:all"]');
+    return { row: dead ? getComputedStyle(dead).opacity : null, ann: ann ? getComputedStyle(ann).opacity : null,
+             btnRowDead: btn ? btn.closest('tr').classList.contains('rsp-dead') : null, btnOpacity: btn ? getComputedStyle(btn).opacity : null };
+  });
+  // the loader's backstop: a fetch that never answers ends on the error + retry path (T247b)
+  const timeout = await pg.evaluate(async () => {
+    const f = window.fetch; window.__rompSpendTimeoutMs = 300;
+    window.fetch = (u, o) => new Promise((res, rej) => { if (o && o.signal) o.signal.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError'))); });
+    try { window.__rompOpenSpend(); await new Promise((r) => setTimeout(r, 900));
+      const err = document.querySelector('#rsp-panel .rsp-err'); return { err: err ? err.textContent : null, retry: !!document.querySelector('#rsp-panel [data-act="retry"]') }; }
+    finally { window.fetch = f; delete window.__rompSpendTimeoutMs; }
+  });
+  await pg.keyboard.press('Escape');
+  await pg.evaluate(() => document.getElementById('rail-usage').click());
+  await pg.waitForSelector('#rsp-panel .rsp-tbl', { timeout: 10000 });
   // the light theme's error line, over a failed fetch
   const lightErr = await pg.evaluate(async () => {
     document.body.classList.add('theme-light');
@@ -97,15 +123,17 @@ const { chromium } = require('playwright');
   await pg.setViewportSize({ width: 390, height: 844 });
   await pg.reload(); await pg.waitForSelector('#mtabs [data-act="usage"]', { timeout: 20000 });
   await pg.evaluate(() => { const bt = document.getElementById('romp-boot'); if (bt) bt.remove(); });
-  const mobile = await pg.evaluate(async () => {
-    const railHidden = getComputedStyle(document.querySelector('.pane-rail')).display === 'none';
-    window.__rompUsagePanel();
-    for (let i = 0; i < 50 && !document.getElementById('ru-bysession'); i++) await new Promise((r) => setTimeout(r, 100));
-    const panelOpened = !!document.getElementById('ru-bysession') && document.getElementById('ru-back').classList.contains('on');
-    if (panelOpened) document.getElementById('ru-bysession').click();
-    const modalOpened = !document.getElementById('rsp-back').hidden && !document.getElementById('ru-back').classList.contains('on');
-    return { railHidden, panelOpened, modalOpened };
-  });
-  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, mobile, foldBefore, foldAfter, errs }));
+  const railHidden = await pg.evaluate(() => getComputedStyle(document.querySelector('.pane-rail')).display === 'none');
+  await pg.evaluate(() => window.__rompUsagePanel());
+  await pg.waitForFunction(() => !!document.getElementById('ru-bysession') && document.getElementById('ru-back').classList.contains('on'), null, { timeout: 10000 });
+  const btn = await pg.evaluate(() => { const bs = document.getElementById('ru-bysession');
+    return { font: getComputedStyle(bs).fontSize, opacity: getComputedStyle(bs.parentNode).opacity, inAge: !!bs.closest('.ru-tip-age') }; });
+  if (shots) await pg.screenshot({ path: shots + '-phone-panel.png' });
+  await pg.click('#ru-bysession');
+  await pg.waitForFunction(() => !document.getElementById('rsp-back').hidden && !document.getElementById('ru-back').classList.contains('on'), null, { timeout: 5000 });
+  await pg.waitForSelector('#rsp-panel .rsp-tbl', { timeout: 10000 });
+  if (shots) await pg.screenshot({ path: shots + '-phone.png' });
+  const mobile = { railHidden, panelOpened: true, modalOpened: true, btn };
+  console.log(JSON.stringify({ hiddenBefore, loaderSeen, out, days, tip, hiddenAfter, hiddenAfterTap, hiddenAfterDrag, lightErr, lightBtn, dim, timeout, mobile, foldBefore, foldAfter, errs }));
   await b.close();
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -252,6 +252,51 @@ class SpendDetail(unittest.TestCase):
         self.assertEqual(d["days"]["stacks"], [])
         self.assertEqual(len(d["days"]["keys"]), 90)
 
+    def test_float_residue_never_conjures_an_unattributed_stack_or_row(self):
+        # T247b review find: the recorder rounds the bucket sum and each sid's sum independently (6
+        # places), so a fully attributed bucket can carry a +1e-6..+6e-6 dollar residue with zero token
+        # residue — 28 of 113 live hour buckets did — and the presence test on the unrounded residues
+        # hung a hatched "unattributed" chip with no bars on the 8-day view. Below the rounding grain
+        # a residue is zero: no stack, no row.
+        hours, days = {}, {}
+        for n in range(0, 40):
+            by = {WEB: {"usd": 0.333333, "turns": 1, "tok": 1000}, API: {"usd": 0.666667, "turns": 1, "tok": 2000}}
+            hours[_hour(n)] = _bucket(1.000001, 3000, 2, by)          # sum of sids: 1.000000 → +1e-6 residue
+        for n in range(0, 30):
+            by = {WEB: {"usd": 2.1, "turns": 3, "tok": 5000}, API: {"usd": 3.9, "turns": 4, "tok": 7000}}
+            days[_day(n)] = _bucket(6.000004, 12000, 7, by)           # +4e-6 residue, every day
+        (km.jd.STATE / "spend.json").write_text(json.dumps({"days": days, "hours": hours}))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual([s["kind"] for s in d["hours"]["stacks"]], ["sid", "sid"], "no unattributed stack from residue")
+        self.assertEqual([s["kind"] for s in d["days"]["stacks"]], ["sid", "sid"])
+        self.assertEqual(d["unattributed"], {"usd": 0.0, "tok": 0, "turns": 0}, "30 days of residue sum to nothing, not $0.0001")
+        # …and a REAL remainder still shows: a sid-less turn's cost is far above the grain
+        days[_day(1)]["usd"] += 0.05
+        (km.jd.STATE / "spend.json").write_text(json.dumps({"days": days, "hours": hours}))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["days"]["stacks"][-1]["kind"], "unattributed")
+        self.assertAlmostEqual(d["unattributed"]["usd"], 0.05, places=4)
+
+    def test_the_keyed_scopes_other_stack_counts_only_sessions_that_billed_the_key(self):
+        # T247b review find: in the keyed scope a login-only session contributed (0,0,0) yet was counted
+        # into "other (N sessions)", while the table dropped it — the legend said 17, the fold said 2
+        km._claude_account = lambda: "acct-digest"
+        (km.jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}}))
+        by = {}
+        for i in range(12):   # twelve key-billed sessions, two beyond the top ten
+            by["11111111-2222-3333-4444-0000000002%02d" % i] = {"usd": 1.0 + i, "turns": 1, "tok": 1000,
+                                                                "key": {"usd": 1.0 + i, "turns": 1, "tok": 1000}}
+        for i in range(5):    # five login-only sessions: no key sub-map
+            by["11111111-2222-3333-4444-0000000003%02d" % i] = {"usd": 9.0, "turns": 9, "tok": 9000}
+        days = {_day(0): _bucket(sum(v["usd"] for v in by.values()), 17000, 26, by,
+                                 key={"usd": sum(12.0 + i for i in range(12)) - 12 * 11.0 + 66.0, "turns": 12, "tok": 12000})}
+        (km.jd.STATE / "spend.json").write_text(json.dumps({"days": days, "hours": {}}))
+        d = km._spend_detail(now=NOW)
+        self.assertEqual(d["scope"], "keyed")
+        self.assertEqual(len(d["sessions"]), 12, "the table lists the key-billed sessions only")
+        other = [s for s in d["days"]["stacks"] if s["kind"] == "other"][0]
+        self.assertEqual(other["count"], 2, "the legend's count is the table's fold: sessions that contributed")
+
     def test_the_route_and_the_shell_are_wired(self):
         ksrc = inspect.getsource(km.Handler.do_GET) if hasattr(km.Handler, "do_GET") else open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         self.assertIn('if p == "/spend/detail":', ksrc, "the kernel route exists")
@@ -273,6 +318,26 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("var rows=spendRowsHTML(LAST||[]);", html, "the modal's window numbers are the hover's own renderer")
         self.assertIn("function fleetSpendHTML(sets){", html, "…whose signature the other suites pin, untouched")
         self.assertIn("body.theme-light #rsp-panel{", html, "a light-theme step of its own")
+        # T247b: the pressed toggle's light rule is written explicitly — a state rule must win the cascade
+        # (body.theme-light .rsp-btn at 0,1,1,0 beat .rsp-btn.on at 0,2,0 and painted dark text on the clay)
+        self.assertIn("body.theme-light .rsp-btn.on{background:var(--accent,#C2410C);color:var(--accent-fg,#FFF8F2);border-color:transparent}", html)
+        # T247b: the loader has a backstop — an AbortController with a generous timeout lands on the
+        # existing error + retry path, so a hung socket can never trap the modal
+        self.assertIn("var spAbort=new AbortController()", html)
+        self.assertIn("setTimeout(function(){spAbort.abort();}", html)
+        self.assertIn("signal:spAbort.signal", html)
+        # T247b: dimmed rows dim ONCE — the annotation inside a dimmed row stays at the row's level, and
+        # the fold row's "show all" is a control, never dimmed
+        self.assertIn(".rsp-dead td{opacity:.55}", html)
+        self.assertIn(".rsp-dead .ru-tip-reset{opacity:1}", html)
+        self.assertNotIn("<tr class=rsp-dead><td><i class=rsp-sw style=\"background:'+SP_OTHER+'\"></i></td><td class=rsp-name>'+rest.length+' more session", html,
+                         "the fold row is not a dead row")
+        self.assertIn("<tr class=rsp-fold>", html)
+        # T247b: the phone's door is its own row at the hover's button size, full opacity — not an
+        # annotation inside .ru-tip-age (10px, .55)
+        self.assertIn("<div class=ru-tip-more><button class=rsp-btn id=ru-bysession>", html)
+        self.assertNotIn("<div class=ru-tip-age><button class=rsp-btn id=ru-bysession>", html)
+        self.assertIn(".ru-tip-more{", html)
 
 
 if __name__ == "__main__":

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -289,13 +289,15 @@ class SpendDetail(unittest.TestCase):
         for i in range(5):    # five login-only sessions: no key sub-map
             by["11111111-2222-3333-4444-0000000003%02d" % i] = {"usd": 9.0, "turns": 9, "tok": 9000}
         days = {_day(0): _bucket(sum(v["usd"] for v in by.values()), 17000, 26, by,
-                                 key={"usd": sum(12.0 + i for i in range(12)) - 12 * 11.0 + 66.0, "turns": 12, "tok": 12000})}
+                                 key={"usd": sum(1.0 + i for i in range(12)), "turns": 12, "tok": 12000})}
         (km.jd.STATE / "spend.json").write_text(json.dumps({"days": days, "hours": {}}))
         d = km._spend_detail(now=NOW)
         self.assertEqual(d["scope"], "keyed")
         self.assertEqual(len(d["sessions"]), 12, "the table lists the key-billed sessions only")
         other = [s for s in d["days"]["stacks"] if s["kind"] == "other"][0]
         self.assertEqual(other["count"], 2, "the legend's count is the table's fold: sessions that contributed")
+        self.assertEqual(d["unattributed"]["usd"], 0.0, "every key dollar is a session's: nothing unattributed")
+        self.assertEqual([s["kind"] for s in d["days"]["stacks"]][-1], "other")
 
     def test_the_route_and_the_shell_are_wired(self):
         ksrc = inspect.getsource(km.Handler.do_GET) if hasattr(km.Handler, "do_GET") else open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
@@ -319,7 +321,7 @@ class SpendDetail(unittest.TestCase):
         self.assertIn("function fleetSpendHTML(sets){", html, "…whose signature the other suites pin, untouched")
         self.assertIn("body.theme-light #rsp-panel{", html, "a light-theme step of its own")
         # T247b: the pressed toggle's light rule is written explicitly — a state rule must win the cascade
-        # (body.theme-light .rsp-btn at 0,1,1,0 beat .rsp-btn.on at 0,2,0 and painted dark text on the clay)
+        # (body.theme-light .rsp-btn at (0,2,1) beat .rsp-btn.on at (0,2,0) and painted dark text on the clay)
         self.assertIn("body.theme-light .rsp-btn.on{background:var(--accent,#C2410C);color:var(--accent-fg,#FFF8F2);border-color:transparent}", html)
         # T247b: the loader has a backstop — an AbortController with a generous timeout lands on the
         # existing error + retry path, so a hung socket can never trap the modal

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -165,9 +165,16 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["dim"]["ann"], "1", "no second dimming inside a dimmed row")
         self.assertIs(o["dim"]["btnRowDead"], False, "the 'show all' row is not dimmed")
         self.assertEqual(o["dim"]["btnOpacity"], "1")
-        # T247b: the loader's backstop lands on the error + retry path
-        self.assertTrue(o["timeout"]["err"] and "load the spend detail" in o["timeout"]["err"], o["timeout"])
+        # T247b: the loader's backstop lands on the error + retry path, and names the timeout (the AbortError
+        # mapping is pinned, not just the shared prefix — review find); a re-open over a pending fetch keeps
+        # the loader up: the superseded fetch's abort paints nothing (review find)
+        self.assertTrue(o["timeout"]["err"] and "no answer from the kernel after 1 s" in o["timeout"]["err"], o["timeout"])
         self.assertTrue(o["timeout"]["retry"])
+        self.assertEqual(o["timeout"]["early"], {"err": False, "loader": True}, o["timeout"])
+        # the unattributed chip dims like its row (review find: same class, two weights)
+        self.assertIn("unattributed:0.55", o["out"]["chipOpacity"], o["out"]["chipOpacity"])
+        self.assertIn("web:1", o["out"]["chipOpacity"])
+        self.assertIn("tests:0.55", o["out"]["chipOpacity"])
         # T247b: the phone's door is a real button — the hover's size, full opacity, not an annotation
         self.assertEqual(o["mobile"]["btn"]["font"], "11px", o["mobile"]["btn"])
         self.assertEqual(o["mobile"]["btn"]["opacity"], "1", o["mobile"]["btn"])

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -158,6 +158,20 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(o["mobile"]["railHidden"] and o["mobile"]["panelOpened"] and o["mobile"]["modalOpened"],
                         "on a phone the Usage panel's 'By session' button is the door (review find): " + json.dumps(o["mobile"]))
         self.assertEqual(o["lightErr"], "rgb(154, 51, 36)", "the error line has a light-theme step")
+        # T247b: the pressed toggle in the light theme wears the accent chip with --accent-fg text and no hairline
+        self.assertEqual(o["lightBtn"], {"color": "rgb(255, 248, 242)", "border": "rgba(0, 0, 0, 0)", "bg": "rgb(194, 65, 12)"}, o["lightBtn"])
+        # T247b: dim once — the annotation inside a dead row is at the row's level; the fold row is a control row
+        self.assertEqual(o["dim"]["row"], "0.55", o["dim"])
+        self.assertEqual(o["dim"]["ann"], "1", "no second dimming inside a dimmed row")
+        self.assertIs(o["dim"]["btnRowDead"], False, "the 'show all' row is not dimmed")
+        self.assertEqual(o["dim"]["btnOpacity"], "1")
+        # T247b: the loader's backstop lands on the error + retry path
+        self.assertTrue(o["timeout"]["err"] and "load the spend detail" in o["timeout"]["err"], o["timeout"])
+        self.assertTrue(o["timeout"]["retry"])
+        # T247b: the phone's door is a real button — the hover's size, full opacity, not an annotation
+        self.assertEqual(o["mobile"]["btn"]["font"], "11px", o["mobile"]["btn"])
+        self.assertEqual(o["mobile"]["btn"]["opacity"], "1", o["mobile"]["btn"])
+        self.assertIs(o["mobile"]["btn"]["inAge"], False)
         own = [e for e in o["errs"] if "rsp" in e or "Spend" in e or "spend" in e]
         self.assertEqual(own, [], "no page errors from the modal's own code")
 


### PR DESCRIPTION
**Fixes (T247b).** Six should-fix items from the adversarial review of the merged usage modal, each reproduced red first.

**Data (`_spend_detail`)**
- **Float residue conjured an unattributed stack.** The recorder rounds a bucket's sum and each sid's sum to six places independently, so a fully attributed bucket carries a few millionths of a dollar the sids do not (28 of 113 live hour buckets did), and the presence test on the unrounded residues hung a hatched "unattributed" chip with no bars on the 8-day view. A residue below the rounding grain (5e-5, anything that rounds to nothing at the payload's four places) is zero, and presence is tested on the rounded values. Test: two sids whose six-decimal sums differ from the bucket by 1e-6 produce no stack and no row, thirty days of such residue sum to nothing, and a sid-less five-cent turn still shows.
- **Keyed "other" counted login-only sessions.** They contribute nothing and the table drops them; only contributors count, so the legend's count is the table's fold (a mixed host with twelve key-billed and five login-only sessions reads "other (2 sessions)", not 7).

**UI**
- **Light pressed toggle.** `.rsp-btn.on` lost the cascade to `body.theme-light .rsp-btn`; the light state rule is written out, so the pressed chip is the accent with `--accent-fg` text and no hairline. Pinned by computed colors in the served test.
- **Loader backstop.** The detail fetch carries an AbortController with a 20 s timer that lands on the existing error and retry path; a close or re-open aborts the in-flight fetch. Pinned by a never-answering fetch in the served test.
- **Dim once.** The row's cells carry the .55, the annotation inside stays at the row's level, and the fold row is a control row with a muted count and a full-opacity "show all".
- **Phone door.** The "By session →" button has its own row at the hover's button size, full opacity, no longer inside the 10px annotation.

**Review folds (second commit).** Adversarial review, two lenses, eight findings, all confirmed and folded: a re-open while the detail fetch was pending painted a false "no answer" over the loader (the superseded fetch's abort rejects before the successor answers, and the guard leaned on the data being present), so ownership is captured before the controller is nulled and a fetch that is no longer current yields on success or failure; the unattributed legend chip dims like its row; the keyed fixture's key total is the sum of its sids with an assertion that nothing is unattributed; the timeout test pins the AbortError text ("no answer from the kernel after 1 s") and a double-open that keeps the loader up; two comments' specificity arithmetic corrected. One verified-clean report covered the cascade, dim-once, the phone button, hermeticity and privacy.

**Screenshots** (served-page harness, synthetic world): light theme with the pressed toggles, the phone's Usage panel with its button, and the modal at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
