### PR TITLE
Tools: offline performance benches for the kernel's payload builders and the dashboard panes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,17 +161,38 @@ jobs:
         run: npm test
       - name: Build
         run: npm run build
+      - name: Cache Playwright's browsers
+        # Keyed on the lockfile, so the download below runs once per playwright version.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('vscode-extension/package-lock.json') }}
+      - name: Install the pinned Playwright Chromium
+        # The pane bench below needs a browser. It is playwright's own download for the version
+        # package-lock pins (1.62.x fetches its matching Chromium build, about 150 MB, cached above), NOT
+        # the runner image's Google Chrome: the image's browser is unpinned and auto-updated, so a Chrome
+        # release the pinned driver cannot speak, or an image without one, would have turned this REQUIRED
+        # check red with no change in the repo (review find, 2026-09-08). The same stance as the node pin
+        # above: the step never rides whatever the image has. No --with-deps: that runs apt, which the bats
+        # step stopped trusting after a mirror outage, and the shared libraries Chromium needs come with
+        # the image. tools/ui-bench.mjs prefers this browser to any system Chrome, and the step's log says
+        # which one ran ("browser: playwright chromium").
+        timeout-minutes: 5
+        run: npx playwright install chromium
       - name: Dashboard pane bench (node --test)
-        # tools/ui-bench.mjs replays a synthetic frame stream into the real feed and timeline pages in a
-        # headless Chrome (the runner image's Google Chrome through playwright's channel option, so no
-        # browser download), served by the kernel's own page route from the dist the Build step just
-        # wrote; python3 comes with the image. The test file lives at the repo root, hence the
-        # working-directory override of the job's vscode-extension/ default. On a contributor's machine
-        # the browser tests skip, and say why, when no browser, python3 or dist is present. Here
+        # tools/ui-bench.mjs replays a synthetic frame stream into the real feed and timeline pages in the
+        # headless Chromium installed above, served by the kernel's own page route from the dist the Build
+        # step just wrote; python3 comes with the image (every Ubuntu image ships one inside the kernel's
+        # 3.10 to 3.13 range, which the Python cells above cover). The test file lives at the repo root,
+        # hence the working-directory override of the job's vscode-extension/ default. On a contributor's
+        # machine the browser tests skip, and say why, when no browser, python3 or dist is present. Here
         # ROMP_UI_BENCH_REQUIRE makes that skip a failure: this is the only CI run of the real pane
-        # bundles, and a runner image that drops Chrome from PATH must turn the job red rather than
-        # green with the coverage gone (the same stance as the cryptography install above, which exists
-        # so its tests RUN).
+        # bundles, and a runner without the browser or python3 must turn the job red rather than green
+        # with the coverage gone (the same stance as the cryptography install above, which exists so its
+        # tests RUN). The replays assert only what holds under any scheduling (totals, ordering, the
+        # handoff's accounting); the timing relations are assertions only under ROMP_UI_BENCH_TIMING,
+        # which this step deliberately leaves unset: a shared runner's scheduler is not what the required
+        # check measures (review find, 2026-09-08).
         working-directory: ${{ github.workspace }}
         env:
           ROMP_UI_BENCH_REQUIRE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,18 @@ jobs:
         run: npm test
       - name: Build
         run: npm run build
+      - name: Dashboard pane bench (node --test)
+        # tools/ui-bench.mjs replays a synthetic frame stream into the real feed and timeline pages in a
+        # headless Chrome (the runner image's Google Chrome through playwright's channel option, so no
+        # browser download), served by the kernel's own page route from the dist the Build step just
+        # wrote; python3 comes with the image. The test file lives at the repo root, hence the
+        # working-directory override of the job's vscode-extension/ default. On a contributor's machine
+        # the browser tests skip, and say why, when no browser, python3 or dist is present. Here
+        # ROMP_UI_BENCH_REQUIRE makes that skip a failure: this is the only CI run of the real pane
+        # bundles, and a runner image that drops Chrome from PATH must turn the job red rather than
+        # green with the coverage gone (the same stance as the cryptography install above, which exists
+        # so its tests RUN).
+        working-directory: ${{ github.workspace }}
+        env:
+          ROMP_UI_BENCH_REQUIRE: "1"
+        run: node --test tests/ui-bench.test.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,11 @@ not.
 The numbers come from the real pages: the kernel's own HTTP handler serves the
 HTML, the shim, and the bundles from a `python3` subprocess under an isolated
 environment, the pattern of `tests/test_color_route.py` with the floors
-`tests/conftest.py` applies (the manager variables and the API-key variables
-are removed, the manager's key file and the boot model-catalog fetch are
+`tests/conftest.py` applies (the manager variables are removed and the manager
+port set to a dead one; every credential and key-source name conftest pops is
+removed, the API keys, the key reference and command, the token credentials,
+the auth declaration and 1Password's names; the manager's key file and the
+boot model-catalog fetch are
 pointed away, the Claude binary is `/bin/false`, the CLI scope is off, the
 postal peer bus is off, the serve token is minted for the run, and the
 subprocess exits when the bench does). Run state, the browser's profile
@@ -115,9 +118,17 @@ built by `build_session` and is too rich to fake, so record it.
 `tests/ui-bench.test.mjs` (`node --test tests/ui-bench.test.mjs`) covers the
 tool, including the recording client against a local WebSocket server and the
 Handler subprocess's isolation, and replays synthetic feed and timeline streams
-in a real browser. The browser tests skip, saying why, when no Chromium, no
-`python3` or no built `dist/` is available; with `ROMP_UI_BENCH_REQUIRE=1` in
-the environment (CI sets it) that skip is a failure instead.
+in a real browser. The browser tests skip, saying why, when no Chromium (either
+playwright's own, `cd vscode-extension && npx playwright install chromium`,
+which CI installs so the required check never rides the runner image's
+browser, or a system Google Chrome), no `python3` or no built `dist/` is
+available; with `ROMP_UI_BENCH_REQUIRE=1` in the environment (CI sets it) that
+skip is a failure instead. The replays assert
+what holds under any scheduling (frame totals, ordering, the handoff's
+accounting); the timing relations the bench measures (a settle margin, a render
+outweighing a parse, the CPU throttle's slowdown) are assertions only with
+`ROMP_UI_BENCH_TIMING=1`, which a loaded machine can fail and CI does not set;
+without it a relation that did not hold is a diagnostic line in the output.
 
 ## Test environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,107 @@ The Python and shell suites are also the CI gate, across Python 3.10 to 3.13 on
 Linux; the macOS cells run on demand from the Actions tab (they are billed even
 on a public repo, so they are not part of the per-push matrix).
 
+## Measuring dashboard pane performance
+
+`tools/ui-bench.mjs` replays a pane's frame stream into the real pane page in
+a headless Chromium and reports where the browser's time goes, so a rendering
+change can be measured before and after it lands, on the same input. It needs
+the extension's `node_modules` (`cd vscode-extension && npm ci`), a built
+`dist/` (`npm run build` there), `python3`, and a Chromium: Playwright's own
+(`npx playwright install chromium` in `vscode-extension/`) or a system Google
+Chrome. The tool is POSIX-only (Linux and macOS).
+
+```bash
+# a frame stream with invented content, for a bench that needs no live kernel
+node tools/ui-bench.mjs --synthesize feed --cards 200 --out /tmp/romp-perf/synth-feed.jsonl
+# replay it into the real feed page, a frame every 100 ms, and print per-frame timings
+node tools/ui-bench.mjs --replay feed --frames /tmp/romp-perf/synth-feed.jsonl --gap 100 --json /tmp/romp-perf/before.json
+# change the bundle, rebuild, replay again, then compare the two reports
+node tools/ui-bench.mjs --compare /tmp/romp-perf/before.json /tmp/romp-perf/after.json
+# record 90 seconds of what a running kernel sends the feed page, then replay that
+node tools/ui-bench.mjs --record feed --seconds 90 --out /tmp/romp-perf/frames-feed.jsonl
+node tools/ui-bench.mjs --replay feed --frames /tmp/romp-perf/frames-feed.jsonl --json /tmp/romp-perf/live.json
+```
+
+The pane page's shim does not render a frame inside its WebSocket handler. The
+handler parses the frame, applies a view delta to the state it holds, and
+queues the result; a separate task (a `MessageChannel` message, so it runs
+while the tab is hidden too) hands the queued frames to the bundle, where a
+newer whole-state frame (a full feed, the timeline's bars or skeleton, a tab
+order) replaces an older one still queued, and the task stops after 8 ms and
+re-arms itself so input can land between slices. A wire frame and the
+bundle's render of it are therefore two measurements, and a replay reports
+both, per frame type: the bytes; the handler time (the shim's synchronous
+work per wire frame); the bundle time for each frame the shim delivered on its
+own; and the settle, the time from a frame's receipt until the main thread is
+free again (the second `requestAnimationFrame` after the delivery that
+carried it), each as p50, p90, and max. A `delivered` column beside `count`
+says how many frames of a type reached the bundle as their own delivery; the
+rest were coalesced into a newer frame's (the report counts them) or, for
+keepalives and the resync asks the shim answers itself, never left the shim.
+Frames sent back-to-back with `--fast` queue together, so most of a stream's
+deltas coalesce into one delivery and the bundle column covers only that
+one; for the bundle's cost per frame, replay at the recorded pacing or with
+`--gap 100` (a fixed gap in milliseconds between frames). On a kernel whose
+shim still renders inside the handler, the report says so and the handler
+column includes the bundle's time.
+
+After the table come the long-animation-frame entries with script
+attribution, the JavaScript heap after a forced garbage collection (and before
+it, so the line shows what the collection freed), the DOM size, and every
+console error and uncaught exception. The attribution names each task's entry point
+(the WebSocket message handler, the shim's flush task, a
+`requestAnimationFrame` callback, a timer, a script's evaluation), not the
+function inside the bundle that did the work. For that, add
+`--cpu-profile /tmp/romp-perf/feed.cpuprofile`: it samples the page's
+JavaScript with the V8 profiler across the replay, writes a file Chrome
+DevTools loads (Performance panel), and prints the functions with the most
+self and total time as `bundle.js:function:line` with the source position from
+the dist's `.map` files (a `--production` dist is minified and has none; the
+report says so), overall and inside the delivery that carried the first
+content frame and the largest frame of each type. For the hottest functions
+it also names the lines that hold the time; a forced synchronous layout, for
+instance, shows up as one line of one function owning most of its self time.
+The end-of-run layout, style, script and task counters are cumulative since
+navigation, so they include page load and idle timers (the timeline redraws
+every animation frame while it follows the present), and `--compare` shows
+them without percentages when the two runs differ in pacing or length.
+`--cpu-throttle 4` emulates a machine four times slower (the default is no
+throttling). `--iters 3` pools three runs. With `--fast`, settle times overlap
+(a frame's includes the frames queued behind it); handler and bundle times do
+not.
+
+The numbers come from the real pages: the kernel's own HTTP handler serves the
+HTML, the shim, and the bundles from a `python3` subprocess under an isolated
+environment, the pattern of `tests/test_color_route.py` with the floors
+`tests/conftest.py` applies (the manager variables and the API-key variables
+are removed, the manager's key file and the boot model-catalog fetch are
+pointed away, the Claude binary is `/bin/false`, the CLI scope is off, the
+postal peer bus is off, the serve token is minted for the run, and the
+subprocess exits when the bench does). Run state, the browser's profile
+included, lives under one per-user directory in the temp root; a run killed
+with its whole process group leaves its entry there until the next run sweeps
+it. A Node front server answers the page's WebSocket and proxies everything
+else to the subprocess.
+
+A recording holds real session data. `--record` connects to the running kernel
+as one more pane (the same URL and query, the token as the page's cookie),
+sends the ready handshake and nothing else, and writes only under the system
+temp directory (private to your user: directory 0700, file 0600), refusing a
+path inside a git checkout or through a symlink. Never copy one into the repo;
+the tests use synthetic streams. Apps: `feed`, `fleet` (the Outline pane),
+`chat`, `timeline`. Only the chat cannot be synthesized: its session frame is
+built by `build_session` and is too rich to fake, so record it.
+
+`tests/ui-bench.test.mjs` (`node --test tests/ui-bench.test.mjs`) covers the
+tool, including the recording client against a local WebSocket server and the
+Handler subprocess's isolation, and replays synthetic feed and timeline streams
+in a real browser. The browser tests skip, saying why, when no Chromium, no
+`python3` or no built `dist/` is available; with `ROMP_UI_BENCH_REQUIRE=1` in
+the environment (CI sets it) that skip is a failure instead.
+
+## Test environment
+
 Three things about the test environment are worth knowing, because all have
 produced confusing failures:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1044,6 +1044,12 @@ romp-manager -f | grep romp-perf`; under launchd (macOS), `tail -f
 ~/.local/state/romp/manager.log | grep romp-perf`. Setting `ROMP_PERF=1` in the
 kernel's environment still turns it on at start.
 
+The counters describe a running kernel. To time the same builders offline, on
+a copy of a state directory and with no live kernel, `tools/perf-bench.py`
+loads a checkout's kernel in-process and reports each builder's cost on
+real-sized data; two checkouts can run against one copy for a before-and-after
+comparison. Its module docstring is the reference.
+
 ## Browser-side performance telemetry
 
 The counters above say what the kernel spent. What the browser spent on the
@@ -1171,6 +1177,12 @@ in progress in the same shape, plus a derived `p90_le` per type, `active`
 (the node test stand-ins) gets no telemetry and an unwrapped handler; every
 other browser API is behind a feature check, and nothing in the module throws
 into the pane.
+
+The telemetry describes what the panes did while people used them. To measure
+a pane change before and after on the same input, `tools/ui-bench.mjs` replays
+a recorded or synthetic frame stream into the real pane page in a headless
+Chromium and reports where the browser's time went; the "Measuring dashboard
+pane performance" section of CONTRIBUTING.md describes it.
 
 ## The API-health signal
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,9 @@ Every bug fix or feature change lands with a test (repo rule). Five suites:
   Run `node --test tests/ui-bench.test.mjs` from the repo root after
   `cd vscode-extension && npm ci && npm run build`. The browser tests skip,
   saying why, when no Chromium, `python3` or dist is present;
-  `ROMP_UI_BENCH_REQUIRE=1` (CI) turns that skip into a failure.
+  `ROMP_UI_BENCH_REQUIRE=1` (CI) turns that skip into a failure, and
+  `ROMP_UI_BENCH_TIMING=1` (a quiet machine, never CI) also asserts the timing
+  relations the replays otherwise report as diagnostics.
 
 **Temp files and git are hermetic, suite-wide.** Two mechanisms, one per half.
 `tests/__init__.py` wraps `tempfile.mkdtemp` so every directory the test process

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # tests/ — every suite in one place
 
-Every bug fix or feature change lands with a test (repo rule). Four suites:
+Every bug fix or feature change lands with a test (repo rule). Five suites:
 
 - **`test_*.py`** (pytest) — the Python pipeline: event model, judges, kernel,
   backends, postal. They load the sources by file path via `SourceFileLoader`
@@ -59,6 +59,14 @@ Every bug fix or feature change lands with a test (repo rule). Four suites:
 - **`manager-*.test.js`** — the node supervisor (`bin/romp-manager`): restart
   gating, the kernel registry, and the drain-poll handshake. Run:
   `node --test tests/manager-*.test.js`.
+- **`ui-bench.test.mjs`** — the dashboard pane bench (`tools/ui-bench.mjs`):
+  the classifier, synthesizer, temp-path guard, recording client, front
+  server, Handler-subprocess isolation, in-page instrument, profile fold, and
+  real headless replays of synthetic feed and timeline streams.
+  Run `node --test tests/ui-bench.test.mjs` from the repo root after
+  `cd vscode-extension && npm ci && npm run build`. The browser tests skip,
+  saying why, when no Chromium, `python3` or dist is present;
+  `ROMP_UI_BENCH_REQUIRE=1` (CI) turns that skip into a failure.
 
 **Temp files and git are hermetic, suite-wide.** Two mechanisms, one per half.
 `tests/__init__.py` wraps `tempfile.mkdtemp` so every directory the test process

--- a/tests/test_perf_bench.py
+++ b/tests/test_perf_bench.py
@@ -54,20 +54,39 @@ WEB_TURNS = 400       # a transcript large enough that the cold row's full assem
 EXPECTED_NEUTRALIZED = {
     "km._refresh_remote_prices", "km._warm_fleet_bg", "km._system_notify", "km._push_notify", "km._push_forward",
     "km._badge_push", "romp_kernel_perf_bench.subprocess", "romp_judge.subprocess", "romp_sdk_backend.subprocess",
+    "romp_keysource.subprocess",   # loaded by sdk_backend; its key command is a subprocess (review find, 2026-09-08)
     "km._atomic_write (checked)", "pwd.getpwnam (counted)", "pwd.getpwuid (counted)"}
-# The caches the tool empties before each cold build_session sample, as this kernel has them. The tool
-# skips a name a revision lacks, so a rename here would silently leave that cache warm: this pins the
-# HEAD set, and a kernel change that renames or adds one must change it deliberately.
-EXPECTED_COLD_CACHES = {
-    "kernel": {"_parse_cache", "_built_chat", "_prev_chat_events", "_prev_chat_ledger", "_arch_tops_cache",
-               "_PATH_LINK_CACHE", "_states_notes_cache", "_state_ev_cache", "_bgtasks_cache", "_bgall_cache",
-               "_queued_parse_cache", "_wake_tail_cache", "_session_meta_cache", "_session_tok_cache",
-               "_machine_cut_cache", "_chat_fold"},
-    "event_model": {"_JSONL_CACHE", "_ASM_CACHE", "_TRAILING_CACHE"}}
-# What the builders and the push write into the copy on a normal run: the import-time repo-root
-# marker, the tab-order audit and the session order the push maintains. A new write path in a
-# builder must change this set deliberately.
+# The caches whose emptiness the cold rows' PROOF rests on: the event model's parse-layer caches (the
+# per-sample assembly check reads _ASM_CACHE and the counters) and the kernel's parse cache (the
+# build_feed_noparse row empties it too). The tool skips a name a revision lacks and reports what it did
+# empty, and the per-sample assembly check is what proves a sample cold, so the rest of the tool's list is
+# checked only to be drawn from that list: the first form pinned every kernel-private cache name at HEAD,
+# which an unrelated kernel rename would have broken with the proof intact (review find, 2026-09-08).
+EXPECTED_COLD_CACHES = {"kernel": {"_parse_cache"}, "event_model": {"_JSONL_CACHE", "_ASM_CACHE"}}
+# The writes a normal run is known to make into the copy: the import-time repo-root marker, the
+# tab-order audit and the session order the push maintains. The test asks that these appear, that every
+# write landed under the copy (the guard's own record) and that nothing was removed; it does not pin the
+# set exactly, so a kernel that adds a write path reports it in the tool's output without failing the
+# tool's test (the first form pinned the exact set; review find, 2026-09-08).
 EXPECTED_WRITES = {"+ order-audit.jsonl", "+ repo-root", "+ session-order.json"}
+
+
+def _module_constants(path, names):
+    """Module-level `NAME = <string or tuple of strings and NAMEs>` assignments, read from the source with
+    ast and resolved against each other, so a kernel constant is pinned without loading any romp module
+    in this process."""
+    import ast
+    found = {}
+    for node in ast.parse(open(path).read()).body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and node.targets[0].id in names:
+            v = node.value
+            if isinstance(v, ast.Tuple):
+                found[node.targets[0].id] = tuple(e.value if isinstance(e, ast.Constant) else found[e.id] for e in v.elts)
+            elif isinstance(v, ast.Constant):
+                found[node.targets[0].id] = v.value
+    missing = set(names) - set(found)
+    assert not missing, "not found at module level in %s: %s" % (path, sorted(missing))
+    return found
 
 
 def _iso(t):
@@ -127,8 +146,9 @@ def _git(*args, cwd):
 def build_synthetic(root, web_turns=WEB_TURNS, age_api_days=0):
     """A state directory at root/romp (named `romp` so XDG_STATE_HOME=root resolves it as the default)
     plus a Claude config dir at root/claude holding the transcripts. Returns (state, claude_dir). The
-    state carries the two credential-shaped files a real one has (synthetic contents) and a placeholder
-    sdkvenv, all of which the mirror must leave behind. The web and tests sessions' cwd is a one-commit
+    state carries the credential-shaped files a real one has (synthetic contents: the serve token, the Web
+    Push key and subscriptions, the remote kernels' tokens) and a placeholder sdkvenv, all of which the
+    mirror must leave behind. The web and tests sessions' cwd is a one-commit
     checkout with a GitHub origin, so the kernel's read-only git queries run for real and the tripwire's
     allow list is exercised; the api session's cwd is a plain directory, where the kernel cannot cache
     the ls-files answer and re-runs the query on every build. `age_api_days` moves the api transcript's
@@ -148,6 +168,8 @@ def build_synthetic(root, web_turns=WEB_TURNS, age_api_days=0):
         (state / d).mkdir(parents=True)
     (state / "serve-token").write_text("synthetic-serve-token-not-real\n")
     (state / "push-vapid.json").write_text(json.dumps({"synthetic": True}))
+    (state / "push-subscriptions.json").write_text(json.dumps({"synthetic-endpoint": {"auth": "not-a-secret"}}))
+    (state / "remotes.json").write_text(json.dumps([{"host": "TESTHOST", "token": "synthetic-remote-token-not-real"}]))
     (state / "sdkvenv" / "bin" / "python").write_text("placeholder: not an interpreter\n")
     claude = root / "claude"
     now = int(time.time())
@@ -247,8 +269,12 @@ class PerfBench(unittest.TestCase):
         self.assertEqual(out["threads_new"], [], "no builder left a thread running")
         self.assertEqual(set(out["neutralized"]), EXPECTED_NEUTRALIZED)
         self.assertEqual(os.stat(self.transcript).st_mtime_ns, self.transcript_mtime, "transcripts are read-only")
-        self.assertEqual(set(out["writes"]["sample"]), EXPECTED_WRITES)
+        self.assertTrue(EXPECTED_WRITES <= set(out["writes"]["sample"]), out["writes"])
+        self.assertFalse([w for w in out["writes"]["sample"] if w.startswith("- ")], "nothing removed from the copy")
         self.assertEqual(out["writes"]["removed"], 0)
+        self.assertEqual(out["refused_writes"], [], "every _atomic_write landed under the copy")
+        for rel in out["writes"]["atomic_writes"]:
+            self.assertFalse(os.path.isabs(rel) or rel.startswith(".."), "recorded relative to the copy: %s" % rel)
         prof = out["profiles"]
         for name in ("build_feed", "build_timeline_bars", "build_session_cold:11111111", "load_goals:11111111", "push_steady"):
             self.assertIn(name, prof)
@@ -266,7 +292,12 @@ class PerfBench(unittest.TestCase):
         self.assertEqual(cold["asm"].get("fold", 0), 0, "nothing grows between reads in a static fixture")
         self.assertEqual(em["asm"].get("full", 0), 0, "the em-warm row never re-parses")
         self.assertIn("git_per_build", cold)
-        self.assertEqual({k: set(v) for k, v in self._out()["cold_caches"].items()}, EXPECTED_COLD_CACHES)
+        cc = {k: set(v) for k, v in self._out()["cold_caches"].items()}
+        for layer, need in EXPECTED_COLD_CACHES.items():
+            self.assertTrue(need <= cc[layer], "%s: %s emptied before each cold sample (emptied: %s)" % (layer, sorted(need), sorted(cc[layer])))
+        pb = SourceFileLoader("perf_bench_caches_under_test", TOOL).load_module()
+        self.assertTrue(cc["kernel"] <= set(pb.COLD_KERNEL_CACHES) | {"_chat_fold"}, "every kernel cache emptied is one the tool names")
+        self.assertTrue(cc["event_model"] <= {n for n, _lock in pb.COLD_EM_CACHES})
 
     def test_path_token_lookups_are_counted(self):
         out = self._out()
@@ -290,10 +321,15 @@ class PerfBench(unittest.TestCase):
         # Per build, beside the rows: the api session's cwd is a plain directory, where the kernel cannot cache
         # the ls-files answer on the index and tree mtimes, so every build of it runs the query once; the web
         # session's cwd is a checkout, whose answers the warm-up cached, so its kept samples run none.
+        # The figures are the kernel's caching policy, not this tool's, so they are asserted as the relation just
+        # described (at least one query per build in the plain directory, fewer in the checkout), never as exact
+        # counts an unrelated kernel change would move (review find, 2026-09-08).
         b = out["benchmarks"]
         for row in ("build_session_cold:22222222", "build_session_emwarm:22222222", "build_session_warm:22222222"):
-            self.assertEqual(b[row]["git_per_build"], {"ls-files": 1.0}, row)
-        self.assertEqual(b["build_session_cold:11111111"]["git_per_build"], {})
+            self.assertGreaterEqual(b[row]["git_per_build"].get("ls-files", 0), 1.0, "%s: %s" % (row, b[row]["git_per_build"]))
+            self.assertEqual(set(b[row]["git_per_build"]) - {"rev-parse", "ls-files"}, set(), "only admitted queries ran")
+        checkout, plain = b["build_session_cold:11111111"]["git_per_build"], b["build_session_cold:22222222"]["git_per_build"]
+        self.assertLess(sum(checkout.values()), sum(plain.values()), "the checkout's answers are cached across the kept samples: %s vs %s" % (checkout, plain))
 
     def test_push_rows_report_bytes_and_rebuild_flags(self):
         b = self._out()["benchmarks"]
@@ -371,8 +407,9 @@ class PerfBench(unittest.TestCase):
         mirror = out["state"]
         self.assertNotEqual(os.path.realpath(mirror), os.path.realpath(state))
         self.assertTrue(os.path.isdir(os.path.join(mirror, "sdk")), "the mirror is a state directory")
-        for name in ("serve-token", "push-vapid.json", "sdkvenv"):
+        for name in ("serve-token", "push-vapid.json", "push-subscriptions.json", "remotes.json", "sdkvenv"):
             self.assertFalse(os.path.exists(os.path.join(mirror, name)), "%s is not copied into the mirror" % name)
+        self.assertEqual(set(self.pb_mirror_ignore()), {"serve-token", "push-vapid.json", "push-subscriptions.json", "remotes.json", "sdkvenv"})
         self.assertIn("build_feed", out["benchmarks"])
         self.assertNotIn("push_steady", out["benchmarks"], "--clients '' skips the push benchmarks")
         self.assertEqual(len([k for k in out["benchmarks"] if k.startswith("build_session_cold:")]), 1,
@@ -412,6 +449,15 @@ class PerfBench(unittest.TestCase):
         r = run_tool(["--compare", self.json_path, self.json_path])
         self._ok(r)
         self.assertNotIn("MISMATCH", r.stdout)
+        # a run that stopped on a guard is not a world to diff against: its `error` is flagged first
+        c = copy.deepcopy(out)
+        c["error"] = "a guard tripped"
+        c_path = os.path.join(self.root, "c.json")
+        with open(c_path, "w") as f:
+            json.dump(c, f)
+        r = run_tool(["--compare", self.json_path, c_path])
+        self._ok(r)
+        self.assertRegex(r.stdout, r"run error\s+A=None\s+B=a guard tripped\s+MISMATCH")
 
     def test_requires_a_state_dir(self):
         r = run_tool([])
@@ -456,6 +502,76 @@ class PerfBench(unittest.TestCase):
         self.assertEqual(out["repo"], os.path.realpath(scratch))
         self.assertNotIn("benchmarks", out)
         self.assertEqual(out["error"], "this kernel lacks _live_scope; the harness does not know how to drive it")
+
+    def pb_mirror_ignore(self):
+        return SourceFileLoader("perf_bench_mirror_under_test", TOOL).load_module().MIRROR_IGNORE
+
+    def _planted_kernel(self, plant):
+        """A copy of this checkout's kernel/ with one line planted inside _push's try block, right after its
+        tab-order audit: the one place on the benched paths where the kernel catches every exception of its
+        own build and carries on."""
+        # The scratch path spells the tool's name on purpose: the tripwire's frame filter must exclude the tool's
+        # own file, not every path that contains "perf-bench" (its first form did, and the spawn record's `via`
+        # came out empty for a kernel living under such a directory).
+        scratch = self._scratch_root("perf-bench-planted-")
+        shutil.copytree(os.path.join(ROOT, "kernel"), os.path.join(scratch, "kernel"), ignore=shutil.ignore_patterns("__pycache__"))
+        kp = os.path.join(scratch, "kernel", "kernel.py")
+        with open(kp) as f:
+            src = f.read()
+        anchor = '        _order_audit("push", _last_tab_order, tab_order, only_permuted=True)\n'
+        self.assertEqual(src.count(anchor), 1, "the plant's anchor line inside _push's try block")
+        with open(kp, "w") as f:
+            f.write(src.replace(anchor, anchor + "        " + plant + "\n"))
+        return scratch
+
+    def test_a_guard_tripped_inside_push_fails_the_run_naming_the_guard(self):
+        # The tripwire raises inside _push, which catches every exception of its build (writes `push build:` to
+        # stderr and returns), so the first form timed the aborted cycle as a number and exited 0 with no error
+        # in the JSON and the refusal visible only as a count (review find, 2026-09-08). Now the run ends the way
+        # any other tripped guard ends it: rows so far kept, JSON marked partial, exit 1, the guard named.
+        root = self._scratch_root("perf-bench-tripped-")
+        state, claude = build_synthetic(root, web_turns=3)
+        out_json = os.path.join(root, "out.json")
+        scratch = self._planted_kernel('subprocess.run(["date"], capture_output=True)')
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", scratch, "--iters", "1", "--sessions", "1", "--json", out_json])
+        self.assertEqual(r.returncode, 1, "rc=%d\nstdout:\n%s\nstderr:\n%s" % (r.returncode, r.stdout[-3000:], r.stderr[-3000:]))
+        self.assertIn("perf-bench: a guard tripped inside a call the kernel catches", r.stderr)
+        self.assertIn("subprocess tripwire: ", r.stderr)
+        self.assertIn("refused spawn", r.stderr)
+        self.assertIn("push build:", r.stderr, "the kernel's own report of the exception it swallowed")
+        self.assertIn("(partial: the run stopped on an error)", r.stdout)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertIn("subprocess tripwire", out["error"])
+        self.assertTrue(out["spawn_attempts"], "the refused spawns are listed")
+        for attempt in out["spawn_attempts"]:
+            self.assertIn("['date']", attempt)
+            self.assertIn("_push", attempt)
+        self.assertEqual(out["refused_writes"], [])
+        self.assertIn("push_cold_cycle", out["benchmarks"], "the rows measured before the check are kept")
+        self.assertEqual(out["benchmarks"]["push_cold_cycle"]["bytes"]["feed"]["frames"], 0, "and show the aborted cycle for what it was")
+
+    def test_an_out_of_copy_write_inside_push_fails_the_run_and_is_recorded(self):
+        # The write guard raised before recording anything, so a refused write inside _push left no trace in the
+        # JSON or the text report (only the kernel's stderr traceback) while the tool exited 0. The refusal is now
+        # on record before the raise, and the run fails on it (review find, 2026-09-08).
+        root = self._scratch_root("perf-bench-tripped-write-")
+        state, claude = build_synthetic(root, web_turns=3)
+        elsewhere = os.path.join(os.path.realpath(root), "elsewhere", "y.json")
+        out_json = os.path.join(root, "out.json")
+        scratch = self._planted_kernel('_atomic_write(%r, "{}")' % elsewhere)
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", scratch, "--iters", "1", "--sessions", "1", "--json", out_json])
+        self.assertEqual(r.returncode, 1, "rc=%d\nstdout:\n%s\nstderr:\n%s" % (r.returncode, r.stdout[-3000:], r.stderr[-3000:]))
+        self.assertIn("_atomic_write guard: ", r.stderr)
+        self.assertIn(elsewhere, r.stderr, "the refused path is named")
+        self.assertIn("refused writes: ", r.stdout, "the text report counts them")
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertIn("_atomic_write guard", out["error"])
+        self.assertTrue(out["refused_writes"])
+        self.assertEqual(set(out["refused_writes"]), {elsewhere})
+        self.assertEqual(out["spawn_attempts"], [])
+        self.assertFalse(os.path.exists(elsewhere), "the refused write never happened")
 
 
 class Tripwire(unittest.TestCase):
@@ -590,6 +706,8 @@ class Recorders(unittest.TestCase):
         self.assertIn("outside the state copy", str(cm.exception))
         self.assertEqual(len(self.writes), 1, "the refused write never reached the kernel's function")
         self.assertEqual(rec["atomic_writes"], ["sub/x.json"])
+        self.assertEqual(rec["refused_writes"], [os.path.realpath(os.path.join(elsewhere, "y.json"))],
+                         "on record before the raise, so a caller that swallows the exception cannot hide it")
 
     def test_a_missing_safety_target_is_an_error(self):
         km = self._kernel()
@@ -665,12 +783,20 @@ class InProcessChecks(unittest.TestCase):
         state, claude, private, other = (os.path.join(root, d) for d in ("romp", "claude", "private", "other"))
         for d in (state, claude, private, other):
             os.makedirs(d)
-        planted = {"ANTHROPIC_API_KEY": "not-a-key", "ANTHROPIC_BASE_URL": "http://127.0.0.1:1", "ROMP_MANAGER_PORT": "7432",
-                   "ROMP_MANAGER_PID": "1", "ROMP_STATE_DIR": other, "TMUX": "planted", "ROMP_MODEL_CATALOG": "on"}
+        # every key-source and credential name conftest pops, planted with synthetic values (the first form planted
+        # ANTHROPIC_* only, so a key command, an OAuth token or 1Password's names would have reached the kernel
+        # import; review find, 2026-09-08)
+        keys = {k: "planted-" + k.lower() for k in self.pb.KEY_SOURCE_ENV}
+        keys["OP_SESSION_testaccount"] = "planted-op-session"
+        planted = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:1", "ROMP_MANAGER_PORT": "7432",
+                   "ROMP_MANAGER_PID": "1", "ROMP_STATE_DIR": other, "TMUX": "planted", "ROMP_MODEL_CATALOG": "on", **keys}
         with mock.patch.dict(os.environ, planted):
             changes = self.pb.prepare_env(state, claude, private)
             env = dict(os.environ)
-        self.assertFalse([k for k in env if k.startswith("ANTHROPIC_")], "every ANTHROPIC_* variable is gone")
+        self.assertFalse([k for k in env if k.startswith("ANTHROPIC_") or k.startswith("OP_SESSION_")], "every ANTHROPIC_* and OP_SESSION_* variable is gone")
+        for k in keys:
+            self.assertNotIn(k, env, k)
+            self.assertIn("unset " + k, changes)
         self.assertEqual(env["ROMP_MANAGER_PORT"], "1", "a dead port, not an absent variable (absent maps to the live default)")
         self.assertNotIn("ROMP_MANAGER_PID", env)
         self.assertNotIn("TMUX", env)
@@ -690,6 +816,29 @@ class InProcessChecks(unittest.TestCase):
                   "set ROMP_MANAGER_PORT", "set ROMP_MODEL_CATALOG", "set ROMP_CLI_SCOPE", "set ROMP_CLAUDE_BIN", "set ROMP_TMUX_AVAILABLE",
                   "set TMUX_TMPDIR", "set ROMP_SERVICE_ENV_FILE", "set ROMP_STATE_DIR", "set XDG_STATE_HOME", "set CLAUDE_CONFIG_DIR"):
             self.assertIn(c, changes)
+
+    def test_the_key_source_list_is_the_kernels_own(self):
+        # The names come from the code's constants, the way tests/conftest.py's floor is pinned on main: a
+        # provider that adds a credential name adds it there, and this fails until the tool drops it too. Read
+        # from the source text, so no romp module loads in this process.
+        ks = _module_constants(os.path.join(ROOT, "kernel", "keysource.py"), ("KEY_VAR", "REF_VAR", "CMD_VAR", "SOURCE_VARS", "OP_ENV_NAMES", "OP_ENV_PREFIX"))
+        sb = _module_constants(os.path.join(ROOT, "kernel", "sdk_backend.py"), ("AUTH_ENV_NAMES",))
+        expected = set(ks["SOURCE_VARS"]) | set(sb["AUTH_ENV_NAMES"]) | set(ks["OP_ENV_NAMES"]) | {"ROMP_EXPECTED_AUTH"}
+        self.assertEqual(set(self.pb.KEY_SOURCE_ENV), expected)
+        self.assertEqual(set(self.pb.KEY_SOURCE_ENV_PREFIXES), {"ANTHROPIC_", ks["OP_ENV_PREFIX"]})
+
+    # ── check_guards_held ────────────────────────────────────────────────────────────────────────
+    def test_a_refusal_still_on_record_at_the_end_of_the_run_is_an_error_naming_the_guard(self):
+        clean = {"spawns": [], "refused_writes": []}
+        self.assertIsNone(self.pb.check_guards_held(clean))
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.check_guards_held({"spawns": ["subprocess.run ['date'] via kernel.py:1 _push"], "refused_writes": []})
+        self.assertIn("subprocess tripwire: 1 refused spawn(s): subprocess.run ['date']", str(cm.exception))
+        self.assertIn("push build:", str(cm.exception), "says where the swallowed traceback went")
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.check_guards_held({"spawns": [], "refused_writes": ["/x/y.json"] * 5})
+        self.assertIn("_atomic_write guard: 5 refused write(s) outside the copy: /x/y.json, /x/y.json, /x/y.json, ...", str(cm.exception))
+        self.assertNotIn("tripwire", str(cm.exception))
 
     # ── make_backend ─────────────────────────────────────────────────────────────────────────────
     def _sbmod(self):

--- a/tests/test_perf_bench.py
+++ b/tests/test_perf_bench.py
@@ -58,7 +58,7 @@ WEB_TURNS = 400       # a transcript large enough that the cold row's full assem
 EXPECTED_NEUTRALIZED = {
     "km._refresh_remote_prices", "km._warm_fleet_bg", "km._system_notify", "km._push_notify", "km._push_forward",
     "km._badge_push", "romp_kernel_perf_bench.subprocess", "romp_judge.subprocess", "romp_sdk_backend.subprocess",
-    "romp_keysource.subprocess",   # loaded by sdk_backend; its key command is a subprocess (review find, 2026-09-08)
+    "romp_credentials.subprocess",   # loaded by sdk_backend; its credential helper runs as a subprocess (review find, 2026-09-08)
     "km._atomic_write (shadowed)", "km._read_state_json (shadow overlay)", "km._order_audit_path (shadowed)",
     "pwd.getpwnam (counted)", "pwd.getpwuid (counted)"}
 # The caches whose emptiness the cold rows' PROOF rests on: the event model's parse-layer caches (the
@@ -116,18 +116,34 @@ def _redact_cwds(state, root):
 
 
 def _module_constants(path, names):
-    """Module-level `NAME = <string or tuple of strings and NAMEs>` assignments, read from the source with
-    ast and resolved against each other, so a kernel constant is pinned without loading any romp module
-    in this process."""
+    """Module-level `NAME = <string, tuple of strings and NAMEs, or a `+` chain of those tuples>`
+    assignments, read from the source with ast and resolved against each other, so a kernel constant is
+    pinned without loading any romp module in this process. Every NAME a wanted constant refers to is
+    resolved too, whether or not it was asked for."""
     import ast
     found = {}
+
+    def resolve(v):
+        if isinstance(v, ast.Constant):
+            return v.value
+        if isinstance(v, ast.Name):
+            return found[v.id]
+        if isinstance(v, ast.Tuple):
+            return tuple(resolve(e) for e in v.elts)
+        if isinstance(v, ast.BinOp) and isinstance(v.op, ast.Add):     # credentials.FLOOR_ENV_NAMES is a tuple sum
+            return resolve(v.left) + resolve(v.right)
+        raise AssertionError("unsupported constant form in %s: %s" % (path, ast.dump(v)))
+
     for node in ast.parse(open(path).read()).body:
-        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and node.targets[0].id in names:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
             v = node.value
-            if isinstance(v, ast.Tuple):
-                found[node.targets[0].id] = tuple(e.value if isinstance(e, ast.Constant) else found[e.id] for e in v.elts)
-            elif isinstance(v, ast.Constant):
-                found[node.targets[0].id] = v.value
+            if isinstance(v, (ast.Constant, ast.Tuple, ast.BinOp)):
+                try:
+                    found[node.targets[0].id] = resolve(v)
+                except (KeyError, AssertionError):
+                    if node.targets[0].id in names:
+                        raise
+    found = {k: v for k, v in found.items() if k in names}
     missing = set(names) - set(found)
     assert not missing, "not found at module level in %s: %s" % (path, sorted(missing))
     return found
@@ -1081,11 +1097,11 @@ class InProcessChecks(unittest.TestCase):
         # The names come from the code's constants, the way tests/conftest.py's floor is pinned on main: a
         # provider that adds a credential name adds it there, and this fails until the tool drops it too. Read
         # from the source text, so no romp module loads in this process.
-        ks = _module_constants(os.path.join(ROOT, "kernel", "keysource.py"), ("KEY_VAR", "REF_VAR", "CMD_VAR", "SOURCE_VARS", "OP_ENV_NAMES", "OP_ENV_PREFIX"))
+        cr = _module_constants(os.path.join(ROOT, "kernel", "credentials.py"), ("FLOOR_ENV_NAMES", "FLOOR_ENV_PREFIXES"))
         sb = _module_constants(os.path.join(ROOT, "kernel", "sdk_backend.py"), ("AUTH_ENV_NAMES",))
-        expected = set(ks["SOURCE_VARS"]) | set(sb["AUTH_ENV_NAMES"]) | set(ks["OP_ENV_NAMES"]) | {"ROMP_EXPECTED_AUTH"}
+        expected = set(cr["FLOOR_ENV_NAMES"]) | set(sb["AUTH_ENV_NAMES"])
         self.assertEqual(set(self.pb.KEY_SOURCE_ENV), expected)
-        self.assertEqual(set(self.pb.KEY_SOURCE_ENV_PREFIXES), {"ANTHROPIC_", ks["OP_ENV_PREFIX"]})
+        self.assertEqual(set(self.pb.KEY_SOURCE_ENV_PREFIXES), {"ANTHROPIC_"} | set(cr["FLOOR_ENV_PREFIXES"]))
 
     # ── check_guards_held ────────────────────────────────────────────────────────────────────────
     def test_a_refusal_still_on_record_at_the_end_of_the_run_is_an_error_naming_the_guard(self):

--- a/tests/test_perf_bench.py
+++ b/tests/test_perf_bench.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """tools/perf-bench.py against a SYNTHETIC state directory (invented sessions in the notes-api demo
 domain, placeholder uuids, no real data): it runs end to end and emits the JSON shape, its cold
-build_session row is a real cold parse, it refuses the live default state directory without the flag
-and mirrors it with the flag, and --compare prints deltas. The sessions' directory is a real git
+build_session row is a real cold parse, it leaves the copy byte-identical (every write the kernel
+aims at it lands in the tool's shadow, and the census says so on the error path too), it finds
+transcripts older than the discovery window through the backfill, --cwd-map resolves a redacted copy's
+registry cwds, it refuses the live default state directory without the flag and mirrors it with the
+flag, and --compare prints deltas. The sessions' directory is a real git
 checkout with a fabricated GitHub origin, as every real state's is: the chat build's path-link git
 queries (rev-parse, ls-files) reach the tripwire's allow list, which a plain directory never
 exercised; the `remote get-url` pair the list also admits is checked in-process below. The tool is
@@ -12,6 +15,7 @@ and of the tripwire's allow rule (its import pulls in only the standard library)
 import atexit
 import contextlib
 import copy
+import hashlib
 import io
 import json
 import os
@@ -55,7 +59,8 @@ EXPECTED_NEUTRALIZED = {
     "km._refresh_remote_prices", "km._warm_fleet_bg", "km._system_notify", "km._push_notify", "km._push_forward",
     "km._badge_push", "romp_kernel_perf_bench.subprocess", "romp_judge.subprocess", "romp_sdk_backend.subprocess",
     "romp_keysource.subprocess",   # loaded by sdk_backend; its key command is a subprocess (review find, 2026-09-08)
-    "km._atomic_write (checked)", "pwd.getpwnam (counted)", "pwd.getpwuid (counted)"}
+    "km._atomic_write (shadowed)", "km._read_state_json (shadow overlay)", "km._order_audit_path (shadowed)",
+    "pwd.getpwnam (counted)", "pwd.getpwuid (counted)"}
 # The caches whose emptiness the cold rows' PROOF rests on: the event model's parse-layer caches (the
 # per-sample assembly check reads _ASM_CACHE and the counters) and the kernel's parse cache (the
 # build_feed_noparse row empties it too). The tool skips a name a revision lacks and reports what it did
@@ -63,12 +68,51 @@ EXPECTED_NEUTRALIZED = {
 # checked only to be drawn from that list: the first form pinned every kernel-private cache name at HEAD,
 # which an unrelated kernel rename would have broken with the proof intact (review find, 2026-09-08).
 EXPECTED_COLD_CACHES = {"kernel": {"_parse_cache"}, "event_model": {"_JSONL_CACHE", "_ASM_CACHE"}}
-# The writes a normal run is known to make into the copy: the import-time repo-root marker, the
-# tab-order audit and the session order the push maintains. The test asks that these appear, that every
-# write landed under the copy (the guard's own record) and that nothing was removed; it does not pin the
-# set exactly, so a kernel that adds a write path reports it in the tool's output without failing the
-# tool's test (the first form pinned the exact set; review find, 2026-09-08).
-EXPECTED_WRITES = {"+ order-audit.jsonl", "+ repo-root", "+ session-order.json"}
+# The writes a normal run is known to aim at the copy, every one of which the tool's shadow takes: the
+# import-time repo-root marker, the tab-order audit and the session order the push maintains. The test asks
+# that these appear among the shadowed paths and that the copy itself changed by nothing (the tree hash
+# below); it does not pin the shadowed set exactly, so a kernel that adds a write path reports it in the
+# tool's output without failing the tool's test (review find, 2026-09-08), while one that reaches the copy
+# fails the hash.
+EXPECTED_SHADOWED = {"order-audit.jsonl", "repo-root", "session-order.json"}
+REDACTED_PREFIX = "/XXXX/XXXXXX"     # what a redaction tool leaves where a home path stood
+
+
+def _tree_hash(root):
+    """Every directory, file and symlink under root, keyed by relative path: a directory as "dir", a
+    symlink as its target, a file as the sha256 of its bytes. Two equal maps mean a byte-identical tree
+    (mtimes aside, which a read may not touch either; the mirror test checks those)."""
+    out = {}
+    for dp, dns, fns in os.walk(root):
+        for d in dns:
+            out[os.path.relpath(os.path.join(dp, d), root) + "/"] = "dir"
+        for f in fns:
+            p = os.path.join(dp, f)
+            if os.path.islink(p):
+                out[os.path.relpath(p, root)] = "link:" + os.readlink(p)
+            else:
+                with open(p, "rb") as fh:
+                    out[os.path.relpath(p, root)] = hashlib.sha256(fh.read()).hexdigest()
+    return out
+
+
+def _age_transcripts(claude, days):
+    """Set every transcript's mtime `days` back: a copy taken from a machine whose sessions last wrote
+    that long ago, outside discovery's 48 h window and inside the 365-day backfill."""
+    t = time.time() - days * 86400
+    for p in Path(claude, "projects").rglob("*.jsonl"):
+        os.utime(p, (t, t))
+
+
+def _redact_cwds(state, root):
+    """Rewrite every registry cwd (names/ and sdk/) so the fixture's root reads as REDACTED_PREFIX, the
+    way a redaction tool replaces a home path, while the projects/ directory keeps its original name."""
+    for f in Path(state, "names").iterdir():
+        f.write_text(f.read_text().replace(str(root), REDACTED_PREFIX))
+    for f in Path(state, "sdk").glob("*.json"):
+        reg = json.loads(f.read_text())
+        reg["cwd"] = reg["cwd"].replace(str(root), REDACTED_PREFIX)
+        f.write_text(json.dumps(reg))
 
 
 def _module_constants(path, names):
@@ -212,10 +256,12 @@ class PerfBench(unittest.TestCase):
                                       re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(os.path.join(cls.root, "notes-api"))),
                                       SID_WEB + ".jsonl")
         cls.transcript_mtime = os.stat(cls.transcript).st_mtime_ns
+        cls.state_before, cls.claude_before = _tree_hash(cls.state), _tree_hash(cls.claude)
         # a planted API-key variable (not a key), which the tool must drop before the import
         cls.main = run_tool(["--state", cls.state, "--claude-dir", cls.claude, "--repo", ROOT, "--iters", "2",
                              "--sessions", "2", "--profile", "--json", cls.json_path],
                             env_extra={"ANTHROPIC_API_KEY": "not-a-key"})
+        cls.state_after, cls.claude_after = _tree_hash(cls.state), _tree_hash(cls.claude)
 
     @classmethod
     def tearDownClass(cls):
@@ -236,7 +282,7 @@ class PerfBench(unittest.TestCase):
 
     def test_runs_and_reports_every_builder(self):
         out = self._out()
-        self.assertEqual(out["schema"], 2)
+        self.assertEqual(out["schema"], 3)
         self.assertEqual(os.path.realpath(out["state"]), os.path.realpath(self.state))
         b = out["benchmarks"]
         for name in ("liveness_snapshot", "names_snapshot", "discover_cold", "discover_warm", "build_feed",
@@ -269,12 +315,13 @@ class PerfBench(unittest.TestCase):
         self.assertEqual(out["threads_new"], [], "no builder left a thread running")
         self.assertEqual(set(out["neutralized"]), EXPECTED_NEUTRALIZED)
         self.assertEqual(os.stat(self.transcript).st_mtime_ns, self.transcript_mtime, "transcripts are read-only")
-        self.assertTrue(EXPECTED_WRITES <= set(out["writes"]["sample"]), out["writes"])
-        self.assertFalse([w for w in out["writes"]["sample"] if w.startswith("- ")], "nothing removed from the copy")
-        self.assertEqual(out["writes"]["removed"], 0)
-        self.assertEqual(out["refused_writes"], [], "every _atomic_write landed under the copy")
-        for rel in out["writes"]["atomic_writes"]:
+        self.assertTrue(EXPECTED_SHADOWED <= set(out["writes"]["shadowed"]), out["writes"])
+        self.assertEqual((out["writes"]["changed"], out["writes"]["new"], out["writes"]["removed"]), (0, 0, 0), out["writes"])
+        self.assertEqual(out["refused_writes"], [], "every _atomic_write was aimed under the copy")
+        for rel in out["writes"]["shadowed"]:
             self.assertFalse(os.path.isabs(rel) or rel.startswith(".."), "recorded relative to the copy: %s" % rel)
+        self.assertEqual(out["live_transcripts"]["searched"], {"cwds": 2, "project_dirs": 2, "transcripts": 3})
+        self.assertEqual(out["cwd_map"], [])
         prof = out["profiles"]
         for name in ("build_feed", "build_timeline_bars", "build_session_cold:11111111", "load_goals:11111111", "push_steady"):
             self.assertIn(name, prof)
@@ -375,6 +422,171 @@ class PerfBench(unittest.TestCase):
         c["send"](other)
         self.assertEqual(c["bytes"], {"bars-delta": len(delta), "('timeline',)": len(full), "warn": len(other)})
         self.assertEqual(c["frames"], 3)
+
+    def test_the_copy_is_byte_identical_after_a_run(self):
+        # the files the kernel aims at the copy (EXPECTED_SHADOWED) landed in the tool's shadow, so the copy
+        # has the same directories, files and bytes it started with; without the shadow the run creates
+        # repo-root, session-order.json and order-audit.jsonl inside it
+        self._ok(self.main)
+        self.assertEqual(self.state_after, self.state_before, "the state copy is only read")
+        self.assertEqual(self.claude_after, self.claude_before, "the transcripts are only read")
+        self.assertIn("writes into the state copy: 0 changed, 0 new, 0 removed", self.main.stdout)
+        shadowed_line = next(l for l in self.main.stdout.splitlines() if l.startswith("writes shadowed (landed in the private dir, not the copy): "))
+        for name in EXPECTED_SHADOWED:
+            self.assertIn(name, shadowed_line)
+
+    def test_the_census_runs_on_the_error_path_and_names_what_was_searched(self):
+        # a claude dir with no projects/ at all: discovery finds nothing, the window and the backfill both
+        # count zero, and the run stops with the counts it worked from. The census still runs and prints,
+        # the JSON carries it beside the error, and the copy is untouched (the kernel WAS imported, so
+        # without the shadow repo-root would be in it)
+        root = self._scratch_root("perf-bench-nofind-")
+        state, claude = build_synthetic(root, web_turns=3)
+        empty_claude = os.path.join(root, "claude-empty")
+        os.makedirs(empty_claude)
+        before = _tree_hash(state)
+        out_json = os.path.join(root, "out.json")
+        r = run_tool(["--state", state, "--claude-dir", empty_claude, "--repo", ROOT, "--iters", "1", "--json", out_json])
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        # the two windows are the kernel's constants (jd.WINDOW, jd.DEATH_BACKFILL_WINDOW), so their values
+        # are not pinned here, only that the error names them with the counts
+        self.assertRegex(r.stderr, r"discovery found no transcript for any of the 2 live sessions: 0 in the \d+ h window, "
+                                   r"0 more in the \d+-day backfill; their 2 registry cwd\(s\) resolve to 0 existing project "
+                                   r"directories holding 0 transcript\(s\)")
+        self.assertIn("--cwd-map", r.stderr, "the error points at the redacted-copy remedy")
+        self.assertNotIn(root, r.stderr.split("perf-bench: discovery")[1], "the error names counts, not paths")
+        self.assertIn("writes into the state copy: 0 changed, 0 new, 0 removed", r.stdout)
+        self.assertIn("writes shadowed (landed in the private dir, not the copy): repo-root", r.stdout)
+        self.assertEqual(_tree_hash(state), before, "an error run leaves the copy byte-identical too")
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertIn("no transcript for any", out["error"])
+        self.assertEqual((out["writes"]["changed"], out["writes"]["new"], out["writes"]["removed"]), (0, 0, 0))
+        self.assertEqual(out["writes"]["shadowed"], ["repo-root"])
+        self.assertIn("(partial: the run stopped on an error)", r.stdout)
+
+    def test_transcripts_older_than_the_window_are_found_by_the_backfill(self):
+        # every transcript is 3 days old: outside discovery's 48 h window, inside the 365-day backfill. A
+        # no-transcript error raised before the backfill runs would stop this run; raised after it, the
+        # backfill finds both
+        root = self._scratch_root("perf-bench-old-")
+        state, claude = build_synthetic(root, web_turns=3)
+        _age_transcripts(claude, days=3)
+        out_json = os.path.join(root, "out.json")
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1", "--sessions", "2",
+                      "--clients", "", "--json", out_json])
+        self._ok(r)
+        with open(out_json) as f:
+            out = json.load(f)
+        lt = out["live_transcripts"]
+        self.assertEqual((lt["in_window"], lt["backfilled"], lt["count"], lt["no_transcript"]), (0, 2, 2, []))
+        self.assertIn("build_session_cold:11111111", out["benchmarks"])
+        self.assertIn("build_session_cold:22222222", out["benchmarks"])
+        self.assertIn("2 live transcripts (0 in the discovery window, 2 backfilled, 0 without one)", r.stdout)
+
+    def test_cwd_map_resolves_a_redacted_copy(self):
+        # the registry cwds read /XXXX/XXXXXX/notes-api while the project directory is still named after
+        # the real path: without a map discovery resolves the cwd to a directory that does not exist and
+        # the run stops; with --cwd-map the same run finds both transcripts and reports the rule's hits
+        root = self._scratch_root("perf-bench-redacted-")
+        state, claude = build_synthetic(root, web_turns=3)
+        _redact_cwds(state, root)
+        before = _tree_hash(state)
+        out_json = os.path.join(root, "out.json")
+        base = ["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1", "--clients", "", "--json", out_json]
+        maps = ["--cwd-map", "/nowhere/else=/nowhere", "--cwd-map", REDACTED_PREFIX + "=" + root]
+        r = run_tool(base + ["--sessions", "2"])
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("their 2 registry cwd(s) resolve to 0 existing project directories", r.stderr)
+        r = run_tool(base + ["--sessions", "2"] + maps)
+        self._ok(r)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual((out["live_transcripts"]["count"], out["live_transcripts"]["no_transcript"]), (2, []))
+        self.assertEqual(out["live_transcripts"]["searched"], {"cwds": 2, "project_dirs": 2, "transcripts": 3})
+        self.assertEqual([(m["from"], m["to"]) for m in out["cwd_map"]], [("/nowhere/else", "/nowhere"), (REDACTED_PREFIX, root)])
+        self.assertEqual(out["cwd_map"][0]["hits"], 0)
+        self.assertGreater(out["cwd_map"][1]["hits"], 0, "the matching rule counted its hits")
+        self.assertIn("build_session_cold:11111111", out["benchmarks"])
+        self.assertIn("cwd-map hits: rule 1=0, rule 2=%d" % out["cwd_map"][1]["hits"], r.stdout)
+        self.assertIn("jd._proj_dir (cwd-map)", out["neutralized"], "the report says the derivation is wrapped")
+        self.assertEqual(_tree_hash(state), before, "the map rewrites nothing in the copy")
+        self.assertEqual(out["spawn_attempts"], [], "the git queries against the redacted cwd failed quietly, no tripwire")
+        # the count is read when the run ends, so the builders' transcript-path derivations are in it: one
+        # more benched session is more hits, where a count taken at discovery (which does not depend on
+        # --sessions) would be the same for both runs
+        r = run_tool(base + ["--sessions", "1"] + maps)
+        self._ok(r)
+        with open(out_json) as f:
+            hits_one = json.load(f)["cwd_map"][1]["hits"]
+        self.assertGreater(hits_one, 0)
+        self.assertGreater(out["cwd_map"][1]["hits"], hits_one, "the hits cover the whole run, not the discovery stage alone")
+
+    def test_an_exception_out_of_the_candidate_kernel_still_prints_the_census(self):
+        # a --repo whose kernel raises at import (a broken candidate checkout) is not a BenchError. Left to
+        # propagate past main(), it would take the census run() had taken with it (no census line, no JSON,
+        # only the traceback). The census prints, the JSON carries the error beside it, the copy is
+        # byte-identical, and the traceback still follows
+        root = self._scratch_root("perf-bench-broken-")
+        state, claude = build_synthetic(root, web_turns=3)
+        repo = os.path.join(root, "broken-repo")
+        os.makedirs(os.path.join(repo, "kernel"))
+        Path(repo, "kernel", "kernel.py").write_text("raise RuntimeError('synthetic import failure')\n")
+        before = _tree_hash(state)
+        out_json = os.path.join(root, "out.json")
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", repo, "--iters", "1", "--json", out_json])
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("writes into the state copy: 0 changed, 0 new, 0 removed", r.stdout)
+        self.assertIn("writes shadowed (landed in the private dir, not the copy): none", r.stdout)
+        self.assertIn("(partial: the run stopped on an error)", r.stdout)
+        self.assertIn("perf-bench: RuntimeError: synthetic import failure", r.stderr)
+        self.assertIn("Traceback", r.stderr, "the exception still leaves main() with its traceback")
+        self.assertEqual(_tree_hash(state), before)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual(out["error"], "RuntimeError: synthetic import failure")
+        self.assertEqual((out["writes"]["changed"], out["writes"]["new"], out["writes"]["removed"]), (0, 0, 0))
+        self.assertEqual(out["writes"]["shadowed"], [])
+
+    def test_fingerprint_sees_directories_and_symlink_targets(self):
+        # the census fingerprints directories and link targets too: a directory the kernel creates (its
+        # mkdir sites on STATE subdirectories) or a link it retargets is a write into the copy, and one
+        # that records files only would report it as 0 changed, 0 new, 0 removed
+        pb = SourceFileLoader("perf_bench_fingerprint_under_test", TOOL).load_module()
+        root = self._scratch_root("perf-bench-fp-")
+        os.makedirs(os.path.join(root, "sdk"))
+        Path(root, "sdk", "a.json").write_text("{}")
+        os.symlink("sdk", os.path.join(root, "alias"))
+        before = pb.fingerprint(root)
+        self.assertEqual(before["sdk/"], "dir")
+        self.assertEqual(before["alias/"], ("link", "sdk"))
+        os.makedirs(os.path.join(root, "goals"))
+        os.remove(os.path.join(root, "alias"))
+        os.symlink("goals", os.path.join(root, "alias"))
+        diff = pb.fingerprint_diff(before, pb.fingerprint(root))
+        self.assertEqual((diff["changed"], diff["new"], diff["removed"]), (1, 1, 0))
+        self.assertEqual(diff["sample"], ["~ alias/", "+ goals/"])
+
+    def test_install_cwd_map_wraps_nothing_without_rules(self):
+        # the default run pays no extra frame per _proj_dir call; with a rule the wrapper counts its hits
+        pb = SourceFileLoader("perf_bench_cwdmap_under_test", TOOL).load_module()
+        real = lambda d: "proj:" + str(d)
+        jd = SimpleNamespace(_proj_dir=real)
+        self.assertEqual(pb.install_cwd_map(jd, []), [])
+        self.assertIs(jd._proj_dir, real)
+        hits = pb.install_cwd_map(jd, [("/XXXX/XXXXXX", "/repo")])
+        self.assertIsNot(jd._proj_dir, real)
+        self.assertEqual(jd._proj_dir("/XXXX/XXXXXX/notes-api"), "proj:/repo/notes-api")
+        self.assertEqual(jd._proj_dir("/XXXX/XXXXXXX/other"), "proj:/XXXX/XXXXXXX/other", "whole-component match only")
+        self.assertEqual(hits, [1])
+
+    def test_cwd_map_refuses_a_malformed_rule(self):
+        r = run_tool(["--state", self.state, "--claude-dir", self.claude, "--repo", ROOT, "--cwd-map", "no-equals-sign"])
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("expected FROM=TO", r.stderr)
+        r = run_tool(["--state", self.state, "--claude-dir", self.claude, "--repo", ROOT, "--cwd-map", "=/somewhere"])
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("FROM is empty", r.stderr)
 
     def test_refuses_the_live_default_dir_without_the_flag(self):
         root = self._scratch_root("perf-bench-live-")
@@ -657,17 +869,35 @@ class Recorders(unittest.TestCase):
         self.addCleanup(setattr, threading.Thread, "start", saved_start)
         self.state = tempfile.mkdtemp(prefix="perf-bench-recorders-")
         self.addCleanup(shutil.rmtree, self.state, ignore_errors=True)
+        self.shadow_root = tempfile.mkdtemp(prefix="perf-bench-recorders-shadow-")
+        self.addCleanup(shutil.rmtree, self.shadow_root, ignore_errors=True)
         self.writes = []
 
+    def _fake_atomic_write(self, path, text, mode=None):
+        """The fake kernel's write door: records the call and publishes the file where it was told to, so the
+        shadow overlay's reads have a file to find."""
+        self.writes.append((path, text))
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(text)
+
     def _kernel(self):
-        return SimpleNamespace(jd=SimpleNamespace(STATE=self.state),
-                               _atomic_write=lambda path, text, mode=None: self.writes.append((path, text)),
+        return SimpleNamespace(jd=SimpleNamespace(STATE=Path(self.state)),
+                               _atomic_write=self._fake_atomic_write,
+                               _read_state_json=lambda path, st=None, expect=None: None,
+                               _order_audit_path=lambda: Path(self.state) / "order-audit.jsonl",
                                _refresh_remote_prices=None, _warm_fleet_bg=None, _system_notify=None,
                                _push_notify=None, _push_forward=None, _badge_push=None)
 
+    def _guards(self, km):
+        """install_guards the way run() calls it: a recorder and a shadow made before the kernel loads, so
+        the census can read them whichever way the run ends. Returns (names, rec, shadow)."""
+        rec = self.pb.new_recorder()
+        shadow = self.pb.StateShadow(self.state, self.shadow_root, rec["refused_writes"])
+        return self.pb.install_guards(km, None, shadow, rec), rec, shadow
+
     def test_the_recorders_take_every_shape_the_kernel_calls_with(self):
         km = self._kernel()
-        names, rec = self.pb.install_guards(km, None)
+        names, rec, _shadow = self._guards(km)
         self.assertEqual(set(names), {n for n in EXPECTED_NEUTRALIZED if not n.endswith(".subprocess")},
                          "a namespace without a subprocess attribute gets no tripwire; everything else is guarded")
         # _cached_feed's two card pushes (quiet when the turn push already buzzed), the turn tick's push
@@ -693,28 +923,58 @@ class Recorders(unittest.TestCase):
         t.join()
         self.assertEqual(rec["thread_starts"], 1)
 
-    def test_atomic_writes_outside_the_copy_are_refused(self):
+    def test_atomic_writes_aimed_at_the_copy_land_in_the_shadow_and_the_rest_are_refused(self):
         km = self._kernel()
-        _names, rec = self.pb.install_guards(km, None)
+        _names, rec, shadow = self._guards(km)
         km._atomic_write(os.path.join(self.state, "sub", "x.json"), "{}")
-        self.assertEqual([os.path.basename(p) for p, _t in self.writes], ["x.json"], "a write under the copy goes through")
-        self.assertEqual(rec["atomic_writes"], ["sub/x.json"], "and is recorded relative to the copy")
+        self.assertEqual([os.path.basename(p) for p, _t in self.writes], ["x.json"], "a write aimed under the copy goes through")
+        self.assertEqual(Path(self.writes[0][0]), Path(self.shadow_root) / "sub" / "x.json", "to the shadow, not the copy")
+        self.assertFalse(os.path.exists(os.path.join(self.state, "sub")), "the copy gained nothing")
+        self.assertEqual(shadow.written, ["sub/x.json"], "and is recorded relative to the copy")
         elsewhere = tempfile.mkdtemp(prefix="perf-bench-elsewhere-")
         self.addCleanup(shutil.rmtree, elsewhere, ignore_errors=True)
         with self.assertRaises(self.pb.BenchError) as cm:
             km._atomic_write(os.path.join(elsewhere, "y.json"), "{}")
         self.assertIn("outside the state copy", str(cm.exception))
         self.assertEqual(len(self.writes), 1, "the refused write never reached the kernel's function")
-        self.assertEqual(rec["atomic_writes"], ["sub/x.json"])
+        self.assertEqual(shadow.written, ["sub/x.json"])
         self.assertEqual(rec["refused_writes"], [os.path.realpath(os.path.join(elsewhere, "y.json"))],
                          "on record before the raise, so a caller that swallows the exception cannot hide it")
+        # the shadow's own files are written in place: the audit log's trim rewrites the shadowed log
+        km._atomic_write(os.path.join(self.shadow_root, "order-audit.jsonl"), "")
+        self.assertEqual(Path(self.writes[1][0]), Path(self.shadow_root) / "order-audit.jsonl")
+        self.assertEqual(shadow.written, ["sub/x.json"], "a write already inside the shadow is not a diverted one")
+
+    def test_the_kernels_state_reads_see_the_shadow_once_it_holds_the_file(self):
+        # the session order's read-modify-write: the push reads session-order.json, appends the new sids and
+        # writes it back. The write lands in the shadow, so a reader still pointed at the copy would find the
+        # file unchanged and every later build would append again (an audit record with a captured stack
+        # each time, inside the rows this tool times); the overlaid reader serves the shadowed file instead
+        km = self._kernel()
+        seen = []
+        km._read_state_json = lambda path, st=None, expect=None: seen.append((Path(path), st)) or None
+        _names, _rec, shadow = self._guards(km)
+        order = os.path.join(self.state, "session-order.json")
+        km._read_state_json(order, "a-stat", expect=list)
+        self.assertEqual(seen[-1], (Path(order), "a-stat"), "nothing shadowed yet: the copy's file, with the caller's stat")
+        km._atomic_write(order, "[]")
+        km._read_state_json(order, "a-stat", expect=list)
+        self.assertEqual(seen[-1], (Path(self.shadow_root) / "session-order.json", None),
+                         "the shadowed file, and the caller's stat of the copy's file is dropped")
+        self.assertEqual(km._order_audit_path(), Path(self.shadow_root) / "order-audit.jsonl")
+        self.assertEqual(shadow.written, ["session-order.json", "order-audit.jsonl"])
 
     def test_a_missing_safety_target_is_an_error(self):
         km = self._kernel()
         del km._push_notify
         with self.assertRaises(self.pb.BenchError) as cm:
-            self.pb.install_guards(km, None)
+            self._guards(km)
         self.assertIn("_push_notify", str(cm.exception))
+        km = self._kernel()
+        del km._read_state_json                     # a kernel whose state reads bypass the overlay would re-fire the order's append per build
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self._guards(km)
+        self.assertIn("_read_state_json", str(cm.exception))
 
 
 class InProcessChecks(unittest.TestCase):

--- a/tests/test_perf_bench.py
+++ b/tests/test_perf_bench.py
@@ -1,0 +1,789 @@
+#!/usr/bin/env python3
+"""tools/perf-bench.py against a SYNTHETIC state directory (invented sessions in the notes-api demo
+domain, placeholder uuids, no real data): it runs end to end and emits the JSON shape, its cold
+build_session row is a real cold parse, it refuses the live default state directory without the flag
+and mirrors it with the flag, and --compare prints deltas. The sessions' directory is a real git
+checkout with a fabricated GitHub origin, as every real state's is: the chat build's path-link git
+queries (rev-parse, ls-files) reach the tripwire's allow list, which a plain directory never
+exercised; the `remote get-url` pair the list also admits is checked in-process below. The tool is
+driven as a subprocess with the same env recipe a person would use, so nothing here loads romp code
+in-process; the tool module itself is loaded for direct checks of its fake client's frame labelling
+and of the tripwire's allow rule (its import pulls in only the standard library)."""
+import atexit
+import contextlib
+import copy
+import io
+import json
+import os
+import pwd
+import re
+import shutil
+from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+TOOL = os.path.join(ROOT, "tools", "perf-bench.py")
+
+# Two effects. For the CHILD (the tool runs as a subprocess and sets its own state root before it loads
+# the kernel) this points the default state root at a temp dir, so the refusal tests' XDG_STATE_HOME /
+# ROMP_STATE_DIR overrides are the only "live" candidates the tool can see. It is also the ratchet's
+# preamble for the one in-process load below, the tool module, which loads no romp code at import. It
+# replaces conftest's suite-wide floor with another temp dir for the modules collected after this one,
+# which changes nothing for them. Every temp dir this module makes is removed when it is done with it
+# (this one at interpreter exit): a suite that leaves its directories behind fills /tmp over time.
+_XDG_TMP = tempfile.mkdtemp()
+os.environ["XDG_STATE_HOME"] = _XDG_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+atexit.register(shutil.rmtree, _XDG_TMP, ignore_errors=True)
+
+SID_WEB = "11111111-2222-3333-4444-555555555555"
+SID_API = "22222222-3333-4444-5555-666666666666"
+SID_TESTS = "33333333-4444-5555-6666-777777777777"
+MANAGER_VARS = ("ROMP_MANAGER_PORT", "ROMP_SERVE_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED")
+WEB_TURNS = 400       # a transcript large enough that the cold row's full assembly shows in the counters
+EXPECTED_NEUTRALIZED = {
+    "km._refresh_remote_prices", "km._warm_fleet_bg", "km._system_notify", "km._push_notify", "km._push_forward",
+    "km._badge_push", "romp_kernel_perf_bench.subprocess", "romp_judge.subprocess", "romp_sdk_backend.subprocess",
+    "km._atomic_write (checked)", "pwd.getpwnam (counted)", "pwd.getpwuid (counted)"}
+# The caches the tool empties before each cold build_session sample, as this kernel has them. The tool
+# skips a name a revision lacks, so a rename here would silently leave that cache warm: this pins the
+# HEAD set, and a kernel change that renames or adds one must change it deliberately.
+EXPECTED_COLD_CACHES = {
+    "kernel": {"_parse_cache", "_built_chat", "_prev_chat_events", "_prev_chat_ledger", "_arch_tops_cache",
+               "_PATH_LINK_CACHE", "_states_notes_cache", "_state_ev_cache", "_bgtasks_cache", "_bgall_cache",
+               "_queued_parse_cache", "_wake_tail_cache", "_session_meta_cache", "_session_tok_cache",
+               "_machine_cut_cache", "_chat_fold"},
+    "event_model": {"_JSONL_CACHE", "_ASM_CACHE", "_TRAILING_CACHE"}}
+# What the builders and the push write into the copy on a normal run: the import-time repo-root
+# marker, the tab-order audit and the session order the push maintains. A new write path in a
+# builder must change this set deliberately.
+EXPECTED_WRITES = {"+ order-audit.jsonl", "+ repo-root", "+ session-order.json"}
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _transcript(path, sid, cwd, n_turns, t0):
+    """A synthetic Claude Code transcript: n_turns of prompt, one tool round, reply. One reply carries a
+    `~someone/...` path token, which the chat build's path-link pass hands to os.path.expanduser."""
+    n = [0]
+    parent = [None]
+    t = [t0]
+
+    def rec(typ, message, **extra):
+        n[0] += 1
+        t[0] += 3
+        u = "aaaaaaaa-0000-0000-0000-%012d" % n[0]
+        r = {"type": typ, "timestamp": _iso(t[0]), "uuid": u, "parentUuid": parent[0], "sessionId": sid,
+             "cwd": cwd, "version": "2.1.0", "gitBranch": "main", "message": message}
+        r.update(extra)
+        parent[0] = u
+        return r
+
+    with open(path, "w") as f:
+        for i in range(n_turns):
+            tid = "toolu_%06d" % i
+            reply = "Step %d done: the suite passes." % i
+            if i == 1:
+                reply += " Notes are in `~someone/notes/index.md` for later."
+            rows = [
+                rec("user", {"role": "user", "content": "step %d: tighten the search index and rerun the suite" % i},
+                    promptSource="typed"),
+                rec("assistant", {"role": "assistant", "model": "claude-sonnet-4", "stop_reason": "tool_use",
+                                  "content": [{"type": "text", "text": "Round %d: adjusting `search.py`." % i},
+                                              {"type": "tool_use", "id": tid, "name": "Bash",
+                                               "input": {"command": "uv run pytest -q tests/test_search.py"}}]}),
+                rec("user", {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tid, "content": "ok\n"}]},
+                    toolUseResult={"stdout": "ok"}),
+                rec("assistant", {"role": "assistant", "model": "claude-sonnet-4", "stop_reason": "end_turn",
+                                  "content": [{"type": "text", "text": reply}]}),
+            ]
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+
+ORIGIN = "https://github.com/example-org/notes-api.git"   # fabricated; `remote get-url` reads config, no network
+
+
+def _git(*args, cwd):
+    """A fixture git call that reads no global or system config (a developer's commit signing or
+    url.insteadOf must not bend the fixture) and commits as a synthetic author."""
+    env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+    subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t", "-c", "commit.gpgsign=false"] + list(args),
+                   cwd=str(cwd), check=True, capture_output=True, env=env)
+
+
+def build_synthetic(root, web_turns=WEB_TURNS, age_api_days=0):
+    """A state directory at root/romp (named `romp` so XDG_STATE_HOME=root resolves it as the default)
+    plus a Claude config dir at root/claude holding the transcripts. Returns (state, claude_dir). The
+    state carries the two credential-shaped files a real one has (synthetic contents) and a placeholder
+    sdkvenv, all of which the mirror must leave behind. The web and tests sessions' cwd is a one-commit
+    checkout with a GitHub origin, so the kernel's read-only git queries run for real and the tripwire's
+    allow list is exercised; the api session's cwd is a plain directory, where the kernel cannot cache
+    the ls-files answer and re-runs the query on every build. `age_api_days` moves the api transcript's
+    mtime that many days into the past, outside discovery's window."""
+    root = Path(root)
+    state = root / "romp"
+    cwd = root / "notes-api"
+    cwd.mkdir(parents=True)
+    _git("init", "-q", "-b", "main", cwd=cwd)
+    (cwd / "README.md").write_text("# notes-api\n")
+    _git("add", "README.md", cwd=cwd)
+    _git("commit", "-q", "-m", "seed", cwd=cwd)
+    _git("remote", "add", "origin", ORIGIN, cwd=cwd)
+    plain = root / "notes-api-docs"
+    plain.mkdir()
+    for d in ("names", "sdk", "states", "goals", "sdkvenv/bin"):
+        (state / d).mkdir(parents=True)
+    (state / "serve-token").write_text("synthetic-serve-token-not-real\n")
+    (state / "push-vapid.json").write_text(json.dumps({"synthetic": True}))
+    (state / "sdkvenv" / "bin" / "python").write_text("placeholder: not an interpreter\n")
+    claude = root / "claude"
+    now = int(time.time())
+    for sid, name, color, alive, turns, wd in ((SID_WEB, "web", "#4a7bd0", True, web_turns, cwd),
+                                               (SID_API, "api", "#d07b4a", True, 3, plain),
+                                               (SID_TESTS, "tests", "#4ad07b", False, 1, cwd)):
+        proj = claude / "projects" / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(wd)))
+        proj.mkdir(parents=True, exist_ok=True)
+        (state / "names" / sid).write_text("%s\t%s\t%s\t#ffffff\n" % (name, wd, color))
+        (state / "sdk" / (sid + ".json")).write_text(json.dumps(
+            {"sid": sid, "name": name, "cwd": str(wd), "mode": "acceptEdits", "effort": "medium",
+             "lastSid": "", "alive": alive}))
+        with open(state / "states" / (sid + ".jsonl"), "w") as f:
+            f.write(json.dumps({"t": now - 3600, "state": "waiting"}) + "\n")
+            f.write(json.dumps({"t": now - 60, "state": "working" if name == "web" else "waiting"}) + "\n")
+        _transcript(proj / (sid + ".jsonl"), sid, str(wd), turns, now - 3 * turns * 4 - 60)
+        if sid == SID_API and age_api_days:
+            old = now - age_api_days * 86400
+            os.utime(proj / (sid + ".jsonl"), (old, old))
+    (state / "goals" / (SID_WEB + ".json")).write_text(json.dumps(
+        {"rompUuid": SID_WEB, "seq": 1, "rev": 1, "placementsV": 11,
+         "nodes": {"g1": {"parentId": None, "t": now - 500, "text": "wire the notes search index"}},
+         "status": {"g1": "working"}, "lastNode": "g1", "placements": {}}))
+    return str(state), str(claude)
+
+
+def run_tool(args, env_extra=None, timeout=300):
+    env = {k: v for k, v in os.environ.items() if k not in MANAGER_VARS}
+    env.update(env_extra or {})
+    return subprocess.run([sys.executable, TOOL] + list(args), capture_output=True, text=True, env=env, timeout=timeout)
+
+
+class PerfBench(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp(prefix="perf-bench-test-")
+        cls.state, cls.claude = build_synthetic(cls.root)
+        cls.json_path = os.path.join(cls.root, "out.json")
+        cls.transcript = os.path.join(cls.claude, "projects",
+                                      re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(os.path.join(cls.root, "notes-api"))),
+                                      SID_WEB + ".jsonl")
+        cls.transcript_mtime = os.stat(cls.transcript).st_mtime_ns
+        # a planted API-key variable (not a key), which the tool must drop before the import
+        cls.main = run_tool(["--state", cls.state, "--claude-dir", cls.claude, "--repo", ROOT, "--iters", "2",
+                             "--sessions", "2", "--profile", "--json", cls.json_path],
+                            env_extra={"ANTHROPIC_API_KEY": "not-a-key"})
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def _scratch_root(self, prefix):
+        root = tempfile.mkdtemp(prefix=prefix)
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        return root
+
+    def _ok(self, r):
+        self.assertEqual(r.returncode, 0, "rc=%d\nstdout:\n%s\nstderr:\n%s" % (r.returncode, r.stdout[-4000:], r.stderr[-4000:]))
+
+    def _out(self):
+        self._ok(self.main)
+        with open(self.json_path) as f:
+            return json.load(f)
+
+    def test_runs_and_reports_every_builder(self):
+        out = self._out()
+        self.assertEqual(out["schema"], 2)
+        self.assertEqual(os.path.realpath(out["state"]), os.path.realpath(self.state))
+        b = out["benchmarks"]
+        for name in ("liveness_snapshot", "names_snapshot", "discover_cold", "discover_warm", "build_feed",
+                     "build_feed_noparse", "build_timeline_bars", "build_timeline_skel", "warm_all_parses",
+                     "build_session_cold:11111111", "build_session_emwarm:11111111", "build_session_warm:11111111",
+                     "build_session_cold:22222222", "load_goals:11111111", "push_cold_cycle", "push_steady",
+                     "push_connect:chat", "push_connect:feed", "push_connect:timeline"):
+            self.assertIn(name, b, "missing benchmark %s in %s" % (name, sorted(b)))
+            self.assertIsInstance(b[name]["median"], (int, float), name)
+        self.assertNotIn("build_session_cold:33333333", b, "a closed reg (alive=false) is not a live session")
+        self.assertEqual(b["warm_all_parses"]["sessions"], 2, "one parse per live session")
+        self.assertEqual(out["liveness"]["live"], 2)
+        self.assertEqual(out["liveness"]["closed_regs"], 1)
+        self.assertEqual(out["liveness"]["states"], {"11111111": "working", "22222222": "waiting"},
+                         "each row's state is the last states/ record, not the dormant mapping")
+        self.assertEqual(out["live_transcripts"]["count"], 2)
+        self.assertEqual(out["live_transcripts"]["no_transcript"], [])
+        self.assertEqual(out["discover_cache_cleared"], 3, "the cold discover row empties the cache before the warm-up and each of the 2 samples")
+        self.assertEqual(out["repo_head"], subprocess.run(["git", "-C", ROOT, "rev-parse", "HEAD"], capture_output=True, text=True,
+                                                          check=True).stdout.strip()[:12], "the checkout's HEAD, read from the git files")
+        self.assertIn("unset ANTHROPIC_API_KEY", out["env_changes"], "the planted key variable was dropped before the import")
+        self.assertIn("set ROMP_MANAGER_PORT", out["env_changes"], "the manager port is set to a dead port, not left absent")
+        self.assertEqual(out["thread_starts"], 0, "no builder started a thread (the parse-warming thread is a recorder)")
+        self.assertGreaterEqual(out["warm_calls_suppressed"], 1, "build_feed's cold-parse branch asked for the background warm, which the recorder took")
+        web = next(s for s in out["benched_sessions"] if s["sid8"] == "11111111")
+        self.assertGreater(web["events"], 0, "the chat build saw the synthetic transcript's events")
+        self.assertEqual(out["benched_sessions"][0]["sid8"], "11111111", "largest transcript first")
+        self.assertEqual(out["goal_stores"][0]["nodes"], 1)
+        self.assertEqual(out["spawn_attempts"], [], "no builder spawned a process")
+        self.assertEqual(out["threads_new"], [], "no builder left a thread running")
+        self.assertEqual(set(out["neutralized"]), EXPECTED_NEUTRALIZED)
+        self.assertEqual(os.stat(self.transcript).st_mtime_ns, self.transcript_mtime, "transcripts are read-only")
+        self.assertEqual(set(out["writes"]["sample"]), EXPECTED_WRITES)
+        self.assertEqual(out["writes"]["removed"], 0)
+        prof = out["profiles"]
+        for name in ("build_feed", "build_timeline_bars", "build_session_cold:11111111", "load_goals:11111111", "push_steady"):
+            self.assertIn(name, prof)
+            self.assertLessEqual(len(prof[name]["cumulative"]), 25)
+            self.assertLessEqual(len(prof[name]["tottime"]), 25)
+            self.assertEqual(set(prof[name]["cumulative"][0]), {"func", "file", "line", "ncalls", "tottime_ms", "cumtime_ms"})
+        self.assertIn("build_feed", self.main.stdout)
+        self.assertIn("top 25 by cumulative time", self.main.stdout)
+
+    def test_cold_build_is_a_full_parse(self):
+        b = self._out()["benchmarks"]
+        cold, em = b["build_session_cold:11111111"], b["build_session_emwarm:11111111"]
+        self.assertEqual(cold["asm"].get("full", 0), cold["n"], "every kept cold sample ran exactly one full assembly")
+        self.assertEqual(cold["asm"].get("serve", 0), 0, "a single-session transcript is assembled once per cold build")
+        self.assertEqual(cold["asm"].get("fold", 0), 0, "nothing grows between reads in a static fixture")
+        self.assertEqual(em["asm"].get("full", 0), 0, "the em-warm row never re-parses")
+        self.assertIn("git_per_build", cold)
+        self.assertEqual({k: set(v) for k, v in self._out()["cold_caches"].items()}, EXPECTED_COLD_CACHES)
+
+    def test_path_token_lookups_are_counted(self):
+        out = self._out()
+        self.assertGreaterEqual(out["nss_lookups"].get("getpwnam", 0), 1,
+                                "the `~someone/...` token reached pwd.getpwnam through os.path.expanduser")
+
+    def test_the_checkout_git_queries_pass_the_tripwire_and_are_counted(self):
+        # the sessions' cwd is a checkout, so the chat build's path-link pass runs `git rev-parse` and
+        # `git ls-files` there; the tripwire admits exactly those and counts them (a refusal would have
+        # aborted the run — spawn_attempts stays empty and every row is present). The `remote get-url`
+        # pair is the file-link route's query, which no benched builder reaches: the Tripwire class
+        # below checks its admission in-process.
+        out = self._out()
+        g = out["git_queries"]
+        self.assertFalse(g["answered_as_failure"])
+        self.assertGreaterEqual(g["calls"].get("rev-parse", 0), 1, g)
+        self.assertGreaterEqual(g["calls"].get("ls-files", 0), 1, g)
+        self.assertEqual(out["spawn_attempts"], [])
+        self.assertIn("rev-parse=", self.main.stdout, "the report names each query it counted")
+        self.assertIn("ls-files=", self.main.stdout)
+        # Per build, beside the rows: the api session's cwd is a plain directory, where the kernel cannot cache
+        # the ls-files answer on the index and tree mtimes, so every build of it runs the query once; the web
+        # session's cwd is a checkout, whose answers the warm-up cached, so its kept samples run none.
+        b = out["benchmarks"]
+        for row in ("build_session_cold:22222222", "build_session_emwarm:22222222", "build_session_warm:22222222"):
+            self.assertEqual(b[row]["git_per_build"], {"ls-files": 1.0}, row)
+        self.assertEqual(b["build_session_cold:11111111"]["git_per_build"], {})
+
+    def test_push_rows_report_bytes_and_rebuild_flags(self):
+        b = self._out()["benchmarks"]
+        chat = b["push_cold_cycle"]["bytes"]["chat"]["slots"]
+        self.assertIn("chat:11111111", chat, "the fake chat client received the active tab's session frame")
+        self.assertGreater(chat["chat:11111111"], 0)
+        self.assertIn("feed", b["push_cold_cycle"]["bytes"]["feed"]["slots"])
+        self.assertIn("chat:11111111", b["push_connect:chat"]["bytes"]["slots"], "a fresh chat client gets the full session")
+        self.assertIn("feed", b["push_connect:feed"]["bytes"]["slots"])
+        self.assertIn("timeline", b["push_connect:timeline"]["bytes"]["slots"])
+        # a connect sample is a FRESH client with empty dedup state, so it receives what the cold cycle's fresh
+        # client did: the same frame count per app, and for the chat the same bytes (the session frame does not
+        # depend on the parse caches; the cold cycle's feed and timeline were built before any parse, so their
+        # sizes differ from the warm ones). A client reused across samples accumulates frames instead.
+        for app in ("chat", "feed", "timeline"):
+            self.assertEqual(b["push_connect:" + app]["bytes"]["frames"], b["push_cold_cycle"]["bytes"][app]["frames"], app)
+        self.assertEqual(b["push_connect:chat"]["bytes"], b["push_cold_cycle"]["bytes"]["chat"])
+        self.assertGreaterEqual(b["push_cold_cycle"]["asm"].get("full", 0), 2, "the cold cycle parsed both live transcripts inside itself")
+        st = b["push_steady"]
+        self.assertGreaterEqual(len(st["samples"]), st["n"])
+        self.assertEqual(st["n"], 2, "the loop ran until two quiet samples existed")
+        for s in st["samples"]:
+            self.assertEqual(set(s), {"ms", "rebuilt_feed", "rebuilt_timeline", "bytes"})
+        quiet = [s for s in st["samples"] if not (s["rebuilt_feed"] or s["rebuilt_timeline"])]
+        self.assertEqual(len(quiet), st["n"])
+        self.assertEqual(st["rebuild_samples"], len(st["samples"]) - len(quiet))
+        for name, row in b.items():
+            if name.startswith("push") and row.get("bytes"):
+                self.assertNotIn("unknown", json.dumps(row["bytes"]), "%s: every frame the fake clients got was labelled" % name)
+
+    def test_fake_client_labels_direct_delta_frames_by_their_slot(self):
+        # the static fixture never changes between pushes, so no delta frame reaches a fake client in the
+        # run above; this drives the client's send() directly with the three frame shapes it can see
+        pb = SourceFileLoader("perf_bench_under_test", TOOL).load_module()
+        c = pb.fake_client(SimpleNamespace(), "timeline")      # no _perf_slot: a keyed label is str(key)
+        delta = '{"type": "delta", "slot": "bars", "base": 3, "rev": 4, "coll": {}}'
+        c["send"](delta)                                        # _send_slot_delta: send() directly, no curSlot
+        c["curSlot"] = ("timeline",)                            # what _client_send sets around its call
+        full = '{"type": "timeline", "sessions": []}'
+        c["send"](full)
+        del c["curSlot"]
+        other = '{"type": "warn", "text": "not a slot frame"}'
+        c["send"](other)
+        self.assertEqual(c["bytes"], {"bars-delta": len(delta), "('timeline',)": len(full), "warn": len(other)})
+        self.assertEqual(c["frames"], 3)
+
+    def test_refuses_the_live_default_dir_without_the_flag(self):
+        root = self._scratch_root("perf-bench-live-")
+        state, claude = build_synthetic(root, web_turns=3)
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1"],
+                     env_extra={"XDG_STATE_HOME": root})
+        self.assertEqual(r.returncode, 2, r.stderr)
+        self.assertIn("--i-know-this-is-live", r.stderr)
+        self.assertFalse(os.path.exists(os.path.join(state, "repo-root")), "the kernel was never imported against it")
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1"],
+                     env_extra={"ROMP_STATE_DIR": state})
+        self.assertEqual(r.returncode, 2, "ROMP_STATE_DIR names the live dir too")
+
+    def test_live_flag_benches_a_mirror_and_leaves_the_original_alone(self):
+        root = self._scratch_root("perf-bench-live-")
+        state, claude = build_synthetic(root, web_turns=3)
+        before = {p: os.stat(p).st_mtime_ns for p in Path(state).rglob("*") if p.is_file()}
+        out_json = os.path.join(root, "out.json")
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1", "--sessions", "1",
+                      "--clients", "", "--i-know-this-is-live", "--keep-mirror", "--json", out_json],
+                     env_extra={"XDG_STATE_HOME": root})
+        self._ok(r)
+        self.assertIn("mirrored", r.stderr)
+        self.assertIn("mirror kept at", r.stderr)
+        after = {p: os.stat(p).st_mtime_ns for p in Path(state).rglob("*") if p.is_file()}
+        self.assertEqual(before, after, "the live directory is only read")
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual(os.path.realpath(out["state_mirror_of"]), os.path.realpath(state))
+        mirror = out["state"]
+        self.assertNotEqual(os.path.realpath(mirror), os.path.realpath(state))
+        self.assertTrue(os.path.isdir(os.path.join(mirror, "sdk")), "the mirror is a state directory")
+        for name in ("serve-token", "push-vapid.json", "sdkvenv"):
+            self.assertFalse(os.path.exists(os.path.join(mirror, name)), "%s is not copied into the mirror" % name)
+        self.assertIn("build_feed", out["benchmarks"])
+        self.assertNotIn("push_steady", out["benchmarks"], "--clients '' skips the push benchmarks")
+        self.assertEqual(len([k for k in out["benchmarks"] if k.startswith("build_session_cold:")]), 1,
+                         "--sessions 1 benches one transcript (the two live ones are the same size here)")
+        self.assertEqual([k for k in out["benchmarks"] if k.startswith("load_goals:")], ["load_goals:11111111"])
+        mirror_root = os.path.dirname(os.path.realpath(mirror))      # the tool's mkdtemp dir; the mirror is its romp/
+        self.assertTrue(os.path.basename(mirror_root).startswith("romp-perf-live-mirror-"), mirror_root)
+        shutil.rmtree(mirror_root, ignore_errors=True)                # kept for the assertions above, not beyond
+        # without --keep-mirror the mirror is removed
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1", "--sessions", "1",
+                      "--clients", "", "--i-know-this-is-live", "--json", out_json], env_extra={"XDG_STATE_HOME": root})
+        self._ok(r)
+        self.assertIn("mirror removed", r.stderr)
+        with open(out_json) as f:
+            self.assertFalse(os.path.exists(json.load(f)["state"]))
+
+    def test_compare_prints_per_benchmark_deltas(self):
+        out = self._out()
+        b = copy.deepcopy(out)
+        feed = out["benchmarks"]["build_feed"]["median"]
+        b["benchmarks"]["build_feed"]["median"] = feed * 2
+        del b["benchmarks"]["discover_warm"]
+        b["benchmarks"]["invented_row"] = {"n": 1, "median": 1.0}
+        b["iters"] = 9
+        b_path = os.path.join(self.root, "b.json")
+        with open(b_path, "w") as f:
+            json.dump(b, f)
+        r = run_tool(["--compare", self.json_path, b_path])
+        self._ok(r)
+        lines = r.stdout.splitlines()
+        feed_line = next(l for l in lines if l.startswith("build_feed "))
+        self.assertEqual(feed_line.split(), ["build_feed", "%.2f" % feed, "%.2f" % (feed * 2), "%+.2f" % feed, "+100.0%"])
+        self.assertIn("only in A: discover_warm", r.stdout)
+        self.assertIn("only in B: invented_row", r.stdout)
+        self.assertIn("MISMATCH", r.stdout, "a differing iters count is flagged before the table")
+        self.assertIn("push_cold_cycle bytes chat", r.stdout)
+        r = run_tool(["--compare", self.json_path, self.json_path])
+        self._ok(r)
+        self.assertNotIn("MISMATCH", r.stdout)
+
+    def test_requires_a_state_dir(self):
+        r = run_tool([])
+        self.assertEqual(r.returncode, 2)
+        r = run_tool(["--state", os.path.join(self.root, "not-a-state-dir")])
+        self.assertEqual(r.returncode, 2)
+
+    def test_a_transcript_outside_the_discovery_window_is_backfilled(self):
+        # the api transcript's mtime is four days old, outside discovery's 48 h window, while its registry
+        # entry is alive: the tool resolves it through the long backfill window, as _alive_sessions does for
+        # the builders, so the pick list and the builders see one world and the session gets its cold row
+        root = self._scratch_root("perf-bench-backfill-")
+        state, claude = build_synthetic(root, web_turns=3, age_api_days=4)
+        out_json = os.path.join(root, "out.json")
+        r = run_tool(["--state", state, "--claude-dir", claude, "--repo", ROOT, "--iters", "1", "--sessions", "2",
+                      "--clients", "", "--json", out_json])
+        self._ok(r)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual(out["live_transcripts"]["count"], 2)
+        self.assertEqual(out["live_transcripts"]["in_window"], 1)
+        self.assertEqual(out["live_transcripts"]["backfilled"], 1)
+        self.assertEqual(out["live_transcripts"]["no_transcript"], [])
+        self.assertIn("build_session_cold:22222222", out["benchmarks"])
+        self.assertIn("1 backfilled", r.stdout)
+
+    def test_a_kernel_lacking_a_builder_is_refused(self):
+        # --repo selects the kernel; one without the symbols the harness drives is refused with a message
+        # naming the first missing one, and the partial JSON records which checkout was tried
+        scratch = self._scratch_root("perf-bench-norepo-")
+        os.makedirs(os.path.join(scratch, "kernel"))
+        with open(os.path.join(scratch, "kernel", "kernel.py"), "w") as f:
+            f.write("x = 1\n")
+        open(os.path.join(scratch, "kernel", "sdk_backend.py"), "w").close()
+        out_json = os.path.join(scratch, "out.json")
+        r = run_tool(["--state", self.state, "--claude-dir", self.claude, "--repo", scratch, "--iters", "1", "--json", out_json])
+        self.assertEqual(r.returncode, 1, r.stderr)
+        self.assertIn("this kernel lacks _live_scope", r.stderr)
+        self.assertNotIn("Traceback", r.stderr)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual(out["repo"], os.path.realpath(scratch))
+        self.assertNotIn("benchmarks", out)
+        self.assertEqual(out["error"], "this kernel lacks _live_scope; the harness does not know how to drive it")
+
+
+class Tripwire(unittest.TestCase):
+    """The tripwire's allow rule, in-process: exactly the kernel's read-only git queries pass —
+    `rev-parse`, `ls-files`, and the pair `remote get-url` — and everything else raises. `git remote`
+    is not read-only as a whole (add / set-url / remove rewrite config), so only the get-url pair is
+    admitted, by both words."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pb = SourceFileLoader("perf_bench_tripwire_under_test", TOOL).load_module()
+        cls.root = tempfile.mkdtemp(prefix="perf-bench-tripwire-")
+        cls.repo = os.path.join(cls.root, "notes-api")
+        os.makedirs(cls.repo)
+        _git("init", "-q", "-b", "main", cwd=cls.repo)
+        _git("remote", "add", "origin", ORIGIN, cwd=cls.repo)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def _tw(self, no_git=False):
+        log = []
+        return self.pb.SubprocessTripwire(subprocess, log, no_git=no_git), log
+
+    def test_the_allow_rule_names_exactly_three_queries(self):
+        q = self.pb.SubprocessTripwire._git_query
+        self.assertEqual(q(["git", "-C", "/x", "rev-parse", "--show-toplevel"]), "rev-parse")
+        self.assertEqual(q(["git", "ls-files", "-co", "--exclude-standard"]), "ls-files")
+        self.assertEqual(q(["git", "-C", "/x", "remote", "get-url", "origin"]), "remote get-url")
+        for argv in (["git", "-C", "/x", "remote", "set-url", "origin", "u"],
+                     ["git", "-C", "/x", "remote", "add", "origin", "u"],
+                     ["git", "-C", "/x", "remote", "remove", "origin"],
+                     ["git", "-C", "/x", "remote"],
+                     ["git", "-C", "/x", "fetch", "origin"],
+                     ["git", "-C", "/x", "push"],
+                     ["git"], ["gh", "pr", "view", "1"], "git rev-parse HEAD", None):
+            self.assertIsNone(q(argv), argv)
+
+    def test_the_repo_query_runs_and_is_counted_by_its_pair(self):
+        tw, log = self._tw()
+        r = tw.run(["git", "-C", self.repo, "remote", "get-url", "origin"], capture_output=True, text=True, timeout=5)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), ORIGIN)
+        self.assertEqual(tw.git_calls, {"remote get-url": 1})
+        self.assertEqual(log, [])
+
+    def test_a_writing_remote_form_trips(self):
+        tw, log = self._tw()
+        with self.assertRaises(self.pb.BenchError):
+            tw.run(["git", "-C", self.repo, "remote", "set-url", "origin", "https://github.com/other-org/x.git"],
+                   capture_output=True, text=True)
+        self.assertEqual(len(log), 1)
+        self.assertIn("remote', 'set-url'", log[0])
+        self.assertEqual(tw.git_calls, {})
+        with self.assertRaises(self.pb.BenchError):
+            tw.run(["git", "-C", self.repo, "remote"], capture_output=True, text=True)
+        r = subprocess.run(["git", "-C", self.repo, "remote", "get-url", "origin"], capture_output=True, text=True)
+        self.assertEqual(r.stdout.strip(), ORIGIN, "the refused set-url never ran")
+
+    def test_no_git_answers_the_repo_query_as_a_failure(self):
+        tw, log = self._tw(no_git=True)
+        r = tw.run(["git", "-C", self.repo, "remote", "get-url", "origin"], capture_output=True, text=True)
+        self.assertEqual(r.returncode, 1)
+        self.assertEqual(r.stdout, "")
+        self.assertEqual(tw.git_calls, {"remote get-url": 1}, "counted even when answered as a failure")
+        self.assertEqual(log, [])
+
+
+class Recorders(unittest.TestCase):
+    """install_guards' recorders, in-process, called the way kernel/kernel.py calls the functions they
+    replace. The kernel passes _push_notify keywords the recorder never reads (kind=, card_id=, quiet=,
+    host=), and a recorder that refused them would not fail the run: _push catches every exception in
+    its build, writes `push build: <traceback>` to stderr and returns, so that cycle was timed with its
+    frames dropped and the notification count came up short while the tool exited 0. A safety target
+    the kernel lacks is still an error, since the real function would otherwise stay in place."""
+
+    def setUp(self):
+        self.pb = SourceFileLoader("perf_bench_recorders_under_test", TOOL).load_module()
+        saved = pwd.getpwnam, pwd.getpwuid                 # install_guards counts these process-wide
+        self.addCleanup(lambda: (setattr(pwd, "getpwnam", saved[0]), setattr(pwd, "getpwuid", saved[1])))
+        saved_start = threading.Thread.start               # and wraps this
+        self.addCleanup(setattr, threading.Thread, "start", saved_start)
+        self.state = tempfile.mkdtemp(prefix="perf-bench-recorders-")
+        self.addCleanup(shutil.rmtree, self.state, ignore_errors=True)
+        self.writes = []
+
+    def _kernel(self):
+        return SimpleNamespace(jd=SimpleNamespace(STATE=self.state),
+                               _atomic_write=lambda path, text, mode=None: self.writes.append((path, text)),
+                               _refresh_remote_prices=None, _warm_fleet_bg=None, _system_notify=None,
+                               _push_notify=None, _push_forward=None, _badge_push=None)
+
+    def test_the_recorders_take_every_shape_the_kernel_calls_with(self):
+        km = self._kernel()
+        names, rec = self.pb.install_guards(km, None)
+        self.assertEqual(set(names), {n for n in EXPECTED_NEUTRALIZED if not n.endswith(".subprocess")},
+                         "a namespace without a subprocess attribute gets no tripwire; everything else is guarded")
+        # _cached_feed's two card pushes (quiet when the turn push already buzzed), the turn tick's push
+        # without a badge, the federation handler's with a host, and a keyword this tree does not have
+        km._push_notify("api: done", "body", SID_API, 2, kind="card", card_id="g7", quiet=True)
+        km._push_notify("api: done", "body", SID_API, 2, kind="card", card_id="g7")
+        km._push_notify("web finished a turn", "body", SID_WEB, kind="turn")
+        km._push_notify("tests: done", "body", SID_TESTS, kind="card", card_id="g1", host="TESTHOST")
+        km._push_notify("later", "body", SID_WEB, kind="card", card_id="g1", later_keyword=1)
+        km._system_notify("romp: api", "body")
+        km._push_forward([{"title": "api: done", "body": "body", "sid": SID_API, "kind": "card", "cardId": "g7"}])
+        km._badge_push(3)
+        self.assertIsNone(km._refresh_remote_prices(time.time()))
+        self.assertIsNone(km._warm_fleet_bg(time.time()))
+        self.assertEqual(rec["notifications"],
+                         [("push", "api: done"), ("push", "api: done"), ("push", "web finished a turn"), ("push", "tests: done"),
+                          ("push", "later"), ("system", "romp: api"), ("forward", 1), ("badge", 3)])
+        self.assertEqual(len(rec["warm_calls"]), 1, "the background-parse call is counted, not run")
+        # threads started after the guards are counted (the real _warm_fleet_bg would start one per call)
+        self.assertEqual(rec["thread_starts"], 0)
+        t = threading.Thread(target=lambda: None)
+        t.start()
+        t.join()
+        self.assertEqual(rec["thread_starts"], 1)
+
+    def test_atomic_writes_outside_the_copy_are_refused(self):
+        km = self._kernel()
+        _names, rec = self.pb.install_guards(km, None)
+        km._atomic_write(os.path.join(self.state, "sub", "x.json"), "{}")
+        self.assertEqual([os.path.basename(p) for p, _t in self.writes], ["x.json"], "a write under the copy goes through")
+        self.assertEqual(rec["atomic_writes"], ["sub/x.json"], "and is recorded relative to the copy")
+        elsewhere = tempfile.mkdtemp(prefix="perf-bench-elsewhere-")
+        self.addCleanup(shutil.rmtree, elsewhere, ignore_errors=True)
+        with self.assertRaises(self.pb.BenchError) as cm:
+            km._atomic_write(os.path.join(elsewhere, "y.json"), "{}")
+        self.assertIn("outside the state copy", str(cm.exception))
+        self.assertEqual(len(self.writes), 1, "the refused write never reached the kernel's function")
+        self.assertEqual(rec["atomic_writes"], ["sub/x.json"])
+
+    def test_a_missing_safety_target_is_an_error(self):
+        km = self._kernel()
+        del km._push_notify
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.install_guards(km, None)
+        self.assertIn("_push_notify", str(cm.exception))
+
+
+class InProcessChecks(unittest.TestCase):
+    """The tool's factored guards and folds, called directly: the two proofs a cold build_session sample
+    must pass, the liveness row count, the environment rewrite, the constructor-free backend's liveness
+    rows, the steady-push bucketing, the partial output a late BenchError leaves, and the mirror copy's
+    tolerance for vanished files. Each is a function of the tool module (loaded from its path; the import
+    pulls in only the standard library), so no kernel runs here."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pb = SourceFileLoader("perf_bench_checks_under_test", TOOL).load_module()
+
+    def _tmp(self, prefix):
+        d = tempfile.mkdtemp(prefix=prefix)
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return d
+
+    # ── check_cold_sample ────────────────────────────────────────────────────────────────────────
+    def _em(self, **stats):
+        return SimpleNamespace(_ASM_STATS=dict(stats), _ASM_CACHE={}, _ASM_LOCK=threading.Lock())
+
+    def test_a_cold_sample_that_ran_no_full_assembly_is_an_error(self):
+        em = self._em(full=3, serve=10)
+        before = dict(em._ASM_STATS)
+        em._ASM_STATS["serve"] += 1                          # served from a cache: not a cold parse
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.check_cold_sample(em, "11111111", "/x/t.jsonl", before)
+        self.assertIn("ran no full assembly", str(cm.exception))
+        self.assertIn("'serve': 1", str(cm.exception), "the message carries the counters that did move")
+
+    def test_a_cold_sample_whose_own_transcript_is_not_in_the_assembly_cache_is_an_error(self):
+        em = self._em(full=3)
+        before = dict(em._ASM_STATS)
+        em._ASM_STATS["full"] += 1
+        em._ASM_CACHE[("/x/other.jsonl", 7)] = object()      # a peer's transcript assembled, not this session's
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.check_cold_sample(em, "11111111", "/x/t.jsonl", before)
+        self.assertIn("never assembled its own transcript", str(cm.exception))
+        self.assertIn("t.jsonl", str(cm.exception))
+
+    def test_a_cold_sample_with_a_full_assembly_of_its_own_transcript_passes(self):
+        em = self._em(full=3)
+        before = dict(em._ASM_STATS)
+        em._ASM_STATS["full"] += 1
+        em._ASM_CACHE[("/x/t.jsonl", 7)] = object()
+        self.assertEqual(self.pb.check_cold_sample(em, "11111111", "/x/t.jsonl", before), {"full": 1})
+
+    # ── check_snapshot_rows ──────────────────────────────────────────────────────────────────────
+    REGS = [{"sid": SID_WEB, "alive": True}, {"sid": SID_API, "alive": True}, {"sid": SID_TESTS, "alive": False},
+            {"sid": "44444444-5555-6666-7777-888888888888", "alive": True, "threadOf": SID_WEB}]
+
+    def test_a_snapshot_with_fewer_rows_than_qualifying_regs_is_an_error(self):
+        with self.assertRaises(self.pb.BenchError) as cm:
+            self.pb.check_snapshot_rows({SID_WEB: {}}, self.REGS, False)
+        self.assertIn("1 rows but 2 registry entries", str(cm.exception))
+        self.assertEqual(self.pb.check_snapshot_rows({SID_WEB: {}, SID_API: {}}, self.REGS, False), 2)
+        self.assertEqual(self.pb.check_snapshot_rows({SID_WEB: {}, SID_API: {}, SID_TESTS: {}}, self.REGS, True), 3,
+                         "--all-regs-live counts the closed reg too, never the comment thread")
+        with self.assertRaises(self.pb.BenchError):
+            self.pb.check_snapshot_rows({SID_WEB: {}, SID_API: {}}, self.REGS, True)
+
+    # ── prepare_env ──────────────────────────────────────────────────────────────────────────────
+    def test_prepare_env_drops_the_keys_and_floors_every_seam_before_the_import(self):
+        root = self._tmp("perf-bench-env-")
+        state, claude, private, other = (os.path.join(root, d) for d in ("romp", "claude", "private", "other"))
+        for d in (state, claude, private, other):
+            os.makedirs(d)
+        planted = {"ANTHROPIC_API_KEY": "not-a-key", "ANTHROPIC_BASE_URL": "http://127.0.0.1:1", "ROMP_MANAGER_PORT": "7432",
+                   "ROMP_MANAGER_PID": "1", "ROMP_STATE_DIR": other, "TMUX": "planted", "ROMP_MODEL_CATALOG": "on"}
+        with mock.patch.dict(os.environ, planted):
+            changes = self.pb.prepare_env(state, claude, private)
+            env = dict(os.environ)
+        self.assertFalse([k for k in env if k.startswith("ANTHROPIC_")], "every ANTHROPIC_* variable is gone")
+        self.assertEqual(env["ROMP_MANAGER_PORT"], "1", "a dead port, not an absent variable (absent maps to the live default)")
+        self.assertNotIn("ROMP_MANAGER_PID", env)
+        self.assertNotIn("TMUX", env)
+        self.assertEqual(env["ROMP_STATE_DIR"], state)
+        self.assertEqual(env["XDG_STATE_HOME"], os.path.dirname(state))
+        self.assertEqual(env["ROMP_MODEL_CATALOG"], "off")
+        self.assertEqual(env["ROMP_CLI_SCOPE"], "0")
+        self.assertEqual(env["ROMP_CLAUDE_BIN"], "/bin/false")
+        self.assertEqual(env["ROMP_TMUX_AVAILABLE"], "0")
+        self.assertEqual(env["ROMP_KERNEL_NO_OPEN"], "1")
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], claude)
+        self.assertTrue(env["TMUX_TMPDIR"].startswith(private + os.sep) and os.path.isdir(env["TMUX_TMPDIR"])
+                        and os.listdir(env["TMUX_TMPDIR"]) == [], "tmux is pointed at an existing, empty, private socket directory")
+        self.assertTrue(env["ROMP_SERVICE_ENV_FILE"].startswith(private + os.sep) and not os.path.exists(env["ROMP_SERVICE_ENV_FILE"]))
+        self.assertEqual(env["ROMP_SERVICE_ENV"], env["ROMP_SERVICE_ENV_FILE"])
+        for c in ("unset ANTHROPIC_API_KEY", "unset ANTHROPIC_BASE_URL", "unset ROMP_MANAGER_PID", "unset TMUX", "unset ROMP_STATE_DIR",
+                  "set ROMP_MANAGER_PORT", "set ROMP_MODEL_CATALOG", "set ROMP_CLI_SCOPE", "set ROMP_CLAUDE_BIN", "set ROMP_TMUX_AVAILABLE",
+                  "set TMUX_TMPDIR", "set ROMP_SERVICE_ENV_FILE", "set ROMP_STATE_DIR", "set XDG_STATE_HOME", "set CLAUDE_CONFIG_DIR"):
+            self.assertIn(c, changes)
+
+    # ── make_backend ─────────────────────────────────────────────────────────────────────────────
+    def _sbmod(self):
+        class FakeSdkBackend:
+            def _live_row(self, reg, sid):
+                return {"sid": sid, "state": "waiting", "connected": False}
+        regs = [{"sid": SID_WEB, "alive": True}, {"sid": SID_API, "alive": True}, {"sid": SID_TESTS, "alive": False},
+                {"sid": "44444444-5555-6666-7777-888888888888", "alive": True, "threadOf": SID_WEB}]
+        return SimpleNamespace(SdkBackend=FakeSdkBackend, list_regs=lambda d: regs,
+                               last_state_value=lambda d, sid: "working" if sid == SID_WEB else "")
+
+    def test_the_bench_backend_lists_alive_regs_with_their_last_state_and_skips_threads(self):
+        be = self.pb.make_backend(self._sbmod(), "/x/state", dormant_rows=False, all_regs=False)
+        rows = be.live_sessions()
+        self.assertEqual(set(rows), {SID_WEB, SID_API}, "alive regs only; the closed reg and the comment thread are out")
+        self.assertEqual(rows[SID_WEB]["state"], "working", "the last states/ record wins over the dormant mapping")
+        self.assertIs(rows[SID_WEB]["connected"], True, "and the row reads as connected, as a running session reports")
+        self.assertEqual(rows[SID_API]["state"], "waiting", "an empty last state leaves _live_row's value")
+        self.assertEqual(be._owns_memo, {}, "the slot owns() memoizes on")
+        with self.assertRaises(self.pb.BenchError) as cm:
+            be.no_such_attribute
+        self.assertIn("no_such_attribute", str(cm.exception))
+
+    def test_dormant_rows_and_all_regs_live_change_the_bench_backend_rows(self):
+        dormant = self.pb.make_backend(self._sbmod(), "/x/state", dormant_rows=True, all_regs=False).live_sessions()
+        self.assertEqual(dormant[SID_WEB], {"sid": SID_WEB, "state": "waiting", "connected": False}, "--dormant-rows keeps _live_row's row verbatim")
+        every = self.pb.make_backend(self._sbmod(), "/x/state", dormant_rows=False, all_regs=True).live_sessions()
+        self.assertEqual(set(every), {SID_WEB, SID_API, SID_TESTS}, "--all-regs-live includes the closed reg, still not the thread")
+
+    # ── the steady push's buckets ────────────────────────────────────────────────────────────────
+    def test_push_steady_reports_the_quiet_samples_and_sets_the_rebuilds_aside(self):
+        # The subprocess fixture cannot force a rebuild (it depends on the 5 s view-signature bucket rolling
+        # REBUILD_MIN_S after the previous build, wall-clock alignment), so its assertions hold with zero
+        # rebuild samples; this drives the bucketing with samples of both kinds.
+        mk = lambda ms, feed=False, tl=False: {"ms": ms, "rebuilt_feed": feed, "rebuilt_timeline": tl, "bytes": 100}
+        samples = [mk(10), mk(3000, feed=True), mk(12), mk(2800, tl=True), mk(11)]
+        quiet, rebuilt = self.pb.bucket_steady_samples(samples)
+        self.assertEqual([q["ms"] for q in quiet], [10, 12, 11])
+        self.assertEqual([r["ms"] for r in rebuilt], [3000, 2800])
+        st, st2 = self.pb.steady_rows(samples, ["chat"])
+        self.assertEqual((st["n"], st["median"], st["rebuild_samples"], len(st["samples"])), (3, 11, 2, 5))
+        self.assertEqual((st2["n"], st2["median"]), (2, 2900))
+        self.assertEqual(self.pb.steady_rows(samples[:1], ["chat"])[1], None, "no rebuild row without a rebuild sample")
+
+    # ── a late BenchError keeps what was measured ────────────────────────────────────────────────
+    def test_a_late_bench_error_still_prints_the_rows_and_writes_the_partial_json(self):
+        state = self._tmp("perf-bench-partial-")
+        for d in ("sdk", "names"):
+            os.mkdir(os.path.join(state, d))
+        out_json = os.path.join(state, "out.json")
+
+        def fake_run(args, st, mirror_of, out, private):
+            out["repo"], out["repo_head"], out["state"], out["state_mirror_of"] = "/x/repo", "abc", st, mirror_of
+            out["benchmarks"] = {"build_feed": {"n": 1, "min": 1.0, "median": 1.0, "max": 1.0}}
+            raise self.pb.BenchError("late guard")
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.object(self.pb, "run", fake_run), contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            rc = self.pb.main(["--state", state, "--json", out_json])
+        self.assertEqual(rc, 1)
+        with open(out_json) as f:
+            out = json.load(f)
+        self.assertEqual(out["error"], "late guard")
+        self.assertIn("build_feed", out["benchmarks"])
+        self.assertIn("build_feed", stdout.getvalue(), "the rows measured before the error are printed")
+        self.assertIn("(partial: the run stopped on an error)", stdout.getvalue())
+        self.assertIn("perf-bench: late guard", stderr.getvalue())
+
+    # ── mirror_state ─────────────────────────────────────────────────────────────────────────────
+    def test_the_mirror_tolerates_files_that_vanished_during_the_copy_and_nothing_else(self):
+        src = self._tmp("perf-bench-mirror-src-")
+        real_mkdtemp, made = tempfile.mkdtemp, []
+
+        def tracking_mkdtemp(*a, **k):
+            made.append(real_mkdtemp(*a, **k))
+            return made[-1]
+        self.addCleanup(lambda: [shutil.rmtree(d, ignore_errors=True) for d in made])
+        vanished = shutil.Error([(os.path.join(src, "tmp"), "/x/tmp", "[Errno 2] No such file or directory: 'tmp'")])
+        stderr = io.StringIO()
+        with mock.patch.object(self.pb.tempfile, "mkdtemp", tracking_mkdtemp):
+            with mock.patch.object(self.pb.shutil, "copytree", side_effect=vanished), contextlib.redirect_stderr(stderr):
+                root, dst = self.pb.mirror_state(src)
+            self.assertEqual((root, dst), (made[-1], os.path.join(made[-1], "romp")))
+            self.assertIn("1 file(s) vanished during the mirror copy", stderr.getvalue())
+            denied = shutil.Error([(os.path.join(src, "a"), "/x/a", "[Errno 13] Permission denied: 'a'")])
+            with mock.patch.object(self.pb.shutil, "copytree", side_effect=denied):
+                with self.assertRaises(shutil.Error):
+                    self.pb.mirror_state(src)
+            self.assertFalse(os.path.exists(made[-1]), "a copy that failed for another reason leaves no half-made mirror")
+            mixed = shutil.Error([(os.path.join(src, "tmp"), "/x/tmp", "[Errno 2] No such file or directory: 'tmp'"),
+                                  (os.path.join(src, "a"), "/x/a", "[Errno 13] Permission denied: 'a'")])
+            with mock.patch.object(self.pb.shutil, "copytree", side_effect=mixed):
+                with self.assertRaises(shutil.Error):
+                    self.pb.mirror_state(src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ui-bench.test.mjs
+++ b/tests/ui-bench.test.mjs
@@ -949,6 +949,40 @@ const required = !!process.env.ROMP_UI_BENCH_REQUIRE;
 const gate = (why) => ({ skip: required ? false : why });
 const requireOrSkip = (why) => { if (why) assert.fail(`ROMP_UI_BENCH_REQUIRE is set and this test cannot run: ${why}`); };
 
+test("the replays have a browser when ROMP_UI_BENCH_REQUIRE is set, and the log says which", (t) => {
+  // CI's only browser is the runner image's Google Chrome, found by the PATH scan below; this line in the step's
+  // log is what says so, and under ROMP_UI_BENCH_REQUIRE a runner without one fails here, before the replays.
+  if (required) assert.ok(avail.ok, avail.why);
+  t.diagnostic(`browser: ${avail.ok ? avail.how + (avail.channel ? ` (channel ${avail.channel})` : "") : "none: " + avail.why}`);
+});
+
+test("browserAvailability finds a system Chrome or Chromium on PATH when playwright's browser is absent, and names its channel", () => {
+  // The module in a fresh process: playwright's browsers directory pointed at an empty one (so its own Chromium is
+  // absent, as on the CI runner), PATH holding one fake browser binary. No browser is launched.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-path-"));
+  try {
+    const noBrowsers = path.join(tmp, "no-browsers");
+    const bin = path.join(tmp, "bin");
+    fs.mkdirSync(noBrowsers);
+    fs.mkdirSync(bin);
+    const probe = (PATH) => {
+      const r = spawnSync(process.execPath, ["--input-type=module", "-e", `import(${JSON.stringify(pathToFileURL(TOOL).href)}).then((m) => console.log(JSON.stringify(m.browserAvailability())))`],
+        { env: { HOME: os.homedir(), PATH, PLAYWRIGHT_BROWSERS_PATH: noBrowsers }, encoding: "utf8", timeout: 30_000 });
+      assert.equal(r.status, 0, r.stderr);
+      return JSON.parse(r.stdout.trim());
+    };
+    fs.writeFileSync(path.join(bin, "google-chrome"), "", { mode: 0o755 });
+    assert.deepEqual(probe(bin), { ok: true, how: "system google-chrome", exe: path.join(bin, "google-chrome"), channel: "chrome" });
+    fs.renameSync(path.join(bin, "google-chrome"), path.join(bin, "chromium"));
+    assert.deepEqual(probe(bin), { ok: true, how: "system chromium", exe: path.join(bin, "chromium"), channel: "chromium" });
+    const none = probe(path.join(tmp, "empty-path"));
+    assert.equal(none.ok, false);
+    assert.match(none.why, /npx playwright install chromium/, "the refusal says how to get a browser");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("ROMP_UI_BENCH_REQUIRE turns the browser skip into a failure that names the reason", { timeout: 60_000 }, () => {
   const empty = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-nobrowser-"));
   try {

--- a/tests/ui-bench.test.mjs
+++ b/tests/ui-bench.test.mjs
@@ -10,7 +10,8 @@
 // feed and bars slots, contiguous delta revisions, a byte-stable stream), the --record client against a local
 // WebSocket server (the query, the cookie and Origin credential form, the ready handshake and nothing
 // else, the JSONL shape, the early-close and refusal errors), and the CPU-profile fold over a
-// synthetic .cpuprofile, and the per-user run directory with its dead-owner sweep. With python3 and a
+// synthetic .cpuprofile, the per-user run directory with its dead-owner sweep, and the CLI's argument
+// parsing with its browser-free commands. With python3 and a
 // built dist: the Handler subprocess's environment (seen through a stub interpreter that echoes it)
 // and its exit when the node process that started it is SIGKILLed. With a browser as well: a synthetic
 // feed stream replayed at a fixed gap (so most frames reach the bundle as their own delivery) and a
@@ -20,7 +21,10 @@
 // shim's own), and no console error, uncaught exception or failed resource load; the feed run also writes
 // a CPU profile whose windows are the deliveries. Those tests skip, naming
 // the reason, when a prerequisite is missing, unless ROMP_UI_BENCH_REQUIRE is set (CI sets it), when
-// the skip becomes a failure so a runner image that lost its browser cannot pass silently.
+// the skip becomes a failure so a runner image that lost its browser cannot pass silently. The replays
+// assert only what holds under any scheduling (totals, ordering, presence, the handoff's accounting
+// identity); the timing relations the bench exists to measure are assertions only under
+// ROMP_UI_BENCH_TIMING=1 and diagnostics otherwise (see TIMING below).
 //
 // Everything here is synthetic: the notes-api demo domain, placeholder uuids, a fixed clock.
 // Run: node --test tests/ui-bench.test.mjs
@@ -34,8 +38,8 @@ import { createRequire } from "node:module";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
-  APPS, DELTA_SEP, INIT_SCRIPT, REPO, STRIPPED_ENV, WHOLE_STATE_KINDS, aggregateProfile, assertTmpPath, attributeDeliveries, barsKeys, benchRoot, browserAvailability,
-  buildReport, classifyFrame, compareReports, deliveredKind, feedKeys, frameKey, launchBrowser, loadFrames, mergeAggregates, mergeWindows, percentile,
+  APPS, DELTA_SEP, INIT_SCRIPT, REPO, STRIPPED_ENV, STRIPPED_KEY_ENV, STRIPPED_KEY_ENV_PREFIXES, WHOLE_STATE_KINDS, aggregateProfile, assertTmpPath, attributeDeliveries, barsKeys, benchRoot, browserAvailability,
+  buildReport, classifyFrame, compareReports, deliveredKind, feedKeys, frameKey, launchBrowser, loadFrames, mergeAggregates, mergeWindows, parseArgs, percentile,
   rankProfile, recordFrames, refineAlignment, renderCompare, renderProfile, renderReport, replay, sourceLocator, startFront, startPageServer, streamSummary,
   stripProfileQueries, summarize, sweepDeadRuns, synthesizeFrames, writeFrames,
 } from "../tools/ui-bench.mjs";
@@ -180,6 +184,32 @@ test("buildReport folds runs per frame type with percentiles, attribution and en
   assert.match(text, /entry point .*not the bundle function/);
   assert.doesNotMatch(text, /warning:/);
   assert.doesNotMatch(text, /secret-looking/, "no query string from a page URL reaches the report");
+});
+
+test("attribution never files a row under the instrument's own file: its wrappers are labelled for what runs inside them, its other entry points as its own bookkeeping", () => {
+  // The instrument's settle stamp (a requestAnimationFrame callback reading the clock), its long-animation-frame
+  // observer callback and its end-of-run collector appear as entries only when a descheduled main thread stretches
+  // one past the threshold; the first two were each seen once on a loaded box, and the first form filed them as
+  // `ui-bench-instrument.js:(anonymous)`, as if the instrument had done pane work (review find, 2026-09-08).
+  const run = fakeRun({
+    handoff: "handler", deliveries: 1,
+    perFrame: [pf(0, "feed", 5000, 40, 90, "delivered", 38, 0)],
+    loaf: [
+      { start: 0, duration: 120, blocking: 70, scripts: [{ url: "ui-bench-instrument.js", fn: "rompBenchOnMessage", invoker: "DOMWebSocket.onmessage", duration: 100 }] },
+      { start: 200, duration: 60, blocking: 10, scripts: [{ url: "ui-bench-instrument.js", fn: "", invoker: "FrameRequestCallback", duration: 55 }] },
+      { start: 300, duration: 58, blocking: 8, scripts: [{ url: "ui-bench-instrument.js", fn: "", invoker: "PerformanceObserverCallback", duration: 52 }] },
+      { start: 400, duration: 51, blocking: 1, scripts: [{ url: "ui-bench-instrument.js", fn: "collect", invoker: "?", duration: 50 }] },
+    ],
+  });
+  const r = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 1, browser: "t", runs: [run] });
+  const keys = r.loaf.topScripts.map((s) => s.key);
+  assert.ok(!keys.some((k) => /ui-bench-instrument/.test(k)), `no row under the instrument's file: ${keys.join(" | ")}`);
+  assert.deepEqual(keys, [
+    "message handler (shim + bundle) <DOMWebSocket.onmessage>",
+    "instrument bookkeeping (the settle stamp's requestAnimationFrame; no pane work) <FrameRequestCallback>",
+    "instrument bookkeeping (the long-animation-frame observer's callback; no pane work) <PerformanceObserverCallback>",
+    "instrument bookkeeping (collect; no pane work) <?>",
+  ]);
 });
 
 test("buildReport keeps the shim's handler and the bundle's delivery apart when the shim hands frames over in its flush task, and counts the frames the queue coalesced", () => {
@@ -934,6 +964,74 @@ test("aggregateProfile on an empty or window-less profile yields nothing rather 
   assert.equal(aggregateProfile(SYNTH_PROFILE, [5000, 6000]).samples, 0);
 });
 
+// ── the CLI ──────────────────────────────────────────────────────────────────────────────────────
+
+test("parseArgs takes --key value pairs and the two bare flags, keeps positionals, and refuses a flag without its value", () => {
+  assert.deepEqual(parseArgs(["--replay", "feed", "--frames", "/tmp/f.jsonl", "--gap", "100", "--json", "/tmp/o.json"]),
+    { _: [], replay: "feed", frames: "/tmp/f.jsonl", gap: "100", json: "/tmp/o.json" });
+  assert.deepEqual(parseArgs(["--replay", "timeline", "--frames", "f", "--fast", "--cpu-throttle", "4", "--iters", "2", "--cpu-profile", "p"]),
+    { _: [], replay: "timeline", frames: "f", fast: true, "cpu-throttle": "4", iters: "2", "cpu-profile": "p" });
+  assert.deepEqual(parseArgs(["--compare", "a.json", "b.json"]), { _: ["b.json"], compare: "a.json" }, "the second report is a positional");
+  assert.deepEqual(parseArgs(["--help"]), { _: [], help: true });
+  assert.deepEqual(parseArgs([]), { _: [] });
+  assert.throws(() => parseArgs(["--replay"]), /--replay needs a value/);
+  assert.throws(() => parseArgs(["--gap", "--fast"]), /--gap needs a value/, "the next flag is not a value");
+});
+
+test("the CLI: --synthesize writes a frames file the tool reads back, --compare prints the deltas, no arguments print the usage, and a malformed command exits 1 naming the problem", { timeout: 60_000 }, () => {
+  // CONTRIBUTING documents these flags; this drives the entry point as a subprocess with the commands that need
+  // neither a browser nor python3 (review find, 2026-09-08: the CLI had no test of its own).
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-cli-"));
+  const run = (...args) => spawnSync(process.execPath, [TOOL, ...args], { encoding: "utf8", timeout: 50_000 });
+  try {
+    const out = path.join(tmp, "synth", "feed.jsonl");
+    const r = run("--synthesize", "feed", "--cards", "12", "--out", out, "--seed", "3");
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /ui-bench: wrote \d+ synthetic frames \([\d.]+ [KM]?B\) for app=feed/);
+    const { meta, frames } = loadFrames(out);
+    assert.deepEqual(meta, { tool: "ui-bench", mode: "synthesize", app: "feed", cards: 12, seed: 3, synthetic: true });
+    assert.deepEqual(frames, synthesizeFrames("feed", 12, { seed: 3 }), "the file holds the synthesizer's stream for those arguments");
+    if (process.platform !== "win32") { assert.equal(mode(out), 0o600); assert.equal(mode(path.dirname(out)), 0o700); }
+    // --compare over two report files: the header names both pacings, the first-frame line carries the deltas
+    const mk = (settle) => ({
+      app: "feed", cpuThrottle: 1, fast: false, gapMs: 100, frames: { replayMs: 1000 }, handoff: { mode: "flush" },
+      first: { type: "feed", bytes: 5000, handlerMs: 1, bundleMs: settle / 2, settleMs: settle },
+      types: { feed: { count: 1, delivered: 1, bytes: 5000, handlerMs: { p50: 1, p90: 1, max: 1 }, bundleMs: { p50: settle / 2, p90: settle / 2, max: settle / 2 }, settleMs: { p50: settle, p90: settle, max: settle } } },
+      loaf: { count: 0, durationMs: 0, blockingMs: 0, maxMs: 0 }, end: { heapUsed: 1000, domElements: 100, layoutCount: 5, scriptMs: 50, taskMs: 80 }, console: { errors: [] },
+    });
+    const a = path.join(tmp, "a.json"), b = path.join(tmp, "b.json");
+    fs.writeFileSync(a, JSON.stringify(mk(200)));
+    fs.writeFileSync(b, JSON.stringify(mk(100)));
+    const c = run("--compare", a, b);
+    assert.equal(c.status, 0, c.stderr);
+    assert.match(c.stdout, /^compare: feed \(cpu x1, 100 ms gaps\) → feed \(cpu x1, 100 ms gaps\)/);
+    assert.match(c.stdout, /first content frame: .*settled 200 → 100 ms \(-100, -50%\)/);
+    const usage = run();
+    assert.equal(usage.status, 0);
+    assert.match(usage.stdout, /^usage:\n  node tools\/ui-bench\.mjs --record/);
+    assert.equal(run("--help").status, 0);
+    const nothing = run("--seed", "1");
+    assert.equal(nothing.status, 2, "flags without a command print the usage and exit 2");
+    assert.match(nothing.stdout, /^usage:/);
+    // each refusal is one line on stderr, exit 1, before anything is launched
+    for (const [args, why] of [
+      [["--replay", "feed"], "--replay needs --frames FILE"],
+      [["--replay", "feed", "--frames", out, "--fast", "--gap", "5"], "--fast and --gap are two pacings; give one"],
+      [["--record", "feed"], "--record needs --out"],
+      [["--compare", a], "--compare needs two report files"],
+      [["--synthesize", "chat", "--out", path.join(tmp, "chat.jsonl")], "chat frames are not synthesized"],
+      [["--synthesize", "feed", "--out"], "--out needs a value"],
+    ]) {
+      const bad = run(...args);
+      assert.equal(bad.status, 1, `${args.join(" ")}: ${bad.stdout}${bad.stderr}`);
+      assert.ok(bad.stderr.startsWith(`ui-bench: ${why}`), `${args.join(" ")} -> ${bad.stderr}`);
+    }
+    assert.ok(!fs.existsSync(path.join(tmp, "chat.jsonl")));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ── a real replay, when a browser is at hand ─────────────────────────────────────────────────────
 
 const avail = browserAvailability();
@@ -948,10 +1046,29 @@ const skipReplay = !avail.ok ? `no browser: ${avail.why}` : skipServer;
 const required = !!process.env.ROMP_UI_BENCH_REQUIRE;
 const gate = (why) => ({ skip: required ? false : why });
 const requireOrSkip = (why) => { if (why) assert.fail(`ROMP_UI_BENCH_REQUIRE is set and this test cannot run: ${why}`); };
+// The timing RELATIONS the replays measure (a settle margin's floor, a render outweighing a parse, the share
+// of profiler samples inside their windows, the CPU throttle's slowdown, a delta reaching the bundle on its
+// own at a given gap) hold on a quiet machine and are what the bench is for, but every one is a function of
+// the scheduler: a shared CI runner that deschedules the renderer's main thread across two frames coalesces
+// a delta, stretches a handler past a render, or starves the sampler. The upstream run of this file's first
+// form went red on exactly that (a 50 ms-gap replay asserting that no delta ever coalesces, 22 !== 23, while
+// the same sha passed elsewhere; review find, 2026-09-08). So the required CI step asserts only what must
+// hold under ANY scheduling: totals, ordering, presence, and the handoff's accounting identity (delivered +
+// coalesced + shim + queued = count). A relation is an assertion only under ROMP_UI_BENCH_TIMING=1 (a quiet
+// developer machine; CI never sets it); otherwise one that did not hold is a diagnostic line in the log,
+// never a failure.
+const TIMING = !!process.env.ROMP_UI_BENCH_TIMING;
+const timingCheck = (t) => (cond, msg) => {
+  if (TIMING) assert.ok(cond, msg);
+  else if (!cond) t.diagnostic(`timing relation not held on this run (informational; ROMP_UI_BENCH_TIMING=1 asserts it): ${msg}`);
+};
 
 test("the replays have a browser when ROMP_UI_BENCH_REQUIRE is set, and the log says which", (t) => {
-  // CI's only browser is the runner image's Google Chrome, found by the PATH scan below; this line in the step's
-  // log is what says so, and under ROMP_UI_BENCH_REQUIRE a runner without one fails here, before the replays.
+  // CI installs playwright's own Chromium (the build package-lock's playwright pins) before this step, so the
+  // required check never rides the runner image's Google Chrome (unpinned, auto-updated; review find,
+  // 2026-09-08); a developer's machine may have only a system Chrome, found by the PATH scan below. This line
+  // in the step's log says which one ran, and under ROMP_UI_BENCH_REQUIRE a runner without any fails here,
+  // before the replays.
   if (required) assert.ok(avail.ok, avail.why);
   t.diagnostic(`browser: ${avail.ok ? avail.how + (avail.channel ? ` (channel ${avail.channel})` : "") : "none: " + avail.why}`);
 });
@@ -1003,7 +1120,7 @@ test("ROMP_UI_BENCH_REQUIRE turns the browser skip into a failure that names the
 
 // ── the Handler subprocess ───────────────────────────────────────────────────────────────────────
 
-test("startPageServer hands the Handler an isolated environment: a minted token, no manager, no API keys, no key reference, no CLI scope, no postal peers", { timeout: 30_000 }, async () => {
+test("startPageServer hands the Handler an isolated environment: a minted token, a dead manager port, no key source or credential conftest pops, no CLI scope, no postal peers", { timeout: 30_000 }, async () => {
   // A stub interpreter stands in for python3: it echoes its environment, announces a port, and blocks on
   // stdin the way the Handler's watcher thread does. So this needs neither python nor the kernel.
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-env-"));
@@ -1015,9 +1132,18 @@ test("startPageServer hands the Handler an isolated environment: a minted token,
     // the manager's, the live kernel's ports and state root, the perf switch and tmux's.
     const NEVER = ["ROMP_MANAGER_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "ROMP_STATE_DIR", "ROMP_SERVE_PORT", "ROMP_KERNEL_PORT", "ROMP_PERF", "TMUX"];
     assert.deepEqual([...STRIPPED_ENV].sort(), [...NEVER].sort(), "the tool's list is exactly this one");
-    const planted = { UI_BENCH_STUB_ENV_OUT: envOut, ANTHROPIC_PROBE_FOR_THE_TEST: "must-not-cross", ROMP_CLAUDE_BIN: "/nonexistent/claude", ROMP_POSTAL_PEERS: "1",
-      ROMP_SERVICE_ENV_FILE: path.join(tmp, "planted-service.env"), ROMP_MODEL_CATALOG: "on", ROMP_API_KEY_REF: "planted-reference", ROMP_CLI_SCOPE: "1",
-      ...Object.fromEntries(NEVER.map((k) => [k, k === "TMUX" ? "/tmp/tmux-0/default,1,0" : k === "ROMP_STATE_DIR" ? path.join(tmp, "planted-state") : "1"])) };
+    // Every key-source and credential name tests/conftest.py pops before any test (its KEY_SOURCE_ENV_NAMES and
+    // KEY_SOURCE_ENV_PREFIXES, plus the ANTHROPIC_ prefix): a replay run from inside a romp session inherits all
+    // of them from the manager. The first form of this test planted ANTHROPIC_* and the key reference only, so a
+    // Handler holding the key command, the OAuth token and 1Password's names passed it (review find, 2026-09-08).
+    const NEVER_KEYS = ["ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "ROMP_EXPECTED_AUTH",
+      "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT"];
+    assert.deepEqual([...STRIPPED_KEY_ENV].sort(), [...NEVER_KEYS].sort(), "the tool's key-source list is exactly conftest's");
+    assert.deepEqual([...STRIPPED_KEY_ENV_PREFIXES].sort(), ["ANTHROPIC_", "OP_SESSION_"]);
+    const plantedKeys = { ...Object.fromEntries(NEVER_KEYS.map((k) => [k, `planted-${k.toLowerCase()}`])), OP_SESSION_testaccount: "planted-op-session", ANTHROPIC_PROBE_FOR_THE_TEST: "must-not-cross" };
+    const planted = { UI_BENCH_STUB_ENV_OUT: envOut, ...plantedKeys, ROMP_CLAUDE_BIN: "/nonexistent/claude", ROMP_POSTAL_PEERS: "1",
+      ROMP_SERVICE_ENV_FILE: path.join(tmp, "planted-service.env"), ROMP_MODEL_CATALOG: "on", ROMP_CLI_SCOPE: "1",
+      ...Object.fromEntries(NEVER.map((k) => [k, k === "TMUX" ? "/tmp/tmux-0/default,1,0" : k === "ROMP_STATE_DIR" ? path.join(tmp, "planted-state") : k === "ROMP_MANAGER_PORT" ? "7432" : "1"])) };
     const srv = await withEnv(planted, () => startPageServer({ dist, python: stub }));
     try {
       assert.equal(srv.port, 1);
@@ -1034,7 +1160,7 @@ test("startPageServer hands the Handler an isolated environment: a minted token,
       assert.equal(env.ROMP_MODEL_CATALOG, "off", "no boot fetch of the Models API");
       assert.equal(env.ROMP_CLAUDE_BIN, "/bin/false", "a binary that runs nothing; removing the variable would resolve the real CLI");
       assert.equal(env.ROMP_CLI_SCOPE, "0", "no route that constructs the SDK backend probes systemd-run");
-      assert.equal(env.ROMP_API_KEY_REF, undefined, "an inherited key reference never reaches the Handler");
+      for (const k of Object.keys(plantedKeys)) assert.equal(env[k], undefined, `${k} was planted and must not reach the Handler (a key source or credential conftest pops)`);
       assert.equal(path.dirname(srv.tmp), srv.root, "the run directory sits under the per-user parent");
       assert.equal(path.basename(srv.root), `romp-ui-bench-${UID}`);
       assert.equal(fs.readFileSync(path.join(srv.tmp, "owner.pid"), "utf8").trim(), String(process.pid), "the run records its owner for the dead-owner sweep");
@@ -1043,8 +1169,11 @@ test("startPageServer hands the Handler an isolated environment: a minted token,
       assert.ok(env.XDG_STATE_HOME.startsWith(srv.tmp + path.sep), "a private state root");
       assert.ok(env.TMUX_TMPDIR.startsWith(srv.tmp + path.sep));
       assert.ok(fs.readFileSync(envOut, "utf8").includes(`\nTMPARG ${srv.tmp}\n`), "the subprocess is told its directory so it can remove it");
-      for (const k of Object.keys(env)) assert.ok(!k.startsWith("ANTHROPIC_"), `${k} must not reach the Handler`);
-      for (const k of NEVER) assert.equal(env[k], undefined, `${k} was planted and must not reach the Handler`);
+      for (const k of Object.keys(env)) assert.ok(!k.startsWith("ANTHROPIC_") && !k.startsWith("OP_SESSION_"), `${k} must not reach the Handler`);
+      for (const k of NEVER) if (k !== "ROMP_MANAGER_PORT") assert.equal(env[k], undefined, `${k} was planted and must not reach the Handler`);
+      // conftest's form of the manager floor: a DEAD port, never an absent variable (one kernel consumer maps an
+      // absent port to the default, live, one), so the planted 7432 comes out as 1, not as nothing.
+      assert.equal(env.ROMP_MANAGER_PORT, "1", "the manager port is a dead one, not absent");
       assert.equal(env.UI_BENCH_STUB_ENV_OUT, envOut, "unrelated variables pass through");
       // a second run mints its own token: the Handler is the kernel's whole route surface on a loopback port
       const other = await startPageServer({ dist, python: stub });
@@ -1165,6 +1294,7 @@ test("the front server's /ws admits the page's own origin only, and no other pat
   });
   try {
     assert.deepEqual(await attempt("/ws?app=feed", "http://evil.example"), { status: 403 }, "a foreign Origin is refused");
+    assert.deepEqual(await attempt("/ws?app=feed"), { status: 403 }, "and so is a client that sends no Origin at all: a browser page always sends one, so that is some other local process, and the frames it would receive may be a recording of real session data (review find, 2026-09-08)");
     assert.deepEqual(await attempt("/other", `http://127.0.0.1:${front.port}`), { status: 403 }, "no path but /ws upgrades");
     assert.deepEqual(reached, [], "neither reached the replay's socket handler");
     assert.deepEqual(await attempt("/ws?app=feed", `http://127.0.0.1:${front.port}`), { message: "front /ws" }, "the page's own origin upgrades");
@@ -1274,8 +1404,9 @@ const REPLAY_PACING = { feed: { gapMs: 100 }, timeline: { fast: true } };
 
 for (const app of ["feed", "timeline"]) {
   test(`replay: a synthetic ${app} stream renders in headless Chromium, every frame type measured and accounted for by the handoff, no console errors`,
-    { ...gate(skipReplay), timeout: 180_000 }, async () => {
+    { ...gate(skipReplay), timeout: 180_000 }, async (t) => {
       requireOrSkip(skipReplay);
+      const timing = timingCheck(t);
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-replay-"));
       try {
         const frames = synthesizeFrames(app, 40);
@@ -1337,26 +1468,28 @@ for (const app of ["feed", "timeline"]) {
         assert.equal(report.handoff.unattributed, 0, "no delivery the frames do not explain (federation re-dispatches every frame inside its inbound; that is one delivery, not two)");
         assert.deepEqual(report.handoff.deliverySeams, { inbound: report.handoff.deliveries }, "every delivery came through federation's published inbound, none through the MessageEvent fallback");
         // The columns are measurements, not constants: the shim's parse of the first content frame is measurable at
-        // performance.now() resolution and cheaper than the bundle's render of it; the settle of a keepalive, which the
-        // shim answers with no render, is the two animation frames after receipt, at least one frame interval.
+        // performance.now() resolution. How the measurements RELATE (the parse cheaper than the render, a settle
+        // margin of two animation frames, a keepalive's settle at least one frame interval, how many deltas reach the
+        // bundle on their own at this gap, the forced collection freeing garbage) is the scheduler's to decide on a
+        // loaded runner, so those are timing() relations: asserted under ROMP_UI_BENCH_TIMING, diagnostics otherwise.
         assert.ok(report.first.handlerMs > 0, `the first frame's handler time is a measurement: ${report.first.handlerMs}`);
         assert.ok(report.types[report.first.type].handlerMs.max > 0);
         if (report.first.handoff === "delivered") {
-          assert.ok(report.first.handlerMs < report.first.bundleMs, `the shim's parse is cheaper than the bundle's render: ${JSON.stringify(report.first)}`);
-          assert.ok(report.first.settleMs - report.first.bundleMs - report.first.handlerMs >= 5, `settle waits for the main thread after the delivery: ${JSON.stringify(report.first)}`);
+          timing(report.first.handlerMs < report.first.bundleMs, `the shim's parse is cheaper than the bundle's render: ${JSON.stringify(report.first)}`);
+          timing(report.first.settleMs - report.first.bundleMs - report.first.handlerMs >= 5, `settle waits for the main thread after the delivery: ${JSON.stringify(report.first)}`);
         }
-        assert.ok(report.types.ka.settleMs.p50 >= 10, `a keepalive settles two animation frames after receipt, not when its handler returns: ${JSON.stringify(report.types.ka.settleMs)}`);
+        timing(report.types.ka.settleMs.p50 >= 10, `a keepalive settles two animation frames after receipt, not when its handler returns: ${JSON.stringify(report.types.ka.settleMs)}`);
         const content = frames.length - report.types.ka.count;
         if (pacing.fast) {
-          assert.ok(report.handoff.coalesced >= 1, `back-to-back, frames queue together and the whole-state kinds coalesce: ${JSON.stringify(report.handoff)}`);
-          assert.ok(report.handoff.delivered < content, "so fewer deliveries than content frames");
+          timing(report.handoff.coalesced >= 1, `back-to-back, frames queue together and the whole-state kinds coalesce: ${JSON.stringify(report.handoff)}`);
+          timing(report.handoff.delivered < content, "so fewer deliveries than content frames");
         } else {
           assert.equal(report.types.feed.delivered + report.types.feed.coalesced, 1);
-          assert.ok(report.types["delta:feed"].delivered >= report.types["delta:feed"].count / 2, `at ${pacing.gapMs} ms gaps most deltas reach the bundle on their own: ${JSON.stringify(report.types["delta:feed"])}`);
-          assert.ok(report.types["delta:feed"].bundleMs.p50 < report.types.feed.settleMs.max, "a delta's render is cheaper than the whole board's settle");
+          timing(report.types["delta:feed"].delivered >= report.types["delta:feed"].count / 2, `at ${pacing.gapMs} ms gaps most deltas reach the bundle on their own: ${JSON.stringify(report.types["delta:feed"])}`);
+          timing(report.types["delta:feed"].bundleMs.p50 < report.types.feed.settleMs.max, "a delta's render is cheaper than the whole board's settle");
         }
         assert.equal(report.end.afterGc, true);
-        if (app === "feed") assert.ok(report.end.heapUsed < report.end.heapBeforeGc, `the forced collection freed the replay's garbage: ${report.end.heapBeforeGc} before, ${report.end.heapUsed} after`);
+        if (app === "feed") timing(report.end.heapUsed < report.end.heapBeforeGc, `the forced collection freed the replay's garbage: ${report.end.heapBeforeGc} before, ${report.end.heapUsed} after`);
         assert.equal(report.first.type, app === "feed" ? "feed" : "data");
         assert.ok(report.first.bytes > 1000);
         assert.ok(["delivered", "coalesced"].includes(report.first.handoff), `the first content frame reached the bundle: ${JSON.stringify(report.first)}`);
@@ -1396,13 +1529,16 @@ for (const app of ["feed", "timeline"]) {
           assert.deepEqual(cp.files, [cpuProfile]);
           const raw = JSON.parse(fs.readFileSync(cpuProfile, "utf8"));
           for (const k of ["nodes", "startTime", "endTime", "samples", "timeDeltas"]) assert.ok(k in raw, `.cpuprofile has ${k}`);
-          assert.ok(raw.samples.length > 100, `enough samples (${raw.samples.length})`);
+          assert.ok(raw.samples.length > 0, "the profile holds samples");
+          // The sampler is a thread of its own: how densely it sampled, and whether its clock could be refined against
+          // the wrappers' windows, are the scheduler's on a loaded runner (timing relations, like the ones above).
+          timing(raw.samples.length > 100, `enough samples (${raw.samples.length})`);
           assert.equal(cp.samplingIntervalUs, 500);
           const deltas = raw.timeDeltas.slice().sort((a, b) => a - b);
-          assert.ok(deltas[deltas.length >> 1] < 750, `the profiler sampled at the requested 500 us, not V8's default millisecond (median delta ${deltas[deltas.length >> 1]} us)`);
-          assert.equal(cp.alignRefined, true, "the wrappers' samples refined the clock alignment");
+          timing(deltas[deltas.length >> 1] < 750, `the profiler sampled at the requested 500 us, not V8's default millisecond (median delta ${deltas[deltas.length >> 1]} us)`);
+          timing(cp.alignRefined === true, "the wrappers' samples refined the clock alignment");
           assert.ok(cp.alignMs > 0 && cp.alignMs <= cp.alignBoundMs, `the refined uncertainty (${cp.alignMs} ms) is within the bracketing bound (${cp.alignBoundMs} ms)`);
-          assert.ok(cp.wrapperSamplesInWindows >= 0.9, `the wrappers' samples fall inside the handler, flush and delivery windows (${cp.wrapperSamplesInWindows})`);
+          timing(cp.wrapperSamplesInWindows >= 0.9, `the wrappers' samples fall inside the handler, flush and delivery windows (${cp.wrapperSamplesInWindows})`);
           assert.equal(cp.sourceMaps, true);
           assert.deepEqual(cp.sourceMapsMissing, [], "every profiled bundle had its map beside it");
           assert.ok(cp.sourceMapsLoaded.includes("feed.js"), cp.sourceMapsLoaded.join(", "));
@@ -1420,10 +1556,10 @@ for (const app of ["feed", "timeline"]) {
           const first = cp.windows.find((w) => w.label.split(" + ").includes("first content frame"));
           assert.equal(first.type, "feed");
           assert.equal(first.window, "delivery", "the window is the delivery that carried the frame, where the bundle's render runs");
-          assert.ok(first.windowMs > first.handlerMs, `the delivery (${first.windowMs} ms) outweighs the shim's handler (${first.handlerMs} ms)`);
-          assert.ok(first.samples > 0 && first.topSelf.length > 0, "the first frame's delivery window has samples");
-          assert.ok(Math.abs(first.sampledMs - first.windowMs) <= Math.max(5, first.windowMs * 0.25), `the window's sampled time (${first.sampledMs}) tracks the delivery's time (${first.windowMs})`);
-          assert.ok(first.topSelf.some((f) => /^feed\.js:/.test(f.key)), `the bundle's functions are what the window holds: ${first.topSelf.slice(0, 3).map((f) => f.key).join(", ")}`);
+          timing(first.windowMs > first.handlerMs, `the delivery (${first.windowMs} ms) outweighs the shim's handler (${first.handlerMs} ms)`);
+          timing(first.samples > 0 && first.topSelf.length > 0, "the first frame's delivery window has samples");
+          timing(Math.abs(first.sampledMs - first.windowMs) <= Math.max(5, first.windowMs * 0.25), `the window's sampled time (${first.sampledMs}) tracks the delivery's time (${first.windowMs})`);
+          if (first.samples > 0) assert.ok(first.topSelf.some((f) => /^feed\.js:/.test(f.key)), `the bundle's functions are what the window holds: ${first.topSelf.slice(0, 3).map((f) => f.key).join(", ")}`);
           assert.match(text, /cpu profile: \d+ samples over/);
           assert.match(text, /window: first content frame[^\n]*\(feed, [^\n]*: delivery [\d.]+ ms, shim handler [\d.]+ ms/);
         } else {
@@ -1489,8 +1625,9 @@ test("replay: a delta the shim refuses stays the shim's, and a frame the pane th
   }
 });
 
-test("replay: --iters pools runs and --cpu-throttle slows the page", { ...gate(skipReplay), timeout: 180_000 }, async () => {
+test("replay: --iters pools runs and --cpu-throttle slows the page", { ...gate(skipReplay), timeout: 180_000 }, async (t) => {
   requireOrSkip(skipReplay);
+  const timing = timingCheck(t);
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-replay-iters-"));
   try {
     const frames = synthesizeFrames("timeline", 40);
@@ -1505,12 +1642,14 @@ test("replay: --iters pools runs and --cpu-throttle slows the page", { ...gate(s
     assert.equal(pooled.types.data.settleMs.n, 8);
     assert.match(renderReport(pooled), /^ui-bench timeline: 36 frames, [\d.]+ KB, replay [\d.]+ ms \(back-to-back\), cpu x1, 2 iterations/);
     // Chromium's CPU throttle is a deterministic emulation (the renderer's main thread runs a quarter of the time),
-    // so the cumulative script time of the same replay grows by about the rate; the floor is half of it, wide enough
-    // for a loaded runner that inflates the unthrottled run (measured 2.3 to 4.2 here).
+    // so the cumulative script time of the same replay grows by about the rate; the floor is half of it. Measured
+    // 1.7 to 6.2 under load: a host that already deschedules the thread shrinks the wall-clock ratio, so the floor
+    // is a timing relation, asserted under ROMP_UI_BENCH_TIMING and a diagnostic otherwise (review find, 2026-09-08).
     const slow = await replay({ app: "timeline", framesFile: file, fast: true, iters: 1, cpuThrottle: 4, log: () => {} });
     assert.equal(slow.cpuThrottle, 4);
     assert.match(renderReport(slow), /cpu x4, 1 iteration,/);
-    assert.ok(slow.end.scriptMs >= 1.5 * pooled.end.scriptMs, `script time under a 4x throttle (${slow.end.scriptMs} ms) against unthrottled (${pooled.end.scriptMs} ms)`);
+    assert.ok(slow.end.scriptMs > 0 && pooled.end.scriptMs > 0, "script time was measured in both runs");
+    timing(slow.end.scriptMs >= 1.5 * pooled.end.scriptMs, `script time under a 4x throttle (${slow.end.scriptMs} ms) against unthrottled (${pooled.end.scriptMs} ms)`);
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }

--- a/tests/ui-bench.test.mjs
+++ b/tests/ui-bench.test.mjs
@@ -1,0 +1,1483 @@
+// tests/ui-bench.test.mjs: tools/ui-bench.mjs, the headless-Chrome bench for the dashboard panes.
+//
+// Three layers. Browser-free: the frame classifier (the report's rows), the percentile and compare
+// arithmetic, the pairing of the shim's deliveries with the wire frames they carried (the shim's queue
+// rules: whole-state kinds coalesce, chained kinds go one by one, keepalives and refused deltas stay
+// with the shim, a shim from before the flush task delivers inside the handler), the report fold, the
+// /tmp path guard that keeps a recording of real session data out
+// of any git checkout (with a simulated macOS layout, where /tmp is a symlink), the private file
+// modes a recording is written with, the synthesizer's wire shapes (the kernel's _keys lists for the
+// feed and bars slots, contiguous delta revisions, a byte-stable stream), the --record client against a local
+// WebSocket server (the query, the cookie and Origin credential form, the ready handshake and nothing
+// else, the JSONL shape, the early-close and refusal errors), and the CPU-profile fold over a
+// synthetic .cpuprofile, and the per-user run directory with its dead-owner sweep. With python3 and a
+// built dist: the Handler subprocess's environment (seen through a stub interpreter that echoes it)
+// and its exit when the node process that started it is SIGKILLed. With a browser as well: a synthetic
+// feed stream replayed at a fixed gap (so most frames reach the bundle as their own delivery) and a
+// synthetic timeline stream replayed back-to-back (so the shim's queue coalesces them) into the REAL
+// pages, served by the kernel's own page route and the built bundles, must produce a report with every
+// frame type measured and settled, every frame accounted for by the handoff (delivered, coalesced, or the
+// shim's own), and no console error, uncaught exception or failed resource load; the feed run also writes
+// a CPU profile whose windows are the deliveries. Those tests skip, naming
+// the reason, when a prerequisite is missing, unless ROMP_UI_BENCH_REQUIRE is set (CI sets it), when
+// the skip becomes a failure so a runner image that lost its browser cannot pass silently.
+//
+// Everything here is synthetic: the notes-api demo domain, placeholder uuids, a fixed clock.
+// Run: node --test tests/ui-bench.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  APPS, DELTA_SEP, INIT_SCRIPT, REPO, STRIPPED_ENV, WHOLE_STATE_KINDS, aggregateProfile, assertTmpPath, attributeDeliveries, barsKeys, benchRoot, browserAvailability,
+  buildReport, classifyFrame, compareReports, deliveredKind, feedKeys, frameKey, launchBrowser, loadFrames, mergeAggregates, mergeWindows, percentile,
+  rankProfile, recordFrames, refineAlignment, renderCompare, renderProfile, renderReport, replay, sourceLocator, startFront, startPageServer, streamSummary,
+  stripProfileQueries, summarize, sweepDeadRuns, synthesizeFrames, writeFrames,
+} from "../tools/ui-bench.mjs";
+
+const TOOL = path.join(REPO, "tools", "ui-bench.mjs");
+const THIS_FILE = fileURLToPath(import.meta.url);
+const requireExt = createRequire(path.join(REPO, "vscode-extension", "package.json"));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const mode = (p) => fs.statSync(p).mode & 0o777;
+const UID = os.userInfo().uid;
+
+/** A stand-in interpreter: announces a port and blocks on stdin the way the Handler's watcher does. */
+function writeStub(dir, name = "python-stub", prelude = "") {
+  const stub = path.join(dir, name);
+  fs.writeFileSync(stub, `#!/bin/sh\n${prelude}echo "PORT 1"\ncat > /dev/null\n`, { mode: 0o755 });
+  return stub;
+}
+/** A directory that passes startPageServer's dist check. */
+function fakeDist(dir) {
+  const dist = path.join(dir, "dist");
+  fs.mkdirSync(dist, { recursive: true });
+  fs.writeFileSync(path.join(dist, "feed.js"), "");
+  return dist;
+}
+
+/** Set environment variables for the duration of `fn`, restoring the previous values after. */
+async function withEnv(vars, fn) {
+  const saved = {};
+  for (const [k, v] of Object.entries(vars)) { saved[k] = process.env[k]; if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  try { return await fn(); }
+  finally { for (const [k, v] of Object.entries(saved)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; } }
+}
+
+// ── the classifier ───────────────────────────────────────────────────────────────────────────────
+
+test("classifyFrame files kernel frames by type, and a view delta by its slot", () => {
+  assert.equal(classifyFrame('{"type": "delta", "slot": "bars", "base": 3, "rev": 4, "coll": {"turns": {"set": {"x": {"type": "not-me"}}}}}'), "delta:bars");
+  assert.equal(classifyFrame('{"type": "delta", "slot": "feed", "base": 0, "rev": 1, "coll": {}}'), "delta:feed");
+  assert.equal(classifyFrame('{"type":"delta","slot":"feed","base":3,"rev":4,"coll":{"asks":{"set":{}}},"rest":{"now":1760000000,"buildId":4}}'), "delta:feed", "the compact form too");
+  assert.equal(classifyFrame('{"now": 1760000000, "type": "feed", "asks": []}'), "feed", "the feed frame carries now before type");
+  assert.equal(classifyFrame('{"type": "ka", "dv": 1760000000}'), "ka");
+  assert.equal(classifyFrame('{"type": "chatTail", "id": "11111111-2222-3333-4444-555555555555", "from": 3, "events": []}'), "chatTail");
+  assert.equal(classifyFrame('{"type": "bars", "turns": {}, "judging": [], "messages": [], "now": 1, "warming": false}'), "bars");
+  assert.equal(classifyFrame('{"type": "data", "data": {"type": "timeline", "sessions": []}}'), "data", "the outer frame's type, not the nested one");
+});
+
+test("classifyFrame falls back to a parse when the type is not in the head, and says other for the rest", () => {
+  const late = '{"pad": "' + "x".repeat(5000) + '", "type": "session", "id": "s"}';
+  assert.equal(classifyFrame(late), "session");
+  assert.equal(classifyFrame('{"type": "delta", "pad": "' + "y".repeat(5000) + '", "slot": "bars"}'), "delta:?", "a delta whose slot is out of reach is still a delta");
+  assert.equal(classifyFrame("not json at all"), "other");
+  assert.equal(classifyFrame('{"x": 1}'), "other");
+  assert.equal(classifyFrame('{"type": 7}'), "other");
+  assert.equal(classifyFrame(null), "other");
+  assert.equal(classifyFrame(Buffer.from("{}")), "other");
+});
+
+// ── arithmetic ───────────────────────────────────────────────────────────────────────────────────
+
+test("percentile is nearest-rank and summarize folds a sample", () => {
+  const xs = [10, 1, 5, 3, 8, 2, 9, 4, 7, 6];
+  assert.equal(percentile(xs, 50), 5);
+  assert.equal(percentile(xs, 90), 9);
+  assert.equal(percentile(xs, 100), 10);
+  assert.equal(percentile(xs, 0), 1);
+  assert.equal(percentile([], 50), null);
+  assert.equal(percentile([NaN, 4, undefined, 2], 50), 2, "non-numbers are dropped");
+  assert.deepEqual(summarize([]), { n: 0, p50: null, p90: null, max: null, mean: null });
+  assert.deepEqual(summarize([4, 2]), { n: 2, p50: 2, p90: 4, max: 4, mean: 3 });
+});
+
+function fakeRun({ perFrame, loaf = [], heapUsed = 1000, domElements = 10, consoleErrors = [], addListenerMessages = 0, banner = null,
+  handoff = "none", flushes = 0, deliveries = 0, deliveryRows = [], flushRows = [], unattributed = 0, unattributedMs = 0, queueDrained = true, deliveryErrors = [],
+  deliverySeams = {}, afterGc = true }) {
+  return {
+    readyMs: 100, replayMs: 50, sent: perFrame, perFrame, misaligned: 0, reconnects: 0, clientMessages: { ready: 1 }, clientDiag: {},
+    handoff, flushes, deliveries, deliveryRows, flushRows, unattributed, unattributedMs, queueDrained, deliveryErrors, deliverySeams, afterGc,
+    loaf, loafKind: "long-animation-frame", domElements, heap: { used: heapUsed, total: heapUsed * 2 }, addListenerMessages, banner,
+    cdp: { nodes: domElements * 3, documents: 1, jsEventListeners: 5, layoutCount: 3, recalcStyleCount: 4, layoutMs: 1.5, recalcStyleMs: 0.5, scriptMs: 20, taskMs: 30, heapUsed, heapTotal: heapUsed * 2, heapBeforeGc: heapUsed + 512 },
+    consoleErrors, pageErrors: [], warnings: 0, failedResources: [],
+  };
+}
+/** A per-frame row as replayOnce builds it; `handoff` and `bundleMs` are the delivery pairing's verdict. */
+const pf = (i, type, bytes, handlerMs, settleMs, handoff = undefined, bundleMs = null, delivery = -1) => ({ i, type, bytes, at: i, handlerMs, settleMs, t0: 1000 + i * 100, lenMatch: true, handoff, bundleMs, delivery });
+
+test("buildReport folds runs per frame type with percentiles, attribution and end state; a shim that delivers inside the handler is read as shim plus bundle", () => {
+  const run = fakeRun({
+    // A shim from before the flush task: every frame the bundle sees is delivered inside its own handler.
+    handoff: "handler", deliveries: 4,
+    perFrame: [pf(0, "ka", 30, 0.1, 5, "shim"), pf(1, "feed", 5000, 40, 90, "delivered", 38, 0), pf(2, "delta:feed", 300, 4, 20, "delivered", 3, 1), pf(3, "delta:feed", 500, 6, 30, "delivered", 5, 2), pf(4, "delta:feed", 100, 2, 10, "delivered", 1, 3)],
+    // The keys long-animation-frame entries produce on this harness: the bench's onmessage wrapper (the
+    // entry point of every pushed frame) and a script's own evaluation, invoked by its URL.
+    loaf: [{ start: 0, duration: 120, blocking: 70, scripts: [{ url: "ui-bench-instrument.js", fn: "rompBenchOnMessage", invoker: "DOMWebSocket.onmessage", duration: 100 },
+      { url: "", fn: "", invoker: "http://127.0.0.1:1/feed?token=secret-looking", duration: 15 }] }],
+    heapUsed: 4096, domElements: 250,
+  });
+  const r = buildReport({ app: "feed", framesFile: "/tmp/x.jsonl", cpuThrottle: 1, fast: true, iters: 1, browser: "test", runs: [run] });
+  assert.equal(r.tool, "ui-bench");
+  assert.equal(r.frames.total, 5);
+  assert.equal(r.frames.bytes, 5930);
+  assert.deepEqual(r.first, { index: 1, type: "feed", bytes: 5000, handlerMs: 40, bundleMs: 38, deliveredRuns: 1, handoff: "delivered", settleMs: 90 }, "the first content frame skips the keepalive");
+  assert.deepEqual(Object.keys(r.types), ["feed", "delta:feed", "ka"], "rows ordered by bytes");
+  assert.equal(r.types["delta:feed"].count, 3);
+  assert.equal(r.types["delta:feed"].measured, 3);
+  assert.equal(r.types["delta:feed"].delivered, 3);
+  assert.equal(r.types["delta:feed"].coalesced, 0);
+  assert.equal(r.types["delta:feed"].bytes, 900);
+  assert.equal(r.types["delta:feed"].bytesMax, 500);
+  assert.deepEqual(r.types["delta:feed"].handlerMs, { n: 3, p50: 4, p90: 6, max: 6, mean: 4 });
+  assert.deepEqual(r.types["delta:feed"].bundleMs, { n: 3, p50: 3, p90: 5, max: 5, mean: 3 });
+  assert.deepEqual(r.types["delta:feed"].settleMs, { n: 3, p50: 20, p90: 30, max: 30, mean: 20 });
+  assert.equal(r.types.ka.shim, 1);
+  assert.equal(r.types.ka.delivered, 0);
+  assert.deepEqual(r.types.ka.bundleMs, { n: 0, p50: null, p90: null, max: null, mean: null }, "a keepalive never reaches the bundle");
+  assert.equal(r.handoff.mode, "handler");
+  assert.equal(r.handoff.delivered, 4);
+  assert.equal(r.handoff.shim, 1);
+  assert.equal(r.loaf.count, 1);
+  assert.equal(r.loaf.blockingMs, 70);
+  assert.equal(r.loaf.topScripts[0].key, "message handler (shim + bundle) <DOMWebSocket.onmessage>", "the wrapper's row is labelled for what runs inside it, not the instrument's file");
+  assert.equal(r.loaf.topScripts[1].key, "(inline):(anonymous) <script feed>", "a URL-shaped invoker keeps its basename and loses its query");
+  assert.equal(r.end.heapUsed, 4096);
+  assert.equal(r.end.afterGc, true, "the heap figure is read after a forced GC: the run reported its collection returned");
+  assert.equal(r.end.heapBeforeGc, 4608, "and the figure read before it stands beside");
+  assert.equal(r.end.domElements, 250);
+  assert.equal(r.end.cdpNodes, 750);
+  assert.equal(r.frames.settleMissing, 0);
+  assert.equal(r.frames.addListenerMessages, 0);
+  assert.equal(r.frames.buildBannerRaised, 0);
+  assert.equal(r.cpuProfile, undefined, "no profile unless one was taken");
+  assert.equal(r.perFrame.length, 5, "a single run keeps the per-frame rows");
+  assert.deepEqual(r.perFrame[1], { i: 1, type: "feed", bytes: 5000, at: 1, handlerMs: 40, handoff: "delivered", bundleMs: 38, settleMs: 90 });
+  const text = renderReport(r);
+  assert.match(text, /first content frame: feed, 4\.9 KB, handler 40\.0 ms, bundle 38\.0 ms, settled 90\.0 ms/);
+  assert.match(text, /delta:feed\s+3\s+3\s+900 B\s+500 B\s+4\.0 \/ 6\.0 \/ 6\.0\s+3\.0 \/ 5\.0 \/ 5\.0\s+20\.0 \/ 30\.0 \/ 30\.0/, "count, delivered, bytes, max, handler, bundle, settle");
+  assert.match(text, /ka\s+1\s+0\s+30 B\s+30 B\s+0\.1 \/ 0\.1 \/ 0\.1\s+-\s+5\.0/);
+  assert.match(text, /handoff: the shim hands frames to the bundle inside the WebSocket handler, so the handler column includes the bundle's render/);
+  assert.match(text, /1 frame answered by the shim alone/);
+  assert.match(text, /console: 0 errors/);
+  assert.match(text, /JS heap 4\.0 KB used of 8\.0 KB after a forced GC \(4\.5 KB before it\)/);
+  assert.match(text, /cumulative since navigation .*3 layouts/, "the counters are labelled for what they are");
+  assert.match(text, /entry point .*not the bundle function/);
+  assert.doesNotMatch(text, /warning:/);
+  assert.doesNotMatch(text, /secret-looking/, "no query string from a page URL reaches the report");
+});
+
+test("buildReport keeps the shim's handler and the bundle's delivery apart when the shim hands frames over in its flush task, and counts the frames the queue coalesced", () => {
+  const run = fakeRun({
+    handoff: "flush", flushes: 3, deliveries: 3, flushRows: [{ t0: 1101, ms: 121 }, { t0: 1401, ms: 41 }, { t0: 1601, ms: 6 }],
+    deliveryRows: [{ t0: 1102, ms: 120, type: "feed" }, { t0: 1402, ms: 40, type: "feed" }, { t0: 1602, ms: 5, type: "session" }],
+    // the full feed frame delivered on its own; the first delta coalesced into the second's delivery; a chained
+    // session frame delivered; a keepalive the shim answered
+    perFrame: [pf(0, "ka", 30, 0.1, 5, "shim"), pf(1, "feed", 5000, 2, 150, "delivered", 120, 0), pf(2, "delta:feed", 300, 0.5, 260, "coalesced", null, 1),
+      pf(3, "delta:feed", 500, 0.6, 60, "delivered", 40, 1), pf(4, "session", 800, 0.2, 20, "delivered", 5, 2)],
+    loaf: [{ start: 0, duration: 130, blocking: 80, scripts: [{ url: "ui-bench-instrument.js", fn: "rompBenchFlush", invoker: "MessagePort.onmessage", duration: 125 }] },
+      { start: 200, duration: 60, blocking: 10, scripts: [{ url: "ui-bench-instrument.js", fn: "rompBenchOnMessage", invoker: "DOMWebSocket.onmessage", duration: 55 }] }],
+  });
+  const r = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: false, gapMs: 100, iters: 1, browser: "t", runs: [run] });
+  assert.equal(r.gapMs, 100);
+  assert.deepEqual(r.handoff, { mode: "flush", flushes: 3, deliveries: 3, delivered: 3, coalesced: 1, shim: 1, queued: 0, unattributed: 0, unattributedMs: 0, queueDrained: true, deliveryErrors: [], deliverySeams: {} });
+  assert.equal(r.types["delta:feed"].count, 2);
+  assert.equal(r.types["delta:feed"].delivered, 1);
+  assert.equal(r.types["delta:feed"].coalesced, 1);
+  assert.deepEqual(r.types["delta:feed"].handlerMs, { n: 2, p50: 0.5, p90: 0.6, max: 0.6, mean: 0.6 }, "the handler column times every wire frame");
+  assert.deepEqual(r.types["delta:feed"].bundleMs, { n: 1, p50: 40, p90: 40, max: 40, mean: 40 }, "the bundle column times the frames delivered on their own");
+  assert.deepEqual(r.types["delta:feed"].settleMs, { n: 2, p50: 60, p90: 260, max: 260, mean: 160 }, "settle is end to end for both, the coalesced frame's running to the delivery that carried it");
+  assert.deepEqual(r.types.session.bundleMs, { n: 1, p50: 5, p90: 5, max: 5, mean: 5 });
+  assert.equal(r.first.bundleMs, 120);
+  assert.equal(r.first.handoff, "delivered");
+  assert.equal(r.loaf.topScripts[0].key, "bundle handoff (shim flush + bundle) <MessagePort.onmessage>", "the flush wrapper's row is labelled for what runs inside it");
+  assert.equal(r.loaf.topScripts[1].key, "message handler (shim) <DOMWebSocket.onmessage>", "and the handler row no longer claims the bundle");
+  const text = renderReport(r);
+  assert.match(text, /replay 50\.0 ms \(100 ms gaps\)/);
+  assert.match(text, /first content frame: feed, 4\.9 KB, handler 2\.0 ms, bundle 120 ms, settled 150 ms/);
+  assert.match(text, /delta:feed\s+2\s+1\s+800 B\s+500 B\s+0\.5 \/ 0\.6 \/ 0\.6\s+40\.0 \/ 40\.0 \/ 40\.0\s+60\.0 \/ 260 \/ 260\s+\(1 coalesced\)/);
+  assert.match(text, /handoff: the shim hands frames to the bundle in its own flush task \(3 tasks carrying 3 deliveries per run\)\. handler = the shim's synchronous work per wire frame/);
+  assert.match(text, /1 frame coalesced into a newer frame of the same kind before delivery \(no bundle time of their own\); 1 answered by the shim alone/);
+  assert.doesNotMatch(text, /warning:/);
+  assert.doesNotMatch(text, /note: back-to-back/);
+  // Pooled iterations: a frame delivered on its own in one run and coalesced in another says so.
+  const other = fakeRun({ handoff: "flush", flushes: 1, deliveries: 1, perFrame: [pf(0, "ka", 30, 0.1, 5, "shim"), pf(1, "feed", 5000, 2, 200, "coalesced", null, 0), pf(2, "delta:feed", 300, 0.5, 100, "coalesced", null, 0),
+    pf(3, "delta:feed", 500, 0.6, 30, "delivered", 150, 0), pf(4, "session", 800, 0.2, 20, "queued")] });
+  const pooled = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 2, browser: "t", runs: [run, other] });
+  assert.equal(pooled.first.handoff, "mixed");
+  assert.equal(pooled.first.deliveredRuns, 1);
+  assert.equal(pooled.first.bundleMs, 120, "the mean over the runs that delivered it on their own");
+  assert.equal(pooled.types.feed.delivered, 0.5);
+  assert.equal(pooled.types.feed.coalesced, 0.5);
+  assert.equal(pooled.handoff.queued, 0.5);
+  const pt = renderReport(pooled);
+  assert.match(pt, /bundle 120 ms \(delivered on its own in 1 of 2 runs, coalesced in the others\)/);
+  assert.match(pt, /feed\s+1\s+0\.5\s+.*\(0\.5 coalesced\)/);
+  assert.match(pt, /warning: 0\.5 frames were still queued in the shim when the run ended/);
+  assert.match(pt, /note: back-to-back replay; frames queued together coalesce/);
+  // No delivery seen at all: the report says so rather than claiming the handler column is shim plus bundle.
+  const blind = renderReport(buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 1, browser: "t", runs: [fakeRun({ perFrame: [pf(0, "feed", 5000, 40, 90)] })] }));
+  assert.match(blind, /handoff: no delivery to the bundle was observed/);
+  assert.match(blind, /feed\s+1\s+0\s+4\.9 KB/, "no frame counted as delivered");
+  // The seam each delivery came through is summed over the runs, and the fallback seam gets a note; a run whose
+  // forced collection did not return says so on the heap line instead of claiming the GC.
+  const seams = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 2, browser: "t",
+    runs: [fakeRun({ handoff: "flush", flushes: 1, deliveries: 2, deliverySeams: { inbound: 2 }, perFrame: [pf(0, "feed", 5000, 2, 150, "delivered", 120, 0)] }),
+      fakeRun({ handoff: "flush", flushes: 1, deliveries: 2, deliverySeams: { inbound: 1, dispatch: 1 }, afterGc: false, perFrame: [pf(0, "feed", 5000, 2, 150, "delivered", 120, 0)] })] });
+  assert.deepEqual(seams.handoff.deliverySeams, { inbound: 3, dispatch: 1 });
+  assert.equal(seams.end.afterGc, false, "true only when every run's collection returned");
+  const st = renderReport(seams);
+  assert.match(st, /note: 1 delivery reached the pane through the MessageEvent fallback/);
+  assert.match(st, /with NO forced GC/);
+  assert.doesNotMatch(st, /after a forced GC/);
+});
+
+test("attributeDeliveries pairs the shim's deliveries with the wire frames they carried by the shim's own queue rules", () => {
+  assert.equal(deliveredKind("delta:feed"), "feed", "a delta is reassembled into the whole slot it patches");
+  assert.equal(deliveredKind("delta:bars"), "bars");
+  assert.equal(deliveredKind("session"), "session");
+  assert.ok(WHOLE_STATE_KINDS.has("feed") && WHOLE_STATE_KINDS.has("bars") && WHOLE_STATE_KINDS.has("data") && WHOLE_STATE_KINDS.has("tabOrder") && !WHOLE_STATE_KINDS.has("session"), "the shim's WHOLE set");
+  const rec = (t0, handler, extra = {}) => ({ t0, handler, settle: 5, needSlot: false, ...extra });
+  // The tip's shim: frames are enqueued in the handler and delivered in a later flush task.
+  const types = ["feed", "delta:feed", "ka", "delta:feed", "delta:feed", "session", "delta:feed", "restarting", "feed"];
+  const recs = [rec(0, 2), rec(150, 1), rec(200, 0.1), rec(300, 1), rec(400, 1), rec(500, 0.5), rec(600, 1, { needSlot: true }), rec(700, 0.2), rec(900, 1)];
+  const flushes = [{ i: 0, t0: 3, ms: 101 }, { i: 1, t0: 152, ms: 21 }, { i: 2, t0: 402, ms: 26 }, { i: 3, t0: 501, ms: 6 }];
+  const deliveries = [
+    { i: 0, type: "feed", t0: 3, ms: 100, settle: 130, flush: 0, rec: -1 },
+    { i: 1, type: "feed", t0: 152, ms: 20, settle: 40, flush: 1, rec: -1 },
+    { i: 2, type: "feed", t0: 402, ms: 25, settle: 50, flush: 2, rec: -1 },      // frames 3 and 4 were both queued: one delivery
+    { i: 3, type: "session", t0: 501, ms: 5, settle: 20, flush: 3, rec: -1 },
+    { i: 4, type: "tabOrder", t0: 800, ms: 2, settle: 10, flush: -1, rec: -1 },   // the page re-emitting on its own: no frame behind it
+  ];
+  const a = attributeDeliveries({ types, recs, flushes, deliveries });
+  assert.equal(a.handoff, "flush");
+  assert.deepEqual(a.frames[0], { handoff: "delivered", bundleMs: 100, delivery: 0, settleMs: 133 }, "settle runs from the wire frame's receipt to the main thread free after its delivery");
+  assert.deepEqual(a.frames[1], { handoff: "delivered", bundleMs: 20, delivery: 1, settleMs: 42 });
+  assert.deepEqual(a.frames[2], { handoff: "shim", bundleMs: null, delivery: -1, settleMs: 5 }, "a keepalive is the shim's alone, its settle the handler's own");
+  assert.deepEqual(a.frames[3], { handoff: "coalesced", bundleMs: null, delivery: 2, settleMs: 152 }, "the older of two queued deltas was replaced by the newer: no render of its own, its settle the shared delivery's");
+  assert.deepEqual(a.frames[4], { handoff: "delivered", bundleMs: 25, delivery: 2, settleMs: 52 });
+  assert.deepEqual(a.frames[5], { handoff: "delivered", bundleMs: 5, delivery: 3, settleMs: 21 }, "a chained kind is delivered one frame per delivery");
+  assert.deepEqual(a.frames[6], { handoff: "shim", bundleMs: null, delivery: -1, settleMs: 5 }, "a delta the shim answered with needSlot never reached the bundle");
+  assert.deepEqual(a.frames[7], { handoff: "shim", bundleMs: null, delivery: -1, settleMs: 5 }, "a restart notice is the shim's alone");
+  assert.deepEqual(a.frames[8], { handoff: "queued", bundleMs: null, delivery: -1, settleMs: 5 }, "a frame with no flush after it was still queued when the run ended");
+  assert.deepEqual(a.unattributed.map((d) => d.i), [4]);
+  // Two chained frames queued before one flush: two deliveries, one frame each, in order; a whole-state rule
+  // applied to them would coalesce the first and leave the second delivery unexplained.
+  const chained = attributeDeliveries({ types: ["session", "session"], recs: [rec(0, 1), rec(10, 1)], flushes: [{ i: 0, t0: 12, ms: 10 }],
+    deliveries: [{ i: 0, type: "session", t0: 12, ms: 4, settle: 9, flush: 0, rec: -1 }, { i: 1, type: "session", t0: 17, ms: 4, settle: 9, flush: 0, rec: -1 }] });
+  assert.deepEqual(chained.frames.map((f) => [f.handoff, f.delivery]), [["delivered", 0], ["delivered", 1]]);
+  assert.deepEqual(chained.unattributed, []);
+  // A flush that started before a frame's handler finished cannot have carried it; the frame waits for the next.
+  const late = attributeDeliveries({ types: ["feed", "feed"], recs: [rec(0, 2), rec(1, 5)], flushes: [{ i: 0, t0: 3, ms: 10 }, { i: 1, t0: 20, ms: 10 }],
+    deliveries: [{ i: 0, type: "feed", t0: 3, ms: 9, settle: 15, flush: 0, rec: -1 }, { i: 1, type: "feed", t0: 20, ms: 9, settle: 15, flush: 1, rec: -1 }] });
+  assert.deepEqual(late.frames.map((f) => [f.handoff, f.delivery]), [["delivered", 0], ["delivered", 1]]);
+  // A shim from before the flush task delivers inside the handler: the delivery belongs to that handler's frame.
+  const old = attributeDeliveries({ types: ["feed", "delta:feed", "ka"], recs: [rec(0, 50), rec(100, 10), rec(200, 0.1)], flushes: [],
+    deliveries: [{ i: 0, type: "feed", t0: 1, ms: 48, settle: 70, flush: -1, rec: 0 }, { i: 1, type: "feed", t0: 101, ms: 9, settle: 30, flush: -1, rec: 1 }] });
+  assert.equal(old.handoff, "handler");
+  assert.deepEqual(old.frames[0], { handoff: "delivered", bundleMs: 48, delivery: 0, settleMs: 71 });
+  assert.deepEqual(old.frames[1], { handoff: "delivered", bundleMs: 9, delivery: 1, settleMs: 31 });
+  assert.deepEqual(old.frames[2], { handoff: "shim", bundleMs: null, delivery: -1, settleMs: 5 });
+  assert.deepEqual(old.unattributed, []);
+  // No deliveries at all: nothing is claimed.
+  const none = attributeDeliveries({ types: ["feed"], recs: [rec(0, 50)], flushes: [], deliveries: [] });
+  assert.equal(none.handoff, "none");
+  assert.deepEqual(none.frames[0], { handoff: "queued", bundleMs: null, delivery: -1, settleMs: 5 });
+  // A frame the page never dispatched has no record and no verdict.
+  const missing = attributeDeliveries({ types: ["feed", "feed"], recs: [rec(0, 1)], flushes: [{ i: 0, t0: 2, ms: 5 }], deliveries: [{ i: 0, type: "feed", t0: 2, ms: 4, settle: 9, flush: 0, rec: -1 }] });
+  assert.deepEqual(missing.frames[1], { handoff: null, bundleMs: null, delivery: -1, settleMs: null });
+});
+
+test("buildReport counts frames whose settle never stamped, extra message listeners and a raised banner, and renderReport warns", () => {
+  const run = fakeRun({ perFrame: [pf(0, "feed", 5000, 40, 90), pf(1, "delta:feed", 300, 4, -1), pf(2, "delta:feed", 300, 5, 20), pf(3, "ka", 30, 0.1, -1)], addListenerMessages: 2, banner: "build" });
+  const r = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 1, browser: "t", runs: [run] });
+  assert.equal(r.types["delta:feed"].settleMissing, 1);
+  assert.equal(r.types["delta:feed"].measured, 2, "the handler was still timed");
+  assert.deepEqual(r.types["delta:feed"].settleMs, { n: 1, p50: 20, p90: 20, max: 20, mean: 20 }, "settle percentiles cover the stamped frames only");
+  assert.equal(r.types.ka.settleMissing, 1);
+  assert.equal(r.frames.settleMissing, 2);
+  assert.equal(r.frames.addListenerMessages, 2);
+  assert.equal(r.frames.buildBannerRaised, 1);
+  assert.equal(r.frames.connBannerRaised, 0);
+  const text = renderReport(r);
+  assert.match(text, /delta:feed .*\(1 settle missing\)/);
+  assert.match(text, /warning: 2 frames never received a settle stamp/);
+  assert.match(text, /warning: 2 message listeners were added with addEventListener/);
+  assert.match(text, /warning: the page raised its "newer build" banner in 1 run/);
+});
+
+test("buildReport pools iterations: counts per run, percentiles over every sample", () => {
+  const a = fakeRun({ perFrame: [pf(0, "feed", 100, 10, 20), pf(1, "ka", 10, 1, 2)] });
+  const b = fakeRun({ perFrame: [pf(0, "feed", 100, 30, 40), pf(1, "ka", 10, 3, 4)] });
+  const r = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 2, fast: false, iters: 2, browser: "t", runs: [a, b] });
+  assert.equal(r.iters, 2);
+  assert.equal(r.types.feed.count, 1);
+  assert.deepEqual(r.types.feed.handlerMs, { n: 2, p50: 10, p90: 30, max: 30, mean: 20 });
+  assert.equal(r.first.handlerMs, 20, "the first frame's time is the mean over iterations");
+  assert.equal(r.perFrame, undefined, "pooled runs carry no single per-frame list");
+  assert.equal(r.cpuThrottle, 2);
+});
+
+test("compareReports subtracts B from A per type and for the totals", () => {
+  const mk = (settle, loafBlocking, heap, errors, replayMs = 1000, bundle = settle * 0.4) => ({
+    app: "feed", cpuThrottle: 1, fast: true, frames: { replayMs }, handoff: { mode: "flush" },
+    first: { type: "feed", bytes: 5000, handlerMs: settle / 2, bundleMs: bundle, settleMs: settle },
+    types: { feed: { count: 1, delivered: 1, bytes: 5000, handlerMs: { p50: settle / 2, p90: settle / 2, max: settle / 2 }, bundleMs: { p50: bundle, p90: bundle, max: bundle }, settleMs: { p50: settle, p90: settle, max: settle } },
+      ka: { count: 3, delivered: 0, bytes: 90, handlerMs: { p50: 0.1, p90: 0.2, max: 0.2 }, bundleMs: { n: 0, p50: null, p90: null, max: null }, settleMs: { p50: 1, p90: 2, max: 2 } } },
+    loaf: { count: 2, durationMs: 300, blockingMs: loafBlocking, maxMs: 200 },
+    end: { heapUsed: heap, domElements: 100, layoutCount: 5, scriptMs: 50, taskMs: 80 },
+    console: { errors },
+  });
+  const A = mk(200, 100, 4000, []);
+  const B = mk(150, 60, 5000, ["boom"]);
+  B.types["delta:feed"] = { count: 4, delivered: 3, bytes: 400, handlerMs: { p50: 1, p90: 2, max: 3 }, bundleMs: { p50: 4, p90: 5, max: 6 }, settleMs: { p50: 5, p90: 6, max: 7 } };
+  const c = compareReports(A, B);
+  assert.deepEqual(c.types.feed.settleP50, { a: 200, b: 150, diff: -50, pct: -25 });
+  assert.deepEqual(c.types.feed.handlerP50, { a: 100, b: 75, diff: -25, pct: -25 });
+  assert.deepEqual(c.types.feed.bundleP50, { a: 80, b: 60, diff: -20, pct: -25 });
+  assert.deepEqual(c.types.feed.delivered, { a: 1, b: 1, diff: 0, pct: 0 });
+  assert.deepEqual(c.types.ka.bundleP50, { a: null, b: null, diff: null, pct: null }, "a kind the bundle never sees has no bundle time to compare");
+  assert.deepEqual(c.first.settleMs, { a: 200, b: 150, diff: -50, pct: -25 });
+  assert.deepEqual(c.first.bundleMs, { a: 80, b: 60, diff: -20, pct: -25 });
+  assert.deepEqual(c.loaf.blockingMs, { a: 100, b: 60, diff: -40, pct: -40 });
+  assert.deepEqual(c.end.heapUsed, { a: 4000, b: 5000, diff: 1000, pct: 25 });
+  assert.deepEqual(c.types["delta:feed"].count, { a: null, b: 4, diff: null, pct: null }, "a type present on one side only compares to nothing");
+  assert.deepEqual(c.console.errors, [0, 1]);
+  assert.deepEqual(c.replayMs, [1000, 1000]);
+  assert.deepEqual(c.handoff, ["flush", "flush"]);
+  assert.equal(c.endComparable, true);
+  const text = renderCompare(c);
+  assert.match(text, /feed\s+count 1 → 1 \(unchanged\) \(delivered 1 → 1 \(unchanged\)\); settle p50 200 → 150 ms \(-50, -25%\)/);
+  assert.match(text, /handler p50 100 → 75 ms \(-25, -25%\); bundle p50 80 → 60 ms \(-20, -25%\)/);
+  assert.match(text, /^ka\s+count 3 → 3 \(unchanged\) \(delivered 0 → 0 \(unchanged\)\); settle .*handler p50 0\.1 → 0\.1 ms \(unchanged\)$/m, "no bundle column for a kind the bundle never sees");
+  assert.match(text, /first content frame: bytes 5000 → 5000 \(unchanged\); handler 100 → 75 ms \(-25, -25%\); bundle 80 → 60 ms \(-20, -25%\)/);
+  assert.match(text, /delta:feed\s+count - → 4 \(delivered - → 3\);/);
+  assert.doesNotMatch(text, /shims differ/);
+  const older = renderCompare(compareReports({ ...A, handoff: { mode: "handler" } }, B));
+  assert.match(older, /the shims differ in how they hand frames to the bundle \(handler → flush\)/, "a shim that renders inside the handler is not compared on the handler column");
+  const legacy = compareReports({ ...A, handoff: undefined, first: { type: "feed", bytes: 5000, handlerMs: 100, settleMs: 200 }, types: { feed: { count: 1, bytes: 5000, handlerMs: { p50: 100 }, settleMs: { p50: 200 } } } }, B);
+  assert.deepEqual(legacy.types.feed.bundleP50, { a: null, b: 60, diff: null, pct: null }, "a report from before the bundle column compares to nothing there");
+  assert.match(renderCompare(legacy), /bundle - → 60 ms/);
+  assert.match(text, /heap 4000 → 5000 B \(\+1000, \+25%\)/);
+  assert.match(text, /console errors: 0 → 1/);
+  A.end.layoutCount = 100; B.end.layoutCount = 50;
+  assert.match(renderCompare(compareReports(A, B)), /layouts 100 → 50 \(-50, -50%\)/, "runs of the same pacing and length compare with percentages");
+  assert.doesNotMatch(renderCompare(compareReports(A, B)), /carry no percentage/);
+  // A paced run against a fast one, or runs of different length: the cumulative counters lose their percentages.
+  const longer = mk(150, 60, 5000, [], 5000); longer.end.layoutCount = 50;
+  const cl = compareReports(A, longer);
+  assert.equal(cl.endComparable, false);
+  const tl = renderCompare(cl);
+  assert.match(tl, /layouts 100 → 50 \(-50\); script/);
+  assert.match(tl, /cumulative since navigation and the runs differ in pacing or length \(replay 1000 → 5000 ms\)/);
+  assert.match(tl, /heap 4000 → 5000 B \(\+1000, \+25%\)/, "the heap is a state, not a cumulative counter, so it keeps its percentage");
+  const paced = mk(150, 60, 5000, [], 1000); paced.fast = false;
+  assert.equal(compareReports(A, paced).endComparable, false);
+  assert.equal(compareReports(A, mk(150, 60, 5000, [], 1200)).endComparable, true, "a fifth is within tolerance");
+  assert.equal(compareReports({ ...A, frames: undefined }, B).endComparable, false, "an older report without replayMs is not assumed comparable");
+});
+
+// ── the path guard ───────────────────────────────────────────────────────────────────────────────
+
+test("assertTmpPath allows /tmp, refuses the repo, other roots, and a checkout under /tmp", () => {
+  const ok = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-guard-"));
+  try {
+    assert.equal(assertTmpPath(path.join(ok, "frames.jsonl")), path.join(ok, "frames.jsonl"));
+    assert.equal(assertTmpPath(path.join(ok, "deeper", "frames.jsonl")), path.join(ok, "deeper", "frames.jsonl"), "a not-yet-created leaf directory is fine");
+    assert.equal(assertTmpPath(path.join(ok, "a", "b", "c", "frames.jsonl")), path.join(ok, "a", "b", "c", "frames.jsonl"), "several missing directories are fine");
+    assert.throws(() => assertTmpPath(path.join(REPO, "frames.jsonl")), /outside \/tmp/);
+    assert.throws(() => assertTmpPath("/var/tmp/frames.jsonl"), /outside \/tmp/);
+    assert.throws(() => assertTmpPath("frames.jsonl"), /outside \/tmp/, "a relative path resolves against the cwd, which is not /tmp here");
+    fs.mkdirSync(path.join(ok, "clone", ".git"), { recursive: true });
+    assert.throws(() => assertTmpPath(path.join(ok, "clone", "sub", "frames.jsonl")), /inside a git checkout/);
+  } finally {
+    fs.rmSync(ok, { recursive: true, force: true });
+  }
+});
+
+test("assertTmpPath resolves symlinks on both sides: a root that is a link (macOS's /tmp) and an ancestor that is one", () => {
+  // The macOS layout in miniature: <base>/tmp -> <base>/private/tmp, and $TMPDIR under <base>/private/var.
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-mac-"));
+  try {
+    fs.mkdirSync(path.join(base, "private", "tmp"), { recursive: true });
+    fs.mkdirSync(path.join(base, "private", "var", "folders", "T"), { recursive: true });
+    fs.symlinkSync(path.join(base, "private", "tmp"), path.join(base, "tmp"));
+    fs.symlinkSync(path.join(base, "private", "var"), path.join(base, "var"));
+    const roots = [path.join(base, "tmp"), path.join(base, "var", "folders", "T")];
+    const fresh = path.join(base, "tmp", "romp-perf", "frames.jsonl");
+    assert.equal(assertTmpPath(fresh, { roots }), fresh, "first run: the directory does not exist yet");
+    fs.mkdirSync(path.join(base, "tmp", "romp-perf"));
+    assert.equal(assertTmpPath(fresh, { roots }), fresh, "second run: the directory exists and resolves through the link");
+    assert.equal(assertTmpPath(path.join(base, "private", "tmp", "romp-perf", "x.jsonl"), { roots }), path.join(base, "private", "tmp", "romp-perf", "x.jsonl"), "the resolved form of the root is accepted too");
+    assert.equal(assertTmpPath(path.join(base, "var", "folders", "T", "x.jsonl"), { roots }), path.join(base, "var", "folders", "T", "x.jsonl"), "a $TMPDIR path");
+    assert.throws(() => assertTmpPath(path.join(base, "private", "var", "elsewhere", "x.jsonl"), { roots }), /outside \/tmp/, "a sibling of the roots is still refused");
+    assert.throws(() => assertTmpPath(path.join(base, "x.jsonl"), { roots }), /outside \/tmp/);
+    // An ancestor link that points OUT of /tmp: the resolved parent decides.
+    fs.mkdirSync(path.join(base, "private", "home", "sub"), { recursive: true });
+    fs.symlinkSync(path.join(base, "private", "home"), path.join(base, "tmp", "away"));
+    assert.throws(() => assertTmpPath(path.join(base, "tmp", "away", "sub", "x.jsonl"), { roots }), /outside \/tmp/, "a link under /tmp that leaves it is refused");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("assertTmpPath refuses a symlink at the leaf, and writeFrames will not write through one", () => {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-leaf-"));
+  try {
+    fs.mkdirSync(path.join(base, "fakeco", ".git"), { recursive: true });
+    fs.mkdirSync(path.join(base, "fakeco", "sub"));
+    const leaf = path.join(base, "leaf.jsonl");
+    fs.symlinkSync(path.join(base, "fakeco", "sub", "target.jsonl"), leaf);
+    assert.throws(() => assertTmpPath(leaf), /through a symlink/);
+    assert.throws(() => writeFrames(leaf, { synthetic: true }, synthesizeFrames("feed", 2)), /ELOOP|EMLINK|symlink/i, "O_NOFOLLOW refuses the open");
+    assert.ok(!fs.existsSync(path.join(base, "fakeco", "sub", "target.jsonl")), "nothing landed in the checkout");
+    const dangling = path.join(base, "dangling.jsonl");
+    fs.symlinkSync(path.join(base, "nowhere", "x.jsonl"), dangling);
+    assert.throws(() => assertTmpPath(dangling), /through a symlink/, "a dangling link is a link");
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+// ── the synthesizer ──────────────────────────────────────────────────────────────────────────────
+
+test("synthesizeFrames: the feed stream is the keyed full frame, then feed deltas and keepalives, byte-stable", () => {
+  const frames = synthesizeFrames("feed", 30);
+  const types = frames.map((f) => classifyFrame(f.data));
+  assert.equal(types[0], "feed");
+  const full = JSON.parse(frames[0].data);
+  assert.equal(full.asks.length, 30);
+  assert.ok(full.asks.every((a) => a.itemId && a.sid && a.name && a.column && Array.isArray(a.tree) && a.tree.length), "every card has an id, a session and a tree");
+  assert.ok(full.asks.every((a) => /^11111111-2222-3333-4444-5555555555\d\d$/.test(a.sid)), "placeholder uuids only");
+  assert.ok(full.asks.every((a) => Array.isArray(a.trgb) && a.trgb.length === 3 && a.trgb.every((x) => Number.isInteger(x) && x >= 0 && x <= 255)), "every card carries its recency tint (feed.ts destructures it)");
+  assert.ok(new Set(full.asks.map((a) => JSON.stringify(a.trgb))).size > 1, "older cards are tinted differently from recent ones");
+  assert.deepEqual(full._keys, { asks: full.asks.map((a) => a.itemId) }, "the keyed full carries the kernel's key list, in payload order");
+  assert.deepEqual(full._keys, feedKeys(full));
+  for (const k of ["views", "judgeLimit", "working", "awaiting", "stateUnknown", "bgServices", "dismissedCount", "showDismissed", "order", "sessions", "clearNotices", "sdkNotices", "syncNotices", "selfHost", "canUndoClear", "buildId"]) assert.ok(k in full, `build_feed's ${k}`);
+  assert.equal(full.selfHost, "TESTHOST");
+  assert.ok(!("ledgers" in full), "the feed page's frame carries no ledgers");
+  assert.ok(types.includes("delta:feed") && types.includes("ka"));
+  assert.equal(types.filter((t) => t === "feed").length, 1);
+  let rev = 0, prevBuild = full.buildId, withDel = 0, withAll = 0, withOrder = 0;
+  for (const f of frames) {
+    const m = JSON.parse(f.data);
+    if (m.type !== "delta") continue;
+    assert.equal(m.slot, "feed");
+    assert.equal(m.base, rev, "each delta's base is the revision the pane holds");
+    assert.equal(m.rev, rev + 1); rev = m.rev;
+    assert.ok(!("asks" in m) && !("_keys" in m), "a delta carries its cards under coll, never at the top level");
+    const asks = m.coll.asks;
+    assert.ok(asks.set && Object.keys(asks.set).length >= 1, "every delta sets at least one card");
+    for (const [k, card] of Object.entries(asks.set)) { assert.equal(k, card.itemId, "cards are keyed by itemId"); assert.equal(card.trgb.length, 3); }
+    if (asks.del) { withDel++; assert.ok(asks.del.every((k) => typeof k === "string")); }
+    if (asks.order) { withOrder++; assert.ok(asks.order.every((k) => typeof k === "string")); }
+    assert.equal(typeof m.rest.now, "number", "the clock rides every delta");
+    assert.ok(m.rest.buildId > prevBuild, "buildId advances on every delta"); prevBuild = m.rest.buildId;
+    if (m.restAll) {
+      withAll++;
+      assert.equal(m.rest.type, "feed", "the whole remainder carries the frame type (the shim drops every key it does not name)");
+      assert.ok(Array.isArray(m.rest.working) && "canUndoClear" in m.rest && !("asks" in m.rest), "the whole non-keyed remainder");
+    } else {
+      assert.deepEqual(Object.keys(m.rest).sort(), ["buildId", "now"], "an unchanged remainder sends only the clock fields");
+    }
+  }
+  assert.ok(rev >= 20);
+  assert.ok(withDel >= 1, "some deltas retire a card");
+  assert.ok(withAll >= 1, "some deltas carry the whole remainder");
+  assert.ok(withOrder >= 1, "some deltas reorder the cards");
+  assert.ok(frames.every((f, i) => i === 0 || f.t >= frames[i - 1].t), "timestamps are monotonic");
+  assert.deepEqual(synthesizeFrames("feed", 30), frames, "the same seed gives the same bytes");
+  assert.notDeepEqual(synthesizeFrames("feed", 30, { seed: 8 }), frames, "another seed gives another stream");
+  assert.deepEqual(Object.keys(streamSummary(frames).byType).sort(), ["delta:feed", "feed", "ka"]);
+});
+
+test("synthesizeFrames: the Outline stream carries ledgers in the full frame and re-sends them with the whole remainder", () => {
+  const frames = synthesizeFrames("fleet", 12);
+  const outlineFull = JSON.parse(frames[0].data);
+  assert.equal(outlineFull.ledgers.length, 3);
+  assert.ok(outlineFull.ledgers.every((l) => l.sid && l.name && l.ledger && Array.isArray(l.ledger.tree)));
+  assert.deepEqual(outlineFull._keys, feedKeys(outlineFull));
+  const withLedgers = frames.map((f) => JSON.parse(f.data)).filter((m) => m.type === "delta" && Array.isArray(m.rest.ledgers));
+  assert.ok(withLedgers.length >= 1, "some deltas carry the ledgers");
+  assert.ok(withLedgers.every((m) => m.restAll === 1 && m.rest.type === "feed"), "the ledgers are non-keyed remainder, so they ride only with the whole remainder");
+  assert.ok(withLedgers.every((m) => m.rest.ledgers.length === 3), "the whole ledgers list, not one session's");
+});
+
+test("synthesizeFrames: the timeline stream is the skeleton, the keyed bars slot, then bar-level deltas", () => {
+  const frames = synthesizeFrames("timeline", 30);
+  const types = frames.map((f) => classifyFrame(f.data));
+  assert.equal(types[0], "data");
+  assert.equal(types[1], "bars");
+  const skel = JSON.parse(frames[0].data);
+  assert.equal(skel.data.type, "timeline");
+  assert.equal(skel.data.sessions.length, 3);
+  assert.ok(skel.data.sessions.every((s) => s.id && s.name && typeof s.live === "boolean" && s.color), "lanes carry id, name, live and color");
+  assert.deepEqual(skel.data.turns, {}, "the skeleton carries no bars");
+  const bars = JSON.parse(frames[1].data);
+  assert.equal(Object.keys(bars.turns).length, 3);
+  assert.equal(Object.values(bars.turns).reduce((a, lane) => a + lane.length, 0), 30);
+  assert.ok(bars._keys, "a keyed full frame carries the kernel's key list");
+  assert.deepEqual(bars._keys, barsKeys(bars));
+  assert.ok(bars._keys.turns.every((k) => k.includes(DELTA_SEP)), "a bar's key is lane + separator + id");
+  assert.equal(bars._keys.turns.length, 30);
+  assert.ok(bars._keys.judging.every((k) => k.split(DELTA_SEP).length === 4), "a judging key is sid, t, judge, t1");
+  let rev = 0;
+  for (const f of frames) {
+    const m = JSON.parse(f.data);
+    if (m.type !== "delta") continue;
+    assert.equal(m.slot, "bars");
+    assert.equal(m.base, rev, "each delta's base is the revision the pane holds");
+    assert.equal(m.rev, rev + 1); rev = m.rev;
+    assert.ok(m.coll.turns.set && Object.keys(m.coll.turns.set).every((k) => k.includes(DELTA_SEP)));
+    assert.equal(typeof m.rest.now, "number", "the clock rides every delta");
+  }
+  assert.ok(rev >= 20);
+  assert.ok(types.filter((t) => t === "data").length >= 2, "the skeleton is re-pushed during the stream");
+  assert.deepEqual(Object.keys(streamSummary(frames).byType).sort(), ["bars", "data", "delta:bars", "ka"]);
+});
+
+test("barsKeys mints the kernel's keys: an empty lane is its bare prefix, messages key by id", () => {
+  const keys = barsKeys({ turns: { a: [], b: [{ id: "x" }, { id: 7 }] }, judging: [{ sid: "s", t: 1, judge: "closer", t1: 2 }], messages: [{ id: "m1" }] });
+  assert.deepEqual(keys, { turns: ["a" + DELTA_SEP, "b" + DELTA_SEP + "x", "b" + DELTA_SEP + "7"], judging: ["s" + DELTA_SEP + "1" + DELTA_SEP + "closer" + DELTA_SEP + "2"], messages: ["m1"] });
+});
+
+test("synthesizeFrames refuses the chat, which it cannot fake, and unknown apps", () => {
+  assert.throws(() => synthesizeFrames("chat", 5), /not synthesized .*build_session/);
+  assert.throws(() => synthesizeFrames("board", 5), /unknown app/);
+  assert.throws(() => synthesizeFrames("waiting", 5), /unknown app/, "no such pane");
+  assert.deepEqual(APPS, ["feed", "fleet", "chat", "timeline"]);
+});
+
+test("writeFrames and loadFrames round-trip a stream with its meta row", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-rt-"));
+  try {
+    const frames = synthesizeFrames("feed", 4);
+    const file = path.join(tmp, "nested", "s.jsonl");
+    writeFrames(file, { synthetic: true, app: "feed" }, frames);
+    const back = loadFrames(file);
+    assert.deepEqual(back.meta, { synthetic: true, app: "feed" });
+    assert.deepEqual(back.frames, frames.map((f) => ({ t: f.t, data: f.data })));
+    const rows = fs.readFileSync(file, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    assert.equal(rows[1].bytes, Buffer.byteLength(frames[0].data, "utf8"), "each row records its byte length");
+    if (process.platform !== "win32") {
+      assert.equal(mode(file), 0o600, "a recording is private to the user");
+      assert.equal(mode(path.join(tmp, "nested")), 0o700, "and so is a directory it creates");
+      const shared = path.join(tmp, "shared.jsonl");
+      fs.writeFileSync(shared, "old\n", { mode: 0o644 });
+      writeFrames(shared, { synthetic: true }, frames);
+      assert.equal(mode(shared), 0o600, "an overwritten file is made private too");
+      assert.deepEqual(loadFrames(shared).frames.length, frames.length, "and truncated first");
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── the --record client, against a local WebSocket server ────────────────────────────────────────
+
+/** A loopback WebSocket server standing in for the kernel: records the upgrade request and every client
+ *  message, and runs `onReady(ws)` when the client's handshake arrives. */
+async function fakeKernel(onReady) {
+  const { WebSocketServer } = requireExt("ws");
+  const server = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
+  const wss = new WebSocketServer({ server });
+  const seen = { requests: [], messages: [] };
+  wss.on("connection", (ws, req) => {
+    seen.requests.push({ url: req.url, headers: req.headers });
+    ws.on("message", (d) => { seen.messages.push(d.toString()); if (JSON.parse(d.toString()).type === "ready") onReady(ws); });
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  return { port: server.address().port, seen, close: () => { for (const c of wss.clients) c.terminate(); server.close(); } };
+}
+
+test("recordFrames connects as the page does, sends only the ready handshake, and writes the frames as JSONL", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-rec-"));
+  const token = "synthetic-serve-token-for-the-test";
+  const pushed = [JSON.stringify({ type: "feed", asks: [], now: 1_760_000_000, buildId: 1 }), JSON.stringify({ type: "ka", dv: 1_760_000_000 })];
+  const k = await fakeKernel((ws) => { for (const f of pushed) ws.send(f); });
+  try {
+    fs.mkdirSync(path.join(tmp, "state"));
+    fs.writeFileSync(path.join(tmp, "state", "serve-token"), token + "\n");
+    const out = path.join(tmp, "rec", "frames.jsonl");
+    const res = await withEnv({ ROMP_STATE_DIR: path.join(tmp, "state") }, () => recordFrames({ app: "feed", seconds: 0.5, out, port: k.port, log: () => {} }));
+    assert.equal(res.frames, 2);
+    assert.equal(k.seen.requests.length, 1, "one connection");
+    const u = new URL(k.seen.requests[0].url, "http://127.0.0.1");
+    assert.equal(u.pathname, "/ws");
+    assert.equal(u.searchParams.get("app"), "feed");
+    assert.equal(u.searchParams.get("delta"), "1");
+    assert.equal(u.searchParams.get("caps"), null, "the shim's query and nothing more");
+    assert.match(u.searchParams.get("iid"), /^[0-9a-f-]{36}$/);
+    assert.equal(u.searchParams.get("token"), null, "no token in the query");
+    const h = k.seen.requests[0].headers;
+    assert.equal(h.cookie, `romp_token=${token}`, "the browser's credential: the cookie");
+    assert.equal(h.origin, `http://127.0.0.1:${k.port}`, "with a same-origin Origin");
+    assert.equal(h["x-romp-token"], undefined, "and no header token");
+    assert.deepEqual(k.seen.messages.map((m) => JSON.parse(m)), [{ type: "ready" }], "the ready handshake and nothing else");
+    const back = loadFrames(out);
+    assert.equal(back.meta.mode, "record");
+    assert.equal(back.meta.app, "feed");
+    assert.equal(back.meta.frames, 2);
+    assert.equal(back.meta.port, k.port);
+    assert.ok(back.meta.events.some((e) => e.event === "open"));
+    assert.deepEqual(back.frames.map((f) => f.data), pushed, "the frames round-trip byte for byte");
+    assert.ok(back.frames.every((f) => f.t >= Date.parse(back.meta.startedAt)), "receive timestamps");
+    if (process.platform !== "win32") assert.equal(mode(out), 0o600);
+  } finally {
+    k.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("recordFrames is loud when the kernel closes early or refuses the upgrade, and still writes what it got", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-rec2-"));
+  const k = await fakeKernel((ws) => { ws.send(JSON.stringify({ type: "ka", dv: 1 })); setTimeout(() => ws.close(1012, "restarting"), 50); });
+  const refusing = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
+  refusing.on("upgrade", (_req, socket) => { socket.end("HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: 9\r\nConnection: close\r\n\r\nforbidden"); });
+  await new Promise((r) => refusing.listen(0, "127.0.0.1", r));
+  try {
+    fs.mkdirSync(path.join(tmp, "state"));
+    fs.writeFileSync(path.join(tmp, "state", "serve-token"), "t\n");
+    await withEnv({ ROMP_STATE_DIR: path.join(tmp, "state") }, async () => {
+      const early = path.join(tmp, "early.jsonl");
+      await assert.rejects(recordFrames({ app: "timeline", seconds: 5, out: early, port: k.port, log: () => {} }), /closed the socket early \(code 1012\) after 1 frames/);
+      const back = loadFrames(early);
+      assert.equal(back.frames.length, 1, "the frame received before the close was written");
+      assert.ok(back.meta.events.some((e) => e.event === "close" && e.code === 1012));
+      await assert.rejects(recordFrames({ app: "feed", seconds: 5, out: path.join(tmp, "refused.jsonl"), port: refusing.address().port, log: () => {} }), /refused the WebSocket: HTTP 403 forbidden/);
+      await assert.rejects(recordFrames({ app: "board", seconds: 1, out: path.join(tmp, "x.jsonl"), port: 1, log: () => {} }), /unknown app/);
+      await assert.rejects(recordFrames({ app: "feed", seconds: 1, out: path.join(REPO, "x.jsonl"), port: 1, log: () => {} }), /outside \/tmp/, "the path guard runs before any network use");
+    });
+    assert.equal(process.listenerCount("SIGINT"), 0, "no interrupt listener outlives a recording");
+  } finally {
+    k.close();
+    refusing.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── the CPU-profile fold ─────────────────────────────────────────────────────────────────────────
+
+/** A tiny .cpuprofile: main -> render -> fmt, with one recursive render call, beside (program) and GC. */
+const SYNTH_PROFILE = (() => {
+  const cf = (functionName, lineNumber, url = "http://127.0.0.1:1/dist/feed.js?v=3") => ({ functionName, url, lineNumber, columnNumber: 0, scriptId: "7" });
+  return {
+    nodes: [
+      { id: 1, callFrame: cf("(root)", -1, ""), children: [2, 3, 6] },
+      { id: 2, callFrame: cf("(program)", -1, "") },
+      { id: 3, callFrame: cf("main", 9), children: [4], hitCount: 1 },
+      // V8's per-line ticks: the first render node's two samples fell on bundle lines 20 and 25, the recursive one's on 25.
+      { id: 4, callFrame: cf("render", 19), children: [5, 7], hitCount: 2, positionTicks: [{ line: 20, ticks: 1 }, { line: 25, ticks: 1 }] },
+      { id: 5, callFrame: cf("fmt", 29), hitCount: 2 },
+      { id: 6, callFrame: cf("(garbage collector)", -1, "") },
+      { id: 7, callFrame: cf("render", 19), hitCount: 1, positionTicks: [{ line: 25, ticks: 1 }] },
+    ],
+    startTime: 1000, endTime: 1900,
+    samples: [3, 4, 5, 5, 7, 2, 6, 4],
+    timeDeltas: [100, 100, 100, 100, 100, 100, 100, 100],
+  };
+})();
+
+test("frameKey labels a call frame url-basename:function:line, 1-based, and keeps V8's bookkeeping names", () => {
+  assert.equal(frameKey({ functionName: "render", url: "http://127.0.0.1:1/dist/feed.js?v=3", lineNumber: 19 }), "feed.js:render:20");
+  assert.equal(frameKey({ functionName: "", url: "http://127.0.0.1:1/dist/feed.js", lineNumber: 0 }), "feed.js:(anonymous):1");
+  assert.equal(frameKey({ functionName: "tick", url: "", lineNumber: 4 }), "(inline):tick:5", "code without a url but with a line: an eval");
+  assert.equal(frameKey({ functionName: "getBoundingClientRect", url: "", lineNumber: -1 }), "(native):getBoundingClientRect", "a builtin has neither");
+  assert.equal(frameKey({ functionName: "ws.onmessage", url: "http://127.0.0.1:1/feed?token=secret-looking", lineNumber: 135 }), "feed:ws.onmessage:136", "the page's inline shim, query dropped");
+  assert.equal(frameKey({ functionName: "(program)", url: "", lineNumber: -1 }), "(program)");
+  assert.equal(frameKey({ functionName: "(garbage collector)", url: "", lineNumber: -1 }), "(garbage collector)");
+  assert.equal(frameKey(null), "(unknown)");
+});
+
+test("aggregateProfile attributes each sample's interval as self time to its node and once as total time to every function on its stack", () => {
+  const a = aggregateProfile(SYNTH_PROFILE);
+  assert.equal(a.durationMs, 0.9);
+  assert.equal(a.sampledMs, 0.8, "eight samples of 100 us, the last owning the interval to endTime");
+  assert.equal(a.samples, 8);
+  assert.deepEqual(a.meta, { "(program)": 0.1, "(garbage collector)": 0.1 }, "bookkeeping nodes are totalled, not ranked");
+  const by = Object.fromEntries(a.functions.map((f) => [f.key, { key: f.key, selfMs: f.selfMs, totalMs: f.totalMs, samples: f.samples }]));
+  assert.deepEqual(Object.keys(by).sort(), ["feed.js:fmt:30", "feed.js:main:10", "feed.js:render:20"]);
+  assert.equal(a.functions.find((f) => f.key === "feed.js:render:20").cf.lineNumber, 19, "each function keeps a call frame for the source locator");
+  assert.deepEqual(a.functions.find((f) => f.key === "feed.js:render:20").lines, [{ line: 25, ms: 0.2 }, { line: 20, ms: 0.1 }], "self time split over the function's lines by V8's ticks, both render nodes pooled");
+  assert.equal(a.functions.find((f) => f.key === "feed.js:fmt:30").lines, undefined, "no ticks, no lines");
+  assert.deepEqual(by["feed.js:render:20"], { key: "feed.js:render:20", selfMs: 0.3, totalMs: 0.5, samples: 3 }, "the recursive call's sample counts once in total");
+  assert.deepEqual(by["feed.js:fmt:30"], { key: "feed.js:fmt:30", selfMs: 0.2, totalMs: 0.2, samples: 2 });
+  assert.deepEqual(by["feed.js:main:10"], { key: "feed.js:main:10", selfMs: 0.1, totalMs: 0.6, samples: 1 });
+  const ranked = rankProfile(a, 2);
+  assert.deepEqual(ranked.topSelf.map((f) => f.key), ["feed.js:render:20", "feed.js:fmt:30"]);
+  assert.deepEqual(ranked.topSelf[0].lines, [{ line: 25, ms: 0.2, share: 0.67 }, { line: 20, ms: 0.1, share: 0.33 }], "the hottest functions carry their lines");
+  assert.equal(ranked.topTotal[1].lines, undefined, "the total ranking does not");
+  assert.deepEqual(ranked.topTotal.map((f) => f.key), ["feed.js:main:10", "feed.js:render:20"]);
+  assert.equal(ranked.functions, 3);
+  // A window on the profile's clock: samples at 1300 and 1400 (both fmt under render under main).
+  const w = aggregateProfile(SYNTH_PROFILE, [1250, 1450]);
+  assert.ok(w.functions.every((f) => f.lines === undefined), "ticks cover the whole profile, so a window gets no lines");
+  assert.equal(w.durationMs, 0.2, "a window's duration is its own width, not the profile's");
+  assert.equal(w.samples, 2);
+  assert.equal(w.sampledMs, 0.2);
+  assert.deepEqual(w.meta, {});
+  assert.deepEqual(Object.fromEntries(w.functions.map((f) => [f.key, [f.selfMs, f.totalMs]])), { "feed.js:fmt:30": [0.2, 0.2], "feed.js:render:20": [0, 0.2], "feed.js:main:10": [0, 0.2] });
+  const merged = rankProfile(mergeAggregates([a, a]), 3);
+  assert.equal(merged.sampledMs, 1.6);
+  assert.equal(merged.topSelf[0].selfMs, 0.6, "iterations pool by summing");
+  assert.deepEqual(merged.topSelf[0].lines, [{ line: 25, ms: 0.4, share: 0.67 }, { line: 20, ms: 0.2, share: 0.33 }], "and so do the lines");
+  assert.deepEqual(merged.meta, { "(program)": 0.2, "(garbage collector)": 0.2 });
+  const text = renderProfile({ files: ["/tmp/x.cpuprofile"], samplingIntervalUs: 500, alignMs: 0.4, ...ranked, windows: [{ label: "first content frame", index: 0, type: "feed", bytes: 5000, handlerMs: 0.3, ...rankProfile(w, 2) }] });
+  assert.match(text, /cpu profile: 8 samples over 0\.9 ms at 500 us, 3 functions; bookkeeping: \(program\) 0\.1 ms, \(garbage collector\) 0\.1 ms/);
+  assert.match(text, /written: \/tmp\/x\.cpuprofile/);
+  assert.match(text, /top 2 by self time \(under a function, the lines[^\n]*\n\s+self ms\s+total ms\s+samples\s+url:function:line\n\s+0\.3\s+0\.5\s+3\s+feed\.js:render:20\n\s+67%\s+0\.2 ms  line 25\n\s+33%\s+0\.1 ms  line 20\n/);
+  assert.match(text, /top 2 by total time\n[^\n]*\n\s+0\.1\s+0\.6\s+1\s+feed\.js:main:10/);
+  assert.match(text, /window: first content frame \(feed, 4\.9 KB, frame 0\): handler 0\.3 ms, 2 samples/);
+  assert.doesNotMatch(text, /source:line/, "no source column without maps");
+});
+
+test("sourceLocator maps a bundle position to its source through the dist's .map file, and rankProfile carries it", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-map-"));
+  try {
+    // A two-line bundle whose map says: generated line 1 <- src/a.ts line 1, generated line 2 <- src/a.ts line 2 ("AAAA;AACA").
+    fs.writeFileSync(path.join(tmp, "feed.js.map"), JSON.stringify({ version: 3, sources: ["../src/a.ts"], names: [], mappings: "AAAA;AACA" }));
+    const locate = sourceLocator(tmp);
+    assert.equal(locate({ functionName: "f", url: "http://127.0.0.1:1/dist/feed.js?v=9", lineNumber: 1, columnNumber: 4 }), "src/a.ts:2", "the leading ../ segments go when the source lies outside the repo");
+    assert.equal(locate({ functionName: "f", url: "http://127.0.0.1:1/dist/feed.js", lineNumber: 0, columnNumber: 0 }), "src/a.ts:1");
+    assert.equal(locate({ functionName: "g", url: "http://127.0.0.1:1/dist/other.js", lineNumber: 0, columnNumber: 0 }), null, "no map, no position");
+    assert.equal(locate({ functionName: "native", url: "", lineNumber: -1 }), null);
+    assert.equal(locate(null), null);
+    assert.equal(locate.probe("feed.js"), true);
+    assert.equal(locate.probe("other.js"), false);
+    assert.deepEqual([...locate.loaded], ["feed.js"], "the locator says which maps it loaded");
+    assert.deepEqual([...locate.missing], ["other.js"], "and which it could not");
+    // A bundle whose second line first maps at column 4 (bundled node_modules code does this): a column-0
+    // probe lands on line 1's mapping and the same-line guard refuses it; the per-line probe steps to it.
+    fs.writeFileSync(path.join(tmp, "indent.js.map"), JSON.stringify({ version: 3, sources: ["../src/b.ts"], names: [], mappings: "AAAA;IACA" }));
+    const cfi = { functionName: "f", url: "http://127.0.0.1:1/dist/indent.js?v=1", lineNumber: 1, columnNumber: 0 };
+    assert.equal(locate(cfi), null, "the function-level lookup at column 0 refuses the previous line's mapping");
+    assert.equal(locate.line(cfi, 1), "src/b.ts:2", "the per-line lookup finds the line's first mapping at column 4");
+    assert.equal(locate.line(cfi, 0), "src/b.ts:1");
+    assert.equal(locate.line(cfi, 7), null, "an unmapped line stays unresolved");
+    assert.equal(locate.line({ functionName: "n", url: "", lineNumber: -1 }, 3), null);
+    assert.equal(locate.line({ ...cfi, url: "http://127.0.0.1:1/dist/other.js" }, 1), null);
+    const ranked = rankProfile(aggregateProfile(SYNTH_PROFILE), 1, locate);
+    assert.equal(ranked.topSelf[0].src, undefined, "a line the map does not cover gets no position");
+    const one = rankProfile({ durationMs: 1, sampledMs: 1, samples: 1, meta: {}, functions: [{ key: "feed.js:f:2", selfMs: 1, totalMs: 1, samples: 1, cf: { url: "http://x/dist/feed.js", lineNumber: 1, columnNumber: 0 }, lines: [{ line: 2, ms: 0.9 }, { line: 1, ms: 0.1 }, { line: 7, ms: 0.01 }] }] }, 1, locate);
+    assert.deepEqual(one.topSelf, [{ key: "feed.js:f:2", selfMs: 1, totalMs: 1, samples: 1, src: "src/a.ts:2", lines: [{ line: 2, ms: 0.9, share: 0.9, src: "src/a.ts:2" }, { line: 1, ms: 0.1, share: 0.1, src: "src/a.ts:1" }] }], "lines resolve to their own source position; a line under a twentieth of the function's time is left out");
+    const native = rankProfile({ durationMs: 1, sampledMs: 1, samples: 1, meta: {}, functions: [{ key: "(native):append", selfMs: 1, totalMs: 1, samples: 1, cf: { functionName: "append", url: "", lineNumber: -1 }, lines: [{ line: 5, ms: 1 }] }] }, 1, locate);
+    assert.deepEqual(native.topSelf, [{ key: "(native):append", selfMs: 1, totalMs: 1, samples: 1 }], "a builtin's ticks name call sites in a file it does not have, so no lines");
+    assert.match(renderProfile({ files: [], samplingIntervalUs: 500, alignMs: 0.1, sourceMaps: true, ...one, windows: [] }), /url:function:line  source:line\n\s+1\.0\s+1\.0\s+1\s+feed\.js:f:2  src\/a\.ts:2/);
+    // The real dist, when built: the feed bundle's positions resolve into ui/webview.
+    const dist = path.join(REPO, "vscode-extension", "dist");
+    if (fs.existsSync(path.join(dist, "feed.js.map"))) {
+      const real = sourceLocator(dist)({ functionName: "x", url: "http://127.0.0.1:1/dist/feed.js?v=1", lineNumber: 200, columnNumber: 0 });
+      assert.match(real, /^(?!\.\.)(?!\/)\S+\.(ts|js):\d+$/, `a repo-relative source position: ${real}`);
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("the report claims source positions only for bundles whose maps loaded, and warns about the ones without", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-maps-"));
+  try {
+    const mkRun = () => { const run = fakeRun({ perFrame: [pf(0, "feed", 5000, 40, 90), pf(1, "delta:feed", 300, 4, 20)] }); run.profiling = { profile: SYNTH_PROFILE, p0: 0, alignMs: 1 }; return run; };
+    const build = (sourceMapDir) => buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 1, browser: "t", runs: [mkRun()], cpuProfileFiles: ["/tmp/x.cpuprofile"], sourceMapDir });
+    const noMaps = path.join(tmp, "nomaps");
+    fs.mkdirSync(noMaps);
+    const r1 = build(noMaps).cpuProfile;
+    assert.equal(r1.sourceMaps, false, "a configured directory is not a loaded map");
+    assert.deepEqual(r1.sourceMapsMissing, ["feed.js"]);
+    assert.deepEqual(r1.sourceMapsLoaded, []);
+    const t1 = renderProfile(r1);
+    assert.match(t1, /warning: no feed\.js\.map beside the served bundle; names and lines are the bundle's own, and a --production build is minified/);
+    assert.doesNotMatch(t1, /source positions from/);
+    assert.doesNotMatch(t1, /source:line/);
+    const withMaps = path.join(tmp, "maps");
+    fs.mkdirSync(withMaps);
+    fs.writeFileSync(path.join(withMaps, "feed.js.map"), JSON.stringify({ version: 3, sources: ["../src/a.ts"], names: [], mappings: "AAAA;AACA" }));
+    const r2 = build(withMaps).cpuProfile;
+    assert.equal(r2.sourceMaps, true);
+    assert.deepEqual(r2.sourceMapsLoaded, ["feed.js"]);
+    assert.deepEqual(r2.sourceMapsMissing, []);
+    const t2 = renderProfile(r2);
+    assert.match(t2, /source positions from feed\.js\.map/);
+    assert.doesNotMatch(t2, /warning:/);
+    assert.equal(r2.alignRefined, false, "this profile has no wrapper samples, so the bracketing estimate stands");
+    assert.equal(r2.alignMs, 1);
+    assert.equal(r2.alignBoundMs, 1);
+    assert.match(t2, /±1\.0 ms \(the bracketing estimate; the refinement did not apply: no windows to check against\)/);
+    const first = r2.windows.find((w) => w.label === "first content frame");
+    assert.equal(first.window, "handler", "a run that saw no delivery falls back to the handler window");
+    assert.equal(first.durationMs, 40, "a window's duration is the handler window's width");
+    assert.equal(first.samples, 0, "and this profile has no samples in it");
+    assert.match(t2, /window: first content frame \(feed, 4\.9 KB, frame 0\): handler 40\.0 ms, 0 samples/);
+    // A run whose frames were delivered in the shim's flush task: the window is the delivery's, and frames
+    // that shared one delivery share one window under a joined label.
+    const flushRun = fakeRun({ handoff: "flush", flushes: 1, deliveries: 1, flushRows: [{ t0: 1300, ms: 61 }], deliveryRows: [{ t0: 1301, ms: 60, type: "feed" }],
+      perFrame: [pf(0, "feed", 5000, 2, 150, "coalesced", null, 0), pf(1, "delta:feed", 300, 0.4, 70, "delivered", 60, 0)] });
+    flushRun.profiling = { profile: SYNTH_PROFILE, p0: 0, alignMs: 1 };
+    const r3 = buildReport({ app: "feed", framesFile: "f", cpuThrottle: 1, fast: true, iters: 1, browser: "t", runs: [flushRun], cpuProfileFiles: [], sourceMapDir: withMaps }).cpuProfile;
+    assert.equal(r3.windows.length, 1);
+    assert.equal(r3.windows[0].label, "first content frame + largest delta:feed");
+    assert.equal(r3.windows[0].window, "delivery");
+    assert.equal(r3.windows[0].windowMs, 60);
+    assert.equal(r3.windows[0].durationMs, 60, "the window is the delivery's width");
+    assert.equal(r3.windows[0].coalesced, true, "the first content frame rode in the delta's delivery");
+    assert.equal(r3.windows[0].handlerMs, 2);
+    assert.match(renderProfile(r3), /window: first content frame \+ largest delta:feed \(feed, 4\.9 KB, frame 0\): delivery 60\.0 ms \(a newer frame's delivery, this one coalesced into it\), shim handler 2\.0 ms, 0 samples/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("refineAlignment recovers the page-to-profile offset from the wrapper's samples", () => {
+  // Ten wrapper samples 100 us apart from t=100 us, then ten (program) samples. The true page time of the
+  // profile's start is 50 ms, so the handler window is [50.1, 51.05) ms; the bracketing estimate is 3 ms off.
+  const cf = (functionName, url) => ({ functionName, url, lineNumber: 1, columnNumber: 0 });
+  const profile = {
+    nodes: [{ id: 1, callFrame: cf("(root)", ""), children: [2, 4] }, { id: 2, callFrame: cf("rompBenchOnMessage", "ui-bench-instrument.js"), children: [3] },
+      { id: 3, callFrame: cf("render", "http://x/dist/feed.js") }, { id: 4, callFrame: cf("(program)", "") }],
+    startTime: 0, endTime: 2100, samples: [...Array(10).fill(3), ...Array(10).fill(4)], timeDeltas: Array(20).fill(100),
+  };
+  const al = refineAlignment(profile, 53, 5, [[50.1, 51.05]]);
+  assert.ok(Math.abs(al.p0 - 50) <= 0.13, `refined to ${al.p0}`);
+  assert.equal(al.alignMs, 0.125, "a single grid point fits: the uncertainty is a quarter of the sampling interval");
+  assert.equal(al.inside, 1, "every wrapper sample lands inside a handler window");
+  assert.equal(al.refined, true);
+  const none = refineAlignment(profile, 53, 5, []);
+  assert.deepEqual(none, { p0: 53, alignMs: 5, inside: null, refined: false }, "without windows the estimate stands");
+  const noWrapper = refineAlignment({ ...profile, samples: Array(20).fill(4) }, 53, 5, [[50.1, 51.05]]);
+  assert.deepEqual(noWrapper, { p0: 53, alignMs: 5, inside: null, refined: false }, "without wrapper samples too");
+  const far = refineAlignment(profile, 53, 5, [[80, 81]]);
+  assert.deepEqual(far, { p0: 53, alignMs: 5, inside: 0, refined: false }, "when no offset within the bound fits, the estimate and its bound stand and the result says so");
+  // The windows may overlap (a delivery inside its flush task, a flush starting as a handler ends): they are
+  // merged before the search, so a window nested in another cannot hide the samples from it.
+  assert.deepEqual(mergeWindows([[10, 20], [15, 30], [40, 50], [50, 60], [5, 1], [12, 13]]), [[10, 30], [40, 60]], "overlapping and touching windows merge; an empty one is dropped");
+  assert.deepEqual(refineAlignment(profile, 53, 5, [[50.1, 51.05], [50.3, 50.6]]).inside, 1);
+  // Only the instrument's wrappers count as wrapper time: its settle stamps and its passthrough of other
+  // events are in the same file but run outside every window.
+  const stampOnly = { ...profile, nodes: [...profile.nodes.slice(0, 1), { id: 2, callFrame: cf("", "ui-bench-instrument.js"), children: [3] }, ...profile.nodes.slice(2)] };
+  assert.deepEqual(refineAlignment(stampOnly, 53, 5, [[50.1, 51.05]]), { p0: 53, alignMs: 5, inside: null, refined: false }, "an anonymous instrument frame is not a wrapper");
+  const flushed = { ...profile, nodes: [...profile.nodes.slice(0, 1), { id: 2, callFrame: cf("rompBenchFlush", "ui-bench-instrument.js"), children: [3] }, ...profile.nodes.slice(2)] };
+  assert.equal(refineAlignment(flushed, 53, 5, [[50.1, 51.05]]).inside, 1, "the flush wrapper's samples count");
+  // Two long handler windows with slack at both edges (the shape of a real run: samples every 0.5 ms
+  // from 0.4 ms after each window opens): every offset within the slack scores the same, so the answer
+  // is the plateau's midpoint and half its width is the uncertainty, not the grid step. The true offset
+  // lies within that uncertainty; the data cannot place it more precisely.
+  const wins = [[100, 800], [900, 1760]];
+  const truth = 50;   // the page time of the profile's start
+  const pageTimes = [];
+  for (const [a, b] of wins) for (let x = a + 0.4; x <= b - 0.4 + 1e-9; x += 0.5) pageTimes.push(x);
+  const us = pageTimes.map((x) => Math.round((x - truth) * 1000));
+  const long = { nodes: profile.nodes, startTime: 0, endTime: us[us.length - 1] + 500, samples: us.map(() => 3), timeDeltas: us.map((u, i) => u - (i ? us[i - 1] : 0)) };
+  const pl = refineAlignment(long, truth + 0.7, 2, wins);
+  assert.equal(pl.refined, true);
+  assert.equal(pl.inside, 1);
+  assert.ok(pl.alignMs >= 0.3 && pl.alignMs <= 0.5, `half the plateau's width (about a millisecond of slack), not the grid step: ${pl.alignMs}`);
+  assert.ok(Math.abs(pl.p0 - truth) <= pl.alignMs, `the true offset lies within the reported uncertainty: ${pl.p0} ± ${pl.alignMs}`);
+  assert.ok(Math.abs(pl.p0 - truth) < 0.7, `and the 0.7 ms estimate error was corrected: ${pl.p0}`);
+});
+
+test("aggregateProfile spreads self time over lines by V8's ticks per hit, not per sample, and gives no lines when no hit was recorded", () => {
+  // The real profile has nodes whose hitCount is below their sample count (V8 records ticks with
+  // update_stats off) and nodes with hitCount 0 that were still sampled.
+  const cf = (functionName, lineNumber) => ({ functionName, url: "http://127.0.0.1:1/dist/feed.js", lineNumber, columnNumber: 0 });
+  const prof = {
+    nodes: [
+      { id: 1, callFrame: { functionName: "(root)", url: "", lineNumber: -1 }, children: [2, 3] },
+      { id: 2, callFrame: cf("render", 19), hitCount: 1, positionTicks: [{ line: 20, ticks: 1 }] },   // one tick recorded, two samples landed
+      { id: 3, callFrame: cf("rk", 39), hitCount: 0 },
+    ],
+    startTime: 0, endTime: 400, samples: [2, 2, 3], timeDeltas: [100, 100, 100],
+  };
+  const a = aggregateProfile(prof);
+  const render = a.functions.find((f) => f.key === "feed.js:render:20");
+  assert.equal(render.selfMs, 0.2);
+  assert.deepEqual(render.lines, [{ line: 20, ms: 0.2 }], "the lines sum to the node's self time (a per-sample split would say 0.1)");
+  const rk = a.functions.find((f) => f.key === "feed.js:rk:40");
+  assert.equal(rk.selfMs, 0.1);
+  assert.equal(rk.lines, undefined, "self time but no lines when V8 recorded no hit");
+  const ranked = rankProfile(a, 5);
+  assert.deepEqual(ranked.topSelf[0].lines, [{ line: 20, ms: 0.2, share: 1 }]);
+  assert.equal(ranked.topSelf[1].lines, undefined);
+});
+
+test("stripProfileQueries drops every call frame's URL query before the profile is written", () => {
+  const prof = { nodes: [
+    { id: 1, callFrame: { functionName: "ws.onmessage", url: "http://127.0.0.1:1/feed?token=secret-looking", lineNumber: 135 } },
+    { id: 2, callFrame: { functionName: "render", url: "http://127.0.0.1:1/dist/feed.js?v=3", lineNumber: 19 } },
+    { id: 3, callFrame: { functionName: "(program)", url: "", lineNumber: -1 } },
+  ], startTime: 0, endTime: 1, samples: [1], timeDeltas: [1] };
+  const out = stripProfileQueries(prof);
+  assert.deepEqual(out.nodes.map((n) => n.callFrame.url), ["http://127.0.0.1:1/feed", "http://127.0.0.1:1/dist/feed.js", ""]);
+  assert.doesNotMatch(JSON.stringify(out), /secret-looking|token=/);
+  assert.ok(prof.nodes[0].callFrame.url.includes("token="), "the in-memory profile is untouched");
+  assert.equal(out.samples, prof.samples);
+});
+
+test("aggregateProfile on an empty or window-less profile yields nothing rather than NaN", () => {
+  const e = aggregateProfile({ nodes: [{ id: 1, callFrame: { functionName: "(root)", url: "", lineNumber: -1 } }], startTime: 5, endTime: 5, samples: [], timeDeltas: [] });
+  assert.deepEqual(e, { durationMs: 0, sampledMs: 0, samples: 0, meta: {}, functions: [] });
+  assert.deepEqual(rankProfile(e, 5).topSelf, []);
+  assert.equal(aggregateProfile(SYNTH_PROFILE, [5000, 6000]).samples, 0);
+});
+
+// ── a real replay, when a browser is at hand ─────────────────────────────────────────────────────
+
+const avail = browserAvailability();
+const distBuilt = fs.existsSync(path.join(REPO, "vscode-extension", "dist", "feed.js"));
+const pythonOk = (() => { try { return spawnSync("python3", ["--version"]).status === 0; } catch { return false; } })();
+const skipServer = !distBuilt ? "no built bundles at vscode-extension/dist (run: cd vscode-extension && npm run build)"
+  : !pythonOk ? "python3 is not on PATH (the replay serves the page through the kernel's own Handler)"
+  : false;
+const skipReplay = !avail.ok ? `no browser: ${avail.why}` : skipServer;
+// ROMP_UI_BENCH_REQUIRE (CI sets it) turns a skip into a failure that names the missing prerequisite:
+// a runner image that lost its Chrome must not turn the only CI run of the real pages into a green skip.
+const required = !!process.env.ROMP_UI_BENCH_REQUIRE;
+const gate = (why) => ({ skip: required ? false : why });
+const requireOrSkip = (why) => { if (why) assert.fail(`ROMP_UI_BENCH_REQUIRE is set and this test cannot run: ${why}`); };
+
+test("ROMP_UI_BENCH_REQUIRE turns the browser skip into a failure that names the reason", { timeout: 60_000 }, () => {
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-nobrowser-"));
+  try {
+    const env = { ROMP_UI_BENCH_REQUIRE: "1", PATH: "", PLAYWRIGHT_BROWSERS_PATH: empty, HOME: os.homedir() };
+    const r = spawnSync(process.execPath, ["--test", "--test-name-pattern", "^replay:", THIS_FILE], { env, encoding: "utf8", timeout: 50_000 });
+    assert.notEqual(r.status, 0, `the nested run must fail\n${r.stdout}\n${r.stderr}`);
+    assert.match(r.stdout, /ROMP_UI_BENCH_REQUIRE is set and this test cannot run: no browser/);
+    assert.match(r.stdout, /# fail 4/, "every replay test, not a skip");
+    assert.doesNotMatch(r.stdout, /# skipped [1-9]/);
+    delete env.ROMP_UI_BENCH_REQUIRE;
+    const s = spawnSync(process.execPath, ["--test", "--test-name-pattern", "^replay:", THIS_FILE], { env, encoding: "utf8", timeout: 50_000 });
+    assert.equal(s.status, 0, `without the variable the same run skips\n${s.stdout}\n${s.stderr}`);
+    assert.match(s.stdout, /# skipped 4/);
+  } finally {
+    fs.rmSync(empty, { recursive: true, force: true });
+  }
+});
+
+// ── the Handler subprocess ───────────────────────────────────────────────────────────────────────
+
+test("startPageServer hands the Handler an isolated environment: a minted token, no manager, no API keys, no key reference, no CLI scope, no postal peers", { timeout: 30_000 }, async () => {
+  // A stub interpreter stands in for python3: it echoes its environment, announces a port, and blocks on
+  // stdin the way the Handler's watcher thread does. So this needs neither python nor the kernel.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-env-"));
+  try {
+    const stub = writeStub(tmp, "python-stub", `env > "$UI_BENCH_STUB_ENV_OUT"\nprintf 'ARGS %s\\n' "$#" >> "$UI_BENCH_STUB_ENV_OUT"\nprintf 'TMPARG %s\\n' "$4" >> "$UI_BENCH_STUB_ENV_OUT"\n`);
+    const dist = fakeDist(tmp);
+    const envOut = path.join(tmp, "env.txt");
+    // The variables the Handler must never inherit, named here so a shrinking export cannot shrink the check:
+    // the manager's, the live kernel's ports and state root, the perf switch and tmux's.
+    const NEVER = ["ROMP_MANAGER_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "ROMP_STATE_DIR", "ROMP_SERVE_PORT", "ROMP_KERNEL_PORT", "ROMP_PERF", "TMUX"];
+    assert.deepEqual([...STRIPPED_ENV].sort(), [...NEVER].sort(), "the tool's list is exactly this one");
+    const planted = { UI_BENCH_STUB_ENV_OUT: envOut, ANTHROPIC_PROBE_FOR_THE_TEST: "must-not-cross", ROMP_CLAUDE_BIN: "/nonexistent/claude", ROMP_POSTAL_PEERS: "1",
+      ROMP_SERVICE_ENV_FILE: path.join(tmp, "planted-service.env"), ROMP_MODEL_CATALOG: "on", ROMP_API_KEY_REF: "planted-reference", ROMP_CLI_SCOPE: "1",
+      ...Object.fromEntries(NEVER.map((k) => [k, k === "TMUX" ? "/tmp/tmux-0/default,1,0" : k === "ROMP_STATE_DIR" ? path.join(tmp, "planted-state") : "1"])) };
+    const srv = await withEnv(planted, () => startPageServer({ dist, python: stub }));
+    try {
+      assert.equal(srv.port, 1);
+      assert.match(srv.token, /^[A-Za-z0-9_-]{24}$/, "a per-run token, 18 random bytes as base64url");
+      assert.ok(srv.pid > 0);
+      assert.ok(fs.existsSync(srv.tmp));
+      const env = Object.fromEntries(fs.readFileSync(envOut, "utf8").trim().split("\n").map((l) => { const i = l.indexOf("="); return i < 0 ? [l, ""] : [l.slice(0, i), l.slice(i + 1)]; }));
+      assert.equal(env.ROMP_SERVE_TOKEN, srv.token);
+      assert.equal(env.ROMP_POSTAL_PEERS, "0", "the Handler never asks the live postal bus for its peers");
+      assert.equal(env.ROMP_KERNEL_NO_OPEN, "1");
+      assert.equal(env.ROMP_SERVICE_ENV_FILE, path.join(srv.tmp, "no-service.env"), "the manager's key file is pointed at a path that never exists (the kernel would otherwise read ~/.config/romp/service.env)");
+      assert.equal(env.ROMP_SERVICE_ENV, env.ROMP_SERVICE_ENV_FILE);
+      assert.ok(!fs.existsSync(env.ROMP_SERVICE_ENV_FILE));
+      assert.equal(env.ROMP_MODEL_CATALOG, "off", "no boot fetch of the Models API");
+      assert.equal(env.ROMP_CLAUDE_BIN, "/bin/false", "a binary that runs nothing; removing the variable would resolve the real CLI");
+      assert.equal(env.ROMP_CLI_SCOPE, "0", "no route that constructs the SDK backend probes systemd-run");
+      assert.equal(env.ROMP_API_KEY_REF, undefined, "an inherited key reference never reaches the Handler");
+      assert.equal(path.dirname(srv.tmp), srv.root, "the run directory sits under the per-user parent");
+      assert.equal(path.basename(srv.root), `romp-ui-bench-${UID}`);
+      assert.equal(fs.readFileSync(path.join(srv.tmp, "owner.pid"), "utf8").trim(), String(process.pid), "the run records its owner for the dead-owner sweep");
+      if (process.platform !== "win32") { assert.equal(mode(srv.root), 0o700); assert.equal(mode(srv.tmp), 0o700); }
+      assert.equal(env.ROMP_DIST_DIR, dist);
+      assert.ok(env.XDG_STATE_HOME.startsWith(srv.tmp + path.sep), "a private state root");
+      assert.ok(env.TMUX_TMPDIR.startsWith(srv.tmp + path.sep));
+      assert.ok(fs.readFileSync(envOut, "utf8").includes(`\nTMPARG ${srv.tmp}\n`), "the subprocess is told its directory so it can remove it");
+      for (const k of Object.keys(env)) assert.ok(!k.startsWith("ANTHROPIC_"), `${k} must not reach the Handler`);
+      for (const k of NEVER) assert.equal(env[k], undefined, `${k} was planted and must not reach the Handler`);
+      assert.equal(env.UI_BENCH_STUB_ENV_OUT, envOut, "unrelated variables pass through");
+      // a second run mints its own token: the Handler is the kernel's whole route surface on a loopback port
+      const other = await startPageServer({ dist, python: stub });
+      try { assert.notEqual(other.token, srv.token, "a token minted per run, never a constant"); }
+      finally { other.stop(); }
+      await other.exited;
+    } finally {
+      srv.stop();
+    }
+    await srv.exited;   // the event, not a timer: on a loaded machine SIGTERM-to-reaped ran past 100 ms
+    assert.ok(!fs.existsSync(srv.tmp), "stop removes the directory");
+    assert.throws(() => process.kill(srv.pid, 0), /ESRCH/, "and ends the subprocess");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("startPageServer cleans up when the interpreter exits before announcing a port, and refuses without a dist before creating anything", { timeout: 30_000 }, async () => {
+  // os.tmpdir() follows TMPDIR, so the server's directories land in a private one this test can list
+  // (the machine's shared temp root is never enumerated).
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-fail-"));
+  const scratch = path.join(tmp, "scratch");
+  fs.mkdirSync(scratch);
+  try {
+    await withEnv({ TMPDIR: scratch }, async () => {
+      assert.equal(os.tmpdir(), scratch);
+      await assert.rejects(startPageServer({ dist: path.join(tmp, "nodist") }), /no built bundles/);
+      assert.deepEqual(fs.readdirSync(scratch), [], "the dist check runs before any directory is created");
+      const dist = fakeDist(tmp);
+      const dying = path.join(tmp, "python-dying");
+      fs.writeFileSync(dying, "#!/bin/sh\necho 'ImportError: fake' >&2\nexit 3\n", { mode: 0o755 });
+      await assert.rejects(startPageServer({ dist, python: dying }), /exited with 3[\s\S]*ImportError: fake/);
+      const root = path.join(scratch, `romp-ui-bench-${UID}`);
+      assert.deepEqual(fs.readdirSync(scratch), [path.basename(root)], "only the per-user parent is created");
+      assert.deepEqual(fs.readdirSync(root), [], "an interpreter that dies before its port leaves no run directory behind");
+      await assert.rejects(startPageServer({ dist, python: path.join(tmp, "no-such-interpreter") }), /could not start \S*no-such-interpreter: spawn \S*no-such-interpreter ENOENT/);
+      assert.deepEqual(fs.readdirSync(root), [], "nor does one that cannot be spawned (an unhandled 'error' event used to crash the process and leak it)");
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("benchRoot is a private per-user directory, and sweepDeadRuns reclaims the runs whose owner is gone", { timeout: 30_000 }, async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-root-"));
+  const scratch = path.join(tmp, "scratch");
+  fs.mkdirSync(scratch);
+  try {
+    await withEnv({ TMPDIR: scratch }, async () => {
+      const root = benchRoot();
+      assert.equal(root, path.join(scratch, `romp-ui-bench-${UID}`));
+      if (process.platform !== "win32") {
+        assert.equal(mode(root), 0o700);
+        fs.chmodSync(root, 0o755);
+        assert.equal(benchRoot(), root);
+        assert.equal(mode(root), 0o700, "a loosened mode is restored");
+      }
+      const dead = spawnSync(process.execPath, ["-e", "0"]).pid;   // a process that has already exited
+      const mk = (name, pid) => { fs.mkdirSync(path.join(root, name)); if (pid !== undefined) fs.writeFileSync(path.join(root, name, "owner.pid"), `${pid}\n`); };
+      mk("run-dead", dead); mk("run-live", process.pid); mk("run-nopid"); mk("run-garbage", "abc");
+      assert.deepEqual(sweepDeadRuns(root), ["run-dead"]);
+      assert.deepEqual(fs.readdirSync(root).sort(), ["run-garbage", "run-live", "run-nopid"], "a live owner, a missing pid file and an unreadable one are left alone");
+      mk("run-dead2", dead);
+      const logged = [];
+      const srv = await startPageServer({ dist: fakeDist(tmp), python: writeStub(tmp), log: (l) => logged.push(l) });
+      try {
+        assert.ok(!fs.existsSync(path.join(root, "run-dead2")), "a start sweeps the dead runs first");
+        assert.ok(fs.existsSync(path.join(root, "run-live")), "and leaves the live ones");
+        assert.ok(logged.some((l) => /removed 1 run directory left behind by dead runs/.test(l)), logged.join("\n"));
+        assert.equal(path.dirname(srv.tmp), root);
+      } finally {
+        srv.stop();
+      }
+      assert.deepEqual(fs.readdirSync(root).sort(), ["run-garbage", "run-live", "run-nopid"], "stop removed its own run directory");
+      assert.deepEqual(sweepDeadRuns(path.join(tmp, "absent")), [], "a missing root is nothing to sweep");
+      // Something else holding the parent's name is refused, never adopted.
+      const linkBase = path.join(tmp, "linkbase");
+      fs.mkdirSync(path.join(tmp, "elsewhere"));
+      fs.mkdirSync(linkBase);
+      fs.symlinkSync(path.join(tmp, "elsewhere"), path.join(linkBase, `romp-ui-bench-${UID}`));
+      assert.throws(() => benchRoot(linkBase), /not a directory; refusing/);
+    });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("launchBrowser puts Playwright's profile and artifacts directories under the run directory", { ...gate(skipReplay), timeout: 60_000 }, async () => {
+  requireOrSkip(skipReplay);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-browser-"));
+  const srv = await startPageServer({ dist: fakeDist(tmp), python: writeStub(tmp) });
+  const before = process.env.TMPDIR;
+  let browser;
+  try {
+    browser = await launchBrowser({ tmpRoot: srv.tmp });
+    assert.equal(process.env.TMPDIR, before, "TMPDIR is restored once the browser is up");
+    const names = fs.readdirSync(srv.tmp);
+    assert.ok(names.some((n) => n.startsWith("playwright")), `the browser's directories live in the run directory, where stop() and the sweep reach them: ${names.join(", ")}`);
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+    srv.stop();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+  assert.ok(!fs.existsSync(srv.tmp), "stop takes the browser's directories with the run's");
+});
+
+test("the front server's /ws admits the page's own origin only, and no other path upgrades", async () => {
+  // The kernel Handler is never consulted for /ws (pagePort is a dead port here); the front answers the upgrade.
+  const front = await startFront({ pagePort: 1 });
+  const reached = [];
+  front.setSocketHandler((ws, u) => { reached.push(u.pathname + u.search); ws.send("front " + u.pathname); });
+  const WebSocket = requireExt("ws");
+  const attempt = (p, origin) => new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${front.port}${p}`, origin ? { origin } : {});
+    ws.on("unexpected-response", (_req, res) => { resolve({ status: res.statusCode }); ws.terminate(); });
+    ws.on("message", (d) => { resolve({ message: d.toString() }); ws.close(); });
+    ws.on("error", (e) => resolve({ error: e.message }));
+  });
+  try {
+    assert.deepEqual(await attempt("/ws?app=feed", "http://evil.example"), { status: 403 }, "a foreign Origin is refused");
+    assert.deepEqual(await attempt("/other", `http://127.0.0.1:${front.port}`), { status: 403 }, "no path but /ws upgrades");
+    assert.deepEqual(reached, [], "neither reached the replay's socket handler");
+    assert.deepEqual(await attempt("/ws?app=feed", `http://127.0.0.1:${front.port}`), { message: "front /ws" }, "the page's own origin upgrades");
+    assert.deepEqual(reached, ["/ws?app=feed"]);
+  } finally {
+    front.stop();
+  }
+});
+
+test("the in-page instrument counts the flush task's arming posts, stamps a delivery's settle after two animation frames, and records the seam and a throw", { ...gate(skipReplay), timeout: 60_000 }, async () => {
+  requireOrSkip(skipReplay);
+  // The instrument on a blank page, driven directly: a MessageChannel whose handler re-posts from inside the flush
+  // (the shim's sliced flush re-arming itself), a stub federation object whose inbound re-dispatches the frame on
+  // window (federation re-emitting the merged frame to the pane), one that throws, and a dispatch outside any inbound.
+  const browser = await launchBrowser();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.addInitScript(INIT_SCRIPT);
+    await page.goto("about:blank");
+    const r = await page.evaluate(async () => {
+      const R = window.__rompBench;
+      const out = {};
+      const ch = new MessageChannel();
+      let n = 0;
+      const drained = new Promise((res) => { ch.port1.onmessage = () => { if (n++ < 2) ch.port2.postMessage(0); else res(); }; });
+      ch.port2.postMessage(0);   // armed from outside any handler or flush: not a re-arm, not counted
+      await drained;
+      out.portPosts = R.portPosts; out.portFires = R.portFires; out.flushes = R.flushes.map((f) => ({ ms: f.ms, deliveries: f.deliveries }));
+      window.__rompFed = { inbound(_h, m) { window.dispatchEvent(new MessageEvent("message", { data: m })); } };
+      window.__rompFed.inbound("", { type: "feed" });
+      out.afterInbound = R.deliveries.map((d) => ({ type: d.type, via: d.via, flush: d.flush, rec: d.rec, err: d.err }));
+      out.settleSync = R.deliveries[0].settle;
+      await new Promise((res) => requestAnimationFrame(res));
+      out.settleAfterOneFrame = R.deliveries[0].settle;
+      await new Promise((res) => requestAnimationFrame(() => setTimeout(res, 0)));
+      out.settleAfterTwoFrames = R.deliveries[0].settle;
+      window.dispatchEvent(new MessageEvent("message", { data: { type: "bars" } }));
+      window.__rompFed = { inbound() { throw new Error("bundle refused the frame"); } };
+      let thrown = null;
+      try { window.__rompFed.inbound("", { type: "session" }); } catch (e) { thrown = e.message; }
+      out.thrown = thrown;
+      out.deliveries = R.deliveries.map((d) => ({ type: d.type, via: d.via, err: d.err }));
+      out.recs = R.recs.length;
+      return out;
+    });
+    await context.close();
+    assert.equal(r.portPosts, 2, "the two posts made inside a flush are counted; the one from outside is not");
+    assert.equal(r.portFires, 3, "every armed flush fired");
+    assert.equal(r.flushes.length, 3);
+    assert.ok(r.flushes.every((f) => f.ms >= 0 && f.deliveries === 0), JSON.stringify(r.flushes));
+    assert.deepEqual(r.afterInbound, [{ type: "feed", via: "inbound", flush: -1, rec: -1, err: null }], "a dispatch inside an inbound is part of that delivery, never a second one");
+    assert.equal(r.settleSync, -1, "settle is not stamped when the delivery returns");
+    assert.equal(r.settleAfterOneFrame, -1, "nor after one animation frame");
+    assert.ok(r.settleAfterTwoFrames >= 0, `stamped after the second: ${r.settleAfterTwoFrames}`);
+    assert.deepEqual(r.deliveries, [{ type: "feed", via: "inbound", err: null }, { type: "bars", via: "dispatch", err: null }, { type: "session", via: "inbound", err: "bundle refused the frame" }],
+      "a dispatch outside any inbound is a delivery through the fallback seam; a throwing inbound is recorded and rethrown");
+    assert.equal(r.thrown, "bundle refused the frame");
+    assert.equal(r.recs, 0, "no WebSocket frame was involved");
+  } finally {
+    await browser.close().catch(() => {});
+  }
+});
+
+test("the Handler subprocess ends and removes its directory when the node process that started it is SIGKILLed", { ...gate(skipServer), timeout: 90_000 }, async () => {
+  requireOrSkip(skipServer);
+  const script = `
+    import { startPageServer } from ${JSON.stringify(pathToFileURL(TOOL).href)};
+    const s = await startPageServer({ log: () => {} });
+    process.stdout.write(JSON.stringify({ pid: s.pid, tmp: s.tmp, port: s.port }) + "\\n");
+    setInterval(() => {}, 1000);
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", script], { stdio: ["ignore", "pipe", "pipe"] });
+  let info = null;
+  try {
+    let buf = "", err = "";
+    child.stderr.on("data", (c) => { err += c; });
+    info = await new Promise((resolve, reject) => {
+      child.stdout.on("data", (c) => { buf += c; const nl = buf.indexOf("\n"); if (nl >= 0) resolve(JSON.parse(buf.slice(0, nl))); });
+      child.on("exit", (code) => reject(new Error(`the child exited early with ${code}: ${err}`)));
+    });
+    assert.ok(fs.existsSync(info.tmp), "the Handler's directory exists while it runs");
+    assert.doesNotThrow(() => process.kill(info.pid, 0), "the Handler is alive");
+    const page = await new Promise((resolve, reject) => http.get({ host: "127.0.0.1", port: info.port, path: "/feed" }, (res) => { res.resume(); resolve(res.statusCode); }).on("error", reject));
+    assert.equal(page, 403, "and without the minted token the page route refuses");
+  } finally {
+    child.kill("SIGKILL");
+  }
+  const t0 = Date.now();
+  let alive = true, dirThere = true;
+  while (Date.now() - t0 < 20_000) {
+    try { process.kill(info.pid, 0); alive = true; } catch (e) { alive = e.code !== "ESRCH"; }
+    dirThere = fs.existsSync(info.tmp);
+    if (!alive && !dirThere) break;
+    await sleep(50);
+  }
+  assert.equal(alive, false, "the Handler ended once its stdin pipe closed");
+  assert.equal(dirThere, false, "and removed its directory");
+});
+
+// ── a real replay, when a browser is at hand ─────────────────────────────────────────────────────
+
+// The feed stream goes in at a fixed gap wide enough for the shim's flush to run between frames, so most
+// frames reach the bundle as their own delivery and the bundle column is per frame; the timeline stream goes
+// in back-to-back, so the frames queue together and the shim coalesces the whole-state kinds.
+const REPLAY_PACING = { feed: { gapMs: 100 }, timeline: { fast: true } };
+
+for (const app of ["feed", "timeline"]) {
+  test(`replay: a synthetic ${app} stream renders in headless Chromium, every frame type measured and accounted for by the handoff, no console errors`,
+    { ...gate(skipReplay), timeout: 180_000 }, async () => {
+      requireOrSkip(skipReplay);
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-replay-"));
+      try {
+        const frames = synthesizeFrames(app, 40);
+        const file = path.join(tmp, `${app}.jsonl`);
+        writeFrames(file, { synthetic: true, app }, frames);
+        const jsonOut = path.join(tmp, "report.json");
+        const cpuProfile = app === "feed" ? path.join(tmp, "prof", "feed.cpuprofile") : undefined;
+        const pacing = REPLAY_PACING[app];
+        const timersBefore = process.getActiveResourcesInfo().filter((x) => x === "Timeout").length;
+        const report = await replay({ app, framesFile: file, ...pacing, jsonOut, cpuProfile, log: () => {} });
+        const timersAfter = process.getActiveResourcesInfo().filter((x) => x === "Timeout").length;
+        assert.ok(timersAfter <= timersBefore, `replay left ${timersAfter - timersBefore} timer(s) armed (the handshake timeout must be cleared)`);
+        assert.equal(process.listenerCount("SIGINT"), 0, "the signal handlers are removed on the way out");
+        assert.equal(report.tool, "ui-bench");
+        assert.equal(report.app, app);
+        assert.equal(report.fast, !!pacing.fast);
+        assert.equal(report.gapMs, pacing.gapMs ?? null);
+        assert.equal(report.cpuThrottle, 1);
+        assert.equal(report.frames.total, frames.length);
+        assert.equal(report.frames.misaligned, 0, "every page record matched its frame by length");
+        assert.equal(report.frames.reconnects, 0);
+        for (const k of ["first", "types", "handoff", "loaf", "end", "console", "clientMessages", "perFrame"]) assert.ok(k in report, `report.${k}`);
+        assert.ok(report.frames.readyMs > 0, "the page reached its ready handshake");
+        const expected = new Set(frames.map((f) => classifyFrame(f.data)));
+        assert.ok(expected.size >= 3);
+        for (const type of expected) {
+          const s = report.types[type];
+          assert.ok(s, `a row for ${type}`);
+          assert.ok(s.measured >= 1, `${type}: at least one measured frame`);
+          assert.equal(s.measured, s.count, `${type}: every frame measured`);
+          assert.equal(s.handlerMs.n, s.count, `${type}: every frame's handler timed`);
+          assert.equal(s.settleMs.n, s.count, `${type}: every frame's settle stamped (null percentiles compare as 0, so the sample size is what proves it)`);
+          assert.equal(s.settleMissing, 0, `${type}: no settle stamp missing`);
+          assert.equal(typeof s.settleMs.p50, "number");
+          assert.ok(s.handlerMs.p50 >= 0 && s.handlerMs.max >= s.handlerMs.p50, `${type}: handler percentiles`);
+          assert.ok(s.settleMs.p50 >= 0 && s.settleMs.max >= s.settleMs.p50, `${type}: settle percentiles`);
+          assert.ok(s.settleMs.p50 >= s.handlerMs.p50, `${type}: the main thread is free no sooner than the handler returns`);
+          // The handoff accounts for every frame: delivered on its own, coalesced into a newer frame's delivery,
+          // or the shim's alone; nothing left queued.
+          assert.equal(s.delivered + s.coalesced + s.shim + s.queued, s.count, `${type}: every frame accounted for (${JSON.stringify(s)})`);
+          assert.equal(s.queued, 0, `${type}: nothing still queued`);
+          assert.equal(s.bundleMs.n, s.delivered, `${type}: a bundle time for each frame delivered on its own`);
+          if (s.delivered) assert.ok(s.bundleMs.p50 > 0 && s.bundleMs.max >= s.bundleMs.p50, `${type}: bundle percentiles`);
+          if (type === "ka") { assert.equal(s.shim, s.count, "keepalives are the shim's alone"); assert.equal(s.delivered, 0); }
+          else if (s.delivered) assert.ok(s.settleMs.max >= s.bundleMs.p50, `${type}: the main thread is free no sooner than a delivery returns`);
+        }
+        assert.equal(report.frames.settleMissing, 0);
+        assert.equal(report.frames.addListenerMessages, 0, "the pane's socket handler is the onmessage the bench times");
+        assert.equal(report.frames.buildBannerRaised, 0, "a synthetic stream's keepalive dv never outruns the dist");
+        assert.equal(report.frames.connBannerRaised, 0);
+        // The tip's shim hands frames over in its flush task, and the bench saw every handoff through it.
+        assert.equal(report.handoff.mode, "flush", JSON.stringify(report.handoff));
+        assert.ok(report.handoff.flushes >= 1 && report.handoff.deliveries >= 1, JSON.stringify(report.handoff));
+        assert.equal(report.handoff.queueDrained, true, "every flush the frames armed ran before the collection");
+        assert.deepEqual(report.handoff.deliveryErrors, []);
+        assert.equal(report.handoff.deliveries, report.handoff.delivered + report.handoff.unattributed, "one delivery per frame delivered on its own, the rest the page's own re-emits");
+        assert.equal(report.handoff.delivered + report.handoff.coalesced + report.handoff.shim, frames.length, "the frames add up");
+        assert.equal(report.handoff.queued, 0);
+        assert.equal(report.handoff.unattributed, 0, "no delivery the frames do not explain (federation re-dispatches every frame inside its inbound; that is one delivery, not two)");
+        assert.deepEqual(report.handoff.deliverySeams, { inbound: report.handoff.deliveries }, "every delivery came through federation's published inbound, none through the MessageEvent fallback");
+        // The columns are measurements, not constants: the shim's parse of the first content frame is measurable at
+        // performance.now() resolution and cheaper than the bundle's render of it; the settle of a keepalive, which the
+        // shim answers with no render, is the two animation frames after receipt, at least one frame interval.
+        assert.ok(report.first.handlerMs > 0, `the first frame's handler time is a measurement: ${report.first.handlerMs}`);
+        assert.ok(report.types[report.first.type].handlerMs.max > 0);
+        if (report.first.handoff === "delivered") {
+          assert.ok(report.first.handlerMs < report.first.bundleMs, `the shim's parse is cheaper than the bundle's render: ${JSON.stringify(report.first)}`);
+          assert.ok(report.first.settleMs - report.first.bundleMs - report.first.handlerMs >= 5, `settle waits for the main thread after the delivery: ${JSON.stringify(report.first)}`);
+        }
+        assert.ok(report.types.ka.settleMs.p50 >= 10, `a keepalive settles two animation frames after receipt, not when its handler returns: ${JSON.stringify(report.types.ka.settleMs)}`);
+        const content = frames.length - report.types.ka.count;
+        if (pacing.fast) {
+          assert.ok(report.handoff.coalesced >= 1, `back-to-back, frames queue together and the whole-state kinds coalesce: ${JSON.stringify(report.handoff)}`);
+          assert.ok(report.handoff.delivered < content, "so fewer deliveries than content frames");
+        } else {
+          assert.equal(report.types.feed.delivered + report.types.feed.coalesced, 1);
+          assert.ok(report.types["delta:feed"].delivered >= report.types["delta:feed"].count / 2, `at ${pacing.gapMs} ms gaps most deltas reach the bundle on their own: ${JSON.stringify(report.types["delta:feed"])}`);
+          assert.ok(report.types["delta:feed"].bundleMs.p50 < report.types.feed.settleMs.max, "a delta's render is cheaper than the whole board's settle");
+        }
+        assert.equal(report.end.afterGc, true);
+        if (app === "feed") assert.ok(report.end.heapUsed < report.end.heapBeforeGc, `the forced collection freed the replay's garbage: ${report.end.heapBeforeGc} before, ${report.end.heapUsed} after`);
+        assert.equal(report.first.type, app === "feed" ? "feed" : "data");
+        assert.ok(report.first.bytes > 1000);
+        assert.ok(["delivered", "coalesced"].includes(report.first.handoff), `the first content frame reached the bundle: ${JSON.stringify(report.first)}`);
+        if (report.first.handoff === "delivered") assert.ok(report.first.bundleMs > 0 && report.first.settleMs >= report.first.bundleMs, JSON.stringify(report.first));
+        assert.deepEqual(report.console.errors, [], "console errors");
+        assert.deepEqual(report.console.pageErrors, [], "uncaught exceptions");
+        assert.deepEqual(report.console.failedResources, [], "every page resource served");
+        assert.equal(report.clientMessages.ready, 1, "the bundle's handshake, once");
+        assert.ok(!report.clientMessages.needSlot, "the pane applied every frame without asking for a resync");
+        assert.ok(report.end.heapUsed > 0);
+        assert.ok(report.end.domElements > 20);
+        assert.ok(report.end.cdpNodes >= report.end.domElements);
+        assert.equal(typeof report.loaf.count, "number");
+        assert.ok(["long-animation-frame", "longtask"].includes(report.loaf.kind), "an observer kind was chosen");
+        if (app === "feed") assert.ok(report.end.domElements > 40 * 5, "forty cards render as more than a handful of elements each");
+        const disk = JSON.parse(fs.readFileSync(jsonOut, "utf8"));
+        assert.equal(disk.frames.total, frames.length, "--json wrote the same report");
+        const text = renderReport(report);
+        assert.match(text, new RegExp(`^ui-bench ${app}: ${frames.length} frames, [\\d.]+ KB, replay [\\d.]+ ms \\(${pacing.fast ? "back-to-back" : `${pacing.gapMs} ms gaps`}\\)`));
+        assert.match(text, /console: 0 errors, 0 uncaught exceptions/);
+        assert.match(text, /handoff: the shim hands frames to the bundle in its own flush task/);
+        // The attribution labels the instrument's wrappers for what runs inside them, never for its file, and
+        // the handler row no longer claims the bundle. A delivery of 50 ms or more is a long animation frame,
+        // so when one occurred its row names the flush task (the timeline stream is small enough to have none).
+        assert.ok(!report.loaf.topScripts.some((s) => /ui-bench-instrument/.test(s.key)), `no attribution row under the instrument's file: ${JSON.stringify(report.loaf.topScripts)}`);
+        assert.doesNotMatch(text, /message handler \(shim \+ bundle\)/);
+        if (report.loaf.kind === "long-animation-frame" && Object.values(report.types).some((s) => s.bundleMs.max >= 50)) {
+          assert.match(text, /bundle handoff \(shim flush \+ bundle\) <MessagePort\.onmessage>/, `a delivery of 50 ms or more is a long animation frame, and its attribution names the flush task: ${JSON.stringify(report.loaf.topScripts)}`);
+        }
+        if (pacing.fast) assert.match(text, /note: back-to-back replay; frames queued together coalesce/);
+        else assert.doesNotMatch(text, /note: back-to-back/);
+        assert.doesNotMatch(text, /warning:/);
+        assert.doesNotMatch(text, /not caused by a wire frame/);
+        if (cpuProfile) {
+          const cp = report.cpuProfile;
+          assert.ok(cp, "a CPU profile was taken");
+          assert.deepEqual(cp.files, [cpuProfile]);
+          const raw = JSON.parse(fs.readFileSync(cpuProfile, "utf8"));
+          for (const k of ["nodes", "startTime", "endTime", "samples", "timeDeltas"]) assert.ok(k in raw, `.cpuprofile has ${k}`);
+          assert.ok(raw.samples.length > 100, `enough samples (${raw.samples.length})`);
+          assert.equal(cp.samplingIntervalUs, 500);
+          const deltas = raw.timeDeltas.slice().sort((a, b) => a - b);
+          assert.ok(deltas[deltas.length >> 1] < 750, `the profiler sampled at the requested 500 us, not V8's default millisecond (median delta ${deltas[deltas.length >> 1]} us)`);
+          assert.equal(cp.alignRefined, true, "the wrappers' samples refined the clock alignment");
+          assert.ok(cp.alignMs > 0 && cp.alignMs <= cp.alignBoundMs, `the refined uncertainty (${cp.alignMs} ms) is within the bracketing bound (${cp.alignBoundMs} ms)`);
+          assert.ok(cp.wrapperSamplesInWindows >= 0.9, `the wrappers' samples fall inside the handler, flush and delivery windows (${cp.wrapperSamplesInWindows})`);
+          assert.equal(cp.sourceMaps, true);
+          assert.deepEqual(cp.sourceMapsMissing, [], "every profiled bundle had its map beside it");
+          assert.ok(cp.sourceMapsLoaded.includes("feed.js"), cp.sourceMapsLoaded.join(", "));
+          assert.ok(!fs.readFileSync(cpuProfile, "utf8").includes("token="), "the written profile carries no serve token (the page URL's query is dropped from every frame)");
+          assert.ok(cp.topSelf.some((f) => /^ui\/webview\/\S+\.ts:\d+$/.test(f.src || "")), `source positions resolved: ${cp.topSelf.slice(0, 5).map((f) => f.src).join(", ")}`);
+          assert.ok(cp.topSelf.slice(0, 5).some((f) => f.lines && f.lines.length && f.lines[0].src), `the hottest functions name their lines: ${JSON.stringify(cp.topSelf[0].lines)}`);
+          assert.ok(cp.windows.every((w) => w.topSelf.every((f) => !f.lines)), "windows carry no line split");
+          assert.ok(cp.topSelf.length > 5 && cp.topTotal.length > 5);
+          assert.ok(cp.topSelf.some((f) => /^feed\.js:[^:]+:\d+$/.test(f.key)), `functions of the feed bundle are named: ${cp.topSelf.slice(0, 5).map((f) => f.key).join(", ")}`);
+          assert.ok(cp.topSelf.every((f) => !/^\((program|idle|garbage collector|root)\)$/.test(f.key)), "bookkeeping nodes are not ranked");
+          assert.ok(cp.topTotal[0].totalMs >= cp.topSelf[0].selfMs);
+          const labels = cp.windows.map((w) => w.label);
+          assert.ok(labels.some((l) => l.split(" + ").includes("first content frame")), labels.join(", "));
+          assert.ok(labels.some((l) => l.split(" + ").includes("largest delta:feed")), labels.join(", "));
+          const first = cp.windows.find((w) => w.label.split(" + ").includes("first content frame"));
+          assert.equal(first.type, "feed");
+          assert.equal(first.window, "delivery", "the window is the delivery that carried the frame, where the bundle's render runs");
+          assert.ok(first.windowMs > first.handlerMs, `the delivery (${first.windowMs} ms) outweighs the shim's handler (${first.handlerMs} ms)`);
+          assert.ok(first.samples > 0 && first.topSelf.length > 0, "the first frame's delivery window has samples");
+          assert.ok(Math.abs(first.sampledMs - first.windowMs) <= Math.max(5, first.windowMs * 0.25), `the window's sampled time (${first.sampledMs}) tracks the delivery's time (${first.windowMs})`);
+          assert.ok(first.topSelf.some((f) => /^feed\.js:/.test(f.key)), `the bundle's functions are what the window holds: ${first.topSelf.slice(0, 3).map((f) => f.key).join(", ")}`);
+          assert.match(text, /cpu profile: \d+ samples over/);
+          assert.match(text, /window: first content frame[^\n]*\(feed, [^\n]*: delivery [\d.]+ ms, shim handler [\d.]+ ms/);
+        } else {
+          assert.equal(report.cpuProfile, undefined);
+        }
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+}
+
+test("replay: a delta the shim refuses stays the shim's, and a frame the pane throws on is reported as an uncaught exception", { ...gate(skipReplay), timeout: 180_000 }, async () => {
+  requireOrSkip(skipReplay);
+  // The synthetic feed stream with its LAST delta's base set to a revision the pane does not hold (so the shim
+  // answers needSlot, which nothing answers in a replay, and only that one delta is refused), then one more full
+  // frame whose first cards lack the recency tint feed.ts destructures. The pane's handler runs inside the
+  // MessageEvent federation re-dispatches, and a listener's exception is reported to the page, not thrown to the
+  // dispatcher, so it surfaces as an uncaught exception and not as a delivery error (the instrument test above
+  // covers a delivery that throws to its caller).
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-replay-bad-"));
+  try {
+    const frames = synthesizeFrames("feed", 40);
+    const deltas = frames.map((f, i) => [f, i]).filter(([f]) => classifyFrame(f.data) === "delta:feed");
+    const [last, li] = deltas[deltas.length - 1];
+    const refused = JSON.parse(last.data);
+    refused.base = 99;
+    frames[li] = { t: last.t, data: JSON.stringify(refused) };
+    const full = JSON.parse(frames[0].data);
+    const bad = { ...full, now: full.now + 100, buildId: 999, asks: full.asks.slice(0, 3).map((a) => { const c = { ...a }; delete c.trgb; return c; }) };
+    bad._keys = feedKeys(bad);
+    frames.push({ t: frames[frames.length - 1].t + 500, data: JSON.stringify(bad) });
+    const file = path.join(tmp, "feed.jsonl");
+    writeFrames(file, { synthetic: true, app: "feed" }, frames);
+    const report = await replay({ app: "feed", framesFile: file, gapMs: 50, log: () => {} });
+    assert.equal(report.clientMessages.needSlot, 1, "the pane asked for one resync");
+    const deltaRow = report.types["delta:feed"];
+    assert.equal(deltaRow.shim, 1, "the refused delta is the shim's alone");
+    assert.equal(report.perFrame[li].handoff, "shim", `the refused one is the delta whose base the pane does not hold: ${JSON.stringify(report.perFrame[li])}`);
+    // Every other delta reached the bundle, on its own or coalesced into a newer delivery of the feed's state: the
+    // shim applies a delta and queues the whole result, and a newer whole-state entry replaces an older one still
+    // queued (kernel.py _shim WHOLE), so a delta whose flush has not run when the next frame's handler runs rides
+    // in that frame's delivery. At 50 ms gaps that takes a stalled renderer, which a loaded runner supplies now
+    // and then (one delta of 23 on one CI run), so the split between delivered and coalesced is the scheduler's;
+    // the sum is the invariant.
+    assert.equal(deltaRow.delivered + deltaRow.coalesced, deltaRow.count - 1, `every other delta reached the bundle, on its own or coalesced into a newer delivery: ${JSON.stringify(deltaRow)}`);
+    assert.equal(report.types.feed.count, 2);
+    // The first full frame can coalesce the same way; the throwing frame is the stream's last, so nothing newer can
+    // replace it: it was delivered on its own (the shim does not know the pane threw).
+    assert.equal(report.types.feed.delivered + report.types.feed.coalesced, 2, `both full frames reached the bundle: ${JSON.stringify(report.types.feed)}`);
+    assert.equal(report.perFrame[frames.length - 1].handoff, "delivered", `the throwing frame was delivered on its own: ${JSON.stringify(report.perFrame[frames.length - 1])}`);
+    assert.equal(report.handoff.queued, 0);
+    assert.equal(report.handoff.delivered + report.handoff.coalesced + report.handoff.shim, frames.length, "every frame accounted for");
+    assert.equal(report.handoff.queueDrained, true);
+    assert.ok(report.console.pageErrors.length >= 1, `the pane's exception was collected: ${JSON.stringify(report.console)}`);
+    assert.match(report.console.pageErrors[0], /iterable|trgb|undefined/);
+    assert.deepEqual(report.handoff.deliveryErrors, [], "the listener's exception did not propagate to the delivery");
+    const text = renderReport(report);
+    assert.match(text, /console: 0 errors, 1 uncaught exceptions/);
+    assert.match(text, /\n  uncaught: .*iterable/);
+    assert.match(text, /messages the pane sent: .*needSlot 1/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("replay: --iters pools runs and --cpu-throttle slows the page", { ...gate(skipReplay), timeout: 180_000 }, async () => {
+  requireOrSkip(skipReplay);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "romp-ui-bench-replay-iters-"));
+  try {
+    const frames = synthesizeFrames("timeline", 40);
+    const file = path.join(tmp, "timeline.jsonl");
+    writeFrames(file, { synthetic: true, app: "timeline" }, frames);
+    const pooled = await replay({ app: "timeline", framesFile: file, fast: true, iters: 2, log: () => {} });
+    assert.equal(pooled.iters, 2);
+    assert.equal(pooled.perFrame, undefined, "pooled runs carry no single per-frame list");
+    assert.equal(pooled.types.bars.count, 1, "a per-run count");
+    assert.equal(pooled.types.bars.settleMs.n, 2, "samples pooled over both runs");
+    assert.equal(pooled.types.data.count, 4);
+    assert.equal(pooled.types.data.settleMs.n, 8);
+    assert.match(renderReport(pooled), /^ui-bench timeline: 36 frames, [\d.]+ KB, replay [\d.]+ ms \(back-to-back\), cpu x1, 2 iterations/);
+    // Chromium's CPU throttle is a deterministic emulation (the renderer's main thread runs a quarter of the time),
+    // so the cumulative script time of the same replay grows by about the rate; the floor is half of it, wide enough
+    // for a loaded runner that inflates the unthrottled run (measured 2.3 to 4.2 here).
+    const slow = await replay({ app: "timeline", framesFile: file, fast: true, iters: 1, cpuThrottle: 4, log: () => {} });
+    assert.equal(slow.cpuThrottle, 4);
+    assert.match(renderReport(slow), /cpu x4, 1 iteration,/);
+    assert.ok(slow.end.scriptMs >= 1.5 * pooled.end.scriptMs, `script time under a 4x throttle (${slow.end.scriptMs} ms) against unthrottled (${pooled.end.scriptMs} ms)`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -10,9 +10,11 @@ same copy and `--compare` prints the per-benchmark deltas.
 
 Usage (every path below is an example; the copy lives OUTSIDE any repo):
 
-    # 1. copy the state directory, leaving out the SDK venv (hundreds of MB, not data) and the two
-    #    credential files the bench never needs
+    # 1. copy the state directory, leaving out the SDK venv (hundreds of MB, not data) and the
+    #    credential files the bench never needs (MIRROR_IGNORE below: the serve token, the Web Push key
+    #    and subscriptions, the remote kernels' tokens)
     rsync -a --exclude sdkvenv --exclude serve-token --exclude push-vapid.json \\
+        --exclude push-subscriptions.json --exclude remotes.json \\
         ~/.local/state/romp/ /tmp/romp-state-copy/
     #    transcripts are read from Claude's own directory; for a strict A/B (an active session's
     #    transcript grows between runs) copy that too and pass --claude-dir:
@@ -27,7 +29,7 @@ Usage (every path below is an example; the copy lives OUTSIDE any repo):
 
 The tool REFUSES the live default state directory ($ROMP_STATE_DIR, $XDG_STATE_HOME/romp, or
 ~/.local/state/romp) unless `--i-know-this-is-live` is passed — and even then it never runs the
-kernel against that directory: it mirrors the directory to a fresh temp copy (sdkvenv and the two
+kernel against that directory: it mirrors the directory to a fresh temp copy (sdkvenv and the
 credential files excluded) and benches the mirror, so the live directory is only ever read. The
 mirror is removed afterwards unless `--keep-mirror`.
 
@@ -108,7 +110,9 @@ error, never a silent skip):
     is set to a dead port rather than unset — an ABSENT value maps to the default, live, port in
     one consumer; see tests/conftest.py), so nothing this process does can reach the live manager.
   * ROMP_MODEL_CATALOG=off, ROMP_CLI_SCOPE=0, ROMP_CLAUDE_BIN=/bin/false, the service env file
-    pointed at a missing path, every ANTHROPIC_* variable removed.
+    pointed at a missing path, and every key-source and credential name tests/conftest.py pops removed
+    (KEY_SOURCE_ENV below: the API keys, the key reference and command, the token credentials, the auth
+    declaration and 1Password's names, plus every ANTHROPIC_* and OP_SESSION_* name).
   * Functions that would start a network fetch, a background parse thread, a desktop notification,
     a Web Push or a badge push are replaced with recorders (they are not builders; the push path
     reaches them from _cached_feed and the pricing table).
@@ -116,6 +120,9 @@ error, never a silent skip):
     except the kernel's read-only local git queries: `git rev-parse` and `git ls-files` (the chat
     build's path-link pass) and the pair `git remote get-url` (the file-link route; the pair only —
     `git remote` also has writing subcommands, and those trip). Those run and are counted per build.
+    "Every loaded romp module" is the kernel, the judge, the event model, the SDK backend, and every
+    sibling kernel/ module one of them loaded (keysource among them); the report's `neutralized` list
+    names each one.
     The kernel caches their answers only for a cwd inside a git checkout (on the index and tree
     mtimes, and the config file's mtime for the remote); for any other cwd it re-runs `git ls-files`
     on EVERY build, so the per-build count beside the build_session rows says how much of a sample is
@@ -125,6 +132,10 @@ error, never a silent skip):
     glibc consult the name service — AF_UNIX connects to nscd and systemd-userdb, local, not network.
   * Every kernel _atomic_write is checked to land under the state copy; the copy's files are
     fingerprinted before and after so the output lists exactly what the run wrote.
+  * A guard that trips inside a call the kernel CATCHES is still an error: _push wraps its whole build in
+    `except Exception` and returns, so a refused spawn or write during the push rows would otherwise be
+    timed as an aborted cycle and the run would exit 0. Every refusal is recorded before it raises, and a
+    run that ends with one on record fails naming the guard (check_guards_held).
 
 Verification: run once under `strace -f -e trace=execve,connect`. Expected: the interpreter's own
 execve, plus (without `--no-git`) one execve of git per counted git query and nothing else; connect()
@@ -155,8 +166,14 @@ from pathlib import Path
 
 SCHEMA = 2
 DEFAULT_CLIENTS = "chat,feed,timeline"
+_TOOL_FILE = os.path.realpath(__file__)          # the tripwire's frame filter excludes this file, by path
 PROFILE_TOP = 25
-MIRROR_IGNORE = ("sdkvenv", "serve-token", "push-vapid.json")
+# What a mirror of the live directory (and the rsync recipe above) leaves out: the SDK venv, and every file the
+# kernel writes 0600 because it holds a credential: the serve token, the Web Push VAPID key, the Web Push
+# subscriptions (each carries a browser's auth secret) and the remote kernels' serve tokens. The bench reads
+# none of them (the notification functions are recorders; remotes are re-attached only at kernel boot); the
+# first form of this list copied the last two into every mirror (review find, 2026-09-08).
+MIRROR_IGNORE = ("sdkvenv", "serve-token", "push-vapid.json", "push-subscriptions.json", "remotes.json")
 # The kernel-side caches a freshly started kernel lacks and build_session reads (all plain dicts, no
 # lock). Missing names are skipped: older revisions lack some, and the assembly-counter check below
 # is what proves a sample cold, not this list.
@@ -166,11 +183,23 @@ COLD_KERNEL_CACHES = ("_parse_cache", "_built_chat", "_prev_chat_events", "_prev
                       "_machine_cut_cache")
 # (cache, its lock) in the event model: the parse layer under _parse. Missing names are skipped here too
 # (the trailing-record cache is newer than the assembly counters this tool requires); cold_caches in the
-# report says which of both lists were emptied, and the test pins that list at HEAD.
+# report says which of both lists were emptied, and tests/test_perf_bench.py checks the ones the cold
+# proof rests on.
 COLD_EM_CACHES = (("_JSONL_CACHE", "_JSONL_CACHE_LOCK"), ("_ASM_CACHE", "_ASM_LOCK"), ("_TRAILING_CACHE", "_TRAILING_LOCK"))
 WORLD_KEYS = (("liveness.live", "live rows"), ("live_transcripts.count", "transcripts"), ("iters", "iters"),
               ("sessions_requested", "sessions"), ("git_queries.answered_as_failure", "no-git"),
-              ("push_rebuilds", "push_steady rebuild samples"))
+              ("push_rebuilds", "push_steady rebuild samples"),
+              ("error", "run error"))      # a run that stopped on a guard is flagged before its rows are diffed
+# Every key-source and credential name tests/conftest.py pops before any test runs (its KEY_SOURCE_ENV_NAMES
+# and KEY_SOURCE_ENV_PREFIXES: keysource.SOURCE_VARS, sdk_backend.AUTH_ENV_NAMES, the auth declaration,
+# keysource.OP_ENV_NAMES and OP_ENV_PREFIX), removed here before the import for the same reason: every shell
+# under a romp-managed session inherits the manager's credentials, and keysource selects a key COMMAND or
+# REFERENCE straight from the environment when the isolated env file is absent. The first form dropped
+# ANTHROPIC_* only (review find, 2026-09-08); tests/test_perf_bench.py pins this list against the kernel's
+# own constants.
+KEY_SOURCE_ENV = ("ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+                  "ROMP_EXPECTED_AUTH", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT")
+KEY_SOURCE_ENV_PREFIXES = ("ANTHROPIC_", "OP_SESSION_")
 
 
 class BenchError(Exception):
@@ -239,7 +268,7 @@ def prepare_env(state, claude_dir, private_dir):
         if k in os.environ:
             os.environ.pop(k)
             changes.append("unset " + k)
-    for k in [k for k in os.environ if k.startswith("ANTHROPIC_")]:
+    for k in [k for k in os.environ if k in KEY_SOURCE_ENV or k.startswith(KEY_SOURCE_ENV_PREFIXES)]:
         os.environ.pop(k)
         changes.append("unset " + k)
     tmux_dir = os.path.join(private_dir, "tmux")
@@ -311,7 +340,10 @@ class SubprocessTripwire:
                     if self._no_git:
                         return self._real.CompletedProcess(argv, 1, "" if k.get("text") else b"", "" if k.get("text") else b"")
                     return self._real.run(*a, **k)
-                where = [fr for fr in traceback.extract_stack()[:-1] if "perf-bench" not in fr.filename][-4:]
+                # the caller's frames, this file's own excluded by identity: a substring match on the tool's name
+                # emptied the attribution for any checkout or state path that spelled it (found by the test whose
+                # scratch kernel lives under a perf-bench-* directory, 2026-09-08)
+                where = [fr for fr in traceback.extract_stack()[:-1] if os.path.realpath(fr.filename) != _TOOL_FILE][-4:]
                 via = " <- ".join("%s:%d %s" % (os.path.basename(fr.filename), fr.lineno, fr.name) for fr in reversed(where))
                 self._log.append("subprocess.%s %r via %s" % (name, argv, via))
                 raise BenchError("perf-bench tripwire: subprocess.%s called (argv %r) via %s" % (name, argv, via))
@@ -323,8 +355,8 @@ def install_guards(km, sbmod, no_git=False):
     """Neutralize the non-builder side effects the push path can reach; return (names, recorder).
     A safety target the kernel revision lacks is an error: a renamed notification function would
     otherwise leave the real one in place (Web Push to every subscription in the copy's store)."""
-    rec = {"spawns": [], "notifications": [], "atomic_writes": [], "tripwires": [], "nss": {}, "warm_calls": [],
-           "thread_starts": 0}
+    rec = {"spawns": [], "notifications": [], "atomic_writes": [], "refused_writes": [], "tripwires": [], "nss": {},
+           "warm_calls": [], "thread_starts": 0}
     names = []
 
     def stub(attr, fn):
@@ -343,8 +375,19 @@ def install_guards(km, sbmod, no_git=False):
     stub("_push_notify", lambda t, b, *a, **k: rec["notifications"].append(("push", t)))
     stub("_push_forward", lambda evs, *a, **k: rec["notifications"].append(("forward", len(evs))))
     stub("_badge_push", lambda n, *a, **k: rec["notifications"].append(("badge", n)))
-    for mod in (km, getattr(km, "jd", None), getattr(km, "em", None), sbmod):
-        if mod is not None and getattr(mod, "subprocess", None) is not None:
+    # Every loaded romp module: the four the harness drives, plus every sibling of kernel.py that one of them
+    # loaded (sdk_backend loads keysource, whose key command is a subprocess). The first form guarded the four
+    # only, while the docstring promised every loaded module (review find, 2026-09-08).
+    mods = [km, getattr(km, "jd", None), getattr(km, "em", None), sbmod]
+    kfile = getattr(km, "__file__", None)
+    if isinstance(kfile, str):
+        kdir = os.path.dirname(os.path.realpath(kfile))
+        for m in list(sys.modules.values()):
+            f = getattr(m, "__file__", None)
+            if isinstance(f, str) and os.path.dirname(os.path.realpath(f)) == kdir and not any(m is x for x in mods):
+                mods.append(m)
+    for mod in mods:
+        if mod is not None and isinstance(getattr(mod, "subprocess", None), type(sys)):
             tw = SubprocessTripwire(_real_subprocess, rec["spawns"], no_git=no_git)
             mod.subprocess = tw
             rec["tripwires"].append(tw)
@@ -355,6 +398,7 @@ def install_guards(km, sbmod, no_git=False):
     def guarded(path, text, mode=None):
         p = Path(path).resolve()
         if state not in p.parents and p != state:
+            rec["refused_writes"].append(str(p))      # on record BEFORE the raise: _push swallows the exception
             raise BenchError("perf-bench: _atomic_write outside the state copy: %s" % p)
         rec["atomic_writes"].append(str(p.relative_to(state)))
         return real_aw(path, text, mode) if mode is not None else real_aw(path, text)
@@ -378,6 +422,26 @@ def install_guards(km, sbmod, no_git=False):
         return real_start(self, *a, **k)
     threading.Thread.start = counted_start
     return names, rec
+
+
+def check_guards_held(rec):
+    """A guard that tripped is an error even when the kernel caught it. The tripwire and the write guard raise
+    BenchError, but _push wraps its whole build in `except Exception` (it writes `push build: <traceback>` to
+    stderr and returns), so a spawn or an out-of-copy write attempted during the push rows was refused and the
+    cycle went on, timed with its frames dropped, while the run exited 0 with no `error` in the JSON (review
+    find, 2026-09-08). Every refusal is recorded before its raise, so an entry still on record at the end of
+    the run means a caller swallowed it; the run then ends the way any other tripped guard ends it (the rows
+    so far print, the JSON carries `error`, the exit status is 1), naming the guard."""
+    spawns, writes = rec["spawns"], rec["refused_writes"]
+    if not spawns and not writes:
+        return
+    what = []
+    if spawns:
+        what.append("subprocess tripwire: %d refused spawn(s): %s" % (len(spawns), "; ".join(spawns[:3]) + ("; ..." if len(spawns) > 3 else "")))
+    if writes:
+        what.append("_atomic_write guard: %d refused write(s) outside the copy: %s" % (len(writes), ", ".join(writes[:3]) + (", ..." if len(writes) > 3 else "")))
+    raise BenchError("a guard tripped inside a call the kernel catches (its traceback is on stderr under `push build:`), so the "
+                     "push rows timed an aborted cycle; " + "; ".join(what))
 
 
 def git_calls_total(rec):
@@ -1035,6 +1099,8 @@ def run(args, state, mirror_of, out, private):
     out["git_queries"] = {"answered_as_failure": bool(args.no_git), "calls": git_calls_total(rec)}
     out["nss_lookups"] = dict(rec["nss"])
     out["threads_new"] = sorted({t.name for t in threading.enumerate()} - threads_before)
+    out["refused_writes"] = list(rec["refused_writes"])
+    check_guards_held(rec)
     return out
 
 
@@ -1107,9 +1173,9 @@ def render_text(out, profile):
     if cc:
         L.append("caches emptied before each cold build_session sample: kernel %s; event model %s"
                  % (", ".join(cc.get("kernel") or []) or "none", ", ".join(cc.get("event_model") or []) or "none"))
-    L.append("notifications suppressed: %d; background parses suppressed: %d; refused spawns: %d; threads started: %d; new threads: %s"
+    L.append("notifications suppressed: %d; background parses suppressed: %d; refused spawns: %d; refused writes: %d; threads started: %d; new threads: %s"
              % (out.get("notifications_suppressed", 0), out.get("warm_calls_suppressed", 0), len(out.get("spawn_attempts", [])),
-                out.get("thread_starts", 0), out.get("threads_new") or "none"))
+                len(out.get("refused_writes", [])), out.get("thread_starts", 0), out.get("threads_new") or "none"))
     if profile and out.get("profiles"):
         for name, p in out["profiles"].items():
             L.append("")

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -1,0 +1,1238 @@
+#!/usr/bin/env python3
+"""perf-bench — offline timing of the romp kernel's payload builders against a COPY of a state directory.
+
+The live kernel's pusher thread spends most of a core rebuilding payloads: build_session (chat),
+build_feed, build_timeline (kernel/kernel.py) and jd.load_goals (kernel/judge.py). This tool imports a
+checkout's kernel IN-PROCESS, points it at a state directory copy, reconstructs the pusher's liveness
+snapshot from that copy's registry files, and times each builder on real-sized data — with no live
+kernel, no restart, no network, no WebSocket. Two checkouts (HEAD and a candidate) run against the
+same copy and `--compare` prints the per-benchmark deltas.
+
+Usage (every path below is an example; the copy lives OUTSIDE any repo):
+
+    # 1. copy the state directory, leaving out the SDK venv (hundreds of MB, not data) and the two
+    #    credential files the bench never needs
+    rsync -a --exclude sdkvenv --exclude serve-token --exclude push-vapid.json \\
+        ~/.local/state/romp/ /tmp/romp-state-copy/
+    #    transcripts are read from Claude's own directory; for a strict A/B (an active session's
+    #    transcript grows between runs) copy that too and pass --claude-dir:
+    rsync -a ~/.claude/projects/ /tmp/claude-copy/projects/
+
+    # 2. bench this checkout, then a candidate checkout, against the same copy
+    tools/perf-bench.py --state /tmp/romp-state-copy --profile --json /tmp/bench-head.json
+    tools/perf-bench.py --state /tmp/romp-state-copy --repo ../romp-candidate --json /tmp/bench-cand.json
+
+    # 3. deltas, A -> B (the header flags any difference in the two runs' worlds first)
+    tools/perf-bench.py --compare /tmp/bench-head.json /tmp/bench-cand.json
+
+The tool REFUSES the live default state directory ($ROMP_STATE_DIR, $XDG_STATE_HOME/romp, or
+~/.local/state/romp) unless `--i-know-this-is-live` is passed — and even then it never runs the
+kernel against that directory: it mirrors the directory to a fresh temp copy (sdkvenv and the two
+credential files excluded) and benches the mirror, so the live directory is only ever read. The
+mirror is removed afterwards unless `--keep-mirror`.
+
+What is measured. Unless noted, each row is one untimed warm-up call followed by `--iters` timed
+calls, reported as ms min/median/max:
+  liveness_snapshot      Sessions.live() — the pusher cycle's one liveness read (tmux backend off)
+  names_snapshot         _names_snapshot() — the cycle's names-registry read
+  discover_cold/warm     jd.discover(now) with and without its fingerprint cache
+  build_session_cold:S   build_session for each of the K largest live transcripts with EVERY cache a
+                         freshly started kernel lacks emptied before each call: the event model's
+                         jsonl / assembly / trailing-record caches and the kernel's parse, chat-fold,
+                         path-link and states-fold caches (COLD_KERNEL_CACHES and COLD_EM_CACHES below; a
+                         name this kernel lacks is skipped and the report lists what was emptied). Each
+                         sample is then checked: the event model's assembly counters must show a full
+                         assembly, and the session's own transcript must be present in the assembly
+                         cache the sample started with empty — proof it was assembled inside the
+                         sample. A sample that fails either is an ERROR, not a number, so a cache this
+                         tool does not know about (above or below the parse) is caught instead of
+                         quietly warming the row. A serve or fold counted INSIDE a sample is reported
+                         beside the row, not treated as pre-warmth: with the cache emptied under its
+                         lock beforehand, such a hit can only be on an entry the same build created — a
+                         transcript the build reads twice (a peer's, for postal resolution), folded
+                         when that file grew between the two reads (a live session's).
+  build_session_emwarm:S the same call with only the kernel-side caches emptied — the event model
+                         still serves the assembled transcript. The difference to _cold is the parse.
+  build_session_warm:S   the same call again with everything cached (an unchanged tab's push)
+  warm_all_parses        one _parse() per live session from an empty parse cache (single call)
+  build_feed             build_feed with every live session's parse cached (the steady state)
+  build_feed_noparse     build_feed with the parse cache empty (the cards-first boot shape)
+  build_timeline_bars    build_timeline(with_bars=True)
+  build_timeline_skel    build_timeline(with_bars=False) — the lanes skeleton the push sends first
+  load_goals:S           jd.load_goals for each of the K largest goal stores
+  push_cold_cycle        ONE periodic _push over the fake clients with every cache empty and empty
+                         dedup state: the pusher's first cycle after a restart (single call, no
+                         warm-up). Reports the full frames' bytes per slot.
+  push_connect:APP       _push([fresh client], connect=True) per app after a warming cycle: the path
+                         a page load pays (pusher-warmed feed served, no baseline move). A fresh
+                         client with empty dedup state for every sample.
+  push_steady            the periodic _push over the same clients, repeated; no warm-up of its own
+                         (it follows the rows above). Each sample records whether _cached_feed /
+                         _cached_timeline rebuilt inside it (they do whenever the 5 s view signature
+                         bucket rolls at least REBUILD_MIN_S after the previous build, which depends on
+                         wall-clock alignment, not on the code under test); the row's numbers are the
+                         samples WITHOUT a rebuild, and the samples with one form push_steady_rebuild.
+                         The loop runs until `--iters` no-rebuild samples exist (at most 3x iters).
+                         A loop that runs past _DEDUP_REPOST_S (60 s) also absorbs one re-send of every
+                         unchanged slot; the per-sample bytes in the JSON show it.
+Beside the build_session rows the report prints the git queries the chat build ran per call (see the
+tripwire note below); the push rows report bytes handed to each fake client per slot.
+
+How the liveness snapshot is reconstructed, and what is approximated:
+  * The SDK backend object is built WITHOUT its constructor (no boot heal, no reconcile thread, no
+    key claim, no scope probe): a subclass allocated with __new__ and given only the attributes the
+    read-side methods use. Its live_sessions() reads sdk/<sid>.json exactly as the real backend does
+    for a session with no running thread (_live_row), so every reg with alive=true is a live row.
+  * The state of each row is the last STATE record of states/<sid>.jsonl, verbatim, and the row is
+    marked connected — what a running session would report — instead of the dormant mapping that
+    turns an in-flight state into "waiting". `--dormant-rows` keeps the dormant mapping instead.
+    A running session's snapshot also carries live-only fields (subagents, bgTasks); those read
+    empty here. ctxTokens and the context percentage come from the reg's persisted values, as for a
+    dormant row. `--all-regs-live` also lists regs with alive=false.
+  * The tmux backend is switched off (ROMP_TMUX_AVAILABLE=0, the kernel's own seam) and TMUX_TMPDIR
+    points at an empty private directory, so no `tmux` is ever run and tmux-backed sessions are not
+    represented. Comment threads (threadOf regs) are skipped, as the real live_sessions skips them.
+  * The SDK backend's manager key is pinned empty (dormant rows read auth=login).
+  * The session list is discovery's (jd.discover, a 48 h window keyed to the real clock) restricted to
+    the live rows, plus — as _alive_sessions does for the builders — every live sid outside that
+    window resolved through the long backfill window, so the pick list, the parse warm-up and the
+    builders see ONE world. A live sid with no transcript anywhere is listed in the report; a run
+    where discovery finds nothing for a non-empty live set is an error (a wrong --claude-dir, a
+    registry cwd that does not exist here, or a stale copy).
+  * Transcripts are read from Claude Code's own directory ($CLAUDE_CONFIG_DIR or ~/.claude), which
+    the registry references; `--claude-dir` points at a copy or a synthetic one.
+
+Side-effect guards (all reported in the output; a guard whose target a kernel revision lacks is an
+error, never a silent skip):
+  * The manager control-port variables are removed or poisoned before the import (ROMP_MANAGER_PORT
+    is set to a dead port rather than unset — an ABSENT value maps to the default, live, port in
+    one consumer; see tests/conftest.py), so nothing this process does can reach the live manager.
+  * ROMP_MODEL_CATALOG=off, ROMP_CLI_SCOPE=0, ROMP_CLAUDE_BIN=/bin/false, the service env file
+    pointed at a missing path, every ANTHROPIC_* variable removed.
+  * Functions that would start a network fetch, a background parse thread, a desktop notification,
+    a Web Push or a badge push are replaced with recorders (they are not builders; the push path
+    reaches them from _cached_feed and the pricing table).
+  * `subprocess` in every loaded romp module is replaced with a tripwire that raises on any spawn —
+    except the kernel's read-only local git queries: `git rev-parse` and `git ls-files` (the chat
+    build's path-link pass) and the pair `git remote get-url` (the file-link route; the pair only —
+    `git remote` also has writing subcommands, and those trip). Those run and are counted per build.
+    The kernel caches their answers only for a cwd inside a git checkout (on the index and tree
+    mtimes, and the config file's mtime for the remote); for any other cwd it re-runs `git ls-files`
+    on EVERY build, so the per-build count beside the build_session rows says how much of a sample is
+    spawn time. `--no-git` answers those queries as failures instead, for a strict zero-exec run.
+  * pwd.getpwnam / pwd.getpwuid are wrapped as counters (nss_lookups in the output): the chat build's
+    path-link pass calls os.path.expanduser on every path-shaped token, and a `~name/...` token makes
+    glibc consult the name service — AF_UNIX connects to nscd and systemd-userdb, local, not network.
+  * Every kernel _atomic_write is checked to land under the state copy; the copy's files are
+    fingerprinted before and after so the output lists exactly what the run wrote.
+
+Verification: run once under `strace -f -e trace=execve,connect`. Expected: the interpreter's own
+execve, plus (without `--no-git`) one execve of git per counted git query and nothing else; connect()
+calls only to AF_UNIX name-service sockets (/var/run/nscd/socket, /run/systemd/userdb/...), matching
+nss_lookups in the report, and NO AF_INET / AF_INET6 connect:
+    strace -f -e trace=execve,connect -o /tmp/bench.strace tools/perf-bench.py --state ... --no-git
+    grep -E 'execve\\(|AF_INET' /tmp/bench.strace     # one execve line (python), no AF_INET line
+
+Not a test (pytest collects test_*.py); tests/test_perf_bench.py drives it against a synthetic state
+directory."""
+import argparse
+import cProfile
+import gc
+import json
+import os
+import pstats
+import pwd
+import re
+import shutil
+import statistics
+import subprocess as _real_subprocess
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = 2
+DEFAULT_CLIENTS = "chat,feed,timeline"
+PROFILE_TOP = 25
+MIRROR_IGNORE = ("sdkvenv", "serve-token", "push-vapid.json")
+# The kernel-side caches a freshly started kernel lacks and build_session reads (all plain dicts, no
+# lock). Missing names are skipped: older revisions lack some, and the assembly-counter check below
+# is what proves a sample cold, not this list.
+COLD_KERNEL_CACHES = ("_parse_cache", "_built_chat", "_prev_chat_events", "_prev_chat_ledger", "_arch_tops_cache",
+                      "_PATH_LINK_CACHE", "_states_notes_cache", "_state_ev_cache", "_bgtasks_cache", "_bgall_cache",
+                      "_queued_parse_cache", "_wake_tail_cache", "_session_meta_cache", "_session_tok_cache",
+                      "_machine_cut_cache")
+# (cache, its lock) in the event model: the parse layer under _parse. Missing names are skipped here too
+# (the trailing-record cache is newer than the assembly counters this tool requires); cold_caches in the
+# report says which of both lists were emptied, and the test pins that list at HEAD.
+COLD_EM_CACHES = (("_JSONL_CACHE", "_JSONL_CACHE_LOCK"), ("_ASM_CACHE", "_ASM_LOCK"), ("_TRAILING_CACHE", "_TRAILING_LOCK"))
+WORLD_KEYS = (("liveness.live", "live rows"), ("live_transcripts.count", "transcripts"), ("iters", "iters"),
+              ("sessions_requested", "sessions"), ("git_queries.answered_as_failure", "no-git"),
+              ("push_rebuilds", "push_steady rebuild samples"))
+
+
+class BenchError(Exception):
+    pass
+
+
+# ── argument parsing ────────────────────────────────────────────────────────────────────────────
+def parse_args(argv):
+    ap = argparse.ArgumentParser(prog="perf-bench", description=__doc__.split("\n\n")[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--state", help="a COPY of a romp state directory (see the module docstring)")
+    ap.add_argument("--repo", help="the checkout whose kernel to bench (default: the one this script lives in)")
+    ap.add_argument("--claude-dir", help="CLAUDE_CONFIG_DIR for the run: where transcripts (projects/) live")
+    ap.add_argument("--iters", type=int, default=5, help="timed calls per benchmark after one warm-up (default 5)")
+    ap.add_argument("--sessions", type=int, default=5, help="how many of the largest transcripts / goal stores to bench (default 5)")
+    ap.add_argument("--clients", default=DEFAULT_CLIENTS,
+                    help="fake client apps for the push benchmarks, comma-separated (default %s); empty skips them" % DEFAULT_CLIENTS)
+    ap.add_argument("--profile", action="store_true", help="cProfile one call per builder; print the top %d by cumulative and by tottime" % PROFILE_TOP)
+    ap.add_argument("--json", help="write the machine-readable result here")
+    ap.add_argument("--compare", nargs=2, metavar=("A.json", "B.json"), help="print per-benchmark deltas A -> B and exit")
+    ap.add_argument("--no-git", action="store_true",
+                    help="answer the kernel's read-only git queries (rev-parse, ls-files, remote get-url) as failures instead of running git")
+    ap.add_argument("--dormant-rows", action="store_true", help="liveness rows exactly as a restarted kernel reports dormant sessions")
+    ap.add_argument("--all-regs-live", action="store_true", help="treat regs with alive=false as live too")
+    ap.add_argument("--i-know-this-is-live", action="store_true",
+                    help="allow --state to name the live default state directory; it is mirrored to a temp copy first")
+    ap.add_argument("--keep-mirror", action="store_true", help="keep the temp mirror of a live directory (default: removed at exit)")
+    return ap.parse_args(argv)
+
+
+# ── live-directory refusal ──────────────────────────────────────────────────────────────────────
+def live_state_dirs(env):
+    """Every path the CALLER's environment would resolve as the live state directory."""
+    out = set()
+    if env.get("ROMP_STATE_DIR"):
+        out.add(os.path.realpath(os.path.expanduser(env["ROMP_STATE_DIR"])))
+    xdg = env.get("XDG_STATE_HOME") or "~/.local/state"
+    out.add(os.path.realpath(os.path.join(os.path.expanduser(xdg), "romp")))
+    out.add(os.path.realpath(os.path.expanduser("~/.local/state/romp")))
+    return out
+
+
+def mirror_state(src):
+    """Copy `src` (sdkvenv and the credential files excluded) into a fresh temp directory; return
+    (root, copy). A file that vanished between the directory listing and its copy — a live kernel's
+    atomic-write temp file — is tolerated; any other copy error is raised."""
+    root = tempfile.mkdtemp(prefix="romp-perf-live-mirror-")
+    dst = os.path.join(root, "romp")
+    try:
+        shutil.copytree(src, dst, symlinks=True, ignore=shutil.ignore_patterns(*MIRROR_IGNORE))
+    except shutil.Error as e:
+        errors = e.args[0] if e.args and isinstance(e.args[0], list) else []
+        if not errors or not all(("[Errno 2]" in str(why)) or ("No such file" in str(why)) for _s, _d, why in errors):
+            shutil.rmtree(root, ignore_errors=True)       # a half-made mirror is not benched; leave nothing behind
+            raise
+        sys.stderr.write("perf-bench: %d file(s) vanished during the mirror copy (a live writer's temp files); continuing\n" % len(errors))
+    return root, dst
+
+
+# ── environment for the in-process kernel ───────────────────────────────────────────────────────
+def prepare_env(state, claude_dir, private_dir):
+    """Rewrite os.environ for the kernel import. Returns the list of applied changes (for the report)."""
+    changes = []
+    for k in ("ROMP_SERVE_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "TMUX", "TMUX_PANE",
+              "ROMP_SID", "ROMP_SESSION_NAME", "ROMP_STATE_DIR"):
+        if k in os.environ:
+            os.environ.pop(k)
+            changes.append("unset " + k)
+    for k in [k for k in os.environ if k.startswith("ANTHROPIC_")]:
+        os.environ.pop(k)
+        changes.append("unset " + k)
+    tmux_dir = os.path.join(private_dir, "tmux")
+    os.makedirs(tmux_dir, exist_ok=True)          # tmux falls back to the default socket dir when this is missing
+    no_env = os.path.join(private_dir, "no-such-service.env")
+    sets = {
+        "ROMP_MANAGER_PORT": "1",                 # a dead port: absent maps to the default (live) port in _run_main_update
+        "ROMP_KERNEL_NO_OPEN": "1",
+        "ROMP_MODEL_CATALOG": "off",
+        "ROMP_CLI_SCOPE": "0",
+        "ROMP_CLAUDE_BIN": "/bin/false",
+        "ROMP_TMUX_AVAILABLE": "0",
+        "TMUX_TMPDIR": tmux_dir,
+        "ROMP_SERVE_TOKEN": "perf-bench-token-not-for-use",
+        "ROMP_SERVICE_ENV_FILE": no_env,
+        "ROMP_SERVICE_ENV": no_env,
+        "ROMP_STATE_DIR": state,
+        "XDG_STATE_HOME": os.path.dirname(state),
+    }
+    if claude_dir:
+        sets["CLAUDE_CONFIG_DIR"] = claude_dir
+    for k, v in sets.items():
+        os.environ[k] = v
+        changes.append("set %s" % k)
+    return changes
+
+
+# ── side-effect tripwires ───────────────────────────────────────────────────────────────────────
+class SubprocessTripwire:
+    """Stands in for the `subprocess` module inside the loaded romp modules: constants and helpers pass
+    through; every spawn raises, except the kernel's read-only local git queries — `git rev-parse` and
+    `git ls-files` (the chat build's path-link pass) and the pair `git remote get-url` (the file-link
+    route; the get-url pair only, never `git remote` at large, whose add/set-url/remove forms rewrite
+    config). Those are counted. With no_git they are answered as failures (the "no git on this box"
+    shape) instead of run, so a strict zero-exec run is possible without replacing any kernel function."""
+    _SPAWN = ("Popen", "run", "call", "check_call", "check_output", "getoutput", "getstatusoutput")
+    _GIT_READ_ONLY = ("rev-parse", "ls-files")          # single-word queries admitted by their subcommand
+    _GIT_READ_ONLY_PAIRS = (("remote", "get-url"),)      # two-word queries admitted only as the whole pair
+
+    def __init__(self, real, log, no_git=False):
+        self._real, self._log, self._no_git = real, log, no_git
+        self.git_calls = {}
+
+    @classmethod
+    def _git_query(cls, argv):
+        """The read-only git query `argv` spells — "rev-parse", "ls-files" or "remote get-url" (the
+        counter's key) — or None for anything else, `git remote set-url` included."""
+        if not (isinstance(argv, (list, tuple)) and argv and argv[0] == "git"):
+            return None
+        i = 1
+        while i < len(argv) and argv[i] == "-C":
+            i += 2
+        rest = tuple(argv[i:])
+        if rest and rest[0] in cls._GIT_READ_ONLY:
+            return rest[0]
+        for pair in cls._GIT_READ_ONLY_PAIRS:
+            if rest[:2] == pair:
+                return " ".join(pair)
+        return None
+
+    def __getattr__(self, name):
+        if name in self._SPAWN:
+            def refuse(*a, **k):
+                import traceback
+                argv = a[0] if a else k.get("args")
+                sub = self._git_query(argv)
+                if name == "run" and sub:
+                    self.git_calls[sub] = self.git_calls.get(sub, 0) + 1
+                    if self._no_git:
+                        return self._real.CompletedProcess(argv, 1, "" if k.get("text") else b"", "" if k.get("text") else b"")
+                    return self._real.run(*a, **k)
+                where = [fr for fr in traceback.extract_stack()[:-1] if "perf-bench" not in fr.filename][-4:]
+                via = " <- ".join("%s:%d %s" % (os.path.basename(fr.filename), fr.lineno, fr.name) for fr in reversed(where))
+                self._log.append("subprocess.%s %r via %s" % (name, argv, via))
+                raise BenchError("perf-bench tripwire: subprocess.%s called (argv %r) via %s" % (name, argv, via))
+            return refuse
+        return getattr(self._real, name)
+
+
+def install_guards(km, sbmod, no_git=False):
+    """Neutralize the non-builder side effects the push path can reach; return (names, recorder).
+    A safety target the kernel revision lacks is an error: a renamed notification function would
+    otherwise leave the real one in place (Web Push to every subscription in the copy's store)."""
+    rec = {"spawns": [], "notifications": [], "atomic_writes": [], "tripwires": [], "nss": {}, "warm_calls": [],
+           "thread_starts": 0}
+    names = []
+
+    def stub(attr, fn):
+        if not hasattr(km, attr):
+            raise BenchError("this kernel has no %s; the harness's guard list needs adjusting for this revision" % attr)
+        setattr(km, attr, fn)
+        names.append("km." + attr)
+
+    # Each recorder takes whatever the kernel passes: _push_notify is called with kind=, card_id=, quiet=
+    # and host= keywords the recorder never reads, and a shape mismatch would not fail the run. _push
+    # catches every exception in its build, writes `push build: <traceback>` to stderr and returns, so
+    # that cycle would be timed with its frames dropped and the notification count would come up short.
+    stub("_refresh_remote_prices", lambda *a, **k: None)            # network fetch thread
+    stub("_warm_fleet_bg", lambda *a, **k: rec["warm_calls"].append(time.time()))   # background parse thread; counted
+    stub("_system_notify", lambda t, b, *a, **k: rec["notifications"].append(("system", t)))
+    stub("_push_notify", lambda t, b, *a, **k: rec["notifications"].append(("push", t)))
+    stub("_push_forward", lambda evs, *a, **k: rec["notifications"].append(("forward", len(evs))))
+    stub("_badge_push", lambda n, *a, **k: rec["notifications"].append(("badge", n)))
+    for mod in (km, getattr(km, "jd", None), getattr(km, "em", None), sbmod):
+        if mod is not None and getattr(mod, "subprocess", None) is not None:
+            tw = SubprocessTripwire(_real_subprocess, rec["spawns"], no_git=no_git)
+            mod.subprocess = tw
+            rec["tripwires"].append(tw)
+            names.append("%s.subprocess%s" % (getattr(mod, "__name__", "?"), " (git answers as failure)" if no_git else ""))
+    state = Path(km.jd.STATE).resolve()
+    real_aw = km._atomic_write
+
+    def guarded(path, text, mode=None):
+        p = Path(path).resolve()
+        if state not in p.parents and p != state:
+            raise BenchError("perf-bench: _atomic_write outside the state copy: %s" % p)
+        rec["atomic_writes"].append(str(p.relative_to(state)))
+        return real_aw(path, text, mode) if mode is not None else real_aw(path, text)
+    km._atomic_write = guarded
+    names.append("km._atomic_write (checked)")
+    for fn in ("getpwnam", "getpwuid"):            # os.path.expanduser's name-service lookups, counted
+        real = getattr(pwd, fn)
+
+        def counted(*a, _real=real, _fn=fn, **k):
+            rec["nss"][_fn] = rec["nss"].get(_fn, 0) + 1
+            return _real(*a, **k)
+        setattr(pwd, fn, counted)
+        names.append("pwd.%s (counted)" % fn)
+    # Every thread started from here on is counted (thread_starts in the output). threads_new, the other
+    # thread check, compares the live set at exit with the one before the import, so it sees only a thread
+    # still alive at the end; a parse thread that ran and finished inside a sample would pass it.
+    real_start = threading.Thread.start
+
+    def counted_start(self, *a, **k):
+        rec["thread_starts"] += 1
+        return real_start(self, *a, **k)
+    threading.Thread.start = counted_start
+    return names, rec
+
+
+def git_calls_total(rec):
+    out = {}
+    for tw in rec["tripwires"]:
+        for sub, n in tw.git_calls.items():
+            out[sub] = out.get(sub, 0) + n
+    return out
+
+
+def asm_delta(em, before):
+    """The event model's assembly counters that moved since `before` (a copy of em._ASM_STATS)."""
+    return {k: em._ASM_STATS.get(k, 0) - before.get(k, 0) for k in set(em._ASM_STATS) | set(before)
+            if em._ASM_STATS.get(k, 0) != before.get(k, 0)}
+
+
+def check_cold_sample(em, tag, path, asm_before):
+    """Prove one cold build_session sample was cold: the assembly counters moved by at least one full
+    assembly since `asm_before`, and `path` (the session's own transcript) is now a key of the assembly
+    cache the sample started with empty. Returns the counter delta; raises BenchError otherwise, so a
+    cache this tool does not clear (above or below the parse) is an error, never a warm row."""
+    d = asm_delta(em, asm_before)
+    if not d.get("full"):
+        raise BenchError("build_session_cold:%s ran no full assembly (assembly counters moved %r): a cache "
+                         "this harness does not clear served the parse" % (tag, d))
+    asm_cache = getattr(em, "_ASM_CACHE", {})
+    with em._ASM_LOCK:
+        own = any(isinstance(k, tuple) and k and k[0] == path for k in asm_cache)
+    if not own:
+        raise BenchError("build_session_cold:%s never assembled its own transcript (%s is absent from the "
+                         "assembly cache the sample started with empty; counters moved %r): a cache above the "
+                         "event model served it" % (tag, os.path.basename(path), d))
+    return d
+
+
+def check_snapshot_rows(rows, regs, all_regs):
+    """The liveness snapshot must hold exactly one row per qualifying registry entry (alive, not a comment
+    thread; with all_regs, closed entries too). Sessions.live() catches and logs a failing backend merge and
+    carries on with whatever rows it has, so a bench backend that a kernel revision drives differently would
+    otherwise be timed against an empty or partial world and report success."""
+    expected = sum(1 for r in regs if not r.get("threadOf") and (r.get("alive") or all_regs))
+    if len(rows) != expected:
+        raise BenchError("liveness snapshot has %d rows but %d registry entries qualify — the backend merge "
+                         "failed inside the kernel (its traceback is on stderr); the bench backend needs "
+                         "adjusting for this revision" % (len(rows), expected))
+    return expected
+
+
+def bucket_steady_samples(samples):
+    """Split push_steady's samples into (quiet, rebuilt): a sample in which _cached_feed or _cached_timeline
+    rebuilt is set aside, because the rebuild is decided by wall-clock alignment (the 5 s view-signature
+    bucket rolling REBUILD_MIN_S after the previous build), not by the code under test."""
+    quiet = [f for f in samples if not (f["rebuilt_feed"] or f["rebuilt_timeline"])]
+    rebuilt = [f for f in samples if f["rebuilt_feed"] or f["rebuilt_timeline"]]
+    return quiet, rebuilt
+
+
+def steady_rows(samples, apps):
+    """The push_steady row (the quiet samples' numbers, every sample listed) and the push_steady_rebuild
+    row (None when no sample rebuilt)."""
+    quiet, rebuilt = bucket_steady_samples(samples)
+    st = ms_stats([f["ms"] for f in quiet])
+    st.update({"bytes_per_push": (sum(f["bytes"] for f in quiet) / len(quiet)) if quiet else None,
+               "samples": samples, "clients": apps, "rebuild_samples": len(rebuilt)})
+    st2 = None
+    if rebuilt:
+        st2 = ms_stats([f["ms"] for f in rebuilt])
+        st2["bytes_per_push"] = sum(f["bytes"] for f in rebuilt) / len(rebuilt)
+    return st, st2
+
+
+# ── the constructor-free SDK backend ────────────────────────────────────────────────────────────
+def make_backend(sbmod, state, dormant_rows, all_regs):
+    class BenchSdkBackend(sbmod.SdkBackend):
+        def __getattr__(self, name):          # only reached for attributes the constructor would have set
+            raise BenchError("perf-bench: the bench backend lacks attribute %r (a code path this tool "
+                             "did not anticipate reached it — add it to make_backend)" % name)
+
+        def live_sessions(self):
+            out = {}
+            for reg in sbmod.list_regs(self.state_dir):
+                if reg.get("threadOf"):
+                    continue
+                if not reg.get("alive") and not self._bench_all_regs:
+                    continue
+                sid = reg.get("sid")
+                if not sid:
+                    continue
+                row = self._live_row(reg, sid)                 # the real dormant-row derivation
+                if not self._bench_dormant:
+                    lsv = getattr(sbmod, "last_state_value", None)
+                    if lsv is not None:
+                        st = lsv(self.state_dir, sid)
+                    else:
+                        st = (sbmod.last_state(self.state_dir, sid) or {}).get("state") or ""
+                    if st:
+                        row["state"] = st
+                    row["connected"] = True
+                out[sid] = row
+            return out
+
+    be = BenchSdkBackend.__new__(BenchSdkBackend)
+    be.__dict__.update({
+        "state_dir": Path(state), "claude_bin": "/bin/false", "sessions": {},
+        "_lock": threading.Lock(), "_reg_lock": threading.Lock(), "_pending_ask": {}, "_live": {},
+        "_owns_memo": {},   # owns() memoizes on the reg file's identity here, and build_session and
+        #   _alive_sessions reach owns() through Sessions.backend_for: without the slot the first chat
+        #   build raises on the attribute instead of answering
+        "_fork_children_memo": None, "_work_key_pin": "", "work_key": "",   # a property with a pin at
+        #   HEAD (the pin wins), a plain attribute in older revisions (the instance value wins)
+        "_problems": [], "_problem_seq": 0,
+        "_problem_lock": threading.Lock(), "_sdk_missing": False, "_turn_seq": {}, "_drive_marks": {},
+        "_drive_inflight": set(), "_heal_attempts": {}, "_notify": None, "_poke_cb": None,
+        "_push_cb": None, "_push_session_cb": None, "_log_cb": None,
+        "mcp_config": None, "append_prompt_path": None, "cli_scope": False, "thread_wake_model": None,
+        "_bench_dormant": bool(dormant_rows), "_bench_all_regs": bool(all_regs),
+    })
+    return be
+
+
+# ── loading ─────────────────────────────────────────────────────────────────────────────────────
+def load_kernel(repo):
+    from importlib.machinery import SourceFileLoader
+    kpath = os.path.join(repo, "kernel", "kernel.py")
+    if not os.path.isfile(kpath):
+        raise BenchError("no kernel at %s" % kpath)
+    km = SourceFileLoader("romp_kernel_perf_bench", kpath).load_module()
+    sbmod = sys.modules.get("romp_sdk_backend")
+    if sbmod is None:
+        sbmod = SourceFileLoader("romp_sdk_backend", os.path.join(repo, "kernel", "sdk_backend.py")).load_module()
+    for sym in ("_live_scope", "Sessions", "build_session", "build_feed", "build_timeline", "_push",
+                "_names_snapshot", "_sessions", "_parse", "_parse_cache", "_tmux_sessions", "_atomic_write",
+                "_built_feed", "_built_timeline", "em", "jd"):
+        if not hasattr(km, sym):
+            raise BenchError("this kernel lacks %s; the harness does not know how to drive it" % sym)
+    if not hasattr(km.em, "_ASM_STATS"):
+        raise BenchError("this kernel's event model has no _ASM_STATS; the cold-build check cannot run")
+    return km, sbmod
+
+
+def git_head(repo):
+    """The checkout's HEAD sha (12 chars) read from the git files directly — no `git` process, so a
+    strace of this tool shows only the kernel's own spawns. None when it cannot be read."""
+    try:
+        dotgit = os.path.join(repo, ".git")
+        gitdir = dotgit
+        if os.path.isfile(dotgit):                       # a worktree: one line, gitdir: <private dir>
+            with open(dotgit) as f:
+                line = f.readline().strip()
+            if not line.startswith("gitdir:"):
+                return None
+            gitdir = line[len("gitdir:"):].strip()
+            if not os.path.isabs(gitdir):
+                gitdir = os.path.normpath(os.path.join(repo, gitdir))
+        with open(os.path.join(gitdir, "HEAD")) as f:
+            head = f.read().strip()
+        if not head.startswith("ref:"):
+            return head[:12]
+        ref = head[4:].strip()
+        common = gitdir
+        cf = os.path.join(gitdir, "commondir")           # a worktree's refs live in the main repo's dir
+        if os.path.isfile(cf):
+            with open(cf) as f:
+                common = os.path.normpath(os.path.join(gitdir, f.read().strip()))
+        rp = os.path.join(common, ref)
+        if os.path.isfile(rp):
+            with open(rp) as f:
+                return f.read().strip()[:12]
+        with open(os.path.join(common, "packed-refs")) as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) == 2 and parts[1] == ref:
+                    return parts[0][:12]
+    except OSError:
+        return None
+    return None
+
+
+# ── timing ──────────────────────────────────────────────────────────────────────────────────────
+def ms_stats(samples):
+    if not samples:
+        return {"n": 0, "min": None, "median": None, "max": None, "mean": None}
+    return {"n": len(samples), "min": round(min(samples), 2), "median": round(statistics.median(samples), 2),
+            "max": round(max(samples), 2), "mean": round(statistics.fmean(samples), 2)}
+
+
+def single(ms, **extra):
+    d = {"n": 1, "min": None, "median": round(ms, 2), "max": None, "mean": None}
+    d.update(extra)
+    return d
+
+
+def timed(fn, iters, before=None, warmup=1, after=None):
+    """Call `before` (untimed) then `fn` (timed), `warmup` times discarded, then `iters` times kept;
+    `after(sample_ms)` runs untimed after each kept sample."""
+    last = None
+    for _ in range(warmup):
+        if before:
+            before()
+        last = fn()
+    samples = []
+    for _ in range(iters):
+        if before:
+            before()
+        t0 = time.perf_counter()
+        last = fn()
+        ms = (time.perf_counter() - t0) * 1000.0
+        samples.append(ms)
+        if after:
+            after(ms)
+    return ms_stats(samples), last
+
+
+def profile_once(fn, before=None):
+    if before:
+        before()
+    pr = cProfile.Profile()
+    pr.enable()
+    t0 = time.perf_counter()
+    fn()
+    ms = (time.perf_counter() - t0) * 1000.0
+    pr.disable()
+    return pr, ms
+
+
+def profile_rows(pr, key, top, repo):
+    st = pstats.Stats(pr)
+    idx = 3 if key == "cumulative" else 2
+    rows = []
+    for (fn, line, name), (cc, nc, tt, ct, _callers) in st.stats.items():
+        rows.append((ct if idx == 3 else tt, fn, line, name, nc, cc, tt, ct))
+    rows.sort(key=lambda r: r[0], reverse=True)
+    out = []
+    repo_p = os.path.realpath(repo) + os.sep
+    for _k, fn, line, name, nc, cc, tt, ct in rows[:top]:
+        f = fn
+        if f.startswith(repo_p):
+            f = f[len(repo_p):]
+        elif f.startswith("<") or f.startswith("~"):
+            pass
+        else:
+            f = os.path.basename(f)
+        out.append({"func": name, "file": f, "line": line, "ncalls": nc if nc == cc else "%d/%d" % (nc, cc),
+                    "tottime_ms": round(tt * 1000, 2), "cumtime_ms": round(ct * 1000, 2)})
+    return out
+
+
+def profile_entry(fn, before, repo):
+    pr, ms = profile_once(fn, before=before)
+    return {"ms": round(ms, 2), "cumulative": profile_rows(pr, "cumulative", PROFILE_TOP, repo),
+            "tottime": profile_rows(pr, "tottime", PROFILE_TOP, repo)}
+
+
+def fmt_profile(title, rows):
+    lines = ["  %s" % title, "  %10s %12s %12s  %s" % ("ncalls", "tottime ms", "cumtime ms", "function")]
+    for r in rows:
+        lines.append("  %10s %12.2f %12.2f  %s:%s(%s)" % (r["ncalls"], r["tottime_ms"], r["cumtime_ms"],
+                                                        r["file"], r["line"], r["func"]))
+    return "\n".join(lines)
+
+
+# ── state fingerprint (what did the run write) ──────────────────────────────────────────────────
+def fingerprint(state):
+    out = {}
+    for root, dirs, files in os.walk(state):
+        dirs[:] = [d for d in dirs if d != "sdkvenv"]
+        for f in files:
+            p = os.path.join(root, f)
+            try:
+                st = os.lstat(p)
+            except OSError:
+                continue
+            out[os.path.relpath(p, state)] = (st.st_mtime_ns, st.st_size)
+    return out
+
+
+def fingerprint_diff(before, after):
+    changed = sorted(k for k in after if k in before and after[k] != before[k])
+    new = sorted(k for k in after if k not in before)
+    gone = sorted(k for k in before if k not in after)
+    return {"changed": len(changed), "new": len(new), "removed": len(gone),
+            "sample": (["~ " + k for k in changed] + ["+ " + k for k in new] + ["- " + k for k in gone])[:40]}
+
+
+# ── fake WebSocket clients ──────────────────────────────────────────────────────────────────────
+_FRAME_HEAD_RE = re.compile(r'"(type|slot)": "([^"]*)"')
+
+
+def frame_label(km, c, s):
+    """The per-slot label for one frame handed to a fake client. _client_send leaves the dedup key on
+    the client (`curSlot`) for the length of its call, and that key names the slot. A frame that arrives
+    with no key set (a --repo checkout from before the keyed delta path went through _client_send, or a
+    one-shot reply) is labelled from its own head: `{"type": "delta", "slot": "bars", ...}` books as
+    bars-delta, and any other direct frame as its type."""
+    key = c.get("curSlot")
+    if key is not None:
+        return km._perf_slot(key) if hasattr(km, "_perf_slot") else str(key)
+    head = dict(_FRAME_HEAD_RE.findall(s[:160]))
+    if head.get("slot"):
+        return head["slot"] + "-delta"
+    return head.get("type") or "unknown"
+
+
+def fake_client(km, app, active=None):
+    c = {"app": app, "wid": "perf-bench-" + app, "alive": True, "ready": True, "sock": None,
+         "dlock": threading.RLock(), "qlock": threading.Lock(), "sent": {}, "echat": {},
+         "delta": True, "caps": set(), "bytes": {}, "frames": 0}
+    for cap in ("FEED_DELTA_CAP", "READY_GATE_CAP"):
+        if hasattr(km, cap):
+            c["caps"].add(getattr(km, cap))
+    if active:
+        c["active"] = active
+
+    def send(s):
+        label = frame_label(km, c, s)
+        c["bytes"][label] = c["bytes"].get(label, 0) + len(s)
+        c["frames"] += 1
+    c["send"] = send
+    return c
+
+
+def reset_client_bytes(clients):
+    for c in clients:
+        c["bytes"] = {}
+        c["frames"] = 0
+
+
+def client_bytes(clients):
+    return {c["app"]: {"frames": c["frames"], "slots": dict(sorted(c["bytes"].items()))} for c in clients}
+
+
+def total_bytes(clients):
+    return sum(sum(c["bytes"].values()) for c in clients)
+
+
+# ── the run ─────────────────────────────────────────────────────────────────────────────────────
+def run(args, state, mirror_of, out, private):
+    repo = os.path.realpath(args.repo) if args.repo else os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
+    out["repo"], out["repo_head"], out["state"], out["state_mirror_of"] = repo, git_head(repo), state, mirror_of
+    out["env_changes"] = prepare_env(state, args.claude_dir, private)
+    fp_before = fingerprint(state)
+    threads_before = {t.name for t in threading.enumerate()}
+
+    km, sbmod = load_kernel(repo)
+    jd, em = km.jd, km.em
+    be = make_backend(sbmod, state, args.dormant_rows, args.all_regs_live)
+    km._sdk_backend = be                       # _sdk() returns this without constructing the real one
+    if hasattr(km, "_codex_backend"):
+        km._codex_backend = False              # "module unavailable": _codex() returns None, loads nothing
+    out["neutralized"], rec = install_guards(km, sbmod, no_git=args.no_git)
+    bench = out["benchmarks"] = {}
+    profiles = out["profiles"] = {}
+    iters = max(1, args.iters)
+    out["cold_caches"] = {"kernel": [n for n in COLD_KERNEL_CACHES + ("_chat_fold",) if isinstance(getattr(km, n, None), dict)],
+                          "event_model": [n for n, _lock in COLD_EM_CACHES if isinstance(getattr(em, n, None), dict)]}
+
+    def now():
+        return int(time.time())
+
+    def scope(tmux):
+        """The pusher cycle's scope, as _pusher_cycle opens it: the liveness snapshot, the sid->path memo,
+        the discover-rows memo (a per-cycle memo slot some kernel revisions read) and the names snapshot."""
+        km._live_scope.snapshot = tmux
+        km._live_scope.paths = {}
+        km._live_scope.sessions = {}
+        km._live_scope.names = km._names_snapshot()
+
+    def unscope():
+        km._live_scope.snapshot = None
+        km._live_scope.names = None
+        km._live_scope.paths = None
+        km._live_scope.sessions = None
+
+    def new_cycle():
+        """A fresh cycle's per-cycle memos (what _pusher_cycle resets between two cycles)."""
+        km._live_scope.paths = {}
+        km._live_scope.sessions = {}
+
+    def clear_kernel_caches():
+        """The kernel-side caches a freshly started kernel lacks (build_session's inputs above the parse)."""
+        for name in COLD_KERNEL_CACHES:
+            d = getattr(km, name, None)
+            if isinstance(d, dict):
+                d.clear()
+        if hasattr(km, "_chat_fold"):
+            lock = getattr(km, "_chat_fold_lock", None)
+            if lock is not None:
+                with lock:
+                    km._chat_fold.clear()
+            else:
+                km._chat_fold.clear()
+
+    def clear_em_caches():
+        """The event model's parse-layer caches, under their locks; a name this revision lacks is skipped
+        (out["cold_caches"] says which were emptied; the per-sample assembly check is what proves a
+        sample cold)."""
+        for name, lock_name in COLD_EM_CACHES:
+            d = getattr(em, name, None)
+            if not isinstance(d, dict):
+                continue
+            lock = getattr(em, lock_name, None)
+            if lock is not None:
+                with lock:
+                    d.clear()
+            else:
+                d.clear()
+
+    def clear_all_caches():
+        clear_kernel_caches()
+        clear_em_caches()
+        gc.collect()
+
+    class Counters:
+        """Per-row deltas of the git call counter, the assembly counters and the NSS counter, over the
+        KEPT samples only: timed_counted() runs the warm-up first, then resets these, then times."""
+        def __init__(self):
+            self.reset()
+
+        def reset(self):
+            self.git0, self.asm0, self.nss0, self.n = git_calls_total(rec), dict(em._ASM_STATS), dict(rec["nss"]), 0
+
+        def row(self):
+            g1, nss1 = git_calls_total(rec), rec["nss"]
+            git = {k: g1.get(k, 0) - self.git0.get(k, 0) for k in set(g1) | set(self.git0) if g1.get(k, 0) != self.git0.get(k, 0)}
+            nss = {k: nss1.get(k, 0) - self.nss0.get(k, 0) for k in set(nss1) | set(self.nss0) if nss1.get(k, 0) != self.nss0.get(k, 0)}
+            n = max(1, self.n)
+            return {"git_per_build": {k: round(v / n, 2) for k, v in git.items()},
+                    "asm": asm_delta(em, self.asm0), "nss_per_build": {k: round(v / n, 2) for k, v in nss.items()}}
+
+    def timed_counted(fn, before=None, after=None):
+        """timed() with the per-row counters reset AFTER the warm-up, so a row's git/asm/nss deltas
+        describe exactly its kept samples."""
+        if before:
+            before()
+        fn()
+        ctr.reset()
+        st, last = timed(fn, iters, before=before, warmup=0, after=after)
+        st.update(ctr.row())
+        return st, last
+
+    # liveness + names snapshots (the pusher cycle's per-cycle reads)
+    bench["liveness_snapshot"], tmux = timed(lambda: km.Sessions.live(), iters)
+    bench["names_snapshot"], _ = timed(lambda: km._names_snapshot(), iters)
+    regs = sbmod.list_regs(state)
+    check_snapshot_rows(tmux, regs, args.all_regs_live)      # exact by construction: one row per counted reg
+    out["liveness"] = {"live": len(tmux), "alive_regs": sum(1 for r in regs if r.get("alive") and not r.get("threadOf")),
+                       "closed_regs": sum(1 for r in regs if not r.get("alive") and not r.get("threadOf")),
+                       "thread_regs": sum(1 for r in regs if r.get("threadOf")),
+                       "rows": "dormant" if args.dormant_rows else "states-file",
+                       "states": {sid[:8]: (row.get("state") if isinstance(row, dict) else None) for sid, row in tmux.items()}}
+    scope(tmux)
+    try:
+        # discovery
+        discover_clears = [0]
+
+        def cold_discover():
+            cache = getattr(jd, "_discover_cache", None)
+            if isinstance(cache, dict):
+                cache.clear()
+                discover_clears[0] += 1
+        bench["discover_cold"], _ = timed(lambda: jd.discover(now()), iters, before=cold_discover)
+        out["discover_cache_cleared"] = discover_clears[0]      # iters + the warm-up: one clear per sample
+        bench["discover_warm"], _ = timed(lambda: jd.discover(now()), iters)
+
+        # ONE world: discovery's live sessions, plus every live sid outside its window resolved the way
+        # _alive_sessions resolves them for the builders
+        sessions = [s for s in km._sessions(now()) if s["sid"] in tmux]
+        if tmux and not sessions:
+            raise BenchError("discovery found no transcript for any of the %d live sessions: a wrong --claude-dir, "
+                             "registry cwds that do not exist on this machine, or a copy older than the discovery "
+                             "window" % len(tmux))
+        have = {s["sid"] for s in sessions}
+        missing = [sid for sid in tmux if sid not in have]
+        backfilled = []
+        if missing and hasattr(jd, "DEATH_BACKFILL_WINDOW"):
+            wide = {f[0]: f for f in jd.discover(now(), window=jd.DEATH_BACKFILL_WINDOW)}
+            for sid in missing:
+                ent = wide.get(sid)
+                if ent is None:
+                    continue
+                fsid, path, anchor, name = ent
+                try:
+                    mtime = os.stat(path).st_mtime
+                except OSError:
+                    mtime = 0
+                sessions.append({"sid": fsid, "name": name or fsid[:8], "anchor": anchor, "path": str(path), "mtime": mtime})
+                backfilled.append(sid)
+        no_transcript = [sid for sid in missing if sid not in set(backfilled)]
+        for s in sessions:
+            try:
+                s["bytes"] = os.path.getsize(s["path"])
+            except OSError:
+                s["bytes"] = 0
+        sessions.sort(key=lambda s: s["bytes"], reverse=True)
+        picked = sessions[:max(0, args.sessions)]
+        out["live_transcripts"] = {"count": len(sessions), "bytes": sum(s["bytes"] for s in sessions),
+                                   "in_window": len(have), "backfilled": len(backfilled),
+                                   "no_transcript": [sid[:8] for sid in no_transcript]}
+
+        # build_session: cold (every cache), emwarm (kernel caches only), warm — per picked transcript
+        out["benched_sessions"] = []
+        ctr = Counters()
+        for s in picked:
+            sid, tag = s["sid"], s["sid"][:8]
+            km._live_scope.paths = {}
+            asm_before = {}
+
+            def cold_before():
+                clear_all_caches()
+                asm_before.clear()
+                asm_before.update(em._ASM_STATS)
+
+            def cold_after(ms, _tag=tag, _path=os.path.realpath(s["path"])):
+                check_cold_sample(em, _tag, _path, asm_before)
+                ctr.n += 1
+            st_cold, m = timed_counted(lambda: km.build_session(sid, now(), tmux), before=cold_before, after=cold_after)
+            bench["build_session_cold:" + tag] = st_cold
+
+            def emwarm_before():
+                clear_kernel_caches()
+                gc.collect()
+
+            def count_after(ms):
+                ctr.n += 1
+            st_em, _ = timed_counted(lambda: km.build_session(sid, now(), tmux), before=emwarm_before, after=count_after)
+            bench["build_session_emwarm:" + tag] = st_em
+            st_warm, _ = timed_counted(lambda: km.build_session(sid, now(), tmux), after=count_after)
+            bench["build_session_warm:" + tag] = st_warm
+            out["benched_sessions"].append({"sid8": tag, "name": s.get("name", ""), "bytes": s["bytes"],
+                                            "events": len((m or {}).get("events") or [])})
+            if args.profile:
+                profiles["build_session_cold:" + tag] = profile_entry(lambda: km.build_session(sid, now(), tmux), clear_all_caches, repo)
+                profiles["build_session_warm:" + tag] = profile_entry(lambda: km.build_session(sid, now(), tmux), None, repo)
+
+        # every live parse once from empty (the boot-time cost); kept warm for the feed/timeline
+        clear_all_caches()
+        t0 = time.perf_counter()
+        for s in sessions:
+            km._parse(s["path"], s["sid"], now())
+        bench["warm_all_parses"] = single((time.perf_counter() - t0) * 1000, sessions=len(sessions))
+
+        # feed + timeline in the steady state
+        bench["build_feed"], feed = timed(lambda: km.build_feed(now(), tmux), iters)
+        bench["build_feed"]["cards"] = {k: len(feed.get(k) or []) for k in ("asks", "working", "awaiting") if isinstance(feed, dict)}
+        bench["build_timeline_bars"], tl = timed(lambda: km.build_timeline(now(), tmux, with_bars=True), iters)
+        bench["build_timeline_bars"]["lanes"] = len((tl or {}).get("sessions") or [])
+        bench["build_timeline_skel"], _ = timed(lambda: km.build_timeline(now(), tmux, with_bars=False), iters)
+        if args.profile:
+            profiles["build_feed"] = profile_entry(lambda: km.build_feed(now(), tmux), None, repo)
+            profiles["build_timeline_bars"] = profile_entry(lambda: km.build_timeline(now(), tmux, with_bars=True), None, repo)
+        # the feed with nothing parsed (cards-first boot)
+        bench["build_feed_noparse"], _ = timed(lambda: km.build_feed(now(), tmux), iters, before=km._parse_cache.clear)
+        for s in sessions:
+            km._parse(s["path"], s["sid"], now())
+
+        # goal stores, largest first
+        gdir = Path(jd.GOALDIR)
+        stores = []
+        if gdir.is_dir():
+            for p in gdir.glob("*.json"):
+                try:
+                    stores.append((p.stat().st_size, p.stem))
+                except OSError:
+                    pass
+        stores.sort(reverse=True)
+        out["goal_stores"] = []
+        for size, fsid in stores[:max(0, args.sessions)]:
+            tag = fsid[:8]
+            bench["load_goals:" + tag], store = timed(lambda: jd.load_goals(fsid), iters)
+            out["goal_stores"].append({"fsid8": tag, "bytes": size, "nodes": len((store or {}).get("nodes") or {})})
+            if args.profile and not any(k.startswith("load_goals:") for k in profiles):
+                profiles["load_goals:" + tag] = profile_entry(lambda: jd.load_goals(fsid), None, repo)
+
+        # the push over fake clients
+        apps = [a.strip() for a in (args.clients or "").split(",") if a.strip()]
+        if apps:
+            active = picked[0]["sid"] if picked else None
+            clients = [fake_client(km, a, active if a == "chat" else None) for a in apps]
+
+            def built_at():
+                return (km._built_feed[2], km._built_timeline[2])
+
+            # the pusher's first cycle after a restart: every cache empty, empty dedup state
+            clear_all_caches()
+            for e in (km._built_feed, km._built_timeline):
+                e[1] = None
+            for name in ("_feed_wire", "_bars_wire"):
+                if hasattr(km, name):
+                    setattr(km, name, None)
+            unscope()
+            scope(tmux)
+            asm0 = dict(em._ASM_STATS)
+            t0 = time.perf_counter()
+            km._push(clients, tmux=tmux)
+            bench["push_cold_cycle"] = single((time.perf_counter() - t0) * 1000, bytes=client_bytes(clients), clients=apps,
+                                              asm=asm_delta(em, asm0))   # every live transcript parsed inside the cycle
+            reset_client_bytes(clients)
+            new_cycle()
+            km._push(clients, tmux=tmux)               # a warming cycle: baselines, wire caches, chat cache
+            reset_client_bytes(clients)
+
+            # a page load: one fresh client with empty dedup state, connect=True
+            for app in apps:
+                holder = {}
+
+                def connect_before(_app=app):
+                    holder["c"] = fake_client(km, _app, active if _app == "chat" else None)
+                    new_cycle()
+
+                def connect_push():
+                    km._push([holder["c"]], connect=True, tmux=tmux)
+                st, _ = timed(connect_push, iters, before=connect_before)
+                st["bytes"] = client_bytes([holder["c"]])[app]
+                bench["push_connect:" + app] = st
+            reset_client_bytes(clients)
+
+            # the periodic push, steady state; rebuild samples separated
+            samples = []
+            for _ in range(3 * iters):
+                new_cycle()
+                reset_client_bytes(clients)
+                b0 = built_at()
+                t0 = time.perf_counter()
+                km._push(clients, tmux=tmux)
+                ms = (time.perf_counter() - t0) * 1000
+                b1 = built_at()
+                samples.append({"ms": round(ms, 2), "rebuilt_feed": b1[0] != b0[0], "rebuilt_timeline": b1[1] != b0[1],
+                                "bytes": total_bytes(clients)})
+                if len(bucket_steady_samples(samples)[0]) >= iters:
+                    break
+            st, st2 = steady_rows(samples, apps)
+            rebuilt = bucket_steady_samples(samples)[1]
+            bench["push_steady"] = st
+            if st2 is not None:
+                bench["push_steady_rebuild"] = st2
+            reset_client_bytes(clients)
+            new_cycle()
+            km._push(clients, tmux=tmux)
+            bench["push_steady"]["bytes"] = client_bytes(clients)   # one further cycle's per-slot bytes
+            out["push_rebuilds"] = len(rebuilt)
+            if args.profile:
+                def one_push():
+                    new_cycle()
+                    km._push(clients, tmux=tmux)
+                profiles["push_steady"] = profile_entry(one_push, None, repo)
+    finally:
+        unscope()
+
+    out["writes"] = fingerprint_diff(fp_before, fingerprint(state))
+    out["writes"]["atomic_writes"] = sorted(set(rec["atomic_writes"]))
+    out["notifications_suppressed"] = len(rec["notifications"])
+    out["warm_calls_suppressed"] = len(rec["warm_calls"])
+    out["thread_starts"] = rec["thread_starts"]
+    out["spawn_attempts"] = rec["spawns"]
+    out["git_queries"] = {"answered_as_failure": bool(args.no_git), "calls": git_calls_total(rec)}
+    out["nss_lookups"] = dict(rec["nss"])
+    out["threads_new"] = sorted({t.name for t in threading.enumerate()} - threads_before)
+    return out
+
+
+# ── reporting ───────────────────────────────────────────────────────────────────────────────────
+def fmt_ms(v):
+    return "%9.2f" % v if isinstance(v, (int, float)) else "%9s" % "-"
+
+
+def row_note(name, st):
+    parts = []
+    g = st.get("git_per_build") or {}
+    if g:
+        parts.append("git/build " + ",".join("%s=%s" % kv for kv in sorted(g.items())))
+    a = st.get("asm") or {}
+    if a:
+        parts.append("asm " + ",".join("%s=%s" % kv for kv in sorted(a.items())))
+    if name.startswith("build_session_cold") and (a.get("serve") or a.get("fold")):
+        # the sample started with the assembly cache empty, so a serve or fold inside it can only be a
+        # second read of a transcript the same build assembled (the emwarm row's serve is its definition)
+        parts.append("(a transcript read twice inside one build)")
+    if st.get("rebuild_samples") is not None:
+        parts.append("%d rebuild sample(s) set aside" % st["rebuild_samples"])
+    if st.get("bytes_per_push") is not None:
+        parts.append("%.0f B/push" % st["bytes_per_push"])
+    return "  ".join(parts)
+
+
+def render_text(out, profile):
+    L = []
+    L.append("perf-bench  repo=%s (%s)  state=%s%s" % (out["repo"], out.get("repo_head") or "no git",
+                                                     out["state"], ("  [mirror of %s]" % out["state_mirror_of"]) if out.get("state_mirror_of") else ""))
+    lv = out.get("liveness", {})
+    lt = out.get("live_transcripts", {})
+    L.append("liveness: %d live rows (%d alive regs, %d closed, %d threads skipped; rows from %s); "
+             "%d live transcripts (%d in the discovery window, %d backfilled, %d without one), %.1f MB total"
+             % (lv.get("live", 0), lv.get("alive_regs", 0), lv.get("closed_regs", 0), lv.get("thread_regs", 0), lv.get("rows", "?"),
+                lt.get("count", 0), lt.get("in_window", 0), lt.get("backfilled", 0), len(lt.get("no_transcript") or []), lt.get("bytes", 0) / 1e6))
+    if lt.get("no_transcript"):
+        L.append("live sids with no transcript anywhere: " + ", ".join(lt["no_transcript"]))
+    if out.get("benched_sessions"):
+        L.append("transcripts benched: " + ", ".join("%s (%.1f MB, %d events)" % (s["sid8"], s["bytes"] / 1e6, s["events"])
+                                                    for s in out["benched_sessions"]))
+    if out.get("goal_stores"):
+        L.append("goal stores benched: " + ", ".join("%s (%.0f KB, %d nodes)" % (g["fsid8"], g["bytes"] / 1e3, g["nodes"])
+                                                     for g in out["goal_stores"]))
+    L.append("")
+    L.append("%-34s %4s %9s %9s %9s  %s" % ("benchmark", "n", "min ms", "median", "max", "notes"))
+    for name, st in out["benchmarks"].items():
+        L.append("%-34s %4d %s %s %s  %s" % (name, st.get("n", 0), fmt_ms(st.get("min")), fmt_ms(st.get("median")), fmt_ms(st.get("max")), row_note(name, st)))
+    for name, st in out["benchmarks"].items():
+        if name.startswith("push") and st.get("bytes"):
+            L.append("")
+            L.append("%s bytes per client slot:" % name)
+            b = st["bytes"] if "frames" not in st["bytes"] else {name.split(":", 1)[1]: st["bytes"]}
+            for app, d in b.items():
+                slots = ", ".join("%s=%d" % (k, v) for k, v in d["slots"].items()) or "nothing sent"
+                L.append("  %-9s %4d frames  %s" % (app, d["frames"], slots))
+    L.append("")
+    w = out.get("writes", {})
+    L.append("writes into the state copy: %d changed, %d new, %d removed" % (w.get("changed", 0), w.get("new", 0), w.get("removed", 0)))
+    for s in w.get("sample", []):
+        L.append("  " + s)
+    L.append("neutralized: " + ", ".join(out.get("neutralized", [])))
+    g = out.get("git_queries", {})
+    L.append("git read-only queries %s: %s" % ("answered as failures (--no-git)" if g.get("answered_as_failure") else "run",
+                                             ", ".join("%s=%d" % kv for kv in sorted(g.get("calls", {}).items())) or "none"))
+    L.append("name-service lookups (AF_UNIX connects under strace): %s"
+             % (", ".join("%s=%d" % kv for kv in sorted(out.get("nss_lookups", {}).items())) or "none"))
+    cc = out.get("cold_caches") or {}
+    if cc:
+        L.append("caches emptied before each cold build_session sample: kernel %s; event model %s"
+                 % (", ".join(cc.get("kernel") or []) or "none", ", ".join(cc.get("event_model") or []) or "none"))
+    L.append("notifications suppressed: %d; background parses suppressed: %d; refused spawns: %d; threads started: %d; new threads: %s"
+             % (out.get("notifications_suppressed", 0), out.get("warm_calls_suppressed", 0), len(out.get("spawn_attempts", [])),
+                out.get("thread_starts", 0), out.get("threads_new") or "none"))
+    if profile and out.get("profiles"):
+        for name, p in out["profiles"].items():
+            L.append("")
+            L.append("profile %s (%.1f ms under cProfile)" % (name, p["ms"]))
+            L.append(fmt_profile("top %d by cumulative time" % PROFILE_TOP, p["cumulative"]))
+            L.append(fmt_profile("top %d by own time" % PROFILE_TOP, p["tottime"]))
+    return "\n".join(L)
+
+
+def _dig(d, dotted):
+    for k in dotted.split("."):
+        d = d.get(k) if isinstance(d, dict) else None
+    return d
+
+
+def compare(a_path, b_path):
+    with open(a_path) as f:
+        a = json.load(f)
+    with open(b_path) as f:
+        b = json.load(f)
+    L = ["perf-bench compare  A=%s (%s)  B=%s (%s)" % (a_path, a.get("repo_head") or "?", b_path, b.get("repo_head") or "?")]
+    L.append("world:")
+    mismatched = []
+    for key, label in WORLD_KEYS:
+        va, vb = _dig(a, key), _dig(b, key)
+        flag = "" if va == vb else "   MISMATCH"
+        if flag:
+            mismatched.append(label)
+        L.append("  %-28s A=%-8s B=%-8s%s" % (label, va, vb, flag))
+    if mismatched:
+        L.append("  the two runs saw different worlds (%s); deltas below compare unlike things" % ", ".join(mismatched))
+    L.append("%-34s %9s %9s %10s %8s" % ("benchmark", "A median", "B median", "delta ms", "delta %"))
+    ab, bb = a.get("benchmarks", {}), b.get("benchmarks", {})
+    for name in ab:
+        if name not in bb:
+            continue
+        ma, mb = ab[name].get("median"), bb[name].get("median")
+        if not isinstance(ma, (int, float)) or not isinstance(mb, (int, float)):
+            continue
+        d = mb - ma
+        pct = (d / ma * 100.0) if ma else float("inf")
+        L.append("%-34s %9.2f %9.2f %+10.2f %+7.1f%%" % (name, ma, mb, d, pct))
+    only_a = sorted(set(ab) - set(bb))
+    only_b = sorted(set(bb) - set(ab))
+    if only_a:
+        L.append("only in A: " + ", ".join(only_a))
+    if only_b:
+        L.append("only in B: " + ", ".join(only_b))
+    for name in sorted(set(ab) & set(bb)):
+        if not name.startswith("push"):
+            continue
+        ba, bbb = (ab.get(name) or {}).get("bytes"), (bb.get(name) or {}).get("bytes")
+        if not (ba and bbb):
+            continue
+        if "frames" in ba:                                  # a per-app row
+            ba, bbb = {name.split(":", 1)[1]: ba}, {name.split(":", 1)[1]: bbb}
+        for app in ba:
+            if app in bbb:
+                ta, tb = sum(ba[app]["slots"].values()), sum(bbb[app]["slots"].values())
+                L.append("%s bytes %-9s A=%d B=%d delta=%+d" % (name, app, ta, tb, tb - ta))
+    return "\n".join(L)
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.compare:
+        print(compare(*args.compare))
+        return 0
+    if not args.state:
+        sys.stderr.write("perf-bench: --state DIR is required (or --compare A B)\n")
+        return 2
+    state = os.path.realpath(os.path.expanduser(args.state))
+    if not os.path.isdir(state):
+        sys.stderr.write("perf-bench: %s is not a directory\n" % state)
+        return 2
+    for sub in ("sdk", "names"):
+        if not os.path.isdir(os.path.join(state, sub)):
+            sys.stderr.write("perf-bench: %s has no %s/ — not a romp state directory?\n" % (state, sub))
+            return 2
+    mirror_of = mirror_root = None
+    if state in live_state_dirs(os.environ):
+        if not args.i_know_this_is_live:
+            sys.stderr.write("perf-bench: %s is the LIVE state directory. Bench a copy (see --help), or pass "
+                             "--i-know-this-is-live to have it mirrored to a temp directory first.\n" % state)
+            return 2
+        mirror_of = state
+        mirror_root, state = mirror_state(state)
+        sys.stderr.write("perf-bench: mirrored the live directory to %s (%s excluded); benching the mirror\n"
+                         % (state, ", ".join(MIRROR_IGNORE)))
+    private = tempfile.mkdtemp(prefix="romp-perf-private-")
+    out = {"schema": SCHEMA, "tool": "perf-bench", "generated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+           "python": sys.version.split()[0], "iters": args.iters, "sessions_requested": args.sessions}
+    rc = 0
+    try:
+        try:
+            run(args, state, mirror_of, out, private)
+        except BenchError as e:
+            # keep what was measured: the rows so far print and the JSON carries the error, so a
+            # revision that trips a guard late in the run still yields its earlier numbers
+            out["error"] = str(e)
+            rc = 1
+        if out.get("benchmarks"):
+            print(render_text(out, args.profile))
+        if out.get("error"):
+            sys.stderr.write("perf-bench: %s\n" % out["error"])
+        if args.json:
+            with open(args.json, "w") as f:
+                json.dump(out, f, indent=1, sort_keys=True)
+            print("\njson written to %s%s" % (args.json, " (partial: the run stopped on an error)" if rc else ""))
+    finally:
+        shutil.rmtree(private, ignore_errors=True)
+        if mirror_root:
+            if args.keep_mirror:
+                sys.stderr.write("perf-bench: mirror kept at %s\n" % state)
+            else:
+                shutil.rmtree(mirror_root, ignore_errors=True)
+                sys.stderr.write("perf-bench: mirror removed\n")
+    return rc
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except BenchError as e:
+        sys.stderr.write("perf-bench: %s\n" % e)
+        sys.exit(1)

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -149,7 +149,7 @@ error, never a silent skip):
     build's path-link pass) and the pair `git remote get-url` (the file-link route; the pair only —
     `git remote` also has writing subcommands, and those trip). Those run and are counted per build.
     "Every loaded romp module" is the kernel, the judge, the event model, the SDK backend, and every
-    sibling kernel/ module one of them loaded (keysource among them); the report's `neutralized` list
+    sibling kernel/ module one of them loaded (credentials among them); the report's `neutralized` list
     names each one.
     The kernel caches their answers only for a cwd inside a git checkout (on the index and tree
     mtimes, and the config file's mtime for the remote); for any other cwd it re-runs `git ls-files`
@@ -232,12 +232,13 @@ WORLD_KEYS = (("liveness.live", "live rows"), ("live_transcripts.count", "transc
               ("push_rebuilds", "push_steady rebuild samples"),
               ("error", "run error"))      # a run that stopped on a guard is flagged before its rows are diffed
 # Every key-source and credential name tests/conftest.py pops before any test runs (its KEY_SOURCE_ENV_NAMES
-# and KEY_SOURCE_ENV_PREFIXES: keysource.SOURCE_VARS, sdk_backend.AUTH_ENV_NAMES, the auth declaration,
-# keysource.OP_ENV_NAMES and OP_ENV_PREFIX), removed here before the import for the same reason: every shell
-# under a romp-managed session inherits the manager's credentials, and keysource selects a key COMMAND or
-# REFERENCE straight from the environment when the isolated env file is absent. The first form dropped
-# ANTHROPIC_* only (review find, 2026-09-08); tests/test_perf_bench.py pins this list against the kernel's
-# own constants.
+# and KEY_SOURCE_ENV_PREFIXES: credentials.FLOOR_ENV_NAMES, which is the retired provider names, the login
+# tokens, the auth declaration and 1Password's names, plus credentials.FLOOR_ENV_PREFIXES and
+# sdk_backend.AUTH_ENV_NAMES), removed here before the import for the same reason: every shell under a
+# romp-managed session inherits the manager's credentials, a retired provider name in the kernel's
+# environment is a boot failure (credentials.check_boot_environment), and the login tokens would be claimed
+# for a launch. The first form dropped ANTHROPIC_* only (review find, 2026-09-08); tests/test_perf_bench.py
+# pins this list against the kernel's own constants.
 KEY_SOURCE_ENV = ("ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
                   "ROMP_EXPECTED_AUTH", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT")
 KEY_SOURCE_ENV_PREFIXES = ("ANTHROPIC_", "OP_SESSION_")
@@ -521,7 +522,7 @@ def install_guards(km, sbmod, shadow, rec, no_git=False):
     stub("_push_forward", lambda evs, *a, **k: rec["notifications"].append(("forward", len(evs))))
     stub("_badge_push", lambda n, *a, **k: rec["notifications"].append(("badge", n)))
     # Every loaded romp module: the four the harness drives, plus every sibling of kernel.py that one of them
-    # loaded (sdk_backend loads keysource, whose key command is a subprocess). The first form guarded the four
+    # loaded (sdk_backend loads credentials, whose apiKeyHelper runs as a subprocess). The first form guarded the four
     # only, while the docstring promised every loaded module (review find, 2026-09-08).
     mods = [km, getattr(km, "jd", None), getattr(km, "em", None), sbmod]
     kfile = getattr(km, "__file__", None)

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -33,6 +33,33 @@ kernel against that directory: it mirrors the directory to a fresh temp copy (sd
 credential files excluded) and benches the mirror, so the live directory is only ever read. The
 mirror is removed afterwards unless `--keep-mirror`.
 
+The copy is only READ, whichever way it was given. Every write the kernel aims at the state
+directory lands in a shadow directory under the tool's private temp dir instead (the state shadow,
+below): the repo-root marker the kernel writes when it is imported, the session order the push
+appends new sids to, the order audit log. The end-of-run census fingerprints the copy before the
+kernel is imported and after the last row, on the error path too, and prints what changed; a run
+that reports anything but 0 changed, 0 new, 0 removed found a writer the shadow does not take. One
+such writer is known: a state file the kernel cannot parse is quarantined by an os.replace to a
+.corrupt-<stamp> sibling in the same directory, which goes through none of the shadowed doors, so
+on a copy holding such a file the census lists that file removed and its sibling new; anything
+else is a writer this tool does not know about. The census records mtimes, sizes, directories and
+link targets, not modes: the kernel import sets the state root it is pointed at to 0700, a change
+only on a copy whose root was not already 0700 (a live directory is, and rsync -a keeps it).
+
+Redacted copies. A copy tool that rewrites the cwd in every registry file (a home path replaced by
+X-es) while Claude's projects/ directory keeps the original name leaves discovery with nothing: the
+kernel derives the project directory from the registry cwd (judge.py's _proj_dir), so no transcript
+is found for any session. `--cwd-map FROM=TO` (repeatable) rewrites a registry cwd's leading path
+components before that derivation (`--cwd-map /XXXX/XXXXXX=$HOME` maps /XXXX/XXXXXX/code/notes-api
+to $HOME/code/notes-api), and the report counts, per rule, every _proj_dir call of the whole run
+that the rule rewrote (discovery's, the tool's own transcript search's and the builders'), read
+when the run ends. It touches nothing else: the cwd
+the chat build hands to its git queries stays the redacted one (a directory that does not exist
+here, so those queries fail as they would on a machine without the checkout). The no-transcript
+error names the counts it worked from (live sessions, hits in the 48 h window and in the 365-day
+backfill, registry cwds and how many of them map to an existing project directory) so a wrong
+--claude-dir, a redacted cwd and a stale copy read differently.
+
 What is measured. Unless noted, each row is one untimed warm-up call followed by `--iters` timed
 calls, reported as ms min/median/max:
   liveness_snapshot      Sessions.live() — the pusher cycle's one liveness read (tmux backend off)
@@ -99,8 +126,9 @@ How the liveness snapshot is reconstructed, and what is approximated:
     the live rows, plus — as _alive_sessions does for the builders — every live sid outside that
     window resolved through the long backfill window, so the pick list, the parse warm-up and the
     builders see ONE world. A live sid with no transcript anywhere is listed in the report; a run
-    where discovery finds nothing for a non-empty live set is an error (a wrong --claude-dir, a
-    registry cwd that does not exist here, or a stale copy).
+    where neither the window nor the backfill finds a transcript for ANY live sid is an error (a wrong
+    --claude-dir; registry cwds a redaction rewrote, see --cwd-map above; or a copy older than the
+    backfill window), raised only after the backfill has run.
   * Transcripts are read from Claude Code's own directory ($CLAUDE_CONFIG_DIR or ~/.claude), which
     the registry references; `--claude-dir` points at a copy or a synthetic one.
 
@@ -130,8 +158,20 @@ error, never a silent skip):
   * pwd.getpwnam / pwd.getpwuid are wrapped as counters (nss_lookups in the output): the chat build's
     path-link pass calls os.path.expanduser on every path-shaped token, and a `~name/...` token makes
     glibc consult the name service — AF_UNIX connects to nscd and systemd-userdb, local, not network.
-  * Every kernel _atomic_write is checked to land under the state copy; the copy's files are
-    fingerprinted before and after so the output lists exactly what the run wrote.
+  * The state shadow: every kernel _atomic_write (the ONE write door for the small JSON state files
+    among them), every Path.write_text the kernel import performs against the state directory (the
+    repo-root marker) and the order audit log's append are redirected to <private dir>/shadow/<same
+    relative path>, and the kernel's ONE strict reader of the small JSON state files
+    (_read_state_json) reads a shadowed file from the shadow, so a read-modify-write such as the
+    session order's append of new sids lands once, as it does live, instead of re-firing on every
+    build against a file that never changed. A write aimed anywhere else is recorded and refused
+    (refused_writes in the output). The copy's files, directories and symlink targets are
+    fingerprinted before the kernel is imported and again at the end, on EVERY exit path (a guard's
+    error, an exception out of the candidate kernel at import or inside a builder, Ctrl-C), and the
+    output lists what changed (nothing; the quarantine move of an unparseable state file, the one
+    known writer the shadow does not take; or a writer this tool does not know about) beside the
+    relative paths that were shadowed; the JSON, when asked for, is written on those paths too, with
+    the error beside the census.
   * A guard that trips inside a call the kernel CATCHES is still an error: _push wraps its whole build in
     `except Exception` and returns, so a refused spawn or write during the push rows would otherwise be
     timed as an aborted cycle and the run would exit 0. Every refusal is recorded before it raises, and a
@@ -155,6 +195,7 @@ import pstats
 import pwd
 import re
 import shutil
+import stat
 import statistics
 import subprocess as _real_subprocess
 import sys
@@ -164,7 +205,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-SCHEMA = 2
+SCHEMA = 3          # the JSON shape: writes.shadowed and refused_writes beside the census, live_transcripts.searched, cwd_map
 DEFAULT_CLIENTS = "chat,feed,timeline"
 _TOOL_FILE = os.path.realpath(__file__)          # the tripwire's frame filter excludes this file, by path
 PROFILE_TOP = 25
@@ -227,7 +268,53 @@ def parse_args(argv):
     ap.add_argument("--i-know-this-is-live", action="store_true",
                     help="allow --state to name the live default state directory; it is mirrored to a temp copy first")
     ap.add_argument("--keep-mirror", action="store_true", help="keep the temp mirror of a live directory (default: removed at exit)")
+    ap.add_argument("--cwd-map", action="append", default=[], metavar="FROM=TO",
+                    help="rewrite a registry cwd's leading path FROM to TO before the project directory is derived "
+                         "from it (a redacted copy whose projects/ kept the original names; see the module docstring); "
+                         "repeatable, first matching rule wins")
     return ap.parse_args(argv)
+
+
+def parse_cwd_maps(specs):
+    """[(FROM, TO)] from the --cwd-map values; a rule without '=' or with an empty FROM is a BenchError.
+    FROM and TO lose a trailing slash so the match is on whole path components."""
+    out = []
+    for spec in specs or ():
+        if "=" not in spec:
+            raise BenchError("--cwd-map %r: expected FROM=TO" % spec)
+        frm, to = spec.split("=", 1)
+        frm, to = frm.rstrip("/"), to.rstrip("/")
+        if not frm:
+            raise BenchError("--cwd-map %r: FROM is empty" % spec)
+        out.append((frm, to))
+    return out
+
+
+def install_cwd_map(jd, maps):
+    """Wrap jd._proj_dir so a registry cwd under a FROM prefix is rewritten to TO before the kernel
+    derives Claude's project directory from it (whole-component prefix match; the first matching rule
+    wins). judge.py resolves _proj_dir by name on every call and the kernel reaches it as jd._proj_dir,
+    so the wrapper is seen by discovery, the liveness rows' transcript paths and the chat build alike;
+    nothing else reads the map. Returns the per-rule hit counters (a list the wrapper updates for as
+    long as the run lasts, so a count read at the end covers every _proj_dir call of the run: the
+    discovery rows', the tool's own transcript search's (one per distinct registry cwd) and the
+    builders' transcript-path derivations). With no rules nothing is wrapped: the default run's timed
+    rows call the kernel's own _proj_dir, with no extra frame."""
+    if not maps:
+        return []
+    real = jd._proj_dir
+    hits = [0] * len(maps)
+
+    def mapped(d):
+        cwd = str(d)
+        for i, (frm, to) in enumerate(maps):
+            if cwd == frm or cwd.startswith(frm + "/"):
+                hits[i] += 1
+                cwd = to + cwd[len(frm):]
+                break
+        return real(cwd)
+    jd._proj_dir = mapped
+    return hits
 
 
 # ── live-directory refusal ──────────────────────────────────────────────────────────────────────
@@ -296,6 +383,65 @@ def prepare_env(state, claude_dir, private_dir):
     return changes
 
 
+# ── the state shadow (where writes aimed at the copy land) ──────────────────────────────────────
+class StateShadow:
+    """Where every write the kernel aims at the state copy lands instead: <root>/<the same relative
+    path>, in the tool's private temp dir. The copy stays byte-identical, and the kernel's own re-reads
+    of the small JSON state files (installed on _read_state_json by install_guards) see the shadow, so a
+    read-modify-write (the session order's append of new sids) lands once, as it does live, instead of
+    re-firing on every build against a file that never changed (each re-fire would add an audit record
+    with a captured stack to the very rows this tool times). `written` lists every relative path that
+    was diverted, in order, duplicates kept; the report dedups it. A write aimed anywhere else is
+    appended to `refused` (the recorder's refused_writes list) before it is refused, so a caller that
+    swallows the error cannot hide it (check_guards_held)."""
+
+    def __init__(self, state, root, refused=None):
+        self.state = Path(state).resolve()
+        self.root = Path(root)
+        self.written = []
+        self.refused = refused if refused is not None else []
+
+    def rel(self, path):
+        """The path relative to the state copy, or None when `path` is not under it."""
+        p = Path(path).resolve()
+        if p == self.state or self.state in p.parents:
+            return p.relative_to(self.state)
+        return None
+
+    def target(self, path):
+        """Where a write to `path` lands: its shadow when it aims at the copy (recorded), itself when it
+        is already in the shadow (the audit log's own trim); a write aimed anywhere else is refused."""
+        r = self.rel(path)
+        if r is not None:
+            self.written.append(str(r))
+            t = self.root / r
+            t.parent.mkdir(parents=True, exist_ok=True)
+            return t
+        p = Path(path).resolve()
+        if self.root.resolve() in p.parents:
+            return p
+        self.refused.append(str(p))      # on record BEFORE the raise: _push swallows the exception
+        raise BenchError("perf-bench: _atomic_write outside the state copy: %s" % p)
+
+    def read_path(self, path):
+        """Where a read of `path` looks: its shadow once one has been written, else `path` itself. One
+        resolve() and one stat per call, paid inside the timed rows by every read of a small JSON state
+        file: microseconds against rows measured in milliseconds, and the same on both sides of an A/B."""
+        r = self.rel(path)
+        if r is not None and (self.root / r).exists():
+            return self.root / r
+        return Path(path)
+
+
+def new_recorder():
+    """What the guards see, made before the kernel loads so the census can read it whichever way the run
+    ends: refused spawns, suppressed notifications and background parses, refused writes, the tripwires
+    (for their git counters), the name-service lookups, the threads started and the --cwd-map rules'
+    hit counters (install_cwd_map's list, empty without rules)."""
+    return {"spawns": [], "notifications": [], "refused_writes": [], "tripwires": [], "nss": {}, "warm_calls": [],
+            "thread_starts": 0, "cwd_map_hits": []}
+
+
 # ── side-effect tripwires ───────────────────────────────────────────────────────────────────────
 class SubprocessTripwire:
     """Stands in for the `subprocess` module inside the loaded romp modules: constants and helpers pass
@@ -351,12 +497,11 @@ class SubprocessTripwire:
         return getattr(self._real, name)
 
 
-def install_guards(km, sbmod, no_git=False):
-    """Neutralize the non-builder side effects the push path can reach; return (names, recorder).
+def install_guards(km, sbmod, shadow, rec, no_git=False):
+    """Neutralize the non-builder side effects the push path can reach; return the list of names for
+    the report (`rec`, from new_recorder(), collects what the guards saw; `shadow` takes the writes).
     A safety target the kernel revision lacks is an error: a renamed notification function would
     otherwise leave the real one in place (Web Push to every subscription in the copy's store)."""
-    rec = {"spawns": [], "notifications": [], "atomic_writes": [], "refused_writes": [], "tripwires": [], "nss": {},
-           "warm_calls": [], "thread_starts": 0}
     names = []
 
     def stub(attr, fn):
@@ -392,18 +537,24 @@ def install_guards(km, sbmod, no_git=False):
             mod.subprocess = tw
             rec["tripwires"].append(tw)
             names.append("%s.subprocess%s" % (getattr(mod, "__name__", "?"), " (git answers as failure)" if no_git else ""))
-    state = Path(km.jd.STATE).resolve()
     real_aw = km._atomic_write
 
-    def guarded(path, text, mode=None):
-        p = Path(path).resolve()
-        if state not in p.parents and p != state:
-            rec["refused_writes"].append(str(p))      # on record BEFORE the raise: _push swallows the exception
-            raise BenchError("perf-bench: _atomic_write outside the state copy: %s" % p)
-        rec["atomic_writes"].append(str(p.relative_to(state)))
-        return real_aw(path, text, mode) if mode is not None else real_aw(path, text)
-    km._atomic_write = guarded
-    names.append("km._atomic_write (checked)")
+    def shadowed_write(path, text, mode=None):
+        t = shadow.target(path)                     # the shadow's path; a write aimed elsewhere is recorded, then refused
+        return real_aw(t, text, mode) if mode is not None else real_aw(t, text)
+    stub("_atomic_write", shadowed_write)
+    names[-1] = "km._atomic_write (shadowed)"
+    real_rsj = getattr(km, "_read_state_json", None)   # stub() below is what refuses a kernel without it
+
+    def overlaid_read(path, st=None, *a, **k):
+        t = shadow.read_path(path)
+        if t != Path(path):
+            st = None                               # the caller's stat is of the copy's file, not the shadow's
+        return real_rsj(t, st, *a, **k)
+    stub("_read_state_json", overlaid_read)
+    names[-1] = "km._read_state_json (shadow overlay)"
+    stub("_order_audit_path", lambda: shadow.target(Path(km.jd.STATE) / "order-audit.jsonl"))
+    names[-1] = "km._order_audit_path (shadowed)"
     for fn in ("getpwnam", "getpwuid"):            # os.path.expanduser's name-service lookups, counted
         real = getattr(pwd, fn)
 
@@ -421,7 +572,7 @@ def install_guards(km, sbmod, no_git=False):
         rec["thread_starts"] += 1
         return real_start(self, *a, **k)
     threading.Thread.start = counted_start
-    return names, rec
+    return names
 
 
 def check_guards_held(rec):
@@ -563,15 +714,29 @@ def make_backend(sbmod, state, dormant_rows, all_regs):
 
 
 # ── loading ─────────────────────────────────────────────────────────────────────────────────────
-def load_kernel(repo):
+def load_kernel(repo, shadow=None):
+    """Import the checkout's kernel in-process. With a `shadow`, every Path.write_text the import
+    performs against the state copy lands in the shadow instead (the kernel writes its repo-root
+    marker at import, before any guard can be installed on the module); the diversion is removed
+    once the import returns, and the guards install_guards puts on the named write doors take over."""
     from importlib.machinery import SourceFileLoader
     kpath = os.path.join(repo, "kernel", "kernel.py")
     if not os.path.isfile(kpath):
         raise BenchError("no kernel at %s" % kpath)
-    km = SourceFileLoader("romp_kernel_perf_bench", kpath).load_module()
-    sbmod = sys.modules.get("romp_sdk_backend")
-    if sbmod is None:
-        sbmod = SourceFileLoader("romp_sdk_backend", os.path.join(repo, "kernel", "sdk_backend.py")).load_module()
+    real_write_text = Path.write_text
+
+    def diverted_write_text(self, data, *a, **k):
+        target = shadow.target(self) if shadow.rel(self) is not None else self
+        return real_write_text(target, data, *a, **k)
+    if shadow is not None:
+        Path.write_text = diverted_write_text
+    try:
+        km = SourceFileLoader("romp_kernel_perf_bench", kpath).load_module()
+        sbmod = sys.modules.get("romp_sdk_backend")
+        if sbmod is None:
+            sbmod = SourceFileLoader("romp_sdk_backend", os.path.join(repo, "kernel", "sdk_backend.py")).load_module()
+    finally:
+        Path.write_text = real_write_text
     for sym in ("_live_scope", "Sessions", "build_session", "build_feed", "build_timeline", "_push",
                 "_names_snapshot", "_sessions", "_parse", "_parse_cache", "_tmux_sessions", "_atomic_write",
                 "_built_feed", "_built_timeline", "em", "jd"):
@@ -705,16 +870,28 @@ def fmt_profile(title, rows):
 
 # ── state fingerprint (what did the run write) ──────────────────────────────────────────────────
 def fingerprint(state):
+    """Every directory (keyed with a trailing slash), symlink (its target) and file (mtime and size)
+    under the copy, so a directory the kernel creates (its many mkdir sites on STATE subdirectories)
+    or a link it retargets shows in the census beside a changed file."""
     out = {}
     for root, dirs, files in os.walk(state):
         dirs[:] = [d for d in dirs if d != "sdkvenv"]
+        for d in dirs:
+            p = os.path.join(root, d)
+            try:
+                out[os.path.relpath(p, state) + "/"] = ("link", os.readlink(p)) if os.path.islink(p) else "dir"
+            except OSError:
+                continue
         for f in files:
             p = os.path.join(root, f)
             try:
                 st = os.lstat(p)
             except OSError:
                 continue
-            out[os.path.relpath(p, state)] = (st.st_mtime_ns, st.st_size)
+            if stat.S_ISLNK(st.st_mode):
+                out[os.path.relpath(p, state)] = ("link", os.readlink(p))
+            else:
+                out[os.path.relpath(p, state)] = (st.st_mtime_ns, st.st_size)
     return out
 
 
@@ -781,17 +958,66 @@ def total_bytes(clients):
 def run(args, state, mirror_of, out, private):
     repo = os.path.realpath(args.repo) if args.repo else os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
     out["repo"], out["repo_head"], out["state"], out["state_mirror_of"] = repo, git_head(repo), state, mirror_of
+    maps = parse_cwd_maps(args.cwd_map)
+    out["cwd_map"] = [{"from": frm, "to": to, "hits": 0} for frm, to in maps]
     out["env_changes"] = prepare_env(state, args.claude_dir, private)
+    rec = new_recorder()
+    shadow = StateShadow(state, os.path.join(private, "shadow"), rec["refused_writes"])
     fp_before = fingerprint(state)
     threads_before = {t.name for t in threading.enumerate()}
+    try:
+        _bench(args, state, repo, out, shadow, rec, maps)
+        check_guards_held(rec)
+    finally:
+        # the census runs on EVERY exit path: a run that stopped on an error has still imported the
+        # kernel and may have built, and what it wrote into the copy is what the caller needs to know
+        out["writes"] = fingerprint_diff(fp_before, fingerprint(state))
+        out["writes"]["shadowed"] = sorted(set(shadow.written))
+        for rule, n in zip(out["cwd_map"], rec["cwd_map_hits"]):   # read here, after the builders' calls, not at discovery
+            rule["hits"] = n
+        out["notifications_suppressed"] = len(rec["notifications"])
+        out["warm_calls_suppressed"] = len(rec["warm_calls"])
+        out["thread_starts"] = rec["thread_starts"]
+        out["spawn_attempts"] = rec["spawns"]
+        out["git_queries"] = {"answered_as_failure": bool(args.no_git), "calls": git_calls_total(rec)}
+        out["nss_lookups"] = dict(rec["nss"])
+        out["threads_new"] = sorted({t.name for t in threading.enumerate()} - threads_before)
+        out["refused_writes"] = list(rec["refused_writes"])
+    return out
 
-    km, sbmod = load_kernel(repo)
+
+def transcript_search(jd, state, sids):
+    """Counts of what discovery had to work with for `sids`: their distinct names-registry cwds, how many
+    of those resolve (through any --cwd-map) to a project directory that exists, and the transcripts in
+    those directories. Counts only, no paths: this goes into the report and the no-transcript error."""
+    cwds = set()
+    for sid in sids:
+        try:
+            parts = (Path(state) / "names" / sid).read_text().rstrip("\n").split("\t")
+        except OSError:
+            continue
+        if len(parts) > 1 and parts[1]:
+            cwds.add(parts[1])
+    present = jsonl = 0
+    for cwd in cwds:
+        pdir = jd._proj_dir(cwd)
+        if os.path.isdir(pdir):
+            present += 1
+            jsonl += sum(1 for n in os.listdir(pdir) if n.endswith(".jsonl"))
+    return {"cwds": len(cwds), "project_dirs": present, "transcripts": jsonl}
+
+
+def _bench(args, state, repo, out, shadow, rec, maps):
+    km, sbmod = load_kernel(repo, shadow)
     jd, em = km.jd, km.em
     be = make_backend(sbmod, state, args.dormant_rows, args.all_regs_live)
     km._sdk_backend = be                       # _sdk() returns this without constructing the real one
     if hasattr(km, "_codex_backend"):
         km._codex_backend = False              # "module unavailable": _codex() returns None, loads nothing
-    out["neutralized"], rec = install_guards(km, sbmod, no_git=args.no_git)
+    out["neutralized"] = install_guards(km, sbmod, shadow, rec, no_git=args.no_git)
+    map_hits = rec["cwd_map_hits"] = install_cwd_map(jd, maps)   # run()'s census copies the counts when the run ends
+    if maps:
+        out["neutralized"].append("jd._proj_dir (cwd-map)")   # the derivation is wrapped: say so in the report
     bench = out["benchmarks"] = {}
     profiles = out["profiles"] = {}
     iters = max(1, args.iters)
@@ -909,10 +1135,6 @@ def run(args, state, mirror_of, out, private):
         # ONE world: discovery's live sessions, plus every live sid outside its window resolved the way
         # _alive_sessions resolves them for the builders
         sessions = [s for s in km._sessions(now()) if s["sid"] in tmux]
-        if tmux and not sessions:
-            raise BenchError("discovery found no transcript for any of the %d live sessions: a wrong --claude-dir, "
-                             "registry cwds that do not exist on this machine, or a copy older than the discovery "
-                             "window" % len(tmux))
         have = {s["sid"] for s in sessions}
         missing = [sid for sid in tmux if sid not in have]
         backfilled = []
@@ -930,6 +1152,20 @@ def run(args, state, mirror_of, out, private):
                 sessions.append({"sid": fsid, "name": name or fsid[:8], "anchor": anchor, "path": str(path), "mtime": mtime})
                 backfilled.append(sid)
         no_transcript = [sid for sid in missing if sid not in set(backfilled)]
+        searched = transcript_search(jd, state, tmux)
+        if tmux and not sessions:
+            # after the backfill, not before it: a copy whose transcripts are all older than the
+            # discovery window is a normal copy, and the backfill is what finds them
+            raise BenchError("discovery found no transcript for any of the %d live sessions: %d in the %d h window, "
+                             "%d more in the %d-day backfill; their %d registry cwd(s) resolve to %d existing project "
+                             "director%s holding %d transcript(s)%s. Causes: a wrong --claude-dir; registry cwds a "
+                             "redaction rewrote while the project directories kept their names (see --cwd-map); a copy "
+                             "whose transcripts are older than the backfill window"
+                             % (len(tmux), len(have), int(getattr(jd, "WINDOW", 0)) // 3600, len(backfilled),
+                                int(getattr(jd, "DEATH_BACKFILL_WINDOW", 0)) // 86400, searched["cwds"],
+                                searched["project_dirs"], "y" if searched["project_dirs"] == 1 else "ies",
+                                searched["transcripts"],
+                                (" (%s)" % ", ".join("cwd-map rule %d hit %d" % (i + 1, n) for i, n in enumerate(map_hits))) if maps else ""))
         for s in sessions:
             try:
                 s["bytes"] = os.path.getsize(s["path"])
@@ -939,7 +1175,7 @@ def run(args, state, mirror_of, out, private):
         picked = sessions[:max(0, args.sessions)]
         out["live_transcripts"] = {"count": len(sessions), "bytes": sum(s["bytes"] for s in sessions),
                                    "in_window": len(have), "backfilled": len(backfilled),
-                                   "no_transcript": [sid[:8] for sid in no_transcript]}
+                                   "no_transcript": [sid[:8] for sid in no_transcript], "searched": searched}
 
         # build_session: cold (every cache), emwarm (kernel caches only), warm — per picked transcript
         out["benched_sessions"] = []
@@ -1090,19 +1326,6 @@ def run(args, state, mirror_of, out, private):
     finally:
         unscope()
 
-    out["writes"] = fingerprint_diff(fp_before, fingerprint(state))
-    out["writes"]["atomic_writes"] = sorted(set(rec["atomic_writes"]))
-    out["notifications_suppressed"] = len(rec["notifications"])
-    out["warm_calls_suppressed"] = len(rec["warm_calls"])
-    out["thread_starts"] = rec["thread_starts"]
-    out["spawn_attempts"] = rec["spawns"]
-    out["git_queries"] = {"answered_as_failure": bool(args.no_git), "calls": git_calls_total(rec)}
-    out["nss_lookups"] = dict(rec["nss"])
-    out["threads_new"] = sorted({t.name for t in threading.enumerate()} - threads_before)
-    out["refused_writes"] = list(rec["refused_writes"])
-    check_guards_held(rec)
-    return out
-
 
 # ── reporting ───────────────────────────────────────────────────────────────────────────────────
 def fmt_ms(v):
@@ -1128,6 +1351,20 @@ def row_note(name, st):
     return "  ".join(parts)
 
 
+def render_writes(out):
+    """The write census, one block: what changed in the copy (nothing, when every writer is known) and
+    the relative paths whose writes the shadow took. Printed whether or not the run got as far as a
+    benchmark row, so an error run says what it did to the copy too."""
+    w = out.get("writes")
+    if w is None:
+        return ["writes into the state copy: not measured (the run stopped before the census could start)"]
+    L = ["writes into the state copy: %d changed, %d new, %d removed" % (w.get("changed", 0), w.get("new", 0), w.get("removed", 0))]
+    for s in w.get("sample", []):
+        L.append("  " + s)
+    L.append("writes shadowed (landed in the private dir, not the copy): %s" % (", ".join(w.get("shadowed") or []) or "none"))
+    return L
+
+
 def render_text(out, profile):
     L = []
     L.append("perf-bench  repo=%s (%s)  state=%s%s" % (out["repo"], out.get("repo_head") or "no git",
@@ -1140,6 +1377,12 @@ def render_text(out, profile):
                 lt.get("count", 0), lt.get("in_window", 0), lt.get("backfilled", 0), len(lt.get("no_transcript") or []), lt.get("bytes", 0) / 1e6))
     if lt.get("no_transcript"):
         L.append("live sids with no transcript anywhere: " + ", ".join(lt["no_transcript"]))
+    sr = lt.get("searched") or {}
+    if sr:
+        L.append("transcript search: %d registry cwd(s) -> %d existing project director%s holding %d transcript(s)%s"
+                 % (sr.get("cwds", 0), sr.get("project_dirs", 0), "y" if sr.get("project_dirs", 0) == 1 else "ies",
+                    sr.get("transcripts", 0),
+                    ("; cwd-map hits: " + ", ".join("rule %d=%d" % (i + 1, r.get("hits", 0)) for i, r in enumerate(out["cwd_map"]))) if out.get("cwd_map") else ""))
     if out.get("benched_sessions"):
         L.append("transcripts benched: " + ", ".join("%s (%.1f MB, %d events)" % (s["sid8"], s["bytes"] / 1e6, s["events"])
                                                     for s in out["benched_sessions"]))
@@ -1159,10 +1402,7 @@ def render_text(out, profile):
                 slots = ", ".join("%s=%d" % (k, v) for k, v in d["slots"].items()) or "nothing sent"
                 L.append("  %-9s %4d frames  %s" % (app, d["frames"], slots))
     L.append("")
-    w = out.get("writes", {})
-    L.append("writes into the state copy: %d changed, %d new, %d removed" % (w.get("changed", 0), w.get("new", 0), w.get("removed", 0)))
-    for s in w.get("sample", []):
-        L.append("  " + s)
+    L.extend(render_writes(out))
     L.append("neutralized: " + ", ".join(out.get("neutralized", [])))
     g = out.get("git_queries", {})
     L.append("git read-only queries %s: %s" % ("answered as failures (--no-git)" if g.get("answered_as_failure") else "run",
@@ -1251,6 +1491,11 @@ def main(argv=None):
     if not os.path.isdir(state):
         sys.stderr.write("perf-bench: %s is not a directory\n" % state)
         return 2
+    try:
+        parse_cwd_maps(args.cwd_map)                 # an argument error, refused before anything is touched
+    except BenchError as e:
+        sys.stderr.write("perf-bench: %s\n" % e)
+        return 2
     for sub in ("sdk", "names"):
         if not os.path.isdir(os.path.join(state, sub)):
             sys.stderr.write("perf-bench: %s has no %s/ — not a romp state directory?\n" % (state, sub))
@@ -1269,6 +1514,7 @@ def main(argv=None):
     out = {"schema": SCHEMA, "tool": "perf-bench", "generated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
            "python": sys.version.split()[0], "iters": args.iters, "sessions_requested": args.sessions}
     rc = 0
+    unexpected = None
     try:
         try:
             run(args, state, mirror_of, out, private)
@@ -1277,14 +1523,26 @@ def main(argv=None):
             # revision that trips a guard late in the run still yields its earlier numbers
             out["error"] = str(e)
             rc = 1
+        except BaseException as e:
+            # a candidate kernel that raises at import or inside a builder, or a Ctrl-C: the census
+            # run() took in its finally is the answer to "what did this do to the copy", so it prints
+            # and the JSON is written before the exception continues out of main() with its traceback
+            out["error"] = "%s: %s" % (type(e).__name__, e)
+            rc = 1
+            unexpected = e
         if out.get("benchmarks"):
             print(render_text(out, args.profile))
+        else:
+            print("\n".join(render_writes(out)))        # the run stopped before its first row: the census still prints
         if out.get("error"):
             sys.stderr.write("perf-bench: %s\n" % out["error"])
         if args.json:
             with open(args.json, "w") as f:
-                json.dump(out, f, indent=1, sort_keys=True)
+                json.dump(out, f, indent=1, sort_keys=True, default=repr)   # repr: a half-built row must not mask the error
             print("\njson written to %s%s" % (args.json, " (partial: the run stopped on an error)" if rc else ""))
+        sys.stdout.flush()
+        if unexpected is not None:
+            raise unexpected
     finally:
         shutil.rmtree(private, ignore_errors=True)
         if mirror_root:

--- a/tools/ui-bench.mjs
+++ b/tools/ui-bench.mjs
@@ -610,12 +610,13 @@ srv.serve_forever()
 export const STRIPPED_ENV = ["ROMP_MANAGER_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "ROMP_STATE_DIR", "ROMP_SERVE_PORT", "ROMP_KERNEL_PORT", "ROMP_PERF", "TMUX"];
 
 /** The key-source names tests/conftest.py pops before any test runs (its KEY_SOURCE_ENV_NAMES and
- *  KEY_SOURCE_ENV_PREFIXES: keysource.SOURCE_VARS, sdk_backend.AUTH_ENV_NAMES, the auth declaration
- *  and 1Password's names), stripped here for the same reason: every shell under a romp-managed session
- *  inherits the manager's credentials, and keysource selects a key COMMAND or REFERENCE straight from
- *  the environment when the isolated env file is absent, so a replay run from inside a session would
- *  otherwise start a kernel Handler holding the operator's key command, OAuth token and op token. The
- *  first form of this list stripped ANTHROPIC_* and the key reference only (review find, 2026-09-08). */
+ *  KEY_SOURCE_ENV_PREFIXES: credentials.FLOOR_ENV_NAMES, which is the retired provider names, the login
+ *  tokens, the auth declaration and 1Password's names, plus sdk_backend.AUTH_ENV_NAMES), stripped here
+ *  for the same reason: every shell under a romp-managed session inherits the manager's credentials, a
+ *  retired provider name in the kernel's environment is a boot failure (credentials.check_boot_environment)
+ *  and the login tokens would be claimed for a launch, so a replay run from inside a session would
+ *  otherwise start a kernel Handler holding the operator's OAuth token and op token, or refuse to start.
+ *  The first form of this list stripped ANTHROPIC_* and the key reference only (review find, 2026-09-08). */
 export const STRIPPED_KEY_ENV = ["ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
   "ROMP_EXPECTED_AUTH", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT"];
 export const STRIPPED_KEY_ENV_PREFIXES = ["ANTHROPIC_", "OP_SESSION_"];
@@ -683,17 +684,17 @@ export async function startPageServer({ dist, python = "python3", log = () => {}
   fs.mkdirSync(env.TMUX_TMPDIR, { recursive: true });
   env.ROMP_KERNEL_NO_OPEN = "1";
   env.ROMP_POSTAL_PEERS = "0";   // the feed page polls /tunnels, which otherwise asks the LIVE postal bus for its peers
-  // The floors tests/conftest.py applies, for the same reasons. The kernel's live API key is the manager's
-  // env FILE (kernel/keysource.py falls back to ~/.config/romp/service.env when these two are unset), the
-  // boot model-catalog fetch would carry that key to the Models API from the first /sessions request a
-  // pane makes, and a missing ROMP_CLAUDE_BIN resolves to the real CLI, so it is set to a binary that runs
-  // nothing rather than removed.
+  // The floors tests/conftest.py applies, for the same reasons. The kernel's boot check reads the manager's
+  // env FILE for retired provider lines (kernel/credentials.py falls back to ~/.config/romp/service.env
+  // when these two are unset), the boot model-catalog fetch would run the operator's apiKeyHelper and
+  // carry its key to the Models API from the first /sessions request a pane makes, and a missing
+  // ROMP_CLAUDE_BIN resolves to the real CLI, so it is set to a binary that runs nothing rather than removed.
   env.ROMP_SERVICE_ENV_FILE = env.ROMP_SERVICE_ENV = path.join(tmp, "no-service.env");   // never created
   env.ROMP_MODEL_CATALOG = "off";
   env.ROMP_CLAUDE_BIN = "/bin/false";
   // One more of conftest's floors: a route that constructs the SDK backend decides whether to wrap CLIs in
-  // systemd-run scopes (on by default under a supervised kernel, probing the user manager). The key
-  // reference and command keysource would resolve through their providers went with STRIPPED_KEY_ENV above.
+  // systemd-run scopes (on by default under a supervised kernel, probing the user manager). The retired
+  // key reference and command names the boot check refuses went with STRIPPED_KEY_ENV above.
   env.ROMP_CLI_SCOPE = "0";
   env.ROMP_SERVE_TOKEN = token;
   env.ROMP_DIST_DIR = distDir;

--- a/tools/ui-bench.mjs
+++ b/tools/ui-bench.mjs
@@ -39,8 +39,10 @@
 //
 //      Serving design: the REAL kernel HTTP Handler runs in a python3 subprocess under an isolated
 //      environment, the pattern of tests/test_color_route.py with the floors tests/conftest.py applies:
-//      private XDG_STATE_HOME and TMUX_TMPDIR; the manager variables, the API-key variables and the key
-//      reference removed; the manager's key FILE and the boot model-catalog fetch pointed away (the
+//      private XDG_STATE_HOME and TMUX_TMPDIR; the manager variables removed (the manager port set to a
+//      dead one, as conftest does) and every key-source name conftest pops removed too (the API keys,
+//      the key reference and command, the token credentials, the auth declaration and 1Password's
+//      names; STRIPPED_KEY_ENV below); the manager's key FILE and the boot model-catalog fetch pointed away (the
 //      kernel would otherwise read ~/.config/romp/service.env and carry its key to the Models API); the
 //      Claude binary floored to /bin/false; the CLI scope off (ROMP_CLI_SCOPE=0, so nothing probes
 //      systemd-run); the postal peer bus off; ROMP_KERNEL_NO_OPEN=1; a serve token minted for the run.
@@ -607,6 +609,17 @@ srv.serve_forever()
  *  and Claude binary a spawned session would run with (nothing the bench needs reads them). */
 export const STRIPPED_ENV = ["ROMP_MANAGER_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "ROMP_STATE_DIR", "ROMP_SERVE_PORT", "ROMP_KERNEL_PORT", "ROMP_PERF", "TMUX"];
 
+/** The key-source names tests/conftest.py pops before any test runs (its KEY_SOURCE_ENV_NAMES and
+ *  KEY_SOURCE_ENV_PREFIXES: keysource.SOURCE_VARS, sdk_backend.AUTH_ENV_NAMES, the auth declaration
+ *  and 1Password's names), stripped here for the same reason: every shell under a romp-managed session
+ *  inherits the manager's credentials, and keysource selects a key COMMAND or REFERENCE straight from
+ *  the environment when the isolated env file is absent, so a replay run from inside a session would
+ *  otherwise start a kernel Handler holding the operator's key command, OAuth token and op token. The
+ *  first form of this list stripped ANTHROPIC_* and the key reference only (review find, 2026-09-08). */
+export const STRIPPED_KEY_ENV = ["ANTHROPIC_API_KEY", "ROMP_API_KEY_REF", "ROMP_API_KEY_CMD", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+  "ROMP_EXPECTED_AUTH", "OP_SERVICE_ACCOUNT_TOKEN", "OP_CONNECT_HOST", "OP_CONNECT_TOKEN", "OP_ACCOUNT"];
+export const STRIPPED_KEY_ENV_PREFIXES = ["ANTHROPIC_", "OP_SESSION_"];
+
 /** The parent every run of this tool on this machine keeps its state under: <tmp>/romp-ui-bench-<uid>,
  *  private to the user and refused when something else holds the name. Each run gets a subdirectory
  *  holding owner.pid, the Handler's XDG_STATE_HOME and TMUX_TMPDIR and, through TMPDIR at launch, the
@@ -660,7 +673,10 @@ export async function startPageServer({ dist, python = "python3", log = () => {}
   fs.writeFileSync(path.join(tmp, "owner.pid"), `${process.pid}\n`);
   const token = crypto.randomBytes(18).toString("base64url");
   const env = { ...process.env };
-  for (const k of Object.keys(env)) if (k.startsWith("ANTHROPIC_") || STRIPPED_ENV.includes(k)) delete env[k];
+  for (const k of Object.keys(env)) if (STRIPPED_KEY_ENV_PREFIXES.some((p) => k.startsWith(p)) || STRIPPED_ENV.includes(k) || STRIPPED_KEY_ENV.includes(k)) delete env[k];
+  // conftest's form of the manager-port floor, not a bare removal: one kernel consumer maps an ABSENT port
+  // to the default, live, one, so a dead value is the state that is safe against every consumer.
+  env.ROMP_MANAGER_PORT = "1";
   env.XDG_STATE_HOME = path.join(tmp, "state");
   env.TMUX_TMPDIR = path.join(tmp, "tmux");
   fs.mkdirSync(env.XDG_STATE_HOME, { recursive: true });
@@ -675,11 +691,10 @@ export async function startPageServer({ dist, python = "python3", log = () => {}
   env.ROMP_SERVICE_ENV_FILE = env.ROMP_SERVICE_ENV = path.join(tmp, "no-service.env");   // never created
   env.ROMP_MODEL_CATALOG = "off";
   env.ROMP_CLAUDE_BIN = "/bin/false";
-  // Two more of conftest's floors: a route that constructs the SDK backend decides whether to wrap CLIs in
-  // systemd-run scopes (on by default under a supervised kernel, probing the user manager), and keysource
-  // resolves an inherited key REFERENCE through its provider when the env file is absent.
+  // One more of conftest's floors: a route that constructs the SDK backend decides whether to wrap CLIs in
+  // systemd-run scopes (on by default under a supervised kernel, probing the user manager). The key
+  // reference and command keysource would resolve through their providers went with STRIPPED_KEY_ENV above.
   env.ROMP_CLI_SCOPE = "0";
-  delete env.ROMP_API_KEY_REF;
   env.ROMP_SERVE_TOKEN = token;
   env.ROMP_DIST_DIR = distDir;
   const child = spawn(python, ["-c", PAGE_SERVER_PY, REPO, tmp], { env, stdio: ["pipe", "pipe", "pipe"] });
@@ -728,7 +743,10 @@ export async function startFront({ pagePort }) {
   server.on("upgrade", (req, socket, head) => {
     const u = new URL(req.url, "http://127.0.0.1");
     const selfOrigin = `http://127.0.0.1:${server.address().port}`;
-    if (u.pathname !== "/ws" || (req.headers.origin && req.headers.origin !== selfOrigin)) {
+    // The page's own origin, REQUIRED: a browser page always sends Origin on a WebSocket upgrade, so a client
+    // without one is some other local process on this loopback port, and the frames it would be handed may be a
+    // recording of real session data. The first form let an Origin-less upgrade through (review find, 2026-09-08).
+    if (u.pathname !== "/ws" || req.headers.origin !== selfOrigin) {
       socket.write("HTTP/1.1 403 Forbidden\r\n\r\n"); socket.destroy(); return;
     }
     wss.handleUpgrade(req, socket, head, (ws) => { if (onSocket) onSocket(ws, u); else ws.close(); });
@@ -1108,12 +1126,22 @@ function attributeLoaf(loaf, handoff = "none") {
       // the bench's own onmessage wrapper, and for every flush of the shim's queue its flush wrapper, so
       // those rows are labelled for what runs inside them rather than for the instrument's file: the shim's
       // handler (plus the bundle's render, on a shim that hands frames over inside the handler), and the
-      // flush task with the bundle's renders it carries.
+      // flush task with the bundle's renders it carries. The instrument's OTHER entry points are its own
+      // bookkeeping: the settle stamp (the requestAnimationFrame callback that reads the clock), the
+      // long-animation-frame observer's callback (which records the entries) and the collector the bench
+      // evaluates at the end. No pane work runs inside any of them, and one appears here only when a
+      // descheduled main thread stretched it past the entry threshold (the settle stamp once on a run pinned
+      // to one CPU, the observer's callback once on a loaded box; review find, 2026-09-08), so its row says
+      // what it is instead of naming the file as if the instrument had done work.
       let key;
       if (url !== "ui-bench-instrument.js") key = `${url}:${s.fn || "(anonymous)"} <${invoker}>`;
       else if (s.fn === "rompBenchFlush" || /MessagePort/.test(inv)) key = `bundle handoff (shim flush + bundle) <${invoker}>`;
       else if (s.fn === "rompBenchOnMessage" || /WebSocket/.test(inv)) key = `message handler (${handoff === "flush" ? "shim" : "shim + bundle"}) <${invoker}>`;
-      else key = `${url}:${s.fn || "(anonymous)"} <${invoker}>`;
+      else {
+        const what = /FrameRequestCallback/.test(inv) ? "the settle stamp's requestAnimationFrame"
+          : /PerformanceObserver/.test(inv) ? "the long-animation-frame observer's callback" : s.fn || "(anonymous)";
+        key = `instrument bookkeeping (${what}; no pane work) <${invoker}>`;
+      }
       const row = by.get(key) || { key, count: 0, durationMs: 0 };
       row.count++; row.durationMs += s.duration || 0;
       by.set(key, row);

--- a/tools/ui-bench.mjs
+++ b/tools/ui-bench.mjs
@@ -1,0 +1,1815 @@
+#!/usr/bin/env node
+// tools/ui-bench.mjs: a reproducible headless-Chrome performance bench for romp's dashboard panes.
+//
+// The kernel pushes JSON frames over a WebSocket to each pane page: the feed, the Outline pane (app id
+// fleet), the chat and the timeline. How long the page's main thread takes to absorb a frame is what the
+// user feels as a laggy dashboard, and until now it was measured by eye. This tool makes it a number, in
+// three steps:
+//
+//   1. --record <app> --seconds N --out /tmp/…/frames.jsonl
+//      Connect to the LIVE kernel's WebSocket exactly as the browser page does (the shim's own query:
+//      app, delta=1, iid; the token as the romp_token cookie with a same-origin Origin header; the
+//      {type:"ready"} handshake) and save every frame the kernel sends, with a receive timestamp, as
+//      JSONL. The client is read-only: it sends the ready handshake and nothing else (the ws library
+//      answers protocol pings, which the kernel's liveness check needs). Recorded frames are REAL
+//      session data, so the output path must be under /tmp and outside any git checkout; the tool
+//      refuses anything else.
+//
+//   2. --replay <app> --frames FILE [--cpu-throttle K] [--iters N] [--fast | --gap MS] [--json OUT] [--cpu-profile OUT]
+//      Serve the pane page and its bundles from the built dist and replay the recorded frames into a
+//      headless Chromium at their recorded pacing (back-to-back with --fast, or a fixed gap apart with
+//      --gap), measuring per frame the bytes, the WebSocket handler's synchronous time (the shim's own
+//      work on the wire frame: parse, delta application, the held-state stamp), the bundle's time for
+//      the delivery that carried the frame, and the time until the main thread is free again (message
+//      receipt to the second requestAnimationFrame after that delivery); plus long-animation-frame
+//      entries with script attribution (the task's entry point: the message handler, the shim's flush
+//      task, a rAF, a timer, a script's evaluation; not the bundle function), JS heap after a forced
+//      GC, DOM size, and page console errors. The shim hands frames to the bundle in its own task
+//      (kernel.py _shim: a FIFO flushed by a MessageChannel message, where a newer whole-state frame
+//      replaces an older one still queued and the flush is time-sliced), so a wire frame and the
+//      bundle's render of it are two measurements: the report keeps them apart, says how many frames
+//      reached the bundle as their own delivery and how many were coalesced into a newer frame's, and
+//      for a shim from before that task (the bundle rendered inside the handler) says so and reads the
+//      handler column as shim plus bundle. --cpu-profile OUT.cpuprofile samples the page's JavaScript
+//      with the V8 profiler across the replay, writes a file Chrome DevTools loads, and prints the
+//      functions with the most self and total time (with their source positions through the dist's
+//      .map files, and for the hottest functions the lines that hold the time), overall and inside the
+//      delivery of the first content frame and of the largest frame of each type: the attribution the
+//      long-animation-frame entries cannot give.
+//
+//      Serving design: the REAL kernel HTTP Handler runs in a python3 subprocess under an isolated
+//      environment, the pattern of tests/test_color_route.py with the floors tests/conftest.py applies:
+//      private XDG_STATE_HOME and TMUX_TMPDIR; the manager variables, the API-key variables and the key
+//      reference removed; the manager's key FILE and the boot model-catalog fetch pointed away (the
+//      kernel would otherwise read ~/.config/romp/service.env and carry its key to the Models API); the
+//      Claude binary floored to /bin/false; the CLI scope off (ROMP_CLI_SCOPE=0, so nothing probes
+//      systemd-run); the postal peer bus off; ROMP_KERNEL_NO_OPEN=1; a serve token minted for the run.
+//      So the page HTML and the WebSocket shim are the kernel's own bytes. The subprocess holds a pipe
+//      from the parent and exits when it closes, so it cannot outlive the bench however the bench ends.
+//      Its directory, and the browser's profile and artifacts, live under one per-user parent whose
+//      dead-owner entries the next run sweeps: a process-group SIGKILL leaves them until then, nothing
+//      else does. The shim connects its
+//      socket to location.host, so a small Node front server sits in front: it answers /ws itself as
+//      the replay server and proxies every other request (the page, /dist/*, /media/*, the small
+//      JSON routes the bundles fetch) to the kernel Handler. Nothing is rewritten. The live kernel is
+//      never started, restarted, or imported with its manager variables set.
+//
+//   3. --synthesize <app> --cards N --out FILE
+//      A plausible frame stream with invented content (the notes-api demo domain, placeholder
+//      uuids) in the kernel's wire shapes, for tests and for a bench that must not depend on a live
+//      board. Frames mirror kernel.py: build_feed's {type:"feed"} as the keyed full frame with the _keys
+//      list _send_slot_delta appends, then its {type:"delta", slot:"feed"} frames, for the feed and
+//      Outline pages; build_timeline's skeleton ({type:"data"}), the {type:"bars"} slot with its _keys
+//      list and {type:"delta", slot:"bars"} for the timeline; keepalives throughout. The chat's
+//      {type:"session"} frame is not synthesized:
+//      build_session's shape is too rich to fake faithfully, so record it from the live kernel.
+//
+//   --compare A.json B.json prints the deltas between two replay reports.
+//
+// Run from the repo root; playwright and ws come from vscode-extension/node_modules. Examples:
+//   node tools/ui-bench.mjs --synthesize feed --cards 200 --out /tmp/romp-perf/synth-feed.jsonl
+//   node tools/ui-bench.mjs --replay feed --frames /tmp/romp-perf/synth-feed.jsonl --fast --json /tmp/romp-perf/a.json
+//   node tools/ui-bench.mjs --record feed --seconds 90 --out /tmp/romp-perf/frames-feed.jsonl
+//   node tools/ui-bench.mjs --replay feed --frames /tmp/romp-perf/frames-feed.jsonl --json /tmp/romp-perf/b.json
+//   node tools/ui-bench.mjs --compare /tmp/romp-perf/a.json /tmp/romp-perf/b.json
+//
+// tests/ui-bench.test.mjs covers the classifier, the compare arithmetic, the synthesizer's shapes,
+// the /tmp path guard, the recording client against a local WebSocket server, the Handler subprocess's
+// environment and its exit with the parent, the CPU-profile aggregation, and a real replay of
+// synthetic streams on the feed and timeline pages.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import { createRequire, SourceMap } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const REPO = path.resolve(HERE, "..");
+const EXT_DIR = path.join(REPO, "vscode-extension");
+const requireExt = createRequire(path.join(EXT_DIR, "package.json"));
+
+// The pane pages the kernel serves, by the app id their shim connects with (kernel.py: the /feed,
+// /fleet, /chat and /timeline routes; `fleet` is the Outline pane).
+export const APPS = ["feed", "fleet", "chat", "timeline"];
+export const DELTA_SEP = "\u001f";   // kernel.py _DELTA_SEP: joins the keys of a keyed collection
+
+// ── frame classification ─────────────────────────────────────────────────────────────────────────
+
+const TYPE_RE = /"type"\s*:\s*"([^"\\]*)"/;
+const SLOT_RE = /"slot"\s*:\s*"([^"\\]*)"/;
+
+/** The report row a wire frame files under: its `type`, or `delta:<slot>` for a view delta; "other"
+ *  when the text carries no type. A regex over the head of the string, so classifying a multi-megabyte
+ *  frame costs nothing like a parse; the kernel writes `type` (and a delta's `slot`) first or right
+ *  after `now`, in both json.dumps spacing and the hand-concatenated compact form. */
+export function classifyFrame(text) {
+  if (typeof text !== "string") return "other";
+  const head = text.length > 4096 ? text.slice(0, 4096) : text;
+  let type = null, slot = null;
+  const m = TYPE_RE.exec(head);
+  if (m) {
+    type = m[1];
+    if (type === "delta") { const s = SLOT_RE.exec(head); slot = s ? s[1] : null; }
+  } else {
+    try {
+      const o = JSON.parse(text);
+      if (o && typeof o.type === "string") { type = o.type; if (type === "delta") slot = typeof o.slot === "string" ? o.slot : null; }
+    } catch { return "other"; }
+  }
+  if (!type) return "other";
+  return type === "delta" ? "delta:" + (slot || "?") : type;
+}
+
+// ── statistics ───────────────────────────────────────────────────────────────────────────────────
+
+/** Nearest-rank percentile of a numeric array (p in 0..100); null for an empty array. */
+export function percentile(values, p) {
+  const xs = values.filter((v) => typeof v === "number" && Number.isFinite(v)).sort((a, b) => a - b);
+  if (!xs.length) return null;
+  const rank = Math.min(xs.length - 1, Math.max(0, Math.ceil((p / 100) * xs.length) - 1));
+  return xs[rank];
+}
+
+export function summarize(values) {
+  const xs = values.filter((v) => typeof v === "number" && Number.isFinite(v));
+  if (!xs.length) return { n: 0, p50: null, p90: null, max: null, mean: null };
+  const sum = xs.reduce((a, b) => a + b, 0);
+  return { n: xs.length, p50: percentile(xs, 50), p90: percentile(xs, 90), max: Math.max(...xs), mean: sum / xs.length };
+}
+
+// ── paths ────────────────────────────────────────────────────────────────────────────────────────
+
+/** A recording holds real session data, so it may live only under /tmp and never inside a git
+ *  checkout (a stray `git add` there would publish it). Both sides of the comparison are resolved
+ *  through symlinks: on macOS /tmp is a link to /private/tmp and os.tmpdir() lives under /var/folders,
+ *  so a root compared by name never matched a candidate compared by realpath. A directory that does
+ *  not exist yet is resolved through its deepest existing ancestor. A symlink at the leaf is refused:
+ *  a write through it lands wherever the link points. Returns the absolute path or throws. `roots` is
+ *  a test seam; the default is /tmp and os.tmpdir(). */
+export function assertTmpPath(p, { roots = ["/tmp", os.tmpdir()] } = {}) {
+  const abs = path.resolve(p);
+  const resolvedRoots = new Set();
+  for (const r of roots) {
+    if (!r) continue;
+    const named = path.resolve(r);
+    resolvedRoots.add(named);
+    const real = safeReal(named);
+    if (real) resolvedRoots.add(real);
+  }
+  const dir = resolveExistingPrefix(path.dirname(abs));
+  const inTmp = [...resolvedRoots].some((r) => dir === r || dir.startsWith(r + path.sep));
+  if (!inTmp) throw new Error(`refusing to write a recording outside /tmp: ${abs}`);
+  let leaf = null;
+  try { leaf = fs.lstatSync(abs); } catch (e) { if (e.code !== "ENOENT" && e.code !== "ENOTDIR") throw e; }
+  if (leaf && leaf.isSymbolicLink()) throw new Error(`refusing to write a recording through a symlink: ${abs}`);
+  for (let d = dir; ; d = path.dirname(d)) {
+    if (fs.existsSync(path.join(d, ".git"))) throw new Error(`refusing to write a recording inside a git checkout: ${abs} (a .git lives at ${d})`);
+    if (path.dirname(d) === d) break;
+  }
+  return abs;
+}
+
+function safeReal(p) {
+  try { return fs.realpathSync(p); } catch { return null; }
+}
+
+/** The realpath of the deepest existing ancestor of `p`, with the missing tail appended unchanged. */
+function resolveExistingPrefix(p) {
+  const missing = [];
+  for (let d = p; ; d = path.dirname(d)) {
+    const real = safeReal(d);
+    if (real) return missing.length ? path.join(real, ...missing) : real;
+    if (path.dirname(d) === d) return p;
+    missing.unshift(path.basename(d));
+  }
+}
+
+// ── JSONL frame files ────────────────────────────────────────────────────────────────────────────
+
+/** Read a frames file: rows {t, data} in file order (meta and event rows skipped). */
+export function loadFrames(file) {
+  const rows = [];
+  let meta = null;
+  for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line);
+    if (row.meta) { meta = row.meta; continue; }
+    if (typeof row.data !== "string") continue;
+    rows.push({ t: Number(row.t) || 0, data: row.data });
+  }
+  return { meta, frames: rows };
+}
+
+/** Write a frames file private to the user: directory 0700, file 0600 (re-applied when the file
+ *  already existed), and never through a symlink at the leaf (O_NOFOLLOW). A recording holds every
+ *  frame the kernel pushed, and /tmp is readable by every local account. */
+export function writeFrames(file, meta, frames) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const out = [JSON.stringify({ meta })];
+  for (const f of frames) out.push(JSON.stringify({ t: f.t, bytes: Buffer.byteLength(f.data, "utf8"), data: f.data }));
+  const buf = Buffer.from(out.join("\n") + "\n", "utf8");
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | (fs.constants.O_NOFOLLOW || 0);
+  const fd = fs.openSync(file, flags, 0o600);
+  try {
+    fs.fchmodSync(fd, 0o600);
+    for (let off = 0; off < buf.length;) off += fs.writeSync(fd, buf, off, buf.length - off);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// ── --record: a read-only client of the live kernel ──────────────────────────────────────────────
+
+function stateDir() {
+  if (process.env.ROMP_STATE_DIR) return process.env.ROMP_STATE_DIR;
+  const xdg = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state");
+  return path.join(xdg, "romp");
+}
+
+export function readServeToken() {
+  const f = path.join(stateDir(), "serve-token");
+  const t = fs.readFileSync(f, "utf8").trim();
+  if (!t) throw new Error(`empty serve token at ${f}`);
+  return t;
+}
+
+export async function recordFrames({ app, seconds, out, port, log = console.error }) {
+  if (!APPS.includes(app)) throw new Error(`unknown app ${app}; one of ${APPS.join(", ")}`);
+  const file = assertTmpPath(out);
+  const token = readServeToken();
+  const WebSocket = requireExt("ws");
+  const origin = `http://127.0.0.1:${port}`;
+  const iid = crypto.randomUUID();
+  const url = `ws://127.0.0.1:${port}/ws?app=${app}&delta=1&iid=${encodeURIComponent(iid)}`;   // the shim's connect query (kernel.py _shim)
+  // The browser's credential form: the romp_token cookie plus a same-origin Origin header (the kernel's
+  // _authorize accepts the cookie only with an acceptable Origin). No ?token=, no X-Romp-Token.
+  const ws = new WebSocket(url, { origin, headers: { Cookie: `romp_token=${token}` }, maxPayload: 512 * 1024 * 1024 });
+  const frames = [];
+  const events = [];
+  const started = Date.now();
+  const meta = { tool: "ui-bench", mode: "record", app, port, seconds, startedAt: new Date(started).toISOString(), iid };
+  await new Promise((resolve, reject) => {
+    let done = false;
+    const onInterrupt = () => { log("ui-bench: interrupted; writing what was recorded"); finish(); };
+    const finish = (err) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      process.removeListener("SIGINT", onInterrupt);   // one listener per recording, gone when it ends
+      try { ws.close(); } catch {}
+      err ? reject(err) : resolve();
+    };
+    const timer = setTimeout(() => finish(), seconds * 1000);
+    process.once("SIGINT", onInterrupt);
+    ws.on("open", () => {
+      events.push({ t: Date.now(), event: "open" });
+      // The bundle's handshake (kernel _ws: ready → _push_one). There is no ready gate: the pusher serves a
+      // fresh socket from its next cycle as well, and whichever runs first sends the keyed full frame while the
+      // other is deduped against it, so a recording opens with one full frame per slot and then the tab order
+      // the ready handler pushes, as a browser's stream does.
+      ws.send(JSON.stringify({ type: "ready" }));
+    });
+    ws.on("message", (data, isBinary) => {
+      const text = isBinary ? data.toString("utf8") : data.toString();
+      frames.push({ t: Date.now(), data: text });
+    });
+    ws.on("unexpected-response", (_req, res) => {
+      let body = "";
+      res.on("data", (c) => { body += c; });
+      res.on("end", () => finish(new Error(`the kernel refused the WebSocket: HTTP ${res.statusCode} ${body.trim()}`)));
+    });
+    ws.on("error", (e) => finish(new Error(`WebSocket error: ${e.message}`)));
+    ws.on("close", (code, reason) => {
+      events.push({ t: Date.now(), event: "close", code, reason: String(reason || "") });
+      if (!done) finish(new Error(`the kernel closed the socket early (code ${code}) after ${frames.length} frames`));
+    });
+  }).finally(() => {
+    meta.endedAt = new Date().toISOString();
+    meta.frames = frames.length;
+    meta.events = events;
+    writeFrames(file, meta, frames);
+  });
+  const summary = streamSummary(frames);
+  log(`ui-bench: recorded ${frames.length} frames (${fmtBytes(summary.bytes)}) from app=${app} over ${((Date.now() - started) / 1000).toFixed(1)}s → ${file}`);
+  for (const [type, s] of Object.entries(summary.byType)) log(`  ${type.padEnd(12)} ${String(s.count).padStart(6)}  ${fmtBytes(s.bytes).padStart(10)}  max ${fmtBytes(s.max)}`);
+  return { file, frames: frames.length, summary };
+}
+
+export function streamSummary(frames) {
+  const byType = {};
+  let bytes = 0;
+  for (const f of frames) {
+    const type = classifyFrame(f.data);
+    const n = Buffer.byteLength(f.data, "utf8");
+    bytes += n;
+    const s = (byType[type] ||= { count: 0, bytes: 0, max: 0 });
+    s.count++; s.bytes += n; if (n > s.max) s.max = n;
+  }
+  return { frames: frames.length, bytes, byType };
+}
+
+// ── --synthesize: invented frames in the kernel's shapes ─────────────────────────────────────────
+
+const SIDS = ["11111111-2222-3333-4444-555555555501", "11111111-2222-3333-4444-555555555502", "11111111-2222-3333-4444-555555555503"];
+const NAMES = ["web", "api", "tests"];
+const COLORS = [{ bg: "#1EA1EB", fg: "white" }, { bg: "#54B204", fg: "black" }, { bg: "#E0B020", fg: "black" }];
+const VERBS = ["Add", "Fix", "Refactor", "Document", "Test", "Wire", "Profile", "Remove"];
+const OBJECTS = ["pagination on the notes list", "the notes-api auth middleware", "the search index rebuild", "the markdown export",
+  "the tag filter query", "the rate limiter", "the notes sync endpoint", "the attachment upload path", "the CLI's note picker",
+  "the flaky integration test", "the OpenAPI schema", "the migration runner"];
+const SYNTH_NOW = 1_760_000_000;   // a fixed clock so a synthesized stream is byte-stable run to run
+// A card's recency tint (kernel: "trgb": list(cm.age_rgb(age)), bright when recent, dark when old): a fixed
+// four-step palette by age in place of the kernel's colormap. feed.ts destructures it on every card.
+const TINTS = [[253, 231, 37], [94, 201, 98], [33, 145, 140], [68, 1, 84]];
+const synthTint = (age) => TINTS[age < 600 ? 0 : age < 3600 ? 1 : age < 6 * 3600 ? 2 : 3];
+
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => { a |= 0; a = (a + 0x6D2B79F5) | 0; let t = Math.imul(a ^ (a >>> 15), 1 | a); t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t; return ((t ^ (t >>> 14)) >>> 0) / 4294967296; };
+}
+const pick = (r, xs) => xs[Math.floor(r() * xs.length)];
+
+function synthCard(i, r, now) {
+  const k = i % SIDS.length;
+  const column = i % 5 === 3 ? "needs_input" : i % 5 === 4 ? "completed" : "working";
+  const text = `${VERBS[i % VERBS.length]} ${OBJECTS[i % OBJECTS.length]} (#${i + 1})`;
+  const t = now - 300 * i - 17;
+  const nodes = [];
+  const kids = 1 + (i % 3);
+  for (let j = 0; j < kids; j++) {
+    nodes.push({
+      id: `n${i}-${j}`, kind: "ask", text: `${text}: step ${j + 1}`, who: NAMES[k], whoSid: SIDS[k], whoColor: COLORS[k],
+      status: column === "completed" ? "done" : (column === "needs_input" && j === kids - 1) ? "question" : (j === 0 ? "done" : "open"),
+      t: t + 30 * j, last: t + 60 * j + 5, anchorUuid: null, promptAnchorUuid: null, children: [],
+    });
+  }
+  const card = {
+    itemId: `card-${i}`, sid: SIDS[k], name: NAMES[k], color: COLORS[k], text, t, trgb: synthTint(now - t), live: true, turnId: `turn-${i}`,
+    column, tree: nodes, notify: null, summary: column === "completed" ? `Done: ${text.toLowerCase()} landed with a test.` : null,
+    blockSummary: null, background: null, distillState: column === "completed" ? "completed" : null,
+  };
+  if (column === "working") card.working = { since: now - 40 - (i % 7) * 10, toolUses: 1 + (i % 9) };
+  if (i % 11 === 6) card.awaiting = { why: "waiting on the test suite", kind: "task", since: now - 90, tasks: ["npm test"] };
+  return card;
+}
+
+function synthLedger(k, cards, now) {
+  const own = cards.filter((c) => c.sid === SIDS[k]);
+  const tree = [];
+  for (const c of own) {
+    tree.push({ id: c.itemId, text: c.text, depth: 0, done: c.column === "completed", blocked: c.column === "needs_input", t: c.t, mt: c.t + 120,
+      current: c.column === "working", children: c.tree.map((n) => n.id), summary: c.summary, blockSummary: null });
+    for (const n of c.tree) tree.push({ id: n.id, text: n.text, depth: 1, done: n.status === "done", blocked: n.status === "question", t: n.t, mt: n.last, current: false, children: [] });
+  }
+  return { sid: SIDS[k], name: NAMES[k], color: COLORS[k], status: { state: k === 2 ? "ready" : "working" },
+    ledger: { summary: `${NAMES[k]} is working through ${own.length} goals on notes-api.`, tree, current: { t: now - 60 } } };
+}
+
+/** build_feed's wire keys in its order, the pusher's buildId after them and, for the Outline page, the
+ *  ledgers it attaches; `views` is the shape a kernel with no views file ships. */
+function synthFeedFull(cards, now, buildId, withLedgers) {
+  const frame = {
+    type: "feed", asks: cards.map((c) => ({ ...c })), now,
+    views: { active: "all", actives: { chat: { all: true }, timeline: { all: true }, outline: { all: true } }, tags: [] },
+    judgeLimit: null, working: [NAMES[0], NAMES[1]], awaiting: [], stateUnknown: [], bgServices: {},
+    dismissedCount: 0, showDismissed: false, order: SIDS.slice(),
+    sessions: SIDS.map((sid, k) => ({ sid, name: NAMES[k], color: COLORS[k] })),
+    clearNotices: [], sdkNotices: [], syncNotices: [], selfHost: "TESTHOST", canUndoClear: false, buildId,
+  };
+  if (withLedgers) frame.ledgers = SIDS.map((_s, k) => synthLedger(k, cards, now));
+  return frame;
+}
+
+/** The kernel's _keys list for a {type:"feed"} full frame: the asks by itemId in payload order (kernel.py
+ *  _DELTA_SLOTS feed: asks "byid:itemId"; _delta_key). The shim files the asks under these keys and applies
+ *  every later delta against them; a full frame without the list makes it answer each delta with needSlot. */
+export function feedKeys(feed) {
+  return { asks: (feed.asks || []).map((a) => String(a.itemId)) };
+}
+
+/** The non-keyed remainder of a feed frame as _delta_parts splits it: every key but the keyed collection.
+ *  `type`, the clock fields and the ledgers are part of it, so when a delta carries the WHOLE remainder
+ *  (restAll) the shim keeps exactly the keys it names and drops the rest. */
+function feedRest(frame) {
+  const rest = {};
+  for (const [k, v] of Object.entries(frame)) if (k !== "asks") rest[k] = v;
+  return rest;
+}
+
+/** A feed-protocol stream (feed and Outline pages): the keyed full frame, then {type:"delta", slot:"feed"}
+ *  frames and keepalives over about a minute of invented activity, in the shapes _send_slot_delta writes.
+ *  Revisions run contiguously from the full's 0. `coll.asks.set` carries changed and appended cards (the
+ *  shim appends a new key on its own, so no `order` rides for one), `coll.asks.del` a retired card, and
+ *  `coll.asks.order` crosses only when a card moves. `rest` is the clock fields alone (_DEDUP_VOLATILE: now,
+ *  buildId) until the remainder changes, when the WHOLE remainder rides with `restAll` (the Outline's
+ *  ledgers are remainder, so a changed ledger goes this way). */
+function synthFeedStream(app, cards, r, now) {
+  const t0 = now * 1000;
+  const withLedgers = app === "fleet";
+  const items = [];
+  for (let i = 0; i < cards; i++) items.push(synthCard(i, r, now));
+  let buildId = 1;
+  const full = synthFeedFull(items, now, buildId, withLedgers);
+  const frames = [{ t: t0, data: JSON.stringify({ ...full, _keys: feedKeys(full) }) }];
+  let rev = 0;
+  let nextNew = cards;
+  const ka = (t) => frames.push({ t, data: JSON.stringify({ type: "ka", dv: now }) });
+  for (let step = 1; step <= 24; step++) {
+    const t = t0 + step * 2500;
+    if (step % 4 === 0) ka(t - 400);
+    buildId++;
+    full.now = now + Math.round((t - t0) / 1000); full.buildId = buildId;
+    const set = {};
+    const asks = { set };
+    const nUp = 1 + Math.floor(r() * 3);
+    for (let u = 0; u < nUp && items.length; u++) {
+      const c = items[Math.floor(r() * items.length)];
+      c.text = c.text.replace(/( · rev \d+)?$/, ` · rev ${step}`);
+      if (c.working) c.working = { ...c.working, toolUses: (c.working.toolUses || 0) + 1 };
+      set[c.itemId] = { ...c };
+    }
+    if (step % 5 === 0 && items.length > 1) {
+      const gone = items.splice(Math.floor(r() * items.length), 1)[0];
+      asks.del = [gone.itemId];
+      const fresh = synthCard(nextNew++, r, full.now);
+      items.push(fresh);
+      set[fresh.itemId] = { ...fresh };
+    }
+    if (step % 9 === 0 && items.length > 2) {
+      const moved = items.splice(items.length - 1, 1)[0];   // the newest card surfaces at the top
+      items.unshift(moved);
+      asks.order = items.map((c) => c.itemId);
+    }
+    let restChanged = false;
+    if (step % 7 === 0) { full.working = step % 2 ? [NAMES[0]] : [NAMES[0], NAMES[1], NAMES[2]]; restChanged = true; }
+    if (withLedgers && step % 3 === 0) { full.ledgers[step % SIDS.length] = synthLedger(step % SIDS.length, items, full.now); restChanged = true; }
+    const d = { type: "delta", slot: "feed", base: rev, rev: rev + 1, coll: { asks } };
+    if (restChanged) { d.rest = feedRest(full); d.restAll = 1; }
+    else d.rest = { now: full.now, buildId };
+    frames.push({ t, data: JSON.stringify(d) });
+    rev++;
+  }
+  ka(t0 + 63_000);
+  return frames;
+}
+
+function synthLane(k, now, live) {
+  return {
+    id: SIDS[k], name: NAMES[k], live, state: live ? (k === 2 ? "idle" : "working") : "idle",
+    awaitingBg: null, awaitingKind: null, awaitingCount: null, awaitingPeers: null, awaitingTasks: [],
+    since: now - 120 * (k + 1), color: COLORS[k].bg, model: "opus", effort: "high", modelPending: false,
+    modelColor: null, effortColor: null, fast: "", modelTone: null, effortTone: null, ctxTone: null,
+    context: 20 + 15 * k, ctxColor: null, subagents: [], awaiting: [], compacting: [], compactions: [], clears: [],
+    faded: false, branch: null, comments: [], hideFromFeed: false, postalServiceOff: false, notify: true,
+  };
+}
+
+function synthBar(k, j, now, open) {
+  const start = now - 3600 + 240 * j;
+  const text = `${VERBS[(j + k) % VERBS.length]} ${OBJECTS[(j * 3 + k) % OBJECTS.length]}`;
+  return {
+    id: `seg-${k}-${j}`, promptId: `aaaaaaaa-0000-4000-8000-${String(k).padStart(4, "0")}${String(j).padStart(8, "0")}`,
+    workId: `bbbbbbbb-0000-4000-8000-${String(k).padStart(4, "0")}${String(j).padStart(8, "0")}`,
+    start, end: open ? now : start + 150, open, cont: false, prompt: text, summary: `Working on ${text.toLowerCase()}`,
+    msgCaption: text, src: "typed", mids: [], pending: false, tid: SIDS[k],
+    uuid: `aaaaaaaa-0000-4000-8000-${String(k).padStart(4, "0")}${String(j).padStart(8, "0")}`,
+    nudgeAuto: false, romp: false,
+    workUuid: `bbbbbbbb-0000-4000-8000-${String(k).padStart(4, "0")}${String(j).padStart(8, "0")}`,
+    replyUuid: `cccccccc-0000-4000-8000-${String(k).padStart(4, "0")}${String(j).padStart(8, "0")}`,
+  };
+}
+
+/** The kernel's _keys list for a {type:"bars"} full frame (kernel.py _delta_split / _delta_key). */
+export function barsKeys(bars) {
+  const turns = [];
+  for (const [sid, lane] of Object.entries(bars.turns || {})) {
+    if (!Array.isArray(lane) || !lane.length) { turns.push(sid + DELTA_SEP); continue; }
+    for (const b of lane) turns.push(sid + DELTA_SEP + String(b.id));
+  }
+  const judging = (bars.judging || []).map((row) => ["sid", "t", "judge", "t1"].map((f) => String(row[f])).join(DELTA_SEP));
+  const messages = (bars.messages || []).map((m) => String(m.id));
+  return { turns, judging, messages };
+}
+
+/** A timeline stream: the lanes skeleton, the keyed bars slot, then bar-level deltas, a skeleton
+ *  re-push and keepalives. */
+function synthTimelineStream(cards, r, now) {
+  const t0 = now * 1000;
+  const skeleton = () => ({
+    type: "data",
+    data: { type: "timeline", now, sessions: SIDS.map((_s, k) => synthLane(k, now, true)), turns: {}, messages: [], judging: [],
+      palette: COLORS.map((c) => c.bg), cmapGrad: null, activeChat: null, focus: null, hover: null, usage: null },
+  });
+  const frames = [{ t: t0, data: JSON.stringify(skeleton()) }];
+  const perLane = Math.max(1, Math.ceil(cards / SIDS.length));
+  const turns = {};
+  SIDS.forEach((sid, k) => {
+    turns[sid] = [];
+    for (let j = 0; j < perLane; j++) turns[sid].push(synthBar(k, j, now, k < 2 && j === perLane - 1));
+  });
+  const judging = [];
+  for (let j = 0; j < Math.min(perLane, 12); j++) {
+    const k = j % SIDS.length;
+    const t = now - 3400 + 240 * j;
+    judging.push({ judge: pick(r, ["planner", "closer", "distiller", "captioner"]), sid: SIDS[k], t, t1: t + 8, kind: "run", text: "",
+      ms: 7200, in: 4000 + j * 10, out: 300, sent: t, recv: t + 8 });
+  }
+  const bars = { type: "bars", turns, judging, messages: [], now, warming: false };
+  frames.push({ t: t0 + 300, data: JSON.stringify({ ...bars, _keys: barsKeys(bars) }) });
+  let rev = 0;
+  const ka = (t) => frames.push({ t, data: JSON.stringify({ type: "ka", dv: now }) });
+  for (let step = 1; step <= 24; step++) {
+    const t = t0 + step * 2500;
+    const nowS = now + Math.round((t - t0) / 1000);
+    if (step % 4 === 0) ka(t - 400);
+    const k = step % 2;   // the two working lanes take turns
+    const lane = turns[SIDS[k]];
+    const set = {};
+    if (step % 6 === 0) {
+      // the open bar closes and a new one opens: two entries cross
+      const last = lane[lane.length - 1];
+      last.open = false; last.end = nowS - 5;
+      set[SIDS[k] + DELTA_SEP + last.id] = { ...last };
+      const fresh = synthBar(k, lane.length, nowS, true);
+      lane.push(fresh);
+      set[SIDS[k] + DELTA_SEP + fresh.id] = fresh;
+    } else {
+      const last = lane[lane.length - 1];
+      last.end = nowS;
+      set[SIDS[k] + DELTA_SEP + last.id] = { ...last };
+    }
+    frames.push({ t, data: JSON.stringify({ type: "delta", slot: "bars", base: rev, rev: rev + 1, coll: { turns: { set } }, rest: { now: nowS } }) });
+    rev++;
+    if (step % 8 === 0) {
+      const sk = skeleton();
+      sk.data.now = nowS;
+      sk.data.sessions[2].state = step % 16 ? "working" : "idle";
+      frames.push({ t: t + 200, data: JSON.stringify(sk) });
+    }
+  }
+  ka(t0 + 63_000);
+  return frames;
+}
+
+export function synthesizeFrames(app, cards, { seed = 7, now = SYNTH_NOW } = {}) {
+  if (!APPS.includes(app)) throw new Error(`unknown app ${app}; one of ${APPS.join(", ")}`);
+  if (app === "chat") throw new Error("chat frames are not synthesized (the session frame is built by build_session and is too rich to fake); record them from the live kernel with --record");
+  const r = rng(seed);
+  if (app === "timeline") return synthTimelineStream(cards, r, now);
+  return synthFeedStream(app, cards, r, now);
+}
+
+// ── --replay: the kernel page route in a subprocess, a Node front server, headless Chromium ─────
+
+// The kernel's HTTP Handler, alone, in a python3 subprocess. The import pattern is tests/test_color_route.py's:
+// the two sibling modules first (they resolve their state root at import), then the kernel by its bin/ name.
+// The Handler is the kernel's whole route surface (the pages, /ws, the POST routes that spawn and revive
+// sessions), gated by the serve token, so it must not outlive the bench: a daemon thread blocks on stdin,
+// which the parent holds open as a pipe, and when the parent exits, however it exits, the read returns
+// EOF, the thread removes the run directory and the process ends. When the whole process group is
+// killed the thread never runs and the directory stays; the next run's dead-owner sweep reclaims it.
+const PAGE_SERVER_PY = `
+import importlib.util, os, shutil, sys, threading
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+root, tmp = sys.argv[1], sys.argv[2]
+def _parent_gone():
+    try:
+        sys.stdin.buffer.read()
+    except Exception:
+        pass
+    shutil.rmtree(tmp, ignore_errors=True)
+    os._exit(0)
+threading.Thread(target=_parent_gone, daemon=True).start()
+b = os.path.join(root, "bin")
+def _load(name, p):
+    # the bin/ names carry no .py suffix, hence the explicit SourceFileLoader; registered before exec so
+    # the module resolves its own name the way an import would
+    spec = importlib.util.spec_from_loader(name, SourceFileLoader(name, p))
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+_load("romp_event_model", os.path.join(b, "romp-event-model"))
+_load("romp_judge", os.path.join(b, "romp-judge"))
+km = _load("romp_kernel_ui_bench", os.path.join(b, "romp-kernel"))
+srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+sys.stdout.write("PORT %d\\n" % srv.server_address[1]); sys.stdout.flush()
+srv.serve_forever()
+`;
+
+/** The variables the Handler subprocess must not inherit: the manager's (so the kernel module never
+ *  believes it is the supervised live kernel), the live kernel's ports and state root, and the API keys
+ *  and Claude binary a spawned session would run with (nothing the bench needs reads them). */
+export const STRIPPED_ENV = ["ROMP_MANAGER_PORT", "ROMP_MANAGER_PID", "ROMP_SUPERVISED", "ROMP_STATE_DIR", "ROMP_SERVE_PORT", "ROMP_KERNEL_PORT", "ROMP_PERF", "TMUX"];
+
+/** The parent every run of this tool on this machine keeps its state under: <tmp>/romp-ui-bench-<uid>,
+ *  private to the user and refused when something else holds the name. Each run gets a subdirectory
+ *  holding owner.pid, the Handler's XDG_STATE_HOME and TMUX_TMPDIR and, through TMPDIR at launch, the
+ *  browser's profile and artifacts. This small parent is the only directory the tool ever lists. */
+export function benchRoot(base = os.tmpdir()) {
+  const uid = typeof os.userInfo === "function" ? os.userInfo().uid : -1;
+  const root = path.join(base, `romp-ui-bench-${uid}`);
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const st = fs.lstatSync(root);
+  if (st.isSymbolicLink() || !st.isDirectory()) throw new Error(`${root} is not a directory; refusing to use it`);
+  if (uid >= 0 && st.uid !== uid) throw new Error(`${root} belongs to uid ${st.uid}; refusing to use it`);
+  if ((st.mode & 0o077) !== 0) fs.chmodSync(root, 0o700);
+  return root;
+}
+
+/** Remove the run directories under `root` whose recorded owner process is gone: what a process-group
+ *  SIGKILL leaves behind (the Handler dies with the group before its rmtree runs; Playwright removes its
+ *  directories from exit hooks a SIGKILL skips). An entry without owner.pid is left alone. Returns the
+ *  names removed. */
+export function sweepDeadRuns(root) {
+  const swept = [];
+  let names = [];
+  try { names = fs.readdirSync(root); } catch { return swept; }
+  for (const name of names) {
+    const dir = path.join(root, name);
+    let pid = NaN;
+    try { pid = Number(fs.readFileSync(path.join(dir, "owner.pid"), "utf8").trim()); } catch { continue; }
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    let alive = true;
+    try { process.kill(pid, 0); } catch (e) { alive = e.code === "EPERM"; }   // EPERM: it exists and is not ours
+    if (alive) continue;
+    try { fs.rmSync(dir, { recursive: true, force: true }); swept.push(name); } catch {}
+  }
+  return swept;
+}
+
+/** Start the kernel Handler subprocess under the isolated environment. Resolves to {port, token, pid,
+ *  tmp, root, stderr, stop, exited}; `exited` settles once the child is gone (reaped, so a kill(pid, 0)
+ *  after it reports ESRCH), which is what a caller waits on after stop() rather than a timer. On a start
+ *  failure (an interpreter that cannot be spawned, exits before its port, or never announces one) the
+ *  child is gone and its directory removed before the rejection.
+ *  The serve token is minted per run: the Handler is the kernel's whole route surface on a loopback
+ *  port any local process can reach, and a token in the source would open it to all of them. */
+export async function startPageServer({ dist, python = "python3", log = () => {} } = {}) {
+  const distDir = dist || path.join(EXT_DIR, "dist");
+  if (!fs.existsSync(path.join(distDir, "feed.js"))) throw new Error(`no built bundles at ${distDir} (run: cd vscode-extension && npm run build)`);
+  const root = benchRoot();
+  const swept = sweepDeadRuns(root);
+  if (swept.length) log(`ui-bench: removed ${swept.length} run director${swept.length === 1 ? "y" : "ies"} left behind by dead runs`);
+  const tmp = fs.mkdtempSync(path.join(root, "run-"));
+  fs.writeFileSync(path.join(tmp, "owner.pid"), `${process.pid}\n`);
+  const token = crypto.randomBytes(18).toString("base64url");
+  const env = { ...process.env };
+  for (const k of Object.keys(env)) if (k.startsWith("ANTHROPIC_") || STRIPPED_ENV.includes(k)) delete env[k];
+  env.XDG_STATE_HOME = path.join(tmp, "state");
+  env.TMUX_TMPDIR = path.join(tmp, "tmux");
+  fs.mkdirSync(env.XDG_STATE_HOME, { recursive: true });
+  fs.mkdirSync(env.TMUX_TMPDIR, { recursive: true });
+  env.ROMP_KERNEL_NO_OPEN = "1";
+  env.ROMP_POSTAL_PEERS = "0";   // the feed page polls /tunnels, which otherwise asks the LIVE postal bus for its peers
+  // The floors tests/conftest.py applies, for the same reasons. The kernel's live API key is the manager's
+  // env FILE (kernel/keysource.py falls back to ~/.config/romp/service.env when these two are unset), the
+  // boot model-catalog fetch would carry that key to the Models API from the first /sessions request a
+  // pane makes, and a missing ROMP_CLAUDE_BIN resolves to the real CLI, so it is set to a binary that runs
+  // nothing rather than removed.
+  env.ROMP_SERVICE_ENV_FILE = env.ROMP_SERVICE_ENV = path.join(tmp, "no-service.env");   // never created
+  env.ROMP_MODEL_CATALOG = "off";
+  env.ROMP_CLAUDE_BIN = "/bin/false";
+  // Two more of conftest's floors: a route that constructs the SDK backend decides whether to wrap CLIs in
+  // systemd-run scopes (on by default under a supervised kernel, probing the user manager), and keysource
+  // resolves an inherited key REFERENCE through its provider when the env file is absent.
+  env.ROMP_CLI_SCOPE = "0";
+  delete env.ROMP_API_KEY_REF;
+  env.ROMP_SERVE_TOKEN = token;
+  env.ROMP_DIST_DIR = distDir;
+  const child = spawn(python, ["-c", PAGE_SERVER_PY, REPO, tmp], { env, stdio: ["pipe", "pipe", "pipe"] });
+  child.stdin.on("error", () => {});   // EPIPE once the child is gone
+  let stderr = "";
+  child.stderr.on("data", (c) => { stderr += c; if (stderr.length > 64_000) stderr = stderr.slice(-32_000); log(String(c)); });
+  const exited = new Promise((resolve) => child.on("exit", resolve));   // before the port wait, so a start-failure exit settles it too
+  let stopped = false;
+  const stop = (signal = "SIGTERM") => {
+    if (!stopped) { stopped = true; try { child.stdin.end(); } catch {} }
+    try { child.kill(signal); } catch {}
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+  };
+  const port = await new Promise((resolve, reject) => {
+    let buf = "";
+    const timer = setTimeout(() => { stop("SIGKILL"); reject(new Error(`the kernel page server did not start within 60s\n${stderr}`)); }, 60_000);
+    // An interpreter that cannot be spawned (ENOENT) emits 'error' and never 'exit'; unhandled, that is an
+    // uncaught exception thrown from a tick outside the promise chain, and the directory stays behind.
+    child.on("error", (e) => { clearTimeout(timer); try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {} reject(new Error(`could not start ${python}: ${e.message}`)); });
+    child.stdout.on("data", (c) => {
+      buf += c;
+      const m = /PORT (\d+)/.exec(buf);
+      if (m) { clearTimeout(timer); resolve(Number(m[1])); }
+    });
+    child.on("exit", (code) => { clearTimeout(timer); try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {} reject(new Error(`the kernel page server exited with ${code}\n${stderr}`)); });
+  });
+  return { port, token, pid: child.pid, tmp, root, stderr: () => stderr, stop: () => stop(), exited };
+}
+
+/** The front server: /ws is ours (the replay socket), everything else proxies to the kernel Handler. */
+export async function startFront({ pagePort }) {
+  const { WebSocketServer } = requireExt("ws");
+  let onSocket = null;
+  const server = http.createServer((req, res) => {
+    // The browser's Host header passes through untouched: the kernel's _origin_ok compares a request's Origin
+    // against its Host, and Chrome sends Origin on CORS-mode subresource loads (the woff2 fonts), so a
+    // rewritten Host turned every font load into a 403.
+    const upstream = http.request({ host: "127.0.0.1", port: pagePort, method: req.method, path: req.url, headers: req.headers }, (up) => {
+      res.writeHead(up.statusCode, up.headers);
+      up.pipe(res);
+    });
+    upstream.on("error", (e) => { res.writeHead(502, { "Content-Type": "text/plain" }); res.end("front proxy: " + e.message); });
+    req.pipe(upstream);
+  });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 512 * 1024 * 1024 });
+  server.on("upgrade", (req, socket, head) => {
+    const u = new URL(req.url, "http://127.0.0.1");
+    const selfOrigin = `http://127.0.0.1:${server.address().port}`;
+    if (u.pathname !== "/ws" || (req.headers.origin && req.headers.origin !== selfOrigin)) {
+      socket.write("HTTP/1.1 403 Forbidden\r\n\r\n"); socket.destroy(); return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => { if (onSocket) onSocket(ws, u); else ws.close(); });
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  return {
+    port: server.address().port,
+    setSocketHandler(fn) { onSocket = fn; },
+    stop() { for (const c of wss.clients) { try { c.terminate(); } catch {} } server.close(); },
+  };
+}
+
+// In-page instrumentation, installed before any page script runs. Three seams of the kernel's pane shim
+// (kernel.py _shim) are wrapped, each recorded in the instrument's file under a named function so a CPU
+// profile can tell its samples apart:
+//   1. WebSocket.prototype's onmessage setter, so the shim's handler is timed per wire frame: t0 at entry,
+//      `handler` when it returns. That is the shim's synchronous work (parse, the keepalive and restart
+//      answers, delta application, the held-state stamp, the enqueue); a resync ask (needSlot) sent from
+//      inside it marks the frame as one the shim refused. On a shim from before the flush task the bundle's
+//      render ran in here too, and the delivery wrapper below records it inside the handler.
+//   2. MessagePort.prototype's onmessage setter, so the shim's flush task (ch.port1.onmessage = flush) is
+//      timed per task, and MessagePort.prototype.postMessage, so the posts that arm it from inside a
+//      handler (a frame queued) or a flush (the slice budget spent, the rest re-armed) are counted: the
+//      queue is drained once every counted post has fired.
+//   3. The handoff to the bundle: the shim's deliver() calls window.__rompFed.inbound("", m) once
+//      federation.js has published its object, else dispatches a MessageEvent on window. The window slot
+//      is trapped so the published inbound is wrapped, and window.dispatchEvent is wrapped for the
+//      fallback; a dispatch made inside an inbound (federation re-emitting the merged frame to the pane)
+//      is part of that delivery, never a second one. Each delivery records the delivered object's type,
+//      its time, the flush or handler it ran in, and `settle` at the second requestAnimationFrame after
+//      it (the main thread has rendered and is free). Handlers stamp a settle of their own for the
+//      frames that never reach the bundle.
+// Long animation frames are observed with script attribution; longtask is the fallback.
+// Exported for the test that drives it on a blank page with a MessageChannel and a stub federation object.
+export const INIT_SCRIPT = `
+(() => {
+  const R = window.__rompBench = { recs: [], flushes: [], deliveries: [], loaf: [], loafKind: null, n: 0, addListenerMessages: 0, portPosts: 0, portFires: 0 };
+  let curRec = -1, curFlush = -1, depth = 0;
+  const settleAfter = (row) => requestAnimationFrame(() => requestAnimationFrame(() => { row.settle = performance.now() - row.t0; }));
+  const wsProto = WebSocket.prototype;
+  const wsDesc = Object.getOwnPropertyDescriptor(wsProto, "onmessage");
+  function wrapOnMessage(fn) {
+    return function rompBenchOnMessage(ev) {
+      const i = R.n++;
+      const t0 = performance.now();
+      const rec = { i, t0, len: typeof ev.data === "string" ? ev.data.length : -1, handler: -1, settle: -1, needSlot: false };
+      R.recs.push(rec);
+      const prev = curRec;
+      curRec = i;
+      try { return fn.call(this, ev); }
+      finally {
+        curRec = prev;
+        rec.handler = performance.now() - t0;
+        settleAfter(rec);
+      }
+    };
+  }
+  Object.defineProperty(wsProto, "onmessage", {
+    configurable: true, enumerable: wsDesc.enumerable,
+    get() { return wsDesc.get.call(this); },
+    set(fn) { wsDesc.set.call(this, typeof fn === "function" ? wrapOnMessage(fn) : fn); },
+  });
+  const origAdd = wsProto.addEventListener;
+  wsProto.addEventListener = function (type, fn, opts) { if (type === "message") R.addListenerMessages++; return origAdd.call(this, type, fn, opts); };
+  const origSend = wsProto.send;
+  wsProto.send = function (data) {
+    if (curRec >= 0 && typeof data === "string" && data.indexOf('"needSlot"') >= 0) R.recs[curRec].needSlot = true;
+    return origSend.call(this, data);
+  };
+  const portProto = MessagePort.prototype;
+  const portDesc = Object.getOwnPropertyDescriptor(portProto, "onmessage");
+  function wrapFlush(fn) {
+    return function rompBenchFlush(ev) {
+      const i = R.flushes.length;
+      const t0 = performance.now();
+      const row = { i, t0, ms: -1, deliveries: 0, err: null };
+      R.flushes.push(row);
+      R.portFires++;
+      const prev = curFlush;
+      curFlush = i;
+      try { return fn.call(this, ev); }
+      catch (e) { row.err = String((e && e.message) || e); throw e; }
+      finally { curFlush = prev; row.ms = performance.now() - t0; }
+    };
+  }
+  Object.defineProperty(portProto, "onmessage", {
+    configurable: true, enumerable: portDesc.enumerable,
+    get() { return portDesc.get.call(this); },
+    set(fn) { portDesc.set.call(this, typeof fn === "function" ? wrapFlush(fn) : fn); },
+  });
+  const origPost = portProto.postMessage;
+  portProto.postMessage = function () { if (curRec >= 0 || curFlush >= 0) R.portPosts++; return origPost.apply(this, arguments); };
+  function rompBenchDeliver(type, via, run) {
+    if (depth > 0) return run();
+    const i = R.deliveries.length;
+    const t0 = performance.now();
+    const row = { i, type, via, t0, ms: -1, settle: -1, flush: curFlush, rec: curRec, err: null };
+    R.deliveries.push(row);
+    if (curFlush >= 0) R.flushes[curFlush].deliveries++;
+    depth++;
+    try { return run(); }
+    catch (e) { row.err = String((e && e.message) || e); throw e; }
+    finally { depth--; row.ms = performance.now() - t0; settleAfter(row); }
+  }
+  const typeOf = (m) => ((m && typeof m.type === "string") ? m.type : "?");
+  let fed;
+  Object.defineProperty(window, "__rompFed", {
+    configurable: true, enumerable: true,
+    get() { return fed; },
+    set(v) {
+      fed = v;
+      if (v && typeof v.inbound === "function") { const inbound = v.inbound; v.inbound = function rompBenchInbound(h, m) { return rompBenchDeliver(typeOf(m), "inbound", () => inbound.call(v, h, m)); }; }
+    },
+  });
+  const origDispatch = window.dispatchEvent;
+  window.dispatchEvent = function rompBenchDispatch(ev) {
+    if (ev && ev.type === "message" && typeof MessageEvent === "function" && ev instanceof MessageEvent) return rompBenchDeliver(typeOf(ev.data), "dispatch", () => origDispatch.call(this, ev));
+    return origDispatch.call(this, ev);
+  };
+  const types = (window.PerformanceObserver && PerformanceObserver.supportedEntryTypes) || [];
+  if (types.includes("long-animation-frame")) {
+    R.loafKind = "long-animation-frame";
+    R.obs = new PerformanceObserver((list) => { for (const e of list.getEntries()) R.loaf.push(loafRow(e)); });
+    R.obs.observe({ type: "long-animation-frame", buffered: true });
+  } else if (types.includes("longtask")) {
+    R.loafKind = "longtask";
+    R.obs = new PerformanceObserver((list) => { for (const e of list.getEntries()) R.loaf.push({ start: e.startTime, duration: e.duration, blocking: Math.max(0, e.duration - 50), scripts: [] }); });
+    R.obs.observe({ type: "longtask", buffered: true });
+  }
+  function loafRow(e) {
+    return { start: e.startTime, duration: e.duration, blocking: e.blockingDuration, renderStart: e.renderStart, styleAndLayoutStart: e.styleAndLayoutStart,
+      scripts: Array.from(e.scripts || [], (s) => ({ url: s.sourceURL || "", fn: s.sourceFunctionName || "", invoker: s.invoker || "", invokerType: s.invokerType || "", duration: s.duration, line: s.sourceCharPosition })) };
+  }
+  R.collect = () => {
+    if (R.obs) for (const e of R.obs.takeRecords()) R.loaf.push(R.loafKind === "long-animation-frame" ? loafRow(e) : { start: e.startTime, duration: e.duration, blocking: Math.max(0, e.duration - 50), scripts: [] });
+    const mem = performance.memory ? { used: performance.memory.usedJSHeapSize, total: performance.memory.totalJSHeapSize, limit: performance.memory.jsHeapSizeLimit } : null;
+    const bar = document.getElementById("romp-stale-self");   // the shim's banner: "build" when a keepalive's dv outran the served dist, "conn" for a dead socket
+    return { recs: R.recs, flushes: R.flushes, deliveries: R.deliveries, portPosts: R.portPosts, portFires: R.portFires,
+      loaf: R.loaf, loafKind: R.loafKind, domElements: document.getElementsByTagName("*").length, heap: mem, addListenerMessages: R.addListenerMessages,
+      banner: bar ? (bar.dataset.kind || "?") : null };
+  };
+})();
+//# sourceURL=ui-bench-instrument.js
+`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(fn, timeoutMs, what) {
+  const t0 = Date.now();
+  for (;;) {
+    if (await fn()) return;
+    if (Date.now() - t0 > timeoutMs) throw new Error(`timed out after ${timeoutMs} ms waiting for ${what}`);
+    await sleep(25);
+  }
+}
+
+/** Which browser --replay can launch: {ok, how, why}. Playwright's own Chromium when installed, else a
+ *  system Google Chrome / Chromium through playwright's channel option. */
+export function browserAvailability() {
+  let chromium;
+  try { ({ chromium } = requireExt("playwright")); } catch (e) { return { ok: false, why: `playwright is not installed under vscode-extension/ (npm ci there): ${e.message}` }; }
+  try { const exe = chromium.executablePath(); if (exe && fs.existsSync(exe)) return { ok: true, how: "playwright chromium", exe }; } catch {}
+  for (const name of ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser"]) {
+    for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+      const p = path.join(dir, name);
+      if (dir && fs.existsSync(p)) return { ok: true, how: `system ${name}`, exe: p, channel: name.startsWith("google") ? "chrome" : "chromium" };
+    }
+  }
+  return { ok: false, why: "no Chromium: run `cd vscode-extension && npx playwright install chromium`, or install Google Chrome" };
+}
+
+/** Launch headless Chromium. Playwright creates the browser's profile and its artifacts directory with
+ *  mkdtemp under os.tmpdir(), which follows TMPDIR, and removes them only from exit hooks a SIGKILL
+ *  skips; with TMPDIR pointed at the run directory for the launch, both land inside it, where stop() and
+ *  the next run's dead-owner sweep reach them. The browser process inherits the same TMPDIR. */
+export async function launchBrowser({ tmpRoot } = {}) {
+  const avail = browserAvailability();
+  if (!avail.ok) throw new Error(avail.why);
+  const { chromium } = requireExt("playwright");
+  const saved = process.env.TMPDIR;
+  if (tmpRoot) process.env.TMPDIR = tmpRoot;
+  try {
+    if (avail.how === "playwright chromium") return await chromium.launch({ headless: true });
+    try { return await chromium.launch({ headless: true, channel: avail.channel }); }
+    catch { return await chromium.launch({ headless: true, executablePath: avail.exe }); }
+  } finally {
+    if (tmpRoot) { if (saved === undefined) delete process.env.TMPDIR; else process.env.TMPDIR = saved; }
+  }
+}
+
+async function replayOnce({ browser, app, frames, fast, gapMs = null, cpuThrottle, front, token, cpuProfile = false, log }) {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+  const consoleErrors = [], pageErrors = [];
+  let warnings = 0;
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); else if (m.type() === "warning") warnings++; });
+  page.on("pageerror", (e) => pageErrors.push(String((e && e.message) || e)));
+  const failedResources = [];
+  page.on("response", (resp) => { if (resp.status() >= 400) failedResources.push(`${resp.status()} ${new URL(resp.url()).pathname}`); });
+  await page.addInitScript(INIT_SCRIPT);
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("Performance.enable");
+  if (cpuThrottle && cpuThrottle !== 1) await cdp.send("Emulation.setCPUThrottlingRate", { rate: cpuThrottle });
+  if (cpuProfile) {
+    await cdp.send("Profiler.enable");
+    await cdp.send("Profiler.setSamplingInterval", { interval: PROFILE_INTERVAL_US });
+  }
+
+  const session = { current: null, clientMessages: {}, clientDiag: {}, reconnects: 0, readyAt: 0 };
+  let readyResolve;
+  const ready = new Promise((r) => { readyResolve = r; });
+  front.setSocketHandler((ws) => {
+    ws.on("message", (data) => {
+      let m = null;
+      try { m = JSON.parse(data.toString()); } catch {}
+      const type = (m && typeof m.type === "string") ? m.type : "?";
+      session.clientMessages[type] = (session.clientMessages[type] || 0) + 1;
+      if (type === "clientDiag" && m) { const w = `${m.surface || "?"}:${m.what || "?"}`; session.clientDiag[w] = (session.clientDiag[w] || 0) + 1; }
+      if (type === "ready") {
+        if (session.current && session.current !== ws) session.reconnects++;
+        session.current = ws;
+        if (!session.readyAt) session.readyAt = Date.now();
+        readyResolve();
+      }
+    });
+  });
+
+  const navT0 = Date.now();
+  await page.goto(`http://127.0.0.1:${front.port}/${app}?token=${encodeURIComponent(token)}`, { waitUntil: "load", timeout: 60_000 });
+  let handshakeTimer;
+  try {
+    await Promise.race([ready, new Promise((_, rej) => { handshakeTimer = setTimeout(() => rej(new Error("the pane never sent its {type:\"ready\"} handshake within 30s")), 30_000); })]);
+  } finally {
+    clearTimeout(handshakeTimer);   // a losing timer left armed kept every replay process alive for the full 30 s
+  }
+  const readyMs = session.readyAt - navT0;
+  // The profile's clock is V8's; the page's records are performance.now(). Bracketing Profiler.start
+  // with two reads of performance.now() puts the profile's startTime between them, so a page time maps to
+  // the profile's to within half the gap (alignMs, about a millisecond).
+  let profiling = null;
+  if (cpuProfile) {
+    const before = await page.evaluate(() => performance.now());
+    await cdp.send("Profiler.start");
+    const after = await page.evaluate(() => performance.now());
+    profiling = { p0: (before + after) / 2, alignMs: (after - before) / 2, profile: null };
+  }
+
+  const sent = [];
+  const t0 = Date.now();
+  let prev = frames.length ? frames[0].t : 0;
+  for (const f of frames) {
+    const gap = fast ? 0 : gapMs != null ? gapMs : Math.max(0, f.t - prev);
+    prev = f.t;
+    if (gap > 0) await sleep(gap);
+    const ws = session.current;
+    if (!ws || ws.readyState !== 1) throw new Error(`the pane's socket is not open at frame ${sent.length} (state ${ws ? ws.readyState : "none"})`);
+    ws.send(f.data);
+    sent.push({ type: classifyFrame(f.data), bytes: Buffer.byteLength(f.data, "utf8"), at: Date.now() - t0 });
+  }
+  const replayMs = Date.now() - t0;
+  // Every sent frame dispatched in the page, then the shim's queue drained (every flush the frames armed has
+  // run; a sliced flush re-arms itself and is counted again), then every settle stamped, then one more
+  // rendered frame.
+  const budget = 30_000 + sent.reduce((a, s) => a + s.bytes, 0) / 1024;   // a second per MB on top of the floor
+  await waitFor(async () => (await page.evaluate(() => window.__rompBench.n)) >= sent.length, budget, `the page to dispatch all ${sent.length} frames`);
+  await waitFor(async () => page.evaluate(() => window.__rompBench.portFires >= window.__rompBench.portPosts), budget, "the shim's queue to drain").catch((e) => log(`ui-bench: ${e.message}`));
+  await waitFor(async () => page.evaluate(() => window.__rompBench.recs.every((r) => r.settle >= 0) && window.__rompBench.deliveries.every((d) => d.settle >= 0)), 10_000, "every frame's and delivery's settle stamp").catch((e) => log(`ui-bench: ${e.message}`));
+  await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 0)))));
+  if (profiling) {
+    profiling.profile = (await cdp.send("Profiler.stop")).profile;
+    await cdp.send("Profiler.disable");
+  }
+  // Collect the heap after a forced GC: without it the figure is live objects plus whatever garbage
+  // happens to be pending, and two replays of the same page differed by a third. The figure before the
+  // GC is kept beside it, so the report can show that the collection ran (afterGc is true only once the
+  // CDP call has returned).
+  const heapBeforeGc = Object.fromEntries((await cdp.send("Performance.getMetrics")).metrics.map((m) => [m.name, m.value])).JSHeapUsedSize;
+  await cdp.send("HeapProfiler.collectGarbage");
+  const afterGc = true;
+  const data = await page.evaluate(() => window.__rompBench.collect());
+  const { metrics } = await cdp.send("Performance.getMetrics");
+  const met = Object.fromEntries(metrics.map((m) => [m.name, m.value]));
+  await context.close();
+  // which seam each delivery came through: federation's published inbound, or the MessageEvent fallback
+  // the shim uses before federation.js has run (a page without federation would take it throughout)
+  const deliverySeams = {};
+  for (const d of data.deliveries) deliverySeams[d.via || "?"] = (deliverySeams[d.via || "?"] || 0) + 1;
+
+  const handoffs = attributeDeliveries({ types: sent.map((s) => s.type), recs: data.recs, flushes: data.flushes, deliveries: data.deliveries });
+  const perFrame = sent.map((s, i) => {
+    const r = data.recs[i], h = handoffs.frames[i];
+    return { i, type: s.type, bytes: s.bytes, at: s.at, handlerMs: r ? r.handler : null, settleMs: h.settleMs, t0: r ? r.t0 : null, lenMatch: r ? r.len === frames[i].data.length : false,
+      handoff: h.handoff, bundleMs: h.bundleMs, delivery: h.delivery };
+  });
+  const misaligned = perFrame.filter((f) => f.handlerMs != null && !f.lenMatch).length;
+  return {
+    readyMs, replayMs, sent, perFrame, misaligned, reconnects: session.reconnects, clientMessages: session.clientMessages, clientDiag: session.clientDiag,
+    handoff: handoffs.handoff, flushes: data.flushes.length, deliveries: data.deliveries.length, deliveryRows: data.deliveries.map((d) => ({ t0: d.t0, ms: d.ms, type: d.type })),
+    flushRows: data.flushes.map((f) => ({ t0: f.t0, ms: f.ms })), unattributed: handoffs.unattributed.length, unattributedMs: handoffs.unattributed.reduce((a, d) => a + Math.max(0, d.ms), 0),
+    deliveryErrors: data.deliveries.filter((d) => d.err).map((d) => `${d.type}: ${d.err}`), queueDrained: data.portFires >= data.portPosts, deliverySeams,
+    loaf: data.loaf, loafKind: data.loafKind, domElements: data.domElements, heap: data.heap, addListenerMessages: data.addListenerMessages, banner: data.banner,
+    profiling, afterGc,
+    cdp: { nodes: met.Nodes, documents: met.Documents, jsEventListeners: met.JSEventListeners, layoutCount: met.LayoutCount, recalcStyleCount: met.RecalcStyleCount,
+      layoutMs: (met.LayoutDuration || 0) * 1000, recalcStyleMs: (met.RecalcStyleDuration || 0) * 1000, scriptMs: (met.ScriptDuration || 0) * 1000,
+      taskMs: (met.TaskDuration || 0) * 1000, heapUsed: met.JSHeapUsedSize, heapTotal: met.JSHeapTotalSize, heapBeforeGc },
+    consoleErrors, pageErrors, warnings, failedResources,
+  };
+}
+
+// ── the handoff: which wire frame each delivery to the bundle carried ─────────────────────────────
+
+/** kernel.py _shim WHOLE: the kinds whose newer frame replaces an older one still queued (a whole state,
+ *  not a chained update), so several wire frames of one kind can reach the bundle as one delivery. */
+export const WHOLE_STATE_KINDS = new Set(["feed", "bars", "data", "tabOrder", "working", "globalRetryPaused"]);
+/** Frames the shim answers itself and never hands on: keepalives and the kernel's restart notice. */
+const SHIM_ANSWERS = new Set(["ka", "restarting"]);
+/** The kind a wire frame reaches the bundle as: a view delta is reassembled into the whole slot it patches. */
+export const deliveredKind = (wireType) => (typeof wireType === "string" && wireType.startsWith("delta:") ? wireType.slice("delta:".length) : wireType);
+
+/** Pair the page's deliveries with the wire frames they carried. `types` are the sent frames' wire types
+ *  in order, `recs` the page's per-frame handler records (t0, handler, needSlot, settle), `flushes` its
+ *  flush tasks (i, t0, ms) and `deliveries` its handoffs to the bundle (i, type, t0, ms, settle, flush,
+ *  rec). The shim's rules decide the pairing: a delivery made inside a handler belongs to that handler's
+ *  frame (a shim from before the flush task); a delivery made in a flush carries frames whose handler had
+ *  finished before the flush began and whose delivered kind is the delivery's type, all of them for a
+ *  whole-state kind (the newest is the one delivered, the others were coalesced into it) and the oldest
+ *  one for a chained kind; keepalives, restart notices and deltas the shim refused (needSlot) are the
+ *  shim's alone. Frames left over were still queued when the run ended. Each frame's settle becomes
+ *  end-to-end: its own receipt to the main thread free after the delivery that carried it.
+ *  Returns {frames: [{handoff, bundleMs, delivery, settleMs}], handoff: "flush"|"handler"|"none",
+ *  unattributed: deliveries no frame explains (the page re-emitting state on its own)}. */
+export function attributeDeliveries({ types, recs, flushes, deliveries }) {
+  const frames = types.map((type, i) => {
+    const r = recs[i];
+    if (!r || r.handler == null || r.handler < 0) return { handoff: null, bundleMs: null, delivery: -1, settleMs: r ? r.settle : null };
+    return { handoff: (SHIM_ANSWERS.has(type) || r.needSlot) ? "shim" : null, bundleMs: null, delivery: -1, settleMs: r.settle };
+  });
+  const attach = (i, d, own) => {
+    const f = frames[i];
+    f.handoff = own ? "delivered" : "coalesced";
+    f.delivery = d.i;
+    if (own) f.bundleMs = d.ms;
+    f.settleMs = d.settle != null && d.settle >= 0 ? d.t0 + d.settle - recs[i].t0 : -1;
+  };
+  const unattributed = [];
+  const inFlush = new Map();
+  for (const d of deliveries) {
+    if (d.rec != null && d.rec >= 0 && frames[d.rec] && frames[d.rec].handoff === null) { attach(d.rec, d, true); continue; }
+    if (d.flush != null && d.flush >= 0) { if (!inFlush.has(d.flush)) inFlush.set(d.flush, []); inFlush.get(d.flush).push(d); continue; }
+    unattributed.push(d);
+  }
+  for (const fl of [...flushes].sort((a, b) => a.t0 - b.t0)) {
+    for (const d of inFlush.get(fl.i) || []) {
+      const cands = [];
+      for (let i = 0; i < frames.length; i++) {
+        const r = recs[i];
+        if (frames[i].handoff === null && r && r.t0 + r.handler <= fl.t0 && deliveredKind(types[i]) === d.type) cands.push(i);
+      }
+      if (!cands.length) { unattributed.push(d); continue; }
+      if (WHOLE_STATE_KINDS.has(d.type)) { const last = cands[cands.length - 1]; for (const i of cands) attach(i, d, i === last); }
+      else attach(cands[0], d, true);
+    }
+  }
+  for (const f of frames) if (f.handoff === null && f.settleMs != null) f.handoff = "queued";
+  const handoff = flushes.length ? "flush" : deliveries.some((d) => d.rec != null && d.rec >= 0) ? "handler" : "none";
+  return { frames, handoff, unattributed };
+}
+
+function attributeLoaf(loaf, handoff = "none") {
+  const by = new Map();
+  for (const e of loaf) {
+    for (const s of e.scripts || []) {
+      const url = s.url ? path.basename(s.url.split("?")[0]) : "(inline)";
+      const inv = s.invoker || s.invokerType || "?";
+      const invoker = /^https?:\/\//.test(inv) ? "script " + (path.basename(inv.split("?")[0]) || "/") : inv;   // a script's own evaluation is invoked by its URL; keep the basename, never the query
+      // A long-animation-frame script entry names the task's ENTRY POINT. For every pushed frame that is
+      // the bench's own onmessage wrapper, and for every flush of the shim's queue its flush wrapper, so
+      // those rows are labelled for what runs inside them rather than for the instrument's file: the shim's
+      // handler (plus the bundle's render, on a shim that hands frames over inside the handler), and the
+      // flush task with the bundle's renders it carries.
+      let key;
+      if (url !== "ui-bench-instrument.js") key = `${url}:${s.fn || "(anonymous)"} <${invoker}>`;
+      else if (s.fn === "rompBenchFlush" || /MessagePort/.test(inv)) key = `bundle handoff (shim flush + bundle) <${invoker}>`;
+      else if (s.fn === "rompBenchOnMessage" || /WebSocket/.test(inv)) key = `message handler (${handoff === "flush" ? "shim" : "shim + bundle"}) <${invoker}>`;
+      else key = `${url}:${s.fn || "(anonymous)"} <${invoker}>`;
+      const row = by.get(key) || { key, count: 0, durationMs: 0 };
+      row.count++; row.durationMs += s.duration || 0;
+      by.set(key, row);
+    }
+  }
+  return Array.from(by.values()).sort((a, b) => b.durationMs - a.durationMs).slice(0, 10)
+    .map((r) => ({ ...r, durationMs: round1(r.durationMs) }));
+}
+
+const round1 = (x) => (x == null ? null : Math.round(x * 10) / 10);
+const roundStats = (s) => ({ n: s.n, p50: round1(s.p50), p90: round1(s.p90), max: round1(s.max), mean: round1(s.mean) });
+
+/** Fold one or more replay runs into the report shape --json writes and --compare reads. */
+export function buildReport({ app, framesFile, cpuThrottle, fast, gapMs = null, iters, browser, runs, cpuProfileFiles = [], sourceMapDir = null }) {
+  const frames = runs.flatMap((r) => r.perFrame);
+  const byType = {};
+  for (const f of frames) {
+    const s = (byType[f.type] ||= { count: 0, measured: 0, delivered: 0, coalesced: 0, shim: 0, queued: 0, settleMissing: 0, bytes: 0, bytesMax: 0, handler: [], bundle: [], settle: [] });
+    s.count++; s.bytes += f.bytes; if (f.bytes > s.bytesMax) s.bytesMax = f.bytes;
+    if (f.handlerMs != null && f.handlerMs >= 0) { s.measured++; s.handler.push(f.handlerMs); }
+    if (f.handoff === "delivered") { s.delivered++; if (f.bundleMs != null && f.bundleMs >= 0) s.bundle.push(f.bundleMs); }
+    else if (f.handoff === "coalesced") s.coalesced++;
+    else if (f.handoff === "shim") s.shim++;
+    else if (f.handoff === "queued") s.queued++;
+    if (f.settleMs != null && f.settleMs >= 0) s.settle.push(f.settleMs);
+    else if (f.settleMs != null) s.settleMissing++;   // dispatched and timed, but the two-rAF settle stamp never landed
+  }
+  const types = {};
+  const perRun = (n) => round1(n / runs.length);   // pooled iterations: a per-run count, fractional when the runs differ
+  for (const [type, s] of Object.entries(byType).sort((a, b) => b[1].bytes - a[1].bytes)) {
+    types[type] = { count: perRun(s.count), measured: perRun(s.measured), delivered: perRun(s.delivered), coalesced: perRun(s.coalesced),
+      shim: perRun(s.shim), queued: perRun(s.queued), settleMissing: s.settleMissing, bytes: s.bytes / runs.length, bytesMax: s.bytesMax,
+      handlerMs: roundStats(summarize(s.handler)), bundleMs: roundStats(summarize(s.bundle)), settleMs: roundStats(summarize(s.settle)) };
+  }
+  const settleMissing = Object.values(byType).reduce((a, s) => a + s.settleMissing, 0);
+  const firstIdx = runs[0].perFrame.findIndex((f) => f.type !== "ka");
+  const first = firstIdx >= 0 ? runs.map((r) => r.perFrame[firstIdx]).filter(Boolean) : [];
+  const loafAll = runs.flatMap((r) => r.loaf);
+  const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null);
+  // How the shim handed frames to the bundle in these runs: in its flush task, inside the WebSocket handler
+  // (a shim from before the task), or not seen at all (no delivery reached either wrapper).
+  const modes = new Set(runs.map((r) => r.handoff || "none"));
+  const handoff = modes.size === 1 ? [...modes][0] : "mixed";
+  const firstBundle = first.filter((f) => f.handoff === "delivered" && f.bundleMs != null);
+  return {
+    tool: "ui-bench", version: 2, app, framesFile, cpuThrottle: cpuThrottle || 1, fast: !!fast, gapMs: fast ? null : gapMs, iters: runs.length, browser,
+    generatedAt: new Date().toISOString(),
+    frames: { total: runs[0].perFrame.length, bytes: runs[0].perFrame.reduce((a, f) => a + f.bytes, 0), replayMs: round1(mean(runs.map((r) => r.replayMs))),
+      readyMs: round1(mean(runs.map((r) => r.readyMs))), reconnects: runs.reduce((a, r) => a + r.reconnects, 0), misaligned: runs.reduce((a, r) => a + r.misaligned, 0),
+      settleMissing, addListenerMessages: runs.reduce((a, r) => a + (r.addListenerMessages || 0), 0),
+      buildBannerRaised: runs.filter((r) => r.banner === "build").length, connBannerRaised: runs.filter((r) => r.banner === "conn").length },
+    handoff: { mode: handoff, flushes: round1(mean(runs.map((r) => r.flushes || 0))), deliveries: round1(mean(runs.map((r) => r.deliveries || 0))),
+      delivered: perRun(Object.values(byType).reduce((a, s) => a + s.delivered, 0)), coalesced: perRun(Object.values(byType).reduce((a, s) => a + s.coalesced, 0)),
+      shim: perRun(Object.values(byType).reduce((a, s) => a + s.shim, 0)), queued: perRun(Object.values(byType).reduce((a, s) => a + s.queued, 0)),
+      unattributed: runs.reduce((a, r) => a + (r.unattributed || 0), 0), unattributedMs: round1(runs.reduce((a, r) => a + (r.unattributedMs || 0), 0)),
+      queueDrained: runs.every((r) => r.queueDrained !== false), deliveryErrors: runs.flatMap((r) => r.deliveryErrors || []),
+      deliverySeams: runs.reduce((acc, r) => { for (const [k, v] of Object.entries(r.deliverySeams || {})) acc[k] = (acc[k] || 0) + v; return acc; }, {}) },
+    // The first content frame over the iterations; its bundle time is the mean over the runs that delivered it
+    // on its own (`deliveredRuns`), since a run that queued a newer frame behind it before the flush ran
+    // coalesced it and has no render of it to time.
+    first: first.length ? { index: firstIdx, type: first[0].type, bytes: first[0].bytes, handlerMs: round1(mean(first.map((f) => f.handlerMs))),
+      bundleMs: firstBundle.length ? round1(mean(firstBundle.map((f) => f.bundleMs))) : null, deliveredRuns: firstBundle.length,
+      handoff: firstBundle.length === first.length ? (first[0].handoff || null) : firstBundle.length ? "mixed" : (first[0].handoff || null),
+      settleMs: round1(mean(first.map((f) => f.settleMs))) } : null,
+    types,
+    loaf: { kind: runs[0].loafKind, count: round1(loafAll.length / runs.length), durationMs: round1(mean(runs.map((r) => r.loaf.reduce((a, e) => a + e.duration, 0)))),
+      blockingMs: round1(mean(runs.map((r) => r.loaf.reduce((a, e) => a + (e.blocking || 0), 0)))), maxMs: round1(Math.max(0, ...loafAll.map((e) => e.duration))),
+      topScripts: attributeLoaf(loafAll, handoff) },
+    // afterGc is what the runs report: true only when every run's forced collection returned before the read
+    end: { afterGc: runs.every((r) => r.afterGc === true), heapUsed: Math.round(mean(runs.map((r) => r.cdp.heapUsed ?? (r.heap ? r.heap.used : 0)))),
+      heapBeforeGc: runs.every((r) => r.cdp.heapBeforeGc != null) ? Math.round(mean(runs.map((r) => r.cdp.heapBeforeGc))) : null,
+      heapTotal: Math.round(mean(runs.map((r) => r.cdp.heapTotal ?? (r.heap ? r.heap.total : 0)))),
+      domElements: Math.round(mean(runs.map((r) => r.domElements))), cdpNodes: Math.round(mean(runs.map((r) => r.cdp.nodes))), jsEventListeners: Math.round(mean(runs.map((r) => r.cdp.jsEventListeners))),
+      layoutCount: Math.round(mean(runs.map((r) => r.cdp.layoutCount))), recalcStyleCount: Math.round(mean(runs.map((r) => r.cdp.recalcStyleCount))),
+      layoutMs: round1(mean(runs.map((r) => r.cdp.layoutMs))), recalcStyleMs: round1(mean(runs.map((r) => r.cdp.recalcStyleMs))),
+      scriptMs: round1(mean(runs.map((r) => r.cdp.scriptMs))), taskMs: round1(mean(runs.map((r) => r.cdp.taskMs))) },
+    console: { errors: runs.flatMap((r) => r.consoleErrors), pageErrors: runs.flatMap((r) => r.pageErrors), warnings: runs.reduce((a, r) => a + r.warnings, 0),
+      failedResources: runs.flatMap((r) => r.failedResources) },
+    clientMessages: runs.reduce((acc, r) => { for (const [k, v] of Object.entries(r.clientMessages)) acc[k] = (acc[k] || 0) + v; return acc; }, {}),
+    clientDiag: runs.reduce((acc, r) => { for (const [k, v] of Object.entries(r.clientDiag)) acc[k] = (acc[k] || 0) + v; return acc; }, {}),
+    perFrame: runs.length === 1 ? runs[0].perFrame.map((f) => ({ i: f.i, type: f.type, bytes: f.bytes, at: f.at, handlerMs: round1(f.handlerMs), handoff: f.handoff ?? null, bundleMs: round1(f.bundleMs), settleMs: round1(f.settleMs) })) : undefined,
+    cpuProfile: runs.some((r) => r.profiling && r.profiling.profile) ? profileReport(runs, firstIdx, cpuProfileFiles, sourceMapDir) : undefined,
+  };
+}
+
+export async function replay({ app, framesFile, cpuThrottle = 1, iters = 1, fast = false, gapMs = null, dist, jsonOut, cpuProfile, log = console.error }) {
+  if (!APPS.includes(app)) throw new Error(`unknown app ${app}; one of ${APPS.join(", ")}`);
+  if (gapMs != null && !(Number.isFinite(gapMs) && gapMs >= 0)) throw new Error(`--gap needs a number of milliseconds, not ${gapMs}`);
+  const { frames } = loadFrames(framesFile);
+  if (!frames.length) throw new Error(`no frames in ${framesFile}`);
+  const pageServer = await startPageServer({ dist, log: (s) => log("kernel page server: " + s.trimEnd()) });
+  let front, browser;
+  // A signal aimed at this process stops both servers before it exits; the finally below covers every
+  // other way out. The Handler would also end on its own when its stdin pipe closes, but not the front.
+  const onSignal = (sig) => {
+    if (browser) browser.close().catch(() => {});
+    if (front) front.stop();
+    pageServer.stop();
+    process.exit(sig === "SIGINT" ? 130 : 143);
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+  try {
+    front = await startFront({ pagePort: pageServer.port });
+    browser = await launchBrowser({ tmpRoot: pageServer.tmp });
+    const runs = [];
+    for (let i = 0; i < iters; i++) {
+      log(`ui-bench: replaying ${frames.length} frames into app=${app} (${pacingLabel(fast, gapMs)}, cpu x${cpuThrottle})${iters > 1 ? ` iteration ${i + 1}/${iters}` : ""}`);
+      runs.push(await replayOnce({ browser, app, frames, fast, gapMs, cpuThrottle, front, token: pageServer.token, cpuProfile: !!cpuProfile, log }));
+    }
+    const cpuProfileFiles = cpuProfile ? writeProfiles(cpuProfile, runs) : [];
+    const report = buildReport({ app, framesFile, cpuThrottle, fast, gapMs, iters, browser: browser.version(), runs, cpuProfileFiles, sourceMapDir: dist || path.join(EXT_DIR, "dist") });
+    if (jsonOut) { fs.mkdirSync(path.dirname(path.resolve(jsonOut)), { recursive: true }); fs.writeFileSync(jsonOut, JSON.stringify(report, null, 1) + "\n"); }
+    return report;
+  } finally {
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    if (browser) await browser.close().catch(() => {});
+    if (front) front.stop();
+    pageServer.stop();
+  }
+}
+
+// ── --cpu-profile: V8 samples across the replay, folded by function ─────────────────────────────
+
+export const PROFILE_INTERVAL_US = 500;
+const PROFILE_META = new Set(["(root)", "(program)", "(idle)", "(garbage collector)"]);
+const TOP_OVERALL = 25, TOP_WINDOW = 20;
+
+/** The label a call frame files under: url-basename:function:line, the line 1-based as DevTools shows
+ *  it. V8's bookkeeping nodes ((program), (idle), (garbage collector), (root)) keep their bare names; a
+ *  builtin (no url, no line: getBoundingClientRect, querySelectorAll) is "(native):name"; code without a
+ *  url but with a line (an eval) is "(inline)". A page's inline script carries the page URL, so the shim
+ *  files under the page's basename with the query dropped. */
+export function frameKey(cf) {
+  if (!cf) return "(unknown)";
+  const fn = cf.functionName || "";
+  const line = cf.lineNumber ?? -1;
+  if (!cf.url) {
+    if (PROFILE_META.has(fn)) return fn;
+    if (line < 0) return `(native):${fn || "(anonymous)"}`;
+    return `(inline):${fn || "(anonymous)"}:${line + 1}`;
+  }
+  return `${path.basename(cf.url.split("?")[0]) || cf.url}:${fn || "(anonymous)"}:${line + 1}`;
+}
+
+/** Bundle positions to source positions through the .map files esbuild writes beside the bundles in
+ *  `distDir`. Returns a function of a call frame giving "ui/webview/feed.ts:4477" (relative to the repo
+ *  when the source lies inside it) or null when there is no map or no mapping. */
+export function sourceLocator(distDir) {
+  const maps = new Map();
+  const loaded = new Set(), missing = new Set();
+  const load = (base) => {
+    if (maps.has(base)) return maps.get(base);
+    let m = null;
+    const file = path.join(distDir, base + ".map");
+    try { m = { sm: new SourceMap(JSON.parse(fs.readFileSync(file, "utf8"))), dir: path.dirname(file) }; } catch { m = null; }
+    maps.set(base, m);
+    (m ? loaded : missing).add(base);
+    return m;
+  };
+  const locate = (cf) => {
+    if (!cf || !cf.url || cf.lineNumber == null || cf.lineNumber < 0) return null;
+    const m = load(path.basename(cf.url.split("?")[0]));
+    if (!m) return null;
+    const e = m.sm.findEntry(cf.lineNumber, Math.max(0, cf.columnNumber || 0));
+    // findEntry returns the nearest mapping at or before the position, on any line; a line the map does not
+    // cover would borrow the previous line's source, so the mapping must sit on the asked-for line.
+    if (!e || e.originalSource == null || e.originalLine == null || e.generatedLine !== cf.lineNumber) return null;
+    const abs = path.resolve(m.dir, e.originalSource);
+    const rel = path.relative(REPO, abs);
+    const shown = rel && !rel.startsWith("..") && !path.isAbsolute(rel) ? rel : e.originalSource.replace(/^(\.\.\/)+/, "");
+    return `${shown}:${e.originalLine + 1}`;
+  };
+  /** The source of a 0-based bundle LINE's first mapping, for V8's per-line ticks. A line's first mapping
+   *  can start at its indentation column (bundled node_modules code does this), where a column-0 probe
+   *  lands on the previous line and the same-line guard refuses it; so the columns are stepped until a
+   *  mapping on the line answers. */
+  locate.line = (cf, line) => {
+    if (!cf || !cf.url || line == null || line < 0 || !load(path.basename(cf.url.split("?")[0]))) return null;
+    for (let c = 0; c < 256; c++) { const r = locate({ ...cf, lineNumber: line, columnNumber: c }); if (r) return r; }
+    return null;
+  };
+  /** Whether a bundle's map is beside it (loads it). */
+  locate.probe = (base) => !!load(base);
+  locate.loaded = loaded;
+  locate.missing = missing;
+  return locate;
+}
+
+/** The instrument's wrappers whose samples are wrapper time: the shim's handler, its flush task and a
+ *  delivery to the bundle. The settle stamps and the passthrough of other events are in the same file but
+ *  run outside every window, so a URL match alone would count them against the alignment. */
+const WRAPPER_FUNCTIONS = new Set(["rompBenchOnMessage", "rompBenchFlush", "rompBenchDeliver"]);
+
+/** Sort [t0, t1] windows and merge the ones that touch or overlap (a delivery inside a flush, a flush
+ *  starting as a handler ends), so a binary search on the starts answers "inside any window". */
+export function mergeWindows(windows) {
+  const out = [];
+  for (const w of windows.filter((w) => w[1] > w[0]).sort((a, b) => a[0] - b[0])) {
+    const last = out[out.length - 1];
+    if (last && w[0] <= last[1]) last[1] = Math.max(last[1], w[1]);
+    else out.push([w[0], w[1]]);
+  }
+  return out;
+}
+
+/** Pin the page-to-profile clock offset with the profile's own evidence. Every sample whose stack holds
+ *  one of the bench's wrappers was taken inside some frame's handler window, some flush of the shim's
+ *  queue or some delivery, so the offsets that put the most of them inside the windows hold the right
+ *  one; the bracketing reads of performance.now() only bound it. A grid search over ±bound ms at a
+ *  quarter of the sampling interval; the offsets that tie for the maximum form a plateau, and the answer
+ *  is its midpoint with half its width (at least one grid step) as the uncertainty. When even the best
+ *  offset places under half the wrapper's samples inside, the evidence does not fit the windows and the
+ *  bracketing estimate is returned unchanged. `windows` are [t0, t1] in page ms, overlapping allowed.
+ *  Returns {p0, alignMs, inside, refined}. */
+export function refineAlignment(profile, p0, bound, windows) {
+  const nodes = new Map(), parent = new Map(), wrapped = new Map();
+  for (const n of profile.nodes || []) { nodes.set(n.id, n); for (const c of n.children || []) parent.set(c, n.id); }
+  const underWrapper = (id) => {
+    if (wrapped.has(id)) return wrapped.get(id);
+    let r = false;
+    for (let cur = id; cur != null && nodes.has(cur); cur = parent.get(cur)) {
+      const cf = nodes.get(cur).callFrame;
+      if (cf && cf.url && WRAPPER_FUNCTIONS.has(cf.functionName) && path.basename(cf.url.split("?")[0]) === "ui-bench-instrument.js") { r = true; break; }
+    }
+    wrapped.set(id, r);
+    return r;
+  };
+  const xs = [];
+  const samples = profile.samples || [], deltas = profile.timeDeltas || [];
+  let t = profile.startTime || 0;
+  for (let i = 0; i < samples.length; i++) { t += deltas[i] || 0; if (underWrapper(samples[i])) xs.push((t - (profile.startTime || 0)) / 1000 + p0); }
+  const sorted = mergeWindows(windows);
+  if (!xs.length || !sorted.length) return { p0, alignMs: bound, inside: null, refined: false };
+  const inside = (x) => {
+    let lo = 0, hi = sorted.length - 1;
+    while (lo <= hi) { const mid = (lo + hi) >> 1; if (sorted[mid][0] <= x) lo = mid + 1; else hi = mid - 1; }
+    return hi >= 0 && x < sorted[hi][1];
+  };
+  const step = PROFILE_INTERVAL_US / 1000 / 4;
+  const span = Math.max(bound, 1);
+  let bestN = -1;
+  const plateau = [];
+  for (let k = 0, d = -span; d <= span + 1e-9; k++, d = -span + k * step) {
+    let n = 0;
+    for (const x of xs) if (inside(x + d)) n++;
+    if (n > bestN) { bestN = n; plateau.length = 0; }
+    if (n === bestN) plateau.push(d);
+  }
+  const share = bestN / xs.length;
+  if (share < 0.5) return { p0, alignMs: bound, inside: share, refined: false };
+  const lo = plateau[0], hi = plateau[plateau.length - 1];
+  return { p0: p0 + (lo + hi) / 2, alignMs: Math.max(step, (hi - lo) / 2), inside: share, refined: true };
+}
+
+/** Fold a V8 .cpuprofile ({nodes, samples, timeDeltas, startTime, endTime}, times in microseconds)
+ *  into per-function time. Sample i owns the interval to sample i+1 (the last owns the interval to
+ *  endTime): its node's function takes it as self time, and every distinct function on its stack takes
+ *  it once as total time, so recursion is not double counted. The bookkeeping nodes are reported in
+ *  `meta`, never ranked. `window` = [fromUs, toUs] on the profile's clock restricts the fold. */
+export function aggregateProfile(profile, window = null) {
+  const nodes = new Map(), parent = new Map(), keyOf = new Map(), stacks = new Map(), cfOf = new Map();
+  for (const n of profile.nodes || []) { nodes.set(n.id, n); for (const c of n.children || []) parent.set(c, n.id); }
+  const key = (id) => {
+    let k = keyOf.get(id);
+    if (k === undefined) { const n = nodes.get(id); k = frameKey(n && n.callFrame); keyOf.set(id, k); if (n && n.callFrame && !cfOf.has(k)) cfOf.set(k, n.callFrame); }
+    return k;
+  };
+  const stackKeys = (id) => {
+    let s = stacks.get(id);
+    if (s) return s;
+    const seen = new Set();
+    for (let cur = id; cur != null && nodes.has(cur); cur = parent.get(cur)) { const k = key(cur); if (!PROFILE_META.has(k)) seen.add(k); }
+    s = [...seen]; stacks.set(id, s); return s;
+  };
+  const self = new Map(), total = new Map(), count = new Map(), nodeSelf = new Map(), meta = {};
+  const samples = profile.samples || [], deltas = profile.timeDeltas || [];
+  let t = profile.startTime || 0, sampledUs = 0, inWindow = 0;
+  for (let i = 0; i < samples.length; i++) {
+    t += deltas[i] || 0;
+    const dur = i + 1 < samples.length ? (deltas[i + 1] || 0) : Math.max(0, (profile.endTime || t) - t);
+    if (window && (t < window[0] || t >= window[1])) continue;
+    sampledUs += dur; inWindow++;
+    const k = key(samples[i]);
+    if (PROFILE_META.has(k)) { meta[k] = (meta[k] || 0) + dur; continue; }
+    self.set(k, (self.get(k) || 0) + dur);
+    count.set(k, (count.get(k) || 0) + 1);
+    nodeSelf.set(samples[i], (nodeSelf.get(samples[i]) || 0) + dur);
+    for (const sk of stackKeys(samples[i])) total.set(sk, (total.get(sk) || 0) + dur);
+  }
+  // V8's per-line ticks (positionTicks) split a node's self time over the lines of its function, 1-based
+  // lines of the bundle. They cover the whole profile, so a window gets none; a node's self time is spread
+  // over its lines in proportion to their ticks.
+  const lines = new Map();
+  if (!window) for (const n of profile.nodes || []) {
+    if (!n.positionTicks || !n.positionTicks.length || !n.hitCount || !nodeSelf.has(n.id)) continue;
+    const k = key(n.id);
+    if (PROFILE_META.has(k)) continue;
+    const perTick = nodeSelf.get(n.id) / n.hitCount;
+    const m = lines.get(k) || new Map();
+    for (const pt of n.positionTicks) m.set(pt.line, (m.get(pt.line) || 0) + pt.ticks * perTick);
+    lines.set(k, m);
+  }
+  const functions = [...total.keys()].map((k) => ({ key: k, selfMs: (self.get(k) || 0) / 1000, totalMs: total.get(k) / 1000, samples: count.get(k) || 0, cf: cfOf.get(k),
+    ...(lines.has(k) ? { lines: [...lines.get(k)].map(([line, us]) => ({ line, ms: us / 1000 })).sort((a, b) => b.ms - a.ms) } : {}) }));
+  return { durationMs: (window ? window[1] - window[0] : (profile.endTime || 0) - (profile.startTime || 0)) / 1000, sampledMs: sampledUs / 1000, samples: inWindow,
+    meta: Object.fromEntries(Object.entries(meta).map(([k, v]) => [k, v / 1000])), functions };
+}
+
+const bySelf = (fns) => [...fns].sort((a, b) => b.selfMs - a.selfMs || b.totalMs - a.totalMs || a.key.localeCompare(b.key));
+const byTotal = (fns) => [...fns].sort((a, b) => b.totalMs - a.totalMs || b.selfMs - a.selfMs || a.key.localeCompare(b.key));
+const HOT_LINES = 4, HOT_LINE_SHARE = 0.05;
+const roundFn = (locate, withLines = false) => (f) => {
+  const src = locate ? locate(f.cf) : null;
+  const row = { key: f.key, selfMs: round1(f.selfMs), totalMs: round1(f.totalMs), samples: f.samples, ...(src ? { src } : {}) };
+  if (withLines && f.lines && f.selfMs > 0 && f.cf && f.cf.url) {
+    // The lines of the function that hold its self time (the 1-based bundle line, its share, its source). A
+    // builtin's ticks name its call sites' lines with no file to read them in, so those stay unlisted.
+    row.lines = f.lines.filter((l) => l.ms / f.selfMs >= HOT_LINE_SHARE).slice(0, HOT_LINES).map((l) => {
+      const at = locate && f.cf ? locate.line(f.cf, l.line - 1) : null;
+      return { line: l.line, ms: round1(l.ms), share: Math.round((l.ms / f.selfMs) * 100) / 100, ...(at ? { src: at } : {}) };
+    });
+  }
+  return row;
+};
+
+/** Sum aggregates from several runs (iterations) by function key. */
+export function mergeAggregates(aggs) {
+  const fns = new Map(), meta = {};
+  let durationMs = 0, sampledMs = 0, samples = 0;
+  for (const a of aggs) {
+    durationMs += a.durationMs; sampledMs += a.sampledMs; samples += a.samples;
+    for (const [k, v] of Object.entries(a.meta)) meta[k] = (meta[k] || 0) + v;
+    for (const f of a.functions) {
+      const m = fns.get(f.key) || { key: f.key, selfMs: 0, totalMs: 0, samples: 0, cf: f.cf };
+      m.selfMs += f.selfMs; m.totalMs += f.totalMs; m.samples += f.samples;
+      if (f.lines) { const ln = new Map((m.lines || []).map((l) => [l.line, l.ms])); for (const l of f.lines) ln.set(l.line, (ln.get(l.line) || 0) + l.ms); m.lines = [...ln].map(([line, ms]) => ({ line, ms })).sort((a, b) => b.ms - a.ms); }
+      fns.set(f.key, m);
+    }
+  }
+  return { durationMs, sampledMs, samples, meta, functions: [...fns.values()] };
+}
+
+/** Rank an aggregate: the top functions by self time and by total time, the bookkeeping totals beside;
+ *  `locate` (sourceLocator) adds each function's source position when the dist carries maps. */
+export function rankProfile(agg, top, locate = null) {
+  const r = roundFn(locate), rl = roundFn(locate, true);
+  const self = bySelf(agg.functions);
+  const hot = Math.min(top, HOT_FUNCTIONS);
+  return { durationMs: round1(agg.durationMs), sampledMs: round1(agg.sampledMs), samples: agg.samples, functions: agg.functions.length,
+    meta: Object.fromEntries(Object.entries(agg.meta).map(([k, v]) => [k, round1(v)])),
+    topSelf: [...self.slice(0, hot).map(rl), ...self.slice(hot, top).map(r)], topTotal: byTotal(agg.functions).slice(0, top).map(r) };
+}
+const HOT_FUNCTIONS = 5;   // the top self-time functions whose lines are shown
+
+/** The frames worth their own window: the first content frame and the largest frame of every type
+ *  except keepalives. A frame's window is the delivery that carried it (t0 to t0 + the bundle's time;
+ *  for a coalesced frame, the newer frame's delivery it rode in), the part of a frame's cost the
+ *  JavaScript sampler can see; style, layout and paint after it are not JavaScript. A frame that never
+ *  reached the bundle falls back to its handler window. Frames that share a delivery share a window. */
+function profileWindows(perFrame, firstIdx) {
+  const picks = [];
+  if (firstIdx >= 0 && perFrame[firstIdx]) picks.push({ label: "first content frame", f: perFrame[firstIdx] });
+  const largest = new Map();
+  for (const f of perFrame) { if (f.type === "ka") continue; const cur = largest.get(f.type); if (!cur || f.bytes > cur.bytes) largest.set(f.type, f); }
+  for (const [type, f] of largest) if (!picks.some((p) => p.f.i === f.i)) picks.push({ label: `largest ${type}`, f });
+  const byWindow = new Map();
+  for (const p of picks) {
+    const key = p.f.delivery != null && p.f.delivery >= 0 ? `d${p.f.delivery}` : `h${p.f.i}`;
+    const cur = byWindow.get(key);
+    if (cur) cur.label += ` + ${p.label}`; else byWindow.set(key, { ...p });
+  }
+  return [...byWindow.values()];
+}
+
+/** The page-time window of frame `f` in run `r`: its delivery's [t0, t0 + ms] when one carried it, else
+ *  its handler's; null when the run holds no record of it. */
+function frameWindow(r, f) {
+  const pf = r.perFrame[f.i];
+  if (!pf || pf.t0 == null) return null;
+  const d = pf.delivery != null && pf.delivery >= 0 && r.deliveryRows ? r.deliveryRows[pf.delivery] : null;
+  if (d && d.ms >= 0) return { kind: "delivery", t0: d.t0, ms: d.ms };
+  if (pf.handlerMs != null && pf.handlerMs >= 0) return { kind: "handler", t0: pf.t0, ms: pf.handlerMs };
+  return null;
+}
+
+function profileReport(runs, firstIdx, files, sourceMapDir) {
+  const locate = sourceMapDir ? sourceLocator(sourceMapDir) : null;
+  const profiled = runs.filter((r) => r.profiling && r.profiling.profile);
+  // Every interval a wrapper was on the stack: the handlers, the flushes of the shim's queue and the
+  // deliveries outside both (a shim from before the flush task delivers inside the handler).
+  const wrapperWindows = (r) => [
+    ...r.perFrame.filter((f) => f.t0 != null && f.handlerMs != null && f.handlerMs >= 0).map((f) => [f.t0, f.t0 + f.handlerMs]),
+    ...(r.flushRows || []).filter((x) => x.ms >= 0).map((x) => [x.t0, x.t0 + x.ms]),
+    ...(r.deliveryRows || []).filter((x) => x.ms >= 0).map((x) => [x.t0, x.t0 + x.ms]),
+  ];
+  const aligned = profiled.map((r) => ({ r, al: refineAlignment(r.profiling.profile, r.profiling.p0, r.profiling.alignMs, wrapperWindows(r)) }));
+  const overall = rankProfile(mergeAggregates(profiled.map((r) => aggregateProfile(r.profiling.profile))), TOP_OVERALL, locate);
+  const windows = [];
+  for (const { label, f } of profileWindows(runs[0].perFrame, firstIdx)) {
+    const aggs = [];
+    let kind = null, ms = [];
+    for (const { r, al } of aligned) {
+      const w = frameWindow(r, f);
+      if (!w) continue;
+      const { profile } = r.profiling;
+      const toUs = (x) => profile.startTime + (x - al.p0) * 1000;
+      aggs.push(aggregateProfile(profile, [toUs(w.t0), toUs(w.t0 + w.ms)]));
+      kind = kind || w.kind; ms.push(w.ms);
+    }
+    if (!aggs.length) continue;
+    windows.push({ label, index: f.i, type: f.type, bytes: f.bytes, window: kind, windowMs: round1(ms.reduce((a, b) => a + b, 0) / ms.length), handlerMs: round1(f.handlerMs),
+      bundleMs: f.handoff === "delivered" ? round1(f.bundleMs) : null, coalesced: f.handoff === "coalesced", ...rankProfile(mergeAggregates(aggs), TOP_WINDOW, locate) });
+  }
+  const insides = aligned.map(({ al }) => al.inside).filter((x) => x != null);
+  // The bundles the profile names (served from /dist/): the source-position claim rests on their maps
+  // having loaded, not on a directory having been configured. A --production dist is minified and has none.
+  const bundles = new Set();
+  for (const r of profiled) for (const n of r.profiling.profile.nodes || []) {
+    const url = n.callFrame && n.callFrame.url;
+    if (!url) continue;
+    try { const u = new URL(url); if (u.pathname.startsWith("/dist/") && u.pathname.endsWith(".js")) bundles.add(path.basename(u.pathname)); } catch {}
+  }
+  const sourceMapsLoaded = [], sourceMapsMissing = [];
+  for (const b of [...bundles].sort()) (locate && locate.probe(b) ? sourceMapsLoaded : sourceMapsMissing).push(b);
+  return { files, samplingIntervalUs: PROFILE_INTERVAL_US,
+    alignMs: round1(Math.max(...aligned.map(({ al }) => al.alignMs))), alignBoundMs: round1(Math.max(...profiled.map((r) => r.profiling.alignMs))),
+    alignRefined: aligned.length > 0 && aligned.every(({ al }) => al.refined),
+    wrapperSamplesInWindows: insides.length ? round1(Math.min(...insides) * 100) / 100 : null,
+    sourceMaps: sourceMapsLoaded.length > 0, sourceMapsLoaded, sourceMapsMissing, ...overall, windows };
+}
+
+/** Write each profiled iteration's .cpuprofile (Chrome DevTools loads it); with several iterations the
+ *  index goes before the extension. Returns the paths written. */
+function writeProfiles(out, runs) {
+  const abs = path.resolve(out);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  const profiled = runs.filter((r) => r.profiling && r.profiling.profile);
+  const files = [];
+  profiled.forEach((r, i) => {
+    const ext = path.extname(abs);
+    const file = profiled.length === 1 ? abs : path.join(path.dirname(abs), `${path.basename(abs, ext)}-${i + 1}${ext}`);
+    fs.writeFileSync(file, JSON.stringify(stripProfileQueries(r.profiling.profile)));
+    files.push(file);
+  });
+  return files;
+}
+
+/** The profile with every call frame's URL query dropped: V8 records the document URL for the page's inline
+ *  shim, and the page was navigated to /feed?token=<the run's serve token>; the file is meant to be opened
+ *  and shared, so the token never reaches it (frameKey and the locator already drop the query). */
+export function stripProfileQueries(profile) {
+  const nodes = (profile.nodes || []).map((n) => (n.callFrame && typeof n.callFrame.url === "string" && n.callFrame.url.includes("?"))
+    ? { ...n, callFrame: { ...n.callFrame, url: n.callFrame.url.split("?")[0] } } : n);
+  return { ...profile, nodes };
+}
+
+const fmtFn = (f) => `${fmtMs(f.selfMs).padStart(9)} ${fmtMs(f.totalMs).padStart(9)} ${String(f.samples).padStart(7)}  ${f.key}${f.src ? `  ${f.src}` : ""}`;
+const fmtMeta = (meta) => Object.entries(meta).map(([k, v]) => `${k} ${fmtMs(v)} ms`).join(", ") || "none";
+
+export function renderProfile(cp) {
+  const out = [];
+  out.push(`cpu profile: ${cp.samples} samples over ${fmtMs(cp.durationMs)} ms at ${cp.samplingIntervalUs} us, ${cp.functions} functions; bookkeeping: ${fmtMeta(cp.meta)}`);
+  const pct = cp.wrapperSamplesInWindows != null ? `${Math.round(cp.wrapperSamplesInWindows * 100)}% of the instrument's samples inside the handler, flush and delivery windows` : "no windows to check against";
+  out.push(`  page-to-profile clock alignment ±${fmtMs(cp.alignMs)} ms ${cp.alignRefined ? `(refined from the ±${fmtMs(cp.alignBoundMs)} ms bracketing estimate; ${pct})` : `(the bracketing estimate; the refinement did not apply: ${pct})`}${cp.sourceMaps ? `; source positions from ${(cp.sourceMapsLoaded || []).map((b) => b + ".map").join(", ")}` : ""}`);
+  if (cp.sourceMapsMissing && cp.sourceMapsMissing.length) out.push(`  warning: no ${cp.sourceMapsMissing.map((b) => b + ".map").join(", ")} beside the served bundle${cp.sourceMapsMissing.length === 1 ? "" : "s"}; names and lines are the bundle's own, and a --production build is minified (rebuild with node esbuild.js, no --production)`);
+  for (const f of cp.files || []) out.push(`  written: ${f} (load it in Chrome DevTools, Performance panel)`);
+  const head = `${"self ms".padStart(9)} ${"total ms".padStart(9)} ${"samples".padStart(7)}  url:function:line${cp.sourceMaps ? "  source:line" : ""}`;
+  out.push(`  top ${cp.topSelf.length} by self time${cp.topSelf.some((f) => f.lines) ? " (under a function, the lines that hold its self time: share, ms, bundle line, source)" : ""}`, `  ${head}`);
+  for (const f of cp.topSelf) {
+    out.push(`  ${fmtFn(f)}`);
+    for (const l of f.lines || []) out.push(`  ${" ".repeat(28)}${String(Math.round(l.share * 100)).padStart(3)}%  ${fmtMs(l.ms).padStart(7)} ms  line ${l.line}${l.src ? `  ${l.src}` : ""}`);
+  }
+  out.push(`  top ${cp.topTotal.length} by total time`, `  ${head}`);
+  for (const f of cp.topTotal) out.push(`  ${fmtFn(f)}`);
+  for (const w of cp.windows || []) {
+    const span = w.window === "delivery"
+      ? `delivery ${fmtMs(w.windowMs)} ms${w.coalesced ? " (a newer frame's delivery, this one coalesced into it)" : ""}, shim handler ${fmtMs(w.handlerMs)} ms`
+      : `handler ${fmtMs(w.handlerMs)} ms`;
+    out.push("", `  window: ${w.label} (${w.type}, ${fmtBytes(w.bytes)}, frame ${w.index}): ${span}, ${w.samples} samples, ${fmtMs(w.sampledMs)} ms sampled; bookkeeping: ${fmtMeta(w.meta)}`);
+    out.push(`    top ${w.topSelf.length} by self time`, `    ${head}`);
+    for (const f of w.topSelf) out.push(`    ${fmtFn(f)}`);
+    out.push(`    top ${w.topTotal.length} by total time`, `    ${head}`);
+    for (const f of w.topTotal) out.push(`    ${fmtFn(f)}`);
+  }
+  return out.join("\n");
+}
+
+// ── text rendering ───────────────────────────────────────────────────────────────────────────────
+
+export function fmtBytes(n) {
+  if (n == null) return "-";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+const fmtMs = (x) => (x == null ? "-" : x >= 100 ? String(Math.round(x)) : x.toFixed(1));
+const stats3 = (s) => (s && s.n ? `${fmtMs(s.p50)} / ${fmtMs(s.p90)} / ${fmtMs(s.max)}` : "-");
+const fmtCount = (x) => (x == null ? "-" : Number.isInteger(x) ? String(x) : x.toFixed(1));
+const plural = (n, one, many = one + "s") => (n === 1 ? one : many);
+const pacingLabel = (fast, gapMs) => (fast ? "back-to-back" : gapMs != null ? `${gapMs} ms gaps` : "recorded pacing");
+
+/** The lines under the table that say what its timing columns hold, by how the shim handed frames on. */
+function handoffLines(r) {
+  const h = r.handoff || { mode: "none" };
+  const out = [];
+  if (h.mode === "flush") {
+    out.push(`handoff: the shim hands frames to the bundle in its own flush task (${fmtCount(h.flushes)} ${plural(h.flushes, "task")} carrying ${fmtCount(h.deliveries)} ${plural(h.deliveries, "delivery", "deliveries")} per run). handler = the shim's synchronous work per wire frame (parse, delta application, the held-state stamp); bundle = the pane's render per delivery; settle = a frame's receipt to the main thread free after the delivery that carried it.`);
+    const parts = [];
+    if (h.coalesced) parts.push(`${fmtCount(h.coalesced)} ${plural(h.coalesced, "frame")} coalesced into a newer frame of the same kind before delivery (no bundle time of their own)`);
+    if (h.shim) parts.push(`${fmtCount(h.shim)} answered by the shim alone (keepalives, restart notices, resync asks)`);
+    if (parts.length) out.push(`  ${parts.join("; ")}`);
+  } else if (h.mode === "handler") {
+    out.push("handoff: the shim hands frames to the bundle inside the WebSocket handler, so the handler column includes the bundle's render; bundle = that handoff's own time within it.");
+    if (h.shim) out.push(`  ${fmtCount(h.shim)} ${plural(h.shim, "frame")} answered by the shim alone (keepalives, restart notices, resync asks)`);
+  } else if (h.mode === "mixed") {
+    out.push("warning: the runs disagree on how the shim handed frames to the bundle (some in a flush task, some inside the handler); the bundle and settle columns pool both");
+  } else {
+    out.push("handoff: no delivery to the bundle was observed; the handler column is the WebSocket handler's synchronous time and the bundle column is empty");
+  }
+  if (h.queued) out.push(`warning: ${fmtCount(h.queued)} ${plural(h.queued, "frame was", "frames were")} still queued in the shim when the run ended`);
+  if (h.queueDrained === false) out.push("warning: the shim's queue had not drained when the run ended (a flush it armed never ran)");
+  if (h.unattributed) out.push(`note: ${h.unattributed} ${plural(h.unattributed, "render")} (${fmtMs(h.unattributedMs)} ms) not caused by a wire frame: the page re-emitted state on its own`);
+  if (h.deliverySeams && h.deliverySeams.dispatch) out.push(`note: ${h.deliverySeams.dispatch} ${plural(h.deliverySeams.dispatch, "delivery", "deliveries")} reached the pane through the MessageEvent fallback (no federation object published when the frame arrived), so the bundle column omits federation's prefixing and merge for them`);
+  for (const e of (h.deliveryErrors || []).slice(0, 5)) out.push(`  delivery threw: ${e.slice(0, 300)}`);
+  return out;
+}
+
+export function renderReport(r) {
+  const out = [];
+  out.push(`ui-bench ${r.app}: ${r.frames.total} frames, ${fmtBytes(r.frames.bytes)}, replay ${fmtMs(r.frames.replayMs)} ms (${pacingLabel(r.fast, r.gapMs)}), cpu x${r.cpuThrottle}, ${r.iters} iteration${r.iters === 1 ? "" : "s"}, ${r.browser}`);
+  out.push(`page ready (navigation to the bundle's handshake): ${fmtMs(r.frames.readyMs)} ms${r.frames.reconnects ? `; shim reconnects during replay: ${r.frames.reconnects}` : ""}${r.frames.misaligned ? `; frames whose page record did not match in length: ${r.frames.misaligned}` : ""}`);
+  if (r.first) {
+    const bundle = r.first.handoff === "coalesced" ? "bundle - (coalesced into a newer frame's delivery)"
+      : r.first.handoff === "mixed" ? `bundle ${fmtMs(r.first.bundleMs)} ms (delivered on its own in ${r.first.deliveredRuns} of ${r.iters} runs, coalesced in the others)`
+      : `bundle ${fmtMs(r.first.bundleMs)} ms`;
+    out.push(`first content frame: ${r.first.type}, ${fmtBytes(r.first.bytes)}, handler ${fmtMs(r.first.handlerMs)} ms, ${bundle}, settled ${fmtMs(r.first.settleMs)} ms`);
+  }
+  out.push("");
+  out.push(`${"type".padEnd(14)} ${"count".padStart(7)} ${"delivered".padStart(9)} ${"bytes".padStart(10)} ${"max".padStart(10)}   ${"handler p50/p90/max ms".padEnd(24)} ${"bundle p50/p90/max ms".padEnd(24)} ${"settle p50/p90/max ms".padEnd(24)}`);
+  for (const [type, s] of Object.entries(r.types)) {
+    const notes = [];
+    if (s.measured < s.count) notes.push(`${fmtCount(s.count - s.measured)} unmeasured`);
+    if (s.coalesced) notes.push(`${fmtCount(s.coalesced)} coalesced`);
+    if (s.queued) notes.push(`${fmtCount(s.queued)} still queued`);
+    if (s.settleMissing) notes.push(`${s.settleMissing} settle missing`);
+    out.push(`${type.padEnd(14)} ${fmtCount(s.count).padStart(7)} ${(s.delivered == null ? "-" : fmtCount(s.delivered)).padStart(9)} ${fmtBytes(s.bytes).padStart(10)} ${fmtBytes(s.bytesMax).padStart(10)}   ${stats3(s.handlerMs).padEnd(24)} ${stats3(s.bundleMs).padEnd(24)} ${stats3(s.settleMs).padEnd(24)}${notes.length ? `  (${notes.join(", ")})` : ""}`);
+  }
+  out.push(...handoffLines(r));
+  if (r.frames.settleMissing) out.push(`warning: ${r.frames.settleMissing} frame${r.frames.settleMissing === 1 ? "" : "s"} never received a settle stamp; the settle columns are computed over the frames that did`);
+  if (r.frames.addListenerMessages) out.push(`warning: ${r.frames.addListenerMessages} message listener${r.frames.addListenerMessages === 1 ? " was" : "s were"} added with addEventListener; the handler column does not time work done there`);
+  if (r.frames.buildBannerRaised) out.push(`warning: the page raised its "newer build" banner in ${r.frames.buildBannerRaised} run${r.frames.buildBannerRaised === 1 ? "" : "s"} (a keepalive's dv is newer than the dist under test): a few extra elements and a layout the frames did not cause`);
+  if (r.frames.connBannerRaised) out.push(`warning: the page raised its "connection stale" banner in ${r.frames.connBannerRaised} run${r.frames.connBannerRaised === 1 ? "" : "s"}`);
+  out.push("");
+  out.push(`long animation frames (${r.loaf.kind || "unsupported"}): ${r.loaf.count} entries, ${fmtMs(r.loaf.durationMs)} ms total, ${fmtMs(r.loaf.blockingMs)} ms blocking, longest ${fmtMs(r.loaf.maxMs)} ms`);
+  out.push("  script attribution names each task's entry point (the message handler, the shim's flush task, a rAF, a timer, a script's evaluation), not the bundle function; --cpu-profile gives functions");
+  for (const s of r.loaf.topScripts) out.push(`  ${fmtMs(s.durationMs).padStart(8)} ms  x${String(s.count).padEnd(4)} ${s.key}`);
+  const gc = r.end.afterGc ? `after a forced GC${r.end.heapBeforeGc != null ? ` (${fmtBytes(r.end.heapBeforeGc)} before it)` : ""}` : "with NO forced GC (the collection did not run; the figure includes pending garbage)";
+  out.push(`end state: JS heap ${fmtBytes(r.end.heapUsed)} used of ${fmtBytes(r.end.heapTotal)} ${gc}; DOM ${r.end.domElements} elements (${r.end.cdpNodes} nodes, ${r.end.jsEventListeners} listeners)`);
+  out.push(`  cumulative since navigation (page load and idle timers included; the timeline redraws every animation frame while it follows now): ${r.end.layoutCount} layouts ${fmtMs(r.end.layoutMs)} ms; ${r.end.recalcStyleCount} style recalcs ${fmtMs(r.end.recalcStyleMs)} ms; script ${fmtMs(r.end.scriptMs)} ms; tasks ${fmtMs(r.end.taskMs)} ms`);
+  out.push(`console: ${r.console.errors.length} errors, ${r.console.pageErrors.length} uncaught exceptions, ${r.console.warnings} warnings`);
+  for (const e of r.console.errors.slice(0, 10)) out.push(`  error: ${e.slice(0, 300)}`);
+  for (const e of r.console.pageErrors.slice(0, 10)) out.push(`  uncaught: ${e.slice(0, 300)}`);
+  for (const e of r.console.failedResources.slice(0, 10)) out.push(`  failed resource: ${e}`);
+  out.push(`messages the pane sent: ${Object.entries(r.clientMessages).map(([k, v]) => `${k} ${v}`).join(", ") || "none"}${Object.keys(r.clientDiag || {}).length ? ` (clientDiag: ${Object.entries(r.clientDiag).map(([k, v]) => `${k} ${v}`).join(", ")})` : ""}`);
+  if (r.fast) out.push("note: back-to-back replay; frames queued together coalesce (a newer whole-state frame replaces its older queued twin), so the bundle column covers the frames that were delivered, and a frame's settle time includes the frames dispatched after it before the next rendered frame, so settle percentiles overlap while handler times do not. Use --gap or the recorded pacing for the bundle's cost per frame.");
+  if (r.cpuProfile) out.push("", renderProfile(r.cpuProfile));
+  return out.join("\n");
+}
+
+// ── --compare ────────────────────────────────────────────────────────────────────────────────────
+
+function delta(a, b) {
+  if (a == null || b == null) return { a, b, diff: null, pct: null };
+  const diff = b - a;
+  return { a, b, diff: round1(diff), pct: a ? round1((diff / a) * 100) : null };
+}
+
+/** The differences between two replay reports: per-type timing percentiles, long-animation-frame
+ *  totals, and end state. Pure arithmetic over the JSON shape, no browser. */
+export function compareReports(a, b) {
+  const types = {};
+  for (const type of new Set([...Object.keys(a.types || {}), ...Object.keys(b.types || {})])) {
+    const x = a.types[type] || {}, y = b.types[type] || {};
+    const sx = x.settleMs || {}, sy = y.settleMs || {}, hx = x.handlerMs || {}, hy = y.handlerMs || {}, bx = x.bundleMs || {}, by = y.bundleMs || {};
+    types[type] = { count: delta(x.count ?? null, y.count ?? null), delivered: delta(x.delivered ?? null, y.delivered ?? null), bytes: delta(x.bytes ?? null, y.bytes ?? null),
+      settleP50: delta(sx.p50, sy.p50), settleP90: delta(sx.p90, sy.p90), settleMax: delta(sx.max, sy.max),
+      handlerP50: delta(hx.p50, hy.p50), handlerP90: delta(hx.p90, hy.p90), handlerMax: delta(hx.max, hy.max),
+      bundleP50: delta(bx.p50 ?? null, by.p50 ?? null), bundleP90: delta(bx.p90 ?? null, by.p90 ?? null), bundleMax: delta(bx.max ?? null, by.max ?? null) };
+  }
+  // LayoutCount, ScriptDuration and TaskDuration are cumulative since navigation, so they scale with how
+  // long the page sat there: a percentage between runs of different pacing or length says nothing.
+  const replayMs = [a.frames?.replayMs ?? null, b.frames?.replayMs ?? null];
+  const sameLength = replayMs[0] > 0 && replayMs[1] > 0 && Math.max(replayMs[0] / replayMs[1], replayMs[1] / replayMs[0]) <= 1.25;
+  const endComparable = !!a.fast === !!b.fast && (a.gapMs ?? null) === (b.gapMs ?? null) && sameLength;
+  const handoff = [a.handoff?.mode ?? null, b.handoff?.mode ?? null];
+  return {
+    apps: [a.app, b.app], cpuThrottle: [a.cpuThrottle, b.cpuThrottle], fast: [a.fast, b.fast], gapMs: [a.gapMs ?? null, b.gapMs ?? null], replayMs, endComparable, handoff,
+    first: { bytes: delta(a.first?.bytes, b.first?.bytes), handlerMs: delta(a.first?.handlerMs, b.first?.handlerMs), bundleMs: delta(a.first?.bundleMs ?? null, b.first?.bundleMs ?? null), settleMs: delta(a.first?.settleMs, b.first?.settleMs) },
+    types,
+    loaf: { count: delta(a.loaf?.count, b.loaf?.count), durationMs: delta(a.loaf?.durationMs, b.loaf?.durationMs), blockingMs: delta(a.loaf?.blockingMs, b.loaf?.blockingMs), maxMs: delta(a.loaf?.maxMs, b.loaf?.maxMs) },
+    end: { heapUsed: delta(a.end?.heapUsed, b.end?.heapUsed), domElements: delta(a.end?.domElements, b.end?.domElements), layoutCount: delta(a.end?.layoutCount, b.end?.layoutCount),
+      scriptMs: delta(a.end?.scriptMs, b.end?.scriptMs), taskMs: delta(a.end?.taskMs, b.end?.taskMs) },
+    console: { errors: [a.console?.errors?.length ?? 0, b.console?.errors?.length ?? 0] },
+  };
+}
+
+const fmtNum = (x) => (x == null ? "-" : Number.isInteger(x) ? String(x) : fmtMs(x));
+const fmtDelta = (d, unit = "", { pct = true } = {}) => {
+  if (d.diff == null) return `${fmtNum(d.a)} → ${fmtNum(d.b)}${unit}`;
+  if (d.diff === 0) return `${fmtNum(d.a)} → ${fmtNum(d.b)}${unit} (unchanged)`;
+  const sign = (x) => (x > 0 ? "+" : "-");
+  return `${fmtNum(d.a)} → ${fmtNum(d.b)}${unit} (${sign(d.diff)}${fmtNum(Math.abs(d.diff))}${pct && d.pct != null ? `, ${sign(d.pct)}${fmtNum(Math.abs(d.pct))}%` : ""})`;
+};
+
+export function renderCompare(c) {
+  const out = [];
+  const pacing = (i) => (c.fast[i] ? "fast" : c.gapMs && c.gapMs[i] != null ? `${c.gapMs[i]} ms gaps` : "paced");
+  out.push(`compare: ${c.apps[0]} (cpu x${c.cpuThrottle[0]}, ${pacing(0)}) → ${c.apps[1]} (cpu x${c.cpuThrottle[1]}, ${pacing(1)})`);
+  if (c.handoff && c.handoff[0] && c.handoff[1] && c.handoff[0] !== c.handoff[1]) out.push(`  the shims differ in how they hand frames to the bundle (${c.handoff[0]} → ${c.handoff[1]}): on a shim that delivers inside the handler the handler column includes the bundle's render, so compare bundle and settle, not handler`);
+  out.push(`first content frame: bytes ${fmtDelta(c.first.bytes)}; handler ${fmtDelta(c.first.handlerMs, " ms")}; bundle ${fmtDelta(c.first.bundleMs || { a: null, b: null, diff: null, pct: null }, " ms")}; settled ${fmtDelta(c.first.settleMs, " ms")}`);
+  for (const [type, t] of Object.entries(c.types)) {
+    const delivered = t.delivered && (t.delivered.a != null || t.delivered.b != null) ? ` (delivered ${fmtDelta(t.delivered)})` : "";
+    const bundle = t.bundleP50 && (t.bundleP50.a != null || t.bundleP50.b != null) ? `; bundle p50 ${fmtDelta(t.bundleP50, " ms")}` : "";
+    out.push(`${type.padEnd(14)} count ${fmtDelta(t.count)}${delivered}; settle p50 ${fmtDelta(t.settleP50, " ms")}, p90 ${fmtDelta(t.settleP90, " ms")}, max ${fmtDelta(t.settleMax, " ms")}; handler p50 ${fmtDelta(t.handlerP50, " ms")}${bundle}`);
+  }
+  out.push(`long animation frames: count ${fmtDelta(c.loaf.count)}; total ${fmtDelta(c.loaf.durationMs, " ms")}; blocking ${fmtDelta(c.loaf.blockingMs, " ms")}; longest ${fmtDelta(c.loaf.maxMs, " ms")}`);
+  const pct = { pct: c.endComparable !== false };
+  out.push(`end state: heap ${fmtDelta(c.end.heapUsed, " B")}; DOM elements ${fmtDelta(c.end.domElements)}; layouts ${fmtDelta(c.end.layoutCount, "", pct)}; script ${fmtDelta(c.end.scriptMs, " ms", pct)}; tasks ${fmtDelta(c.end.taskMs, " ms", pct)}`);
+  if (c.endComparable === false) out.push(`  layouts, script and tasks are cumulative since navigation and the runs differ in pacing or length (replay ${fmtNum(c.replayMs?.[0])} → ${fmtNum(c.replayMs?.[1])} ms), so they carry no percentage`);
+  out.push(`console errors: ${c.console.errors[0]} → ${c.console.errors[1]}`);
+  return out.join("\n");
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────────────────────────
+
+const USAGE = `usage:
+  node tools/ui-bench.mjs --record <app> --seconds N --out /tmp/…/frames.jsonl [--port P]
+  node tools/ui-bench.mjs --replay <app> --frames FILE [--cpu-throttle K] [--iters N] [--fast | --gap MS] [--json OUT] [--dist DIR] [--cpu-profile OUT.cpuprofile]
+  node tools/ui-bench.mjs --synthesize <app> --cards N --out FILE [--seed S]
+  node tools/ui-bench.mjs --compare A.json B.json
+apps: ${APPS.join(", ")} (synthesize: feed, fleet, timeline)`;
+
+export function parseArgs(argv) {
+  const o = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) { o._.push(a); continue; }
+    const key = a.slice(2);
+    const flags = new Set(["fast", "help"]);
+    if (flags.has(key)) { o[key] = true; continue; }
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) throw new Error(`--${key} needs a value`);
+    o[key] = v; i++;
+  }
+  return o;
+}
+
+async function main(argv) {
+  const o = parseArgs(argv);
+  if (o.help || !argv.length) { console.log(USAGE); return 0; }
+  const num = (k, d) => (o[k] === undefined ? d : Number(o[k]));
+  if (o.record) {
+    const port = num("port", Number(process.env.ROMP_KERNEL_PORT) || 29855);
+    if (!o.out) throw new Error("--record needs --out");
+    await recordFrames({ app: o.record, seconds: num("seconds", 60), out: o.out, port });
+    return 0;
+  }
+  if (o.synthesize) {
+    if (!o.out) throw new Error("--synthesize needs --out");
+    const frames = synthesizeFrames(o.synthesize, num("cards", 50), { seed: num("seed", 7) });
+    writeFrames(o.out, { tool: "ui-bench", mode: "synthesize", app: o.synthesize, cards: num("cards", 50), seed: num("seed", 7), synthetic: true }, frames);
+    const s = streamSummary(frames);
+    console.error(`ui-bench: wrote ${frames.length} synthetic frames (${fmtBytes(s.bytes)}) for app=${o.synthesize} → ${o.out}`);
+    for (const [type, st] of Object.entries(s.byType)) console.error(`  ${type.padEnd(12)} ${String(st.count).padStart(6)}  ${fmtBytes(st.bytes).padStart(10)}`);
+    return 0;
+  }
+  if (o.replay) {
+    if (!o.frames) throw new Error("--replay needs --frames FILE");
+    if (o.fast && o.gap !== undefined) throw new Error("--fast and --gap are two pacings; give one");
+    const report = await replay({ app: o.replay, framesFile: o.frames, cpuThrottle: num("cpu-throttle", 1), iters: num("iters", 1), fast: !!o.fast, gapMs: o.gap === undefined ? null : Number(o.gap), dist: o.dist, jsonOut: o.json, cpuProfile: o["cpu-profile"] });
+    console.log(renderReport(report));
+    return 0;
+  }
+  if (o.compare) {
+    const b = o._[0];
+    if (!b) throw new Error("--compare needs two report files: --compare A.json B.json");
+    const A = JSON.parse(fs.readFileSync(o.compare, "utf8")), B = JSON.parse(fs.readFileSync(b, "utf8"));
+    console.log(renderCompare(compareReports(A, B)));
+    return 0;
+  }
+  console.log(USAGE);
+  return 2;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main(process.argv.slice(2)).then((code) => process.exit(code), (e) => { console.error(`ui-bench: ${e.message}`); process.exit(1); });
+}


### PR DESCRIPTION
Two development tools, both instruments rather than savings. `tools/perf-bench.py` loads a checkout's kernel in-process against a copy of a state directory and times the payload builders on real-sized data, with no live kernel, no network and every write listed. `tools/ui-bench.mjs` records a pane's WebSocket frame stream, replays it into the real pane page in a headless Chromium, and reports where the browser's time goes. Neither touches the kernel, the panes or any payload: the diff is about 5,900 added lines under `tools/`, `tests/`, `CONTRIBUTING.md`, `tests/README.md`, `docs/reference.md` and three CI steps. The kernel performance counters (#1003) and the browser-side telemetry (#1009) are on main; these tools reference nothing from either, and the two `docs/reference.md` sections they added each end with a pointer to the offline instrument for the same layer. They are one PR because the performance PRs that follow cite both tools' rows as their before-and-after evidence, and because the part worth reviewing closely is the same in both: each runs kernel code outside the live kernel, so the guard lists (what is floored, what is tripwired, what may be written where) are the design. The four commits of the offer are separable and ordered so that each stands without the ones after it: the kernel bench alone; the pane bench with its tests; its docs; its CI step last, so the branch is complete without it. A fifth commit, the review commit, sits on top and touches all four, and a sixth, added after review, makes the bench leave its state copy byte-identical (the section Added after review says what it changed); the paragraph after the list says what the review commit changed, and every section below describes the branch as it stands at the sixth commit.

## Commits

1. **An offline bench times the kernel's payload builders against a copy of a state directory, with no live kernel, no network and every write listed.** `tools/perf-bench.py` and `tests/test_perf_bench.py`. Rows: `Sessions.live` and the names snapshot, `discover` cold and warm, `build_session` per largest transcript three ways (cold with every cache a freshly started kernel lacks emptied, each cold sample checked against the event model's assembly counters and the assembly cache; event-model-warm; warm), one parse of every live transcript, `build_feed` with and without warm parses, `build_timeline` bars and skeleton, `load_goals` per largest store, and the pusher's cold cycle (its parses counted inside it), per-app connect and steady cycle with rebuild samples set aside. `--profile` adds cProfile tables per builder; `--repo` picks the kernel so two checkouts run against one copy; `--compare A.json B.json` prints per-row deltas after flagging any difference in the two runs' worlds, a run that stopped on a guard (its `error`) among them. Isolation, all reported in the output: the state root rebound to the copy and the manager port set to a dead port before the import, the catalog, CLI-scope and Claude-binary seams floored, every key-source and credential name `tests/conftest.py` pops dropped (`ROMP_API_KEY_CMD` and `ROMP_API_KEY_REF`, `ANTHROPIC_*`, `CLAUDE_CODE_OAUTH_TOKEN`, `ROMP_EXPECTED_AUTH`, the `OP_*` names and the `OP_SESSION_*` prefix; the test pins the list against the kernel's own constants), `subprocess` in every loaded romp module (the kernel, judge and SDK backend modules and every sibling `kernel/` module one of them loaded, `keysource` among them) replaced by a tripwire that raises on any spawn except the kernel's read-only git queries (`rev-parse`, `ls-files` and the pair `remote get-url`, counted per build; `--no-git` answers even those as failures), network fetches and notifications replaced by recorders that take the kernel's full call shapes (a mismatch there would not raise: `_push` catches its build's exceptions, prints `push build:` to stderr and returns), the background parse asked for and counted rather than started, every thread start counted, `pwd` lookups counted, every write the kernel aims under the copy (`_atomic_write`, the import-time repo-root marker, the order audit log) landing in a shadow directory under the tool's private temp dir, with the kernel's own re-reads of the small JSON state files served from the shadow, every refusal (a spawn, a write aimed outside the copy) recorded before it raises so that a run ending with one on record fails naming the guard even when the kernel's `_push` caught the error and went on, and the copy (files, directories and link targets) fingerprinted before and after on every exit path, byte-identical afterwards. The live default state directory is refused without `--i-know-this-is-live`, and then only a temporary mirror without `sdkvenv` or the kernel's 0600 credential files (`serve-token`, `push-vapid.json`, `push-subscriptions.json`, `remotes.json`) is benched. The guards that decide whether a number is a number are module-level functions, so the test drives each with inputs the fixture cannot produce. Measured with the tool at the main this branch was first built on (3d23d779; not re-measured after either rebase: the first hop's changes to the timed builders were wrapper-level, stores read through `load_goals_or_fault` and a stat before each store read; the second hop's are not, #1060 and #1059 having landed, and the Measurements section says what that does to the table), on a copy of a 31-session state directory (506 MB of transcripts, `--iters 5`, medians): steady pusher cycle 425 ms (rebuild samples 3.0 s), `build_feed` 882 ms, `build_timeline` bars 1061 ms plus a 155 ms skeleton, cold `build_session` 1.3 to 5.3 s on 26 to 75 MB transcripts (the parse over half of it), `load_goals` 5.2 to 7.3 ms on 1.1 to 1.6 MB stores. The full table is in the commit body.

2. **A headless-Chromium bench records a pane's frame stream and replays it into the real page, reporting where the browser's time goes.** `tools/ui-bench.mjs` and `tests/ui-bench.test.mjs`. `--record <app>` connects to a running kernel as the page's shim does (`/ws?app=&delta=1&iid=`, the token as the `romp_token` cookie with a same-origin Origin, the `{type:"ready"}` handshake and nothing else) and writes the frames as JSONL only under the system temp directory (0700 directory, 0600 file, no path inside a git checkout or through a symlink), because a recording is real session data. `--replay <app> --frames FILE` serves the real page, shim and bundles through the kernel's own `Handler` in a python3 subprocess under the floors `tests/conftest.py` applies (the manager variables removed and the manager port set to a dead one, every key-source and credential name conftest pops removed, service env file and model-catalog fetch pointed away, `ROMP_CLAUDE_BIN=/bin/false`, `ROMP_CLI_SCOPE=0`, `ROMP_POSTAL_PEERS=0`, a serve token minted per run, a stdin watchdog), with a Node front server owning `/ws` (the page's own origin, required: an upgrade with a foreign Origin or none at all is refused). The pane shim hands frames to the bundle in its own task (a `MessageChannel` flush that coalesces same-type whole-state frames and stops after 8 ms), so a wire frame and its render are two measurements: the in-page instrument wraps the WebSocket handler (the shim's synchronous work per wire frame; a `needSlot` sent from inside it marks a refused frame), the flush task and the posts that arm it (so the run waits for the queue to drain), and the handoff itself (`window.__rompFed.inbound`, else the `MessageEvent` fallback), and pairs each delivery with the wire frames it carried by the shim's own queue rules. Per frame type the report gives the bytes, `count` and `delivered`, the handler, bundle and settle times (settle end to end: receipt to the main thread free after the delivery that carried it), how many frames coalesced, which seam the deliveries came through, long-animation-frame attribution naming the flush task (the instrument's own entry points, the settle stamp, the observer callback and the collector, are labelled as its bookkeeping, never as a row under its file), the heap before and after a forced GC, DOM and layout counters, console errors and uncaught exceptions, and the messages the pane sent. `--cpu-profile` samples V8 at 500 us, writes a DevTools-loadable profile with the token stripped, and ranks functions by self and total time with source positions from the dist's `.map` files, overall and inside the deliveries that carried the first content frame and the largest frame per type. `--synthesize <app>` writes a byte-stable stream in this tree's wire shapes for the feed, Outline and timeline pages; the chat is recorded, not synthesized. `--gap MS` paces a replay at a fixed interval; `--fast` sends back to back; `--iters N` pools runs; `--cpu-throttle K` slows the page. Measured at this tree on a synthetic 200-card feed stream, `--gap 100`, 3 iterations: the 192 KB full frame handler 1.3 ms, bundle 125 ms, settle 160 ms; the 24 deltas each delivered on their own, handler p50 0.2 ms, bundle 9.9 / 44.3 / 54.6 ms (p50 / p90 / max), settle 28.8 / 66.4 / 89.2 ms; back to back the 25 content frames coalesce into 1.7 deliveries per run (bundle 114 ms for the delivered ones). The same stream through this tool's earlier form, at a main whose shim rendered inside the handler, read handler 118 ms and settle 424 ms for the full frame. The profile puts 93% of `render()`'s self time on the `scrollTop` restore in `ui/webview/feed.ts`, and 99% of the instrument's samples fall inside the handler, flush and delivery windows. For scale, the same tool on a downstream kernel whose shim still rendered inside the handler, on a recorded feed stream of about 800 cards: the first 6.6 MB frame about 90 ms of `JSON.parse` and 870 ms in the handler for 47,000 DOM elements, a 542 KB delta 775 ms, and 97 to 98% of `render()`'s self time on the same line.

3. **CONTRIBUTING documents the pane bench, and tests/README names its node suite.** A "Measuring dashboard pane performance" section (prerequisites, the five commands of a before-and-after measurement with the replay a frame every 100 ms, why the handler and bundle columns are two measurements and what `--fast` coalesces, what a replay and `--cpu-profile` report, how the pages are served, why a recording may land only under the temp directory, which apps can be synthesized, how the node suite runs and skips, POSIX-only) and a "Test environment" heading over the existing notes; `tests/README.md` lists `ui-bench.test.mjs` beside the other node suites; the two performance sections of `docs/reference.md` each end with a pointer to the offline instrument for that layer. Docs only; every command in the section was run as written from the repo root. The review commit extends the section with the pinned playwright Chromium as a way to get a browser (`cd vscode-extension && npx playwright install chromium`, which CI installs), the manager-port and key-source floors as conftest applies them, and `ROMP_UI_BENCH_TIMING=1` for the timing relations; `tests/README.md` names that flag beside `ROMP_UI_BENCH_REQUIRE`.

4. **CI runs the pane bench's node suite after the extension build, with a browser required.** The `vscode-extension` job gains `node --test tests/ui-bench.test.mjs` after Build with `ROMP_UI_BENCH_REQUIRE=1`, so the four headless replays exercise the feed and timeline bundles just built, and a runner without a browser or python3 turns the job red instead of skipping. As posted, the step ran on the runner image's Google Chrome through playwright's channel option with no browser download; the review commit puts two steps before it, an `actions/cache` of playwright's browsers keyed on the extension lockfile and `npx playwright install chromium` (no `--with-deps`), so the required check runs the Chromium the pinned playwright fetches, never the image's unpinned Chrome, and it leaves `ROMP_UI_BENCH_TIMING` unset. Two tests go with the step: the PATH scan that finds a system browser is exercised in a subprocess with a fake `google-chrome` or `chromium` and an empty playwright browsers directory, and a test before the replays asserts a browser was found when the variable is set and prints which one as a diagnostic, so the step's log names the browser the replays ran in. Observed as posted, on ubuntu-latest, in the two CI runs of the pre-amendment tree (6db5b129): 29 and 21 s for the step (42 tests, 0 skipped; the log's browser line read `system google-chrome (channel chrome)`); in the first, 11.8 s was the nested-run test that proves the variable fails rather than skips, and the four replays took 4.7, 1.0, 2.5 and 2.5 s. At the review head, in this PR's CI run (34222961761): the install step 13 s on a cache miss, the bench step 13 s, 45 tests, 0 skipped, no timing diagnostic in the log, the browser line `playwright chromium`, the four replays 3.8, 0.5, 2.2 and 1.4 s.

5. **Review fixes: the bench step asserts nothing timing-dependent, a tripped guard fails the bench, the browser is provisioned by the workflow, the env floor matches conftest.** The review commit, not one of ours; it touches `.github/workflows/ci.yml`, `CONTRIBUTING.md`, `tests/README.md`, both tools and both test modules.

## Review commit

The review commit changed five things, plus two from findings it judged real. (1) The replay tests in the required CI step assert only what holds under any scheduling: frame totals, ordering, presence, and the handoff's accounting identity delivered + coalesced + shim + queued = count; every timing relation (settle margins, the parse cheaper than the render, the share of deltas delivered on their own, the heap freed by the forced GC, the sampler's density, the wrappers' sample share, the CPU-throttle ratio) is an assertion only under `ROMP_UI_BENCH_TIMING=1` and a diagnostic line otherwise, and CI leaves the flag unset; a unit test pins how the instrument attributes its own entry points (the settle stamp, the long-animation-frame observer callback, the collector), so a stretched bookkeeping task never files a row under the instrument's file. (2) `tools/perf-bench.py` records every refused write before its raise and, at the end of `run()`, `check_guards_held` fails the run (rows so far kept, JSON marked partial, `error` set, exit 1) naming the tripwire or the write guard when a refusal is still on record, since `_push` swallows the `BenchError`; `--compare` flags a run with `error` before diffing its rows; two end-to-end tests plant a spawn and an out-of-copy write inside `_push`. (3) `ci.yml` installs the pinned playwright Chromium (`npx playwright install chromium`, cached on the lockfile hash) before the bench step, so the required check never rides the runner image's unpinned Google Chrome; chosen over a loud skip because the bench's only CI run of the real pane bundles is the coverage the step exists for, and a skip in the required job would leave it green with nothing run, while a pinned download is the workflow's own stance for node and bats; no `--with-deps` (apt), no test-count pin. (4) Both tools drop every key-source and credential name `tests/conftest.py` pops (`ROMP_API_KEY_CMD` and `ROMP_API_KEY_REF`, `ANTHROPIC_*`, `CLAUDE_CODE_OAUTH_TOKEN`, `ROMP_EXPECTED_AUTH`, the `OP_*` names and the `OP_SESSION_*` prefix) and set a dead manager port; the ui-bench env test plants all of them, `test_perf_bench` pins the list against `keysource.SOURCE_VARS`, `OP_ENV_NAMES`, `OP_ENV_PREFIX` and `sdk_backend.AUTH_ENV_NAMES` read from source, and the tripwire covers every sibling `kernel/` module a driven module loaded (`keysource` among them), the docstring saying which. (5) `test_perf_bench.py` pins only the caches the cold proof rests on, checks the writes as a superset plus the guard's own record, and asserts the git-per-build relation (at least one `ls-files` per build in a plain directory, fewer in a checkout) instead of exact counts; a CLI test drives `tools/ui-bench.mjs` as a subprocess (`--synthesize`, `--compare`, the usage, each refusal) and a unit test covers `parseArgs`. Also: the front server's `/ws` refuses an upgrade without an Origin header (a page always sends one), and the mirror and the rsync recipe leave `push-subscriptions.json` and `remotes.json` out with the other 0600 credential files. It was reconciled onto the amended head 09896597, keeping that head's rewrite of the refused-delta test.

## Rebased onto main on 2026-09-08

The branch was first built on 3d23d779, was rebased once onto d31e1b1c, and now sits on 66bb933e. The commits at this base, oldest first: e630a5db, 94cec35a, a1a57db7, 8a31befb (the amended head, 09896597 before this rebase) and 75127a4f (the review commit, 0d4454db before it); every author, message and diff is the one reviewed, the one context change being the paragraph below. Of the second hop's 245 commits, one conflicted: `docs/reference.md`, where #998's new API-health section sits between the browser-side telemetry section and "Where things live", the spot commit 3's `ui-bench` pointer was anchored to; the pointer keeps its place as the last paragraph of the telemetry section, ahead of the new section, and the `perf-bench` pointer merged untouched. `.github/workflows/ci.yml` (main's per-merge concurrency group) and `tests/README.md` (the per-session memory-limits docs) merged without conflict, the three CI steps still last in the `vscode-extension` job and the README still counting four suites before this one. Two merges changed the kernel the bench times: #1060 (the pusher and timeline changes) and #1059 (the goal-store memos), the changes the Measurements table's right column was cited for, are on main now, so that table's left column describes the kernel before them and is not this base's numbers (not re-measured; the section says so). At this base: `tests/test_perf_bench.py` 33 passed; `node --test tests/ui-bench.test.mjs` under `ROMP_UI_BENCH_REQUIRE=1` 45 of 45, 0 skipped, on playwright's Chromium, in 12.9 s after `npm ci` and a build; the full pytest under `-n 8` on a loaded machine that self-hosts a kernel had failures in three modules this branch does not touch, `test_rename_route` and `test_tag_edit_ack` green alone and `test_postal_token` red identically at bare main in a scratch checkout of it (an xdist temp-directory failure on that machine). `kernel/`, `ui/` and `vscode-extension/` stay byte-identical to main. Of what main gained in the first hop, three changes touched this work. #1016 moved the pane shim's handoff to the bundle out of the WebSocket handler into a `MessageChannel` flush with same-type coalescing and 8 ms slices, so commit 2's instrument was reworked: it wraps the three seams named above instead of one, the report separates the handler, bundle and settle columns and counts coalesced frames, the CPU-profile windows and the clock alignment use the deliveries, and the feed replay in the tests runs at 100 ms gaps so each delta reaches the bundle on its own (the earlier alignment assertion over handler windows of about a millisecond was quantized to a handful of samples and failed most runs at the tip; it now holds at 99%; since the review commit both are timing relations, asserted under `ROMP_UI_BENCH_TIMING=1` and diagnostics otherwise). Commit 3's section explains the two measurements. #1019 made an unparseable goals file a quarantine (moved aside as `<file>.corrupt-<stamp>`) and a read fault an error; the kernel bench's builders reach stores through `load_goals_or_fault` because they are the live code paths, and on a copy holding such a file the kernel moves it aside inside the copy, which the before-and-after fingerprint lists. #1020 (state readers proved) changed no file the bench's expected write set names; the set (`order-audit.jsonl`, `repo-root`, `session-order.json`) is what a run aims at the copy at the tip, and since the sixth commit those writes land in the tool's shadow while the copy stays byte-identical (the test checks the shadowed set as a floor and the copy's census as 0 changed, 0 new, 0 removed). #1003 and #1009 landed, so nothing here depends on an open PR any more, and the `docs/reference.md` pointers the first draft left out (their anchors were those PRs' sections) are in commit 3. Nothing was dropped.

## Nothing visible changes

No kernel, `ui/webview`, payload or protocol edit; no new route; no runtime dependency; the extension bundles are unchanged. The tests pin the invariants that make the tools safe to run beside a live kernel:

- `perf-bench` refuses the live state directory without its flag and mirrors it even with the flag (the four 0600 credential files and `sdkvenv` excluded, mirror removed); every spawn other than the three read-only git queries raises; the writes the kernel aims at the copy (`order-audit.jsonl`, `repo-root` and `session-order.json`) land in the tool's shadow and are listed by relative path while the copy is byte-identical afterwards (a tree hash before and after), one aimed outside the copy is refused before it runs and recorded, and a refusal still on record when the run ends fails it, even one the kernel's `_push` caught; transcript mtimes are unchanged after a run; no thread is started and none is left running.
- `ui-bench`'s replays run against the real pages served through the kernel's own `Handler` (the front server pipes every non-`/ws` response through unmodified and refuses a foreign or missing Origin or any other path on `/ws`; the tests assert the pages render with no failed resource, no console error and no resync request); the recorder sends the ready handshake and nothing else; a recording lands only under the system temp directory; the page-server subprocess never starts with the manager variables (each planted and asserted absent by name, the manager port set to a dead value as conftest does) or any key-source or credential name conftest pops (each planted and asserted absent) and gets a token minted per run; the written profile carries no token.
- CI: three steps added to the `vscode-extension` job (a cache of playwright's browsers, the pinned Chromium install, the bench), no change to the python or shell jobs.

## Tests

Commit 1: `tests/test_perf_bench.py`, 29 tests as posted, 33 at the review head, 42 at the head (the class setup benches a 400-turn synthetic transcript under cProfile, about 2 s on the CI runners). Red-first, recorded at the first base: (1) the tool's earlier module loader, which needed a loader helper this tree lacks: 7 of 14 red with the tool's own error; re-derived to `SourceFileLoader(...).load_module()`, as `kernel/kernel.py` loads its siblings: green. (2) The constructor-free backend dict without `_owns_memo` (which `SdkBackend.owns()` memoizes on at this tree): 7 red with the BenchError naming the attribute; entry added: green. (3) The cold row: dropping `_ASM_CACHE`/`_ASM_LOCK` from the caches emptied before a cold sample made `test_cold_build_is_a_full_parse` red through the pinned cache set; making the clearing a no-op made 7 red with the tool's own "ran no full assembly" error; restored: green. (4) Dropping `ls-files` from the tripwire's allow list: 8 red, the tripwire naming `_repo_file_index <- _resolve_path_token <- _path_links <- build_session`; restored: green. (5) The recorders called in-process with the kernel's call shapes: red on the tool's first stubs, a `TypeError` on `_push_notify`'s `kind=` keyword, which `_cached_feed` passes on every bell; tolerant stubs: green. Then, at this base, a mutation pass over the claims the earlier tests did not execute added 13 tests and a fixture change (the api session's cwd a plain directory, a placeholder `sdkvenv`, a planted `ANTHROPIC_API_KEY` variable that is not a key, an `age_api_days` knob): the two cold-sample proofs, the snapshot row count (both directions, and `--all-regs-live`), `prepare_env`'s every floor and change, the bench backend's rows (threads skipped, states from the log, `--dormant-rows`, `--all-regs-live`, a missing attribute named), the steady push's rebuild bucketing (the fixture cannot force a rebuild, so this is where that split is executed), a late BenchError leaving the rows printed and the partial JSON written, the mirror tolerating vanished files only and leaving no half-made copy otherwise, an `_atomic_write` outside the copy refused before it runs, the background parse recorded and threads counted, a transcript outside discovery's window backfilled, a kernel lacking a builder refused by name, the git queries per build (as posted the exact counts, one `ls-files` per build of the plain-directory session and none for the checkout's kept samples; at the review head the relation, at least one per build in the plain directory and fewer for the checkout, whose warm-up cached the answer), a connect sample's fresh client receiving what the cold cycle's did, the cold cycle's parses counted inside it, `--sessions` bounding the rows, `repo_head` equal to `git rev-parse HEAD`, `warm_all_parses` over both sessions, the discovery cache cleared before every cold sample, and the planted key dropped. Each was run against a mutation of the guard it covers: 26 mutations, every one red at the mutation and green at the commit. The module passes `tests/test_state_isolation_order.py` and `tests/test_tempdir_hygiene.py`. The review commit adds four tests: two end-to-end runs against a copy of `kernel/` with a spawn or an out-of-copy write planted inside `_push`'s try block (exit 1, the JSON marked partial with `error` naming the guard, the refusal listed, the rows measured before the check kept), the key-source list pinned against `keysource.SOURCE_VARS`, `OP_ENV_NAMES`, `OP_ENV_PREFIX` and `sdk_backend.AUTH_ENV_NAMES` read from the source with `ast`, and `check_guards_held` in-process; the env test plants every name on that list. It also loosens three pins: the cold-cache check asks that `_parse_cache`, `_JSONL_CACHE` and `_ASM_CACHE` were emptied and that the rest came from the tool's own list, the writes are a floor plus the guard's record with nothing removed (since the sixth commit, the shadowed set as a floor beside a copy census of zero), and the git counts are the relation above, so an unrelated kernel cache rename or a new write path no longer fails the tool's test.

Commit 2: `tests/ui-bench.test.mjs`, 40 tests in 10 to 11 s as posted (43 at the review head, which adds a unit test for the instrument's attribution of its own entry points, a `parseArgs` unit test and a CLI test that drives the tool as a subprocess: `--synthesize`, `--compare`, the usage, each refusal), four real headless replays. Red-first at the first base: the tool as it ran on this fork, unchanged: 33 of 34, the feed replay red with a page error from a synthetic card lacking `trgb`; the re-derived tests against the unchanged tool: 6 red; the tool re-derived except the two floors: only the floor test red; floors added: 34 of 34. At the rebase the instrument was reworked for the shim's flush task (above): 36 tests, the alignment assertion moved to the delivery windows. Then the mutation pass added four tests (the front server's `/ws` origin and path check; the instrument on a blank page: the posts that arm the flush counted only from inside a handler or flush, every armed flush fired, a delivery's settle stamped after the second animation frame and not before, a dispatch inside an inbound one delivery and not two, the seam recorded, a throwing inbound recorded and rethrown; a replay of the feed with its last delta's base wrong and a final frame the pane throws on, the refused delta the shim's alone with one `needSlot` sent and the exception collected as uncaught; a replay of the timeline with `--iters 2` and with `--cpu-throttle 4`) and new assertions in the existing ones (a token minted per run, the stripped variables planted and named by the test, two chained frames in one flush giving two deliveries, every delivery explained by a frame and every one through federation's inbound, the first frame's handler time a measurement and below its bundle time, a keepalive's settle at least one frame interval, the heap smaller after the collection than before it, the profile's sampling interval a median under 750 us, a run whose collection did not return saying so). 19 mutations of the tool, every one red (a constant token, a shrunk stripped list, the whole-state rule applied to every kind, the depth guard, the `needSlot` wrap or the `postMessage` count removed, the GC, the sampling interval, the throttle or the Origin check dropped, the inbound trap gone, a handler time of zero, a settle stamped synchronously or after one frame, the iters loop running once, the pageerror listener dropped, a delivery error not recorded, `afterGc` a literal). One claim is not executed by a replay: the shim and the pane bundles log nothing through `console.error`, so the console-error listener is covered only by the fold test that renders collected errors. Two things changed after the mutation pass. When this PR's first CI run went red on the refused-delta replay (a 50 ms-gap replay asserting that no delta ever coalesces; one delta of 23 coalesced on the runner while the same tree passed on the fork), the test was amended (09896597) to pin the refused and the throwing frame by index and to sum delivered + coalesced for the rest. The review commit keeps that rewrite and applies the principle to every replay: what holds under any scheduling stays an assertion (frame totals, ordering, presence, the handoff's identity delivered + coalesced + shim + queued = count, the seams, the token, the profile's shape and source maps), and every timing relation in the list above (the first frame's handler below its bundle time, the settle margins, the keepalive's settle, the share of deltas delivered on their own, the heap smaller after the collection, the sampler's median interval and refined alignment, the wrappers' sample share, the CPU-throttle ratio) is an assertion only under `ROMP_UI_BENCH_TIMING=1` and a diagnostic line otherwise; a mutation caught only by one of those relations (the throttle's ratio, the sampler's density, the heap the collection freed) is red only with the flag set.

Commit 3: docs, no test module. Both insertion anchors were asserted verbatim before the edit; every command in the section was run as written against temp-directory paths (the `--record` command against a loopback WebSocket server standing in for a kernel).

Commit 4: two tests plus the step. The PATH-scan test spawns the module with an empty playwright browsers directory and a PATH holding only a fake `google-chrome` (channel `chrome`), then `chromium` (channel `chromium`), then nothing (the refusal says how to install a browser); removing the scan turns it red. The diagnostic test fails under `ROMP_UI_BENCH_REQUIRE=1` when no browser is found and prints `# browser: <how>` otherwise. Before the step existed, with the browsers hidden and `PLAYWRIGHT_BROWSERS_PATH` at an empty directory, the replay tests under `ROMP_UI_BENCH_REQUIRE=1` fail naming the missing browser, and without the variable they skip and the run exits 0 (a nested run in the suite checks both, now over four replay tests). On the fork's CI at the pre-amendment head 6db5b129 (run 34192675657) the step passed 42 of 42 with 0 skipped in 21 s (29 s in the run of the identical tree before the last message edit), the browser line reading `system google-chrome (channel chrome)`, and every job of both runs was green; this PR's CI run of that same tree failed the refused-delta replay on one coalesced delta, which the amendment and then the review commit answer (Commit 2 above). At the review head this PR's CI run (34222961761) passed the step 45 of 45, 0 skipped, in 13 s after a 13 s browser install, the browser line reading `playwright chromium`.

Suites. `kernel/`, `ui/` and `vscode-extension/` are byte-identical to main on this branch. The full pytest at the branch's head before this pass (the same kernel), twice under `-n 8` on a loaded machine that self-hosts a kernel: 4 failures, none of this branch: `test_paste_to_focus_browser::ServedPaste` (an environment failure on this machine, known), the two `test_scroll_marks_growth::ServedNotchFollowsGrowth` tests (new on main in this hop; the hermetic chat page renders two turns with no overflow on this headless machine, so the scrollbar notch stays hidden; they fail identically at the bare base in a scratch worktree), and `test_ship_reship::ServedWedge::test_restart_between_ship_and_ack...` (browser-driven; it failed 1 of 3 solo runs at the bare base too, load-sensitive). At the head as posted (09896597), the touched modules with the hygiene suites: `tests/test_perf_bench.py`, `tests/test_tempdir_hygiene.py`, `tests/test_state_isolation_order.py` 50 passed (63 subtests); `node --test tests/ui-bench.test.mjs` 42 of 42 with `ROMP_UI_BENCH_REQUIRE=1`, three runs, 10.3 to 11.4 s. At the review head, this PR's CI run (34222961761) is green on every job: the four Python cells (the 3.12 cell 8921 passed, 50 skipped, `tests/test_perf_bench.py` among them), bats, and the extension job with 45 of 45 node tests in 13.0 s.

## Measurements

Kernel builders (`perf-bench`, medians in ms unless noted). The left column was measured at the main this branch was first built on (3d23d779) on a copy of a 31-session state directory with 506 MB of transcripts, `--iters 5`, and not re-measured after either rebase (a fresh copy of that size is what a re-measurement needs). The first rebase's builder changes were wrapper-level; the second's are not: #1060 and #1059 landed, so the left column describes the kernel before the pusher, timeline and goal-store changes those PRs made, not this base. The right column is this fork's kernel, which carried the pusher changes #1060 has since landed, measured with the same tool on a 31-session copy with 386 MB of transcripts; it is cited for scale, not as this tree's numbers.

| Row | This branch's first base | This fork's kernel |
| --- | --- | --- |
| steady pusher cycle | 425 (rebuild samples 3039) | 350 at head, 4350 one revision earlier |
| `build_feed` | 882 | about 900 |
| `build_timeline` bars / skeleton | 1061 / 155 | 800 to 1300 / 200 |
| cold `build_session` | 1277 to 5346 on 26 to 75 MB transcripts, parse over half | 800 to 2600 on 40 to 56 MB |
| `load_goals` | 5.2 to 7.3 on 1.1 to 1.6 MB stores | 6 to 9 per MB |

Feed pane (`ui-bench`, headless Chromium). The synthetic row is this tree; the recorded row is this fork's kernel and its recorded stream, and its shim rendered inside the WebSocket handler, so its handler figures are shim plus bundle.

| Input | First full frame | A delta | Profile |
| --- | --- | --- | --- |
| synthetic, 200 cards, `--gap 100`, 3 iterations (this tree) | 192 KB, handler 1.3 ms, bundle 125 ms, settle 160 ms | handler p50 0.2 ms, bundle p50 9.9 ms (max 54.6), settle p50 28.8 ms (frames up to 3.6 KB) | 93% of `render()` self time on the `scrollTop` restore |
| the same stream, `--fast` (this tree) | coalesced into a delta's delivery in every run; settle 159 ms | 25 content frames in 1.7 deliveries per run, bundle 114 ms for the delivered ones | same line |
| the same stream at a main whose shim rendered in the handler (this tool's earlier form) | handler 118 ms, settle 424 ms | handler p50 6.1 ms | same line |
| recorded, about 800 cards (this fork, handler-rendering shim) | 6.6 MB, `JSON.parse` about 90 ms, handler 870 ms, 47,000 DOM elements | 542 KB, 775 ms | 97 to 98% of `render()` self time on the same line |

The recorded measurement is the basis of a feed-pane incremental-render change offered separately, which the same tool measured at a delta handler 454 to 63 ms, settle 524 to 105 ms and layouts per delta 127 to 5, with the first full frame unchanged at about 600 ms. The CI step took 29 and 21 s on ubuntu-latest in the two runs of the tree as posted, python3 startup included, on the image's Chrome; in the first, 11.8 s was the nested check that the REQUIRE variable fails rather than skips and the four replays took 4.7, 1.0, 2.5 and 2.5 s. At the review head, on the workflow's own Chromium: 13 s to install it on a cache miss and 13 s for the step, the replays 3.8, 0.5, 2.2 and 1.4 s.

## Contracts changed

None in code. Two things the tree inherits: `tests/test_perf_bench.py` pins the set of functions the bench neutralizes against this tree (`keysource.subprocess` among them since the review commit) and the key-source names against `keysource` and `sdk_backend`'s own constants, checks the caches emptied before a cold sample for the three the cold proof rests on and the shadowed writes as a floor beside a copy that must change by nothing (so an unrelated cache rename or a new write path shows in the tool's output without failing its test, while a write that reaches the copy fails it), and the bench's constructor-free backend dict in `make_backend` mirrors the attributes `SdkBackend`'s read-side methods reach; a renamed safety target, a new credential name in the kernel's constants or a new attribute fails loudly and is fixed in that one place (named in commit 1's body). The `vscode-extension` CI job now downloads playwright's pinned Chromium (about 150 MB, cached on the extension lockfile's hash, no `--with-deps`) and needs python3 on the runner; its bench step fails rather than skips without either.

## Not included

- No kernel, `ui/webview` or payload change, and no performance counters: the counters (#1003) and the browser-side telemetry (#1009) are on main and these tools reference nothing from them beyond the two `docs/reference.md` pointers.
- The tools load modules with `SourceFileLoader(...).load_module()`, the idiom `kernel/kernel.py` uses today; a shared loader helper the fork uses is not part of this offer.
- The pane bench speaks this tree's protocol only (a keyed full plus `{type:"delta", slot:...}`). A second feed-delta protocol and a pane-capabilities announcement that exist on the fork are not offered, and neither are synthesizers or docs for panes this tree does not have.
- A CONTRIBUTING subsection on message listeners from other browsing contexts belongs with a later browser-side offer.
- No `--with-deps` on the CI playwright install (that runs apt; the shared libraries Chromium needs come with the image) and no test-count pin on the bench step.
- `tests/bench_chatbuild.py` is untouched.

## Questions

None open. The one question as posted (hard-fail without a browser, or skip with a reason) is settled by the review commit: the step keeps `ROMP_UI_BENCH_REQUIRE=1` and the workflow provisions the browser itself, a loud skip in the required job having been judged worse because it would leave the only CI run of the real pane bundles green with nothing run.

### Added after review

The bench wrote three files into the copy it measured (the import-time repo-root marker, session-order.json and order-audit.jsonl), so an A/B's second run measured a copy the first had changed, and the census ran only when the run returned. Every write the kernel aims at the copy now lands in a shadow directory under the tool's private temp dir, with the kernel's own re-reads of the small JSON state files served from the shadow so the session order's read-modify-write lands once; the copy is byte-identical afterwards (the test pins it with a tree hash), and the census, which now records directories and symlink targets too, prints on every exit path, an exception out of the candidate kernel included. The one known writer the shadow does not take is the kernel's quarantine of an unparseable state file (an os.replace to a `.corrupt-<stamp>` sibling in the same directory), which the docstring names so a census listing such a file reads as that. The no-transcript error follows the 365-day backfill instead of preceding it and names the counts it worked from, and `--cwd-map FROM=TO` (repeatable) rewrites redacted registry cwds before the project-directory derivation, for a copy whose projects/ directory names kept the original path; its per-rule hit counts are read when the run ends, so they cover the builders' derivations beside discovery's. In the JSON, writes.shadowed replaces writes.atomic_writes (schema 3; `--compare` reads no schema, so a JSON of the earlier shape still compares); refused_writes and check_guards_held are unchanged.


Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

