### PR TITLE
The PR watch judges each check by its newest run — no more false FAILED mail

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16708,13 +16708,31 @@ def _pr_watch_verdict(d):
         return "merged", ""
     if state == "CLOSED":
         return "closed", ""
-    busy = False
+    # ONE verdict per check NAME, from its NEWEST run (T256, 2026-09-07): gh's rollup keeps superseded
+    # runs beside their re-runs — the label workflow left a failed run next to the passing one on every
+    # `gh pr create --label` PR, and any manual re-run does the same — and the first FAILURE in list
+    # order mailed a false "FAILED check … will not land" twice in one night. The merge box's own rule:
+    # group by name (plus the app/workflow when the API gives it — two workflows may share a job name),
+    # keep the run with the latest completion (a still-running re-run outranks any finished one: the
+    # name's story is not over), and only then decide across the survivors.
+    newest = {}
     for c in (d or {}).get("statusCheckRollup") or []:
         if not isinstance(c, dict):
             continue
+        app = c.get("app")
+        app_name = (app.get("name") if isinstance(app, dict) else None) or c.get("workflowName") or ""
+        key = (str(c.get("name") or c.get("context") or "a check"), str(app_name))
+        done = str(c.get("status") or "").upper() == "COMPLETED" or bool(c.get("conclusion"))
+        # sort key: an unfinished run is the newest by definition; among finished runs, completedAt,
+        # then startedAt; a run with no stamps at all sorts oldest
+        rank = (0 if done else 1, str(c.get("completedAt") or ""), str(c.get("startedAt") or ""))
+        if key not in newest or rank > newest[key][0]:
+            newest[key] = (rank, c)
+    busy = False
+    for (name, _app), (_rank, c) in newest.items():
         con = str(c.get("conclusion") or "").upper()
         if con in ("FAILURE", "TIMED_OUT"):
-            return "failed", str(c.get("name") or c.get("context") or "a check")
+            return "failed", name
         if str(c.get("status") or "").upper() in ("IN_PROGRESS", "QUEUED", "PENDING") or con == "":
             busy = True
     return None, ("busy" if busy else "")

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -282,5 +282,41 @@ class Route(unittest.TestCase):
                                     token=False)[0], 403)
 
 
+
+class VerdictJudgesEachCheckByItsNewestRun(unittest.TestCase):
+    """T256: gh's statusCheckRollup keeps SUPERSEDED runs beside their re-runs — the label workflow
+    left a failed run next to the passing one on every `gh pr create --label` PR, and any manual
+    re-run does the same. The first FAILURE in list order was treated as terminal, so a stale red run
+    mailed a false "FAILED check … will not land" (twice on 2026-09-07). The merge box's own rule:
+    group by check name, judge each name by its NEWEST run (completion time), decide only then."""
+
+    def _run(self, name, conclusion, completed, status="COMPLETED"):
+        return {"name": name, "conclusion": conclusion, "status": status,
+                "startedAt": completed.replace("Z", "") and "2026-09-07T05:00:00Z", "completedAt": completed}
+
+    def test_a_stale_failure_beside_a_newer_success_of_the_same_name_is_not_failed(self):
+        d = {"state": "OPEN", "statusCheckRollup": [
+            self._run("label check", "FAILURE", "2026-09-07T05:40:00Z"),     # the superseded run, listed first
+            self._run("Python 3.12", "SUCCESS", "2026-09-07T05:45:00Z"),
+            self._run("label check", "SUCCESS", "2026-09-07T05:50:00Z"),     # the re-run that actually counts
+        ]}
+        self.assertEqual(km._pr_watch_verdict(d), (None, ""),
+                         "every name's NEWEST run passed and the PR is open → keep watching, never 'failed'")
+
+    def test_a_newer_failure_after_an_older_success_is_failed(self):
+        d = {"state": "OPEN", "statusCheckRollup": [
+            self._run("Shell (bats)", "SUCCESS", "2026-09-07T05:40:00Z"),
+            self._run("Shell (bats)", "FAILURE", "2026-09-07T05:50:00Z"),
+        ]}
+        self.assertEqual(km._pr_watch_verdict(d), ("failed", "Shell (bats)"), "the newest run of that name is red")
+
+    def test_a_running_rerun_of_a_failed_name_keeps_watching(self):
+        d = {"state": "OPEN", "statusCheckRollup": [
+            self._run("Shell (bats)", "FAILURE", "2026-09-07T05:40:00Z"),
+            {"name": "Shell (bats)", "conclusion": "", "status": "IN_PROGRESS", "startedAt": "2026-09-07T05:55:00Z", "completedAt": None},
+        ]}
+        self.assertEqual(km._pr_watch_verdict(d), (None, "busy"), "its newest run is still in flight — the old red is superseded")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
T256: gh's `statusCheckRollup` keeps superseded runs beside their re-runs — the label workflow left a failed run next to the passing one on every `gh pr create --label` PR until tonight, and any manual re-run leaves the same shape — and `_pr_watch_verdict` treated the first FAILURE in list order as terminal. A stale red run mailed the user 'FAILED check … will not land' for a PR that was landing (twice on 2026-09-07).

The verdict now follows the merge box's own rule: **group rollup entries by check name** (plus the app or workflow when the API gives it — two workflows may share a job name), **keep each name's newest run** — a still-running re-run outranks any finished one, then completion time, then start time — and only then decide across the survivors: any name whose newest run failed → failed; merged state → merged; otherwise keep watching, with the cadence hint when a run is in flight. Still pure for tests.

Red-first: a stale failure listed beside a newer success of the same name is no longer 'failed'; a newer failure after an older success still is; a running re-run of a failed name keeps watching. Python 8642 passed / extension 3272 passed on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)