### PR TITLE
Key cross-host waits and held mail by the recipient's stable id

### DIFF
--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -284,6 +284,13 @@ triggers).
 not a session); the recipient's stable id rides the additive `to_sid` key (rows since
 2026-09-08), with `toName` = `<host>:<name>` for display. peer = null only when the id
 isn't in the log (legacy/rare).
+Two rules the wait readers apply to these rows: only a `question` or a `delegate` opens
+a wait, so the answered clock walks reply-requiring sends and a coordinate-only exchange
+neither opens nor reopens one (a reply of any kind still answers). A row without
+`to_sid` keys by whoever wore the name AT the row's send time, so a pre-2026-09-08 ask
+to a recreated same-named peer whose first sighting here is its own reply stays keyed
+to the prior wearer and reads open until the 6h wake: a known residual, legacy rows
+only, since new rows carry the id.
 The postal log is the authoritative sender-identity source (the same contract
 postal-spec.ts relies on), so identity needs no inline `from=` marker. Never key on
 the `"Stop hook feedback"` prefix: it is Claude Code's generic wrapper around any

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -280,7 +280,10 @@ triggers).
 **Postal detection.** A user atom is postal when it carries the
 `<!-- romp-msg-id: <id> -->` marker. Fill the peer ROMP UUID by joining that id to
 `timeline/messages.jsonl`: the `sent` row's `from_id` is the sender's anchor sid,
-`to_id` the recipient. peer = null only when the id isn't in the log (legacy/rare).
+`to_id` the recipient. A cross-host relay row's `to_id` is `peer:<host>` (the relay,
+not a session); the recipient's stable id rides the additive `to_sid` key (rows since
+2026-09-08), with `toName` = `<host>:<name>` for display. peer = null only when the id
+isn't in the log (legacy/rare).
 The postal log is the authoritative sender-identity source (the same contract
 postal-spec.ts relies on), so identity needs no inline `from=` marker. Never key on
 the `"Stop hook feedback"` prefix: it is Claude Code's generic wrapper around any

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13174,13 +13174,17 @@ def _handoff_backref(mid):
     return "", ""
 
 
-def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tracked=False):
+def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tracked=False, to_sid=None):
     """Mint a precise '↪ delegated to <peer>' TRACKING node in the SENDER's own tree (the user 2026-06-22):
     the exact item B's completion checks off, so a PARTIAL handoff doesn't over-complete the sender's broader
     goal. Filed under the courier's linked goal (parent_id) if any, else top-level. Carries handoff:{peer,
     msgId} both as the run_propagate target and so the feed can badge it; a TRACKED report-back delegation
     (the user 2026-08-24) adds handoff.tracked — this node's card is the pair's PRIMARY, and the recipient's
-    planted goal is marked its satellite. Idempotent by msgId. Returns its id."""
+    planted goal is marked its satellite. `to_sid` (review find, 2026-09-08) is the recipient's STABLE id
+    when the sent row carried one (a cross-host relay row's `to_sid`): it rides as handoff.toSid beside the
+    display identity in handoff.peer ("<host>:<name>"), so run_propagate's remote arm keys the report-back
+    on the exact sid the send resolved, the same key the kernel's wait maps use for that row, instead of
+    re-deriving it from the name. Idempotent by msgId. Returns its id."""
     nodes = store["nodes"]
     for nid, nd in nodes.items():
         h = nd.get("handoff")
@@ -13188,6 +13192,9 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
             if tracked and not h.get("tracked"):
                 h["tracked"] = True                     # a replant that learned the flag (a crash between
                 #                                         the two store saves) upgrades in place; never down
+            if to_sid and not h.get("toSid"):
+                h["toSid"] = str(to_sid)                # same in-place upgrade for the exact key: a tracker
+                #                                         planted before the row's to_sid was read learns it
             return nid                                  # already planted for this message → idempotent
     if parent_id is not None and parent_id not in nodes:
         parent_id = None                                # linked goal vanished → file as a top, never orphan
@@ -13214,6 +13221,8 @@ def _plant_handoff_track(store, parent_id, text, peer_sid, peer_name, t, mid, tr
             #                                            fan-out contract, test_chain_rooted_minting)
     if tracked:
         handoff["tracked"] = True
+    if to_sid:
+        handoff["toSid"] = str(to_sid)
     nodes[nid] = GuardedNode({"id": nid, "text": label[:120], "parentId": parent_id,
                   "nodeComplete": False, "blocked": False, "cleared": False,
                   "trail": [], "t": t, "mt": t, "handoff": handoff, "log": []})
@@ -13601,9 +13610,13 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     # Granularity is per-PEER, not per-message — the log carries no reply→delegate join, so one
     # reply completes every outstanding cross-host handoff to that peer sent at/before it; coarse,
     # but forward-only and honest, where the alternative was a wait no event could ever end. Keys
-    # re-derive from the stored toName exactly as the wait maps do: the alias the name resolved to
-    # AT the handoff's send time when the peer has spoken (it must have, to reply), else the raw
-    # relay key — anchored so a name a later session reused cannot make that stranger's mail the
+    # derive exactly as the wait maps derive them for the same row (review find, 2026-09-08: the
+    # arm re-derived by name alone while the kernel's maps read the row's to_sid, so a handoff to a
+    # recreated same-named peer whose first mail here was its report-back lifted the stamp and
+    # left the tracker open forever): the row's own stable id when the plant carried it
+    # (handoff.toSid), else, a legacy row, the alias the stored toName resolved to AT the
+    # handoff's send time when the peer has spoken (it must have, to reply), else the raw relay
+    # key. Anchored so a name a later session reused cannot make that stranger's mail the
     # report-back (2026-09-08).
     last_any, _la, alias = _postal_ask_maps()
     _rmemo = {}                                        # recipient sid -> merged nodes (per-pass, read-only)
@@ -13681,9 +13694,12 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                 reply = last_any.get((pk, fsid), 0)
             else:
                 keys = {"peer:" + pk}
-                asid = _alias_at(alias, pk, nd.get("t") or 0)
-                if asid:
-                    keys.add(asid)
+                if h.get("toSid"):
+                    keys.add(str(h["toSid"]))          # the sid the send resolved: exact, rename-proof
+                else:
+                    asid = _alias_at(alias, pk, nd.get("t") or 0)   # legacy plant: the wearer at send time
+                    if asid:
+                        keys.add(asid)
                 reply = max((last_any.get((k, fsid), 0) for k in keys), default=0)
             if reply and reply >= (nd.get("t") or 0):
                 why = (("reported back by %s (delegated; the recipient's card was dismissed)" % pk[:8])
@@ -13772,7 +13788,9 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     # judge, and the send ack already told the sender "they own it now". Declared-only on purpose:
     # a kindless legacy row is indistinguishable from a coordinate, and planting from a guess mints
     # noise. handoff.peer stores toName ("<host>:<name>") — the identity every display resolves
-    # (the quiet host: prefix) and the key run_propagate's remote arm re-derives pair keys from.
+    # (the quiet host: prefix) and the key run_propagate's remote arm re-derives pair keys from
+    # for a row without to_sid; a row that carries to_sid (relay rows since 2026-09-08) also
+    # plants it as handoff.toSid, the exact key that arm reads first (review find, 2026-09-08).
     # `tracked` never rides here: the relay drops the flag by design (a primary/satellite pair
     # cannot span kernels yet). Horizon-bounded like every courier retry, so old history is never
     # backfilled; idempotent by msgId, so one plant per message ever.
@@ -13802,7 +13820,8 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                for nd in sstore["nodes"].values()):
             continue
         head = " ".join(str(o.get("body") or "").split())[:120]
-        _plant_handoff_track(sstore, None, head, str(o["toName"]), str(o["toName"]), int(o["t"]), o["id"])
+        _plant_handoff_track(sstore, None, head, str(o["toName"]), str(o["toName"]), int(o["t"]), o["id"],
+                             to_sid=(str(o["to_sid"]) if o.get("to_sid") else None))   # the row's exact key rides along (review find, 2026-09-08)
         rollup_status(sstore, False)
         save_goals(o["from_id"], sstore)
         placed += 1

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9457,7 +9457,61 @@ _PEER_ASK_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)   # legacy pre-`kin
 _PEER_ASK_CACHE = [None, ({}, {}, {})]   # (mtime_ns, size) , (last_any, last_ask, alias) — one scan per log change
 
 
+def _learn_alias(alias, o):
+    """Record one name→sid sighting from a row a REMOTE sender stamped: alias["<host>:<name>"] is the
+    time-ordered history [(t, sid), …] of who wore that name on that host (see _alias_at)."""
+    if o.get("from_host") and o.get("from") and o.get("from_id"):
+        try:
+            at = int(o.get("t") or 0)
+        except (TypeError, ValueError):
+            at = 0
+        alias.setdefault(str(o["from_host"]) + ":" + str(o["from"]), []).append((at, str(o["from_id"])))
+
+
+def _alias_settle(alias):
+    """Order each name's sightings by t and collapse CONSECUTIVE sightings of one sid into one entry, so
+    the history is per WEARER CHANGE, not per row (a chatty peer name otherwise carries thousands of
+    identical sightings that _alias_at walks for every legacy row). Result-identical: the sid in force
+    at any t is unchanged. Call once after the scan, before any _alias_at."""
+    for key, hist in alias.items():
+        hist.sort(key=lambda e: e[0])
+        kept = []
+        for e in hist:
+            if not kept or kept[-1][1] != e[1]:
+                kept.append(e)
+        alias[key] = kept
+
+
+def _alias_at(alias, key, t):
+    """The sid the cross-host name `key` ("<host>:<name>") resolved to AT time t: the most recent
+    sighting at or before t, else the earliest known (a message sent before the peer first spoke
+    still went to the session that then answered). None when the name was never seen. The map used
+    to be last-write-wins over the whole log (2026-09-08), so a name a NEW session reused re-keyed
+    every OLD message to the new sid: an answered question read unanswered (its reply sits under the
+    old sid), a stamp awaiting the old sid could never see its answer, and a stranger's coordinate
+    counted as the reply. Anchoring each row at its own send time keeps it keyed to the session it
+    really went to. `alias` must have been through _alias_settle (sorted, one entry per wearer change)."""
+    hist = alias.get(key)
+    if not hist:
+        return None
+    sid = hist[0][1]
+    for at, s in hist:
+        if at <= t:
+            sid = s
+        else:
+            break
+    return sid
+
+
 def _postal_ask_maps():
+    """(last_any, last_ask, alias) from the postal log, cached on (mtime, size). Per ordered pair
+    (from_id, to_id): last_any the latest t of ANY message, last_ask the latest t of a reply-expecting
+    ask (kind=question; a kindless legacy row by its QUESTION/ASK lead word).
+    A cross-host row (to_id "peer:<host>") keys on the recipient's STABLE id: `to_sid` when the row
+    carries it (relay rows since 2026-09-08), else the name alias AT the row's send time (_alias_at),
+    else the raw "peer:<host>:<name>". `alias` is the time-ordered name→sid history the re-key used;
+    consumers resolve a name through _alias_at with the time of the message they hold, never by a
+    bare lookup."""
     try:
         st = MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
@@ -9473,15 +9527,18 @@ def _postal_ask_maps():
             except Exception:
                 continue
             rows.append(o)
-            if o.get("from_host") and o.get("from") and o.get("from_id"):
-                alias[str(o["from_host"]) + ":" + str(o["from"])] = str(o["from_id"])
+            _learn_alias(alias, o)
+        _alias_settle(alias)
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
                 continue
-            if isinstance(t_, str) and t_.startswith("peer:") and o.get("toName"):
-                t_ = alias.get(str(o["toName"]), "peer:" + str(o["toName"]))
             ts = int(ts)
+            if isinstance(t_, str) and t_.startswith("peer:"):
+                if o.get("to_sid"):
+                    t_ = str(o["to_sid"])                # the id the send resolved — exact, rename-proof
+                elif o.get("toName"):
+                    t_ = _alias_at(alias, str(o["toName"]), ts) or "peer:" + str(o["toName"])
             last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             k = o.get("kind")
             is_ask = (k == "question") if k else bool(_PEER_ASK_RE.match(o.get("body") or ""))
@@ -13544,8 +13601,10 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     # Granularity is per-PEER, not per-message — the log carries no reply→delegate join, so one
     # reply completes every outstanding cross-host handoff to that peer sent at/before it; coarse,
     # but forward-only and honest, where the alternative was a wait no event could ever end. Keys
-    # re-derive from the stored toName exactly as the wait maps do: the alias when the peer has
-    # spoken (it must have, to reply), else the raw relay key.
+    # re-derive from the stored toName exactly as the wait maps do: the alias the name resolved to
+    # AT the handoff's send time when the peer has spoken (it must have, to reply), else the raw
+    # relay key — anchored so a name a later session reused cannot make that stranger's mail the
+    # report-back (2026-09-08).
     last_any, _la, alias = _postal_ask_maps()
     _rmemo = {}                                        # recipient sid -> merged nodes (per-pass, read-only)
 
@@ -13622,8 +13681,9 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                 reply = last_any.get((pk, fsid), 0)
             else:
                 keys = {"peer:" + pk}
-                if alias.get(pk):
-                    keys.add(alias[pk])
+                asid = _alias_at(alias, pk, nd.get("t") or 0)
+                if asid:
+                    keys.add(asid)
                 reply = max((last_any.get((k, fsid), 0) for k in keys), default=0)
             if reply and reply >= (nd.get("t") or 0):
                 why = (("reported back by %s (delegated; the recipient's card was dismissed)" % pk[:8])

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2265,7 +2265,7 @@ def _debt_asks(sid, alive_ids):
     asks this session OWES: the exact inverse of _wait_for_graph's sender edge, from the same maps. An
     ask counts only while the ASKER is alive (answering a dead session releases nobody), and any later
     message back — whatever its kind — already answered it (same rule as the sender's chip)."""
-    last_any, last_ask = _postal_wait_maps()
+    last_any, last_ask, _aw = _postal_wait_maps()
     out = []
     for (f, t_), rec in last_ask.items():
         if t_ != str(sid) or f not in (alive_ids or ()):
@@ -2395,7 +2395,7 @@ def _debt_reminder_outcomes(sid, lt, now):
     dn0 = _auto_nudge_data().get("debtNudged") or {}
     if not dn0:
         return
-    last_any, _ask = _postal_wait_maps()
+    last_any, _ask, _aw = _postal_wait_maps()
     lt_end = (lt.get("end", lt.get("t", 0)) or 0) if lt else 0
     drop = []
     for key, fire_t in dn0.items():
@@ -2427,7 +2427,7 @@ def _debt_backstop_tick(now):
     dn0 = _auto_nudge_data().get("debtNudged") or {}
     if not dn0:
         return
-    last_any, _ask = _postal_wait_maps()
+    last_any, _ask, _aw = _postal_wait_maps()
     drop = []
     for key, fire_t in dn0.items():
         parsed = _debt_key_parse(key)
@@ -28097,12 +28097,12 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
 # word). Rows that CARRY a kind use it directly — the sender's declared intent is the designed source; the
 # body regex is only the fallback for old log rows (the user 2026-06-22 / the 2026-07-22 unification).
 _WAIT_Q_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)
-_POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask) — one log scan per file change
+_POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask, last_await) — one log scan per file change
 
 
 def _postal_wait_maps():
-    """(last_any, last_ask) from the postal log, cached on the file's (mtime, size): per ordered pair
-    (from_id, to_id), last_any holds the latest t of ANY message, last_ask the latest (t, kind) of a
+    """(last_any, last_ask, last_await) from the postal log, cached on the file's (mtime, size): per ordered
+    pair (from_id, to_id), last_any holds the latest t of ANY message, last_ask the latest (t, kind) of a
     reply-EXPECTING ask — a QUESTION only (an answer is definitionally required). A DELEGATE transfers
     OWNERSHIP and sets no edge (the user 2026-08-15: a handoff whose body said "no reply needed" still
     parked its sender as awaiting-peer, and a sender with many outstanding handoffs read as permanently
@@ -28112,42 +28112,58 @@ def _postal_wait_maps():
     who genuinely needs a report-back asks with kind=question). COORDINATE/FYI rows never make last_ask.
     Rows carrying the schema `kind` use it; kindless legacy rows fall back to the QUESTION/ASK body
     prefix. Shared by _wait_for_graph (twice per push) and _peer_answered_at (the stamp readers), which
-    each re-scanned the log per call before this cache."""
+    each re-scanned the log per call before this cache.
+
+    last_await (2026-09-08): per pair, the latest t of a reply-REQUIRING send — a QUESTION or a DELEGATE
+    (tracked or not; the sender acts on the report either way), never a COORDINATE. It is the clock the
+    answered-supersede reads (_peer_answered_at / _peer_answered): those used to walk last_any, so a
+    coordinate the asker sent AFTER receiving the answer ("thanks", "one more thing") re-opened the
+    pair — the reply now predated the newest outbound — and a stamp the answer had ended stood until the
+    6h backstop. The chip edge stays question-only (last_ask), exactly as before.
+
+    Cross-host rows key on the recipient's STABLE id: `to_sid` when the row carries it (relay rows since
+    2026-09-08), else the name alias AT the row's own send time (jd._alias_at — last-write-wins re-keyed
+    every old message to whichever session most recently wore the name), else the raw
+    "peer:<host>:<name>"."""
     try:
         st = jd.MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
     except OSError:
-        return {}, {}
+        return {}, {}, {}
     if _POSTAL_WAIT_CACHE[0] == key:
         return _POSTAL_WAIT_CACHE[1]
-    last_any, last_ask = {}, {}
+    last_any, last_ask, last_await = {}, {}, {}
     try:
         rows = []
-        alias = {}   # "host:name" -> sid, learned from every row a remote sender stamped
+        alias = {}   # "host:name" -> [(t, sid), …], learned from every row a remote sender stamped
         for o in _messages_rows():                    # append-incremental rows (2026-09-03); the fold
             if not isinstance(o, dict):               # itself stays whole-log: aliases learned from LATER
                 continue                              # rows resolve EARLIER peer: rows
             rows.append(o)
-            if o.get("from_host") and o.get("from") and o.get("from_id"):
-                alias[str(o["from_host"]) + ":" + str(o["from"])] = str(o["from_id"])
+            jd._learn_alias(alias, o)
+        jd._alias_settle(alias)
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
                 continue
+            ts = int(ts)
             # a CROSS-HOST row is addressed to the RELAY ("peer:<host>"), not the recipient's sid —
             # so the (from,to) pair could never close and the asker wore "Awaiting <peer>" forever
             # (obsidian↔lab_manager, 2026-08-15: the reply landed, the edge never cleared). The row's
-            # toName ("<host>:<name>") resolves to the real sid through the alias map above; an
-            # unresolvable relay keeps the raw id and behaves exactly as before.
-            if isinstance(t_, str) and t_.startswith("peer:") and o.get("toName"):
-                # unresolvable (the peer never sent a row, so the alias map can't know its sid) →
-                # key on the NAMED recipient rather than the bare relay: two asks to different
-                # sessions on one detached host used to collapse onto the single (from, relay)
-                # pair, the later silently overwriting the earlier (the 2026-08-18 audit found a
-                # 29.6h-invisible ask eaten this way). The maps rebuild from the full log, so the
-                # moment the peer speaks the alias resolves and every row re-keys to the real sid.
-                t_ = alias.get(str(o["toName"]), "peer:" + str(o["toName"]))
-            ts = int(ts)
+            # own to_sid names the recipient exactly; an older row's toName ("<host>:<name>")
+            # resolves through the alias history at the row's send time; an unresolvable relay
+            # keeps the raw id and behaves exactly as before.
+            if isinstance(t_, str) and t_.startswith("peer:"):
+                if o.get("to_sid"):
+                    t_ = str(o["to_sid"])
+                elif o.get("toName"):
+                    # unresolvable (the peer never sent a row, so the alias map can't know its sid) →
+                    # key on the NAMED recipient rather than the bare relay: two asks to different
+                    # sessions on one detached host used to collapse onto the single (from, relay)
+                    # pair, the later silently overwriting the earlier (the 2026-08-18 audit found a
+                    # 29.6h-invisible ask eaten this way). The maps rebuild from the full log, so the
+                    # moment the peer speaks the alias resolves and every row re-keys to the real sid.
+                    t_ = jd._alias_at(alias, str(o["toName"]), ts) or "peer:" + str(o["toName"])
             last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins
             is_ask = (k == "question") if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
@@ -28155,10 +28171,13 @@ def _postal_wait_maps():
                 # the ask's HEAD rides along (the user 2026-07-26): the debt reminder quotes the asker's
                 # own first words back at the debtor, so the reminder needs no second log scan
                 last_ask[(f, t_)] = (ts, k or "question", str(o.get("body") or "")[:300])
+            is_await = (k in ("question", "delegate")) if k else is_ask   # reply-requiring; kindless rows by the ask prefix
+            if is_await:
+                last_await[(f, t_)] = max(last_await.get((f, t_), 0), ts)
     except OSError:
         pass
-    _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask)]
-    return last_any, last_ask
+    _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask, last_await)]
+    return last_any, last_ask, last_await
 
 
 def _wait_for_graph(now, alive_sids):
@@ -28172,7 +28191,7 @@ def _wait_for_graph(now, alive_sids):
     DELEGATE edges since 2026-07-25: a handoff previously made no edge, so the card fell through to the
     judge's generic ⏳ stamp ("Awaiting background agents") and, with no edge to clear, the peer's actual
     reply lifted nothing — a card read awaiting for 5h after the answer landed. Best-effort {}."""
-    last_any, last_ask = _postal_wait_maps()
+    last_any, last_ask, _aw = _postal_wait_maps()
     edge = {}                                            # X → Y: X's most-recent UNANSWERED ask to a LIVE peer
     for (f, t_), (ts, _k, _h) in last_ask.items():
         if t_ not in alive_sids:                         # dead peer won't reply → not a wait
@@ -28206,19 +28225,21 @@ def _peer_answered_at(sid):
     AFTER the reply survives — the closer's verdict is fresher than the answer it already saw. If the
     stamp was really about non-peer work (subagents, a build), the LIVE sources that outrank it still
     carry the wait, and the closer's next pass can re-stamp with a fresh awaitingAt."""
-    last_any, last_ask = _postal_wait_maps()
+    last_any, _ask, last_await = _postal_wait_maps()
     best = 0
-    # OUTBOUND rides last_any, not last_ask (2026-08-18 audit): the 2026-08-15 change that stopped
+    # OUTBOUND rides last_await, not last_ask (2026-08-18 audit): the 2026-08-15 change that stopped
     # DELEGATES from making chip edges also emptied last_ask of them — which silently removed this
     # release, so a delegated peer's reply no longer superseded a judge kind=peer stamp (a cross-host
     # handoff answered in 23 minutes still wore Awaiting six hours later, with the 6h wake as the
-    # only exit). Reading every outbound restores the designed exact ending event for questions and
-    # handoffs alike; the chip edge stays question-only, exactly as #430 intended.
-    for (f, t_), sent in last_any.items():
+    # only exit). Reading every reply-requiring outbound (question or delegate) restores the designed
+    # exact ending event for both; the chip edge stays question-only, exactly as #430 intended. Not
+    # last_any (2026-09-08): a COORDINATE the asker sent after the answer landed ("thanks") counted as
+    # a newer outbound awaiting a reply, so the answer read as stale and the stamp stood.
+    for (f, t_), sent in last_await.items():
         if f != sid:
             continue
         r = last_any.get((t_, f), 0)
-        if r >= sent:                                    # the pair's newest outbound is answered
+        if r >= sent:                                    # the pair's newest reply-requiring send is answered
             best = max(best, r)
     return best
 
@@ -28232,9 +28253,9 @@ def _peer_answered(sid):
     (sids, or "peer:<host>:<name>" for an unresolved cross-host recipient) — the same alias re-key
     the admit gate derives them from, so the two sides can never disagree."""
     best = _peer_answered_at(sid)        # the scalar rides the existing name — the tests' stub seam
-    last_any, _la = _postal_wait_maps()
+    last_any, _la, last_await = _postal_wait_maps()
     per = {}
-    for (f, t_), sent in last_any.items():
+    for (f, t_), sent in last_await.items():   # reply-requiring sends only — see _peer_answered_at
         if f != sid:
             continue
         r = last_any.get((t_, f), 0)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20082,17 +20082,37 @@ def _peer_identity(psid):
     wait names the ACTUAL session — 'a peer' is a bug to trace, not a style). Accepts the three
     recorded shapes — a bare sid, the courier's cross-host "<host>:<tail>" composite, the wait map's
     "peer:<host>:<name>" key — and resolves {name, host, sid, color}: the names REGISTRY first
-    (identity persists for DORMANT sessions; liveness is never a prerequisite for naming), else the
+    (identity persists for DORMANT sessions; liveness is never a prerequisite for naming), else, a
+    bare sid another kernel owns (review find, 2026-09-08: the wait maps key a cross-host ask on the
+    row's to_sid, and the registry knows no remote sid, so every such chip read an eight-hex stub with
+    no host), what its host calls it in the tunnel supervisor's snapshot of that host's /sessions
+    (_remote_name_of, the ladder the user ruled on 2026-09-06 for a federated session), else the
+    "<host>:<name>" the postal log itself paired with the sid (_postal_peer_names: the relay row's
+    to_sid + toName, or the peer's own from_host + from stamp, the only source for a host reached
+    through gossip, which the supervisor never polls), else the
     composite's own parts (display-join on the canonical pair, per the federation rule — a name tail
-    reads whole, a sid tail stubs to 8), else the sid stub. Color is registry-only: a peer another
-    kernel owns keeps color None (its identity colors live on its home kernel), so the UIs render an
-    uncolored host-prefixed name rather than a guessed hue."""
+    reads whole, a sid tail stubs to 8), else the sid stub, host-prefixed when the supervisor at
+    least knows which host owns the sid. Color is registry-only: a peer another kernel owns keeps
+    color None (its identity colors live on its home kernel), so the UIs render an uncolored
+    host-prefixed name rather than a guessed hue."""
     raw = str(psid or "")
     if raw.startswith("peer:"):
         raw = raw[len("peer:"):]
     pn = _name_of(raw)
     if pn:
         return {"name": pn, "host": "", "sid": raw, "color": _name_color(raw)}
+    if _UUIDISH_RE.match(raw):
+        r = _host_for_sid(raw)
+        host = str((r or {}).get("host") or "")
+        rn = _remote_name_of(host, raw) if r else None
+        if rn:
+            return {"name": rn, "host": host, "sid": raw, "color": None}
+        hn = _postal_peer_names().get(raw) or ""
+        if hn:
+            h, _, tail = hn.partition(":")
+            return {"name": tail or raw[:8], "host": h, "sid": raw, "color": None}
+        if host:
+            return {"name": raw[:8], "host": host, "sid": raw, "color": None}   # owner known, name not (yet)
     if ":" in raw:
         h, _, tail = raw.partition(":")
         return {"name": (tail[:8] if _UUIDISH_RE.match(tail) else tail) or raw[:8],
@@ -28098,6 +28118,7 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
 # body regex is only the fallback for old log rows (the user 2026-06-22 / the 2026-07-22 unification).
 _WAIT_Q_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)
 _POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask, last_await) — one log scan per file change
+_POSTAL_PEER_NAMES = [None, {}]     # (mtime_ns, size) , {remote sid: "<host>:<name>"}: the same scan's display join
 
 
 def _postal_wait_maps():
@@ -28124,15 +28145,28 @@ def _postal_wait_maps():
     Cross-host rows key on the recipient's STABLE id: `to_sid` when the row carries it (relay rows since
     2026-09-08), else the name alias AT the row's own send time (jd._alias_at — last-write-wins re-keyed
     every old message to whichever session most recently wore the name), else the raw
-    "peer:<host>:<name>"."""
+    "peer:<host>:<name>".
+
+    The sid is the KEY, not the label (review find, 2026-09-08): a bare remote sid names nothing on this
+    kernel (the names registry is local), so a to_sid-keyed wait's chip fell to the eight-hex stub with no
+    host. The same scan therefore keeps the display join beside the maps, _POSTAL_PEER_NAMES, {remote
+    sid: "<host>:<name>"} from every row that pairs the two (a relay row's to_sid + toName, a remote
+    sender's from_id + from_host + from), newest sighting winning, and _peer_identity reads it
+    (_postal_peer_names) so the chip names the peer the row named."""
     try:
         st = jd.MESSAGES.stat()
         key = (st.st_mtime_ns, st.st_size)
     except OSError:
+        _POSTAL_PEER_NAMES[:] = [None, {}]
         return {}, {}, {}
     if _POSTAL_WAIT_CACHE[0] == key:
         return _POSTAL_WAIT_CACHE[1]
     last_any, last_ask, last_await = {}, {}, {}
+    peer_names = {}   # remote sid -> (t, "<host>:<name>"): the display join, newest sighting wins
+
+    def _saw(sid, at, hn):
+        if sid and hn and at >= peer_names.get(sid, (-1, ""))[0]:
+            peer_names[sid] = (at, hn)
     try:
         rows = []
         alias = {}   # "host:name" -> [(t, sid), …], learned from every row a remote sender stamped
@@ -28142,6 +28176,9 @@ def _postal_wait_maps():
             rows.append(o)
             jd._learn_alias(alias, o)
         jd._alias_settle(alias)
+        for hn, hist in alias.items():                # the peer's own stamps, inverted: sid -> what it wore
+            for at, sid in hist:
+                _saw(sid, at, hn)
         for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
@@ -28156,6 +28193,7 @@ def _postal_wait_maps():
             if isinstance(t_, str) and t_.startswith("peer:"):
                 if o.get("to_sid"):
                     t_ = str(o["to_sid"])
+                    _saw(t_, ts, str(o.get("toName") or ""))   # the send resolved this name for this sid
                 elif o.get("toName"):
                     # unresolvable (the peer never sent a row, so the alias map can't know its sid) →
                     # key on the NAMED recipient rather than the bare relay: two asks to different
@@ -28176,8 +28214,17 @@ def _postal_wait_maps():
                 last_await[(f, t_)] = max(last_await.get((f, t_), 0), ts)
     except OSError:
         pass
+    _POSTAL_PEER_NAMES[:] = [key, {sid: hn for sid, (_at, hn) in peer_names.items()}]
     _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask, last_await)]
     return last_any, last_ask, last_await
+
+
+def _postal_peer_names():
+    """{remote sid: "<host>:<name>"}: the postal log's own display join for the recipients the wait maps
+    key by stable id (review find, 2026-09-08; see _postal_wait_maps). Warms the maps' scan when the log
+    changed (a no-op on the cached key), so it costs a stat per call."""
+    _postal_wait_maps()
+    return _POSTAL_PEER_NAMES[1]
 
 
 def _wait_for_graph(now, alive_sids):

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2404,19 +2404,26 @@ def quarantine_decide(mid, action, text=None, feedback=None):
                 # it — the same id-strict rule intake applies (_relay_in: "never a name fallback,
                 # which could hand the mail to a same-named sibling"). Before this, approve
                 # re-matched by NAME unconditionally, and id-addressed mail whose recipient had
-                # ended went to whatever session now wore the name. Nothing live by that id →
-                # refuse loudly; the record stays held (deny carries a note back to the sender).
-                match = [a for a in agents if str(a.get("id") or "") == wire and not _postal_off(a["id"])]
-                if not match:
-                    return False, ("the session this message was addressed to ('%s', id %s) has ended — "
-                                   "nothing by that id is live, and a session that now wears the name "
-                                   "is not the one the sender chose, so it was not delivered. It stays "
-                                   "held: deny it (with a note, so the sender hears) or leave it."
-                                   % (rec.get("to") or "?", wire[:8]))
-            else:                                     # NAME-addressed (an older sender): the name still rules
-                match = [a for a in agents if a["name"] == rec.get("to") and not _postal_off(a["id"])]
-                if not match:
-                    return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
+                # ended went to whatever session now wore the name. The held sid IS the wire id
+                # (intake matched the wire's toId exactly and held that match), so a held sid the
+                # listing no longer carries means nothing live answers to the id the sender chose:
+                # there is no second candidate to look for (review find, 2026-09-08: a re-match on
+                # the wire id here could never succeed). Refuse loudly; the record stays held (deny
+                # carries a note back to the sender). Worded on what the listing proved, no live
+                # session by that id, never "ended": a dormant session is absent from it too.
+                return False, ("no live session carries the id this message was addressed to ('%s', "
+                               "id %s), and a session that now wears the name is not the one the "
+                               "sender chose, so it was not delivered. It stays held: deny it (with a "
+                               "note, so the sender hears) or leave it."
+                               % (rec.get("to") or "?", wire[:8]))
+            # NAME-addressed (an older sender): the name still rules. A record held BEFORE
+            # 2026-09-08 lands here too even when its wire chose a sid, the hold kept only the
+            # resolved sid then, so nothing on the record can tell the two apart; that name
+            # re-match is a known residual for holds from before the upgrade, and it drains with
+            # their next approve/deny (review find, 2026-09-08).
+            match = [a for a in agents if a["name"] == rec.get("to") and not _postal_off(a["id"])]
+            if not match:
+                return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
             to_id = match[0]["id"]
         deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
                 from_host=rec.get("origin") or "",

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -460,7 +460,9 @@ def _queue_read_receipt(meta, unread=False, dmid=""):
 #      {ev:"sent", id, from, from_id, to_id, body, t, park?, kind?, from_host?, tracked?}
 #      (park/kind/from_host/tracked are all additive; `tracked` marks a report-back delegation —
 #      kind stays "delegate" — whose sender-side view is primary: the kernel courier reads it off
-#      this row, never off the message prose).
+#      this row, never off the message prose). A CROSS-HOST relay row has to_id "peer:<host>" and
+#      adds toName ("<host>:<name>") + to_sid (the recipient's stable id — the wait readers key on
+#      it; rows from before 2026-09-08 lack it and fall back to the name alias).
 # The HUMAN-FACING prose (banner text, headers, the "⏸ parked" tag, REPLY_HINT) is
 # NOT a contract — consumers must not parse it, so it stays free to change.
 
@@ -1493,10 +1495,17 @@ class Handler(BaseHTTPRequestHandler):
                     if ua:
                         relay_msg["userAsk"] = ua
                 outbox_put(phost, relay_msg)
+                # `to_sid` (2026-09-08): the recipient's STABLE id, the same value the wire's toId
+                # carries. The row used to name the recipient only ("<host>:<name>"), so every
+                # reader of the wait (the kernel's wait maps, the judge's ask maps) had to join it
+                # back to a sid through a name→sid alias learned from the peer's own rows — and a
+                # name reused by a NEW session re-keyed every OLD message to the new sid. With the
+                # sid on the row the join is exact; the alias stays the fallback for older rows.
                 _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
                                               "from": frm, "from_id": frm_id,
                                               "to_id": "peer:%s" % phost,
                                               "toName": "%s:%s" % (phost, hit.get("name") or to),
+                                              "to_sid": str(hit.get("id") or ""),
                                               "body": body, "kind": kind})
                 if PEERS.get(phost, {}).get("up"):
                     return self._send({"ok": True, "id": mid,
@@ -2284,17 +2293,28 @@ def fleet_presence(exclude_host):
 # cards (fast, bus-down-resilient); mutations go through the bus routes below (delivery is postal's).
 QUARANTINE = STATE / "quarantine"
 
-def _quarantine_put(origin, m, to_id, via=""):
+def _quarantine_put(origin, m, to_id, via="", wire_id=None):
     """Hold one inbound relay from a directed host: quarantine/<mid>.json with everything approve needs
     to replay deliver(). Idempotent by mid (a resend overwrites the same file, never double-holds).
     `via` is the DIRECT peer it arrived from — kept so an approved delivery still carries the
-    read-receipt route (older held records lack it; approve falls back to the origin)."""
+    read-receipt route (older held records lack it; approve falls back to the origin).
+    `wire_id` (2026-09-08) is the sid the WIRE message was addressed to (intake's sanitized toId),
+    stored as `toWireId` so approve knows whether the sender chose a sid or a name: the record used
+    to keep only the RESOLVED local sid, and once that session ended approve re-matched by NAME —
+    handing id-addressed mail to whatever session wore the name, the very swap intake refuses. None
+    reads the wire toId off `m`; either way a malformed shape is dropped (never a path, never a
+    match key), exactly as intake blanks it."""
     mid = m.get("mid") or ""
     if not _safe_id(mid):
         return False
+    wire = str((m.get("toId") if wire_id is None else wire_id) or "")
+    if wire and _ID_FORM_RE.fullmatch(wire) is None:
+        wire = ""
     rec = {"mid": mid, "to": m.get("to") or "", "toId": to_id, "frm": m.get("frm") or "?",
            "frmId": m.get("frm_id") or "", "body": m.get("body") or "", "kind": m.get("kind") or "",
            "origin": origin, "via": via or origin, "at": int(time.time())}
+    if wire:
+        rec["toWireId"] = wire
     if isinstance(m.get("userAsk"), dict):
         rec["userAsk"] = m["userAsk"]                # held with its provenance; approve replays it (T126)
     try:
@@ -2377,10 +2397,26 @@ def quarantine_decide(mid, action, text=None, feedback=None):
             return False, ("the liveness source (the romp kernel) didn't answer — likely "
                            "mid-restart. The held message is untouched; retry the approve shortly.")
         live = {a["id"] for a in agents}
-        if to_id not in live:                         # session renamed/revived since it was held → re-match by name
-            match = [a for a in agents if a["name"] == rec.get("to") and not _postal_off(a["id"])]
-            if not match:
-                return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
+        if to_id not in live:                         # the held sid is gone: renamed/revived, or ended
+            wire = str(rec.get("toWireId") or "")
+            if wire:
+                # ID-ADDRESSED mail (2026-09-08): the sender chose a sid, so only that sid may take
+                # it — the same id-strict rule intake applies (_relay_in: "never a name fallback,
+                # which could hand the mail to a same-named sibling"). Before this, approve
+                # re-matched by NAME unconditionally, and id-addressed mail whose recipient had
+                # ended went to whatever session now wore the name. Nothing live by that id →
+                # refuse loudly; the record stays held (deny carries a note back to the sender).
+                match = [a for a in agents if str(a.get("id") or "") == wire and not _postal_off(a["id"])]
+                if not match:
+                    return False, ("the session this message was addressed to ('%s', id %s) has ended — "
+                                   "nothing by that id is live, and a session that now wears the name "
+                                   "is not the one the sender chose, so it was not delivered. It stays "
+                                   "held: deny it (with a note, so the sender hears) or leave it."
+                                   % (rec.get("to") or "?", wire[:8]))
+            else:                                     # NAME-addressed (an older sender): the name still rules
+                match = [a for a in agents if a["name"] == rec.get("to") and not _postal_off(a["id"])]
+                if not match:
+                    return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
             to_id = match[0]["id"]
         deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
                 from_host=rec.get("origin") or "",
@@ -2458,7 +2494,9 @@ def _relay_in(host, m, token_proven=False):
                     relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
                     user_ask=m.get("userAsk"))           # origin-kernel walked record rides through (T126)
         elif trust == "directed":
-            _quarantine_put(origin, m, match[0]["id"], via=host)   # HELD for human approve/deny/edit; never injects
+            _quarantine_put(origin, m, match[0]["id"], via=host, wire_id=to_id)   # HELD for human approve/deny/edit;
+            #                                                                        never injects; remembers whether
+            #                                                                        the wire chose a sid (approve is id-strict then)
         # else isolated → drop: ack so the sender stops resending, but deliver nothing (no communication).
         # An isolated host normally never peers at all (the kernel forces its notify down), so this is a
         # defensive backstop for the checkin-peer path where the mobile dials our /peer-exchange.

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -168,7 +168,7 @@ class MatrixCloserGate(_Base):
         # alive-filtered _wait_for_graph: the gate deliberately keeps a dead/unknown peer's open ask
         # (the dead-wait sweep owns that ending, not the write gate).
         def km_open(sid):
-            last_any, last_ask = km._postal_wait_maps()
+            last_any, last_ask, _aw = km._postal_wait_maps()
             return any(f == sid and last_any.get((p, sid), 0) < meta[0]
                        for (f, p), meta in last_ask.items())
         grid = [
@@ -186,6 +186,69 @@ class MatrixCloserGate(_Base):
         # and where the peer IS alive, the user-facing graph agrees with the gate too
         self._log([_msg(1, SID, MGR, T0, "question")])
         self.assertTrue(jd._open_peer_asks(SID) and SID in km._wait_for_graph(NOW, {SID, MGR}))
+
+
+class TwinsKeyMailByStableId(_Base):
+    """Both readers of the postal log key a cross-host row on the recipient's STABLE id (2026-09-08):
+    the row's own `to_sid`, else the name alias AT the row's send time (jd._alias_at). The alias used
+    to be last-write-wins over the whole log, so a name a NEW session reused re-keyed every OLD
+    message to the new sid — the judge's admit gate then read an answered question as an open ask to
+    a stranger, and would have stamped awaitingPeers with the wrong sid."""
+
+    X = "11111111-2222-3333-4444-000000000003"   # wore "api" on TESTHOST when SID asked
+    Y = "11111111-2222-3333-4444-000000000004"   # reused the name later
+    C = "11111111-2222-3333-4444-000000000005"   # whoever Y mailed (how the alias learns Y)
+
+    def _row(self, **kw):
+        r = {"ev": "sent", "id": "m%d" % kw.pop("i"), "body": "x"}
+        r.update(kw)
+        return json.dumps(r)
+
+    def _reused_name(self):
+        return [
+            self._row(i=1, **{"from": "web"}, from_id=SID, to_id="peer:TESTHOST", toName="TESTHOST:api",
+                      t=T0, kind="question"),
+            self._row(i=2, **{"from": "api"}, from_id=self.X, to_id=SID, t=T0 + 50, kind="coordinate",
+                      from_host="TESTHOST"),
+            self._row(i=3, **{"from": "api"}, from_id=self.Y, to_id=self.C, t=T0 + 400, kind="coordinate",
+                      from_host="TESTHOST"),
+        ]
+
+    def test_the_judge_gate_keeps_an_answered_ask_answered_through_a_name_reuse(self):
+        self._log(self._reused_name())
+        self.assertEqual(jd._open_ask_peers(SID), [],
+                         "X answered; main: [Y] — the ask re-keyed to the new wearer, whom SID never asked")
+        _any, last_ask, alias = jd._postal_ask_maps()
+        self.assertIn((SID, self.X), last_ask)
+        self.assertEqual(jd._alias_at(alias, "TESTHOST:api", T0), self.X)
+        self.assertEqual(jd._alias_at(alias, "TESTHOST:api", T0 + 500), self.Y)
+
+    def test_the_judge_gate_reads_to_sid(self):
+        self._log([self._row(i=1, **{"from": "web"}, from_id=SID, to_id="peer:TESTHOST",
+                             toName="TESTHOST:api", to_sid=self.X, t=T0, kind="question")])
+        self.assertEqual(jd._open_ask_peers(SID), [self.X],
+                         "the open ask names the sid the send resolved (main: ['peer:TESTHOST:api'])")
+
+    def test_both_readers_agree_on_the_reused_name(self):
+        def km_open(sid):
+            last_any, last_ask, _aw = km._postal_wait_maps()
+            return sorted(p for (f, p), meta in last_ask.items()
+                          if f == sid and last_any.get((p, sid), 0) < meta[0])
+        for rows in (self._reused_name(),
+                     self._reused_name()[:1],                      # X never spoke: raw relay key on both
+                     [self._row(i=1, **{"from": "web"}, from_id=SID, to_id="peer:TESTHOST",
+                                toName="TESTHOST:api", to_sid=self.X, t=T0, kind="question")]):
+            self._log(rows)
+            self.assertEqual(jd._open_ask_peers(SID), km_open(SID), "gate and wait-maps disagree on: %s" % rows)
+
+    def test_alias_at_rule(self):
+        hist = {"TESTHOST:api": [(150, self.X), (400, self.Y)]}
+        self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 100), self.X, "before any sighting: the earliest known")
+        self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 150), self.X)
+        self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 399), self.X)
+        self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 400), self.Y, "at the sighting: the new wearer")
+        self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 9_000), self.Y)
+        self.assertIsNone(jd._alias_at(hist, "TESTHOST:web", 100), "a name never seen resolves to nothing")
 
 
 class MatrixPlannerGate(_Base):
@@ -260,7 +323,9 @@ class MatrixSupersedeTwins(_Base):
 class PairAwareSupersede(_Base):
     """Hole (b), 2026-08-24: an identity-carrying stamp ends only on the AWAITED pair's answer; an
     unrelated exchange no longer hides a real wait. Legacy identity-less stamps keep the pair-blind
-    read — nothing strands. One predicate for every reader (pinned below)."""
+    read — nothing strands. One predicate for every reader (pinned below). Since 2026-09-08 the
+    answered clock walks reply-REQUIRING sends (question/delegate), so the "unrelated exchange" here
+    is a QUESTION the other peer answered; a coordinate-only exchange answers nothing (last test)."""
 
     OTHER = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"    # an unrelated peer on the same log
 
@@ -279,7 +344,7 @@ class PairAwareSupersede(_Base):
         future = int(time.time()) + 10_000
         # an answered exchange with a DIFFERENT peer, after the stamp's write time
         self._log([_msg(1, SID, MGR, T0 + 10, "question"),
-                   _msg(2, SID, self.OTHER, T0 + 20, "coordinate"),
+                   _msg(2, SID, self.OTHER, T0 + 20, "question"),      # PIN MOVED 2026-09-08: was a coordinate
                    _msg(3, self.OTHER, SID, future, "coordinate")])
         answered = km._peer_answered(SID)
         self.assertGreater(answered[0], 0, "the pair-blind scalar WOULD have superseded")
@@ -304,10 +369,24 @@ class PairAwareSupersede(_Base):
         del s["nodes"][gid]["awaitingPeers"]           # a pre-identity stamp, as stored stores hold
         future = int(time.time()) + 10_000
         self._log([_msg(1, SID, MGR, T0 + 10, "question"),
-                   _msg(2, SID, self.OTHER, T0 + 20, "coordinate"),
+                   _msg(2, SID, self.OTHER, T0 + 20, "question"),      # PIN MOVED 2026-09-08: was a coordinate
                    _msg(3, self.OTHER, SID, future, "coordinate")])
         self.assertIsNone(km._goal_awaiting_stamp_full(s["nodes"], gid, answered_at=km._peer_answered(SID)),
                           "no identity on the stamp -> today's behavior exactly (never strand legacy)")
+
+    def test_a_coordinate_only_exchange_answers_nothing_even_pair_blind(self):
+        # 2026-09-08 (the two fixtures above sent OTHER a coordinate before this): the answered clock
+        # walks reply-REQUIRING sends, so a heads-up OTHER happened to reply to is not an answer to
+        # anything and cannot end even a legacy identity-less stamp. main: superseded (walked last_any).
+        s, gid = self._stamped()
+        del s["nodes"][gid]["awaitingPeers"]
+        future = int(time.time()) + 10_000
+        self._log([_msg(1, SID, MGR, T0 + 10, "question"),
+                   _msg(2, SID, self.OTHER, T0 + 20, "coordinate"),
+                   _msg(3, self.OTHER, SID, future, "coordinate")])
+        self.assertEqual(km._peer_answered(SID), (0, {}), "nothing SID asked has been answered")
+        self.assertIsNotNone(km._goal_awaiting_stamp_full(s["nodes"], gid, answered_at=km._peer_answered(SID)),
+                             "the open question to MGR stands; a stranger's heads-up is not its answer")
 
     def test_every_reader_shares_the_one_predicate(self):
         # the twins rule, extended (the manager's ask): no reader may inline its own compare — the

--- a/tests/test_awaiting_peer_matrix.py
+++ b/tests/test_awaiting_peer_matrix.py
@@ -250,6 +250,35 @@ class TwinsKeyMailByStableId(_Base):
         self.assertEqual(jd._alias_at(hist, "TESTHOST:api", 9_000), self.Y)
         self.assertIsNone(jd._alias_at(hist, "TESTHOST:web", 100), "a name never seen resolves to nothing")
 
+    def test_alias_settle_rule(self):
+        # review find, 2026-09-08 (untested until now): the settle SORTS each name's sightings by t and
+        # keeps one entry per WEARER CHANGE, so a chatty peer name is one entry, not one per row, and a
+        # name that went X -> Y -> X keeps all three changes. Result-identical for _alias_at at every t.
+        raw = {"TESTHOST:api": [(400, self.Y), (150, self.X), (450, self.Y), (200, self.X), (900, self.X)],
+               "TESTHOST:web": [(300, self.C), (100, self.C)]}
+        probe = {k: [(t, jd._alias_at({k: sorted(v)}, k, t)) for t in (50, 150, 200, 400, 450, 900, 5_000)]
+                 for k, v in raw.items()}                       # the sorted, uncollapsed reading
+        jd._alias_settle(raw)
+        self.assertEqual(raw["TESTHOST:api"], [(150, self.X), (400, self.Y), (900, self.X)],
+                         "sorted; consecutive sightings of one sid collapse; a returning wearer is a new entry")
+        self.assertEqual(raw["TESTHOST:web"], [(100, self.C)], "one wearer, however many rows")
+        for k, want in probe.items():
+            self.assertEqual([(t, jd._alias_at(raw, k, t)) for t, _ in want], want,
+                             "the sid in force at every t is unchanged by the collapse: %s" % k)
+
+    def test_learn_alias_reads_only_rows_a_remote_sender_stamped(self):
+        # the history is built from the peer's OWN stamps (from_host + from + from_id); a local row, a
+        # relay row (no from_host) and a row without a name file nothing, and a garbage t reads as 0
+        alias = {}
+        for o in ({"from": "web", "from_id": SID, "to_id": MGR, "t": 10},                  # local: no from_host
+                  {"from": "web", "from_id": SID, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api",
+                   "to_sid": self.X, "t": 20},                                              # a relay row
+                  {"from_host": "TESTHOST", "from_id": self.X, "t": 30},                    # no name
+                  {"from_host": "TESTHOST", "from": "api", "from_id": self.X, "t": "nope"},
+                  {"from_host": "TESTHOST", "from": "api", "from_id": self.Y, "t": 40}):
+            jd._learn_alias(alias, o)
+        self.assertEqual(alias, {"TESTHOST:api": [(0, self.X), (40, self.Y)]})
+
 
 class MatrixPlannerGate(_Base):
     """The nudge planner's awaiting op: kind=peer demotes to kindless without an open ask (the op's
@@ -407,11 +436,14 @@ class CrossHostDelegation(_Base):
     RHOST, RNAME = "TESTHOST-B", "web"
     RSID = "eeeeeeee-ffff-0000-1111-222222222222"     # the remote recipient's sid, learned on reply
 
-    def _xrow(self, i, ts, kind="delegate", body="own the exporter work"):
-        return json.dumps({"id": "px-%d.mail.TESTHOST-A" % i, "ev": "sent", "from": "api",
-                           "from_id": SID, "to_id": "peer:%s" % self.RHOST,
-                           "toName": "%s:%s" % (self.RHOST, self.RNAME), "t": ts,
-                           "kind": kind, "body": body})
+    def _xrow(self, i, ts, kind="delegate", body="own the exporter work", to_sid=None):
+        r = {"id": "px-%d.mail.TESTHOST-A" % i, "ev": "sent", "from": "api",
+             "from_id": SID, "to_id": "peer:%s" % self.RHOST,
+             "toName": "%s:%s" % (self.RHOST, self.RNAME), "t": ts,
+             "kind": kind, "body": body}
+        if to_sid:
+            r["to_sid"] = to_sid                       # a relay row since 2026-09-08 names the recipient by id
+        return json.dumps(r)
 
     def _reply(self, i, ts):
         return json.dumps({"id": "rx-%d.mail.%s" % (i, self.RHOST), "ev": "sent", "from": self.RNAME,
@@ -483,6 +515,44 @@ class CrossHostDelegation(_Base):
         jd.run_propagate(now=T0 + 400)
         self.assertFalse(self._handoffs()[0].get("nodeComplete"),
                          "only the delegated peer's own reply is the report-back event")
+
+    def test_a_row_that_carries_to_sid_plants_it_as_the_trackers_exact_key(self):
+        # review find, 2026-09-08: the plant had the row's to_sid in hand and dropped it, so the remote
+        # arm re-derived the recipient by NAME while the kernel's wait maps read the same row by sid
+        self._fleet_stub()
+        # two real dispatches, so each keeps its own tracker: the plant collapses a byte-identical
+        # OPEN twin (same peer, label AND recorded body) into one node by design (2026-08-28)
+        self._log([self._xrow(1, T0 + 10, to_sid=self.RSID),
+                   self._xrow(2, T0 + 20, body="own the importer work")])
+        jd.run_courier(now=T0 + 100)
+        by_mid = {nd["handoff"]["msgId"]: nd["handoff"] for nd in self._handoffs()}
+        h = by_mid["px-1.mail.TESTHOST-A"]
+        self.assertEqual((h["peer"], h["toSid"]), ("TESTHOST-B:web", self.RSID),   # KeyError before the fix
+                         "the display identity stays toName; the exact key rides beside it")
+        self.assertNotIn("toSid", by_mid["px-2.mail.TESTHOST-A"],
+                         "a legacy row plants no toSid: the arm falls to the send-time alias for it")
+
+    def test_both_readers_complete_a_to_sid_handoff_on_the_recreated_peers_first_mail(self):
+        # the twins rule, for handoffs (review find, 2026-09-08): a peer recreated under the same name
+        # (new sid RSID) whose FIRST mail to this host is its report-back. The kernel's wait maps key
+        # the row on to_sid and read it answered; the courier must agree, anchoring the NAME at send
+        # time picked the old wearer, found no reply, and left the tracker open while the stamp lifted.
+        self._fleet_stub()
+        old = "eeeeeeee-ffff-0000-1111-333333333333"    # the name's earlier wearer, sighted before the send
+        rows = [json.dumps({"id": "rx-0.mail.%s" % self.RHOST, "ev": "sent", "from": self.RNAME,
+                            "from_id": old, "from_host": self.RHOST, "to_id": SID, "t": T0 - 500,
+                            "kind": "coordinate", "body": "hello from the first web"}),
+                self._xrow(1, T0 + 10, to_sid=self.RSID)]
+        self._log(rows)
+        jd.run_courier(now=T0 + 100)
+        rows.append(self._reply(1, T0 + 300))            # RSID's first sighting is the report-back
+        self._log(rows)
+        self.assertEqual(km._peer_answered_at(SID), T0 + 300, "the wait maps read the row answered")
+        self.assertEqual(jd.run_propagate(now=T0 + 400), 1,
+                         "the courier agrees (name-anchored: 0: keyed to the old wearer, who never replied)")
+        nd = self._handoffs()[0]
+        self.assertTrue(nd.get("nodeComplete"))
+        self.assertIn("reported back by TESTHOST-B:web", nd.get("doneWhy") or "")
 
 
 if __name__ == "__main__":

--- a/tests/test_decline_never_closes.py
+++ b/tests/test_decline_never_closes.py
@@ -62,11 +62,11 @@ class _Base(unittest.TestCase):
         if jd.MESSAGES.exists():
             jd.MESSAGES.unlink()
 
-    def _seed_sender(self, peer=RECIP):
+    def _seed_sender(self, peer=RECIP, **handoff):
         st = jd.load_goals(SENDER)
         st["nodes"][U] = _node(U, "Improve the notes app across surfaces", None)
         st["nodes"][H] = _node(H, "↪ delegated to api: rework the gear menu", U,
-                               handoff={"peer": peer, "msgId": MID})
+                               handoff=dict({"peer": peer, "msgId": MID}, **handoff))
         # the adjacent ask the report will DECLINE — open, nothing ever filed under it
         st["nodes"][X] = _node(X, "Add tag editing to the tab dropdown", H, t=T + 10)
         # a step that earned its own verdict — it belongs to the delegation's history and stays
@@ -160,7 +160,11 @@ class CrossHostReplyKeyedByWearerAtSendTime(_Base):
     """The remote arm resolves the handoff's peer NAME to a sid AT the handoff's send time (2026-09-08,
     jd._alias_at): the name→sid alias used to be last-write-wins over the whole log, so a name a NEW
     session reused re-pointed every OLD handoff at the new wearer — the real recipient's report-back was
-    missed (its reply sits under the old sid), and the stranger's first mail read as the report-back."""
+    missed (its reply sits under the old sid), and the stranger's first mail read as the report-back.
+    That alias read is the LEGACY path (a tracker planted from a row without to_sid, the first two
+    tests). A tracker planted from a row that carries to_sid keys on that sid alone (handoff.toSid,
+    review find 2026-09-08, the last two): the same key the kernel's wait maps use for the row, so the
+    two readers of one log cannot disagree about one handoff."""
 
     WX = "77777777-8888-9999-aaaa-000000000001"    # wore "worker_two" on boxa when the handoff was sent
     WY = "77777777-8888-9999-aaaa-000000000002"    # reused the name later
@@ -194,6 +198,30 @@ class CrossHostReplyKeyedByWearerAtSendTime(_Base):
                    self._row(2, self.WY, SENDER, T + 500)])     # WY, wearing it later, mails SENDER
         self.assertEqual(jd.run_propagate(now=T + 1000), 0,
                          "a stranger's mail cannot complete WX's handoff (last-write-wins: done)")
+        self.assertFalse(jd.load_goals(SENDER)["nodes"][H].get("nodeComplete"))
+
+    def test_a_tracker_carrying_the_rows_to_sid_completes_on_that_sid_alone(self):
+        # review find, 2026-09-08: WY was recreated under WX's name and its FIRST mail to this host is
+        # its report-back, the shape no name alias can read (at T the name meant WX). The row named WY
+        # by id; the kernel's wait maps read that and called the row answered, while the arm, anchoring
+        # the name, keyed to WX and left the tracker open forever (main's last-write-wins completed it).
+        self._seed_sender(peer="boxa:worker_two", toSid=self.WY)
+        self._log([self._row(0, self.WX, SENDER, T - 100),      # WX wore the name before the handoff
+                   self._row(1, self.WY, SENDER, T + 60)])      # WY's first sighting IS the report-back
+        self.assertEqual(jd.run_propagate(now=T + 1000), 1,
+                         "keyed to the row's own sid: WY's reply completes it (anchored alias: WX, open)")
+        st = jd.load_goals(SENDER)
+        self.assertTrue(st["nodes"][H].get("nodeComplete"))
+        done = [e for e in st["nodes"][H]["log"] if e.get("kind") == "done" and e.get("src") == "courier"]
+        self.assertEqual([e.get("ev_t") for e in done], [T + 60], "the courier's verdict rides WY's reply")
+
+    def test_with_to_sid_the_names_earlier_wearer_is_a_stranger(self):
+        # the converse: the sid rules. WX, whom the send-time alias would pick, mails the sender; the
+        # row named WY, so that is not the report-back (anchored alias: done, on the wrong evidence)
+        self._seed_sender(peer="boxa:worker_two", toSid=self.WY)
+        self._log([self._row(0, self.WX, SENDER, T - 100),
+                   self._row(1, self.WX, SENDER, T + 60)])
+        self.assertEqual(jd.run_propagate(now=T + 1000), 0)
         self.assertFalse(jd.load_goals(SENDER)["nodes"][H].get("nodeComplete"))
 
 

--- a/tests/test_decline_never_closes.py
+++ b/tests/test_decline_never_closes.py
@@ -156,6 +156,47 @@ class LinkBackLift(_Base):
         self.assertFalse(st["nodes"][X].get("nodeComplete"))
 
 
+class CrossHostReplyKeyedByWearerAtSendTime(_Base):
+    """The remote arm resolves the handoff's peer NAME to a sid AT the handoff's send time (2026-09-08,
+    jd._alias_at): the name→sid alias used to be last-write-wins over the whole log, so a name a NEW
+    session reused re-pointed every OLD handoff at the new wearer — the real recipient's report-back was
+    missed (its reply sits under the old sid), and the stranger's first mail read as the report-back."""
+
+    WX = "77777777-8888-9999-aaaa-000000000001"    # wore "worker_two" on boxa when the handoff was sent
+    WY = "77777777-8888-9999-aaaa-000000000002"    # reused the name later
+    ELSE = "88888888-9999-aaaa-bbbb-cccccccccccc"  # some other local session WY mailed
+
+    def _log(self, rows):
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        jd.MESSAGES.write_text("".join(json.dumps(r) + "\n" for r in rows))
+        jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+
+    def _row(self, i, sid, to, t):
+        return {"id": "m%d" % i, "ev": "sent", "from": "worker_two", "from_id": sid, "from_host": "boxa",
+                "to_id": to, "t": t, "kind": "coordinate", "body": "x"}
+
+    def test_the_wearer_at_send_time_reports_back_even_after_the_name_is_reused(self):
+        self._seed_sender(peer="boxa:worker_two")               # handoff sent at T
+        self._log([self._row(0, self.WX, SENDER, T - 100),      # WX wore the name before the handoff
+                   self._row(1, self.WX, SENDER, T + 60),       # …and is the one who reported back
+                   self._row(2, self.WY, self.ELSE, T + 500)])  # WY took the name later (never mailed SENDER)
+        self.assertEqual(jd.run_propagate(now=T + 1000), 1,
+                         "keyed to WX, the wearer at T: its reply completes the handoff (last-write-wins: "
+                         "keyed to WY, no reply, the handoff stays open)")
+        st = jd.load_goals(SENDER)
+        self.assertTrue(st["nodes"][H].get("nodeComplete"))
+        done = [e for e in st["nodes"][H]["log"] if e.get("kind") == "done" and e.get("src") == "courier"]
+        self.assertEqual([e.get("ev_t") for e in done], [T + 60], "the courier's verdict rides WX's reply")
+
+    def test_a_later_wearers_mail_is_not_the_report_back(self):
+        self._seed_sender(peer="boxa:worker_two")
+        self._log([self._row(0, self.WX, SENDER, T - 100),      # WX wore the name at T, never replied
+                   self._row(2, self.WY, SENDER, T + 500)])     # WY, wearing it later, mails SENDER
+        self.assertEqual(jd.run_propagate(now=T + 1000), 0,
+                         "a stranger's mail cannot complete WX's handoff (last-write-wins: done)")
+        self.assertFalse(jd.load_goals(SENDER)["nodes"][H].get("nodeComplete"))
+
+
 class MigrateGateKeyPresence(_Base):
     """The era marker is the diary KEY: eventless flags on a diary-era node never become history."""
 

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -5,13 +5,19 @@ The 2026-08-15 change that stopped DELEGATES from making chip edges (ownership t
 dependency) also emptied last_ask of them — which silently removed _peer_answered_at's release, so a
 delegated peer's reply no longer superseded a judge kind=peer stamp: the audit found a cross-host
 handoff answered in 23 minutes still wearing Awaiting six hours later, with the 6h wake as the only
-exit. The release now reads every OUTBOUND from last_any, restoring the designed exact ending event
-for questions and handoffs alike, while the chip edge stays question-only exactly as intended.
+exit. The release reads every reply-REQUIRING outbound (question or delegate: last_await, 2026-09-08 —
+it walked last_any first, until a coordinate the asker sent after the answer re-opened the pair),
+restoring the designed exact ending event for questions and handoffs alike, while the chip edge stays
+question-only exactly as intended.
 
 Also pinned: an UNRESOLVABLE cross-host ask (the peer never sent a row, so the alias map cannot know
 its sid) keys on the NAMED recipient — two asks to different sessions on one detached host used to
 collapse onto the single (from, relay) pair, the later silently overwriting the earlier (a
-29.6h-invisible ask found eaten this way). Synthetic rows only (placeholder ids, TESTHOST)."""
+29.6h-invisible ask found eaten this way). Synthetic rows only (placeholder ids, TESTHOST).
+
+Since 2026-09-08 (mail keyed by the recipient's stable id): a relay row's own `to_sid` keys it exactly,
+and the name→sid alias older rows fall back to is anchored at each row's SEND time (jd._alias_at), so a
+name a NEW session reused no longer re-keys every OLD message to the new sid."""
 import json
 import os
 import tempfile
@@ -31,46 +37,63 @@ A = "11111111-2222-3333-4444-000000000001"
 B = "11111111-2222-3333-4444-000000000002"
 
 
-class AwaitRelease(unittest.TestCase):
+class _AwaitBase(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self._saved = km.jd.MESSAGES
         km.jd.MESSAGES = Path(self.td.name) / "messages.jsonl"
-        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {}, {})]
 
     def tearDown(self):
         km.jd.MESSAGES = self._saved
-        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {}, {})]
         self.td.cleanup()
 
     def _write(self, rows):
         km.jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
         km.jd.MESSAGES.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
-        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {}, {})]
 
+
+class AwaitRelease(_AwaitBase):
     def test_a_delegated_peers_reply_supersedes_the_stamp(self):
         self._write([
             {"from_id": A, "to_id": B, "t": 100, "kind": "delegate", "body": "own this now"},
             {"from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "done, shipped"},
         ])
-        last_any, last_ask = km._postal_wait_maps()
+        last_any, last_ask, last_await = km._postal_wait_maps()
         self.assertNotIn((A, B), last_ask, "a DELEGATE still makes no chip edge — ownership transferred")
-        self.assertEqual(km._peer_answered_at(A), 200, "…but the reply IS the stamp's ending event again")
+        self.assertEqual(last_await.get((A, B)), 100, "…but it IS a reply-requiring send")
+        self.assertEqual(km._peer_answered_at(A), 200, "…and the reply IS the stamp's ending event again")
 
-    def test_a_reply_older_than_the_newest_outbound_does_not_supersede(self):
+    def test_a_reply_older_than_the_newest_reply_requiring_send_does_not_supersede(self):
+        # the newest send that AWAITS something is unanswered → nothing supersedes (the rule this
+        # test always pinned, now stated on the send that carries the wait)
+        self._write([
+            {"from_id": A, "to_id": B, "t": 100, "kind": "delegate", "body": "own this"},
+            {"from_id": B, "to_id": A, "t": 150, "kind": "coordinate", "body": "ack"},
+            {"from_id": A, "to_id": B, "t": 300, "kind": "question", "body": "and the port?"},
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0, "the newest reply-requiring send is unanswered")
+
+    def test_a_coordinate_after_the_answer_does_not_reopen_the_wait(self):
+        # PIN MOVED 2026-09-08 (this fixture asserted 0 before): A's "one more thing" is a COORDINATE
+        # — by declaration it requests nothing — so the handoff answered at 150 stays answered. Read
+        # off last_any, the coordinate was "a newer outbound awaiting a reply" and the stamp the
+        # answer had ended stood until the 6h backstop. main: 0.
         self._write([
             {"from_id": A, "to_id": B, "t": 100, "kind": "delegate", "body": "own this"},
             {"from_id": B, "to_id": A, "t": 150, "kind": "coordinate", "body": "ack"},
             {"from_id": A, "to_id": B, "t": 300, "kind": "coordinate", "body": "one more thing"},
         ])
-        self.assertEqual(km._peer_answered_at(A), 0, "the newest outbound is unanswered — nothing supersedes")
+        self.assertEqual(km._peer_answered_at(A), 150, "the delegate's answer is the clock; a heads-up is not a wait")
 
     def test_question_release_unchanged(self):
         self._write([
             {"from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
             {"from_id": B, "to_id": A, "t": 180, "kind": "coordinate", "body": "8080"},
         ])
-        last_any, last_ask = km._postal_wait_maps()
+        last_any, last_ask, _aw = km._postal_wait_maps()
         self.assertIn((A, B), last_ask, "a QUESTION still makes the chip edge")
         self.assertEqual(km._peer_answered_at(A), 180)
 
@@ -81,7 +104,7 @@ class AwaitRelease(unittest.TestCase):
             {"from_id": A, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api", "t": 120,
              "kind": "question", "body": "status of the api thing?"},
         ])
-        _any, last_ask = km._postal_wait_maps()
+        _any, last_ask, _aw = km._postal_wait_maps()
         self.assertIn((A, "peer:TESTHOST:web"), last_ask, "the earlier ask survives")
         self.assertIn((A, "peer:TESTHOST:api"), last_ask, "…beside the later one — no overwrite")
 
@@ -93,10 +116,113 @@ class AwaitRelease(unittest.TestCase):
             {"from_id": W, "to_id": A, "t": 150, "kind": "coordinate", "body": "all good",
              "from_host": "TESTHOST", "from": "web"},
         ])
-        _any, last_ask = km._postal_wait_maps()
+        _any, last_ask, _aw = km._postal_wait_maps()
         self.assertIn((A, W), last_ask, "the maps rebuild from the full log — the row re-keys to the real sid")
         self.assertNotIn((A, "peer:TESTHOST:web"), last_ask)
         self.assertEqual(km._peer_answered_at(A), 150, "and the reply releases the wait")
+
+
+class AnswerClockIgnoresCoordinates(_AwaitBase):
+    """The answered-supersede walks reply-REQUIRING sends (2026-09-08). On main it walked last_any, so a
+    coordinate the asker sent after the answer landed made the answer read stale — and the card kept
+    "Awaiting <peer>" although the peer had answered, until the 6h backstop."""
+
+    def _stamp(self, written_at):
+        # a closer stamp awaiting B, written at `written_at` (the write time is the supersede key)
+        return {"awaitingAt": written_at, "awaitingKind": "peer", "awaitingPeers": [B],
+                "awaitingWhy": "asked the api session which port", "log": [{"kind": "awaiting", "at": written_at}]}
+
+    def test_thanks_after_the_answer_leaves_the_question_answered(self):
+        self._write([
+            {"from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "8080"},
+            {"from_id": A, "to_id": B, "t": 300, "kind": "coordinate", "body": "thanks, going with 8080"},
+        ])
+        self.assertEqual(km._peer_answered_at(A), 200, "main: 0 — the thanks re-opened the pair")
+        self.assertEqual(km._peer_answered(A), (200, {B: 200}), "…pair-aware alike")
+        self.assertTrue(km._peer_stamp_superseded(self._stamp(120), km._peer_answered(A)),
+                        "a stamp written between the ask and its answer is ended by the answer (main: stands)")
+        self.assertFalse(km._peer_stamp_superseded(self._stamp(250), km._peer_answered(A)),
+                         "a stamp written AFTER the answer is fresher than it — it stands, as before")
+
+    def test_a_later_question_does_reopen(self):
+        # the boundary: a NEW reply-requiring send after the answer is a new wait
+        self._write([
+            {"from_id": A, "to_id": B, "t": 100, "kind": "question", "body": "which port?"},
+            {"from_id": B, "to_id": A, "t": 200, "kind": "coordinate", "body": "8080"},
+            {"from_id": A, "to_id": B, "t": 300, "kind": "question", "body": "and the host?"},
+        ])
+        self.assertEqual(km._peer_answered_at(A), 0)
+        self.assertFalse(km._peer_stamp_superseded(self._stamp(120), km._peer_answered(A)))
+
+    def test_a_kindless_legacy_row_counts_by_its_ask_prefix(self):
+        # rows from before the schema `kind`: the QUESTION/ASK lead word is the ask tell (last_ask's
+        # own rule); a kindless row without it requests nothing
+        self._write([
+            {"from_id": A, "to_id": B, "t": 100, "body": "QUESTION: which port?"},
+            {"from_id": B, "to_id": A, "t": 200, "body": "8080"},
+            {"from_id": A, "to_id": B, "t": 300, "body": "thanks"},
+        ])
+        _any, _ask, last_await = km._postal_wait_maps()
+        self.assertEqual(last_await.get((A, B)), 100)
+        self.assertEqual(km._peer_answered_at(A), 200)
+
+
+class MailKeyedByStableId(_AwaitBase):
+    """Cross-host rows key on the recipient's stable id (2026-09-08): the row's own `to_sid` when it has
+    one; else the name alias AT the row's send time. Last-write-wins re-keyed every old message to
+    whichever session most recently wore the name."""
+
+    X = "11111111-2222-3333-4444-000000000003"   # the session that wore "api" on TESTHOST first
+    Y = "11111111-2222-3333-4444-000000000004"   # a later session that reused the name
+    C = "11111111-2222-3333-4444-000000000005"   # an unrelated local session Y mailed
+
+    def _reused_name(self):
+        # A asks "api" (an OLDER row: no to_sid); X — then wearing the name — answers; later a NEW
+        # session Y wears "api" and mails someone else, which is how the alias learns Y
+        return [
+            {"from_id": A, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api", "t": 100,
+             "kind": "question", "body": "status of the api thing?"},
+            {"from_id": self.X, "to_id": A, "t": 150, "kind": "coordinate", "body": "shipped",
+             "from_host": "TESTHOST", "from": "api"},
+            {"from_id": self.Y, "to_id": self.C, "t": 400, "kind": "coordinate", "body": "hello from the new api",
+             "from_host": "TESTHOST", "from": "api"},
+        ]
+
+    def test_a_reused_name_leaves_the_old_ask_keyed_to_the_session_it_went_to(self):
+        self._write(self._reused_name())
+        _any, last_ask, _aw = km._postal_wait_maps()
+        self.assertIn((A, self.X), last_ask, "keyed to X, who wore the name when the ask was sent (main: Y)")
+        self.assertNotIn((A, self.Y), last_ask)
+        self.assertEqual(km._peer_answered_at(A), 150, "X's reply answers it (main: 0 — the reply sits under X, the ask under Y)")
+        self.assertEqual(km._peer_answered(A)[1], {self.X: 150})
+        self.assertNotIn(A, km._wait_for_graph(1_000_000, {A, self.X, self.Y, self.C}),
+                         "no edge: the ask was answered (main: A → Y, a stranger A never asked, forever)")
+
+    def test_an_ask_sent_after_the_reuse_keys_to_the_new_wearer(self):
+        # the ASSERTIONS hold on main too (last-write-wins also lands on Y); the test itself fails there
+        # on the 3-tuple unpack. The anchor picks the most recent sighting at or before the send.
+        self._write(self._reused_name() + [
+            {"from_id": A, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api", "t": 500,
+             "kind": "question", "body": "new api: status?"}])
+        _any, last_ask, _aw = km._postal_wait_maps()
+        self.assertIn((A, self.Y), last_ask)
+        self.assertIn((A, self.X), last_ask, "…while the old ask keeps its own key")
+
+    def test_to_sid_keys_the_row_without_any_alias(self):
+        # a relay row since 2026-09-08 carries the sid the send resolved: no peer row is needed to
+        # place it, and a later name reuse cannot move it
+        self._write([
+            {"from_id": A, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api", "to_sid": self.X, "t": 100,
+             "kind": "question", "body": "status?"},
+            {"from_id": self.Y, "to_id": self.C, "t": 400, "kind": "coordinate", "body": "hi",
+             "from_host": "TESTHOST", "from": "api"},
+        ])
+        _any, last_ask, last_await = km._postal_wait_maps()
+        self.assertIn((A, self.X), last_ask, "main: (A, Y) — the alias re-key won; to_sid was never read")
+        self.assertNotIn((A, "peer:TESTHOST:api"), last_ask)
+        self.assertNotIn((A, self.Y), last_ask)
+        self.assertEqual(last_await.get((A, self.X)), 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_await_release.py
+++ b/tests/test_kernel_await_release.py
@@ -209,6 +209,35 @@ class MailKeyedByStableId(_AwaitBase):
         self.assertIn((A, self.Y), last_ask)
         self.assertIn((A, self.X), last_ask, "…while the old ask keeps its own key")
 
+    def test_upgrade_time_a_legacy_ask_to_a_recreated_peer_stays_keyed_to_the_prior_wearer(self):
+        # review find, 2026-09-08: the residual the PR body names, pinned so the boundary is visible:
+        # an ask sent BEFORE the upgrade (no to_sid) to a name a recreated session now wears, where the
+        # new wearer's FIRST sighting on this host is its own reply. The anchor can only pick the prior
+        # wearer (the log records no wearer deaths, and nothing sighted the new one before the send), so
+        # the ask reads open on both readers; main's last-write-wins happened to read it answered. The
+        # same exchange on a post-upgrade row keys by to_sid and reads answered: new rows cannot recur.
+        W1 = self.X                                   # wore "api" before the ask; never replied to it
+        W2 = self.Y                                   # recreated under the name; its first row is the reply
+        legacy = [
+            {"from_id": W1, "to_id": self.C, "t": 50, "kind": "coordinate", "body": "hello from the first api",
+             "from_host": "TESTHOST", "from": "api"},
+            {"from_id": A, "to_id": "peer:TESTHOST", "toName": "TESTHOST:api", "t": 100,
+             "kind": "question", "body": "status?"},
+            {"from_id": W2, "to_id": A, "t": 150, "kind": "coordinate", "body": "shipped",
+             "from_host": "TESTHOST", "from": "api"},
+        ]
+        self._write(legacy)
+        km.jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+        _any, last_ask, _aw = km._postal_wait_maps()
+        self.assertIn((A, W1), last_ask, "anchored at the send: the prior wearer (main: W2, the answerer)")
+        self.assertEqual(km._peer_answered_at(A), 0, "the documented residual: open until the 6h wake (main: 150)")
+        self.assertEqual(km.jd._open_ask_peers(A), [W1], "the judge's gate agrees with the wait maps")
+        # the same exchange as a post-upgrade row: the relay wrote the recipient's id, no alias involved
+        self._write([dict(legacy[1], to_sid=W2)] + [legacy[0], legacy[2]])
+        km.jd._PEER_ASK_CACHE[:] = [None, ({}, {}, {})]
+        self.assertEqual(km._peer_answered_at(A), 150, "to_sid keys the row to W2; W2's reply answers it")
+        self.assertEqual(km.jd._open_ask_peers(A), [])
+
     def test_to_sid_keys_the_row_without_any_alias(self):
         # a relay row since 2026-09-08 carries the sid the send resolved: no peer row is needed to
         # place it, and a later name reuse cannot move it

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -47,7 +47,7 @@ class DebtBase(unittest.TestCase):
         km._name_of = lambda sid: {ASKER: "web", ASKER2: "api", DEBTOR: "tests"}.get(sid)
         self.rec = _Recorder()
         km.Sessions.backend_for = lambda sid: self.rec
-        self._maps = ({}, {})
+        self._maps = ({}, {}, {})   # (last_any, last_ask, last_await)
         km._postal_wait_maps = lambda: self._maps
 
     def tearDown(self):
@@ -60,7 +60,7 @@ class DebtBase(unittest.TestCase):
         if answered_at is not None:
             last_any[(DEBTOR, asker)] = answered_at
         last_ask = {(asker, DEBTOR): (ts, kind, head)}
-        self._maps = (last_any, last_ask)
+        self._maps = (last_any, last_ask, {})
         km._postal_wait_maps = lambda: self._maps
 
 
@@ -82,7 +82,7 @@ class DebtAsks(DebtBase):
 
     def test_legacy_two_tuple_records_still_read(self):
         # a cached (ts, kind) record from before the head rode along must not crash the scan
-        self._maps = ({(ASKER, DEBTOR): T_ASK}, {(ASKER, DEBTOR): (T_ASK, "question")})
+        self._maps = ({(ASKER, DEBTOR): T_ASK}, {(ASKER, DEBTOR): (T_ASK, "question")}, {})
         km._postal_wait_maps = lambda: self._maps
         self.assertEqual(km._debt_asks(DEBTOR, {ASKER}),
                          [(ASKER, "web", T_ASK, "question", "")])
@@ -130,7 +130,7 @@ class DebtReminder(DebtBase):
         last_any = {(ASKER, DEBTOR): T_ASK, (ASKER2, DEBTOR): T_ASK + 5}
         last_ask = {(ASKER, DEBTOR): (T_ASK, "question", "Which port?"),
                     (ASKER2, DEBTOR): (T_ASK + 5, "delegate", "Take the backfill.")}
-        self._maps = (last_any, last_ask)
+        self._maps = (last_any, last_ask, {})
         km._postal_wait_maps = lambda: self._maps
         self.assertTrue(km._fire_debt_reminder(DEBTOR, NOW, {ASKER, ASKER2, DEBTOR}))
         self.assertEqual(len(self.rec.sent), 1, "debts coalesce into one message")

--- a/tests/test_paused_matrix.py
+++ b/tests/test_paused_matrix.py
@@ -128,8 +128,10 @@ class MatrixMint(_Base):
         # the pair-blind trade (documented in _peer_answered_at): the answered exchange is with a
         # DIFFERENT topic/peer than the stamp's subject, and the stamp still goes dark. The sweep's
         # durable lift is what turns this cell from paused-forever into a fresh closer ruling.
+        # PIN MOVED 2026-09-08: the outbound is a QUESTION (was a coordinate) — the answered clock walks
+        # reply-REQUIRING sends, and a coordinate-only exchange answers nothing (test_awaiting_peer_matrix).
         other = "99999999-aaaa-bbbb-cccc-dddddddddddd"
-        self._log([_msg(1, SID, other, STAMP_EV - 50, "coordinate"),
+        self._log([_msg(1, SID, other, STAMP_EV - 50, "question"),
                    _msg(2, other, SID, REPLY, "coordinate")])
         self.assertTrue(self._dark(self._node(kind="peer")),
                         "any answered outbound pair supersedes a peer stamp (the known trade)")

--- a/tests/test_peer_identity_naming.py
+++ b/tests/test_peer_identity_naming.py
@@ -7,8 +7,12 @@ arm hardcoded peers=None even when the stamp recorded its awaitPeers, and build_
 filtered on raw nodeComplete while its gate pierced done-markers for agent-open nodes (an empty scan
 minted a nameless, durationless wait the gate saw as real). One identity ladder (_peer_identity) now
 resolves every recorded shape: the names REGISTRY first — identity persists for DORMANT sessions,
-liveness is never a prerequisite for naming — else the composite's own parts (display-join on the
-canonical pair, per the federation rule), else the sid stub. All fixtures SYNTHETIC."""
+liveness is never a prerequisite for naming, else, for a bare sid another kernel owns, what its host
+calls it in the tunnel supervisor's snapshot, else the "<host>:<name>" the postal log itself paired
+with the sid (review find, 2026-09-08: the wait maps key a cross-host ask on the row's to_sid, and
+the registry knows no remote sid, so the awaiting chip named the peer by an eight-hex stub with no
+host), else the composite's own parts (display-join on the canonical pair, per the federation rule),
+else the sid stub. All fixtures SYNTHETIC."""
 import json
 import os
 import tempfile
@@ -68,6 +72,27 @@ class _Base(unittest.TestCase):
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 9, "placements": {}, "status": status or {}, "nodes": nodes}))
 
+    def _attach(self, host, sid, name=None):
+        # the tunnel supervisor's polled copy of a remote host's registry (the shape _host_for_sid and
+        # _remote_name_of read); a host polled before names were filed has the sid and no name
+        with km._remotes_lock:
+            km._remotes[host] = {"host": host, "sids": [sid], "names": ({sid: name} if name else {})}
+        self.addCleanup(lambda: km._remotes.pop(host, None))
+
+    def _postal(self, rows):
+        # a postal log of SYNTHETIC rows under the temp root; both kernel caches reset around it
+        path = Path(self.td.name) / "timeline" / "messages.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(json.dumps(r) + "\n" for r in rows))
+        saved = km.jd.MESSAGES
+        km.jd.MESSAGES = path
+
+        def _reset():
+            km._POSTAL_WAIT_CACHE[:] = [None, None]
+            km._POSTAL_PEER_NAMES[:] = [None, {}]
+        _reset()
+        self.addCleanup(lambda: (setattr(km.jd, "MESSAGES", saved), _reset()))
+
 
 class PeerIdentityLadder(_Base):
     """_peer_identity — the ONE resolve for every recorded peer shape."""
@@ -96,6 +121,41 @@ class PeerIdentityLadder(_Base):
     def test_bare_unknown_sid_stubs(self):
         got = km._peer_identity(FARSID)
         self.assertEqual((got["name"], got["host"], got["color"]), (FARSID[:8], "", None))
+
+    def test_a_remote_sid_names_from_its_hosts_polled_registry(self):
+        # review find, 2026-09-08: the wait maps key a cross-host ask on the row's to_sid: a bare sid
+        # this kernel's registry cannot name. What its host calls it is one read away (the supervisor's
+        # snapshot, the ladder the user ruled on 2026-09-06 for a federated session); the ladder skipped it.
+        self._attach("TESTHOST", FARSID, "api")
+        self.assertEqual(km._peer_identity(FARSID),
+                         {"name": "api", "host": "TESTHOST", "sid": FARSID, "color": None})   # stub on the PR head
+
+    def test_a_remote_sid_names_from_the_postal_logs_own_join_when_no_host_is_attached(self):
+        # a host reached through gossip is never polled, so no snapshot names its sessions, but the
+        # relay row that keyed the wait paired the sid with "<host>:<name>" itself, and the peer's own
+        # stamps do too; the newest sighting wins, so a rename reads through
+        self._postal([{"ev": "sent", "id": "m1", "from": "web", "from_id": SID, "to_id": "peer:TESTHOST",
+                       "toName": "TESTHOST:api", "to_sid": FARSID, "t": 100, "kind": "question", "body": "x"}])
+        self.assertEqual(km._peer_identity(FARSID),
+                         {"name": "api", "host": "TESTHOST", "sid": FARSID, "color": None})
+        self._postal([{"ev": "sent", "id": "m1", "from": "web", "from_id": SID, "to_id": "peer:TESTHOST",
+                       "toName": "TESTHOST:api", "to_sid": FARSID, "t": 100, "kind": "question", "body": "x"},
+                      {"ev": "sent", "id": "m2", "from": "api2", "from_id": FARSID, "from_host": "TESTHOST",
+                       "to_id": SID, "t": 200, "kind": "coordinate", "body": "renamed myself"}])
+        self.assertEqual(km._peer_identity(FARSID)["name"], "api2", "the peer's own later stamp wins")
+        self.assertEqual(km._peer_identity(FARSID)["host"], "TESTHOST")
+
+    def test_the_polled_registry_outranks_the_postal_join_and_the_owner_alone_keeps_the_host(self):
+        self._postal([{"ev": "sent", "id": "m1", "from": "web", "from_id": SID, "to_id": "peer:TESTHOST",
+                       "toName": "TESTHOST:old", "to_sid": FARSID, "t": 100, "kind": "question", "body": "x"}])
+        self._attach("TESTHOST", FARSID, "api")
+        self.assertEqual(km._peer_identity(FARSID)["name"], "api", "the host's live registry is authoritative")
+        km._remotes["TESTHOST"]["names"] = {}                  # polled before names were filed, no log join
+        km.jd.MESSAGES = Path(self.td.name) / "timeline" / "absent.jsonl"
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+        got = km._peer_identity(FARSID)
+        self.assertEqual((got["name"], got["host"], got["color"]), (FARSID[:8], "TESTHOST", None),
+                         "the stub keeps the host the supervisor knows (was: host '')")
 
 
 class DelegatedWaitNames(_Base):
@@ -147,6 +207,17 @@ class StampArmNamesPeers(_Base):
         aw = km._session_awaiting(SID, "/p", True, stamp=True)
         self.assertEqual(aw["kind"], "peer")
         self.assertEqual(aw["peers"][0]["name"], "web")
+
+    def test_session_arm_names_a_to_sid_keyed_remote_peer_with_its_host(self):
+        # the rendered chip (review find, 2026-09-08): a stamp whose awaitPeers is the bare remote sid
+        # the wait maps now key on carried name FARSID[:8] and host '' to every surface, the feed
+        # joins host+name for the label, so it read an eight-hex stub with no host for the whole wait
+        self._attach("TESTHOST", FARSID, "api")
+        self._stamped(peers=(FARSID,))
+        aw = km._session_awaiting(SID, "/p", True, stamp=True)
+        self.assertEqual(aw["peers"], [{"name": "api", "host": "TESTHOST", "sid": FARSID, "color": None}])
+        self.assertEqual([it["label"] for it in aw["items"]], ["api"], "the item label is the name, not the stub")
+        self.assertEqual(aw["count"], 1)
 
     def test_non_peer_and_recordless_stamps_keep_the_legacy_shape(self):
         # byte-identical dicts for every arm that has nothing to name — no key, not a null

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -13,6 +13,7 @@ last ANSWERED rows when the local listing doesn't answer, so a local blink never
 
 SYNTHETIC fixtures only: placeholder UUIDs, invented names.
 """
+import io
 import json
 import os
 import tempfile
@@ -369,6 +370,116 @@ class QuarantineApproveHonesty(_RelayBase):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
         self.assertIn('HTTPConnection("127.0.0.1", BUS_PORT, timeout=20)', src,
                       "the client half of the approve budget pair — the halves move together")
+
+
+class RelayRowCarriesTheStableId(_RelayBase):
+    """The cross-host send's LOCAL record names the recipient by its stable id (2026-09-08). The wire
+    message has carried `toId` since 2026-09-01, but the sent row kept only "<host>:<name>", so every
+    wait reader joined it back to a sid through a name→sid alias learned from the peer's own rows —
+    a join a reused name could re-point at a stranger. The id was already in hand at the write."""
+
+    def _post_send(self, payload):
+        # the /send route lives inline in do_POST: drive the handler with a fake request
+        h = object.__new__(pm.Handler)
+        raw = json.dumps(payload).encode()
+        h.path = "/send"
+        h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": pm.SERVE_TOKEN}
+        h.rfile = io.BytesIO(raw)
+        out = []
+        h._send = lambda obj, code=200: out.append((obj, code))
+        h.do_POST()
+        return out[0]
+
+    def test_the_relay_sent_row_carries_to_sid_equal_to_the_wire_toid(self):
+        _set_live([{"id": ALPHA, "name": "web"}])            # the sender lives here …
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        pm.PEER_STATE["TESTHOST"] = {"presence": [{"id": GHOST, "name": "api"}], "epoch": 1, "seenAt": 0}
+        parked = []                                           # … the recipient on TESTHOST
+        saved_put = pm.outbox_put
+        pm.outbox_put = lambda h, m: parked.append((h, m))
+        self.addCleanup(lambda: (setattr(pm, "outbox_put", saved_put), pm.PEER_STATE.clear(),
+                                 os.environ.pop("ROMP_POSTAL_PEERS", None)))
+        obj, code = self._post_send({"to": "api", "from": "web", "from_id": ALPHA,
+                                     "body": "which port does staging use?", "kind": "question"})
+        self.assertEqual(code, 200, obj)
+        self.assertEqual(parked[0][1]["toId"], GHOST, "the wire carries the resolved sid (2026-09-01)")
+        rows = [json.loads(l) for l in (pm.TLDIR / "messages.jsonl").read_text().splitlines()]
+        row = next(r for r in rows if r.get("id") == obj["id"])
+        self.assertEqual(row["to_sid"], GHOST, "the local row carries the SAME sid")   # KeyError on main
+        self.assertEqual((row["to_id"], row["toName"], row["kind"]),
+                         ("peer:TESTHOST", "TESTHOST:api", "question"), "the old keys are untouched")
+
+
+class QuarantineApproveIsIdStrict(_RelayBase):
+    """Held mail that was ID-addressed on the wire may only ever reach that id (2026-09-08). The held
+    record kept only the RESOLVED local sid, and approve re-matched by NAME whenever that sid was no
+    longer live — so id-addressed mail whose recipient had ended went to whatever session now wore
+    the name, the exact swap intake refuses ("never a name fallback, which could hand the mail to a
+    same-named sibling"). The record now remembers the wire id (`toWireId`) and approve is id-strict
+    for it: nothing live by that id → a loud refusal that keeps the hold. Name-addressed mail (an
+    older sender) still re-matches by name."""
+
+    def setUp(self):
+        super().setUp()
+        pm.PEERS["TESTHOST"] = {"port": 1, "up": True, "trust": "directed"}
+        self.delivered = []
+        saved = pm.deliver
+        pm.deliver = lambda *a, **k: self.delivered.append((a, k)) or "m-q"
+        self.addCleanup(lambda: (setattr(pm, "deliver", saved), pm.PEERS.clear()))
+
+    def _hold(self, m):
+        verdict, _ = pm._relay_in("TESTHOST", m)
+        self.assertEqual(verdict, "ack", "directed → held, ack'd")
+        rec = pm.quarantine_get(m["mid"])
+        self.assertIsNotNone(rec, "the message is in the hold")
+        self.addCleanup(lambda: pm.quarantine_del(m["mid"]))
+        return rec
+
+    def test_id_addressed_mail_whose_recipient_ended_refuses_a_name_squatter(self):
+        _set_live([{"id": GHOST, "name": "web"}])
+        m = dict(self._msg("web"), toId=GHOST)
+        rec = self._hold(m)
+        self.assertEqual(rec["toWireId"], GHOST, "the hold remembers the wire chose a sid")   # KeyError on main
+        _set_live([{"id": ALPHA, "name": "web"}])            # GHOST ended; ALPHA wears the name now
+        ok, err = pm.quarantine_decide(m["mid"], "approve")
+        self.assertFalse(ok, "main delivers to the squatter here")
+        self.assertEqual(self.delivered, [], "nothing reached the same-named stranger")
+        self.assertIn("has ended", err)
+        self.assertIn("'web'", err, "the refusal names the session the mail was addressed to")
+        self.assertIn(GHOST[:8], err, "…and its id")
+        self.assertIsNotNone(pm.quarantine_get(m["mid"]), "the record stays held (deny carries a note back)")
+
+    def test_id_addressed_mail_whose_recipient_renamed_still_delivers_to_it(self):
+        _set_live([{"id": GHOST, "name": "web"}])
+        m = dict(self._msg("web"), toId=GHOST)
+        self._hold(m)
+        _set_live([{"id": ALPHA, "name": "web"}, {"id": GHOST, "name": "web2"}])   # renamed, still live
+        ok, err = pm.quarantine_decide(m["mid"], "approve")
+        self.assertTrue(ok, err)
+        self.assertEqual(self.delivered[0][0][0], GHOST, "the sid picks the session, not the name")
+
+    def test_name_addressed_mail_still_rematches_by_name(self):
+        # a GUARD (passes on main too): an older sender parks no toId, so the name is all there is
+        _set_live([{"id": GHOST, "name": "web"}])
+        m = self._msg("web")
+        rec = self._hold(m)
+        self.assertNotIn("toWireId", rec, "name-addressed: no wire id recorded")
+        _set_live([{"id": ALPHA, "name": "web"}])
+        ok, err = pm.quarantine_decide(m["mid"], "approve")
+        self.assertTrue(ok, err)
+        self.assertEqual(self.delivered[0][0][0], ALPHA, "the name re-match stands for name-addressed mail")
+
+    def test_the_hold_sanitizes_the_wire_id_itself(self):
+        # belt for callers that pass no wire_id: the record reads the wire toId and drops a malformed
+        # shape exactly as intake does — it is a match key, never a path
+        m = dict(self._msg("web"), toId=GHOST)
+        self.assertTrue(pm._quarantine_put("TESTHOST", m, ALPHA))
+        self.addCleanup(lambda: pm.quarantine_del(m["mid"]))
+        self.assertEqual(pm.quarantine_get(m["mid"])["toWireId"], GHOST)                # KeyError on main
+        m2 = dict(self._msg("web"), toId="../../etc/hostname")
+        self.assertTrue(pm._quarantine_put("TESTHOST", m2, ALPHA))
+        self.addCleanup(lambda: pm.quarantine_del(m2["mid"]))
+        self.assertNotIn("toWireId", pm.quarantine_get(m2["mid"]), "a malformed wire id is not a key")
 
 
 class SetWorkingMissingParamRefuses(unittest.TestCase):

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -444,12 +444,19 @@ class QuarantineApproveIsIdStrict(_RelayBase):
         ok, err = pm.quarantine_decide(m["mid"], "approve")
         self.assertFalse(ok, "main delivers to the squatter here")
         self.assertEqual(self.delivered, [], "nothing reached the same-named stranger")
-        self.assertIn("has ended", err)
+        self.assertIn("no live session carries the id", err,
+                      "worded on what the listing proved (review find, 2026-09-08: it said 'has ended', "
+                      "which a dormant session is not)")
+        self.assertNotIn("has ended", err)
         self.assertIn("'web'", err, "the refusal names the session the mail was addressed to")
         self.assertIn(GHOST[:8], err, "…and its id")
         self.assertIsNotNone(pm.quarantine_get(m["mid"]), "the record stays held (deny carries a note back)")
 
     def test_id_addressed_mail_whose_recipient_renamed_still_delivers_to_it(self):
+        # a GUARD, not the id-strict branch: the held sid is still live, so approve never enters the
+        # gone-sid arm at all (the rename changes nothing the record keys on). Passes on main too.
+        # There is no positive arm to reach in that branch (review find, 2026-09-08): the held sid is
+        # the wire id, so once it is gone nothing live can match it: see the id-strict refusal above.
         _set_live([{"id": GHOST, "name": "web"}])
         m = dict(self._msg("web"), toId=GHOST)
         self._hold(m)
@@ -457,6 +464,28 @@ class QuarantineApproveIsIdStrict(_RelayBase):
         ok, err = pm.quarantine_decide(m["mid"], "approve")
         self.assertTrue(ok, err)
         self.assertEqual(self.delivered[0][0][0], GHOST, "the sid picks the session, not the name")
+
+    def test_id_addressed_mail_whose_recipient_is_gone_refuses_with_nobody_wearing_the_name_too(self):
+        # the same refusal with no squatter in the listing: the branch never looks for one
+        _set_live([{"id": GHOST, "name": "web"}])
+        m = dict(self._msg("web"), toId=GHOST)
+        self._hold(m)
+        _set_live([{"id": ALPHA, "name": "api"}])
+        ok, err = pm.quarantine_decide(m["mid"], "approve")
+        self.assertFalse(ok)
+        self.assertIn("no live session carries the id", err)
+        self.assertEqual(self.delivered, [])
+        self.assertIsNotNone(pm.quarantine_get(m["mid"]), "still held")
+
+    def test_the_id_strict_branch_has_no_name_fallback_and_no_dead_arm(self):
+        # structural pin (review find, 2026-09-08): between reading toWireId and the name re-match
+        # there is exactly one statement path, the refusal, and no re-match on the wire id
+        import inspect
+        src = inspect.getsource(pm.quarantine_decide)
+        body = src[src.index('wire = str(rec.get("toWireId")'):src.index("NAME-addressed")]
+        self.assertNotIn("== wire", body, "no candidate scan on the wire id: it cannot succeed")
+        self.assertNotIn('a["name"] == rec.get("to")', body, "no name re-match for id-addressed mail")
+        self.assertEqual(body.count("return False"), 1)
 
     def test_name_addressed_mail_still_rematches_by_name(self):
         # a GUARD (passes on main too): an older sender parks no toId, so the name is all there is

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -51,14 +51,14 @@ class _StateSandbox(unittest.TestCase):
         for d in (jd.STATESDIR, jd.MESSAGES.parent, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, root / "sdk"):
             d.mkdir(parents=True, exist_ok=True)
         km._postal_index_memo[0] = None
-        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {}, {})]
         self.addCleanup(self._restore_paths)
 
     def _restore_paths(self):
         for k, v in self._saved_paths.items():
             setattr(jd, k, v)
         km._postal_index_memo[0] = None
-        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {})]
+        km._POSTAL_WAIT_CACHE[:] = [None, ({}, {}, {})]
 
 
 def _write_rows(path, rows):


### PR DESCRIPTION
Three name-keyed joins in the cross-host mail path where the stable session id was already in hand, verified on `main`:

- **The relay's sent row dropped the recipient's id.** The wire message carried `toId`, but the local `messages.jsonl` row wrote only `peer:<host>` and the name, so every later reader re-derived the recipient from a name.
- **The answered clock counted every message.** `_peer_answered_at` and `_peer_answered` iterated `last_any`, so an asker's own coordinate note sent after the answer made the newest outbound "unanswered": the answer stopped superseding the stamp and an awaiting row stood against a peer that had already replied.
- **The alias map was last-write-wins.** A name reused by a newer session re-keyed every older message to the new id, in both the kernel's and the judge's readers.
- **Held mail re-matched by name.** Quarantine approve delivered id-addressed mail whose recipient had ended to whatever session now wore the name, while intake was already id-strict for the same mail.

## What changes

The relay's sent row carries `to_sid`, and both readers key an outbound row by it, falling back to the name alias only for older rows. `_postal_wait_maps` returns a third map, `last_await`, the last reply-requiring send (question or delegate) per pair, and the answered clock iterates that. Aliases are time-anchored: `_alias_at` answers the id a name mapped to at the moment the message was sent, so a reused name never re-keys the past. The hold stores the sanitized wire id; approve matches on it alone when the held recipient is gone and refuses loudly when nothing by that id is live, leaving the record held; name-addressed mail still re-matches by name.

## Judgment calls

- Question and delegate are the reply-requiring kinds; a coordinate neither opens nor answers a wait.
- A time-anchored alias falls to the earliest known mapping when none precedes the message, so pre-history rows keep working.
- Three pre-existing tests sent an unrelated peer a coordinate, had it replied to, and asserted that exchange superseded a stamp: exactly the behavior this fixes. A coordinate declares that a reply is optional, so its reply is not evidence that anything awaited was answered, and acting on it moved a card with no new information. Each now sends a question, so its own purpose (pair-aware versus pair-blind supersede; legacy identity-less stamps never strand) holds unchanged, and each is marked as a moved pin.
- The alias history keeps one entry per wearer change, not per row, so a chatty peer name does not make every legacy row's lookup walk thousands of sightings.
- Residual, legacy rows only: a pre-existing ask to a reused name whose new wearer's first sighting on this host is the reply itself anchors to the old wearer and stays open. New rows carry the recipient's id, so the case cannot recur, and across the old rows the anchor keys far more asks correctly than the last-write-wins map did.

## Tests

Postal: the relay row carries the wire id; id-addressed held mail refuses a name squatter while name-addressed mail still re-matches; the hold sanitizes the wire id. Kernel: a coordinate after the answer leaves the question answered; a reused name leaves the old ask keyed to the session it went to; `to_sid` keys a row without any alias. Judge: the gate keeps an answered ask answered through a name reuse and reads `to_sid`; the alias rule itself; the cross-host handoff arm anchored at the handoff's time, with a wearer history that fails both a literal and a last-write-wins revert. Every pre-existing test in the touched modules stays green with its unpack sites and fixtures updated.

Module counts on this tree, one runner at a time: `tests/test_postal_relay_honesty.py` 35; `tests/test_postal_quarantine.py` 30; `tests/test_postal_peers.py` 25; `tests/test_kernel_await_release.py` 12; `tests/test_awaiting_peer_matrix.py` 27; `tests/test_kernel_debt_nudge.py` 17; `tests/test_decline_never_closes.py` 13; `tests/test_stage0_log_readers.py` 37; `tests/test_paused_matrix.py` 19 (12 subtests); `tests/test_dead_wait_block.py` 23; `tests/test_kernel_awaiting_stamp.py` 50; `tests/test_postal_walked_ask.py` 7; `tests/test_postal_read_receipts.py` 16; `tests/test_awaiting_audit_classes.py` 6; `tests/test_postal_self_send.py` 28; `tests/test_injected_voice.py` 8 (190 subtests). On `main` the new tests fail as the commit body names: three in the relay module (the missing `to_sid` and `toWireId` keys), ten in the kernel await module (the three-tuple unpack, and the coordinate re-opening the pair), six in the peer matrix (the gate keeping the reused name, the alias reader missing), fifteen in the debt-nudge module (the stubbed three-tuples), and the two cross-host handoff tests. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
