### PR TITLE
The tier-label check judges current labels from the API and keeps every run; main's CI never cancels itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,22 @@ on:
   pull_request:
   workflow_dispatch:   # the manual on-switch for the macOS cells (see above)
 
-# A newer push to the same ref cancels the older in-flight run OF THE SAME KIND.
-# The event is part of the key on purpose: a release dispatch (the macOS gate)
+# A newer push to a PULL REQUEST cancels the older in-flight run of the same
+# kind: the new head supersedes the old one, and the old verdict is moot. The
+# event is part of the key on purpose: a release dispatch (the macOS gate)
 # shares main's ref with every push, and a bare ref key let an auto-merged PR
 # cancel the in-flight release run mid-watch (2026-07-27).
+# Pushes to main are keyed on the commit sha and never cancelled: main's CI
+# must never cancel itself. With one group per ref, two merges in quick
+# succession cancelled the first merge's run, and a red main (2e9d4492,
+# 2026-09-08) went unseen until a later run happened to fail; a queue would
+# not do either, since a group holds at most one pending run and a third merge
+# would replace the second's. One group per merge commit, so every merge gets
+# its own completed run. A dispatch queues rather than cancels for the same
+# reason: a release gate mid-watch is not superseded by a second dispatch.
 concurrency:
-  group: ci-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   python:

--- a/.github/workflows/pr-tier.yml
+++ b/.github/workflows/pr-tier.yml
@@ -13,12 +13,19 @@ name: PR tier
 # When its job happened to finish AFTER the labeled run's, the newest
 # same-named check run was that stale failure and the PR read blocked with
 # auto-merge armed (pull 1039, 2026-09-08). Every run now judges what the PR
-# carries at the moment it looks, and the concurrency group below serializes
-# the runs for one PR so the newest check run is always the last event's.
-# It is NOT cancel-in-progress: a cancelled run leaves a check run whose
-# conclusion is "cancelled", and when that run started later than the one
-# that survived, IT is the newest, and a required check that is cancelled
-# blocks the merge. Queueing costs a few seconds; cancelling can wedge.
+# carries at the moment it looks, and the concurrency group below runs one
+# job at a time per PR. The merge box follows the newest same-named check run
+# BY TIME (on 1039 the failure that completed last won, though its run was
+# created first), and one-at-a-time makes completion times monotonic in
+# execution order, so the run that executes last is the newest. `queue: max`
+# keeps EVERY pending run (the default keeps one and replaces it, leaving a
+# check run concluding "cancelled"), so no run for a PR is ever cancelled or
+# replaced: each event's run executes, in the order they began waiting, and
+# the last one has read the world after the last event.
+# It is NOT cancel-in-progress: the in-progress run is never cut. Cancelling
+# it would risk its "cancelled" check run COMPLETING after the survivor's (the
+# runner's cancel grace is longer than this job), and a cancelled required
+# check blocks the merge. Queueing costs a few seconds; cancelling can wedge.
 # It re-runs when the labels change, and on every push to the PR, so the
 # status on the PR is always about the labels it carries now. Making it a
 # REQUIRED check on main is a branch-ruleset setting in the repository
@@ -31,10 +38,11 @@ on:
 permissions:
   pull-requests: read
 
-# One run at a time per PR, in event order, never cancelling: see the header.
+# One job at a time per PR, every run kept, none cancelled: see the header.
 concurrency:
   group: pr-tier-${{ github.event.pull_request.number }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   tier:

--- a/.github/workflows/pr-tier.yml
+++ b/.github/workflows/pr-tier.yml
@@ -5,8 +5,20 @@ name: PR tier
 # with no label has not been sorted yet and a PR with two has been sorted two
 # ways; this check fails in both cases and passes otherwise.
 #
-# It reads the labels from the event payload and nothing else: no checkout,
-# no token use, no third-party action, so a PR from a fork can run it safely.
+# It reads the PR's CURRENT labels from the API with the job's read-only token
+# (no checkout, no third-party action, so a PR from a fork can run it safely).
+# Not from the event payload: that is a snapshot taken when the event fired,
+# and `gh pr create --label` fires `opened` with no labels and `labeled` a
+# second later, so the opened run judged a label set that no longer existed.
+# When its job happened to finish AFTER the labeled run's, the newest
+# same-named check run was that stale failure and the PR read blocked with
+# auto-merge armed (pull 1039, 2026-09-08). Every run now judges what the PR
+# carries at the moment it looks, and the concurrency group below serializes
+# the runs for one PR so the newest check run is always the last event's.
+# It is NOT cancel-in-progress: a cancelled run leaves a check run whose
+# conclusion is "cancelled", and when that run started later than the one
+# that survived, IT is the newest, and a required check that is cancelled
+# blocks the merge. Queueing costs a few seconds; cancelling can wedge.
 # It re-runs when the labels change, and on every push to the PR, so the
 # status on the PR is always about the labels it carries now. Making it a
 # REQUIRED check on main is a branch-ruleset setting in the repository
@@ -17,7 +29,12 @@ on:
     types: [opened, reopened, labeled, unlabeled, synchronize, edited]
 
 permissions:
-  contents: read
+  pull-requests: read
+
+# One run at a time per PR, in event order, never cancelling: see the header.
+concurrency:
+  group: pr-tier-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   tier:
@@ -27,8 +44,15 @@ jobs:
     steps:
       - name: Count the tier labels on this PR
         env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # The API is the authority; the payload is a snapshot (see the header). A failed read is a
+          # failed check, never a guessed label set.
+          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '[.labels[].name]') || {
+            echo "::error::Could not read this PR's labels from the API."
+            exit 1
+          }
           count=$(jq '[.[] | select(. == "tests-only" or . == "fix" or . == "feature" or . == "major-feature")] | length' <<<"$LABELS")
           if [ "$count" -eq 1 ]; then
             exit 0

--- a/tests/test_ci_workflow_concurrency.py
+++ b/tests/test_ci_workflow_concurrency.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""main's CI never cancels itself (.github/workflows/ci.yml, 2026-09-08).
+
+The concurrency group was `ci-<event>-<ref>` with cancel-in-progress for every event, so two merges to
+main in quick succession cancelled the first merge's run, and a red main (2e9d4492) went unseen until a
+later run happened to fail. Now: pull-request runs still cancel their superseded predecessor (the new
+head makes the old verdict moot); pushes to main are keyed on the commit sha, one group per merge
+commit, so every merge gets its own completed run (a queue would not do: a group holds at most one
+pending run, so a third merge would replace the second's); a dispatch queues rather than cancels. The
+event name stays in the key so a release dispatch (the macOS gate) is never cancelled by a push to the
+same ref (2026-07-27). Source pins: no YAML library in the test deps, and the stanza is three lines."""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+WF = os.path.join(os.path.dirname(HERE), ".github", "workflows", "ci.yml")
+
+
+class CiConcurrency(unittest.TestCase):
+    def setUp(self):
+        self.src = open(WF).read()
+        m = re.search(r"^concurrency:\n((?:  .*\n)+)", self.src, re.M)
+        self.assertTrue(m, "the concurrency stanza moved - re-anchor this pin")
+        self.stanza = m.group(1)
+
+    def test_the_event_name_keys_the_group(self):
+        # a release dispatch shares main's ref with every push; the event in the key keeps them apart
+        self.assertIn("group: ci-${{ github.event_name }}-", self.stanza)
+
+    def test_pushes_to_main_are_keyed_on_the_commit_sha(self):
+        # one group per merge commit: never cancelled, never replaced as a pending run
+        self.assertIn("${{ github.event_name == 'push' && github.sha || github.ref }}", self.stanza)
+
+    def test_only_pull_request_runs_cancel_their_predecessor(self):
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", self.stanza)
+        self.assertNotIn("cancel-in-progress: true", self.stanza, "an unconditional cancel would cancel main's own run")
+
+    def test_the_workflow_still_runs_on_push_to_main_and_on_pull_requests(self):
+        self.assertTrue(re.search(r"^on:\n  push:\n    branches: \[main\]\n  pull_request:\n", self.src, re.M),
+                        "the push-to-main and pull_request triggers are the two the group tells apart")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_tier_workflow.py
+++ b/tests/test_pr_tier_workflow.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """The "Exactly one tier label" check (.github/workflows/pr-tier.yml) judges the PR's CURRENT labels, read
-from the API, and runs one job at a time per PR without cancelling the one in progress.
+from the API, and runs one job at a time per PR, keeping every run: none cancelled, none replaced.
 
 The race this pins closed (pull 1039, 2026-09-08): `gh pr create --label` fires `opened` with an empty
 label snapshot and `labeled` a second later; the opened run judged the snapshot and failed, and when its
@@ -8,11 +8,12 @@ job COMPLETED two seconds after the labeled run's, the merge box (which follows 
 check run by time) took that stale failure and the PR read blocked with auto-merge armed. Two things make
 ordering irrelevant now: every run reads the labels the PR carries at the moment it looks (the API, with
 the job's read-only token), and a concurrency group keyed on the PR number runs one job at a time, which
-makes completion times monotonic in execution order, so the run that executes last is the newest. GitHub's
-default queue replaces a superseded PENDING run with the newer one (whose check run completes later
-still), so the last executed run has always read the world after the last event. Cancel-in-progress is
-deliberately off: cancelling the in-progress run risks its "cancelled" check run completing after the
-survivor's, and a cancelled required check blocks.
+makes completion times monotonic in execution order, so the run that executes last is the newest.
+`queue: max` keeps every pending run (GitHub's default keeps one and replaces it, leaving a "cancelled"
+check run), so each event's run executes and the last has read the world after the last event.
+Cancel-in-progress is deliberately off: cancelling the in-progress run risks its "cancelled" check run
+completing after the survivor's, and a cancelled required check blocks; GitHub also refuses
+`queue: max` beside `cancel-in-progress: true`.
 
 The step's script is run for real, with `gh` replaced by a shim on PATH that prints a canned label list
 (or fails), so the zero / one / two / alias / unreadable cases are behaviour, not a grep. Source pins
@@ -120,9 +121,9 @@ class WorkflowPins(unittest.TestCase):
         types = {t.strip() for t in m.group(1).split(",")}
         self.assertTrue({"opened", "reopened", "labeled", "unlabeled", "synchronize"} <= types, types)
 
-    def test_runs_for_one_pr_never_cancel_the_one_in_progress(self):
+    def test_runs_for_one_pr_are_kept_and_never_cancelled(self):
         self.assertIn("concurrency:\n  group: pr-tier-${{ github.event.pull_request.number }}\n"
-                      "  cancel-in-progress: false\n", self.src)
+                      "  cancel-in-progress: false\n  queue: max\n", self.src)
 
     def test_the_token_is_read_only_and_passed_to_gh(self):
         self.assertIn("permissions:\n  pull-requests: read\n", self.src)

--- a/tests/test_pr_tier_workflow.py
+++ b/tests/test_pr_tier_workflow.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""The "Exactly one tier label" check (.github/workflows/pr-tier.yml) judges the PR's CURRENT labels, read
+from the API, and its runs for one PR are serialized, never cancelled.
+
+The race this pins closed (pull 1039, 2026-09-08): `gh pr create --label` fires `opened` with an empty
+label snapshot and `labeled` a second later; the opened run judged the snapshot and failed, and when its
+job finished two seconds AFTER the labeled run's, the newest same-named check run was that stale failure
+and the PR read blocked with auto-merge armed. Two things make ordering irrelevant now: every run reads
+the labels the PR carries at the moment it looks (the API, with the job's read-only token), and a
+concurrency group keyed on the PR number queues the runs so the newest check run is the last event's.
+Cancel-in-progress would be WRONG here: a cancelled run's check run concludes "cancelled", and when
+that run started later than the survivor it is the newest, and a cancelled required check blocks.
+
+The step's script is run for real, with `gh` replaced by a shim on PATH that prints a canned label list
+(or fails), so the zero / one / two / alias / unreadable cases are behaviour, not a grep. Source pins
+cover what the script cannot show: the trigger types, the token, the concurrency stanza and the check's
+name, which the ruleset requires by name and app and so must never change.
+
+Synthetic only: an invented repository name and PR number, no network."""
+import os
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+WF = os.path.join(os.path.dirname(HERE), ".github", "workflows", "pr-tier.yml")
+
+
+def _run_block(src):
+    """The text of the step's `run: |` block, de-indented (no YAML library in the test deps; the
+    workflow is small and its shape is pinned here)."""
+    m = re.search(r"^( +)run: \|\n((?:\1  .*\n|\n)+)", src, re.M)
+    if not m:
+        raise AssertionError("no `run: |` block found")
+    indent = len(m.group(1)) + 2
+    return "".join(line[indent:] if line.strip() else line for line in m.group(2).splitlines(True))
+
+
+def _accepted_labels(src):
+    return set(re.findall(r'\. == "([a-z-]+)"', src))
+
+
+class LabelCountBehaviour(unittest.TestCase):
+    """The script against a shimmed `gh`."""
+
+    def setUp(self):
+        self.src = open(WF).read()
+        self.script = _run_block(self.src)
+        self.bin = tempfile.mkdtemp()
+        self.accepted = sorted(_accepted_labels(self.src))
+        self.assertTrue(self.accepted, "the jq filter names the tier labels")
+
+    def _gh(self, body, fail=False):
+        p = os.path.join(self.bin, "gh")
+        with open(p, "w") as fh:
+            fh.write("#!/bin/sh\n" + ("exit 1\n" if fail else "printf '%s' '" + body + "'\n"))
+        os.chmod(p, os.stat(p).st_mode | stat.S_IEXEC)
+
+    def _run(self):
+        env = dict(os.environ, PATH=self.bin + os.pathsep + os.environ.get("PATH", ""),
+                   GITHUB_REPOSITORY="example/repo", PR_NUMBER="7", GH_TOKEN="synthetic")
+        return subprocess.run(["bash", "-e", "-c", self.script], env=env, capture_output=True, text=True, timeout=60)
+
+    def test_exactly_one_tier_label_passes(self):
+        self._gh('["%s"]' % self.accepted[0])
+        r = self._run()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_a_non_tier_label_beside_the_tier_label_is_ignored(self):
+        self._gh('["good-first-issue", "%s"]' % self.accepted[0])
+        self.assertEqual(self._run().returncode, 0)
+
+    def test_zero_tier_labels_fail(self):
+        # the opened event's world, as the API reports it BEFORE the label call lands
+        self._gh('[]')
+        r = self._run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("0 tier labels", r.stdout)
+
+    def test_two_tier_labels_fail(self):
+        self._gh('["%s", "%s"]' % (self.accepted[0], self.accepted[1]))
+        r = self._run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("2 tier labels", r.stdout)
+
+    def test_an_unreadable_api_is_a_failed_check_not_a_guess(self):
+        self._gh("", fail=True)
+        r = self._run()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("Could not read", r.stdout)
+
+    def test_the_script_reads_the_pulls_endpoint_not_the_payload(self):
+        self.assertIn('gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER"', self.script)
+        self.assertNotIn("github.event.pull_request.labels", self.src, "the payload snapshot is never consulted")
+
+
+class WorkflowPins(unittest.TestCase):
+    def setUp(self):
+        self.src = open(WF).read()
+
+    def test_the_check_name_is_unchanged(self):
+        # the ruleset requires the check by this name and the Actions app; renaming it would silently
+        # un-require it
+        self.assertIn("    name: Exactly one tier label\n", self.src)
+
+    def test_every_label_changing_event_reruns_it(self):
+        m = re.search(r"pull_request:\n\s+types: \[([^\]]+)\]", self.src)
+        types = {t.strip() for t in m.group(1).split(",")}
+        self.assertTrue({"opened", "reopened", "labeled", "unlabeled", "synchronize"} <= types, types)
+
+    def test_runs_for_one_pr_are_serialized_never_cancelled(self):
+        self.assertIn("concurrency:\n  group: pr-tier-${{ github.event.pull_request.number }}\n"
+                      "  cancel-in-progress: false\n", self.src)
+
+    def test_the_token_is_read_only_and_passed_to_gh(self):
+        self.assertIn("permissions:\n  pull-requests: read\n", self.src)
+        self.assertNotIn("write", self.src.split("jobs:")[0].split("permissions:")[1].split("\n\n")[0])
+        self.assertIn("GH_TOKEN: ${{ github.token }}", self.src)
+        self.assertNotIn("actions/checkout", self.src, "no checkout: nothing from the PR's tree runs")
+        self.assertNotIn("uses:", self.src, "no third-party action")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_tier_workflow.py
+++ b/tests/test_pr_tier_workflow.py
@@ -1,20 +1,25 @@
 #!/usr/bin/env python3
 """The "Exactly one tier label" check (.github/workflows/pr-tier.yml) judges the PR's CURRENT labels, read
-from the API, and its runs for one PR are serialized, never cancelled.
+from the API, and runs one job at a time per PR without cancelling the one in progress.
 
 The race this pins closed (pull 1039, 2026-09-08): `gh pr create --label` fires `opened` with an empty
 label snapshot and `labeled` a second later; the opened run judged the snapshot and failed, and when its
-job finished two seconds AFTER the labeled run's, the newest same-named check run was that stale failure
-and the PR read blocked with auto-merge armed. Two things make ordering irrelevant now: every run reads
-the labels the PR carries at the moment it looks (the API, with the job's read-only token), and a
-concurrency group keyed on the PR number queues the runs so the newest check run is the last event's.
-Cancel-in-progress would be WRONG here: a cancelled run's check run concludes "cancelled", and when
-that run started later than the survivor it is the newest, and a cancelled required check blocks.
+job COMPLETED two seconds after the labeled run's, the merge box (which follows the newest same-named
+check run by time) took that stale failure and the PR read blocked with auto-merge armed. Two things make
+ordering irrelevant now: every run reads the labels the PR carries at the moment it looks (the API, with
+the job's read-only token), and a concurrency group keyed on the PR number runs one job at a time, which
+makes completion times monotonic in execution order, so the run that executes last is the newest. GitHub's
+default queue replaces a superseded PENDING run with the newer one (whose check run completes later
+still), so the last executed run has always read the world after the last event. Cancel-in-progress is
+deliberately off: cancelling the in-progress run risks its "cancelled" check run completing after the
+survivor's, and a cancelled required check blocks.
 
 The step's script is run for real, with `gh` replaced by a shim on PATH that prints a canned label list
 (or fails), so the zero / one / two / alias / unreadable cases are behaviour, not a grep. Source pins
-cover what the script cannot show: the trigger types, the token, the concurrency stanza and the check's
-name, which the ruleset requires by name and app and so must never change.
+cover what the script cannot show: the trigger types, the read-only token (the workflow's one
+permissions block, no job-level override), the concurrency stanza and the check's name, which the
+ruleset requires by name and app and so must never change. The accepted label SET is read back from the
+workflow, not pinned here: tests/test_tier_policy.py (the tier-policy change) pins it against the policy.
 
 Synthetic only: an invented repository name and PR number, no network."""
 import os
@@ -31,11 +36,16 @@ WF = os.path.join(os.path.dirname(HERE), ".github", "workflows", "pr-tier.yml")
 def _run_block(src):
     """The text of the step's `run: |` block, de-indented (no YAML library in the test deps; the
     workflow is small and its shape is pinned here)."""
-    m = re.search(r"^( +)run: \|\n((?:\1  .*\n|\n)+)", src, re.M)
+    m = re.search(r"^( +)run: \|\n((?:\1  .*(?:\n|\Z)|\n)+)", src, re.M)
     if not m:
         raise AssertionError("no `run: |` block found")
     indent = len(m.group(1)) + 2
-    return "".join(line[indent:] if line.strip() else line for line in m.group(2).splitlines(True))
+    script = "".join(line[indent:] if line.strip() else line for line in m.group(2).splitlines(True))
+    # a file saved without its final newline used to drop `exit 1` and fail two tests as `0 != 1`,
+    # pointing nowhere near the extractor (review find): the block's last line is pinned instead
+    if script.rstrip().splitlines()[-1].strip() != "exit 1":
+        raise AssertionError("the extracted script does not end in `exit 1`; the extractor lost a line")
+    return script
 
 
 def _accepted_labels(src):
@@ -110,13 +120,18 @@ class WorkflowPins(unittest.TestCase):
         types = {t.strip() for t in m.group(1).split(",")}
         self.assertTrue({"opened", "reopened", "labeled", "unlabeled", "synchronize"} <= types, types)
 
-    def test_runs_for_one_pr_are_serialized_never_cancelled(self):
+    def test_runs_for_one_pr_never_cancel_the_one_in_progress(self):
         self.assertIn("concurrency:\n  group: pr-tier-${{ github.event.pull_request.number }}\n"
                       "  cancel-in-progress: false\n", self.src)
 
     def test_the_token_is_read_only_and_passed_to_gh(self):
         self.assertIn("permissions:\n  pull-requests: read\n", self.src)
-        self.assertNotIn("write", self.src.split("jobs:")[0].split("permissions:")[1].split("\n\n")[0])
+        # ONE permissions block, the workflow's: a job-level `permissions:` replaces the workflow's grant
+        # for that job, so a write there would hand gh a write token past a pin that read only the top
+        # (review find); and no non-comment line grants a write anywhere
+        self.assertEqual(self.src.count("permissions:"), 1)
+        code = "\n".join(l for l in self.src.splitlines() if not l.lstrip().startswith("#"))
+        self.assertNotIn("write", code)
         self.assertIn("GH_TOKEN: ${{ github.token }}", self.src)
         self.assertNotIn("actions/checkout", self.src, "no checkout: nothing from the PR's tree runs")
         self.assertNotIn("uses:", self.src, "no third-party action")


### PR DESCRIPTION
Two workflow fixes for races that bit tonight. Both touch `.github/`, so under the tier policy this wants the co-maintainer's eyes: @ksarma authored the tier-label workflow this changes, and is asked to review.

## 1. `.github/workflows/pr-tier.yml`: the "Exactly one tier label" check (pull 1039)
`gh pr create --label` fires `opened` with an empty label snapshot and `labeled` a second later. The check read the event payload, so the opened run failed on a label set that no longer existed; when its job **completed** two seconds after the labeled run's, the merge box (which follows the newest same-named check run by time) took that stale failure, and the PR read blocked with auto-merge armed. Every worker and `scripts/release.sh` create PRs this way.

- The step reads the PR's **current** labels from the API with the job's read-only token (`pull-requests: read`; the payload is a snapshot, the API the authority). A failed read is a failed check, never a guessed label set.
- A concurrency group keyed on the PR number runs one job at a time, which makes completion times monotonic in execution order, so the run that executes last is the newest. `queue: max` keeps every pending run (the default keeps one and replaces it, leaving a check run concluding "cancelled"). Cancel-in-progress is deliberately **off**: a cancelled job's check run can complete after the survivor's (the runner's cancel grace exceeds this job), and a cancelled required check blocks; GitHub also refuses `queue: max` beside `cancel-in-progress: true`.
- Unchanged: the check's **name** (the ruleset requires it by name and app), the trigger types, the accepted label set, no checkout, no third-party action. `contents: read` is dropped; nothing used it.

`tests/test_pr_tier_workflow.py` runs the step's script for real against a `gh` shim on PATH: one tier label passes, a non-tier label beside it is ignored, zero and two fail with the count named, an unreadable API fails the check, the script reads the pulls endpoint and never the payload. Source pins hold the name, the triggers, the concurrency stanza, the single read-only permissions block (a job-level override would replace the grant) and the absence of any `uses:`.

## 2. `.github/workflows/ci.yml`: main's CI never cancels itself (2e9d4492)
The group was `ci-<event>-<ref>` with cancel-in-progress for every event, so two merges to main in quick succession cancelled the first merge's run, and a red main went unseen until a later run happened to fail.

- Pull-request runs still cancel their superseded predecessor (the new head makes the old verdict moot): `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
- Pushes to main are keyed on the **commit sha**, one group per merge commit, so every merge gets its own completed run. A queue would not do: a group holds at most one pending run by default, so a third merge would replace the second's.
- A dispatch queues rather than cancels, so a release gate mid-watch is not superseded by a second dispatch. The event name stays in the key: the 2026-07-27 protection of the release run against pushes to the same ref stands.

`tests/test_ci_workflow_concurrency.py` pins the event-keyed group, the sha key for pushes, the pull-request-only cancellation and the triggers.

## Review
A two-lens adversarial review of the label-check commit (GitHub Actions semantics; tests and mutations) confirmed the API read, the token scope for fork PRs, the trigger types and thirteen mutation catches, and upheld three things, all folded: the header's queue semantics (now `queue: max`, with the merge-box mechanism stated as observed on pull 1039), a pin that missed a job-level write permission, and the block extractor's trailing-newline fragility. One finding is outside this PR and reported separately: romp's own `watch-pr` treats the first FAILURE in a PR's check rollup as terminal without deduplicating by check name, so a superseded failed run can produce a false "will not land" mail.

## Notes
- The tier-policy PR (#991) also edits `pr-tier.yml` (the `docs` alias in the jq filter); whichever lands second gets a hand-resolved merge keeping both halves. I own both and will rebase #991 over this.
- Main's Python jobs are red on `tests/test_fleet_restart.py` tonight (a fix rides three open PRs); if that turns this PR's Python cells red, it gets a rebase once one lands, not a fourth copy of the fix.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)