### PR TITLE
Postal heartbeat: one fetch per beat, none once the bus confirms local; the chat fold seals plain Bash turns

### DIFF
--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -22,7 +22,7 @@ From the shell (also how the human drives it): `romp mail send --kind delegate|c
 
 ## On a remote machine
 
-If you SSH'd into another machine and are running romp there, run `romp mail remote` to connect it to the laptop's bus. It configures the remote side and prints the one tunnel command to run from the laptop (an `ssh -R` reverse forward, or a `~C` escape on the open connection), then auto-detects when it connects. Messaging before this setup nudges you to run it.
+Nothing to set up in peer mode (the default): every machine runs its own bus, cross-host mail rides the kernel's peer tunnels, and `romp mail agents` lists a peer's sessions with their host. `romp mail remote` belongs to the legacy singleton scheme (`ROMP_POSTAL_PEERS=0`), where it connects an SSH'd machine to the laptop's bus over a reverse tunnel; in peer mode it refuses and says why (the command would stop the local bus that carries this box's mail).
 
 ## Norms
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -159,7 +159,7 @@ romp mail agents                 # who is live, their branch and working-note
 romp mail working "<note>"       # publish what this session is working on
 romp mail sent                   # your sent messages, and whether each was read
 romp mail recall <to> [id]       # unsend a message the recipient has not read
-romp mail remote                 # connect this remote machine to your laptop's bus
+romp mail remote                 # legacy singleton scheme only (ROMP_POSTAL_PEERS=0): connect this remote machine to your laptop's bus; peer mode refuses
 ```
 
 ### Mail inside a session (MCP tools)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23388,7 +23388,7 @@ def _postal_intent(kind, body=""):
     return m.group(1) if m else ""
 
 
-_postal_index_memo = [None]   # ((mtime_ns, size), idx) — exact-change key of messages.jsonl
+_postal_index_memo = [None]   # ((mtime_ns, size), idx, body_map) — exact-change key of messages.jsonl
 
 
 def _postal_index():
@@ -23397,7 +23397,9 @@ def _postal_index():
     Memoized on the log's (mtime_ns, size): the log is append-only and every send appends, so the key
     moves on exactly the events that change the answer — build_session hydrates every postal card
     through this and re-parsed the whole log per push otherwise (~7% of the pusher's wall time,
-    py-spy 2026-08-31). Consumers only read the index (_hydrate_postal), so sharing one dict is safe."""
+    py-spy 2026-08-31). Consumers only read the index (_hydrate_postal), so sharing one dict is safe.
+    The memo also carries the index's body-keyed map (_postal_body_rows), built once per index version
+    beside it, so the outgoing-card join does not rescan every row per card per build."""
     p = jd.STATE / "timeline" / "messages.jsonl"
     try:
         st = os.stat(p)
@@ -23416,8 +23418,33 @@ def _postal_index():
                             "fromHost": o.get("from_host", ""),
                             "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
                             "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
-    _postal_index_memo[0] = (key, idx)
+    _postal_index_memo[0] = (key, idx, _postal_body_map(idx))
     return idx
+
+
+def _postal_body_map(index):
+    """{body: [rows]} over a postal index, rows in the index's (log) order — the same order the linear
+    scan it replaces walked, so a tie on time still resolves to the same row. Only string bodies are
+    keyed: the far-host relay logs a /send request's body without a type check, so a `sent` row can
+    carry a JSON list or object, which is unhashable. An outgoing card's body is always a string, so
+    such a row never matched the scan's `==` either; skipping it keeps one malformed row from raising
+    inside every session's chat build (review find 2026-09-06)."""
+    m = {}
+    for r in index.values():
+        b = r["body"]
+        if isinstance(b, str):
+            m.setdefault(b, []).append(r)
+    return m
+
+
+def _postal_body_rows(index):
+    """The body-keyed map for `index`: the memoized index's map comes from its memo entry (built once
+    per index version, never per card); any other dict (a caller's own index) gets one built here, once
+    per call. enrich_out in _hydrate_postal joins an outgoing card to its log row through this."""
+    hit = _postal_index_memo[0]
+    if hit is not None and hit[1] is index:
+        return hit[2]
+    return _postal_body_map(index)
 
 
 def _name_color_by_name(name):
@@ -23472,10 +23499,18 @@ def _postal_out_card(ev):
             "status": status, "ts": ev.get("ts"), "uuid": ev.get("uuid")}
 
 
+def _cli_send_match(ev):
+    """The `romp mail send` match over a Bash tool event's input, or None. The ONE matcher behind both
+    _cli_send_card (which renders the card) and _chat_postal_relevant (which decides whether the chat
+    fold keeps the raw event for re-hydration): a send the fold sealed away as a plain Bash row would
+    never pick up the recipient's caption or colour, so the two must agree on what a send is."""
+    return _CLI_SEND_RE.search(ev.get("input") or "")
+
+
 def _cli_send_card(ev):
     """A Bash `romp mail send <to> <body>` tool event → an outgoing card, only once the CLI confirmed
     delivery (else it stays a Bash row so a failure is visible)."""
-    m = _CLI_SEND_RE.search(ev.get("input") or "")
+    m = _cli_send_match(ev)
     if not m:
         return None
     kind, peer, body = m.group(1), m.group(2), _shell_unquote(m.group(3))   # group(1) = optional --kind
@@ -23551,6 +23586,7 @@ def _hydrate_postal(events, index, sid=None):
     # a ~2s cold-cache cost, but MOST sessions carry no incoming postal traffic — so only pay it when this
     # session actually has an incoming card to caption, never on the first-built tab that has no postal mail.
     _msgsum = [None]
+    _bodies = [None]   # the index's body map, fetched on the first outgoing card (none → never)
     def caption_for(mid):
         if _msgsum[0] is None:
             _msgsum[0] = _msg_summaries()
@@ -23561,8 +23597,12 @@ def _hydrate_postal(events, index, sid=None):
         # received, keyed by msg id), the out-card just never joined it. The send tool's output carries no
         # id, so join through the postal log: the sent row wearing this exact body, closest in time to the
         # send when the same text went out more than once. No row / no caption yet → no summary field, and
-        # the client falls back to its two-line clamp until the recipient's judge has run.
-        recs = [r for r in index.values() if r["body"] == card["body"]]
+        # the client falls back to its two-line clamp until the recipient's judge has run. The join is
+        # a body-keyed lookup (_postal_body_rows), not a scan of every row per card: the scan was about
+        # 2% of the kernel's interpreter time with a 2000-row log (GIL profile 2026-09-06).
+        if _bodies[0] is None:
+            _bodies[0] = _postal_body_rows(index)
+        recs = _bodies[0].get(card["body"]) or ()
         if recs:
             et = em.parse_z(ev.get("ts") or "") or 0
             rec = min(recs, key=lambda r: abs((r["t"] or 0) - et)) if et else recs[-1]
@@ -24296,11 +24336,28 @@ def _chat_seam_open_at(events, lo):
 
 def _chat_postal_relevant(ev):
     """The raw (pre-hydration) events _hydrate_postal can turn into something else — the ones whose
-    rendering depends on the postal index and the judges' captions rather than the transcript."""
+    rendering depends on the postal index and the judges' captions rather than the transcript. The
+    chat fold keeps exactly these raw and re-hydrates them when the index or the captions move;
+    everything else it seals as rendered.
+
+    A Bash event counts only when its input is a `romp mail send` (_cli_send_match, the matcher
+    _cli_send_card renders from) or its command is a mail read (_reads_mail). Every plain Bash event
+    used to count, so the fold re-hydrated each one on every judge pass to the same raw row: about
+    7.6 us per sealed Bash event per pass, 2.3% of the kernel's interpreter time (GIL profile
+    2026-09-06). A send whose tool_result has not landed yet is sealed like the rest of its turn, its
+    id recorded in the entry's open_tools, and the tool-fill gate demotes the entry when the result
+    lands; relevance reads only the input, so a result landing later can never change it.
+
+    Invariant, pinned in tests/test_chat_fold.py: when this returns False for an event,
+    _hydrate_postal([ev], index, sid)[0] is ev — the same object, untouched."""
     k = ev.get("kind")
     if k == "tool":
         nm = ev.get("name") or ""
-        return bool(_SEND_TOOL_RE.search(nm)) or nm == "Bash" or _reads_mail(ev)
+        if _SEND_TOOL_RE.search(nm):
+            return True
+        if nm == "Bash" and _cli_send_match(ev) is not None:
+            return True
+        return _reads_mail(ev)
     if k == "user":
         return bool(em.POSTAL_RE.findall(ev.get("md") or ""))
     return False

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -283,24 +283,35 @@ def _self_row():
     return (next((a for a in agents if a.get("id") == sid), None)
             or next((a for a in agents if a.get("lastSid") == sid), None))
 
-def my_id():
+def _self_identity():
+    """(id, name) of THIS session from ONE _self_row() resolution — one GET /sessions, where the
+    `my_name(), my_id()` pair a caller used to write cost two (2026-09-06: with about 30 sessions
+    beating every 30 s the heartbeat was nearly all of the kernel's GET /sessions traffic, and this
+    pair two of the three fetches each beat cost). Both fallbacks kept: no row → the env fsid as the
+    id (mail still routes by id) and the names registry for the name (kernel-down fallback; a
+    comment-thread session withholds its names entry, which is why the row comes first). (None,
+    None) when not in a romp session (no tmux fallback: the bus never shells tmux). Nothing is
+    memoized: a resolution that missed (kernel mid-restart) is retried in full by the next call."""
     row = _self_row()
-    return row["id"] if row else _self_id()
+    sid = row["id"] if row else _self_id()
+    if row and row.get("name"):
+        return sid, row["name"]
+    fsid = _self_id()
+    if not fsid:
+        return sid, None
+    try:
+        return sid, ((NAMES_DIR / fsid).read_text().split("\t")[0].strip() or None)
+    except Exception:
+        return sid, None
+
+def my_id():
+    return _self_identity()[0]
 
 def my_name():
     # The live agent row first (it tracks renames AND survives transcript forks); the names registry as
-    # the kernel-down fallback. None when not in a romp session (no tmux fallback: the bus never shells
-    # tmux).
-    row = _self_row()
-    if row and row.get("name"):
-        return row["name"]
-    sid = _self_id()
-    if not sid:
-        return None
-    try:
-        return (NAMES_DIR / sid).read_text().split("\t")[0].strip() or None
-    except Exception:
-        return None
+    # the kernel-down fallback. A caller that needs BOTH halves calls _self_identity() once instead of
+    # this pair — each of these is a full resolution.
+    return _self_identity()[1]
 
 # ───────────────────────── maildir store ─────────────────────────
 
@@ -850,8 +861,8 @@ def _publish_working(sid, text):
     r = _kernel_post("/working", {"id": str(sid), "text": text})
     return r is not None and r.get("ok") is not False        # None: unreachable; ok false: the kernel refused
 
-def all_agents(threads=False):
-    agents = local_agents(threads=threads)
+def _with_remote_presence(agents):
+    """The local rows plus every heartbeat-known REMOTE session (within HEARTBEAT_TTL, not already local)."""
     local_ids = {a["id"] for a in agents}
     now = time.time()
     for sid, (name, ts) in list(HEARTBEATS.items()):
@@ -859,17 +870,46 @@ def all_agents(threads=False):
             agents.append({"name": name, "id": sid, "remote": True})
     return agents
 
+def all_agents(threads=False):
+    return _with_remote_presence(local_agents(threads=threads))
+
 def _record_heartbeat(sid, name):
     """Record remote-presence for an incoming heartbeat — but ONLY for a sid the local kernel does NOT already
     own. A local session is already visible via the kernel's /sessions, so recording its heartbeat would leave
     it lingering as a phantom [remote] peer for the TTL after it dies. A genuine REMOTE (federated) session,
-    reaching us over an -R tunnel, is NOT in the local kernel — heartbeats are its only presence signal."""
-    if sid and _safe_id(sid) and sid not in {a["id"] for a in local_agents()}:
-        HEARTBEATS[sid] = (name or "?", time.time())
+    reaching us over an -R tunnel, is NOT in the local kernel — heartbeats are its only presence signal.
+
+    Returns True iff the sid is LOCAL: the bus's own listing ANSWERED and contains it (thread rows
+    included — a comment thread heartbeats under its own row, and until 2026-09-06 the thread-less
+    listing read here filed every live thread as REMOTE presence, a phantom that also reached
+    STATE/remote-sids; the by-name consumers that used to find a thread through that phantom,
+    _recip_id_for for recall, now read the listing with thread rows). The /heartbeat route hands that bit
+    back so a local session's MCP can stop heartbeating (2026-09-06: every local beat cost the kernel
+    three GET /sessions for a no-op). An UNANSWERED listing (kernel mid-restart) is False and records
+    the beat exactly as before — the answer is derived from the listing only, never from the
+    client's claim, so a remote session never hears "local" and never stops."""
+    local = False
+    if sid and _safe_id(sid):
+        rows, answered = local_agents_checked(threads=True)
+        if answered and any(a["id"] == sid for a in rows):
+            local = True
+        else:
+            HEARTBEATS[sid] = (name or "?", time.time())
     _write_remote_sids()                           # presence changed → refresh the deadness mirror
+    return local
+
+def present_count_checked():
+    """(present count, answered) for the autostop gate: local rows plus heartbeat presence, and whether
+    the kernel's listing ANSWERED. An answered listing is also remembered (_remember_presence: the
+    in-memory last-good rows and their disk twin), which is the evidence _idle_tick reads when a later
+    listing does not answer."""
+    rows, answered = local_agents_checked()
+    if answered:
+        _remember_presence(rows)
+    return len(_with_remote_presence(list(rows))), answered
 
 def present_count():
-    return len(all_agents())
+    return present_count_checked()[0]
 
 def _postal_off(sid):
     """True if the session toggled POSTAL ISOLATION on (the timeline lane's mailbox icon → postalServiceOff): it's
@@ -896,10 +936,17 @@ def _git_branch(d):
     except Exception:
         return ""
 
-def _name_for_id(sid):
+def _name_for_id(sid, rows=None):
+    """A session's display name: its live row (thread rows included — a comment thread's name lives
+    only on its row, no names entry), else the names registry, else the short id. `rows` is a listing
+    the caller already holds, so an operation that names many ids fetches GET /sessions once, not once
+    per id (2026-09-06: the orphan sweep named every dead mailbox with its own fetch, 28 per 30 s poll
+    on a box with 58 mailboxes; a recall by a dead name fetched once per mailbox). None fetches."""
     if not sid:
         return "?"
-    for a in local_agents():
+    if rows is None:
+        rows = local_agents(threads=True)
+    for a in rows:
         if a["id"] == sid:
             return a["name"]
     try:
@@ -907,11 +954,16 @@ def _name_for_id(sid):
     except Exception:
         return sid[:8]
 
-def _recip_id_for(to):
+def _recip_id_for(to, rows=None):
     """A recipient reference (live name, or UUID with an existing mailbox) -> session
     UUID, or None. Addressing is LIVE-only: a name that isn't a currently-live session
-    fails (no dead-session resurrection)."""
-    for a in all_agents():
+    fails (no dead-session resurrection). Thread rows included, the 2026-08-22 rule every
+    by-name resolver follows (resolve_recipient, GET /agents): a comment thread is addressable
+    by its own name, and recall of mail parked for it must find it (2026-09-06: it used to be
+    found through a phantom remote-presence row its heartbeat left; that phantom is gone).
+    `rows`: a listing the caller already holds (recall shares one across its lookups)."""
+    agents = _with_remote_presence(list(rows)) if rows is not None else all_agents(threads=True)
+    for a in agents:
         if a["name"] == to:
             return a["id"]
     if _safe_id(to) and (MAILROOT / to).is_dir():  # already an id with a mailbox (in-flight mail)
@@ -1094,8 +1146,15 @@ def _recall(from_id, to, mid):
     mail has left `new/` and can't be recalled. Returns [{to, id, body}] removed."""
     if not from_id:
         return []
+    listing = []                                 # ONE listing per recall, at first need; every name lookup reads it
+
+    def _rows():
+        if not listing:
+            listing.append(local_agents(threads=True))
+        return listing[0]
+
     if to:
-        rid = _recip_id_for(to)
+        rid = _recip_id_for(to, rows=_rows())
         if not rid and MAILROOT.is_dir():
             # Addressing is live-only, but RECALL is not addressing: the sender is unsending their
             # own bytes, not raising the dead. Mail parked for a session that has since died sits
@@ -1103,7 +1162,7 @@ def _recall(from_id, to, mid):
             # durable name map so parked mail stays recallable (sighting 2026-08-29: a handoff
             # parked for a dead session could not be unsent by name; only the raw id worked).
             hits = [b.name for b in MAILROOT.iterdir()
-                    if b.is_dir() and _name_for_id(b.name) == to]
+                    if b.is_dir() and _name_for_id(b.name, rows=_rows()) == to]
             rid = hits[0] if len(hits) == 1 else None    # two dead boxes, one name: refuse, stay scoped
         boxes = [rid] if rid else []
     elif MAILROOT.is_dir():
@@ -1132,7 +1191,7 @@ def _recall(from_id, to, mid):
                 f.unlink()
             except Exception:
                 continue
-            removed.append({"to": _name_for_id(rid), "id": f.name, "body": " ".join(body.split())[:120]})
+            removed.append({"to": _name_for_id(rid, rows=_rows()), "id": f.name, "body": " ".join(body.split())[:120]})
             _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "recall", "id": f.name})
         _mark_pending(rid)         # recall may have emptied new/ -> reconcile the marker
     if peers_on() and OUTBOX.is_dir():
@@ -1195,9 +1254,16 @@ def _sent_receipts(mid):
                 return h
         return None
 
+    listing = []                                 # one GET /sessions for every row without toName, at first need
+
+    def _name(sid):
+        if not listing:
+            listing.append(local_agents(threads=True))
+        return _name_for_id(sid, rows=listing[0])
+
     def _row(i, e):
         h = _parked(i, e)
-        r = {"to": e.get("toName") or _name_for_id(e.get("to_id", "")), "id": i, "sent": e["t"],
+        r = {"to": e.get("toName") or _name(e.get("to_id", "")), "id": i, "sent": e["t"],
              "exec": execs.get(i), "recalled": recalls.get(i),
              "relayed": relays.get(i), "bounced": bounced.get(i), "parked": h}
         if h:
@@ -1261,7 +1327,7 @@ def _sweep_orphans():
         newd = box / "new"
         if not newd.is_dir():
             continue
-        recip = _name_for_id(box.name)
+        recip = _name_for_id(box.name, rows=live)  # dead by construction: the registry names it, no fetch
         for f in list(newd.iterdir()):
             if not f.is_file():
                 continue
@@ -1926,8 +1992,8 @@ class Handler(BaseHTTPRequestHandler):
                 threading.Thread(target=_wake_when_ready, args=(sid,), daemon=True).start()
             return self._send({"ok": True})
         if u.path == "/heartbeat":
-            _record_heartbeat(data.get("id"), data.get("name", "?"))
-            return self._send({"ok": True})
+            local = _record_heartbeat(data.get("id"), data.get("name", "?"))
+            return self._send({"ok": True, "local": local})
         if u.path == "/quarantine/act":            # human verdict on a held message (approve/deny), from the
             mid = str(data.get("mid") or "")       # blocked card via the kernel; approve delivers, deny drops
             action = str(data.get("action") or "").strip().lower()
@@ -1984,14 +2050,56 @@ def _maybe_restart_for_code(boot_fp):
         return True
     return False
 
-def _idle_tick(n, idle):
+def _idle_tick(n, idle, answered=True):
     """One autostop decision: (new_idle, stop). Factored out so the gate is unit-testable (the
     monitor loop sleeps). Local clients OR a live local kernel reset the count — a hub with zero
-    local sessions still serves inbound peer exchanges as long as its kernel runs (_kernel_up)."""
+    local sessions still serves inbound peer exchanges as long as its kernel runs (_kernel_up).
+
+    `answered` False means the kernel's listing did not answer. That HOLDS the count only when the
+    bus has evidence that sessions existed: the last ANSWERED listing — in memory, or its disk twin
+    for a bus that started during the blink — was non-empty (_sessions_were_listed). The outage then
+    protects the sessions that were listed before it: the kernel does not own a tmux session's life
+    and lists them again when it returns. Until 2026-09-06 local sessions' heartbeats masked an
+    outage as presence; with those loops ended in peer mode the gate reads the bit itself. A bus
+    that never saw an answered non-empty listing — a kernel-less `romp mail` bus, a box whose kernel
+    stopped after its sessions had all gone — keeps the autostop: the count advances every poll and
+    stops at IDLE_GRACE. In production an answered listing implies a live kernel (both are the same
+    process), so `answered and n == 0` with the kernel down is reached only through the
+    ROMP_SESSIONS_FILE seam; the stop that matters is the unanswered one without evidence."""
     if n > 0 or _kernel_up():
         return 0, False
+    if not answered and _sessions_were_listed():
+        return idle, False
     idle += 1
     return idle, idle >= IDLE_GRACE
+
+
+def _sessions_were_listed():
+    """True iff the last ANSWERED local listing this bus knows of was non-empty: the evidence the
+    autostop gate needs before an unanswered listing counts as an outage rather than an absence.
+    Primed from the disk twin (_PRESENCE_GOOD_FILE) when this process has not answered yet, so a
+    bus that started during the blink is covered."""
+    _presence_good_load()
+    return bool(_LOCAL_PRESENCE_GOOD[1] and _LOCAL_PRESENCE_GOOD[0])
+
+
+def _monitor_tick(idle):
+    """One poll of _monitor after its sleep: the mail sweeps, the deadness-mirror refresh, and the
+    autostop decision. Returns (idle, stop). Factored out so a tick is unit-testable."""
+    try:
+        _sweep_orphans()    # bounce mail stuck unread in dead recipients' mailboxes
+    except Exception:
+        pass
+    try:
+        _warn_stuck_mail()  # warn the sender when a LIVE-but-idle recipient still hasn't read (backstop)
+    except Exception:
+        pass
+    _write_remote_sids()    # the TTL prunes only at write time; the poll is the write that needs no beat to arrive
+    try:
+        n, answered = present_count_checked()
+    except Exception:
+        n, answered = 1, True   # on error, err on the side of staying up
+    return _idle_tick(n, idle, answered)
 
 
 def _monitor(httpd, boot_fp=""):
@@ -1999,19 +2107,7 @@ def _monitor(httpd, boot_fp=""):
     while True:
         time.sleep(POLL)
         _maybe_restart_for_code(boot_fp)   # reload if the on-disk code changed under us (does not return on restart)
-        try:
-            _sweep_orphans()    # bounce mail stuck unread in dead recipients' mailboxes
-        except Exception:
-            pass
-        try:
-            _warn_stuck_mail()  # warn the sender when a LIVE-but-idle recipient still hasn't read (backstop)
-        except Exception:
-            pass
-        try:
-            n = present_count()
-        except Exception:
-            n = 1   # on error, err on the side of staying up
-        idle, stop = _idle_tick(n, idle)
+        idle, stop = _monitor_tick(idle)
         if stop:
             _log("no romp clients remain (and no local kernel); shutting down")
             threading.Thread(target=httpd.shutdown, daemon=True).start()
@@ -2034,15 +2130,18 @@ def _retry_pending():
     revival); a stale marker (new/ already empty) is reconciled away."""
     if not MAILPENDING.is_dir():
         return
-    live = {a["id"]: a for a in local_agents()}
-    for m in list(MAILPENDING.iterdir()):
-        if not m.is_file():
-            continue
+    markers = [m for m in MAILPENDING.iterdir() if m.is_file()]
+    if not markers:
+        return                                 # nothing pending: no GET /sessions this pass (2026-09-06)
+    live = None                                # fetched once, and only for a marker that still holds mail
+    for m in markers:
         sid = m.name
         newd = MAILROOT / sid / "new"
         if not (newd.is_dir() and any(newd.iterdir())):
             _mark_pending(sid)                 # stale marker -> clear it
             continue
+        if live is None:
+            live = {a["id"]: a for a in local_agents()}
         if sid in live:
             try:
                 _push(sid, live[sid])          # re-attempt; the kernel defers again if still unsafe
@@ -2308,7 +2407,14 @@ def _write_remote_sids():
     kernel/judge DEADNESS rule (2026-08-28, the dead-session round): a sid absent from the local
     registry but present here is a live REMOTE session whose local mirror store must never be
     presumed closed. The FILE's existence means the bus has spoken; readers treat a missing file
-    as "cannot determine" and stay conservative."""
+    as "cannot determine" and stay conservative.
+
+    The TTL is applied at WRITE time, so an expired heartbeat leaves the file only when something
+    writes it: every recorded heartbeat, every peer exchange, and (since 2026-09-06) every _monitor
+    poll. In peer mode (the default) a local session's beats end once its bus confirms it local, and
+    remote presence arrives through the peer exchange, which writes here. In legacy singleton mode
+    the beats continue; the poll-time write is the backstop for a hub whose local sessions have all
+    gone quiet while a dead remote's sid waits out its TTL."""
     try:
         now = time.time()
         ids = {sid for sid, (_nm, ts) in HEARTBEATS.items() if now - ts < HEARTBEAT_TTL}
@@ -2628,6 +2734,19 @@ def _presence_good_load():
         pass                                         # no twin yet (fresh box) → nothing to prime
 
 
+def _remember_presence(rows):
+    """Record an ANSWERED local listing as the last-good rows, in memory and in the disk twin
+    (_PRESENCE_GOOD_FILE). Read by _local_presence while the kernel does not answer, and by the
+    autostop gate's _sessions_were_listed."""
+    _LOCAL_PRESENCE_GOOD[0], _LOCAL_PRESENCE_GOOD[1] = rows, True
+    try:
+        tmp = _PRESENCE_GOOD_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(rows))
+        os.replace(tmp, _PRESENCE_GOOD_FILE)     # the disk twin follows every answered read
+    except Exception:
+        pass
+
+
 def _local_presence():
     """Local agent rows for an exchange payload, blink-honest: an UNANSWERED kernel listing (a
     mid-restart blink) must never gossip as "nobody lives here" — the far boxes' PEER_STATE flaps
@@ -2638,13 +2757,7 @@ def _local_presence():
     including ones running older code, because the honesty lands in the payload itself."""
     rows, answered = local_agents_checked()
     if answered:
-        _LOCAL_PRESENCE_GOOD[0], _LOCAL_PRESENCE_GOOD[1] = rows, True
-        try:
-            tmp = _PRESENCE_GOOD_FILE.with_suffix(".tmp")
-            tmp.write_text(json.dumps(rows))
-            os.replace(tmp, _PRESENCE_GOOD_FILE)     # the disk twin follows every answered read
-        except Exception:
-            pass
+        _remember_presence(rows)
         if _PRESENCE_SERVE_WARNED[0]:
             _PRESENCE_SERVE_WARNED[0] = False
             sys.stderr.write("postal: the local listing answers again — presence serves live rows\n")
@@ -3334,27 +3447,68 @@ def restart():
     return ensure()
 
 def _heartbeat(sid, name):
-    if sid:
-        try:
-            _http("POST", "/heartbeat", {"id": sid, "name": name or "?"})
-        except Exception:
-            pass
+    """POST this session's presence to the bus. Returns the bus's answer ({ok, local}) or None when
+    there was none (bus unreachable, no sid); callers that only want the side effect ignore it."""
+    if not sid:
+        return None
+    try:
+        return _http("POST", "/heartbeat", {"id": sid, "name": name or "?"})
+    except Exception:
+        return None
 
-def _heartbeat_loop():
+_LOCAL_CONFIRMED = [False]   # this MCP's session is local to its bus, per a peer-mode `local: true` answer
+
+def _heartbeat_once():
+    """One beat of _heartbeat_loop: ONE identity resolution (one GET /sessions) and one POST /heartbeat.
+    Returns True iff the bus answered `local: true` — its own answered listing holds this sid, so the
+    kernel already publishes this session's presence. A bus that did not answer, answered without the
+    bit (an older bus), or said local=false (a remote session, or a kernel mid-restart that left the
+    listing unanswered) is False: keep beating.
+
+    In peer mode a true answer also latches _LOCAL_CONFIRMED, which _mcp_call reads to skip its
+    per-call beat: there the bus behind BASE is this box's own for the life of the process, so the
+    verdict cannot go stale. It is never latched from an unanswered or false answer, and never in
+    legacy singleton mode (ROMP_POSTAL_PEERS=0), where `romp mail remote` can replace the local bus
+    with the hub's over an -R tunnel under a running session — the beats are then its only presence.
+    The peer-mode premise assumes `romp mail remote` is not run there: nothing in setup_remote refuses
+    it, but peer mode runs a bus per machine and _remote_nudge already treats the command as moot."""
+    sid, name = _self_identity()
+    if not sid:
+        return False
+    resp = _heartbeat(sid, name)
+    local = bool(isinstance(resp, dict) and resp.get("local") is True)
+    if local and peers_on():
+        _LOCAL_CONFIRMED[0] = True
+    return local
+
+def _heartbeat_loop(interval=None, stop=None):
     """Keep THIS session present to the bus while it's alive, so an IDLE session that hasn't touched a postal
     tool is still addressable. This is essential for a REMOTE (federated) session: it appears to the laptop's
     bus ONLY via heartbeats over the -R tunnel (a local session is already visible through the kernel's
-    /sessions). Cadence well under HEARTBEAT_TTL. The bus ignores heartbeats from LOCAL sids, so this costs a
-    local session nothing and is the presence mechanism for remote ones. Runs from the stdio MCP server, which
-    lives exactly as long as the Claude session."""
-    while True:
+    /sessions). Cadence well under HEARTBEAT_TTL. Runs from the stdio MCP server, which lives exactly as long
+    as the Claude session.
+
+    The bus ignores heartbeats from LOCAL sids, and since 2026-09-06 says so in its answer. In PEER mode
+    (the default) the loop ends on the first `local: true`: every box runs its own bus, a session stays
+    local to it for the life of the process, and every further beat would be a no-op that cost the kernel
+    GET /sessions calls (about 30 sessions beating every 30 s were 3 requests per second on a saturated
+    kernel). In legacy singleton mode (ROMP_POSTAL_PEERS=0) the loop never ends: `romp mail remote`
+    replaces the local bus with the hub's over an -R tunnel while sessions run, and from then on these
+    beats are the only presence the hub sees. A remote (client-only box) session never hears "local"
+    from the hub's bus in either mode. `interval` and `stop` (a threading.Event) are test seams; the
+    defaults are the production cadence and no external stop."""
+    if interval is None:
+        interval = max(15, HEARTBEAT_TTL // 3)
+    while not (stop is not None and stop.is_set()):
         try:
-            sid = my_id()
-            if sid:
-                _heartbeat(sid, my_name())
+            if _heartbeat_once() and peers_on():
+                return
         except Exception:
             pass
-        time.sleep(max(15, HEARTBEAT_TTL // 3))
+        if stop is not None:
+            stop.wait(interval)
+        else:
+            time.sleep(interval)
 
 # ───────────────────────── stdio MCP server ─────────────────────────
 
@@ -3415,8 +3569,9 @@ MCP_TOOLS = [
 ]
 
 def _mcp_call(name, args):
-    me, mid = my_name(), my_id()
-    _heartbeat(mid, me)
+    mid, me = _self_identity()               # one GET /sessions for both halves, not one each
+    if not _LOCAL_CONFIRMED[0]:              # a confirmed-local session's beat is a no-op the bus pays a fetch for
+        _heartbeat(mid, me)
     if name == "send_message":
         to, body = args.get("to", ""), args.get("body", "")
         kind = str(args.get("kind", "")).strip().lower()
@@ -3515,7 +3670,8 @@ def mcp():
     ONLY protocol messages; everything else goes to stderr."""
     ensure()
     # Heartbeat presence while this session lives, so an idle REMOTE (federated) session stays addressable
-    # over the -R tunnel even before it uses a postal tool. No-op for local sids (the bus ignores those).
+    # over the -R tunnel even before it uses a postal tool. A LOCAL session's loop ends on the bus's first
+    # `local: true` answer (the bus ignores local beats anyway; see _heartbeat_loop).
     threading.Thread(target=_heartbeat_loop, daemon=True).start()
     out = sys.stdout
 
@@ -3593,7 +3749,7 @@ def cli_send(argv):
         sys.stderr.write("[romp mail] refusing to send an empty message\n"); return 2
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
-    me, mid = my_name(), my_id()
+    mid, me = _self_identity()
     if frm_label:
         me, mid = frm_label, "ext:" + frm_label
     if not mid:
@@ -3637,7 +3793,7 @@ def cli_inbox(peek=False):
 def cli_agents():
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
-    me, mid = my_name(), my_id()
+    mid, me = _self_identity()
     try:
         res = _http("GET", "/agents?me=%s" % urllib.parse.quote(me or ""))
     except BusError as e:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2063,9 +2063,15 @@ def _idle_tick(n, idle, answered=True):
     outage as presence; with those loops ended in peer mode the gate reads the bit itself. A bus
     that never saw an answered non-empty listing — a kernel-less `romp mail` bus, a box whose kernel
     stopped after its sessions had all gone — keeps the autostop: the count advances every poll and
-    stops at IDLE_GRACE. In production an answered listing implies a live kernel (both are the same
-    process), so `answered and n == 0` with the kernel down is reached only through the
-    ROMP_SESSIONS_FILE seam; the stop that matters is the unanswered one without evidence."""
+    stops at IDLE_GRACE. The kernel-less case holds only on a box whose twin holds no rows: a twin left
+    by an earlier kernel primes the hold in a bus spawned later the same way. The hold has ONE release,
+    the next answered listing (which rewrites the twin): a kernel gone for good after listing sessions
+    leaves the bus up until a manual stop or the returning kernel's first answer, and a code-staleness
+    re-exec does not end it (the fresh process re-primes the hold from the twin, which outlives the
+    re-exec by design) (review find, 2026-09-08; pinned by tests/test_postal_bus_lifetime.py). In
+    production an answered listing implies a live kernel (both are the same process), so `answered and
+    n == 0` with the kernel down is reached only through the ROMP_SESSIONS_FILE seam; the stop that
+    matters is the unanswered one without evidence."""
     if n > 0 or _kernel_up():
         return 0, False
     if not answered and _sessions_were_listed():
@@ -3390,7 +3396,9 @@ def looks_remote():
     return bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"))
 
 def _unreachable_hint():
-    if is_client_only() or looks_remote():
+    # the tunnel hint belongs to the legacy singleton scheme: in peer mode (the default) an SSH'd box runs
+    # its own bus and `romp mail remote` refuses, so pointing at it would be a dead end (review find, 2026-09-08)
+    if not peers_on() and (is_client_only() or looks_remote()):
         return "can't reach your laptop's Romp Postal Service bus — is the SSH tunnel up? run: romp mail remote"
     return "can't reach the Romp Postal Service bus (see ~/.local/state/romp/postal/server.log)"
 
@@ -3470,8 +3478,9 @@ def _heartbeat_once():
     verdict cannot go stale. It is never latched from an unanswered or false answer, and never in
     legacy singleton mode (ROMP_POSTAL_PEERS=0), where `romp mail remote` can replace the local bus
     with the hub's over an -R tunnel under a running session — the beats are then its only presence.
-    The peer-mode premise assumes `romp mail remote` is not run there: nothing in setup_remote refuses
-    it, but peer mode runs a bus per machine and _remote_nudge already treats the command as moot."""
+    The peer-mode premise, that `romp mail remote` never swaps the bus behind BASE there, is enforced:
+    setup_remote refuses in peer mode, --force included (review find, 2026-09-08: run after the latch
+    it silenced the session on the hub), as _remote_nudge already treated the command as moot."""
     sid, name = _self_identity()
     if not sid:
         return False
@@ -3496,7 +3505,16 @@ def _heartbeat_loop(interval=None, stop=None):
     replaces the local bus with the hub's over an -R tunnel while sessions run, and from then on these
     beats are the only presence the hub sees. A remote (client-only box) session never hears "local"
     from the hub's bus in either mode. `interval` and `stop` (a threading.Event) are test seams; the
-    defaults are the production cadence and no external stop."""
+    defaults are the production cadence and no external stop.
+
+    What the ended loop changes for a peer's send during a KERNEL BLINK (review find, 2026-09-08): a
+    local session's beat that landed while the listing was unanswered used to be filed as remote
+    presence (the bus could not call it local), so a send to its name during the blink resolved to that
+    row and delivered into its mailbox with no wake, and the mail sat there unannounced until the
+    kernel returned. With the loop ended and the per-call beat skipped no such row appears, and
+    resolve_recipient's standing blink refusal (503, retry shortly, never a death ruling) covers every
+    local peer alike: the mail stays with the sender, who is told so. Pinned by
+    tests/test_postal_heartbeat_fetches.py."""
     if interval is None:
         interval = max(15, HEARTBEAT_TTL // 3)
     while not (stop is not None and stop.is_set()):
@@ -3896,7 +3914,25 @@ def cli_drain(argv):
 def setup_remote(force=False):
     """Point THIS machine at the laptop's Romp Postal Service over an SSH reverse
     tunnel: configure the client side automatically, then guide + verify the one
-    manual step (the tunnel, which can only be opened from the laptop)."""
+    manual step (the tunnel, which can only be opened from the laptop). Legacy
+    singleton scheme only: peer mode refuses, --force included (see below)."""
+    if peers_on():
+        # Peer mode (the default since 2026-07-20) has no laptop bus to point at, and since the
+        # heartbeat latch (2026-09-06) the command would do harm here: a local session's MCP stops
+        # beating for good once its own bus confirms it local, so a hub's bus swapped in behind the
+        # port would never hear of this box's sessions, and the local bus this command stops is the
+        # one carrying their mail. Refuse before any side effect, --force included, and say why
+        # (review find, 2026-09-08: `romp mail remote --force` after the latch silenced the session
+        # on the hub). _remote_nudge already treats the command as moot in peer mode.
+        print("romp mail remote is off in peer mode (the default): every machine runs its own Romp")
+        print("Postal Service bus and cross-host mail rides the kernel's peer tunnels, so there is no")
+        print("laptop bus to point this machine at. Nothing was changed.")
+        print("")
+        print("--force does not override this: a session's heartbeats end for good once its own bus")
+        print("confirms it local, so a hub's bus swapped in behind the port would never see this box's")
+        print("sessions, and the local bus this command would stop is what carries their mail.")
+        print("This command belongs to the legacy singleton scheme (ROMP_POSTAL_PEERS=0).")
+        return 2
     if not force and not looks_remote():
         print("This looks like your Romp Postal Service host (no SSH session detected);")
         print("the bus runs here automatically, so there's nothing to set up.")
@@ -3950,7 +3986,7 @@ USAGE = """romp-postal-service — the Romp Postal Service
   romp mail working <text>          publish what you're working on (empty to clear)
   romp mail sent                    show your sent messages + whether each was read
   romp mail recall <to> [id]        unsend an unread message you sent to <to>
-  romp mail remote                  connect this (remote) machine to your laptop's bus
+  romp mail remote                  connect this (remote) machine to your laptop's bus (legacy scheme, ROMP_POSTAL_PEERS=0)
 (internal: serve | ensure | restart | mcp | drain --id <id> | wake --id <id> | picker-check --name <n> --id <id>)"""
 
 def main(argv):

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -377,6 +377,26 @@ PY
     grep -q "X-Kind: coordinate" "$(mb uuid-b)/new/"*
 }
 
+@test "heartbeat: the bus answers local from its own listing, and only then" {
+    # The bit a session's MCP loop reads to stop beating (2026-09-06): true only for a sid the bus's own
+    # kernel listing holds; a sid it does not list is recorded as remote presence exactly as before.
+    _tok="${ROMP_SERVE_TOKEN:-$(cat "$XDG_STATE_HOME/romp/serve-token")}"
+    run curl -s -X POST -H "X-Romp-Token: $_tok" "127.0.0.1:$ROMP_POSTAL_PORT/heartbeat" \
+        -d '{"id": "uuid-a", "name": "alpha"}'
+    [[ "$output" == *'"local": true'* ]]
+    run curl -s -X POST -H "X-Romp-Token: $_tok" "127.0.0.1:$ROMP_POSTAL_PORT/heartbeat" \
+        -d '{"id": "33333333-4444-5555-6666-777777777777", "name": "gamma"}'
+    [[ "$output" == *'"local": false'* ]]
+    run "$POSTAL" agents
+    [[ "$output" == *"gamma"* ]]                  # the remote beat is presence, as it always was
+    [[ "$output" == *"remote"* ]]
+    # the seam drops alpha (the kernel no longer lists it): the same beat is no longer local
+    printf 'beta|uuid-b\n' > "$SESS"; mksessions
+    run curl -s -X POST -H "X-Romp-Token: $_tok" "127.0.0.1:$ROMP_POSTAL_PORT/heartbeat" \
+        -d '{"id": "uuid-a", "name": "alpha"}'
+    [[ "$output" == *'"local": false'* ]]
+}
+
 @test "bus self-stops when no romp clients remain" {
     : > "$SESS"; mksessions   # drop all sessions (also from the seam the bus reads); heartbeats age out (TTL=2)
     local stopped=0 _

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -408,6 +408,7 @@ PY
 }
 
 @test "remote: on the host (no SSH) refuses and creates no marker" {
+    export ROMP_POSTAL_PEERS=0    # the command belongs to the LEGACY singleton scheme (peer mode refuses it outright, below)
     run "$POSTAL" remote
     [ "$status" -eq 0 ]
     [[ "$output" == *"looks like your Romp Postal Service host"* ]]
@@ -416,6 +417,7 @@ PY
 }
 
 @test "remote --force with the bus reachable configures the client and connects" {
+    export ROMP_POSTAL_PEERS=0    # legacy singleton scheme: the one place `romp mail remote` applies
     rm -f "$XDG_STATE_HOME/romp/postal/server.pid"   # model a tunnel: reachable port, no local bus
     export SSH_CONNECTION="1 2 3 4"
     run "$POSTAL" remote --force
@@ -423,6 +425,21 @@ PY
     [ -e "$HOME/.config/romp-postal/client-only" ]
     [[ "$output" == *"Already connected"* ]]
     [[ "$output" == *"alpha"* ]]
+}
+
+@test "remote: peer mode refuses, --force included, and leaves the bus and marker alone" {
+    # peer mode (the default) has no laptop bus to point at, and a local session's heartbeats end for good
+    # once its own bus confirms it local, so a hub's bus swapped in behind the port would never see this
+    # box's sessions: the command refuses before any side effect and says why (review find, 2026-09-08)
+    export SSH_CONNECTION="1 2 3 4"
+    run "$POSTAL" remote --force
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"peer mode"* ]]
+    [[ "$output" == *"Nothing was changed"* ]]
+    [[ "$output" != *"Stopped the local-only bus"* ]]
+    [ ! -e "$HOME/.config/romp-postal/client-only" ]
+    [ -e "$XDG_STATE_HOME/romp/postal/server.pid" ]
+    curl -sf "127.0.0.1:$ROMP_POSTAL_PORT/ping" >/dev/null   # the local bus is still up
 }
 
 @test "remote: nudge fires for an unconfigured remote, gone once configured" {

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -432,6 +432,319 @@ class PostalCards(_Fold):
         card2 = next(ev for ev in inc2["events"] if ev.get("kind") == "postal-service")
         self.assertEqual(card2.get("summary"), "peer: api tests green")
 
+    # ── the seal keeps only REAL postal Bash events raw (2026-09-06) ──────────────────────────────────
+    def _bash_turn(self, i, command, result="ok\n"):
+        """One complete turn whose single tool round is a Bash call running `command`, its result `result`.
+        build_session stores the input as JSON ({"command", "description"}), truncated at 4000 chars."""
+        recs = self.s.turn(i, tools=("Bash",))
+        recs[1]["message"]["content"][1]["input"] = {"command": command, "description": "step %d" % i}
+        recs[2]["message"]["content"][0]["content"] = result
+        return recs
+
+    def _count_hydrate(self):
+        """Every _hydrate_postal call build_session makes from here on, as the event lists it was handed."""
+        calls = []
+        orig = km._hydrate_postal
+        def counting(events, index, sid=None):
+            calls.append(list(events))
+            return orig(events, index, sid)
+        km._hydrate_postal = counting
+        self.addCleanup(setattr, km, "_hydrate_postal", orig)
+        return calls
+
+    def test_sealing_plain_bash_turns_leaves_no_raw_postal_event(self):
+        # Every plain Bash event used to ride the sealed entry's postal_raw and be re-hydrated on every
+        # judge pass, to the same raw row each time. Only a send or a mail read belongs there.
+        s = self.s
+        self._log()
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        s.append(self._bash_turn(0, "uv run pytest -q"))
+        self.equiv("plain bash")
+        s.append(self._bash_turn(1, "echo " + "x" * 5000))        # its stored input is cut at 4000 chars: not JSON
+        self.equiv("truncated bash")
+        # a marker in a plain Bash OUTPUT is text the agent read (a grep hit), not mail: the row stays raw
+        s.append(self._bash_turn(2, "grep -rn romp-msg-id notes.md",
+                                 result="notes.md:3:<!-- romp-msg-id: %s -->\n" % self.MID))
+        self.equiv("marker in a bash output")
+        s.append(self._bash_turn(3, "uv run pytest -q"))
+        inc = self.equiv("sealed")
+        entry = km._chat_fold_get(SID)
+        self.assertEqual(entry["n"], 3, "three ended turns sealed; the last is never")
+        self.assertEqual(entry["postal_raw"], [], "no plain Bash event rides the entry raw")
+        self.assertEqual(entry["postal_cards"], [])
+        bash_rows = [e for e in entry["events"] if e.get("kind") == "tool" and e.get("name") == "Bash"]
+        self.assertEqual(len(bash_rows), 3, "the three Bash events are sealed as rendered rows")
+        self.assertTrue(any(self.MID in (e.get("output") or "") for e in bash_rows), "the grep hit is one of them")
+        self.assertEqual([e for e in inc["events"] if e.get("kind") == "postal-service"], [])
+
+    def test_a_warm_build_hydrates_once_with_and_without_a_judge_pass(self):
+        # With nothing postal sealed, the tail pass is the ONE hydration a warm build makes: the gate has
+        # nothing to re-hydrate on a judge pass and the re-commit has nothing to hydrate either.
+        s = self.s
+        for i in range(4):
+            s.append(self._bash_turn(i, "uv run pytest -q"))
+        self.equiv("sealed")
+        self.assertEqual(km._chat_fold_get(SID)["postal_raw"], [])
+        calls = self._count_hydrate()
+        n_fold, n_postal = km._CHAT_FOLD_STATS["fold"], km._CHAT_FOLD_STATS.get("g:postal", 0)
+        s.build()
+        self.assertEqual(km._CHAT_FOLD_STATS["fold"], n_fold + 1, "the warm build folded")
+        self.assertEqual(len(calls), 1, "one hydration: the tail pass")
+        for m in MODS:
+            m._judge_gen[0] += 1
+        s.build()
+        self.assertEqual(km._CHAT_FOLD_STATS["fold"], n_fold + 2, "the judge pass did not demote")
+        self.assertEqual(len(calls), 2, "a judge pass with nothing postal sealed adds no hydration")
+        self.assertEqual(km._CHAT_FOLD_STATS.get("g:postal", 0), n_postal, "and filed no postal demotion")
+
+    def test_a_bash_send_stays_raw_and_is_rehydrated_when_the_judges_run(self):
+        # The `romp mail send` twin of the caption-rewrite test above: the send is the one Bash event the
+        # seal keeps raw in this transcript, and a judge pass re-hydrates exactly it, so its card can pick up the recipient's
+        # caption. The card's caption itself is pinned at the hydrator level (PostalRelevance): build_session
+        # stores a Bash input as JSON, which _cli_send_card does not unwrap, so no card renders here (a
+        # limit that predates this change and is not widened by it).
+        s = self.s
+        self._log()
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        s.append(self._bash_turn(0, "uv run pytest -q"))
+        s.append(self._bash_turn(1, 'romp mail send api "the api tests are green now"',
+                                 result="[romp mail] delivered to api\n"))
+        s.append(self._bash_turn(2, "uv run pytest -q"))
+        s.append(self._bash_turn(3, "uv run pytest -q"))
+        self.equiv("send sealed")
+        raw = km._chat_fold_get(SID)["postal_raw"]
+        self.assertEqual(len(raw), 1, "the send, and only the send, rides the entry raw")
+        self.assertEqual((raw[0]["kind"], raw[0]["name"]), ("tool", "Bash"))
+        self.assertIsNotNone(km._cli_send_match(raw[0]), "kept by the matcher the card renders from")
+        calls = self._count_hydrate()
+        s.build()
+        # the tail pass, plus the re-commit hydrating the entry's raw list (the send alone)
+        self.assertEqual([len(c) == 1 and c[0] is raw[0] for c in calls], [False, True])
+        for m in MODS:
+            m._judge_gen[0] += 1
+        s.build()
+        # the gate re-hydrates the sealed send against the new captions, then the tail pass and the re-commit
+        self.assertEqual([len(c) == 1 and c[0] is raw[0] for c in calls[2:]], [True, False, True])
+        self.assertEqual(len(calls), 5)
+
+
+class PostalRelevance(_Fold):
+    """_chat_postal_relevant decides what the fold keeps raw; _hydrate_postal decides what renders. The
+    invariant tying them: an event the predicate rejects comes back from hydration as the same object."""
+    MID = PostalCards.MID
+    PEER = PostalCards.PEER
+    BODY = "the api tests are green now"
+
+    def _index(self, **rows):
+        idx = {self.MID: {"id": self.MID, "from": "api", "fromId": self.PEER, "fromHost": "", "toId": SID,
+                          "body": self.BODY, "kind": "coordinate", "t": 1788400000, "park": False}}
+        idx.update(rows)
+        return idx
+
+    def _cases(self):
+        """(label, event, relevant, renders a card) — one row per shape the plan names, plus the neighbours
+        that must NOT count: an echo of a marker in an assistant reply, a Read whose output carries one."""
+        marker = "<!-- romp-msg-id: %s -->" % self.MID
+        ts = iso(1788400010)
+        def bash(command, output="ok\n", input=None):
+            inp = input if input is not None else json.dumps({"command": command, "description": "d"})
+            return {"kind": "tool", "name": "Bash", "input": inp, "output": output, "isError": False,
+                    "uuid": "t", "ts": ts}
+        def tool(name, output, **inp):
+            return {"kind": "tool", "name": name, "input": json.dumps(inp), "output": output,
+                    "isError": False, "uuid": "t", "ts": ts}
+        return [
+            ("plain bash", bash("uv run pytest -q"), False, False),
+            ("truncated bash", bash(None, input=json.dumps({"command": "echo " + "x" * 5000})[:4000]), False, False),
+            ("bash output carrying a marker", bash("grep -rn romp-msg-id notes.md", output="notes.md:3:" + marker), False, False),
+            ("bash send, raw input", bash(None, input='romp mail send api "%s"' % self.BODY,
+                                          output="[romp mail] delivered to api"), True, True),
+            ("bash send, json input", bash('romp mail send api "%s"' % self.BODY,
+                                           output="[romp mail] delivered to api"), True, False),
+            ("bash inbox read", bash("romp mail inbox", output="from api:\n" + marker), True, True),
+            ("check_inbox", tool("mcp__romp-postal-service__check_inbox", marker), True, True),
+            ("send_message", tool("mcp__romp-postal-service__send_message", "Delivered to 'api'.",
+                                  to="api", body=self.BODY), True, True),
+            ("read whose output carries a marker", tool("Read", marker, file_path="/tmp/notes-api/notes.md"), False, False),
+            ("user text with a marker", {"kind": "user", "md": "####\nfrom api\n####\n%s\n%s" % (self.BODY, marker),
+                                         "uuid": "u", "ts": ts, "human": False}, True, True),
+            ("plain user text", {"kind": "user", "md": "please run the tests", "uuid": "u", "ts": ts, "human": True}, False, False),
+            ("assistant echo of a marker", {"kind": "assistant", "md": "noted " + marker, "uuid": "a", "ts": ts}, False, False),
+        ]
+
+    def test_only_postal_events_are_relevant_and_the_rest_pass_through_by_identity(self):
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        index = self._index()
+        for label, ev, relevant, renders in self._cases():
+            with self.subTest(label):
+                self.assertEqual(km._chat_postal_relevant(ev), relevant, label)
+                out = km._hydrate_postal([ev], index, SID)
+                self.assertEqual(len(out), 1)
+                if not relevant:
+                    self.assertIs(out[0], ev, "a rejected event comes back as the same object")
+                self.assertEqual(out[0].get("kind") == "postal-service", renders, label)
+                if ev.get("name") == "Bash":
+                    # the two Bash predicates agree with the renderers they stand for
+                    self.assertEqual(km._cli_send_match(ev) is not None or km._reads_mail(ev), relevant)
+                    if km._cli_send_card(ev) is not None:
+                        self.assertTrue(relevant, "a Bash event that renders a send card is never sealed away")
+
+    def test_a_bash_send_card_follows_the_recipients_caption(self):
+        # the hydrator-level half of PostalCards' Bash-send test: the card joins the log row wearing its
+        # body and wears whatever caption the recipient's judge has filed by now
+        ev = {"kind": "tool", "name": "Bash", "input": 'romp mail send api "%s"' % self.BODY,
+              "output": "[romp mail] delivered to api", "isError": False, "uuid": "t", "ts": iso(1788400010)}
+        caps = {self.MID: "peer: tests green (live)"}
+        for m in MODS:
+            m._msg_summaries = lambda caps=caps: dict(caps)
+        card = km._hydrate_postal([ev], self._index(), SID)[0]
+        self.assertEqual((card["kind"], card["direction"], card["mid"], card["summary"]),
+                         ("postal-service", "out", self.MID, "peer: tests green (live)"))
+        caps[self.MID] = "peer: api tests green"
+        card2 = km._hydrate_postal([ev], self._index(), SID)[0]
+        self.assertEqual(card2["summary"], "peer: api tests green")
+
+    def test_the_body_map_joins_the_row_the_linear_scan_found(self):
+        # enrich_out used to scan every index row per outgoing card; the body-keyed map must pick the
+        # same row: closest in time to the send, the FIRST such row on a tie, the last row when the send
+        # carries no time
+        body = "please pick up the notes-api deploy"
+        def row(mid, t, b=body):
+            return {"id": mid, "from": "web", "fromId": "", "fromHost": "", "toId": "", "body": b,
+                    "kind": "", "t": t, "park": False}
+        index = {"m1": row("m1", 100), "m2": row("m2", 5000), "m9": row("m9", 5000, "a different message"),
+                 "m3": row("m3", 9000), "m4": row("m4", 5000)}
+        def linear(et):
+            recs = [r for r in index.values() if r["body"] == body]
+            return (min(recs, key=lambda r: abs((r["t"] or 0) - et)) if et else recs[-1])["id"]
+        def send(ts):
+            return {"kind": "tool", "name": "mcp__romp-postal-service__send_message",
+                    "input": json.dumps({"to": "api", "body": body}), "output": "Delivered to 'api'.",
+                    "isError": False, "uuid": "t", "ts": ts}
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        for et, want in ((4980, "m2"), (120, "m1"), (8000, "m3"), (2550, "m1"), (0, "m4")):
+            with self.subTest(et=et):
+                card = km._hydrate_postal([send(iso(et) if et else None)], index)[0]
+                self.assertEqual(card["mid"], want)
+                self.assertEqual(card["mid"], linear(et), "the same row the linear scan picked")
+        plain = km._hydrate_postal([send(iso(4980))], {"m9": index["m9"]})[0]
+        self.assertNotIn("mid", plain, "no row wearing the body: the card stays unjoined")
+
+    def test_the_memoized_index_carries_one_body_map_per_version(self):
+        self.addCleanup(km._postal_index_memo.__setitem__, 0, None)
+        d = jd.STATE / "timeline"; d.mkdir(exist_ok=True)
+        log = d / "messages.jsonl"
+        def line(mid, t):
+            return json.dumps({"ev": "sent", "id": mid, "from": "web", "from_id": self.PEER, "to_id": SID,
+                               "body": "deploy please", "kind": "coordinate", "t": t}) + "\n"
+        log.write_text(line("m1", 100) + line("m2", 5000))
+        idx = km._postal_index()
+        bm = km._postal_body_rows(idx)
+        self.assertIs(km._postal_body_rows(km._postal_index()), bm, "one map per index version, not per call")
+        self.assertEqual([r["id"] for r in bm["deploy please"]], ["m1", "m2"])
+        with open(log, "a") as f:
+            f.write(line("m3", 9000))
+        idx2 = km._postal_index()
+        self.assertIsNot(idx2, idx, "the log grew: a new index version")
+        bm2 = km._postal_body_rows(idx2)
+        self.assertIsNot(bm2, bm)
+        self.assertEqual([r["id"] for r in bm2["deploy please"]], ["m1", "m2", "m3"])
+        own = dict(idx2)                                  # a caller's own dict never borrows the memo's map
+        self.assertIsNot(km._postal_body_rows(own), bm2)
+        self.assertEqual(km._postal_body_rows(own), bm2)
+
+    def test_a_sent_row_whose_body_is_not_a_string_neither_breaks_the_index_nor_the_join(self):
+        # the far-host relay logs a /send request's body with no type check, so a sent row can carry a
+        # JSON list or object; the body map must skip it (unhashable) rather than raise inside every
+        # session's chat build, and an outgoing card still joins its own string-bodied row
+        self.addCleanup(km._postal_index_memo.__setitem__, 0, None)
+        d = jd.STATE / "timeline"; d.mkdir(exist_ok=True)
+        def line(mid, body):
+            return json.dumps({"ev": "sent", "id": mid, "from": "web", "from_id": self.PEER, "to_id": SID,
+                               "body": body, "kind": "coordinate", "t": 5000}) + "\n"
+        (d / "messages.jsonl").write_text(line("m1", "deploy please") + line("m2", ["not", "a", "string"])
+                                          + line("m3", {"text": "an object"}))
+        idx = km._postal_index()
+        self.assertEqual(sorted(idx), ["m1", "m2", "m3"], "every row is indexed, as before")
+        bm = km._postal_body_rows(idx)
+        self.assertEqual({k: [r["id"] for r in v] for k, v in bm.items()}, {"deploy please": ["m1"]})
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        def send(body):
+            return {"kind": "tool", "name": "mcp__romp-postal-service__send_message",
+                    "input": json.dumps({"to": "api", "body": body}), "output": "Delivered to 'api'.",
+                    "isError": False, "uuid": "t", "ts": iso(5010)}
+        card = km._hydrate_postal([send("deploy please")], idx, SID)[0]
+        self.assertEqual((card["kind"], card["direction"], card["mid"]), ("postal-service", "out", "m1"))
+        other = km._hydrate_postal([send("a body no row wears")], idx, SID)[0]
+        self.assertEqual(other["kind"], "postal-service")
+        self.assertNotIn("mid", other, "no row wearing the body: the card passes through unjoined")
+
+
+    def test_outgoing_cards_join_through_one_body_map_not_a_scan_per_card(self):
+        # the saving the body map buys, pinned: a hydration walks a caller's own index ONCE to build the
+        # map, and the memoized index not at all (its map rides the memo entry) — never a walk of every
+        # row per outgoing card, which the linear scan it replaces did
+        body = "please pick up the notes-api deploy"
+        def row(mid, t, b=body):
+            return {"id": mid, "from": "web", "fromId": "", "fromHost": "", "toId": "", "body": b,
+                    "kind": "", "t": t, "park": False}
+        def send(t):
+            return {"kind": "tool", "name": "mcp__romp-postal-service__send_message",
+                    "input": json.dumps({"to": "api", "body": body}), "output": "Delivered to 'api'.",
+                    "isError": False, "uuid": "t", "ts": iso(t)}
+        sends = [send(t) for t in (1010, 2010, 3010, 4010, 5010)]
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        walks = [0]
+        class Counting(dict):
+            def values(self):
+                walks[0] += 1
+                return super().values()
+        own = Counting({"m1": row("m1", 1000), "x1": row("x1", 1500, "another message"), "m2": row("m2", 3000),
+                        "x2": row("x2", 3500, "a third message"), "m3": row("m3", 5000), "x3": row("x3", 5500, "a fourth")})
+        cards = km._hydrate_postal(sends, own, SID)
+        self.assertEqual([c.get("kind") for c in cards], ["postal-service"] * 5)
+        self.assertEqual([c["mid"] for c in cards], ["m1", "m2", "m2", "m3", "m3"])
+        self.assertEqual(walks[0], 1, "one walk of the index builds the map; no card walks it again")
+        # the memoized index: its map was built beside it, so a hydration builds none at all
+        self.addCleanup(km._postal_index_memo.__setitem__, 0, None)
+        d = jd.STATE / "timeline"; d.mkdir(exist_ok=True)
+        (d / "messages.jsonl").write_text("".join(
+            json.dumps({"ev": "sent", "id": mid, "from": "web", "from_id": self.PEER, "to_id": SID,
+                        "body": body, "kind": "coordinate", "t": t}) + "\n"
+            for mid, t in (("m1", 1000), ("m2", 2000), ("m3", 3000))))
+        idx = km._postal_index()
+        builds = []
+        orig = km._postal_body_map
+        km._postal_body_map = lambda index: (builds.append(len(index)), orig(index))[1]
+        self.addCleanup(setattr, km, "_postal_body_map", orig)
+        cards = km._hydrate_postal(sends, idx, SID)
+        self.assertEqual([c["mid"] for c in cards], ["m1", "m2", "m3", "m3", "m3"])
+        self.assertEqual(builds, [], "the memo's map is reused: no build per hydration, none per card")
+
+    def test_a_send_awaiting_its_result_is_relevant_but_renders_no_card_yet(self):
+        # relevance reads only the input: a `romp mail send` whose tool_result has not landed is kept raw
+        # (relevant) and renders no card until the CLI confirms delivery; the same event with its result
+        # hydrates to the card. Had relevance read the output, the fold would have sealed the pending
+        # send as a plain Bash row and its card could never appear.
+        ev = {"kind": "tool", "name": "Bash", "input": 'romp mail send api "%s"' % self.BODY,
+              "output": "", "isError": False, "uuid": "t", "ts": iso(1788400010)}
+        for m in MODS:
+            m._msg_summaries = lambda: {}
+        self.assertTrue(km._chat_postal_relevant(ev), "a send is postal before its result lands")
+        self.assertIsNone(km._cli_send_card(ev), "no delivery confirmed: no card yet")
+        self.assertIs(km._hydrate_postal([ev], {}, SID)[0], ev, "and the raw event passes through as itself")
+        landed = dict(ev, output="[romp mail] delivered to api")
+        self.assertTrue(km._chat_postal_relevant(landed), "the verdict did not move with the result")
+        card = km._hydrate_postal([landed], self._index(), SID)[0]
+        self.assertEqual((card["kind"], card["direction"], card["peer"], card["mid"]),
+                         ("postal-service", "out", "api", self.MID))
+
 
 class TaskOutputs(_Fold):
     def test_a_notification_whose_output_file_grows_after_the_seal_demotes(self):

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -86,11 +86,11 @@ class SpawnedSessionPath(unittest.TestCase):
 class CliSendEchoesRouting(unittest.TestCase):
     def _send(self, resp):
         saved_http, saved_ensure = ps._http, ps.ensure
-        saved_name, saved_id = ps.my_name, ps.my_id
+        saved_identity = ps._self_identity
         # the sender must be IDENTIFIED (2026-08-18: an anonymous send is refused before _http —
         # the guard these routing tests would otherwise trip in CI, where no session env exists);
         # this class tests echo ROUTING, and its scenario always implied an identified sender
-        ps.my_name, ps.my_id = (lambda: "alpha"), (lambda: "uuid-a")
+        ps._self_identity = lambda: ("uuid-a", "alpha")     # cli_send resolves both halves in one call (2026-09-06)
         ps.ensure = lambda: True
         ps._http = lambda method, path, payload=None: resp
         out = io.StringIO()
@@ -101,7 +101,7 @@ class CliSendEchoesRouting(unittest.TestCase):
         finally:
             ps.sys.stdout = saved_out
             ps._http, ps.ensure = saved_http, saved_ensure
-            ps.my_name, ps.my_id = saved_name, saved_id
+            ps._self_identity = saved_identity
         return rc, out.getvalue()
 
     def test_local_delivery_still_reads_delivered(self):

--- a/tests/test_postal_bus_lifetime.py
+++ b/tests/test_postal_bus_lifetime.py
@@ -14,10 +14,13 @@ while the kernel runs. Two guards land here:
 Synthetic everything: hermetic state dir, stub HTTP server for the kernel, dead ports, no ssh.
 """
 import http.server
+import json
 import os
 import socket
 import tempfile
 import threading
+import time
+import types
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -92,12 +95,25 @@ class KernelUp(unittest.TestCase):
             self.assertFalse(pm._kernel_up())
 
 
+ALPHA = "11111111-2222-3333-4444-555555555555"
+GAMMA = "99999999-8888-7777-6666-555555555555"
+
+
+def _forget_presence():
+    """A bus that has never seen an answered listing: no in-memory rows, no disk twin."""
+    pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False
+    pm._PRESENCE_GOOD_FILE.unlink(missing_ok=True)
+
+
 class IdleGate(unittest.TestCase):
     def setUp(self):
         self._ku = pm._kernel_up
+        pm.STATE.mkdir(parents=True, exist_ok=True)
+        _forget_presence()
 
     def tearDown(self):
         pm._kernel_up = self._ku
+        _forget_presence()
 
     def test_local_clients_keep_the_bus_no_kernel_probe_needed(self):
         pm._kernel_up = lambda: (_ for _ in ()).throw(AssertionError("must not probe with clients present"))
@@ -118,6 +134,187 @@ class IdleGate(unittest.TestCase):
             self.assertFalse(stop)
         idle, stop = pm._idle_tick(0, idle)
         self.assertTrue(stop, "a machine with no kernel and no sessions keeps the old autostop")
+
+    def test_never_answered_keeps_the_autostop(self):
+        # a kernel-less bus (a CLI `romp mail` spawned it; the kernel never came): an unanswered listing
+        # with no evidence that sessions ever existed is an absence, not an outage — it stops as on main,
+        # so a later kernel does not adopt a stale process with the old token and state root
+        pm._kernel_up = lambda: False
+        idle, stop = 0, False
+        for _ in range(pm.IDLE_GRACE):
+            self.assertFalse(stop)
+            idle, stop = pm._idle_tick(0, idle, answered=False)
+        self.assertTrue(stop)
+
+    def test_an_outage_after_listed_sessions_holds_the_count(self):
+        # the last answered listing held sessions; the kernel then stops answering (mid-restart): the
+        # count holds where it was, for as long as the outage lasts — those sessions outlive the kernel
+        pm._kernel_up = lambda: False
+        pm._remember_presence([{"id": ALPHA, "name": "web"}])
+        for start in (0, pm.IDLE_GRACE - 1):
+            idle = start
+            for _ in range(10):
+                idle, stop = pm._idle_tick(0, idle, answered=False)
+                self.assertEqual((idle, stop), (start, False))
+
+    def test_a_fresh_bus_primes_the_evidence_from_the_twin(self):
+        # a bus restarted during the kernel's blink has empty memory; the disk twin the last process
+        # wrote carries the evidence across (the review find of 2026-09-01 made the twin for this)
+        pm._kernel_up = lambda: False
+        pm._PRESENCE_GOOD_FILE.write_text(json.dumps([{"id": ALPHA, "name": "web"}]))
+        self.assertEqual(pm._idle_tick(0, 0, answered=False), (0, False))
+        self.assertTrue(pm._LOCAL_PRESENCE_GOOD[1], "primed")
+
+    def test_an_empty_twin_is_no_evidence(self):
+        pm._kernel_up = lambda: False
+        pm._PRESENCE_GOOD_FILE.write_text("[]")
+        idle, stop = 0, False
+        for _ in range(pm.IDLE_GRACE):
+            idle, stop = pm._idle_tick(0, idle, answered=False)
+        self.assertTrue(stop, "the last answered listing was empty: nothing to protect")
+
+    def test_an_answered_empty_listing_advances_the_count(self):
+        # reachable only through the ROMP_SESSIONS_FILE seam in practice (an answered listing implies
+        # a live kernel, which resets the count first); pinned so the seam-driven bats autostop holds
+        pm._kernel_up = lambda: False
+        idle, stop = 0, False
+        for _ in range(pm.IDLE_GRACE):
+            idle, stop = pm._idle_tick(0, idle, answered=True)
+        self.assertTrue(stop)
+
+
+class MonitorTick(unittest.TestCase):
+    """One _monitor poll, end to end: an answered listing is remembered as evidence, an unanswered one
+    holds the count only on that evidence, and the deadness mirror (STATE/remote-sids) is rewritten
+    every poll so an expired heartbeat leaves it within one tick (2026-09-06)."""
+
+    def setUp(self):
+        self._saved = (pm._kernel_sessions_checked, pm._kernel_up, pm._sweep_orphans, pm._warn_stuck_mail)
+        pm._kernel_up = lambda: False
+        pm._sweep_orphans = pm._warn_stuck_mail = lambda: None
+        pm.HEARTBEATS.clear()
+        pm.STATE.mkdir(parents=True, exist_ok=True)
+        _forget_presence()
+
+    def tearDown(self):
+        pm._kernel_sessions_checked, pm._kernel_up, pm._sweep_orphans, pm._warn_stuck_mail = self._saved
+        pm.HEARTBEATS.clear()
+        _forget_presence()
+
+    def test_a_never_answered_bus_stops_at_the_grace(self):
+        pm._kernel_sessions_checked = lambda threads=False: ([], False)
+        idle, stop = 0, False
+        for _ in range(pm.IDLE_GRACE):
+            self.assertFalse(stop)
+            idle, stop = pm._monitor_tick(idle)
+        self.assertTrue(stop, "no kernel ever answered: main's autostop")
+
+    def test_an_outage_after_sessions_never_reaches_stop(self):
+        listing = [([{"id": ALPHA, "name": "web"}], True)]
+        pm._kernel_sessions_checked = lambda threads=False: listing[0]
+        self.assertEqual(pm._monitor_tick(0), (0, False))                # sessions listed: the evidence
+        self.assertEqual(json.loads(pm._PRESENCE_GOOD_FILE.read_text())[0]["id"], ALPHA,
+                         "the evidence reached the disk twin for a bus restarted during the outage")
+        listing[0] = ([], False)                                          # the kernel stops answering
+        idle = 0
+        for _ in range(pm.IDLE_GRACE * 5):
+            idle, stop = pm._monitor_tick(idle)
+            self.assertEqual((idle, stop), (0, False))
+
+    def test_an_answered_empty_listing_clears_the_evidence(self):
+        listing = [([{"id": ALPHA, "name": "web"}], True)]
+        pm._kernel_sessions_checked = lambda threads=False: listing[0]
+        pm._monitor_tick(0)
+        listing[0] = ([], True)                                           # the sessions are gone, says the kernel
+        idle, stop = pm._monitor_tick(0)
+        self.assertEqual((idle, stop), (1, False))
+        listing[0] = ([], False)                                          # and then the kernel goes too
+        for _ in range(pm.IDLE_GRACE):
+            idle, stop = pm._monitor_tick(idle)
+        self.assertTrue(stop, "no sessions were listed when the kernel last answered: stop")
+
+    def test_a_beat_within_ttl_keeps_the_bus_even_unanswered(self):
+        pm._kernel_sessions_checked = lambda threads=False: ([], False)
+        pm.HEARTBEATS[GAMMA] = ("gamma", pm.time.time())
+        self.assertEqual(pm._monitor_tick(pm.IDLE_GRACE - 1), (0, False))
+
+    def test_an_expired_heartbeat_leaves_the_mirror_after_one_tick(self):
+        pm._kernel_sessions_checked = lambda threads=False: ([], True)
+        old, fresh = GAMMA, "99999999-8888-7777-6666-555555555556"
+        now = pm.time.time()
+        pm.HEARTBEATS[old] = ("gamma", now - pm.HEARTBEAT_TTL - 1)
+        pm.HEARTBEATS[fresh] = ("delta", now)
+        (pm.STATE / "remote-sids").write_text(old + "\n" + fresh + "\n")   # what the last beat wrote
+        pm._monitor_tick(0)
+        self.assertEqual((pm.STATE / "remote-sids").read_text(), fresh + "\n",
+                         "the expired sid is pruned by the poll's write, not by the next beat")
+
+
+class MonitorLoop(unittest.TestCase):
+    """_monitor, the production poll loop, runs _monitor_tick, so the tick's outage hold reaches the loop
+    that shuts the server down: a kernel blink after listed sessions no longer stops the bus, while a
+    bus no kernel ever answered still stops at the grace. The sleep is replaced through the module's
+    OWN `time` binding (a proxy over the real module), never process-wide, and it is the test's hand on
+    the loop: it counts the polls, flips the listing, and ends a loop that must not end by itself."""
+
+    class _Clock:
+        def __init__(self, on_sleep):
+            self._on_sleep = on_sleep
+
+        def __getattr__(self, name):
+            return getattr(time, name)
+
+        def sleep(self, secs):
+            self._on_sleep(secs)
+
+    class _EnoughPolls(Exception):
+        pass
+
+    def setUp(self):
+        self._saved = (pm.time, pm._kernel_sessions_checked, pm._kernel_up, pm._sweep_orphans,
+                       pm._warn_stuck_mail, pm._maybe_restart_for_code)
+        pm._kernel_up = lambda: False
+        pm._sweep_orphans = pm._warn_stuck_mail = lambda: None
+        pm._maybe_restart_for_code = lambda boot_fp: False
+        pm.HEARTBEATS.clear()
+        pm.STATE.mkdir(parents=True, exist_ok=True)
+        _forget_presence()
+        self.polls = []
+        self.stopped = threading.Event()
+        self.httpd = types.SimpleNamespace(shutdown=self.stopped.set)
+
+    def tearDown(self):
+        (pm.time, pm._kernel_sessions_checked, pm._kernel_up, pm._sweep_orphans,
+         pm._warn_stuck_mail, pm._maybe_restart_for_code) = self._saved
+        pm.HEARTBEATS.clear()
+        _forget_presence()
+
+    def test_the_loop_holds_through_an_outage_after_listed_sessions(self):
+        # the first poll's listing holds a session; from the second poll on the kernel does not answer
+        # (mid-restart). The loop keeps polling for as long as the outage lasts, so the test ends it.
+        listing = [([{"id": ALPHA, "name": "web"}], True)]
+        pm._kernel_sessions_checked = lambda threads=False: listing[0]
+
+        def on_sleep(secs):
+            self.polls.append(secs)
+            if len(self.polls) > pm.IDLE_GRACE * 5:
+                raise self._EnoughPolls()
+            if len(self.polls) > 1:
+                listing[0] = ([], False)
+        pm.time = self._Clock(on_sleep)
+        with self.assertRaises(self._EnoughPolls):
+            pm._monitor(self.httpd)
+        self.assertFalse(self.stopped.is_set(), "the sessions the kernel listed outlive its blink: no shutdown")
+        self.assertEqual(self.polls, [pm.POLL] * (pm.IDLE_GRACE * 5 + 1), "one production-cadence sleep per poll")
+
+    def test_a_never_answered_bus_stops_and_shuts_the_server_down(self):
+        # the exit path: no kernel ever answered, no clients; the loop returns at the grace and the
+        # shutdown reaches the server
+        pm._kernel_sessions_checked = lambda threads=False: ([], False)
+        pm.time = self._Clock(self.polls.append)
+        pm._monitor(self.httpd)
+        self.assertTrue(self.stopped.wait(5), "the loop's shutdown thread reached the server")
+        self.assertEqual(self.polls, [pm.POLL] * pm.IDLE_GRACE)
 
 
 class RefusedNotifyRevives(unittest.TestCase):

--- a/tests/test_postal_bus_lifetime.py
+++ b/tests/test_postal_bus_lifetime.py
@@ -173,6 +173,29 @@ class IdleGate(unittest.TestCase):
             idle, stop = pm._idle_tick(0, idle, answered=False)
         self.assertTrue(stop, "the last answered listing was empty: nothing to protect")
 
+    def test_the_hold_releases_only_through_an_answered_listing(self):
+        # the hold's one release is the next answered listing, which rewrites the twin: a kernel gone for
+        # good after listing sessions leaves the bus up for as long as nothing answers, a code-staleness
+        # re-exec re-primes the hold from the twin (a fresh process: empty memory, the twin still on disk),
+        # and the first answered listing (here: nobody left) is what lets the autostop resume
+        # (review find, 2026-09-08: the re-exec was described as ending the hold; it does not)
+        pm._kernel_up = lambda: False
+        pm._remember_presence([{"id": ALPHA, "name": "web"}])
+        idle = 0
+        for _ in range(pm.IDLE_GRACE * 3):
+            idle, stop = pm._idle_tick(0, idle, answered=False)
+            self.assertEqual((idle, stop), (0, False), "no number of unanswered polls ends the hold")
+        pm._LOCAL_PRESENCE_GOOD[0], pm._LOCAL_PRESENCE_GOOD[1] = [], False   # the re-exec: fresh memory, same twin
+        for _ in range(pm.IDLE_GRACE * 3):
+            idle, stop = pm._idle_tick(0, idle, answered=False)
+            self.assertEqual((idle, stop), (0, False), "the re-exec'd bus primes the hold back from the twin")
+        pm._remember_presence([])                    # the kernel returns, lists nobody, and is gone again
+        for _ in range(pm.IDLE_GRACE - 1):
+            idle, stop = pm._idle_tick(0, idle, answered=False)
+            self.assertFalse(stop)
+        idle, stop = pm._idle_tick(0, idle, answered=False)
+        self.assertTrue(stop, "with the twin rewritten empty the autostop resumes")
+
     def test_an_answered_empty_listing_advances_the_count(self):
         # reachable only through the ROMP_SESSIONS_FILE seam in practice (an answered listing implies
         # a live kernel, which resets the count first); pinned so the seam-driven bats autostop holds

--- a/tests/test_postal_delivery.py
+++ b/tests/test_postal_delivery.py
@@ -71,20 +71,53 @@ class PushThroughKernel(unittest.TestCase):
         self.assertEqual(self.posted[0][0], "/deliver")
         self.assertEqual(self.posted[0][1]["id"], "sid-r")
 
+    # The bus's /heartbeat handler decides locality from ITS OWN listing (the kernel's GET /sessions,
+    # thread rows included) and answers with the bit, so a local session's MCP can stop beating
+    # (2026-09-06). The listing is stubbed at _kernel_sessions_checked, the seam every bus-side
+    # fetch goes through, so the tests also count fetches.
+    LOCAL, THREAD = "local-1", "22222222-3333-4444-5555-666666666666"
+    REMOTE = "11111111-2222-3333-4444-555555555555"
+
+    def _listing(self, rows, answered=True):
+        self.fetches = []
+        pm._kernel_sessions_checked = lambda threads=False: (self.fetches.append(threads), (rows, answered))[1]
+
+    def _with_bus_listing(self, rows, answered=True):
+        saved = pm._kernel_sessions_checked
+        self._listing(rows, answered)
+        pm.HEARTBEATS.clear()
+        self.addCleanup(lambda: (setattr(pm, "_kernel_sessions_checked", saved), pm.HEARTBEATS.clear()))
+
     def test_heartbeat_records_remote_but_ignores_local(self):
         # Only sids the local kernel does NOT own get remote-presence; a local session is already visible via
         # /sessions and must not linger as a phantom [remote] after it dies.
-        saved = pm.local_agents
-        pm.local_agents = lambda: [{"id": "local-1", "name": "mysess"}]
-        try:
-            pm.HEARTBEATS.clear()
-            pm._record_heartbeat("11111111-2222-3333-4444-555555555555", "remotetest")   # not local → recorded
-            pm._record_heartbeat("local-1", "mysess")                                    # local → ignored
-            self.assertIn("11111111-2222-3333-4444-555555555555", pm.HEARTBEATS)
-            self.assertNotIn("local-1", pm.HEARTBEATS)
-        finally:
-            pm.local_agents = saved
-            pm.HEARTBEATS.clear()
+        self._with_bus_listing([{"id": self.LOCAL, "name": "mysess"}])
+        self.assertFalse(pm._record_heartbeat(self.REMOTE, "remotetest"), "not local → recorded, answer False")
+        self.assertTrue(pm._record_heartbeat(self.LOCAL, "mysess"), "local → ignored, answer True")
+        self.assertIn(self.REMOTE, pm.HEARTBEATS)
+        self.assertNotIn(self.LOCAL, pm.HEARTBEATS)
+        self.assertEqual(self.fetches, [True, True], "one listing fetch per beat, thread rows included")
+
+    def test_heartbeat_unanswered_listing_is_not_local(self):
+        # A kernel mid-restart leaves the listing UNANSWERED: the bus must not tell anyone it is local
+        # (a remote session that heard that would stop beating for good), and it records the beat
+        # exactly as before, so presence survives the restart the way it always did.
+        # The rows are NON-empty and hold the sid on purpose: only the answered bit can make this
+        # False, so dropping the `answered and` guard fails here (the seam never returns rows with
+        # answered=False today; the guard is the docstring's promise, and this is its test).
+        self._with_bus_listing([{"id": self.LOCAL, "name": "mysess"}], answered=False)
+        self.assertFalse(pm._record_heartbeat(self.LOCAL, "mysess"),
+                         "the sid is in the rows, but the rows did not ANSWER: never local")
+        self.assertIn(self.LOCAL, pm.HEARTBEATS, "an unanswered listing records the beat, as before")
+
+    def test_heartbeat_from_a_thread_row_is_local(self):
+        # A comment thread heartbeats under its own row; the default listing hides thread rows, so the
+        # handler asks for them or it would file every live thread as a phantom remote peer.
+        self._with_bus_listing([{"id": self.LOCAL, "name": "mysess"},
+                                {"id": self.THREAD, "name": "mysess-t1", "thread": True, "parent": self.LOCAL}])
+        self.assertTrue(pm._record_heartbeat(self.THREAD, "mysess-t1"))
+        self.assertNotIn(self.THREAD, pm.HEARTBEATS)
+        self.assertEqual(self.fetches, [True], "the handler asks for thread rows")
 
     def test_source_uses_the_kernel_deliver_not_a_tmux_inject(self):
         src = open(os.path.join(BIN, "romp-postal-service"), encoding="utf-8").read()
@@ -320,6 +353,51 @@ class PushOverTheWire(unittest.TestCase):
             self.assertLessEqual(n, pm._POST_MAX_BYTES)
         self.assertEqual(pm.read_box(self.SID, consume=False), [], "both landed: nothing left in new/")
         self.assertEqual([l for l in self.logged if "deferred" in l or "refused" in l], [])
+
+
+class HeartbeatRoute(unittest.TestCase):
+    """POST /heartbeat answers {ok, local} over the wire: the contract a session's MCP loop reads to
+    stop beating (2026-09-06). The real Handler serves on a loopback ThreadingHTTPServer (the token
+    gate's pattern) and the bus's listing is stubbed at _kernel_sessions_checked, so an edit that drops
+    the bit, or answers local for a sid the listing does not hold, fails here and not as a remote
+    session that never stops beating."""
+    LOCAL, REMOTE = PushThroughKernel.LOCAL, PushThroughKernel.REMOTE
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), pm.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        self._saved = pm._kernel_sessions_checked
+        pm._kernel_sessions_checked = lambda threads=False: ([{"id": self.LOCAL, "name": "mysess"}], True)
+        pm.HEARTBEATS.clear()
+        pm.STATE.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        pm._kernel_sessions_checked = self._saved
+        pm.HEARTBEATS.clear()
+
+    def _beat(self, sid, name):
+        req = urllib.request.Request("http://127.0.0.1:%d/heartbeat" % self.port, method="POST",
+                                     data=json.dumps({"id": sid, "name": name}).encode("utf-8"),
+                                     headers={"Content-Type": "application/json", "X-Romp-Token": pm.SERVE_TOKEN})
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return json.loads(r.read())
+
+    def test_a_sid_the_listing_holds_hears_local(self):
+        self.assertEqual(self._beat(self.LOCAL, "mysess"), {"ok": True, "local": True})
+        self.assertNotIn(self.LOCAL, pm.HEARTBEATS, "a local beat is not remote presence")
+
+    def test_a_sid_the_listing_lacks_hears_remote_and_is_recorded(self):
+        self.assertEqual(self._beat(self.REMOTE, "remotetest"), {"ok": True, "local": False})
+        self.assertIn(self.REMOTE, pm.HEARTBEATS, "the beat is presence, as it always was")
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_heartbeat_fetches.py
+++ b/tests/test_postal_heartbeat_fetches.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""The postal heartbeat's cost to the kernel: GET /sessions per beat and per tool call (2026-09-06).
+
+Each MCP heartbeat used to resolve this session's identity twice (my_id, then my_name — one GET /sessions
+each) and the bus's handler fetched a third time, so about 30 local sessions beating every 30 s were
+3 requests per second against a kernel already at one core, for a beat the bus ignores (local sids are
+already in its listing). Now: one resolution per beat and per tool call (_self_identity), and the loop
+ends the first time the bus confirms this session local from its own answered listing. A remote
+(client-only box) session never hears "local" from the hub's bus and keeps beating exactly as before.
+
+The kernel is the ROMP_SESSIONS_FILE seam; fetches are counted at _kernel_sessions_checked, the one
+function every listing read goes through. Synthetic only: placeholder UUIDs, the notes-api demo sessions."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+WEB = "11111111-2222-3333-4444-555555555555"
+API = "11111111-2222-3333-4444-666666666666"
+THREAD = "11111111-2222-3333-4444-777777777777"
+FORK = "99999999-8888-7777-6666-555555555555"
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([
+    {"id": WEB, "name": "web", "dir": "", "state": "working", "working": "", "lastSid": FORK},
+    {"id": API, "name": "api", "dir": "", "state": "idle", "working": "", "lastSid": ""},
+    {"id": THREAD, "name": "web-t1", "dir": "", "state": "working", "working": "", "lastSid": "",
+     "thread": True, "parent": WEB}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+pm = SourceFileLoader("romp_postal_hb_fetches", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class Counting(unittest.TestCase):
+    """Every listing fetch is counted; the bus is stubbed at _http and answers what each test says."""
+
+    def setUp(self):
+        # os.environ is process-wide: other modules in the same pytest worker pop or repoint the seam
+        # between tests, so pin both env halves here and put them back after (the self-identity test's idiom)
+        self._env = (os.environ.get("CLAUDE_CODE_SESSION_ID"), os.environ.get("ROMP_SESSIONS_FILE"),
+                     os.environ.get("ROMP_POSTAL_PEERS"))
+        os.environ["CLAUDE_CODE_SESSION_ID"] = WEB
+        os.environ["ROMP_SESSIONS_FILE"] = _SESS
+        os.environ.pop("ROMP_POSTAL_PEERS", None)               # peer mode, the default; legacy tests set 0
+        pm._LOCAL_CONFIRMED[0] = False                          # a fresh MCP process
+        self._saved = (pm._kernel_sessions_checked, pm._http, pm.ensure)
+        self.fetches, self.posts = [], []
+        real = self._saved[0]
+        pm._kernel_sessions_checked = lambda threads=False: (self.fetches.append(threads),
+                                                             real(threads=threads))[1]
+        self.answer = {"ok": True, "local": True, "agents": []}
+        pm._http = lambda method, path, payload=None: (self.posts.append((method, path, payload))
+                                                      or dict(self.answer))
+        pm.ensure = lambda: True
+
+    def tearDown(self):
+        pm._kernel_sessions_checked, pm._http, pm.ensure = self._saved
+        pm._LOCAL_CONFIRMED[0] = False
+        for key, val in zip(("CLAUDE_CODE_SESSION_ID", "ROMP_SESSIONS_FILE", "ROMP_POSTAL_PEERS"), self._env):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    # ── one resolution ────────────────────────────────────────────────────────────────────────
+
+    def test_self_identity_is_one_fetch_with_thread_rows(self):
+        self.assertEqual(pm._self_identity(), (WEB, "web"))
+        self.assertEqual(self.fetches, [True], "one GET /sessions?threads=1 for both halves")
+
+    def test_self_identity_keeps_both_fallbacks(self):
+        # the fork fsid resolves to the stable row (the 2026-07-27 rule) in the same single fetch
+        os.environ["CLAUDE_CODE_SESSION_ID"] = FORK
+        self.assertEqual(pm._self_identity(), (WEB, "web"))
+        # no row anywhere: the env value passes through as the id, the names registry is the name
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "abcdef00-0000-0000-0000-000000000000"
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+        (pm.NAMES_DIR / "abcdef00-0000-0000-0000-000000000000").write_text("tests\t\t#111111\t#ffffff\n")
+        self.assertEqual(pm._self_identity(), ("abcdef00-0000-0000-0000-000000000000", "tests"))
+        os.environ.pop("CLAUDE_CODE_SESSION_ID")
+        self.assertEqual(pm._self_identity(), (None, None), "not a romp session")
+        self.assertEqual(pm.my_id(), None)
+        self.assertEqual(pm.my_name(), None)
+
+    def test_a_thread_row_heartbeats_under_its_row_name(self):
+        # a comment thread withholds its names entry, so the name must come from the row and nothing else
+        os.environ["CLAUDE_CODE_SESSION_ID"] = THREAD
+        self.assertTrue(pm._heartbeat_once())
+        self.assertEqual(self.posts, [("POST", "/heartbeat", {"id": THREAD, "name": "web-t1"})])
+        self.assertEqual(self.fetches, [True])
+
+    def test_one_heartbeat_iteration_is_one_fetch(self):
+        pm._heartbeat_once()
+        self.assertEqual(self.fetches, [True], "was two: my_id() then my_name()")
+        self.assertEqual(self.posts, [("POST", "/heartbeat", {"id": WEB, "name": "web"})])
+
+    def test_one_tool_call_is_one_fetch(self):
+        for tool, args in (("list_agents", {}), ("check_inbox", {}),
+                           ("send_message", {"to": "api", "body": "the staging port?", "kind": "question"})):
+            self.fetches.clear(); self.posts.clear()
+            pm._mcp_call(tool, args)
+            self.assertEqual(self.fetches, [True], "%s: one GET /sessions per tool call (was two)" % tool)
+            self.assertEqual(self.posts[0], ("POST", "/heartbeat", {"id": WEB, "name": "web"}),
+                             "%s: the per-call beat still goes out" % tool)
+        self.assertEqual(self.posts[1][2]["from_id"], WEB)
+        self.assertEqual(self.posts[1][2]["from"], "web")
+
+    def test_cli_agents_and_cli_send_are_one_fetch_each(self):
+        import io, sys
+        out, saved_out = io.StringIO(), sys.stdout
+        sys.stdout = out
+        try:
+            self.assertEqual(pm.cli_agents(), 0)
+            self.assertEqual(self.fetches, [True])
+            self.assertEqual(self.posts[-1][1], "/agents?me=web")
+            self.fetches.clear()
+            self.assertEqual(pm.cli_send(["--kind", "coordinate", "api", "synthetic body"]), 0)
+            self.assertEqual(self.fetches, [True])
+            self.assertEqual(self.posts[-1][2]["from_id"], WEB)
+        finally:
+            sys.stdout = saved_out
+
+    # ── the loop's exit ───────────────────────────────────────────────────────────────────────
+
+    def test_heartbeat_once_reads_the_bus_verdict(self):
+        self.answer = {"ok": True, "local": True}
+        self.assertTrue(pm._heartbeat_once(), "the bus confirmed local from its own listing")
+        self.answer = {"ok": True, "local": False}
+        self.assertFalse(pm._heartbeat_once(), "remote, or the bus's listing was unanswered: keep beating")
+        self.answer = {"ok": True}
+        self.assertFalse(pm._heartbeat_once(), "an older bus without the bit: keep beating")
+        pm._http = lambda *a, **k: (_ for _ in ()).throw(pm.BusError("down"))
+        self.assertFalse(pm._heartbeat_once(), "no bus: keep beating")
+        os.environ.pop("CLAUDE_CODE_SESSION_ID")
+        self.assertFalse(pm._heartbeat_once(), "no identity: nothing to end")
+
+    def test_loop_ends_on_the_first_local_answer_and_not_before(self):
+        answers = [{"ok": True, "local": False}, {"ok": True}, {"ok": True, "local": True},
+                   {"ok": True, "local": True}]
+        pm._http = lambda method, path, payload=None: (self.posts.append(path) or answers.pop(0))
+        stop = threading.Event()
+        self.addCleanup(stop.set)              # a regression that never returns must not leave a beating thread
+        t = threading.Thread(target=pm._heartbeat_loop, kwargs={"interval": 0.01, "stop": stop}, daemon=True)
+        t.start()
+        t.join(5)
+        self.assertFalse(t.is_alive(), "the loop ends once the bus says local")
+        self.assertFalse(stop.is_set(), "and it ended on its own, before the cleanup's stop")
+        self.assertEqual(self.posts, ["/heartbeat"] * 3, "two non-local answers kept it beating")
+        self.assertEqual(self.fetches, [True] * 3, "one listing fetch per beat")
+
+    def _run_loop_until(self, n_posts, stop):
+        """Start the loop on a fast cadence and wait until it has posted n_posts beats (5 s cap)."""
+        self.addCleanup(stop.set)              # whatever the assertions do, the thread ends with the test
+        t = threading.Thread(target=pm._heartbeat_loop, kwargs={"interval": 0.005, "stop": stop}, daemon=True)
+        t.start()
+        deadline = time.time() + 5
+        while len(self.posts) < n_posts and time.time() < deadline:
+            time.sleep(0.005)
+        return t
+
+    def test_repeated_non_local_answers_never_end_the_loop(self):
+        # the remote-session shape: the hub's bus never lists this sid and answers local=false on every
+        # beat, so the loop keeps beating and each beat is a full resolution — no memo of the sid or the
+        # verdict between beats; the external stop is the only thing that ends it here
+        self.answer = {"ok": True, "local": False}
+        stop = threading.Event()
+        t = self._run_loop_until(4, stop)
+        self.assertTrue(t.is_alive(), "four non-local answers and the loop is still running")
+        stop.set(); t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertGreaterEqual(len(self.posts), 4)
+        self.assertEqual(self.fetches, [True] * len(self.posts), "one full resolution per beat")
+        self.assertFalse(pm._LOCAL_CONFIRMED[0], "a false answer never latches")
+
+    def test_legacy_mode_keeps_the_loop_through_a_local_answer(self):
+        # ROMP_POSTAL_PEERS=0: `romp mail remote` can swap the local bus for the hub's under a running
+        # session, so a `local: true` from the bus of the moment must not end the beats (review, 2026-09-06)
+        os.environ["ROMP_POSTAL_PEERS"] = "0"
+        self.answer = {"ok": True, "local": True}
+        stop = threading.Event()
+        t = self._run_loop_until(3, stop)
+        self.assertTrue(t.is_alive(), "local:true in legacy mode: still beating")
+        stop.set(); t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertGreaterEqual(len(self.posts), 3)
+        self.assertFalse(pm._LOCAL_CONFIRMED[0], "and the per-call beat is not spared either")
+
+    def test_peer_mode_ends_the_loop_without_an_external_stop(self):
+        # the same answer in peer mode (the default): the loop returns on its own, once
+        self.answer = {"ok": True, "local": True}
+        stop = threading.Event()
+        self.addCleanup(stop.set)
+        t = threading.Thread(target=pm._heartbeat_loop, kwargs={"interval": 0.005, "stop": stop}, daemon=True)
+        t.start(); t.join(5)
+        self.assertFalse(t.is_alive())
+        self.assertFalse(stop.is_set(), "returned on its own")
+        self.assertEqual(self.posts, [("POST", "/heartbeat", {"id": WEB, "name": "web"})])
+        self.assertTrue(pm._LOCAL_CONFIRMED[0])
+
+    # ── the per-call beat ─────────────────────────────────────────────────────────────────────
+
+    def test_confirmed_local_session_skips_the_per_call_beat(self):
+        self.assertTrue(pm._heartbeat_once())                    # peer mode, local:true → latched
+        self.posts.clear(); self.fetches.clear()
+        pm._mcp_call("list_agents", {})
+        self.assertEqual([p[1] for p in self.posts], ["/agents?me=web"], "no /heartbeat for a confirmed-local session")
+        self.assertEqual(self.fetches, [True], "the tool call still resolves identity once")
+
+    def test_remote_session_beats_on_every_call(self):
+        self.answer = {"ok": True, "local": False}
+        self.assertFalse(pm._heartbeat_once())
+        for _ in range(3):
+            self.posts.clear()
+            pm._mcp_call("list_agents", {})
+            self.assertEqual(self.posts[0][1], "/heartbeat", "local:false never spares the beat")
+
+    def test_unanswered_bus_never_latches(self):
+        self.answer = {"ok": True}                                # an older bus: no bit
+        self.assertFalse(pm._heartbeat_once())
+        pm._http = lambda *a, **k: (_ for _ in ()).throw(pm.BusError("down"))
+        self.assertFalse(pm._heartbeat_once())
+        self.assertFalse(pm._LOCAL_CONFIRMED[0])
+
+    # ── the bus's side of the beat ────────────────────────────────────────────────────────────
+
+    def test_the_bus_answers_local_for_a_thread_row_through_the_seam(self):
+        # the handler decides locality from a listing WITH thread rows; the seam filters them out on
+        # threads=False exactly as the route does, so a comment thread's beat is local here only if the
+        # handler asked for them (otherwise it is filed as remote presence, the phantom of 2026-09-06)
+        pm.HEARTBEATS.clear()
+        self.addCleanup(pm.HEARTBEATS.clear)
+        self.assertTrue(pm._record_heartbeat(THREAD, "web-t1"), "a thread row is local to its own bus")
+        self.assertNotIn(THREAD, pm.HEARTBEATS, "and never remote presence")
+        self.assertEqual(self.fetches, [True], "one listing for the beat, thread rows included")
+
+    # ── the bus's retry pass ──────────────────────────────────────────────────────────────────
+
+    def _dead_boxes(self, names):
+        """Mailboxes for sessions the listing does not hold, each with an empty new/ and a names entry."""
+        pm.NAMES_DIR.mkdir(parents=True, exist_ok=True)
+        sids = []
+        for i, name in enumerate(names):
+            sid = "99999999-8888-7777-6666-%012d" % i
+            (pm.MAILROOT / sid / "new").mkdir(parents=True, exist_ok=True)
+            (pm.NAMES_DIR / sid).write_text("%s\t\t#111111\t#ffffff\n" % name)
+            sids.append(sid)
+        self.addCleanup(lambda: [__import__("shutil").rmtree(pm.MAILROOT / sid, ignore_errors=True) for sid in sids])
+        return sids
+
+    def test_orphan_sweep_fetches_once_per_poll(self):
+        # every dead mailbox used to cost its own GET /sessions to learn a name the listing could not
+        # hold (the box is dead by construction); the registry names it, and the sweep's one listing
+        # is the only fetch (28 per 30 s poll on a box with 58 mailboxes, review 2026-09-06)
+        self._dead_boxes(["ghost-a", "ghost-b", "ghost-c"])
+        pm._sweep_orphans()
+        self.assertEqual(self.fetches, [False], "one listing for the whole sweep")
+
+    def test_recall_by_a_dead_name_fetches_once(self):
+        dead = self._dead_boxes(["ghost-a", "ghost-b", "ghost-c"])
+        (pm.MAILROOT / dead[1] / "new" / "m3").write_text("From: web\nFrom-Id: %s\nX-Park: 1\n\nparked body" % WEB)
+        removed = pm._recall(WEB, "ghost-b", None)
+        self.assertEqual([(r["id"], r["to"]) for r in removed], [("m3", "ghost-b")])
+        self.assertEqual(self.fetches, [True], "one listing for the whole recall, shared by every name lookup")
+
+    def test_recall_by_a_live_name_fetches_once(self):
+        (pm.MAILROOT / API / "new").mkdir(parents=True, exist_ok=True)
+        (pm.MAILROOT / API / "new" / "m4").write_text("From: web\nFrom-Id: %s\n\nthe body" % WEB)
+        try:
+            removed = pm._recall(WEB, "api", None)
+            self.assertEqual([(r["id"], r["to"]) for r in removed], [("m4", "api")])
+            self.assertEqual(self.fetches, [True])
+        finally:
+            for f in (pm.MAILROOT / API / "new").iterdir():
+                f.unlink()
+
+    def test_recall_by_id_fetches_only_when_a_removed_row_needs_a_name(self):
+        # by id with no recipient, the listing serves only the removed rows' names: a recall that
+        # removes nothing fetches nothing, and one that removes a row fetches once, at first need
+        # (the sent-receipts idiom)
+        dead = self._dead_boxes(["ghost-a", "ghost-b", "ghost-c"])
+        (pm.MAILROOT / dead[2] / "new" / "m5").write_text("From: web\nFrom-Id: %s\nX-Park: 1\n\nparked body" % WEB)
+        self.assertEqual(pm._recall(WEB, "", "no-such-id"), [])
+        self.assertEqual(self.fetches, [], "nothing removed, no name to look up, no listing")
+        removed = pm._recall(WEB, "", "m5")
+        self.assertEqual([(r["id"], r["to"]) for r in removed], [("m5", "ghost-c")])
+        self.assertEqual(self.fetches, [True], "one listing, fetched when the first removed row needs its name")
+
+    def test_sent_receipts_fetch_once_for_every_unnamed_row(self):
+        # check_sent names each row's recipient; rows without a stored toName used to cost one
+        # GET /sessions each — one listing per call now, fetched only when a row needs it
+        pm.TLDIR.mkdir(parents=True, exist_ok=True)
+        log = pm.TLDIR / "messages.jsonl"
+        had = log.read_text() if log.exists() else None
+        self.addCleanup(lambda: log.write_text(had) if had is not None else log.unlink(missing_ok=True))
+        dead = "99999999-8888-7777-6666-000000000009"
+        log.write_text("".join(json.dumps(e) + "\n" for e in (
+            {"t": 5, "ev": "sent", "id": "m1", "from_id": WEB, "to_id": API},
+            {"t": 6, "ev": "sent", "id": "m2", "from_id": WEB, "to_id": THREAD},
+            {"t": 7, "ev": "sent", "id": "m3", "from_id": WEB, "to_id": dead},
+            {"t": 8, "ev": "sent", "id": "m4", "from_id": WEB, "to_id": "peer:farhost", "toName": "farhost:api"})))
+        rows = pm._sent_receipts(WEB)
+        self.assertEqual([r["to"] for r in rows], ["api", "web-t1", dead[:8], "farhost:api"])
+        self.assertEqual(self.fetches, [True], "one listing for the whole call (was one per unnamed row)")
+        self.fetches.clear()
+        log.write_text(json.dumps({"t": 8, "ev": "sent", "id": "m4", "from_id": WEB, "to_id": "peer:farhost",
+                                   "toName": "farhost:api"}) + "\n")
+        pm._sent_receipts(WEB)
+        self.assertEqual(self.fetches, [], "no row needed a name: no fetch at all")
+
+    def test_retry_pending_fetches_nothing_without_pending_mail(self):
+        pm.MAILPENDING.mkdir(parents=True, exist_ok=True)
+        for m in pm.MAILPENDING.iterdir():
+            m.unlink()
+        pm._retry_pending()
+        self.assertEqual(self.fetches, [], "no marker files: no GET /sessions (was one every 5 s)")
+        (pm.MAILPENDING / API).write_text("")                   # a stale marker: new/ is empty
+        pm._retry_pending()
+        self.assertEqual(self.fetches, [], "a stale marker is cleared without a fetch")
+        self.assertFalse((pm.MAILPENDING / API).exists(), "the stale marker was reconciled away")
+
+    def test_retry_pending_fetches_once_for_real_pending_mail(self):
+        saved_push = pm._push
+        pushed = []
+        pm._push = lambda sid, row: pushed.append(sid)
+        try:
+            pm.deliver(API, "web", WEB, "synthetic body", kind="coordinate")
+            pm.deliver(WEB, "api", API, "synthetic reply", kind="coordinate")
+            self.fetches.clear()
+            pm._retry_pending()
+            self.assertEqual(self.fetches, [False], "one listing fetch for the whole pass, not one per marker")
+            self.assertEqual(sorted(pushed), sorted([API, WEB]))
+        finally:
+            pm._push = saved_push
+            for sid in (API, WEB):
+                for f in (pm.MAILROOT / sid / "new").glob("*"):
+                    f.unlink()
+                pm._mark_pending(sid)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_postal_heartbeat_fetches.py
+++ b/tests/test_postal_heartbeat_fetches.py
@@ -10,6 +10,8 @@ ends the first time the bus confirms this session local from its own answered li
 
 The kernel is the ROMP_SESSIONS_FILE seam; fetches are counted at _kernel_sessions_checked, the one
 function every listing read goes through. Synthetic only: placeholder UUIDs, the notes-api demo sessions."""
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -343,6 +345,98 @@ class Counting(unittest.TestCase):
                 for f in (pm.MAILROOT / sid / "new").glob("*"):
                     f.unlink()
                 pm._mark_pending(sid)
+
+    # ── a peer's send during a kernel blink ───────────────────────────────────────────────────
+
+    def test_after_the_latch_a_local_peer_is_unreachable_by_name_during_a_blink(self):
+        # What changed on 2026-09-06, pinned (review find, 2026-09-08): a local session's beat that landed
+        # while the kernel's listing was unanswered used to be filed as remote presence (the bus could not
+        # call it local), so a send to its name during the blink resolved to that row and delivered into its
+        # mailbox with no wake; the mail sat there unannounced until the kernel returned. Once the bus has
+        # confirmed the session local, its loop has ended and its per-call beat is skipped, so no such row
+        # appears, and the standing blink refusal (503, retry shortly, never a death ruling) covers every
+        # local peer alike: the mail stays with the sender, who is told so.
+        pm.HEARTBEATS.clear()
+        self.addCleanup(pm.HEARTBEATS.clear)
+        self.assertTrue(pm._heartbeat_once(), "web is confirmed local while the kernel answers")
+        self.assertTrue(pm._record_heartbeat(WEB, "web"), "the bus's side of that beat: local, no presence row")
+        self.assertNotIn(WEB, pm.HEARTBEATS)
+        # the kernel blinks: the listing does not answer
+        pm._kernel_sessions_checked = lambda threads=False: (self.fetches.append(threads), ([], False))[1]
+        self.posts.clear()
+        pm._mcp_call("list_agents", {})                          # web keeps using postal through the blink...
+        self.assertEqual([p[1] for p in self.posts], ["/agents?me="], "...and beats nothing: the latch holds")
+        r = pm.resolve_recipient("web", frm_id=API)
+        self.assertEqual((r["kind"], r["status"]), ("error", 503))
+        self.assertIn("Retry shortly", r["error"])
+        self.assertNotIn("no live romp session", r["error"], "never a death ruling")
+        # the pre-latch shape, still what a beat landing in the blink does (legacy mode, a remote session)
+        self.assertFalse(pm._record_heartbeat(WEB, "web"), "unanswered listing: not local")
+        self.assertIn(WEB, pm.HEARTBEATS, "filed as remote presence")
+        r = pm.resolve_recipient("web", frm_id=API)
+        self.assertEqual(r["kind"], "direct", "which is what made the name reachable before the latch")
+        self.assertTrue(r["agent"].get("remote"), "as a presence row, delivered with no wake")
+
+    # ── `romp mail remote` after the latch ────────────────────────────────────────────────────
+
+    def _remote_setup_sandbox(self):
+        """setup_remote's side effects land in a scratch dir: the client-only marker and the bus pid file."""
+        root = Path(tempfile.mkdtemp())
+        saved = (pm.CLIENT_ONLY, pm.PIDFILE)
+        pm.CLIENT_ONLY, pm.PIDFILE = root / "client-only", root / "server.pid"
+        pm.PIDFILE.write_text("not-a-pid")     # a bus "running" here; a stop attempt prints its line and fails
+        self.addCleanup(lambda: (setattr(pm, "CLIENT_ONLY", saved[0]), setattr(pm, "PIDFILE", saved[1])))
+        return root
+
+    def test_peer_mode_remote_setup_refuses_after_the_latch_force_included(self):
+        # the latch's premise is that the bus behind BASE stays this box's own for the life of the process;
+        # `romp mail remote --force` used to break it in peer mode: it stopped the local bus, and a hub's bus
+        # swapped in behind the port never heard from a session whose beats had ended, so the session went
+        # silent on the hub (review find, 2026-09-08). The command refuses in peer mode before any side
+        # effect, --force included, and says why.
+        self._remote_setup_sandbox()
+        self.assertTrue(pm._heartbeat_once(), "peer mode, local:true: latched")
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = pm.setup_remote(force=True)
+        self.assertEqual(rc, 2, "a refusal, not the 0 of 'nothing to set up'")
+        text = out.getvalue()
+        self.assertIn("peer mode", text)
+        self.assertIn("heartbeat", text, "the refusal names its reason: the beats that ended")
+        self.assertNotIn("Stopped the local-only bus", text, "the local bus is left running")
+        self.assertFalse(pm.CLIENT_ONLY.exists(), "no client-only marker")
+        self.assertTrue(pm._LOCAL_CONFIRMED[0], "the latch stands, and its premise with it")
+        self.posts.clear()
+        pm._mcp_call("list_agents", {})
+        self.assertEqual([p[1] for p in self.posts], ["/agents?me=web"],
+                         "the per-call beat stays skipped: the bus behind BASE is still this box's own")
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(pm.main(["remote", "--force"]), 2, "the CLI route refuses the same way")
+            self.assertEqual(pm.main(["remote"]), 2, "with or without --force")
+        self.assertFalse(pm.CLIENT_ONLY.exists())
+
+    def test_peer_mode_unreachable_hint_never_points_at_remote_setup(self):
+        # the bus-unreachable hint used to send every SSH'd box to `romp mail remote`; in peer mode that
+        # command refuses (above), so the hint would be a dead end: the generic server.log hint instead,
+        # and the tunnel hint only in the legacy scheme the command belongs to (review find, 2026-09-08)
+        os.environ["SSH_CONNECTION"] = "1 2 3 4"
+        self.addCleanup(os.environ.pop, "SSH_CONNECTION", None)
+        self.assertNotIn("romp mail remote", pm._unreachable_hint(), "peer mode: never the refused command")
+        self.assertIn("server.log", pm._unreachable_hint())
+        os.environ["ROMP_POSTAL_PEERS"] = "0"
+        self.assertIn("run: romp mail remote", pm._unreachable_hint(), "legacy scheme: the tunnel hint stands")
+
+    def test_legacy_mode_remote_setup_still_configures_the_client(self):
+        # ROMP_POSTAL_PEERS=0 is where the command applies: the loop never ends there, so the hub hears every
+        # beat once the tunnel is up; with the bus reachable the command configures the client and connects
+        os.environ["ROMP_POSTAL_PEERS"] = "0"
+        self._remote_setup_sandbox()
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = pm.setup_remote(force=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("Already connected", out.getvalue())
+        self.assertTrue(pm.CLIENT_ONLY.exists(), "the client-only marker is written")
 
 
 if __name__ == "__main__":

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -22,6 +22,8 @@ pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).l
 
 ALPHA = "11111111-2222-3333-4444-555555555555"
 GHOST = "99999999-8888-7777-6666-555555555555"
+THREAD = "11111111-2222-3333-4444-777777777777"
+PEER = "99999999-8888-7777-6666-555555555557"    # a federated peer: known here only by its heartbeat
 
 
 def _tool_names():
@@ -55,6 +57,15 @@ class LiveOnlyAddressing(unittest.TestCase):
         _set_live([{"id": ALPHA, "name": "alpha"}])
         self.assertIsNone(pm._recip_id_for(GHOST))
 
+    def test_a_live_thread_row_resolves_by_its_own_name(self):
+        # a comment thread is hidden from the default listing; recipient resolution asks for thread
+        # rows (the 2026-08-22 rule), so recall by the thread's name still finds it now that its
+        # heartbeat no longer leaves a phantom remote row (2026-09-06)
+        _set_live([{"id": ALPHA, "name": "alpha"},
+                   {"id": THREAD, "name": "alpha-t1", "thread": True, "parent": ALPHA}])
+        self.assertEqual(pm._recip_id_for("alpha-t1"), THREAD)
+        self.assertEqual(pm._name_for_id(THREAD), "alpha-t1", "the thread's name lives only on its row")
+
     def test_heartbeat_remote_resolves(self):
         # a heartbeating remote peer is LIVE for addressing purposes
         _set_live([])
@@ -75,7 +86,7 @@ class RecallReachesParkedMailForTheDead(unittest.TestCase):
 
     def tearDown(self):
         os.environ.pop("ROMP_SESSIONS_FILE", None)
-        for rid in (GHOST, "99999999-8888-7777-6666-555555555556"):
+        for rid in (GHOST, "99999999-8888-7777-6666-555555555556", PEER):
             box = pm.MAILROOT / rid / "new"
             if box.is_dir():
                 for f in box.iterdir():
@@ -103,6 +114,36 @@ class RecallReachesParkedMailForTheDead(unittest.TestCase):
     def test_only_the_senders_own_mail_comes_back(self):
         self._park(GHOST, "ghost")
         self.assertEqual(pm._recall("00000000-0000-0000-0000-000000000001", "ghost", None), [])
+
+    def test_recall_by_a_live_thread_name(self):
+        # a comment thread withholds its names entry, so only its live row can carry the name
+        _set_live([{"id": ALPHA, "name": "alpha"},
+                   {"id": THREAD, "name": "alpha-t1", "thread": True, "parent": ALPHA}])
+        box = pm.MAILROOT / THREAD / "new"
+        box.mkdir(parents=True, exist_ok=True)
+        (box / "m7").write_text("From: alpha\nFrom-Id: %s\n\nthe reply body" % ALPHA)
+        try:
+            removed = pm._recall(ALPHA, "alpha-t1", None)
+            self.assertEqual([(r["id"], r["to"]) for r in removed], [("m7", "alpha-t1")])
+            self.assertEqual(list(box.iterdir()), [])
+        finally:
+            for f in box.iterdir():
+                f.unlink()
+
+
+    def test_recall_by_a_remote_peers_name(self):
+        # a peer known here only through its heartbeat (a federated session: no local row, no names
+        # entry): recall by its name resolves through the remote presence _recip_id_for folds into the
+        # listing it is handed, as it did when it fetched the listing itself (2026-09-06)
+        pm.HEARTBEATS[PEER] = ("ghost", pm.time.time())
+        self.addCleanup(pm.HEARTBEATS.clear)
+        (pm.NAMES_DIR / PEER).unlink(missing_ok=True)       # only the heartbeat may name it
+        box = pm.MAILROOT / PEER / "new"
+        box.mkdir(parents=True, exist_ok=True)
+        (box / "m8").write_text("From: alpha\nFrom-Id: %s\n\nthe body" % ALPHA)
+        removed = pm._recall(ALPHA, "ghost", None)
+        self.assertEqual([r["id"] for r in removed], ["m8"])
+        self.assertEqual(list(box.iterdir()), [])
 
 
 class KernelSilenceIsNotDeadness(unittest.TestCase):

--- a/tests/test_postal_relay_honesty.py
+++ b/tests/test_postal_relay_honesty.py
@@ -375,13 +375,12 @@ class SetWorkingMissingParamRefuses(unittest.TestCase):
     """Fold-in: a missing param is never a clear command."""
 
     def setUp(self):
-        self.saved = (pm.my_name, pm.my_id, pm._publish_working)
+        self.saved = (pm._self_identity, pm._publish_working)
         self.calls = []
-        pm.my_name, pm.my_id = (lambda: "web"), (lambda: ALPHA)
+        pm._self_identity = lambda: (ALPHA, "web")     # the one resolver every tool call reads (2026-09-06)
         pm._publish_working = lambda mid, text: self.calls.append((mid, text))
-        self.addCleanup(lambda: (setattr(pm, "my_name", self.saved[0]),
-                                 setattr(pm, "my_id", self.saved[1]),
-                                 setattr(pm, "_publish_working", self.saved[2])))
+        self.addCleanup(lambda: (setattr(pm, "_self_identity", self.saved[0]),
+                                 setattr(pm, "_publish_working", self.saved[1])))
 
     def test_missing_text_refuses_and_changes_nothing(self):
         msg, is_err = pm._mcp_call("set_working", {})

--- a/tests/test_postal_self_send.py
+++ b/tests/test_postal_self_send.py
@@ -229,9 +229,8 @@ class DeliveredMeansDelivered(unittest.TestCase):
     """A relayed or parked message is not a delivered one, and the tool surface has to say which."""
 
     def setUp(self):
-        self._saved = {k: getattr(pm, k) for k in ("_http", "my_name", "my_id", "_heartbeat")}
-        pm.my_name = lambda: "web"
-        pm.my_id = lambda: ME
+        self._saved = {k: getattr(pm, k) for k in ("_http", "_self_identity", "_heartbeat")}
+        pm._self_identity = lambda: (ME, "web")     # the one resolver every tool call reads (2026-09-06)
         pm._heartbeat = lambda *a, **k: None
 
     def tearDown(self):

--- a/tests/test_postal_send_echo.py
+++ b/tests/test_postal_send_echo.py
@@ -20,15 +20,14 @@ ps = SourceFileLoader("romp_postal_echo", os.path.join(BIN, "romp-postal-service
 
 class SendEcho(unittest.TestCase):
     def setUp(self):
-        self._saved = (ps._http, ps.my_name, ps.my_id, ps._heartbeat)
+        self._saved = (ps._http, ps._self_identity, ps._heartbeat)
         self.posts = []
         ps._http = lambda method, path, payload=None: (self.posts.append((method, path, payload)) or {})
-        ps.my_name = lambda: "web"
-        ps.my_id = lambda: "id-web"
+        ps._self_identity = lambda: ("id-web", "web")     # the one resolver every tool call reads (2026-09-06)
         ps._heartbeat = lambda *a, **k: None
 
     def tearDown(self):
-        ps._http, ps.my_name, ps.my_id, ps._heartbeat = self._saved
+        ps._http, ps._self_identity, ps._heartbeat = self._saved
 
     def _send(self, kind):
         out, err = ps._mcp_call("send_message", {"to": "api", "body": "the staging port?", "kind": kind})

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -307,8 +307,10 @@ class TrackedIsABoolean(_BusServer):
         def http(*a, **k):
             dialed.append(a)
             raise ps.BusError("stubbed: the bus is not dialed here")
-        saved = (ps._http, ps.my_name, ps.my_id, ps._heartbeat)
-        ps._http, ps.my_name, ps.my_id, ps._heartbeat = http, (lambda: "web"), (lambda: self.SID), (lambda mid, me: None)
+        # _mcp_call resolves its identity through _self_identity (the one resolution behind my_id and
+        # my_name), so that is the seam to stub; stubbing the two wrappers leaves the call unresolved.
+        saved = (ps._http, ps._self_identity, ps._heartbeat)
+        ps._http, ps._self_identity, ps._heartbeat = http, (lambda: (self.SID, "web")), (lambda mid, me: None)
         try:
             for bad in ("false", "true", 1):
                 text, is_err = ps._mcp_call("send_message", {"to": "api", "body": "hello", "kind": "delegate", "tracked": bad})
@@ -319,7 +321,7 @@ class TrackedIsABoolean(_BusServer):
             self.assertEqual(dialed[0][:2], ("POST", "/send"))
             self.assertIs(dialed[0][2]["tracked"], True, "a real true rides the wire as itself")
         finally:
-            ps._http, ps.my_name, ps.my_id, ps._heartbeat = saved
+            ps._http, ps._self_identity, ps._heartbeat = saved
 def _mode(p):
     return stat.S_IMODE(os.stat(p).st_mode)
 


### PR DESCRIPTION
Two postal-path costs on a loaded kernel, each fixed in its own separable commit. The postal MCP server's heartbeat fetched the kernel's session listing three times per 30 s beat for a beat the bus then discarded; the chat fold kept every plain Bash turn raw as a possible postal event and re-hydrated it on every judge pass. The commits share no file and neither depends on the other; the perf counters (#1003) and the pane telemetry (#1009) are on main now, and this PR wires nothing into either. They are one PR because both belong to the postal path and one review covers the postal service together with the kernel's postal hydration. Commit 1 touches `postal/postal_service.py` and its tests; commit 2 touches `kernel/kernel.py` and `tests/test_chat_fold.py`.

## Commits

1. **Postal: the heartbeat resolves the session once per beat and stops once the bus confirms it local.** Each session's MCP server resolved its identity twice per 30 s beat (`my_id`, then `my_name`, one `GET /sessions` each) and the bus fetched the listing a third time to learn the beat was local and drop it; `_mcp_call`, `cli_send` and `cli_agents` paid the same pair per call. Now `_self_identity()` resolves both halves from one `_self_row()`, both fallbacks kept, and `my_id`/`my_name` wrap it. The bus decides locality from its own listing, thread rows included, and answers `{ok, local}`; local only when the listing answered and holds the sid, so a kernel mid-restart never tells anyone it is local. In peer mode (the default) the loop ends on the first `local: true` and a latched confirmation skips the per-call beat. In the legacy singleton mode (`ROMP_POSTAL_PEERS=0`) the loop keeps beating, because `romp mail remote` can swap the local bus for a hub's under a running session and the beats are then its only presence. With local beats gone the autostop gate reads the listing's answered bit itself: an unanswered listing holds the idle count only when the last answered listing was non-empty (in memory, or the presence disk twin for a bus that started during the blink). The remote-sids mirror is rewritten each monitor poll. The orphan sweep fetches one listing per pass, recall and sent receipts one at first need, and the retry pass none when nothing is pending. Measured on this fork's live kernel, whose per-route counters are not upstream: with about 30 sessions, `GET /sessions` ran at 92 requests per 30 s, about 203 ms each, all heartbeat-driven. Saving pinned at the `ROMP_SESSIONS_FILE` seam by `tests/test_postal_heartbeat_fetches.py`: listing fetches per beat 3 -> 2 on the first beat, then 0 for a confirmed local session; per tool call 3 -> 2, then 1; orphan sweep one fetch per dead mailbox plus one -> 1 (the test pins 4 -> 1 with 3 dead mailboxes; 28 -> 1 per 30 s poll on this fork's box with 58 mailboxes); recall by id 1 -> 0 when nothing is removed; idle retry pass 1 -> 0 with nothing pending.

2. **The chat fold seals plain Bash turns, and outgoing postal cards join the log through a body-keyed index.** A Bash tool event is postal-relevant only when the one `romp mail send` matcher (`_cli_send_match`, which `_cli_send_card` also renders from) or `_reads_mail` recognises it, so plain Bash turns seal like any other turn instead of riding the fold raw and being re-hydrated on every judge pass. Relevance reads only the tool input, so a result landing later cannot change it. The postal index memo carries a body-keyed map (string bodies only) built once per index version, and `enrich_out` in `_hydrate_postal` joins an outgoing card through it instead of scanning every log row per card; tie-breaking is unchanged because the map preserves log order. Re-measured at this PR's base with an offline bench that imports the kernel in-process and times `build_session` with every cache warm (an unchanged tab's push): one untimed warm-up, three timed calls, medians, five transcripts of 26 to 75 MB, a 120 MB copy of a state directory with 31 live sessions. Warm chat builds went from 190, 184, 154, 77 and 109 ms to 89, 101, 117, 44 and 93 ms (15 to 53% less); a second interleaved base/head pair gave 24 to 50%. Cold builds, which never consult the fold, moved within load noise both ways. Invariant pinned by test: an event the predicate rejects comes back from `_hydrate_postal` as the same object.

## Nothing visible changes

- Postal addressing, delivery, recall and receipts behave as before, with one addition: recall by a comment thread's name now resolves through the thread's own row. It used to succeed only through a phantom remote-presence row the thread's heartbeat left behind, and that phantom is gone. Recall by the name of a peer known only through its heartbeat (a federated session) still resolves, pinned by test.
- A remote (client-only box) session never hears `local: true` from a hub's bus and beats exactly as before. A new MCP keeps beating against an older bus that sends no `local` key; an older MCP ignores the key a new bus sends. No wire break in either direction.
- A kernel blink no longer stops the bus under live sessions; a bus that never saw an answered, non-empty listing keeps its autostop. Deliberate consequence: a kernel that dies for good after listing sessions leaves the bus up until a code-staleness restart, a manual stop or a reboot. The sessions it listed outlive the kernel, and the returning kernel reuses the serve token, so it reconnects to the bus it left.
- Chat pages render the same rows. The Bash events the fold still keeps raw are a `romp mail send` and a mail read (`romp mail inbox`, `recv`, `peek` or `drain`, as `_reads_mail` recognises them); every other Bash turn seals. Outgoing cards pick the same log row as before (closest in time to the send; first row on a tie; last row when the send carries no time).
- Pre-existing on both trees and left alone here: an outgoing card never renders for a real `romp mail send` Bash row, because `build_session` stores the tool input as JSON and `_shell_unquote` rejects the captured group. Such a row stays raw as before, so the new test's `renders=False` for that shape is not a regression.

## Rebased onto main on 2026-09-08

Both commits are on main at b0ca406f with nothing dropped or reworked. This is the second rebase of the day, after #1038 (request bodies typed) landed; the first had applied without conflict. The second had one conflict, in `tests/test_postal_delivery.py`, where #1038 adds three test classes (`PushIsChunkedUnderTheKernelsCap`, `_FakeKernel`, `PushOverTheWire`) and their imports at the same two places commit 1 adds `HeartbeatRoute` and its imports. Both sides are kept: the imports are the union (every import commit 1 added is now on main, so the commit no longer touches the import block), `HeartbeatRoute` follows `PushOverTheWire`, and no test name collides. `postal/postal_service.py` merged without conflict. #1038's changes there (`_kernel_post` returning a refusal as `{ok: false, status}`, the chunked `_push`, the typed `Handler._body`, `_as_bool`) touch none of the functions commit 1 changes; commit 1's `_with_remote_presence` now sits directly after #1038's rewritten `_publish_working`. Commit 2 (`kernel/kernel.py`, `tests/test_chat_fold.py`) applied identically; `git range-diff` shows it as `=`. Commit 1 now also touches `tests/test_postal_token.py`: #1038's `TrackedIsABoolean` MCP test stubbed `my_id` and `my_name` around `_mcp_call`, which after this PR reads `_self_identity`, so the call resolved no identity and refused on that ground before reaching the `tracked` check; the stub is switched to `_self_identity`. CI caught it on the first push of this rebase; locally the harness's `CLAUDE_CODE_SESSION_ID` masked it. The Questions section names the same switch for #994 and #1010. The perf counters (#1003) and the pane telemetry (#1009) are on main; this PR adds no keys to either.

## Tests

Red first: each commit's tests were run against the base code before the fix, then green after it.

- Commit 1: with the tests in place and `postal/postal_service.py` at the base, the 34 postal modules (`tests/test_postal_*.py` plus `test_fresh_install_federation.py`) gave 53 failed / 318 passed (`test_postal_heartbeat_fetches` 22/22 failed at setUp on the missing `_LOCAL_CONFIRMED`, the base having none of `_LOCAL_CONFIRMED`, `_self_identity`, `_heartbeat_once`; `test_postal_delivery` 5: the thread-row and unanswered-listing beats, and the wire route answering without the `local` bit; `test_postal_bus_lifetime` 11 on `_idle_tick`'s missing `answered` argument, `_monitor_tick`, and the poll loop stopping through an outage; `test_postal_live_only` 2; the four modules whose identity stubs moved to `_self_identity` 13, expected), and the new `tests/romp-postal.bats` case `heartbeat: the bus answers local from its own listing, and only then` failed on the missing `"local"` key. After the change: 371 passed, 35 subtests; `tests/romp-postal.bats` 27/27. The recall-by-id test was also run red alone against the eager listing fetch it replaces (`[True]` where `[]` is expected) and green after. New: `tests/test_postal_heartbeat_fetches.py`, 22 tests counting `GET /sessions` at the seam (one per identity, beat, tool call and CLI command; the loop ends on the first local answer in peer mode and never in legacy mode; an unanswered bus never latches; a thread row's beat is local through the seam, which filters thread rows out unless asked for them as the route does; sweep, recall, receipts and retry counts, including a recall by id that removes nothing and fetches nothing). Extended: `test_postal_bus_lifetime.py` (IdleGate +5, MonitorTick +5, new MonitorLoop +2: the production poll loop holds through an outage after listed sessions and still stops a never-answered bus, driven through the module's own `time` binding rather than a process-wide patch), `test_postal_delivery.py` (+2 handler tests: the unanswered listing and thread rows; new HeartbeatRoute, 2 tests that POST to the real handler on a loopback server and read `{ok, local}` off the wire, in place of a source-text pin), `test_postal_live_only.py` (+3: thread rows in recall, and recall by the name of a peer known only through its heartbeat, which `_recip_id_for` folds into the listing a recall hands it).
- Commit 2: with `tests/test_chat_fold.py` extended and `kernel/kernel.py` at the base: 12 failed / 27 passed (plain Bash events held in `postal_raw`; 3 hydrations where 1 is expected; `_cli_send_match`, `_postal_body_map` and `_postal_body_rows` absent). After the change: 33 passed, 17 subtests. `PostalCards` +3 (plain, truncated and marker-in-output Bash turns seal with an empty raw list; one hydration per warm build with and without a judge pass; in a transcript of plain Bash turns and one `romp mail send`, the send is the one event kept raw and a judge pass re-hydrates exactly it); new `PostalRelevance`, 7 tests (the predicate and the identity invariant over 12 event shapes; a Bash send card follows the recipient's caption; the body map picks the row the linear scan picked over duplicates, ties and a timeless send; one map per index version, and a caller's own dict never borrows it; a non-string `sent` body neither breaks the index nor the join; five outgoing cards join through one walk of a caller's own index and none of the memoized one, never a walk per card; a `romp mail send` whose result has not landed is relevant and renders no card until it does).
- Full suites at the head, rebased onto main at b0ca406f on 2026-09-08. `pytest tests/ -n 8`: 8887 passed, 46 skipped, 1441 subtests, 9 failed, all in two modules this PR does not touch (`test_tag_edit_ack`, `test_postal_read_receipts`) on a box whose load average was above 9; both pass alone and together under `-n 8` (94 and 16 passed), and the same tree before the one-test stub switch ran 8896 passed, 0 failed. The ten test modules this PR touches: 211 passed, 17 subtests under `-n 4`; `test_postal_token.py` also 18 passed under a scrubbed environment (no `CLAUDE_CODE_SESSION_ID`, as in CI). `bats tests/romp-postal.bats`: 27/27. No `ui/` or `vscode-extension/` file changes here, so `npm test` and `npm run typecheck` were not run for this revision.

## Measurements

| Change | Before | After | How |
|---|---|---|---|
| Kernel `GET /sessions` from heartbeats, about 30 sessions | 92 requests per 30 s, about 203 ms each | not re-measured live | this fork's per-route kernel counters, 2026-09-06 |
| Listing fetches per heartbeat | 3 | 2 on the first beat, then 0 once confirmed local (peer mode) | pinned by `tests/test_postal_heartbeat_fetches.py` at the `ROMP_SESSIONS_FILE` seam |
| Listing fetches per MCP tool call | 3 | 2, then 1 once confirmed local | same |
| Listing fetches per orphan sweep | one per dead mailbox plus the sweep's own (28 per 30 s poll on this fork's box with 58 mailboxes, 2026-09-06) | 1 | before: counted on this fork's box during review (the base's `_name_for_id` fetched per id); after: pinned by `tests/test_postal_heartbeat_fetches.py` (3 dead mailboxes, 4 -> 1 at the `ROMP_SESSIONS_FILE` seam) |
| Listing fetches per recall by id, nothing removed | 1 | 0 (1, at first need, when a removed row needs its name) | pinned by the same module |
| Listing fetches per idle retry pass, nothing pending | 1 | 0 | same |
| Warm `build_session`, five transcripts (26 to 75 MB), this PR's base -> head | 190, 184, 154, 77, 109 ms | 89, 101, 117, 44, 93 ms (15 to 53% less; a second pair 24 to 50%) | offline bench, in-process kernel, one warm-up then three timed calls, medians, 120 MB state copy with 31 live sessions, `nice -n 19` |
| Warm `build_session`, same rows, measured on this fork's kernel before the port | 165.9, 60.7, 116.3, 114.5, 125.9 ms | 81.6, 29.0, 99.4, 96.8, 63.3 ms | same bench on the fork tree, which lacked 3b6b0af9 (warm rebuilds were more frequent there; the per-rebuild saving is what this PR carries) |

Cold `build_session` rows moved within load noise both ways (-6 to +4% on the second pair); cold builds never consult the fold. The bench tool is offered in its own PR.

## Contracts changed

- `POST /heartbeat` answers `{"ok": true, "local": <bool>}`; the `local` key is additive and older clients ignore it.
- `_record_heartbeat(sid, name)` returns the locality bit; `_idle_tick(n, idle, answered=True)` gains the listing's answered bit; `_heartbeat_loop(interval=None, stop=None)` gains two test seams; `_name_for_id(sid, rows=None)` and `_recip_id_for(to, rows=None)` accept a listing the caller already holds. New: `_self_identity`, `_with_remote_presence`, `present_count_checked`, `_sessions_were_listed`, `_monitor_tick`, `_remember_presence`, `_heartbeat_once`, `_LOCAL_CONFIRMED`.
- `_postal_index_memo[0]` widens from `(key, idx)` to `(key, idx, body_map)`; every reader in the tree indexes `[0]`/`[1]` or resets the slot, none unpacks. New: `_postal_body_map`, `_postal_body_rows`, `_cli_send_match`.
- `docs/read-side.md`'s federation paragraph stays true: remote sessions still heartbeat for presence.

## Not included

- No `/perf` counters or `romp perf` rows: the counter collector (#1003) is on main, and this PR adds no keys to it.
- Kernel-side postal changes from other offers: the incoming card's `peerHost` and the `fromHost` default (#1004). #1004 edits a context line of this PR's memo-tuple hunk, so whichever lands second re-anchors that one hunk; no semantic conflict.
- The render bug named above (outgoing cards for real `romp mail send` Bash rows), which is its own change.
- A lazily built body map. The map is built eagerly per index version (every `messages.jsonl` append), proportional to the log's row count, at the cadence the index itself is rebuilt; a lazy variant needs a once-only fill on the memo tuple, and this PR adds no lock for it.
- A peer-mode refusal in `romp mail remote`. The latch's premise (in peer mode the bus behind `BASE` is this box's own for the life of the process) holds because peer mode runs a bus per machine and `_remote_nudge` treats the command as moot there, but `setup_remote` itself does not refuse in peer mode; `_heartbeat_once`'s docstring now says so. Making it refuse is a one-hunk CLI change that mirrors `_remote_nudge`, left for the maintainer's call.
- A split of commit 1. The loop exit and the idle-gate hold land together on purpose: once local sessions stop beating, an unanswered listing would otherwise autostop the bus under live sessions. If a split is wanted, the clean cut is identity + beat path + route + loop exit + idle gate with their tests, then the one-listing operations (sweep, recall, receipts, retry) with theirs.

## Questions

- #994 (user todos) and #1010 (session emoji) add tests that stub `my_id`/`my_name` around `_mcp_call`; after this PR the call reads `_self_identity`, so whichever lands second switches those stubs to `pm._self_identity = lambda: (SID, "api")` (and `("", "api")` for the outside-a-session refusals). #1038 landed first with the same stub shape, and this PR carries that switch (see the rebase note above). The hunks are adjacent, not overlapping. Fine to handle on landing, or should this PR wait for them?

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
