### PR TITLE
Tests: the restart-sweep planner stub accepts the head the sweep now passes

### DIFF
--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -291,7 +291,8 @@ class AnAskStaysOnThatPeer(unittest.TestCase):
                        ("_fleet_restart_plan", "_peer_call", "_peer_hub_name", "_local_head",
                         "_local_branch", "_restart_this_kernel")}
         self._remotes = dict(km._remotes)
-        km._fleet_restart_plan = lambda r: ("ask", "checked in here; asking it to fast-forward itself")
+        # the sweep hands the plan the head it read once (#1025); the stub takes it like the real function
+        km._fleet_restart_plan = lambda r, head=None: ("ask", "checked in here; asking it to fast-forward itself")
         km._peer_hub_name = lambda r: "hubname"
         km._local_head = lambda short=False: ("abc1234" if short else LOCAL_SHA)
         km._local_branch = lambda: "main"


### PR DESCRIPTION
Two tests in tests/test_fleet_restart.py (AnAskStaysOnThatPeer, from #1027) stub the planner with a one-argument lambda, while since #1025 the sweep calls it as `_fleet_restart_plan(r, head=head)`. Each branch was green on its own; the merged main was never re-run, so main has failed those two tests since 2e9d4492, and every PR whose CI runs on that main now shows the same two failures (#1043, #1038). The stub takes the keyword like the real function. Tests only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)