### PR TITLE
Peer kernel payloads render as text; the page never holds a remote token

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14924,6 +14924,121 @@ def _safe_ssh_host(host):
         and not host.startswith("-") and bool(_SSH_HOST_RE.match(host))
 
 
+# ── what a PEER kernel's answer may say, field by field ──────────────────────────────────────────────────
+# Two peer answers cross a tunnel into this kernel and on to the page: /version (polled into the row and
+# saved in remotes.json) and /tunnels (relayed whole by tunnels_of for the "its connections" expand). Both
+# used to pass through as they came, so a hostile or merely broken peer chose what the panel rendered and
+# what this kernel remembered about it. Every field now has to fit a shape; what doesn't is dropped, and
+# a dropped sha/version is said once on stderr rather than silently blanked (2026-09-08).
+_PEER_SHA_RE = re.compile(r"^[0-9a-f]{7,40}(-dirty)?$")   # a git short or full sha; '-dirty' is what _kernel_sha
+#                                                            appends on an uncommitted worktree, and _sha_base /
+#                                                            _shas_agree read through it — so must this (review find)
+_PEER_VER_RE = re.compile(r"^v\d+\.\d+\.\d+\+?$")          # _kernel_ver's shape: vN.N.N, '+' when past the bump
+_PEER_STATUSES = frozenset(("up", "authorizing", "connecting", "starting", "no-kernel", "restarting",
+                            "down", "error"))              # the words the panel's LBL/TIP maps know
+_PEER_PHASE_RE = re.compile(r"^[a-z][a-z-]{0,23}$")       # an auto-sync phase word (pushing, waiting, failed…)
+_PEER_KEY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")     # a settings key, a session id
+_PEER_TUNNELS_MAX = 128                                    # rows one peer may contribute to the expand
+_PEER_TEXT_MAX = 200                                       # characters of free text per field
+
+
+def _peer_text(v, n=_PEER_TEXT_MAX):
+    """A peer's free text as INERT text: a str only, printable characters only, the four markup-significant
+    characters (< > " ') removed, at most `n` characters. Anything that is not a string is ''."""
+    if not isinstance(v, str):
+        return ""
+    return "".join(ch for ch in v if ch.isprintable() and ch not in '<>"\'')[:n]
+
+
+def _peer_int(v, lo=0, hi=2 ** 53):
+    """An int in [lo, hi] (a bool is not one), else 0."""
+    return v if isinstance(v, int) and not isinstance(v, bool) and lo <= v <= hi else 0
+
+
+def _peer_sha(v):
+    return v if isinstance(v, str) and _PEER_SHA_RE.match(v) else ""
+
+
+def _peer_ver(v):
+    return v if isinstance(v, str) and _PEER_VER_RE.match(v) else ""
+
+
+_peer_shape_said = set()          # (host, field) pairs already complained about — once per process
+
+
+def _peer_shape_complain(host, field, value, note=None):
+    """Say ONCE per (host, field), on stderr where the kernel's own log lands, that a peer reported a value
+    that does not fit the field's shape and was dropped. Loud, not silent (CLAUDE.md): the row then reads
+    as missing that field, and this line is what says why. `note` replaces the default sentence when the
+    finding is not "this value is not one" (tunnels_of's dropped rows)."""
+    key = (str(host), field)
+    if key in _peer_shape_said:
+        return
+    _peer_shape_said.add(key)
+    print(note or ("romp: %s reported a %s that is not one (%r) — ignoring it" % (host, field, str(value)[:60])),
+          file=sys.stderr, flush=True)
+
+
+def _remote_payload_public_row(raw):
+    """ONE row of a peer's /tunnels answer, re-read through the shape _remote_public publishes — the
+    whitelist tunnels_of applies before the page sees a peer's rows. Every key the panel's sub-row and
+    strip.ts's subRow read is here, so the expand loses nothing; nothing else passes. The host must be one
+    _safe_ssh_host would accept (it is posted back as the target of every forwarded action) or the row is
+    dropped (None). A peer's `token` (its OWN remote's credential) collapses to the fact of one, like every
+    row this kernel publishes; numbers must be ints; a boolean must be True itself; sha, version, status
+    and phase words must fit their shapes, else ''; free text is bounded and inert (_peer_text)."""
+    if not isinstance(raw, dict) or not _safe_ssh_host(raw.get("host")):
+        return None
+    ap = raw.get("autoPush")
+    if isinstance(ap, dict):
+        ph = ap.get("phase")
+        ap = {"phase": ph if isinstance(ph, str) and _PEER_PHASE_RE.match(ph) else "",
+              "detail": _peer_text(ap.get("detail")), "at": _peer_int(ap.get("at"))}
+    else:
+        ap = None
+    st = raw.get("settings")
+    if isinstance(st, dict):
+        def _scalar(v):
+            if isinstance(v, bool) or (isinstance(v, int) and abs(v) <= 2 ** 53):
+                return True
+            if isinstance(v, float):
+                return v == v and abs(v) != float("inf")
+            return isinstance(v, str) and v == _peer_text(v)
+        st = {k: v for k, v in list(st.items())[:64]
+              if isinstance(k, str) and _PEER_KEY_RE.match(k) and _scalar(v)}
+    else:
+        st = None
+    status, trust, an = raw.get("status"), raw.get("trust"), raw.get("autoNudge")
+    sids = raw.get("sids")
+    tok = raw.get("token")
+
+    def _drift(v):                # behindBy/aheadBy: an int, or None (the panel says "different build")
+        return v if isinstance(v, int) and not isinstance(v, bool) and abs(v) <= 2 ** 53 else None
+    return {"host": raw["host"],
+            "kernelPort": _peer_int(raw.get("kernelPort"), 0, 65535),
+            "localPort": _peer_int(raw.get("localPort"), 0, 65535),
+            "busPort": _peer_int(raw.get("busPort"), 0, 65535),
+            "checkin": raw.get("checkin") is True, "checkinPeer": raw.get("checkinPeer") is True,
+            "hasToken": raw.get("hasToken") is True or (isinstance(tok, str) and bool(tok)),
+            "status": status if isinstance(status, str) and status in _PEER_STATUSES else "",
+            "detail": _peer_text(raw.get("detail")),
+            "sids": [x for x in (sids if isinstance(sids, list) else [])[:512]
+                     if isinstance(x, str) and _PEER_KEY_RE.match(x)],
+            "trust": trust if isinstance(trust, str) and trust in TRUST_LEVELS else "",
+            "kernelSha": _peer_sha(raw.get("kernelSha")), "localSha": _peer_sha(raw.get("localSha")),
+            "kernelVer": _peer_ver(raw.get("kernelVer")), "localVer": _peer_ver(raw.get("localVer")),
+            "outOfDate": raw.get("outOfDate") is True,
+            "behindBy": _drift(raw.get("behindBy")), "aheadBy": _drift(raw.get("aheadBy")),
+            "kernelDate": _peer_text(raw.get("kernelDate"), 40),
+            "autoNudge": an if isinstance(an, bool) else None,
+            "settings": st,
+            "fastForward": raw.get("fastForward") is True, "fastPull": raw.get("fastPull") is True,
+            "askPull": raw.get("askPull") is True,
+            "autoPush": ap,
+            "fails": _peer_int(raw.get("fails")), "nextTry": _peer_int(raw.get("nextTry")),
+            "stale": raw.get("stale") is True, "lastOk": _peer_int(raw.get("lastOk"))}
+
+
 def _free_port():
     import socket
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -15517,10 +15632,31 @@ def tunnels_of(host):
     st, j, err = _remote_kernel_call(r, "GET", "/tunnels", timeout=6)
     if err or not isinstance(j, dict):
         return {"ok": False, "error": err or ("HTTP %s from %s" % (st, host))}
-    j = dict(j)
-    j["ok"] = True
-    j["of"] = host
-    return j
+    rows = j.get("tunnels")
+    if not isinstance(rows, list):
+        return {"ok": False, "error": "%s answered /tunnels without a list of tunnels (got %s)"
+                                      % (host, type(rows).__name__)}
+    # The answer is a PEER's. Every row is re-read through _remote_payload_public_row — a host ssh would
+    # accept, an enumerated status, sha/version shapes, exact booleans, bounded inert text — rows without
+    # a usable host are dropped and counted, the row count is capped, and every other top-level key the
+    # peer sent (its known list, its gossip, its own build) stays behind: the expand reads only `tunnels`.
+    # Before this the peer's JSON went to the page verbatim (2026-09-08).
+    out, dropped = [], 0
+    for raw in rows[:4096]:
+        row = _remote_payload_public_row(raw)
+        if row is None:
+            dropped += 1
+        elif len(out) < _PEER_TUNNELS_MAX:
+            out.append(row)
+    ans = {"ok": True, "of": host, "tunnels": out}
+    if dropped:
+        # said twice, neither silently: once here (per host, per process) and in BOTH panels' sub-notes,
+        # which render `dropped` beneath the rows that did pass (review find)
+        ans["dropped"] = dropped
+        _peer_shape_complain(host, "tunnels", dropped,
+                             "romp: %s answered /tunnels with %d row%s without a usable host — left out of "
+                             "its connections list" % (host, dropped, "" if dropped == 1 else "s"))
+    return ans
 
 
 # Forwarded row actions block on the via machine's own ssh work; update/start push code and wait
@@ -15939,7 +16075,10 @@ def _expected_restart_status(r, st, rsha, now):
 
 
 def _remote_public(r):
-    """The API view of a remote row — everything the browser needs to open its own WS, minus the Popen.
+    """The API view of a remote row — everything the browser needs, minus the Popen and minus the remote's
+    credential. The browser reaches a remote through /remote/<host>/ws, where _remote_ws injects that
+    machine's token itself, so the page only ever needs to know one EXISTS: `hasToken`. The token string
+    itself used to ride here to every dashboard and every /tunnels reader (2026-09-08).
     kernelSha/localSha/outOfDate let the dashboard flag a remote running older code + offer to update it;
     behindBy/aheadBy/kernelDate say HOW it drifted (computed only when it actually did).
 
@@ -15966,7 +16105,7 @@ def _remote_public(r):
             "busPort": r.get("bus_port") or 0,   # peer-bus mode: a restarted bus reseeds its peer table from this
             "checkin": bool(r.get("checkin")),           # we publish ourselves to this hub (stage 3)
             "checkinPeer": bool(r.get("checkin_peer")),  # this host checked in to US (no ssh of ours)
-            "token": r.get("token") or "", "status": r.get("status") or "down",
+            "hasToken": bool(r.get("token")), "status": r.get("status") or "down",
             "detail": r.get("detail") or "", "sids": list(r.get("sids") or []),
             "trust": r.get("trust") or "directed",   # per-host federation trust: trusted|directed|isolated
             "kernelSha": r.get("kernel_sha") or "", "localSha": (_local_head(short=True) or _kernel_sha() or ""),
@@ -16528,11 +16667,24 @@ def _poll_remote_version(r):
         if resp.status != 200:
             return None
         j = json.loads(data.decode("utf-8")) or {}
+        if not isinstance(j, dict):
+            return None
+        # The sha and the release name are a PEER's words, and they get saved (remotes.json) and drawn
+        # (the panel row): each must fit its shape — 7-40 hex, vN.N.N(+) — or it is dropped and said once
+        # (_peer_shape_complain), never stored as it came (2026-09-08).
+        host = r.get("host") or "?"
         sha = j.get("kernel_sha") or None
+        if sha and not _peer_sha(sha):
+            _peer_shape_complain(host, "kernel_sha", sha)
+            sha = None                        # an unusable sha is no sha at all
+        ver = j.get("kernel_ver") or ""
+        if ver and not _peer_ver(ver):
+            _peer_shape_complain(host, "kernel_ver", ver)
+            ver = ""
         an = j.get("autoNudge")
         st = j.get("settings")
         gts = j.get("settingsGt")
-        return {"sha": sha, "ver": str(j.get("kernel_ver") or ""),
+        return {"sha": sha, "ver": ver,
                 "autoNudge": an if isinstance(an, bool) else None,
                 "settings": st if isinstance(st, dict) else None,
                 "settingsGt": gts if isinstance(gts, dict) else None} if sha else None
@@ -38051,10 +38203,18 @@ fetch('/tunnels/of?host='+encodeURIComponent(h),{cache:'no-store'}).then(functio
 if(_openSub[h])repaint();});}
 function pendLvl(map,host,current){var p=map[host];if(p&&current===p){delete map[host];p=null;}return p;}
 function fillHosts(){if(!dl)return;var hs=[];
-[[mruHost()],_seen,_cfg].forEach(function(g){(g||[]).forEach(function(h){if(h&&hs.indexOf(h)<0)hs.push(h);});});   // most-recently-connected first, not just ssh-config order
-dl.innerHTML=hs.map(function(h){return '<option value=\"'+h+'\"></option>';}).join('');}
+[[mruHost()],_seen,_cfg].forEach(function(g){(g||[]).forEach(function(h){if(typeof h==='string'&&h&&hs.indexOf(h)<0)hs.push(h);});});   // most-recently-connected first, not just ssh-config order
+// option ELEMENTS, never markup: an alias is whatever ~/.ssh/config says, and a datalist parses its
+// innerHTML like any element, so a crafted alias used to run there (2026-09-08)
+dl.textContent='';var cut=hs.length>512?hs.length-512:0;hs.slice(0,512).forEach(function(h){var o=document.createElement('option');o.value=h;dl.appendChild(o);});
+if(cut){var mo=document.createElement('option');mo.value=mo.textContent='\\u2026 '+cut+' more not shown';mo.disabled=true;dl.appendChild(mo);}}   // a cut list says so (strip.ts fillHostSelect wears the same marker)
 function loadHosts(){fetch('/ssh-hosts',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
 _cfg=(d&&d.hosts)||[];fillHosts();}).catch(function(){});}
+// Every string a PEER chose is rendered as TEXT: esc() before it meets innerHTML. That is a host it named
+// (a checked-in peer names itself), its status word, its build, the rows it reports for its own connections
+// (/tunnels/of — whitelisted by the kernel too), and the bus gossip below (tiers, relay hosts, holds).
+// Before this, those strings were concatenated into markup as they came (2026-09-08).
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,function(c){return c==='&'?'&amp;':c==='<'?'&lt;':c==='>'?'&gt;':c==='"'?'&quot;':'&#39;';});}
 var LBL={up:'connected',authorizing:'authorizing\\u2026',connecting:'connecting\\u2026',starting:'connecting\\u2026','no-kernel':'kernel not answering',restarting:'restarting after update\\u2026',down:'reconnecting\\u2026',error:'error'};
 // Every status explains itself on hover (the user 2026-07-22: learn it from tooltips, not the CLI).
 var TIP={up:'Connected: the ssh tunnel is open and that machine\\u2019s romp kernel is answering through it. Its sessions appear in your tabs and timeline.',
@@ -38159,7 +38319,7 @@ var _head=!ts.length?'':(_bad?(_bad+' host'+(_bad===1?'':'s')+' need'+(_bad===1?
 icon.title=ts.length?('Remote kernels \\u00b7 '+_head+'\\n'+ts.map(function(t){var n=(t.sids&&t.sids.length)||0;
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
 var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):'';
-return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+dw+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
+return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+dw+(t.hasToken?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
 _lastArgs=[ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{}];
 _lastUp=ts.filter(function(t){return t.status==='up';}).length;
 if(!back.hidden){render.apply(null,_lastArgs);refreshPairs();}   // pmode is refresh-local — render must be GIVEN it (it rides _lastArgs)
@@ -38207,7 +38367,8 @@ var live={};ts.forEach(function(t){live[t.host]=1;});
 // owner; hidden while this machine is the only choice. Rebuilt per render, keeping the selection.
 if(fromSel){var ups=ts.filter(function(t){return t.status==='up';}).map(function(t){return t.host;});
 var fcur=fromSel.value;
-fromSel.innerHTML="<option value=''>from: this machine</option>"+ups.map(function(h){return '<option value="'+h+'"'+(fcur===h?' selected':'')+'>from: '+h+'</option>';}).join('');
+fromSel.textContent='';var fcut=ups.length>512?ups.length-512:0;[''].concat(ups.slice(0,512)).forEach(function(h){var o=document.createElement('option');o.value=h;o.textContent=h?'from: '+h:'from: this machine';o.selected=(fcur===h);fromSel.appendChild(o);});
+if(fcut){var fo=document.createElement('option');fo.value=fo.textContent='\\u2026 '+fcut+' more not shown';fo.disabled=true;fromSel.appendChild(fo);}
 fromSel.hidden=!ups.length;}
 via=via.filter(function(v){return !live[v.host];});
 var viaHosts={};via.forEach(function(v){viaHosts[v.host]=1;});
@@ -38217,36 +38378,39 @@ var TRUSTW={trusted:'trusted (auto-accept)',directed:'directed (held for you)',i
 // the controls its own popover would offer — drift there is measured between the via machine and
 // its remote (its own numbers), and every action rides the normal route + {via}. Loading and a
 // failed read say so (with Retry), never a silent blank.
-function subBlock(via){var box=document.createElement('div');box.className='rnet-subwrap';
+function subBlock(via){var box=document.createElement('div');box.className='rnet-subwrap';var ev=esc(via);
 var d=_subInfo[via];
-if(!d){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+spin()+'Reading '+via+'\\u2019s connections\\u2026</div>';return box;}
-if(!d.ok){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">Couldn\\u2019t read '+via+'\\u2019s connections: '+(d.error||'unknown error')+' <button data-xr=\"'+via+'\">Retry</button></div>';return box;}
-var rows=d.tunnels||[];
-if(!rows.length){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+via+' has no hosts attached.</div>';return box;}
-rows.forEach(function(s){
+if(!d){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+spin()+'Reading '+ev+'\\u2019s connections\\u2026</div>';return box;}
+if(!d.ok){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">Couldn\\u2019t read '+ev+'\\u2019s connections: '+esc(d.error||'unknown error')+' <button data-xr=\"'+ev+'\">Retry</button></div>';return box;}
+var rows=d.tunnels||[];var drop=(typeof d.dropped==='number'&&d.dropped>0)?Math.floor(d.dropped):0;
+if(!rows.length&&!drop){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+ev+' has no hosts attached.</div>';return box;}
+rows.forEach(function(s){var sh=esc(s.host),sst=esc(LBL[s.status]||s.status);
 var sr=document.createElement('div');sr.className='rnet-row rnet-subrow';
 var sdot=s.status==='up'?'background:var(--accent)':(s.status==='error'||s.status==='no-kernel')?'background:#E5534B':(s.status==='down')?'background:#8a8a8a':'background:transparent;box-shadow:inset 0 0 0 1.5px var(--accent)';
-var sver='',sbw=buildWord(s.kernelVer,s.kernelSha);
+var sver='',sbw=esc(buildWord(s.kernelVer,s.kernelSha));
 if(s.outOfDate){var sar=driftCounts(s);
-sver=' \\u00b7 <span class=rnet-old title=\"'+s.host+' runs '+(sbw||'?')+'; '+via+' is at '+(buildWord(s.localVer,s.localSha)||'?')+' \\u2014 drift here is between THOSE two machines, not this one.\">'+(sbw?sbw+' ':'')+(sar?'('+sar+')':driftWord(s))+'</span>';}
-else if(sbw){sver=' \\u00b7 <span class=rnet-sha title=\"same build as '+via+'\">'+sbw+'</span>';}
-var vk=via+'|'+s.host;
+sver=' \\u00b7 <span class=rnet-old title=\"'+sh+' runs '+(sbw||'?')+'; '+ev+' is at '+esc(buildWord(s.localVer,s.localSha)||'?')+' \\u2014 drift here is between THOSE two machines, not this one.\">'+(sbw?sbw+' ':'')+(sar?'('+sar+')':driftWord(s))+'</span>';}
+else if(sbw){sver=' \\u00b7 <span class=rnet-sha title=\"same build as '+ev+'\">'+sbw+'</span>';}
+var vk=via+'|'+s.host,evk=esc(vk);
 var spd=pendLvl(_pendSub,vk,s.trust||'directed');
 var scur=spd||s.trust||'directed';
-var strust='<select class=\"rnet-trust'+(spd?' rnet-applying':'')+'\"'+(spd?' disabled':'')+' data-vt=\"'+vk+'\" title=\"What '+via+' does with postal mail from '+s.host+'. Set on '+via+', over your tunnel + its own token \\u2014 the you-with-both-tokens boundary.\">'+
+var strust='<select class=\"rnet-trust'+(spd?' rnet-applying':'')+'\"'+(spd?' disabled':'')+' data-vt=\"'+evk+'\" title=\"What '+ev+' does with postal mail from '+sh+'. Set on '+ev+', over your tunnel + its own token \\u2014 the you-with-both-tokens boundary.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(scur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(spd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'');
 // the same provably-possible gating as the top rows, judged with the fields VIA computed about
 // ITS remote (fastForward/fastPull/askPull are relative to via's own build).
 var sapx=s.autoPush&&apBusy(s.autoPush.phase);
 var sb='';
-if(s.status==='up'&&s.fastForward&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vu=\"'+vk+'\" title=\"Push '+via+'\\u2019s committed romp to '+s.host+' and restart its kernel \\u2014 the work runs on '+via+'.\">Push</button>';
-if(s.status==='up'&&s.askPull&&!sapx)sb+='<button class=rnet-upd data-va=\"'+vk+'\" title=\"'+s.host+' checked in to '+via+' over its own tunnel, so '+via+' cannot push to it. This asks it to pull '+via+'\\u2019s commits over the link it already holds.\">Update</button>';
-if(s.status==='up'&&s.fastPull&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vp=\"'+vk+'\" title=\"Pull '+s.host+'\\u2019s newer commits into '+via+'\\u2019s romp (fast-forward only) \\u2014 the work runs on '+via+'.\">Pull</button>';
-if(s.status==='no-kernel')sb+='<button class=rnet-upd data-vs=\"'+vk+'\" title=\"No kernel answers '+via+'\\u2019s tunnel to '+s.host+'. This has '+via+' push its romp there and boot it.\">Start</button>';
+if(s.status==='up'&&s.fastForward&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vu=\"'+evk+'\" title=\"Push '+ev+'\\u2019s committed romp to '+sh+' and restart its kernel \\u2014 the work runs on '+ev+'.\">Push</button>';
+if(s.status==='up'&&s.askPull&&!sapx)sb+='<button class=rnet-upd data-va=\"'+evk+'\" title=\"'+sh+' checked in to '+ev+' over its own tunnel, so '+ev+' cannot push to it. This asks it to pull '+ev+'\\u2019s commits over the link it already holds.\">Update</button>';
+if(s.status==='up'&&s.fastPull&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vp=\"'+evk+'\" title=\"Pull '+sh+'\\u2019s newer commits into '+ev+'\\u2019s romp (fast-forward only) \\u2014 the work runs on '+ev+'.\">Pull</button>';
+if(s.status==='no-kernel')sb+='<button class=rnet-upd data-vs=\"'+evk+'\" title=\"No kernel answers '+ev+'\\u2019s tunnel to '+sh+'. This has '+ev+' push its romp there and boot it.\">Start</button>';
 sr.innerHTML='<span class=rnet-dot style=\"'+sdot+'\" title=\"'+(TIP[s.status]||'')+'\"></span>'+
-'<span class=nm><b>'+s.host+'</b> <span class=st title=\"'+via+'\\u2019s tunnel to '+s.host+'. '+(TIP[s.status]||'')+'\">'+(busyStatus(s.status)?spin():'')+(LBL[s.status]||s.status)+sver+'</span></span>'+
-strust+sb+'<button data-vh=\"'+vk+'\" title=\"Close '+via+'\\u2019s ssh tunnel to '+s.host+'. It stays in '+via+'\\u2019s previously-attached list.\">Detach</button>';
+'<span class=nm><b>'+sh+'</b> <span class=st title=\"'+ev+'\\u2019s tunnel to '+sh+'. '+(TIP[s.status]||'')+'\">'+(busyStatus(s.status)?spin():'')+sst+sver+'</span></span>'+
+strust+sb+'<button data-vh=\"'+evk+'\" title=\"Close '+ev+'\\u2019s ssh tunnel to '+sh+'. It stays in '+ev+'\\u2019s previously-attached list.\">Detach</button>';
 box.appendChild(sr);});
+// rows the kernel's whitelist left out (no host ssh would accept) are SAID beneath the rows that passed —
+// as text, the same sentence strip.ts renderSub wears (net-remote-controls.test.ts pins both)
+if(drop){var dn=document.createElement('div');dn.className='rnet-empty rnet-subnote';dn.textContent=drop+' row'+(drop===1?'':'s')+' from '+via+' had no usable host and '+(drop===1?'was':'were')+' left out';box.appendChild(dn);}
 return box;}
 // Every host romp knows about feeds the add box's completions, so a machine you typed in once is a
 // couple of keystrokes the next time even after you forget its exact spelling.
@@ -38257,7 +38421,7 @@ if(!ts.length&&!known.length){var e=document.createElement('div');e.className='r
 if(addBox&&addBox.hidden&&!_autoAdd){_autoAdd=true;showAdd(true);}
 return;}
 ts.forEach(function(t){var item=document.createElement('div');item.className='rnet-item';
-var row=document.createElement('div');row.className='rnet-row';
+var row=document.createElement('div');row.className='rnet-row';var th=esc(t.host);
 // connected -> solid accent dot (matches the lit rail icon); mid-attach -> hollow accent RING (glanceably
 // "in progress"); down -> grey; error -> red. Word beside it names the phase.
 var dot=t.status==='up'?'background:var(--accent)':(t.status==='error'||t.status==='no-kernel')?'background:#E5534B':(t.status==='down')?'background:#8a8a8a':'background:transparent;box-shadow:inset 0 0 0 1.5px var(--accent)';
@@ -38272,22 +38436,22 @@ var dot=t.status==='up'?'background:var(--accent)':(t.status==='error'||t.status
 // is remembered, and date it on hover: glanceable mark, mechanics one hover away.
 var stl=!!t.stale;
 var sw=stl?(t.lastOk?('last confirmed '+new Date(t.lastOk*1000).toLocaleTimeString()):'never confirmed since this kernel started'):'';
-var sq=stl?(' \\u2014 '+sw+'; not re-checked while '+(LBL[t.status]||t.status)+'.'):'';
+var sq=stl?(' \\u2014 '+sw+'; not re-checked while '+(LBL[t.status]||esc(t.status))+'.'):'';
 // The build reads as a NAME plus a distance: "v0.2.0+ 682d232 (behind 3)" — the release and commit it is
 // on, then how far that sits from here, said in words (the user 2026-07-30). A remote whose commit this
 // repo has never seen has no distance to report, so it says "different build" where the count would go.
-var ver='',bw=buildWord(t.kernelVer,t.kernelSha);
+var ver='',bw=esc(buildWord(t.kernelVer,t.kernelSha));
 if(t.outOfDate){var w=driftWord(t),ar=driftCounts(t);
 var tt='running '+(buildWord(t.kernelVer,t.kernelSha)||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(buildWord(t.localVer,t.localSha)||'?')+((t.aheadBy>0&&t.behindBy>0)?' (each has commits the other lacks)':'')
 +(t.checkinPeer?(t.askPull?' No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds.':' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.'):'');
-ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+(bw?bw+' ':'')+(ar?'('+ar+')':w)+'</span>';}
+ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+esc(tt)+sq+'\">'+(stl?'last known: ':'')+(bw?bw+' ':'')+(ar?'('+ar+')':w)+'</span>';}
 else if(bw){ver=' \\u00b7 <span class=\"rnet-sha'+(stl?' rnet-stale':'')+'\" title=\"'+(stl?'same build as this machine when last reached.'+sq:'same build as this machine')+'\">'+(stl?'last known: ':'')+bw+'</span>';}
 // A connected host that reports NO build at all is running a plain file copy — no git checkout, so its
 // kernel cannot name a release or commit, and drift against this machine cannot be measured (it may be
 // months behind and never say so; the user 2026-08-11, whose devbox ran months-old code beside a bare
 // "connected"). Fail loudly where the build word would sit, never a silent blank that reads as fine.
 // strip.ts's popover row carries the same word (rnet parity pins).
-else if(t.status==='up'){ver=' \\u00b7 <span class=\"rnet-old\" title=\"'+t.host+' is running romp from a plain file copy \\u2014 not a git checkout \\u2014 so it cannot name its release or commit, and how far it is from this machine cannot be measured: it may be far behind and never say so. Reinstall it as a git clone to restore the build name and updates.\">unversioned copy</span>';}
+else if(t.status==='up'){ver=' \\u00b7 <span class=\"rnet-old\" title=\"'+th+' is running romp from a plain file copy \\u2014 not a git checkout \\u2014 so it cannot name its release or commit, and how far it is from this machine cannot be measured: it may be far behind and never say so. Reinstall it as a git clone to restore the build name and updates.\">unversioned copy</span>';}
 // A push romp is ALREADY doing needs no button — offering one would just invite a duplicate of the work in
 // flight. The row shows the live phase instead (below), and the manual Push returns if it fails.
 var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling'||t.autoPush.phase==='asking');
@@ -38298,18 +38462,18 @@ var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'|
 // an ancestor of its HEAD). Those states get the action that CAN work instead: Pull when the remote is
 // strictly ahead, Update when a checked-in peer is behind, and otherwise the drift word plus its tooltip,
 // which say what happened without dead-ending on a button.
-var upd=(t.status==='up'&&t.fastForward&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-u=\"'+t.host+'\" title=\"Push this machine\\u2019s committed romp to '+t.host+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first.\">Push</button>':'';
-var ask=(t.status==='up'&&t.askPull&&!apx)?'<button class=rnet-upd data-a=\"'+t.host+'\" title=\"'+t.host+' checked in over its own tunnel, so this machine cannot push to it. This asks its romp to pull these commits from here and restart, over the link it already holds.\">Update</button>':'';
-var pull=(t.status==='up'&&t.fastPull&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-p=\"'+t.host+'\" title=\"Pull '+t.host+'\\u2019s newer commits into this machine\\u2019s romp (fast-forward only; refuses if this tree has uncommitted changes). This kernel keeps running the old build until you restart romp.\">Pull</button>':'';
+var upd=(t.status==='up'&&t.fastForward&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-u=\"'+th+'\" title=\"Push this machine\\u2019s committed romp to '+th+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first.\">Push</button>':'';
+var ask=(t.status==='up'&&t.askPull&&!apx)?'<button class=rnet-upd data-a=\"'+th+'\" title=\"'+th+' checked in over its own tunnel, so this machine cannot push to it. This asks its romp to pull these commits from here and restart, over the link it already holds.\">Update</button>':'';
+var pull=(t.status==='up'&&t.fastPull&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-p=\"'+th+'\" title=\"Pull '+th+'\\u2019s newer commits into this machine\\u2019s romp (fast-forward only; refuses if this tree has uncommitted changes). This kernel keeps running the old build until you restart romp.\">Pull</button>':'';
 // ssh alive but no kernel answering -> the explicit ASK (the user 2026-07-10): a Start button that
 // pushes this machine's committed romp to the host FIRST, then boots its kernel. Never auto-starts —
 // a stopped kernel may be stopped on purpose; the click is the consent.
-var strt=(t.status==='no-kernel')?'<button class=rnet-upd data-s=\"'+t.host+'\" title=\"No kernel is answering on '+t.host+'. This pushes this machine\\u2019s romp there and boots its kernel.\">Start</button>':'';
+var strt=(t.status==='no-kernel')?'<button class=rnet-upd data-s=\"'+th+'\" title=\"No kernel is answering on '+th+'. This pushes this machine\\u2019s romp there and boots its kernel.\">Start</button>':'';
 // A down row is BEING re-dialed on a widening backoff (the user 2026-07-29), so it says when the next
 // dial lands — a silent retry loop is indistinguishable from a dead row — and offers to skip the wait.
 var wait=(t.nextTry&&(t.status==='down'||t.status==='error'))?Math.max(0,t.nextTry-Math.floor(Date.now()/1000)):0;
 var when=wait>90?('next try in '+Math.round(wait/60)+'m'):(wait>0?('next try in '+wait+'s'):'retrying\\u2026');
-var again=(t.status==='down'||t.status==='error')?'<span class=rnet-retry title=\"romp keeps dialing '+t.host+' on its own, waiting longer between tries the longer it is down ('+(t.fails||0)+' so far).\">'+when+'</span>':'';
+var again=(t.status==='down'||t.status==='error')?'<span class=rnet-retry title=\"romp keeps dialing '+th+' on its own, waiting longer between tries the longer it is down ('+(t.fails||0)+' so far).\">'+when+'</span>':'';
 // Offered on EVERY row that is not up, not just down/error (the user 2026-07-29). A 'no-kernel' row used
 // to carry only Start — "this pushes this machine's romp there and boots its kernel" — so a link that had
 // quietly stopped carrying traffic read as a dead remote, and the only button on offer told you to go
@@ -38319,18 +38483,18 @@ var again=(t.status==='down'||t.status==='error')?'<span class=rnet-retry title=
 // is up — no backoff is running), where the same name beside Start read as a redundant second attempt
 // button, distinguished only by tooltips. There it is named for what it does: Re-dial.
 var wedged=(t.status==='no-kernel');
-var retry=(t.status!=='up'&&t.status!=='starting')?'<button data-ra=\"'+t.host+'\" title=\"'+(wedged?'Drop the ssh link to '+t.host+' and dial a fresh one. The link reports connected while nothing answers through it \u2014 a wedged tunnel can make a running kernel look absent, so re-dial before restarting anything.':'Dial '+t.host+' now: drop the current ssh and open a fresh one, instead of waiting out the automatic retry.')+'\">'+(wedged?'Re-dial':'Try now')+'</button>':'';
+var retry=(t.status!=='up'&&t.status!=='starting')?'<button data-ra=\"'+th+'\" title=\"'+(wedged?'Drop the ssh link to '+th+' and dial a fresh one. The link reports connected while nothing answers through it \u2014 a wedged tunnel can make a running kernel look absent, so re-dial before restarting anything.':'Dial '+th+' now: drop the current ssh and open a fresh one, instead of waiting out the automatic retry.')+'\">'+(wedged?'Re-dial':'Try now')+'</button>':'';
 // The check-in publishes THIS machine TO that host, which is the opposite direction from everything else
 // in the row. Its old label, "keep connected", read as the reconnect setting so plainly that the tooltip
 // had to spend a sentence saying what it was NOT. Name it for what it does instead.
-var keep=(pmode&&!t.checkinPeer)?'<label class=rnet-keep title=\"Publish this machine to '+t.host+' over your own outbound ssh, so its dashboard gains your sessions and its bus peers with yours. Uncheck to be forgotten there. Attach and Detach control the other direction.\"><input type=checkbox data-k=\"'+t.host+'\"'+(t.checkin?' checked':'')+'>Share my sessions there</label>':'';
+var keep=(pmode&&!t.checkinPeer)?'<label class=rnet-keep title=\"Publish this machine to '+th+' over your own outbound ssh, so its dashboard gains your sessions and its bus peers with yours. Uncheck to be forgotten there. Attach and Detach control the other direction.\"><input type=checkbox data-k=\"'+th+'\"'+(t.checkin?' checked':'')+'>Share my sessions there</label>':'';
 // Federation trust (per-host): trusted = full two-way postal; directed (default) = its mail is HELD for
 // your approval, never auto-injected; isolated = dashboard only, no postal. The gate lives in the bus.
 // Each option carries its own plain gloss: the bare words are romp's vocabulary, not English, and a
 // dropdown whose meaning only appears on hover makes you uncover every option before you can choose.
 var tpd=pendLvl(_pendTrust,t.host,t.trust||'directed');
 var tcur=tpd||t.trust||'directed';
-var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=\"rnet-trust'+(tpd?' rnet-applying':'')+'\"'+(tpd?' disabled':'')+' data-t=\"'+t.host+'\" title=\"What happens to postal mail from '+t.host+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
+var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=\"rnet-trust'+(tpd?' rnet-applying':'')+'\"'+(tpd?' disabled':'')+' data-t=\"'+th+'\" title=\"What happens to postal mail from '+th+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(tcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(tpd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'')+'</span>';
 // The OTHER direction of the pair (how that host holds mail FROM this machine, declared by its bus on
 // the last exchange). Trust is receiver-evaluated on purpose, so a half-open pair is legal — but it
@@ -38340,9 +38504,9 @@ var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select cl
 var theirs=tiers[t.host]||'';
 if(theirs){var mm=theirs!==tcur;
 var mpd=pendLvl(_pendMirror,t.host,theirs);   // confirmed by the peer's next tier gossip, not the POST
-trust+='<span class=\"rnet-back'+(mm&&!mpd?' rnet-mismatch':'')+(stl?' rnet-stale':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.'+sq+'\">'+t.host+' holds yours: '+(stl?'last known ':'')+theirs+'</span>';
-if(mpd){trust+='<button class=rnet-mirror disabled title=\"Set on '+t.host+'; waiting for its bus to confirm on the next exchange.\">'+spin()+'Matching\\u2026</button>';}
-else if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" data-lvl=\"'+tcur+'\" title=\"Set '+t.host+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
+trust+='<span class=\"rnet-back'+(mm&&!mpd?' rnet-mismatch':'')+(stl?' rnet-stale':'')+'\" title=\"How '+th+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.'+sq+'\">'+th+' holds yours: '+(stl?'last known ':'')+esc(theirs)+'</span>';
+if(mpd){trust+='<button class=rnet-mirror disabled title=\"Set on '+th+'; waiting for its bus to confirm on the next exchange.\">'+spin()+'Matching\\u2026</button>';}
+else if(mm){trust+='<button class=rnet-mirror data-m=\"'+th+'\" data-lvl=\"'+tcur+'\" title=\"Set '+th+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
 // Line 1 is what this host is doing right now plus the acts you perform on it; line 2 is the pair of
 // settings you set once and leave. They shared a single flat row before, which gave Detach the same
 // weight as a dropdown, and on a phone pushed it off the edge entirely.
@@ -38350,11 +38514,11 @@ row.innerHTML='<span class=rnet-dot style=\"'+dot+'\" title=\"'+(TIP[t.status]||
 // A host mid-attach gets the romp loader inline (the user 2026-07-29): the swirl glyph spinning beside
 // the status word, so "connecting" reads as something HAPPENING rather than a label that might be stuck.
 // The repo's loading rule spelled small: same glyph, same reverse spin as the composer's slash spinner.
-'<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(busyStatus(t.status)?spin():'')+(LBL[t.status]||t.status)+((t.status==='up'&&pendingIn(t.host))?' \\u00b7 <span class=rnet-pend title=\"The tunnel is up; this dashboard is still loading '+t.host+'\\u2019s sessions. They appear the moment its first payload lands.\">'+spin()+'loading sessions\\u2026</span>':'')+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+(again?' \\u00b7 '+again:'')+ver+'</span></span>'+
-retry+pull+ask+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>'+
+'<span class=nm><b>'+th+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(busyStatus(t.status)?spin():'')+(LBL[t.status]||esc(t.status))+((t.status==='up'&&pendingIn(t.host))?' \\u00b7 <span class=rnet-pend title=\"The tunnel is up; this dashboard is still loading '+th+'\\u2019s sessions. They appear the moment its first payload lands.\">'+spin()+'loading sessions\\u2026</span>':'')+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.hasToken?'':' \\u00b7 no token')+(again?' \\u00b7 '+again:'')+ver+'</span></span>'+
+retry+pull+ask+upd+strt+'<button data-h=\"'+th+'\" title=\"Close the ssh tunnel to '+th+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>'+
 // ITS CONNECTIONS toggle — the keyed expand (progressive disclosure): compact row by default,
 // that machine's own attached list one click deeper, fetched on the click, never the poll.
-(t.status==='up'?'<button class=rnet-subtoggle data-x=\"'+t.host+'\" title=\"'+t.host+'\\u2019s own attached hosts \\u2014 see and manage what IT is connected to, from here. Rows read live from its kernel over your tunnel + its own token; actions run there.\">'+(_openSub[t.host]?'\\u25be':'\\u25b8')+' connections</button>':'');
+(t.status==='up'?'<button class=rnet-subtoggle data-x=\"'+th+'\" title=\"'+th+'\\u2019s own attached hosts \\u2014 see and manage what IT is connected to, from here. Rows read live from its kernel over your tunnel + its own token; actions run there.\">'+(_openSub[t.host]?'\\u25be':'\\u25b8')+' connections</button>':'');
 item.appendChild(row);
 // Live automatic-update phase, on its own line under the row — this is the whole reason the modal could
 // go away: the work still announces itself, it just does it here instead of over your screen. A FAILURE
@@ -38379,13 +38543,13 @@ list.appendChild(item);});
 if(known.length){var hd=document.createElement('div');hd.className='rnet-khead';
 hd.textContent='Previously attached';hd.title='Hosts romp remembers. Most were attached before and keep the trust level you last chose, so re-attaching restores it. A row marked \\u201ctrust remembered\\u201d was never attached from this machine \\u2014 it only records how to hold that host\\u2019s mail. Forget removes a host from this list.';
 list.appendChild(hd);
-known.forEach(function(k){var kr=document.createElement('div');kr.className='rnet-row rnet-known';
+known.forEach(function(k){var kr=document.createElement('div');kr.className='rnet-row rnet-known';var kh=esc(k.host);
 var kpd=pendLvl(_pendTrust,k.host,k.trust||'directed');
 var kcur=kpd||k.trust||'directed';
 // The SAME trust select as an attached row (data-t → /tunnels/trust): trust is judged by ORIGIN at
 // delivery, so the level applies to this host's mail even when it arrives relayed through a hub —
 // no tunnel required to set it (the user 2026-07-25).
-var ktrust='<select class=\"rnet-trust'+(kpd?' rnet-applying':'')+'\"'+(kpd?' disabled':'')+' data-t=\"'+k.host+'\" title=\"What happens to postal mail from '+k.host+', however it arrives (a direct tunnel later, or relayed through a hub now): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+var ktrust='<select class=\"rnet-trust'+(kpd?' rnet-applying':'')+'\"'+(kpd?' disabled':'')+' data-t=\"'+kh+'\" title=\"What happens to postal mail from '+kh+', however it arrives (a direct tunnel later, or relayed through a hub now): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(kcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(kpd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'');
 // A row that only remembers a mail-trust tier must SAY so (the user 2026-08-12, who read
 // "Previously attached: <host>" on a machine that never held that tunnel and went looking for an
@@ -38395,11 +38559,11 @@ var ktrust='<select class=\"rnet-trust'+(kpd?' rnet-applying':'')+'\"'+(kpd?' di
 var kwas=!!k.attached;
 var kst=kwas?'not attached':'trust remembered \\u00b7 never attached here';
 var kstt=kwas?'Not attached; the trust level applies to its mail by origin, and re-attaching keeps it.'
-:'No tunnel to '+k.host+' has ever been attached from this machine \\u2014 this row only records how its mail is held (trust is judged by origin, e.g. for a relayed peer). Attaching is still one click.';
+:'No tunnel to '+kh+' has ever been attached from this machine \\u2014 this row only records how its mail is held (trust is judged by origin, e.g. for a relayed peer). Attaching is still one click.';
 kr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #5a5a5a\" title=\"Not attached right now.\"></span>'+
-'<span class=nm><b>'+k.host+'</b> <span class=st title=\"'+kstt+'\">'+kst+'</span></span>'+ktrust+
-'<button data-ra=\"'+k.host+'\" title=\"'+(kwas?'Open the ssh tunnel to '+k.host+' again, restoring its remembered trust level.':'Open an ssh tunnel to '+k.host+' (first attach from this machine); its remembered trust level rides along.')+'\">'+(kwas?'Re-attach':'Attach')+'</button>'+
-'<button data-fg=\"'+k.host+'\" title=\"Remove '+k.host+' from this list. It does not touch the host itself; attaching again will re-add it.\">Forget</button>';
+'<span class=nm><b>'+kh+'</b> <span class=st title=\"'+kstt+'\">'+kst+'</span></span>'+ktrust+
+'<button data-ra=\"'+kh+'\" title=\"'+(kwas?'Open the ssh tunnel to '+kh+' again, restoring its remembered trust level.':'Open an ssh tunnel to '+kh+' (first attach from this machine); its remembered trust level rides along.')+'\">'+(kwas?'Re-attach':'Attach')+'</button>'+
+'<button data-fg=\"'+kh+'\" title=\"Remove '+kh+' from this list. It does not touch the host itself; attaching again will re-add it.\">Forget</button>';
 list.appendChild(kr);});}
 // REACHABLE VIA RELAY (the user 2026-07-25): machines with no direct tunnel from here, one relay hop
 // away through an attached hub. Their mail is judged by ORIGIN, so the same trust select applies —
@@ -38407,13 +38571,13 @@ list.appendChild(kr);});}
 if(via.length){var vh=document.createElement('div');vh.className='rnet-khead';
 vh.textContent='Reachable via relay';vh.title='Machines you have no direct tunnel to; a hub you are attached to relays their mail one hop. Trust is judged by origin, so the level you set here applies to their mail even though it arrives through the hub.';
 list.appendChild(vh);
-via.forEach(function(v){var vr=document.createElement('div');vr.className='rnet-row rnet-known';
+via.forEach(function(v){var vr=document.createElement('div');vr.className='rnet-row rnet-known';var evh=esc(v.host),vv=esc(v.via);
 var vpd=pendLvl(_pendTrust,v.host,v.trust||'directed');
 var vcur=vpd||v.trust||'directed';
-var vtrust='<select class=\"rnet-trust'+(vpd?' rnet-applying':'')+'\"'+(vpd?' disabled':'')+' data-t=\"'+v.host+'\" title=\"What happens to postal mail from '+v.host+' (it arrives relayed through '+v.via+'; trust is judged by its true origin): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+var vtrust='<select class=\"rnet-trust'+(vpd?' rnet-applying':'')+'\"'+(vpd?' disabled':'')+' data-t=\"'+evh+'\" title=\"What happens to postal mail from '+evh+' (it arrives relayed through '+vv+'; trust is judged by its true origin): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
 ['trusted','directed','isolated'].map(function(w){return '<option value='+w+(vcur===w?' selected':'')+'>'+TRUSTW[w]+'</option>';}).join('')+'</select>'+(vpd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'');
-vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+v.via+'.\"></span>'+
-'<span class=nm><b>'+v.host+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+v.via+'; attach it directly for full control.\">via '+v.via+' \\u00b7 '+(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
+vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+vv+'.\"></span>'+
+'<span class=nm><b>'+evh+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+vv+'; attach it directly for full control.\">via '+vv+' \\u00b7 '+esc(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
 list.appendChild(vr);});}
 // BETWEEN YOUR MACHINES (the user 2026-08-11): how attached machines hold EACH OTHER's mail. The
 // pair link a\\u2194b appears nowhere above — every list in this panel manages only THIS machine's own
@@ -38427,23 +38591,23 @@ var bh=document.createElement('div');bh.className='rnet-khead';bh.textContent='B
 bh.title='How your attached machines hold each other\\u2019s postal mail, one line per direction, read live from each machine\\u2019s own kernel. Changing a line writes to the holding machine through your tunnel and its own access token (like Match): you are acting on both ends; the machines never set each other\\u2019s trust.';
 list.appendChild(bh);
 if(_pairs&&_pairs.pairs){_pairs.pairs.forEach(function(pr){
-[[pr.a,pr.b,pr.ab],[pr.b,pr.a,pr.ba]].forEach(function(dd){var hold=dd[0],frm=dd[1],tier=dd[2];
+[[pr.a,pr.b,pr.ab],[pr.b,pr.a,pr.ba]].forEach(function(dd){var hold=dd[0],frm=dd[1],tier=dd[2],eh=esc(hold),ef=esc(frm);
 var br=document.createElement('div');br.className='rnet-row rnet-known';
 // null = that machine's table was unreadable this pass (named error, retried next kick); '' = no
 // explicit row there yet, which the receiving bus treats as directed for a relayed origin.
-if(tier===null){var he=(_pairs.hosts&&_pairs.hosts[hold]&&_pairs.hosts[hold].error)||'unreadable';
-br.innerHTML='<span class=nm><b>'+hold+'</b> holds <b>'+frm+'</b>\\u2019s mail: <span class=st title=\"Could not read '+hold+'\\u2019s trust table over the tunnel: '+he+'. It keeps gating mail by its own last-set levels; retried on the next refresh.\">unreadable \\u2014 '+he+'</span></span>';
+if(tier===null){var he=esc((_pairs.hosts&&_pairs.hosts[hold]&&_pairs.hosts[hold].error)||'unreadable');
+br.innerHTML='<span class=nm><b>'+eh+'</b> holds <b>'+ef+'</b>\\u2019s mail: <span class=st title=\"Could not read '+eh+'\\u2019s trust table over the tunnel: '+he+'. It keeps gating mail by its own last-set levels; retried on the next refresh.\">unreadable \\u2014 '+he+'</span></span>';
 list.appendChild(br);return;}
 var pk=hold+'|'+frm;
 var ppd=pendLvl(_pendPair,pk,tier||'');   // confirmed when the holder's own table shows the chosen level
 var pcur=ppd||tier||'directed';
 var imp=(!tier&&!ppd)?' Never set explicitly \\u2014 directed is its default.':'';
-br.innerHTML='<span class=nm><b>'+hold+'</b> holds <b>'+frm+'</b>\\u2019s mail</span>'+
-'<span class=rnet-set><select class=\"rnet-trust'+(ppd?' rnet-applying':'')+'\"'+(ppd?' disabled':'')+' data-pt-on=\"'+hold+'\" data-pt-of=\"'+frm+'\" title=\"What '+hold+' does with postal mail from '+frm+'.'+imp+' trusted: delivered straight to its sessions. directed: held on '+hold+' for your approval. isolated: none.\">'+
+br.innerHTML='<span class=nm><b>'+eh+'</b> holds <b>'+ef+'</b>\\u2019s mail</span>'+
+'<span class=rnet-set><select class=\"rnet-trust'+(ppd?' rnet-applying':'')+'\"'+(ppd?' disabled':'')+' data-pt-on=\"'+eh+'\" data-pt-of=\"'+ef+'\" title=\"What '+eh+' does with postal mail from '+ef+'.'+imp+' trusted: delivered straight to its sessions. directed: held on '+eh+' for your approval. isolated: none.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(pcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(ppd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'')+'</span>';
 list.appendChild(br);});});}
 else if(_pairs&&_pairs.error){var be=document.createElement('div');be.className='rnet-row rnet-known';
-be.innerHTML='<span class=st>Could not read how your machines hold each other: '+_pairs.error+' \\u2014 retrying.</span>';list.appendChild(be);}
+be.innerHTML='<span class=st>Could not read how your machines hold each other: '+esc(_pairs.error)+' \\u2014 retrying.</span>';list.appendChild(be);}
 else{var bl=document.createElement('div');bl.className='rnet-row rnet-known';
 bl.innerHTML='<span class=st>'+spin()+'reading how your machines hold each other\\u2026</span>';list.appendChild(bl);}
 }
@@ -38455,11 +38619,11 @@ var hh=document.createElement('div');hh.className='rnet-khead';
 hh.textContent='Held for approval elsewhere';
 hh.title='Postal mail quarantined on another machine (its trust for the sender is directed). Open that machine\u2019s dashboard to approve or deny; the hold itself lives there.';
 list.appendChild(hh);
-Object.keys(byHost).sort().forEach(function(hn){var rows=byHost[hn];
+Object.keys(byHost).sort().forEach(function(hn){var rows=byHost[hn],ehn=esc(hn);
 var gl=rows.slice(0,6).map(function(r){return r.frm+' \\u2192 '+r.to+((r.origin&&r.origin!==hn)?' (from '+r.origin+')':'')+': '+(r.gist||'');}).join('\\n');
 var hr=document.createElement('div');hr.className='rnet-row rnet-known';
-hr.innerHTML='<span class=rnet-dot style=\"background:#b58900\" title=\"Mail is waiting for approval on '+hn+'.\"></span>'+
-'<span class=nm><b>'+hn+'</b> <span class=st title=\"'+gl.replace(/\"/g,'&quot;')+'\">'+rows.length+' message'+(rows.length===1?'':'s')+' held for your approval</span></span>';
+hr.innerHTML='<span class=rnet-dot style=\"background:#b58900\" title=\"Mail is waiting for approval on '+ehn+'.\"></span>'+
+'<span class=nm><b>'+ehn+'</b> <span class=st title=\"'+esc(gl)+'\">'+rows.length+' message'+(rows.length===1?'':'s')+' held for your approval</span></span>';
 list.appendChild(hr);});}
 // Pending is recorded ON THE CLICK (ack now — the buttons rule), so any re-render in the round-trip
 // window repaints the chosen level + applying cue instead of the stale snapshot's old value. A
@@ -43439,6 +43603,7 @@ class Handler(BaseHTTPRequestHandler):
         if not self.headers.get("Sec-WebSocket-Key"):
             return self._send(400, "expected websocket", "text/plain")
         q = parse_qs(query or "")
+        q.pop("token", None)         # whatever the browser sent never travels — with or without a row token
         if rtok:
             q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
         try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15190,8 +15190,9 @@ def _tunnel_argv(r):
 def _notify_bus_peer(host, port, up, peer_token="", trust="directed"):
     """Tell the LOCAL bus about a peer bus endpoint (event: a tunnel transition, never a poll). True on
     ack. Guarded: postal being down must never break the tunnel supervisor — the caller records success
-    and retries an unacked notify on the next pass. Stage 2's HELLO re-learns the table after a bus
-    restart; until then a restarted bus heals on the next tunnel transition or retry. Authorizes to the
+    and retries an unacked notify on the next pass. A RESTARTED bus is re-told every peer by the next
+    supervisor pass, since its /tunnels seed learns ports and trust but no token: its /peers answer names
+    a new process (_note_bus_incarnation), which voids each row's notify memo. Authorizes to the
     local bus with OUR serve token; peer_token is the PEER machine's serve token (r["token"]), which the
     bus needs to dial that peer's /peer-exchange through the tunnel — both buses are token-gated now.
     trust rides too: the bus gates inbound mail from a 'directed' peer into quarantine and drops an
@@ -15251,17 +15252,45 @@ def _push_origin_trust_rows():
 
 
 _via_cache = {"t": 0.0, "snap": {}}
+_bus_seen = [None]   # (busId, epoch) of the bus PROCESS the kernel last heard from at GET /peers; None until one answers
 
 
-def _bus_peers_snap():
+def _note_bus_incarnation(snap):
+    """A /peers answer names the bus process that gave it (`busId`, minted per process; `epoch`, its boot
+    second). When that pair differs from the last one heard, the bus RESTARTED under a running kernel: a
+    crash revived by _revive_postal_bus, its own code-change re-exec, a manual restart. Its peer table is
+    then only what it seeded from /tunnels, and /tunnels carries no peer token any more (the page must
+    never see one, 2026-09-08), so every dialer it built would knock on its peer's bus with no credential
+    and be refused, and the kernel would never say the token again: the supervisor re-tells the bus a
+    peer only when (up, trust) changes. The restart is the event, so this voids every row's notify memo
+    (the supervisor's want != notified branch then re-runs _notify_bus_peer with the stored token and trust
+    on its next pass, and the bus's peer_update overwrites the seeded blank) and the origin-only trust
+    memo with it, since that table is new too. A first sighting counts as a change: harmless (a notify is
+    idempotent) and simpler than a special case. True when a new bus was noticed. (review find, 2026-09-08)"""
+    inc = (snap.get("busId"), snap.get("epoch")) if isinstance(snap, dict) else (None, None)
+    if inc == (None, None) or inc == _bus_seen[0]:
+        return False
+    was, _bus_seen[0] = _bus_seen[0], inc
+    with _remotes_lock:
+        for r in _remotes.values():
+            r.pop("_peer_notified", None)
+    _origin_trust_pushed.clear()
+    if was is not None:
+        _tunnel_log("-", "bus-restarted", busId=str(inc[0] or "")[:12], epoch=inc[1],
+                    note="the local bus is a new process; every peer is re-told, token included")
+    return True
+
+
+def _bus_peers_snap(fresh=False):
     """The bus's /peers snapshot (via-reach rows + remote hold summaries), cached ~3s — it rides
     every /tunnels poll. Empty when the bus is down or peering is off: the popover simply shows no
     relay/holds sections (display-only; the trust GATE itself lives in the bus and fails safe to
-    directed)."""
+    directed). `fresh` skips the cache: the supervisor asks once per pass so a bus restart is
+    noticed by the pass that can act on it (_note_bus_incarnation), dashboard or no dashboard."""
     if not _postal_peers_on():
         return {}
     now = time.time()
-    if now - _via_cache["t"] < 3.0:
+    if not fresh and now - _via_cache["t"] < 3.0:
         return _via_cache["snap"]
     snap = {}
     try:
@@ -15274,6 +15303,8 @@ def _bus_peers_snap():
     except Exception:
         snap = {}
     _via_cache["t"], _via_cache["snap"] = now, snap
+    if snap:
+        _note_bus_incarnation(snap)
     return snap
 
 
@@ -16103,6 +16134,8 @@ def _remote_public(r):
         ver = _kernel_ver() or ver
     return {"host": r["host"], "kernelPort": r["kernel_port"], "localPort": r["local_port"],
             "busPort": r.get("bus_port") or 0,   # peer-bus mode: a restarted bus reseeds its peer table from this
+            #                                       (port, up, trust; the token it needs to dial follows by the
+            #                                       supervisor's re-notify, _note_bus_incarnation)
             "checkin": bool(r.get("checkin")),           # we publish ourselves to this hub (stage 3)
             "checkinPeer": bool(r.get("checkin_peer")),  # this host checked in to US (no ssh of ours)
             "hasToken": bool(r.get("token")), "status": r.get("status") or "down",
@@ -16670,21 +16703,26 @@ def _poll_remote_version(r):
         if not isinstance(j, dict):
             return None
         # The sha and the release name are a PEER's words, and they get saved (remotes.json) and drawn
-        # (the panel row): each must fit its shape — 7-40 hex, vN.N.N(+) — or it is dropped and said once
-        # (_peer_shape_complain), never stored as it came (2026-09-08).
+        # (the panel row): each must fit its shape (7-40 hex; vN.N.N, optional +) or it is said once
+        # (_peer_shape_complain) and the row KEEPS THE LAST GOOD VALUE it held, never the bad one, while
+        # the other fields of the same answer still land (2026-09-08). The first cut returned None for a
+        # bad sha, which froze the whole answer (version, settings, Auto Nudge) and blanked a bad
+        # version outright; both contradicted "keeps the last good value" (review find, 2026-09-08).
+        # `shaConfirmed` says whether THIS poll vouched for the sha returned: a kept one was not
+        # confirmed now, so the supervisor must not re-date it (last_ok) as if it had been.
         host = r.get("host") or "?"
-        sha = j.get("kernel_sha") or None
+        sha, sha_ok = j.get("kernel_sha") or None, True
         if sha and not _peer_sha(sha):
             _peer_shape_complain(host, "kernel_sha", sha)
-            sha = None                        # an unusable sha is no sha at all
+            sha, sha_ok = r.get("kernel_sha") or None, False   # what the row last knew, undated; None if nothing
         ver = j.get("kernel_ver") or ""
         if ver and not _peer_ver(ver):
             _peer_shape_complain(host, "kernel_ver", ver)
-            ver = ""
+            ver = r.get("kernel_ver") or ""                    # the last good name, not a blank
         an = j.get("autoNudge")
         st = j.get("settings")
         gts = j.get("settingsGt")
-        return {"sha": sha, "ver": ver,
+        return {"sha": sha, "ver": ver, "shaConfirmed": sha_ok,
                 "autoNudge": an if isinstance(an, bool) else None,
                 "settings": st if isinstance(st, dict) else None,
                 "settingsGt": gts if isinstance(gts, dict) else None} if sha else None
@@ -18666,6 +18704,11 @@ def _tunnel_supervisor():
                             except Exception:
                                 pass
             last_addr[0] = addr
+            if _postal_peers_on():
+                # Who is the bus this pass? A NEW bus process holds a peer table with no tokens in it
+                # (see _note_bus_incarnation); noticing it HERE, before the rows below decide whether
+                # they owe the bus a notify, means the same pass re-tells it every peer.
+                _bus_peers_snap(fresh=True)
             now = time.time()               # bound per PASS, not per remote row: the pass tail below
             #                                 (_pr_watch_tick) reads it, and on a box with NO remotes the
             #                                 loop body never ran — every pass died on UnboundLocalError
@@ -18831,8 +18874,12 @@ def _tunnel_supervisor():
                         if _tunnel_established(r):
                             r["fails"], r["next_try"] = 0, 0   # healthy end-to-end → clear the backoff, so a
                             r.pop("gave_up", None)             #   later drop starts its ladder from 15s again
-                        r["last_ok"] = time.time()         # the moment the cached sha/tier below were TRUE,
-                        #                                    so a later down row can date what it remembers
+                        if (rver or {}).get("shaConfirmed", True):
+                            r["last_ok"] = time.time()     # the moment the cached sha/tier below were TRUE,
+                            #                                so a later down row can date what it remembers.
+                            #                                Not when the peer's sha did not fit its shape and
+                            #                                the row kept its old one: that one was not
+                            #                                confirmed now (review find, 2026-09-08)
                         if r.get("detail"):
                             r["detail"] = ""               # any parked error/hint is moot once it answers
                     elif st == "restarting":

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -80,7 +80,8 @@ SESSION_FLAGS = STATE.parent / "session-flags.json"   # the kernel's per-session
 # request except the /ping liveness probe. The 0600 file is the same-user trust boundary; kernel
 # and bus share it (whichever daemon starts first mints it, identical logic). A peer bus dialing
 # through an ssh forward authorizes with the DIALED machine's token (?token=), which rides the
-# kernel's /peer notifies and /tunnels rows.
+# kernel's /peer notifies only (never /tunnels rows, which a page reads too; since 2026-09-08 a
+# restarted bus gets every token re-notified, see peers_snapshot).
 def _load_serve_token():
     t = (os.environ.get("ROMP_SERVE_TOKEN") or "").strip()
     if t:
@@ -1932,6 +1933,12 @@ def _write_remote_sids():
 
 
 def peers_snapshot():
+    """GET /peers: the table, plus WHICH BUS PROCESS is answering (busId, minted per process; epoch, its
+    boot second). The kernel compares that pair across its supervisor passes: a change means this bus
+    restarted, so it re-tells every peer with its token (kernel _note_bus_incarnation). The /tunnels seed
+    below cannot learn tokens (that payload carries none since 2026-09-08), so without this a bus that
+    restarted under a running kernel dialed every peer credential-less until a tunnel bounced
+    (review find, 2026-09-08)."""
     peers = {}
     for h, p in PEERS.items():
         d = dict(p)
@@ -1939,7 +1946,8 @@ def peers_snapshot():
         if tt:
             d["theirTier"] = tt        # how that host holds US, from its last exchange declaration
         peers[h] = d
-    return {"peers": peers, "viaReach": via_reach(), "remoteHolds": remote_holds()}
+    return {"peers": peers, "viaReach": via_reach(), "remoteHolds": remote_holds(),
+            "busId": BUS_ID, "epoch": BUS_EPOCH}
 
 # ── peering protocol (peer-bus mode, stage 2) ───────────────────────────────────
 # One EXCHANGE carries both directions (plans/postal-peer-buses.md): the dialer POSTs
@@ -2804,7 +2812,10 @@ def _peer_threads_reconcile(host):
 
 def _seed_peers_from_kernel():
     """A restarted bus starts with an empty peer table (the kernel notifies on TRANSITIONS). Best-effort
-    seed from the kernel's /tunnels so peering resumes without waiting for the next transition."""
+    seed from the kernel's /tunnels so peering resumes without waiting for the next transition. The seed
+    learns each peer's port, up-state and trust; the peer's TOKEN is not in that payload (a page reads it
+    too, 2026-09-08), so a seeded row cannot dial yet. The kernel supplies it: its next supervisor pass
+    sees a new busId/epoch on GET /peers and re-notifies every peer (peer_update fills the token in)."""
     try:
         req = urllib.request.Request(KERNEL_BASE + "/tunnels", headers={"X-Romp-Token": SERVE_TOKEN})
         with urllib.request.urlopen(req, timeout=3) as r:
@@ -2814,8 +2825,8 @@ def _seed_peers_from_kernel():
             port = row.get("busPort")
             if row.get("host") and isinstance(port, int) and port:
                 peer_update({"host": row["host"], "port": port, "up": row.get("status") == "up",
-                             "token": row.get("token") or "",   # the peer's serve token — its bus is gated too
                              "trust": row.get("trust") or "directed"})   # per-host trust for the inbound gate
+                # no "token": /tunnels has not carried one since 2026-09-08; the kernel's re-notify brings it
         # Origin-only trust heals on restart too: the kernel's remembered-hosts list (`known` in the
         # same payload) carries the tier for every UNATTACHED host the user has set one on; without
         # this a bus bounce would silently drop a relayed origin back to `directed` (the user

--- a/tests/test_bus_seed_token.py
+++ b/tests/test_bus_seed_token.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""A restarted bus is re-told every peer, token included, by the kernel's next supervisor pass (review find,
+2026-09-08).
+
+GET /tunnels stopped carrying each peer's serve token on 2026-09-08 (the page reads that payload, and the
+relay injects the credential itself). The bus's restart seed reads the same payload: after a bus-only
+restart (a crash revived by _revive_postal_bus, the bus's own code-change re-exec, a manual restart) every
+peer was seeded with an empty token, the dialer knocked on the peer's bus credential-less and was refused,
+and the kernel never said the token again, since it re-notifies only when (up, trust) changes. Now the bus
+names its process on GET /peers (busId, epoch); the kernel's supervisor asks once per pass, and a NEW
+process voids every row's notify memo, so the pass re-runs _notify_bus_peer with the stored token
+(kernel _note_bus_incarnation; postal peers_snapshot). The seed itself still learns port, up and trust.
+
+The same one-pass supervisor drive covers a second finding on the same pass: last_ok, the stamp that dates
+the row's remembered sha, no longer advances on a poll whose sha did not fit its shape (the row keeps the
+last good sha, undated; _poll_remote_version's shaConfirmed).
+
+Synthetic only: hostname TESTHOST, an invented token, a fake bus and a fake peer kernel on loopback.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_busseed", os.path.join(BIN, "romp-kernel")).load_module()
+pm = SourceFileLoader("romp_postal_busseed", os.path.join(BIN, "romp-postal-service")).load_module()
+
+SECRET = "peer-secret-DO-NOT-USE"
+IMG = "<img src=x onerror=alert(1)>"
+
+
+class _Json(BaseHTTPRequestHandler):
+    def _json(self, obj, status=200):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+class _FakeBus(_Json):
+    """The local bus as the kernel sees it: records every POST /peer body, answers GET /peers as a bus of
+    the given incarnation would."""
+    SNAP = {"peers": {}, "epoch": 1000}
+    POSTED = []
+
+    def do_GET(self):
+        self._json(self.SNAP if self.path.startswith("/peers") else {})
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)).decode() or "{}")
+        if self.path.startswith("/peer"):
+            self.POSTED.append(body)
+        self._json({"ok": True})
+
+
+class _FakeKernel(_Json):
+    """The local kernel as the BUS sees it: GET /tunnels answers with the kernel's real listing."""
+    SERVED = []
+
+    def do_GET(self):
+        body = km._tunnels_listing() if self.path.startswith("/tunnels") else {}
+        self.SERVED.append(json.dumps(body))
+        self._json(body)
+
+
+class _FakeVersion(_Json):
+    """A peer kernel's /version (every GET answers it; the other polls are stubbed out)."""
+    PAYLOAD = {}
+
+    def do_GET(self):
+        self._json(self.PAYLOAD)
+
+
+def _serve(handler):
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv
+
+
+class _OnePass(Exception):
+    pass
+
+
+class _Wake:
+    """Stands in for _tunnel_wake: the supervisor's end-of-pass wait raises, so one call runs one pass."""
+    def clear(self):
+        pass
+
+    def set(self):
+        pass
+
+    def wait(self, timeout=None):
+        raise _OnePass()
+
+
+class _Harness(unittest.TestCase):
+    """Two fakes on loopback (bus, peer /version), the kernel's remote polls stubbed, one supervisor pass on
+    demand. Every module seam is restored on the way out."""
+    STUBS = ("_port_open", "_poll_remote_sessions", "_poll_remote_version", "_poll_remote_usage",
+             "_poll_remote_views", "_maybe_auto_push", "_adopt_peer_settings", "_pending_tag_rows",
+             "_pr_watch_tick", "_watch_tick", "_conserve_tick", "_primary_addr", "_tunnel_wake", "BUS_PORT")
+
+    def setUp(self):
+        self._saved = {k: getattr(km, k) for k in self.STUBS}
+        self._rem = dict(km._remotes)
+        km._remotes.clear()
+        with km._known_lock:
+            self._known = dict(km._known)
+            km._known.clear()
+        self.bus, self.ver = _serve(_FakeBus), _serve(_FakeVersion)
+        _FakeBus.POSTED = []
+        _FakeBus.SNAP = {"peers": {}, "epoch": 1000}
+        km.BUS_PORT = self.bus.server_address[1]
+        km._tunnel_wake = _Wake()
+        km._port_open = lambda port: True
+        km._poll_remote_sessions = lambda r: []
+        km._poll_remote_version = lambda r: None
+        km._poll_remote_usage = lambda r: None
+        km._poll_remote_views = lambda r: None
+        km._maybe_auto_push = lambda r: None
+        km._adopt_peer_settings = lambda host, rver: None
+        km._pending_tag_rows = lambda: []
+        km._pr_watch_tick = km._watch_tick = km._conserve_tick = lambda now: None
+        km._primary_addr = lambda: "10.0.0.1"
+        km._bus_seen[0] = None
+        km._via_cache.update(t=0.0, snap={})
+        km._origin_trust_pushed.clear()
+        km._peer_shape_said.clear()
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(km, k, v)
+        km._remotes.clear()
+        km._remotes.update(self._rem)
+        with km._known_lock:
+            km._known.clear()
+            km._known.update(self._known)
+        km._bus_seen[0] = None
+        km._via_cache.update(t=0.0, snap={})
+        km._peer_shape_said.clear()
+        for srv in (self.bus, self.ver):
+            srv.shutdown()
+            srv.server_close()
+
+    def _row(self, **over):
+        # a checked-in peer: no ssh of ours to supervise, so the pass goes straight to the polls
+        r = {"host": "TESTHOST", "checkin_peer": True, "kernel_port": 29855,
+             "local_port": self.ver.server_address[1], "bus_port": 50002, "token": SECRET,
+             "status": "up", "trust": "directed"}
+        r.update(over)
+        km._remotes[r["host"]] = r
+        return r
+
+    def _pass(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            try:
+                km._tunnel_supervisor()
+            except _OnePass:
+                pass
+        self.assertNotIn("tunnel-supervisor:", err.getvalue(), "the pass must not have died: %s" % err.getvalue())
+        return err.getvalue()
+
+
+class TheBusNamesItsProcess(unittest.TestCase):
+    def test_peers_carries_the_bus_id_and_boot_epoch(self):
+        snap = pm.peers_snapshot()
+        self.assertEqual((snap["busId"], snap["epoch"]), (pm.BUS_ID, pm.BUS_EPOCH))
+        self.assertEqual(len(pm.BUS_ID), 32, "minted per process, so two restarts in one second still differ")
+
+
+class ANewBusIsRetoldEveryPeer(_Harness):
+    def test_one_notify_per_incarnation_each_carrying_the_stored_token(self):
+        self._row()
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 1, "a row the bus has not been told about: one notify")
+        self.assertEqual(_FakeBus.POSTED[0], {"host": "TESTHOST", "port": 50002, "up": True,
+                                              "token": SECRET, "trust": "directed"})
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 1, "same bus, nothing changed: the memo holds")
+        _FakeBus.SNAP = {"peers": {}, "epoch": 1001}           # the bus restarted: a new boot second
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 2, "a NEW bus process is re-told in the same pass that noticed it")
+        self.assertEqual(_FakeBus.POSTED[1]["token"], SECRET, "...token included, which its /tunnels seed never had")
+        self.assertEqual(_FakeBus.POSTED[1], _FakeBus.POSTED[0])
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 2, "same incarnation again: no third")
+
+    def test_the_bus_id_alone_is_a_new_incarnation_too(self):
+        # two restarts inside one second share an epoch; the per-process id still tells them apart
+        _FakeBus.SNAP = {"peers": {}, "epoch": 1000, "busId": "a" * 32}
+        self._row()
+        self._pass()
+        _FakeBus.SNAP = {"peers": {}, "epoch": 1000, "busId": "b" * 32}
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 2)
+
+    def test_a_bus_that_does_not_say_who_it_is_changes_nothing(self):
+        # an older bus, or one that is down: no incarnation to compare, so the memo stands as before
+        _FakeBus.SNAP = {"peers": {}}
+        self._row()
+        self._pass()
+        self._pass()
+        self.assertEqual(len(_FakeBus.POSTED), 1)
+        self.assertIsNone(km._bus_seen[0])
+
+    def test_noticing_a_new_bus_voids_the_memo_for_every_row(self):
+        self._row()
+        self._row(host="OTHERHOST", bus_port=50003)
+        self._pass()
+        self.assertEqual(sorted(p["host"] for p in _FakeBus.POSTED), ["OTHERHOST", "TESTHOST"])
+        _FakeBus.SNAP = {"peers": {}, "epoch": 1001}
+        self._pass()
+        self.assertEqual(sorted(p["host"] for p in _FakeBus.POSTED[2:]), ["OTHERHOST", "TESTHOST"])
+        self.assertTrue(all(p["token"] == SECRET for p in _FakeBus.POSTED))
+
+
+class TheSeedLearnsNoTokenAndTheNotifySuppliesIt(_Harness):
+    def setUp(self):
+        super().setUp()
+        self.kern = _serve(_FakeKernel)
+        _FakeKernel.SERVED = []
+        self._pm_saved = (pm.KERNEL_BASE, pm._peer_threads_reconcile, dict(pm.PEERS))
+        pm.KERNEL_BASE = "http://127.0.0.1:%d" % self.kern.server_address[1]
+        pm._peer_threads_reconcile = lambda host: None      # the dialer is not under test
+        pm.PEERS.clear()
+
+    def tearDown(self):
+        pm.KERNEL_BASE, pm._peer_threads_reconcile, saved = self._pm_saved
+        pm.PEERS.clear()
+        pm.PEERS.update(saved)
+        self.kern.shutdown()
+        self.kern.server_close()
+        super().tearDown()
+
+    def test_the_tunnels_seed_lands_port_up_and_trust_but_no_token(self):
+        # documents what the seed can and cannot learn now that /tunnels carries no token
+        self._row(trust="trusted")
+        pm._seed_peers_from_kernel()
+        row = pm.PEERS["TESTHOST"]
+        self.assertEqual((row["port"], row["up"], row["trust"]), (50002, True, "trusted"))
+        self.assertEqual(row["token"], "", "the payload the seed reads has no token in it...")
+        self.assertEqual(len(_FakeKernel.SERVED), 1)
+        self.assertNotIn(SECRET, _FakeKernel.SERVED[0], "...because the page reads the same payload")
+
+    def test_the_kernels_notify_fills_the_token_in_over_the_seeded_row(self):
+        self._row(trust="trusted")
+        pm._seed_peers_from_kernel()
+        self.assertEqual(pm.PEERS["TESTHOST"]["token"], "")
+        self._pass()                                          # the kernel notices the bus and re-tells it
+        self.assertEqual(len(_FakeBus.POSTED), 1)
+        body = _FakeBus.POSTED[0]
+        self.assertEqual(body["token"], SECRET, "the notify carries what the seed could not")
+        payload, status = pm.peer_update(body)                 # what the bus does with that body
+        self.assertEqual(status, 200, payload)
+        row = pm.PEERS["TESTHOST"]
+        self.assertEqual((row["port"], row["up"], row["trust"], row["token"]), (50002, True, "trusted", SECRET),
+                         "the seeded row keeps its port, up-state and trust and gains the token")
+
+
+class AMalformedShaKeepsTheRowUndated(_Harness):
+    """The second finding on the same pass: a peer whose /version sha does not fit its shape used to freeze
+    the whole answer on the row while last_ok kept advancing, so a stale build read as freshly confirmed."""
+
+    def setUp(self):
+        super().setUp()
+        km._poll_remote_version = self._saved["_poll_remote_version"]    # the real poll, against the fake /version
+        _FakeVersion.PAYLOAD = {"kernel_sha": "abc1234", "kernel_ver": "v0.5.0"}
+
+    def test_last_ok_dates_only_a_sha_this_pass_confirmed(self):
+        r = self._row()
+        self._pass()
+        self.assertEqual((r["kernel_sha"], r["kernel_ver"]), ("abc1234", "v0.5.0"))
+        self.assertGreater(r["last_ok"], 0, "a confirmed sha is dated")
+        r["last_ok"] = 100.0                                   # an unmistakable old stamp
+        _FakeVersion.PAYLOAD = {"kernel_sha": IMG, "kernel_ver": "v0.6.0", "autoNudge": True}
+        said = self._pass()
+        self.assertEqual(r["status"], "up", "the row itself is fine: it answered")
+        self.assertEqual(r["kernel_sha"], "abc1234", "the row keeps the sha it last knew, never the bad one")
+        self.assertEqual(r["last_ok"], 100.0, "...and is NOT re-dated: nothing confirmed that sha this pass")
+        self.assertEqual((r["kernel_ver"], r["auto_nudge"]), ("v0.6.0", True), "the rest of the answer still lands")
+        self.assertIn("TESTHOST reported a kernel_sha that is not one", said)
+        _FakeVersion.PAYLOAD = {"kernel_sha": "def5678", "kernel_ver": "v0.6.0"}
+        self._pass()
+        self.assertEqual(r["kernel_sha"], "def5678")
+        self.assertGreater(r["last_ok"], 100.0, "a confirmed sha dates the row again")
+
+    def test_a_malformed_version_keeps_the_last_good_one_on_the_row(self):
+        r = self._row()
+        self._pass()
+        _FakeVersion.PAYLOAD = {"kernel_sha": "abc1234", "kernel_ver": "v1" + IMG}
+        before = r["last_ok"]
+        r["last_ok"] = 100.0
+        self._pass()
+        self.assertEqual(r["kernel_ver"], "v0.5.0", "the release name the row last knew, not a blank")
+        self.assertGreater(r["last_ok"], 100.0, "the sha itself was confirmed, so the row is dated")
+        self.assertGreater(before, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fleet_sync_log.py
+++ b/tests/test_fleet_sync_log.py
@@ -127,7 +127,11 @@ class VersionTag(unittest.TestCase):
 
     def test_a_remote_poll_carries_the_tag_alongside_the_sha(self):
         src = inspect.getsource(km._poll_remote_version)
-        self.assertIn('"ver": str(j.get("kernel_ver") or "")', src)
+        # the tag is read off /version beside the sha and returned as `ver` — since 2026-09-08 only when it
+        # fits _kernel_ver's shape (a peer's word, judged before it is stored; test_peer_payloads_as_text)
+        self.assertIn('ver = j.get("kernel_ver") or ""', src)
+        self.assertIn("if ver and not _peer_ver(ver):", src)
+        self.assertIn('"ver": ver,', src)
         self.assertIn('"sha": sha', src)
 
     def test_the_row_publishes_both_sides(self):

--- a/tests/test_kernel_remote_ws_proxy.py
+++ b/tests/test_kernel_remote_ws_proxy.py
@@ -174,6 +174,39 @@ class RemoteWsProxy(unittest.TestCase):
         finally:
             fake.close()
 
+    def _forwarded_query(self, host, browser_path):
+        """Dial the relay for `host` with `browser_path` and return the query the FAR side received, parsed."""
+        from urllib.parse import parse_qs, urlsplit
+        fake = _FakeRemoteKernel()
+        try:
+            self._register(host, fake.port, token=km._remotes[host]["token"] if host in km._remotes else REMOTE_TOKEN)
+            s, status, _, _, _ = self._upgrade(browser_path)
+            try:
+                self.assertEqual(status, 101, "the relay must splice before the query can be judged")
+                self.assertTrue(fake.done.wait(0.1) or fake.request, "the far side saw the request")
+            finally:
+                s.close()
+            req = fake.request.split(b"\r\n", 1)[0].decode("latin-1")
+            self.assertTrue(req.startswith("GET /ws?"), req)
+            return parse_qs(urlsplit(req.split(" ")[1]).query)
+        finally:
+            fake.close()
+
+    def test_a_row_without_a_stored_token_forwards_no_token_at_all(self):
+        # The pop is unconditional (2026-09-08): with no credential of its own to inject, the relay used to
+        # let whatever the browser sent ride through to the far kernel. Mutant this kills: delete the
+        # `q.pop("token", None)` and `token=evil` reaches the far side.
+        with km._remotes_lock:
+            km._remotes["gpu2"] = {"host": "gpu2", "kernel_port": 29855, "local_port": 0, "token": "", "status": "up"}
+        q = self._forwarded_query("gpu2", "/remote/gpu2/ws?app=chat&token=evil")
+        self.assertNotIn("token", q, "nothing the browser sent may stand in for a credential: %r" % q)
+        self.assertEqual(q.get("app"), ["chat"], "the rest of the query still travels")
+
+    def test_a_row_with_a_token_forwards_exactly_that_one(self):
+        q = self._forwarded_query("gpu1", "/remote/gpu1/ws?app=chat&token=evil&token=evil2")
+        self.assertEqual(q.get("token"), [REMOTE_TOKEN], "exactly the stored credential, once — never the browser's")
+        self.assertEqual(q.get("app"), ["chat"])
+
     def test_unknown_host_404s(self):
         s, status, _, _, _ = self._upgrade("/remote/nosuch/ws")
         s.close()

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -123,7 +123,9 @@ class TunnelConcierge(unittest.TestCase):
         self.assertTrue(body["ok"])
         t = body["tunnel"]
         self.assertEqual(t["host"], "testhost")
-        self.assertEqual(t["token"], FAKE_TOKEN, "the remote serve-token must be fetched over ssh")
+        self.assertNotIn("token", t, "the page is never handed the remote's credential (2026-09-08)")
+        self.assertIs(t["hasToken"], True, "…only the fact that one was fetched")
+        self.assertEqual(km._remotes["testhost"]["token"], FAKE_TOKEN, "the remote serve-token must be fetched over ssh")
         self.assertGreater(t["localPort"], 0, "a local -L port must be allocated for the browser")
         self.assertIn(t["status"], ("authorizing", "connecting", "starting", "up"))
         self.assertTrue(km._tunnel_proc_alive(km._remotes["testhost"]), "the ssh tunnel proc must be running")
@@ -134,7 +136,8 @@ class TunnelConcierge(unittest.TestCase):
         self.assertEqual(status, 200)
         hosts = {t["host"]: t for t in body["tunnels"]}
         self.assertIn("testhost", hosts)
-        self.assertEqual(hosts["testhost"]["token"], FAKE_TOKEN)
+        self.assertIs(hosts["testhost"]["hasToken"], True)
+        self.assertNotIn(FAKE_TOKEN, json.dumps(body), "the token string never rides /tunnels (2026-09-08)")
 
     def test_detach_kills_and_forgets(self):
         _req(self.port, "POST", "/tunnels", {"host": "testhost"})
@@ -281,14 +284,15 @@ class BootstrapRemoteKernel(unittest.TestCase):
         status, body = _req(self.port, "POST", "/tunnels", {"host": "testhost"})
         self.assertEqual(status, 200)
         self.assertTrue(os.path.exists(marker), "the bootstrap ran the remote start command")
-        self.assertEqual(body["tunnel"]["token"], FAKE_TOKEN,
-                         "the token is fetched AFTER the bootstrapped kernel comes up")
+        self.assertIs(body["tunnel"]["hasToken"], True,
+                      "the token is fetched AFTER the bootstrapped kernel comes up")
+        self.assertEqual(km._remotes["testhost"]["token"], FAKE_TOKEN)
 
     def test_attach_without_romp_reports_the_next_step(self):
         self._mock(MOCK_SSH_NOROMP)
         status, body = _req(self.port, "POST", "/tunnels", {"host": "barehost"})
         self.assertEqual(status, 200)
-        self.assertEqual(body["tunnel"]["token"], "", "no kernel to authorize against")
+        self.assertIs(body["tunnel"]["hasToken"], False, "no kernel to authorize against")
         self.assertIn("install.sh", body["tunnel"]["detail"],
                       "the popover tells the user the one command to run")
 

--- a/tests/test_peer_payloads_as_text.py
+++ b/tests/test_peer_payloads_as_text.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Peer kernel payloads are read through a shape, and the page never receives a remote's token (2026-09-08).
+
+Two answers from a PEER kernel cross a tunnel into this kernel and on to the dashboard, and both used to
+pass through as they came: tunnels_of relayed a peer's whole /tunnels JSON verbatim (no schema, no bound),
+and _poll_remote_version stored whatever /version said as the row's sha and release name (then remotes.json
+remembered it). Separately, _remote_public shipped each remote's reusable serve token to every /tunnels
+reader and the page put it back into the relay URL — even though _remote_ws already injects that token
+itself, so the page never needed it.
+
+Now: tunnels_of returns only `tunnels`, each row re-read through _remote_payload_public_row (a host ssh
+would accept, an enumerated status, sha/version shapes, exact booleans, bounded inert text, unknown keys
+gone, the count capped); _remote_public publishes `hasToken`; _poll_remote_version drops a sha/version that
+does not fit and says so once on stderr; _remote_ws discards the browser's token whether or not the row
+has one. Synthetic only: hostname TESTHOST, invented tokens, a stubbed transport, a loopback fake /version.
+"""
+import contextlib
+import io
+import inspect
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_peertext", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+IMG = "<img src=x onerror=alert(1)>"
+QUOTE = 'x" onmouseover="alert(1)'
+SECRET = "peer-secret-DO-NOT-USE"
+
+# One row of a peer's answer with a hostile or ill-shaped value in EVERY field the panel reads, plus keys
+# it never asked for. The host itself is a real one so the row survives and its fields can be inspected.
+HOSTILE_ROW = {
+    "host": "peerbox", "kernelPort": "29855", "localPort": 70000, "busPort": True,
+    "checkin": "yes", "checkinPeer": 1, "token": SECRET, "status": "<b>up</b>",
+    "detail": ("d" + IMG) * 400, "sids": [SID, 42, IMG, "x" * 200], "trust": "<i>trusted</i>",
+    "kernelSha": "abc" + QUOTE, "localSha": "ABC1234", "kernelVer": "v1" + IMG, "localVer": "v0.2.0+",
+    "outOfDate": "true", "behindBy": "2", "aheadBy": 1.5, "kernelDate": "<b>2026-01-01</b>",
+    "autoNudge": "false", "settings": {"a<b": 1, "ok": "v", "bad": IMG, "n": 3, "nested": {"x": 1}},
+    "fastForward": "yes", "fastPull": None, "askPull": 1,
+    "autoPush": {"phase": "<i>pushing</i>", "detail": "p" * 1000, "at": "now", "extra": 1},
+    "fails": -3, "nextTry": 10 ** 20, "stale": 0, "lastOk": 1785272930,
+    "evil": IMG, "__proto__": {"polluted": True},
+}
+
+
+class _Stubbed(unittest.TestCase):
+    def setUp(self):
+        self._rkc = km._remote_kernel_call
+        self._rem = dict(km._remotes)
+        km._remotes.clear()
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+
+    def tearDown(self):
+        km._remote_kernel_call = self._rkc
+        km._remotes.clear()
+        km._remotes.update(self._rem)
+
+    def _answer(self, body, status=200):
+        # the stub's own `payload=` parameter mirrors _remote_kernel_call's signature, so the answer must
+        # be bound under another name or the parameter shadows it
+        km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (status, body, None)
+
+
+class TunnelsOfIsAWhitelist(_Stubbed):
+    def test_every_field_is_read_through_its_shape_and_nothing_else_passes(self):
+        self._answer({"tunnels": [HOSTILE_ROW], "known": [{"host": IMG}], "local": {"sha": "abc"},
+                      "peerTiers": {"x": IMG}, "autoUpdate": True})
+        d = km.tunnels_of("TESTHOST")
+        self.assertTrue(d["ok"])
+        self.assertEqual(d["of"], "TESTHOST")
+        self.assertEqual(set(d), {"ok", "of", "tunnels"}, "only the rows are relayed — the peer's other sections stay behind")
+        row = d["tunnels"][0]
+        self.assertEqual(row["host"], "peerbox")
+        self.assertNotIn("evil", row); self.assertNotIn("__proto__", row); self.assertNotIn("token", row)
+        self.assertIs(row["hasToken"], True, "a peer's token collapses to the fact of one")
+        self.assertEqual(row["status"], "", "a status word the panel does not know is not a status")
+        self.assertEqual(row["trust"], "")
+        self.assertEqual(row["kernelSha"], ""); self.assertEqual(row["kernelVer"], "")
+        self.assertEqual(row["localSha"], "", "a sha is lowercase hex — the shape, not just the length")
+        self.assertEqual(row["localVer"], "v0.2.0+")
+        self.assertEqual((row["kernelPort"], row["localPort"], row["busPort"]), (0, 0, 0), "ints in range, or 0")
+        for k in ("checkin", "checkinPeer", "outOfDate", "fastForward", "fastPull", "askPull", "stale"):
+            self.assertIs(row[k], False, "%s: only True itself is True" % k)
+        self.assertIsNone(row["behindBy"]); self.assertIsNone(row["aheadBy"])
+        self.assertIsNone(row["autoNudge"])
+        self.assertEqual(row["sids"], [SID], "session ids: id-shaped strings only")
+        self.assertEqual(row["settings"], {"ok": "v", "n": 3}, "settings: plain keys, inert scalars")
+        self.assertEqual(row["autoPush"], {"phase": "", "detail": "p" * 200, "at": 0})
+        self.assertEqual((row["fails"], row["nextTry"], row["lastOk"]), (0, 0, 1785272930))
+        self.assertLessEqual(len(row["detail"]), 200)
+        self.assertEqual(row["kernelDate"], "b2026-01-01/b")
+        # the contract the page relies on: no string anywhere in the answer can open a tag or an attribute
+        flat = json.dumps(d)
+        self.assertNotIn("<", flat); self.assertNotIn(">", flat); self.assertNotIn('\\"', flat)
+        self.assertNotIn(SECRET, flat)
+
+    def test_a_well_formed_row_survives_intact_so_the_expand_loses_nothing(self):
+        good = {"host": "peerbox", "kernelPort": 29855, "localPort": 51000, "busPort": 51001,
+                "checkin": False, "checkinPeer": True, "hasToken": True, "status": "up", "detail": "fine",
+                "sids": [SID], "trust": "trusted", "kernelSha": "abc1234", "localSha": "def5678",
+                "kernelVer": "v0.1.3", "localVer": "v0.2.0+", "outOfDate": True, "behindBy": 2, "aheadBy": 0,
+                "kernelDate": "2026-08-11", "autoNudge": False, "settings": {"autoNudge": False, "theme": "dark"},
+                "fastForward": True, "fastPull": False, "askPull": True,
+                "autoPush": {"phase": "pushing", "detail": "sending", "at": 1785272930},
+                "fails": 3, "nextTry": 1785272990, "stale": False, "lastOk": 1785272930}
+        self._answer({"tunnels": [good]})
+        self.assertEqual(km.tunnels_of("TESTHOST")["tunnels"], [good])
+
+    def test_rows_without_a_usable_host_are_dropped_and_counted_and_the_count_is_capped(self):
+        rows = [{"host": IMG, "status": "up"}, {"host": QUOTE}, {"host": "-oProxyCommand=x"}, "not a row", None]
+        rows += [{"host": "h%d" % i, "status": "up"} for i in range(500)]
+        self._answer({"tunnels": rows})
+        km._peer_shape_said.clear()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            d = km.tunnels_of("TESTHOST")
+            km.tunnels_of("TESTHOST")
+        self.assertTrue(d["ok"])
+        self.assertEqual(len(d["tunnels"]), km._PEER_TUNNELS_MAX)
+        self.assertEqual(d["dropped"], 5, "rows with no host ssh would accept are counted for the panels' note")
+        self.assertEqual(err.getvalue().count("\n"), 1, "…and said on stderr ONCE per host, not per read")
+        self.assertIn("TESTHOST answered /tunnels with 5 rows without a usable host", err.getvalue())
+        self.assertTrue(all(km._safe_ssh_host(r["host"]) for r in d["tunnels"]))
+        self.assertEqual(d["tunnels"][0]["host"], "h0", "the drop does not eat the valid rows' places")
+        km._peer_shape_said.clear()
+
+    def test_a_dirty_worktree_sha_is_a_sha_in_a_peers_row_too(self):
+        # _kernel_sha appends '-dirty' on an uncommitted worktree and the rest of this file reads through it
+        # (_sha_base); a whitelist that refused it would blank a legitimately dirty peer's build (review find)
+        self._answer({"tunnels": [{"host": "peerbox", "status": "up", "kernelSha": "abc1234-dirty",
+                                   "localSha": "a" * 40 + "-dirty"}]})
+        row = km.tunnels_of("TESTHOST")["tunnels"][0]
+        self.assertEqual((row["kernelSha"], row["localSha"]), ("abc1234-dirty", "a" * 40 + "-dirty"))
+        for bad in ("abc1234-DIRTY", "abc1234-dirty-dirty", "-dirty", "abc1234-clean", "abc1234 -dirty"):
+            with self.subTest(sha=bad):
+                self.assertEqual(km._peer_sha(bad), "", "only the one suffix _kernel_sha writes")
+
+    def test_a_tunnels_that_is_not_a_list_is_a_loud_error(self):
+        for bad in ({"tunnels": {"host": "x"}}, {"tunnels": "x"}, {"tunnels": None}, {}):
+            with self.subTest(payload=bad):
+                self._answer(bad)
+                d = km.tunnels_of("TESTHOST")
+                self.assertFalse(d["ok"])
+                self.assertIn("without a list of tunnels", d["error"])
+                self.assertIn("TESTHOST", d["error"])
+
+    def test_a_peer_token_in_a_row_never_reaches_the_answer(self):
+        self._answer({"tunnels": [{"host": "peerbox", "token": SECRET, "status": "up"}]})
+        d = km.tunnels_of("TESTHOST")
+        self.assertNotIn(SECRET, json.dumps(d))
+        self.assertIs(d["tunnels"][0]["hasToken"], True)
+        self._answer({"tunnels": [{"host": "peerbox", "token": "", "status": "up"}]})
+        self.assertIs(km.tunnels_of("TESTHOST")["tunnels"][0]["hasToken"], False)
+
+
+class TheRemotesPayloadCarriesNoToken(unittest.TestCase):
+    def _row(self, token):
+        return {"host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "bus_port": 51001,
+                "token": token, "status": "up", "detail": "", "sids": [SID], "trust": "directed",
+                "kernel_sha": "abc1234", "kernel_ver": "v0.1.3", "proc": None}
+
+    def test_the_public_row_says_whether_a_token_exists_never_which(self):
+        pub = km._remote_public(self._row(SECRET))
+        self.assertNotIn("token", pub, "the page dials through the relay, which injects the credential itself")
+        self.assertIs(pub["hasToken"], True)
+        self.assertNotIn(SECRET, json.dumps(pub))
+        self.assertIs(km._remote_public(self._row(""))["hasToken"], False)
+
+    def test_the_tunnels_listing_never_serializes_a_token(self):
+        saved = dict(km._remotes)
+        km._remotes.clear()
+        try:
+            km._remotes["TESTHOST"] = self._row(SECRET)
+            self.assertNotIn(SECRET, json.dumps(km.list_remotes()))
+            self.assertEqual(km.list_remotes()[0]["hasToken"], True)
+        finally:
+            km._remotes.clear()
+            km._remotes.update(saved)
+
+
+class _FakeVersion(BaseHTTPRequestHandler):
+    PAYLOAD = {}
+
+    def do_GET(self):
+        body = json.dumps(self.PAYLOAD).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+class TheVersionPollReadsShapes(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), _FakeVersion)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        km._peer_shape_said.clear()
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+        km._peer_shape_said.clear()
+
+    def _poll(self, payload, host="TESTHOST"):
+        _FakeVersion.PAYLOAD = payload
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            got = km._poll_remote_version({"host": host, "local_port": self.port, "token": "tok"})
+        return got, err.getvalue()
+
+    def test_good_values_pass_unchanged_and_quietly(self):
+        got, said = self._poll({"kernel_sha": "abc1234", "kernel_ver": "v0.5.0+", "autoNudge": False})
+        self.assertEqual((got["sha"], got["ver"], got["autoNudge"]), ("abc1234", "v0.5.0+", False))
+        self.assertEqual(said, "")
+        got, said = self._poll({"kernel_sha": "a" * 40, "kernel_ver": "v12.0.3"})
+        self.assertEqual((got["sha"], got["ver"]), ("a" * 40, "v12.0.3"))
+
+    def test_a_sha_that_is_not_one_is_refused_and_said_once(self):
+        for bad in ("abc" + QUOTE, IMG, "ABC1234", "abc12", "g" * 8, "a" * 41):
+            with self.subTest(sha=bad):
+                km._peer_shape_said.clear()
+                got, said = self._poll({"kernel_sha": bad, "kernel_ver": "v0.5.0"})
+                self.assertIsNone(got, "an unusable sha is no sha — the row keeps what it last knew")
+                self.assertIn("TESTHOST reported a kernel_sha that is not one", said)
+                self.assertIn(repr(bad[:60]), said, "the complaint quotes what came, so the offender is identifiable")
+                got, said2 = self._poll({"kernel_sha": bad, "kernel_ver": "v0.5.0"})
+                self.assertEqual(said2, "", "said ONCE per host and field, not once per poll")
+
+    def test_a_version_that_is_not_one_is_blanked_and_said_once(self):
+        for bad in ("v1" + IMG, "1.2.3", "v1.2", "v1.2.3-dirty", "v1.2.3++", QUOTE):
+            with self.subTest(ver=bad):
+                km._peer_shape_said.clear()
+                got, said = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad})
+                self.assertEqual(got["sha"], "abc1234", "the sha still lands — the fields are judged apart")
+                self.assertEqual(got["ver"], "", "the row falls back to the sha alone, as against an older kernel")
+                self.assertIn("TESTHOST reported a kernel_ver that is not one", said)
+                _, said2 = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad})
+                self.assertEqual(said2, "")
+
+    def test_a_missing_version_is_not_a_complaint(self):
+        got, said = self._poll({"kernel_sha": "abc1234"})
+        self.assertEqual(got["ver"], "")
+        self.assertEqual(said, "", "an older kernel that predates the field is not misbehaving")
+
+    def test_a_peer_on_a_dirty_worktree_keeps_its_sha(self):
+        # The suffix _kernel_sha appends on uncommitted edits is a sha to every reader here (_sha_base strips
+        # it, _shas_agree ignores it); a shape that refused it froze that peer's row on its last clean poll
+        # and the panel called it an unversioned copy (review find). Guard: passes on origin/main too.
+        got, said = self._poll({"kernel_sha": "abc1234-dirty", "kernel_ver": "v0.5.0+"})
+        self.assertEqual((got["sha"], got["ver"]), ("abc1234-dirty", "v0.5.0+"))
+        self.assertEqual(said, "", "nothing to complain about")
+        self.assertEqual(km._sha_base(got["sha"]), "abc1234", "the drift readers see the commit under it")
+        self.assertIs(km._remote_out_of_date({"kernel_sha": got["sha"]}, head="abc1234"), False,
+                      "same commit, dirty or not, is not out of date")
+        self.assertIs(km._remote_out_of_date({"kernel_sha": got["sha"]}, head="def5678"), True)
+
+
+class TheRelayDiscardsTheBrowsersToken(unittest.TestCase):
+    def test_the_browser_query_token_is_dropped_before_the_remote_credential_is_set(self):
+        # test_kernel_remote_ws_proxy drives the splice end to end for a row WITH a token; this pins the
+        # order for the row without one: the browser's `token` is popped unconditionally, so nothing a page
+        # sends can ever travel to the far kernel — the relay speaks for itself or not at all.
+        src = inspect.getsource(km.Handler._remote_ws)
+        drop, inject = src.index('q.pop("token", None)'), src.index('q["token"] = [rtok]')
+        self.assertLess(drop, inject)
+        self.assertLess(src.index("q = parse_qs(query"), drop)
+
+
+class TheAttachRouteSpeaksInHasToken(unittest.TestCase):
+    def test_no_kernel_source_publishes_the_token_key_on_a_public_row(self):
+        src = inspect.getsource(km._remote_public)
+        self.assertNotIn('"token": r.get("token")', src)
+        self.assertIn('"hasToken": bool(r.get("token"))', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_peer_payloads_as_text.py
+++ b/tests/test_peer_payloads_as_text.py
@@ -10,13 +10,14 @@ itself, so the page never needed it.
 
 Now: tunnels_of returns only `tunnels`, each row re-read through _remote_payload_public_row (a host ssh
 would accept, an enumerated status, sha/version shapes, exact booleans, bounded inert text, unknown keys
-gone, the count capped); _remote_public publishes `hasToken`; _poll_remote_version drops a sha/version that
-does not fit and says so once on stderr; _remote_ws discards the browser's token whether or not the row
-has one. Synthetic only: hostname TESTHOST, invented tokens, a stubbed transport, a loopback fake /version.
+gone, the count capped); _remote_public publishes `hasToken`; _poll_remote_version says once on stderr when
+a sha/version does not fit and keeps the row's last good value in its place, marking a kept sha as not
+confirmed by this poll; _remote_ws discards the browser's token whether or not the row has one (driven end
+to end, both rows, in test_kernel_remote_ws_proxy.py). Synthetic only: hostname TESTHOST, invented tokens,
+a stubbed transport, a loopback fake /version.
 """
 import contextlib
 import io
-import inspect
 import json
 import os
 import tempfile
@@ -217,41 +218,56 @@ class TheVersionPollReadsShapes(unittest.TestCase):
         self.srv.server_close()
         km._peer_shape_said.clear()
 
-    def _poll(self, payload, host="TESTHOST"):
+    def _poll(self, payload, host="TESTHOST", row=None):
+        """Poll the fake /version for a row that may already remember a sha/version (`row`)."""
         _FakeVersion.PAYLOAD = payload
+        r = {"host": host, "local_port": self.port, "token": "tok"}
+        r.update(row or {})
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
-            got = km._poll_remote_version({"host": host, "local_port": self.port, "token": "tok"})
+            got = km._poll_remote_version(r)
         return got, err.getvalue()
 
     def test_good_values_pass_unchanged_and_quietly(self):
         got, said = self._poll({"kernel_sha": "abc1234", "kernel_ver": "v0.5.0+", "autoNudge": False})
         self.assertEqual((got["sha"], got["ver"], got["autoNudge"]), ("abc1234", "v0.5.0+", False))
+        self.assertIs(got["shaConfirmed"], True, "this poll vouched for the sha it returns")
         self.assertEqual(said, "")
         got, said = self._poll({"kernel_sha": "a" * 40, "kernel_ver": "v12.0.3"})
         self.assertEqual((got["sha"], got["ver"]), ("a" * 40, "v12.0.3"))
 
-    def test_a_sha_that_is_not_one_is_refused_and_said_once(self):
+    def test_a_sha_that_is_not_one_keeps_the_last_good_one_undated_and_is_said_once(self):
+        # The first cut returned None here, which froze the WHOLE answer (version, settings, Auto Nudge) on
+        # the row while the supervisor kept re-dating it as freshly confirmed (review find, 2026-09-08).
         for bad in ("abc" + QUOTE, IMG, "ABC1234", "abc12", "g" * 8, "a" * 41):
             with self.subTest(sha=bad):
                 km._peer_shape_said.clear()
                 got, said = self._poll({"kernel_sha": bad, "kernel_ver": "v0.5.0"})
-                self.assertIsNone(got, "an unusable sha is no sha — the row keeps what it last knew")
+                self.assertIsNone(got, "nothing remembered and nothing usable: no answer, as against a kernel that sent no sha")
                 self.assertIn("TESTHOST reported a kernel_sha that is not one", said)
                 self.assertIn(repr(bad[:60]), said, "the complaint quotes what came, so the offender is identifiable")
-                got, said2 = self._poll({"kernel_sha": bad, "kernel_ver": "v0.5.0"})
+                got, said2 = self._poll({"kernel_sha": bad, "kernel_ver": "v0.6.0", "autoNudge": True},
+                                        row={"kernel_sha": "0ld5ha0", "kernel_ver": "v0.5.0"})
                 self.assertEqual(said2, "", "said ONCE per host and field, not once per poll")
+                self.assertEqual(got["sha"], "0ld5ha0", "the row keeps the sha it last knew, never the bad one")
+                self.assertIs(got["shaConfirmed"], False,
+                              "...and this poll did not vouch for it, so the supervisor will not re-date the row")
+                self.assertEqual((got["ver"], got["autoNudge"]), ("v0.6.0", True),
+                                 "the rest of the answer still lands: the fields are judged apart")
 
-    def test_a_version_that_is_not_one_is_blanked_and_said_once(self):
+    def test_a_version_that_is_not_one_keeps_the_last_good_one_and_is_said_once(self):
+        # The first cut blanked it, against the PR's own account of itself (review find, 2026-09-08).
         for bad in ("v1" + IMG, "1.2.3", "v1.2", "v1.2.3-dirty", "v1.2.3++", QUOTE):
             with self.subTest(ver=bad):
                 km._peer_shape_said.clear()
-                got, said = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad})
-                self.assertEqual(got["sha"], "abc1234", "the sha still lands — the fields are judged apart")
-                self.assertEqual(got["ver"], "", "the row falls back to the sha alone, as against an older kernel")
+                got, said = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad}, row={"kernel_ver": "v0.4.0"})
+                self.assertEqual(got["sha"], "abc1234", "the sha still lands: the fields are judged apart")
+                self.assertIs(got["shaConfirmed"], True, "the sha was fine; only the version is in question")
+                self.assertEqual(got["ver"], "v0.4.0", "the row keeps the release name it last knew, never the bad one")
                 self.assertIn("TESTHOST reported a kernel_ver that is not one", said)
-                _, said2 = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad})
+                got, said2 = self._poll({"kernel_sha": "abc1234", "kernel_ver": bad})
                 self.assertEqual(said2, "")
+                self.assertEqual(got["ver"], "", "with nothing remembered the row falls back to the sha alone, as against an older kernel")
 
     def test_a_missing_version_is_not_a_complaint(self):
         got, said = self._poll({"kernel_sha": "abc1234"})
@@ -261,7 +277,9 @@ class TheVersionPollReadsShapes(unittest.TestCase):
     def test_a_peer_on_a_dirty_worktree_keeps_its_sha(self):
         # The suffix _kernel_sha appends on uncommitted edits is a sha to every reader here (_sha_base strips
         # it, _shas_agree ignores it); a shape that refused it froze that peer's row on its last clean poll
-        # and the panel called it an unversioned copy (review find). Guard: passes on origin/main too.
+        # and the panel called it an unversioned copy (review find). This guards _PEER_SHA_RE's next edit,
+        # not the pre-shape code: the module cannot run on origin/main, where setUp fails on the missing
+        # _peer_shape_said (review find, 2026-09-08: the comment here used to claim it passed there).
         got, said = self._poll({"kernel_sha": "abc1234-dirty", "kernel_ver": "v0.5.0+"})
         self.assertEqual((got["sha"], got["ver"]), ("abc1234-dirty", "v0.5.0+"))
         self.assertEqual(said, "", "nothing to complain about")
@@ -271,22 +289,47 @@ class TheVersionPollReadsShapes(unittest.TestCase):
         self.assertIs(km._remote_out_of_date({"kernel_sha": got["sha"]}, head="def5678"), True)
 
 
-class TheRelayDiscardsTheBrowsersToken(unittest.TestCase):
-    def test_the_browser_query_token_is_dropped_before_the_remote_credential_is_set(self):
-        # test_kernel_remote_ws_proxy drives the splice end to end for a row WITH a token; this pins the
-        # order for the row without one: the browser's `token` is popped unconditionally, so nothing a page
-        # sends can ever travel to the far kernel — the relay speaks for itself or not at all.
-        src = inspect.getsource(km.Handler._remote_ws)
-        drop, inject = src.index('q.pop("token", None)'), src.index('q["token"] = [rtok]')
-        self.assertLess(drop, inject)
-        self.assertLess(src.index("q = parse_qs(query"), drop)
+class _Proc:
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
 
 
 class TheAttachRouteSpeaksInHasToken(unittest.TestCase):
-    def test_no_kernel_source_publishes_the_token_key_on_a_public_row(self):
-        src = inspect.getsource(km._remote_public)
-        self.assertNotIn('"token": r.get("token")', src)
-        self.assertIn('"hasToken": bool(r.get("token"))', src)
+    """attach_remote answers the popover's Connect with the public row (POST /tunnels hands it back as
+    `tunnel`), and that row used to carry the very credential the attach had just fetched over ssh. Driven
+    through the real attach with ssh and the tunnel stubbed, as test_kernel_remote_identity does; a pin on
+    _remote_public's source text stood here first (review find, 2026-09-08)."""
+
+    def setUp(self):
+        self._saved = (km._fetch_remote_token, km._remote_kernel_up, km._spawn_tunnel, km._notify_bus_peer)
+        self._rem = dict(km._remotes)
+        km._remotes.clear()
+        with km._known_lock:
+            self._known = dict(km._known)
+            km._known.clear()
+        km._fetch_remote_token = lambda h: SECRET
+        km._remote_kernel_up = lambda h, p: True
+        km._spawn_tunnel = lambda r: r.update(proc=_Proc(), status="starting", detail="")
+        km._notify_bus_peer = lambda *a, **k: True
+
+    def tearDown(self):
+        km._fetch_remote_token, km._remote_kernel_up, km._spawn_tunnel, km._notify_bus_peer = self._saved
+        km._remotes.clear()
+        km._remotes.update(self._rem)
+        with km._known_lock:
+            km._known.clear()
+            km._known.update(self._known)
+
+    def test_the_row_the_attach_returns_says_only_that_a_token_was_fetched(self):
+        pub = km.attach_remote("TESTHOST")
+        self.assertIs(pub["hasToken"], True, "the fetch happened...")
+        self.assertNotIn("token", pub)
+        self.assertNotIn(SECRET, json.dumps(pub), "...and the page learns only that")
+        self.assertEqual(km._remotes["TESTHOST"]["token"], SECRET, "the kernel, not the page, holds what was fetched")
+        self.assertIs(km._remote_public(km._remotes["TESTHOST"])["hasToken"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -32,7 +32,7 @@ km = SourceFileLoader("romp_kernel_rpanel", os.path.join(BIN, "romp-kernel")).lo
 TUNNELS = {
     "tunnels": [{
         "host": "TESTHOST", "kernelPort": 29855, "localPort": 51000, "busPort": 51001,
-        "checkin": False, "checkinPeer": False, "token": "tok", "status": "up", "detail": "",
+        "checkin": False, "checkinPeer": False, "hasToken": True, "status": "up", "detail": "",
         "sids": ["11111111-2222-3333-4444-555555555555"], "trust": "directed",
         "kernelSha": "abc1234", "localSha": "abc1234", "outOfDate": False,
         "behindBy": 0, "aheadBy": 0, "kernelDate": "",
@@ -45,13 +45,16 @@ TUNNELS = {
 # Minimal DOM/browser stub: enough for the panel IIFE to wire itself up and run one refresh.
 HARNESS = r"""
 'use strict';
+const HTML_SETS = [];           // every string any element was given as innerHTML, in order (the markup sinks)
 function mkEl(id){
-  return {id:id, hidden:true, textContent:'', title:'', style:{}, value:'', className:'',
+  return {id:id, hidden:true, _text:'', title:'', style:{}, value:'', className:'',
     children:[], _listeners:{}, _html:'',
     // Assigning innerHTML replaces an element's contents, so it must drop appended children too. Without
     // that, render()'s opening `list.innerHTML=''` left the previous pass's rows in place and every
     // refresh doubled the list.
-    get innerHTML(){return this._html;}, set innerHTML(v){this._html=v; this.children=[];},
+    get innerHTML(){return this._html;}, set innerHTML(v){this._html=v; this.children=[]; HTML_SETS.push(String(v));},
+    // …and so does assigning textContent (the DOM's rule) — the option lists clear themselves that way
+    get textContent(){return this._text;}, set textContent(v){this._text=v; this.children=[];},
     classList:{_s:new Set(), add(){}, remove(){}, toggle(){}, contains(){return false;}},
     appendChild(c){this.children.push(c); return c;},
     querySelector(){return null;}, querySelectorAll(){return [];},
@@ -70,6 +73,7 @@ const document = {
 const localStorage = { getItem(){return null;}, setItem(){} };
 const TUNNELS = __TUNNELS__;
 const PAIRS = __PAIRS__;        // /tunnels/pairs answer; null = the read never lands (loader-state test)
+const SUB = __SUB__;            // /tunnels/of answer (a PEER's own rows); null = answer with TUNNELS as before
 const POSTS = [];               // every write the panel makes, so a test can assert what Attach sent
 function fetch(url, opts){
   if (opts && opts.method === 'POST') {
@@ -79,6 +83,9 @@ function fetch(url, opts){
   if (url.indexOf('/tunnels/pairs') >= 0) {
     if (PAIRS === null) return new Promise(function(){});
     return Promise.resolve({ ok:true, json(){ return Promise.resolve(PAIRS); } });
+  }
+  if (url.indexOf('/tunnels/of') >= 0 && SUB !== null) {
+    return Promise.resolve({ ok:true, json(){ return Promise.resolve(SUB); } });
   }
   const body = url.indexOf('/ssh-hosts') >= 0 ? {hosts:['TESTHOST']} : TUNNELS;
   return Promise.resolve({ ok:true, json(){ return Promise.resolve(body); } });
@@ -109,26 +116,37 @@ setTimeout_(() => {
     const list = ELS['rnet-list'];
     const rows = list.children.length;
     const html = list.children.map(collect).join(' | ');
-    const add = ELS['rnet-add'], plus = ELS['rnet-plus'], dl = ELS['rnet-hosts'];
+    const add = ELS['rnet-add'], plus = ELS['rnet-plus'], dl = ELS['rnet-hosts'], fs = ELS['rnet-from'];
     process.stdout.write(JSON.stringify({rows:rows, html:html, errors:console_err,
-      addHidden:!!add.hidden, plusHidden:!!plus.hidden, hostsHtml:String(dl.innerHTML||''),
-      posts:POSTS, alerts:ALERTS}));
-    process.exit(0);   // the panel re-arms its own poll timer forever, so exit once measured
+      addHidden:!!add.hidden, plusHidden:!!plus.hidden,
+      hosts:dl.children.map(function(o){return o.value;}), hostsHtml:String(dl.innerHTML||''),
+      hostsLastDisabled:!!(dl.children.length&&dl.children[dl.children.length-1].disabled),
+      fromOpts:fs.children.map(function(o){return [o.value, o.textContent];}), fromHtml:String(fs.innerHTML||''),
+      htmlSets:HTML_SETS, posts:POSTS, alerts:ALERTS}), function(){process.exit(0);});
+    // exit once the measurement has FLUSHED: a pipe write is asynchronous, and exit() right after it cut a
+    // 600-row report mid-string (unterminated JSON); the panel re-arms its own poll timer forever otherwise
   }, 40);
 }, 60);
 """
 
 
-class RemotesPanelRender(unittest.TestCase):
-    def _run(self, drive="", tunnels=None, pairs=None):
+class _PanelHarness:
+    """Runs the real panel JS in node against the DOM stub above and returns what it measured. A MIXIN with
+    no tests of its own, so the classes below share the driver without inheriting each other's tests (a
+    subclass of a TestCase re-runs every inherited test — three copies of 26 node spawns, review find)."""
+
+    def _run(self, drive="", tunnels=None, pairs=None, sub=None):
         js = (HARNESS.replace("__PANEL_JS__", km._LANDING_REMOTES_JS)
                      .replace("__TUNNELS__", json.dumps(tunnels if tunnels is not None else TUNNELS))
                      .replace("__PAIRS__", json.dumps(pairs))
+                     .replace("__SUB__", json.dumps(sub))
                      .replace("__DRIVE__", drive))
         p = subprocess.run(["node", "-e", js], capture_output=True, text=True, timeout=30)
         self.assertEqual(p.returncode, 0, "panel JS crashed:\n%s" % p.stderr[-2000:])
         return json.loads(p.stdout or "{}")
 
+
+class RemotesPanelRender(_PanelHarness, unittest.TestCase):
     def test_an_attached_host_renders_a_row(self):
         out = self._run()
         self.assertEqual(out.get("errors"), [], "the refresh must not report a failure")
@@ -289,8 +307,9 @@ class RemotesPanelRender(unittest.TestCase):
         tun = json.loads(json.dumps(TUNNELS))
         tun["known"] = [{"host": "otherbox", "trust": "trusted", "lastAttachedAt": 1}]
         out = self._run(tunnels=tun)
-        self.assertIn("TESTHOST", out.get("hostsHtml", ""))
-        self.assertIn("otherbox", out.get("hostsHtml", ""))
+        self.assertIn("TESTHOST", out.get("hosts", []))
+        self.assertIn("otherbox", out.get("hosts", []))
+        self.assertEqual(out.get("hostsHtml"), "", "the datalist is built from option elements, never markup (2026-09-08)")
 
     def test_a_down_host_says_it_is_still_being_dialed_and_when(self):
         # romp never stops dialing an attached host (the user 2026-07-29), so the row's job is to prove
@@ -359,7 +378,121 @@ class RemotesPanelRender(unittest.TestCase):
         self.assertIn("/tunnels/pairs", js)
 
 
-class PendingHostsRowCopy(RemotesPanelRender):
+# A hostile string in every place a peer gets to choose one. Markers are chosen so a raw one is unambiguous
+# in any innerHTML the panel assigned (`<img src=x` / `<script` / `" onmouseover=`) and its escaped form is
+# equally unambiguous (`&lt;img src=x`).
+IMG = "<img src=x onerror=alert(1)>"
+QUOTE = 'x" onmouseover="alert(1)'
+SCRIPT = "<script>alert(1)</script>"
+
+
+class PeerStringsRenderAsText(_PanelHarness, unittest.TestCase):
+    """Every string a PEER chooses reaches this panel through innerHTML — a host it named (a checked-in
+    peer names itself; the rows /tunnels/of relays are a peer's whole list), its status word, its build,
+    the bus gossip (tiers, relay hosts, holds). They were concatenated into markup as they came, so a
+    hostile or merely odd peer scripted the dashboard that displayed it (2026-09-08). Executed against the
+    real panel JS: every innerHTML the panel assigned is recorded, and none may carry a raw marker while
+    the escaped text must actually be shown (rendered as text, not dropped)."""
+
+    def _assert_inert(self, out, *markers):
+        sets = out.get("htmlSets", [])
+        self.assertTrue(sets, "the panel rendered something")
+        for h in sets:
+            for m in ("<img src=x", "<script", '" onmouseover='):
+                self.assertNotIn(m, h, "a peer string reached innerHTML as markup:\n%s" % h[:400])
+        html = out.get("html", "")
+        for m in markers:
+            self.assertIn(m, html, "the hostile string must still be SHOWN, as text")
+
+    def test_a_peer_named_host_build_status_and_gossip_render_as_text_on_the_main_rows(self):
+        tn = json.loads(json.dumps(TUNNELS))
+        tn["tunnels"][0].update({"host": "TEST" + IMG + "HOST", "status": "up", "outOfDate": True,
+                                 "behindBy": 2, "aheadBy": 0, "kernelSha": "abc" + QUOTE,
+                                 "kernelVer": "v1" + SCRIPT, "localSha": "def5678", "localVer": "v0.2.0",
+                                 "kernelDate": "<b>2026</b>", "stale": True, "lastOk": 1785272930})
+        tn["peerTiers"] = {"TEST" + IMG + "HOST": "<i>trusted</i>"}
+        tn["known"] = [{"host": "known" + IMG, "trust": "trusted", "lastAttachedAt": 1, "attached": True}]
+        tn["viaReach"] = [{"host": "relay" + IMG, "via": "hub" + QUOTE, "agents": "<u>3</u>", "trust": "directed"}]
+        tn["remoteHolds"] = [{"atHost": "holder" + IMG, "frm": "a", "to": "b", "gist": QUOTE, "origin": "a"}]
+        out = self._run(tunnels=tn)
+        self.assertEqual(out.get("errors"), [], "the render must not throw on any of it")
+        self._assert_inert(out, "TEST&lt;img src=x onerror=alert(1)&gt;HOST", "abc" + "x&quot; onmouseover=&quot;alert(1)",
+                           "v1&lt;script&gt;", "&lt;i&gt;trusted&lt;/i&gt;", "known&lt;img", "relay&lt;img",
+                           "hub" + "x&quot; onmouseover", "holder&lt;img")
+        # the completions list carries the raw NAME as an option value — a value, not markup
+        self.assertIn("TEST" + IMG + "HOST", out.get("hosts", []))
+        self.assertEqual(out.get("hostsHtml"), "")
+
+    def test_the_connect_from_select_is_option_elements_naming_the_up_hosts(self):
+        tn = json.loads(json.dumps(TUNNELS))
+        tn["tunnels"][0]["host"] = "up" + QUOTE
+        out = self._run(tunnels=tn)
+        self.assertEqual(out.get("fromHtml"), "", "no markup was assigned to the select (2026-09-08)")
+        self.assertEqual(out.get("fromOpts"), [["", "from: this machine"], ["up" + QUOTE, "from: up" + QUOTE]])
+
+    def test_a_peers_own_rows_in_the_connections_expand_render_as_text(self):
+        # The stub has no selector engine, so the expand toggle is stood in for: a button the panel finds
+        # under `button[data-x]`, whose data-x names the up host — the panel binds its onclick on render,
+        # the drive re-renders (a hostsPending post) and clicks it, and the /tunnels/of stub answers SUB.
+        sub = {"ok": True, "of": "TESTHOST", "tunnels": [{
+            "host": "peer" + IMG, "status": "up" + SCRIPT, "outOfDate": True, "behindBy": 1, "aheadBy": 0,
+            "kernelSha": "abc" + QUOTE, "kernelVer": "v9" + SCRIPT, "localSha": "def5678", "localVer": "v0.2.0",
+            "trust": "directed", "fastForward": True, "hasToken": True, "localPort": 5, "kernelPort": 6}]}
+        drive = ("var BTN=mkEl('button');BTN.getAttribute=function(){return 'TESTHOST';};"
+                 "ELS['rnet-list'].querySelectorAll=function(sel){return sel==='button[data-x]'?[BTN]:[];};"
+                 + PendingHostsRowCopy.DELIVER + "BTN.click();")
+        out = self._run(drive=drive, sub=sub)
+        self.assertEqual(out.get("errors"), [])
+        html = out.get("html", "")
+        self.assertIn("rnet-subrow", html, "the expand rendered the peer's rows")
+        self._assert_inert(out, "peer&lt;img src=x onerror=alert(1)&gt;", "up&lt;script&gt;", "v9&lt;script&gt;")
+
+    def test_rows_the_kernel_left_out_are_said_beneath_the_rows_that_passed(self):
+        # tunnels_of counts the peer rows it dropped (no host ssh would accept) as `dropped`; a list that is
+        # simply shorter would be a silent thinning, so the note names the count — as text — in BOTH panels
+        # (strip.ts droppedRowsNote wears the same sentence; net-remote-controls.test.ts pins the pair)
+        sub = {"ok": True, "of": "TESTHOST", "dropped": 2,
+               "tunnels": [{"host": "peerbox", "status": "up", "trust": "directed", "hasToken": True}]}
+        drive = ("var BTN=mkEl('button');BTN.getAttribute=function(){return 'TESTHOST';};"
+                 "ELS['rnet-list'].querySelectorAll=function(sel){return sel==='button[data-x]'?[BTN]:[];};"
+                 + PendingHostsRowCopy.DELIVER + "BTN.click();")
+        out = self._run(drive=drive, sub=sub)
+        self.assertEqual(out.get("errors"), [])
+        html = out.get("html", "")
+        self.assertIn("peerbox", html, "the rows that passed still render")
+        self.assertIn("2 rows from TESTHOST had no usable host and were left out", html)
+        one = json.loads(json.dumps(sub)); one["dropped"] = 1; one["tunnels"] = []
+        html1 = self._run(drive=drive, sub=one).get("html", "")
+        self.assertIn("1 row from TESTHOST had no usable host and was left out", html1)
+        self.assertNotIn("has no hosts attached", html1, "a list emptied by the drop is not 'no hosts attached'")
+
+    def test_a_cut_completions_list_says_how_many_it_left_out(self):
+        # 600 remembered hosts + the attached one: 512 option values, then ONE disabled marker naming the rest
+        # (strip.ts fillHostSelect and the connect-from select wear the same marker)
+        tun = json.loads(json.dumps(TUNNELS))
+        tun["known"] = [{"host": "h%d" % i, "trust": "directed", "lastAttachedAt": 1} for i in range(600)]
+        out = self._run(tunnels=tun)
+        hosts = out.get("hosts", [])
+        self.assertEqual(len(hosts), 513)
+        self.assertEqual(hosts[-1], "\u2026 89 more not shown")
+        self.assertTrue(out.get("hostsLastDisabled"), "the marker is not a pickable host")
+        self.assertFalse(any("\u2026" in h for h in hosts[:-1]), "the marker is the only non-host entry")
+
+    def test_the_markup_sinks_no_longer_interpolate_a_peers_strings_raw(self):
+        js = km._LANDING_REMOTES_JS
+        self.assertIn("function esc(s)", js, "one escape helper, beside the panel's other one-liners")
+        # the rail icon's hover summary keeps a raw `(LBL[t.status]||t.status)`: that is a title PROPERTY (text)
+        for gone in ("'<b>'+t.host+'</b>'", "'<b>'+s.host+'</b>'", "'<b>'+k.host+'</b>'", "'<b>'+v.host+'</b>'",
+                     "'<b>'+hn+'</b>'", "(LBL[t.status]||t.status)+((t.status", "(LBL[t.status]||t.status)+'.'",
+                     "(LBL[s.status]||s.status)+sver", "dl.innerHTML=", "fromSel.innerHTML=", "t.token"):
+            self.assertNotIn(gone, js, "a raw peer string in a markup sink came back: %s" % gone)
+        self.assertEqual(js.count("document.createElement('option')"), 4,
+                         "the completions datalist and the connect-from select build option ELEMENTS — each its "
+                         "hosts plus the one disabled cut marker")
+        self.assertIn("t.hasToken", js, "the row reads the fact of a token, never the token")
+
+
+class PendingHostsRowCopy(_PanelHarness, unittest.TestCase):
     """The panel must not contradict a blank board (the user 2026-09-02): after a kernel restart or a
     phone re-foreground the panes can show no trace of an attached host for a while (their relay
     sockets are still (re)dialing, the first payload has not landed) while this panel's row, read off

--- a/tests/test_tunnels_via.py
+++ b/tests/test_tunnels_via.py
@@ -58,7 +58,8 @@ class TunnelsOf(_Stubbed):
         self.assertTrue(d["ok"])
         self.assertEqual(d["of"], "TESTHOST")
         self.assertEqual(d["tunnels"][0]["host"], "third")
-        self.assertEqual(d["tunnels"][0]["behindBy"], 2, "row fields pass through untouched")
+        self.assertEqual(d["tunnels"][0]["behindBy"], 2, "a well-formed row field passes through the whitelist")
+        self.assertNotIn("local", d, "only `tunnels` is relayed — the peer's other sections stay behind (2026-09-08)")
 
     def test_a_failed_read_carries_the_transport_error(self):
         km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}

--- a/ui/webview/federation-reconnect.test.ts
+++ b/ui/webview/federation-reconnect.test.ts
@@ -90,10 +90,11 @@ const localFeed = { type: "feed", asks: [], items: [], working: [], ledgers: [],
 
 test("a relay socket that opens and then goes silent past the bound is abandoned with a breadcrumb, and a fresh one dialed at once", async () => {
   await withManager((fm, _emitted, diag) => {
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     assert.equal(FakeWS.made.length, 1, "an up host is dialed at once");
     const ws = FakeWS.made[0];
-    assert.match(ws.url, /\/remote\/TESTHOST\/ws\?app=chat&token=tok/, "the dial goes through the local kernel's relay");
+    assert.match(ws.url, /\/remote\/TESTHOST\/ws\?app=chat/, "the dial goes through the local kernel's relay");
+    assert.doesNotMatch(ws.url, /token=/, "…which adds the remote's credential itself; the page never carries one (2026-09-08)");
     ws.open();
     clock += 10_000;
     fm.watchdog(clock);
@@ -127,7 +128,7 @@ test("a relay socket that opens and then goes silent past the bound is abandoned
 
 test("the foreground fast-path kills a socket still CONNECTING, whatever its age — the sleeping tab's unfinished handshake", async () => {
   await withManager((fm, _e, diag) => {
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const ws = FakeWS.made[0];              // never opens (readyState 0)
     clock += 1000;
     fm.watchdog(clock);
@@ -142,7 +143,7 @@ test("the foreground fast-path kills a socket still CONNECTING, whatever its age
 
 test("a CLOSED socket whose retry timer was lost is redialed directly (the throttled-tab case)", async () => {
   await withManager((fm) => {
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const conn = fm.conns.get("TESTHOST");
     conn.ws.readyState = 3;                 // closed under us with no onclose → no 2s timer armed
     clock += REMOTE_REDIAL_MS + 1000;
@@ -154,12 +155,12 @@ test("a CLOSED socket whose retry timer was lost is redialed directly (the throt
 
 test("a detached host is never touched by the watchdog, and a DOWN tunnel is never dialed by it", async () => {
   await withManager((fm) => {
-    fm.openRemote("TESTHOST", "tok", false);   // /tunnels says not up → no socket
+    fm.openRemote("TESTHOST", false);   // /tunnels says not up → no socket
     assert.equal(FakeWS.made.length, 0);
     clock += 999_999;
     fm.watchdog(clock);
     assert.equal(FakeWS.made.length, 0, "no dial against a tunnel the kernel calls down");
-    fm.openRemote("HOSTB", "tok", true);
+    fm.openRemote("HOSTB", true);
     fm.closeRemote("HOSTB");                  // detach → closed:true
     const n = FakeWS.made.length;
     clock += 999_999;
@@ -177,9 +178,9 @@ test("a detached host is never touched by the watchdog, and a DOWN tunnel is nev
 // foreground pass see fresh sockets and keep them. socketVerdict itself is unchanged.
 test("`resume` stamps every OPEN relay socket's lastRecv — and only the open ones", async () => {
   await withManager((fm) => {
-    fm.openRemote("TESTHOST", "tok", true);
-    fm.openRemote("HOSTB", "tok", true);
-    fm.openRemote("HOSTC", "tok", true);
+    fm.openRemote("TESTHOST", true);
+    fm.openRemote("HOSTB", true);
+    fm.openRemote("HOSTC", true);
     const [a, b, c] = FakeWS.made;
     a.open(); b.open();                                   // c never finishes its handshake (CONNECTING)
     clock += 45_000;                                      // frozen: no JS ran, so no frame was stamped
@@ -194,8 +195,8 @@ test("`resume` stamps every OPEN relay socket's lastRecv — and only the open o
 
 test("thaw: `resume` then the foreground watchdog pass closes NOTHING — and silence AFTER the resume still counts", async () => {
   await withManager((fm, _e, diag) => {
-    fm.openRemote("TESTHOST", "tok", true);
-    fm.openRemote("HOSTB", "tok", true);
+    fm.openRemote("TESTHOST", true);
+    fm.openRemote("HOSTB", true);
     const [a, b] = FakeWS.made;
     a.open(); b.open();
     clock += 45_000;                                      // well past REMOTE_STALE_MS with no frame
@@ -222,7 +223,7 @@ test("thaw: `resume` then the foreground watchdog pass closes NOTHING — and si
 
 test("no `resume` (a browser without Page Lifecycle, or a tab that was hidden but running): the stale verdict still closes on foreground", async () => {
   await withManager((fm, _e, diag) => {
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const ws = FakeWS.made[0];
     ws.open();
     clock += 45_000;                                      // 45s with no frame and no resume = real silence
@@ -238,7 +239,7 @@ test("no `resume` (a browser without Page Lifecycle, or a tab that was hidden bu
 
 test("a CONNECTING socket is still killed on foreground after a `resume` — the stamp never reaches an unfinished handshake", async () => {
   await withManager((fm, _e, diag) => {
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const ws = FakeWS.made[0];                            // never opens
     clock += 1000;
     fm.resumed(clock);
@@ -263,7 +264,7 @@ test("the document wiring: `resume` then `visibilitychange`→visible keeps an o
     fm.watchLifecycle(doc);
     assert.equal((listeners.resume || []).length, 1, "one resume listener");
     assert.equal((listeners.visibilitychange || []).length, 1, "one visibilitychange listener");
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const ws = FakeWS.made[0];
     ws.open();
     clock += 45_000;
@@ -298,8 +299,8 @@ test("a resumed keep is provisional: silence after the thaw is put down at REMOT
       fire(t: string) { for (const fn of listeners[t] || []) fn(); },
     };
     fm.watchLifecycle(doc);
-    fm.openRemote("TESTHOST", "tok", true);
-    fm.openRemote("HOSTB", "tok", true);
+    fm.openRemote("TESTHOST", true);
+    fm.openRemote("HOSTB", true);
     const [a, b] = FakeWS.made;
     a.open(); b.open();
     clock += 1000;
@@ -347,7 +348,7 @@ test("a socket already overdue before the freeze is not stamped by `resume`: the
       fire(t: string) { for (const fn of listeners[t] || []) fn(); },
     };
     fm.watchLifecycle(doc);
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     const ws = FakeWS.made[0];
     ws.open();
     const opened = clock;
@@ -390,7 +391,7 @@ test("mergeHostTimelines names attached hosts that have no lanes payload yet, an
 test("the merged lanes emission carries the pending set, so the timeline can draw its placeholder rows", async () => {
   await withManager((fm, emitted) => {
     fm.app = "timeline";
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     fm.inbound("", { type: "data", data: { sessions: [{ id: U, name: "web" }], turns: {}, messages: [], judging: [], now: 1000 } });
     const lanes = emitted.filter((m) => m.type === "data").pop();
     assert.deepEqual(lanes.data.pendingHosts, ["TESTHOST"]);
@@ -405,7 +406,7 @@ test("the merged lanes emission carries the pending set, so the timeline can dra
 test("each pane tells the shell which hosts IT still waits on — by its own channel, on change only", async () => {
   await withManager((fm, _e, _d, posted) => {
     fm.app = "feed";
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     fm.inbound("", localFeed);
     assert.deepEqual(posted.pop(), { romp: "hostsPending", app: "feed", hosts: ["TESTHOST"] },
       "the feed pane pends TESTHOST until its feed payload lands");
@@ -417,7 +418,7 @@ test("each pane tells the shell which hosts IT still waits on — by its own cha
   });
   await withManager((fm, _e, _d, posted) => {
     fm.app = "timeline";
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     fm.inbound("", { type: "data", data: { sessions: [], turns: {}, messages: [], judging: [], now: 1000 } });
     assert.deepEqual(posted.pop(), { romp: "hostsPending", app: "timeline", hosts: ["TESTHOST"] },
       "the timeline pends on the LANES channel, not the feed");
@@ -430,7 +431,7 @@ test("each pane tells the shell which hosts IT still waits on — by its own cha
 test("a host that ATTACHES is pending from that moment: the poll re-emits the merged payloads it can complete", async () => {
   const g: any = globalThis;
   const hadFetch = "fetch" in g, prevFetch = g.fetch;
-  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", token: "tok", localPort: 5, status: "up" }] }) });
+  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", hasToken: true, localPort: 5, status: "up" }] }) });
   try {
     await withManager(async (fm, emitted) => {
       fm.app = "feed";
@@ -450,7 +451,7 @@ test("a host that ATTACHES is pending from that moment: the poll re-emits the me
 test("…but never drops an EMPTY merged feed onto a page still waiting for its local kernel", async () => {
   const g: any = globalThis;
   const hadFetch = "fetch" in g, prevFetch = g.fetch;
-  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", token: "tok", localPort: 5, status: "up" }] }) });
+  g.fetch = async () => ({ json: async () => ({ tunnels: [{ host: "TESTHOST", hasToken: true, localPort: 5, status: "up" }] }) });
   try {
     await withManager(async (fm, emitted) => {
       fm.app = "feed";
@@ -466,7 +467,7 @@ test("…but never drops an EMPTY merged feed onto a page still waiting for its 
 test("the CHAT pane pends on the TAB LIST channel — the set its pin prune reads as __rompFed.pending (render.ts reachableHosts): an attached host pends from openRemote until its own tabOrder lands here, whatever else arrives; a detach retires it", async () => {
   await withManager((fm) => {
     fm.app = "chat";
-    fm.openRemote("TESTHOST", "tok", true);
+    fm.openRemote("TESTHOST", true);
     assert.deepEqual(fm.pendingFor(), ["TESTHOST"], "attached and dialed, no tab list from it yet");
     fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });
     assert.deepEqual(fm.pendingFor(), ["TESTHOST"], "the LOCAL list is not the remote's");
@@ -477,4 +478,34 @@ test("the CHAT pane pends on the TAB LIST channel — the set its pin prune read
     fm.closeRemote("TESTHOST");
     assert.deepEqual(fm.pendingFor(), [], "detached: in no list at all");
   });
+});
+
+// ── the page never holds, nor sends, a remote's credential (2026-09-08) ──────────────────────────────
+// /tunnels used to ship each remote's serve token to the page, and the dial URL carried it back — even
+// though the relay (_remote_ws) injects that token itself. The row now says only whether one exists.
+test("the poll dials the hosts that HAVE a token, and no dial URL carries a token — not even one a row still ships", async () => {
+  const g: any = globalThis;
+  const hadFetch = "fetch" in g, prevFetch = g.fetch;
+  const LEAKED = "remote-secret-DO-NOT-USE";
+  g.fetch = async () => ({ json: async () => ({ tunnels: [
+    { host: "TESTHOST", hasToken: true, localPort: 5, status: "up" },
+    { host: "HOSTB", hasToken: false, localPort: 6, status: "up" },          // no admin path to it: not dialed
+    { host: "HOSTC", hasToken: true, token: LEAKED, localPort: 7, status: "up" },   // an older kernel's row shape
+  ] }) });
+  try {
+    await withManager(async (fm) => {
+      fm.app = "feed";
+      await fm.poll();
+      assert.deepEqual([...fm.conns.keys()].sort(), ["HOSTC", "TESTHOST"], "hasToken gates the dial; HOSTB is left alone");
+      assert.equal(FakeWS.made.length, 2, "one socket per dialed host");
+      for (const ws of FakeWS.made) {
+        assert.match(ws.url, /\/remote\/(TESTHOST|HOSTC)\/ws\?app=feed/, "through the local kernel's relay");
+        assert.doesNotMatch(ws.url, /token=/, "the relay adds the remote's credential; the page sends none");
+        assert.ok(!ws.url.includes(LEAKED), "a token a row still carries never leaves the page");
+      }
+      for (const c of fm.conns.values()) c.closed = true;
+    });
+  } finally {
+    if (hadFetch) g.fetch = prevFetch; else delete g.fetch;
+  }
 });

--- a/ui/webview/federation-remote-gate.test.ts
+++ b/ui/webview/federation-remote-gate.test.ts
@@ -23,7 +23,7 @@ test("the /tunnels poll refreshes live from t.status and re-dials a closed conn 
   assert.match(FED, /c\.live = t\.status === "up";/);
   assert.match(FED, /if \(c\.live && \(!c\.ws \|\| c\.ws\.readyState === 3\)\) this\.connect\(c\);/);
   // openRemote seeds the flag from the same status so the first dial is gated too
-  assert.match(FED, /this\.openRemote\(host, t\.token, t\.status === "up"\)/);
+  assert.match(FED, /this\.openRemote\(host, t\.status === "up"\)/);
 });
 
 test("remotes are dialed through the kernel's /remote relay on the page origin, never a loopback port", () => {

--- a/ui/webview/federation-send-queue.test.ts
+++ b/ui/webview/federation-send-queue.test.ts
@@ -71,7 +71,7 @@ function withFed(fn: (fm: any, winEvents: any[], localSends: any[]) => void): vo
 
 /** Dial a remote host through the real openRemote/connect path; returns its (CONNECTING) socket. */
 function attach(fm: any, host: string): FakeSocket {
-  fm.openRemote(host, "token-" + host, true);
+  fm.openRemote(host, true);
   return fm.conns.get(host).ws as FakeSocket;
 }
 

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -1173,9 +1173,13 @@ export class FederationManager {
     } catch (e) {
       return;
     }
-    const want = new Map<string, any>(tunnels.filter((t) => t.token && t.localPort).map((t) => [t.host, t]));
+    // `hasToken`, never the token: the kernel publishes whether a remote's credential EXISTS, and the
+    // relay it dials through (/remote/<host>/ws, _remote_ws) injects that credential itself — so the
+    // page never holds a remote's reusable secret (2026-09-08). A row without one has no admin path
+    // to that kernel and is not dialed.
+    const want = new Map<string, any>(tunnels.filter((t) => t.hasToken && t.localPort).map((t) => [t.host, t]));
     let opened = false;
-    for (const [host, t] of want) if (!this.conns.has(host)) { this.openRemote(host, t.token, t.status === "up"); opened = true; }
+    for (const [host, t] of want) if (!this.conns.has(host)) { this.openRemote(host, t.status === "up"); opened = true; }
     for (const host of [...this.conns.keys()]) if (!want.has(host)) this.closeRemote(host);
     // A host just ATTACHED is pending from this moment, not from the next push that happens to land:
     // re-emit the merged payloads so the placeholders appear at the attach event. Each emission holds
@@ -1217,20 +1221,20 @@ export class FederationManager {
     if (changed) window.dispatchEvent(new Event("romp-hosts"));   // panes repaint their disconnected marks
   }
 
-  private openRemote(host: string, token: string, live: boolean): void {
+  private openRemote(host: string, live: boolean): void {
     // Dial the remote through THIS kernel's /remote/<host>/ws relay, on the same origin that served
     // the page — never at 127.0.0.1:<forwarded port>, which only exists on the kernel's machine:
     // from a phone reading the dashboard over `tailscale serve`, that address is the phone itself,
     // and every remote host silently vanished with no disconnected mark (the user 2026-07-30).
-    // Same-origin also means the local auth cookie rides the upgrade; the ?token (the remote
-    // kernel's credential, from /tunnels) is re-checked and rewritten by the relay either way.
+    // Same-origin also means the local auth cookie rides the upgrade; the remote kernel's own
+    // credential is added by the relay (_remote_ws), so this URL carries no token at all.
     const proto = location.protocol === "https:" ? "wss://" : "ws://";
     // …carrying this dashboard's `wid`, exactly as the pane's own local socket does. Without it a remote
     // kernel sees every federated viewer as one anonymous client and BROADCASTS its per-viewer messages,
     // so one dashboard's jump to a remote session yanked every other open dashboard to that tab — the
     // very cross-window yank the local path fixed (the user 2026-07-29).
     const w = dashboardWid();
-    const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`
+    const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}`
       + (w ? `&wid=${encodeURIComponent(w)}` : "");
     const conn: Conn = { host, ws: null, url, closed: false, live, lastRecv: 0, resumeProvisional: 0, connT: 0, pending: new Map() };
     this.conns.set(host, conn);

--- a/ui/webview/net-known-label.test.ts
+++ b/ui/webview/net-known-label.test.ts
@@ -26,7 +26,7 @@ test("web popover: a trust-only row is labeled, tooltipped, and buttoned as neve
   assert.match(KERNEL, /var kwas=!!k\.attached;/);
   // \uXXXX escapes in the inline JS are literally two backslashes in the file — hence \\\\
   assert.match(KERNEL, /trust remembered \\\\u00b7 never attached here/);
-  assert.match(KERNEL, /No tunnel to '\+k\.host\+' has ever been attached from this machine/);
+  assert.match(KERNEL, /No tunnel to '\+kh\+' has ever been attached from this machine/);
   assert.match(KERNEL, /\(kwas\?'Re-attach':'Attach'\)/);
   assert.match(KERNEL, /A row marked \\\\u201ctrust remembered\\\\u201d was never attached from this machine/,
     "the section header explains the mixed rows");

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -80,8 +80,8 @@ test("a down row says romp is still dialing, when next, and offers to try now", 
     assert.doesNotMatch(src, /no longer dialing it in the background/, `${name}: and its copy with it`);
   }
   assert.match(KERNEL, /next try in /, "the row counts down to the next dial");
-  assert.match(KERNEL, /romp keeps dialing '\+t\.host\+' on its own/, "and says it is unconditional");
-  assert.match(KERNEL, /data-ra=\\"'\+t\.host\+'\\" title=/, "the web row offers the re-dial action");
+  assert.match(KERNEL, /romp keeps dialing '\+th\+' on its own/, "and says it is unconditional");
+  assert.match(KERNEL, /data-ra=\\"'\+th\+'\\" title=/, "the web row offers the re-dial action");
   // per-state name (the user 2026-08-23): beside the countdown it reads as skip-the-wait (Try now);
   // on a no-kernel row there is no countdown and it sat beside Start as a lookalike — there it is
   // named for what it does (Re-dial). Same button, same action, one wording rule.
@@ -100,7 +100,7 @@ test("the check-in control is named for what it does, not for what it is not", (
   assert.doesNotMatch(KERNEL, /this attach auto-reconnects/);
   assert.doesNotMatch(KERNEL, /keep connected<\/label>/, "the misleading label is gone");
   assert.match(KERNEL, /Share my sessions there<\/label>/, "it says which way the sharing goes");
-  assert.match(KERNEL, /Publish this machine to '\+t\.host/, "and the tooltip leads with that");
+  assert.match(KERNEL, /Publish this machine to '\+th/, "and the tooltip leads with that");
 });
 
 test("the panel opens on the host list, with adding a host one click away", () => {

--- a/ui/webview/net-remote-controls.test.ts
+++ b/ui/webview/net-remote-controls.test.ts
@@ -42,9 +42,18 @@ test("web popover: rows expand into that machine's connections, fetched on deman
     "the block renders under the host's own row");
   // loading and a failed read SAY so, with Retry — never a silent blank (the inline JS lives in a
   // Python string, so its \uXXXX escapes are literally TWO backslashes in the file — hence \\\\)
-  assert.match(KERNEL, /Reading '\+via\+'\\\\u2019s connections/);
-  assert.match(KERNEL, /Couldn\\\\u2019t read '\+via\+'\\\\u2019s connections/);
+  // `ev` is esc(via): the note names a host as TEXT (2026-09-08)
+  assert.match(KERNEL, /Reading '\+ev\+'\\\\u2019s connections/);
+  assert.match(KERNEL, /Couldn\\\\u2019t read '\+ev\+'\\\\u2019s connections/);
   assert.match(KERNEL, /data-xr=/);
+  // rows the kernel's whitelist left out of the peer's answer (`dropped`) are SAID beneath the rows that
+  // passed, in the same sentence in both copies (2026-09-08, review find: a silently shorter list)
+  assert.match(KERNEL, /var drop=\(typeof d\.dropped==='number'&&d\.dropped>0\)\?Math\.floor\(d\.dropped\):0;/);
+  assert.match(KERNEL, /if\(!rows\.length&&!drop\)/, "a list emptied by the drop is not 'no hosts attached'");
+  assert.match(KERNEL, / had no usable host and '\+\(drop===1\?'was':'were'\)\+' left out'/);
+  assert.match(STRIP, /export function droppedRowsNote\(via: string, dropped: unknown\): string/);
+  assert.match(STRIP, / had no usable host and \$\{n === 1 \? "was" : "were"\} left out/);
+  assert.match(STRIP, /const note = droppedRowsNote\(via, d\.dropped\);/);
 });
 
 test("web popover: sub-row actions ride the normal routes with {via}, refusals alert loudly", () => {

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { usageColor, fmtAgo, fmtReset, fmtUsd, fmtTok, usageWindows, apiCell, STRIP_PANES } from "./strip";
+import { usageColor, fmtAgo, fmtReset, fmtUsd, fmtTok, usageWindows, apiCell, STRIP_PANES, fillHostSelect, droppedRowsNote } from "./strip";
 
 test("fmtTok: 3 significant figures at every magnitude (the user 2026-08-13)", () => {
   assert.equal(fmtTok(1_318_619_909), "1.32B");
@@ -233,4 +233,84 @@ test("an unknown window is not drawn on the bar at all — its last-known lives 
   assert.doesNotMatch(src, /ru-qmark/, "the '?' slot is gone");
   assert.doesNotMatch(css, /ru-qmark/);
   assert.doesNotMatch(css, /\.ru-w\.ru-unk \.ru-fill \{ opacity: 0\.3; \}/, "the faded fill stays gone");
+});
+
+// ── the attach box's host list is built from ELEMENTS, never markup (2026-09-08) ─────────────────────
+// An ssh alias is whatever ~/.ssh/config says. loadHosts used to render `<option value="${h}">${h}</option>`
+// through innerHTML, so an alias that closed the attribute carried a handler into the popover. Executed
+// against a minimal element stand-in whose innerHTML setter THROWS, so the only way to pass is to set
+// value/textContent on option elements.
+class FakeEl {
+  tagName: string;
+  value = "";
+  children: FakeEl[] = [];
+  attrs: Record<string, string> = {};
+  private _text = "";
+  constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  get textContent(): string { return this._text; }
+  set textContent(v: string) { this._text = v; this.children = []; }   // the DOM's: assigning text drops children
+  set innerHTML(_v: string) { throw new Error("innerHTML is not how host options are built"); }
+  appendChild(c: FakeEl): FakeEl { this.children.push(c); return c; }
+  setAttribute(k: string, v: string): void { this.attrs[k] = v; }
+}
+function withDocument(fn: () => void): void {
+  const g: any = globalThis;
+  const had = "document" in g, prev = g.document;
+  g.document = { createElement: (t: string) => new FakeEl(t) };
+  try { fn(); } finally { if (had) g.document = prev; else delete g.document; }
+}
+
+test("fillHostSelect: a crafted alias is an option's VALUE and TEXT, never markup; non-strings are dropped", () => {
+  withDocument(() => {
+    const sel: any = new FakeEl("select");
+    const hostile = ['x"onmouseover="alert(1)', "<img src=x onerror=alert(1)>"];
+    fillHostSelect(sel, [...hostile, 42, "", null], "(none)");
+    assert.equal(sel.children.length, 2, "the two strings; the number, the empty string and the null are dropped");
+    assert.deepEqual(sel.children.map((o: any) => o.tagName), ["OPTION", "OPTION"]);
+    assert.deepEqual(sel.children.map((o: any) => o.value), hostile, "the value IS the string, character for character");
+    assert.deepEqual(sel.children.map((o: any) => o.textContent), hostile, "…and so is the label");
+    for (const o of sel.children) assert.deepEqual(o.attrs, {}, "nothing went through the attribute/markup path");
+  });
+});
+
+test("fillHostSelect: an empty or malformed list still says why, and the list is capped", () => {
+  withDocument(() => {
+    const sel: any = new FakeEl("select");
+    fillHostSelect(sel, [], "(kernel unreachable)");
+    assert.equal(sel.children.length, 1);
+    assert.equal(sel.children[0].value, "");
+    assert.equal(sel.children[0].textContent, "(kernel unreachable)", "loud, never silently empty");
+    fillHostSelect(sel, "not-a-list", "(no ~/.ssh/config hosts)");
+    assert.equal(sel.children.length, 1, "a previous fill is replaced, not appended to");
+    assert.equal(sel.children[0].textContent, "(no ~/.ssh/config hosts)");
+    fillHostSelect(sel, Array.from({ length: 600 }, (_, i) => "h" + i), "x");
+    assert.equal(sel.children.length, 513, "512 real options, then ONE marker for the rest");
+    assert.deepEqual(sel.children.slice(0, 512).map((o: any) => o.value), Array.from({ length: 512 }, (_, i) => "h" + i));
+    const marker = sel.children[512];
+    assert.equal(marker.textContent, "… 88 more not shown", "a cut list says how much it left out, never silently");
+    assert.equal(marker.disabled, true, "…and the marker is not a pickable host");
+    assert.ok(sel.children.slice(0, 512).every((o: any) => !o.disabled));
+    fillHostSelect(sel, Array.from({ length: 512 }, (_, i) => "h" + i), "x");
+    assert.equal(sel.children.length, 512, "exactly at the cap: no marker");
+  });
+});
+
+test("droppedRowsNote: the sub-panel names the peer rows the kernel left out, in one sentence both panels share", () => {
+  assert.equal(droppedRowsNote("TESTHOST", 2), "2 rows from TESTHOST had no usable host and were left out");
+  assert.equal(droppedRowsNote("TESTHOST", 1), "1 row from TESTHOST had no usable host and was left out");
+  for (const none of [0, -1, "2", undefined, null, NaN]) assert.equal(droppedRowsNote("TESTHOST", none), "", `${String(none)} is not a count`);
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  const sub = src.slice(src.indexOf("function renderSub(via: string)"), src.indexOf("function subRow(via: string"));
+  assert.match(sub, /const note = droppedRowsNote\(via, d\.dropped\);/, "renderSub reads the kernel's count");
+  assert.match(sub, /if \(!rows\.length && !note\)/, "a list emptied by the drop is not 'no hosts attached'");
+  assert.match(sub, /e\.textContent = note;/, "…and the note is rendered as text beneath the rows");
+});
+
+test("loadHosts routes both outcomes through fillHostSelect — no innerHTML host rendering remains in strip.ts", () => {
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  assert.match(src, /fillHostSelect\(sel, d && d\.hosts, "\(no ~\/\.ssh\/config hosts\)"\)/);
+  assert.match(src, /fillHostSelect\(sel, \[\], "\(kernel unreachable\)"\)/);
+  assert.doesNotMatch(src, /<option value="\$\{h\}">/, "the template that rendered an alias as markup");
 });

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -352,6 +352,37 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     .catch(() => { /* the live pushes fill it in */ });
 }
 
+// The attach box's host list, as <option> ELEMENTS: value and text set as properties, never as markup.
+// An alias is whatever ~/.ssh/config says, and the old innerHTML template (an option tag with the alias
+// interpolated into its value attribute) let a crafted one close the attribute and add a handler (2026-09-08). Non-strings are dropped, the list is capped, and an
+// empty list still names why (loud, never silently empty). Exported so the shape is testable on its own;
+// the web shell's datalist twin (_LANDING_REMOTES_JS fillHosts) builds its options the same way.
+export function fillHostSelect(sel: HTMLSelectElement, hosts: unknown, empty: string): void {
+  sel.textContent = "";
+  const all = (Array.isArray(hosts) ? hosts : []).filter((h): h is string => typeof h === "string" && h.length > 0);
+  const hs = all.slice(0, 512);
+  for (const h of hs.length ? hs : [""]) {
+    const o = document.createElement("option");
+    o.value = h;
+    o.textContent = h || empty;
+    sel.appendChild(o);
+  }
+  if (all.length > hs.length) {                    // a cut list says so, never silently (the kernel's fillHosts wears the same marker)
+    const o = document.createElement("option");
+    o.value = o.textContent = `… ${all.length - hs.length} more not shown`;
+    o.disabled = true;
+    sel.appendChild(o);
+  }
+}
+
+// The sub-panel's note for rows the kernel's whitelist left out of a peer's /tunnels/of answer (a row whose
+// host ssh would not accept): one sentence, worn by BOTH panels — the web shell's subBlock carries the same
+// words (net-remote-controls.test.ts pins both). "" when nothing was left out, or the count is not a count.
+export function droppedRowsNote(via: string, dropped: unknown): string {
+  const n = typeof dropped === "number" && dropped > 0 ? Math.floor(dropped) : 0;
+  return n ? `${n} row${n === 1 ? "" : "s"} from ${via} had no usable host and ${n === 1 ? "was" : "were"} left out` : "";
+}
+
 // The remote-kernels popover — the strip twin of the web shell's rail-net
 // popover (_LANDING_REMOTES_JS in bin/romp-kernel): same kernel endpoints
 // (/ssh-hosts, /tunnels, /tunnels/detach|update|start), leaner chrome. The two
@@ -430,12 +461,9 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
   const busy = (s: string) => s !== "up" && s !== "down" && s !== "error" && s !== "no-kernel";
 
   function loadHosts() {
-    fetch(kernelUrl("/ssh-hosts"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
-      const hs: string[] = (d && d.hosts) || [];
-      sel.innerHTML = hs.length
-        ? hs.map((h) => `<option value="${h}">${h}</option>`).join("")
-        : `<option value="">(no ~/.ssh/config hosts)</option>`;
-    }).catch(() => { sel.innerHTML = `<option value="">(kernel unreachable)</option>`; });   // loud, never silently empty
+    fetch(kernelUrl("/ssh-hosts"), { cache: "no-store" }).then((r) => r.json())
+      .then((d) => { fillHostSelect(sel, d && d.hosts, "(no ~/.ssh/config hosts)"); })
+      .catch(() => { fillHostSelect(sel, [], "(kernel unreachable)"); });   // loud, never silently empty
   }
 
   function act(path: string, host: string, b: HTMLButtonElement, busyText: string, via?: string) {
@@ -865,7 +893,8 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       return;
     }
     const rows = d.tunnels || [];
-    if (!rows.length) {
+    const note = droppedRowsNote(via, d.dropped);
+    if (!rows.length && !note) {
       const e = document.createElement("div");
       e.className = "sn-sub sn-empty";
       e.textContent = `${via} has no hosts attached.`;
@@ -873,6 +902,12 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       return;
     }
     for (const s of rows) subRow(via, s);
+    if (note) {                                    // said beneath the rows that passed, never a silently shorter list
+      const e = document.createElement("div");
+      e.className = "sn-sub sn-empty";
+      e.textContent = note;
+      list.appendChild(e);
+    }
   }
 
   function subRow(via: string, s: any) {


### PR DESCRIPTION
Two untrusted-string sinks on the same two surfaces, the landing page's remotes panel (script inside the kernel) and the strip and federation TypeScript, plus a credential the page never needed. Verified on `main`:

- **A peer's payload passed straight through.** `tunnels_of` returned a peer kernel's `/tunnels` JSON verbatim, with no schema, whitelist or bound; `_poll_remote_version` persisted whatever sha and version a peer reported; and the landing page built its remote rows with `innerHTML` from peer-supplied strings: host, status, version, sha, and more (known rows, relay rows, pair rows, holds, the tier text, error texts). A peer, or anyone who could answer as one, could put markup on every attached dashboard. `checkin_apply` records a checked-in peer's self-declared host unchecked, so the main-row escape is load-bearing.
- **The page received a remote's reusable token.** `_remote_public` shipped each remote's credential to page script, and `federation.ts` put it in the relay URL, although the relay already injects the stored credential server-side.
- **ssh aliases rendered as markup.** The strip's host picker built `<option>` tags by string interpolation from `GET /ssh-hosts`, and the kernel-served panel's datalist and connect-from select did the same. A datalist parses in body mode, so an `<img onerror>` in an alias would run.

## What changes

**Peer payloads are whitelisted per field.** `_remote_payload_public_row` admits exactly the keys `_remote_public` publishes: the host through `_safe_ssh_host` (a row whose host fails is dropped and counted), the status from the eight words the kernel writes, sha and version through regexes that mirror what `_kernel_sha` and `_kernel_ver` emit (a `-dirty` suffix included, as `_sha_base` already accepts), booleans as exact booleans, text bounded to 200 characters, nested `autoPush` and `settings` bounded field by field. `tunnels_of` returns at most 128 whitelisted rows from at most 4096 scanned, says how many rows were left out, both in the sub-panel note and once on stderr, and answers a loud `ok: false` for a non-list. `_poll_remote_version` complains once per host and field about a malformed sha or version and keeps the last good value instead of storing the bad one.

**The page never sees a remote's token.** `_remote_public` publishes `hasToken` instead; `federation.ts` filters on it and dials without a token; the relay drops any token the browser sent and injects the stored one, unconditionally. No shipped flow ever carried a browser-supplied remote token: the only dial site is `openRemote`, tokens enter a row only over ssh or through the peer's own check-in, and the relay forwards no cookie, so a token-less row never worked from the page.

**Peer strings render as text.** An `esc()` helper covers every interpolation in the landing page's remote rows; the datalist, the connect-from select and the strip's host picker build option elements, strings only, capped at 512 with a disabled marker naming how many were left out.

## Judgment calls

- Escaping at each interpolation rather than rebuilding the row builders with `createElement`: the builders are a hundred lines with thirty-odd attributes, pinned by eleven test modules; the executed panel harness records every `innerHTML` assignment, so a missed interpolation fails a test.
- The `/ssh-hosts` producer is left alone: the file is the user's own; the sinks are fixed.
- `checkin_apply` recording an unchecked self-declared host is flagged as a follow-up, not changed here.

## Tests

`tests/test_peer_payloads_as_text.py` drives the real `tunnels_of`, `_remote_public`, `list_remotes` and `_poll_remote_version` against a fake peer answering hostile JSON: markup in every string field, an oversize detail, hundreds of rows, unknown keys, a non-list; the serialized payload the page receives never contains the peer's secret; a `-dirty` sha is kept. `tests/test_remotes_panel_render.py` executes the landing script under a DOM stand-in that records every `innerHTML` assignment and reads option values. `tests/test_kernel_remote_ws_proxy.py` drives the relay splice: a browser token never reaches the far side, the stored one always does. `ui/webview/strip.test.ts` and the federation tests cover the host picker and the token-free dial. Mutants (the token passed through, the whitelist keeping unknown keys, the caps removed, the sha regex loosened, `esc()` returning its input or missing the quote, the datalist back on `innerHTML`, the token drop removed) each fail a test.

Module counts on this tree, one runner at a time: `tests/test_peer_payloads_as_text.py` 15 (21 subtests); `tests/test_remotes_panel_render.py` 36; `tests/test_kernel_remote_ws_proxy.py` 7; `tests/test_tunnels_via.py` 11; `tests/test_per_viewer_focus.py` 15; `tests/test_kernel_remote_update.py` 61; `tests/test_auto_nudge_every_kernel.py` 6 (9 subtests); `tests/test_fleet_sync_log.py` 31; the ten touched TypeScript test files 111 of 111. On `main` the new module fails 21 of 24 (12 tests and 9 subtests), the panel harness 7 of 36, and the relay module 1 of 7 (a browser-supplied token reaching the far side). Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
