### PR TITLE
Identity memos on the judge's goal-store loads, saves and scans, and a shared read-only cache for the pusher

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -467,7 +467,10 @@ permission/API-error floors: one interrupt at a time, the present event first.
   and surfaced loudly, store-unreadable: a goals file that cannot be read,
   filed once per fault episode and ended by the next successful read,
   store-unwritable: a goals file whose publish failed under a user gesture,
-  and store-quarantined: a goals file whose bytes did not parse, moved aside).
+  store-quarantined: a goals file whose bytes did not parse, moved aside,
+  frozen-store-write: a read-only site wrote to the shared store view, naming
+  the site, after which the shared cache is off for the process, and
+  frozen-store-save: a shared store view was handed to `save_goals`, refused).
   A file that does not parse is never deleted: it is moved beside its path as
   `<file>.corrupt-<utc stamp>` (a `-n` suffix when two land in the same second)
   before a fresh one is written, so the bytes survive for inspection, and the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1039,8 +1039,19 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.
-- `goals`: `loads`, `saves`, `writes` on the goal stores. A save that would
-  rewrite identical bytes is a save without a write.
+- `goals`: `loads`, `saves`, `writes` on the goal stores through the writer's
+  loader (`load_goals`) and `save_goals`; the pusher's read-only loads go
+  through the shared store cache and show under `memos.shared`, not here. A
+  save that would rewrite identical bytes is a save without a write.
+- `memos`: the three identity memos on the goal-store path. `pass` is the
+  judge pass's stat-keyed store memo (`hit`, `miss`, `fail`, `evict`, `punch`,
+  and its occupancy `entries`, `bytes`); `shared` is the pusher's shared
+  read-only store cache (`hit`, `miss`, `compare_miss`, `refuse`, `dup`,
+  `absent`, `corrupt`, `unreadable_journal`, `evict`, `fallback`, `poisoned`,
+  with `entries`, `bytes` and `off`); `chain` is the write-moment chain memo
+  (`hit`, `miss`, `populate`, `bypass`). The compaction sweep after each judge
+  pass evicts from `pass` and `shared` the entries of stores no session in the
+  discover window owns, so both stay bounded by the live board.
 - `judge`: `passes`, `ms_sum`, `ms_last`, `ms_mean` (wall time; a pass waits
   on model calls), `cpu_ms_sum` (CPU time of the judge tier threads and every
   per-session worker they run; the workers' share is `cpu_ms_workers`).

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1401,21 +1401,23 @@ class FileAdapter:
         and a late-written burst veto it). A branch qualifies when its fork-side HEAD is an
         assistant record (a user gesture's head is always the user's own record) and it
         carries reply text anywhere in the sub-tree; the winner is the branch with the
-        latest-written reply text, tiebroken by head seq. The text witness is landed_text_uuids
-        MINUS isApiErrorMessage records (error-as-text failure echoes, which atoms() likewise
-        refuses to treat as replies) — so junk carries no weight in the key, and no textless
-        tail can move the pick whatever its file position. The unit is deliberately the WHOLE
-        branch, never a leaf-chain within it: leaf-chains of one branch share records, and
-        every per-chain read of shared state proved breakable (a full-chain gate laundered a
-        junk tail's steal; a unique-suffix gate let a branch's own twin sub-branches strip
-        their turn's text and hand the keep to an older sibling — reply loss, this repo's one
-        fatal error). The accepted cost is cosmetic: a stub twin inside the winning branch
-        renders one output-less duplicate tool row, and a grafted burst inside it costs
-        nothing (system records never become atoms). The qualifying properties are the ones
-        every incident's salvaged branch has in the author's corpus scan (49/49 across 4,678
-        transcripts; the 2,809 non-eclipse rewind forks: 2,035 stub pairs, 700 superseded
-        retries, 42 user-gesture rollbacks, 32 other; zero overlap). Sibling branches demote
-        to "rewind", exactly as their on-spine twins classify.
+        latest-written reply text, tiebroken by head seq. The text witness is the eclipse
+        set's text-bearing assistant records (landed_text_uuids' own test, applied to the
+        eclipse set alone — the ranking reads it for sub-tree members only, and the sub-trees
+        lie inside that set) MINUS isApiErrorMessage records (error-as-text failure echoes,
+        which atoms() likewise refuses to treat as replies) — so junk carries no weight in the
+        key, and no textless tail can move the pick whatever its file position. The unit is
+        deliberately the WHOLE branch, never a leaf-chain within it: leaf-chains of one branch
+        share records, and every per-chain read of shared state proved breakable (a full-chain
+        gate laundered a junk tail's steal; a unique-suffix gate let a branch's own twin
+        sub-branches strip their turn's text and hand the keep to an older sibling — reply
+        loss, this repo's one fatal error). The accepted cost is cosmetic: a stub twin inside
+        the winning branch renders one output-less duplicate tool row, and a grafted burst
+        inside it costs nothing (system records never become atoms). The qualifying properties
+        are the ones every incident's salvaged branch has in the author's corpus scan (49/49
+        across 4,678 transcripts; the 2,809 non-eclipse rewind forks: 2,035 stub pairs, 700
+        superseded retries, 42 user-gesture rollbacks, 32 other; zero overlap). Sibling
+        branches demote to "rewind", exactly as their on-spine twins classify.
 
         When NO chain qualifies, the two eclipse terminals part ways, each on its own event:
           "user"      — the flush COMPLETED (the next prompt sits past the spur), so a machine-
@@ -1437,19 +1439,28 @@ class FileAdapter:
         ecl = {u for u, v in verdict.items() if v == "eclipsed"}
         if not ecl:
             return
-        children = {}
-        for u in self.by_uuid:
-            p = self.parent_of.get(u)
-            if p is not None:
-                children.setdefault(p, []).append(u)
+        # Everything below reads only uuids INSIDE the eclipse set, so build only that much: the
+        # child map over ecl (the component walk skips any popped uuid outside ecl, and a sub-tree
+        # walk skips anything outside its component, so children outside ecl were never followed)
+        # and the text witness over ecl (the ranking tests it for sub-tree members only). A
+        # whole-graph child map and landed_text_uuids() over every record made this walk a third
+        # of chain_membership's cost on a large transcript with a handful of eclipsed records; the
+        # verdicts are identical. Nothing here is cached on the adapter: _run_graph_passes mutates
+        # parent_of after ingest, so a per-adapter child map would go stale under the repair passes.
+        children = {}                     # parent -> its children in ecl
         forks = {}                        # fork uuid -> its eclipsed branch heads
         for u in ecl:
             p = self.parent_of.get(u)
+            if p is None:
+                continue
+            children.setdefault(p, []).append(u)
             if p in active:
                 forks.setdefault(p, []).append(u)
-        landed = None                     # text-bearing assistant uuids (the reply witness) — computed
-        #                                   lazily: chain_verdicts runs on every build of a held
-        #                                   session, and most transcripts carry no eclipse at all
+        landed = set()                    # text-bearing assistant uuids in ecl (the reply witness)
+        for u in ecl:
+            r = self.by_uuid.get(u) or {}
+            if r.get("type") == "assistant" and _text_of(_content(r.get("message"))).strip():
+                landed.add(u)
         for F, heads in forks.items():
             comp, stack = set(), list(heads)
             while stack:                  # the branch component: child-closure of the eclipsed heads
@@ -1458,8 +1469,6 @@ class FileAdapter:
                     continue
                 comp.add(x)
                 stack.extend(children.get(x, ()))
-            if landed is None:
-                landed = self.landed_text_uuids()
             # SELECTION IS PER BRANCH — the sub-tree under each fork-side head — never per
             # leaf-chain. Leaf-chains of one branch SHARE records, and any per-chain read of
             # shared state proved breakable by construction: a full-chain gate let a junk tail

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,7 +13,7 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
-import contextlib, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading
+import contextlib, copy, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading, traceback
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -174,6 +174,8 @@ def _rebind_state(path):
     #                         entries could never hit under the new one; cleared anyway so a rebind starts empty
     with _ABSENT_FLAGS_LOCK:
         _ABSENT_FLAGS.clear()   # the absent-store predicate memo: same full-path keys, same reasoning
+    _shared_clear()             # the shared read-only store cache: same path keying, same reason; also lifts
+    #                         a test's deliberate write-guard trip (the poison flag) so the next class starts clean
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 
@@ -3251,18 +3253,22 @@ def _read_store_json(path, *, quarantine=False, _tries=3):
     return _read_store_json(path, quarantine=True, _tries=_tries - 1)   # declined: the file changed under us
 
 
-def load_goals(fsid):
-    _goal_io_bump("loads")
-    raw = _read_store_json(GOALDIR / (fsid + ".json"), quarantine=True)
-    if raw is None:
-        # a FRESH store is born at the current identity version — only stores with history recorded
-        # under an OLDER derivation are ever sealed (see _migrate_placements)
-        store = {"rompUuid": fsid, "seq": 0, "nodes": {}, "placements": {}, "status": {},
-                 "placementsV": PLACEMENTS_V}
-        store["_baseRev"] = 0            # no file yet; a writer that CREATES one still trips the CAS
-        return store
-    store = _guard_nodes(raw)
-    if _replay_overrides(fsid, store):
+def _fresh_store(fsid):
+    """The store a session has before its first publish: no file at the path (or the unparseable one that was
+    there was just moved aside by _read_store_json). Born at the current identity version — only stores with
+    history recorded under an OLDER derivation are ever sealed (see _migrate_placements). Carries _baseRev 0:
+    a writer that CREATES the file still trips the CAS. Never marked: the empty store IS what disk holds."""
+    store = {"rompUuid": fsid, "seq": 0, "nodes": {}, "placements": {}, "status": {},
+             "placementsV": PLACEMENTS_V}
+    store["_baseRev"] = 0
+    return store
+
+
+def _finish_load(fsid, store, lines=None):
+    """The tail every loader runs on a freshly parsed, node-guarded store: replay the override journal
+    (`lines` when the caller already read it, else from the file), re-derive the rollup when the replay
+    wrote, and stamp the CAS base. One function so load_goals and load_goals_shared cannot drift."""
+    if _replay_overrides(fsid, store, lines=lines):
         # the replay WROTE (a clobbered user resolve/clear re-flagged): the published status/confirming
         # predate it, and every reader now trusts those exports as the one truth (no raw-flag second
         # opinions since 2026-08-13) — so re-derive them at the replay's own write, never serve stale
@@ -3272,6 +3278,24 @@ def load_goals(fsid):
     # minutes-long model call). Transient — popped before the store is ever serialized.
     store["_baseRev"] = int(store.get("rev") or 0)
     return store
+
+
+def load_goals(fsid):
+    """The WRITER's loader: a private, mutable store the caller may mutate and hand to save_goals. Read-only
+    callers on the pusher thread take load_goals_shared instead (one parse per file version, shared).
+
+    The session's goal store: the file parsed, the override journal replayed onto it, and two TRANSIENT
+    keys that are never serialized (save_goals pops both; _store_content keeps both out of the content hash):
+    `_baseRev`, the revision read, for save_goals' CAS; and `_unread` ("journal"), set by _replay_overrides
+    when the journal exists and could not be read. A store file that cannot be read RAISES, never an empty
+    store (load_goals_or_fault is the per-session boundary that catches it); an unparseable one is moved
+    aside by _read_store_json and the fresh store is the legitimate answer; an ABSENT file is the fresh
+    store, unmarked (empty IS its content)."""
+    _goal_io_bump("loads")
+    raw = _read_store_json(GOALDIR / (fsid + ".json"), quarantine=True)
+    if raw is None:
+        return _fresh_store(fsid)
+    return _finish_load(fsid, _guard_nodes(raw))
 
 
 _STORE_FAULTS = {}                       # fsid -> the fault text of its CURRENT unreadable episode (load_goals_or_fault)
@@ -3299,11 +3323,20 @@ def load_goals_or_fault(fsid):
     return _or_fault(fsid, load_goals)
 
 
+def load_goals_shared_or_fault(fsid):
+    """load_goals_or_fault for the pusher's read-only sites: the same boundary (one `store-unreadable` row per
+    fault episode, `(None, exc)` on a fault, never an empty store) around load_goals_shared, so the builders
+    that share one parsed store per file version keep the per-session containment. A read fault raises out
+    of load_goals_shared exactly as it does out of load_goals, and the cache keeps nothing for it."""
+    return _or_fault(fsid, load_goals_shared)
+
+
 def _or_fault(fsid, loader):
     """load_goals_or_fault's boundary around any reader of `fsid`'s store: `loader(fsid)` is load_goals
-    itself there, and a pass's shared per-store read elsewhere (run_propagate's _get, so a recipient read
-    through the boundary is still the one read that pass takes of the store). Same episode table, same
-    `store-unreadable` row once per fault episode, same `(store, None)` / `(None, exc)` answer."""
+    itself there, load_goals_shared for the pusher's read-only sites, and a pass's shared per-store read
+    elsewhere (run_propagate's _get, so a recipient read through the boundary is still the one read that
+    pass takes of the store). Same episode table, same `store-unreadable` row once per fault episode, same
+    `(store, None)` / `(None, exc)` answer."""
     try:
         store = loader(fsid)
     except OSError as e:
@@ -3584,7 +3617,7 @@ def append_restore(fsid, nodes, status, t):
                             "status": dict(status)}) + "\n")
 
 
-def _replay_overrides(fsid, store):
+def _replay_overrides(fsid, store, lines=None):
     """Re-apply journaled user overrides to a freshly loaded store. Idempotent: an entry whose effect
     is already in the store (the normal case — the kernel's own save survived) is a no-op, so a node's
     log gains exactly one user event no matter how many loads replay the journal. A journaled node the
@@ -3606,20 +3639,26 @@ def _replay_overrides(fsid, store):
     a card reply in the same second are two gestures, and the old >= guard silently dropped the
     reply's replay, bouncing the card back mid-pass). Judge events do not cancel a replay: the user
     event is appended anyway and the fold's authority rules arbitrate. `block` keeps at-or-after: a
-    user reply in the same second as a nudge stamp genuinely answers it."""
-    fp = _overrides_dir() / (fsid + ".jsonl")
-    if not fp.is_file():
-        return False
-    try:
-        lines = fp.read_text().splitlines()
-    except OSError as e:
-        _log_judge_error("romp", fsid, "history-unreadable",
-                         note="override journal unreadable: %s — user actions may show undone until it reads" % e)
-        # the store parsed but the journal exists and did not read: the user's gestures are missing from
-        # this view until it does. The journal replays on every load, so a publish of this store loses
-        # nothing durable; the mark tells an identity-keyed reader not to cache it (see the docstring).
-        store["_unread"] = "journal"
-        return False
+    user reply in the same second as a nudge stamp genuinely answers it.
+
+    `lines`: the journal's lines when the caller has already read them (load_goals_shared reads the
+    journal from a descriptor it also takes the file's identity from, so the replayed rows and the key
+    that stands for them are one file version); None reads the file here, and a journal that exists but
+    cannot be read marks the store `_unread` (see above) after the judge-errors row."""
+    if lines is None:
+        fp = _overrides_dir() / (fsid + ".jsonl")
+        if not fp.is_file():
+            return False
+        try:
+            lines = fp.read_text().splitlines()
+        except OSError as e:
+            _log_judge_error("romp", fsid, "history-unreadable",
+                             note="override journal unreadable: %s — user actions may show undone until it reads" % e)
+            # the store parsed but the journal exists and did not read: the user's gestures are missing from
+            # this view until it does. The journal replays on every load, so a publish of this store loses
+            # nothing durable; the mark tells an identity-keyed reader not to cache it (see the docstring).
+            store["_unread"] = "journal"
+            return False
     applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
     for ln in lines:
@@ -3950,6 +3989,431 @@ def _matches_disk(fsid, store, mine=None):
     return mine is not None and ent[1] == mine
 
 
+# ── the shared read-only goal-store cache (2026-09-06) ───────────────────────────────────────────────
+# The pusher thread loads a goal store at nine read-only sites per cycle (the timeline's per-lane load,
+# the feed's peer-origin badge, the chat's seams and ledger tree, the stamp readers, the working-note
+# expiry, the deferral sweep, the message-summary scan), and every one of those loads parsed the file
+# again: on a self-hosted 30-session deployment about 7% of the kernel's interpreter time went to
+# re-parsing stores that had not changed since the previous cycle. load_goals_shared serves those sites
+# ONE parsed object per file version; every writer stays on load_goals (a private copy it may mutate and
+# hand to save_goals).
+#
+# A hit is a proof about CONTENT, not identity. Each call opens the store, takes the file's identity
+# (inode, mtime_ns, size) from the descriptor, reads the bytes from the same descriptor and compares
+# them to the entry's (a memcmp, about 6% of a parse), so the coarse-timestamp blind spot the judge
+# pass's stat-keyed snapshot memo documents (kernel.py: an equal-size republish onto a recycled inode
+# inside one clock tick reproduces the stat key) cannot serve a stale parse here. The override journal
+# is keyed on its (inode, mtime_ns, size) alone: its only writers append (append_override / append_block
+# / append_restore), so an equal key is an equal content. The goals-archive is keyed the same way; it is
+# read only when a restore row replays, and its key has no byte compare, so the equal-size same-tick
+# recycled-inode case is the one blind spot left — it needs a restore row in the journal AND a kernel
+# without multigrain timestamps (Linux before 6.13).
+#
+# The entry is the view load_goals gives (same guard, same replay, same rollup, same _baseRev, so a
+# shallow copy handed to save_goals still meets the CAS), deep-frozen: the store, its nested maps
+# (nodes, status, placements, rewindSwept, rewindRestored, ...), every node, and every list (log,
+# warns, seams, confirming, ...) are dict and list SUBCLASSES whose write methods raise
+# FrozenStoreError. Subclasses, not proxies or tuples: consumers isinstance-test dict and list and
+# json.dumps the store, and a proxy or a tuple is neither. A write attempt is a bug in a reader, and it
+# is handled so the bug is loud and the board keeps rendering: the guard files a judge-errors row that
+# names the call site, switches the cache OFF for the process (every later load_goals_shared takes its
+# own load_goals) and raises, so the shared object is never corrupted and shared_store_stats reports
+# `off`. copy.copy / copy.deepcopy of a frozen container hand back plain, writable ones.
+#
+# Documented drift: record_verdict's `at` on a row the replay appends and a replay-triggered seam's `t`
+# are stamped at fill time and then shared, where every load_goals re-stamps them on each load. `at` is
+# an arrival stamp nothing reads back. The seam's `t` is not: apply_seams splits segments at it, so the
+# shared view and a writer's private load can place that split at different seconds until the next
+# writer publish (which persists the writer's stamp and moves the store's identity) makes the two
+# loaders agree again. The view's verdicts, flags and status are identical throughout, and no writer
+# persists a stamp from a read-only load.
+#
+# Invalidation is exact by construction: a store publish is a rename to a new inode (save_goals), a
+# journal write an append, an archive publish a rename. save_goals also pops its path after the rename
+# (the writer's object is never the shared one), _rebind_state and migrate_all_stores clear, and the
+# kernel's compaction sweep evicts absent paths (_shared_evict_absent). Two fills of one path race
+# harmlessly: the second checks under the lock for an entry with its exact keys and bytes and returns
+# that object, so concurrent readers of one file version receive one object.
+_SHARED = {}                                     # store path → (keys, store bytes, frozen store)
+_SHARED_LOCK = threading.Lock()
+_SHARED_OFF = [False]                            # a write attempt on a shared object switches the cache off (see _shared_poison)
+_SHARED_STATS = {"hit": 0, "miss": 0, "compare_miss": 0, "refuse": 0, "dup": 0, "absent": 0, "corrupt": 0,
+                 "unreadable_journal": 0, "evict": 0, "fallback": 0, "poisoned": 0}
+
+
+class FrozenStoreError(TypeError):
+    """A write to a goal store served by load_goals_shared. Writers load their own copy with load_goals."""
+
+
+def _shared_bump(key, n=1):
+    with _SHARED_LOCK:
+        _SHARED_STATS[key] += n
+
+
+_FROZEN_INTERNAL = frozenset(("_frozen_write", "_shared_poison", "_write_site", "_frozen_sid", "__setitem__", "__delitem__",
+                              "pop", "popitem", "setdefault", "update", "clear", "__ior__", "__iadd__",
+                              "__imul__", "append", "extend", "insert", "remove", "sort", "reverse"))
+
+
+def _write_site():
+    """The frames that wrote to a frozen container, outermost first, as `file:line function()` joined by
+    ` -> `: the innermost frame above the frozen classes' own methods, and, when that frame is in this
+    module (a judge helper such as rollup_status handed a shared store by a kernel site), the nearest frame
+    outside this module — the site to fix, not only the helper that wrote:
+    `kernel.py:8037 _open_top_goal() -> judge.py:5432 rollup_status()`."""
+    frames = [fr for fr in reversed(traceback.extract_stack())
+              if not (fr.filename == __file__ and fr.name in _FROZEN_INTERNAL)]
+    if not frames:
+        return "?"
+    chain = [frames[0]]
+    if frames[0].filename == __file__:
+        outer = next((fr for fr in frames[1:] if fr.filename != __file__), None)
+        if outer is not None:
+            chain.insert(0, outer)
+    return " -> ".join("%s:%d %s()" % (os.path.basename(fr.filename), fr.lineno, fr.name) for fr in chain)
+
+
+def _frozen_sid(container):
+    """The session whose shared store a written container belongs to: the store's own `_fsid` when the
+    container IS the store, a node's id prefix (`<sid>:gN`) when it is a node, else "" — a nested map or
+    list (a status map, a log) carries no way back to its store."""
+    if isinstance(container, FrozenStore):
+        return getattr(container, "_fsid", None) or ""
+    if isinstance(container, FrozenGuardedNode):
+        return str(container.get("id") or "").rsplit(":", 1)[0]
+    return ""
+
+
+def _shared_poison(what, container=None):
+    """A reader tried to write a shared object. File the row that names the site chain and, when the
+    container can say, the sid (once), switch the cache off for the process and count the attempt; the raise
+    follows in the caller and the object is untouched."""
+    with _SHARED_LOCK:
+        first = not _SHARED_OFF[0]
+        _SHARED_OFF[0] = True
+        _SHARED_STATS["poisoned"] += 1
+    if first:
+        _log_judge_error("romp", _frozen_sid(container), "frozen-store-write",
+                         note="%s at %s — a reader wrote to the shared read-only goal store; the shared cache is "
+                              "off until the kernel restarts (every reader takes its own load)" % (what, _write_site()))
+
+
+def _frozen_write(container, what):
+    _shared_poison(what, container)
+    raise FrozenStoreError("%s on a shared read-only goal store (load_goals_shared); a writer loads its own "
+                           "copy with load_goals" % what)
+
+
+class FrozenDict(dict):
+    """A dict whose every write path raises FrozenStoreError after reporting the site (_shared_poison).
+    Reads, iteration, isinstance(x, dict) and json.dumps behave as on a dict; copy.copy and copy.deepcopy
+    hand back plain, writable containers; pickling writes a plain dict."""
+    __slots__ = ()
+
+    def __setitem__(self, k, v):
+        _frozen_write(self, "assignment of %r" % (k,))
+
+    def __delitem__(self, k):
+        _frozen_write(self, "deletion of %r" % (k,))
+
+    def pop(self, *a):
+        _frozen_write(self, "pop of %r" % (a[0] if a else None,))
+
+    def popitem(self):
+        _frozen_write(self, "popitem")
+
+    def setdefault(self, k, default=None):
+        _frozen_write(self, "setdefault of %r" % (k,))
+
+    def update(self, *a, **kw):
+        _frozen_write(self, "update")
+
+    def clear(self):
+        _frozen_write(self, "clear")
+
+    def __ior__(self, other):
+        _frozen_write(self, "|= update")
+
+    def __copy__(self):
+        return dict(self)
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(dict(self), memo)
+
+    def __reduce_ex__(self, protocol):
+        return (dict, (dict(self),))
+
+
+class FrozenList(list):
+    """The list twin of FrozenDict: every write path raises after reporting the site. isinstance(x, list)
+    holds, `+` with a list yields a plain list, slicing and copy() yield plain lists."""
+    __slots__ = ()
+
+    def __setitem__(self, i, v):
+        _frozen_write(self, "list assignment")
+
+    def __delitem__(self, i):
+        _frozen_write(self, "list deletion")
+
+    def __iadd__(self, other):
+        _frozen_write(self, "list +=")
+
+    def __imul__(self, n):
+        _frozen_write(self, "list *=")
+
+    def append(self, v):
+        _frozen_write(self, "list append")
+
+    def extend(self, it):
+        _frozen_write(self, "list extend")
+
+    def insert(self, i, v):
+        _frozen_write(self, "list insert")
+
+    def pop(self, *a):
+        _frozen_write(self, "list pop")
+
+    def remove(self, v):
+        _frozen_write(self, "list remove")
+
+    def clear(self):
+        _frozen_write(self, "list clear")
+
+    def sort(self, *a, **kw):
+        _frozen_write(self, "list sort")
+
+    def reverse(self):
+        _frozen_write(self, "list reverse")
+
+    def __copy__(self):
+        return list(self)
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(list(self), memo)
+
+    def __reduce_ex__(self, protocol):
+        return (list, (list(self),))
+
+
+class FrozenGuardedNode(FrozenDict, GuardedNode):
+    """A node of a shared store: a GuardedNode for every consumer that isinstance-tests one, whose every
+    write raises — PROTECTED key or not, inside _authority() or not. record_verdict and rollup_status on a
+    shared node fail instead of unlocking it."""
+    __slots__ = ()
+
+
+class FrozenStore(FrozenDict):
+    """The top-level object load_goals_shared returns: a FrozenDict by behavior, its own class so save_goals
+    can name the misuse. `_fsid`: the session's id, set by _freeze_store, so the write-guard's row can name
+    the store a top-level write reached."""
+    __slots__ = ("_fsid",)
+
+
+def _freeze(o):
+    """Freeze a parsed store's object graph: every dict becomes a FrozenDict, every GuardedNode a
+    FrozenGuardedNode, every list a FrozenList, leaves stay. Containers are re-typed bottom-up in place
+    (one C-level copy each), and only EXACT types convert — a parse plus the replay yields nothing else."""
+    t = type(o)
+    if t is dict or t is GuardedNode:
+        for k, v in o.items():
+            tv = type(v)
+            if tv is dict or tv is list or tv is GuardedNode:
+                dict.__setitem__(o, k, _freeze(v))       # bypass GuardedNode's key guard: this re-types a value
+        return FrozenGuardedNode(o) if t is GuardedNode else FrozenDict(o)
+    if t is list:
+        for i, v in enumerate(o):
+            tv = type(v)
+            if tv is dict or tv is list or tv is GuardedNode:
+                o[i] = _freeze(v)
+        return FrozenList(o)
+    return o
+
+
+def _freeze_store(store, fsid=None):
+    for k, v in store.items():
+        tv = type(v)
+        if tv is dict or tv is list or tv is GuardedNode:
+            store[k] = _freeze(v)
+    fs = FrozenStore(store)
+    fs._fsid = fsid if fsid is not None else store.get("rompUuid")
+    return fs
+
+
+def _file_key(path_s):
+    """(inode, mtime_ns, size) of a regular file by path; None when there is none; a fresh sentinel when it
+    exists but cannot be stat'ed or is not a regular file, so no entry matches and the fill reports it."""
+    try:
+        st = os.stat(path_s)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return object()
+    if not stat.S_ISREG(st.st_mode):
+        return None                                  # _replay_overrides' is_file(): not a file is no journal
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _journal_key(fsid):
+    return _file_key(str(_overrides_dir() / (fsid + ".jsonl")))
+
+
+def _archive_key(fsid):
+    return _file_key(str(GOALARCHDIR / (fsid + ".json")))
+
+
+def _journal_read(fsid):
+    """(identity, lines) of the override journal from ONE descriptor — (None, ()) when there is none.
+    Raises OSError when it exists but cannot be read; the caller does not memoize then."""
+    p = str(_overrides_dir() / (fsid + ".jsonl"))
+    try:
+        fd = os.open(p, os.O_RDONLY)
+    except FileNotFoundError:
+        return None, ()
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None, ()
+        data = _disk_read(fd, p)
+    finally:
+        os.close(fd)
+    return (st.st_ino, st.st_mtime_ns, st.st_size), data.decode().splitlines()
+
+
+def _shared_forget(path_s):
+    with _SHARED_LOCK:
+        _SHARED.pop(path_s, None)
+
+
+def _shared_clear():
+    """Drop every entry and lift the off switch: a rebind or the boot sweep changed the world."""
+    with _SHARED_LOCK:
+        _SHARED.clear()
+        _SHARED_OFF[0] = False
+
+
+def _shared_evict_absent():
+    """Drop entries whose store file is gone (a removed session); the kernel's compaction sweep calls this
+    beside _disk_memo_evict_absent."""
+    with _SHARED_LOCK:
+        gone = [k for k in _SHARED if not os.path.exists(k)]
+        for k in gone:
+            del _SHARED[k]
+        _SHARED_STATS["evict"] += len(gone)
+    return len(gone)
+
+
+def shared_store_stats():
+    """The cache's counters plus its occupancy. hit: identity and bytes matched. miss: no entry, or its keys
+    moved. compare_miss: identity matched and the bytes did not. refuse: a fill not published because the
+    archive moved under it. dup: a fill discarded for a concurrent fill's identical entry. absent: no store
+    file. corrupt: bytes that did not parse, handed to load_goals (which moves them aside); nothing cached.
+    unreadable_journal: served uncached from load_goals. evict:
+    entries dropped for gone files. fallback: calls served by load_goals because the cache is off. poisoned:
+    write attempts on a shared object (the first switched the cache off). Gauges: entries, bytes (the raw
+    store bytes held for the compare), off."""
+    with _SHARED_LOCK:
+        out = dict(_SHARED_STATS)
+        out["entries"] = len(_SHARED)
+        out["bytes"] = sum(len(e[1]) for e in _SHARED.values())
+        out["off"] = int(_SHARED_OFF[0])
+    return out
+
+
+def store_key(fsid):
+    """The store file's identity (inode, mtime_ns, size) from a fresh stat, None when absent — the per-session
+    key a view signature can carry. Independent of the cache: one stat, no entry consulted."""
+    return _file_key(str(GOALDIR / (fsid + ".json")))
+
+
+def load_goals_shared(fsid):
+    """A READ-ONLY view of a session's goal store, shared by every caller until the store, its override
+    journal or the goals-archive changes: exactly what load_goals returns (guarded nodes, journal replayed,
+    rollup re-derived when the replay wrote, _baseRev), deep-frozen — see the note above. Callers must not
+    write to it (a write raises FrozenStoreError and switches the cache off) and must not hand it to
+    save_goals (refused). A writer, and anything that calls rollup_status or record_verdict on the object,
+    stays on load_goals.
+
+    No store file: load_goals' fresh store (private, mutable; nothing to share). A store file that cannot be
+    read: the OSError RAISES, exactly as load_goals raises it, and nothing is cached for the path; the
+    pusher's builders call this through load_goals_shared_or_fault, the per-session boundary that files one
+    store-unreadable row per fault episode. Unreadable journal: not memoized; load_goals' own result, so its
+    judge-errors row keeps logging until the journal reads. Bytes that do not parse: handed to load_goals,
+    which moves the file aside (a stderr line and a store-quarantined row, once: the path then reads as
+    absent) and answers the legitimate fresh store; nothing is cached for it. A store carrying `_unread` is
+    never published: a view missing the journal's rows is not the files' content."""
+    if _SHARED_OFF[0]:
+        _shared_bump("fallback")
+        return load_goals(fsid)
+    path_s = str(GOALDIR / (fsid + ".json"))
+    jkey0, akey0 = _journal_key(fsid), _archive_key(fsid)   # BEFORE the store read: see the fill below
+    try:
+        fd = os.open(path_s, os.O_RDONLY)
+    except FileNotFoundError:
+        _shared_forget(path_s)
+        _shared_bump("absent")
+        return load_goals(fsid)                      # the fresh store: private, nothing to share
+    except OSError:
+        _shared_forget(path_s)                       # a read FAULT raises, as load_goals' does (the caller's
+        raise                                        # boundary files it); nothing is cached for the path
+    try:
+        skey = _disk_ident(fd)
+        data = _disk_read(fd, path_s)
+    except OSError:
+        _shared_forget(path_s)
+        raise
+    finally:
+        os.close(fd)
+    keys = (skey, jkey0, akey0)
+    with _SHARED_LOCK:
+        ent = _SHARED.get(path_s)
+    if ent is not None and ent[0] == keys:
+        if ent[1] == data:
+            _shared_bump("hit")
+            return ent[2]
+        _shared_bump("compare_miss")                 # same identity, other bytes: the blind spot, closed here
+    else:
+        _shared_bump("miss")
+    # FILL. The journal's rows and identity come from one descriptor, as the store's bytes and identity
+    # did above, so both keys stand for exactly what the entry replayed. The archive is read by path
+    # inside the replay (only when a restore row needs it), between the stat above and the one below:
+    # equal keys bracket the read, so the entry describes what it holds; unequal, it is not published.
+    try:
+        jkey, lines = _journal_read(fsid)
+    except OSError:
+        _shared_bump("unreadable_journal")
+        _shared_forget(path_s)
+        return load_goals(fsid)                      # uncached: its replay files history-unreadable every load
+    try:
+        store = _guard_nodes(_disk_parse(path_s, data))
+    except ValueError:
+        _shared_bump("corrupt")
+        _shared_forget(path_s)
+        return load_goals(fsid)                      # load_goals moves the bytes aside (one stderr line, one
+                                                     # store-quarantined row) and answers the fresh store; the
+                                                     # path then reads as absent, so nothing is cached for it
+    store = _finish_load(fsid, store, lines=lines)   # a malformed row raises, as in load_goals
+    if store.get("_unread"):
+        # the replay marked the store (its journal did not read): not the files' content, so not shared.
+        # Unreachable while the journal's rows arrive as `lines` (the only marker left is the lines-is-None
+        # OSError path, taken above through load_goals); kept so the invariant holds at the write moment
+        _shared_bump("unreadable_journal")
+        _shared_forget(path_s)
+        return store
+    frozen = _freeze_store(store, fsid)
+    akey1 = _archive_key(fsid)
+    keys = (skey, jkey, akey1)
+    with _SHARED_LOCK:
+        cur = _SHARED.get(path_s)
+        if cur is not None and cur[0] == keys and cur[1] == data:
+            _SHARED_STATS["dup"] += 1                # a concurrent fill of this version published first:
+            return cur[2]                            # one object for every reader of it
+        if akey1 != akey0:
+            _SHARED_STATS["refuse"] += 1             # the archive moved under the replay: right for this
+            return frozen                            # caller, unproven for the next, so not published
+        _SHARED[path_s] = (keys, data, frozen)
+    return frozen
+
+
 def save_goals(fsid, store):
     """Publish the store, REBASING first if anyone else published while we held it (the user 2026-07-22).
 
@@ -3978,8 +4442,19 @@ def save_goals(fsid, store):
     serialization of our own store, not a parse of the file, and the write seeds the entry for the next check
     when no rebase changed what we wrote. The CAS below reads the file's revision from the file (_disk_rev),
     never from the memo, so a real publish parses once, for the CAS. Both readers raise on a read fault or a
-    corrupt file, as _rebase_onto_disk does: nothing is published over bytes this save could not read."""
+    corrupt file, as _rebase_onto_disk does: nothing is published over bytes this save could not read.
+
+    A store served by load_goals_shared (or a shallow copy of one, whose nodes map is still the shared one)
+    is refused here, FIRST — before the no-op check, which would otherwise take a shared view for a
+    writer's, and before any write that the frozen containers would turn into a cache-poisoning raise.
+    The row makes the misuse visible through the except-Exception wrappers around every tick job."""
     _goal_io_bump("saves")
+    if isinstance(store, FrozenDict) or isinstance(store.get("nodes"), FrozenDict):
+        _log_judge_error("romp", fsid, "frozen-store-save",
+                         note="save_goals was handed the shared read-only store (load_goals_shared); a writer "
+                              "loads its own copy with load_goals — nothing was published")
+        raise FrozenStoreError("save_goals refuses a shared read-only store (load_goals_shared); load the "
+                               "writer's copy with load_goals")
     GOALDIR.mkdir(parents=True, exist_ok=True)
     mine = _own_hash(store) if "_baseRev" in store else None
     if mine is not None and _matches_disk(fsid, store, mine):
@@ -4005,6 +4480,8 @@ def save_goals(fsid, store):
     if mine is not None and not rebased:             # a rebase changed the content `mine` describes
         _disk_seed(GOALDIR / (fsid + ".json"), tmp, mine)
     tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish
+    _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes with
+    #                                                   it (its identity check would miss anyway; this frees the bytes)
 
 
 def load_goal_archive(fsid):
@@ -7989,6 +8466,7 @@ def migrate_all_stores():
                 tmp.write_text(json.dumps(store))
                 tmp.rename(p)                         # atomic publish
                 n += 1
+    _shared_clear()                                   # the shared read-only views predate the sweep's publishes
     return n
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -172,6 +172,8 @@ def _rebind_state(path):
     with _DISK_CONTENT_LOCK:
         _DISK_CONTENT.clear()   # save_goals' disk-side memo is keyed on full store paths, so an old root's
     #                         entries could never hit under the new one; cleared anyway so a rebind starts empty
+    with _ABSENT_FLAGS_LOCK:
+        _ABSENT_FLAGS.clear()   # the absent-store predicate memo: same full-path keys, same reasoning
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 
@@ -3294,8 +3296,16 @@ def load_goals_or_fault(fsid):
 
     NEVER hands back an empty store: a caller that gets `(None, exc)` skips that session's goal-derived
     work for this build or pass, and writes nothing."""
+    return _or_fault(fsid, load_goals)
+
+
+def _or_fault(fsid, loader):
+    """load_goals_or_fault's boundary around any reader of `fsid`'s store: `loader(fsid)` is load_goals
+    itself there, and a pass's shared per-store read elsewhere (run_propagate's _get, so a recipient read
+    through the boundary is still the one read that pass takes of the store). Same episode table, same
+    `store-unreadable` row once per fault episode, same `(store, None)` / `(None, exc)` answer."""
     try:
-        store = load_goals(fsid)
+        store = loader(fsid)
     except OSError as e:
         _file_store_fault(fsid, e, "store-unreadable",
                           "goals store cannot be read; this session's goal-derived work is skipped until it "
@@ -12947,6 +12957,125 @@ def rearm_failed_summaries(now=None, auto=False):
             save_goals(fsid, store)
     return n
 
+# ── the absent-store predicate memo (the two triage sweeps over stores no discovered session owns) ──
+# run_propagate's sender-coverage sweep and _drain_undiscovered each walk every goal store OUTSIDE the
+# discover set to evaluate one predicate over the loaded store: "holds an open handoff tracker" and
+# "owes a distill". Absent stores are the dead sessions, and dead stores change only when one of these
+# sweeps writes them, so at steady state both sweeps parsed the same unchanged files every pass (41 stores,
+# about 8 MB, twice per pass on the audited kernel, 2026-09-06). The answers are memoized on the identity of
+# the THREE files load_goals reads for a sid — the store, its override journal (replayed on every load) and
+# its archive (a journaled restore consults it) — so a memoized answer is exactly what the load would have
+# produced for those file versions, and any write to any of the three is a miss. Every romp publish is a
+# tmp+rename and every gesture appends the journal, so a version change moves the identity.
+#
+# Precision of the key: (ino, mtime_ns, size) tells two versions apart when the filesystem's timestamps are
+# fine-grained (Linux 6.13+ multigrain timestamps; the audited kernel is one). A rename gives the store a
+# new inode too, but a freed inode number can be reused by the next temp file, so on a coarse-timestamp
+# kernel two same-size publishes inside one tick can alias — and a wrong "no open tracker" for a dead
+# store would pin until its next write, because the gated sweep is that store's only writer. That is the
+# one known exception, pinned in tests/test_judge_propagate_loads.py (a same-size in-place rewrite with the
+# mtime put back); no romp writer produces it. Keyed by the store's FULL PATH, so a rebind or a bare
+# GOALDIR reassignment can never serve the old root's answer; cleared in _rebind_state; entries for stores
+# gone from the GOALDIR glob are evicted at the start of each sweep.
+_ABSENT_FLAGS = {}        # store path string -> (identity from _store_identity, (open_handoff, owed_distill))
+_ABSENT_FLAGS_LOCK = threading.Lock()
+
+
+def _store_identity(fsid):
+    """The identity of every file load_goals(fsid) reads, taken by stat BEFORE any read: the store
+    goals/<fsid>.json, its override journal and its goals-archive entry, each (ino, mtime_ns, size) or
+    None when absent, behind the store's full path. Stat-then-read is the safe order: a publish landing
+    between the stat and the read pairs an OLD identity with NEW content, which _absent_store_flags
+    catches by re-taking the identity after the read (and declines to memoize); read-then-stat would pair
+    the new identity with old content and never heal."""
+    def _ident(p):
+        try:
+            st = os.stat(str(p))
+        except OSError:
+            return None
+        return (st.st_ino, st.st_mtime_ns, st.st_size)
+    path_s = str(GOALDIR / (fsid + ".json"))
+    return (path_s, _ident(path_s), _ident(_overrides_dir() / (fsid + ".jsonl")),
+            _ident(GOALARCHDIR / (fsid + ".json")))
+
+
+def _open_handoff_flag(store):
+    """run_propagate's absent-sender predicate: the store holds a handoff tracker that is neither complete
+    nor cleared, so the recipient's reply may still need to check it off. Pure over the loaded store."""
+    return any(isinstance(v, dict) and isinstance(v.get("handoff"), dict)
+               and not v.get("nodeComplete") and not v.get("cleared")
+               for v in (store.get("nodes") or {}).values())
+
+
+def _owed_distill_flag(store):
+    """_drain_undiscovered's predicate: a completed (or confirming) top, not cleared, whose summary is
+    still None owes a distill. Pure over the loaded store."""
+    status, nodes = store.get("status", {}), store.get("nodes", {})
+    confirming = set(store.get("confirming") or ())
+    return any((st == "completed" or nid in confirming)
+               and isinstance(nodes.get(nid), dict)
+               and not nodes[nid].get("cleared")
+               and nodes[nid].get("summary") is None
+               for nid, st in status.items())
+
+
+def _absent_flags_evict(present):
+    """Drop memo entries for store paths not in `present` (this sweep's GOALDIR glob): a deleted or
+    compacted-away store, or an old root's entries after a bare GOALDIR reassignment."""
+    with _ABSENT_FLAGS_LOCK:
+        for path_s in [k for k in _ABSENT_FLAGS if k not in present]:
+            del _ABSENT_FLAGS[path_s]
+
+
+def _absent_store_flags(fsid, loaded=None, idents=None):
+    """(open_handoff, owed_distill) for a store no discovered session owns, or None when the load
+    itself raised (the caller skips the store this pass, as the sweeps always did; a store file that
+    cannot be read raises out of load_goals). Memoized on _store_identity; a miss loads once and
+    evaluates both predicates, so the two sweeps of one pass share one load and an unchanged store costs
+    three stats per sweep. Two answers are served but NOT memoized: a store loaded without its unreadable
+    override journal (the `_unread` mark, _replay_overrides), and one whose files moved between the
+    identity and the read (the identity is re-taken after the load and must match). `loaded`/`idents` are
+    run_propagate's per-pass dicts: a store this pass already read (identity taken before the read,
+    object unmutated — every dirty sender is saved and dropped before the sweep) is evaluated from
+    that object instead of read again, and a store read here is left in `loaded` for the sender loop."""
+    if loaded is not None and fsid in loaded and fsid in idents:
+        key, store = idents[fsid], loaded[fsid]
+    else:
+        key, store = _store_identity(fsid), None
+    path_s = key[0]
+    with _ABSENT_FLAGS_LOCK:
+        ent = _ABSENT_FLAGS.get(path_s)
+    if ent is not None and ent[0] == key:
+        return ent[1]
+    if store is None:
+        try:
+            store = load_goals(fsid)
+        except Exception:
+            return None
+        if loaded is not None:
+            loaded[fsid] = store
+            idents[fsid] = key
+    flags = (_open_handoff_flag(store), _owed_distill_flag(store))
+    if store.get("_unread"):
+        # The object is NOT what its files say: the store parsed but its override journal exists and did
+        # not read (_replay_overrides), so a tracker the user resolved still shows open. Answer this pass
+        # from it, as the sweeps always did, but never memoize: nothing on disk need change before the
+        # next read succeeds (an EMFILE, an EIO), so an entry here would serve the un-resolved tracker
+        # until the store's next write, which for a dead store may never come. (A store FILE that cannot
+        # be read raises out of load_goals and is answered None above; an unparseable one is quarantined
+        # aside by load_goals, and the identity check below sees the file go.)
+        return flags
+    if _store_identity(fsid) != key:
+        # The files moved under the read: a publish or a journal append landed between the identity and
+        # the read (the entry would pair the OLD identity with the NEW content and heal only at the next
+        # write), or load_goals moved an unparseable store aside and answered the legitimate fresh store
+        # (the key still names the corrupt file, which is gone). Answer this pass, memoize nothing; the
+        # next call takes the new identity and reads again.
+        return flags
+    with _ABSENT_FLAGS_LOCK:
+        _ABSENT_FLAGS[path_s] = (key, flags)
+    return flags
+
 
 def _drain_undiscovered(now, fleet_sids):
     """Stragglers the fleet walk can't reach (the user 2026-08-26, T110): a completed top whose
@@ -12961,23 +13090,17 @@ def _drain_undiscovered(now, fleet_sids):
     through _distill_session's own no-work branch, the "" sentinel plus the history-unreadable
     warn, loud instead of an eternal spinner. Self-retiring: the sentinel is non-null, so a drained
     store never re-enters the predicate and the steady state costs one status read per absent
-    store. Returns goals distilled."""
+    store — three stats since the predicate moved onto _absent_store_flags (memoized on file
+    identity, shared with run_propagate's sweep over the same stores). Returns goals distilled."""
     stuck = []
-    for f in sorted(GOALDIR.glob("*.json")):
+    files = sorted(GOALDIR.glob("*.json"))
+    _absent_flags_evict({str(f) for f in files})
+    for f in files:
         sid = f.stem
         if sid in fleet_sids:
             continue
-        try:
-            store = load_goals(sid)
-        except Exception:
-            continue
-        status, nodes = store.get("status", {}), store.get("nodes", {})
-        confirming = set(store.get("confirming") or ())
-        if any((st == "completed" or nid in confirming)
-               and isinstance(nodes.get(nid), dict)
-               and not nodes[nid].get("cleared")
-               and nodes[nid].get("summary") is None
-               for nid, st in status.items()):
+        flags = _absent_store_flags(sid)
+        if flags is not None and flags[1]:
             stuck.append(sid)
     if not stuck:
         return 0
@@ -13954,19 +14077,65 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     origin.goalId DONE too — so a '↪ delegated to B' item checks off the instant B finishes and reports. NO
     LLM: the closer already judged G done on B; this just follows the origin pointer (origin.goalId points at
     the sender's precise tracking node, planted by _plant_handoff_track). Forward-only + idempotent: it never
-    reopens the sender's node, and a node already done (or gone) is a no-op. Returns completions propagated."""
+    reopens the sender's node, and a node already done (or gone) is a no-op. Returns completions propagated.
+
+    Every store is read at most ONCE per pass (2026-09-06): `loaded` holds this pass's load_goals objects
+    and serves the recipient scan, the per-ref done check, _ref_goal's recipient maps and the sender loop;
+    the archive reads ride `archives` the same way. The pass used to load every recipient, load the sender
+    again per ref BEFORE checking whether the tracker was already done (it was, for every live ref), and
+    load every sender a third time in the sender loop. Now the done check reads the shared object and a
+    sender is read only when nothing this pass has read it yet. A ref's verdict lands on the shared object
+    with today's per-ref rollup, and each dirty sender is PUBLISHED ONCE, after the recipient loop (the
+    rebase unions per-node logs by (ev_t, src, kind), so one publish carrying several courier rows merges
+    exactly as several publishes did). A saved object leaves `loaded` in a finally: it is dropped so the
+    next touch reloads with a fresh CAS base (save_goals pops the base on publish), and a failed publish
+    drops it too, never leaving a base-less object for the sender loop. The absent-store sweep answers from
+    _absent_store_flags, memoized across passes on file identity. The per-session catches stand around the
+    shared read: a store that raises files its `pass-crash` row where it is reached (the recipient scan, a
+    ref's sender read, the sender loop) and is not kept, so the next touch retries the read; _ref_goal's
+    recipient read goes through the store-fault boundary (_or_fault) as before."""
     if now is None:
         now = int(time.time())
     n = 0
-    for fsid, path, anchor, name in discover(now)[:sessions_cap]:
+    sessions = discover(now)[:sessions_cap]
+    seen = {f for f, _p, _a, _n in sessions}
+    loaded, idents, archives = {}, {}, {}   # sid -> store / its pre-read identity (absent sids only) / archive
+
+    def _get(sid):
+        """This pass's one load_goals of `sid`."""
+        st = loaded.get(sid)
+        if st is None:
+            if sid not in seen:
+                idents[sid] = _store_identity(sid)      # an absent store read here can fill the predicate
+            st = loaded[sid] = load_goals(sid)          # memo below: its identity is taken BEFORE the read
+        return st
+
+    def _arch(sid):
+        a = archives.get(sid)
+        if a is None:
+            a = archives[sid] = load_goal_archive(sid)
+        return a
+
+    def _publish(sid):
+        """Save the shared object once and forget it: the next touch reloads with a fresh CAS base
+        (save_goals pops the base on publish)."""
+        try:
+            save_goals(sid, loaded[sid])
+        finally:
+            loaded.pop(sid, None)
+            idents.pop(sid, None)
+
+    closed = {}                                         # sender sid -> _presumed_closed, once per pass
+    dirty = {}                                          # sender sids with verdicts to publish, in order
+    for fsid, path, anchor, name in sessions:
         # live + ARCHIVE merged for the RECIPIENT-side scan (2026-08-26, the working-column audit):
         # a recipient goal that completed and was then ARCHIVED (the user cleared the done card)
         # vanished from the live-only scan, so the sender's tracker never checked off — a live
         # specimen sat open seven hours with its completion event already fired and recorded.
         # Read-only on this side: propagate writes SENDER stores only.
-        rnodes = dict(load_goal_archive(fsid).get("nodes") or {})
+        rnodes = dict(_arch(fsid).get("nodes") or {})
         try:
-            rnodes.update(load_goals(fsid).get("nodes") or {})
+            rnodes.update(_get(fsid).get("nodes") or {})
         except Exception as e:                         # an unreadable store: this session's row, the next session's turn
             _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
             continue
@@ -13980,7 +14149,7 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
             for ref in refs:
                 a_sid, a_gid = ref["peer"], ref["goalId"]
                 try:
-                    a_store = load_goals(a_sid)
+                    a_store = _get(a_sid)               # the shared read: no load when this pass has it
                 except Exception as e:                 # the sender's store faulted: its tracker waits for the next pass
                     _log_judge_error("propagate", fsid, "pass-crash", note="sender %s store: %r" % (a_sid[:8], e))
                     continue
@@ -14001,13 +14170,20 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                     why += ": " + sub[:220]
                 record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now, why=why)
                 _mark_node_done(a_store, a_gid, why, now, src="courier")
-                rollup_status(a_store, _presumed_closed(a_sid, now))   # sender just had work close →
+                if a_sid not in closed:
+                    closed[a_sid] = _presumed_closed(a_sid, now)
+                rollup_status(a_store, closed[a_sid])   # sender just had work close →
                 #                                        recompute its columns, SETTLING them when the
                 #                                        sender is determined dead (2026-08-28: a live
                 #                                        sender's own pass settles as before; a dead one
-                #                                        has no pass, so this write is its only settler)
-                save_goals(a_sid, a_store)
+                #                                        has no pass, so this write is its only settler).
+                #                                        Per ref, as before: a later recipient in this
+                #                                        loop reads the shared object, and this keeps it
+                #                                        exactly what the per-ref publish used to leave.
+                dirty[a_sid] = True
                 n += 1
+    for a_sid in list(dirty):
+        _publish(a_sid)                                 # one publish per dirty sender
     # REMOTE recipients (the user 2026-08-24): their goal stores live on another kernel, so the
     # origin back-link above can never fire for them. The local log still records the exact
     # report-back event: the recipient's REPLY mail — any kind — at/after the delegate's send, the
@@ -14029,11 +14205,14 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     _rmemo = {}                                        # recipient sid -> merged nodes (per-pass, read-only)
 
     def _ref_goal(peer_sid, mid):
-        """The recipient goal a tracker's msgId joins to (origin or links), live+archive merged."""
+        """The recipient goal a tracker's msgId joins to (origin or links), live+archive merged. The
+        values are COPIES of the shared objects' nodes, taken at first use: the sender loop below
+        mutates the shared store, and this map must read as the snapshot it always was."""
         if peer_sid not in _rmemo:
-            m = dict(load_goal_archive(peer_sid).get("nodes") or {})
-            live, fault = load_goals_or_fault(peer_sid)   # a faulting recipient joins to nothing this pass
-            m.update((live or {}).get("nodes") or {})     # (forward-only: the tracker simply stays open)
+            m = {k: dict(v) for k, v in (_arch(peer_sid).get("nodes") or {}).items() if isinstance(v, dict)}
+            live, fault = _or_fault(peer_sid, _get)      # a faulting recipient joins to nothing this pass
+            m.update({k: dict(v) for k, v in ((live or {}).get("nodes") or {}).items()   # (forward-only: the
+                      if isinstance(v, dict)})                                            #  tracker stays open)
             _rmemo[peer_sid] = m
         for rd in _rmemo[peer_sid].values():
             if not isinstance(rd, dict):
@@ -14051,24 +14230,21 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     # forever (the audited board: 18 of 23 stale cards, all on exactly these sids). The recipient's
     # reply is the event and this sweep is its only writer for such stores, so absent stores that
     # still hold open trackers join the walk (the T110 straggler-drain shape; self-retiring — a
-    # closed tracker leaves the predicate).
-    _sw_fleet = discover(now)[:sessions_cap]
-    _sw_seen = {f for f, _p, _a, _n in _sw_fleet}
-    _sw_senders = [f for f, _p, _a, _n in _sw_fleet]
-    for _f in sorted(GOALDIR.glob("*.json")):
-        if _f.stem in _sw_seen:
+    # closed tracker leaves the predicate). The predicate is answered by _absent_store_flags: an
+    # unchanged absent store costs three stats, not a parse, and a store it does read stays in
+    # `loaded` for the loop below.
+    _sw_senders = [f for f, _p, _a, _n in sessions]
+    _sw_files = sorted(GOALDIR.glob("*.json"))
+    _absent_flags_evict({str(f) for f in _sw_files})
+    for _f in _sw_files:
+        if _f.stem in seen:
             continue
-        try:
-            _st0 = load_goals(_f.stem)
-        except Exception:
-            continue
-        if any(isinstance(v, dict) and isinstance(v.get("handoff"), dict)
-               and not v.get("nodeComplete") and not v.get("cleared")
-               for v in (_st0.get("nodes") or {}).values()):
+        _flags = _absent_store_flags(_f.stem, loaded, idents)
+        if _flags is not None and _flags[0]:
             _sw_senders.append(_f.stem)
     for fsid in _sw_senders:
         try:
-            store = load_goals(fsid)
+            store = _get(fsid)
         except Exception as e:
             _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
             continue
@@ -14118,8 +14294,8 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
                     changed = True
                     n += 1
         if changed:
-            rollup_status(store, fsid not in _sw_seen and _presumed_closed(fsid, now))
-            save_goals(fsid, store)
+            rollup_status(store, fsid not in seen and _presumed_closed(fsid, now))
+            _publish(fsid)
     if verbose:
         sys.stderr.write("romp-judge: propagated %d delegation completions\n" % n)
     return n

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2226,7 +2226,8 @@ _CHAIN_STATS = {"hit": 0, "miss": 0, "populate": 0, "bypass": 0}   # read throug
 def chain_memo_stats():
     """The write-moment chain memo's counters, snapshotted under the lock: hit (served from the
     memo), miss (key computed, no usable entry, built and memoized), populate (entries written),
-    bypass (the key itself hit OSError: built fresh, not memoized)."""
+    bypass (the key itself hit OSError: built fresh, not memoized). The kernel's GET /perf reports
+    the dict as memos.chain."""
     with _CHAIN_LOCK:
         return dict(_CHAIN_STATS)
 
@@ -3152,8 +3153,11 @@ def _guard_nodes(store):
 
 # ── goal-store I/O counters (the kernel's GET /perf reads them through goal_io_stats) ─────────────
 # How often the stores are read and written is the first question when the kernel is busy: every
-# judge stage, the feed build and the nudge tick load stores, so the load rate says whether a change
-# added a pass over every session. Plain counters, one lock, no formatting on the path.
+# judge stage and the nudge tick load stores through load_goals, so the load rate says whether a change
+# added a writer-side pass over every session. The pusher's read-only sites (the feed, chat and timeline
+# builds) read through load_goals_shared, whose hits and misses shared_store_stats reports (GET /perf
+# memos.shared), so a pass added THERE shows as shared misses, not here (review find, 2026-09-08).
+# Plain counters, one lock, no formatting on the path.
 _GOAL_IO = {"loads": 0, "saves": 0, "writes": 0}
 _GOAL_IO_LOCK = threading.Lock()
 
@@ -4031,9 +4035,10 @@ def _matches_disk(fsid, store, mine=None):
 # Invalidation is exact by construction: a store publish is a rename to a new inode (save_goals), a
 # journal write an append, an archive publish a rename. save_goals also pops its path after the rename
 # (the writer's object is never the shared one), _rebind_state and migrate_all_stores clear, and the
-# kernel's compaction sweep evicts absent paths (_shared_evict_absent). Two fills of one path race
-# harmlessly: the second checks under the lock for an entry with its exact keys and bytes and returns
-# that object, so concurrent readers of one file version receive one object.
+# kernel's compaction sweep evicts absent paths (_shared_evict_absent) and the entries of stores no
+# discovered session owns (_shared_evict_unowned), so the cache is bounded by the live board. Two fills
+# of one path race harmlessly: the second checks under the lock for an entry with its exact keys and
+# bytes and returns that object, so concurrent readers of one file version receive one object.
 _SHARED = {}                                     # store path → (keys, store bytes, frozen store)
 _SHARED_LOCK = threading.Lock()
 _SHARED_OFF = [False]                            # a write attempt on a shared object switches the cache off (see _shared_poison)
@@ -4302,27 +4307,35 @@ def _shared_evict_absent():
     return len(gone)
 
 
+def _shared_evict_unowned(owned):
+    """Drop the entries of stores no session in `owned` (the discover set's sids) holds. The cache had no
+    cap: a store's view stayed resident for the process once read (review find, 2026-09-08). The kernel's
+    compaction sweep calls this beside _shared_evict_absent; a later read of an evicted store is a miss
+    that refills it."""
+    with _SHARED_LOCK:
+        gone = [k for k in _SHARED if os.path.basename(k)[:-5] not in owned]
+        for k in gone:
+            del _SHARED[k]
+        _SHARED_STATS["evict"] += len(gone)
+    return len(gone)
+
+
 def shared_store_stats():
     """The cache's counters plus its occupancy. hit: identity and bytes matched. miss: no entry, or its keys
     moved. compare_miss: identity matched and the bytes did not. refuse: a fill not published because the
     archive moved under it. dup: a fill discarded for a concurrent fill's identical entry. absent: no store
     file. corrupt: bytes that did not parse, handed to load_goals (which moves them aside); nothing cached.
-    unreadable_journal: served uncached from load_goals. evict:
-    entries dropped for gone files. fallback: calls served by load_goals because the cache is off. poisoned:
-    write attempts on a shared object (the first switched the cache off). Gauges: entries, bytes (the raw
-    store bytes held for the compare), off."""
+    unreadable_journal: served uncached from load_goals. evict: entries dropped for gone files and for
+    stores no discovered session owns (the compaction sweep). fallback: calls served by load_goals because
+    the cache is off. poisoned: write attempts on a shared object (the first switched the cache off).
+    Gauges: entries, bytes (the raw store bytes held for the compare), off. The kernel's GET /perf reports
+    the dict as memos.shared."""
     with _SHARED_LOCK:
         out = dict(_SHARED_STATS)
         out["entries"] = len(_SHARED)
         out["bytes"] = sum(len(e[1]) for e in _SHARED.values())
         out["off"] = int(_SHARED_OFF[0])
     return out
-
-
-def store_key(fsid):
-    """The store file's identity (inode, mtime_ns, size) from a fresh stat, None when absent — the per-session
-    key a view signature can carry. Independent of the cache: one stat, no entry consulted."""
-    return _file_key(str(GOALDIR / (fsid + ".json")))
 
 
 def load_goals_shared(fsid):
@@ -14565,13 +14578,17 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
     sender is read only when nothing this pass has read it yet. A ref's verdict lands on the shared object
     with today's per-ref rollup, and each dirty sender is PUBLISHED ONCE, after the recipient loop (the
     rebase unions per-node logs by (ev_t, src, kind), so one publish carrying several courier rows merges
-    exactly as several publishes did). A saved object leaves `loaded` in a finally: it is dropped so the
-    next touch reloads with a fresh CAS base (save_goals pops the base on publish), and a failed publish
-    drops it too, never leaving a base-less object for the sender loop. The absent-store sweep answers from
-    _absent_store_flags, memoized across passes on file identity. The per-session catches stand around the
-    shared read: a store that raises files its `pass-crash` row where it is reached (the recipient scan, a
-    ref's sender read, the sender loop) and is not kept, so the next touch retries the read; _ref_goal's
-    recipient read goes through the store-fault boundary (_or_fault) as before."""
+    exactly as several publishes did). A raise mid-loop publishes the senders reached before it and
+    re-raises, the sender being applied dropped unpublished; a failed publish does not stop the others,
+    and the first is raised once the rest are out (review find, 2026-09-08: the per-ref save this
+    replaced persisted each verdict as it was reached). A saved object leaves `loaded` in a finally: it
+    is dropped so the next touch reloads with a fresh CAS base (save_goals pops the base on publish), and
+    a failed publish drops it too, never leaving a base-less object for the sender loop. The absent-store
+    sweep answers from _absent_store_flags, memoized across passes on file identity. The per-session
+    catches stand around the shared read: a store that raises files its `pass-crash` row where it is
+    reached (the recipient scan, a ref's sender read, the sender loop) and is not kept, so the next touch
+    retries the read; _ref_goal's recipient read goes through the store-fault boundary (_or_fault) as
+    before."""
     if now is None:
         now = int(time.time())
     n = 0
@@ -14603,65 +14620,93 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
             loaded.pop(sid, None)
             idents.pop(sid, None)
 
+    def _publish_dirty():
+        """One publish per dirty sender, every one of them whatever happened to the one before: the first
+        failed publish is the pass's error, raised once the rest are out (review find, 2026-09-08)."""
+        first = None
+        for a_sid in list(dirty):
+            try:
+                _publish(a_sid)
+            except Exception as e:
+                if first is None:
+                    first = e
+        if first is not None:
+            raise first
+
     closed = {}                                         # sender sid -> _presumed_closed, once per pass
     dirty = {}                                          # sender sids with verdicts to publish, in order
-    for fsid, path, anchor, name in sessions:
-        # live + ARCHIVE merged for the RECIPIENT-side scan (2026-08-26, the working-column audit):
-        # a recipient goal that completed and was then ARCHIVED (the user cleared the done card)
-        # vanished from the live-only scan, so the sender's tracker never checked off — a live
-        # specimen sat open seven hours with its completion event already fired and recorded.
-        # Read-only on this side: propagate writes SENDER stores only.
-        rnodes = dict(_arch(fsid).get("nodes") or {})
-        try:
-            rnodes.update(_get(fsid).get("nodes") or {})
-        except Exception as e:                         # an unreadable store: this session's row, the next session's turn
-            _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
-            continue
-        for nid, nd in list(rnodes.items()):
-            if not nd.get("nodeComplete"):
-                continue                                # B hasn't finished it yet
-            o = nd.get("origin")
-            refs = ([o] if (isinstance(o, dict) and o.get("peer") and o.get("goalId")) else [])
-            refs += [l for l in (nd.get("links") or [])
-                     if isinstance(l, dict) and l.get("peer") and l.get("goalId")]
-            for ref in refs:
-                a_sid, a_gid = ref["peer"], ref["goalId"]
-                try:
-                    a_store = _get(a_sid)               # the shared read: no load when this pass has it
-                except Exception as e:                 # the sender's store faulted: its tracker waits for the next pass
-                    _log_judge_error("propagate", fsid, "pass-crash", note="sender %s store: %r" % (a_sid[:8], e))
-                    continue
-                a_node = a_store.get("nodes", {}).get(a_gid)
-                if not a_node or a_node.get("nodeComplete"):
-                    continue                            # sender's tracking node gone or already done → idempotent
-                # Carry the RECIPIENT'S OWN RESOLUTION across (the user 2026-08-25, the re-asking
-                # umbrella): the bare "completed by <peer>" why gave the sender-side closer nothing
-                # to rule a delegated ask done WITH — the steps-finished nomination saw an ask whose
-                # only visible history was the dispatch, omitted, and the look-stamp sealed it while
-                # the auto-nudge re-asked a finished question seven times in 75 minutes. The
-                # recipient's doneWhy (else its summary head) IS the report-back's substance; capped
-                # like every quoted why.
-                why = "completed by %s (delegated)" % (name or fsid[:8])
-                sub = str(nd.get("doneWhy") or "").strip() \
-                    or (str(nd.get("summary") or "").strip().splitlines() or [""])[0]
-                if sub:
-                    why += ": " + sub[:220]
-                record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now, why=why)
-                _mark_node_done(a_store, a_gid, why, now, src="courier")
-                if a_sid not in closed:
-                    closed[a_sid] = _presumed_closed(a_sid, now)
-                rollup_status(a_store, closed[a_sid])   # sender just had work close →
-                #                                        recompute its columns, SETTLING them when the
-                #                                        sender is determined dead (2026-08-28: a live
-                #                                        sender's own pass settles as before; a dead one
-                #                                        has no pass, so this write is its only settler).
-                #                                        Per ref, as before: a later recipient in this
-                #                                        loop reads the shared object, and this keeps it
-                #                                        exactly what the per-ref publish used to leave.
-                dirty[a_sid] = True
-                n += 1
-    for a_sid in list(dirty):
-        _publish(a_sid)                                 # one publish per dirty sender
+    applying = None                                     # the sender whose object a ref's verdict is landing on
+    try:
+        for fsid, path, anchor, name in sessions:
+            # live + ARCHIVE merged for the RECIPIENT-side scan (2026-08-26, the working-column audit):
+            # a recipient goal that completed and was then ARCHIVED (the user cleared the done card)
+            # vanished from the live-only scan, so the sender's tracker never checked off — a live
+            # specimen sat open seven hours with its completion event already fired and recorded.
+            # Read-only on this side: propagate writes SENDER stores only.
+            rnodes = dict(_arch(fsid).get("nodes") or {})
+            try:
+                rnodes.update(_get(fsid).get("nodes") or {})
+            except Exception as e:                         # an unreadable store: this session's row, the next session's turn
+                _log_judge_error("propagate", fsid, "pass-crash", note="store: %r" % e)
+                continue
+            for nid, nd in list(rnodes.items()):
+                if not nd.get("nodeComplete"):
+                    continue                                # B hasn't finished it yet
+                o = nd.get("origin")
+                refs = ([o] if (isinstance(o, dict) and o.get("peer") and o.get("goalId")) else [])
+                refs += [l for l in (nd.get("links") or [])
+                         if isinstance(l, dict) and l.get("peer") and l.get("goalId")]
+                for ref in refs:
+                    a_sid, a_gid = ref["peer"], ref["goalId"]
+                    try:
+                        a_store = _get(a_sid)               # the shared read: no load when this pass has it
+                    except Exception as e:                 # the sender's store faulted: its tracker waits for the next pass
+                        _log_judge_error("propagate", fsid, "pass-crash", note="sender %s store: %r" % (a_sid[:8], e))
+                        continue
+                    a_node = a_store.get("nodes", {}).get(a_gid)
+                    if not a_node or a_node.get("nodeComplete"):
+                        continue                            # sender's tracking node gone or already done → idempotent
+                    # Carry the RECIPIENT'S OWN RESOLUTION across (the user 2026-08-25, the re-asking
+                    # umbrella): the bare "completed by <peer>" why gave the sender-side closer nothing
+                    # to rule a delegated ask done WITH — the steps-finished nomination saw an ask whose
+                    # only visible history was the dispatch, omitted, and the look-stamp sealed it while
+                    # the auto-nudge re-asked a finished question seven times in 75 minutes. The
+                    # recipient's doneWhy (else its summary head) IS the report-back's substance; capped
+                    # like every quoted why.
+                    why = "completed by %s (delegated)" % (name or fsid[:8])
+                    sub = str(nd.get("doneWhy") or "").strip() \
+                        or (str(nd.get("summary") or "").strip().splitlines() or [""])[0]
+                    if sub:
+                        why += ": " + sub[:220]
+                    applying = a_sid                    # half-applied from here until dirty: see the except
+                    record_verdict(a_store, a_store["nodes"][a_gid], "courier", "done", now, why=why)
+                    _mark_node_done(a_store, a_gid, why, now, src="courier")
+                    if a_sid not in closed:
+                        closed[a_sid] = _presumed_closed(a_sid, now)
+                    rollup_status(a_store, closed[a_sid])   # sender just had work close →
+                    #                                        recompute its columns, SETTLING them when the
+                    #                                        sender is determined dead (2026-08-28: a live
+                    #                                        sender's own pass settles as before; a dead one
+                    #                                        has no pass, so this write is its only settler).
+                    #                                        Per ref, as before: a later recipient in this
+                    #                                        loop reads the shared object, and this keeps it
+                    #                                        exactly what the per-ref publish used to leave.
+                    dirty[a_sid] = True
+                    applying = None
+                    n += 1
+    except Exception:
+        # A raise mid-loop must not turn one ref's trip into the loss of every verdict the pass reached
+        # before it (review find, 2026-09-08; the per-ref save this single publish replaced persisted each
+        # as it was reached): the senders reached are published, then the error goes up. The sender whose
+        # ref raised is dropped unpublished, its object half-applied (a verdict recorded without its rollup
+        # is no verdict); the next pass re-derives it from the recipient's completion, forward-only.
+        if applying is not None:
+            dirty.pop(applying, None)
+            loaded.pop(applying, None)
+            idents.pop(applying, None)
+        _publish_dirty()                                # a publish that fails here raises with the loop's error chained
+        raise
+    _publish_dirty()                                    # one publish per dirty sender
     # REMOTE recipients (the user 2026-08-24): their goal stores live on another kernel, so the
     # origin back-link above can never fire for them. The local log still records the exact
     # report-back event: the recipient's REPLY mail — any kind — at/after the delegate's send, the

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12471,22 +12471,72 @@ def _failed_nodes(store):
                 yield nid, nd, w["kind"]
 
 
+_jf_store_memo = {}             # {store path: ((st_ino, st_mtime_ns, st_size), failed count)} — see judge_failure_scan
+_jf_cause_memo = (None, None)   # (the store keys the cause was named against, (cause, ratelimited))
+
+
 def judge_failure_scan():
-    """Fleet-wide give-up state for the top banner (the user 2026-07-03): every card whose summary/brief/
-    stall note GAVE UP carries a live "*-failed" warn; count them across all goal stores and name the CAUSE (an
-    account usage limit if one is maxed, else errors/timeouts). Returns {count, cause, ratelimited} or None
-    when nothing is failing. Cheap: read-only, one parse per store; the kernel mtime-caches it."""
+    """Give-up state across every session for the top banner (the user 2026-07-03): every card whose
+    summary/brief/stall note GAVE UP carries a live "*-failed" warn; count them across all goal stores and
+    name the CAUSE (an account usage limit if one is maxed, else errors/timeouts). Returns {count, cause,
+    ratelimited} or None when nothing is failing. Read-only.
+
+    Per-store memo: the kernel calls this from every timeline build and every dashboard connect push once
+    its goals-dir fingerprint moves, and one saved store made it parse EVERY store again (megabytes of
+    JSON on a busy instance). Each store's failed count is memoized on the identity of the file it was
+    counted from, (st_ino, st_mtime_ns, st_size) taken by fstat on the fd that is read, so a call stats
+    every store and parses only the ones whose key changed. A store's failed count changes only when its
+    file changes, so the key must change whenever the file does, and the inode number alone does not
+    guarantee that: save_goals publishes by tmp+rename, and on ext4 (measured) consecutive publishes of one
+    path alternate between two inode numbers, so the version two publishes back reuses the inode number
+    the memo recorded. The inode distinguishes one publish only; past that, soundness depends on
+    st_mtime_ns strictly increasing across publishes of one path. Linux 6.13+ guarantees that with
+    multigrain timestamps: this scan's own stat marks the prior inode as queried, so its unlink by the
+    next rename takes a fine-grained ctime and every file created after it gets a strictly greater
+    mtime_ns. A kernel with coarse timestamps (Linux < 6.13; macOS unmeasured) aliases two publishes of
+    the same size inside one clock tick, and the store's memoized count then stays stale until its next
+    publish. That is the same failure class as, and a narrower window than, kernel.py's _jf_cache gate in
+    front of this function, keyed on int(st_mtime), which already serves a stale value for a store
+    re-saved within one second. No stat-only key closes the residual window; comparing content would cost
+    the read the memo exists to avoid. The memo is rebuilt from this call's glob and swapped in with one
+    assignment: a deleted store drops out, and concurrent callers never mutate a shared dict.
+    A store that fails to parse counts nothing and is not memoized, so it is retried next call. The cause
+    is named again only when some store key changed, the cadence the kernel's fingerprint cache already
+    imposed, so the notification center's count|cause signature does not churn per call. Counts RAW file
+    content, never a load_goals-replayed store."""
     import glob
+    global _jf_store_memo, _jf_cause_memo
+    old, new = _jf_store_memo, {}
     count = 0
     for fp in glob.glob(str(GOALDIR / "*.json")):
         try:
-            store = json.loads(Path(fp).read_text())
-        except Exception:
-            continue
-        count += sum(1 for _ in _failed_nodes(store))
+            st = os.stat(fp)
+        except OSError:
+            continue                                   # gone between the glob and the stat
+        key = (st.st_ino, st.st_mtime_ns, st.st_size)
+        hit = old.get(fp)
+        if hit is not None and hit[0] == key:
+            n = hit[1]
+        else:
+            try:
+                with open(fp, "rb") as f:              # one fd: the key describes exactly the bytes read
+                    st = os.fstat(f.fileno())
+                    key = (st.st_ino, st.st_mtime_ns, st.st_size)
+                    store = json.loads(f.read())
+            except Exception:
+                continue
+            n = sum(1 for _ in _failed_nodes(store))
+        new[fp] = (key, n)
+        count += n
+    _jf_store_memo = new
     if not count:
         return None
-    cause, ratelimited = _giveup_cause()
+    keys = tuple(sorted((fp, k) for fp, (k, _n) in new.items()))
+    cm = _jf_cause_memo
+    if cm[0] != keys:
+        cm = (keys, _giveup_cause())
+        _jf_cause_memo = cm
+    cause, ratelimited = cm[1]
     return {"count": count, "cause": cause, "ratelimited": ratelimited}
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3580,8 +3580,13 @@ def _replay_overrides(fsid, store):
     log gains exactly one user event no matter how many loads replay the journal. A journaled node the
     store lacks is skipped (resolve/followup/move: it was cleared and compacted to the archive, which
     kept its flags). An unreadable journal logs a loud judge-errors row instead of silently skipping;
-    the store is still returned. Entries are rare (one manual click each), so the journal is never
-    pruned — replay is a few dict lookups.
+    the store is still returned, MARKED: `store["_unread"] = "journal"`, a transient key beside `_baseRev`
+    (save_goals pops it; _store_content keeps it out of the content hash) that says the store returned is
+    not the files' content. A reader that caches a load's answer by the files' identity consults the mark
+    before caching (the kernel's awaiting-lift gate today); a store FILE that cannot be read never reaches
+    here (load_goals raises), and an unparseable one is quarantined aside and legitimately fresh, so this
+    is the one load that answers with less than the files hold. Entries are rare (one manual click each),
+    so the journal is never pruned — replay is a few dict lookups.
 
     The SUPERSEDE guard on the event ops: a STRICTLY-LATER user event means a newer gesture outranks
     the entry — replaying past it would undo what the user did next (e.g. re-complete a card they
@@ -3600,6 +3605,10 @@ def _replay_overrides(fsid, store):
     except OSError as e:
         _log_judge_error("romp", fsid, "history-unreadable",
                          note="override journal unreadable: %s — user actions may show undone until it reads" % e)
+        # the store parsed but the journal exists and did not read: the user's gestures are missing from
+        # this view until it does. The journal replays on every load, so a publish of this store loses
+        # nothing durable; the mark tells an identity-keyed reader not to cache it (see the docstring).
+        store["_unread"] = "journal"
         return False
     applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
@@ -3745,7 +3754,8 @@ def _replay_overrides(fsid, store):
     return applied
 
 
-_NONCONTENT_KEYS = ("rev", "_baseRev")   # the revision counter + the transient CAS base: not store CONTENT
+_NONCONTENT_KEYS = ("rev", "_baseRev", "_unread")   # the revision counter + the transient CAS base and
+#                                                      unread-journal mark (_replay_overrides): not store CONTENT
 
 
 def _store_content(store):
@@ -3965,6 +3975,7 @@ def save_goals(fsid, store):
     if mine is not None and _matches_disk(fsid, store, mine):
         return                                       # nothing of ours to publish → leave the file (and its
     base = store.pop("_baseRev", None)               # mtime) alone.  transient: never serialized
+    store.pop("_unread", None)                       # likewise transient (_replay_overrides' unread-journal mark)
     rebased = False
     if base is not None:
         disk = 0

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -163,6 +163,7 @@ def _rebind_state(path):
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
+    _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
@@ -2187,6 +2188,41 @@ def _fileset_key(files):
 
 _PARSE_CACHE = {}          # fsid -> (fileset_key, parsed_session)
 
+# ── the write-moment chain memo ──
+# _rewound_away builds a FRESH FileAdapter on every call by design (the pass frame pins a stale
+# world; the guard must read the live one), and it is called at every mint site of every planner
+# pass, most of them from _plan_session's per-pass stand-down. On a kernel running a few dozen
+# sessions a CPU profile put that walk at 11.5% of interpreter time, the largest single item, and
+# nearly every call re-derived the same answer from unchanged files. This memo keeps one entry per
+# session, keyed on the exact inputs the adapter reads: the candidate paths, their (mtime, size)
+# with the states file's, the lineage closure the states' resume links add (with the from-files'
+# (mtime, size) too), and the pending cut. A rewind always moves one of them (a branch-take appends
+# to the leaf, a resume fork writes a states row, a bare rollback arms the cut), so the invariant
+# of "a writer whose evidence predates the diary stands down" holds exactly: same inputs, same
+# verdict. The key is computed BEFORE the build reads anything, so a file that changes mid-build is
+# caught by the next call's stat (an extra miss), never served stale (a stat taken after the read
+# could match a future call whose content the build never saw). A build that raises is never
+# memoized, and a key that hits OSError bypasses the memo for that call. The entry holds the base
+# key and the cut separately so the on-disk slot (cut-independent) survives a cut arming or
+# clearing and reconcile_rewound_goals shares it. The build runs outside _CHAIN_LOCK: two threads
+# that miss together both build (wasted work, never a wrong answer; the later populate replaces
+# the earlier one).
+_CHAIN_MEMO = {}           # fsid -> {"base": key, "cut": cut the "mem" slot was built under or None,
+#                            "mem": five-way dict under that cut or None, "disk": the same with no cut
+#                            or None}; dict order = LRU, hits reinsert; evicts the oldest-used one at
+#                            the cap, never clear-at-cap (the same LRU shape as em._ASM_CACHE)
+_CHAIN_MEMO_MAX = 256
+_CHAIN_LOCK = threading.Lock()     # the judge tiers' worker pools and the kernel's tick jobs all call in
+_CHAIN_STATS = {"hit": 0, "miss": 0, "populate": 0, "bypass": 0}   # read through chain_memo_stats()
+
+
+def chain_memo_stats():
+    """The write-moment chain memo's counters, snapshotted under the lock: hit (served from the
+    memo), miss (key computed, no usable entry, built and memoized), populate (entries written),
+    bypass (the key itself hit OSError: built fresh, not memoized)."""
+    with _CHAIN_LOCK:
+        return dict(_CHAIN_STATS)
+
 # ── the pending-cut wire (the rewind goal-cleanup fix, 2026-08-17) ──
 # A PENDING bare rollback (chat delete) writes NOTHING to the transcript, so for its whole armed
 # window — unbounded; the user's next message may never come — the file leaf IS the abandoned tail.
@@ -2231,13 +2267,82 @@ def _judge_candidates(fsid, files):
     return list(files)
 
 
+def _chain_key(path, cands, states):
+    """The chain memo's base key for one session, computed BEFORE the build reads anything: stat the
+    candidates and the states file first, then read the states rows once for the resume links the
+    lineage closure needs, then stat the from-files the closure added. Every file the adapter will
+    read is stat'd before it is read, so a key can never match a later call whose content this
+    build did not see (see the note at _CHAIN_MEMO). Raises OSError when any stat fails.
+
+    Two of the four components do the work and two are redundant guards: `fk` (the candidates' and
+    the states file's stats) moves on an append, a states row and an anchor appearing; the closure
+    moves when a from-file joins or vanishes. The candidate tuple repeats what `fk`'s length and
+    entries already say, and the from-file stats cover a rewrite of files the CLI never writes
+    again after their fork; both are kept because a stat costs nothing and the key must not depend
+    on that reasoning staying true. The key covers exactly what em.chain_membership reads today
+    (_load_states -> resume_fork_links -> _lineage_closure -> the candidate files, and the cut the
+    caller keys separately); if chain_membership ever reads another input, the key must grow with
+    it or the memo serves stale verdicts."""
+    fk = _fileset_key(list(cands) + ([states] if states else []))
+    links = em.resume_fork_links(em._load_states(states))
+    closure = em._lineage_closure(Path(path), cands, links)
+    extra = closure[len(cands):]                   # the lineage from-files (frozen after their fork,
+    #                                                but a stat costs nothing and covers a rewrite)
+    return (tuple(cands), fk, tuple(closure), _fileset_key(extra) if extra else [])
+
+
+def _chain_membership(fsid, path, cut):
+    """em.chain_membership over the judge's inputs for `fsid` (leaf, anchor candidate, states, the
+    lineage closure) under `cut` (the pending bare-rollback cut, "" for the on-disk graph), served
+    from _CHAIN_MEMO when the inputs are unchanged. Returns the five-way dict with FROZENSET values,
+    shared with the memo (immutable, so no per-hit copy; the dict itself is a fresh shallow copy).
+    A build that raises propagates and leaves the memo untouched."""
+    states = STATESDIR / (fsid + ".jsonl")
+    states_s = str(states) if states.exists() else None
+    cands = _judge_candidates(fsid, [str(path)])
+    try:
+        base = _chain_key(path, cands, states_s)
+    except OSError:
+        base = None
+    if base is None:
+        with _CHAIN_LOCK:
+            _CHAIN_STATS["bypass"] += 1
+    else:
+        with _CHAIN_LOCK:
+            e = _CHAIN_MEMO.get(fsid)
+            if e is not None and e["base"] == base:
+                mem = e["disk"] if not cut else (e["mem"] if e["cut"] == cut else None)
+                if mem is not None:
+                    _CHAIN_MEMO.pop(fsid, None)
+                    _CHAIN_MEMO[fsid] = e          # a served entry is a USED entry (LRU touch)
+                    _CHAIN_STATS["hit"] += 1
+                    return dict(mem)
+            _CHAIN_STATS["miss"] += 1
+    raw = em.chain_membership(path, candidate_files=cands, states=states_s, leaf_override=cut or None)
+    mem = {k: frozenset(v) for k, v in raw.items()}
+    if base is not None:
+        with _CHAIN_LOCK:
+            e = _CHAIN_MEMO.pop(fsid, None)
+            if e is None or e["base"] != base:
+                e = {"base": base, "cut": None, "mem": None, "disk": None}
+            e = dict(e, cut=cut, mem=mem) if cut else dict(e, disk=mem)   # replace, never mutate in
+            #                                                              place: a reader outside the
+            #                                                              lock holds the old dict
+            while len(_CHAIN_MEMO) >= _CHAIN_MEMO_MAX:
+                _CHAIN_MEMO.pop(next(iter(_CHAIN_MEMO)))   # oldest-used first; hot entries survive floods
+            _CHAIN_MEMO[fsid] = e
+            _CHAIN_STATS["populate"] += 1
+    return dict(mem)
+
+
 def _rewound_away(fsid, path, uuid):
     """WRITE-MOMENT chain check: does `uuid` PROVABLY sit on a rewound-away branch RIGHT NOW?
 
     Deliberately frame-independent: inside a producer pass parsed_session returns the frame-pinned
     parse — precisely the stale world in which a mid-pass rewind's dead branch still reads active —
-    so this builds a FRESH FileAdapter (cheap: the jsonl reads are append-incremental) over the same
-    inputs the display parse uses, including the backend's pending cut. The one-shot t>=cut_t sweep
+    so this reads the LIVE inputs the display parse uses, including the backend's pending cut, and
+    builds a fresh FileAdapter over them whenever they differ from the last build's (_chain_membership
+    memoizes on the inputs' identity, never on time). The one-shot t>=cut_t sweep
     runs at gesture time and never again; a mint applied after it from a pass framed before it was
     the primary observed leak (the g44 shape), and this is the stand-down that closes it
     (CLAUDE.md: a writer whose evidence predates the diary stands down).
@@ -2263,17 +2368,13 @@ def _rewound_away(fsid, path, uuid):
     if not uuid:
         return False
     try:
-        states = STATESDIR / (fsid + ".jsonl")
         cut = _pending_cut(fsid)
-        mem = em.chain_membership(path, candidate_files=_judge_candidates(fsid, [str(path)]),
-                                  states=str(states) if states.exists() else None,
-                                  leaf_override=cut or None)
+        mem = _chain_membership(fsid, path, cut)
         if uuid not in mem["rewind"]:
             return False
         if not cut:
             return "durable"                           # proven from the on-disk graph alone
-        on_disk = em.chain_membership(path, candidate_files=_judge_candidates(fsid, [str(path)]),
-                                      states=str(states) if states.exists() else None)
+        on_disk = _chain_membership(fsid, path, "")
         return "durable" if uuid in on_disk["rewind"] else "pending"
     except Exception as e:
         _log_judge_error("romp", fsid, "chain-check",
@@ -4043,9 +4144,8 @@ def reconcile_rewound_goals(fsid, path, now):
     if key is not None and memo and memo[0] == key:
         sig, kept = memo[1], memo[2]   # store-only event → reuse the memoized abandoned set, no walk
     else:
-        mem = em.chain_membership(path, candidate_files=files,
-                                  states=str(states) if states.exists() else None)
-        kept = frozenset(mem["kept"])
+        mem = _chain_membership(fsid, path, "")   # the on-disk graph, shared with _rewound_away's memo
+        kept = mem["kept"]                        # already a frozenset
         pf, pf_fails = _per_file_rewound(fsid, files)
         sig = frozenset(mem["rewind"] | (pf - kept))
     n = 0

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,7 +13,7 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
-import contextlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading
+import contextlib, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -169,6 +169,9 @@ def _rebind_state(path):
     _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
     #                         rebind that collides and serves the OLD root's project dir (found 2026-07-27:
     #                         the second test in a run discovered nothing, its fleet resolved into an rm'd tmpdir)
+    with _DISK_CONTENT_LOCK:
+        _DISK_CONTENT.clear()   # save_goals' disk-side memo is keyed on full store paths, so an old root's
+    #                         entries could never hit under the new one; cleared anyway so a rebind starts empty
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 
@@ -3341,10 +3344,25 @@ def _end_store_fault(fsid):
 
 
 def _disk_rev(fsid):
-    """The revision currently published on disk (0 only when ABSENT). A read fault or unparseable file
-    raises: read as 0 it matched a fresh store's base of 0, and save_goals then published that empty
-    store over a file it never managed to read."""
-    return int((_read_store_json(GOALDIR / (fsid + ".json")) or {}).get("rev") or 0)
+    """The revision the file holds NOW (0 only when ABSENT), from a fresh read. save_goals' CAS compares its
+    base against this, and the answer must be the file's, never the memo's: the memo's identity can, in one
+    rare interleaving, sit on a file it does not describe (see _DISK_CONTENT). The no-op check can afford
+    that (it skips a publish of content the file once held); the CAS cannot. An earlier draft served it from
+    the memo, and in that interleaving a writer with a stale base passed the CAS and wrote over the events
+    published since. A read fault or unparseable file RAISES, the rule every reader on the save path follows
+    (_read_store_json): read as 0 it matched a fresh store's base of 0, and save_goals then published that
+    empty store over a file it never managed to read. Reads through _disk_read, so a test can count the
+    read."""
+    path_s = str(GOALDIR / (fsid + ".json"))
+    try:
+        fd = os.open(path_s, os.O_RDONLY)
+    except FileNotFoundError:
+        return 0
+    try:
+        data = _disk_read(fd, path_s)
+    finally:
+        os.close(fd)
+    return int(_disk_parse(path_s, data).get("rev") or 0)
 
 
 def _rebase_onto_disk(fsid, store):
@@ -3736,19 +3754,180 @@ def _store_content(store):
     return json.dumps({k: v for k, v in store.items() if k not in _NONCONTENT_KEYS}, sort_keys=True)
 
 
-def _matches_disk(fsid, store):
+def _content_hash(canon):
+    """sha1 of a canonical content string. The disk-side memo keeps this instead of the string: a store's
+    canonical form is about the size of its file, and the memo holds one entry per store."""
+    return hashlib.sha1(canon.encode("utf-8")).hexdigest()
+
+
+def _own_hash(store):
+    """The content hash of the store a writer holds, or None when it does not serialize (the publish then
+    raises on its own terms, as it always did; a no-op check must never swallow a publish it merely failed
+    to understand)."""
+    try:
+        return _content_hash(_store_content(store))
+    except (TypeError, ValueError):
+        return None
+
+
+# ── the disk side of the no-op check, memoized by file identity (2026-09-06) ─────────────────────────
+# save_goals asks "does the file already hold exactly this content?" on every save, and most saves are
+# no-ops (a pass ends with a rollup + save whether or not it placed anything). Before this the check
+# re-read and re-parsed the file and serialized BOTH sides with sort_keys on every save, then the CAS
+# parsed the file again for its revision: a few percent of the interpreter time on a busy kernel's judge
+# threads, about 20 ms per save of the largest store.
+#
+# The memo maps a store's PATH to ((st_ino, st_mtime_ns, st_size), sha1 of the canonical disk content).
+# Every publish is a rename of a fresh temp, so a changed file is a different inode with its own stamps:
+# while the identity still matches, the file still holds the memoized content and the check is one open +
+# fstat plus one serialization of the in-memory side. Keyed on the full path string because tests rebind
+# GOALDIR, and a bare reassignment must not be served the other root's entry.
+#
+# The identity and the bytes come from the SAME open descriptor (open, fstat, read from the fd): a stat
+# by path followed by a read by path could pair the old file's stamps with a concurrent publisher's
+# bytes. An entry is therefore always a true fact about a file that existed, and a wrong answer needs a
+# different file with the same inode number, size and nanosecond mtime. A rename of a fresh temp cannot
+# produce that for the file it replaces (the temp's inode is allocated while the old one is still
+# linked). Two cases remain: a same-size rewrite in place within one mtime tick, which nothing here does
+# (save_goals' rename is the only writer), and a freed inode number handed to a later temp of the same
+# size within the same tick: three publishes of one store inside one timestamp tick, where a rebase can
+# keep the size because it keeps the in-memory node's text and only unions logs. The memo therefore
+# serves the NO-OP CHECK ONLY. A false match there skips a publish whose content the file already held
+# once and every later publisher rebased over, so nothing of ours is lost. It holds no revision and the
+# CAS never reads it: an earlier draft served _disk_rev from the entry too, and in that interleaving a
+# writer whose base equalled the stale revision passed the CAS without rebasing and wrote over the
+# events published since. The CAS reads the file (_disk_rev).
+#
+# Filled lazily (the first check after a foreign publish parses once) and by the publisher itself
+# (_disk_seed: the temp file's identity, which the rename keeps). Entries for absent files go at the
+# kernel's compaction sweep (_disk_memo_evict_absent). An absent file drops the entry and the caller
+# publishes (a create); a read fault or unparseable bytes drop the entry and RAISE, the rule every reader on
+# the save path follows (_read_store_json), so nothing is published over bytes the check could not read. A
+# warm entry answers without a read, so a fault the file develops while its identity stands is not seen by
+# the no-op check; that answer is still safe (a match publishes nothing), and a real publish's CAS read
+# (_disk_rev) raises on it.
+_DISK_CONTENT = {}
+_DISK_CONTENT_LOCK = threading.Lock()
+
+
+def _disk_forget(path_s):
+    with _DISK_CONTENT_LOCK:
+        _DISK_CONTENT.pop(path_s, None)
+
+
+def _disk_read(fd, path_s):
+    """The whole store from an already-open descriptor. The one place the memo reads a store file, so a
+    test can count reads by store path; `path_s` is only for that filter."""
+    chunks = []
+    while True:
+        b = os.read(fd, 1 << 20)
+        if not b:
+            return b"".join(chunks)
+        chunks.append(b)
+
+
+def _disk_parse(path_s, data):
+    """The store object in `data`, the bytes _disk_read returned for the file at `path_s`. Anything else
+    RAISES ValueError naming the file (not UTF-8, not JSON, a top-level value that is not an object): the
+    save path's readers never quarantine (that is load_goals' job, once the evidence is preserved) and never
+    answer a corrupt file with the absent-file value, so the publish that asked does not happen. The same
+    rule _read_store_json applies to the save path, for the descriptor readers."""
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except UnicodeError as e:
+        raise ValueError("%s: not UTF-8: %s" % (path_s, e)) from e
+    except ValueError as e:                          # json.JSONDecodeError is a ValueError
+        raise ValueError("%s: invalid JSON: %s" % (path_s, e)) from e
+    if not isinstance(value, dict):
+        raise ValueError("%s: top-level JSON value is %s, not an object" % (path_s, type(value).__name__))
+    return value
+
+
+def _disk_ident(fd):
+    """The identity of an OPEN store, (inode, mtime_ns, size), from the descriptor: the identity of the file
+    whose bytes _disk_read returns, whatever is linked at the path by then. Its own seam so a test can land
+    a publish between the open and this stat."""
+    st = os.fstat(fd)
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _disk_entry(fsid):
+    """The published store's ((ino, mtime_ns, size), content hash): from the memo when the file's identity
+    still matches, else from one read and parse. None only when the file is ABSENT (a create); a read fault
+    (the open, the stat or the read) raises the OSError and unparseable bytes raise ValueError, exactly as
+    _read_store_json does for the save path, and either DROPS the entry: nothing is remembered about a file
+    that could not be read, and the caller publishes nothing over it."""
+    path_s = str(GOALDIR / (fsid + ".json"))
+    try:
+        fd = os.open(path_s, os.O_RDONLY)
+    except FileNotFoundError:
+        _disk_forget(path_s)
+        return None
+    except OSError:
+        _disk_forget(path_s)
+        raise
+    try:
+        ident = _disk_ident(fd)
+        with _DISK_CONTENT_LOCK:
+            ent = _DISK_CONTENT.get(path_s)
+        if ent is not None and ent[0] == ident:
+            return ent
+        data = _disk_read(fd, path_s)
+    except OSError:
+        _disk_forget(path_s)
+        raise
+    finally:
+        os.close(fd)
+    try:
+        canon = _store_content(_disk_parse(path_s, data))
+    except (TypeError, ValueError):
+        _disk_forget(path_s)                         # not a store: no fact to remember, and no publish over it
+        raise
+    ent = (ident, _content_hash(canon))
+    with _DISK_CONTENT_LOCK:
+        _DISK_CONTENT[path_s] = ent
+    return ent
+
+
+def _disk_seed(path, tmp, canon_hash):
+    """Memoize a publish's own content under the identity its TEMP file carries, before the rename. A
+    rename keeps the inode, size and mtime, so the temp's stat is the destination's afterwards, and the
+    temp is ours alone. Never stat the destination after the rename: a concurrent publisher's file could
+    be captured there and paired with our content."""
+    try:
+        st = os.stat(tmp)
+    except OSError:
+        return
+    with _DISK_CONTENT_LOCK:
+        _DISK_CONTENT[str(path)] = ((st.st_ino, st.st_mtime_ns, st.st_size), canon_hash)
+
+
+def _disk_memo_evict_absent():
+    """Drop memo entries whose store file is gone (a removed session). The kernel's compaction sweep calls
+    this at its start; the memo otherwise holds one small entry per store ever saved."""
+    with _DISK_CONTENT_LOCK:
+        gone = [k for k in _DISK_CONTENT if not os.path.exists(k)]
+        for k in gone:
+            del _DISK_CONTENT[k]
+    return len(gone)
+
+
+def _matches_disk(fsid, store, mine=None):
     """True when publishing `store` would write back exactly what the file already holds (see save_goals).
     An absent file answers False (a create), and an unserializable `store` answers False so the real write
     still raises on its own terms — a no-op check must never swallow a publish it merely failed to
     understand. A file that cannot be READ raises instead: answering False there let the publish go ahead
-    over the very bytes it failed to compare against."""
-    disk = _read_store_json(GOALDIR / (fsid + ".json"))
-    if disk is None:
+    over the very bytes it failed to compare against. The disk side comes from _disk_entry: the memo while
+    the file's identity still matches (no read, so a fault the file develops meanwhile is not seen here,
+    and the answer is still safe: a match publishes nothing), else one read that raises as above. `mine` is
+    the store's own content hash when the caller already has it (save_goals reuses it to seed the memo
+    after its write)."""
+    ent = _disk_entry(fsid)
+    if ent is None:
         return False                                 # no file yet (a create) → publish
-    try:
-        return _store_content(disk) == _store_content(store)
-    except (TypeError, ValueError):
-        return False
+    if mine is None:
+        mine = _own_hash(store)
+    return mine is not None and ent[1] == mine
 
 
 def save_goals(fsid, store):
@@ -3773,25 +3952,37 @@ def save_goals(fsid, store):
     stats"), and a no-op republish moved every mtime every pass, so the sweep re-processed the whole live
     fleet forever. Skipping is safe precisely BECAUSE nothing changed: we have no events to contribute, so
     declining to publish can neither lose our work nor clobber a concurrent writer's. `rev` does not advance
-    on a no-op, which is the honest reading of a counter that means "publications"."""
+    on a no-op, which is the honest reading of a counter that means "publications".
+
+    The disk side of that check is memoized by file identity (_disk_entry), so a no-op save costs one
+    serialization of our own store, not a parse of the file, and the write seeds the entry for the next check
+    when no rebase changed what we wrote. The CAS below reads the file's revision from the file (_disk_rev),
+    never from the memo, so a real publish parses once, for the CAS. Both readers raise on a read fault or a
+    corrupt file, as _rebase_onto_disk does: nothing is published over bytes this save could not read."""
     _goal_io_bump("saves")
     GOALDIR.mkdir(parents=True, exist_ok=True)
-    if "_baseRev" in store and _matches_disk(fsid, store):
+    mine = _own_hash(store) if "_baseRev" in store else None
+    if mine is not None and _matches_disk(fsid, store, mine):
         return                                       # nothing of ours to publish → leave the file (and its
     base = store.pop("_baseRev", None)               # mtime) alone.  transient: never serialized
+    rebased = False
     if base is not None:
+        disk = 0
         for _ in range(4):                           # a busy store settles in a pass or two
             disk = _disk_rev(fsid)
             if disk == base:
                 break                                # nobody published since we loaded → ours is current
             _rebase_onto_disk(fsid, store)           # fold their events in, then re-check
+            rebased = True
             base = disk
-        store["rev"] = _disk_rev(fsid) + 1
+        store["rev"] = disk + 1                      # the revision the loop settled on; no second parse
     else:
         store["rev"] = int(store.get("rev") or 0) + 1
     _goal_io_bump("writes")
     tmp = _publish_tmp(GOALDIR, fsid)
     tmp.write_text(json.dumps(store))
+    if mine is not None and not rebased:             # a rebase changed the content `mine` describes
+        _disk_seed(GOALDIR / (fsid + ".json"), tmp, mine)
     tmp.rename(GOALDIR / (fsid + ".json"))            # atomic publish
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8986,6 +8986,12 @@ def _lift_spent_awaiting(now, tmux):
             # reply), the SDK reg (the CLI epoch) and the backend's live task set. Unchanged since the
             # last cycle → the ruling is unchanged → skip the load (2026-09-03: this ran a full store
             # load + journal replay per live session per 0.5 s cycle on a quiet board).
+            # A recorded fingerprint stands for a ruling made from the files' CONTENT. A load that raises
+            # forgets its entry (the except below), a load that FAULTS forgets it (the boundary's (None,
+            # fault) answer below), and so does one whose store parsed but whose override JOURNAL did not
+            # read: _replay_overrides logs history-unreadable, returns the store without the user's rows
+            # and marks it `_unread`. A ruling on that store is not a ruling on the files (a stamp the
+            # journal restored is missing from it), so the entry is forgotten and the next cycle retries.
             snap = tmux.get(sid) or {}
             # …plus the two facts the ruling reads that no file records: the live subagent count, and
             # for every dispatch the transcript pairs, WHETHER its recorded deadline has passed (a
@@ -9005,6 +9011,8 @@ def _lift_spent_awaiting(now, tmux):
             if fault is not None:                     # its row is filed; forget the gate so the next cycle
                 _lift_seen.pop(sid, None)             # retries this session, and go on to the others
                 continue
+            if store.get("_unread"):                  # the store read but its journal did not (the mark):
+                _lift_seen.pop(sid, None)             # not a ruling on the files; the next cycle retries
             nodes = store.get("nodes") or {}
             stamped = [nd for nd in nodes.values()
                        if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8156,7 +8156,7 @@ def _open_top_goal(sid):
     their notes lifted while they still held exactly those). Was _working_top_goal ('working' only), whose
     sole caller was that expiry."""
     try:
-        store = jd.load_goals(sid)
+        store = jd.load_goals_shared(sid)           # read-only: a top's status
     except Exception:
         return None
     nodes = store.get("nodes", {}); status = store.get("status", {})
@@ -10121,7 +10121,7 @@ def _deferral_sweep_tick(now):
     drop = []
     for sid, recs in by_sid.items():
         try:
-            store = jd.load_goals(sid)
+            store = jd.load_goals_shared(sid)           # read-only: nodes, status, confirming, log rows
         except Exception:
             continue                                   # unreadable store → records stand; nothing silent
         nodes, status = store.get("nodes", {}) or {}, store.get("status", {}) or {}
@@ -21872,7 +21872,7 @@ def _session_stamp_read(sid):
         return hit[1]
     full, tops, deleg = (None, None, None, None, ()), set(), ()
     try:                                               # load_goals (not a raw read) so overrides replay —
-        store = jd.load_goals(sid)                     # the same view _goal_awaiting_stamp sees on the card
+        store = jd.load_goals_shared(sid)              # the same view _goal_awaiting_stamp sees on the card
         nodes = store.get("nodes", {})
         status = store.get("status", {}) or {}
         best = None
@@ -22781,7 +22781,7 @@ def _owned_yield_why(sid, path):
     if not owned:
         return None
     try:
-        store = jd.load_goals(sid)
+        store = jd.load_goals_shared(sid)           # read-only: nodes + status
         nodes = store.get("nodes", {})
         status = store.get("status", {}) or {}
     except Exception:
@@ -28397,8 +28397,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     events, by_tool = [], {}                  # by_tool: tool_use_id → its tool event (fill output later)
     uuid2seg, seg_anchors = {}, {}            # atom uuid → seg id; seg id → (promptId, workId) for the dot/bar split
     seg_trig, seg_work = {}, {}               # goal-node DEEP-LINK anchors: prompt = the segment's trigger
-    _bs_store, _bs_fault = jd.load_goals_or_fault(sid)   # seam-aware seg ids (mirror the judge's split); a
-    #                                                      FAULT (row filed) → None → seams off, the tab still builds
+    _bs_store, _bs_fault = jd.load_goals_shared_or_fault(sid)   # seam-aware seg ids (mirror the judge's split):
+    #                                                             the shared read-only view; a FAULT (row filed) →
+    #                                                             None → seams off, the tab still builds
     #                                          (the per-turn seg loop runs below, after the fold decision)
     last_t = None
     last_model = ""                           # the model on the most recent assistant message (system-card meta)
@@ -29282,9 +29283,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # LEAF: its descendants are hidden even if open. Skip cleared nodes. `current` marks the focus node
     # being worked on (the graph's lastNode) so render can point a line at it; done nodes carry their
     # time for a recency-coloured "(Xm ago)" on the right.
-    gstore, gfault = jd.load_goals_or_fault(sid)   # a FAULT (row filed) → None: this tab's ledger tree
-    if gfault is None:                             # renders EMPTY instead of every tab's build failing
-        gstore = _apply_rewind_hold(sid, gstore)   # a pending rewind's cards hide on EVERY
+    gstore, gfault = jd.load_goals_shared_or_fault(sid)   # the shared read-only view; a FAULT (row filed) →
+    if gfault is None:                                    # None: this tab's ledger tree renders EMPTY instead
+        gstore = _apply_rewind_hold(sid, gstore)          # of every tab's build failing. A pending rewind's cards hide on EVERY
     #                                            surface — this ledger tree (and the tab-hover
     #                                            recents derived from it) used to keep showing the
     #                                            doomed asks for the whole armed window while the
@@ -30140,6 +30141,7 @@ def _compact_goal_stores():
     moved = 0
     try:
         jd._disk_memo_evict_absent()                   # save_goals' disk-side memo: drop removed stores' entries
+        jd._shared_evict_absent()                      # ...and the shared read-only views of removed stores
     except Exception:
         pass
     try:
@@ -31378,7 +31380,7 @@ def build_feed(now, tmux=None):
                 # offered Continue. Badges persist for the card's life, so one absorbed badge
                 # poisoned the session's whole card tail.
                 psid, gid = o["peer"], o.get("goalId")
-                pstore, pfault = jd.load_goals_or_fault(psid) if gid else (None, None)
+                pstore, pfault = jd.load_goals_shared_or_fault(psid) if gid else (None, None)   # read-only peer view
                 sgoal = pstore.get("nodes", {}).get(gid) if pstore is not None else None
                 origin_live = bool(sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared")
                                    and gid not in cleared)   # a sender whose store faults reads absorbed (dimmed,
@@ -33042,7 +33044,7 @@ def _msg_sum_scan_session(sid, path, now):
         return {}
     sub = {}
     session = _parse(path, sid, now)
-    mstore = jd.load_goals(sid)
+    mstore = jd.load_goals_shared(sid)               # read-only: the seams for the seg ids
     for turn in session["turns"]:
         for seg in _segs_seam(turn, mstore):
             cap = _seg_work_caption(caps, seg["id"])     # drift-safe: the store id came from the judge's parse
@@ -34352,9 +34354,9 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         tm = tmux.get(sid)
         live = tm is not None
         hexcol = (tm and tm["color"]) or (_name_color(sid) or {}).get("bg", "#888888")
-        goals, gfault = jd.load_goals_or_fault(sid)  # a FAULT (row filed) → None: this lane renders without
-        if gfault is not None:                       # goal-derived data (blocked state, seams, judging marks)
-            _bars_complain(sid, "goals", gfault)     # and the frame ships for every other lane
+        goals, gfault = jd.load_goals_shared_or_fault(sid)   # read-only view (seams + judging marks); a FAULT (row
+        if gfault is not None:                       # filed) → None: this lane renders without goal-derived data
+            _bars_complain(sid, "goals", gfault)     # (blocked state, seams, marks) and the frame ships for every other lane
         if with_bars:
             try:
                 session = _parse(s["path"], sid, now)
@@ -37689,7 +37691,15 @@ def _push(targets, connect=False, tmux=None):
                     _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
                     started = time.time()                # the _views_dirty floor for this build (start-keyed)
                     _t0 = time.monotonic()
-                    m = build_session(s["sid"], now, tmux)
+                    try:
+                        m = build_session(s["sid"], now, tmux)
+                    except Exception:
+                        # One session's failed chat build costs that session's frame this cycle, not every
+                        # client's whole push: the cycle-level catch below ("push build:") would return
+                        # before the feed and the timeline were built, and a build that fails the same way
+                        # every cycle would freeze the board for as long as its input stands (2026-09-06).
+                        sys.stderr.write("push build: chat %s: %s\n" % (str(s["sid"])[:8], traceback.format_exc()))
+                        continue
                     # The full serialization is LAZY (the 2026-08-10 CPU fix, round two): steady state
                     # sends only chatTail suffixes, so an eager json.dumps of the WHOLE payload — multi-MB
                     # for a busy active tab, re-dumped every cycle just to be discarded — was the largest

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24537,7 +24537,52 @@ _judge_gen = [0]                                 # bumped when a producer pass C
 _goals_snap = [None]                             # {sid: store} while a judge pass is mid-flight, else None
 _goals_snap_at = [0.0]                           # when that snapshot's file reads STARTED (see _feed_goals)
 _goals_snap_done = {}                            # sid → the user-write mark already punched onto THIS snapshot
+_goals_snap_owned = set()                        # sids whose snapshot entry is THIS pass's private copy (copy-on-punch)
 _goals_snap_lock = threading.Lock()
+# STAT-KEYED STORE MEMO (2026-09-06). The snapshot used to json.loads EVERY goals/<fsid>.json at the
+# start of every pass — on one busy kernel 72 files of up to 1.3 MB, about 3% of its interpreter time
+# and most of the producer thread's cost — although a pass changes only a few of them. Every writer
+# publishes by rename (save_goals), so the bytes under an inode never change once it is at its path. The
+# memo keeps the parsed object per path under (st_ino, st_mtime_ns, st_size); a pass stats every file,
+# decodes only the ones whose key moved, and builds the snapshot from memo REFERENCES. Consequence: a
+# snapshot entry is shared with later passes, so nothing may mutate it — _feed_goals copies an entry
+# before punching a user gesture onto it (the _apply_rewind_hold idiom), and build_feed only reads. A
+# version that fails to decode is remembered under its key too, so a corrupt store is decoded (and
+# reported) once per file version rather than once per pass; its sid stays out of the snapshot and the
+# feed reads it live. A read that fails (EMFILE under descriptor pressure, EIO) is not remembered: that
+# is the pass's failure, not the version's, so the next pass reads the file again, as every pass did
+# before the memo. Entries for paths gone from the directory are evicted at the next pass.
+# WHAT THE KEY RESTS ON: st_mtime_ns moving between publishes, not the inode. Inode numbers recycle
+# (on ext4, consecutive tmp+rename publishes of one path alternate between two numbers, so the third
+# version can sit on the first's inode), and equal sizes are common (a digit bump, a same-length
+# status word). On Linux 6.13+ (multigrain timestamps) the move is guaranteed: the pass's own stat
+# marks the inode as queried, so the next publish gets a fine-grained stamp. On a coarse-timestamp
+# kernel, two equal-size publishes of one store inside one clock tick after the pass's stat reproduce
+# the memoized key and pin the earlier parse until the store's next publish — a known blind spot. A byte
+# compare on a stat hit closes it; this memo does not carry one, so the cost is one pass serving the
+# earlier parse (a stale card until the store's next publish, never a wrong write).
+_goals_memo = [{}]                               # path → ((st_ino, st_mtime_ns, st_size), parsed store | _GOALS_MEMO_BAD)
+_GOALS_MEMO_BAD = object()                       # a file version that did not decode: no snapshot entry, no retry until it changes
+# Bare `+= 1` increments with one writer per key: hit/miss/fail/evict are written only by the producer thread
+# (_begin_goals_pass runs only from _producer) and punch only under _goals_snap_lock, so no key has two writers.
+_goals_memo_stats = {"hit": 0, "miss": 0, "fail": 0, "evict": 0, "punch": 0}   # read by tests; surfaced on GET /perf once that route exists
+
+
+def _goals_memo_decode(data):
+    """The memo's one decode: a raw parse of the file's bytes, exactly what the snapshot always held
+    (no _guard_nodes, no replay — those are load_goals' business). A module function so tests count
+    decodes here rather than by patching json.loads."""
+    return json.loads(data)
+
+
+def _goals_memo_report():
+    """The memo's counters plus its current occupancy: `entries` memoized paths and `bytes` their summed
+    on-disk size (a proxy for the parsed objects' footprint). GET /perf reports it once that route exists."""
+    memo = _goals_memo[0]
+    out = dict(_goals_memo_stats)
+    out["entries"] = len(memo)
+    out["bytes"] = sum(k[2] for k, v in memo.values() if v is not _GOALS_MEMO_BAD)
+    return out
 # A USER gesture (card reply, Move to Working, resolve) must NEVER wait out a pass (the user 2026-07-21).
 # The snapshot above exists to hide half-applied JUDGE writes; it was also hiding the user's own, because
 # optimistic_followup writes the LIVE store while the feed reads the frozen copy. A reply landing
@@ -24552,27 +24597,77 @@ def _note_user_goal_write(sid):
     _user_goal_write[str(sid)] = time.time()
 
 def _begin_goals_pass():
-    """Capture the PRE-pass goal stores so build_feed serves a pass-boundary-consistent view for the pass."""
-    at = time.time()          # stamped BEFORE the reads: a write racing this loop must count as AFTER them,
-    snap = {}                 # so it gets replayed onto the snapshot rather than lost to the read order
+    """Capture the PRE-pass goal stores so build_feed serves a pass-boundary-consistent view for the pass.
+
+    Stat-keyed (see the memo note above): each store is decoded only when its (ino, mtime_ns, size)
+    moved since the last pass; an unchanged one is served as the memoized object. The key is taken by
+    fstat on the fd the bytes are read from, so key and content are the same file version: a rename
+    landing between the listing's stat and the open is read whole from the new inode and keyed as
+    such. Any race the other way (content newer than its key) only costs one extra decode next pass;
+    it can never pin a stale parse, because the next stat sees a moved key. The one way a stale parse
+    CAN pin is the coarse-timestamp blind spot in the memo note above (equal size, recycled inode, same
+    clock tick); on a multigrain-timestamp kernel it does not occur."""
+    # ui/webview/feed-move-ack.test.ts pins the next line's comment text ("stamped BEFORE the reads").
+    at = time.time()          # stamped BEFORE the reads and the stats that gate them: a write racing this loop
+    snap = {}                 # must count as AFTER them, so it is replayed onto the snapshot, not lost to the read order
+    prev = _goals_memo[0]
+    memo = {}
+    hit = miss = fail = 0
     try:
-        for p in jd.GOALDIR.glob("*.json"):
-            try:
-                snap[p.stem] = json.loads(p.read_text())
-            except Exception:
-                pass
-    except Exception:
-        pass
+        entries = [e for e in os.scandir(jd.GOALDIR) if e.name.endswith(".json") and e.is_file()]
+    except OSError:
+        entries = []
+    for ent in entries:
+        path, sid = ent.path, ent.name[:-5]
+        try:
+            st = ent.stat()
+            key = (st.st_ino, st.st_mtime_ns, st.st_size)
+            old = prev.get(path)
+            if old is not None and old[0] == key:
+                hit += 1                                   # same file version → the memoized parse (or its
+                memo[path] = old                           # remembered decode failure) stands
+                if old[1] is not _GOALS_MEMO_BAD:
+                    snap[sid] = old[1]
+                continue
+            with open(path, "rb") as fh:
+                st = os.fstat(fh.fileno())
+                key = (st.st_ino, st.st_mtime_ns, st.st_size)
+                data = fh.read()
+            store = _goals_memo_decode(data)
+        except FileNotFoundError:
+            continue                                       # gone between the listing and the read: no store
+        except OSError as e:                               # unreadable (EMFILE, EIO): out of the snapshot for THIS
+            fail += 1                                      # pass and not remembered, so the next pass reads it again
+            sys.stderr.write("goals-pass: %s: %s: %s (not in the pass snapshot; served live, read again next pass)\n"
+                             % (ent.name, type(e).__name__, e))
+            continue
+        except Exception as e:                             # undecodable: out of the snapshot (the feed reads it
+            fail += 1                                      # live, as before), said once per version
+            memo[path] = (key, _GOALS_MEMO_BAD)
+            sys.stderr.write("goals-pass: %s: %s: %s (not in the pass snapshot; served live until the file changes)\n"
+                             % (ent.name, type(e).__name__, e))
+            continue
+        miss += 1
+        memo[path] = (key, store)
+        snap[sid] = store
+    _goals_memo[0] = memo
+    _goals_memo_stats["hit"] += hit
+    _goals_memo_stats["miss"] += miss
+    _goals_memo_stats["fail"] += fail
+    _goals_memo_stats["evict"] += len(prev.keys() - memo.keys())
     with _goals_snap_lock:
         _goals_snap[0] = snap
         _goals_snap_at[0] = at
         _goals_snap_done.clear()
+        _goals_snap_owned.clear()
 
 def _end_goals_pass():
-    """Pass over — drop the snapshot so reads go live again (post-pass results + any user writes show now)."""
+    """Pass over — drop the snapshot so reads go live again (post-pass results + any user writes show now).
+    The memo keeps its parsed stores: they are the next pass's cache hits."""
     with _goals_snap_lock:
         _goals_snap[0] = None
         _goals_snap_done.clear()
+        _goals_snap_owned.clear()
 
 def _feed_goals(sid):
     """Goal store for the FEED, frozen at the pre-pass snapshot while a judge pass is mid-flight (so a card
@@ -24591,6 +24686,14 @@ def _feed_goals(sid):
         if snap is not None and sid in snap:
             store, mark = snap[sid], _user_goal_write.get(str(sid), 0.0)
             if mark >= _goals_snap_at[0] and _goals_snap_done.get(sid) != mark:
+                if sid not in _goals_snap_owned:
+                    # COPY-ON-PUNCH: the entry is the memo's object, shared with every later pass that
+                    # finds the file unchanged, so the replay and rollup below must land on a copy of it
+                    # (the _apply_rewind_hold idiom). Once per pass per sid: a second gesture in the
+                    # same pass punches the copy this one made.
+                    store = snap[sid] = json.loads(json.dumps(store))
+                    _goals_snap_owned.add(sid)
+                    _goals_memo_stats["punch"] += 1
                 try:
                     jd._replay_overrides(sid, store)   # the reopen/move/resolve/unclear event, applied by the judge's own code
                     jd.rollup_status(store, False)     # …and the card's column follows it (the user just acted → working)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30131,6 +30131,10 @@ def _compact_goal_stores():
     import glob
     moved = 0
     try:
+        jd._disk_memo_evict_absent()                   # save_goals' disk-side memo: drop removed stores' entries
+    except Exception:
+        pass
+    try:
         paths = glob.glob(str(jd.GOALDIR / "*.json"))
     except Exception:
         return 0

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -211,9 +211,15 @@ class _PerfStats:
       sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
                                    name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
                                    under "other"). A deduped frame was built and compared, not sent
-      goals                        loads, saves, writes: judge.load_goals calls, save_goals calls,
-                                   and the saves that reached the disk (a byte-identical republish
-                                   is a save without a write)
+      goals                        loads, saves, writes: judge.load_goals calls (the writer's loader;
+                                   the pusher's read-only loads ride load_goals_shared and show under
+                                   memos.shared), save_goals calls, and the saves that reached the
+                                   disk (a byte-identical republish is a save without a write)
+      memos                        pass / shared / chain: the judge pass's stat-keyed store memo
+                                   (_goals_memo_report: hit, miss, fail, evict, punch, entries,
+                                   bytes), the pusher's shared read-only store cache
+                                   (judge.shared_store_stats) and the write-moment chain memo
+                                   (judge.chain_memo_stats)
       judge                        passes (one per _producer pass), ms_sum / ms_last / ms_mean (wall:
                                    a pass is a join over the tier threads, so this is mostly model
                                    latency), cpu_ms_sum (CPU: the two tier threads' own time, from
@@ -364,10 +370,20 @@ class _PerfStats:
             goals = jd.goal_io_stats()
         except Exception:
             goals = {}
+        # The three identity memos' readers land here (review find, 2026-09-08: they had no consumer): the
+        # judge pass's stat-keyed store memo, the pusher's shared read-only store cache and the write-moment
+        # chain memo. `goals.loads` is the writer's loader alone; the pusher's loads show under memos.shared.
+        memos = {}
+        for key, read in (("pass", _goals_memo_report), ("shared", jd.shared_store_stats),
+                          ("chain", jd.chain_memo_stats)):
+            try:
+                memos[key] = read()
+            except Exception:
+                memos[key] = {}
         now = time.time()
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
-                "builds": builds, "sends": sends, "goals": goals, "judge": judge, "http": http}
+                "builds": builds, "sends": sends, "goals": goals, "memos": memos, "judge": judge, "http": http}
 
 
 _PERF_STATS = _PerfStats()
@@ -19060,8 +19076,9 @@ SYNC_RING = 40
 def _sync_notice(text, ok=True, kind="sync"):
     """One row on the ring the shell's bell mirrors. `kind` is the bell kind the row is filed under:
     "sync" (the default, the ring's original tenant: a machine sync) or "refused" (a state file that
-    could not be read or written, or was moved aside), so a mute on one never hides the other (review
-    find, 2026-09-08). The shell allowlists the value; anything it does not know reads as sync."""
+    could not be read or written, or was moved aside, or a session's chat frame that could not be
+    built), so a mute on one never hides the other (review find, 2026-09-08). The shell allowlists the
+    value; anything it does not know reads as sync."""
     global _SYNC_SEQ
     with _SYNC_LOCK:
         _SYNC_SEQ += 1
@@ -24559,7 +24576,9 @@ _goals_snap_lock = threading.Lock()
 # reported) once per file version rather than once per pass; its sid stays out of the snapshot and the
 # feed reads it live. A read that fails (EMFILE under descriptor pressure, EIO) is not remembered: that
 # is the pass's failure, not the version's, so the next pass reads the file again, as every pass did
-# before the memo. Entries for paths gone from the directory are evicted at the next pass.
+# before the memo. Entries for paths gone from the directory are evicted at the next pass, and the
+# compaction sweep after each pass evicts the entries of stores no discovered session owns
+# (_goals_memo_evict_unowned), so the resident set is bounded by the live board.
 # WHAT THE KEY RESTS ON: st_mtime_ns moving between publishes, not the inode. Inode numbers recycle
 # (on ext4, consecutive tmp+rename publishes of one path alternate between two numbers, so the third
 # version can sit on the first's inode), and equal sizes are common (a digit bump, a same-length
@@ -24573,7 +24592,7 @@ _goals_memo = [{}]                               # path → ((st_ino, st_mtime_n
 _GOALS_MEMO_BAD = object()                       # a file version that did not decode: no snapshot entry, no retry until it changes
 # Bare `+= 1` increments with one writer per key: hit/miss/fail/evict are written only by the producer thread
 # (_begin_goals_pass runs only from _producer) and punch only under _goals_snap_lock, so no key has two writers.
-_goals_memo_stats = {"hit": 0, "miss": 0, "fail": 0, "evict": 0, "punch": 0}   # read by tests; surfaced on GET /perf once that route exists
+_goals_memo_stats = {"hit": 0, "miss": 0, "fail": 0, "evict": 0, "punch": 0}   # read by tests and GET /perf (memos.pass)
 
 
 def _goals_memo_decode(data):
@@ -24585,12 +24604,30 @@ def _goals_memo_decode(data):
 
 def _goals_memo_report():
     """The memo's counters plus its current occupancy: `entries` memoized paths and `bytes` their summed
-    on-disk size (a proxy for the parsed objects' footprint). GET /perf reports it once that route exists."""
+    on-disk size (a proxy for the parsed objects' footprint). GET /perf reports it as memos.pass."""
     memo = _goals_memo[0]
     out = dict(_goals_memo_stats)
     out["entries"] = len(memo)
     out["bytes"] = sum(k[2] for k, v in memo.values() if v is not _GOALS_MEMO_BAD)
     return out
+
+
+def _goals_memo_evict_unowned(owned):
+    """Drop the entries of stores no session in `owned` (the discover set's sids) holds. The memo had no
+    cap: every store the directory held stayed decoded in memory between passes, tens of MB on a large
+    board (review find, 2026-09-08). The compaction sweep calls this after the tiers, on the producer
+    thread, the memo's one writer. The price is one decode at the next pass for such a store the pass
+    still lists (what every pass paid before the memo); the stores a discovered session owns keep their
+    entries. A swap, never an in-place mutation: a /perf reader may be iterating the old dict."""
+    memo = _goals_memo[0]
+    kept = {path: ent for path, ent in memo.items() if os.path.basename(path)[:-5] in owned}
+    gone = len(memo) - len(kept)
+    if gone:
+        _goals_memo[0] = kept
+        _goals_memo_stats["evict"] += gone
+    return gone
+
+
 # A USER gesture (card reply, Move to Working, resolve) must NEVER wait out a pass (the user 2026-07-21).
 # The snapshot above exists to hide half-applied JUDGE writes; it was also hiding the user's own, because
 # optimistic_followup writes the LIVE store while the feed reads the frozen copy. A reply landing
@@ -30136,7 +30173,9 @@ _compact_seen = {}                                     # fsid → live-store mti
 
 def _compact_goal_stores():
     """Sweep every session's goal store, archiving newly-cleared tops. Cheap: skips a store whose live file
-    hasn't changed since the last sweep (no new clears, no judge write), so the steady state is just stats."""
+    hasn't changed since the last sweep (no new clears, no judge write), so the steady state is just stats.
+    Runs on the producer thread after the tiers join (its caller's single-writer slot): the pass memo it
+    evicts from has that thread as its one writer."""
     import glob
     moved = 0
     try:
@@ -30144,6 +30183,16 @@ def _compact_goal_stores():
         jd._shared_evict_absent()                      # ...and the shared read-only views of removed stores
     except Exception:
         pass
+    try:
+        # ...and, for the two memos that hold PARSED stores, the entries of stores no discovered session
+        # owns: neither had a cap (review find, 2026-09-08). discover is cached behind the transcript
+        # directory's fingerprint, so this is the tiers' own list, not a second walk. A discover that
+        # raises evicts nothing: with no owner list there is no unowned.
+        owned = {f for f, _p, _a, _n in jd.discover(int(time.time()))}
+        jd._shared_evict_unowned(owned)
+        _goals_memo_evict_unowned(owned)
+    except Exception:
+        sys.stderr.write("compact: memo eviction: %s\n" % traceback.format_exc())
     try:
         paths = glob.glob(str(jd.GOALDIR / "*.json"))
     except Exception:
@@ -37612,6 +37661,38 @@ def _note_chat_divergence(sid, name, chat_state, row_state, now):
         pass
 
 
+_chat_build_faults = {}   # sid -> the fault text of its CURRENT chat-build episode; ONE stderr traceback + bell row per episode
+_chat_build_faults_lock = threading.Lock()   # the pusher and a connect push both run _push, on their own threads
+
+
+def _chat_build_fault(s, exc):
+    """Name a session whose chat build raised, on stderr (with the traceback) AND as a dashboard bell row,
+    ONCE per fault episode. _push skips the session's frame for the cycle (see its catch), so without this
+    the user's only sign was a pane that stopped updating, and a build that fails the same way every cycle
+    (its input stands) wrote a full traceback every 0.5-3 s (review find, 2026-09-08). The episode is the
+    fault TEXT, the _git_file_fault rule: an identical repeat says nothing, a different fault on the same
+    session is a new episode, and a build that succeeds ends it (_chat_build_ok). The bell row wears the
+    kind a state file that cannot be read wears. Never raises: the bell is a courtesy inside the push."""
+    sid = str(s.get("sid") or "")
+    text = "%s: %s" % (type(exc).__name__, exc)
+    with _chat_build_faults_lock:                     # check-and-set as ONE step: two _push threads faulting
+        if _chat_build_faults.get(sid) == text:       # the same session must not both speak
+            return
+        _chat_build_faults[sid] = text
+    sys.stderr.write("push build: chat %s: %s\n" % (sid[:8], traceback.format_exc()))
+    try:
+        _sync_notice("chat: the pane for %s cannot be built (%s); it keeps its last frame until a build succeeds"
+                     % (s.get("name") or sid[:8], text), ok=False, kind="refused")
+    except Exception:
+        pass
+
+
+def _chat_build_ok(sid):
+    """A chat build that succeeded ends the session's fault episode, so the same fault later is said anew."""
+    if _chat_build_faults:                            # the common case (no episode open) pays no lock
+        with _chat_build_faults_lock:
+            _chat_build_faults.pop(str(sid), None)
+
 
 def _push(targets, connect=False, tmux=None):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
@@ -37693,13 +37774,16 @@ def _push(targets, connect=False, tmux=None):
                     _t0 = time.monotonic()
                     try:
                         m = build_session(s["sid"], now, tmux)
-                    except Exception:
+                    except Exception as e:
                         # One session's failed chat build costs that session's frame this cycle, not every
                         # client's whole push: the cycle-level catch below ("push build:") would return
                         # before the feed and the timeline were built, and a build that fails the same way
                         # every cycle would freeze the board for as long as its input stands (2026-09-06).
-                        sys.stderr.write("push build: chat %s: %s\n" % (str(s["sid"])[:8], traceback.format_exc()))
+                        # Said ONCE per fault episode, on stderr and as a dashboard bell row, so the pane
+                        # that stopped updating is not a silent degrade (review find, 2026-09-08).
+                        _chat_build_fault(s, e)
                         continue
+                    _chat_build_ok(s["sid"])             # a build that succeeds ends its fault episode
                     # The full serialization is LAZY (the 2026-08-10 CPU fix, round two): steady state
                     # sends only chatTail suffixes, so an eager json.dumps of the WHOLE payload — multi-MB
                     # for a busy active tab, re-dumped every cycle just to be discarded — was the largest

--- a/tests/test_ask_unit_cards.py
+++ b/tests/test_ask_unit_cards.py
@@ -96,7 +96,7 @@ class CourierWorld(unittest.TestCase):
         jd.discover = lambda now, window=None, forks=True: fleet
         self._llm = jd.courier_llm
         jd.courier_llm = lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 1, "text": "drag-range selection"}'
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd._delegate_user_rooted = self._rooted
@@ -168,7 +168,7 @@ class CourierWorld(unittest.TestCase):
              "to_id": WK1, "kind": "delegate", "body": BODY1},
             {"t": T0 + 120, "ev": "sent", "id": MID2, "from": "web", "from_id": MGR,
              "to_id": WK1, "kind": "delegate", "body": BODY2}]) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         self.assertEqual(len(self._trackers_under(MGR + ":g1")), 1)
         self.assertEqual(len(self._trackers_under(MGR + ":g2")), 1,

--- a/tests/test_chain_rooted_minting.py
+++ b/tests/test_chain_rooted_minting.py
@@ -518,7 +518,7 @@ class CourierMintMatrix(unittest.TestCase):
         jd.discover = lambda now, window=None, forks=True: fleet
         self._llm = jd.courier_llm
         jd.courier_llm = lambda text, menu, declared=None: LINK_REPLY
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd.MESSAGES = self._msgs
@@ -609,7 +609,7 @@ class CourierMintMatrix(unittest.TestCase):
         self.mpath.write_text("\n".join(json.dumps(r) for r in [
             uline(T0 - 600, "please verify the staged run references", "hu"),
             aline(T0 - 540, "Dispatching.", "ha", "hu")]) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
         planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
@@ -638,7 +638,7 @@ class CourierMintMatrix(unittest.TestCase):
                                origin={"peer": GRAND, "goalId": GRAND + ":t1", "msgId": "m0"})},
             "placements": {}, "status": {}})
         self.mpath.write_text(json.dumps(aline(T0 - 540, "Working the round.", "ha")) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
         planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
@@ -664,7 +664,7 @@ class CourierMintMatrix(unittest.TestCase):
                                origin={"peer": GRAND, "goalId": GRAND + ":t1", "msgId": "m0"})},
             "placements": {}, "status": {}})
         self.mpath.write_text(json.dumps(aline(T0 - 540, "Working the round.", "ha")) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
         planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
@@ -749,7 +749,7 @@ class FanOutDedupe(unittest.TestCase):
         self._llm = jd.courier_llm
         jd.courier_llm = lambda text, menu, declared=None: LINK_REPLY
         self.gpath.write_text(json.dumps(aline(T0 - 1000, "quiet.", "gz")) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd.MESSAGES = self._msgs
@@ -785,7 +785,7 @@ class FanOutDedupe(unittest.TestCase):
              "to_id": WKR, "kind": "delegate", "body": BODY.split("\n")[0]},
             {"t": T0 + 120, "ev": "sent", "id": MID_B, "from": "web", "from_id": MGR,
              "to_id": WKR, "kind": "delegate", "body": BODY_B.split("\n")[0]}]) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
         planted = [nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)]
@@ -821,7 +821,7 @@ class FanOutDedupe(unittest.TestCase):
         jd.MESSAGES.write_text(json.dumps(
             {"t": T0, "ev": "sent", "id": MID, "from": "web", "from_id": MGR,
              "to_id": WKR, "kind": "delegate", "body": BODY.split("\n")[0]}) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.run_courier(now=NOW)
         w = jd.load_goals(WKR)
         self.assertEqual([nd for nd in w["nodes"].values() if isinstance(nd.get("origin"), dict)],

--- a/tests/test_clear_turn_no_card.py
+++ b/tests/test_clear_turn_no_card.py
@@ -78,7 +78,7 @@ class ClearTurnNoCard(unittest.TestCase):
         jd.STATESDIR.mkdir(parents=True, exist_ok=True)
         (jd.STATESDIR / (SID + ".jsonl")).write_text(
             "\n".join(json.dumps(m) for m in markers) + ("\n" if markers else ""))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         return jd.parsed_session(SID, [str(tpath)], NOW)
 
     def test_no_content_marker_never_becomes_an_atom(self):

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -79,7 +79,7 @@ class CommentBase(unittest.TestCase):
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._thread_msgs_cache.clear()
         self.now = int(time.time())
         self.cdir = str(Path(self._td) / "work")
@@ -427,7 +427,7 @@ class ThreadProjection(CommentBase):
 
     def _frame_thread(self, records, state=""):
         self._write(THREAD, records)
-        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._sdk = lambda: self._State(state)
         return km._comments_frame(PARENT)["threads"][0]
 
@@ -869,7 +869,7 @@ class ThreadProjection(CommentBase):
         # it now rides the frame's error channel, in the user's words
         self._seed_thread()
         (self.proj / (THREAD + ".jsonl")).unlink()
-        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._thread_unreadable_warned.clear()
         km._sdk = lambda: self._State("")
         th = km._comments_frame(PARENT)["threads"][0]
@@ -883,7 +883,7 @@ class ThreadProjection(CommentBase):
         import contextlib, io
         self._seed_thread()
         (self.proj / (THREAD + ".jsonl")).unlink()
-        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._thread_unreadable_warned.clear()
         km._sdk = lambda: self._State("working")
         err = io.StringIO()
@@ -952,7 +952,7 @@ class ThreadProjection(CommentBase):
         import contextlib, io
         self._seed_thread()
         (self.proj / (THREAD + ".jsonl")).unlink()
-        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear()
+        km._thread_msgs_cache.clear(); km._parse_cache.clear(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._thread_unreadable_warned.clear()
         km._sdk = lambda: self._State("")
         err = io.StringIO()

--- a/tests/test_context_frames.py
+++ b/tests/test_context_frames.py
@@ -133,7 +133,7 @@ class CourierMintCarriesTheFrame(unittest.TestCase):
         jd.discover = lambda now, window=None, forks=True: fleet
         self._llm = jd.courier_llm
         jd.courier_llm = lambda text, menu, declared=None: '{"verdict": "delegating", "goal": 0, "text": "verify refs"}'
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd._delegate_user_rooted = self._rooted

--- a/tests/test_courier_kind_demote_only.py
+++ b/tests/test_courier_kind_demote_only.py
@@ -83,7 +83,7 @@ class CourierKindDemoteOnly(unittest.TestCase):
         self.calls = []
         jd.courier_llm = lambda *a, **k: self.calls.append(k.get("declared", "")) or self.reply
         self.reply = DELEGATING
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd._discover_cache["result"] = None
         jd._postal_from_memo["key"] = None
@@ -100,7 +100,7 @@ class CourierKindDemoteOnly(unittest.TestCase):
                 aline(T0 + 30, "It's on the flat /24.", "a1", "u1")]
         (self.proj_dir / (RECIP + ".jsonl")).write_text(
             "\n".join(json.dumps(r) for r in recs) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd.run_courier(now=T0 + 100)
         store = jd.load_goals(RECIP)

--- a/tests/test_courier_origin_host.py
+++ b/tests/test_courier_origin_host.py
@@ -79,7 +79,7 @@ class CourierOriginHost(unittest.TestCase):
         jd.MESSAGES = self.tl / "messages.jsonl"
         jd.ERRORS = td / "judge-errors.jsonl"
         jd.courier_llm = lambda *a, **k: '{"verdict": "delegating", "goal": 0, "text": "wire up the export button"}'
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd._discover_cache["result"] = None
         jd._postal_from_memo["key"] = None

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -1663,6 +1663,85 @@ class EclipsedChainSelection(unittest.TestCase):
         self.assertIn("second persisted attempt", texts)
         self.assertNotIn("first persisted attempt", texts)
 
+    # ── the five-way membership on a fork holding every sibling kind at once: the oracle for the
+    # narrowed selection. _select_eclipsed_chains builds its child map and its text witness over
+    # the eclipse set alone; these literals were recorded from the whole-graph version before that
+    # change and must not move. ──
+
+    def _sibling_fork(self, reply=True, completed=True):
+        """One fork (remA) with three sibling branches: the bypassed reply branch (assistant-headed,
+        a tool cycle then text), a textless stub pair, and a user-headed branch carrying a reply.
+        `reply=False` drops the reply branch (no branch qualifies); `completed=False` ends the
+        spine at the api_error record (the "exhausted" terminal)."""
+        recs = self.base() + [reminder_line(T0 + 10, "remA", "u1")]
+        if reply:
+            recs += [aline(T0 + 20, "", "tuA1", "remA", tools=("Bash",), stop=None),
+                     trline(T0 + 25, "tu_tuA1_0", "trA1", "tuA1"),
+                     aline(T0 + 30, "the reply the user watched stream", "rpA", "trA1")]
+        recs += [aline(T0 + 21, "", "stubA", "remA", tools=("Read",), stop=None),
+                 trline(T0 + 26, "tu_stubA_0", "stubB", "stubA"),
+                 uline(T0 + 40, "prompt on a side branch", "ux", "remA", ps="typed"),
+                 aline(T0 + 50, "reply on that side branch", "ax", "ux"),
+                 api_error_line(T0 + 11, "eA1", "remA", attempt=1)]
+        if completed:
+            recs += [stop_hook_line(T0 + 31, "shA", "eA1"),
+                     uline(T0 + 100, "next ask", "u2", "shA"),
+                     aline(T0 + 130, "done", "a2", "u2")]
+        return recs
+
+    def _five_way(self, records):
+        """chain_membership's dict beside the same five sets derived from a FRESH FileAdapter with
+        no help from the exported predicate (PredicateParityGolden's oracle, all five sets)."""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / (SID + ".jsonl")
+            path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            mem = em.chain_membership(str(path))
+            ad = em.FileAdapter([str(path)], path)
+        active = ad.active_path()
+        fresh = {"kept": ad.kept_uuids(active), "rewind": set(), "clear": set(), "broken": set(),
+                 "eclipsed": set()}
+        for u, v in ad.chain_verdicts(active).items():
+            if v != "active":
+                fresh[v].add(u)
+        return mem, fresh
+
+    def test_sibling_fork_five_way_verdicts_are_pinned_and_match_a_fresh_adapter(self):
+        mem, fresh = self._five_way(self._sibling_fork())
+        self.assertEqual(mem, fresh)
+        self.assertEqual(mem, {
+            "kept": {"u1", "remA", "eA1", "shA", "u2", "a2", "tuA1", "trA1", "rpA"},
+            "eclipsed": {"tuA1", "trA1", "rpA"},
+            "rewind": {"stubA", "stubB", "ux", "ax"},
+            "clear": set(), "broken": set()})
+
+    def test_sibling_fork_with_no_qualifying_branch_demotes_only_the_user_headed_one(self):
+        mem, fresh = self._five_way(self._sibling_fork(reply=False))
+        self.assertEqual(mem, fresh)
+        self.assertEqual(mem, {
+            "kept": {"u1", "remA", "eA1", "shA", "u2", "a2", "stubA", "stubB"},
+            "eclipsed": {"stubA", "stubB"},
+            "rewind": {"ux", "ax"},
+            "clear": set(), "broken": set()})
+
+    def test_sibling_fork_at_a_tail_spur_still_picks_the_reply(self):
+        # the terminal decides only when NO branch qualifies; with the reply present the
+        # selection is the same at an exhausted spur as behind a completed flush
+        mem, fresh = self._five_way(self._sibling_fork(completed=False))
+        self.assertEqual(mem, fresh)
+        self.assertEqual(mem, {
+            "kept": {"u1", "remA", "eA1", "tuA1", "trA1", "rpA"},
+            "eclipsed": {"tuA1", "trA1", "rpA"},
+            "rewind": {"stubA", "stubB", "ux", "ax"},
+            "clear": set(), "broken": set()})
+
+    def test_sibling_fork_at_a_tail_spur_with_no_qualifying_branch_keeps_every_sibling(self):
+        mem, fresh = self._five_way(self._sibling_fork(reply=False, completed=False))
+        self.assertEqual(mem, fresh)
+        self.assertEqual(mem, {
+            "kept": {"u1", "remA", "eA1", "stubA", "stubB", "ux", "ax"},
+            "eclipsed": {"stubA", "stubB", "ux", "ax"},
+            "rewind": set(), "clear": set(), "broken": set()})
+
 
 class SlashCommandTurn(unittest.TestCase):
     def test_command_turn_is_tracked_and_flagged(self):

--- a/tests/test_fork_lineage.py
+++ b/tests/test_fork_lineage.py
@@ -127,7 +127,7 @@ class BuildSessionLineage(unittest.TestCase):
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         self.now = int(time.time())
         self.cdir = str(Path(self._td) / "work")
         self.proj = jd._proj_dir(self.cdir)

--- a/tests/test_git_pointer_file_bytes.py
+++ b/tests/test_git_pointer_file_bytes.py
@@ -314,7 +314,7 @@ class PushCycle(unittest.TestCase):
 
     def _clear_build_state(self):
         km._parse_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._built_chat.clear()
         km._prev_chat_events.clear()
         km._prev_chat_ledger.clear()

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -509,7 +509,9 @@ class TriagePassBoundary(_World):
     def test_run_propagate_continues_past_a_faulting_session(self):
         with _fault_on(self.a_file):
             jd.run_propagate(now=NOW)
-        self.assertGreaterEqual(self.seen.count(B), 2, "both arms of the pass reached the healthy session")
+        self.assertEqual(self.seen.count(B), 1, "the healthy session is read once per pass, shared by both arms")
+        self.assertGreaterEqual(self.seen.count(A), 2,
+                                "both arms of the pass reached the faulting session (a read that raised is not kept)")
         rows = self._rows("pass-crash")
         self.assertTrue(rows, "the faulting session's rows are filed")
         self.assertEqual({(r["judge"], r["fsid"]) for r in rows}, {("propagate", A)},

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -14,6 +14,7 @@ made it.
 
 SYNTHETIC fixtures only: private synthetic sids, the notes-api demo world (`web` / `api` / `tests`),
 message ids stamped TESTHOST; the per-sid override journals are cleaned in tearDown."""
+import contextlib
 import errno
 import itertools
 import json
@@ -81,15 +82,24 @@ def _store(sid, text, **node):
             "lastNode": gid}
 
 
+@contextlib.contextmanager
 def _fault_on(path):
-    """Path.read_text raises EIO for `path` alone; every other read is untouched."""
-    orig = Path.read_text
+    """Every reader of `path` raises EIO; every other read is untouched. Path.read_text is the load path's
+    reader; the save path's memoized readers (_disk_entry, _disk_rev) open a descriptor of their own and
+    read from it (_disk_read), so os.open faults for the path as well."""
+    orig_read_text, orig_open = Path.read_text, os.open
 
     def faulting(p, *a, **kw):
         if p == path:
             raise OSError(errno.EIO, "Input/output error", str(p))
-        return orig(p, *a, **kw)
-    return mock.patch.object(Path, "read_text", faulting)
+        return orig_read_text(p, *a, **kw)
+
+    def faulting_open(p, *a, **kw):
+        if os.fspath(p) == str(path):
+            raise OSError(errno.EIO, "Input/output error", str(path))
+        return orig_open(p, *a, **kw)
+    with mock.patch.object(Path, "read_text", faulting), mock.patch.object(os, "open", faulting_open):
+        yield
 
 
 class _World(unittest.TestCase):

--- a/tests/test_goal_store_fault_boundary.py
+++ b/tests/test_goal_store_fault_boundary.py
@@ -104,7 +104,7 @@ class _World(unittest.TestCase):
         self._write(A, _store(A, "the faulting session's goal"))
         self._write(B, _store(B, "the healthy session's goal"))
         km._parse_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         for sid in (A, B, P):
@@ -121,7 +121,7 @@ class _World(unittest.TestCase):
         p = Path(self.td.name) / (sid + ".jsonl")
         p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         km._parse_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         return str(p)
 
     def _rows(self, err=None):
@@ -273,7 +273,7 @@ class InterruptLiftBoundary(_World):
             f.write(json.dumps(_uline(self.RESUME_T, "use the staging host for now", "u3", "u2")) + "\n")
             f.write(json.dumps(_aline(self.RESUME_T + 40, "done", "a2", "u3")) + "\n")
         km._parse_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def test_a_fault_at_the_reengage_tick_keeps_the_marker_so_the_next_tick_lifts(self):
         gid = A + ":g1"
@@ -312,7 +312,7 @@ class InterruptLiftBoundary(_World):
             for r in recs:
                 f.write(json.dumps(r) + "\n")
         km._parse_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def test_a_second_stop_during_the_fault_keeps_the_marker_so_the_block_is_still_lifted_after(self):
         """The kept-marker promise has to survive the block branch too: a SECOND genuine stop while the

--- a/tests/test_interrupt_marks_memo.py
+++ b/tests/test_interrupt_marks_memo.py
@@ -210,7 +210,7 @@ class _MemoHarness(unittest.TestCase):
         km._autonudge_cache.clear()
         km._pending_ops.clear()
         km._intr_marks_memo.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd._rebind_state(self.saved[0])

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -479,17 +479,17 @@ class LiveWorkCaption(_FleetHarness, unittest.TestCase):
                 self.assertEqual(len(lives()), 1, "the first live caption fires once a CHUNK of work has accrued")
                 self.assertEqual(lives()[0]["grain"], "segment", "no turn-grain while open")
                 # grow by ONE atom (< CHUNK) → throttled, NO re-caption
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 self._tpath.write_text("\n".join(json.dumps(r) for r in self._opened(CHUNK + 2)) + "\n")
                 jd.run_index(now=now + 10)
                 self.assertEqual(len(lives()), 1, "a sub-chunk growth does NOT re-caption (throttled)")
                 # grow by a full CHUNK more → re-caption
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 self._tpath.write_text("\n".join(json.dumps(r) for r in self._opened(2 * CHUNK + 2)) + "\n")
                 jd.run_index(now=now + 20)
                 self.assertEqual(len(lives()), 2, "re-captioned once a full new chunk of atoms accrues")
                 # CLOSE the turn → a FINAL non-live segment caption, and the seg id becomes deduped
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 self._tpath.write_text("\n".join(json.dumps(r) for r in [
                     uline(T0, "investigate the crash", "u1", ps="typed"),
                     aline(T0 + 30, "Fixed the off-by-one crash.", "a1", "u1", tools=("Bash", "Edit"), stop="end_turn")]) + "\n")
@@ -733,11 +733,11 @@ class PlanParseStorm(unittest.TestCase):
             jd._group_store = lambda *a, **k: None         # don't fire the real grouper model after a placement
             try:
                 tpath.write_text("\n".join(json.dumps(r) for r in recs1) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 if recs2 is not None:
                     tpath.write_text("\n".join(json.dumps(r) for r in recs2) + "\n")
-                    jd._PARSE_CACHE.clear()
+                    jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                     jd._plan_session(SID, str(tpath), NOW + 100)
                 store = jd.load_goals(SID)
             finally:
@@ -1124,7 +1124,7 @@ class SegKeyDrift(unittest.TestCase):
             jd._group_store = lambda *a, **k: None
             try:
                 tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd.plan_llm = lambda *a, **k: '{"ops":[{"why":"asked","do":"mint","text":"Ship the exporter"}]}'
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
@@ -1140,7 +1140,7 @@ class SegKeyDrift(unittest.TestCase):
 
                 calls = []
                 jd.plan_llm = lambda *a, **k: (calls.append(1), '{"ops":[{"why":"dup","do":"mint","text":"DUP"}]}')[1]
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW + 100)
                 self.assertEqual(calls, [], "a drift-shifted placement still dedups — the planner is not re-run")
                 self.assertEqual(len(jd.load_goals(SID)["nodes"]), 1, "no duplicate goal was minted")
@@ -1684,7 +1684,7 @@ class Grouper(unittest.TestCase):
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.group_llm)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR = names, proj, td / "goals"
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         gcalls = []
         try:
             jd.plan_llm = (lambda text, menu, human=False, **_kw:
@@ -1701,7 +1701,7 @@ class Grouper(unittest.TestCase):
             self.assertGreaterEqual(len(gcalls), 1, "the planner invoked the grouper after a placement")
         finally:
             (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.group_llm) = saved
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
 
 class Consolidator(unittest.TestCase):
@@ -2300,7 +2300,7 @@ class PostalDelegation(unittest.TestCase):
                 jd.save_goals(SID, store)
                 if view_cleared and gid:
                     jd._view_cleared = lambda g=gid: {g}   # the user crossed G off the feed → _reopen won't unseal it
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 for _ in range(passes):
                     jd._plan_session(SID, str(tpath), NOW)
                 return jd.load_goals(SID), seg_id, gid
@@ -2404,7 +2404,7 @@ class PostalDelegation(unittest.TestCase):
                 for s in peers:                            # the courier marked every one coordination
                     store["placements"][s["id"]] = "fyi"
                 jd.save_goals(SID, store)
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)     # ONE pass
                 store = jd.load_goals(SID)
                 tops = [nd for nd in store["nodes"].values() if nd["parentId"] is None]
@@ -2467,7 +2467,7 @@ class NudgeMustResolve(unittest.TestCase):
                                          "nodeComplete": False, "blocked": False, "cleared": False,
                                          "trail": ["seed"], "t": T0, "mt": T0}}}
                 jd.save_goals(SID, store)
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 return jd.load_goals(SID), gid
             finally:
@@ -2550,7 +2550,7 @@ class NudgeMustResolve(unittest.TestCase):
                 self.assertEqual([n for n in mid["nodes"].values() if n.get("parentId") == gid], [],
                                  "no stub node is minted — the reopen event alone holds the top open")
                 self.assertEqual(mid["status"][gid], "working", "held at working through the optimistic window")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
                 subs = [n for n in store["nodes"].values() if n.get("parentId") == gid]
@@ -4372,13 +4372,13 @@ class SettledGateStates(unittest.TestCase):
         statesdir = td / "states"; statesdir.mkdir()
         self._saved = (jd.STATESDIR, dict(jd._PARSE_CACHE))
         jd.STATESDIR = statesdir
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         return str(path), statesdir
 
     def tearDown(self):
         if hasattr(self, "_saved"):
             jd.STATESDIR = self._saved[0]
-            jd._PARSE_CACHE.clear(); jd._PARSE_CACHE.update(self._saved[1])
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._PARSE_CACHE.update(self._saved[1])
 
     def test_ended_turn_is_settled_without_idle(self):
         # the fix: an ended turn (assistant handed back the floor) is settled immediately — no idle needed.
@@ -4424,7 +4424,7 @@ class SettledGateStates(unittest.TestCase):
         Path(path).write_text("\n".join(json.dumps(r) for r in
                               [uline(T0, "ship it", "u1", ps="typed"),
                                aline(T0 + 10, "shipped", "a1", "u1", stop="end_turn")]) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.rollup_status(s, jd._session_closed(jd.parsed_session(SID, [path], now)))
         self.assertEqual(s["status"][g["id"]], "completed", "turn ended → focus goal finalizes (no prompt, no idle)")
 
@@ -4455,14 +4455,14 @@ class FollowUp(unittest.TestCase):
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self._saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.group_llm)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR = names, proj, td / "goals"
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd.migrate_store(store)                        # fixtures are legacy-shaped: adopt their diaries
         jd.save_goals(SID, store)
 
     def tearDown(self):
         if hasattr(self, "_saved"):
             (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.group_llm) = self._saved
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def _completed_top(self, gid, blocked=False):
         return {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "status": {gid: "blocked" if blocked else "completed"},
@@ -5370,11 +5370,11 @@ class KnownTargetContext(unittest.TestCase):
             jd._group_store = lambda *a, **k: None
             try:
                 tpath.write_text("\n".join(json.dumps(r) for r in recs1) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd.plan_llm = plan1
                 jd._plan_session(SID, str(tpath), NOW)
                 tpath.write_text("\n".join(json.dumps(r) for r in recs2) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd.plan_llm = plan2
                 jd._plan_session(SID, str(tpath), NOW + 200)
                 return jd.load_goals(SID)
@@ -5649,13 +5649,13 @@ class Distiller(unittest.TestCase):
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self._saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, jd.distill_llm, jd.brief_llm)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR = names, proj, td / "goals", td / "states"
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         return str(path)
 
     def tearDown(self):
         if hasattr(self, "_saved"):
             (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATESDIR, jd.distill_llm, jd.brief_llm) = self._saved
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def test_distills_completed_top_from_its_discontinuous_trail(self):
         records = [uline(T0, "do part one", "u1", ps="typed"),
@@ -7583,7 +7583,7 @@ class LiveReplan(unittest.TestCase):
         jd.GOALDIR.mkdir()
         jd._group_store = lambda *a, **k: None           # never fire the real grouper model
         jd.opener_llm = self._boom                  # the deduped prompt-run must never re-fire
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         (jd.GOALDIR, jd.GOALARCHDIR, jd.PCACHE, jd.STATE,
@@ -7689,7 +7689,7 @@ class LiveReplan(unittest.TestCase):
         tpath.write_text("\n".join(json.dumps(r) for r in (recs or self.OPEN_RECS)) + "\n")
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
         jd.plan_llm = llm
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._plan_session(SID, str(tpath), now)
         return jd.load_goals(SID)
 
@@ -7717,7 +7717,7 @@ class LiveReplan(unittest.TestCase):
         self.assertEqual(store["placements"].get(seg + "#live"), tops[0]["id"],
                          "keyed seg#live so it runs exactly once")
         jd.plan_llm = self._boom                        # a second pass must not re-fire the live run
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._plan_session(SID, str(Path(self.td.name) / (SID + ".jsonl")), NOW + 5)
 
     def test_live_phase_skip_is_coerced_the_invariant_is_hard(self):
@@ -7745,7 +7745,7 @@ class LiveReplan(unittest.TestCase):
             calls.append(k)
             return '{"ops":[{"why":"the work landed","do":"sub","under":%d,"text":"Reworked the grid"}]}' % k["goal_num"]
         jd.plan_llm = work_llm
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._plan_session(SID, str(tpath), NOW + 1000)
         store = jd.load_goals(SID)
         self.assertEqual(len(calls), 1, "one work-run call for the ended segment")
@@ -8536,7 +8536,7 @@ class FollowupContinuationCarry(unittest.TestCase):
                 recs1 = [uline(T0, "add a GUI control for the deep-sleep window", "u1", ps="typed"),
                          aline(T0 + 10, "Built it, pushed, verified.", "a1", "u1", stop="end_turn")]
                 tpath.write_text("\n".join(json.dumps(r) for r in recs1) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
                 gid = next(iter(store["nodes"]))
@@ -8546,7 +8546,7 @@ class FollowupContinuationCarry(unittest.TestCase):
                                  aline(T0 + 110, "Confirmed: defaults to off, verified on device.",
                                        "a2", "u2", stop="end_turn")]
                 tpath.write_text("\n".join(json.dumps(r) for r in recs2) + "\n")
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW + 200)
                 return jd.load_goals(SID), gid
             finally:

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6321,6 +6321,194 @@ class Distiller(unittest.TestCase):
             jd._judge_run = saved
 
 
+class JudgeFailureScanMemo(unittest.TestCase):
+    """judge_failure_scan's per-store memo. The kernel asks for the give-up count on every timeline build
+    once any store is saved, and the scan used to parse EVERY store each time. Now a store is parsed only
+    when its file identity (inode, mtime_ns, size) changed. What makes that sound is st_mtime_ns strictly
+    increasing across publishes of one path; the inode alone does not, because tmp+rename recycles inode
+    numbers on the second publish (measured on ext4), so the inode distinguishes one publish only. Linux
+    6.13+ multigrain timestamps guarantee the mtime ordering (the scan's own stat marks the prior inode as
+    queried); a coarse-timestamp kernel has a one-tick aliasing window, smaller than the one-second window
+    of kernel.py's _jf_cache gate. Raw stores under PRIVATE synthetic sids (CLAUDE.md, goal-store
+    fixtures); nothing here goes through load_goals, and the scan must not either (it counts raw file
+    content)."""
+
+    A = "b9b9b9b9-0000-4000-8000-00000000000a"
+    B = "b9b9b9b9-0000-4000-8000-00000000000b"
+    C = "b9b9b9b9-0000-4000-8000-00000000000c"
+
+    def setUp(self):
+        self.td = Path(tempfile.mkdtemp())
+        self.saved_state = jd.STATE
+        self.saved = (jd._jf_store_memo, jd._jf_cause_memo, jd._giveup_cause, jd._failed_nodes, jd.load_goals)
+        jd._rebind_state(self.td)
+        jd._jf_store_memo, jd._jf_cause_memo = {}, (None, None)
+        self.parses, self.causes = [], []
+        real = jd._failed_nodes
+        jd._failed_nodes = lambda store: (self.parses.append(1), real(store))[1]      # one call per parsed store
+        jd._giveup_cause = lambda: (self.causes.append(1), ("the summarizer kept hitting errors or timeouts", False))[1]
+        jd.load_goals = lambda *a, **k: self.fail("the scan counts raw file content, never a load_goals-replayed store")
+
+    def tearDown(self):
+        jd._jf_store_memo, jd._jf_cause_memo, jd._giveup_cause, jd._failed_nodes, jd.load_goals = self.saved
+        jd._rebind_state(self.saved_state)
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    def _store(self, sid, failed, mt=T0 + 10, kind="summary-failed"):
+        """`kind` is the warn's kind; one outside _FAILED_WARN_KINDS of the same length ("summary-landed")
+        publishes a store of the same byte size that counts nothing."""
+        nid = sid + ":g1"
+        nd = {"id": nid, "text": "Ship the notes-api tests", "parentId": None, "nodeComplete": True,
+              "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": mt, "summary": ""}
+        if failed:
+            nd["warns"] = [{"kind": kind, "t": T0 + 20, "msg": "the summary gave up"}]
+        jd.save_goals(sid, {"rompUuid": sid, "seq": 1, "placementsV": jd.PLACEMENTS_V, "placements": {},
+                            "status": {nid: "completed"}, "nodes": {nid: nd}})
+
+    def _path(self, sid):
+        return str(jd.GOALDIR / (sid + ".json"))
+
+    def test_parses_each_store_once_until_its_file_changes(self):
+        self._store(self.A, failed=True); self._store(self.B, failed=False); self._store(self.C, failed=False)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(len(self.parses), 3, "the first call parses every store")
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(len(self.parses), 3, "no store changed: nothing is parsed")
+        self._store(self.B, failed=False, mt=T0 + 500)         # one store republished: a new mtime_ns
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(len(self.parses), 4, "only the changed store is parsed")
+
+    def test_the_count_clears_when_the_warn_clears(self):
+        self._store(self.A, failed=True)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self._store(self.A, failed=False)                       # a landed summary drops the warn
+        self.assertIsNone(jd.judge_failure_scan(), "the rewritten store is re-read and the count clears")
+        self._store(self.A, failed=True)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1, "and a fresh give-up counts again")
+
+    def test_a_deleted_store_drops_from_the_sum(self):
+        self._store(self.A, failed=True); self._store(self.B, failed=True)
+        self.assertEqual(jd.judge_failure_scan()["count"], 2)
+        os.unlink(self._path(self.B))
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertNotIn(self._path(self.B), jd._jf_store_memo, "the memo is rebuilt from the glob, so the deleted store is gone")
+        self.assertEqual(len(self.parses), 2, "the surviving store was not re-parsed")
+
+    def test_the_cause_is_named_once_per_store_change(self):
+        self._store(self.A, failed=True); self._store(self.C, failed=False)
+        first = jd.judge_failure_scan()
+        self.assertEqual(jd.judge_failure_scan(), first)
+        self.assertEqual(len(self.causes), 1, "no store changed: the cause is not recomputed, so count|cause holds")
+        self._store(self.C, failed=False, mt=T0 + 500)         # any store's change re-names the cause
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(len(self.causes), 2)
+
+    def test_an_unparseable_store_counts_nothing_and_is_retried(self):
+        self._store(self.A, failed=True)
+        Path(self._path(self.B)).write_bytes(b"{not a store")
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertNotIn(self._path(self.B), jd._jf_store_memo, "a parse failure is not memoized")
+        self.assertEqual(len(self.parses), 1, "the good store is parsed once; the broken one never reaches _failed_nodes")
+        self._store(self.B, failed=True)                        # repaired and republished: a new mtime_ns, read like any change
+        self.assertEqual(jd.judge_failure_scan()["count"], 2)
+
+    def test_the_scan_returns_none_when_no_store_is_failing(self):
+        self._store(self.A, failed=False); self._store(self.B, failed=False)
+        self.assertIsNone(jd.judge_failure_scan())
+        self.assertIsNone(jd.judge_failure_scan())
+        self.assertEqual(len(self.parses), 2, "nothing failing is the common case: the memo is kept on a None "
+                                              "return too, so the second call parses nothing")
+        self.assertEqual(self.causes, [], "no give-up: the cause is never asked for")
+
+    def _rewrite_in_place(self, path, body, mtime_ns):
+        """Rewrite a store IN PLACE (same inode) and pin its mtime_ns, so one key component moves at a time
+        without depending on inode recycling or on the clock's granularity."""
+        st = os.stat(path)
+        with open(path, "r+b") as f:
+            f.write(body)
+            f.truncate()
+        os.utime(path, ns=(st.st_atime_ns, mtime_ns))
+        return os.stat(path)
+
+    def test_a_newer_mtime_ns_alone_re_reads_a_store_of_the_same_inode_and_size(self):
+        """st_mtime_ns is what keeps the memo sound once tmp+rename has recycled an inode number (two
+        publishes back on ext4): a version with the memo's inode and size but a later mtime_ns is re-read."""
+        self._store(self.A, failed=True)
+        path = self._path(self.A)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        st1 = os.stat(path)
+        st2 = self._rewrite_in_place(path, Path(path).read_bytes().replace(b"summary-failed", b"summary-landed"),
+                                     st1.st_mtime_ns + 1)
+        self.assertEqual((st2.st_ino, st2.st_size), (st1.st_ino, st1.st_size), "precondition: only mtime_ns moved")
+        self.assertIsNone(jd.judge_failure_scan(), "a later mtime_ns alone is a new version: re-read, and the count clears")
+        self.assertEqual(len(self.parses), 2)
+
+    def test_the_inode_distinguishes_a_publish_when_the_clock_does_not_move(self):
+        """A coarse-timestamp kernel (Linux < 6.13) gives two same-size publishes inside one tick the same
+        mtime_ns; st_ino tells them apart for one publish. save_goals' tmp+rename takes a fresh inode; the
+        new file's mtime_ns is pinned back to the memo's value explicitly."""
+        self._store(self.A, failed=True)
+        path = self._path(self.A)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        st1 = os.stat(path)
+        self._store(self.A, failed=True, kind="summary-landed")      # same size, not a give-up kind, new inode
+        os.utime(path, ns=(st1.st_atime_ns, st1.st_mtime_ns))
+        st2 = os.stat(path)
+        self.assertEqual((st2.st_size, st2.st_mtime_ns), (st1.st_size, st1.st_mtime_ns), "precondition: size and mtime_ns held")
+        self.assertNotEqual(st2.st_ino, st1.st_ino, "precondition: the publish took a fresh inode")
+        self.assertIsNone(jd.judge_failure_scan(), "the inode alone is a new version")
+        self.assertEqual(len(self.parses), 2)
+
+    def test_a_size_change_alone_is_a_new_version(self):
+        """st_size is defense in depth: romp's writers publish by tmp+rename, so a size change never arrives
+        without a new inode. The one deterministic way to isolate it models a non-rename writer under a clock
+        that does not move: an in-place rewrite at another size with mtime_ns pinned to the memo's."""
+        self._store(self.A, failed=True)
+        path = self._path(self.A)
+        self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        st1 = os.stat(path)
+        st2 = self._rewrite_in_place(path, Path(path).read_bytes().replace(b"summary-failed", b"landed"), st1.st_mtime_ns)
+        self.assertEqual((st2.st_ino, st2.st_mtime_ns), (st1.st_ino, st1.st_mtime_ns), "precondition: only the size moved")
+        self.assertNotEqual(st2.st_size, st1.st_size)
+        self.assertIsNone(jd.judge_failure_scan(), "the size alone is a new version")
+        self.assertEqual(len(self.parses), 2)
+
+    def test_the_key_names_the_version_that_was_read(self):
+        """A publish landing between the listing's stat and the open: the bytes read are the new version's,
+        so the key must be taken by fstat on that descriptor. Keyed on the pre-open stat, the next call
+        would re-parse a store that did not change again (one wasted parse, never a wrong count)."""
+        self._store(self.A, failed=True)
+        path = self._path(self.A)
+        real_open, fired = open, []
+
+        def hooked(fp, *a, **k):
+            if not fired and str(fp) == path:
+                fired.append(1)
+                self._store(self.A, failed=False, mt=T0 + 500)   # a writer lands between the stat and the open
+            return real_open(fp, *a, **k)
+
+        jd.open = hooked                                         # module global shadows the builtin
+        try:
+            self.assertIsNone(jd.judge_failure_scan(), "the bytes read are the new version's")
+        finally:
+            del jd.open
+        self.assertEqual(fired, [1])
+        self.assertEqual(len(self.parses), 1)
+        self.assertIsNone(jd.judge_failure_scan())
+        self.assertEqual(len(self.parses), 1, "the memo key names the version read, so nothing is re-parsed")
+
+    def test_a_store_gone_between_the_glob_and_the_stat_is_skipped(self):
+        import glob
+        self._store(self.A, failed=True)
+        ghost = self._path(self.B)                               # listed, never written
+        real_glob = glob.glob
+        with mock.patch.object(glob, "glob", lambda *a, **k: real_glob(*a, **k) + [ghost]):
+            self.assertEqual(jd.judge_failure_scan()["count"], 1)
+        self.assertEqual(len(self.parses), 1)
+        self.assertNotIn(ghost, jd._jf_store_memo)
+
+
 class RunTriage(unittest.TestCase):
     """run_triage is the TRIAGE-tier sequence as one unit (so the kernel can run it parallel to the
     always-on index tier): plan → close → courier → group → distill, in that order."""

--- a/tests/test_judge_apierror_no_fabricated_done.py
+++ b/tests/test_judge_apierror_no_fabricated_done.py
@@ -72,7 +72,7 @@ class NoFabricatedDone(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = fake
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
             finally:

--- a/tests/test_judge_board_dedup.py
+++ b/tests/test_judge_board_dedup.py
@@ -294,7 +294,7 @@ class OpenerExtend(unittest.TestCase):
         shutil.rmtree(self._state_td, ignore_errors=True)
         if hasattr(self, "_saved"):
             (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.opener_llm, jd.group_llm) = self._saved
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     # ── parse gating ──
     def test_extend_parses_only_when_offered(self):
@@ -394,7 +394,7 @@ class OpenerExtend(unittest.TestCase):
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self._saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.plan_llm, jd.opener_llm, jd.group_llm)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR = names, proj, td / "goals"
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         offered = []
         jd.plan_llm = (lambda text, menu, **kw:
                        '{"ops":[{"why":"x","do":"mint","text":"Fix mobile chat width"}]}')

--- a/tests/test_judge_close_riders.py
+++ b/tests/test_judge_close_riders.py
@@ -88,7 +88,7 @@ class _Riders(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         self._llm, self._menu_text = jd.closer_llm, jd._menu_text
         self.menus = []                                  # [[node id, ...] per closer call], as sent
         self.stamped_at_call = []                        # ids carrying closerLookT when each call was built

--- a/tests/test_judge_courier_defer_abandon.py
+++ b/tests/test_judge_courier_defer_abandon.py
@@ -89,7 +89,7 @@ class CourierDeferAbandon(unittest.TestCase):
         jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
         jd.MESSAGES = tl / "messages.jsonl"
         jd.ERRORS = td / "judge-errors.jsonl"
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd._discover_cache["result"] = None
 

--- a/tests/test_judge_no_fairness_caps.py
+++ b/tests/test_judge_no_fairness_caps.py
@@ -33,7 +33,7 @@ class NoFairnessCaps(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def test_caps_are_unbounded(self):
         # None → list[:None] is the whole list, so no per-pass/per-session throttle survives.

--- a/tests/test_judge_nudge_no_reopen_completed.py
+++ b/tests/test_judge_nudge_no_reopen_completed.py
@@ -35,7 +35,7 @@ class NudgeNoReopenCompleted(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         # a completed top goal (the closer finished it)
         self.store = {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V,
                       "nodes": {GID: {"id": GID, "text": "Clarify the design", "parentId": None,

--- a/tests/test_judge_nudge_wedge_moot_retire.py
+++ b/tests/test_judge_nudge_wedge_moot_retire.py
@@ -81,7 +81,7 @@ class MootPromptRetire(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
 
@@ -100,7 +100,7 @@ class MootPromptRetire(unittest.TestCase):
                 self.assertFalse(self._gate_is_open(store, str(tpath)),
                                  "precondition: the legacy store leaves the moot #p unit unplaced")
 
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW + 100)
                 store = jd.load_goals(SID)
 
@@ -125,7 +125,7 @@ class MootPromptRetire(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
                 before = len(store["nodes"])
@@ -135,7 +135,7 @@ class MootPromptRetire(unittest.TestCase):
 
                 calls = []
                 jd.plan_llm = jd.opener_llm = lambda *a, **k: (calls.append(1), MINT)[1]
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW + 100)
                 store = jd.load_goals(SID)
                 self.assertEqual(calls, [], "a moot phase is retired with NO planner call")

--- a/tests/test_judge_orphan_replies.py
+++ b/tests/test_judge_orphan_replies.py
@@ -132,7 +132,7 @@ class JudgeSeesSalvagedWork(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = fake
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
             finally:

--- a/tests/test_judge_parse_cache.py
+++ b/tests/test_judge_parse_cache.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import time
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
@@ -17,7 +18,7 @@ jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module
 
 
 def test_parsed_session_caches_until_the_transcript_changes():
-    jd._PARSE_CACHE.clear()
+    jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
     calls = []
     orig = jd.em.parse_session
     jd.em.parse_session = lambda *a, **k: calls.append(1) or {"turns": []}   # count real parses
@@ -40,6 +41,22 @@ def test_parsed_session_caches_until_the_transcript_changes():
         os.unlink(p)
 
 
+def test_every_parse_cache_clear_in_tests_clears_the_chain_memo():
+    """_CHAIN_MEMO keys on the same (mtime, size) identity as _PARSE_CACHE over the same transcripts, so a
+    test that clears one for a same-second fixture rewrite must clear the other on the same line, or a memo
+    an earlier test populated serves a stale five-way verdict for the new bytes
+    (test_judge_rewind_cleanup.py::ChainMemo pins the hazard itself). A source scan by necessity: the
+    invariant is about the test corpus, and no behaviour exists to drive."""
+    tests = Path(__file__).resolve().parent
+    bad = []
+    for f in sorted(tests.glob("test_*.py")):
+        for n, line in enumerate(f.read_text().splitlines(), 1):
+            if "_PARSE_CACHE.clear()" in line and "_CHAIN_MEMO.clear()" not in line:
+                bad.append("%s:%d" % (f.name, n))
+    assert bad == [], "parse-cache clears with no chain-memo clear on the same line: " + ", ".join(bad)
+
+
 if __name__ == "__main__":
     test_parsed_session_caches_until_the_transcript_changes()
+    test_every_parse_cache_clear_in_tests_clears_the_chain_memo()
     print("ok")

--- a/tests/test_judge_propagate_loads.py
+++ b/tests/test_judge_propagate_loads.py
@@ -50,6 +50,7 @@ jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module
 
 SENDER = "a4a4a4a4-0001-4000-8000-000000000001"   # discovered, name "web"
 RECIP = "a4a4a4a4-0002-4000-8000-000000000002"    # discovered, name "api"
+SENDER2 = "a4a4a4a4-0006-4000-8000-000000000006"  # a second sender, discovered on demand (name "tests")
 DEAD = "a4a4a4a4-0003-4000-8000-000000000003"     # absent: no discover entry
 DEAD2 = "a4a4a4a4-0004-4000-8000-000000000004"
 DEAD3 = "a4a4a4a4-0005-4000-8000-000000000005"
@@ -256,6 +257,62 @@ class LoadOncePerPass(World):
         self.assertEqual(_rev(SENDER), r0 + 1)
         log = jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["log"]
         self.assertEqual([e["kind"] for e in log if e.get("src") == "courier"], ["done"])
+
+    def _two_senders_one_recipient(self):
+        """SENDER and SENDER2 each delegated one step to RECIP, which completed both; RECIP's g5 (SENDER's ref)
+        is reached before g6 (SENDER2's) in the recipient loop. Returns the two senders' revisions."""
+        self.sessions.append((SENDER2, "/dev/null", None, "tests"))
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID)]})
+        self._publish(SENDER2, {t["id"]: t for t in [_tracker(SENDER2, 1, RECIP, MID2)]})
+        g5 = _complete(RECIP, 5, origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        g6 = _complete(RECIP, 6, origin={"peer": SENDER2, "goalId": SENDER2 + ":t1", "msgId": MID2})
+        self._publish(RECIP, {g5["id"]: g5, g6["id"]: g6})
+        return _rev(SENDER), _rev(SENDER2)
+
+    def test_a_raise_mid_loop_publishes_the_verdicts_already_reached_and_re_raises(self):
+        # The deferred single publish must not turn one ref's trip into the loss of every verdict the pass
+        # recorded before it (review find, 2026-09-08; the per-ref save it replaced had persisted each as it
+        # was reached): the senders reached before the raise are published, the error is re-raised, and the
+        # sender whose ref raised (its object half-applied) is left for the next pass to re-derive.
+        r1, r2 = self._two_senders_one_recipient()
+        orig = jd._presumed_closed
+
+        def tripping(sid, now):
+            if sid == SENDER2:
+                raise RuntimeError("synthetic: the second sender's rollup input trips")
+            return orig(sid, now)
+        jd._presumed_closed = tripping
+        try:
+            with self.assertRaises(RuntimeError):
+                jd.run_propagate(now=T + 900)
+        finally:
+            jd._presumed_closed = orig
+        self.assertEqual(_rev(SENDER), r1 + 1, "the verdict reached before the raise is on disk")
+        self.assertTrue(jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["nodeComplete"])
+        self.assertEqual(_rev(SENDER2), r2, "the sender whose ref raised is not published: half-applied is no verdict")
+        self.assertFalse(jd.load_goals(SENDER2)["nodes"][SENDER2 + ":t1"]["nodeComplete"])
+        self.assertEqual(jd.run_propagate(now=T + 901), 1, "the next pass re-derives the one left, and only it")
+        self.assertEqual((_rev(SENDER), _rev(SENDER2)), (r1 + 1, r2 + 1))
+
+    def test_one_senders_failed_publish_does_not_stop_the_other_senders(self):
+        # Every dirty sender is published whatever happened to the one before it; the first failed publish is
+        # the pass's error, raised once the rest are out (review find, 2026-09-08).
+        r1, r2 = self._two_senders_one_recipient()
+        orig_save = jd.save_goals
+
+        def failing(fsid, store):
+            if fsid == SENDER:
+                raise RuntimeError("disk full")
+            return orig_save(fsid, store)
+        jd.save_goals = failing
+        try:
+            with self.assertRaises(RuntimeError):
+                jd.run_propagate(now=T + 900)
+        finally:
+            jd.save_goals = orig_save
+        self.assertEqual(_rev(SENDER), r1, "the failed publish left its file untouched")
+        self.assertEqual(_rev(SENDER2), r2 + 1, "the other sender's publish still landed")
+        self.assertTrue(jd.load_goals(SENDER2)["nodes"][SENDER2 + ":t1"]["nodeComplete"])
 
     def test_a_kernel_side_write_between_two_refs_survives_the_single_publish(self):
         # The CAS discipline under the deferred publish: the nudge tick blocks a third node and

--- a/tests/test_judge_propagate_loads.py
+++ b/tests/test_judge_propagate_loads.py
@@ -1,0 +1,882 @@
+#!/usr/bin/env python3
+"""run_propagate and _drain_undiscovered read each goal store at most once per pass, and the two
+absent-store predicates are memoized across passes on file identity (2026-09-06). Before: every pass
+loaded each recipient, loaded the sender again per ref BEFORE checking whether its tracker was already
+done (it was, for every live ref), loaded every sender a third time in the sender loop, and both triage
+sweeps parsed every ABSENT store to evaluate one predicate each — about 168 of 455 loads per pass on the
+kernel where this was measured. Pinned here:
+
+- one load_goals per distinct sid per pass across the recipient scan, the per-ref done check,
+  _ref_goal and the sender loop; the same object serves the recipient scan and the sender loop;
+- one publish per dirty sender (rev advances by exactly one for two refs) carrying the rollup over
+  every verdict it holds, the CAS discipline intact under a kernel-side write between two refs, a
+  failed publish leaving the file untouched for the retry, and an absent sender's publish settled (or
+  not) by _presumed_closed;
+- the absent-store memo: an unchanged store is evaluated once across both sweeps and across passes; a
+  changed goals file, a changed override journal and a changed archive each re-evaluate; the identity
+  is taken before the read, in the sweep's own read and in run_propagate's; the key is the full path;
+  entries for vanished stores are evicted; a store read that RAISES is answered None and never
+  memoized, a store loaded without its unreadable override journal (`_unread`) is answered but never
+  memoized, a store whose files moved under the read (a publish, or load_goals' quarantine of an
+  unparseable file) is answered but never memoized under the stale identity; the one documented
+  exception (same-size in-place rewrite with the mtime put back) is pinned as such.
+
+SYNTHETIC fixtures only. Private synthetic sids: load_goals replays the per-sid override journal, and
+node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures);
+every test runs under its own _rebind_state root, so its journal and memo entries die with it. The
+memo keeps no counters of its own: the hit, miss and write counts the tests read come from spies
+World.setUp installs around _absent_store_flags, its first predicate and save_goals' temp-file write."""
+import contextlib
+import errno
+import io
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from collections import Counter
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+
+SENDER = "a4a4a4a4-0001-4000-8000-000000000001"   # discovered, name "web"
+RECIP = "a4a4a4a4-0002-4000-8000-000000000002"    # discovered, name "api"
+DEAD = "a4a4a4a4-0003-4000-8000-000000000003"     # absent: no discover entry
+DEAD2 = "a4a4a4a4-0004-4000-8000-000000000004"
+DEAD3 = "a4a4a4a4-0005-4000-8000-000000000005"
+MID = "msg-propagate-0001"
+MID2 = "msg-propagate-0002"
+T = 1_787_600_000
+
+
+def _node(nid, text, parent=None, t=T, **kw):
+    base = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
+            "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
+    base.update(kw)
+    return jd.GuardedNode(base)
+
+
+def _store(sid, nodes):
+    return {"rompUuid": sid, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": dict(nodes),
+            "placements": {}, "status": {}}
+
+
+def _tracker(sid, k, peer, mid, quiet=False, done=False):
+    h = {"peer": peer, "msgId": mid}
+    if quiet:
+        h["quiet"] = True
+    nd = _node("%s:t%d" % (sid, k), "delegated to a peer: step %d" % k, handoff=h)
+    if done:
+        jd.record_verdict({"nodes": {nd["id"]: nd}}, nd, "courier", "done", T + 1, why="done earlier")
+    return nd
+
+
+def _complete(sid, k, **ref):
+    """A COMPLETE recipient goal carrying an origin (or links) ref back to a sender's tracker."""
+    nd = _node("%s:g%d" % (sid, k), "the delegated work, step %d" % k, **ref)
+    jd.record_verdict({"nodes": {nd["id"]: nd}}, nd, "closer", "done", T + 100, why="shipped step %d" % k)
+    return nd
+
+
+def _rev(sid):
+    return int(json.loads((jd.GOALDIR / (sid + ".json")).read_text()).get("rev") or 0)
+
+
+class World(unittest.TestCase):
+    def setUp(self):
+        self._state = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))          # private root: journal, archive and memo all scoped
+        self._disc = jd.discover
+        self.sessions = [(SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api")]
+        jd.discover = lambda now, window=None, forks=True: list(self.sessions)
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        jd.MESSAGES.write_text("")
+        self._spy_memo()
+
+    def tearDown(self):
+        jd.discover = self._disc
+        jd._rebind_state(self._state)
+        self.td.cleanup()
+
+    def _spy_memo(self):
+        """The counters _io reads, from outside the memo. Seen from a wrapper around _absent_store_flags,
+        a call that ran the predicates is a MISS (no entry matched the store's current identity, so the
+        store was read — or taken from run_propagate's per-pass dict — and evaluated), a call that
+        returned None is a miss whose load raised, and every other call was a HIT answered from the
+        memo. _open_handoff_flag is the first predicate a miss evaluates and has no other caller inside
+        the memo; the direct calls a few tests make land outside the wrapper's frame and are not counted.
+        A WRITE is save_goals' real publish, the temp file it renames over the store (a no-op save
+        returns before it). Module attributes, looked up at call time by every caller."""
+        self.io = {"hits": 0, "misses": 0, "writes": 0}
+        orig_flags, orig_open, orig_tmp = jd._absent_store_flags, jd._open_handoff_flag, jd._publish_tmp
+        frame = {"inside": False, "evaluated": False}
+
+        def flags(fsid, loaded=None, idents=None):
+            frame["inside"], frame["evaluated"] = True, False
+            try:
+                out = orig_flags(fsid, loaded, idents)
+            finally:
+                frame["inside"] = False
+            self.io["misses" if out is None or frame["evaluated"] else "hits"] += 1
+            return out
+
+        def open_flag(store):
+            if frame["inside"]:
+                frame["evaluated"] = True
+            return orig_open(store)
+
+        def publish_tmp(dirpath, fsid):
+            if dirpath == jd.GOALDIR:
+                self.io["writes"] += 1
+            return orig_tmp(dirpath, fsid)
+        jd._absent_store_flags, jd._open_handoff_flag, jd._publish_tmp = flags, open_flag, publish_tmp
+        self.addCleanup(setattr, jd, "_absent_store_flags", orig_flags)
+        self.addCleanup(setattr, jd, "_open_handoff_flag", orig_open)
+        self.addCleanup(setattr, jd, "_publish_tmp", orig_tmp)
+
+    # ── fixtures ──
+    def _publish(self, sid, nodes):
+        st = _store(sid, nodes)
+        jd.rollup_status(st, False)
+        jd.save_goals(sid, st)
+
+    def _reply(self, frm, to, at, mid="r1"):
+        with jd.MESSAGES.open("a") as f:
+            f.write(json.dumps({"t": at, "ev": "sent", "id": mid, "from_id": frm, "to_id": to,
+                                "kind": "coordinate", "body": "done; nothing else owed"}) + "\n")
+
+    def _counting(self, fn):
+        """Run fn with load_goals counted per sid and every returned object kept; restore after."""
+        counts, objs, orig = Counter(), {}, jd.load_goals
+
+        def spy(fsid):
+            counts[fsid] += 1
+            st = orig(fsid)
+            objs.setdefault(fsid, []).append(st)
+            return st
+        jd.load_goals = spy
+        try:
+            out = fn()
+        finally:
+            jd.load_goals = orig
+        return out, counts, objs
+
+    def _io(self):
+        """(absent-memo hits, misses, store writes) so far in this test, from _spy_memo's spies."""
+        return self.io["hits"], self.io["misses"], self.io["writes"]
+
+    def _sids(self, *extra):
+        return {f for f, _p, _a, _n in self.sessions} | set(extra)
+
+
+class LoadOncePerPass(World):
+    """The per-pass dict: one load per distinct sid across every site of run_propagate."""
+
+    def test_a_done_ref_costs_the_sender_no_second_load(self):
+        # THE COMMON LIVE SHAPE: every ref already done. The done check reads the shared object, so
+        # the sender is loaded once whichever order discover lists them in — even when the ref check
+        # runs BEFORE the sender's own recipient turn (discover order recipient-first).
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID, done=True)]})
+        g5 = _complete(RECIP, 5, origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        self._publish(RECIP, {g5["id"]: g5})
+        for order in ((RECIP, SENDER), (SENDER, RECIP)):
+            self.sessions = [(s, "/dev/null", None, n) for s, n in zip(order, ("api", "web"))]
+            n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 900))
+            self.assertEqual(n, 0, "already done: idempotent")
+            self.assertEqual(dict(counts), {SENDER: 1, RECIP: 1},
+                             "one load per sid, discover order %r: the per-ref check took no load" % (order,))
+
+    def test_the_same_object_serves_the_recipient_scan_and_the_sender_loop(self):
+        # SENDER is scanned as a recipient (it is discovered) and then walked as a sender whose quiet
+        # tracker has a reply: one load, and the object the sender loop mutates IS the scan's object.
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID, quiet=True)]})
+        self._publish(RECIP, {})
+        self._reply(RECIP, SENDER, T + 500)
+        rolled, orig_roll = [], jd.rollup_status
+
+        def spy_roll(store, closed, now=None):
+            rolled.append(store)
+            return orig_roll(store, closed, now=now)
+        jd.rollup_status = spy_roll
+        try:
+            n, counts, objs = self._counting(lambda: jd.run_propagate(now=T + 900))
+        finally:
+            jd.rollup_status = orig_roll
+        self.assertEqual(n, 1)
+        self.assertEqual(counts[SENDER], 1, "scan + sender loop: one load")
+        self.assertEqual(len(rolled), 1)
+        self.assertIs(rolled[0], objs[SENDER][0], "the sender loop rolled up the scan's own object")
+        self.assertTrue(jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["nodeComplete"])
+
+    def test_two_dirty_refs_to_one_sender_publish_once(self):
+        self._publish(SENDER, {t["id"]: t for t in (_tracker(SENDER, 1, RECIP, MID),
+                                                    _tracker(SENDER, 2, RECIP, MID2))})
+        g5 = _complete(RECIP, 5, origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        g6 = _complete(RECIP, 6, links=[{"peer": SENDER, "goalId": SENDER + ":t2", "msgId": MID2}])
+        self._publish(RECIP, {g5["id"]: g5, g6["id"]: g6})
+        r0, (_h, _m, w0) = _rev(SENDER), self._io()
+        n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 900))
+        self.assertEqual(n, 2)
+        # one load per FILE VERSION: the recipient loop's publish made a new one, and the sender loop
+        # (SENDER is discovered) must read it fresh for its own CAS base — a saved object is never
+        # kept. Only a pass that completed something pays this; an idle pass loads each sid once.
+        self.assertEqual(counts[SENDER], 2)
+        self.assertEqual(_rev(SENDER), r0 + 1, "two verdicts, one publish")
+        self.assertEqual(self._io()[2], w0 + 1, "exactly one write")
+        got = jd.load_goals(SENDER)
+        snd = got["nodes"]
+        self.assertTrue(snd[SENDER + ":t1"]["nodeComplete"] and snd[SENDER + ":t2"]["nodeComplete"])
+        # the one publish carried the rollup over BOTH verdicts: the saved status is exactly what a
+        # fresh rollup of the saved store derives (a rollup run only after the first ref would have
+        # published t2 still working)
+        saved = dict(got["status"])
+        self.assertEqual(saved, {SENDER + ":t1": "completed", SENDER + ":t2": "completed"})
+        jd.rollup_status(got, False)
+        self.assertEqual(got["status"], saved)
+
+    def test_two_refs_to_one_tracker_record_one_done_event(self):
+        # The second ref reads the flag record_verdict materialized on the shared object: no
+        # duplicate diary row, no second publish.
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID)]})
+        g5 = _complete(RECIP, 5, origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        g6 = _complete(RECIP, 6, links=[{"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID}])
+        self._publish(RECIP, {g5["id"]: g5, g6["id"]: g6})
+        r0 = _rev(SENDER)
+        self.assertEqual(jd.run_propagate(now=T + 900), 1)
+        self.assertEqual(_rev(SENDER), r0 + 1)
+        log = jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["log"]
+        self.assertEqual([e["kind"] for e in log if e.get("src") == "courier"], ["done"])
+
+    def test_a_kernel_side_write_between_two_refs_survives_the_single_publish(self):
+        # The CAS discipline under the deferred publish: the nudge tick blocks a third node and
+        # publishes between the two refs' verdicts; the pass's one save rebases (union of logs),
+        # the two publishes carry distinct revisions, and the saved object carried a fresh base.
+        self._publish(SENDER, {t["id"]: t for t in (_tracker(SENDER, 1, RECIP, MID),
+                                                    _tracker(SENDER, 2, RECIP, MID2),
+                                                    _node(SENDER + ":g3", "an unrelated open ask"))})
+        g5 = _complete(RECIP, 5, origin={"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID})
+        g6 = _complete(RECIP, 6, links=[{"peer": SENDER, "goalId": SENDER + ":t2", "msgId": MID2}])
+        self._publish(RECIP, {g5["id"]: g5, g6["id"]: g6})
+        saves, orig_save, orig_mark, fired = [], jd.save_goals, jd._mark_node_done, []
+
+        def spy_save(fsid, store):
+            had_base = "_baseRev" in store
+            orig_save(fsid, store)
+            saves.append((fsid, had_base, _rev(fsid)))
+
+        def kernel_write_then_mark(store, nid, why, t, src="planner"):
+            if not fired:                                # between the first and the second ref
+                fired.append(1)
+                k = jd.load_goals(SENDER)
+                jd.append_block(SENDER, SENDER + ":g3", "nudge", "owed a decision", T + 600)
+                jd.record_verdict(k, k["nodes"][SENDER + ":g3"], "nudge", "block", T + 600, why="owed a decision")
+                jd.rollup_status(k, False)
+                jd.save_goals(SENDER, k)
+            return orig_mark(store, nid, why, t, src=src)
+        jd.save_goals, jd._mark_node_done = spy_save, kernel_write_then_mark
+        try:
+            n = jd.run_propagate(now=T + 900)
+        finally:
+            jd.save_goals, jd._mark_node_done = orig_save, orig_mark
+        self.assertEqual(n, 2)
+        self.assertEqual([s[0] for s in saves], [SENDER, SENDER], "the kernel's publish, then the pass's one")
+        self.assertTrue(all(s[1] for s in saves), "both saved objects carried a CAS base")
+        self.assertEqual(saves[1][2], saves[0][2] + 1, "no two publishes share a revision")
+        nodes = jd.load_goals(SENDER)["nodes"]
+        self.assertTrue(nodes[SENDER + ":t1"]["nodeComplete"] and nodes[SENDER + ":t2"]["nodeComplete"])
+        self.assertTrue(nodes[SENDER + ":g3"]["blocked"], "the kernel-side block survived the pass's publish")
+
+    def test_a_failed_publish_drops_the_object_and_the_next_pass_retries_from_a_fresh_load(self):
+        # An ABSENT sender with a quiet tracker whose reply has arrived: the sweep memoizes the
+        # store's flags from the unmutated read, the sender loop marks the tracker done, and the
+        # publish raises. Pinned: the memo describes the FILE, not the failed object (still "open
+        # tracker", and a hit, since the file never changed), and the retry publishes once. That a
+        # saved object leaves `loaded` is pinned by test_two_dirty_refs_to_one_sender_publish_once
+        # (the sender loop's fresh load after the recipient loop's publish); a new pass starts with
+        # an empty dict either way, so the failed publish's pop is not observable from here.
+        self._publish(DEAD, {t["id"]: t for t in [_tracker(DEAD, 1, RECIP, MID, quiet=True)]})
+        self._reply(RECIP, DEAD, T + 500)
+        r0, orig_save = _rev(DEAD), jd.save_goals
+
+        def failing(fsid, store):
+            if fsid == DEAD:
+                raise RuntimeError("disk full")
+            return orig_save(fsid, store)
+        jd.save_goals = failing
+        try:
+            with self.assertRaises(RuntimeError):
+                jd.run_propagate(now=T + 900)
+        finally:
+            jd.save_goals = orig_save
+        self.assertEqual(_rev(DEAD), r0, "nothing published")
+        self.assertFalse(jd.load_goals(DEAD)["nodes"][DEAD + ":t1"]["nodeComplete"])
+        h0, m0, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD), (True, False), "the memo describes the FILE, not the failed object")
+        self.assertEqual(self._io()[:2], (h0 + 1, m0), "and it is a hit: the file never changed")
+        n, counts, objs = self._counting(lambda: jd.run_propagate(now=T + 900))
+        self.assertEqual(n, 1)
+        self.assertEqual(counts[DEAD], 1, "the sender loop's fresh load; the sweep answered from the memo")
+        self.assertEqual(_rev(DEAD), r0 + 1)
+        self.assertTrue(jd.load_goals(DEAD)["nodes"][DEAD + ":t1"]["nodeComplete"])
+        n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 901))
+        self.assertEqual((n, counts[DEAD]), (0, 1), "identity moved: one miss, and no sender-loop load")
+
+    def test_an_absent_senders_single_publish_carries_the_settled_rollup(self):
+        # The deferred publish carries the rollup the sender loop ran with _presumed_closed. With the
+        # tracker as the store's focus (lastNode), only a closed session settles it. Nothing knows the
+        # sid and no remote-sids mirror exists: closedness cannot be determined, so the saved status
+        # stays working (done, confirming). Once the bus has spoken (an empty mirror: no live session
+        # anywhere answers to the sid), the same shape saves completed.
+        def _focused_tracker(sid, mid):
+            t1 = _tracker(sid, 1, RECIP, mid, quiet=True)
+            st = _store(sid, {t1["id"]: t1})
+            st["lastNode"] = t1["id"]
+            jd.rollup_status(st, False)
+            jd.save_goals(sid, st)
+            self._reply(RECIP, sid, T + 500, mid="reply-" + mid)
+        _focused_tracker(DEAD2, MID2)
+        self.assertEqual(jd.run_propagate(now=T + 900), 1)
+        got = jd.load_goals(DEAD2)
+        self.assertTrue(got["nodes"][DEAD2 + ":t1"]["nodeComplete"])
+        self.assertEqual(got["status"][DEAD2 + ":t1"], "working", "no mirror: not determinable, not settled")
+        self.assertIn(DEAD2 + ":t1", got.get("confirming") or [])
+        _focused_tracker(DEAD, MID)
+        (jd.STATE / "remote-sids").write_text("")
+        self.assertEqual(jd.run_propagate(now=T + 901), 1)
+        got = jd.load_goals(DEAD)
+        self.assertTrue(got["nodes"][DEAD + ":t1"]["nodeComplete"])
+        self.assertEqual(got["status"][DEAD + ":t1"], "completed", "the bus knows no such live session: settled")
+        self.assertNotIn(DEAD + ":t1", got.get("confirming") or [])
+
+
+    def test_a_dismissed_recipients_lookup_reuses_the_passes_store_and_archive_reads(self):
+        # The sender loop's dismissed-recipient lookup (_ref_goal) reads the recipient's store and archive
+        # through the pass's own dicts: the recipient scan already read both, so the lookup costs no load.
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID)]})   # linked, not quiet
+        rn = {"id": RECIP + ":g5", "text": "Verify the staged refs", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": True, "trail": [], "t": T, "mt": T, "log": [],
+              "origin": {"peer": SENDER, "goalId": SENDER + ":t1", "msgId": MID}}
+        jd.save_goals(RECIP, _store(RECIP, {rn["id"]: rn}))     # the dismissed shape: cleared, not complete; a
+        #                                                          plain dict (GuardedNode refuses `cleared`), no rollup
+        self._reply(RECIP, SENDER, T + 500)
+        arch, orig_arch = Counter(), jd.load_goal_archive
+
+        def arch_spy(fsid):
+            arch[fsid] += 1
+            return orig_arch(fsid)
+        jd.load_goal_archive = arch_spy
+        try:
+            n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 900))
+        finally:
+            jd.load_goal_archive = orig_arch
+        self.assertEqual(n, 1)
+        self.assertTrue(jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["nodeComplete"],
+                        "the dismissed recipient's reply ended the tracker")
+        self.assertEqual(dict(counts), {SENDER: 1, RECIP: 1}, "the lookup reused the recipient scan's store read")
+        self.assertEqual(dict(arch), {SENDER: 1, RECIP: 1}, "...and its archive read")
+
+    def test_a_recipient_node_the_sender_loop_completes_still_reads_as_dismissed_to_a_later_sender(self):
+        # _ref_goal's map is a SNAPSHOT (shallow copies of the recipient's nodes at first use), not a live
+        # view of the shared object the sender loop mutates. A synthetic shape isolates it: api's node g1 is
+        # both a dismissed recipient goal for tests' tracker AND a quiet tracker of its own onto a third
+        # peer. web's sender turn builds the map (g1 dismissed), api's turn completes g1 on the shared
+        # object, tests' turn must still read the dismissal, or its tracker never ends.
+        self.sessions = [(SENDER, "/dev/null", None, "web"), (RECIP, "/dev/null", None, "api"),
+                         (DEAD2, "/dev/null", None, "tests")]
+        self._publish(SENDER, {t["id"]: t for t in [_tracker(SENDER, 1, RECIP, MID)]})
+        g1 = {"id": RECIP + ":g1", "text": "the delegated work", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": True, "trail": [], "t": T, "mt": T, "log": [],
+              "origin": {"peer": DEAD2, "goalId": DEAD2 + ":t1", "msgId": MID2},
+              "handoff": {"peer": DEAD3, "msgId": "msg-propagate-0003", "quiet": True}}
+        jd.save_goals(RECIP, _store(RECIP, {g1["id"]: g1}))
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID2)]})
+        self._reply(DEAD3, RECIP, T + 500, mid="r-onward")
+        self._reply(RECIP, DEAD2, T + 500, mid="r-back")
+        n = jd.run_propagate(now=T + 900)
+        self.assertTrue(jd.load_goals(RECIP)["nodes"][RECIP + ":g1"]["nodeComplete"], "api's onward handoff ended")
+        t1 = jd.load_goals(DEAD2)["nodes"][DEAD2 + ":t1"]
+        self.assertTrue(t1["nodeComplete"], "tests' tracker ended on the reply: the map still said dismissed")
+        self.assertIn("dismissed", t1.get("doneWhy") or "")
+        self.assertEqual(n, 2)
+        self.assertFalse(jd.load_goals(SENDER)["nodes"][SENDER + ":t1"]["nodeComplete"],
+                         "web's live linked recipient (no node joins MID) still defers to the back-link")
+
+    def test_a_back_link_completion_on_an_absent_sender_is_settled_when_the_bus_knows_no_such_session(self):
+        # The recipient loop's per-ref rollup runs with _presumed_closed (once per sender per pass): a dead
+        # sender's back-link completion is SETTLED once the bus knows no live session by that sid, and left
+        # confirming while closedness cannot be determined. The tracker is the store's focus (lastNode), so
+        # only a closed session settles it.
+        def _focused(sid, k, mid):
+            t = _tracker(sid, k, RECIP, mid)
+            st = jd.load_goals(sid) if (jd.GOALDIR / (sid + ".json")).exists() else _store(sid, {})
+            st["nodes"][t["id"]] = t
+            st["lastNode"] = t["id"]
+            jd.rollup_status(st, False)
+            jd.save_goals(sid, st)
+        _focused(DEAD, 1, MID)
+        _focused(DEAD2, 1, MID2)
+        g5 = _complete(RECIP, 5, origin={"peer": DEAD, "goalId": DEAD + ":t1", "msgId": MID})
+        g6 = _complete(RECIP, 6, origin={"peer": DEAD2, "goalId": DEAD2 + ":t1", "msgId": MID2})
+        self._publish(RECIP, {g5["id"]: g5, g6["id"]: g6})
+        self.assertEqual(jd.run_propagate(now=T + 900), 2)
+        for sid in (DEAD, DEAD2):
+            got = jd.load_goals(sid)
+            self.assertTrue(got["nodes"][sid + ":t1"]["nodeComplete"])
+            self.assertEqual(got["status"][sid + ":t1"], "working", "no mirror: not determinable, not settled")
+            self.assertIn(sid + ":t1", got.get("confirming") or [])
+        (jd.STATE / "remote-sids").write_text("")          # the bus has spoken: no live session anywhere by the sid
+        mid7 = "msg-propagate-0007"
+        _focused(DEAD, 2, mid7)
+        g7 = _complete(RECIP, 7, origin={"peer": DEAD, "goalId": DEAD + ":t2", "msgId": mid7})
+        st = jd.load_goals(RECIP)
+        st["nodes"][g7["id"]] = g7
+        jd.rollup_status(st, False)
+        jd.save_goals(RECIP, st)
+        self.assertEqual(jd.run_propagate(now=T + 901), 1)
+        got = jd.load_goals(DEAD)
+        self.assertTrue(got["nodes"][DEAD + ":t2"]["nodeComplete"])
+        self.assertEqual(got["status"][DEAD + ":t2"], "completed", "rolled up with the settled closedness")
+        self.assertNotIn(DEAD + ":t2", got.get("confirming") or [])
+
+
+class AbsentStoreMemo(World):
+    """_absent_store_flags: exact per file version, shared by both sweeps, evicted with the store."""
+
+    def setUp(self):
+        super().setUp()
+        self._distill = jd._distill_session
+        self.visits = []
+        jd._distill_session = lambda sid, path, now: (self.visits.append(sid), 0)[1]   # owed stays owed
+
+    def tearDown(self):
+        jd._distill_session = self._distill
+        super().tearDown()
+
+    def _plain(self, sid):
+        self._publish(sid, {sid + ":g1": _node(sid + ":g1", "ordinary open work")})
+
+    def _owed(self, sid):
+        g = _node(sid + ":g1", "an old finished ask")
+        jd.record_verdict({"nodes": {g["id"]: g}}, g, "closer", "done", T + 100, why="finished long ago")
+        self._publish(sid, {g["id"]: g})              # completed top, summary None → owes a distill
+
+    def _pass(self, now):
+        return self._counting(lambda: (jd.run_propagate(now=now),
+                                       jd._drain_undiscovered(now, self._sids())))
+
+    def test_an_unchanged_store_is_evaluated_once_across_both_sweeps_and_passes(self):
+        self._plain(DEAD)
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        self._owed(DEAD3)
+        h0, m0, _w = self._io()
+        _r, counts, _o = self._pass(T + 900)
+        self.assertEqual({s: counts[s] for s in (DEAD, DEAD2, DEAD3)}, {DEAD: 1, DEAD2: 1, DEAD3: 1},
+                         "each absent store parsed once: the sweep's read serves the sender loop and the drain")
+        self.assertEqual(self._io()[:2], (h0 + 3, m0 + 3), "three misses (propagate), three hits (the drain)")
+        self.assertEqual(self.visits, [DEAD3])
+        _r, counts, _o = self._pass(T + 901)
+        self.assertEqual({s: counts[s] for s in (DEAD, DEAD2, DEAD3)}, {DEAD: 0, DEAD2: 1, DEAD3: 0},
+                         "unchanged: no parse but the open tracker's sender-loop walk")
+        self.assertEqual(self._io()[:2], (h0 + 9, m0 + 3), "six hits, no miss")
+        self.assertEqual(self.visits, [DEAD3, DEAD3], "the drain still finds the owed store, from the memo")
+
+    def test_a_changed_goals_file_journal_or_archive_each_re_evaluate(self):
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        k0 = jd._store_identity(DEAD2)
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        h, m, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        self.assertEqual(self._io()[:2], (h + 1, m), "unchanged triple: a hit")
+        # (1) the JOURNAL alone: a user resolve journaled with no store save — load_goals replays it,
+        # so the tracker is complete on the next load and the memo must say so
+        jd.append_override(DEAD2, DEAD2 + ":t1", "resolve", T + 200)
+        k1 = jd._store_identity(DEAD2)
+        self.assertNotEqual(k1, k0)
+        self.assertEqual(k1[1], k0[1], "the goals file itself did not move")
+        self.assertEqual(jd._absent_store_flags(DEAD2), (False, True),
+                         "the journaled resolve closed the tracker; a completed top with no summary owes a distill")
+        self.assertEqual(self._io()[:2], (h + 1, m + 1))
+        # (2) the GOALS FILE: a publish that opens a second tracker
+        st = jd.load_goals(DEAD2)
+        st["nodes"][DEAD2 + ":t2"] = _tracker(DEAD2, 2, RECIP, MID2, quiet=True)
+        jd.rollup_status(st, False)
+        jd.save_goals(DEAD2, st)
+        k2 = jd._store_identity(DEAD2)
+        self.assertNotEqual(k2[1], k1[1])
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, True))
+        self.assertEqual(self._io()[:2], (h + 1, m + 2))
+        # (3) the ARCHIVE: a cleared subtree parked beside the store
+        jd.save_goal_archive(DEAD2, {"rompUuid": DEAD2, "nodes": {}, "status": {}})
+        k3 = jd._store_identity(DEAD2)
+        self.assertIsNone(k2[3])
+        self.assertIsNotNone(k3[3])
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, True))
+        self.assertEqual(self._io()[:2], (h + 1, m + 3), "a new archive file is a miss")
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, True))
+        self.assertEqual(self._io()[:2], (h + 2, m + 3), "and the unchanged triple hits again")
+
+    def test_the_identity_is_taken_before_the_read(self):
+        # A publish landing between the identity stat and the load would pair the OLD identity with the
+        # NEW content; the identity is re-taken after the read, so nothing is memoized under the stale
+        # key and the next call reads again: one extra miss, never a stale hit.
+        self._plain(DEAD2)
+        orig = jd.load_goals
+        fired = []
+
+        def publish_then_load(fsid):
+            if fsid == DEAD2 and not fired:
+                fired.append(1)
+                st = orig(DEAD2)
+                st["nodes"][DEAD2 + ":t1"] = _tracker(DEAD2, 1, RECIP, MID, quiet=True)
+                jd.rollup_status(st, False)
+                jd.save_goals(DEAD2, st)
+            return orig(fsid)
+        jd.load_goals = publish_then_load
+        try:
+            self.assertEqual(jd._absent_store_flags(DEAD2), (True, False), "the read saw the new content")
+        finally:
+            jd.load_goals = orig
+        self.assertNotIn(str(jd.GOALDIR / (DEAD2 + ".json")), jd._ABSENT_FLAGS,
+                         "the identity moved under the read: nothing memoized under the stale key")
+        h, m, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        self.assertEqual(self._io()[:2], (h, m + 1), "read again under the new identity, and memoized")
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        self.assertEqual(self._io()[:2], (h + 1, m + 1))
+
+    def test_run_propagates_own_read_takes_the_identity_before_the_read_too(self):
+        # The recipient loop's _get reads an absent sender (a complete recipient goal refs a tracker
+        # of its that is already done) and leaves the object for the sweep, which memoizes it under
+        # the identity _get took, after checking the identity still stands. A publish landing between
+        # _get's stat and its read is caught by that check: nothing memoized, one extra miss next pass;
+        # a stat taken only AFTER the read would memoize the post-publish identity against pre-publish
+        # flags and serve it as a hit.
+        self._publish(DEAD, {t["id"]: t for t in [_tracker(DEAD, 1, RECIP, MID, done=True)]})
+        g5 = _complete(RECIP, 5, origin={"peer": DEAD, "goalId": DEAD + ":t1", "msgId": MID})
+        self._publish(RECIP, {g5["id"]: g5})
+        p, k0 = str(jd.GOALDIR / (DEAD + ".json")), jd._store_identity(DEAD)
+        orig, fired = jd.load_goals, []
+
+        def publish_under_the_read(fsid):
+            st = orig(fsid)                             # the pre-publish content
+            if fsid == DEAD and not fired:
+                fired.append(1)
+                new = orig(DEAD)
+                new["nodes"][DEAD + ":t2"] = _tracker(DEAD, 2, RECIP, MID2, quiet=True)
+                jd.rollup_status(new, False)
+                jd.save_goals(DEAD, new)                # the identity moves while the read is in flight
+            return st
+        jd.load_goals = publish_under_the_read
+        try:
+            self.assertEqual(jd.run_propagate(now=T + 900), 0, "the ref's tracker was already done")
+        finally:
+            jd.load_goals = orig
+        self.assertEqual(fired, [1], "_get, not the sweep, performed the read")
+        k1 = jd._store_identity(DEAD)
+        self.assertNotEqual(k1, k0)
+        self.assertNotIn(p, jd._ABSENT_FLAGS,
+                         "the identity taken BEFORE the read no longer stands after it: nothing memoized")
+        h, m, _w = self._io()
+        n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 901))
+        self.assertEqual((n, counts[DEAD]), (0, 1))
+        self.assertEqual(self._io()[:2], (h, m + 1), "read again under the new identity; never a stale hit")
+        self.assertEqual(jd._ABSENT_FLAGS[p], (k1, (True, True)), "re-evaluated on the published content")
+
+    def test_a_dead_sender_that_gains_a_tracker_is_swept_the_next_pass(self):
+        self._plain(DEAD)
+        jd.run_propagate(now=T + 900)
+        self.assertEqual(jd._absent_store_flags(DEAD), (False, False))
+        # the courier's ext: planting shape: a write to the dead store opens a tracker (identity moves)
+        st = jd.load_goals(DEAD)
+        st["nodes"][DEAD + ":t1"] = _tracker(DEAD, 1, RECIP, MID, quiet=True)
+        jd.rollup_status(st, False)
+        jd.save_goals(DEAD, st)
+        self._reply(RECIP, DEAD, T + 500)
+        h, m, _w = self._io()
+        n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 901))
+        self.assertEqual(n, 1, "swept and completed the next pass")
+        self.assertEqual(counts[DEAD], 1, "the miss's read served the sender loop")
+        self.assertEqual(self._io()[:2], (h, m + 1))
+        self.assertTrue(jd.load_goals(DEAD)["nodes"][DEAD + ":t1"]["nodeComplete"])
+        n, counts, _o = self._counting(lambda: jd.run_propagate(now=T + 902))
+        self.assertEqual((n, counts[DEAD]), (0, 1), "the publish moved the identity: one re-evaluation")
+        self.assertEqual(jd._absent_store_flags(DEAD), (False, True),
+                         "no open tracker; the completed top now owes the drain a distill")
+
+    def test_the_drain_re_evaluates_only_changed_absent_stores(self):
+        for sid in (DEAD, DEAD2, DEAD3):
+            self._plain(sid)
+        jd._drain_undiscovered(T + 900, self._sids())
+        st = jd.load_goals(DEAD2)
+        st["nodes"][DEAD2 + ":g2"] = _node(DEAD2 + ":g2", "more open work")
+        jd.rollup_status(st, False)
+        jd.save_goals(DEAD2, st)
+        h, m, _w = self._io()
+        _r, counts, _o = self._counting(lambda: jd._drain_undiscovered(T + 901, self._sids()))
+        self.assertEqual({s: counts[s] for s in (DEAD, DEAD2, DEAD3)}, {DEAD: 0, DEAD2: 1, DEAD3: 0})
+        self.assertEqual(self._io()[:2], (h + 2, m + 1))
+        self.assertEqual(self.visits, [])
+
+    def test_the_drain_distills_a_stuck_store_found_by_the_shared_sweep(self):
+        jd._distill_session = self._distill                  # the real distiller: transcript-less settle
+        self._owed(DEAD3)
+        self.sessions = []
+        h, m, _w = self._io()
+        _n, counts, _o = self._counting(lambda: (jd.run_propagate(now=T + 900), jd.run_distill(now=T + 900)))
+        self.assertEqual(self._io()[:2], (h + 1, m + 1), "propagate's miss, the drain's hit")
+        nd = jd.load_goals(DEAD3)["nodes"][DEAD3 + ":g1"]
+        self.assertEqual(nd.get("summary"), "", "no transcript anywhere: the sentinel ends the spinner")
+        _n, counts, _o = self._counting(lambda: jd.run_distill(now=T + 901))
+        self.assertEqual(counts[DEAD3], 1, "the settle moved the identity: one re-evaluation")
+        self.assertEqual(jd._absent_store_flags(DEAD3), (False, False), "self-retired")
+
+    def test_a_vanished_store_is_evicted_and_the_key_is_the_full_path(self):
+        self._plain(DEAD)
+        self._plain(DEAD2)
+        jd._drain_undiscovered(T + 900, self._sids())
+        p_dead = str(jd.GOALDIR / (DEAD + ".json"))
+        self.assertIn(p_dead, jd._ABSENT_FLAGS)
+        (jd.GOALDIR / (DEAD + ".json")).unlink()
+        jd._drain_undiscovered(T + 901, self._sids())
+        self.assertNotIn(p_dead, jd._ABSENT_FLAGS, "gone from the glob: evicted at the next sweep")
+        self.assertIn(str(jd.GOALDIR / (DEAD2 + ".json")), jd._ABSENT_FLAGS)
+        # a bare GOALDIR reassignment (no _rebind_state): the same file bytes under another root,
+        # mtime preserved, never hit the old root's entry, and the old entry is evicted by the sweep
+        other = Path(self.td.name) / "other"
+        (other / "goals").mkdir(parents=True)
+        shutil.copy2(jd.GOALDIR / (DEAD2 + ".json"), other / "goals" / (DEAD2 + ".json"))
+        saved = jd.GOALDIR, jd.GOALARCHDIR
+        jd.GOALDIR, jd.GOALARCHDIR = other / "goals", other / "goals-archive"
+        try:
+            h, m, _w = self._io()
+            self.assertEqual(jd._absent_store_flags(DEAD2), (False, False))
+            self.assertEqual(self._io()[:2], (h, m + 1), "a different path is a different key")
+            self.assertEqual(jd._store_identity(DEAD2)[0], str(other / "goals" / (DEAD2 + ".json")))
+            jd._drain_undiscovered(T + 902, self._sids())
+            self.assertEqual(set(jd._ABSENT_FLAGS), {str(other / "goals" / (DEAD2 + ".json"))},
+                             "the old root's entries are gone from the new root's glob")
+        finally:
+            jd.GOALDIR, jd.GOALARCHDIR = saved
+
+    # Each component of the identity is load-bearing on its own: the tests above change two at once
+    # (a publish is a new inode AND a new mtime, usually a new size), so a key missing one component
+    # still passes them. One test per component, isolating it with an in-place rewrite or os.utime,
+    # which no romp writer does.
+    def test_a_size_only_change_is_a_miss(self):
+        self._plain(DEAD2)
+        self.assertEqual(jd._absent_store_flags(DEAD2), (False, False))
+        p = jd.GOALDIR / (DEAD2 + ".json")
+        k0, st0 = jd._store_identity(DEAD2), os.stat(p)
+        t1 = _tracker(DEAD2, 1, RECIP, MID, quiet=True)
+        with open(p, "r+b") as f:                        # in place: the same inode
+            f.truncate()
+            f.write(json.dumps(_store(DEAD2, {t1["id"]: t1})).encode())
+        os.utime(p, ns=(st0.st_atime_ns, st0.st_mtime_ns))
+        st1 = os.stat(p)
+        self.assertEqual((st1.st_ino, st1.st_mtime_ns), (st0.st_ino, st0.st_mtime_ns), "same inode, same mtime_ns")
+        self.assertNotEqual(st1.st_size, st0.st_size, "only the size moved")
+        self.assertNotEqual(jd._store_identity(DEAD2), k0, "the key moved with it")
+        h, m, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False), "a miss: the new bytes' open tracker")
+        self.assertEqual(self._io()[:2], (h, m + 1))
+
+    def test_an_mtime_only_change_is_a_miss(self):
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        p = jd.GOALDIR / (DEAD2 + ".json")
+        k0, st0 = jd._store_identity(DEAD2), os.stat(p)
+        raw = p.read_bytes()
+        self.assertEqual(raw.count(b'"nodeComplete": false'), 1)
+        with open(p, "r+b") as f:
+            f.write(raw.replace(b'"nodeComplete": false', b'"nodeComplete": true '))   # the same byte length
+        os.utime(p, ns=(st0.st_atime_ns, st0.st_mtime_ns + 1_000_000_000))
+        st1 = os.stat(p)
+        self.assertEqual((st1.st_ino, st1.st_size), (st0.st_ino, st0.st_size), "same inode, same size")
+        self.assertNotEqual(st1.st_mtime_ns, st0.st_mtime_ns, "only the mtime moved")
+        self.assertNotEqual(jd._store_identity(DEAD2), k0, "the key moved with it")
+        h, m, _w = self._io()
+        self.assertFalse(jd._absent_store_flags(DEAD2)[0], "a miss: the tracker now reads complete")
+        self.assertEqual(self._io()[:2], (h, m + 1))
+
+    def test_an_inode_only_change_is_a_miss(self):
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        p = jd.GOALDIR / (DEAD2 + ".json")
+        k0, st0 = jd._store_identity(DEAD2), os.stat(p)
+        raw = p.read_bytes()
+        tmp = jd.GOALDIR / (DEAD2 + ".json.tmp")
+        tmp.write_bytes(raw.replace(b'"nodeComplete": false', b'"nodeComplete": true '))   # the same byte length
+        os.utime(tmp, ns=(st0.st_atime_ns, st0.st_mtime_ns))
+        os.rename(tmp, p)                                # a publish whose clock did not move
+        st1 = os.stat(p)
+        self.assertEqual((st1.st_mtime_ns, st1.st_size), (st0.st_mtime_ns, st0.st_size), "same mtime_ns, same size")
+        self.assertNotEqual(st1.st_ino, st0.st_ino, "only the inode moved")
+        self.assertNotEqual(jd._store_identity(DEAD2), k0, "the key moved with it")
+        h, m, _w = self._io()
+        self.assertFalse(jd._absent_store_flags(DEAD2)[0], "a miss: the tracker now reads complete")
+        self.assertEqual(self._io()[:2], (h, m + 1))
+
+    def test_run_propagates_sweep_evicts_a_vanished_store(self):
+        # run_propagate's own sweep evicts too, not only _drain_undiscovered's
+        self._plain(DEAD)
+        self._plain(DEAD2)
+        jd.run_propagate(now=T + 900)
+        p_dead = str(jd.GOALDIR / (DEAD + ".json"))
+        self.assertIn(p_dead, jd._ABSENT_FLAGS)
+        (jd.GOALDIR / (DEAD + ".json")).unlink()
+        jd.run_propagate(now=T + 901)
+        self.assertNotIn(p_dead, jd._ABSENT_FLAGS, "gone from run_propagate's glob: evicted by its sweep")
+        self.assertIn(str(jd.GOALDIR / (DEAD2 + ".json")), jd._ABSENT_FLAGS)
+
+    def test_a_same_size_in_place_rewrite_with_the_mtime_put_back_is_the_documented_exception(self):
+        # No romp writer does this: every publish is a tmp+rename (new inode, new mtime) and the
+        # journal only grows. The identity key cannot see it, so the memo serves the previous answer;
+        # pinned so the blind spot is a known, named exception rather than a surprise. A publish of
+        # different size is seen.
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False))
+        p = jd.GOALDIR / (DEAD2 + ".json")
+        k0, st0 = jd._store_identity(DEAD2), os.stat(p)
+        raw = p.read_bytes()
+        self.assertEqual(raw.count(b'"nodeComplete": false'), 1)
+        edited = raw.replace(b'"nodeComplete": false', b'"nodeComplete": true ')   # same byte length
+        self.assertEqual(len(edited), len(raw))
+        with open(p, "r+b") as f:
+            f.write(edited)
+        os.utime(p, ns=(st0.st_atime_ns, st0.st_mtime_ns))
+        self.assertEqual(jd._store_identity(DEAD2), k0, "same inode, mtime and size: the key cannot tell")
+        self.assertFalse(jd._open_handoff_flag(jd.load_goals(DEAD2)), "a fresh evaluation would say closed")
+        h, m, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False), "the memo serves the previous answer (the known exception)")
+        self.assertEqual(self._io()[:2], (h + 1, m))
+        st = jd.load_goals(DEAD2)
+        st["nodes"][DEAD2 + ":g9"] = _node(DEAD2 + ":g9", "a publish of another size")
+        jd.save_goals(DEAD2, st)
+        self.assertNotEqual(jd._store_identity(DEAD2), k0)
+        self.assertEqual(jd._absent_store_flags(DEAD2), (False, False))
+        self.assertEqual(self._io()[:2], (h + 1, m + 1))
+
+    def test_a_load_failure_is_not_memoized(self):
+        self._plain(DEAD)
+        orig = jd.load_goals
+        jd.load_goals = lambda fsid: (_ for _ in ()).throw(OSError("unreadable")) if fsid == DEAD else orig(fsid)
+        try:
+            self.assertIsNone(jd._absent_store_flags(DEAD), "the caller skips the store this pass")
+        finally:
+            jd.load_goals = orig
+        self.assertNotIn(str(jd.GOALDIR / (DEAD + ".json")), jd._ABSENT_FLAGS)
+        self.assertEqual(jd._absent_store_flags(DEAD), (False, False), "retried on the next call")
+
+    # ---- a load that answered less than the files hold is no better than one that raised ----
+    def _read_fails_once(self, target):
+        """Patch Path.read_text so the first read of `target` raises OSError and every later read is
+        real: the store or journal exists and could not be read. load_goals RAISES a store-file
+        failure; _replay_overrides logs and skips the journal and marks the object `_unread`. Returns
+        the counter of raised reads."""
+        real = Path.read_text
+        state = {"fired": 0}
+
+        def flaky(p, *a, **k):
+            if p == target and not state["fired"]:
+                state["fired"] += 1
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real(p, *a, **k)
+        Path.read_text = flaky
+        self.addCleanup(setattr, Path, "read_text", real)
+        return state
+
+    def test_a_store_read_fault_raises_out_of_the_load_and_is_not_memoized(self):
+        # load_goals raises on a store file it cannot read (there is no fallback store to answer from),
+        # so the caller skips the store this pass (None), as the sweeps always did, and no entry is
+        # written: nothing on disk changes before the next read succeeds, so an entry would be a hit
+        # saying "nothing open" for a store holding an open tracker, until its next write.
+        self._publish(DEAD, {t["id"]: t for t in [_tracker(DEAD, 1, RECIP, MID, quiet=True)]})
+        p, k0 = str(jd.GOALDIR / (DEAD + ".json")), jd._store_identity(DEAD)
+        state = self._read_fails_once(jd.GOALDIR / (DEAD + ".json"))
+        h, m, _w = self._io()
+        self.assertIsNone(jd._absent_store_flags(DEAD), "the raise: skipped this pass")
+        self.assertEqual(state["fired"], 1)
+        self.assertNotIn(p, jd._ABSENT_FLAGS, "a store that did not read is never memoized")
+        self.assertEqual(jd._store_identity(DEAD), k0, "nothing on disk moved: the key alone could not tell")
+        self.assertEqual(jd._absent_store_flags(DEAD), (True, False), "the next call re-reads the file")
+        self.assertEqual(self._io()[:2], (h, m + 2), "two misses, no stale hit")
+        self.assertEqual(jd._ABSENT_FLAGS[p], (k0, (True, False)))
+
+    def test_a_quarantined_store_is_not_memoized_under_the_corrupt_files_identity(self):
+        # load_goals moves an unparseable store aside and answers the legitimate fresh store. The key was
+        # taken before the read and names the corrupt file, which is gone by the time the answer is in
+        # hand; the identity re-taken after the read differs, so nothing is memoized under it. The next
+        # call takes the absent identity and memoizes the fresh store's answer there.
+        self._publish(DEAD, {t["id"]: t for t in [_tracker(DEAD, 1, RECIP, MID, quiet=True)]})
+        p = jd.GOALDIR / (DEAD + ".json")
+        p.write_text("{not json")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(jd._absent_store_flags(DEAD), (False, False), "the fresh store's answer, this pass")
+        self.assertFalse(p.exists(), "the corrupt file was moved aside")
+        self.assertEqual(len(list(jd.GOALDIR.glob(DEAD + ".json.corrupt-*"))), 1)
+        self.assertNotIn(str(p), jd._ABSENT_FLAGS, "never memoized under the identity of a file that is gone")
+        self.assertEqual(jd._absent_store_flags(DEAD), (False, False))
+        self.assertIsNone(jd._ABSENT_FLAGS[str(p)][0][1], "memoized under the absent identity")
+
+    def test_a_skipped_journal_replay_is_answered_but_not_memoized(self):
+        # The store file reads; the override journal does not. _replay_overrides logs, skips it and
+        # marks the object `_unread`, so the un-replayed store still shows a tracker the user
+        # resolved. That answer serves this pass only; the next call replays and re-evaluates. An
+        # entry would have pinned the un-resolved tracker: the journal's identity does not move when
+        # it becomes readable again.
+        self._publish(DEAD2, {t["id"]: t for t in [_tracker(DEAD2, 1, RECIP, MID, quiet=True)]})
+        jd.append_override(DEAD2, DEAD2 + ":t1", "resolve", T + 200)
+        self.assertEqual(jd._owed_distill_flag(jd.load_goals(DEAD2)), True, "replayed: the resolve closed the tracker")
+        p, k0 = str(jd.GOALDIR / (DEAD2 + ".json")), jd._store_identity(DEAD2)
+        state = self._read_fails_once(jd._overrides_dir() / (DEAD2 + ".jsonl"))
+        h, m, _w = self._io()
+        self.assertEqual(jd._absent_store_flags(DEAD2), (True, False), "un-replayed: this pass only")
+        self.assertEqual(state["fired"], 1)
+        self.assertNotIn(p, jd._ABSENT_FLAGS, "a store whose journal was skipped is never memoized")
+        self.assertEqual(jd._store_identity(DEAD2), k0)
+        self.assertEqual(jd._absent_store_flags(DEAD2), (False, True), "the next call replays the journal")
+        self.assertEqual(self._io()[:2], (h, m + 2), "two misses, no stale hit")
+        self.assertEqual(jd._ABSENT_FLAGS[p], (k0, (False, True)))
+
+    def test_run_propagate_files_a_row_for_a_sender_whose_read_raises_and_completes_it_the_next_pass(self):
+        # The raise through run_propagate's own read: a complete recipient goal refs an absent sender's
+        # open tracker; _get's read of the sender raises (the store file fails once), the recipient's
+        # pass-crash row names the sender, the ref waits, and nothing is kept for the sweep, which reads
+        # the file itself (the read succeeds now) and memoizes what it says. The next pass reads the file
+        # at the ref and completes the tracker.
+        self._publish(DEAD, {t["id"]: t for t in [_tracker(DEAD, 1, RECIP, MID)]})
+        g5 = _complete(RECIP, 5, origin={"peer": DEAD, "goalId": DEAD + ":t1", "msgId": MID})
+        self._publish(RECIP, {g5["id"]: g5})
+        p = str(jd.GOALDIR / (DEAD + ".json"))
+        state = self._read_fails_once(jd.GOALDIR / (DEAD + ".json"))
+        self.assertEqual(jd.run_propagate(now=T + 900), 0, "the sender's read raised: nothing to complete this pass")
+        self.assertEqual(state["fired"], 1)
+        rows = [json.loads(l) for l in jd.ERRORS.read_text().splitlines()] if jd.ERRORS.exists() else []
+        crash = [r for r in rows if r["err"] == "pass-crash"]
+        self.assertEqual([(r["judge"], r["fsid"]) for r in crash], [("propagate", RECIP)], "the recipient's row, once")
+        self.assertIn(DEAD[:8], crash[0]["note"], "...naming the sender whose store raised")
+        self.assertFalse(jd.load_goals(DEAD)["nodes"][DEAD + ":t1"]["nodeComplete"])
+        self.assertEqual(jd._ABSENT_FLAGS[p][1], (True, False), "the sweep's own read succeeded: the file's truth, memoized")
+        self.assertEqual(jd.run_propagate(now=T + 901), 1, "the next pass reads the file at the ref and completes it")
+        self.assertTrue(jd.load_goals(DEAD)["nodes"][DEAD + ":t1"]["nodeComplete"])
+
+    def test_rebind_clears_the_memo(self):
+        self._plain(DEAD)
+        jd._absent_store_flags(DEAD)
+        self.assertTrue(jd._ABSENT_FLAGS)
+        jd._rebind_state(Path(self.td.name))
+        self.assertEqual(jd._ABSENT_FLAGS, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_retry_burst.py
+++ b/tests/test_judge_retry_burst.py
@@ -56,7 +56,7 @@ class RetryBurstPlansOnce(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = lambda *a, **k: (calls.append(1), llm())[1]
             jd._group_store = lambda *a, **k: None    # don't fire the real grouper model after a placement
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
             finally:

--- a/tests/test_judge_rewind_cleanup.py
+++ b/tests/test_judge_rewind_cleanup.py
@@ -73,8 +73,7 @@ class Base(unittest.TestCase):
     def tearDown(self):
         jd.set_pending_cut_provider(None)
         jd.end_pass_frame(True)
-        jd._PARSE_CACHE.clear()
-        jd._CHAIN_MEMO.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._rebind_state(self._saved_state)
 
     def write(self, recs):
@@ -832,6 +831,36 @@ class ChainMemo(Base):
         self.assertEqual(jd.chain_memo_stats()["populate"] - before["populate"], 2)
         self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
         self.assertEqual(len(self.built), 2, "the third call is a hit")
+
+    def test_a_same_identity_rewrite_is_served_stale_until_the_memo_is_cleared(self):
+        # WHY every test site that clears _PARSE_CACHE clears _CHAIN_MEMO beside it: both key on the
+        # transcript's (mtime, size), so a fixture rewritten in place to the same byte count inside one
+        # clock tick keeps its key, and a memo an earlier test populated serves the OLD verdict for the
+        # new bytes without reading the file. Deterministic here: the mtime is pinned back with
+        # os.utime, never left to the clock. em's records cache keys on the same identity and is
+        # cleared beside the two, so the rebuild reads the new bytes and the chain memo's own
+        # contribution is what the test isolates.
+        recs = self.base_recs() + self.fork_recs()
+        self.write(recs)
+        want = self.path.stat().st_size
+        st = os.stat(self.path)
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 1)
+        # the same byte count with u2 LIVE: the fork rows go, a padded row under a2 makes up the length
+        pad = want - len(("\n".join(json.dumps(r) for r in self.base_recs() + [uline(T0 + 60, "", "u9", "a2")]) + "\n").encode())
+        self.assertGreaterEqual(pad, 0, "the filler row fits inside the original byte count")
+        live = self.base_recs() + [uline(T0 + 60, "x" * pad, "u9", "a2")]
+        self.write(live)
+        os.utime(self.path, ns=(st.st_atime_ns, st.st_mtime_ns))
+        now = os.stat(self.path)
+        self.assertEqual((now.st_mtime_ns, now.st_size), (st.st_mtime_ns, st.st_size), "precondition: same identity")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable",
+                         "the hazard: the memo serves the pre-rewrite verdict for bytes under which u2 is live")
+        self.assertEqual(len(self.built), 1, "...without a build, so nothing read the new bytes")
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()          # the swept sites' form
+        em._JSONL_CACHE.clear()                                  # the records cache under the adapter, same key
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "cleared: rebuilt from the new bytes, u2 kept")
+        self.assertEqual(len(self.built), 2)
 
 
 class PlanSessionIntegration(Base):

--- a/tests/test_judge_rewind_cleanup.py
+++ b/tests/test_judge_rewind_cleanup.py
@@ -74,6 +74,7 @@ class Base(unittest.TestCase):
         jd.set_pending_cut_provider(None)
         jd.end_pass_frame(True)
         jd._PARSE_CACHE.clear()
+        jd._CHAIN_MEMO.clear()
         jd._rebind_state(self._saved_state)
 
     def write(self, recs):
@@ -527,6 +528,310 @@ class WriteMomentStandDown(Base):
         unplanned = [u for u in dead
                      if not jd._placed_key(s["placements"], jd._unit_key(u[0], u[1]), live)]
         self.assertEqual(unplanned, [], "every stood-down unit reads placed — the gate is open")
+
+
+class ChainMemo(Base):
+    """The write-moment chain memo: _rewound_away answers an unchanged session without a second
+    FileAdapter, and every input the adapter reads busts the memo — a
+    transcript append, a states resumeFork row (by the states file's own stat, and by the lineage
+    closure it grows), a from-file leaving that closure, the pending cut — and the key is taken
+    before the build reads, so a write that lands mid-build is never sealed under it. A build that
+    raises and a key that cannot be stat'd never memoize; reconcile_rewound_goals shares the on-disk
+    slot; entries evict oldest-used at the cap and _rebind_state clears them."""
+
+    def setUp(self):
+        super().setUp()
+        jd._CHAIN_MEMO.clear()
+        self.built = []
+        orig = em.FileAdapter.__init__
+
+        def counting(ad, *a, **k):
+            self.built.append(1)
+            return orig(ad, *a, **k)
+        self._orig_init = orig
+        em.FileAdapter.__init__ = counting
+
+    def tearDown(self):
+        em.FileAdapter.__init__ = self._orig_init
+        super().tearDown()
+
+    def test_unchanged_files_build_one_adapter_and_agree(self):
+        self.write(self.base_recs() + self.fork_recs())
+        first = jd._rewound_away(SID, str(self.path), "u2")
+        second = jd._rewound_away(SID, str(self.path), "u2")
+        self.assertEqual((first, second), ("durable", "durable"))
+        self.assertEqual(len(self.built), 1, "the second call served the memo")
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u3"), "a kept uuid, same memo")
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "nobody"), "an unknown uuid, same memo")
+        self.assertEqual(len(self.built), 1)
+
+    def test_a_transcript_append_invalidates_and_answers_fresh(self):
+        self.write(self.base_recs())
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"))
+        self.append(self.fork_recs())                            # the branch-take lands on disk
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 2)
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 2, "the new world is memoized in turn")
+
+    def test_a_states_resume_fork_row_invalidates_and_answers_fresh(self):
+        # the leaf is a fresh head; only the states row's lineage closure joins the from-file in
+        # which u2 sits on a rewound branch, so the row alone must change the answer
+        frm = "22222222-3333-4444-5555-666666666666"
+        (self.td / (frm + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in self.base_recs() + self.fork_recs()) + "\n")
+        self.write([uline(T0 + 100, "continues after the machine cut", "u5", None),
+                    aline(T0 + 110, "Stitched reply.", "a5", "u5")])
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "no lineage: u2 is unknown")
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(
+            json.dumps({"resumeFork": {"from": frm, "to": SID}, "t": T0 + 90}) + "\n")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable",
+                         "the closure joined the from-file and u2 rejoins the stitched spine")
+        self.assertEqual(len(self.built), 2)
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 2, "the stitched world is memoized too")
+
+    def test_a_states_row_whose_from_file_is_already_the_anchor_invalidates_by_its_stat_alone(self):
+        # the common first-hop shape: the SDK's resume fork records from=<the stable sid>, and
+        # _judge_candidates already carries <sid>.jsonl as the anchor, so the row adds NOTHING to
+        # the lineage closure — only the states file's (mtime, size) in the key moves, and that
+        # has to be enough on its own
+        self.write(self.base_recs() + self.fork_recs())                 # SID.jsonl: the anchor
+        other = "33333333-4444-5555-6666-777777777777"
+        leaf = self.td / (other + ".jsonl")
+        leaf.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0 + 100, "continues after the machine cut", "u5", None),
+            aline(T0 + 110, "Stitched reply.", "a5", "u5")]) + "\n")
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        states = jd.STATESDIR / (SID + ".jsonl")
+        states.write_text(json.dumps({"t": T0 + 80, "note": "an unrelated synthetic states row"}) + "\n")
+        self.assertFalse(jd._rewound_away(SID, str(leaf), "u2"), "no link yet: u2 sits in the anchor's own graph")
+        self.assertEqual(len(self.built), 1)
+        with open(states, "a") as f:
+            f.write(json.dumps({"resumeFork": {"from": SID, "to": other}, "t": T0 + 90}) + "\n")
+        self.assertEqual(jd._rewound_away(SID, str(leaf), "u2"), "durable",
+                         "the stitch re-points the fresh head at the anchor's tip, behind which u2 is rewound")
+        self.assertEqual(len(self.built), 2, "the states stat alone busted the memo")
+
+    def test_a_from_file_that_vanishes_invalidates_through_the_closure(self):
+        # the lineage closure's own channel: the from-file is not a candidate and nothing writes
+        # the states file, so neither the candidates' stats nor the states stat move — only the
+        # closure (with the from-file stats it carries) can bust the key
+        frm = "22222222-3333-4444-5555-666666666666"
+        (self.td / (frm + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in self.base_recs() + self.fork_recs()) + "\n")
+        self.write([uline(T0 + 100, "continues after the machine cut", "u5", None),
+                    aline(T0 + 110, "Stitched reply.", "a5", "u5")])
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(
+            json.dumps({"resumeFork": {"from": frm, "to": SID}, "t": T0 + 90}) + "\n")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 1)
+        (self.td / (frm + ".jsonl")).unlink()
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "no from-file: u2 is unknown again")
+        self.assertEqual(len(self.built), 2, "the closure lost a file and the key moved with it")
+        self.assertFalse(jd.ERRORS.exists() and "chain-check" in jd.ERRORS.read_text(),
+                         "a clean rebuild, not a failed one answering False")
+
+    def test_the_key_is_taken_before_the_build_reads(self):
+        # a rewind that lands DURING a build (after the key's stats, while the adapter reads) is
+        # never sealed under that key: the next call re-stats, sees the append and rebuilds,
+        # instead of serving a pre-append verdict as the post-append world's
+        self.write(self.base_recs())
+        orig = em.chain_membership
+
+        def append_mid_build(*a, **k):
+            out = orig(*a, **k)
+            em.chain_membership = orig                          # once: the racing writer
+            self.append(self.fork_recs())
+            return out
+        em.chain_membership = append_mid_build
+        try:
+            self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "built from the pre-append records")
+        finally:
+            em.chain_membership = orig
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable",
+                         "the key predates the append, so the next call's stat misses and rebuilds")
+        self.assertEqual(len(self.built), 2)
+
+    def test_arming_and_clearing_the_cut_each_answer_fresh(self):
+        self.write(self.base_recs())
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"))          # the on-disk build
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "pending")
+        self.assertEqual(len(self.built), 2, "the armed world is a second build; the durability "
+                                             "check reads the on-disk slot already in the memo")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "pending")
+        self.assertEqual(len(self.built), 2, "the armed world is memoized under its cut")
+        jd.set_pending_cut_provider(None)
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "the dissolved rollback's ask is live again")
+        self.assertEqual(len(self.built), 2, "clearing serves the on-disk slot: it never depended on the cut")
+        jd.set_pending_cut_provider(lambda sid: "u1")                          # a different cut
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "a1"), "pending")
+        self.assertEqual(len(self.built), 3, "another cut is another world")
+
+    def test_the_on_disk_slot_is_built_only_when_a_cut_armed_check_needs_it(self):
+        self.write(self.base_recs())
+        jd.set_pending_cut_provider(lambda sid: "a1")
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u1"), "kept under the cut too")
+        self.assertEqual(len(self.built), 1, "no durability question, no on-disk build")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "pending")
+        self.assertEqual(len(self.built), 2, "the first rewind answer under the cut builds the on-disk graph")
+
+    def test_a_build_that_raises_is_loud_and_never_memoized(self):
+        self.write(self.base_recs() + self.fork_recs())
+        orig, calls = em.chain_membership, []
+
+        def boom(*a, **k):
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("synthetic adapter failure")
+            return orig(*a, **k)
+        em.chain_membership = boom
+        try:
+            self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "pre-fix behavior: mint anyway")
+            self.assertIn("chain-check", jd.ERRORS.read_text(), "the failure is loud")
+            self.assertNotIn(SID, jd._CHAIN_MEMO, "a raised build leaves no entry")
+            self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+            self.assertIn(SID, jd._CHAIN_MEMO)
+        finally:
+            em.chain_membership = orig
+
+    def test_a_key_that_cannot_be_stat_ed_bypasses_the_memo(self):
+        self.write(self.base_recs() + self.fork_recs())
+        orig = jd._fileset_key
+
+        def no_stat(files):
+            raise OSError("synthetic stat failure")
+        jd._fileset_key = no_stat
+        try:
+            before = jd.chain_memo_stats()
+            self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable", "built fresh")
+            self.assertNotIn(SID, jd._CHAIN_MEMO, "an unkeyable build is not memoized")
+            self.assertEqual(jd.chain_memo_stats()["bypass"], before["bypass"] + 1)
+        finally:
+            jd._fileset_key = orig
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertIn(SID, jd._CHAIN_MEMO, "with the stat back, the next call memoizes")
+
+    def test_reconcile_shares_the_on_disk_slot_both_ways(self):
+        self.write(self.base_recs() + self.fork_recs())
+        orig, calls = em.chain_membership, []
+
+        def counting(*a, **k):
+            calls.append(1)
+            return orig(*a, **k)
+        em.chain_membership = counting
+        try:
+            jd._RECON_MEMO.clear()
+            self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+            jd.reconcile_rewound_goals(SID, str(self.path), T0 + 200)
+            self.assertEqual(len(calls), 1, "the reconciliation read the memo's on-disk slot")
+            jd._CHAIN_MEMO.clear()
+            jd._RECON_MEMO.clear()
+            jd.reconcile_rewound_goals(SID, str(self.path), T0 + 300)
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+            self.assertEqual(len(calls), 2, "the stand-down read what the reconciliation built")
+        finally:
+            em.chain_membership = orig
+
+    def test_the_served_sets_are_immutable_and_the_dict_is_a_copy(self):
+        self.write(self.base_recs() + self.fork_recs())
+        mem = jd._chain_membership(SID, str(self.path), "")
+        self.assertIsInstance(mem["rewind"], frozenset)
+        mem["rewind"] = set()                                    # a caller scribbling on its copy
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 1)
+
+    def test_the_memo_evicts_the_oldest_used_entry_at_the_cap(self):
+        saved = jd._CHAIN_MEMO_MAX
+        jd._CHAIN_MEMO_MAX = 2
+        try:
+            sids = ["%08d-1111-2222-3333-444444444444" % i for i in range(3)]
+            paths = []
+            for sid in sids:
+                pth = self.td / (sid + ".jsonl")
+                pth.write_text("\n".join(json.dumps(r) for r in self.base_recs() + self.fork_recs()) + "\n")
+                paths.append(str(pth))
+            jd._rewound_away(sids[0], paths[0], "u2")
+            jd._rewound_away(sids[1], paths[1], "u2")
+            jd._rewound_away(sids[0], paths[0], "u2")            # a hit: sids[0] is the hot entry
+            jd._rewound_away(sids[2], paths[2], "u2")            # at the cap: the oldest-USED goes
+            self.assertEqual(set(jd._CHAIN_MEMO), {sids[0], sids[2]})
+        finally:
+            jd._CHAIN_MEMO_MAX = saved
+
+    def test_the_counters_report_hits_misses_and_populates(self):
+        self.write(self.base_recs() + self.fork_recs())
+        before = jd.chain_memo_stats()
+        jd._rewound_away(SID, str(self.path), "u2")
+        jd._rewound_away(SID, str(self.path), "u2")
+        after = jd.chain_memo_stats()
+        self.assertEqual([after[k] - before[k] for k in ("miss", "populate", "hit", "bypass")], [1, 1, 1, 0])
+
+    def test_rebind_state_clears_the_memo(self):
+        self.write(self.base_recs() + self.fork_recs())
+        jd._rewound_away(SID, str(self.path), "u2")
+        self.assertIn(SID, jd._CHAIN_MEMO)
+        jd._rebind_state(self.td / "state")
+        self.assertEqual(jd._CHAIN_MEMO, {})
+
+    def test_a_from_file_rewritten_in_place_invalidates_by_its_own_stat(self):
+        # the lineage from-files are frozen after their fork in practice, but the key stats them anyway:
+        # a from-file that grows in place moves no candidate stat, no states stat and no closure
+        # membership, so only its own (mtime, size) in the key can bust the memo
+        frm = "22222222-3333-4444-5555-666666666666"
+        fpath = self.td / (frm + ".jsonl")
+        fpath.write_text("\n".join(json.dumps(r) for r in self.base_recs()) + "\n")
+        self.write([uline(T0 + 100, "continues after the machine cut", "u5", None),
+                    aline(T0 + 110, "Stitched reply.", "a5", "u5")])
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(
+            json.dumps({"resumeFork": {"from": frm, "to": SID}, "t": T0 + 90}) + "\n")
+        self.assertFalse(jd._rewound_away(SID, str(self.path), "u2"), "the stitch hangs u5 under a2: u2 is kept")
+        self.assertEqual(len(self.built), 1)
+        with open(fpath, "a") as f:
+            for r in self.fork_recs():                            # the from-file's tip is now a3: u2 rewound
+                f.write(json.dumps(r) + "\n")
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 2, "the from-file's stat alone busted the memo")
+
+    def test_two_threads_that_miss_together_both_build_outside_the_lock(self):
+        # the build runs outside _CHAIN_LOCK, which serializes the dict operations only: two callers
+        # that miss together both build (the loser's populate is one wasted adapter walk, never the
+        # judge pools stalled behind one builder holding the lock)
+        import threading
+        self.write(self.base_recs() + self.fork_recs())
+        before = jd.chain_memo_stats()
+        orig, broken, out = em.chain_membership, [], []
+        barrier = threading.Barrier(2, timeout=10)              # the event: both builders inside the build at
+        #                                                         once; the timeout only bounds the failure
+
+        def meeting(*a, **k):
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                broken.append(1)
+            return orig(*a, **k)
+        em.chain_membership = meeting
+        try:
+            ts = [threading.Thread(target=lambda: out.append(jd._rewound_away(SID, str(self.path), "u2")))
+                  for _ in range(2)]
+            for t in ts:
+                t.start()
+            for t in ts:
+                t.join()
+        finally:
+            em.chain_membership = orig
+        self.assertEqual(broken, [], "both builders were inside the build at once: neither held the lock there")
+        self.assertEqual(out, ["durable", "durable"])
+        self.assertEqual(len(self.built), 2)
+        self.assertEqual(jd.chain_memo_stats()["populate"] - before["populate"], 2)
+        self.assertEqual(jd._rewound_away(SID, str(self.path), "u2"), "durable")
+        self.assertEqual(len(self.built), 2, "the third call is a hit")
 
 
 class PlanSessionIntegration(Base):

--- a/tests/test_judge_sdk_human_prompt_run.py
+++ b/tests/test_judge_sdk_human_prompt_run.py
@@ -40,7 +40,7 @@ class SdkHumanPromptRun(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def _open_human_turn(self, sid):
         """A transcript with ONE in-progress human prompt over the SDK channel (promptSource 'sdk'), no

--- a/tests/test_judge_senderless_delegation.py
+++ b/tests/test_judge_senderless_delegation.py
@@ -81,7 +81,7 @@ class SenderlessDelegation(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             tpath = Path(td) / (SID + ".jsonl")
             tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
             phases = [ph for _sg, ph in self._units(str(tpath))]
             self.assertNotIn("delegation", phases,
                              "no sender resolved → the courier can never place a '#d'; none may be yielded")
@@ -96,13 +96,13 @@ class SenderlessDelegation(unittest.TestCase):
             jd.MESSAGES.write_text(json.dumps(
                 {"t": T0 - 1, "ev": "sent", "id": MID, "from_id": SENDER, "to_id": SID}) + "\n")
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 phases = [ph for _sg, ph in self._units(str(tpath))]
                 self.assertIn("delegation", phases, "a resolvable sender keeps the courier's '#d' work-run")
                 self.assertNotIn("work", phases, "and the planner does not double-place it")
             finally:
                 jd.MESSAGES = saved
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def test_one_planner_pass_opens_the_nudge_gate(self):
         """The systemic claim: with the sender-less segment owned by the planner, one ordinary pass
@@ -116,7 +116,7 @@ class SenderlessDelegation(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 store = jd.load_goals(SID)
                 self.assertFalse(self._gate_is_open(store, str(tpath)),
                                  "precondition: the fresh unit starts unplaced (gate closed)")

--- a/tests/test_judge_spliced_done.py
+++ b/tests/test_judge_spliced_done.py
@@ -91,7 +91,7 @@ class SplicedDone(unittest.TestCase):
             jd.plan_llm = jd.opener_llm = fake
             jd._group_store = lambda *a, **k: None
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
             finally:
@@ -142,7 +142,7 @@ class SplicedDone(unittest.TestCase):
             td = Path(td)
             tpath = td / (SID + ".jsonl")
             tpath.write_text("\n".join(json.dumps(r) for r in spliced_records()) + "\n")
-            jd._PARSE_CACHE.clear()
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
             session = jd.parsed_session(SID, [str(tpath)], NOW)
         segs = [seg for turn in session["turns"] for seg in jd.em.segments(turn)]
         by_trig = {seg.get("trigger"): seg for seg in segs}

--- a/tests/test_judge_store_cache.py
+++ b/tests/test_judge_store_cache.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""The shared read-only goal-store cache (kernel/judge.py load_goals_shared).
+
+The pusher thread's read-only sites used to parse a goal store on every load; load_goals_shared serves
+them one deep-frozen parsed object per file version, verified on every call by the store's identity
+(inode, mtime_ns, size) PLUS a byte compare, the override journal's identity and the goals-archive's.
+Writers stay on load_goals. All fixtures SYNTHETIC; this module uses a PRIVATE synthetic sid and a
+fresh state root per test, so another module's journaled overrides against a shared placeholder sid
+cannot land on its nodes mid-test."""
+import contextlib
+import copy
+import errno
+import io
+import json
+import os
+import pickle
+import re
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "77777777-8888-4999-aaaa-bbbbbbbbbbbb"       # private to this module (synthetic)
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def _norm(store):
+    """A store's content as plain JSON with the forensic arrival stamps dropped: record_verdict stamps `at`
+    from the clock at replay time, so two loads a second apart differ there and nowhere else."""
+    out = json.loads(json.dumps({k: v for k, v in store.items() if k != "_baseRev"}))
+    for nd in (out.get("nodes") or {}).values():
+        for e in nd.get("log") or []:
+            e.pop("at", None)
+    return out
+
+
+class SharedStoreCache(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))         # also clears the cache and lifts a previous test's off switch
+        self.stats0 = jd.shared_store_stats()
+
+    def tearDown(self):
+        jp = jd._overrides_dir() / (SID + ".jsonl")
+        if jp.exists():
+            os.chmod(jp, 0o600)
+        jd._rebind_state(self._saved)
+        self.td.cleanup()
+
+    def _nid(self, n):
+        return "%s:g%d" % (SID, n)
+
+    def _seed(self, text="A goal"):
+        """One working top goal, published; returns the store path."""
+        s = {"rompUuid": SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+             "placements": {}, "status": {}}
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": text}], [])
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(SID, s)
+        return jd.GOALDIR / (SID + ".json")
+
+    def _delta(self, key):
+        return jd.shared_store_stats()[key] - self.stats0[key]
+
+    def _errors(self):
+        try:
+            return [json.loads(l) for l in jd.ERRORS.read_text().splitlines() if l.strip()]
+        except FileNotFoundError:
+            return []
+
+    # ── identity, invalidation ────────────────────────────────────────────────────────────────────────
+
+    def test_two_loads_of_an_unchanged_store_return_one_object_and_parse_once(self):
+        self._seed()
+        fills, private = [], []
+        o_freeze, o_load = jd._freeze_store, jd.load_goals
+        jd._freeze_store = lambda store, fsid=None: (fills.append(1), o_freeze(store, fsid))[1]
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            a = jd.load_goals_shared(SID)
+            b = jd.load_goals_shared(SID)
+        finally:
+            jd._freeze_store, jd.load_goals = o_freeze, o_load
+        self.assertIs(a, b, "an unchanged file version is one shared object")
+        self.assertEqual(len(fills), 1, "one parse for two loads")
+        self.assertEqual((self._delta("miss"), self._delta("hit")), (1, 1))
+        self.assertEqual(private, [], "the miss and the hit are both answered here; load_goals ran for neither")
+        self.assertIsInstance(a, jd.FrozenStore)
+        self.assertEqual(jd.shared_store_stats()["entries"], 1)
+        self.assertEqual(jd.shared_store_stats()["bytes"], os.path.getsize(jd.GOALDIR / (SID + ".json")))
+
+    def test_the_shared_view_is_the_writer_loaders_view(self):
+        self._seed()
+        shared, writer = jd.load_goals_shared(SID), jd.load_goals(SID)
+        self.assertEqual(_norm(shared), _norm(writer), "same guard, same replay, same rollup")
+        self.assertEqual(shared["_baseRev"], writer["_baseRev"], "the CAS base rides the shared view too, so a "
+                         "shallow copy handed to save_goals still meets the CAS")
+        self.assertEqual(json.dumps(shared), json.dumps(writer), "json.dumps sees a plain store")
+        nid = self._nid(1)
+        self.assertIsInstance(shared, dict)
+        self.assertIsInstance(shared["nodes"][nid], jd.GuardedNode)
+        self.assertIsInstance(shared["nodes"][nid]["log"], list)
+        self.assertEqual(type(writer), dict, "the writer's loader hands back a plain, mutable store")
+        writer["nodes"][nid]["text"] = "edited"        # and it takes a write
+
+    def test_a_publish_of_a_changed_writer_copy_invalidates(self):
+        self._seed()
+        a = jd.load_goals_shared(SID)
+        w = jd.load_goals(SID)
+        jd.record_verdict(w, w["nodes"][self._nid(1)], "romp", "block", T0 + 30, why="needs a decision")
+        jd.save_goals(SID, w)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "save_goals pops its path after the rename")
+        b = jd.load_goals_shared(SID)
+        self.assertIsNot(a, b)
+        self.assertEqual(b["rev"], a["rev"] + 1)
+        self.assertTrue(b["nodes"][self._nid(1)]["blocked"])
+        self.assertFalse(a["nodes"][self._nid(1)].get("blocked"), "the old object is untouched")
+
+    def test_a_journal_append_replays_onto_the_view_and_the_writer_loader_agrees(self):
+        self._seed()
+        a = jd.load_goals_shared(SID)
+        self.assertFalse(a["nodes"][self._nid(1)].get("nodeComplete"))
+        jd.append_override(SID, self._nid(1), "resolve", T0 + 60)
+        b = jd.load_goals_shared(SID)
+        self.assertIsNot(a, b, "a journal write is a new key: a new object")
+        self.assertTrue(b["nodes"][self._nid(1)]["nodeComplete"], "the journaled resolve is in the view")
+        self.assertIn(self._nid(1), b.get("confirming") or [], "and the rollup followed it (done, awaiting settle)")
+        self.assertEqual(_norm(b), _norm(jd.load_goals(SID)), "the writer's loader sees the same view")
+        self.assertIs(jd.load_goals_shared(SID), b, "and the replayed view is memoized under the journal's key")
+
+    def test_a_restore_row_then_an_archive_change_refill(self):
+        self._seed()
+        nid2 = self._nid(2)
+        payload = {"id": nid2, "text": "Restored goal", "t": T0, "mt": T0, "parentId": None, "log": [], "why": "x"}
+        jd.append_restore(SID, {nid2: payload}, {nid2: "working"}, T0 + 10)
+        a = jd.load_goals_shared(SID)
+        self.assertIn(nid2, a["nodes"], "the restore row re-inserts a node neither file has")
+        # the node is re-cleared into the archive: the archive publish moves the archive key, and the replay
+        # now defers to the archive (nothing lost) — the next load is a refill without the node
+        jd.save_goal_archive(SID, {"rompUuid": SID, "nodes": {nid2: payload}, "status": {}})
+        b = jd.load_goals_shared(SID)
+        self.assertIsNot(a, b)
+        self.assertNotIn(nid2, b["nodes"])
+        self.assertEqual(self._delta("miss"), 2)
+
+    def test_a_fill_under_a_moving_archive_is_served_but_not_published(self):
+        self._seed()
+        calls = []
+        o_ak = jd._archive_key
+        jd._archive_key = lambda fsid: (calls.append(1), None if len(calls) == 1 else ("moved",))[1]
+        try:
+            a = jd.load_goals_shared(SID)
+        finally:
+            jd._archive_key = o_ak
+        self.assertIsInstance(a, jd.FrozenStore, "the caller gets a correct private view")
+        self.assertEqual(self._delta("refuse"), 1)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "not published: the next call refills")
+
+    def test_an_equal_size_in_place_rewrite_with_a_pinned_mtime_is_re_parsed(self):
+        # The identity blind spot: same inode, same size, same mtime_ns, different bytes. Nothing in romp
+        # writes a store in place (save_goals renames), so this stands in for an equal-size republish
+        # onto a recycled inode inside one clock tick. The byte compare catches it.
+        p = self._seed()
+        a = jd.load_goals_shared(SID)
+        key0 = jd.store_key(SID)
+        st = os.stat(p)
+        raw = p.read_bytes()
+        self.assertIn(b'"text": "A goal"', raw)
+        with open(p, "r+b") as f:                         # in place: the inode stays
+            f.write(raw.replace(b'"text": "A goal"', b'"text": "B goal"'))
+        os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))  # pin the stamp: the identity is unchanged
+        self.assertEqual(jd.store_key(SID), key0, "the stat key did not move")
+        b = jd.load_goals_shared(SID)
+        self.assertIsNot(a, b)
+        self.assertEqual(b["nodes"][self._nid(1)]["text"], "B goal")
+        self.assertEqual(self._delta("compare_miss"), 1)
+        self.assertIs(jd.load_goals_shared(SID), b, "the new bytes are memoized")
+
+    def test_eight_concurrent_loaders_receive_one_object(self):
+        """A smoke test over real threads: eight loaders of one unchanged store all receive the one published
+        object, and the cache holds one entry. The scheduler decides how many of the eight fill; the dup path
+        itself, with its exact counts, is forced in test_a_fill_that_loses_the_race_returns_the_published_object.
+
+        The counts asserted here hold for every interleaving, from load_goals_shared's fill path. A call on an
+        unchanged file counts exactly one of hit (an entry with its keys and bytes) or miss (no entry yet); a
+        compare_miss needs other bytes and a refuse a moved archive, so neither occurs. Every miss reaches the
+        publish step under the lock: the first publishes, and each later one finds that entry and counts a dup,
+        so there is one publish and dup == miss - 1. A thread that reads the map after the publish hits while
+        another is still mid-fill, so any split of hit and miss with miss >= 1 is legal. (The sum miss + hit +
+        dup this test once asserted read 9 for eight loads whenever two fills overlapped: the 2026-09-07 CI
+        failure, on a branch that predated the dup-aware arithmetic.) The counters are process-global; the
+        loader is pointed at this test's private state root, where the only store is the one seeded here."""
+        self._seed()
+        n = 8
+        bar = threading.Barrier(n)
+        out, errs = [], []
+
+        def go():
+            try:
+                bar.wait(30)                             # bounds on a hang, not a schedule: a loaded box can
+                out.append(jd.load_goals_shared(SID))    # take seconds to start eight threads
+            except Exception as e:                       # pragma: no cover — a failure here is the finding
+                errs.append(e)
+        ts = [threading.Thread(target=go) for _ in range(n)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join(60)
+        self.assertEqual(errs, [])
+        self.assertEqual(len(out), n)
+        self.assertIsInstance(out[0], jd.FrozenStore)
+        for o in out[1:]:
+            self.assertIs(o, out[0], "one object for every reader")
+        self.assertEqual(jd.shared_store_stats()["entries"], 1, "one publish; a fill that lost the race published nothing")
+        hit, miss, dup = self._delta("hit"), self._delta("miss"), self._delta("dup")
+        self.assertGreaterEqual(miss, 1, "the first call found no entry")
+        self.assertEqual(hit + miss, n, "each call counted once, as a hit or as a miss")
+        self.assertEqual(dup, miss - 1, "one miss published; every other miss found its entry")
+        self.assertEqual((self._delta("compare_miss"), self._delta("refuse")), (0, 0),
+                         "neither is reachable on an unchanged file with an unmoved archive")
+
+    def test_a_fill_that_loses_the_race_returns_the_published_object(self):
+        # The dup path, forced: inside the first fill's freeze a second loader runs the whole fill and
+        # publishes. The first then finds its own version published under equal keys and bytes, counts a
+        # dup and hands back the published object rather than its private freeze.
+        self._seed()
+        inner = []
+        o_freeze = jd._freeze_store
+
+        def racing_freeze(store, fsid=None):
+            jd._freeze_store = o_freeze                    # the inner fill freezes and publishes normally
+            inner.append(jd.load_goals_shared(SID))
+            return o_freeze(store, fsid)
+        jd._freeze_store = racing_freeze
+        try:
+            outer = jd.load_goals_shared(SID)
+        finally:
+            jd._freeze_store = o_freeze
+        self.assertEqual(len(inner), 1)
+        self.assertIsInstance(inner[0], jd.FrozenStore)
+        self.assertIs(outer, inner[0], "the fill that lost the race returns the winner's object")
+        self.assertEqual((self._delta("miss"), self._delta("dup"), self._delta("hit")), (2, 1, 0))
+        self.assertEqual(jd.shared_store_stats()["entries"], 1, "one entry: the loser published nothing")
+        self.assertIs(jd.load_goals_shared(SID), inner[0], "and the next call hits it")
+
+    def test_rebind_state_clears(self):
+        self._seed()
+        jd.load_goals_shared(SID)
+        self.assertEqual(jd.shared_store_stats()["entries"], 1)
+        jd._rebind_state(Path(self.td.name))
+        self.assertEqual(jd.shared_store_stats()["entries"], 0)
+
+    def test_migrate_all_stores_clears(self):
+        self._seed()
+        jd.load_goals_shared(SID)
+        jd.migrate_all_stores()
+        self.assertEqual(jd.shared_store_stats()["entries"], 0)
+
+    def test_evict_absent_drops_a_removed_store(self):
+        p = self._seed()
+        jd.load_goals_shared(SID)
+        os.unlink(p)
+        self.assertEqual(jd._shared_evict_absent(), 1)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0)
+        self.assertEqual(self._delta("evict"), 1)
+
+    def test_a_removed_store_read_as_absent_drops_its_entry(self):
+        # a store file gone at the read drops its stale entry at once (the compaction sweep would evict it
+        # later, and a recycled inode is caught by the byte compare either way: dead weight, not a wrong answer)
+        p = self._seed()
+        jd.load_goals_shared(SID)
+        self.assertEqual(jd.shared_store_stats()["entries"], 1)
+        os.unlink(p)
+        s = jd.load_goals_shared(SID)
+        self.assertIs(type(s), dict, "the fresh store: private, nothing to share")
+        self.assertEqual(self._delta("absent"), 1)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "the removed store's entry went with it")
+
+    def test_store_key(self):
+        self.assertIsNone(jd.store_key(SID), "no file, no key")
+        p = self._seed()
+        st = os.stat(p)
+        self.assertEqual(jd.store_key(SID), (st.st_ino, st.st_mtime_ns, st.st_size))
+
+    # ── the degraded inputs ──────────────────────────────────────────────────────────────────────────
+
+    def test_an_absent_store_is_the_fresh_store_and_is_not_memoized(self):
+        private = []
+        o_load = jd.load_goals
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        try:
+            s = jd.load_goals_shared(SID)
+        finally:
+            jd.load_goals = o_load
+        self.assertEqual(type(s), dict, "nothing to share: load_goals' private fresh store")
+        self.assertEqual((s["nodes"], s["_baseRev"], s["rompUuid"]), ({}, 0, SID))
+        self.assertEqual(self._delta("absent"), 1)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0)
+        self.assertEqual(private, [SID], "handed to load_goals, exactly once: one read per call either way")
+
+    def test_a_corrupt_store_is_handed_to_load_goals_and_quarantined_once(self):
+        # The shared loader never keeps a fresh store for bytes the writer's loader would move aside: bytes
+        # that do not parse go to load_goals, which quarantines the file (one stderr line, one
+        # store-quarantined row) and answers the legitimate fresh store. The path then reads as absent, so
+        # nothing is cached for it and the next call is the absent-store answer.
+        p = self._seed()
+        p.write_bytes(b"{not a store")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            a = jd.load_goals_shared(SID)
+            b = jd.load_goals_shared(SID)
+        self.assertEqual((a["nodes"], a["_baseRev"]), ({}, 0), "load_goals' fresh store, once the bad bytes are aside")
+        self.assertEqual(type(a), dict)
+        self.assertIsNot(a, b, "a fresh store each time (private, mutable)")
+        self.assertNotIn("_unread", a, "legitimately fresh: the evidence is preserved aside")
+        self.assertFalse(p.exists(), "the corrupt file was moved aside")
+        self.assertEqual(len(list(jd.GOALDIR.glob(SID + ".json.corrupt-*"))), 1)
+        rows = [r for r in self._errors() if r["err"] == "store-quarantined"]
+        self.assertEqual([r["fsid"] for r in rows], [SID], "one row, load_goals' own")
+        self.assertIn("could not be parsed", err.getvalue())
+        self.assertEqual((self._delta("corrupt"), self._delta("absent")), (1, 1), "handed over once; then the path is absent")
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "nothing cached for a file that did not parse")
+
+    def _eio_on_open(self, path):
+        orig_open = os.open
+
+        def faulting_open(p, *a, **kw):
+            if os.fspath(p) == str(path):
+                raise OSError(errno.EIO, "Input/output error", str(path))
+            return orig_open(p, *a, **kw)
+        return mock.patch.object(os, "open", faulting_open)
+
+    def test_a_read_fault_raises_from_load_goals_shared_and_caches_nothing(self):
+        # The shared loader raises a read fault exactly as load_goals does: no empty store, no stale view,
+        # and the entry for the path is dropped. The pusher's builders take it through
+        # load_goals_shared_or_fault, which files the fault once per episode (the next test).
+        p = self._seed()
+        self.assertIsInstance(jd.load_goals_shared(SID), jd.FrozenStore)
+        self.assertEqual(jd.shared_store_stats()["entries"], 1)
+        with self._eio_on_open(p):
+            with self.assertRaises(OSError) as cm:
+                jd.load_goals_shared(SID)
+        self.assertEqual(cm.exception.errno, errno.EIO, "the fault itself, at the open")
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "nothing cached for a file that did not read")
+        self.assertIsInstance(jd.load_goals_shared(SID), jd.FrozenStore, "reads again once the fault clears")
+        orig_read = jd._disk_read
+
+        def faulting_read(fd, path_s):
+            if path_s == str(p):
+                raise OSError(errno.EIO, "Input/output error", path_s)
+            return orig_read(fd, path_s)
+        with mock.patch.object(jd, "_disk_read", faulting_read):
+            self.assertRaises(OSError, jd.load_goals_shared, SID)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "...and at the read: a warm entry is re-read every call")
+        self.assertEqual(self._delta("absent"), 0, "a fault is not an absent store")
+
+    def test_load_goals_shared_or_fault_files_one_row_per_episode(self):
+        p = self._seed()
+        store, fault = jd.load_goals_shared_or_fault(SID)
+        self.assertIsInstance(store, jd.FrozenStore)
+        self.assertIsNone(fault)
+        with self._eio_on_open(p):
+            for _ in range(3):
+                store, fault = jd.load_goals_shared_or_fault(SID)
+                self.assertIsNone(store, "never an empty store")
+                self.assertEqual(fault.errno, errno.EIO)
+        rows = [r for r in self._errors() if r["err"] == "store-unreadable"]
+        self.assertEqual([r["fsid"] for r in rows], [SID], "one row for the episode, not one per call")
+        store, fault = jd.load_goals_shared_or_fault(SID)
+        self.assertIsInstance(store, jd.FrozenStore, "the episode ends on the read")
+        with self._eio_on_open(p):
+            jd.load_goals_shared_or_fault(SID)
+        self.assertEqual(len([r for r in self._errors() if r["err"] == "store-unreadable"]), 2, "a new episode files again")
+
+    @unittest.skipIf(os.geteuid() == 0, "root reads a mode-000 file")
+    def test_an_unreadable_journal_is_served_uncached_and_keeps_logging(self):
+        self._seed()
+        jd.append_override(SID, self._nid(1), "resolve", T0 + 60)
+        jp = jd._overrides_dir() / (SID + ".jsonl")
+        os.chmod(jp, 0)
+        a = jd.load_goals_shared(SID)
+        b = jd.load_goals_shared(SID)
+        self.assertEqual(type(a), dict, "load_goals' own result, private")
+        self.assertIsNot(a, b)
+        self.assertEqual(a.get("_unread"), "journal", "load_goals' mark rides along: the view is not what the files say")
+        self.assertEqual(self._delta("unreadable_journal"), 2)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "never memoized while the journal cannot be read")
+        rows = [r for r in self._errors() if r["err"] == "history-unreadable"]
+        self.assertEqual(len(rows), 2, "the loud row is filed on every load, never silenced by a cache")
+        os.chmod(jp, 0o600)
+        c = jd.load_goals_shared(SID)
+        self.assertIsInstance(c, jd.FrozenStore)
+        self.assertTrue(c["nodes"][self._nid(1)]["nodeComplete"], "once it reads, the replayed view is shared")
+
+    def test_a_store_the_replay_marked_unread_is_never_published(self):
+        # The fill hands the journal's rows to _replay_overrides as `lines`, so the one path that marks a
+        # store `_unread` inside the replay (the journal exists and cannot be read) is not reachable from
+        # it — the fill's _journal_read raises first and load_goals answers. The guard after _finish_load
+        # holds the invariant at the write moment anyway: a marked store is a fallback view, and a fallback
+        # view is never published as the disk's content. Stand in for a marker with a stub replay.
+        self._seed()
+
+        def marking_replay(fsid, store, lines=None):
+            store["_unread"] = "journal"
+            return False
+        o_rp = jd._replay_overrides
+        jd._replay_overrides = marking_replay
+        try:
+            a = jd.load_goals_shared(SID)
+        finally:
+            jd._replay_overrides = o_rp
+        self.assertEqual(type(a), dict, "served private and mutable, like load_goals' fallback")
+        self.assertEqual(a.get("_unread"), "journal")
+        self.assertEqual(jd.shared_store_stats()["entries"], 0, "not published")
+        self.assertEqual(self._delta("unreadable_journal"), 1)
+        self.assertIsInstance(jd.load_goals_shared(SID), jd.FrozenStore, "the real replay publishes")
+        self.assertNotIn("_unread", jd.load_goals_shared(SID))
+
+    def test_a_malformed_journal_row_raises_in_both_loaders(self):
+        self._seed()
+        jp = jd._overrides_dir() / (SID + ".jsonl")
+        jp.parent.mkdir(parents=True, exist_ok=True)
+        with jp.open("a") as f:
+            f.write(json.dumps({"node": self._nid(1), "op": "resolve", "t": "not-a-time"}) + "\n")
+        with self.assertRaises(ValueError):
+            jd.load_goals(SID)
+        with self.assertRaises(ValueError):
+            jd.load_goals_shared(SID)
+        self.assertEqual(jd.shared_store_stats()["entries"], 0)
+
+    # ── the freeze ───────────────────────────────────────────────────────────────────────────────────
+
+    def test_every_write_path_raises(self):
+        self._seed()
+        w = jd.load_goals(SID)                                # a diary row, so the log has an entry to write into
+        jd.record_verdict(w, w["nodes"][self._nid(1)], "romp", "block", T0 + 30, why="needs a decision")
+        jd.save_goals(SID, w)
+        s = jd.load_goals_shared(SID)
+        nid = self._nid(1)
+        nd = s["nodes"][nid]
+        self.assertTrue(nd["log"], "the fixture's log is non-empty")
+        writes = {
+            "top-level assignment": lambda: s.__setitem__("x", 1),
+            "top-level deletion": lambda: s.__delitem__("seq"),
+            "top-level setdefault": lambda: s.setdefault("seams", []),
+            "top-level pop": lambda: s.pop("seq"),
+            "top-level popitem": lambda: s.popitem(),
+            "top-level update": lambda: s.update({"x": 1}),
+            "top-level clear": lambda: s.clear(),
+            "top-level |=": lambda: s.__ior__({"x": 1}),
+            "nodes[nid] =": lambda: s["nodes"].__setitem__("n", {}),
+            "del nodes[nid]": lambda: s["nodes"].__delitem__(nid),
+            "node protected key": lambda: nd.__setitem__("blocked", True),
+            "node unprotected key": lambda: nd.__setitem__("text", "y"),
+            "node setdefault": lambda: nd.setdefault("log", []),
+            "node pop": lambda: nd.pop("text"),
+            "node update": lambda: nd.update(text="y"),
+            "status[nid] =": lambda: s["status"].__setitem__(nid, "completed"),
+            "placements write": lambda: s["placements"].__setitem__("seg", nid),
+            "log append": lambda: nd["log"].append({"kind": "done"}),
+            "log +=": lambda: nd["log"].__iadd__([1]),
+            "log item assignment": lambda: nd["log"].__setitem__(0, {}),
+            "log del": lambda: nd["log"].__delitem__(0),
+            "log pop": lambda: nd["log"].pop(),
+            "log clear": lambda: nd["log"].clear(),
+            "log sort": lambda: nd["log"].sort(key=str),
+            "log reverse": lambda: nd["log"].reverse(),
+            "log insert": lambda: nd["log"].insert(0, {}),
+            "log extend": lambda: nd["log"].extend([{}]),
+            "log entry write": lambda: nd["log"][0].__setitem__("why", "y"),
+            "rollup_status(shared)": lambda: jd.rollup_status(s, session_closed=False),
+        }
+        for name, fn in writes.items():
+            with self.assertRaises(jd.FrozenStoreError, msg=name):
+                fn()
+            self.assertIsInstance(jd.FrozenStoreError("x"), TypeError)
+        with jd._authority():                                # the diary layer's token does not unlock it
+            with self.assertRaises(jd.FrozenStoreError):
+                nd["log"].append({"kind": "done"})
+            with self.assertRaises(jd.FrozenStoreError):
+                jd.record_verdict(s, nd, "romp", "block", T0 + 30, why="x")
+        self.assertEqual(_norm(s), _norm(jd.load_goals(SID)), "the shared object is exactly as loaded")
+
+    def test_save_goals_refuses_the_shared_store_and_files_a_row(self):
+        p = self._seed()
+        s = jd.load_goals_shared(SID)
+        st0 = os.stat(p)
+        temps = []
+        o_tmp = jd._publish_tmp
+        jd._publish_tmp = lambda d, fsid: (temps.append(fsid), o_tmp(d, fsid))[1]
+        try:
+            with self.assertRaises(jd.FrozenStoreError):
+                jd.save_goals(SID, s)
+            with self.assertRaises(jd.FrozenStoreError):
+                jd.save_goals(SID, dict(s))               # a shallow copy still carries the shared nodes map
+        finally:
+            jd._publish_tmp = o_tmp
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-save"]
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["fsid"], SID)
+        st1 = os.stat(p)
+        self.assertEqual((st1.st_ino, st1.st_mtime_ns, st1.st_size), (st0.st_ino, st0.st_mtime_ns, st0.st_size),
+                         "nothing was published: the file's identity is unchanged across both refusals")
+        self.assertEqual(temps, [], "the refusal comes before the publish path: no temp file was opened for either save")
+        self.assertEqual(self._delta("poisoned"), 0, "a refused save is not a write to the shared object")
+        self.assertEqual(jd.shared_store_stats()["off"], 0)
+        self.assertTrue(p.exists())
+
+    def test_a_write_attempt_switches_the_cache_off_loudly_and_readers_keep_reading(self):
+        self._seed()
+        s = jd.load_goals_shared(SID)
+        with self.assertRaises(jd.FrozenStoreError):
+            s["status"][self._nid(1)] = "completed"
+        st = jd.shared_store_stats()
+        self.assertEqual((st["off"], self._delta("poisoned")), (1, 1))
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 1, "one row for the first attempt")
+        self.assertIn("test_judge_store_cache.py", rows[0]["note"], "the row names the writing site")
+        self.assertIn("assignment of", rows[0]["note"])
+        with self.assertRaises(jd.FrozenStoreError):
+            s["nodes"][self._nid(1)]["text"] = "again"
+        self.assertEqual(len([r for r in self._errors() if r["err"] == "frozen-store-write"]), 1,
+                         "later attempts count (poisoned) but do not repeat the row")
+        self.assertEqual(self._delta("poisoned"), 2)
+        f = jd.load_goals_shared(SID)
+        self.assertEqual(type(f), dict, "with the cache off every reader takes its own writer-style load")
+        self.assertEqual(self._delta("fallback"), 1)
+        self.assertEqual(_norm(f), _norm(s), "and reads the same view")
+        jd._shared_clear()
+        self.assertIsInstance(jd.load_goals_shared(SID), jd.FrozenStore, "a clear lifts the switch")
+
+    def test_the_write_guard_row_names_the_site_chain_and_the_sid(self):
+        # The row is the only pointer to the misuse, so it must name the site to fix. A kernel-side reader
+        # that hands the shared view to a judge helper which writes (rollup_status here) gets a two-frame
+        # chain, outermost first: the frame outside the judge module, then the judge frame that wrote. The
+        # sid comes from the FrozenStore (_fsid, set by _freeze_store) or a node's id; a nested map or list
+        # carries no way back to its store and reports "".
+        self._seed()
+        nid = self._nid(1)
+        here, judge = os.path.basename(__file__), os.path.basename(jd.__file__)
+
+        def _kernel_side_reader(store):                    # stands in for a wired kernel site
+            return jd.rollup_status(store, session_closed=False)
+        with self.assertRaises(jd.FrozenStoreError):
+            _kernel_side_reader(jd.load_goals_shared(SID))
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["fsid"], SID, "the row names the store")
+        m = re.search(r" at (\S+):(\d+) (\w+)\(\) -> (\S+):(\d+) (\w+)\(\) ", rows[0]["note"])
+        self.assertIsNotNone(m, rows[0]["note"])
+        self.assertEqual((m.group(1), m.group(3)), (here, "_kernel_side_reader"), "first the site to fix")
+        self.assertEqual(m.group(4), judge, "then the judge helper that wrote")
+        self.assertNotIn(m.group(6), jd._FROZEN_INTERNAL, "a real helper, not a frozen class's own method")
+        # a node write from outside the judge module: one frame, and the sid read off the node's id
+        jd._shared_clear()
+        with self.assertRaises(jd.FrozenStoreError):
+            jd.load_goals_shared(SID)["nodes"][nid]["text"] = "y"
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[1]["fsid"], SID)
+        self.assertNotIn(" -> ", rows[1]["note"], "the writer is outside the judge module: one frame is the site")
+        self.assertRegex(rows[1]["note"], r" at %s:\d+ %s\(\) " % (re.escape(here), self._testMethodName))
+        # a TOP-LEVEL write: the container is the store itself, so the sid is the FrozenStore's own _fsid
+        jd._shared_clear()
+        with self.assertRaises(jd.FrozenStoreError):
+            jd.load_goals_shared(SID)["x"] = 1
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[2]["fsid"], SID, "the store names itself")
+        self.assertNotIn(" -> ", rows[2]["note"])
+        # a nested map: the site, no sid
+        jd._shared_clear()
+        with self.assertRaises(jd.FrozenStoreError):
+            jd.load_goals_shared(SID)["status"][nid] = "completed"
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[3]["fsid"], "")
+        self.assertIn(" at %s:" % here, rows[3]["note"])
+
+    def test_copies_of_the_shared_view_are_plain_and_writable(self):
+        self._seed()
+        s = jd.load_goals_shared(SID)
+        nid = self._nid(1)
+        c = copy.copy(s)
+        self.assertEqual(type(c), dict)
+        c["x"] = 1
+        d = copy.deepcopy(s)
+        self.assertEqual((type(d), type(d["nodes"]), type(d["nodes"][nid]), type(d["nodes"][nid]["log"])),
+                         (dict, dict, dict, list))
+        d["nodes"][nid]["log"].append({"kind": "done"})
+        self.assertEqual(len(s["nodes"][nid]["log"]) + 1, len(d["nodes"][nid]["log"]), "a real copy")
+        self.assertEqual(type(dict(s["nodes"])), dict)
+        self.assertEqual(type(s["nodes"][nid]["log"] + [1]), list)
+        self.assertEqual(type(s["nodes"][nid]["log"][:]), list)
+        self.assertEqual(type(s["nodes"][nid]["log"].copy()), list)
+        pk = pickle.loads(pickle.dumps(s))
+        self.assertEqual((type(pk), type(pk["nodes"][nid])), (dict, dict))
+        self.assertEqual(_norm(pk), _norm(s))
+        self.assertEqual(self._delta("poisoned"), 0, "none of these is a write to the shared object")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_store_cache.py
+++ b/tests/test_judge_store_cache.py
@@ -173,14 +173,14 @@ class SharedStoreCache(unittest.TestCase):
         # onto a recycled inode inside one clock tick. The byte compare catches it.
         p = self._seed()
         a = jd.load_goals_shared(SID)
-        key0 = jd.store_key(SID)
+        key0 = jd._file_key(str(p))
         st = os.stat(p)
         raw = p.read_bytes()
         self.assertIn(b'"text": "A goal"', raw)
         with open(p, "r+b") as f:                         # in place: the inode stays
             f.write(raw.replace(b'"text": "A goal"', b'"text": "B goal"'))
         os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))  # pin the stamp: the identity is unchanged
-        self.assertEqual(jd.store_key(SID), key0, "the stat key did not move")
+        self.assertEqual(jd._file_key(str(p)), key0, "the stat key did not move")
         b = jd.load_goals_shared(SID)
         self.assertIsNot(a, b)
         self.assertEqual(b["nodes"][self._nid(1)]["text"], "B goal")
@@ -287,11 +287,18 @@ class SharedStoreCache(unittest.TestCase):
         self.assertEqual(self._delta("absent"), 1)
         self.assertEqual(jd.shared_store_stats()["entries"], 0, "the removed store's entry went with it")
 
-    def test_store_key(self):
-        self.assertIsNone(jd.store_key(SID), "no file, no key")
-        p = self._seed()
-        st = os.stat(p)
-        self.assertEqual(jd.store_key(SID), (st.st_ino, st.st_mtime_ns, st.st_size))
+    def test_the_cache_exports_no_uncalled_key_reader(self):
+        # store_key (a fresh stat of the store's identity) shipped with no caller: the two kernel view signatures
+        # that stat the store carry (mtime, size) inside larger multi-file keys and are not its consumer, so it
+        # is gone rather than kept ahead of a use (review find, 2026-09-08). _file_key stays: the cache's own.
+        self.assertFalse(hasattr(jd, "store_key"))
+
+    def test_the_two_kinds_this_cache_files_are_documented(self):
+        # docs/judges.md lists the judge-errors kinds; the two the frozen guard files were missing from it
+        # (review find, 2026-09-08)
+        doc = (Path(BIN).parent / "docs" / "judges.md").read_text()
+        for kind in ("frozen-store-write", "frozen-store-save"):
+            self.assertIn(kind, doc, "%s is documented" % kind)
 
     # ── the degraded inputs ──────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -73,6 +73,50 @@ class StoreCas(unittest.TestCase):
         self.assertNotIn("_baseRev", json.loads((jd.GOALDIR / (SID + ".json")).read_text()),
                          "the transient base revision is never written to disk")
 
+    @staticmethod
+    @contextlib.contextmanager
+    def _reads_raise(target):
+        """Inside the block, every Path.read_text of `target` raises OSError (the EMFILE/EIO shape a
+        busy kernel meets); other paths read normally."""
+        real = Path.read_text
+        def boom(p, *a, **k):
+            if p == target:
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real(p, *a, **k)
+        Path.read_text = boom
+        try:
+            yield
+        finally:
+            Path.read_text = real
+
+    def test_a_store_loaded_without_its_unreadable_journal_is_marked_and_the_mark_is_never_serialized(self):
+        # A store FILE that exists and cannot be read raises (ReadFaultCas), and an unparseable one is
+        # quarantined aside and legitimately fresh, so the one load that answers with less than the files
+        # hold is a parsed store whose override JOURNAL exists and could not be read: _replay_overrides
+        # returns it without the user's rows. A reader that caches "what the files hold" by their identity
+        # (the kernel's awaiting-lift gate) must tell that answer from a complete one, so it carries a
+        # transient `_unread` mark beside `_baseRev`: popped before a publish and outside the content hash.
+        self.assertNotIn("_unread", jd.load_goals(SID), "no file: an empty store IS the truth")
+        self._seed()
+        self.assertNotIn("_unread", jd.load_goals(SID), "a parsed store with no journal is what the files say")
+        jd.append_override(SID, self._nid(1), "resolve", T0 + 60)
+        with self._reads_raise(jd._overrides_dir() / (SID + ".jsonl")):
+            s = jd.load_goals(SID)
+        self.assertIn(self._nid(1), s["nodes"], "the store itself was read")
+        self.assertEqual(s.get("_unread"), "journal", "...but the journal was not: the user's gestures are missing")
+        self.assertFalse(s["nodes"][self._nid(1)].get("nodeComplete"), "the journaled resolve is not in this view")
+        self.assertEqual(s["_baseRev"], jd._disk_rev(SID), "the CAS base is the parsed store's, as before")
+        self.assertNotIn("_unread", json.loads(jd._store_content(s)), "not store content")
+        s["nodes"][self._nid(1)]["text"] = "A goal, retitled"
+        jd.save_goals(SID, s)
+        gp = jd.GOALDIR / (SID + ".json")
+        self.assertNotIn("_unread", json.loads(gp.read_text()), "the mark is never written to disk")
+        final = jd.load_goals(SID)
+        self.assertNotIn("_unread", final, "a journal that exists and reads leaves no mark")
+        nd = final["nodes"][self._nid(1)]
+        self.assertEqual(nd["text"], "A goal, retitled")
+        self.assertTrue(nd.get("nodeComplete"), "the journal replays on the next load: the publish lost nothing durable")
+
     def test_a_stale_pass_no_longer_erases_a_concurrent_block(self):
         # THE BUG: pass A loads, goes off to its model call; the nudge tick blocks the card and publishes;
         # pass A then saves its pre-block snapshot and wipes the block -> the card flashes back to working.

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -10,6 +10,7 @@ save_goals now compares the revision it loaded at against the one on disk and RE
 logs) instead of clobbering. The store is an append-only event log, so two writers appending different
 events never really conflicted: the right answer is both sets. All fixtures SYNTHETIC.
 """
+import contextlib
 import errno
 import json
 import os
@@ -226,15 +227,24 @@ class ReadFaultCas(unittest.TestCase):
         jd.rollup_status(s, session_closed=False)
         jd.save_goals(self.FSID, s)
 
+    @contextlib.contextmanager
     def _eio_on_the_store(self):
-        """Path.read_text raises EIO for THIS store's path only; every other read is untouched."""
-        target, orig = self._file(), Path.read_text
+        """Every reader of THIS store's path raises EIO; every other read is untouched. Path.read_text is the
+        load path's reader; the save path's memoized readers (_disk_entry, _disk_rev) open a descriptor of
+        their own and read from it (_disk_read), so os.open faults for the path as well."""
+        target, orig_read_text, orig_open = self._file(), Path.read_text, os.open
 
         def faulting(path, *a, **kw):
             if path == target:
                 raise OSError(errno.EIO, "Input/output error", str(path))
-            return orig(path, *a, **kw)
-        return mock.patch.object(Path, "read_text", faulting)
+            return orig_read_text(path, *a, **kw)
+
+        def faulting_open(path, *a, **kw):
+            if os.fspath(path) == str(target):
+                raise OSError(errno.EIO, "Input/output error", str(target))
+            return orig_open(path, *a, **kw)
+        with mock.patch.object(Path, "read_text", faulting), mock.patch.object(os, "open", faulting_open):
+            yield
 
     def test_a_read_fault_raises_from_load_instead_of_reading_as_an_empty_store(self):
         self._seed()
@@ -282,6 +292,21 @@ class ReadFaultCas(unittest.TestCase):
         self._file().write_text("{not json")
         with self.assertRaises(ValueError):
             jd._disk_rev(self.FSID)
+
+    def test_a_fresh_store_is_not_published_over_a_non_object_file(self):
+        """A top-level JSON value that is not an object is neither a store nor an absent file: a fresh store
+        (base 0, minted while the path was empty) is not published over it, and a gesture's boundary answers
+        the fault instead of None."""
+        s = jd.load_goals(self.FSID)                 # absent: a fresh store at base 0
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "A goal"}], [])
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        self._file().write_bytes(b"[]")              # meanwhile the path holds a JSON array
+        with self.assertRaises(ValueError):
+            jd.save_goals(self.FSID, s)
+        self.assertEqual(self._file().read_bytes(), b"[]", "nothing was published over bytes that are not a store")
+        self.assertIsInstance(jd.save_goals_or_fault(self.FSID, s), ValueError,
+                              "the gesture boundary answers the fault, not None")
+        self.assertEqual(self._file().read_bytes(), b"[]")
 
     def test_matches_disk_and_rebase_raise_on_a_fault_or_a_corrupt_file(self):
         """Each reader in the save path on its own: a version of either that swallowed the read and answered

--- a/tests/test_judge_store_noop_publish.py
+++ b/tests/test_judge_store_noop_publish.py
@@ -13,6 +13,7 @@ with no events to contribute can neither lose its own work nor clobber a concurr
 All fixtures SYNTHETIC: placeholder UUID, invented goal text.
 """
 import contextlib
+import errno
 import io
 import json
 import os
@@ -249,6 +250,511 @@ class UnparseableStore(unittest.TestCase):
         self.assertEqual(self._error_rows(), [])
         jd.save_goals(self.QSID, s)
         self.assertTrue(self._file().exists(), "an absent file is a create, exactly as before")
+
+
+class DiskMemo(unittest.TestCase):
+    """The disk side of the no-op check is memoized by file identity (2026-09-06).
+
+    Every save asked "does the file already hold exactly this?" by re-reading and re-parsing the file and
+    serializing both sides, then the CAS parsed the file twice more for its revision: about 20 ms per save
+    of a large store, most saves being no-ops. Now _disk_entry keys the file's canonical-content hash on
+    (inode, mtime_ns, size), taken from the same descriptor the bytes are read from; a save whose file
+    identity still matches serializes only its own side. Every publish is a rename of a fresh temp, so a
+    changed file is a new identity and the memo can never answer True where the full compare would answer
+    False. The CAS's revision is read from the file, never the memo (the tests under "the CAS reads the
+    file" say why). Synthetic fixtures only; a private sid, so no other module's journal reaches it.
+    """
+    SID = "0b400000-1111-2222-3333-444444444444"
+
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+        self.reads = []                                  # store paths the memo read
+        self._orig_read = jd._disk_read
+        self._orig_content = jd._store_content
+        self.content_calls = [0]
+
+        def counting_read(fd, path_s):
+            if path_s.endswith(self.SID + ".json"):
+                self.reads.append(path_s)
+            return self._orig_read(fd, path_s)
+
+        def counting_content(store):
+            self.content_calls[0] += 1
+            return self._orig_content(store)
+        jd._disk_read = counting_read
+        jd._store_content = counting_content
+
+    def tearDown(self):
+        jd._disk_read = self._orig_read
+        jd._store_content = self._orig_content
+        jd._rebind_state(self._saved)
+        self.td.cleanup()
+
+    def _file(self):
+        return jd.GOALDIR / (self.SID + ".json")
+
+    def _seed(self):
+        s = {"rompUuid": self.SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+             "placements": {}, "status": {}}
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "A goal"}], [])
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(self.SID, s)                        # no _baseRev: an unconditional publish, no memo entry
+        jd._disk_forget(str(self._file()))
+
+    def _foreign_replace(self, disk):
+        """A writer outside this process publishes `disk` the way every writer does: a fresh temp renamed
+        over the store. Also moves the mtime by a whole second, because a CI filesystem's timestamp tick
+        can be coarser than the gap between two statements."""
+        tmp = self._file().with_suffix(".json.foreign")
+        tmp.write_text(json.dumps(disk))
+        st = os.stat(self._file())
+        os.utime(tmp, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+        os.replace(tmp, self._file())
+
+    def _ident(self, path):
+        st = os.stat(path)
+        return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+    # ── the saving ───────────────────────────────────────────────────────────
+    def test_a_warm_no_op_save_reads_nothing_and_serializes_only_its_own_side(self):
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm-up: one read and parse of the file
+        self.assertEqual(len(self.reads), 1, "the first check after a foreign publish parses the file once")
+        del self.reads[:]
+        self.content_calls[0] = 0
+        mt = os.stat(self._file()).st_mtime_ns
+        for _ in range(5):
+            jd.save_goals(self.SID, s)
+        self.assertEqual(self.reads, [], "a warm no-op save performs zero reads of the store path")
+        self.assertEqual(self.content_calls[0], 5, "one serialization per save: the in-memory side only")
+        self.assertEqual(os.stat(self._file()).st_mtime_ns, mt, "and still no write")
+
+    def test_a_real_publish_reads_the_file_once_for_the_cas(self):
+        """The check is served by the memo when warm; the CAS reads the file every time (its revision must be
+        the file's: test_a_stale_memo_identity_never_passes_the_cas). So a real publish on a warm memo is one
+        read; on a cold memo two. Counted through the read seam: a _disk_rev served from the memo would show as
+        no read, and one reading by a path of its own would show as no read at all."""
+        self._seed()
+        gid = "%s:g1" % self.SID
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm the memo (one miss)
+        jd.record_verdict(s, s["nodes"][gid], "planner", "block", T0 + 30, why="needs a decision")
+        jd.rollup_status(s, session_closed=False)
+        del self.reads[:]
+        jd.save_goals(self.SID, s)
+        self.assertEqual(len(self.reads), 1, "warm: the check hit, the CAS read the file")
+        self.assertEqual(json.loads(self._file().read_text())["rev"], 2, "and the publish landed")
+        disk = json.loads(self._file().read_text())
+        disk["nodes"][gid]["summary"] = "Written by another process."
+        disk["rev"] = 5
+        self._foreign_replace(disk)                       # the memo is cold again
+        s = jd.load_goals(self.SID)
+        jd.record_verdict(s, s["nodes"][gid], "closer", "done", T0 + 40, why="shipped")
+        del self.reads[:]
+        jd.save_goals(self.SID, s)
+        self.assertEqual(len(self.reads), 2, "cold: the check missed and read, then the CAS read")
+        self.assertEqual(json.loads(self._file().read_text())["rev"], 6)
+
+    def test_a_publish_seeds_the_memo_so_the_next_check_reads_nothing(self):
+        self._seed()
+        s = jd.load_goals(self.SID)
+        gid = "%s:g1" % self.SID
+        jd.record_verdict(s, s["nodes"][gid], "planner", "block", T0 + 30, why="needs a decision")
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(self.SID, s)                        # a real publish, no rebase: seeds from its temp
+        ent = jd._DISK_CONTENT[str(self._file())]
+        self.assertEqual(ent[0], self._ident(self._file()),
+                         "the temp's identity survives the rename: inode, mtime_ns and size all match the destination")
+        del self.reads[:]
+        jd.save_goals(self.SID, jd.load_goals(self.SID))  # the next no-op check
+        self.assertEqual(self.reads, [], "served from the seed: no read")
+
+    def test_the_seed_is_taken_from_the_temp_before_the_rename(self):
+        """Pins the order _disk_seed's docstring states: the identity recorded is the TEMP's, read while the
+        temp still exists and before it is renamed over the destination. A seed taken from the destination
+        after the rename would record whatever file is there by then, a concurrent publisher's included, and
+        pair it with our hash. The spy asserts at call time."""
+        self._seed()
+        dest = self._file()
+        s = jd.load_goals(self.SID)
+        gid = "%s:g1" % self.SID
+        jd.record_verdict(s, s["nodes"][gid], "planner", "block", T0 + 30, why="needs a decision")
+        jd.rollup_status(s, session_closed=False)
+        dest_before = self._ident(dest)
+        orig = jd._disk_seed
+        calls = []
+
+        def spy(path, tmp, canon_hash):
+            calls.append(str(tmp))
+            self.assertEqual(str(path), str(dest))
+            self.assertNotEqual(str(tmp), str(dest), "seeded from the temp, not the destination")
+            self.assertTrue(os.path.exists(tmp), "the temp still exists: it has not been renamed yet")
+            self.assertEqual(self._ident(dest), dest_before, "the destination is still the old file")
+            recorded = self._ident(tmp)
+            self.assertNotEqual(recorded, dest_before)
+            orig(path, tmp, canon_hash)
+            self.assertEqual(jd._DISK_CONTENT[str(dest)][0], recorded, "what went into the memo is the temp's identity")
+        jd._disk_seed = spy
+        try:
+            jd.save_goals(self.SID, s)
+        finally:
+            jd._disk_seed = orig
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(jd._DISK_CONTENT[str(dest)][0], self._ident(dest), "which the rename carried to the destination")
+
+    def test_a_rebased_publish_does_not_seed(self):
+        """After a rebase the store no longer has the content the pre-rebase hash describes."""
+        self._seed()
+        gid = "%s:g1" % self.SID
+        a, b = jd.load_goals(self.SID), jd.load_goals(self.SID)
+        jd.record_verdict(b, b["nodes"][gid], "closer", "done", T0 + 60, why="b's done")
+        jd.save_goals(self.SID, b)
+        jd.record_verdict(a, a["nodes"][gid], "planner", "block", T0 + 50, why="a's block")
+        orig, seeds = jd._disk_seed, []
+        jd._disk_seed = lambda *args: seeds.append(args) or orig(*args)
+        try:
+            jd.save_goals(self.SID, a)                    # base moved: rebases, then publishes
+        finally:
+            jd._disk_seed = orig
+        self.assertEqual(seeds, [], "no seed after a rebase")
+        ent = jd._DISK_CONTENT.get(str(self._file()))
+        self.assertTrue(ent is None or ent[0] != self._ident(self._file()),
+                        "the memo holds no entry claiming the rebased file's identity")
+        del self.reads[:]
+        jd.save_goals(self.SID, jd.load_goals(self.SID))
+        self.assertEqual(len(self.reads), 1, "so the next check parses the file (and finds a no-op)")
+
+    # ── what a changed file must still do ────────────────────────────────────
+    def test_a_foreign_atomic_replace_with_different_content_is_detected(self):
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm
+        disk = json.loads(self._file().read_text())
+        disk["nodes"]["%s:g1" % self.SID]["summary"] = "Written by another process."
+        self._foreign_replace(disk)
+        self.assertFalse(jd._matches_disk(self.SID, s), "a changed file is never mistaken for the memoized one")
+        self.assertEqual(len(self.reads), 2, "the new identity misses and is parsed")
+
+    def test_a_same_size_replace_inside_the_same_mtime_tick_is_told_apart_by_its_inode(self):
+        """The inode carries the headline invariant. Every publish is a rename of a fresh temp, and on kernels
+        with coarse file timestamps two publishes of a same-size store can share an mtime_ns; the new file is
+        then a different inode and nothing else. Staged with the temp's mtime pinned to the destination's."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm
+        dest = self._file()
+        st = os.stat(dest)
+        raw = dest.read_text()
+        self.assertIn('"text": "A goal"', raw)
+        tmp = dest.with_suffix(".json.foreign")
+        tmp.write_text(raw.replace('"text": "A goal"', '"text": "B goal"'))    # same length
+        os.utime(tmp, ns=(st.st_atime_ns, st.st_mtime_ns))                   # same tick, staged
+        os.replace(tmp, dest)
+        new = os.stat(dest)
+        self.assertEqual((new.st_mtime_ns, new.st_size), (st.st_mtime_ns, st.st_size), "only the inode differs")
+        self.assertNotEqual(new.st_ino, st.st_ino)
+        self.assertFalse(jd._matches_disk(self.SID, s), "a new inode is a new file")
+        self.assertEqual(jd._DISK_CONTENT[str(dest)][0][0], new.st_ino, "and the memo now records it")
+        self.assertNotEqual(jd._DISK_CONTENT[str(dest)][0][0], st.st_ino)
+
+    def test_a_different_length_in_place_rewrite_inside_the_same_mtime_tick_is_told_apart_by_its_size(self):
+        """The size twin: same inode, same mtime_ns, different length. No writer here rewrites a store in
+        place, so this is defence in depth for the key's third component."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)
+        dest = self._file()
+        st = os.stat(dest)
+        raw = dest.read_text()
+        dest.write_text(raw.replace('"text": "A goal"', '"text": "A longer goal"'))   # in place: the inode stays
+        os.utime(dest, ns=(st.st_atime_ns, st.st_mtime_ns))
+        new = os.stat(dest)
+        self.assertEqual((new.st_ino, new.st_mtime_ns), (st.st_ino, st.st_mtime_ns), "only the size differs")
+        self.assertNotEqual(new.st_size, st.st_size)
+        self.assertFalse(jd._matches_disk(self.SID, s))
+
+    def test_a_same_size_in_place_rewrite_with_a_new_mtime_is_detected(self):
+        """The mtime part of the key: same inode, same size, different bytes."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)
+        raw = self._file().read_text()
+        self.assertIn('"text": "A goal"', raw)
+        changed = raw.replace('"text": "A goal"', '"text": "B goal"')     # same length
+        self.assertEqual(len(changed), len(raw))
+        st = os.stat(self._file())
+        self._file().write_text(changed)                  # in place: the inode stays
+        os.utime(self._file(), ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+        self.assertFalse(jd._matches_disk(self.SID, s))
+
+    def test_a_replace_landing_between_the_open_and_the_stat_cannot_pair_the_new_identity_with_the_old_bytes(self):
+        """The identity is fstat of the descriptor the bytes are read from. A publisher landing between the
+        open and the stat is the case a stat by path gets wrong: it records the NEW file's identity with the
+        OLD file's content, and every later check of the new file hits that entry and answers for content the
+        file does not hold. Staged inside the identity seam itself, so the order is open, replace, stat, read."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        old_ident = self._ident(self._file())
+        old_disk = json.loads(self._file().read_text())
+        new_disk = json.loads(self._file().read_text())
+        new_disk["nodes"]["%s:g1" % self.SID]["summary"] = "Landed between the open and the stat."
+        inner = jd._disk_ident
+        fired = []
+
+        def racing_ident(fd):
+            if not fired:
+                fired.append(1)
+                self._foreign_replace(new_disk)           # a new inode, mtime and size while the fd is open
+            return inner(fd)
+        jd._disk_ident = racing_ident
+        try:
+            ent = jd._disk_entry(self.SID)                # cold memo: open, the race, then stat and read
+        finally:
+            jd._disk_ident = inner
+        self.assertEqual(len(fired), 1)
+        new_ident = self._ident(self._file())
+        self.assertNotEqual(old_ident, new_ident)
+        self.assertEqual(ent[0], old_ident, "the identity is the opened file's")
+        self.assertEqual(ent[1], jd._content_hash(jd._store_content(old_disk)), "and so are the bytes")
+        self.assertFalse(jd._matches_disk(self.SID, s), "the next check misses on the new identity, parses, and says no")
+        self.assertEqual(jd._DISK_CONTENT[str(self._file())][0], new_ident)
+
+    def test_a_same_size_different_store_under_a_bare_goaldir_reassignment_answers_false(self):
+        """Keyed on the full path: a test that reassigns jd.GOALDIR (not _rebind_state) must not be served
+        the other root's entry."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm under root A
+        raw = self._file().read_text()
+        other = Path(self.td.name) / "other-goals"
+        other.mkdir()
+        (other / (self.SID + ".json")).write_text(raw.replace('"text": "A goal"', '"text": "B goal"'))
+        st = os.stat(self._file())
+        os.utime(other / (self.SID + ".json"), ns=(st.st_atime_ns, st.st_mtime_ns))   # same mtime and size
+        saved = jd.GOALDIR
+        try:
+            jd.GOALDIR = other
+            self.assertFalse(jd._matches_disk(self.SID, s))
+        finally:
+            jd.GOALDIR = saved
+        self.assertTrue(jd._matches_disk(self.SID, s), "root A's entry still answers for root A")
+
+    # ── the CAS reads the file, never the memo ───────────────────────────────
+    def test_disk_rev_reads_the_file_even_when_the_memo_identity_matches(self):
+        """The CAS's revision comes from the file. With a staged identity collision (same inode, size and
+        mtime_ns, different bytes) the memo may still serve the no-op check, whose worst case is a skipped
+        publish of content the file once held; _disk_rev must report what the file holds now."""
+        self._seed()
+        dest = self._file()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm: the memo describes revision 1
+        raw = dest.read_text()
+        self.assertEqual(raw.count('"rev": 1'), 1)
+        st = os.stat(dest)
+        dest.write_text(raw.replace('"rev": 1', '"rev": 7'))       # in place: same inode, same size
+        os.utime(dest, ns=(st.st_atime_ns, st.st_mtime_ns))          # same tick: the collision, staged
+        self.assertEqual(self._ident(dest), jd._DISK_CONTENT[str(dest)][0], "the memo's identity matches the file")
+        self.assertEqual(jd._disk_rev(self.SID), 7, "and the CAS still sees the file's revision")
+
+    def test_a_stale_memo_identity_never_passes_the_cas(self):
+        """Found in review of an earlier draft that served the CAS from the memo (2026-09-06). Three publishes
+        of one store inside one mtime tick can leave the
+        memo's identity on a file the memo does not describe: K publishes and seeds; B and C, holding older
+        snapshots, both check and pass the CAS against K's file, rebase, and publish in turn; C's temp is
+        created after B's rename freed K's inode and gets it back, at K's size, in K's tick. The memo still
+        says K; the file is C's. A writer E that loaded K's file now hits the memo, and a CAS served from the
+        memo would see K's revision, skip the rebase and write over C's event. So the CAS reads the file.
+        Staged here: the inode by a kept hard link, the tick by os.utime, the size by padding C's JSON with
+        trailing spaces; the interleaving is real save_goals calls, B's run from inside C's _publish_tmp."""
+        self._seed()                                      # revision 1
+        gid = "%s:g1" % self.SID
+        dest = self._file()
+        b, c = jd.load_goals(self.SID), jd.load_goals(self.SID)      # revision-1 snapshots
+        k = jd.load_goals(self.SID)
+        k["nodes"][gid]["text"] = "A goal, restated at length " + "x" * 600
+        jd.save_goals(self.SID, k)                        # revision 2; seeds the memo with K's temp identity
+        k_st = os.stat(dest)
+        k_ident = (k_st.st_ino, k_st.st_mtime_ns, k_st.st_size)
+        self.assertEqual(jd._DISK_CONTENT[str(dest)][0], k_ident)
+        e = jd.load_goals(self.SID)                       # E holds K's revision
+        keep = jd.GOALDIR / (self.SID + ".keep")          # K's inode stays allocated across B's rename
+        os.link(dest, keep)
+        jd.record_verdict(b, b["nodes"][gid], "planner", "note", T0 + 50, why="b's note")
+        jd.record_verdict(c, c["nodes"][gid], "nudge", "block", T0 + 60, why="c's block")
+        orig = jd._publish_tmp
+        fired = []
+
+        class PinnedTemp(type(Path())):
+            """C's temp: written in place into K's inode, padded to K's size, stamped with K's mtime."""
+            def write_text(self_, data, *a, **kw):
+                pad = k_st.st_size - len(data.encode("utf-8"))
+                assert pad >= 0, "fixture: C's rebased store must not outgrow K's"
+                n = super().write_text(data + " " * pad, *a, **kw)
+                os.utime(self_, ns=(k_st.st_atime_ns, k_st.st_mtime_ns))
+                return n
+
+        def hooked(dirpath, fsid):
+            jd._publish_tmp = orig
+            jd.save_goals(self.SID, b)                    # B lands first: K's inode leaves the path
+            tmp = PinnedTemp(orig(dirpath, fsid))
+            os.rename(keep, tmp)                          # and is handed to C's temp
+            fired.append(tmp)
+            return tmp
+        jd._publish_tmp = hooked
+        try:
+            jd.save_goals(self.SID, c)                    # C: check and CAS against K's file, then the hook
+        finally:
+            jd._publish_tmp = orig
+        self.assertEqual(len(fired), 1)
+        self.assertEqual(json.loads(dest.read_text())["rev"], 3)
+        self.assertEqual(self._ident(dest), k_ident, "staged: C's file carries K's identity")
+        self.assertEqual(jd._DISK_CONTENT[str(dest)][0], k_ident, "and the memo still describes K")
+        jd.record_verdict(e, e["nodes"][gid], "planner", "note", T0 + 70, why="e's note")
+        jd.save_goals(self.SID, e)                        # base 2; the file holds 3
+        disk = json.loads(dest.read_text())
+        kinds = {(x.get("src"), x.get("kind")) for x in disk["nodes"][gid].get("log") or []}
+        self.assertIn(("nudge", "block"), kinds, "C's event survives E's publish")
+        self.assertEqual(disk["rev"], 4, "E rebased onto the file's revision, not the memo's")
+
+    def test_a_concurrent_publish_between_a_publish_and_a_save_is_detected_and_rebased(self):
+        self._seed()
+        gid = "%s:g1" % self.SID
+        a = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, a)                        # A warms the memo with the seeded file
+        b = jd.load_goals(self.SID)
+        jd.record_verdict(b, b["nodes"][gid], "nudge", "block", T0 + 100, why="owed")
+        jd.rollup_status(b, session_closed=False)
+        jd.save_goals(self.SID, b)                        # the concurrent publish (rev 2)
+        jd.record_verdict(a, a["nodes"][gid], "planner", "note", T0 + 110, why="a's own event")
+        jd.save_goals(self.SID, a)                        # A: content differs, base 1 != disk 2 -> rebase
+        disk = json.loads(self._file().read_text())
+        kinds = {(e.get("src"), e.get("kind")) for e in disk["nodes"][gid].get("log") or []}
+        self.assertIn(("nudge", "block"), kinds, "the concurrent writer's event survives")
+        self.assertIn(("planner", "note"), kinds, "and so does A's")
+        self.assertEqual(disk["rev"], 3)
+
+    def test_disk_rev_follows_a_publish_and_a_foreign_write(self):
+        self._seed()
+        self.assertEqual(jd._disk_rev(self.SID), 1)
+        s = jd.load_goals(self.SID)
+        jd.record_verdict(s, s["nodes"]["%s:g1" % self.SID], "planner", "block", T0 + 30, why="x")
+        jd.save_goals(self.SID, s)
+        self.assertEqual(jd._disk_rev(self.SID), 2, "the revision after our own publish")
+        disk = json.loads(self._file().read_text())
+        disk["rev"] = 42
+        self._foreign_replace(disk)
+        self.assertEqual(jd._disk_rev(self.SID), 42, "the revision after a foreign write")
+        self._file().unlink()
+        self.assertEqual(jd._disk_rev(self.SID), 0, "absent: 0")
+        self.assertIsNone(jd._disk_entry(self.SID), "and the no-op check finds nothing")
+        self.assertNotIn(str(self._file()), jd._DISK_CONTENT, "the entry is gone")
+
+    def test_a_corrupt_or_unreadable_file_drops_the_entry_and_raises(self):
+        """The save path's readers never answer a file they could not read with the absent-file value
+        (ReadFaultCas in test_judge_store_cas.py is the rule): a corrupt file raises ValueError, a read fault
+        raises OSError, and either drops the entry, so nothing is remembered about bytes that are not a
+        store. An absent file alone answers None / False (a create)."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)
+        self.assertIn(str(self._file()), jd._DISK_CONTENT)
+        good, st = self._file().read_bytes(), os.stat(self._file())
+        self._file().write_text("{not json")
+        os.utime(self._file(), ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+        self.assertRaises(ValueError, jd._matches_disk, self.SID, s)
+        self.assertNotIn(str(self._file()), jd._DISK_CONTENT, "nothing to remember about a non-store")
+        self.assertRaises(ValueError, jd._disk_rev, self.SID)
+        self._file().write_bytes(good)
+        os.utime(self._file(), ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+        jd.save_goals(self.SID, s)                       # a no-op: the check reads the restored file and re-fills
+        self.assertIn(str(self._file()), jd._DISK_CONTENT)
+        os.utime(self._file(), ns=(st.st_atime_ns, st.st_mtime_ns + 3_000_000_000))   # a miss, so the read runs
+
+        def faulting(fd, path_s):
+            raise OSError(errno.EIO, "Input/output error", path_s)
+        with mock.patch.object(jd, "_disk_read", faulting):
+            self.assertRaises(OSError, jd._matches_disk, self.SID, s)
+            self.assertRaises(OSError, jd._disk_rev, self.SID)
+        self.assertNotIn(str(self._file()), jd._DISK_CONTENT, "a fault is not a fact about the file")
+        self._file().unlink()
+        self.assertIsNone(jd._disk_entry(self.SID), "absent: a create")
+        self.assertFalse(jd._matches_disk(self.SID, s))
+        self.assertEqual(jd._disk_rev(self.SID), 0)
+
+    def test_every_non_object_top_level_raises_value_error_from_the_save_readers(self):
+        """_disk_parse's last check: a top-level JSON value that is not an object (a list, a string, null, a
+        number) and bytes that are not UTF-8 all raise ValueError from both save-path readers, so the save
+        neither publishes over the file nor escapes with an AttributeError from `.get` on a list, and nothing
+        is remembered about the file."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # warm: the memo holds the healthy file
+        st = os.stat(self._file())
+        for i, shape in enumerate((b"[]", b'"a string"', b"null", b"42", b"\xff\xfe{"), start=1):
+            self._file().write_bytes(shape)
+            os.utime(self._file(), ns=(st.st_atime_ns, st.st_mtime_ns + i * 1_000_000_000))   # a moved key: the read runs
+            with self.assertRaises(ValueError, msg=repr(shape)):
+                jd._matches_disk(self.SID, s)
+            self.assertNotIn(str(self._file()), jd._DISK_CONTENT, "%r: not a store, nothing to remember" % shape)
+            with self.assertRaises(ValueError, msg=repr(shape)):
+                jd._disk_rev(self.SID)
+            self.assertEqual(self._file().read_bytes(), shape, "neither reader touched the file")
+
+    def test_an_unserializable_store_is_not_swallowed_by_the_no_op_check(self):
+        """_own_hash answers None for a store json.dumps cannot serialize; the no-op check then answers False
+        and save_goals raises from its own json.dumps with the file untouched: a publish the check merely
+        failed to understand is never skipped as a no-op."""
+        self._seed()
+        s = jd.load_goals(self.SID)
+        jd.save_goals(self.SID, s)                        # a warm no-op
+        before = self._file().read_bytes()
+        s["nodes"][next(iter(s["nodes"]))]["summary"] = {1, 2}     # a set: not JSON
+        with self.assertRaises(TypeError):
+            jd.save_goals(self.SID, s)
+        self.assertEqual(self._file().read_bytes(), before, "the publish raised on its own terms; the file is untouched")
+
+    def test_the_eviction_sweep_holds_the_memo_lock_while_it_iterates(self):
+        """_disk_memo_evict_absent iterates the memo under _DISK_CONTENT_LOCK, so a judge thread's _disk_seed
+        or _disk_entry landing mid-sweep cannot change the dict under the iteration. Probed from inside the
+        sweep's own os.path.exists calls: the lock is held at every probe. No threads, no clock."""
+        self._seed()
+        jd.save_goals(self.SID, jd.load_goals(self.SID))
+        self.assertIn(str(self._file()), jd._DISK_CONTENT)
+        probes, real_exists = [], os.path.exists
+
+        def probing(p):
+            got = jd._DISK_CONTENT_LOCK.acquire(blocking=False)
+            if got:
+                jd._DISK_CONTENT_LOCK.release()
+            probes.append(got)
+            return real_exists(p)
+        with mock.patch.object(os.path, "exists", probing):
+            jd._disk_memo_evict_absent()
+        self.assertGreaterEqual(len(probes), 1, "the sweep probed the entry's path")
+        self.assertEqual(set(probes), {False}, "the lock was held at every probe")
+
+    # ── housekeeping ─────────────────────────────────────────────────────────
+    def test_rebind_state_clears_the_memo(self):
+        self._seed()
+        jd.save_goals(self.SID, jd.load_goals(self.SID))
+        self.assertTrue(jd._DISK_CONTENT)
+        jd._rebind_state(Path(self.td.name) / "elsewhere")
+        self.assertEqual(jd._DISK_CONTENT, {})
+
+    def test_evict_absent_drops_removed_stores_and_keeps_present_ones(self):
+        self._seed()
+        jd.save_goals(self.SID, jd.load_goals(self.SID))
+        other = "0b400000-aaaa-bbbb-cccc-dddddddddddd"
+        s2 = {"rompUuid": other, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {}, "placements": {}, "status": {}}
+        jd.save_goals(other, s2)
+        jd.save_goals(other, jd.load_goals(other))
+        self.assertEqual(set(jd._DISK_CONTENT), {str(self._file()), str(jd.GOALDIR / (other + ".json"))})
+        (jd.GOALDIR / (other + ".json")).unlink()
+        self.assertEqual(jd._disk_memo_evict_absent(), 1)
+        self.assertEqual(set(jd._DISK_CONTENT), {str(self._file())})
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_unblocker.py
+++ b/tests/test_judge_unblocker.py
@@ -51,7 +51,7 @@ class UnblockerBase(unittest.TestCase):
         self._td = tempfile.mkdtemp()
         jd._rebind_state(Path(self._td))
         jd.GOALDIR.mkdir(parents=True, exist_ok=True)
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         self._saved_llm = jd.unblock_llm
         self.calls = []
 
@@ -190,7 +190,7 @@ class Unblocker(UnblockerBase):
         path2 = self._transcript([(T0 + 200, "unrelated other work", "done that"),
                                   (T0 + 900, "more talk", "more replies"),
                                   (T0 + 950, "tail", "tail reply")])
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._unblock_session(SID, path2, NOW)
         self.assertEqual(len(self.calls), 2, "new evidence → examined again")
 
@@ -369,7 +369,7 @@ class UnblockerCompletedSince(UnblockerBase):
         # and when a real turn arms the examine, the synth row still doesn't ride as evidence
         path2 = self._transcript([(T0 + 40, "please size the pool", "asking and idling"),
                                   (T0 + 400, "unrelated talk", "unrelated reply")])
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         self._stub('{"verdicts": [{"n": 1, "do": "hold", "why": ""}]}')
         jd._unblock_session(SID, path2, NOW)
         self.assertEqual(self.calls[-1][2], "", "the synth completion is excluded from the section")

--- a/tests/test_judge_workless_followup_wedge.py
+++ b/tests/test_judge_workless_followup_wedge.py
@@ -69,7 +69,7 @@ class WorklessFollowupWedge(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.mkdtemp()
         jd._rebind_state(Path(self.td))
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         # an OPEN top the user just replied to: the optimistic msg-reopen is the latch
         self.store = {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V,
                       "nodes": {GID: {"id": GID, "text": "Ship the notes-api deploy", "parentId": None,
@@ -116,7 +116,7 @@ class WorklessFollowupWedge(unittest.TestCase):
         ]
         path = os.path.join(self.td, SID + ".jsonl")
         open(path, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         return path
 
     def _fold(self):
@@ -187,7 +187,7 @@ class WorklessFollowupWedge(unittest.TestCase):
         ]
         path = os.path.join(self.td, SID + ".jsonl")
         open(path, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._plan_session(SID, path, NOW)
         self.assertFalse(self.fu_calls, "a nudge is never a follow-up unit")
         store = jd.load_goals(SID)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5396,6 +5396,39 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._end_goals_pass()
 
+    def test_the_compaction_sweep_evicts_the_entries_of_stores_no_discovered_session_owns(self):
+        # The memo had no cap: every store the directory held stayed decoded in memory between passes (tens
+        # of MB on a large board; the PR that added it asked whether that was welcome). The compaction sweep,
+        # run after the tiers on the same producer thread, drops the entries of stores no session in the
+        # discover set owns; the price is one decode at the next pass for such a store the pass still lists
+        # (review find, 2026-09-08).
+        other = self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {},
+                                                     "placements": {}, "status": {}})
+        mine = str(jd.GOALDIR / (SID + ".json"))
+        km._begin_goals_pass()
+        km._end_goals_pass()
+        self.assertEqual(set(km._goals_memo[0]), {mine, str(other)})
+        before = km._goals_memo_stats["evict"]
+        disc = [(SID, str(self.tpath), None, "testsess"), (self.OTHER_SID, "/dev/null", None, "api")]
+        with mock.patch.object(jd, "discover", lambda now, window=None, forks=True: list(disc)):
+            km._compact_goal_stores()
+            self.assertEqual(set(km._goals_memo[0]), {mine, str(other)}, "both owned: nothing evicted")
+            del disc[1:]                                             # the other session left the discover window
+            km._compact_goal_stores()
+        self.assertEqual(set(km._goals_memo[0]), {mine}, "the unowned store's entry is gone")
+        self.assertEqual(km._goals_memo_stats["evict"] - before, 1)
+        real, calls = self._count_decodes()
+        try:
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 1, "the price: the evicted store is decoded again next pass")
+                self.assertEqual(km._feed_goals(self.OTHER_SID)["seq"], 0, "…and served as before")
+            finally:
+                km._end_goals_pass()
+        finally:
+            km._goals_memo_decode = real
+        self.assertEqual(set(km._goals_memo[0]), {mine, str(other)})
+
     # Each component of the memo key is load-bearing on its own, and none of the tests above pins one:
     # they publish by rename AND change the content's length, so every version differs in two components
     # at once, and a key missing any one component still passes them. The three tests below isolate one
@@ -5474,6 +5507,38 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(decodes, 1, "the inode moved → decoded again")
         self.assertEqual(served["seq"], 1, "…and the new version is what the pass serves")
         self.assertNotEqual(old_key, new_key)
+
+    def test_a_same_size_in_place_rewrite_with_the_mtime_put_back_is_the_documented_blind_spot(self):
+        # All three components held: same inode (in place), same length (seq 0 → 1), mtime pinned back. The
+        # key cannot tell, so the pass serves the EARLIER parse. Pinned as the named exception the memo note
+        # documents, as its two sibling memos pin theirs (the absent-store memo in test_judge_propagate_loads,
+        # the shared cache's byte compare in test_judge_store_cache; review find, 2026-09-08). No romp writer
+        # does this (every publish is a tmp+rename); it stands in for two equal-size publishes onto a
+        # recycled inode inside one clock tick on a coarse-timestamp kernel. A publish of another size is seen.
+        def mutate(path, st, store):
+            store["seq"] = 1
+            data = json.dumps(store)
+            self.assertEqual(len(data.encode()), st.st_size, "same length by construction")
+            path.write_text(data)                                        # same inode, same size
+            os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns))        # same mtime_ns
+            now = path.stat()
+            self.assertEqual((now.st_ino, now.st_mtime_ns, now.st_size), (st.st_ino, st.st_mtime_ns, st.st_size))
+        decodes, served, old_key, new_key = self._memo_key_probe(mutate)
+        self.assertEqual(decodes, 0, "the key did not move → no decode")
+        self.assertEqual(served["seq"], 0, "…so the pass serves the earlier parse: the documented blind spot")
+        self.assertEqual(old_key, new_key)
+        path = self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 2, "nodes": {},
+                                                    "placements": {}, "status": {}, "note": "another size"})
+        real, calls = self._count_decodes()
+        try:
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 1, "a publish of another size is seen")
+                self.assertEqual(km._feed_goals(self.OTHER_SID)["seq"], 2)
+            finally:
+                km._end_goals_pass()
+        finally:
+            km._goals_memo_decode = real
 
     def test_a_publish_between_the_listing_stat_and_the_open_is_keyed_as_the_version_read(self):
         # The key is taken by fstat on the fd the bytes come from, so a rename landing between the

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4,7 +4,10 @@ consume). The WS transport + HTTP serving aren't unit-tested; the projection —
 (chat), goals→feed cards, ledger→TOC — is. Synthetic fleet only: invented text, placeholder
 UUIDs; no real session data.
 """
+import builtins
 import contextlib
+import errno
+import io
 import json
 import os
 import re
@@ -14,6 +17,7 @@ import time
 import types
 import unittest
 from datetime import datetime, timezone
+from unittest import mock
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -119,6 +123,8 @@ class ViewBuilder(unittest.TestCase):
         # gist-specific tests write that caption to drive the card's "Analyzing: …" text.
         jd.gist_llm = lambda p: ""
         km._autonudge_cache.clear()
+        km._goals_snap_owned.clear()                   # the memo tests assume no punch state or user-write
+        km._user_goal_write.pop(SID, None)             # mark left by another test (both process-global)
         # sandbox the system-card's global CLAUDE.md to a nonexistent temp path so a real ~/.claude/CLAUDE.md
         # on the dev machine can't leak a "system context" card into these fixtures (the synthetic transcript
         # carries no cwd/model/branch either, so no card is emitted — system-card behavior is tested in
@@ -5181,6 +5187,477 @@ class ViewBuilder(unittest.TestCase):
                              "the reopen is applied once, no matter how many builds replay the journal")
         finally:
             km._end_goals_pass()
+
+    # ── the pass snapshot's stat-keyed store memo (2026-09-06) ──
+    OTHER_SID = "11111111-2222-3333-4444-666666666666"
+
+    def _publish_store(self, sid, store):
+        """Write a store the way every real writer does: a temp file renamed into place. The temp file
+        is created while the old one still exists, so ONE publish between passes is a new inode and the
+        memo's (ino, mtime_ns, size) key moves on any clock; an in-place write_text keeps the inode and
+        can land inside the same coarse mtime tick on a CI kernel. (Inode numbers do recycle across two
+        publishes; the key-component tests below isolate each component with os.utime.)"""
+        path, tmp = jd.GOALDIR / (sid + ".json"), jd.GOALDIR / (sid + ".json.tmp")
+        tmp.write_text(json.dumps(store))
+        os.replace(tmp, path)
+        return path
+
+    def _count_decodes(self):
+        """Wrap the memo's own decode hook (not json.loads: the punch and _apply_rewind_hold call that
+        for their copies). Returns the call list; the caller restores km._goals_memo_decode."""
+        real, calls = km._goals_memo_decode, []
+        km._goals_memo_decode = lambda data: (calls.append(1), real(data))[1]
+        return real, calls
+
+    def test_a_second_pass_decodes_only_the_stores_whose_file_changed(self):
+        # The pass used to json.loads EVERY goals/*.json at its start (72 files of up to 1.3 MB, about 3%
+        # of the kernel's interpreter time) although a pass changes a few of them. Every writer publishes
+        # by rename, so a file version is named exactly by (ino, mtime_ns, size): a later pass decodes only
+        # the stores whose key moved and serves the rest as the very object an earlier pass parsed.
+        km._user_goal_write.pop(SID, None)                 # no punch pending from another test's gesture
+        g = self._store_with_status("working")
+        self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {},
+                                             "placements": {}, "status": {}})
+        real, calls = self._count_decodes()
+        try:
+            km._begin_goals_pass()
+            first_sid, first_other = km._feed_goals(SID), km._feed_goals(self.OTHER_SID)
+            km._end_goals_pass()
+            self.assertEqual(len(calls), 2, "a cold memo decodes both stores")
+            self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 1, "nodes": {},
+                                                 "placements": {}, "status": {}})
+            del calls[:]
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 1, "one file changed → exactly one decode")
+                self.assertIs(km._feed_goals(SID), first_sid, "the unchanged store is served by identity")
+                served = km._feed_goals(self.OTHER_SID)
+                self.assertIsNot(served, first_other)
+                self.assertEqual(served["seq"], 1, "the changed store is served at its new version")
+                card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+                self.assertEqual(card["column"], "working")
+            finally:
+                km._end_goals_pass()
+            km._begin_goals_pass()                         # a third pass with nothing changed: no decode at all
+            try:
+                self.assertEqual(len(calls), 1)
+                self.assertIs(km._feed_goals(SID), first_sid)
+            finally:
+                km._end_goals_pass()
+        finally:
+            km._goals_memo_decode = real
+
+    def test_a_user_punch_copies_the_entry_and_never_mutates_the_memoized_store(self):
+        # A snapshot entry is a memo reference shared with every later pass that finds the file
+        # unchanged, so the punch (the gesture's replay + rollup, both in place) must land on a copy:
+        # otherwise the reopen would be baked into the object the NEXT pass serves for a file that does
+        # not hold it. Contract: the memoized object always equals a fresh raw parse of its file
+        # version; the served copy carries the reopen; a second gesture in the same pass works the same
+        # copy; build_feed reads and never writes.
+        g = self._settled_store()
+        path = jd.GOALDIR / (SID + ".json")
+        raw = json.loads(path.read_bytes())                # the version this pass memoizes
+        km._begin_goals_pass()
+        try:
+            memo_obj = km._goals_memo[0][str(path)][1]
+            self.assertEqual(memo_obj, raw)
+            km._user_goal_write.pop(SID, None)
+            self.assertIs(km._feed_goals(SID), memo_obj, "no gesture yet: served by identity")
+            self.assertTrue(jd.optimistic_followup(SID, g, text="also handle the empty case", now=NOW))
+            km._note_user_goal_write(SID)
+            served = km._feed_goals(SID)
+            self.assertIsNot(served, memo_obj, "the punch worked on a copy")
+            self.assertEqual(served["status"].get(g), "working", "the served copy carries the reopen")
+            self.assertTrue(any(e.get("src") == "user" and e.get("kind") == "reopen"
+                                for e in served["nodes"][g].get("log") or []))
+            self.assertEqual(memo_obj, raw, "the memoized object is untouched: still the raw parse")
+            self.assertIs(km._feed_goals(SID), served, "later reads in the pass serve that one copy")
+            self.assertTrue(jd.optimistic_followup(SID, g, text="and the null case", now=NOW + 1))
+            km._note_user_goal_write(SID)
+            self.assertIs(km._feed_goals(SID), served, "a second gesture punches the copy already made")
+            self.assertEqual(memo_obj, raw)
+            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            self.assertEqual(card["column"], "working")
+            self.assertEqual(memo_obj, raw, "build_feed reads the store; it never writes it")
+        finally:
+            km._end_goals_pass()
+        km._begin_goals_pass()                             # the gesture's own save published a new version
+        try:
+            self.assertIsNot(km._goals_memo[0][str(path)][1], memo_obj, "…so the next pass re-decodes it")
+            self.assertEqual(km._feed_goals(SID)["status"].get(g), "working")
+        finally:
+            km._end_goals_pass()
+
+    def test_a_store_that_does_not_decode_is_served_live_and_retried_only_when_it_changes(self):
+        # A version that fails to decode stays out of the snapshot (the feed falls to live load_goals,
+        # as before) and is said on stderr — once per file VERSION, not per pass: the failure is
+        # remembered under the same key, so a corrupt megabyte is not re-decoded and re-reported every
+        # 3 s. The file's next publish is a new key and is decoded again. The first two passes take no
+        # live read on purpose: the feed's live read goes through load_goals_or_fault, which QUARANTINES
+        # an unparseable file (moves it aside), and a second pass over a vanished file would prove
+        # nothing about the memo.
+        path = jd.GOALDIR / (SID + ".json")
+        tmp = jd.GOALDIR / (SID + ".json.tmp")
+        tmp.write_text("{not json")
+        os.replace(tmp, path)
+        real, calls = self._count_decodes()
+        err, saved_err = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            km._begin_goals_pass()
+            try:
+                self.assertNotIn(SID, km._goals_snap[0], "no snapshot entry for a version that did not decode")
+                self.assertIs(km._goals_memo[0][str(path)][1], km._GOALS_MEMO_BAD, "remembered under its key")
+            finally:
+                km._end_goals_pass()
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(err.getvalue().count("goals-pass: "), 1, "said once, naming the file")
+            self.assertIn(SID + ".json", err.getvalue())
+            self.assertTrue(path.exists(), "the pass reads; it never moves a file aside")
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 1, "the same version is not decoded again")
+                self.assertEqual(err.getvalue().count("goals-pass: "), 1, "…and not said again")
+                self.assertNotIn(SID, km._goals_snap[0], "…and still out of the snapshot")
+                live = km._feed_goals(SID)
+                self.assertIn("_baseRev", live, "the feed falls to the live loader's object")
+                self.assertEqual(live.get("nodes"), {}, "…the fresh store load_goals answers once it has moved the bytes aside")
+            finally:
+                km._end_goals_pass()
+            g = self._store_with_status("working")         # a new version (its size differs, so the key moves on any clock)
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 2, "a changed file is decoded again")
+                self.assertIn(SID, km._goals_snap[0])
+                card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+                self.assertEqual(card["column"], "working")
+            finally:
+                km._end_goals_pass()
+        finally:
+            sys.stderr = saved_err
+            km._goals_memo_decode = real
+
+    def test_a_store_whose_read_fails_is_read_again_at_the_next_pass(self):
+        # A read that fails (EMFILE under descriptor pressure, EIO) is the pass's failure, not the file
+        # version's, so it is not remembered under the key: the next pass reads the file again, where a
+        # version that does not decode (the test above) stays remembered until the file changes. Before
+        # the memo, every pass re-read every store, so a transient error cost one pass; a memoized read
+        # error would keep the store out of the snapshot until its next publish.
+        path = jd.GOALDIR / (SID + ".json")
+        real, calls = self._count_decodes()
+        real_open, failed = builtins.open, []
+
+        def failing_open(file, *a, **kw):
+            if not failed and str(file) == str(path):
+                failed.append(1)
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real_open(file, *a, **kw)
+        err, saved_err = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            with mock.patch.object(builtins, "open", failing_open):
+                km._begin_goals_pass()
+            try:
+                self.assertEqual(failed, [1], "the store's open failed once")
+                self.assertNotIn(SID, km._goals_snap[0], "out of the snapshot for this pass")
+                self.assertNotIn(str(path), km._goals_memo[0], "…and not remembered under its key")
+                self.assertIn("_baseRev", km._feed_goals(SID), "the feed reads it live")
+            finally:
+                km._end_goals_pass()
+            self.assertEqual(len(calls), 0)
+            self.assertEqual(err.getvalue().count("goals-pass: "), 1, "said, naming the file")
+            self.assertIn(SID + ".json", err.getvalue())
+            km._begin_goals_pass()                             # nothing changed on disk: the next pass reads it
+            try:
+                self.assertEqual(len(calls), 1, "read and decoded at the next pass, with no change to the file")
+                self.assertIn(SID, km._goals_snap[0])
+            finally:
+                km._end_goals_pass()
+        finally:
+            sys.stderr = saved_err
+            km._goals_memo_decode = real
+
+    def test_the_memo_forgets_a_store_whose_file_is_gone(self):
+        # Entries are keyed by path; a file gone from the directory (a test's unlink, a state rebind)
+        # leaves the memo at the next pass, so it cannot grow across the paths a process has seen.
+        path = self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {},
+                                                    "placements": {}, "status": {}})
+        km._begin_goals_pass()
+        km._end_goals_pass()
+        self.assertIn(str(path), km._goals_memo[0])
+        path.unlink()
+        before = km._goals_memo_stats["evict"]
+        km._begin_goals_pass()
+        try:
+            self.assertNotIn(str(path), km._goals_memo[0], "evicted at the next pass")
+            self.assertNotIn(self.OTHER_SID, km._goals_snap[0])
+            self.assertEqual(km._goals_memo_stats["evict"] - before, 1)
+            self.assertIn("_baseRev", km._feed_goals(self.OTHER_SID), "a sid without an entry reads live")
+        finally:
+            km._end_goals_pass()
+
+    # Each component of the memo key is load-bearing on its own, and none of the tests above pins one:
+    # they publish by rename AND change the content's length, so every version differs in two components
+    # at once, and a key missing any one component still passes them. The three tests below isolate one
+    # component each. They rewrite in place or pin mtimes with os.utime, which no real writer does (every
+    # writer publishes by rename): synthetic isolation of one signal, not a model of a writer. mtimes are
+    # moved by os.utime and never by letting the clock run (a same-tick flake on a coarse kernel).
+    def _memo_key_probe(self, mutate):
+        """Publish a seq-0 store, run a pass so the memo holds it, apply mutate(path, st, store) (st is
+        the memoized version's stat, store a copy of its content), and run a second pass. Returns the
+        second pass's decode count, the store it served, and the key before and after."""
+        store = {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        path = self._publish_store(self.OTHER_SID, store)
+        real, calls = self._count_decodes()
+        try:
+            km._begin_goals_pass()
+            km._end_goals_pass()
+            st = path.stat()
+            old_key = km._goals_memo[0][str(path)][0]
+            mutate(path, st, dict(store))
+            del calls[:]
+            km._begin_goals_pass()
+            try:
+                served = km._feed_goals(self.OTHER_SID)
+                new_key = km._goals_memo[0][str(path)][0]
+            finally:
+                km._end_goals_pass()
+            return len(calls), served, old_key, new_key
+        finally:
+            km._goals_memo_decode = real
+
+    def test_the_memo_key_re_decodes_on_a_size_change_alone(self):
+        # st_size: the inode and the mtime held (in-place rewrite, mtime pinned back); only the length
+        # moved. A key without st_size would serve the seq-0 parse for a file that holds seq 1.
+        def mutate(path, st, store):
+            store["seq"], store["note"] = 1, "a longer version of the same store"
+            path.write_text(json.dumps(store))                          # same inode
+            os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns))        # same mtime_ns
+            now = path.stat()
+            self.assertEqual((now.st_ino, now.st_mtime_ns), (st.st_ino, st.st_mtime_ns))
+            self.assertNotEqual(now.st_size, st.st_size)
+        decodes, served, old_key, new_key = self._memo_key_probe(mutate)
+        self.assertEqual(decodes, 1, "the size moved → decoded again")
+        self.assertEqual(served["seq"], 1, "…and the new version is what the pass serves")
+        self.assertNotEqual(old_key, new_key)
+
+    def test_the_memo_key_re_decodes_on_an_mtime_change_alone(self):
+        # st_mtime_ns: same inode, same length (seq 0 → 1 swaps one digit for one digit); only the mtime
+        # moved. This is the component the key rests on in production: inode numbers recycle and equal
+        # sizes are common (the memo note in kernel.py).
+        def mutate(path, st, store):
+            store["seq"] = 1
+            data = json.dumps(store)
+            self.assertEqual(len(data.encode()), st.st_size, "same length by construction")
+            path.write_text(data)                                        # same inode, same size
+            os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))   # moved by 1 ms, deterministically
+            now = path.stat()
+            self.assertEqual((now.st_ino, now.st_size), (st.st_ino, st.st_size))
+            self.assertNotEqual(now.st_mtime_ns, st.st_mtime_ns)
+        decodes, served, old_key, new_key = self._memo_key_probe(mutate)
+        self.assertEqual(decodes, 1, "the mtime moved → decoded again")
+        self.assertEqual(served["seq"], 1, "…and the new version is what the pass serves")
+        self.assertNotEqual(old_key, new_key)
+
+    def test_the_memo_key_re_decodes_on_an_inode_change_alone(self):
+        # st_ino: a real rename publish of same-length content with its mtime pinned to the old value, so
+        # only the inode moved — the shape of a same-tick publish on a coarse-timestamp kernel. One
+        # publish between passes always lands on a fresh inode (the temp file coexists with the old one).
+        def mutate(path, st, store):
+            store["seq"] = 1
+            self._publish_store(self.OTHER_SID, store)                  # new inode, same size
+            os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns))        # same mtime_ns
+            now = path.stat()
+            self.assertEqual((now.st_mtime_ns, now.st_size), (st.st_mtime_ns, st.st_size))
+            self.assertNotEqual(now.st_ino, st.st_ino)
+        decodes, served, old_key, new_key = self._memo_key_probe(mutate)
+        self.assertEqual(decodes, 1, "the inode moved → decoded again")
+        self.assertEqual(served["seq"], 1, "…and the new version is what the pass serves")
+        self.assertNotEqual(old_key, new_key)
+
+    def test_a_publish_between_the_listing_stat_and_the_open_is_keyed_as_the_version_read(self):
+        # The key is taken by fstat on the fd the bytes come from, so a rename landing between the
+        # listing's stat and the open is read whole from the new inode and keyed as THAT version. Keyed
+        # from the listing's stat, the memo would hold seq 1's parse under seq 0's key and decode the
+        # unchanged file again next pass (one wasted decode, never a stale parse).
+        store = {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}}
+        path = self._publish_store(self.OTHER_SID, store)
+        real_open, fired = builtins.open, []
+
+        def publishing_open(file, *a, **kw):
+            if not fired and str(file) == str(path):
+                fired.append(1)
+                self._publish_store(self.OTHER_SID, dict(store, seq=1))   # a writer lands after the listing's stat
+            return real_open(file, *a, **kw)
+        real, calls = self._count_decodes()
+        try:
+            with mock.patch.object(builtins, "open", publishing_open):
+                km._begin_goals_pass()
+            try:
+                self.assertEqual(fired, [1])
+                self.assertEqual(km._feed_goals(self.OTHER_SID)["seq"], 1, "the bytes read are the new version's")
+            finally:
+                km._end_goals_pass()
+            st = path.stat()
+            self.assertEqual(km._goals_memo[0][str(path)][0], (st.st_ino, st.st_mtime_ns, st.st_size),
+                             "…and the key names the version that was read")
+            del calls[:]
+            km._begin_goals_pass()
+            try:
+                self.assertEqual(len(calls), 0, "nothing changed since: no decode")
+                self.assertEqual(km._feed_goals(self.OTHER_SID)["seq"], 1)
+            finally:
+                km._end_goals_pass()
+        finally:
+            km._goals_memo_decode = real
+
+    def test_a_store_gone_between_the_listing_and_the_read_is_no_store_and_no_complaint(self):
+        # A file gone between the listing and the open (a session removed mid-pass) is no store: no
+        # snapshot entry, no memo entry, no stderr line and no fail count — where an unreadable file
+        # (EMFILE, EIO) is said and counted.
+        path = self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {},
+                                                    "placements": {}, "status": {}})
+        real_open, fired = builtins.open, []
+
+        def vanishing_open(file, *a, **kw):
+            if not fired and str(file) == str(path):
+                fired.append(1)
+                path.unlink()
+                raise FileNotFoundError(errno.ENOENT, "No such file or directory", str(path))
+            return real_open(file, *a, **kw)
+        before = km._goals_memo_stats["fail"]
+        err, saved_err = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            with mock.patch.object(builtins, "open", vanishing_open):
+                km._begin_goals_pass()
+            try:
+                self.assertEqual(fired, [1])
+                self.assertNotIn(self.OTHER_SID, km._goals_snap[0])
+                self.assertNotIn(str(path), km._goals_memo[0])
+            finally:
+                km._end_goals_pass()
+        finally:
+            sys.stderr = saved_err
+        self.assertEqual(err.getvalue(), "", "gone is not a failure: nothing said")
+        self.assertEqual(km._goals_memo_stats["fail"], before, "…and nothing counted")
+
+    def test_a_user_write_landing_during_the_reads_punches_through(self):
+        # The pass stamp `at` is taken BEFORE the reads: a gesture that lands while the loop is reading
+        # (after the stamp, before the snapshot is installed) has a mark >= at and is replayed onto the
+        # snapshot. Stamped after the loop, that gesture's mark would predate the snapshot and the
+        # pre-gesture card would stand for the whole pass. (ui/webview/feed-move-ack.test.ts pins the
+        # comment on the stamp line; this drives the behaviour.)
+        g = self._settled_store()
+        real, fired = km._goals_memo_decode, []
+
+        def gesture_mid_loop(data):
+            store = real(data)
+            if not fired and store.get("rompUuid") == SID:
+                fired.append(1)
+                self.assertTrue(jd.optimistic_followup(SID, g, text="also handle the empty case", now=NOW))
+                km._note_user_goal_write(SID)                  # the gesture lands during the read loop
+            return store
+        km._goals_memo_decode = gesture_mid_loop
+        try:
+            km._begin_goals_pass()
+        finally:
+            km._goals_memo_decode = real
+        try:
+            self.assertEqual(fired, [1])
+            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            self.assertEqual(card["column"], "working", "a write racing the read loop counts as after it")
+        finally:
+            km._end_goals_pass()
+
+    def test_the_copy_on_punch_is_per_pass(self):
+        # _goals_snap_owned is cleared at the pass boundaries: a sid that punched a copy in one pass must
+        # copy AGAIN in the next, because the next pass's snapshot entry is the memo's object (re-decoded
+        # after the gesture's own save), not the copy. Without the clear, the second pass's gesture
+        # would land on the shared object.
+        g = self._settled_store()
+        path = jd.GOALDIR / (SID + ".json")
+        km._begin_goals_pass()
+        try:
+            self.assertTrue(jd.optimistic_followup(SID, g, text="one more thing", now=NOW))
+            km._note_user_goal_write(SID)
+            self.assertIsNot(km._feed_goals(SID), km._goals_memo[0][str(path)][1], "pass 1 punched a copy")
+        finally:
+            km._end_goals_pass()
+        km._begin_goals_pass()                             # the gesture's save is a new version: re-decoded
+        try:
+            raw = json.loads(path.read_bytes())
+            memo_obj = km._goals_memo[0][str(path)][1]
+            self.assertEqual(memo_obj, raw)
+            self.assertTrue(jd.optimistic_followup(SID, g, text="and the null case", now=NOW + 1))
+            km._note_user_goal_write(SID)
+            served = km._feed_goals(SID)
+            self.assertIsNot(served, memo_obj, "pass 2 copied the new memo object before punching")
+            self.assertEqual(memo_obj, raw, "…so the memoized object is still the raw parse")
+        finally:
+            km._end_goals_pass()
+
+    def test_the_memo_counters_and_report_follow_the_passes(self):
+        # hit/miss/fail/punch count what the passes did, and the report adds the memo's occupancy.
+        g = self._settled_store()
+        other = self._publish_store(self.OTHER_SID, {"rompUuid": self.OTHER_SID, "seq": 0, "nodes": {},
+                                                     "placements": {}, "status": {}})
+
+        def deltas(fn):
+            before = dict(km._goals_memo_stats)
+            fn()
+            return {k: km._goals_memo_stats[k] - before[k] for k in before}
+        d = deltas(lambda: (km._begin_goals_pass(), km._end_goals_pass()))
+        self.assertEqual((d["miss"], d["hit"], d["fail"]), (2, 0, 0), "a cold pass: two decodes")
+        d = deltas(lambda: (km._begin_goals_pass(), km._end_goals_pass()))
+        self.assertEqual((d["miss"], d["hit"], d["fail"]), (0, 2, 0), "an unchanged pass: two hits")
+        report = km._goals_memo_report()
+        self.assertEqual(report["entries"], 2)
+        self.assertEqual(report["bytes"], sum(p.stat().st_size for p in jd.GOALDIR.glob("*.json")))
+        st = other.stat()
+        os.utime(other, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))   # a moved key, so the read runs
+        real_open = builtins.open
+
+        def failing_open(file, *a, **kw):
+            if str(file) == str(other):
+                raise OSError(errno.EIO, "synthetic: input/output error")
+            return real_open(file, *a, **kw)
+        err, saved_err = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            with mock.patch.object(builtins, "open", failing_open):
+                d = deltas(lambda: (km._begin_goals_pass(), km._end_goals_pass()))
+        finally:
+            sys.stderr = saved_err
+        self.assertEqual((d["miss"], d["hit"], d["fail"]), (0, 1, 1), "one hit, one read failure")
+        self.assertIn(self.OTHER_SID + ".json", err.getvalue())
+        km._begin_goals_pass()
+        try:
+            self.assertTrue(jd.optimistic_followup(SID, g, text="one more thing", now=NOW))
+            km._note_user_goal_write(SID)
+            d = deltas(lambda: (km._feed_goals(SID), km._feed_goals(SID)))
+            self.assertEqual(d["punch"], 1, "one copy per pass per sid, however many reads")
+        finally:
+            km._end_goals_pass()
+
+    def test_sidecars_and_temp_files_in_the_goals_directory_are_not_stores(self):
+        # Only `<sid>.json` regular files are stores: a quarantine sidecar (load_goals' `.json.corrupt-<stamp>`)
+        # and a publisher's temp file sit beside them holding bytes that are not a store, and the pass
+        # neither decodes nor reports them.
+        (jd.GOALDIR / (self.OTHER_SID + ".json.corrupt-20260101T000000Z")).write_text("{not json")
+        (jd.GOALDIR / (self.OTHER_SID + ".json.tmp")).write_text("{half a publ")
+        real, calls = self._count_decodes()
+        err, saved_err = io.StringIO(), sys.stderr
+        sys.stderr = err
+        try:
+            km._begin_goals_pass()
+            km._end_goals_pass()
+        finally:
+            sys.stderr = saved_err
+            km._goals_memo_decode = real
+        self.assertEqual(len(calls), 1, "the one store beside them is decoded; the sidecars are not")
+        self.assertEqual(err.getvalue(), "")
+        self.assertEqual(set(km._goals_memo[0]), {str(jd.GOALDIR / (SID + ".json"))})
 
     def test_the_feed_payload_carries_a_build_id_that_advances_per_build(self):
         # buildId is what lets a client tell "this payload predates my click" from "this is the kernel's

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -16,7 +16,9 @@ stamp (those remain the 6h backstop's job, the one case a timer is the only tool
 
 SYNTHETIC fixtures only: placeholder UUIDs, invented task descriptions.
 """
+import contextlib
 import errno
+import io
 import json
 import os
 import tempfile
@@ -1129,3 +1131,87 @@ class InHarnessWaitLift(unittest.TestCase):
         self._seed(None)
         self._tick({"state": "", "bgTasks": []})
         self.assertIsNotNone(self._stamp(), "a kindless stamp may be a peer wait — untouched, as before")
+
+
+class LiftGateFallback(unittest.TestCase):
+    """The lift's inputs gate (_lift_seen) records a session's fingerprint BEFORE the load and forgets it
+    when the ruling raises or the store read FAULTS (AwaitingLift's
+    test_a_faulting_store_forgets_the_gate_so_the_next_tick_retries). One more load is no better than
+    those: a store that parsed while its override JOURNAL could not be read. _replay_overrides logs
+    history-unreadable and returns the store WITHOUT the user's rows (a restore that carries the stamp,
+    here), so the ruling "nothing stamped" stood against a fingerprint that, for an idle session, may not
+    move for hours. The replay marks that store `_unread`, and the gate forgets its entry for a marked
+    store, so the next cycle retries."""
+
+    def setUp(self):
+        AwaitingLift.setUp(self)
+        km._lift_seen.pop(SID, None)                     # process-global; the harness never clears it
+        self.loads = []
+        real = km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (self.loads.append(fsid), real(fsid))[1]
+        self.addCleanup(setattr, km.jd, "load_goals", real)
+
+    def tearDown(self):
+        km._lift_seen.pop(SID, None)
+        AwaitingLift.tearDown(self)
+
+    _transcript = AwaitingLift._transcript
+    _seed = AwaitingLift._seed
+    _tick = AwaitingLift._tick
+    _stamp = AwaitingLift._stamp
+
+    def _read_fails_once(self, target):
+        """Patch Path.read_text so the FIRST read of `target` (the journal, which _replay_overrides reads
+        that way) raises OSError (the EMFILE/EIO shape a busy kernel meets) and every later read is real.
+        Returns the counter of raised reads."""
+        real = Path.read_text
+        state = {"fired": 0}
+        def flaky(p, *a, **k):
+            if p == target and not state["fired"]:
+                state["fired"] += 1
+                raise OSError(errno.EMFILE, "synthetic: too many open files")
+            return real(p, *a, **k)
+        Path.read_text = flaky
+        self.addCleanup(setattr, Path, "read_text", real)
+        return state
+
+    def test_a_stamp_in_the_file_still_lifts_while_the_journal_does_not_read(self):
+        """The mark changes what the gate REMEMBERS, not what the lift RULES: a store that parsed with its
+        stamp in the file lifts as before and publishes without the mark; only the gate entry is forgotten,
+        so a stamp the unread journal held is retried next cycle."""
+        self._transcript([_launch("t1", LAUNCH), _launch("t2", LAUNCH + 5),
+                          _notification("t1", BACK), _notification("t2", BACK + 5)])
+        self._seed()                                     # the stamp lives in the store FILE
+        km.jd.append_override(SID, SID + ":g9", "resolve", BACK + 50)   # a journal exists: a row for a node the
+        #                                                                  store lacks, skipped on replay
+        state = self._read_fails_once(km.jd._overrides_dir() / (SID + ".jsonl"))
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()
+        self.assertEqual(state["fired"], 1)
+        self.assertGreaterEqual(len(self.loads), 1)
+        self.assertNotIn(SID, km._lift_seen, "ruled without the journal: the gate forgets the entry")
+        self.assertIsNone(self._stamp(), "...and the ruling on the parsed store stands: every dispatch is back, the stamp lifts")
+        self.assertNotIn("_unread", json.loads((km.jd.GOALDIR / (SID + ".json")).read_text()),
+                         "the mark never reaches the file")
+
+    def test_a_swallowed_journal_read_failure_is_not_recorded_as_a_ruling(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {}}))
+        why = "waiting on two dispatched investigations; will act when they return"
+        nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
+              "awaitingWhy": why, "awaitingAt": STAMP,
+              "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP}]}
+        km.jd.append_restore(SID, {self.gid: nd}, {}, BACK + 50)   # the stamp lives in the journal only
+        state = self._read_fails_once(km.jd._overrides_dir() / (SID + ".jsonl"))
+        with contextlib.redirect_stderr(io.StringIO()):
+            self._tick()                                 # the replay logged history-unreadable and skipped
+        self.assertEqual(len(self.loads), 1)
+        self.assertEqual(state["fired"], 1)
+        self.assertNotIn(SID, km._lift_seen, "the journal was not read: no entry")
+        self._tick()                                     # nothing on disk moved
+        self.assertGreaterEqual(len(self.loads), 2, "the journal reads now, unchanged: loaded anyway")
+        nodes = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"]
+        self.assertIn(self.gid, nodes, "the restore replayed and the node was saved back")
+        self.assertIsNone(nodes[self.gid].get("awaitingWhy") or None, "...with its stamp lifted")

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -161,6 +161,23 @@ class SessionLevelStamp(unittest.TestCase):
         self.assertEqual(km._session_stamp_full(SID),
                          ("g1", 200, "slurm 4821 regenerating the parts", "job", ()))
 
+    def test_the_stamp_reader_takes_the_shared_view(self):
+        # _session_stamp_read's one store read per key takes the shared read-only view (kernel/judge.py
+        # load_goals_shared): it reads nodes and status and writes nothing
+        self._seed(("g1", "waiting on the nightly batch", 200))
+        km.jd._shared_clear()
+        km._SESSION_STAMP_CACHE.clear()
+        private, o_load = [], km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        stats0 = km.jd.shared_store_stats()
+        try:
+            full, _tops, _deleg = km._session_stamp_read(SID)
+        finally:
+            km.jd.load_goals = o_load
+        self.assertEqual(full[0], "g1", "the stamp names the goal")
+        self.assertEqual(private, [], "the writer's loader is never asked")
+        self.assertEqual(km.jd.shared_store_stats()["miss"] - stats0["miss"], 1)
+
     def test_session_stamp_takes_the_freshest_across_ALL_tops(self):
         # session-level, so it scans every goal (not one subtree like _goal_awaiting_stamp) for the newest
         self._seed(("g1", "the older wait, padded", 100), ("g2", "the newer wait", 300))

--- a/tests/test_kernel_deferral_sweep.py
+++ b/tests/test_kernel_deferral_sweep.py
@@ -155,6 +155,28 @@ class ReasonsRetireOnTheirEvents(SweepBase):
                          "a live captioner call must not re-dress a durable hold")
 
 
+class SharedViewRead(SweepBase):
+    """The sweep's one store read per session takes the shared read-only view (kernel/judge.py
+    load_goals_shared): it reads nodes, status and confirming and writes nothing, so two ticks over an
+    unchanged store parse it once."""
+
+    def test_the_sweep_reads_the_shared_view(self):
+        self._rec("a reason a future reviver minted")       # an unknown why stands: the record survives both ticks
+        jd._shared_clear()
+        private, o_load = [], jd.load_goals
+        jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        stats0 = jd.shared_store_stats()
+        try:
+            km._deferral_sweep_tick(NOW)
+            km._deferral_sweep_tick(NOW)
+        finally:
+            jd.load_goals = o_load
+        stats = jd.shared_store_stats()
+        self.assertIn(GID, self._d["deferred"])
+        self.assertEqual(private, [], "the writer's loader is never asked")
+        self.assertEqual((stats["miss"] - stats0["miss"], stats["hit"] - stats0["hit"]), (1, 1), "one parse, then a hit")
+
+
 class HardRuleAndRoutingPins(unittest.TestCase):
     """build_feed's presentation, pinned by source (the build_feed test pattern)."""
 

--- a/tests/test_kernel_fork.py
+++ b/tests/test_kernel_fork.py
@@ -270,7 +270,7 @@ class CourierEpisodeFloor(unittest.TestCase):
              "to_id": self.RECIP, "body": "what subnet is the new box on?"}) + "\n")
         self.calls = []
         jd.courier_llm = lambda *a, **k: self.calls.append(1) or '{"verdict": "delegating", "goal": 0, "text": "x"}'
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache.clear()
         jd._postal_from_memo["key"] = None
         # the marker rides the comment-wrapped wire form (see test_courier_origin_host)
@@ -283,7 +283,7 @@ class CourierEpisodeFloor(unittest.TestCase):
         (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
          jd.MESSAGES, jd.ERRORS, jd.EPIDIR, jd.courier_llm) = self.saved
         jd._postal_from_memo["key"] = None
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -95,6 +95,10 @@ class WiringPins(unittest.TestCase):
         src = inspect.getsource(km._compact_goal_stores)
         self.assertIn("jd._disk_memo_evict_absent()", src)
         self.assertIn("jd._shared_evict_absent()", src)
+        # ...and, for the two memos holding PARSED stores, the entries of stores no discovered session owns
+        # (review find, 2026-09-08: neither had a cap)
+        self.assertIn("jd._shared_evict_unowned(", src)
+        self.assertIn("_goals_memo_evict_unowned(", src)
 
 
 class SharedViewInBuilds(unittest.TestCase):
@@ -112,11 +116,18 @@ class SharedViewInBuilds(unittest.TestCase):
         km._timeline_sessions = lambda now, tmux, live_only=False: [
             {"sid": sid, "name": "s%d" % i, "path": os.path.join(self.td.name, "no-such-transcript-%d" % i)}
             for i, sid in enumerate(SIDS)]
+        # the compaction sweep evicts the entries of stores no DISCOVERED session owns, so the three synthetic
+        # stores must be discovered for their entries to survive a sweep (review find, 2026-09-08)
+        self.saved_discover = jd.discover
+        self.discovered = list(SIDS)
+        jd.discover = lambda now, window=None, forks=True: [(sid, "/dev/null", None, "s%d" % i)
+                                                            for i, sid in enumerate(SIDS) if sid in self.discovered]
         self.stats0 = jd.shared_store_stats()
 
     def tearDown(self):
         for nm, v in self.saved.items():
             setattr(km, nm, v)
+        jd.discover = self.saved_discover
         jd._rebind_state(self.saved_state)
         self.td.cleanup()
 
@@ -272,11 +283,34 @@ class SharedViewInBuilds(unittest.TestCase):
         self.assertEqual(jd.shared_store_stats()["entries"], len(SIDS) - 1)
         self.assertEqual(self._delta("evict"), 1)
 
+    def test_the_compaction_sweep_evicts_the_entries_of_stores_no_discovered_session_owns(self):
+        # The cache had no cap: a store's view stayed resident for the process once read, so a board's whole
+        # history of stores sat in memory (review find, 2026-09-08). The sweep drops the entries of stores no
+        # session in the discover set owns; a later read of one is a miss that refills it.
+        for sid in SIDS:
+            jd.load_goals_shared(sid)
+        self.assertEqual(jd.shared_store_stats()["entries"], len(SIDS))
+        km._compact_goal_stores()
+        self.assertEqual(jd.shared_store_stats()["entries"], len(SIDS), "every store is owned: nothing evicted")
+        self.assertEqual(self._delta("evict"), 0)
+        self.discovered[:] = [SIDS[0]]                     # the other two sessions left the discover window
+        km._compact_goal_stores()
+        self.assertEqual(jd.shared_store_stats()["entries"], 1, "the unowned stores' entries are gone")
+        self.assertEqual(self._delta("evict"), 2)
+        miss0 = self._delta("miss")
+        jd.load_goals_shared(SIDS[1])                      # read again: one miss refills it
+        self.assertEqual(self._delta("miss"), miss0 + 1)
+        self.assertEqual(jd.shared_store_stats()["entries"], 2)
+
 
 class PushSurvivesOneFailedChatBuild(unittest.TestCase):
     """A chat build that raises used to abort the whole push (the cycle-level "push build:" catch returns
     before the feed and the timeline are built). One session's build now fails alone: its frame is skipped
-    this cycle, the other sessions' frames and the timeline still go out, and stderr names it."""
+    this cycle, the other sessions' frames and the timeline still go out, and stderr names it, ONCE per
+    fault episode, with a dashboard bell row beside the stderr line, so the pane that stopped updating is
+    not a silent degrade and a build that fails every cycle is not a traceback every cycle (review find,
+    2026-09-08). The episode is the fault text: a repeat says nothing, a different fault is a new episode,
+    and a build that succeeds ends it."""
     STUBS = ("NAMES", "_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
              "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
              "_retry_parked_creates")
@@ -312,6 +346,10 @@ class PushSurvivesOneFailedChatBuild(unittest.TestCase):
         km._comments_frame = lambda sid, tmux: None
         km._retry_parked_creates = lambda: None
         km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.saved_bell = list(km._SYNC_NOTICES)          # the dashboard bell ring the fault reaches
+        del km._SYNC_NOTICES[:]
+        km._chat_build_faults.clear()                     # no fault episode carried in from another test
+        self.fail_with = "synthetic: this session's chat build fails"
         self.built = []
         self.chat_frames, self.tl_frames = [], []
         self.chat = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: self.chat_frames.append(json.loads(s))}
@@ -326,11 +364,12 @@ class PushSurvivesOneFailedChatBuild(unittest.TestCase):
         km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
         km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
         km._last_tab_order[:] = lo
+        km._SYNC_NOTICES[:] = self.saved_bell
 
     def _build_session(self, sid, now, tmux):
         self.built.append(sid)
-        if sid == self.A:
-            raise RuntimeError("synthetic: this session's chat build fails")
+        if sid == self.A and self.fail_with:
+            raise RuntimeError(self.fail_with)
         return {"type": "session", "id": sid, "name": "api", "events": [{"uuid": "e1", "type": "user"}],
                 "ledger": None, "status": {"state": "waiting"}, "color": None}
 
@@ -346,6 +385,38 @@ class PushSurvivesOneFailedChatBuild(unittest.TestCase):
         self.assertIn("synthetic: this session's chat build fails", err.getvalue())
         self.assertNotIn(self.A, km._built_chat, "no cache entry for the failed build")
         self.assertIn(self.B, km._built_chat)
+        # ...and the dashboard hears it (review find, 2026-09-08): one bell row of the kind a state file that
+        # cannot be read wears, naming the session and the fault, so the user is not left reading the kernel
+        # log to learn why one pane stopped updating
+        rows = list(km._SYNC_NOTICES)
+        self.assertEqual(len(rows), 1, "one bell row for the fault: %r" % rows)
+        self.assertEqual(rows[0]["kind"], "refused")
+        self.assertFalse(rows[0]["ok"], "a fault, not a sync that landed")
+        self.assertIn("web", rows[0]["text"], "the row names the session")
+        self.assertIn("RuntimeError: " + self.fail_with, rows[0]["text"], "...and the fault")
+
+    def test_a_build_that_keeps_failing_the_same_way_is_said_once_until_it_changes_or_succeeds(self):
+        def push():
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                km._push([self.chat, self.tl])
+            return err.getvalue().count("push build: chat %s" % self.A[:8])
+        self.assertEqual(push(), 1, "the first cycle says it")
+        self.assertEqual(push(), 0, "the second cycle, same fault: not again")
+        self.assertEqual(push(), 0)
+        self.assertEqual(len(km._SYNC_NOTICES), 1, "one episode, one bell row")
+        self.fail_with = "synthetic: a different fault on the same session"
+        self.assertEqual(push(), 1, "a different fault is a new episode")
+        self.assertEqual(len(km._SYNC_NOTICES), 2)
+        self.assertIn("a different fault", km._SYNC_NOTICES[-1]["text"])
+        self.fail_with = ""                                   # the build succeeds: the episode is over
+        self.assertEqual(push(), 0)
+        self.assertNotIn(self.A, km._chat_build_faults, "a build that succeeds ends the fault episode")
+        self.assertIn(self.A, km._built_chat, "…and its frame is cached like any other")
+        self.fail_with = "synthetic: this session's chat build fails"
+        km._built_chat.pop(self.A, None)                      # the input moved: the build runs again and fails again
+        self.assertEqual(push(), 1, "the same fault after a success is a new episode, said anew")
+        self.assertEqual(len(km._SYNC_NOTICES), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -1,0 +1,352 @@
+"""The kernel side of the shared read-only goal-store cache (kernel/judge.py load_goals_shared).
+
+kernel/judge.py's load_goals_shared serves one deep-frozen parsed store per file version; this module pins
+WHICH kernel sites load through it (the pusher's read-only sites) and which deliberately do not (every
+writer, the probe-then-write tick jobs and the feed's snapshot read), and drives the builders
+over synthetic stores to show the cache in effect: each store parsed once per version across builds, the
+frozen guard reaching a wired site without taking the frame down, the compaction sweep's eviction, and
+one session's failed chat build no longer aborting the whole push. Synthetic fixtures only: placeholder
+sids, invented goal text, transcript paths that do not exist (a lane with no transcript still builds)."""
+import contextlib
+import inspect
+import io
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SIDS = ["66666666-1111-4222-8333-44444444440%d" % i for i in range(3)]   # private to this module (synthetic)
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def _aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def _tm():
+    """One live tmux entry, every key the feed builder reads."""
+    return {"state": "ready", "color": "#888888", "since": NOW - 60, "model": "", "effort": "",
+            "context": None, "backend": "tmux"}
+
+# The pusher-side READ-ONLY sites, wired (kernel.py). Each reads nodes / status / seams / confirming / log
+# rows and hands nothing to rollup_status, record_verdict or save_goals (audited 2026-09-06; the deep
+# freeze would raise if one did). Five sit inside a per-session catch of their own and take the shared view
+# directly; the three builders (four sites) read it through the per-session store-fault boundary
+# (load_goals_shared_or_fault), so one session's unreadable store costs that session's goal-derived data
+# and files one row per fault episode, never the frame.
+WIRED = {"_open_top_goal": 1, "_deferral_sweep_tick": 1, "_session_stamp_read": 1, "_owned_yield_why": 1,
+         "_msg_sum_scan_session": 1}
+WIRED_BOUNDARY = {"build_feed": 1, "build_session": 2, "build_timeline": 1}
+# NOT wired, on purpose: the awaiting-lift job and the background-placement reader do a probe-then-write
+# two-phase read, and the feed's pass snapshot has its own memo (_feed_goals stays on the writer's loader,
+# bare or behind load_goals_or_fault).
+UNWIRED = ("_lift_spent_awaiting", "_bg_placed_tops", "_feed_goals")
+
+
+class WiringPins(unittest.TestCase):
+    def test_the_read_only_pusher_sites_load_through_the_shared_cache(self):
+        for name, n in WIRED.items():
+            src = inspect.getsource(getattr(km, name))
+            self.assertEqual(src.count("jd.load_goals_shared("), n, "%s: shared loads" % name)
+            self.assertEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 0,
+                             "%s: no writer-style load left" % name)
+        for name, n in WIRED_BOUNDARY.items():
+            src = inspect.getsource(getattr(km, name))
+            self.assertEqual(src.count("jd.load_goals_shared_or_fault("), n, "%s: shared loads through the boundary" % name)
+            self.assertEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 0,
+                             "%s: the boundary reads the shared view, not the writer's loader" % name)
+
+    def test_the_writers_and_the_two_phase_readers_stay_on_load_goals(self):
+        for name in UNWIRED:
+            src = inspect.getsource(getattr(km, name))
+            self.assertEqual(src.count("jd.load_goals_shared(") + src.count("jd.load_goals_shared_or_fault("), 0,
+                             "%s: not wired" % name)
+            self.assertGreaterEqual(src.count("jd.load_goals(") + src.count("jd.load_goals_or_fault("), 1,
+                                    "%s: still the writer's loader, bare or behind the boundary" % name)
+
+    def test_the_compaction_sweep_evicts_the_caches_absent_paths(self):
+        src = inspect.getsource(km._compact_goal_stores)
+        self.assertIn("jd._disk_memo_evict_absent()", src)
+        self.assertIn("jd._shared_evict_absent()", src)
+
+
+class SharedViewInBuilds(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd._rebind_state(Path(self.td.name))         # clears the cache and lifts any earlier off switch
+        self.saved = {nm: getattr(km, nm) for nm in ("_timeline_sessions", "_derive_judging")}
+        for i, sid in enumerate(SIDS):
+            s = {"rompUuid": sid, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+                 "placements": {}, "status": {}}
+            jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "x", "text": "Goal %d" % i}], [])
+            jd.rollup_status(s, session_closed=False)
+            jd.save_goals(sid, s)
+        km._timeline_sessions = lambda now, tmux, live_only=False: [
+            {"sid": sid, "name": "s%d" % i, "path": os.path.join(self.td.name, "no-such-transcript-%d" % i)}
+            for i, sid in enumerate(SIDS)]
+        self.stats0 = jd.shared_store_stats()
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        jd._rebind_state(self.saved_state)
+        self.td.cleanup()
+
+    def _delta(self, key):
+        return jd.shared_store_stats()[key] - self.stats0[key]
+
+    def _errors(self):
+        try:
+            return [json.loads(l) for l in jd.ERRORS.read_text().splitlines() if l.strip()]
+        except FileNotFoundError:
+            return []
+
+    def _transcript(self, sid, recs):
+        p = Path(self.td.name) / (sid + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        km._parse_cache.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        return str(p)
+
+    def _private_loads(self):
+        """Count the writer's loader per sid while the context runs: the wired sites must never reach it."""
+        seen, o_load = [], jd.load_goals
+        jd.load_goals = lambda fsid: (seen.append(fsid), o_load(fsid))[1]
+        self.addCleanup(setattr, jd, "load_goals", o_load)
+        return seen
+
+    def test_two_chat_builds_parse_the_store_once(self):
+        # build_session's two loads (the seam-aware seg ids, the ledger tree) take the shared view: two
+        # builds of one tab parse its store once, and the writer's loader is never asked for it.
+        sid = SIDS[0]
+        tpath = self._transcript(sid, [_uline(NOW - 500, "start the next piece", "u1"),
+                                       _aline(NOW - 480, "Done.", "a1", "u1")])
+        sess = [{"sid": sid, "name": "s0", "anchor": None, "path": tpath, "mtime": NOW}]
+        private = self._private_loads()
+        with mock.patch.object(km, "_sessions", lambda now, window=None, forks=True: list(sess)):
+            m1 = km.build_session(sid, NOW, {})
+            m2 = km.build_session(sid, NOW, {})
+        self.assertTrue(m1 and m1["ledger"]["tree"], "premise: the tab's ledger tree shows the goal")
+        self.assertNotIn(sid, private, "the writer's loader was never asked for the tab's store")
+        self.assertEqual(self._delta("miss"), 1, "one parse across two builds")
+        self.assertGreaterEqual(self._delta("hit"), 3, "the first build's second load and both of the second's are hits")
+        self.assertEqual(json.dumps(m1["ledger"]), json.dumps(m2["ledger"]))
+
+    def test_the_feeds_peer_origin_badge_reads_the_shared_peer_view(self):
+        # build_feed's card loop reads a delegation-origin badge's liveness from the PEER's store through the
+        # shared boundary (load_goals_shared_or_fault), never the writer's loader.
+        a, b = SIDS[0], SIDS[1]
+        s = jd.load_goals(b)
+        s["nodes"][b + ":g1"]["origin"] = {"peer": a, "goalId": a + ":g1"}
+        jd.save_goals(b, s)
+        sessions = [{"sid": x, "name": "s%d" % i, "path": "/nonexistent/%s.jsonl" % x, "anchor": 0, "mtime": 0}
+                    for i, x in enumerate((a, b))]
+        shared, o_shared = [], jd.load_goals_shared_or_fault
+        jd.load_goals_shared_or_fault = lambda fsid: (shared.append(fsid), o_shared(fsid))[1]
+        self.addCleanup(setattr, jd, "load_goals_shared_or_fault", o_shared)
+        with mock.patch.object(km, "_alive_sessions", lambda now, tm: list(sessions)), \
+             mock.patch.object(km, "_warm_fleet_bg", lambda now: None):
+            cards = {c["itemId"]: c for c in km.build_feed(NOW, {a: _tm(), b: _tm()})["asks"]}
+        self.assertIn(a, shared, "the peer's store was read through the shared boundary")
+        self.assertTrue(cards[b + ":g1"]["origin"]["live"], "the peer's goal is open: the badge reads live")
+
+    def test_the_message_summary_scan_holds_the_shared_view(self):
+        # _msg_sum_scan_session hands the store to _segs_seam for the seam-aware seg ids: the shared
+        # read-only view, which apply_seams only reads.
+        sid = SIDS[0]
+        tpath = self._transcript(sid, [_uline(NOW - 500, "start the next piece", "u1"),
+                                       _aline(NOW - 480, "Done.", "a1", "u1")])
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (jd.CAPDIR / (sid + ".jsonl")).write_text(json.dumps(
+            {"id": "u1", "grain": "segment", "t": NOW - 500, "caption": "Starting the next piece"}) + "\n")
+        seen, o_segs = [], km._segs_seam
+        km._segs_seam = lambda turn, store: (seen.append(store), [])[1]
+        self.addCleanup(setattr, km, "_segs_seam", o_segs)
+        km._msg_sum_scan_session(sid, tpath, NOW)
+        self.assertTrue(seen, "the scan reached the seg loop")
+        self.assertTrue(all(isinstance(st, jd.FrozenStore) for st in seen), "the shared view, not a private load")
+        self.assertEqual(self._delta("miss"), 1)
+
+    def test_two_timeline_builds_parse_each_store_once(self):
+        fills = []
+        o_freeze = jd._freeze_store
+        jd._freeze_store = lambda store, fsid=None: (fills.append(1), o_freeze(store, fsid))[1]
+        try:
+            tl1 = km.build_timeline(NOW, {}, with_bars=True)
+            tl2 = km.build_timeline(NOW, {}, with_bars=True)
+        finally:
+            jd._freeze_store = o_freeze
+        self.assertEqual(len(fills), len(SIDS), "one parse per store across two full builds")
+        self.assertEqual(self._delta("miss"), len(SIDS))
+        self.assertGreaterEqual(self._delta("hit"), len(SIDS), "the second build's loads are all hits")
+        self.assertEqual(self._delta("poisoned"), 0, "the build wrote nothing into the shared views")
+        self.assertEqual(sorted(l["id"] for l in tl1["sessions"]), sorted(SIDS))
+        self.assertEqual(json.dumps(tl1["turns"]), json.dumps(tl2["turns"]), "same inputs, same frame")
+
+    def test_the_store_a_wired_site_works_on_is_the_frozen_shared_view(self):
+        seen, raised = [], []
+
+        def spy(sid, caps, goals, t0, out, seg_ends=None):
+            seen.append(goals)
+            for attempt in (lambda: goals["status"].__setitem__("x", "y"),
+                            lambda: goals["nodes"][sid + ":g1"]["log"].append({"kind": "done"}),
+                            lambda: goals["nodes"][sid + ":g1"].__setitem__("text", "edited")):
+                try:
+                    attempt()
+                except jd.FrozenStoreError:
+                    raised.append(1)
+            return self.saved["_derive_judging"](sid, caps, goals, t0, out, seg_ends)
+        km._derive_judging = spy
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            tl = km.build_timeline(NOW, {}, with_bars=True)
+        self.assertEqual(len(seen), len(SIDS))
+        # The FIRST lane holds the shared view and every nested write on it raises; the first raise switches
+        # the cache off for the process, so the lanes after it are served private, mutable load_goals stores
+        # (the fallback) — their writes land on a throwaway copy and nothing shared is touched.
+        self.assertIsInstance(seen[0], jd.FrozenStore, "the wired site holds the shared view")
+        self.assertEqual(len(raised), 3, "every nested write on the shared view raised")
+        self.assertTrue(all(type(g) is dict for g in seen[1:]), "later lanes take the fallback (private stores)")
+        self.assertEqual(len(tl["sessions"]), len(SIDS), "the frame still shipped, every lane in it")
+        rows = [r for r in self._errors() if r["err"] == "frozen-store-write"]
+        self.assertEqual(len(rows), 1, "one loud row, naming the writing site")
+        self.assertIn(os.path.basename(__file__), rows[0]["note"])
+        self.assertEqual(jd.shared_store_stats()["off"], 1, "the cache is off for the process")
+        self.assertEqual(self._delta("poisoned"), 3)
+        self.assertEqual(self._delta("fallback"), len(SIDS) - 1)
+        self.assertNotIn("x", seen[0]["status"])         # nothing landed on the shared object
+        self.assertEqual(seen[0]["nodes"][seen[0]["rompUuid"] + ":g1"]["text"], "Goal 0")
+        self.assertEqual(seen[0]["nodes"][seen[0]["rompUuid"] + ":g1"]["log"], [])
+        self.assertEqual(jd.load_goals(SIDS[1])["nodes"][SIDS[1] + ":g1"]["text"], "Goal 1",
+                         "a write on a fallback store reached no file")
+        # the board keeps rendering: the next build's loads take load_goals (private, mutable) and succeed
+        km._derive_judging = self.saved["_derive_judging"]
+        km.build_timeline(NOW, {}, with_bars=True)
+        self.assertEqual(self._delta("fallback"), 2 * len(SIDS) - 1)
+
+    def test_open_top_goal_reads_the_shared_view_and_answers_after_a_write_attempt(self):
+        sid = SIDS[0]
+        self.assertEqual(km._open_top_goal(sid), sid + ":g1")
+        self.assertEqual(self._delta("miss"), 1)
+        self.assertEqual(km._open_top_goal(sid), sid + ":g1")
+        self.assertEqual(self._delta("hit"), 1)
+        with self.assertRaises(jd.FrozenStoreError):
+            jd.load_goals_shared(sid)["status"][sid + ":g1"] = "completed"
+        self.assertEqual(km._open_top_goal(sid), sid + ":g1", "still answers with the cache off")
+        self.assertEqual(self._delta("fallback"), 1)
+
+    def test_the_compaction_sweep_evicts_a_removed_stores_entry(self):
+        for sid in SIDS:
+            jd.load_goals_shared(sid)
+        self.assertEqual(jd.shared_store_stats()["entries"], len(SIDS))
+        os.unlink(jd.GOALDIR / (SIDS[0] + ".json"))
+        km._compact_goal_stores()
+        self.assertEqual(jd.shared_store_stats()["entries"], len(SIDS) - 1)
+        self.assertEqual(self._delta("evict"), 1)
+
+
+class PushSurvivesOneFailedChatBuild(unittest.TestCase):
+    """A chat build that raises used to abort the whole push (the cycle-level "push build:" catch returns
+    before the feed and the timeline are built). One session's build now fails alone: its frame is skipped
+    this cycle, the other sessions' frames and the timeline still go out, and stderr names it."""
+    STUBS = ("NAMES", "_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
+             "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
+             "_retry_parked_creates")
+    A, B = SIDS[1], SIDS[2]
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        names = Path(self.tmp) / "names"
+        names.mkdir()
+        (names / self.A).write_text("web\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        (names / self.B).write_text("api\t/proj/TESTHOST/app\t#1EA1EB\twhite\n")
+        self.tx = {}
+        for sid in (self.A, self.B):
+            self.tx[sid] = Path(self.tmp) / (sid + ".jsonl")
+            self.tx[sid].write_text('{"type": "user"}\n')
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (km.jd.STATE, dict(km._built_chat), dict(km._prev_chat_events),
+                            dict(km._prev_chat_ledger), list(km._last_tab_order))
+        km.NAMES = names
+        km.jd.STATE = Path(self.tmp) / "state"
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": self.A, "api": self.B}
+        km._chat_tab_sessions = lambda now, tmux: [
+            {"sid": sid, "name": nm, "path": str(self.tx[sid]), "anchor": sid}
+            for sid, nm in ((self.A, "web"), (self.B, "api"))]
+        km.build_session = self._build_session
+        km._cached_feed = lambda now, tmux, sig, connect=False: {"working": [], "awaiting": [], "now": now}
+        km._cached_timeline = lambda now, tmux, sig, connect=False: {"turns": {}, "judging": [], "messages": [],
+                                                                      "now": now}
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.built = []
+        self.chat_frames, self.tl_frames = [], []
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "send": lambda s: self.chat_frames.append(json.loads(s))}
+        self.tl = {"app": "timeline", "alive": True, "sent": {}, "send": lambda s: self.tl_frames.append(json.loads(s))}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, bc, pe, pl, lo = self.saved_state
+        km.jd.STATE = st
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+
+    def _build_session(self, sid, now, tmux):
+        self.built.append(sid)
+        if sid == self.A:
+            raise RuntimeError("synthetic: this session's chat build fails")
+        return {"type": "session", "id": sid, "name": "api", "events": [{"uuid": "e1", "type": "user"}],
+                "ledger": None, "status": {"state": "waiting"}, "color": None}
+
+    def test_the_other_sessions_frames_and_the_timeline_still_go_out(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._push([self.chat, self.tl])
+        self.assertEqual(sorted(self.built), sorted([self.A, self.B]), "both builds were attempted")
+        sessions = [f for f in self.chat_frames if f.get("type") == "session"]
+        self.assertEqual([f["id"] for f in sessions], [self.B], "the surviving session's frame went out")
+        self.assertIn("bars", [f["type"] for f in self.tl_frames], "the push went on to the timeline")
+        self.assertIn("push build: chat %s" % self.A[:8], err.getvalue(), "stderr names the failed build")
+        self.assertIn("synthetic: this session's chat build fails", err.getvalue())
+        self.assertNotIn(self.A, km._built_chat, "no cache entry for the failed build")
+        self.assertIn(self.B, km._built_chat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -143,6 +143,18 @@ class GoalCompactionTest(unittest.TestCase):
         self.assertIn(other, km._compact_seen, "...so the next sweep retries it")
         self.assertIn(g("g1"), json.loads((jd.GOALARCHDIR / (other + ".json")).read_text())["nodes"],
                       "and archives its cleared top")
+    def test_g_the_sweep_evicts_the_disk_memo_entries_of_removed_stores(self):
+        """save_goals' no-op check memoizes each store file's identity; the sweep's start is where entries
+        for stores that no longer exist are dropped (2026-09-06)."""
+        jd.save_goals(SID, jd.load_goals(SID))        # a no-op save fills the entry for this store
+        gone = "11111111-2222-3333-4444-666666666666"
+        jd.save_goals(gone, {"rompUuid": gone, "seq": 0, "nodes": {}, "placements": {}, "status": {}})
+        jd.save_goals(gone, jd.load_goals(gone))
+        self.assertIn(str(jd.GOALDIR / (gone + ".json")), jd._DISK_CONTENT)
+        (jd.GOALDIR / (gone + ".json")).unlink()
+        km._compact_goal_stores()
+        self.assertNotIn(str(jd.GOALDIR / (gone + ".json")), jd._DISK_CONTENT, "the removed store's entry is gone")
+        self.assertIn(str(jd.GOALDIR / (SID + ".json")), jd._DISK_CONTENT, "the live store's entry stays")
 
     def test_f_undo_clear_wires_in_the_archive_restore_before_unsetting_the_flag(self):
         import inspect

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -86,6 +86,22 @@ class OwnedYieldAwaiting(unittest.TestCase):
         self.assertEqual(why, "waiting on a background command: " + DESC,
                          "the same why the card shows — one story, both surfaces")
 
+    def test_owned_yield_why_takes_the_shared_view(self):
+        # the rule's one store read takes the shared read-only view (kernel/judge.py load_goals_shared):
+        # it reads nodes and status and writes nothing
+        self._store()
+        km.jd._shared_clear()
+        private, o_load = [], km.jd.load_goals
+        km.jd.load_goals = lambda fsid: (private.append(fsid), o_load(fsid))[1]
+        stats0 = km.jd.shared_store_stats()
+        try:
+            why = km._owned_yield_why(SID, self.path)
+        finally:
+            km.jd.load_goals = o_load
+        self.assertEqual(why, "waiting on a background command: " + DESC)
+        self.assertEqual(private, [], "the writer's loader is never asked")
+        self.assertEqual(km.jd.shared_store_stats()["miss"] - stats0["miss"], 1)
+
     def test_a_dispatch_that_predates_the_block_proves_nothing(self):
         # the block is the NEWER event: the thread has not moved past it, so this is a genuine needs-you
         self._store(blk_t=DISPATCH + 50)

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -535,8 +535,9 @@ class TwoPhaseRewindTiming(unittest.TestCase):
         # asks for the whole armed window — unbounded on a bare delete
         src = inspect.getsource(km.build_session)
         # the read goes through the per-session boundary (a faulting store renders an EMPTY tree
-        # instead of failing every tab's build), and the hold filter is applied to what it read
-        self.assertIn("gstore, gfault = jd.load_goals_or_fault(sid)", src)
+        # instead of failing every tab's build) onto the shared read-only view, and the hold filter is
+        # applied to what it read
+        self.assertIn("gstore, gfault = jd.load_goals_shared_or_fault(sid)", src)
         self.assertIn("gstore = _apply_rewind_hold(sid, gstore)", src)
 
     def test_the_boot_pass_resolves_a_hold_the_transcript_moved_past_out_of_band(self):

--- a/tests/test_mint_hygiene.py
+++ b/tests/test_mint_hygiene.py
@@ -209,7 +209,7 @@ class _PlanWorld(unittest.TestCase):
             if task_plan is not None:
                 em.task_store_plan = lambda fsid: task_plan
             try:
-                jd._PARSE_CACHE.clear()
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
                 jd._plan_session(SID, str(tpath), NOW)
                 store = jd.load_goals(SID)
             finally:

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -47,7 +47,7 @@ SID = "11111111-2222-3333-4444-555555555555"
 # and node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures).
 GOAL_SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
 TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms", "builds", "sends",
-            "goals", "judge", "http"}
+            "goals", "memos", "judge", "http"}
 
 
 def _burn_cpu(seconds):
@@ -114,6 +114,11 @@ class Collector(unittest.TestCase):
         self.assertIn("cpu_ms_sum", snap["judge"])
         self.assertIn("cpu_ms_workers", snap["judge"])
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
+        # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
+        self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain"})
+        self.assertEqual(snap["memos"]["pass"], km._goals_memo_report())
+        self.assertEqual(snap["memos"]["shared"], km.jd.shared_store_stats())
+        self.assertEqual(snap["memos"]["chain"], km.jd.chain_memo_stats())
         for k in ("rss_kb", "threads", "cpu_s", "pid"):
             self.assertIn(k, snap["process"])
         self.assertGreater(snap["process"]["threads"], 0)
@@ -388,6 +393,28 @@ class GoalIoCounters(unittest.TestCase):
         d = self.jd.goal_io_stats()
         d["loads"] = -1
         self.assertNotEqual(self.jd.goal_io_stats()["loads"], -1)
+
+    def test_the_reference_doc_describes_memos_and_routes_the_pushers_loads_there(self):
+        # docs/reference.md read `goals.loads` as every store read; the pusher's loads moved to the shared cache
+        # with this PR, so the doc names the memos section and sends the reader there (review find, 2026-09-08)
+        doc = Path(HERE).parent.joinpath("docs", "reference.md").read_text()
+        self.assertIn("- `memos`:", doc)
+        for k in ("`pass`", "`shared`", "`chain`"):
+            self.assertIn(k, doc)
+        self.assertIn("`memos.shared`", doc)
+
+    def test_the_pushers_shared_loads_count_under_memos_shared_not_under_goals_loads(self):
+        # `goals.loads` is the writer's loader alone; the pusher's read-only loads ride load_goals_shared and
+        # show under memos.shared (review find, 2026-09-08: nine pusher sites left `loads` with the move to the
+        # shared cache, and the doc still read it as every store read). A fill is a miss, a re-read a hit.
+        self.jd.save_goals(GOAL_SID, self.jd.load_goals(GOAL_SID))
+        before, snap0 = self.jd.goal_io_stats(), km._PERF_STATS.snapshot()["memos"]["shared"]
+        self.jd.load_goals_shared(GOAL_SID)
+        self.jd.load_goals_shared(GOAL_SID)
+        after, snap = self.jd.goal_io_stats(), km._PERF_STATS.snapshot()["memos"]["shared"]
+        self.assertEqual(after["loads"], before["loads"], "two shared loads: no writer-side load counted")
+        self.assertEqual((snap["miss"] - snap0["miss"], snap["hit"] - snap0["hit"]), (1, 1),
+                         "...the fill and the hit are the shared cache's, on the snapshot")
 
 
 class JudgeCpu(unittest.TestCase):

--- a/tests/test_planner_episode_floor.py
+++ b/tests/test_planner_episode_floor.py
@@ -81,7 +81,7 @@ class PlannerEpisodeFloor(unittest.TestCase):
     def _plan(self):
         tpath = self.proj / (SID + ".jsonl")
         tpath.write_text("\n".join(json.dumps(r) for r in RECS) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._plan_session(SID, str(tpath), NOW)
         return jd.load_goals(SID)
 

--- a/tests/test_root_ask_anchor.py
+++ b/tests/test_root_ask_anchor.py
@@ -207,7 +207,7 @@ class CourierStoresTheAsk(unittest.TestCase):
         self._llm = jd.courier_llm
         jd.courier_llm = lambda text, menu, declared=None: \
             '{"verdict": "delegating", "goal": 0, "text": "factor the layout engine"}'
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
 
     def tearDown(self):
         jd._delegate_user_rooted = self._rooted

--- a/tests/test_sdk_clear_fork.py
+++ b/tests/test_sdk_clear_fork.py
@@ -60,7 +60,7 @@ class SdkClearForkBase(unittest.TestCase):
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache["fp"] = None
         jd._discover_cache["result"] = None
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         self.now = int(time.time())
         self.cdir = str(Path(self._td) / "work")
         self.proj = jd._proj_dir(self.cdir)

--- a/tests/test_settle_awaits_background_tasks.py
+++ b/tests/test_settle_awaits_background_tasks.py
@@ -101,7 +101,7 @@ class SettleAwaitsBackgroundTasks(unittest.TestCase):
         with open(self.path, "w") as f:
             for r in recs:
                 f.write(json.dumps(r) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._BG_SCAN_CACHE.clear()
 
     def _store(self, **node_extra):

--- a/tests/test_timeline_lineage.py
+++ b/tests/test_timeline_lineage.py
@@ -55,7 +55,7 @@ class TimelineLineageBase(unittest.TestCase):
         jd._rebind_state(Path(self._td))
         jd.PROJECTS = Path(self._td) / "projects"
         jd._discover_cache.clear()
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         km._parse_cache.clear()
         km._dismissed_lanes.clear()   # a durable module-level set: an earlier test file dismissing
         #                               the shared placeholder sid silently filtered these lanes

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -131,7 +131,7 @@ class CourierTracked(unittest.TestCase):
         jd.ERRORS = td / "judge-errors.jsonl"
         jd.courier_llm = lambda *a, **k: self.reply
         self.reply = DELEGATING
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd._discover_cache["result"] = None
         jd._postal_from_memo["key"] = None
@@ -155,7 +155,7 @@ class CourierTracked(unittest.TestCase):
             # the sender must be a DISCOVERED local session for tracked to qualify
             (self.dirs[SENDER] / (SENDER + ".jsonl")).write_text(
                 json.dumps(uline(T0 - 60, "kick off the exporter", "s1")) + "\n")
-        jd._PARSE_CACHE.clear()
+        jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
         jd._discover_cache["fp"] = None
         jd._postal_from_memo["key"] = None
         jd.run_courier(now=T0 + 100)


### PR DESCRIPTION
Seven performance changes on the kernel's goal-store path, in eight commits, plus the review commit described below them: how the judge loads, saves and scans `goals/<sid>.json`, the chain check it runs before writing a goal, and the pusher's read-only loads. Six of them replace a re-read and re-parse of unchanged files with a lookup keyed on file identity: `(st_ino, st_mtime_ns, st_size)` for the store memos, taken by `fstat` on the descriptor the bytes come from so that key and content are one file version, and `(mtime, size)` of the transcript files for the chain memo, the identity `_PARSE_CACHE` already relies on. The seventh (commit 6) marks a store loaded without its override journal, so nothing downstream treats that fallback as an answer. They are one PR because they live in the same code (`kernel/judge.py`'s load, save and chain-check path, the kernel's goals pass and the pusher's builders), rest on one premise (every writer publishes by tmp+rename, so the bytes under an inode never change), and build on each other. Commits 1, 2 and 4 are independent of each other and of the rest; 3 needs 2 (it clears the memo 2 adds at every site that clears the parse cache, and nothing later depends on 3); 5 and 6 are independent of each other; 7 needs 6 (the `_unread` mark keeps a fallback load out of its memo); 8 needs 5 (its fd-based reader) and 6 (a marked store is never published into the cache). Within those constraints each commit can be reviewed or dropped on its own; the review commit touches the code of commits 2, 4, 7 and 8 and the perf snapshot, so it goes with them. The three memo stat readers are reported by `GET /perf` since the review commit (`memos.pass`, `memos.shared`, `memos.chain`); `romp perf` prints no row for them. About 5,800 changed lines at the review head, 71% of them tests (5,300 and 73% before the review commit).

Rebased onto main at db8776fb (2026-09-08, the merge of #1031). Nothing was dropped. One commit was reworked: commit 3's sweep now covers the parse-cache clear that `tests/test_git_pointer_file_bytes.py` (#1028) added, so its count is 91 sites in 35 modules and its corpus scan passes at this base. One conflict, in `tests/test_kernel.py`'s import header, where #1027 and #1047 added `import contextlib` beside the three imports commit 4 adds; both sets are kept. The other six commits are unchanged in content and message. An earlier rebase the same day took upstream's goal-store quarantine (#1019: a store file that exists and cannot be read raises into a per-session boundary, `load_goals_or_fault`, and unparseable bytes are moved aside), which covers what commit 6's store-side mark and commit 8's corrupt-store memo were for, so both were dropped: `_unread` is now the journal-only mark, `load_goals_shared` hands bytes that do not parse to `load_goals` and caches nothing, and the store-read-fails-once lift test duplicated upstream's and went. Three commits were reworked onto it then: commit 5's readers raise on a fault or on a file that is not a store object through `_disk_parse` (the two fault fixtures fault `os.open` as well as `Path.read_text`); commit 7's `run_propagate` keeps #1019's per-session catches around the pass's one shared read, and its identity memo re-takes the identity after the load so a quarantine moving the file under a pre-read key is never memoized; commit 8's builders read the shared view through `load_goals_shared_or_fault`. #1020 (state readers proved before a flag, order or bell write) and #1016 (hidden panes paint once on return) touch `kernel/kernel.py` and the webview beside these changes and merged without conflict; nothing here depends on them. The perf counters (#1003) and the pane telemetry (#1009) are on main, so no commit here depends on an open PR.

## Commits

1. **Judge: the give-up scan parses a goal store only when its file identity changed.** `judge_failure_scan`, called from `_judge_failures` on every timeline build and every dashboard connect push once the goals-directory fingerprint moves, memoizes each store's failed count on `(st_ino, st_mtime_ns, st_size)` taken by `fstat` on the descriptor it reads. The memo is rebuilt from each call's glob and swapped in with one assignment, so a deleted store drops out and concurrent callers never share a mutable dict; a store that fails to parse counts nothing and is retried next call; `_giveup_cause` runs again only when some store's key changed, so the count|cause signature the notification center keys on does not churn per call. The count still comes from raw file content, never a `load_goals` replay, and `_jf_cache` is untouched. Measured on this branch with a throwaway script (40 synthetic stores totalling 1.13 MB, four carrying a failed warn, medians of 15 rounds): 6.5 ms per call before; 5.9 ms cold, 0.26 ms steady, 0.47 ms after one store is republished. `kernel/judge.py`; `tests/test_judge.py::JudgeFailureScanMemo` (11).

2. **Judge: the write-moment chain check is memoized on the inputs the chain graph reads, and the eclipse selection walks the eclipse set only.** `_rewound_away` and `reconcile_rewound_goals` read `em.chain_membership` through `_chain_membership`, a per-session memo keyed on every input the graph reads: the candidate paths and their `(mtime, size)` with the states file's, the resume-fork lineage closure with the from-files' stats, and the pending cut. The key is taken before the build; a build that raises is never memoized; a key whose stat fails bypasses the memo; entries evict oldest-used at 256; `_rebind_state` clears; the on-disk slot is kept apart from the cut slot so arming a cut does not discard the graph. Separately, `_select_eclipsed_chains` builds its child map and text witness over the eclipse set only, with identical verdicts, pinned by four five-way sibling-fork fixtures recorded from the whole-graph version. Measured on this branch (a synthetic 7.7 MB transcript of 24,004 records with one rewound branch and one eclipsed fork, medians of three runs): `chain_membership` with records cached 112 to 125 ms -> 95 to 96 ms; `_rewound_away` 194 to 228 ms cold, 87 to 97 ms on a memo miss with records cached, 0.026 ms on a hit. On the tree it was developed on (a 6.3 MB synthetic transcript): 186 -> 112 ms, and 409 / 148 / 0.026 ms; a CPU profile there of a kernel running a few dozen sessions put the rebuild at 11.5% of interpreter time, the largest single item. `kernel/judge.py`, `kernel/event_model.py`; `tests/test_judge_rewind_cleanup.py::ChainMemo` (17), `tests/test_event_model_golden.py::EclipsedChainSelection` (+4).

3. **Tests: every clear of the judge's parse cache clears the chain memo beside it.** 91 sites in 35 test modules, one substitution checked by grep and by a test (`tests/test_judge_parse_cache.py` scans the test corpus for a parse-cache clear with no chain-memo clear on the same line). Both caches key on the transcript's `(mtime, size)`, so a test that rewrites a fixture in place within one second must clear both, or a memo populated by an earlier test serves a stale verdict for the new bytes; `ChainMemo` pins that hazard with a same-identity in-place rewrite served stale, with no read, until both are cleared. Kept apart from commit 2 so the kernel change reads on its own. No measurement.

4. **Judge pass: a goal store is decoded only when its file changed, and a user punch copies the entry first.** `_begin_goals_pass` keeps the pass snapshot in a memo keyed on each store file's `(st_ino, st_mtime_ns, st_size)`, lists the directory, stats every store and decodes only the ones whose key moved, with the key taken by `fstat` on the descriptor the bytes come from. Files gone from the directory are evicted at the next pass (and, since the review commit, the compaction sweep evicts the entries of stores no discovered session owns). A version that does not decode is remembered under its key, kept out of the snapshot (that session is served live, as before), reported on stderr once per version and decoded again when the file changes. A read that fails (EMFILE under descriptor pressure, EIO) is not remembered: the next pass reads the file again, as every pass did before. `_feed_goals` copies an entry before replaying a user gesture onto it, once per pass per sid, so the shared entry is never mutated. Measured on this branch (60 synthetic stores of 0.5 to 1.0 MB, 45.3 MB, timing `_begin_goals_pass(); _end_goals_pass()`): a steady pass 320 -> 0.3 ms; one republished store 374 -> 9.6 ms; five republished 365 -> 32.7 ms; the cold first pass unchanged (389 -> 393 ms). On the kernel it was developed on, over 12.8 hours with 74 stores, the memo served 704,190 stores and decoded 3,250 (99.5% hits, 0 decode failures). `kernel/kernel.py`; `tests/test_kernel.py::ViewBuilder` (+14 in this commit; +16 at the review head).

5. **save_goals: the no-op check's disk side is memoized by file identity; the CAS still reads the file.** `_disk_entry` keys the file's canonical-content sha1 on `(inode, mtime_ns, size)`, both taken from the same open descriptor, so a stat cannot be paired with a concurrent publisher's bytes. While the identity matches, a no-op check is one open + fstat plus one serialization of the in-memory store, whose hash seeds the memo from the publish's own temp file before the rename when no rebase ran. The CAS never consults the memo: `_disk_rev` reads and parses the file on every call, so a real publish parses once, and an identity collision can only skip a publish of content the file already held, never let a writer pass the CAS on a stale revision. An earlier draft served the CAS from the memo, and review reproduced the failure with three publishes of one store in one clock tick; that interleaving is now a test through real `save_goals` calls. Both readers raise on a read fault or on bytes that are not a store object (#1019's rule, applied to the save path's descriptor readers) and drop the entry, so nothing is published over bytes the save could not read. The compaction sweep evicts entries for removed stores. Measured on this branch (a 1.2 MB synthetic store of 400 nodes, medians over 200 no-op saves and 50 real publishes, two rounds): no-op save 10.8 / 12.6 -> 5.8 / 5.9 ms; real publish 20.9 / 26.1 -> 15.8 / 16.9 ms, the remaining parse being the CAS read; first no-op after a publish 11.1 / 12.9 -> 6.0 / 6.2 ms. On a self-hosted deployment with a 1 MB store: 20.7 -> 8.6 ms, 42.0 -> 22.7 ms and 28.8 -> 8.1 ms, with no-op saves 86% of all saves. `kernel/judge.py`, `kernel/kernel.py`; `tests/test_judge_store_noop_publish.py::DiskMemo` (21), `tests/test_judge_store_cas.py::ReadFaultCas` (+1), `tests/test_kernel_goal_compaction.py` (+1).

6. **A store loaded without its unreadable override journal is marked, and the awaiting lift forgets a ruling made without it.** A store file that exists and cannot be read raises into the per-session boundary, and unparseable bytes are quarantined (#1019, on main), so the one load that answers with less than the files hold is a parsed store whose override journal exists and did not read: `_replay_overrides` returns it without the user's rows and sets a transient `_unread` key (`"journal"`) beside `_baseRev`; an absent journal is not marked, because empty is its content. `save_goals` pops the key and `_NONCONTENT_KEYS` lists it, so it never reaches disk, the content hash or the no-op check. `_lift_spent_awaiting` forgets its `_lift_seen` entry for a marked store, so a swallowed journal read (EMFILE under descriptor pressure, EIO) is retried next cycle instead of standing as a "nothing to lift" ruling until an unrelated input moves or the six-hour wake. The ruling on the store as loaded is unchanged: a stamp in the file still lifts, and the publish carries no mark. No saving to cite: a correctness guard on the existing gate. `kernel/judge.py`, `kernel/kernel.py`; `tests/test_judge_store_cas.py` (+1), `tests/test_kernel_awaiting_lift.py::LiftGateFallback` (2).

7. **Judge: run_propagate reads each goal store once per pass, and the sweeps over unowned stores answer from a file-identity memo.** One `load_goals` object per store serves the recipient scan, the per-ref done check, the recipient maps and the sender loop; each dirty sender is published once after the recipient loop and dropped from the dict, so the next touch reloads with a fresh CAS base. The two sweeps over stores no discovered session owns (`run_propagate`'s absent-sender sweep and `_drain_undiscovered`) answer from `_absent_store_flags`, keyed on the identity of the store, its override journal and its archive, taken before the read so a publish landing under the read costs one extra miss and never a stale hit. A load that fell back (`_unread`) is answered for the pass but never memoized; entries for vanished stores are evicted each sweep; `_rebind_state` clears. The per-session catches #1019 added stand around the shared read: a store that raises files its `pass-crash` row where it is reached and is not kept, so the next touch retries. As this commit shipped, a raise mid-loop lost the pass's unpublished verdicts; the review commit changed that (see below). Measured on this branch (30 synthetic absent stores of about 220 KB plus one sender/recipient pair whose back-reference is already done; `run_propagate` + `_drain_undiscovered` per pass, loads counted by a spy, 7 passes, two rounds): 65 loads and about 40 ms per pass before; 32 loads and 34 to 38 ms on the first pass, then 2 loads and 2.8 ms per steady pass. On the self-hosted 30-session deployment where it was first built, a micro-bench of the pass went 144 -> 24 loads and 74 -> 27 ms, and the memo answered 2214 of 2214 sweep evaluations in a steady window. `kernel/judge.py`; `tests/test_judge_propagate_loads.py` (29, new; 31 at the review head).

8. **Kernel: one parsed goal store per file version for the pusher's read-only sites (load_goals_shared).** The pusher's nine read-only load sites (`_open_top_goal`, `_deferral_sweep_tick`, `_session_stamp_read`, `_owned_yield_why`, both `build_session` loads, `build_feed`'s peer store, `_msg_sum_scan_session`, `build_timeline`) get one deep-frozen parsed store per file version, keyed on the identity of the store, the journal and the archive, plus a byte compare of the store that closes the equal-size same-tick republish the stat key cannot see. The three builders (four sites) read it through `load_goals_shared_or_fault`, the per-session store-fault boundary #1019 added, so one session's unreadable store costs that session's goal-derived data and one row per fault episode, never the frame; the five sites inside a per-session catch of their own take the view directly. The archive key has no byte compare, so an equal-size archive republish onto a recycled inode inside one clock tick, on a kernel without multigrain timestamps, is the one case left; it needs a restore row in the journal to matter. Both loaders share one tail, `_finish_load`, so the shared view equals the writer's. A write to a shared view raises `FrozenStoreError`, files one judge-errors row naming the call-site chain and the sid, and switches the cache off for the process; every later call falls back to `load_goals`, so the board keeps rendering and the misuse is loud. `save_goals` refuses a shared store before its no-op check; the compaction sweep evicts removed stores' entries; a store marked `_unread` is never published into the cache; bytes that do not parse are handed to `load_goals`, which moves them aside (#1019), and nothing is cached for them. This commit also exported `store_key(fsid)`, one stat with no entry consulted, for a view signature that did not exist; the review commit removed it as uncalled. As a companion to the guard, `_push` catches one session's failed chat build and goes on to the other sessions, the feed and the timeline; before, the cycle-level catch returned first (the review commit adds the bell row and the once-per-episode rule for that fault). Measured on this branch with an offline bench of the payload builders (it imports a checkout's kernel in-process and times the builders against a copy of a state directory; offered in its own PR) on a copy of a 31-session state directory (74 stores, 15.1 MB, n=3, medians), commit 7 -> commit 8: `build_timeline` with bars 890 -> 830 ms (-7%); the lanes skeleton 115 -> 61 ms (-47%); a fresh timeline client's connect push 154 -> 83 ms; the steady push cycle 361 -> 293 ms; warm chat builds 6 to 11% lower. On the self-hosted deployment: 771.5 -> 712.2 ms (-8%), with the cache answering 99.8% of shared loads in a steady window (36 entries, 11.9 MB). `kernel/judge.py`, `kernel/kernel.py`; `tests/test_judge_store_cache.py` (26, new; 27 at the review head), `tests/test_kernel_goal_cache_wiring.py` (11, new; 13 at the review head), one behaviour test each in `tests/test_kernel_deferral_sweep.py`, `tests/test_kernel_awaiting_stamp.py` and `tests/test_kernel_owned_yield_awaiting.py`, `tests/test_kernel_rewind.py` (one source pin re-pointed).

9. **Review fixes: a failed chat build rings the bell, the counters and docs match the memos, a mid-loop raise keeps the verdicts already reached.** The review commit, not one of the eight; described next.

## Review commit

The review commit changed six things on top of the eight commits. A session whose chat build raises is named once per fault episode, on stderr with the traceback and as a dashboard bell row of kind `refused` (`_chat_build_fault` / `_chat_build_ok` in `kernel/kernel.py`; the episode is the fault text: an identical repeat says nothing, a different fault on the same session is a new episode, and a build that succeeds ends it), so the pane that stopped updating is not a silent degrade and a build that fails every cycle is not a traceback every cycle. `GET /perf` gains `memos.pass`, `memos.shared` and `memos.chain` from the three stat readers (`_goals_memo_report`, `shared_store_stats`, `chain_memo_stats`), `goals.loads` is documented as the writer's loader alone with the pusher's loads under `memos.shared` (`docs/reference.md`, the `_PerfStats.snapshot` docstring, the `_GOAL_IO` note), and `docs/judges.md`'s judge-errors kinds list names `frozen-store-write` and `frozen-store-save`. In `run_propagate`, a raise mid-loop publishes the senders reached before it and re-raises, the sender being applied at the raise dropped unpublished for the next pass to re-derive, and one sender's failed publish no longer stops the others (`_publish_dirty`: the first failure is raised once the rest are out). The judge-pass memo's documented blind spot (same inode, same size, mtime put back) is pinned by a test like its two siblings' are. The compaction sweep after each judge pass evicts from both parsed-store memos, the judge pass's and the shared cache's, the entries of stores no discovered session owns (`_goals_memo_evict_unowned`, `_shared_evict_unowned`, called from `_compact_goal_stores` on the producer thread after the tiers join), so neither grows without bound; the price is one decode at the next pass for an evicted store the pass still lists, and a `discover` that raises evicts nothing. `store_key` is removed: it had no caller, and the three stat readers now have `GET /perf` as their consumer. On the bare `_PARSE_CACHE.clear()` in `tests/test_git_pointer_file_bytes.py`, no change: the rebase paired it and the corpus scan finds no bare site on this head. Its tests are listed under Tests.

## Nothing on the board changes

Cards, lanes and chat pages render the same rows from the same data. The one visible addition is the review commit's bell row when a session's chat build fails (below). Every memo serves what a fresh parse would, and the tests pin it:

- A store's memoized parse, failed count, chain verdict, no-op answer and predicate flags change only when a file identity changes. The judge-pass memo (commit 4) and the disk memo (commit 5) have one test per key component (size alone, mtime_ns alone, inode alone) that fails with that component dropped; the judge-pass memo's blind spot (same inode, same size, mtime put back serves the earlier parse) is pinned as the documented exception since the review commit. The other memos pin invalidation per input rather than per component: the failure scan on a republish and a delete; the absent-store memo on a journal append, a store publish and an archive change, with the same-size same-mtime in-place rewrite pinned as its documented blind spot; the shared cache on the same three inputs, plus the byte compare on an equal-size in-place rewrite with a pinned mtime (the test reads the identity through `_file_key`; the `store_key` pin went with the function); the chain memo, keyed on (mtime, size) of the transcript, states and lineage files, on a transcript append, a states row that moves only the states file's stat, and a from-file leaving the closure.
- `save_goals`' CAS reads the file on every call, and a publish is a rename of a fresh temp, so a changed file is a new identity and no memo answers "unchanged" where a full compare would not.
- A store file that exists and cannot be read raises into the per-session boundary, and bytes that do not parse are moved aside (#1019, on main); a journal that exists and cannot be read marks the store `_unread`, and the awaiting-lift gate, the absent-store memo and the shared cache never memoize a marked load, so their next cycle or pass retries the read, and the journal keeps filing its `history-unreadable` row per load (commits 6 to 8). The judge-pass memo does not remember a failed read: the next pass reads the store again. It remembers a version that does not decode under that version's key, out of the snapshot and said once on stderr, and decodes the file again when it changes; the feed's live read of that session quarantines the file (commit 4). The shared cache hands such bytes to `load_goals` and caches nothing (commit 8).
- A write to a shared read-only view raises and files one judge-errors row; the cache switches off and the board keeps rendering from private loads.

Behaviour changes to know about:

- Parsed stores stay resident between judge passes (commit 4), and the shared cache holds the raw bytes plus the frozen objects of the stores the pusher reads (commit 8). Before, the pass snapshot was freed at `_end_goals_pass`. The review commit bounds both by the live board: the compaction sweep after each pass evicts from both memos the entries of stores no session in the discover window owns (as posted, the two held every store the directory had, tens of MB for 74 stores: about 14 MB of bytes plus 28 MB of frozen objects in the shared cache alone). An evicted store the pass still lists is decoded once at the next pass.
- An undecodable goal store logs one stderr line per file version, and a store whose read fails in the judge pass logs one per pass; both were silent before (commit 4). A journal that stays unreadable is re-read every cycle and logs one `history-unreadable` row per load (commit 6); a store that stays unreadable is the boundary's business (#1019: one `store-unreadable` row per fault episode). All are intended: a file the kernel cannot read should be visible, not swallowed.
- `store["rev"]` after a publish is the revision the CAS loop settled on plus one, instead of a fresh read after the loop; the two differ only when the four-iteration loop exhausts without settling (commit 5).
- `run_propagate` accumulates a sender's courier verdicts across the recipient loop and writes them once per dirty sender after the loop, where each was persisted per ref before (commit 7). Since the review commit, a raise mid-loop publishes the senders reached before it and then re-raises; only the sender being applied at the raise is dropped unpublished (a verdict recorded without its rollup is no verdict), and the next pass re-derives it from the recipient's completion, forward-only. One sender's failed publish does not stop the others; the first failure is raised once the rest are out.
- One session's failed chat build no longer aborts the push cycle (commit 8): that session's frame is skipped for the cycle, and the other sessions, the feed and the timeline still ship. Before, a build that failed the same way every cycle froze every client's push for as long as its input stood. Since the review commit the fault is named once per episode, on stderr with the traceback and as a bell row of kind `refused` (the kind a state file that cannot be read wears) naming the session and the fault; as posted, the traceback was written every cycle and nothing reached the dashboard.

## Tests

Red first: every commit's tests were run against the code before its change, then green after it.

- Commit 1: `JudgeFailureScanMemo` against the base body: 6 failed at setUp (`_jf_store_memo` absent). With only the two memo globals stubbed in, 4 of 6 fail on their assertions (6 parses where 3 are expected; the surviving store re-parsed after a delete; the cause recomputed twice; the good store parsed twice beside a broken one) and the two behaviour-preserving tests pass. After: 11 passed; `tests/test_judge.py` 526/526.
- Commit 2: `ChainMemo` 15/15 red on the old code (`_CHAIN_MEMO` absent). Then five mutations applied to the finished code, each turning exactly its test red: an unconditional build; the states file dropped from the key; the closure and the from-file stats dropped; the key taken after the build; the rebind clear removed. The four new `EclipsedChainSelection` fixtures pass on both versions of `_select_eclipsed_chains` by design (identity pins recorded from the whole-graph version). After: the two modules pass (`ChainMemo` 17).
- Commit 3: mechanical, verified by grep and by a test: 91 `_PARSE_CACHE.clear()` sites in 35 modules, zero without a memo clear on the same line; the scan goes red with one site reverted.
- Commit 4: the 8 `ViewBuilder` tests against the unchanged kernel: 8 failed (`_goals_memo_decode` and `_goals_memo` absent). The read-failure test was also run against a memo that handled read and decode failures in one branch: red on the assertion that the failed read left no memo entry. After: 14 passed (`ViewBuilder` 336). `ui/webview/feed-move-ack.test.ts` pins two lines of this region's source text; both kept, `npm test` 3130/3130.
- Commit 5: `DiskMemo` against the pre-commit code: 18 errors at setUp (`_disk_read` absent) and `test_kernel_goal_compaction`'s new test on `_DISK_CONTENT`. With the seams stubbed (the memo hit disabled, the fresh `rev` read restored): a warm no-op save performs five reads of the store path where zero are expected, and a real publish parses three times where one is. After: the two modules pass (`DiskMemo` 21), including the two-thread `save_goals` hammer.
- Commit 6: the `test_judge_store_cas.py` journal test fails on the missing key (`None != 'journal'`). The `LiftGateFallback` tests fail without the `_lift_seen.pop` guard (at tick 1 the entry stands after the fallback; at tick 2 the session is skipped, one load in total, the stamp stands) and with a guard that skipped the marked store instead of ruling on it (the stamp in the file stands). After: both modules pass.
- Commit 7: 29/29 red on the pre-change code at the spy install (`_absent_store_flags` absent). With the spy install skipped, 19 fail, four of them on the load counts and the single publish (the sender loaded 3 times where 1; `rev` advanced 4 where 2; unchanged absent stores parsed 2 to 3 times where 1; every absent store re-parsed after one changed). Spy sanity: swapping the identity and the read in `_get` fails exactly the identity-order test. After: 29 passed, and every module that calls `run_propagate` passes.
- Commit 8: against the pre-change code, `SharedStoreCache::test_two_loads_of_an_unchanged_store_return_one_object_and_parse_once` fails on the missing loader, `WiringPins` on the call-site pins (`0 != 1 : _open_top_goal: shared loads`) and the rewind pin on the missing `load_goals_shared` text: every cache test and wiring pin red across the two new modules. After: the two modules pass (26 + 11), and each of the three site modules' behaviour tests goes red with its site moved back to the writer's loader. The guard was also exercised by hand in an isolated kernel: a nested write raised `FrozenStoreError`, one `frozen-store-write` judge-errors row named the site and the sid, `shared_store_stats()["off"]` read 1, and `_open_top_goal` and `build_timeline` kept answering from private loads.
- The review commit: in `tests/test_kernel_goal_cache_wiring.py`, `PushSurvivesOneFailedChatBuild` asserts one `refused` bell row naming the session and the fault, and a new test walks an episode (the same fault said once across three cycles, a different fault a new episode, a success ending it, the same fault after a success said anew); `SharedViewInBuilds` gains the compaction sweep's eviction of unowned entries (nothing evicted while every store is owned, two evicted when two sessions leave the discover window, a re-read one miss that refills), and `WiringPins` pins the two eviction calls in `_compact_goal_stores`' source. In `tests/test_kernel.py::ViewBuilder`, the same eviction for the judge-pass memo (with the one-decode price at the next pass) and the blind-spot pin. In `tests/test_judge_propagate_loads.py`, a `_presumed_closed` that trips on the second sender leaves the first sender's verdict on disk, the second unpublished, and the next pass re-deriving only it; a `save_goals` that fails for one sender leaves the other's publish landed. In `tests/test_perf_stats.py`, the snapshot carries `memos` with the three readers' dicts, `docs/reference.md` names the section, and two shared loads count one miss and one hit under `memos.shared` with `goals.loads` unmoved. In `tests/test_judge_store_cache.py`, `store_key` is asserted absent and the two frozen-store kinds are asserted present in `docs/judges.md`. Module counts at the review head: `test_judge_propagate_loads.py` 31, `test_judge_store_cache.py` 27, `test_kernel_goal_cache_wiring.py` 13, `ViewBuilder` 338.

A second pass on 2026-09-08 added 34 tests and extended four, each written against a named mutation of the finished code and run red under it and green at its commit: for the failure scan, one test per key component (mtime_ns, inode and size alone), the key taken from the descriptor read, the memo kept on a None return, a store gone between the glob and the stat; for the chain memo, a from-file grown in place and two callers that miss together building outside the lock; for the sweep, the corpus scan and the same-identity stale serve; for the judge pass, an undecodable version remembered and kept out of later snapshots, a publish between the listing's stat and the open, a store gone between the listing and the read, a user write landing during the reads, the per-pass copy-on-punch, the counters and the report, sidecars and temp files beside the stores; for the disk memo, every non-object top-level value, an unserializable store, the eviction sweep's lock, and a fresh store not published over a JSON array; for the mark, a stamp in the file lifting while the journal does not read, and a readable journal leaving no mark; for `run_propagate`, the dismissed-recipient lookup's reuse of the pass's reads, the snapshot map, the settled back-link on an absent sender, one test per identity component, and the sweep's eviction; for the shared cache, a top-level write naming the sid, an absent read dropping the entry, two chat builds parsing once, the feed's peer badge through the boundary, the message-summary scan, and one behaviour test per wired site in the deferral sweep, the stamp reader and the owned-yield rule.

Full suites at the head before the review commit, on a loaded machine that self-hosts a kernel: `pytest tests/ -n 8` 8840 passed, 47 skipped, 1403 subtests, 4 failed: `test_paste_to_focus_browser::ServedPaste`, the two `test_scroll_marks_growth::ServedNotchFollowsGrowth` tests and `test_awaiting_box_sync::ServedSync`, Playwright-driven modules that fail identically at the base commit on this machine (the hermetic kernel they start has no Agent SDK) and pass in CI; none of them is touched here. The touched modules alone: 1917 passed. `vscode-extension`: `npm run typecheck` clean, `npm test` 3274/3274. `bats tests/*.bats` 449/449 at an earlier head of this branch; no shell surface has changed since. The review commit's tests are its own; the figures above predate it.

## Measurements

Every row is this branch before the review commit unless the How column says otherwise. Throwaway scripts were run once at the commit's parent and once at the commit, under `nice -n 19`, on a loaded machine. The review commit's eviction is not measured: its price is one decode at the next pass per evicted store the pass still lists, and a store a discovered session owns keeps its entry.

| Change | Before | After | How |
|---|---|---|---|
| `judge_failure_scan`, 40 stores, 1.13 MB (commit 1) | 6.5 ms per call | 5.9 ms cold; 0.26 ms steady; 0.47 ms after one republish | medians of 15 rounds |
| `chain_membership`, 7.7 MB / 24,004-record transcript (commit 2) | 112 to 125 ms, records cached | 95 to 96 ms | medians of three runs; the eclipse-set narrowing alone |
| `_rewound_away`, same transcript (commit 2) | one graph build per call | 0.026 ms on a hit; a miss is the build: 87 to 97 ms with records cached, 194 to 228 ms cold | same |
| Judge-pass snapshot, 60 stores, 45.3 MB (commit 4) | steady pass 320 ms; one changed 374; five changed 365; cold 389 | 0.3 ms; 9.6; 32.7; 393 | `_begin_goals_pass(); _end_goals_pass()`; steady median of 7 passes, republish medians of 3 |
| `save_goals`, 1.2 MB store (commit 5) | no-op 10.8 to 12.6 ms; real publish 20.9 to 26.1; first no-op after a publish 11.1 to 12.9 | 5.8 to 5.9; 15.8 to 16.9; 6.0 to 6.2 | medians over 200 no-op saves and 50 publishes, two rounds |
| `run_propagate` + `_drain_undiscovered`, 30 absent stores (commit 7) | 65 loads, about 40 ms per pass | first pass 32 loads, 34 to 38 ms; steady 2 loads, 2.8 ms | spy-counted loads, 7 passes, two rounds |
| Builders, 31-session copy, 74 stores, 15.1 MB (commit 8) | `build_timeline` bars 890 ms; lanes skeleton 115; timeline connect push 154; steady push cycle 361 | 830 (-7%); 61 (-47%); 83; 293 | offline builder bench, n=3 medians, commit 7 -> commit 8 |
| Same rows, base -> head (all eight commits) | bars 1050 (min 898; one 3.7 s outlier); skeleton 115; connect 146; steady 349; cold push cycle 36.2 s | 830; 61; 83; 293; 31.1 s | same bench and copy |

Figures from the self-hosted 30-session deployment where these changes first ran, cited as measured there: commit 1, 7.8 -> 0.24 ms steady on the same 40-store recipe; commit 2, 186 -> 112 ms and 409 / 148 / 0.026 ms on a 6.3 MB transcript; commit 4, 250 -> 0.6 ms steady and 99.5% memo hits over 12.8 hours; commit 5, no-op save 20.7 -> 8.6 ms and real publish 42.0 -> 22.7 ms, no-op saves 86% of saves; commit 7, 144 -> 24 loads and 74 -> 27 ms per pass, 2214 of 2214 memo hits; commit 8, `build_timeline` bars 771.5 -> 712.2 ms, 99.8% cache hits. On that deployment, after this PR's changes landed together with the judge-side and pusher-side changes offered in separate PRs (so not attributable to this PR alone), at the same judge-pass cadence: the judge threads went from 81% to 35% of a core, saves per pass from about 73 to 1.9, goal-store loads per pass from about 455 to 345 (246 private plus 98 served by the shared cache), and during boot with a dashboard connected the process from 115% to 85% of a core.

## Contracts changed

- `load_goals` may return a store carrying a transient `_unread` key (`"journal"`: the override journal exists and did not read). It is in `_NONCONTENT_KEYS` and popped by `save_goals`, so it is never on disk; a reader that must not act on a fallback checks it. A store file that cannot be read raises and unparseable bytes are quarantined, as #1019 made them.
- New `load_goals_shared(fsid)` returns a deep-frozen store (`FrozenStore`, a dict subclass: `isinstance`, iteration and `json.dumps` behave as before; `copy.copy` and `copy.deepcopy` return plain writable containers). Writes raise `FrozenStoreError` (a `TypeError`); `save_goals` raises it for a shared store or a shallow copy whose nodes map is still shared. The two judge-errors kinds this files, `frozen-store-write` and `frozen-store-save`, are listed in `docs/judges.md` since the review commit.
- `_disk_rev` reads from a descriptor instead of `Path.read_text`, so a test that faked a revision by patching `Path.read_text` would stop seeing it (none does). `store["rev"]` after a publish is the settled CAS revision plus one. `_disk_rev`, `_matches_disk` and `_rebase_onto_disk` raise on a read fault or on bytes that are not a store object, as #1019's `_read_store_json` does; the two fault fixtures (`tests/test_judge_store_cas.py::ReadFaultCas`, `tests/test_goal_store_fault_boundary.py`) fault `os.open` for the path as well as `Path.read_text`.
- `_matches_disk(fsid, store, mine=None)` takes the caller's canonical hash; `_replay_overrides(fsid, store, lines=None)` accepts pre-read journal lines; `load_goals` is split into `_fresh_store`, `_finish_load` and `load_goals`, with `load_goals_shared` sharing the tail. New `load_goals_shared_or_fault(fsid)`: #1019's per-session store-fault boundary around the shared loader, used by the three builders (`build_session` twice, `build_feed`'s peer read, `build_timeline`).
- `run_propagate` publishes each dirty sender once after the recipient loop. Since the review commit, a raise mid-loop publishes the senders reached before it and re-raises, with the sender being applied dropped unpublished; a failed publish does not stop the other senders' publishes, and the first failure is raised once the rest are out.
- New module-level state in `kernel/judge.py`: `_jf_store_memo` and `_jf_cause_memo` (keyed on absolute store paths, so a rebind cannot hit a stale entry); `_CHAIN_MEMO` with `chain_memo_stats()`; `_DISK_CONTENT`; `_ABSENT_FLAGS`; the shared cache with `shared_store_stats()`; all but the first cleared by `_rebind_state`. `store_key()`, exported by commit 8, is removed by the review commit (no caller); `_file_key` stays as the cache's own. In `kernel/kernel.py`: `_goals_memo` and `_goals_memo_stats` with `_goals_memo_report()`; the counters are bare `+= 1` increments with one writer per key, correct under the GIL and lossy only under free threading; and, from the review commit, `_chat_build_faults` with its lock (sid to the fault text of the current episode). Tests that rewrite a transcript fixture in place must clear `_CHAIN_MEMO` beside `_PARSE_CACHE`; commit 3 does so at every existing site.
- `GET /perf` carries a `memos` key since the review commit: `pass` (the judge pass's memo: `hit`, `miss`, `fail`, `evict`, `punch`, `entries`, `bytes`), `shared` (the shared cache's counters and gauges, `off` included) and `chain` (`hit`, `miss`, `populate`, `bypass`). `goals.loads` counts the writer's loader (`load_goals`) alone; the pusher's read-only loads show under `memos.shared`, so a pass added on the pusher side shows as shared misses, not as loads. `docs/reference.md` describes the section. `romp perf` prints no row for it.
- `_compact_goal_stores` evicts the disk memo's and the shared cache's entries for removed stores and, since the review commit, from the judge-pass memo and the shared cache the entries of stores no session in the discover set owns (`_goals_memo_evict_unowned`, `_shared_evict_unowned`); it runs on the producer thread after the tiers join, the pass memo's one writer, and a `discover` that raises evicts nothing. Tests that fill either memo for a store and then run the sweep must have `discover` list that store's session, or the sweep evicts it. `_push` skips one session's failed chat build instead of returning from the cycle, and since the review commit names it once per fault episode on stderr and as a `refused` bell row (`_chat_build_fault`, `_chat_build_ok`).

## Not included

- `romp perf` rows for the memos: the CLI prints the `goals` line as before. `GET /perf` carries the three memo readers since the review commit. The failure scan, the disk memo and the absent-store memo keep no counters; their tests count with spies.
- `_feed_goals`, `_lift_spent_awaiting` and `_bg_placed_tops` stay on `load_goals` on purpose (the pass snapshot has its own memo; the other two are probe-then-write two-phase reads), and the wiring test pins them unwired. A second `build_timeline` load for dead lanes belongs to a timeline offer that follows; it will switch that load to `load_goals_shared` and bump the pin to 2.
- Judge-side follow-ups offered after this PR: a refusal in `save_goals` of a store marked `_unread` (today it publishes the store without the journal's rows as before; the mark only makes that distinguishable, and the journal replays on the next load), an archive-side mark for `load_goal_archive`, and a re-arm of `_baseRev` after a publish, which would make the reload after a publish in `run_propagate` avoidable.
- A byte compare for the judge-pass snapshot memo (commit 4). Its documented blind spot is two equal-size publishes of one store inside one clock tick after the pass's stat, on a kernel with coarse timestamps: it pins the earlier parse for one pass, a stale card until the store's next publish, never a wrong write; Linux 6.13+ multigrain timestamps rule it out. The review commit pins the blind spot with a test; the shared cache carries the compare for its own entries.
- A lock around `_goals_memo_stats`, and a helper that clears `_PARSE_CACHE` and `_CHAIN_MEMO` together.
- Pruning `_lift_seen` of sessions that left the alive set; it touches the job's loop header, which a later pusher offer rewrites.

## Questions

Both questions the PR opened with are settled by the review commit: the three stat readers now have `GET /perf` as their consumer (`memos.pass`, `memos.shared`, `memos.chain`) and `store_key` is gone, and the parsed stores resident between passes are bounded by the compaction sweep's eviction of the entries no discovered session owns, in both the judge-pass memo and the shared cache.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
