### PR TITLE
Codex backoff test releases the backoff on the worker's park, not after a sleep

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -248,6 +248,9 @@ class _Session:
         self.norm = None              # ThreadNormalizer, built by the worker on first need
         self.worker = None
         self.kick = threading.Event() # wake the worker (new send / resume / shutdown)
+        self.parked = threading.Event()  # the worker is inside its backoff wait: a kick from now on wakes it
+                                         # (set just before the wait, cleared after; tests wait on this
+                                         # before releasing a backoff, instead of racing the worker to it)
         self.change_generation = 0    # explicit send/model/effort/resume changes that may fix a rejection
         self.turn_rejection = None    # rejected request generations; parked until either one changes
         self.note = ""                # postal working-note
@@ -1272,7 +1275,11 @@ class CodexBackend:
                     with s.lock:
                         if s.dead:
                             return
+                    # parked is set only once the clear above is behind us, so a kick that arrives
+                    # after a reader saw it can no longer be discarded before the wait sees it
+                    s.parked.set()
                     s.kick.wait(delay)
+                    s.parked.clear()
                     s.kick.clear()
         finally:
             with s.lock:

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -653,21 +653,27 @@ class Lifecycle(unittest.TestCase):
         # gate, twice on the same runner): the real 0.25s floor raced the main thread — a
         # descheduled runner let the LEGITIMATE 250ms retry fire before the assertion ran,
         # and the test read its own backoff expiring as a hot spin. With the floor pinned
-        # high, a second attempt inside the observation window can only be a real hot spin;
-        # the recovery phase then releases the backoff EXPLICITLY instead of racing a timer.
+        # high, a second attempt before the worker parks can only be a real hot spin.
         saved_floor = cb.CLIENT_RETRY_MIN
         cb.CLIENT_RETRY_MIN = 30.0
         self.addCleanup(setattr, cb, "CLIENT_RETRY_MIN", saved_floor)
         be, _, _ = build(factory=flaky_factory)
         sid = be.spawn("web", "/TESTDIR")
+        s = dict(be._session_items())[sid]
         self.assertTrue(be.send(sid, "retry me"))
         self.assertTrue(until(lambda: len(attempts) == 1), "the first attempt fires")
-        time.sleep(0.05)
-        self.assertEqual(len(attempts), 1, "unavailable client must not hot-spin")
+        # Release the backoff only once the worker is PARKED in it (s.parked, set right before its
+        # wait). The worker clears stale kicks just before parking, so a release kicked earlier —
+        # after a fixed sleep, as this test did — was discarded whenever the runner descheduled the
+        # worker between the failed attempt and that clear (its registry save and push sit there),
+        # and the worker slept the whole floor while the assertion below timed out (pulls 1026 and
+        # 991, 2026-09-08; reproduced by slowing that stretch). Waiting on the park makes the release
+        # an event the worker cannot miss, whatever the runner's speed.
+        self.assertTrue(until(lambda: s.parked.is_set(), timeout=20), "the worker parks in its backoff")
+        self.assertEqual(len(attempts), 1, "unavailable client must not hot-spin before parking")
         with be._client_lock:
             be._client_retry_at = 0.0                  # the explicit release, not a timer race
-        for _, s in be._session_items():
-            s.kick.set()
+        s.kick.set()
         # a GENEROUS bound: the recovery is event-shaped (the explicit release above is
         # the event), so only "eventually" matters — the 3s bound starved the worker
         # thread on a runner at load 20+ (the r63 release gate: a 55-minute full suite)


### PR DESCRIPTION
## The flake
`tests/test_codex_backend.py::Lifecycle::test_client_factory_failure_backs_off_then_recovers_queued_session` failed twice tonight on unrelated PRs (pulls 1026 and 991), green on rerun. The test pinned the backoff floor at 30 s, slept 50 ms after the first failed attempt, then released the backoff by zeroing the retry deadline and kicking the worker. But the worker clears stale kicks just before it parks in its wait, and between the failed attempt and that clear sit a registry save and a push: a runner that descheduled the worker there for longer than the sleep discarded the release kick, the worker slept the whole 30 s floor, and the 20 s recovery bound expired.

**Reproduced** by slowing that stretch by 400 ms in a scratch harness: the test times out at 20 s every time. It passes with the fix under the same slowdown.

## The fix
The session gains a `parked` event, set right after the pre-backoff clear and just before the wait, cleared after it: a behaviour-preserving seam in `kernel/codex_backend.py` that says "a kick from now on cannot be discarded". The test waits for the park, asserts exactly one attempt happened before it (the no-hot-spin check, now at an event instead of after a sleep), then releases. No dependence on runner speed remains; the recovery bound stays generous because the condition is event-shaped and only "eventually" matters.

## Evidence
- The file: 50 consecutive runs, 0 failures.
- The test: 60 runs under eight busy loops on an 8-core box, 0 failures.
- The state-isolation meta-test passes.

Tier: tests-only (the only production change is the seam, an event set and cleared around an existing wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)