### PR TITLE
An empty chat build never blanks a session that has content: the kernel keeps its previous build, and the pane never takes an empty session frame as a transcript wipe

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22882,6 +22882,44 @@ WIRE_TAIL = 250                                  # events shipped on a full chat
 WIRE_CHUNK = 250                                 # events per loadOlder (chatHead) response
 
 
+# ── an EMPTY chat build never describes a session that has content (T249b, the user 2026-09-07) ─────────────
+# build_session parses whatever path the session resolves to; a path that is unreadable for one cycle — a resumed
+# SDK session whose registry already names its new leaf while the CLI has not created the file, a transcript moved
+# aside by hand — parses to ZERO events, and that build went out as a full {type:"session"} frame with events: [].
+# The pane took it as the new transcript (a placeholder flash), and the content frame that followed a cycle later
+# was a "first build" that re-landed the reader through the full-show route: the recorded scroll snap (T249). An
+# empty build for a session whose previous build had events is NOT new information about the conversation — it
+# is a read that failed — so the previous build stands until content returns, and the episode is said once on
+# stderr (fail loudly, never degrade silently). A session that genuinely has nothing (a fresh one, a never-run
+# SDK session) has no previous events and is untouched; a /clear is never events-empty (its boundary card).
+_EMPTY_BUILD_NOTED = set()      # sids inside an empty-build episode (one stderr line per episode)
+
+
+def _empty_build_regresses(m, prev_events):
+    """Would sending build `m` blank a session the clients hold WITH content? True when the build carries no events
+    while the previous push's build for the sid did."""
+    return not (m.get("events") or []) and bool(prev_events)
+
+
+def _note_empty_build(sid, path, n_prev):
+    """One stderr line per episode naming the sid, what the previous build held and whether the transcript path is
+    even there; a romp-perf `chatempty` line every time, for the harness/perf log."""
+    sid = str(sid or "")
+    _perf("chatempty", sid=sid[:8], prev=int(n_prev or 0))
+    if sid in _EMPTY_BUILD_NOTED:
+        return
+    _EMPTY_BUILD_NOTED.add(sid)
+    exists = bool(path) and os.path.exists(str(path))
+    sys.stderr.write("romp-kernel: the chat build for %s came back EMPTY while its previous build had %d events "
+                     "(transcript %s) — keeping the previous build until content returns; an empty frame would blank "
+                     "the pane and re-land the reader\n"
+                     % (sid[:8], int(n_prev or 0), "present" if exists else "missing at %s" % path))
+
+
+def _clear_empty_build_note(sid):
+    _EMPTY_BUILD_NOTED.discard(str(sid or ""))
+
+
 def _chat_diff(prev, cur):
     """First index where the freshly-built events `cur` differ from the previously-sent `prev` — i.e. the
     suffix to re-send. Append-only growth returns len(prev) (just the new tail); a tool output filling an
@@ -34445,6 +34483,16 @@ def _push(targets, connect=False, tmux=None):
                               why=_chat_fold_last_info().get("why", ""))         # the demote reason on a full build
                 if not m:
                     continue
+                if _empty_build_regresses(m, _prev_chat_events.get(m["id"])):
+                    # a failed read, not a conversation that emptied (see _empty_build_regresses): the last cached
+                    # build stands in — same events, so the diff below finds nothing to send — or, with nothing
+                    # cached, this cycle sends nothing for the sid; the file's return busts the stat key and rebuilds
+                    _note_empty_build(s["sid"], s.get("path"), len(_prev_chat_events.get(m["id"]) or ()))
+                    if hit is None:
+                        continue
+                    m, ms = hit[1], hit[2]
+                else:
+                    _clear_empty_build_note(s["sid"])
                 _note_chat_divergence(s["sid"], m.get("name") or "",
                                       ((m.get("status") or {}).get("state") or ""),
                                       ((tmux.get(s["sid"]) or {}).get("state") or ""), now)
@@ -34702,6 +34750,10 @@ def _push_session_now(sid):
         m = build_session(sid, now, tmux)
         if not m:
             return
+        if _empty_build_regresses(m, _prev_chat_events.get(sid)):
+            _note_empty_build(sid, next((s.get("path") for s in chat_list if s["sid"] == sid), None),
+                              len(_prev_chat_events.get(sid) or ()))
+            return                                   # the periodic pusher owns the sid until content returns
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
         for c in targets:
             _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _views_client()})

--- a/tests/test_chat_empty_build_guard.py
+++ b/tests/test_chat_empty_build_guard.py
@@ -1,0 +1,137 @@
+"""An EMPTY chat build never blanks a session the clients hold WITH content (T249b, the user 2026-09-07).
+
+build_session parses whatever path the session resolves to; a path unreadable for one pusher cycle — a resumed
+SDK session whose registry already names its new leaf while the CLI has not created the file, a transcript moved
+aside — parses to ZERO events, and that build went out as a full {type:"session"} frame with events: []. The pane
+took it as the new transcript (a placeholder flash), and the content frame a cycle later read as a FIRST build
+that re-landed the reader through the full-show route: the recorded scroll snap (T249). Behavioural pins on the
+pusher and the targeted push, with build_session stubbed to return controlled frames; synthetic ids only.
+"""
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_emptybuild", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-4333-8444-000000000249"
+NOW = 1781300000
+
+
+def _tm():
+    return {"state": "waiting", "color": "#888888", "since": NOW - 60, "model": "", "effort": "",
+            "context": None, "backend": "tmux"}
+
+
+def _ev(i):
+    return {"kind": "assistant", "uuid": "11111111-2222-4333-8444-00000000a%03d" % i, "md": "reply %d" % i}
+
+
+def _frame(events):
+    return {"type": "session", "id": SID, "name": "web", "color": None, "events": list(events),
+            "status": {"state": "ready"}, "ledger": None}
+
+
+class _Pusher(unittest.TestCase):
+    """One chat client, one session; build_session answers from a script of frames, one per cycle."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.td.name, SID + ".jsonl")
+        with open(self.path, "w") as f:
+            f.write("{}\n")                                # stat-able: the build cache keys on it
+        self.sess = {"sid": SID, "name": "web", "anchor": None, "path": self.path, "mtime": NOW}
+        self.tmux = {SID: _tm()}
+        self.sent = []
+        self.builds = []
+        self.client = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: None}
+        km._prev_chat_events.pop(SID, None)
+        km._prev_chat_ledger.pop(SID, None)
+        km._built_chat.pop(SID, None)
+        km._EMPTY_BUILD_NOTED.discard(SID)
+
+    def tearDown(self):
+        km._prev_chat_events.pop(SID, None)
+        km._built_chat.pop(SID, None)
+        km._EMPTY_BUILD_NOTED.discard(SID)
+        self.td.cleanup()
+
+    def _cycle(self, events, stderr=None):
+        """One pusher cycle whose build returns `events`; returns the ("chat", SID) frames it sent."""
+        self.sent.clear()
+        os.utime(self.path, (NOW, NOW + len(self.builds)))   # every cycle's transcript stat differs → a rebuild
+        self.builds.append(events)
+        frame = _frame(events)
+        with mock.patch.object(km, "_alive_sessions", lambda now, tm: [dict(self.sess)]), \
+                mock.patch.object(km, "_chat_tab_sessions", lambda now, tm: [dict(self.sess)]), \
+                mock.patch.object(km, "_warm_fleet_bg", lambda now: None), \
+                mock.patch.object(km, "_tmux_sessions", lambda: dict(self.tmux)), \
+                mock.patch.object(km, "build_session", lambda sid, now, tmux=None, **kw: dict(frame)), \
+                mock.patch.object(km, "_cached_feed", lambda *a, **k: {"working": [], "awaiting": [], "asks": []}), \
+                mock.patch.object(km, "_send_client", lambda c, key, msg, pre=None, sig=None, kind="full": self.sent.append((key, msg))), \
+                mock.patch.object(sys, "stderr", stderr if stderr is not None else io.StringIO()):
+            km._push([self.client], tmux=self.tmux)
+        return [m for k, m in self.sent if k == ("chat", SID)]
+
+    def test_an_empty_build_after_content_sends_nothing_and_the_next_content_is_a_tail(self):
+        first = self._cycle([_ev(1), _ev(2)])
+        self.assertEqual([m["type"] for m in first], ["session"], "premise: the fresh client gets the full session")
+        self.assertEqual(len(first[0]["events"]), 2)
+        err = io.StringIO()
+        empty = self._cycle([], stderr=err)
+        self.assertEqual([m for m in empty if m.get("type") == "session" and not m.get("events")], [],
+                         "an EMPTY build for a session the client holds with content is never sent as a wipe")
+        self.assertIn("came back EMPTY", err.getvalue(), "…and the failed read is said on stderr")
+        # the baseline stood: the content frame that follows is an append onto what the client holds, not a
+        # full frame the pane would take as a first build (the full-show route that re-lands the reader)
+        back = self._cycle([_ev(1), _ev(2), _ev(3)])
+        self.assertEqual([m["type"] for m in back], ["chatTail"], "content returns as a tail, never a first build")
+        self.assertEqual(back[0]["from"], 2)
+
+    def test_the_note_is_said_once_per_episode_and_re_arms_after_content_returns(self):
+        self._cycle([_ev(1)])
+        err = io.StringIO()
+        self._cycle([], stderr=err); self._cycle([], stderr=err)
+        self.assertEqual(err.getvalue().count("came back EMPTY"), 1, "one line per episode, not per cycle")
+        self._cycle([_ev(1), _ev(2)])
+        err2 = io.StringIO()
+        self._cycle([], stderr=err2)
+        self.assertEqual(err2.getvalue().count("came back EMPTY"), 1, "a new episode after content returned is said again")
+
+    def test_a_session_that_never_had_content_is_untouched(self):
+        empty = self._cycle([])
+        self.assertEqual([m["type"] for m in empty], ["session"], "a genuinely empty session still gets its frame")
+        self.assertEqual(empty[0]["events"], [])
+
+    def test_the_targeted_push_skips_an_empty_build_too(self):
+        self._cycle([_ev(1), _ev(2)])
+        self.sent.clear()
+        with mock.patch.object(km, "_clients", [self.client]), \
+                mock.patch.object(km, "_tmux_sessions", lambda: dict(self.tmux)), \
+                mock.patch.object(km, "_chat_tab_sessions", lambda now, tm: [dict(self.sess)]), \
+                mock.patch.object(km, "build_session", lambda sid, now, tmux=None, **kw: _frame([])), \
+                mock.patch.object(km, "_send_client", lambda c, key, msg, pre=None, sig=None, kind="full": self.sent.append((key, msg))), \
+                mock.patch.object(sys, "stderr", io.StringIO()):
+            km._push_session_now(SID)
+        self.assertEqual([m for k, m in self.sent if k == ("chat", SID)], [],
+                         "the targeted push never sends an emptied frame either")
+
+
+class Decision(unittest.TestCase):
+    def test_empty_build_regresses(self):
+        self.assertTrue(km._empty_build_regresses(_frame([]), [_ev(1)]))
+        self.assertFalse(km._empty_build_regresses(_frame([]), []), "nothing held → a genuinely empty session")
+        self.assertFalse(km._empty_build_regresses(_frame([]), None))
+        self.assertFalse(km._empty_build_regresses(_frame([_ev(1)]), [_ev(1), _ev(2)]), "fewer events is a change, not a failed read")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -164,8 +164,9 @@ class RenderHandlesTheTail(unittest.TestCase):
 
     def test_render_handles_a_partial_session_and_streams_older_in(self):
         r = self._render()
-        # upsert records the wire offset → s.events is the tail [headFrom, headTotal)
-        self.assertIn("headFrom: msg.headFrom ?? 0,", r)
+        # upsert records the wire offset → s.events is the tail [headFrom, headTotal); an empty frame for a held
+        # transcript keeps the resident window instead (T249b, frame-merge.ts)
+        self.assertIn("headFrom: kept && prev ? prev.headFrom : (msg.headFrom ?? 0),", r)
         # scroll to the top of the resident tail with older on the server → request the previous chunk
         self.assertIn('vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.headFrom });', r)
         self.assertIn("if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx) { requestOlder(", r)

--- a/ui/webview/empty-session-frame.test.ts
+++ b/ui/webview/empty-session-frame.test.ts
@@ -1,0 +1,40 @@
+// T249b (the user 2026-09-07): the recorded scroll snap's frame path. A kernel whose read of a transcript failed
+// for one pusher cycle sent a full `session` frame with `events: []` for a session with content; render.ts upsert
+// took the empty array as the new transcript (a placeholder flash), and the content frame a cycle later was a
+// FIRST build that re-landed the reader through the full-show route. The kernel now keeps its previous build
+// (tests/test_chat_empty_build_guard.py); this is the pane's half: a frame that would take a held transcript from
+// content to nothing is status-shaped, never a wipe, and is filed once per session in the client-diag journal.
+// Executed rule + render.ts wiring pins, red on the previous render.ts. Synthetic ids only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { keepResidentEvents } from "./frame-merge";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("an empty events array for a held transcript keeps the resident events; everything else takes the frame as before", () => {
+  const held = [{ uuid: "11111111-2222-4333-8444-0000000002a1" }, { uuid: "11111111-2222-4333-8444-0000000002a2" }];
+  assert.equal(keepResidentEvents(held, []), true, "content → nothing is a failed read, not a wipe");
+  assert.equal(keepResidentEvents(held, [{ uuid: "x" }]), false, "a frame with events replaces the transcript");
+  assert.equal(keepResidentEvents(held, undefined), false, "no events field: the caller already keeps the resident events");
+  assert.equal(keepResidentEvents([], []), false, "a session with nothing yet stays empty");
+  assert.equal(keepResidentEvents(null, []), false, "a brand-new session with an empty frame is genuinely empty");
+});
+
+test("render.ts upsert keeps the held events, head window and all, and files the frame once per session", () => {
+  assert.match(RENDER, /import \{ keepResidentEvents \} from "\.\/frame-merge";/);
+  const m = RENDER.match(/^function upsert\(msg: any\) \{([\s\S]*?)\n\}/m);
+  assert.ok(m, "upsert");
+  const body = m![1];
+  assert.match(body, /const kept = keepResidentEvents\(prev \? prev\.events : null, msg\.events\);/);
+  assert.match(body, /const events = kept && prev \? prev\.events : \(msg\.events \|\| \(prev \? prev\.events : \[\]\)\);/);
+  assert.match(body, /headFrom: kept && prev \? prev\.headFrom : \(msg\.headFrom \?\? 0\),/);
+  assert.match(body, /headTotal: kept && prev \? prev\.headTotal : \(msg\.headTotal \?\? events\.length\),/);
+  // the decision is made BEFORE forked/firstBuild read msg.events: an empty array is neither a fork nor a first build
+  assert.ok(body.indexOf("const kept = keepResidentEvents(") < body.indexOf("const forked = "));
+  assert.ok(body.indexOf("const kept = keepResidentEvents(") < body.indexOf("const firstBuild = "));
+  // loud, once: the client-diag row names the session and what it held
+  assert.match(body, /what: "empty-session-frame", data: \{ id: msg\.id, held: prev\.events\.length \}/);
+  assert.match(RENDER, /const emptyFrameDiagSent = new Set<string>\(\);/);
+});

--- a/ui/webview/frame-merge.ts
+++ b/ui/webview/frame-merge.ts
@@ -1,0 +1,20 @@
+// What a `session` frame's events mean for a session the pane already holds (T249b, the user 2026-09-07).
+//
+// The kernel's full frame carries the transcript's events; render.ts upsert took `msg.events` as the new resident
+// transcript whenever the field was present — an EMPTY array included, because `[]` is truthy. A kernel whose read
+// of the transcript failed for one cycle (the file unreadable at build time) sent exactly that: a session frame
+// with `events: []` for a session with content. The pane blanked the transcript to a placeholder, and the content
+// frame a cycle later read as a FIRST build, which re-landed the reader through the full-show route — the
+// recorded scroll snap. The kernel now keeps its previous build instead of sending an emptied one; this is the
+// pane's own half of the same rule: a frame that would take a conversation from content to nothing is
+// status-shaped (its chip, name and meta still apply), never a transcript wipe. Nothing legitimate empties a held
+// transcript through this path — a /clear is never events-empty (its boundary card), a fork mints a new id — and
+// when it fires the pane files one client-diag row per session, so a kernel that does send such frames is seen.
+// Pure and DOM-free so node --test executes it.
+
+/** Keep the resident events instead of taking the frame's? Only when the pane holds a transcript WITH events and
+ *  the frame's events are an EMPTY array. A frame with no `events` field at all is already handled by the caller
+ *  (it keeps the resident events); a frame with events replaces them as before. */
+export function keepResidentEvents(prev: readonly unknown[] | null | undefined, incoming: unknown): boolean {
+  return !!prev && prev.length > 0 && Array.isArray(incoming) && incoming.length === 0;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -55,6 +55,7 @@ import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { followReader, keepPlaceAcrossShow } from "./scroll-keep";
+import { keepResidentEvents } from "./frame-merge";
 import { activeTabToReannounce } from "./relay-active";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
@@ -13284,11 +13285,22 @@ function upsert(msg: any) {
   const existed = sessions.has(msg.id);
   const prev = sessions.get(msg.id);
   awaitingFull.delete(msg.id);   // a full session landed → this session is re-based; a later gap may ask again
+  // A frame that would take a HELD transcript from content to nothing is status-shaped, never a wipe (T249b,
+  // the user 2026-09-07): the kernel sent `events: []` for a session with content when its read of the transcript
+  // failed for a cycle, the pane blanked to a placeholder, and the content frame that followed re-landed the
+  // reader as a first build (the recorded scroll snap). Decision in frame-merge.ts; said once per session in
+  // the client-diag journal so a kernel that sends such frames is seen, never silently absorbed.
+  const kept = keepResidentEvents(prev ? prev.events : null, msg.events);
+  if (kept && prev && !emptyFrameDiagSent.has(msg.id)) {
+    emptyFrameDiagSent.add(msg.id);
+    vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "empty-session-frame", data: { id: msg.id, held: prev.events.length } });
+  }
+  const events = kept && prev ? prev.events : (msg.events || (prev ? prev.events : []));
   const s: Session = {
     id: msg.id,
     name: msg.name,
     color: msg.color || null,
-    events: msg.events || (prev ? prev.events : []),
+    events,
     status: msg.status || (prev ? prev.status : { state: "idle", sinceEpoch: null }),
     firstSeen: msg.firstSeen ?? (prev ? prev.firstSeen : undefined),
     cwd: msg.cwd ?? (prev ? prev.cwd : ""),
@@ -13298,8 +13310,8 @@ function upsert(msg: any) {
     gitBranch: msg.gitBranch ?? (prev ? prev.gitBranch : ""),
     workTree: msg.workTree ?? (prev ? prev.workTree : null),
     // A trimmed full send carries headFrom/headTotal; a whole-transcript send omits them (headFrom 0).
-    headFrom: msg.headFrom ?? 0,
-    headTotal: msg.headTotal ?? ((msg.events || (prev ? prev.events : [])).length),
+    headFrom: kept && prev ? prev.headFrom : (msg.headFrom ?? 0),
+    headTotal: kept && prev ? prev.headTotal : (msg.headTotal ?? events.length),
     bgTasks: ("bgTasks" in msg) ? msg.bgTasks : (prev ? prev.bgTasks : undefined),
     hideFromFeed: ("hideFromFeed" in msg) ? !!msg.hideFromFeed : (prev ? prev.hideFromFeed : undefined),
     postalServiceOff: ("postalServiceOff" in msg) ? !!msg.postalServiceOff : (prev ? prev.postalServiceOff : undefined),
@@ -13424,6 +13436,7 @@ function notifyShell(kind: string, text: string, sid?: string): void {
 // every 0.5-3s and would otherwise re-ask on every rejected delta until the reply lands. Cleared in upsert(),
 // so the next gap can ask again.
 const awaitingFull = new Set<string>();
+const emptyFrameDiagSent = new Set<string>();   // sids whose empty session frame was filed once (see upsert / frame-merge.ts)
 function requestFullSession(id: string): void {
   if (!id || awaitingFull.has(id)) return;
   awaitingFull.add(id);


### PR DESCRIPTION
## What

The frame path behind the recorded scroll snap (romp-on/romp#1036, #1040): a full `session` frame with `events: []` for a session that has content, followed by a content frame one cycle later. The pane took the empty array as the new transcript (a placeholder flash) and read the content frame as a FIRST build, which re-landed the reader through the full-show route.

**Kernel-side cause.** `build_session` parses whatever path the session resolves to. When that path is unreadable for one pusher cycle, `_parse` of a missing file yields zero events, and `_send_chat`'s full path ships whatever the build holds. Two ways a live session's path is briefly unreadable: a resumed SDK session whose registry already names its new leaf while the CLI has not created the file yet (the fingerprint code names this race), and a transcript moved aside. The file-stat cache key is `None` for a missing path, so the empty build is rebuilt and re-sent every cycle until the file returns; the content then diffs against an empty baseline and goes out as a full frame, the client's "first build".

**Fix, both ends, event-based.**
- Kernel: an empty build for a session whose previous push held events is a failed read, not new information about the conversation. The pusher keeps the last cached build (the diff then finds nothing to send) or sends nothing for the sid when nothing is cached; the targeted push skips it. Said once per episode on stderr and on every occurrence as a `romp-perf chatempty` line. A session that never had content is untouched; a `/clear` is never events-empty (its boundary card).
- Pane: a frame that would take a held transcript from content to nothing is status-shaped (chip, name, meta apply), never a wipe; filed once per session as a `clientDiag` row (`empty-session-frame`) so a kernel that sends such frames is seen. The decision is a pure helper (`ui/webview/frame-merge.ts`).

## Tier

- [ ] tests-only
- [x] fix — a bug fix with a test that fails before it
- [ ] feature
- [ ] major-feature

## Tests

New: `tests/test_chat_empty_build_guard.py` drives the pusher with a scripted `build_session` (content, empty, content → a full frame, then nothing, then a tail; the note once per episode and re-armed after content returns; the targeted push; a genuinely empty session untouched; the decision helper) — red on main. New: `ui/webview/empty-session-frame.test.ts` executes the pane's rule and pins upsert's wiring — red on main's render.ts. Suites: node 3270 passed (`npm test`, typecheck clean); Python 8628 passed, 0 failed (`env -u ROMP_API_KEY_CMD`: with that session variable set, 73 key-source/judge/auth tests fail identically on a clean main, an environment effect, not this change).

## Verified live

The two-kernel harness (kernel A serves the page, kernel B attached through A's relay, headless browser, tmux lanes; the trigger is B's transcript file moved aside for two pusher cycles and back) is running on three frozen trees: main before the scroll fix, main today, and this branch. Its result lands here as a comment when the runs finish; the pre-fix tree is expected to reproduce the recorded snap and this branch to show neither the snap nor the placeholder flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
